### PR TITLE
soapyremote: track actual USRP sample rate, add master_clock_rate (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **USRP/SoapySDR actual sample-rate tracking.** The `soapy_remote` driver now
+  implements the `ActualSampleRate()` extension (via the `getSampleRate` RPC), so
+  when a USRP coerces a requested rate to the nearest integer decimation of its
+  master clock, GopherTrunk builds every per-channel down-converter and symbol
+  clock from the *delivered* rate instead of the requested one — the same #402
+  correction RTL-SDR already had. A new `sdr.soapy_remote[].master_clock_rate`
+  option sets the USRP master clock in Hz so a target `sample_rate` lands on an
+  exact divisor (e.g. `61_440_000` for a B210 to stream `6_144_000` cleanly).
+  (#550)
+
 ## [v0.4.0] — 2026-06-12
 
 This release is mostly about **DMR**. The receiver now decodes real

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -358,6 +358,15 @@ sdr:
   #     args: ""                    # extra make() kwargs, "k=v,k=v" (merged
   #                                 #  with driver); e.g. for a USRP TwinRX:
   #                                 #  "rx_subdev_spec=A:0,antenna=RX1"
+  #     master_clock_rate: 0        # USRP master/reference clock in Hz. A USRP
+  #                                 #  only streams integer decimations of this
+  #                                 #  clock, so set it to make your sample_rate
+  #                                 #  an exact divisor and avoid UHD coercing
+  #                                 #  to a nearby rate. B210: 61_440_000 makes
+  #                                 #  sample_rate 6_144_000 exact (÷10). X310's
+  #                                 #  default 200 MHz already divides 6_250_000
+  #                                 #  (÷32) cleanly, so leave it 0. Shorthand
+  #                                 #  for master_clock_rate=… in args.
   #     serial: "usrp-roof"         # generator fills this from addr if blank
   #     role: control               # control | voice | auto
   #     format: "CS16"              # CS16 (16-bit, default) or CF32 (float)

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -585,6 +585,7 @@ sdr:
     - addr: "192.168.1.60:55132"  # bare host gets :55132 appended
       driver: "uhd"               # SoapySDR device key (blank = first device)
       args: ""                    # extra make() kwargs "k=v,k=v" (see below)
+      master_clock_rate: 0        # USRP master clock in Hz; 0 = device default
       serial: "usrp-roof"         # generator fills this from addr when blank
       role: control               # control | voice | auto
       format: "CS16"              # CS16 (16-bit, default) or CF32 (float)
@@ -615,6 +616,18 @@ broker / fan-out path.
 - `ppm` (frequency correction) and `bias_tee` map to SoapySDR's
   `setFrequencyCorrection` / `writeSetting` and silently no-op on
   drivers that don't implement them.
+- **USRP sample rates and the master clock.** A USRP only delivers rates that
+  are integer decimations of its master clock, so UHD silently *coerces* a
+  request that isn't an exact divisor to the nearest achievable rate. GopherTrunk
+  reads the delivered rate back over the RPC (`getSampleRate`) and builds every
+  per-channel down-converter / symbol clock from it — not from the requested
+  value — so a coerced rate stays decode-correct instead of drifting the symbol
+  clock (issues #402, #550). For a clean exact-divisor stream, pick a
+  `sample_rate` that divides the master clock, and set `master_clock_rate` when
+  the default clock doesn't divide your target: an X310's 200 MHz default already
+  divides `6_250_000` (÷32), while a B210 needs `master_clock_rate: 61_440_000`
+  to stream `6_144_000` (÷10) exactly. `master_clock_rate` is a convenience for
+  putting `master_clock_rate=…` in `args`; an explicit value in `args` wins.
 - `gain` is applied as a manual overall gain. AGC is disabled first on a
   best-effort basis, so a numeric gain still applies on front-ends that have
   no AGC at all (e.g. a USRP TwinRX, which rejects `set_rx_agc()`); use

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -744,6 +745,17 @@ type SoapyRemoteConfig struct {
 	// This is server-side device selection/configuration and is distinct
 	// from the top-level Serial, which is the local virtual pool name.
 	Args string `yaml:"args"`
+	// MasterClockHz sets the radio's master/reference clock in Hz via the
+	// SoapySDR make() arg master_clock_rate. A USRP can only deliver rates
+	// that are integer decimations of this clock, so setting it lets the
+	// device hit an exact-divisor sample_rate instead of having UHD coerce
+	// the request to the nearest achievable rate — e.g. a B210 needs
+	// master_clock_rate 61_440_000 to stream 6_144_000 (÷10) cleanly, while
+	// an X310's default 200 MHz clock already divides evenly into 6_250_000
+	// (÷32). Zero leaves the device default. This is a convenience shorthand
+	// for putting "master_clock_rate=..." in Args; an explicit value in Args
+	// wins.
+	MasterClockHz uint32 `yaml:"master_clock_rate"`
 	// Serial is the virtual device serial reported on the pool's
 	// /api/v1/devices snapshot. Empty generates one from Addr.
 	Serial string `yaml:"serial"`
@@ -805,6 +817,11 @@ func (s SoapyRemoteConfig) DeviceArgs() (map[string]string, error) {
 	if s.Driver != "" {
 		if _, ok := args["driver"]; !ok {
 			args["driver"] = s.Driver
+		}
+	}
+	if s.MasterClockHz != 0 {
+		if _, ok := args["master_clock_rate"]; !ok {
+			args["master_clock_rate"] = strconv.FormatUint(uint64(s.MasterClockHz), 10)
 		}
 	}
 	if len(args) == 0 {
@@ -1703,6 +1720,11 @@ func validateSoapyFields(i int, s SoapyRemoteConfig) error {
 	}
 	if _, err := s.DeviceArgs(); err != nil {
 		return fmt.Errorf("sdr.soapy_remote[%d]: args: %w", i, err)
+	}
+	// master_clock_rate is in Hz; a non-zero value below 1 MHz is almost
+	// certainly a units slip (e.g. "61" meaning 61 MHz) — catch it early.
+	if s.MasterClockHz != 0 && s.MasterClockHz < 1_000_000 {
+		return fmt.Errorf("sdr.soapy_remote[%d]: master_clock_rate %d looks too low; it is in Hz (e.g. 61440000 for a B210)", i, s.MasterClockHz)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -384,6 +384,18 @@ func TestSoapyRemoteDeviceArgs(t *testing.T) {
 		},
 		{"malformed missing equals", SoapyRemoteConfig{Args: "rx_subdev_spec"}, nil, true},
 		{"malformed empty key", SoapyRemoteConfig{Args: "=value"}, nil, true},
+		{
+			"master clock injected as Hz string",
+			SoapyRemoteConfig{Driver: "uhd", MasterClockHz: 61_440_000},
+			map[string]string{"driver": "uhd", "master_clock_rate": "61440000"},
+			false,
+		},
+		{
+			"explicit master_clock_rate in args wins",
+			SoapyRemoteConfig{MasterClockHz: 61_440_000, Args: "master_clock_rate=30720000"},
+			map[string]string{"master_clock_rate": "30720000"},
+			false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -119,6 +119,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SoapyRemoteConfig.Addr":             {Label: "Address", Help: "SoapySDRServer host:port, e.g. 192.168.1.60:55132 (bare host gets :55132). Required."},
 	"SoapyRemoteConfig.Driver":           {Help: "SoapySDR device key on the server (uhd, lime, bladerf, hackrf, airspy, rtlsdr). Empty picks the server's first device."},
 	"SoapyRemoteConfig.Args":             {Help: "Extra SoapySDR kwargs as key=value,key2=value2 (server-side device selection)."},
+	"SoapyRemoteConfig.MasterClockHz":    {Label: "Master clock", Hz: true, Help: "USRP master/reference clock in Hz. A USRP only streams integer decimations of it, so set it to make sample_rate an exact divisor (e.g. 61.44 MHz on a B210 → 6.144 MS/s). 0 = device default. Shorthand for master_clock_rate in args."},
 	"SoapyRemoteConfig.Serial":           {Help: "Virtual device serial reported by the pool. Empty derives one from the address."},
 	"SoapyRemoteConfig.Role":             {Help: "Pool role hint: control / voice / auto.", Options: roleOpts()},
 	"SoapyRemoteConfig.Format":           {Help: "Wire sample format: CS16 (16-bit, default) or CF32 (32-bit float).", Options: opts("", "(default)", "CS16", "CS16", "CF32", "CF32")},

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -37,6 +37,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -263,6 +264,38 @@ func (d *device) SetSampleRate(hz uint32) error {
 		p.i32(0)
 		p.f64(float64(hz))
 	})
+}
+
+// ActualSampleRate reports the rate the remote device is actually delivering,
+// which may differ from the value passed to SetSampleRate. A USRP (and other
+// SoapySDR radios) can only run at integer decimations of its master clock, so
+// UHD coerces a non-divisor request to the nearest achievable rate — e.g. a
+// B210 left at its default master clock can't hit 6.144 MS/s exactly. The
+// daemon's effectiveStreamRate() probes this optional extension and builds every
+// per-channel DDC / symbol clock from the delivered rate, so the symbol clock
+// stays aligned on coerced rates instead of drifting (issue #402, #550). It
+// queries getSampleRate over the RPC control socket and rounds to whole Hz; a
+// zero/error return makes effectiveStreamRate fall back to the requested rate.
+func (d *device) ActualSampleRate() (uint32, error) {
+	u, err := d.rpc(func(p *packer) {
+		p.call(callGetSampleRate)
+		p.char(dirRX)
+		p.i32(0)
+	})
+	if err != nil {
+		return 0, err
+	}
+	if err := u.checkException(); err != nil {
+		return 0, err
+	}
+	rate, err := u.f64()
+	if err != nil {
+		return 0, err
+	}
+	if rate <= 0 {
+		return 0, nil
+	}
+	return uint32(math.Round(rate)), nil
 }
 
 func (d *device) SetGain(tenthDB int) error {

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -36,6 +36,14 @@ type fakeSoapyServer struct {
 	// failGainMode makes SET_GAIN_MODE reply with a remote exception, mimicking
 	// a UHD front-end with no AGC ("set_rx_agc() is not supported"). Issue #542.
 	failGainMode bool
+
+	// lastSetRateHz is the most recent rate the client programmed via
+	// SET_SAMPLE_RATE. getSampleRateHz, when non-zero, overrides what
+	// GET_SAMPLE_RATE reports — modelling a USRP that coerces a non-divisor
+	// request to a different achievable rate (issue #550). When zero,
+	// GET_SAMPLE_RATE echoes lastSetRateHz (an exact-divisor device).
+	lastSetRateHz   float64
+	getSampleRateHz float64
 }
 
 type recordedCall struct {
@@ -127,6 +135,19 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 			_, _ = u.char()
 			_, _ = u.i32()
 			rec.freqHz, _ = u.f64()
+			s.mu.Lock()
+			s.lastSetRateHz = rec.freqHz
+			s.mu.Unlock()
+		case callGetSampleRate:
+			_, _ = u.char()
+			_, _ = u.i32()
+			s.mu.Lock()
+			rate := s.getSampleRateHz
+			if rate == 0 {
+				rate = s.lastSetRateHz
+			}
+			s.mu.Unlock()
+			reply = func(p *packer) { p.f64(rate) }
 		case callSetGain:
 			_, _ = u.char()
 			_, _ = u.i32()
@@ -365,6 +386,65 @@ func TestSetGainManualSurvivesAGCException(t *testing.T) {
 	}
 	if !sawGainManual {
 		t.Error("SET_GAIN with 75.0 dB not applied after SET_GAIN_MODE exception")
+	}
+}
+
+// TestActualSampleRateReportsCoercedRate covers issue #550: a USRP can only
+// deliver integer decimations of its master clock, so UHD coerces a non-divisor
+// request to the nearest achievable rate. ActualSampleRate must read back that
+// delivered rate (via GET_SAMPLE_RATE) so the daemon's effectiveStreamRate()
+// builds the symbol clock from the truth, not the requested value.
+func TestActualSampleRateReportsCoercedRate(t *testing.T) {
+	srv := newFakeSoapyServer(t)
+	srv.getSampleRateHz = 6_250_000 // device coerces the request to ÷32 of 200 MHz
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16"}}, testLogger())
+
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	if err := dev.SetSampleRate(6_144_000); err != nil { // a B210-style request
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+
+	ar, ok := dev.(interface{ ActualSampleRate() (uint32, error) })
+	if !ok {
+		t.Fatal("soapyremote device does not implement ActualSampleRate")
+	}
+	got, err := ar.ActualSampleRate()
+	if err != nil {
+		t.Fatalf("ActualSampleRate: %v", err)
+	}
+	if got != 6_250_000 {
+		t.Errorf("ActualSampleRate = %d, want 6_250_000 (the coerced rate)", got)
+	}
+}
+
+// TestActualSampleRateEchoesExactRate confirms the no-coercion path: when the
+// requested rate is an exact divisor the server reports it back unchanged, so
+// effectiveStreamRate stays quiet (requested == actual).
+func TestActualSampleRateEchoesExactRate(t *testing.T) {
+	srv := newFakeSoapyServer(t) // getSampleRateHz==0 → echo the last set rate
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16"}}, testLogger())
+
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	if err := dev.SetSampleRate(6_250_000); err != nil { // X310 ÷32, exact
+		t.Fatalf("SetSampleRate: %v", err)
+	}
+
+	got, err := dev.(interface{ ActualSampleRate() (uint32, error) }).ActualSampleRate()
+	if err != nil {
+		t.Fatalf("ActualSampleRate: %v", err)
+	}
+	if got != 6_250_000 {
+		t.Errorf("ActualSampleRate = %d, want 6_250_000", got)
 	}
 }
 

--- a/internal/sdr/soapyremote/rpc.go
+++ b/internal/sdr/soapyremote/rpc.go
@@ -76,6 +76,7 @@ const (
 	callSetGain                int32 = 703
 	callSetFrequency           int32 = 800
 	callSetSampleRate          int32 = 900
+	callGetSampleRate          int32 = 901
 	callWriteSetting           int32 = 1400
 )
 

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -85,6 +85,7 @@ export interface SoapyRemoteConfig {
   Addr: string;
   Driver: string;
   Args: string;
+  MasterClockHz: number;
   Serial: string;
   Role: string;
   Format: string;

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -121,7 +121,7 @@ export function SDRSection() {
           label="soapy_remote endpoints"
           items={cfg.SoapyRemote}
           onChange={(x) => set({ ...cfg, SoapyRemote: x })}
-          makeNew={() => ({ Addr: "", Driver: "", Args: "", Serial: "", Role: "", Format: "", StreamProtocol: "", PPM: 0, Gain: "auto", BiasTee: false, ConnectTimeoutMs: 0 })}
+          makeNew={() => ({ Addr: "", Driver: "", Args: "", MasterClockHz: 0, Serial: "", Role: "", Format: "", StreamProtocol: "", PPM: 0, Gain: "auto", BiasTee: false, ConnectTimeoutMs: 0 })}
           itemTitle={(s) => s.Addr || "soapy_remote"}
           emptyHint="SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, …)."
           renderItem={(s, set) => (
@@ -129,6 +129,7 @@ export function SDRSection() {
               <TextField label="Address" value={s.Addr} onChange={(v) => set({ ...s, Addr: v })} placeholder="192.168.1.60:55132" />
               <TextField label="Driver" value={s.Driver} onChange={(v) => set({ ...s, Driver: v })} placeholder="uhd / lime / bladerf / hackrf / airspy / rtlsdr" />
               <TextField label="Args" value={s.Args} onChange={(v) => set({ ...s, Args: v })} placeholder="key=value,key2=value2" />
+              <NumberField label="Master clock (Hz)" value={s.MasterClockHz} onChange={(v) => set({ ...s, MasterClockHz: v })} placeholder="0 = device default; B210: 61440000" />
               <TextField label="Serial" value={s.Serial} onChange={(v) => set({ ...s, Serial: v })} />
               <SelectField label="Role" value={s.Role} onChange={(v) => set({ ...s, Role: v })} options={REMOTE_ROLES} />
               <SelectField


### PR DESCRIPTION
A USRP only delivers rates that are integer decimations of its master
clock, so UHD silently coerces a non-divisor request to the nearest
achievable rate. The soapy_remote driver programmed the device but never
read the rate back, so GopherTrunk built every per-channel DDC and symbol
clock from the *requested* rate — drifting the symbol clock and losing
lock on any coerced rate, while exact-divisor rates (e.g. 6.25 MS/s on an
X310) happened to work.

Implement the optional ActualSampleRate() extension on the soapyremote
device, backed by a new getSampleRate RPC (SOAPY_REMOTE_GET_SAMPLE_RATE =
901). This plugs soapy_remote into the existing effectiveStreamRate()
machinery the RTL-SDR path already uses (issue #402), so the daemon builds
the down-converters from the delivered rate. Failure/zero falls back to
the requested rate, so servers without the query degrade gracefully.

Add an sdr.soapy_remote[].master_clock_rate option (Hz) that injects the
SoapySDR master_clock_rate make() arg, letting operators pick an exact
master clock — e.g. 61_440_000 on a B210 to stream 6_144_000 (÷10)
cleanly. It is a shorthand for master_clock_rate=… in args; an explicit
args value wins. A non-zero value below 1 MHz is rejected as a likely
Hz/MHz units slip.

Tests cover the coerced-rate readback, the exact-rate echo path, and the
master_clock_rate arg injection. Docs and the example config updated.

https://claude.ai/code/session_019gEryH8GkbeeUZ1Hdpb6DB