### PR TITLE
hunt/survey: stop mislabeling DMR/TETRA as am; add -survey-deep arbiter (#648)

### DIFF
--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -48,6 +48,7 @@ func runHunt(args []string) {
 	serial := fs.String("serial", "", "SDR serial to sweep for a live hunt (omit -in). Empty + no -in ⇒ error")
 	surveyMode := fs.Bool("survey", false, "signal-survey mode: classify every detected carrier (analog/digital/paging/trunking) and decode the conventional ones, not just trunking control channels (live only)")
 	classifyOnly := fs.Bool("classify-only", false, "survey: classify carriers only, skip all decoding (fast inventory)")
+	surveyDeep := fs.Bool("survey-deep", false, "survey: hand narrowband carriers the classifier called analog (am/nbfm) to the trunking identify too, so a trunked DMR/TETRA/MPT control channel the blind classifier missed is still found (slower, more accurate)")
 	surveyAudio := fs.String("survey-audio", "", "survey: write a WAV clip per active analog FM carrier into this directory")
 	maxDwellSeconds := fs.Float64("max-dwell-seconds", 0, "survey: extend per-candidate dwell up to this many seconds, listening until carrier activity (0 = fixed -dwell-seconds)")
 	identifyMinConf := fs.Float64("identify-min-confidence", 0, "survey: skip the trunking identify for a digital carrier below this classifier confidence (0 = always identify)")
@@ -179,6 +180,7 @@ FLAGS:`)
 			serial:           *serial,
 			survey:           *surveyMode,
 			classifyOnly:     *classifyOnly,
+			surveyDeep:       *surveyDeep,
 			surveyAudioDir:   *surveyAudio,
 			maxDwellSeconds:  *maxDwellSeconds,
 			identifyMinConf:  *identifyMinConf,
@@ -234,6 +236,7 @@ FLAGS:`)
 				Name: *name, State: *state, County: *county, Location: *location,
 				Protocol: proto, MinConfidence: *minConfidence,
 				ClassifyOnly:          *classifyOnly,
+				SurveyDeep:            *surveyDeep,
 				SurveyAudioDir:        *surveyAudio,
 				IdentifyMinConfidence: *identifyMinConf,
 				ClassifyConfig: survey.ClassifyConfig{

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -20,6 +20,7 @@ type huntLiveParams struct {
 	serial           string
 	survey           bool // classify+decode every carrier, not just trunking CCs
 	classifyOnly     bool
+	surveyDeep       bool // hand analog-classed narrowband carriers to siglab identify
 	surveyAudioDir   string
 	maxDwellSeconds  float64
 	identifyMinConf  float64
@@ -119,6 +120,7 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 		County:                p.county,
 		Location:              p.location,
 		ClassifyOnly:          p.classifyOnly,
+		SurveyDeep:            p.surveyDeep,
 		SurveyAudioDir:        p.surveyAudioDir,
 		IdentifyMinConfidence: p.identifyMinConf,
 		ClassifyConfig: survey.ClassifyConfig{

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -56,6 +56,12 @@ type LiveHuntOptions struct {
 	// all decoding (trunking identify, paging, analog tone scan) for a fast
 	// inventory.
 	ClassifyOnly bool
+	// SurveyDeep hands narrowband carriers the blind classifier called analog
+	// (am/nbfm/wfm ≤ NBFM bandwidth) to the authoritative siglab identify before
+	// the analog tone scan, so a trunked DMR/TETRA/MPT control channel the blind
+	// classifier missed is still discovered. Slower (an extra identify per
+	// borderline carrier); the accurate-survey opt-in for digital-dense bands.
+	SurveyDeep bool
 	// Serial requests a specific SDR for the run. Empty ⇒ the daemon
 	// auto-selects (spare SDR, else borrow the control SDR). Consumed by the
 	// daemon Acquirer; RunLiveHunt itself ignores it (the IQSource is already

--- a/internal/hunt/livesurvey.go
+++ b/internal/hunt/livesurvey.go
@@ -247,44 +247,99 @@ func routeSignal(sys *DiscoveredSystem, ds *DetectedSignal, in routeInputs) *Cap
 		if in.opts.IdentifyMinConfidence > 0 && ds.Confidence < in.opts.IdentifyMinConfidence {
 			return nil
 		}
-		buf := siglab.EncodeCapture(in.fullIQ, siglab.FormatF32)
-		rep := decodeAndAccumulate(sys, bytes.NewReader(buf), source, decodeParams{
-			Protocol:      in.opts.Protocol,
-			Format:        siglab.FormatF32,
-			SampleRateHz:  in.fullRate,
-			FrequencyHz:   in.cand.FreqHz,
-			AutoTune:      in.opts.AutoTune,
-			MinConfidence: in.opts.MinConfidence,
-			Log:           in.log,
-		})
-		switch {
-		case rep.Locked:
-			ds.Class = survey.ClassTrunkControl
-			ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence, Locked: true, ControlHz: rep.ControlHz}
-		case !rep.Skipped && rep.Error == "":
-			ds.Class = survey.ClassTrunkVoice
-			ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence}
+		return identifyTrunking(sys, ds, in, source, true)
+	}
+
+	// Deep survey: a narrowband carrier the blind classifier called analog can
+	// still be a trunked DMR/TETRA/MPT control channel whose fragile baud line
+	// was lost (issue #648). Hand it to the authoritative siglab identify first.
+	// If it locks (or decodes) the class is upgraded to trunking and we're done;
+	// otherwise it really is analog, so we still run the tone scan — but return
+	// the identify report so the attempt is recorded — at the cost of one
+	// identify per borderline carrier.
+	if in.opts.SurveyDeep && isAnalogClass(ds.Class) && ds.OccupiedBwHz <= surveyDeepMaxBwHz {
+		// Lock-only: relabel as trunking solely on a genuine control-channel lock,
+		// never on a non-locked best-guess identify — a real analog carrier must
+		// not be promoted to trunk-voice by siglab's weak runner-up protocol.
+		rep := identifyTrunking(sys, ds, in, source, false)
+		if ds.Class == survey.ClassTrunkControl {
+			return rep
 		}
-		// Skipped/errored ⇒ keep the classifier's family label (generic FSK/etc.).
-		return &rep
+		analyzeAnalog(ds, in)
+		return rep
 	}
 
 	// Analog FM / AM: carrier activity + sub-audible squelch identification,
 	// plus an optional WAV clip when -survey-audio is set.
-	switch ds.Class {
-	case survey.ClassNBFM, survey.ClassWideFM, survey.ClassAM:
-		ds.Analog = survey.AnalyzeAnalogFM(in.chIQ, in.chRate)
-		if in.opts.SurveyAudioDir != "" && ds.Analog.Active {
-			path := filepath.Join(in.opts.SurveyAudioDir,
-				fmt.Sprintf("%.4fMHz.wav", float64(in.cand.FreqHz)/1e6))
-			if err := survey.WriteAnalogClip(path, in.chIQ, in.chRate); err != nil {
-				ds.Error = fmt.Sprintf("audio clip: %v", err)
-			} else {
-				ds.Analog.AudioClipPath = path
-			}
+	analyzeAnalog(ds, in)
+	return nil
+}
+
+// analyzeAnalog runs the analog-FM activity + sub-audible squelch scan on the
+// channelised carrier (and writes a WAV clip when -survey-audio is set), for the
+// analog families. A no-op for any other class.
+func analyzeAnalog(ds *DetectedSignal, in routeInputs) {
+	if !isAnalogClass(ds.Class) {
+		return
+	}
+	ds.Analog = survey.AnalyzeAnalogFM(in.chIQ, in.chRate)
+	if in.opts.SurveyAudioDir != "" && ds.Analog.Active {
+		path := filepath.Join(in.opts.SurveyAudioDir,
+			fmt.Sprintf("%.4fMHz.wav", float64(in.cand.FreqHz)/1e6))
+		if err := survey.WriteAnalogClip(path, in.chIQ, in.chRate); err != nil {
+			ds.Error = fmt.Sprintf("audio clip: %v", err)
+		} else {
+			ds.Analog.AudioClipPath = path
 		}
 	}
-	return nil
+}
+
+// surveyDeepMaxBwHz bounds the deep-survey identify to narrowband carriers — a
+// trunked control channel is narrowband, and it keeps the (expensive) identify
+// off wideband broadcast FM. Matches the NBFM/WideFM split.
+const surveyDeepMaxBwHz = 25_000
+
+// isAnalogClass reports whether the blind classifier put the carrier in an
+// analog family (the classes deep survey reconsiders via siglab).
+func isAnalogClass(c survey.SignalClass) bool {
+	switch c {
+	case survey.ClassNBFM, survey.ClassWideFM, survey.ClassAM:
+		return true
+	default:
+		return false
+	}
+}
+
+// identifyTrunking runs the authoritative siglab identify→decode on the full-rate
+// capture and, when it locks (or decodes without skipping), upgrades ds.Class to
+// trunk-control / trunk-voice and attaches the trunking ref. A skipped/errored
+// identify leaves ds.Class as the classifier's family label. Returns the decode
+// report for the shared export tail.
+// voiceUpgrade ⇒ a non-locked but conclusive identify upgrades the carrier to
+// trunk-voice (used for carriers the blind classifier already called digital);
+// when false, only a genuine control-channel lock relabels the carrier, so a
+// blind-analog carrier is never promoted by a weak runner-up identify.
+func identifyTrunking(sys *DiscoveredSystem, ds *DetectedSignal, in routeInputs, source string, voiceUpgrade bool) *CaptureReport {
+	buf := siglab.EncodeCapture(in.fullIQ, siglab.FormatF32)
+	rep := decodeAndAccumulate(sys, bytes.NewReader(buf), source, decodeParams{
+		Protocol:      in.opts.Protocol,
+		Format:        siglab.FormatF32,
+		SampleRateHz:  in.fullRate,
+		FrequencyHz:   in.cand.FreqHz,
+		AutoTune:      in.opts.AutoTune,
+		MinConfidence: in.opts.MinConfidence,
+		Log:           in.log,
+	})
+	switch {
+	case rep.Locked:
+		ds.Class = survey.ClassTrunkControl
+		ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence, Locked: true, ControlHz: rep.ControlHz}
+	case voiceUpgrade && !rep.Skipped && rep.Error == "":
+		ds.Class = survey.ClassTrunkVoice
+		ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence}
+	}
+	// Skipped/errored (or non-locked under lock-only) ⇒ keep the classifier label.
+	return &rep
 }
 
 // surveyCandidates resolves the carriers to examine: an explicit candidate list

--- a/internal/hunt/livesurvey_test.go
+++ b/internal/hunt/livesurvey_test.go
@@ -147,6 +147,58 @@ func TestClassifyLoneWidebandNotTruncated(t *testing.T) {
 	}
 }
 
+// TestSurveyDeepRoutesAnalogToSiglab is the #648 follow-up guard: an opt-in deep
+// survey hands a narrowband carrier the blind classifier called analog to the
+// authoritative siglab identify (so a trunked CC the classifier missed is still
+// found), while the default survey leaves analog carriers untouched. A genuine
+// analog carrier that siglab can't lock still gets its analog tone scan.
+func TestSurveyDeepRoutesAnalogToSiglab(t *testing.T) {
+	const rate = 48_000
+	full := fmNoise(96_000, rate, 3000, 21) // a narrowband carrier siglab won't lock
+	ch, chRate := channelize(full, rate, surveyChannelRateHz)
+	mkInputs := func(opts LiveHuntOptions) routeInputs {
+		return routeInputs{
+			fullIQ: full, fullRate: rate, chIQ: ch, chRate: chRate,
+			cand: Candidate{FreqHz: 451_000_000}, opts: opts, log: slog.New(slog.DiscardHandler),
+		}
+	}
+	// A carrier the blind classifier put in an analog family, narrowband.
+	mkDS := func() *DetectedSignal {
+		return &DetectedSignal{FreqHz: 451_000_000, Class: survey.ClassNBFM, OccupiedBwHz: 12_000}
+	}
+
+	// Default survey: an analog carrier is NOT handed to siglab (no report), but
+	// still gets the analog tone scan.
+	base := mkDS()
+	if rep := routeSignal(&DiscoveredSystem{}, base, mkInputs(LiveHuntOptions{})); rep != nil {
+		t.Errorf("default survey must not hand an analog carrier to siglab; got report %+v", rep)
+	}
+	if base.Analog == nil {
+		t.Errorf("default survey should still run the analog tone scan")
+	}
+
+	// Deep survey: the same carrier IS handed to siglab identify (a report comes
+	// back). Noise won't lock, so it stays analog (lock-only, never promoted to
+	// trunk-voice on a weak guess) and still gets the tone scan.
+	deep := mkDS()
+	deepRep := routeSignal(&DiscoveredSystem{}, deep, mkInputs(LiveHuntOptions{SurveyDeep: true}))
+	if deepRep == nil {
+		t.Errorf("deep survey must hand an analog narrowband carrier to siglab identify")
+	}
+	if deep.Class != survey.ClassNBFM {
+		t.Errorf("non-locking deep identify must keep the analog label, got %q", deep.Class)
+	}
+	if deep.Analog == nil {
+		t.Errorf("deep survey carrier that didn't lock should still get the analog tone scan")
+	}
+
+	// And a wideband analog carrier is left out of the deep identify entirely.
+	wide := &DetectedSignal{FreqHz: 99_500_000, Class: survey.ClassWideFM, OccupiedBwHz: 180_000}
+	if rep := routeSignal(&DiscoveredSystem{}, wide, mkInputs(LiveHuntOptions{SurveyDeep: true})); rep != nil {
+		t.Errorf("deep survey must not identify a wideband carrier; got report %+v", rep)
+	}
+}
+
 // TestRunLiveSurvey_MixedTraffic probes two carriers — a synthesized P25 control
 // channel and an analog FM voice channel — and asserts the survey classifies and
 // routes each correctly: the P25 carrier folds into the discovered system, the

--- a/internal/survey/classify.go
+++ b/internal/survey/classify.go
@@ -101,6 +101,11 @@ type ClassifyConfig struct {
 	// AMEnvelopeCV is the envelope coefficient-of-variation above which a
 	// carrier reads as AM (non-constant envelope).
 	AMEnvelopeCV float64
+	// AMMaxIFStd is the FM-discriminator std (rad/sample) below which a
+	// high-envelope-CV carrier reads as AM. Above it the carrier carries real
+	// angle modulation (FM / digital FM) and is not AM even when noise or
+	// channel clipping has lifted its envelope CV past AMEnvelopeCV.
+	AMMaxIFStd float64
 	// DigitalProminence is the minimum rectified-discriminator baud-line
 	// prominence for a carrier to read as digital.
 	DigitalProminence float64
@@ -119,6 +124,7 @@ func DefaultClassifyConfig() ClassifyConfig {
 		SNRGateDb:         3,
 		OccupiedThreshDb:  6,
 		AMEnvelopeCV:      0.20,
+		AMMaxIFStd:        0.25,
 		DigitalProminence: 15,
 		NBFMMaxBwHz:       25_000,
 		PSKKurtosis:       2,
@@ -138,6 +144,9 @@ func (c ClassifyConfig) withDefaults() ClassifyConfig {
 	}
 	if c.AMEnvelopeCV == 0 {
 		c.AMEnvelopeCV = d.AMEnvelopeCV
+	}
+	if c.AMMaxIFStd == 0 {
+		c.AMMaxIFStd = d.AMMaxIFStd
 	}
 	if c.DigitalProminence == 0 {
 		c.DigitalProminence = d.DigitalProminence
@@ -245,9 +254,15 @@ func decide(f ClassFeatures, cfg ClassifyConfig) (SignalClass, float64) {
 		return ClassFSK, conf
 	}
 
-	// AM: a non-constant envelope with no symbol structure. Constant-envelope
-	// angle modulations sit near CV≈0; voice AM runs well above the gate.
-	if f.EnvelopeCV > cfg.AMEnvelopeCV {
+	// AM: a non-constant envelope with no symbol structure AND little angle
+	// modulation. Real AM carries its message in the envelope (high CV) with a
+	// near-static carrier frequency (IFStd≈0); a constant-envelope FM / digital-FM
+	// carrier (DMR, or an FM repeater with CTCSS) can have its envelope CV lifted
+	// past the gate by noise or channel clipping, but its discriminator still
+	// swings with the deviation. Requiring low IFStd keeps those out of AM — they
+	// fall to the FM split below — so a DMR carrier whose fragile baud line was
+	// lost isn't mislabelled am (issue #648).
+	if f.EnvelopeCV > cfg.AMEnvelopeCV && f.IFStd < cfg.AMMaxIFStd {
 		conf := clamp01((f.EnvelopeCV - cfg.AMEnvelopeCV) / 0.3)
 		return ClassAM, 0.5 + 0.5*conf
 	}
@@ -393,14 +408,16 @@ func baudLine(d []float32, mean float64, rateHz float64) (float64, float64) {
 	out := fft.New(n).Forward(nil, in)
 
 	binHz := rateHz / float64(n)
-	// Plausible baud band: 300 Hz .. rate/3 (above any audio roll-off, below
-	// where a real baud line could fold).
+	// Plausible baud band: 300 Hz .. rate/2.4 (above any audio roll-off, below
+	// the fold region near Nyquist). The upper edge reaches ~20 kHz at a 48 kHz
+	// channel so TETRA's 18 kbaud symbol line is searchable, not just the
+	// sub-16 kHz rates a rate/3 cap allowed.
 	loBin := int(300 / binHz)
 	if loBin < 1 {
 		loBin = 1
 	}
 	hiBin := n / 2
-	if maxBin := int((rateHz / 3) / binHz); maxBin < hiBin {
+	if maxBin := int((rateHz / 2.4) / binHz); maxBin < hiBin {
 		hiBin = maxBin
 	}
 	if hiBin <= loBin {

--- a/internal/survey/classify_test.go
+++ b/internal/survey/classify_test.go
@@ -188,6 +188,59 @@ func TestClassifyDegradesGracefully(t *testing.T) {
 	}
 }
 
+// TestClassifyAMRequiresLowIFStd guards the #648 follow-up: a constant-envelope
+// angle-modulated carrier whose envelope CV is lifted past the AM gate by noise
+// (or channel clipping) must not be mislabelled AM — its FM-discriminator swing
+// (IFStd) marks it as angle modulation, so it reads as FM. Real AM (message in
+// the envelope, static carrier, IFStd≈0) still reads AM.
+func TestClassifyAMRequiresLowIFStd(t *testing.T) {
+	const nSamples = 24_000
+	// Noisy NBFM voice: constant envelope, but AWGN lifts EnvelopeCV above the
+	// AM gate (EnvelopeCV > AMEnvelopeCV). Pre-fix this fell straight to AM.
+	fm := demod.ApplyImpairments(
+		fmModulate(lowpassNoise(nSamples, 4), testRateHz, 3000),
+		testRateHz,
+		demod.Impairments{SNRdB: 10, Seed: 2},
+	)
+	got := Classify(fm, testRateHz)
+	if got.Features.EnvelopeCV <= DefaultClassifyConfig().AMEnvelopeCV {
+		t.Fatalf("fixture invalid: EnvelopeCV %.3f should exceed the AM gate", got.Features.EnvelopeCV)
+	}
+	if got.Features.IFStd <= DefaultClassifyConfig().AMMaxIFStd {
+		t.Fatalf("fixture invalid: IFStd %.3f should exceed AMMaxIFStd", got.Features.IFStd)
+	}
+	if got.Class == ClassAM {
+		t.Errorf("noisy FM mis-fired as AM despite IFStd=%.3f; features: %+v", got.Features.IFStd, got.Features)
+	}
+
+	// A real AM carrier (envelope-modulated, static carrier) still reads AM.
+	if g := Classify(amModulate(lowpassNoise(nSamples, 5), 0.95), testRateHz); g.Class != ClassAM {
+		t.Errorf("clean AM voice = %q, want am; features: %+v", g.Class, g.Features)
+	}
+}
+
+// TestBaudLineFindsTetraRate verifies the widened search band reaches TETRA's
+// 18 kbaud line, which the old rate/3 (16 kHz at 48 kHz) cap excluded. The
+// rectified discriminator is modelled as a DC pedestal plus an 18 kHz line.
+func TestBaudLineFindsTetraRate(t *testing.T) {
+	const n = 16384
+	const baud = 18_000.0
+	r := rand.New(rand.NewSource(1))
+	d := make([]float32, n)
+	for i := range d {
+		// |d-0| = d (kept positive by the pedestal), so the rectified spectrum
+		// carries the 18 kHz component the baud-line search must find.
+		d[i] = float32(1 + 0.5*math.Cos(2*math.Pi*baud*float64(i)/testRateHz) + 0.02*r.NormFloat64())
+	}
+	gotBaud, prom := baudLine(d, 0, testRateHz)
+	if math.Abs(gotBaud-baud)/baud > 0.03 {
+		t.Errorf("baudLine = %.0f Hz, want ≈%.0f (band must reach 18 kHz)", gotBaud, baud)
+	}
+	if prom < DefaultClassifyConfig().DigitalProminence {
+		t.Errorf("prominence = %.1f, want ≥ %.0f", prom, DefaultClassifyConfig().DigitalProminence)
+	}
+}
+
 func TestClassifyShortInputIsUnknown(t *testing.T) {
 	got := Classify(make([]complex64, 100), testRateHz)
 	if got.Class != ClassUnknown {


### PR DESCRIPTION
Follow-up to the merged isolation fix for #648. With occupied bandwidths now sane, the reporter's retest showed the modulation *class* is still wrong: in a DMR/TETRA-dense band almost every carrier reads `am` (including a 61 dB SNR one), because the blind classifier can't separate narrowband digital FM from analog FM once the baud line is lost.

## Changes
- **IFStd-gated AM:** the AM gate fired on `EnvelopeCV` alone and never used `IFStd` (computed but unused). Noise / channel-clipping lifts a constant-envelope DMR carrier's `EnvelopeCV` past the gate → mislabeled `am`. AM now also requires low `IFStd`: real AM has `IFStd≈0`, while DMR / an FM repeater with CTCSS swings the discriminator, so those fall to the FM split (`nbfm`) instead of a contradictory `am`. Adds the `AMMaxIFStd` threshold.
- **Widened baud search band:** was `300 Hz … rate/3` (16 kHz at the 48 kHz channel), which excludes TETRA's 18 kbaud line entirely. Now `rate/2.4` (~20 kHz).
- **`-survey-deep` siglab arbiter (opt-in):** only blind-digital carriers reached the authoritative siglab identify, so a trunked DMR/TETRA/MPT control channel the classifier missed could never be found. The new flag hands narrowband (≤25 kHz) analog-classed carriers to siglab too, **lock-only** (a non-locked best-guess never promotes a real analog carrier to `trunk-voice`). Default survey stays fast.

Refactors the digital→siglab block into `identifyTrunking` and the analog tone scan into `analyzeAnalog`. Adds tests for the IFStd AM guard (noisy FM stays non-AM, clean AM stays AM), the widened baud band (an 18 kbaud line is found), and the deep-routing gating (analog carrier reaches siglab only under `-survey-deep`, wideband excluded, non-lock keeps the analog label). Full suite passes.

## User-visible result
- Default `-survey`: those carriers now read `nbfm` (correct family — they're FM) instead of a contradictory `am`.
- `-survey -survey-deep`: trunked DMR/TETRA/MPT control channels among them get identified and labeled `trunk-control`.

https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK

---
_Generated by [Claude Code](https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK)_