### PR TITLE
Plots default to control channel + surface DMR hunt/autoconfig in the web console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Changed
+
+- **Plots view defaults to the control channel, not the SDR centre.** The
+  Constellation, Symbol scope, Eye diagram, Mixer, Tuning and Histogram panels
+  now rest their view on the system's control-channel frequency (resolved from
+  config and reported per-SDR as `control_channel_hz` on
+  `GET /api/v1/spectrum/devices`) whenever Hold is off and no call is active —
+  so a freshly opened panel lands on a decodable channel clear of the centre DC
+  spike instead of the useless SDR centre. An active call still takes
+  precedence, and the view glides back to the control channel when the call
+  ends; the Hold label shows *following call* or *on control channel*
+  accordingly. SDRs with no control channel in their passband keep the previous
+  centre default. (#557)
+
 ### Fixed
 
 - **Wideband polyphase decode at 6.25 / 5.0 MS/s (USRP-friendly rates).** With

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **Hunt features surfaced in the web console.** Recent hunt-family work that
+  previously only reached the logs / raw event stream is now visible in the web
+  UI. The *CC Activity* tab renders the DMR Tier III autoconfig learner's live
+  `dmr.grant.observed` (LCN, timeslot, talkgroup, source) and
+  `dmr.bandplan.learned` (base frequency, channel spacing, confidence) events —
+  given clean typed DTOs instead of raw passthrough — plus the control-channel
+  hunt lifecycle (`cchunt.progress` / `cchunt.failed`). The *Systems* tab shows
+  the active DMR LCN→frequency band plan per system (`GET /api/v1/systems` →
+  `dmr_band_plan`), whether operator-configured or learned over the air, with a
+  "learned live" indicator. The *Hunt* tab now lists each candidate's capture
+  report (control frequency, protocol, lock / skip reason) and the discovered
+  sites with their control channels. (#638)
+
 ### Changed
 
 - **Plots view defaults to the control channel, not the SDR centre.** The

--- a/cmd/gophertrunk/spectrum_provider.go
+++ b/cmd/gophertrunk/spectrum_provider.go
@@ -65,13 +65,14 @@ func (p *spectrumProvider) Devices() []api.SpectrumDevice {
 		centerHz := br.CenterHz()
 		sampleRateHz := br.SampleRateHz()
 		out = append(out, api.SpectrumDevice{
-			Serial:        e.Info.Serial,
-			Driver:        e.Info.Driver,
-			Product:       e.Info.Product,
-			Role:          e.Role.String(),
-			CenterHz:      centerHz,
-			SampleRateHz:  sampleRateHz,
-			P25Modulation: p25ModulationFor(p.systems, centerHz, sampleRateHz),
+			Serial:           e.Info.Serial,
+			Driver:           e.Info.Driver,
+			Product:          e.Info.Product,
+			Role:             e.Role.String(),
+			CenterHz:         centerHz,
+			SampleRateHz:     sampleRateHz,
+			P25Modulation:    p25ModulationFor(p.systems, centerHz, sampleRateHz),
+			ControlChannelHz: controlChannelFor(p.systems, centerHz, sampleRateHz),
 		})
 	}
 	return out
@@ -112,6 +113,42 @@ func p25ModulationFor(systems []trunking.System, centerHz, sampleRateHz uint32) 
 		return demodModeName(only.P25Phase1DemodMode)
 	}
 	return ""
+}
+
+// controlChannelFor reports the configured P25 control channel that the
+// device at (centerHz, sampleRateHz) can see — the in-band CC closest to
+// centre when several fall inside the passband (|cc - centre| <=
+// sample_rate/2) — or 0 when none does. The web Plots panels rest their
+// view on it (#557): a control SDR parked on its CC yields that CC at
+// offset ~0, and a voice SDR that still spans the CC rests there too.
+//
+// Unlike p25ModulationFor there is deliberately no single-system fallback:
+// an out-of-band CC would mix beyond Nyquist (the panel clamps it to the
+// band edge), resting the view on a frequency the SDR cannot see. Absent
+// (0) instead keeps the old centre default for devices that can't see a CC.
+// Closest-to-centre (rather than first-match) is used because a wideband
+// voice SDR can span several CCs of one system; the nearest one is the
+// deterministic, operator-intuitive choice.
+func controlChannelFor(systems []trunking.System, centerHz, sampleRateHz uint32) uint32 {
+	var best uint32
+	var bestDelta int64 = -1
+	half := int64(sampleRateHz) / 2
+	for i := range systems {
+		if systems[i].Protocol != trunking.ProtocolP25 {
+			continue
+		}
+		for _, cc := range systems[i].ControlChannels {
+			delta := int64(cc) - int64(centerHz)
+			if delta < 0 {
+				delta = -delta
+			}
+			if delta <= half && (bestDelta < 0 || delta < bestDelta) {
+				best = cc
+				bestDelta = delta
+			}
+		}
+	}
+	return best
 }
 
 // demodModeName canonicalises a configured demod-mode string to the

--- a/cmd/gophertrunk/spectrum_provider_test.go
+++ b/cmd/gophertrunk/spectrum_provider_test.go
@@ -316,3 +316,88 @@ func TestP25ModulationFor(t *testing.T) {
 		})
 	}
 }
