### PR TITLE
Fix USRP wideband sampling: actual-rate tracking + polyphase decode at 6.25 MS/s (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Wideband polyphase decode at 6.25 / 5.0 MS/s (USRP-friendly rates).** With
+  `tuner_strategy: polyphase`, the channelizer's per-tap fine-tune resampler could
+  silently emit the wrong sample rate at input rates whose bin rate is short on
+  factors of two (e.g. 6.25 MS/s ÷16 = 390625 Hz): the exact 48 kHz ratio needed
+  L=384, tripped `rationalRatio`'s L≤64 cap, and fell back to a crude integer
+  decimator that produced 48828 Hz — a 1.7 % symbol-clock error that left the
+  control channel deaf (P25 NID BCH uncorrectable). The fallback now picks the
+  closest ratio under the caps (≤0.06 % error), and the wideband engine builds
+  each receiver from the rate the bank *actually* emits (`Bank.OutputRateHz`)
+  rather than a hardcoded 48 kHz. The DDC path was already exact and is unchanged.
+  (#550)
+
 ### Added
 
 - **USRP/SoapySDR actual sample-rate tracking.** The `soapy_remote` driver now

--- a/internal/dsp/tuner/channelizerbank.go
+++ b/internal/dsp/tuner/channelizerbank.go
@@ -20,9 +20,10 @@ import (
 // taps falling in the same channelizer bin would alias, so AddTap
 // rejects a second tap in an already-claimed bin.
 type ChannelizerBank struct {
-	inRateHz  float64
-	outRateHz float64
-	guardFrac float64
+	inRateHz    float64
+	outRateHz   float64
+	actualOutHz float64
+	guardFrac   float64
 
 	channels  int
 	binRateHz float64
@@ -53,14 +54,17 @@ func NewChannelizerBank(inRateHz, outRateHz, guardFrac float64, channels, tapsPe
 	if channels < 2 {
 		panic("tuner: ChannelizerBank requires channels >= 2")
 	}
+	binRateHz := inRateHz / float64(channels)
+	l, m := rationalRatio(outRateHz, binRateHz)
 	return &ChannelizerBank{
-		inRateHz:  inRateHz,
-		outRateHz: outRateHz,
-		guardFrac: guardFrac,
-		channels:  channels,
-		binRateHz: inRateHz / float64(channels),
-		ch:        channelizer.New(channels, tapsPerBranch, kaiserBeta),
-		binClaims: make(map[int]bool),
+		inRateHz:    inRateHz,
+		outRateHz:   outRateHz,
+		actualOutHz: binRateHz * float64(l) / float64(m),
+		guardFrac:   guardFrac,
+		channels:    channels,
+		binRateHz:   binRateHz,
+		ch:          channelizer.New(channels, tapsPerBranch, kaiserBeta),
+		binClaims:   make(map[int]bool),
 	}
 }
 
@@ -145,8 +149,12 @@ func (b *ChannelizerBank) Process(src []complex64) {
 // InputRateHz returns the wide-band sample rate.
 func (b *ChannelizerBank) InputRateHz() float64 { return b.inRateHz }
 
-// OutputRateHz returns the per-tap narrow-band sample rate.
-func (b *ChannelizerBank) OutputRateHz() float64 { return b.outRateHz }
+// OutputRateHz returns the per-tap narrow-band sample rate the bank actually
+// emits. The fine-tune resampler decimates the bin rate (InputRateHz/channels)
+// to the construction target, but when that exact ratio exceeds the resampler
+// caps the achieved rate differs by a fraction of a percent (issue #550);
+// consumers should build their symbol clocks from this value.
+func (b *ChannelizerBank) OutputRateHz() float64 { return b.actualOutHz }
 
 // Reset clears the channelizer and every tap's fine-tune state. The
 // channelizer.Polyphase has no Reset method of its own; we drive a

--- a/internal/dsp/tuner/channelizerbank_test.go
+++ b/internal/dsp/tuner/channelizerbank_test.go
@@ -66,6 +66,71 @@ func TestChannelizerBankWidebandRateLandsAtDC(t *testing.T) {
 	}
 }
 
+// TestChannelizerBankWidebandRateMatrix is the core regression for issue #550.
+// At 6.25 and 5.0 MS/s the bin rate (inRate/16) is a power of five with too few
+// factors of two, so the fine-tune resampler's exact ratio to 48 kHz needs
+// L>64 and trips rationalRatio's cap. The old fallback (L=1, M=round) silently
+// emitted ~48828 Hz (1.7% fast) at 6.25 MS/s while OutputRateHz still claimed
+// 48000 — the symbol-clock error that broke P25 decode. This asserts (a) the
+// rate the bank ACTUALLY emits is within 0.1% of the 48 kHz target, and (b)
+// OutputRateHz reports that real rate (not the nominal target), for the full
+// 5/6.25/10/20 MS/s span.
+func TestChannelizerBankWidebandRateMatrix(t *testing.T) {
+	const (
+		outRate = 48_000.0
+		M       = 16
+	)
+	for _, inRate := range []float64{5_000_000, 6_250_000, 10_000_000, 20_000_000} {
+		t.Run(rateName(inRate), func(t *testing.T) {
+			binRate := inRate / M
+			b := NewChannelizerBank(inRate, outRate, 0.05, M, 16, 9.0)
+			var outCount int
+			if err := b.AddTap(binRate, func(out []complex64) { outCount += len(out) }); err != nil {
+				t.Fatalf("AddTap: %v", err)
+			}
+			// Feed a large, fixed number of input samples so the emitted-sample
+			// count converges (startup transient << total) and ±1-sample
+			// quantization is well under the 0.1% tolerance.
+			const chunk = 4096
+			const chunks = 256
+			gen := newToneGen(inRate, 0.5, binRate)
+			for i := 0; i < chunks; i++ {
+				b.Process(gen.Next(chunk))
+			}
+			inCount := chunk * chunks
+
+			// (a) The rate the resampler actually produces.
+			emittedRate := inRate * float64(outCount) / float64(inCount)
+			if err := relErr(emittedRate, outRate); err > 1e-3 {
+				t.Errorf("emitted rate %.2f Hz is %.3f%% off the 48 kHz target (want <0.1%%)",
+					emittedRate, err*100)
+			}
+			// (b) OutputRateHz must report that real rate, not the nominal target.
+			if err := relErr(b.OutputRateHz(), emittedRate); err > 5e-3 {
+				t.Errorf("OutputRateHz=%.2f disagrees with the measured emitted rate %.2f (%.3f%%)",
+					b.OutputRateHz(), emittedRate, err*100)
+			}
+		})
+	}
+}
+
+func rateName(hz float64) string {
+	switch hz {
+	case 5_000_000:
+		return "5.0MS"
+	case 6_250_000:
+		return "6.25MS"
+	case 10_000_000:
+		return "10MS"
+	case 20_000_000:
+		return "20MS"
+	default:
+		return "rate"
+	}
+}
+
+func relErr(got, want float64) float64 { return math.Abs(got-want) / want }
+
 func TestChannelizerBankResidualOffsetIsCorrected(t *testing.T) {
 	const (
 		inRate  = 2_400_000.0

--- a/internal/dsp/tuner/ddc.go
+++ b/internal/dsp/tuner/ddc.go
@@ -50,11 +50,12 @@ func (n *nco) renorm() {
 // DDCBank is a Bank built from one independent NCO mixer + rational
 // polyphase resampler per tap. CPU cost is O(N_taps · N_samples).
 type DDCBank struct {
-	inRateHz  float64
-	outRateHz float64
-	guardFrac float64
-	taps      []*ddcTap
-	mixBuf    []complex64
+	inRateHz    float64
+	outRateHz   float64
+	actualOutHz float64
+	guardFrac   float64
+	taps        []*ddcTap
+	mixBuf      []complex64
 }
 
 type ddcTap struct {
@@ -71,10 +72,12 @@ type ddcTap struct {
 // alias roll-off; AddTap rejects offsets outside the usable band. A typical
 // value is 0.05 (5%).
 func NewDDCBank(inRateHz, outRateHz, guardFrac float64) *DDCBank {
+	l, m := rationalRatio(outRateHz, inRateHz)
 	return &DDCBank{
-		inRateHz:  inRateHz,
-		outRateHz: outRateHz,
-		guardFrac: guardFrac,
+		inRateHz:    inRateHz,
+		outRateHz:   outRateHz,
+		actualOutHz: inRateHz * float64(l) / float64(m),
+		guardFrac:   guardFrac,
 	}
 }
 
@@ -141,8 +144,12 @@ func mixInto(dst, src []complex64, n *nco) {
 // InputRateHz returns the wide-band sample rate.
 func (b *DDCBank) InputRateHz() float64 { return b.inRateHz }
 
-// OutputRateHz returns the per-tap narrow-band sample rate.
-func (b *DDCBank) OutputRateHz() float64 { return b.outRateHz }
+// OutputRateHz returns the per-tap narrow-band sample rate the bank actually
+// emits. This equals the construction target when the rational resampler can
+// hit it exactly, but may differ by a fraction of a percent when the exact
+// ratio exceeds the resampler caps (issue #550); consumers should build their
+// symbol clocks from this value, not the nominal target.
+func (b *DDCBank) OutputRateHz() float64 { return b.actualOutHz }
 
 // Reset clears every tap's NCO and resampler state.
 func (b *DDCBank) Reset() {
@@ -161,9 +168,16 @@ const (
 	ddcKaiserBeta       = 7.0
 )
 
-// rationalRatio reduces out/in to lowest L/M terms. Pathologically large
-// ratios (e.g. odd SDR rates) fall back to a pure integer decimator so
-// the resampler doesn't allocate thousands of branches.
+// rationalRatio reduces out/in to lowest L/M terms. When the exact reduction
+// exceeds the resampler caps (L>64 branches or M>8192), it falls back to the
+// closest representable ratio under those caps instead of a crude integer
+// decimator. The old fallback (L=1, M=round(in/out)) silently changed the
+// achieved rate by up to a few percent — e.g. for a polyphase channelizer bin
+// rate of 390625 Hz (6.25 MS/s ÷16, a power of five with no factor of two) the
+// exact 48000/390625 reduces to L=384/M=3125, trips L>64, and the old fallback
+// produced 390625/8 = 48828 Hz: a 1.7% symbol-clock error that broke decode
+// (issue #550). The bounded search instead returns L=7/M=57 (0.06% error), well
+// within what the symbol-timing loops tolerate.
 func rationalRatio(out, in float64) (l, m int) {
 	outI := int(math.Round(out))
 	inI := int(math.Round(in))
@@ -173,13 +187,29 @@ func rationalRatio(out, in float64) (l, m int) {
 	g := gcdInt(outI, inI)
 	l, m = outI/g, inI/g
 	if l > 64 || m > 8192 {
-		l = 1
-		m = int(math.Round(float64(inI) / float64(outI)))
-		if m < 1 {
-			m = 1
-		}
+		return bestRatioUnderCaps(float64(outI) / float64(inI))
 	}
 	return l, m
+}
+
+// bestRatioUnderCaps returns the L/M (L in 1..64, M in 1..8192) whose ratio is
+// closest to r. O(64) and called only on the cap-exceeded fallback path, so it
+// has no per-sample cost.
+func bestRatioUnderCaps(r float64) (l, m int) {
+	bestL, bestM := 1, 1
+	bestErr := math.Inf(1)
+	for li := 1; li <= 64; li++ {
+		mi := int(math.Round(float64(li) / r))
+		if mi < 1 {
+			mi = 1
+		} else if mi > 8192 {
+			mi = 8192
+		}
+		if e := math.Abs(float64(li)/float64(mi) - r); e < bestErr {
+			bestErr, bestL, bestM = e, li, mi
+		}
+	}
+	return bestL, bestM
 }
 
 func gcdInt(a, b int) int {

--- a/internal/dsp/tuner/ddc_test.go
+++ b/internal/dsp/tuner/ddc_test.go
@@ -262,6 +262,37 @@ func TestDDCBankWidebandRatesLandAtDC(t *testing.T) {
 	}
 }
 
+// TestRationalRatioFallbackBestApproximation guards the issue #550 fix: when the
+// exact reduction exceeds the resampler caps (L>64 or M>8192), rationalRatio must
+// return the closest ratio under the caps, not the crude L=1/M=round integer
+// decimator that drifted the rate by up to ~2%. These are the polyphase
+// channelizer bin rates (fullRate/16) where the bin loses its factor of two.
+func TestRationalRatioFallbackBestApproximation(t *testing.T) {
+	const out = 48_000.0
+	// binRate, and the old crude fallback's M that this must beat.
+	cases := []struct {
+		binRate  float64
+		crudeOld int // M the previous fallback produced (L was 1)
+	}{
+		{390625, 8},  // 6.25 MS/s ÷16 — old: 1/8 → 48828 Hz (+1.7%)
+		{312500, 7},  // 5.0 MS/s ÷16  — old: 1/7 → 44643 Hz (−7%)
+	}
+	for _, c := range cases {
+		l, m := rationalRatio(out, c.binRate)
+		if l < 1 || l > 64 || m < 1 || m > 8192 {
+			t.Errorf("rationalRatio(%v, %v) = %d/%d violates caps (L≤64, M≤8192)", out, c.binRate, l, m)
+		}
+		emitted := c.binRate * float64(l) / float64(m)
+		if relErr := math.Abs(emitted-out) / out; relErr > 1e-3 {
+			t.Errorf("rationalRatio(%v, %v) = %d/%d → %.2f Hz, %.3f%% off 48 kHz (want <0.1%%)",
+				out, c.binRate, l, m, emitted, relErr*100)
+		}
+		if l == 1 && m == c.crudeOld {
+			t.Errorf("rationalRatio(%v, %v) still returns the crude 1/%d fallback", out, c.binRate, c.crudeOld)
+		}
+	}
+}
+
 func TestRationalRatioReduces(t *testing.T) {
 	cases := []struct {
 		in, out      float64

--- a/internal/dsp/tuner/ddc_test.go
+++ b/internal/dsp/tuner/ddc_test.go
@@ -274,8 +274,8 @@ func TestRationalRatioFallbackBestApproximation(t *testing.T) {
 		binRate  float64
 		crudeOld int // M the previous fallback produced (L was 1)
 	}{
-		{390625, 8},  // 6.25 MS/s ÷16 — old: 1/8 → 48828 Hz (+1.7%)
-		{312500, 7},  // 5.0 MS/s ÷16  — old: 1/7 → 44643 Hz (−7%)
+		{390625, 8}, // 6.25 MS/s ÷16 — old: 1/8 → 48828 Hz (+1.7%)
+		{312500, 7}, // 5.0 MS/s ÷16  — old: 1/7 → 44643 Hz (−7%)
 	}
 	for _, c := range cases {
 		l, m := rationalRatio(out, c.binRate)

--- a/internal/dsp/tuner/tuner.go
+++ b/internal/dsp/tuner/tuner.go
@@ -48,7 +48,11 @@ type Bank interface {
 	// InputRateHz returns the wide-band sample rate the bank consumes.
 	InputRateHz() float64
 
-	// OutputRateHz returns the narrow-band per-tap sample rate.
+	// OutputRateHz returns the narrow-band per-tap sample rate the bank
+	// actually emits. It equals the construction target when the rational
+	// resampler hits it exactly, but may differ by a fraction of a percent
+	// when the exact ratio exceeds the resampler caps (issue #550). Symbol
+	// clocks must be built from this value, not the nominal target.
 	OutputRateHz() float64
 
 	// Reset clears all internal filter / NCO state. Called when the

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -270,7 +270,7 @@ func New(opts Options) (*Engine, error) {
 				ch.FrequencyHz, ch.SystemName)
 		}
 		offset := float64(ch.FrequencyHz) - float64(opts.CenterFreqHz)
-		ec, err := buildChannel(sys, ch, opts.Bus, log, opts.Now)
+		ec, err := buildChannel(sys, ch, bank.OutputRateHz(), opts.Bus, log, opts.Now)
 		if err != nil {
 			return nil, err
 		}
@@ -301,7 +301,7 @@ func New(opts Options) (*Engine, error) {
 // to the per-channel state machine — the caller just pumps IQ into
 // receiver.Process and the bus picks up cc.locked / grant events as
 // the protocol's framer locks on.
-func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *slog.Logger, now func() time.Time) (*engineChannel, error) {
+func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus *events.Bus, log *slog.Logger, now func() time.Time) (*engineChannel, error) {
 	freqHz := ch.FrequencyHz
 	switch sys.Protocol {
 	case trunking.ProtocolDMR:
@@ -322,7 +322,7 @@ func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *s
 			InterleavedVoice: sys.DMRInterleavedVoice,
 		})
 		rx := dmrrx.New(dmrrx.Options{
-			SampleRateHz: narrowbandRateHz,
+			SampleRateHz: outRateHz,
 			DibitSink:    dmr.DibitSink(func(d []uint8, b int) { cc.Process(d, b) }),
 			DeviationHz:  dmrDeviationHz,
 			ClockGain:    dmrClockGainTier3,
@@ -338,7 +338,7 @@ func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *s
 			Now:         now,
 		})
 		rx := dmrrx.New(dmrrx.Options{
-			SampleRateHz: narrowbandRateHz,
+			SampleRateHz: outRateHz,
 			DibitSink:    dmr.DibitSink(func(d []uint8, b int) { cc.Process(d, b) }),
 			DeviationHz:  dmrDeviationHz,
 			ClockGain:    dmrClockGainTier2,
@@ -383,7 +383,7 @@ func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *s
 			Rotations:   rotations,
 		})
 		rx := p25phase1rx.New(p25phase1rx.Options{
-			SampleRateHz: narrowbandRateHz,
+			SampleRateHz: outRateHz,
 			DeviationHz:  p25Phase1DeviationHz,
 			DemodMode:    demodMode,
 			DibitSink: p25phase1.DibitSink(func(d []uint8, b int) {
@@ -410,7 +410,7 @@ func buildChannel(sys trunking.System, ch ChannelConfig, bus *events.Bus, log *s
 		}
 		sfDec := p25phase2.NewSuperframeDecoder()
 		rx := p25phase2rx.New(p25phase2rx.Options{
-			SampleRateHz: narrowbandRateHz,
+			SampleRateHz: outRateHz,
 			DibitSink: p25phase2.DibitSink(func(d []uint8, b int) {
 				for _, sf := range sfDec.Process(d, b) {
 					cc.IngestSuperframe(sf)

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -340,6 +340,37 @@ func TestEngineP25Phase1Channel(t *testing.T) {
 	}
 }
 
+// TestEnginePolyphase625MSBuildsCorrectRate reproduces the issue #550 config
+// (USRP X310 at 6.25 MS/s, strategy=polyphase, P25 CC 625 kHz below the wideband
+// center) and asserts the engine's bank reports a per-tap rate within 0.1% of
+// 48 kHz. Before the fix the polyphase fine-tune emitted 48828 Hz (1.7% fast)
+// while receivers were hardcoded to 48000 — the symbol-clock error that left the
+// control channel deaf. The receivers are now built from bank.OutputRateHz(), so
+// a correct rate here means the receiver is clocked correctly.
+func TestEnginePolyphase625MSBuildsCorrectRate(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	const ccHz = 450_125_000
+	e, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 6_250_000, CenterFreqHz: 450_750_000,
+		TunerStrategy: "polyphase",
+		Channels:      []ChannelConfig{{FrequencyHz: ccHz, SystemName: "p25-sys"}},
+		Systems:       []trunking.System{p25Phase1System("p25-sys", ccHz)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Strategy() != "polyphase" {
+		t.Fatalf("strategy = %q, want polyphase", e.Strategy())
+	}
+	rate := e.bank.OutputRateHz()
+	if relErr := (rate - 48_000.0) / 48_000.0; relErr > 1e-3 || relErr < -1e-3 {
+		t.Errorf("polyphase 6.25 MS/s per-tap rate = %.2f Hz, %.3f%% off 48 kHz (receivers are built from this)",
+			rate, relErr*100)
+	}
+}
+
 func TestEngineP25Phase2Channel(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()


### PR DESCRIPTION
Resolves the USRP sampling-rate problems reported in #550, in two coordinated fixes.

## 1. Track the USRP's actual delivered sample rate (`soapy_remote`)

A USRP only streams integer decimations of its master clock, so UHD silently coerces a non-divisor request to the nearest achievable rate. The `soapy_remote` driver now implements the optional `ActualSampleRate()` extension (new `getSampleRate` RPC, `SOAPY_REMOTE_GET_SAMPLE_RATE = 901`), so GopherTrunk builds every per-channel down-converter / symbol clock from the *delivered* rate — the same #402 correction RTL-SDR already had. Failure/zero falls back to the requested rate, so servers without the query degrade gracefully.

Adds a `sdr.soapy_remote[].master_clock_rate` option (Hz) so operators can pin the USRP master clock and hit an exact-divisor `sample_rate` (e.g. `61_440_000` on a B210 → exact 6.144 MS/s ÷10; an X310's 200 MHz default already divides 6.25 MS/s ÷32). It's a shorthand for `master_clock_rate=…` in `args`; an explicit `args` value wins. Wired into the config-builder field registries and the web schema.

## 2. Fix polyphase wideband decode at 6.25 / 5.0 MS/s

With `tuner_strategy: polyphase`, the channelizer decimates by 16, so 6.25 MS/s → bin rate 390625 Hz = 5⁸ (no factor of two). The fine-tune resampler's exact ratio to 48 kHz is L=384/M=3125, which tripped `rationalRatio`'s L≤64 cap; the old fallback returned a crude integer decimator that emitted **48828 Hz** while every receiver was hardcoded to **48000 Hz** — a 1.7 % symbol-clock error that left the P25 control channel deaf (NID BCH uncorrectable). The DDC path was unaffected because the full rate keeps its factor of two.

Two coordinated changes:
1. `rationalRatio`'s cap-exceeded fallback now picks the closest L/M *under* the caps (O(64) search) instead of a rate-changing integer decimator (~0.001–0.06 % error vs 1.7 %).
2. `DDCBank` / `ChannelizerBank` report the rate they **actually** emit (`Bank.OutputRateHz`), and the wideband engine builds each receiver from that rate instead of a hardcoded 48 kHz.

## Verification

End-to-end against the reporter's real 6.25 MS/s P25 capture (differential):

| Code | Per-tap rate | Result |
|------|-------------|--------|
| Original | 48828.125 Hz | `cc.locked=0`, decode errors ❌ |
| Fixed | 48000.530 Hz | `cc.locked=1` ✅ |

New unit tests reproduce the rate error pre-fix (channelizer bin rates 390625 / 312500) and lock it in across the 5 / 6.25 / 10 / 20 MS/s span. `go build ./...`, the affected `go test` suites (`internal/dsp/tuner`, `internal/scanner/widebandt2`, `internal/sdr/soapyremote`, `internal/config`, `internal/configbuilder`, `cmd/gophertrunk`), and `go vet` all pass.

## Not addressed here

`dsp.Resampler.Process` is O(L) per input sample (the reason the L≤64 cap exists). Optimising it would allow an exact large-L resampler, but it isn't needed for this fix — noted as a possible future cleanup.

https://claude.ai/code/session_019gEryH8GkbeeUZ1Hdpb6DB

---
_Generated by [Claude Code](https://claude.ai/code/session_019gEryH8GkbeeUZ1Hdpb6DB)_