### PR TITLE
Fix empty DMR Tier III recordings: graceful slotRouter phase fallback (#644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ for tagged releases.
 
 ### Fixed
 
+- **Empty DMR Tier III recordings when the embedded LC doesn't decode
+  (#644 follow-up).** The 2-slot interleaved decoder's slot router dropped
+  *every* voice superframe until a CRC-valid embedded Link Control named the
+  call's talkgroup. Real outbound embedded signalling is still capture-pending
+  (the EMB FEC / 5-bit CRC constants are unvalidated against live air), so on a
+  carrier whose LC never decodes the router bound nothing and the call recorded
+  empty files — a 0-byte `.raw` sidecar and a header-only WAV. The router now
+  degrades gracefully: a matching embedded LC still binds (and corrects) the
+  slot, but after a short grace window with no LC it falls back to the active
+  slot's phase so audio records. Foreign-talkgroup LCs still positively exclude
+  their slot, so a call genuinely absent from the carrier still records nothing.
+  The DMR decode-quality log now reports `lc_superframes` and logs once when a
+  call records via the phase fallback, so LC-vs-fallback routing is visible.
 - **Metallic "tin can" DMR voice — AMBE+2 brought to IMBE synthesis parity
   (#644 follow-up).** With the timeslot fix above the speech became
   intelligible but sounded metallic/buzzy ("like someone speaking into a tin

--- a/docs/status.md
+++ b/docs/status.md
@@ -116,6 +116,13 @@ The inner FEC layers still pending real-air validation:
   `internal/voice/composer/dmr_2slot_realair_test.go` (run with
   `-tags integration` and `GOPHERTRUNK_DMR_2SLOT_CFILE`) is where a
   contributor drops a real capture to confirm those remaining constants.
+  Because that embedded LC is capture-pending, the `slotRouter` no longer
+  hard-drops a call when the LC never decodes: a matching LC still binds (and
+  corrects) the slot, but after a short grace window with no LC it falls back
+  to the active slot's phase so audio still records instead of producing empty
+  files (#644). The decode-quality log reports `lc_superframes` and notes once
+  when a call records via the phase fallback, so a capture that exercises the
+  fallback is easy to spot.
 
 - **AMBE+2 synthesis parity with IMBE (#644 follow-up).** Once the
   timeslot fix made DMR speech intelligible it sounded metallic ("tin

--- a/internal/voice/composer/dmr_slot_router_test.go
+++ b/internal/voice/composer/dmr_slot_router_test.go
@@ -45,16 +45,71 @@ func TestSlotRouterRoutesByEmbeddedLC(t *testing.T) {
 	}
 }
 
-func TestSlotRouterDifferentTalkgroupNeverBinds(t *testing.T) {
+func TestSlotRouterBothPhasesForeignNeverBinds(t *testing.T) {
 	r := newSlotRouter(100)
-	// Only ever see the other slot's talkgroup → nothing is accepted and
-	// no phase is bound (so a later LC-less frame still can't leak).
+	// Both phases positively decode as the other talkgroup → neither slot is
+	// ours, so the phase fallback must never leak the foreign audio in.
 	for _, ph := range []uint8{0, 1, 0, 1} {
 		if r.accept(sfWithLC(ph, 200)) {
 			t.Fatalf("accepted foreign talkgroup on phase %d", ph)
 		}
 	}
-	if r.accept(sfNoLC(0)) || r.accept(sfNoLC(1)) {
-		t.Error("accepted an LC-less superframe though our talkgroup was never seen")
+	for i := 0; i < 4; i++ {
+		if r.accept(sfNoLC(0)) || r.accept(sfNoLC(1)) {
+			t.Error("fell back onto a phase positively identified as another talkgroup")
+		}
+	}
+}
+
+// TestSlotRouterPhaseFallbackRecords: when no embedded LC ever decodes (the
+// real-air capture-pending case), the router must stop dropping the whole call
+// and fall back to the active slot's phase after the grace window so audio
+// records (issue #644).
+func TestSlotRouterPhaseFallbackRecords(t *testing.T) {
+	r := newSlotRouter(100)
+	// Within the grace window, an LC-less superframe is held (waiting for a
+	// possible LC to bind the correct phase).
+	for i := 0; i < unboundPhaseFallbackGrace-1; i++ {
+		if r.accept(sfNoLC(1)) {
+			t.Fatalf("accepted before the grace window elapsed (i=%d)", i)
+		}
+	}
+	// At the grace threshold it falls back to this slot's phase and records.
+	if !r.accept(sfNoLC(1)) {
+		t.Fatal("did not fall back to the active phase after the grace window")
+	}
+	if !r.byFallback {
+		t.Error("byFallback not set after a phase-fallback bind")
+	}
+	// Bound to phase 1 now: phase-1 superframes are ours, phase 0 is the other slot.
+	if !r.accept(sfNoLC(1)) {
+		t.Error("rejected a bound-phase superframe after fallback")
+	}
+	if r.accept(sfNoLC(0)) {
+		t.Error("accepted the other phase after binding by fallback")
+	}
+}
+
+// TestSlotRouterLCBeatsFallback: a matching-group LC inside the grace window
+// binds its phase and the fallback never triggers; a later matching LC on a
+// different phase re-binds and clears the fallback flag.
+func TestSlotRouterLCBeatsFallback(t *testing.T) {
+	r := newSlotRouter(100)
+	// One LC-less superframe (still inside the grace window), then our LC.
+	if r.accept(sfNoLC(0)) {
+		t.Fatal("accepted before any bind")
+	}
+	if !r.accept(sfWithLC(0, 100)) {
+		t.Fatal("rejected our talkgroup's LC")
+	}
+	if r.byFallback {
+		t.Error("byFallback set even though an embedded LC bound the phase")
+	}
+	// A later matching LC on the other phase re-binds (corrects routing).
+	if !r.accept(sfWithLC(1, 100)) {
+		t.Fatal("rejected our talkgroup's LC on the other phase")
+	}
+	if !r.accept(sfNoLC(1)) || r.accept(sfNoLC(0)) {
+		t.Error("did not re-bind to the phase named by the newer LC")
 	}
 }

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -55,34 +55,76 @@ type errAwareRawSink interface {
 //
 // slotRouter decides which superframes of a 2-slot interleaved DMR
 // carrier belong to this call. A carrier runs two calls (one per
-// timeslot) whose burst-A voice sync is identical, so the only reliable
+// timeslot) whose burst-A voice sync is identical, so the preferred
 // discriminator is the embedded Link Control: once a superframe's LC
 // names this call's talkgroup, its Phase is bound and subsequent
 // superframes are routed by Phase even when their LC is absent or fails
 // CRC. Superframes whose LC names a different talkgroup are dropped.
+//
+// Real outbound DMR embedded signalling is still capture-pending (the
+// EMB FEC / 5-bit CRC constants are unvalidated against live air, see
+// docs/status.md / issue #644), so on a carrier whose embedded LC never
+// decodes the router would otherwise bind nothing and drop the whole
+// call — recording empty files. To degrade gracefully it falls back to
+// the active slot's Phase after a short grace window with no LC bind, so
+// audio still records; a later valid LC re-binds and corrects the routing.
 type slotRouter struct {
-	groupID uint32
-	bound   int // -1 until a matching LC binds this call's phase
+	groupID          uint32
+	bound            int   // -1 until a phase is bound (by LC or by fallback)
+	unboundSeen      int   // LC-less superframes seen while still unbound
+	foreignPhaseMask uint8 // bit p set when phase p was positively another talkgroup
+	byFallback       bool  // bound was set by the phase fallback, not an embedded LC
 }
+
+// unboundPhaseFallbackGrace is how many consecutive LC-less voice superframes
+// the router tolerates before binding the active slot's phase. Two lets a
+// clean embedded LC on superframe 1 or 2 bind the correct phase first while
+// losing at most one leading superframe to the fallback.
+const unboundPhaseFallbackGrace = 2
 
 func newSlotRouter(groupID uint32) *slotRouter {
 	return &slotRouter{groupID: groupID, bound: -1}
 }
 
-// accept reports whether sf belongs to this call's timeslot.
+// accept reports whether sf belongs to this call's timeslot. An embedded LC
+// naming this call's talkgroup is authoritative and binds (or re-binds) the
+// phase. Absent a usable LC, once a phase is bound we route by it; while still
+// unbound we wait a couple of superframes for an LC and otherwise fall back to
+// the active slot's phase so the call still records rather than dropping it.
 func (r *slotRouter) accept(sf dmrvoice.VoiceSuperframe) bool {
 	if sf.HasLC {
 		if gv, ok := sf.LC.AsGroupVoiceUser(); ok {
 			if gv.GroupAddress == r.groupID {
 				r.bound = int(sf.Phase)
+				r.byFallback = false
 				return true
 			}
-			return false // LC names a different talkgroup — the other slot
+			// LC names a different talkgroup — this phase is positively the
+			// other slot, so never fall back onto it later.
+			r.foreignPhaseMask |= 1 << (sf.Phase & 1)
+			return false
 		}
 	}
-	// No usable group LC this superframe: accept only once our phase is
-	// known, and only for that phase.
-	return r.bound >= 0 && int(sf.Phase) == r.bound
+	if r.bound >= 0 {
+		// Phase already known (by LC or fallback): route by it.
+		return int(sf.Phase) == r.bound
+	}
+	// Unbound and no usable group LC. Never fall back onto a phase we've
+	// positively identified as another talkgroup (if the embedded LC decodes
+	// well enough to read the other TG on a slot, that slot isn't ours).
+	if r.foreignPhaseMask&(1<<(sf.Phase&1)) != 0 {
+		return false
+	}
+	// Otherwise give a valid LC a couple of superframes to bind the correct
+	// phase; if none decodes, fall back to this slot's phase so audio records
+	// instead of the whole call being dropped.
+	r.unboundSeen++
+	if r.unboundSeen >= unboundPhaseFallbackGrace {
+		r.bound = int(sf.Phase)
+		r.byFallback = true
+		return true
+	}
+	return false
 }
 
 func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, groupID uint32, interleaved bool, done chan<- struct{}) {
@@ -135,6 +177,11 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 	var (
 		uncorrectableFrames atomic.Uint64
 		corrErrBits         atomic.Uint64
+		// lcSuperframes counts superframes that carried a CRC-valid embedded
+		// LC, so the decode-quality log shows whether slot routing is driven
+		// by embedded signalling or by the phase fallback (issue #644).
+		lcSuperframes  atomic.Uint64
+		loggedFallback bool
 	)
 	rx := dmrrx.New(dmrrx.Options{
 		SampleRateHz: symbolHz,
@@ -144,10 +191,21 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 		ClockGain:   0.025,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			for _, sf := range voiceDec.Process(dibits, baseIdx) {
+				if sf.HasLC {
+					lcSuperframes.Add(1)
+				}
 				if router != nil && !router.accept(sf) {
 					// A superframe from the other timeslot (or an
 					// as-yet-unbound phase) — not this call's audio.
 					continue
+				}
+				// One-shot: surface when the call records via the active-slot
+				// phase fallback rather than an embedded-LC bind, so empty-vs-
+				// fallback recordings are diagnosable from the logs (#644).
+				if router != nil && router.byFallback && !loggedFallback {
+					loggedFallback = true
+					c.log.Info("composer: DMR slot router bound by phase fallback — embedded LC did not decode; embedded signalling is capture-pending (see #644)",
+						"serial", serial, "phase", router.bound)
 				}
 				superframes.Add(1)
 				bt.onVoice(0)
@@ -197,7 +255,8 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 		c.log.Info("composer: dmr decode quality",
 			"serial", serial,
 			"superframes", n, "uncorrectable_frames", uncorrectableFrames.Load(),
-			"corrected_bit_errs", corrErrBits.Load())
+			"corrected_bit_errs", corrErrBits.Load(),
+			"lc_superframes", lcSuperframes.Load())
 	}
 
 	for {


### PR DESCRIPTION
## Background

Follow-up to the #644 DMR work (timeslot fix #645, tin-can/AMBE+2 fix #652). The reporter then found that a real 46-second Tier III call recorded **empty files** — a **0-byte `.raw` sidecar** and a **header-only 44-byte WAV**.

## Root cause

The 2-slot interleaved decoder (Tier III's default) routes each call to its timeslot with a `slotRouter`. The router starts unbound and **drops every voice superframe** until one arrives with a CRC-valid embedded Link Control naming the call's talkgroup, which binds its phase. But real outbound embedded signalling is still **capture-pending** — the EMB FEC / 5-bit CRC / de-interleave constants are unvalidated against live air (see `docs/status.md`). On a carrier whose embedded LC never decodes, the router binds nothing, so `writeRawFrame` is never called and the entire call is dropped → empty files.

(This is the interleaved-default path from #645 surfaced by a real call, not a regression from the #652 content changes.)

## Fix — graceful phase fallback

`slotRouter` now degrades instead of recording silence:

1. **Embedded LC still wins.** A matching-group LC binds (and can re-bind to correct) the slot exactly as before.
2. **Foreign-talkgroup exclusion.** An LC naming a *different* talkgroup positively marks that phase as the other slot, so the fallback never leaks it in — a call genuinely absent from the carrier still records nothing.
3. **Active-slot fallback.** Otherwise, after a short grace window (`unboundPhaseFallbackGrace = 2`) with no LC, the router binds the active slot's phase so audio records. For a single active voice call only that slot emits a voice sync, so the fallback binds the correct phase.

## Telemetry

There was previously **zero visibility** into LC binding. The DMR decode-quality log now reports `lc_superframes`, and a one-shot line fires when a call records via the phase fallback — so LC-vs-fallback routing (and the capture-pending embedded signalling) is diagnosable from a user's logs.

## Test plan

- New router tests: fallback engages after the grace window and routes by the bound phase; a matching LC beats the fallback and a later LC re-binds; both-phases-foreign never binds.
- Full `internal/voice/composer/...` suite passes under `-race`; `go build ./...`, `go vet`, `gofmt` clean.

## Caveat

No real Tier III capture is in-repo. If this carrier uses inter-burst CACH (288-dibit cadence) and the LC never decodes, the cadence auto-detect also can't lock and stays at 264 — audio would record but be wrong-cadence. The new `lc_superframes` log line will reveal which case a reporter is in; a capture-free cadence heuristic is a separate follow-up.

https://claude.ai/code/session_01ALTPcYUD3Ksi4FSgrANCBW

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALTPcYUD3Ksi4FSgrANCBW)_