+
+// TestControlChannelFor covers the per-device control-channel resolution
+// the web Plots panels rest their view on (#557): the in-band CC closest to
+// centre, with no single-system fallback so out-of-band devices keep the
+// old centre default.
+func TestControlChannelFor(t *testing.T) {
+	c4fm := trunking.System{
+		Name:               "C4FM-sys",
+		Protocol:           trunking.ProtocolP25,
+		ControlChannels:    []uint32{851_000_000},
+		P25Phase1DemodMode: "c4fm",
+	}
+	multiCC := trunking.System{
+		Name:            "Multi-CC-sys",
+		Protocol:        trunking.ProtocolP25,
+		ControlChannels: []uint32{851_000_000, 851_500_000},
+	}
+	dmr := trunking.System{
+		Name:            "DMR-sys",
+		Protocol:        trunking.ProtocolDMR,
+		ControlChannels: []uint32{451_000_000},
+	}
+
+	const sr = 2_048_000 // ±1.024 MHz passband
+
+	tests := []struct {
+		name       string
+		systems    []trunking.System
+		centerHz   uint32
+		sampleRate uint32
+		want       uint32
+	}{
+		{
+			name:       "control SDR parked on its control channel",
+			systems:    []trunking.System{c4fm},
+			centerHz:   851_000_000,
+			sampleRate: sr,
+			want:       851_000_000,
+		},
+		{
+			name:       "two in-band CCs returns the one closest to centre",
+			systems:    []trunking.System{multiCC},
+			centerHz:   851_100_000, // 100 kHz from first CC, 400 kHz from second
+			sampleRate: sr,
+			want:       851_000_000,
+		},
+		{
+			name:       "voice SDR offset but in band matches the CC",
+			systems:    []trunking.System{c4fm},
+			centerHz:   851_500_000, // 500 kHz off the CC, still < Nyquist
+			sampleRate: sr,
+			want:       851_000_000,
+		},
+		{
+			name:       "single system with CC out of band has no fallback",
+			systems:    []trunking.System{c4fm},
+			centerHz:   900_000_000,
+			sampleRate: sr,
+			want:       0,
+		},
+		{
+			name:       "multiple systems, none in band, is absent",
+			systems:    []trunking.System{c4fm, multiCC},
+			centerHz:   700_000_000,
+			sampleRate: sr,
+			want:       0,
+		},
+		{
+			name:       "no P25 systems configured is absent",
+			systems:    []trunking.System{dmr},
+			centerHz:   451_000_000,
+			sampleRate: sr,
+			want:       0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := controlChannelFor(tc.systems, tc.centerHz, tc.sampleRate)
+			if got != tc.want {
+				t.Fatalf("controlChannelFor() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/constellation.md
+++ b/docs/constellation.md
@@ -89,10 +89,16 @@ around the same problem:
   12.5 kHz land precisely), and the **MHz** field lets you type the
   channel's absolute frequency — the two stay in sync.
 - **Hold** — when off, the Offset automatically follows the newest
-  active call on the selected SDR (the "last locked channel"). Turn
-  Hold on to pin the view on a specific offset and stop it from
-  jumping as calls come and go. Editing the Offset or pressing
-  **Centre** pins it too.
+  active call on the selected SDR (the "last locked channel"), and
+  rests on the system's **control channel** when no call is up —
+  resolved from config, so the panel defaults onto a decodable channel
+  off the centre DC spike instead of the useless SDR centre, and glides
+  back to the control channel when a call ends (#557). The label next to
+  the checkbox shows *following call* or *on control channel*
+  accordingly. Turn Hold on to pin the view on a specific offset and
+  stop it from jumping as calls come and go. Editing the Offset or
+  pressing **Centre** pins it too. (Devices with no control channel in
+  their passband keep the old centre default.)
 - **DC block** / **Auto scale** — DC-block subtracts the rolling mean
   to remove any residual offset; auto-scale eases a gain so the cloud
   fills the unit circle (targeting the ~95th-percentile radius, so a

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -157,7 +157,17 @@ to force it off even when a key is configured.
   Progress streams over the event bus (`hunt.progress` / `hunt.candidate` /
   `hunt.done`) via `GET /api/v1/events`. The **web console** has a *Hunt* tab
   (start a run, watch progress, download/commit the result) and the **TUI** has
-  a *Hunt* panel that monitors the run and can stop it.
+  a *Hunt* panel that monitors the run and can stop it. The web *Hunt* tab also
+  lists each candidate's **capture report** (control frequency, protocol, lock /
+  skip reason) and the discovered **sites** with their control channels once a
+  run completes.
+- **DMR Tier III band-plan learning, in the web console.** When the LCN
+  autoconfig learner fits a band plan, the web *CC Activity* tab shows the live
+  `DMR grant` observations and the `Band plan learned` result (base frequency,
+  channel spacing, confidence), and the *Systems* tab shows the active
+  LCN→frequency plan per system (`GET /api/v1/systems` → `dmr_band_plan`),
+  whether operator-configured or learned over the air. The control-channel hunt
+  lifecycle (`cchunt.progress` / `cchunt.failed`) is surfaced there too.
 - **Topology depth.** What the hunt recovers per protocol:
 
   | Protocol | Identity | Neighbor sites | Band plan |

--- a/docs/symbol-scope.md
+++ b/docs/symbol-scope.md
@@ -43,8 +43,12 @@ same controls work around it:
   frequency — the two stay in sync. The tuned frequency is shown as soon
   as an SDR is selected, before any symbols decode.
 - **Hold** — when off, the Offset automatically follows the newest
-  active call on the selected SDR (the "last locked channel"); turn
-  Hold on (or edit the Offset / press **Centre**) to pin it.
+  active call on the selected SDR (the "last locked channel"), and rests
+  on the system's **control channel** (resolved from config) when no call
+  is up — so the scope defaults onto a decodable channel off the centre
+  DC spike and returns there when a call ends (#557). Turn Hold on (or
+  edit the Offset / press **Centre**) to pin it. Devices with no control
+  channel in their passband keep the old centre default.
 
 ## How it works
 

--- a/internal/api/spectrum.go
+++ b/internal/api/spectrum.go
@@ -27,6 +27,12 @@ type SpectrumDevice struct {
 	// instead of asking the operator to pick it. Empty when no P25
 	// Phase 1 system matches (e.g. a DMR-only device).
 	P25Modulation string `json:"p25_modulation,omitempty"`
+	// ControlChannelHz is the configured control-channel frequency that
+	// falls inside this SDR's passband (the one closest to centre when
+	// several are in band), or 0 when none matches. The web Plots panels
+	// rest their view on it so they default off the centre DC spike onto a
+	// decodable channel instead of the useless SDR centre. (#557)
+	ControlChannelHz uint32 `json:"control_channel_hz,omitempty"`
 }
 
 // SpectrumFrame is the wire shape of one frame on the WS stream.

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -99,6 +99,10 @@ func eventToDTO(ev events.Event) EventDTO {
 		dto.Payload = unitRegistrationToDTO(p)
 	case trunking.Patch:
 		dto.Payload = patchToDTO(p)
+	case events.DMRGrantObserved:
+		dto.Payload = dmrGrantObservedToDTO(p)
+	case events.DMRBandPlanLearned:
+		dto.Payload = dmrBandPlanLearnedToDTO(p)
 	default:
 		// Includes sdr.SDRStatus (already JSON-tagged) and any
 		// future payload types the api package hasn't grown an

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -84,3 +84,94 @@ func TestEventToDTOPatchJSON(t *testing.T) {
 		t.Errorf("patch JSON =\n  %s\nwant\n  %s", got, want)
 	}
 }
+
+// TestEventToDTODMRGrantObservedJSON pins the wire shape of the DMR
+// grant-observed event so the web CC Activity panel reads stable snake_case
+// fields rather than the raw PascalCase passthrough. (#638)
+func TestEventToDTODMRGrantObservedJSON(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindDMRGrantObserved,
+		Payload: events.DMRGrantObserved{
+			System:    "County T3",
+			ColorCode: 1,
+			LCN:       12,
+			Timeslot:  1,
+			GroupID:   1001,
+			SourceID:  2002,
+			CCFreqHz:  851_000_000,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(body)
+	want := `{"system":"County T3","color_code":1,"lcn":12,"timeslot":1,"group_id":1001,"source_id":2002,"cc_freq_hz":851000000,"at":"0001-01-01T00:00:00Z"}`
+	if got != want {
+		t.Errorf("dmr grant observed JSON =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// TestEventToDTODMRBandPlanLearnedJSON pins the wire shape of the learned
+// band-plan event (linear plan) the Systems / CC Activity panels render. (#638)
+func TestEventToDTODMRBandPlanLearnedJSON(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindDMRBandPlanLearned,
+		Payload: events.DMRBandPlanLearned{
+			System:     "County T3",
+			BaseHz:     851_012_500,
+			SpacingHz:  12_500,
+			Offset:     1,
+			NumPairs:   6,
+			Confidence: 0.97,
+			ResidualHz: 25,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(body)
+	want := `{"system":"County T3","base_hz":851012500,"spacing_hz":12500,"offset":1,"num_pairs":6,"confidence":0.97,"residual_hz":25}`
+	if got != want {
+		t.Errorf("dmr band plan learned JSON =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// TestSystemToDTODMRBandPlan checks the active DMR band plan is surfaced on
+// the systems API (linear and table forms) and omitted when absent. (#638)
+func TestSystemToDTODMRBandPlan(t *testing.T) {
+	t.Run("linear", func(t *testing.T) {
+		dto := systemToDTO(trunking.System{
+			Name:     "T3",
+			Protocol: trunking.ProtocolDMR,
+			DMRBandPlan: &trunking.DMRBandPlan{
+				Linear: &trunking.DMRLinearBandPlan{BaseHz: 851_012_500, SpacingHz: 12_500, Offset: 1},
+			},
+		})
+		if dto.DMRBandPlan == nil || dto.DMRBandPlan.Linear == nil {
+			t.Fatalf("expected a linear band plan, got %+v", dto.DMRBandPlan)
+		}
+		if dto.DMRBandPlan.Linear.BaseHz != 851_012_500 || dto.DMRBandPlan.Linear.SpacingHz != 12_500 {
+			t.Errorf("linear plan = %+v", dto.DMRBandPlan.Linear)
+		}
+	})
+	t.Run("table", func(t *testing.T) {
+		dto := systemToDTO(trunking.System{
+			Name:     "T3",
+			Protocol: trunking.ProtocolDMR,
+			DMRBandPlan: &trunking.DMRBandPlan{
+				Table: []trunking.DMRBandPlanTableEntry{{LCN: 1, FreqHz: 851_000_000}, {LCN: 2, FreqHz: 851_025_000}},
+			},
+		})
+		if dto.DMRBandPlan == nil || len(dto.DMRBandPlan.Table) != 2 {
+			t.Fatalf("expected a 2-entry table plan, got %+v", dto.DMRBandPlan)
+		}
+	})
+	t.Run("absent", func(t *testing.T) {
+		dto := systemToDTO(trunking.System{Name: "P25", Protocol: trunking.ProtocolP25})
+		if dto.DMRBandPlan != nil {
+			t.Errorf("expected nil band plan, got %+v", dto.DMRBandPlan)
+		}
+	})
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -3,6 +3,7 @@ package api
 import (
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -94,6 +95,50 @@ type SystemDTO struct {
 	MPT1327BCHMode         string  `json:"mpt1327_bch_mode,omitempty"`
 	MPT1327CWSCTolerance   string  `json:"mpt1327_cwsc_tolerance,omitempty"`
 	MotorolaBCHMode        string  `json:"motorola_bch_mode,omitempty"`
+	// DMRBandPlan surfaces the active DMR Tier III LCN→frequency plan
+	// (operator-configured, or learned by the autoconfig learner and
+	// written back to config) so the web Systems panel can show how voice
+	// grants resolve. Nil when the system has no DMR band plan. (#638)
+	DMRBandPlan *DMRBandPlanDTO `json:"dmr_band_plan,omitempty"`
+}
+
+// DMRBandPlanDTO mirrors trunking.DMRBandPlan: exactly one of Linear or
+// Table is populated.
+type DMRBandPlanDTO struct {
+	Linear *DMRLinearBandPlanDTO `json:"linear,omitempty"`
+	Table  []DMRBandPlanLCNDTO   `json:"table,omitempty"`
+}
+
+// DMRLinearBandPlanDTO mirrors trunking.DMRLinearBandPlan — a regular
+// base+spacing grid (freq = base + (lcn-offset)*spacing).
+type DMRLinearBandPlanDTO struct {
+	BaseHz    uint32 `json:"base_hz"`
+	SpacingHz uint32 `json:"spacing_hz"`
+	Offset    int8   `json:"offset,omitempty"`
+}
+
+// DMRBandPlanLCNDTO is one explicit LCN→downlink-frequency entry.
+type DMRBandPlanLCNDTO struct {
+	LCN    uint16 `json:"lcn"`
+	FreqHz uint32 `json:"freq_hz"`
+}
+
+func dmrBandPlanToDTO(p *trunking.DMRBandPlan) *DMRBandPlanDTO {
+	if p == nil {
+		return nil
+	}
+	out := &DMRBandPlanDTO{}
+	if p.Linear != nil {
+		out.Linear = &DMRLinearBandPlanDTO{
+			BaseHz:    p.Linear.BaseHz,
+			SpacingHz: p.Linear.SpacingHz,
+			Offset:    p.Linear.Offset,
+		}
+	}
+	for _, e := range p.Table {
+		out.Table = append(out.Table, DMRBandPlanLCNDTO{LCN: e.LCN, FreqHz: e.FreqHz})
+	}
+	return out
 }
 
 func systemToDTO(s trunking.System) SystemDTO {
@@ -120,6 +165,7 @@ func systemToDTO(s trunking.System) SystemDTO {
 		MPT1327BCHMode:         s.MPT1327BCHMode,
 		MPT1327CWSCTolerance:   s.MPT1327CWSCTolerance,
 		MotorolaBCHMode:        s.MotorolaBCHMode,
+		DMRBandPlan:            dmrBandPlanToDTO(s.DMRBandPlan),
 	}
 }
 
@@ -357,6 +403,66 @@ func patchToDTO(p trunking.Patch) PatchDTO {
 		Add:        p.Add,
 		At:         p.At,
 	}
+}
+
+// DMRGrantObservedDTO mirrors events.DMRGrantObserved — a DMR Tier III
+// voice-grant CSBK seen by the control channel before the LCN is resolved
+// to a frequency. Surfaced so operators can watch the autoconfig learner's
+// raw input in the CC Activity log. Timeslot uses the raw CSBK encoding
+// (0 = TS1, 1 = TS2). (#638)
+type DMRGrantObservedDTO struct {
+	System    string    `json:"system"`
+	ColorCode uint8     `json:"color_code"`
+	LCN       uint16    `json:"lcn"`
+	Timeslot  uint8     `json:"timeslot"`
+	GroupID   uint32    `json:"group_id"`
+	SourceID  uint32    `json:"source_id"`
+	CCFreqHz  uint32    `json:"cc_freq_hz"`
+	At        time.Time `json:"at"`
+}
+
+func dmrGrantObservedToDTO(g events.DMRGrantObserved) DMRGrantObservedDTO {
+	return DMRGrantObservedDTO{
+		System:    g.System,
+		ColorCode: g.ColorCode,
+		LCN:       g.LCN,
+		Timeslot:  g.Timeslot,
+		GroupID:   g.GroupID,
+		SourceID:  g.SourceID,
+		CCFreqHz:  g.CCFreqHz,
+		At:        g.At,
+	}
+}
+
+// DMRBandPlanLearnedDTO mirrors events.DMRBandPlanLearned — the result of
+// the DMR Tier III LCN autoconfig learner fitting a band plan from observed
+// (LCN, frequency) pairs. A linear plan sets BaseHz/SpacingHz/Offset with an
+// empty Table; an irregular plan populates Table. (#638)
+type DMRBandPlanLearnedDTO struct {
+	System     string              `json:"system"`
+	BaseHz     uint32              `json:"base_hz,omitempty"`
+	SpacingHz  uint32              `json:"spacing_hz,omitempty"`
+	Offset     int8                `json:"offset,omitempty"`
+	Table      []DMRBandPlanLCNDTO `json:"table,omitempty"`
+	NumPairs   int                 `json:"num_pairs"`
+	Confidence float64             `json:"confidence"`
+	ResidualHz uint32              `json:"residual_hz,omitempty"`
+}
+
+func dmrBandPlanLearnedToDTO(p events.DMRBandPlanLearned) DMRBandPlanLearnedDTO {
+	dto := DMRBandPlanLearnedDTO{
+		System:     p.System,
+		BaseHz:     p.BaseHz,
+		SpacingHz:  p.SpacingHz,
+		Offset:     p.Offset,
+		NumPairs:   p.NumPairs,
+		Confidence: p.Confidence,
+		ResidualHz: p.ResidualHz,
+	}
+	for _, e := range p.Table {
+		dto.Table = append(dto.Table, DMRBandPlanLCNDTO{LCN: e.LCN, FreqHz: e.FreqHz})
+	}
+	return dto
 }
 
 // ActiveCallDTO mirrors trunking.ActiveCall for JSON.

--- a/web/src/api/spectrum.ts
+++ b/web/src/api/spectrum.ts
@@ -17,6 +17,10 @@ export interface SpectrumDevice {
   // applies. The symbol/constellation panels' "Auto" mode reads this to
   // pick the receiver without operator input.
   p25_modulation?: string;
+  // Configured control-channel frequency in this SDR's passband (Hz), or
+  // absent when none matches. The Plots panels rest their view here so
+  // they default off the centre DC spike onto a decodable channel. (#557)
+  control_channel_hz?: number;
 }
 
 // defaultSymbolDevice picks the SDR the symbol-domain panels (Eye

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -27,6 +27,15 @@ export interface SystemDTO {
   system_id?: number;
   rfss?: number;
   site?: number;
+  // Active DMR Tier III LCN→frequency band plan (configured or learned),
+  // surfaced so the Systems panel can show how voice grants resolve. (#638)
+  dmr_band_plan?: DMRBandPlanDTO;
+}
+
+// DMRBandPlanDTO mirrors api.DMRBandPlanDTO — exactly one of linear/table.
+export interface DMRBandPlanDTO {
+  linear?: { base_hz: number; spacing_hz: number; offset?: number };
+  table?: { lcn: number; freq_hz: number }[];
 }
 
 export interface TalkgroupDTO {
@@ -133,7 +142,69 @@ export interface HuntStatus {
   system_name?: string;
   signals?: DetectedSignal[];
   error?: string;
-  system?: unknown;
+  system?: DiscoveredSystem;
+  // Per-capture decode results from the live run, so the Hunt panel can
+  // show what each surveyed candidate decoded to (or why it was skipped).
+  reports?: CaptureReport[];
+}
+
+// CaptureReport mirrors hunt.CaptureReport — one candidate's decode outcome
+// during a live hunt run.
+export interface CaptureReport {
+  path?: string;
+  protocol?: string;
+  confidence?: number;
+  locked?: boolean;
+  control_hz?: number;
+  talkgroups?: number;
+  skipped?: boolean;
+  skip_reason?: string;
+  error?: string;
+}
+
+// DiscoveredSystem mirrors hunt.DiscoveredSystem — the map a completed hunt
+// produced. Only the fields the Hunt panel renders are typed.
+export interface DiscoveredSystem {
+  name?: string;
+  protocol?: string;
+  state?: string;
+  county?: string;
+  confidence?: number;
+  sites?: DiscoveredSite[];
+}
+
+export interface DiscoveredSite {
+  rfss?: number;
+  site_id?: number;
+  site_name?: string;
+  county?: string;
+  control_channels?: { frequency_hz: number; is_control?: boolean; confidence?: number }[];
+}
+
+// DMRGrantObservedDTO mirrors api.DMRGrantObservedDTO — a raw DMR Tier III
+// voice grant the control channel decoded (pre LCN resolution). (#638)
+export interface DMRGrantObservedDTO {
+  system: string;
+  color_code: number;
+  lcn: number;
+  timeslot: number;
+  group_id: number;
+  source_id: number;
+  cc_freq_hz: number;
+  at: string;
+}
+
+// DMRBandPlanLearnedDTO mirrors api.DMRBandPlanLearnedDTO — the autoconfig
+// learner's fitted band plan for a system. (#638)
+export interface DMRBandPlanLearnedDTO {
+  system: string;
+  base_hz?: number;
+  spacing_hz?: number;
+  offset?: number;
+  table?: { lcn: number; freq_hz: number }[];
+  num_pairs: number;
+  confidence: number;
+  residual_hz?: number;
 }
 
 // DetectedSignal mirrors hunt.DetectedSignal — one classified carrier in a

--- a/web/src/components/TuningControls.test.tsx
+++ b/web/src/components/TuningControls.test.tsx
@@ -14,7 +14,7 @@ function setup(overrides: Partial<Parameters<typeof TuningControls>[0]> = {}) {
       onOffsetChange={onOffsetChange}
       hold={true}
       onHoldChange={onHoldChange}
-      followingActive={false}
+      following={null}
       onCentre={onCentre}
       {...overrides}
     />,
@@ -103,5 +103,23 @@ describe("TuningControls", () => {
     expect(onOffsetChange).toHaveBeenLastCalledWith(12.5);
     fireEvent.keyDown(input, { key: "ArrowDown" });
     expect(onOffsetChange).toHaveBeenLastCalledWith(-12.5);
+  });
+
+  it("labels the Hold checkbox when following an active call", () => {
+    setup({ hold: false, following: "call" });
+    expect(screen.getByText("· following call")).toBeInTheDocument();
+    expect(screen.queryByText("· on control channel")).toBeNull();
+  });
+
+  it("labels the Hold checkbox when resting on the control channel", () => {
+    setup({ hold: false, following: "control" });
+    expect(screen.getByText("· on control channel")).toBeInTheDocument();
+    expect(screen.queryByText("· following call")).toBeNull();
+  });
+
+  it("hides the follow label when the view is held", () => {
+    setup({ hold: true, following: "control" });
+    expect(screen.queryByText("· on control channel")).toBeNull();
+    expect(screen.queryByText("· following call")).toBeNull();
   });
 });

--- a/web/src/components/TuningControls.tsx
+++ b/web/src/components/TuningControls.tsx
@@ -38,8 +38,10 @@ interface TuningControlsProps {
   onOffsetChange: (khz: number) => void;
   hold: boolean;
   onHoldChange: (hold: boolean) => void;
-  // True when, with Hold off, the view is tracking an active call.
-  followingActive: boolean;
+  // What the view is tracking with Hold off: "call" (newest active call on
+  // this SDR) or "control" (resting on the control channel), or null when
+  // neither applies. Drives the label next to the Hold checkbox.
+  following?: "call" | "control" | null;
   // Recentre on the SDR centre (offset 0). Caller pins the view.
   onCentre: () => void;
 }
@@ -58,7 +60,7 @@ export function TuningControls({
   onOffsetChange,
   hold,
   onHoldChange,
-  followingActive,
+  following,
   onCentre,
 }: TuningControlsProps) {
   const freqMHz = centerHz != null ? (centerHz + offsetKHz * 1000) / 1e6 : null;
@@ -179,7 +181,7 @@ export function TuningControls({
 
       <label
         className="flex items-center gap-1.5"
-        title="When off, the view follows the newest active call on this SDR"
+        title="When off, the view follows the newest active call on this SDR, or rests on the control channel when no call is up"
       >
         <input
           type="checkbox"
@@ -189,8 +191,11 @@ export function TuningControls({
         />
         <span>
           Hold
-          {!hold && followingActive && (
+          {!hold && following === "call" && (
             <span className="text-accent"> · following call</span>
+          )}
+          {!hold && following === "control" && (
+            <span className="text-accent"> · on control channel</span>
           )}
         </span>
       </label>

--- a/web/src/panels/CCActivity.test.tsx
+++ b/web/src/panels/CCActivity.test.tsx
@@ -227,6 +227,58 @@ describe("CCActivity panel", () => {
     expect(row!.textContent).toMatch(/\[SG 999\]/);
   });
 
+  it("renders observed DMR grants with LCN, timeslot and source (#638)", () => {
+    setEvents([
+      {
+        kind: "dmr.grant.observed",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: {
+          system: "County T3",
+          color_code: 1,
+          lcn: 12,
+          timeslot: 1, // raw 1 = TS2
+          group_id: 1001,
+          source_id: 2002,
+          cc_freq_hz: 851_000_000,
+        },
+      },
+    ]);
+    renderPanel();
+    const row = screen.getByText("County T3").closest("tr");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toMatch(/DMR grant/);
+    expect(row!.textContent).toMatch(/LCN 12/);
+    expect(row!.textContent).toMatch(/TS2/);
+    expect(row!.textContent).toMatch(/TG 1001/);
+    expect(row!.textContent).toMatch(/2002/);
+    expect(row!.textContent).toMatch(/CC 851\.0000 MHz/);
+  });
+
+  it("renders a learned DMR band plan with spacing and confidence (#638)", () => {
+    setEvents([
+      {
+        kind: "dmr.bandplan.learned",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: {
+          system: "County T3",
+          base_hz: 851_012_500,
+          spacing_hz: 12_500,
+          offset: 1,
+          num_pairs: 6,
+          confidence: 0.97,
+        },
+      },
+    ]);
+    renderPanel();
+    const row = screen.getByText("County T3").closest("tr");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toMatch(/Band plan learned/);
+    expect(row!.textContent).toMatch(/851\.0125 MHz/);
+    expect(row!.textContent).toMatch(/12\.50 kHz spacing/);
+    expect(row!.textContent).toMatch(/6 pairs/);
+    expect(row!.textContent).toMatch(/conf 97%/);
+  });
+
   it("renders talker alias events", () => {
     setEvents([
       {

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -25,6 +25,10 @@ const CC_KINDS: Record<string, string> = {
   "talker.alias": "Talker alias",
   "cc.locked": "CC locked",
   "cc.lost": "CC lost",
+  "cchunt.progress": "CC hunt",
+  "cchunt.failed": "CC hunt failed",
+  "dmr.grant.observed": "DMR grant",
+  "dmr.bandplan.learned": "Band plan learned",
 };
 
 interface Row {
@@ -265,6 +269,62 @@ function renderRow(
       const freq = num(payload.frequency_hz);
       const details =
         freq ? `@ ${(freq / 1e6).toFixed(4)} MHz` : "";
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "cchunt.progress": {
+      const system = str(payload.system);
+      const freq = num(payload.attempted_freq_hz);
+      const idx = num(payload.attempt_index);
+      const total = num(payload.total_candidates);
+      const pos = total ? ` (${idx + 1}/${total})` : "";
+      const details = freq ? `trying ${(freq / 1e6).toFixed(4)} MHz${pos}` : `trying…${pos}`;
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "cchunt.failed": {
+      const system = str(payload.system);
+      const backoff = num(payload.backoff_ms);
+      const details =
+        "candidates exhausted" + (backoff ? ` · retry in ${(backoff / 1000).toFixed(0)}s` : "");
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "dmr.grant.observed": {
+      const system = str(payload.system);
+      const lcn = num(payload.lcn);
+      const ts = num(payload.timeslot); // raw 0 = TS1, 1 = TS2
+      const groupID = num(payload.group_id);
+      const sourceID = num(payload.source_id);
+      const cc = num(payload.cc_freq_hz);
+      const details = (
+        <>
+          {`LCN ${lcn} · TS${ts + 1} · TG ${groupID}`}
+          {sourceID ? (
+            <>
+              {" ← "}
+              {ridLink(sourceID)}
+            </>
+          ) : null}
+          {cc ? <span className="text-muted">{` · CC ${(cc / 1e6).toFixed(4)} MHz`}</span> : null}
+        </>
+      );
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "dmr.bandplan.learned": {
+      const system = str(payload.system);
+      const baseHz = num(payload.base_hz);
+      const spacingHz = num(payload.spacing_hz);
+      const table = (payload.table ?? []) as unknown[];
+      const numPairs = num(payload.num_pairs);
+      const conf = num(payload.confidence);
+      const shape =
+        table.length > 0
+          ? `${table.length} LCNs`
+          : baseHz
+            ? `${(baseHz / 1e6).toFixed(4)} MHz · ${(spacingHz / 1e3).toFixed(2)} kHz spacing`
+            : "learned";
+      const details =
+        shape +
+        (numPairs ? ` · ${numPairs} pairs` : "") +
+        (conf ? ` · conf ${(conf * 100).toFixed(0)}%` : "");
       return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
     }
     default:

--- a/web/src/panels/Constellation.test.tsx
+++ b/web/src/panels/Constellation.test.tsx
@@ -223,6 +223,73 @@ describe("Constellation panel", () => {
     });
   });
 
+  it("rests on the control channel by default when no call is active (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+        p25_modulation: "cqpsk",
+        control_channel_hz: 851_025_000,
+      },
+    ] as never);
+
+    render(<Constellation />);
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      // CC is 25 kHz above the 851.000 MHz centre.
+      expect(last?.offset).toBe(25_000);
+    });
+  });
+
+  it("prefers an active call over the control channel (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_000_000,
+        sample_rate_hz: 2_048_000,
+        p25_modulation: "cqpsk",
+        control_channel_hz: 851_025_000,
+      },
+    ] as never);
+
+    useShared.setState({
+      activeCalls: [
+        {
+          grant: {
+            system: "sys",
+            protocol: "p25",
+            group_id: 1,
+            frequency_hz: 851_050_000,
+          },
+          device_serial: "rtl-1",
+          started_at: "2026-06-07T00:00:00Z",
+        },
+      ] as never,
+    });
+
+    render(<Constellation />);
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      // Follows the call (50 kHz), not the CC (25 kHz).
+      expect(last?.offset).toBe(50_000);
+    });
+  });
+
+  it("stays at centre when the device reports no control channel (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
+
+    render(<Constellation />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    expect(vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1]?.offset).toBe(0);
+  });
+
   it("exposes a zoom control and an absolute-frequency (MHz) input", async () => {
     vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
 

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -267,13 +267,23 @@ export function Constellation() {
     return (newest.grant.frequency_hz - device.center_hz) / 1000;
   }, [activeCalls, device, selected]);
 
-  // Follow the locked channel unless the operator pinned the view.
+  // Offset (kHz) that lands the view on this SDR's control channel — the
+  // rest position when Hold is off and no call is active (#557). Absent
+  // (null) for devices with no in-band CC, leaving the old centre default.
+  const controlOffsetKHz = useMemo(() => {
+    if (!device?.control_channel_hz) return null;
+    return (device.control_channel_hz - device.center_hz) / 1000;
+  }, [device]);
+
+  // Follow the locked channel unless the operator pinned the view: an
+  // active call wins, otherwise rest on the control channel (#557).
+  const restOffsetKHz = followOffsetKHz ?? controlOffsetKHz;
   useEffect(() => {
-    if (hold || followOffsetKHz == null) return;
+    if (hold || restOffsetKHz == null) return;
     setOffsetKHz((cur) =>
-      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+      Math.abs(cur - restOffsetKHz) < 0.05 ? cur : restOffsetKHz,
     );
-  }, [hold, followOffsetKHz]);
+  }, [hold, restOffsetKHz]);
 
   // Clamp the offset to the device's Nyquist so the slider/input can't
   // request a mix that just aliases back into the band.
@@ -487,7 +497,13 @@ export function Constellation() {
           }}
           hold={hold}
           onHoldChange={setHold}
-          followingActive={followOffsetKHz != null}
+          following={
+            followOffsetKHz != null
+              ? "call"
+              : controlOffsetKHz != null
+                ? "control"
+                : null
+          }
           onCentre={() => {
             setHold(true);
             setOffsetKHz(0);

--- a/web/src/panels/EyeDiagram.tsx
+++ b/web/src/panels/EyeDiagram.tsx
@@ -84,12 +84,22 @@ export function EyeDiagram() {
     return (newest.grant.frequency_hz - device.center_hz) / 1000;
   }, [activeCalls, device, selected]);
 
+  // Offset (kHz) that lands the view on this SDR's control channel — the
+  // rest position when Hold is off and no call is active (#557). Absent
+  // (null) for devices with no in-band CC, leaving the old centre default.
+  const controlOffsetKHz = useMemo(() => {
+    if (!device?.control_channel_hz) return null;
+    return (device.control_channel_hz - device.center_hz) / 1000;
+  }, [device]);
+
+  // Active call wins; otherwise rest on the control channel (#557).
+  const restOffsetKHz = followOffsetKHz ?? controlOffsetKHz;
   useEffect(() => {
-    if (hold || followOffsetKHz == null) return;
+    if (hold || restOffsetKHz == null) return;
     setOffsetKHz((cur) =>
-      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+      Math.abs(cur - restOffsetKHz) < 0.05 ? cur : restOffsetKHz,
     );
-  }, [hold, followOffsetKHz]);
+  }, [hold, restOffsetKHz]);
 
   const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
   const clampedOffsetKHz = Math.max(
@@ -183,7 +193,13 @@ export function EyeDiagram() {
           }}
           hold={hold}
           onHoldChange={setHold}
-          followingActive={followOffsetKHz != null}
+          following={
+            followOffsetKHz != null
+              ? "call"
+              : controlOffsetKHz != null
+                ? "control"
+                : null
+          }
           onCentre={() => {
             setHold(true);
             setOffsetKHz(0);

--- a/web/src/panels/Histogram.tsx
+++ b/web/src/panels/Histogram.tsx
@@ -155,12 +155,22 @@ export function Histogram() {
     return (newest.grant.frequency_hz - device.center_hz) / 1000;
   }, [activeCalls, device, selected]);
 
+  // Offset (kHz) that lands the view on this SDR's control channel — the
+  // rest position when Hold is off and no call is active (#557). Absent
+  // (null) for devices with no in-band CC, leaving the old centre default.
+  const controlOffsetKHz = useMemo(() => {
+    if (!device?.control_channel_hz) return null;
+    return (device.control_channel_hz - device.center_hz) / 1000;
+  }, [device]);
+
+  // Active call wins; otherwise rest on the control channel (#557).
+  const restOffsetKHz = followOffsetKHz ?? controlOffsetKHz;
   useEffect(() => {
-    if (hold || followOffsetKHz == null) return;
+    if (hold || restOffsetKHz == null) return;
     setOffsetKHz((cur) =>
-      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+      Math.abs(cur - restOffsetKHz) < 0.05 ? cur : restOffsetKHz,
     );
-  }, [hold, followOffsetKHz]);
+  }, [hold, restOffsetKHz]);
 
   const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
   const clampedOffsetKHz = Math.max(
@@ -312,7 +322,13 @@ export function Histogram() {
           }}
           hold={hold}
           onHoldChange={setHold}
-          followingActive={followOffsetKHz != null}
+          following={
+            followOffsetKHz != null
+              ? "call"
+              : controlOffsetKHz != null
+                ? "control"
+                : null
+          }
           onCentre={() => {
             setHold(true);
             setOffsetKHz(0);

--- a/web/src/panels/Hunt.test.tsx
+++ b/web/src/panels/Hunt.test.tsx
@@ -57,4 +57,49 @@ describe("Hunt panel", () => {
     expect(body.protocol).toBe("p25");
     expect(body.bands).toEqual(["851:869"]); // default band, comma-split
   });
+
+  it("renders per-capture reports and discovered sites from the status", async () => {
+    vi.mocked(api.hunt).mockResolvedValue({
+      run_id: 1,
+      state: "done",
+      running: false,
+      sites: 1,
+      talkgroups: 3,
+      system_name: "County P25",
+      system: {
+        name: "County P25",
+        sites: [
+          {
+            rfss: 1,
+            site_id: 5,
+            site_name: "Downtown",
+            control_channels: [{ frequency_hz: 851_012_500, is_control: true }],
+          },
+        ],
+      },
+      reports: [
+        {
+          protocol: "p25",
+          control_hz: 851_012_500,
+          locked: true,
+          confidence: 0.92,
+          talkgroups: 3,
+        },
+        { protocol: "dmr", skipped: true, skip_reason: "no control" },
+      ],
+    });
+
+    render(<Hunt />);
+    await waitFor(() => expect(api.hunt).toHaveBeenCalled());
+
+    // Captures table.
+    await waitFor(() => expect(screen.getByText(/Captures \(2\)/)).toBeInTheDocument());
+    expect(screen.getByText(/locked · conf 92%/)).toBeInTheDocument();
+    expect(screen.getByText(/skipped — no control/)).toBeInTheDocument();
+
+    // Discovered sites table.
+    expect(screen.getByText(/Sites \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText("Downtown")).toBeInTheDocument();
+    expect(screen.getByText(/851\.0125\*/)).toBeInTheDocument();
+  });
 });

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import { writes } from "../api/write";
-import type { DetectedSignal, HuntStatus } from "../api/types";
+import type { CaptureReport, DetectedSignal, HuntStatus } from "../api/types";
 import { selectCanMutate, selectClientConfig, useShared } from "../store/shared";
 
 const POLL_INTERVAL_MS = 2_000;
@@ -21,6 +21,17 @@ function sortSignals(signals: DetectedSignal[], by: "freq" | "class" | "snr"): D
     }
   });
   return out;
+}
+
+// captureResult summarises one hunt capture's decode outcome: locked /
+// skipped (with reason) / errored / decoded-but-unlocked.
+function captureResult(rep: CaptureReport): string {
+  if (rep.skipped) return `skipped${rep.skip_reason ? ` — ${rep.skip_reason}` : ""}`;
+  if (rep.error) return `error — ${rep.error}`;
+  if (rep.locked) {
+    return `locked${rep.confidence ? ` · conf ${(rep.confidence * 100).toFixed(0)}%` : ""}`;
+  }
+  return "no lock";
 }
 
 // signalDetail renders the per-class decode summary for one surveyed carrier.
@@ -149,6 +160,62 @@ export function Hunt() {
           <div>No system discovered yet.</div>
         )}
       </section>
+
+      {status?.system?.sites && status.system.sites.length > 0 ? (
+        <section className="hunt-sites">
+          <h3>Sites ({status.system.sites.length})</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Site</th>
+                <th>RFSS</th>
+                <th>Control channels</th>
+              </tr>
+            </thead>
+            <tbody>
+              {status.system.sites.map((site, i) => (
+                <tr key={`${site.rfss}-${site.site_id}-${i}`}>
+                  <td>{site.site_name || site.site_id || "—"}</td>
+                  <td>{site.rfss ?? "—"}</td>
+                  <td>
+                    {site.control_channels && site.control_channels.length > 0
+                      ? site.control_channels
+                          .map((c) => `${(c.frequency_hz / 1e6).toFixed(4)}${c.is_control ? "*" : ""}`)
+                          .join(", ")
+                      : "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
+
+      {status?.reports && status.reports.length > 0 ? (
+        <section className="hunt-reports">
+          <h3>Captures ({status.reports.length})</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Control freq</th>
+                <th>Protocol</th>
+                <th>Result</th>
+                <th>TGs</th>
+              </tr>
+            </thead>
+            <tbody>
+              {status.reports.map((rep, i) => (
+                <tr key={`${rep.control_hz}-${i}`}>
+                  <td>{rep.control_hz ? `${(rep.control_hz / 1e6).toFixed(4)} MHz` : "—"}</td>
+                  <td>{rep.protocol || "—"}</td>
+                  <td>{captureResult(rep)}</td>
+                  <td>{rep.talkgroups ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
 
       {status?.signals && status.signals.length > 0 ? (
         <section className="hunt-signals">

--- a/web/src/panels/Mixer.tsx
+++ b/web/src/panels/Mixer.tsx
@@ -87,12 +87,22 @@ export function Mixer() {
     return (newest.grant.frequency_hz - device.center_hz) / 1000;
   }, [activeCalls, device, selected]);
 
+  // Offset (kHz) that lands the view on this SDR's control channel — the
+  // rest position when Hold is off and no call is active (#557). Absent
+  // (null) for devices with no in-band CC, leaving the old centre default.
+  const controlOffsetKHz = useMemo(() => {
+    if (!device?.control_channel_hz) return null;
+    return (device.control_channel_hz - device.center_hz) / 1000;
+  }, [device]);
+
+  // Active call wins; otherwise rest on the control channel (#557).
+  const restOffsetKHz = followOffsetKHz ?? controlOffsetKHz;
   useEffect(() => {
-    if (hold || followOffsetKHz == null) return;
+    if (hold || restOffsetKHz == null) return;
     setOffsetKHz((cur) =>
-      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+      Math.abs(cur - restOffsetKHz) < 0.05 ? cur : restOffsetKHz,
     );
-  }, [hold, followOffsetKHz]);
+  }, [hold, restOffsetKHz]);
 
   const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
   const clampedOffsetKHz = Math.max(
@@ -206,7 +216,13 @@ export function Mixer() {
           }}
           hold={hold}
           onHoldChange={setHold}
-          followingActive={followOffsetKHz != null}
+          following={
+            followOffsetKHz != null
+              ? "call"
+              : controlOffsetKHz != null
+                ? "control"
+                : null
+          }
           onCentre={() => {
             setHold(true);
             setOffsetKHz(0);

--- a/web/src/panels/SymbolScope.test.tsx
+++ b/web/src/panels/SymbolScope.test.tsx
@@ -138,6 +138,60 @@ describe("Symbol scope panel", () => {
     });
   });
 
+  it("rests on the control channel by default when no call is active (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      { ...oneDevice[0], control_channel_hz: 851_025_000 },
+    ]);
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      // CC is 25 kHz above the 851.000 MHz centre.
+      expect(last?.offset).toBe(25_000);
+    });
+  });
+
+  it("prefers an active call over the control channel (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue([
+      { ...oneDevice[0], control_channel_hz: 851_025_000 },
+    ]);
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+
+    useShared.setState({
+      activeCalls: [
+        {
+          grant: {
+            system: "sys",
+            protocol: "p25",
+            group_id: 1,
+            frequency_hz: 851_050_000,
+          },
+          device_serial: "rtl-1",
+          started_at: "2026-06-07T00:00:00Z",
+        },
+      ] as never,
+    });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      const last = vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1];
+      // Follows the call (50 kHz), not the CC (25 kHz).
+      expect(last?.offset).toBe(50_000);
+    });
+  });
+
+  it("stays at centre when the device reports no control channel (#557)", async () => {
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(oneDevice);
+    vi.mocked(openSymbolStream).mockReturnValue({ close: vi.fn() });
+
+    render(<SymbolScope />);
+    await waitFor(() => {
+      expect(openSymbolStream).toHaveBeenCalled();
+    });
+    expect(vi.mocked(openSymbolStream).mock.calls.at(-1)?.[1]?.offset).toBe(0);
+  });
+
   it("shows the tuned frequency before any symbol frame arrives", async () => {
     vi.mocked(fetchSpectrumDevices).mockResolvedValue(oneDevice);
     // Open the stream but never deliver a frame — a quiet channel.

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -108,12 +108,22 @@ export function SymbolScope() {
     return (newest.grant.frequency_hz - device.center_hz) / 1000;
   }, [activeCalls, device, selected]);
 
+  // Offset (kHz) that lands the view on this SDR's control channel — the
+  // rest position when Hold is off and no call is active (#557). Absent
+  // (null) for devices with no in-band CC, leaving the old centre default.
+  const controlOffsetKHz = useMemo(() => {
+    if (!device?.control_channel_hz) return null;
+    return (device.control_channel_hz - device.center_hz) / 1000;
+  }, [device]);
+
+  // Active call wins; otherwise rest on the control channel (#557).
+  const restOffsetKHz = followOffsetKHz ?? controlOffsetKHz;
   useEffect(() => {
-    if (hold || followOffsetKHz == null) return;
+    if (hold || restOffsetKHz == null) return;
     setOffsetKHz((cur) =>
-      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+      Math.abs(cur - restOffsetKHz) < 0.05 ? cur : restOffsetKHz,
     );
-  }, [hold, followOffsetKHz]);
+  }, [hold, restOffsetKHz]);
 
   const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
   const clampedOffsetKHz = Math.max(
@@ -242,7 +252,13 @@ export function SymbolScope() {
           }}
           hold={hold}
           onHoldChange={setHold}
-          followingActive={followOffsetKHz != null}
+          following={
+            followOffsetKHz != null
+              ? "call"
+              : controlOffsetKHz != null
+                ? "control"
+                : null
+          }
           onCentre={() => {
             setHold(true);
             setOffsetKHz(0);

--- a/web/src/panels/Systems.test.tsx
+++ b/web/src/panels/Systems.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/client", () => ({
+  api: { systems: vi.fn(), scanner: vi.fn() },
+}));
+
+import { api } from "../api/client";
+import { useShared } from "../store/shared";
+import { Systems } from "./Systems";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "idle",
+    mutations: null,
+    lastError: null,
+    events: [],
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+describe("Systems panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+    vi.mocked(api.scanner).mockResolvedValue({
+      scan_mode: "all",
+      systems: [],
+      conventional: { enabled: false, channels: [] },
+      tg_scan_count: 0,
+      tg_total: 0,
+    });
+  });
+
+  it("shows the DMR band plan summary in the table (#638)", async () => {
+    vi.mocked(api.systems).mockResolvedValue([
+      {
+        name: "County T3",
+        protocol: "dmr",
+        control_channels: [851_000_000],
+        dmr_band_plan: {
+          linear: { base_hz: 851_012_500, spacing_hz: 12_500, offset: 1 },
+        },
+      },
+    ]);
+
+    render(<Systems />);
+    await waitFor(() => expect(api.systems).toHaveBeenCalled());
+
+    await waitFor(() => {
+      const row = screen.getByText("County T3").closest("tr");
+      expect(row).not.toBeNull();
+      expect(row!.textContent).toMatch(/851\.0125 MHz/);
+      expect(row!.textContent).toMatch(/12\.50 kHz/);
+    });
+  });
+
+  it("renders an em dash for systems without a band plan", async () => {
+    vi.mocked(api.systems).mockResolvedValue([
+      { name: "Metro P25", protocol: "p25", control_channels: [851_000_000] },
+    ]);
+
+    render(<Systems />);
+    await waitFor(() => {
+      const row = screen.getByText("Metro P25").closest("tr");
+      expect(row).not.toBeNull();
+    });
+    const row = screen.getByText("Metro P25").closest("tr")!;
+    // Band plan cell shows the em dash placeholder.
+    expect(row.textContent).toContain("—");
+  });
+});

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -2,10 +2,47 @@ import { useEffect, useMemo, useState } from "react";
 import { api } from "../api/client";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
-import type { SystemDTO, SystemHuntStatusDTO } from "../api/types";
+import type {
+  DMRBandPlanDTO,
+  DMRBandPlanLearnedDTO,
+  EventDTO,
+  SystemDTO,
+  SystemHuntStatusDTO,
+} from "../api/types";
 import { selectClientConfig, useShared } from "../store/shared";
 
 const POLL_INTERVAL_MS = 10_000;
+
+// formatBandPlan renders a compact one-line summary of a DMR Tier III band
+// plan (the LCN→frequency map voice grants resolve through). (#638)
+function formatBandPlan(bp: DMRBandPlanDTO | undefined): string | null {
+  if (!bp) return null;
+  if (bp.linear && bp.linear.base_hz) {
+    const base = (bp.linear.base_hz / 1e6).toFixed(4);
+    const spacing = (bp.linear.spacing_hz / 1e3).toFixed(2);
+    return `${base} MHz · ${spacing} kHz`;
+  }
+  if (bp.table && bp.table.length > 0) {
+    return `${bp.table.length} LCNs (table)`;
+  }
+  return null;
+}
+
+// latestLearned returns the newest dmr.bandplan.learned event payload for a
+// system, so the detail modal can show that the plan was learned live by the
+// autoconfig learner (vs. operator-configured). (#638)
+function latestLearned(
+  events: EventDTO[],
+  systemName: string,
+): DMRBandPlanLearnedDTO | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const ev = events[i];
+    if (ev.kind !== "dmr.bandplan.learned") continue;
+    const p = ev.payload as DMRBandPlanLearnedDTO | undefined;
+    if (p && p.system === systemName) return p;
+  }
+  return null;
+}
 
 // Network identity (WACN/System ID/RFSS/Site) is populated from
 // decoded P25 TSBKs 0x3A/0x3B, not config. Translate the live hunt
@@ -28,6 +65,7 @@ export function Systems() {
   const setSystems = useShared((s) => s.setSystems);
   const scanner = useShared((s) => s.scanner);
   const setScanner = useShared((s) => s.setScanner);
+  const events = useShared((s) => s.events);
   const [selected, setSelected] = useState<SystemDTO | null>(null);
   const [filter, setFilter] = useState("");
 
@@ -90,6 +128,18 @@ export function Systems() {
         sort: (a, b) =>
           (a.control_channels?.length ?? 0) -
           (b.control_channels?.length ?? 0),
+      },
+      {
+        key: "bandplan",
+        header: "Band plan",
+        render: (r) => {
+          const bp = formatBandPlan(r.dmr_band_plan);
+          return bp ? (
+            <span className="font-mono text-xs text-muted">{bp}</span>
+          ) : (
+            <span className="text-muted">—</span>
+          );
+        },
       },
       {
         key: "site",
@@ -186,6 +236,39 @@ export function Systems() {
                     emptyHint={hint}
                   />
                 </div>
+              </div>
+            );
+          })()}
+          {(() => {
+            const bp = selected.dmr_band_plan;
+            if (!bp) return null;
+            const learned = latestLearned(events, selected.name);
+            const lines: string[] = [];
+            if (bp.linear && bp.linear.base_hz) {
+              lines.push(`base ${(bp.linear.base_hz / 1e6).toFixed(4)} MHz`);
+              lines.push(`spacing ${(bp.linear.spacing_hz / 1e3).toFixed(3)} kHz`);
+              if (bp.linear.offset) lines.push(`offset ${bp.linear.offset}`);
+            } else if (bp.table) {
+              for (const e of bp.table) {
+                lines.push(`LCN ${e.lcn} → ${(e.freq_hz / 1e6).toFixed(4)} MHz`);
+              }
+            }
+            return (
+              <div>
+                <p className="text-xs uppercase tracking-wider text-muted mb-2">
+                  DMR band plan
+                  {learned ? (
+                    <span className="ml-2 text-accent normal-case tracking-normal">
+                      · learned live (conf {(learned.confidence * 100).toFixed(0)}%,{" "}
+                      {learned.num_pairs} pairs)
+                    </span>
+                  ) : null}
+                </p>
+                <DetailField
+                  label={bp.linear ? "Linear plan" : "LCN → frequency"}
+                  mono
+                  value={lines.length ? lines.join("\n") : null}
+                />
               </div>
             );
           })()}

--- a/web/src/panels/Tuning.tsx
+++ b/web/src/panels/Tuning.tsx
@@ -105,12 +105,22 @@ export function Tuning() {
     return (newest.grant.frequency_hz - device.center_hz) / 1000;
   }, [activeCalls, device, selected]);
 
+  // Offset (kHz) that lands the view on this SDR's control channel — the
+  // rest position when Hold is off and no call is active (#557). Absent
+  // (null) for devices with no in-band CC, leaving the old centre default.
+  const controlOffsetKHz = useMemo(() => {
+    if (!device?.control_channel_hz) return null;
+    return (device.control_channel_hz - device.center_hz) / 1000;
+  }, [device]);
+
+  // Active call wins; otherwise rest on the control channel (#557).
+  const restOffsetKHz = followOffsetKHz ?? controlOffsetKHz;
   useEffect(() => {
-    if (hold || followOffsetKHz == null) return;
+    if (hold || restOffsetKHz == null) return;
     setOffsetKHz((cur) =>
-      Math.abs(cur - followOffsetKHz) < 0.05 ? cur : followOffsetKHz,
+      Math.abs(cur - restOffsetKHz) < 0.05 ? cur : restOffsetKHz,
     );
-  }, [hold, followOffsetKHz]);
+  }, [hold, restOffsetKHz]);
 
   const maxOffsetKHz = device ? device.sample_rate_hz / 2000 : 1500;
   const clampedOffsetKHz = Math.max(
@@ -259,7 +269,13 @@ export function Tuning() {
           }}
           hold={hold}
           onHoldChange={setHold}
-          followingActive={followOffsetKHz != null}
+          following={
+            followOffsetKHz != null
+              ? "call"
+              : controlOffsetKHz != null
+                ? "control"
+                : null
+          }
           onCentre={() => {
             setHold(true);
             setOffsetKHz(0);


### PR DESCRIPTION
Addresses the follow-ups on issue #557 and the broader "make recent hunt features visible in the web UI" request. Two commits:

## 1. Plots view defaults to the control channel, not the SDR centre (#557)

The reporter asked for the Plots view to default to the configured control-channel frequency rather than the SDR centre (which sits under the DDC's DC spike and is useless).

- **Backend**: resolve each SDR's in-band configured control channel (closest to centre) and report it per device as `control_channel_hz` on `GET /api/v1/spectrum/devices` (reuses the passband-matching already used for `p25_modulation`; no single-system fallback, since an out-of-band CC would mix beyond Nyquist).
- **Frontend** (all six Plots tabs — Constellation, Symbol scope, Eye diagram, Mixer, Tuning, Histogram): when Hold is off the view rests on `followOffsetKHz ?? controlOffsetKHz` — an active call still wins, otherwise it lands on the control channel and glides back there when a call ends. `TuningControls` gained a `following: "call" | "control" | null` prop so the Hold label reads *following call* or *on control channel*. SDRs with no in-band CC keep the old centre default.

## 2. Surface DMR Tier III hunt / autoconfig features in the web console (#638)

An audit (web panels + TUI + backend) found recent hunt-family work only reached the logs / raw event stream. This wires it into the UI.

- **Backend** (`internal/api`): typed snake_case DTOs + `eventToDTO` arms for `dmr.grant.observed` and `dmr.bandplan.learned` (previously raw PascalCase passthrough); add the active DMR band plan to `SystemDTO` (`dmr_band_plan`) via `systemToDTO` for a durable, queryable LCN→frequency view. (`cchunt.progress` / `cchunt.failed` already carry snake_case tags, so they needed rendering only.)
- **Frontend**:
  - *CC Activity*: render DMR grant, "Band plan learned", and the CC-hunt lifecycle with filters.
  - *Systems*: a band-plan column + detail section, with a "learned live" indicator derived from the newest band-plan event in the store.
  - *Hunt*: per-capture reports (control freq, protocol, lock / skip reason) and discovered sites with their control channels, from the polled status.

## Tests / docs

- Go: `eventToDTO` JSON-shape tests for the new events; `systemToDTO` band-plan tests; `controlChannelFor` table test.
- Frontend: new/extended tests for the Plots panels, CC Activity, Systems, Hunt, and TuningControls.
- `docs/constellation.md`, `docs/symbol-scope.md`, `docs/hunt.md`, and `CHANGELOG.md` updated.

## Verification

`go build ./...`, `go vet`, `go test ./internal/api/ ./cmd/gophertrunk/` pass; full frontend suite (209 tests) and `npm run build` (tsc + vite) pass.

Scope note: the audit also flagged two non-hunt gaps — per-call loudness normalization (#627) and USRP actual sample rate (#550) — which are intentionally left out of this PR.

https://claude.ai/code/session_01Ly3soSDKQDfVPzjvMMQDa8