### PR TITLE
hunt: resolve neighbor freqs + NDJSON streaming/resume for survey

### DIFF
--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -49,6 +49,8 @@ func runHunt(args []string) {
 	surveyMode := fs.Bool("survey", false, "signal-survey mode: classify every detected carrier (analog/digital/paging/trunking) and decode the conventional ones, not just trunking control channels (live only)")
 	classifyOnly := fs.Bool("classify-only", false, "survey: classify carriers only, skip all decoding (fast inventory)")
 	surveyDeep := fs.Bool("survey-deep", false, "survey: hand narrowband carriers the classifier called analog (am/nbfm) to the trunking identify too, so a trunked DMR/TETRA/MPT control channel the blind classifier missed is still found (slower, more accurate)")
+	surveyNDJSON := fs.String("survey-ndjson", "", "survey: append each classified carrier to this newline-delimited JSON file as it is found (crash-safe, the cumulative record across -resume runs)")
+	resume := fs.Bool("resume", false, "survey: skip carriers already present in -survey-ndjson (resume an interrupted survey)")
 	surveyAudio := fs.String("survey-audio", "", "survey: write a WAV clip per active analog FM carrier into this directory")
 	maxDwellSeconds := fs.Float64("max-dwell-seconds", 0, "survey: extend per-candidate dwell up to this many seconds, listening until carrier activity (0 = fixed -dwell-seconds)")
 	identifyMinConf := fs.Float64("identify-min-confidence", 0, "survey: skip the trunking identify for a digital carrier below this classifier confidence (0 = always identify)")
@@ -181,6 +183,8 @@ FLAGS:`)
 			survey:           *surveyMode,
 			classifyOnly:     *classifyOnly,
 			surveyDeep:       *surveyDeep,
+			surveyNDJSON:     *surveyNDJSON,
+			resume:           *resume,
 			surveyAudioDir:   *surveyAudio,
 			maxDwellSeconds:  *maxDwellSeconds,
 			identifyMinConf:  *identifyMinConf,

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -346,8 +346,9 @@ func finishHunt(rep *diag.Reporter, sys *hunt.DiscoveredSystem, reports []hunt.C
 	// Optional read-only RadioReference duplicate check. Non-fatal: the export
 	// still happens, just without hints.
 	var hints []hunt.DuplicateHint
+	var rrDiff *hunt.RRDiff
 	if !p.noRR {
-		hints = gatherRRHints(sys, p.rr)
+		hints, rrDiff = gatherRRHints(sys, p.rr)
 	}
 
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
@@ -363,7 +364,7 @@ func finishHunt(rep *diag.Reporter, sys *hunt.DiscoveredSystem, reports []hunt.C
 		if cerr != nil {
 			rep.Fatal(1, fmt.Errorf("create %s: %w", fname, cerr))
 		}
-		werr := hunt.Write(f, sys, hf, hints)
+		werr := hunt.WriteWithRRDiff(f, sys, hf, hints, rrDiff)
 		cerr = f.Close()
 		if werr != nil {
 			rep.Fatal(1, fmt.Errorf("write %s: %w", fname, werr))
@@ -434,7 +435,7 @@ type rrOptions struct {
 // password fall back to GOPHERTRUNK_RR_USER / GOPHERTRUNK_RR_PASS. With no key
 // the check is skipped (a note is printed) and the export proceeds without
 // hints. All RR errors are non-fatal.
-func gatherRRHints(sys *hunt.DiscoveredSystem, opts rrOptions) []hunt.DuplicateHint {
+func gatherRRHints(sys *hunt.DiscoveredSystem, opts rrOptions) ([]hunt.DuplicateHint, *hunt.RRDiff) {
 	key := opts.key
 	if key == "" {
 		key = os.Getenv("GOPHERTRUNK_RR_KEY")
@@ -446,11 +447,11 @@ func gatherRRHints(sys *hunt.DiscoveredSystem, opts rrOptions) []hunt.DuplicateH
 	}))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "hunt: RadioReference duplicate check skipped (no API key configured — set -rr-key or GOPHERTRUNK_RR_KEY)")
-		return nil
+		return nil, nil
 	}
 	if opts.countyID == 0 && len(opts.checkSIDs) == 0 {
 		fmt.Fprintln(os.Stderr, "hunt: RadioReference key present but no -rr-county-id or -rr-check-sid given; nothing to compare against")
-		return nil
+		return nil, nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -503,14 +504,65 @@ func gatherRRHints(sys *hunt.DiscoveredSystem, opts rrOptions) []hunt.DuplicateH
 	rrHints := radioreference.MatchAgainst(cand, existing)
 	if len(rrHints) == 0 {
 		fmt.Fprintf(os.Stderr, "hunt: RadioReference check found no existing match among %d system(s)\n", len(existing))
-		return nil
+		return nil, nil
 	}
 	out := make([]hunt.DuplicateHint, 0, len(rrHints))
 	for _, h := range rrHints {
 		fmt.Fprintf(os.Stderr, "hunt: possible duplicate — RR SID %d (%s): %s\n", h.SID, h.Name, h.Reason)
 		out = append(out, hunt.DuplicateHint{SID: h.SID, Name: h.Name, Reason: h.Reason, Confidence: h.Confidence})
 	}
-	return out
+
+	// Cross-reference: for the strongest confident match, pull the full RR system
+	// and diff our discovered freqs/talkgroups against it (offsets + new items).
+	diff := buildRRDiff(ctx, client, sys, rrHints)
+	return out, diff
+}
+
+// rrDiffMinConfidence is the match confidence above which a diff is worth
+// fetching the full RR system for (the WACN+SYSID / control-overlap tiers).
+const rrDiffMinConfidence = 0.80
+
+// buildRRDiff fetches the strongest confident hint's full RR system and diffs
+// the discovered system against it. Returns nil on any error or when no hint is
+// confident enough (the diff is best-effort, never fatal).
+func buildRRDiff(ctx context.Context, client *radioreference.Client, sys *hunt.DiscoveredSystem, hints []radioreference.Hint) *hunt.RRDiff {
+	var top radioreference.Hint
+	for _, h := range hints {
+		if h.SID != 0 && h.Confidence >= rrDiffMinConfidence && h.Confidence > top.Confidence {
+			top = h
+		}
+	}
+	if top.SID == 0 {
+		return nil
+	}
+	fs, err := client.GetFullSystem(ctx, top.SID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hunt: RadioReference getFullSystem(%d): %v\n", top.SID, err)
+		return nil
+	}
+	var rrFreqs []uint32
+	for _, st := range fs.Sites {
+		rrFreqs = append(rrFreqs, st.Frequencies...)
+	}
+	rrTGs := make([]uint32, 0, len(fs.Talkgroups))
+	for _, tg := range fs.Talkgroups {
+		rrTGs = append(rrTGs, tg.Dec)
+	}
+	d := hunt.DiffAgainstRR(sys, top.SID, nonEmptyName(fs.Name, top.Name), rrFreqs, rrTGs)
+	if d.Empty() {
+		return nil
+	}
+	fmt.Fprintf(os.Stderr, "hunt: RadioReference diff vs SID %d — %d offset(s), %d new freq(s), %d new talkgroup(s)\n",
+		top.SID, len(d.FreqOffsets), len(d.FreqsNotInRR), len(d.TalkgroupsNotInRR))
+	return &d
+}
+
+// nonEmptyName returns a if non-empty, else b.
+func nonEmptyName(a, b string) string {
+	if a != "" {
+		return a
+	}
+	return b
 }
 
 // slugName lowercases a display name into a filesystem-safe stem.

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -51,6 +51,8 @@ func runHunt(args []string) {
 	surveyDeep := fs.Bool("survey-deep", false, "survey: hand narrowband carriers the classifier called analog (am/nbfm) to the trunking identify too, so a trunked DMR/TETRA/MPT control channel the blind classifier missed is still found (slower, more accurate)")
 	surveyNDJSON := fs.String("survey-ndjson", "", "survey: append each classified carrier to this newline-delimited JSON file as it is found (crash-safe, the cumulative record across -resume runs)")
 	resume := fs.Bool("resume", false, "survey: skip carriers already present in -survey-ndjson (resume an interrupted survey)")
+	autoGain := fs.Bool("auto-gain", false, "live: after the run, sweep gains on each locked control channel and recommend the one minimizing decode errors (does not apply it)")
+	autoGainSet := fs.String("auto-gain-set", "", "live: comma-separated gains in dB for -auto-gain (default: a conservative spread; use a device-appropriate set for RTL/Airspy)")
 	surveyAudio := fs.String("survey-audio", "", "survey: write a WAV clip per active analog FM carrier into this directory")
 	maxDwellSeconds := fs.Float64("max-dwell-seconds", 0, "survey: extend per-candidate dwell up to this many seconds, listening until carrier activity (0 = fixed -dwell-seconds)")
 	identifyMinConf := fs.Float64("identify-min-confidence", 0, "survey: skip the trunking identify for a digital carrier below this classifier confidence (0 = always identify)")
@@ -185,6 +187,9 @@ FLAGS:`)
 			surveyDeep:       *surveyDeep,
 			surveyNDJSON:     *surveyNDJSON,
 			resume:           *resume,
+			autoGain:         *autoGain,
+			autoGainSet:      *autoGainSet,
+			outDir:           *out,
 			surveyAudioDir:   *surveyAudio,
 			maxDwellSeconds:  *maxDwellSeconds,
 			identifyMinConf:  *identifyMinConf,

--- a/cmd/gophertrunk/hunt_iqsource.go
+++ b/cmd/gophertrunk/hunt_iqsource.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -18,11 +19,22 @@ type streamIQSource struct {
 	ch      <-chan []complex64
 	tune    func(uint32) error
 	rate    func() uint32
+	setGain func(int) error // nil on the shared-SDR broker path (gain control unavailable)
 	pending []complex64
 	settle  time.Duration
 }
 
 func (s *streamIQSource) SampleRateHz() uint32 { return s.rate() }
+
+// SetGain implements hunt.GainSettable for the auto-gain sweep. It is only wired
+// on the standalone device path; the broker path returns an error because
+// changing gain would disrupt the daemon's other consumers of the shared SDR.
+func (s *streamIQSource) SetGain(tenthDB int) error {
+	if s.setGain == nil {
+		return fmt.Errorf("gain control unavailable on this IQ source")
+	}
+	return s.setGain(tenthDB)
+}
 
 func (s *streamIQSource) Tune(centerHz uint32) error {
 	if err := s.tune(centerHz); err != nil {
@@ -69,10 +81,11 @@ func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*strea
 		return nil, err
 	}
 	return &streamIQSource{
-		ch:     ch,
-		tune:   dev.SetCenterFreq,
-		rate:   func() uint32 { return rate },
-		settle: 50 * time.Millisecond,
+		ch:      ch,
+		tune:    dev.SetCenterFreq,
+		rate:    func() uint32 { return rate },
+		setGain: dev.SetGain,
+		settle:  50 * time.Millisecond,
 	}, nil
 }
 

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -20,7 +20,9 @@ type huntLiveParams struct {
 	serial           string
 	survey           bool // classify+decode every carrier, not just trunking CCs
 	classifyOnly     bool
-	surveyDeep       bool // hand analog-classed narrowband carriers to siglab identify
+	surveyDeep       bool   // hand analog-classed narrowband carriers to siglab identify
+	surveyNDJSON     string // append each classified carrier here (crash-safe, resumable)
+	resume           bool   // skip carriers already recorded in surveyNDJSON
 	surveyAudioDir   string
 	maxDwellSeconds  float64
 	identifyMinConf  float64
@@ -95,6 +97,32 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 	if p.survey {
 		mode = "survey"
 	}
+
+	// Survey NDJSON stream + resume: append each classified carrier to disk
+	// (fsync per record) and, on -resume, skip carriers already recorded.
+	var onSignal func(hunt.DetectedSignal)
+	var skipFreqs map[uint32]struct{}
+	if p.surveyNDJSON != "" {
+		if p.resume {
+			skipFreqs, err = hunt.LoadSurveyedFreqs(p.surveyNDJSON)
+			if err != nil {
+				rep.Fatal(1, fmt.Errorf("resume %s: %w", p.surveyNDJSON, err))
+			}
+			if len(skipFreqs) > 0 {
+				fmt.Fprintf(os.Stderr, "%s: resuming — skipping %d already-surveyed carrier(s)\n", mode, len(skipFreqs))
+			}
+		}
+		sink, serr := hunt.OpenNDJSONSink(p.surveyNDJSON)
+		if serr != nil {
+			rep.Fatal(1, fmt.Errorf("open survey ndjson: %w", serr))
+		}
+		defer sink.Close()
+		onSignal = func(ds hunt.DetectedSignal) {
+			if werr := sink.Write(ds); werr != nil {
+				fmt.Fprintf(os.Stderr, "%s: ndjson write: %v\n", mode, werr)
+			}
+		}
+	}
 	if len(bands) > 0 {
 		fmt.Fprintf(os.Stderr, "%s: live sweep on %s[%s] @ %g MS/s across %d band(s)…\n",
 			mode, info.Driver, info.Serial, p.sampleRateHz/1e6, len(bands))
@@ -122,6 +150,8 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 		ClassifyOnly:          p.classifyOnly,
 		SurveyDeep:            p.surveyDeep,
 		SurveyAudioDir:        p.surveyAudioDir,
+		SkipFreqs:             skipFreqs,
+		OnSignal:              onSignal,
 		IdentifyMinConfidence: p.identifyMinConf,
 		ClassifyConfig: survey.ClassifyConfig{
 			SNRGateDb:         p.classSNRGate,

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -23,6 +25,9 @@ type huntLiveParams struct {
 	surveyDeep       bool   // hand analog-classed narrowband carriers to siglab identify
 	surveyNDJSON     string // append each classified carrier here (crash-safe, resumable)
 	resume           bool   // skip carriers already recorded in surveyNDJSON
+	autoGain         bool   // after the run, sweep gains per locked CC and recommend one
+	autoGainSet      string // comma-separated gains in dB to try (empty ⇒ default spread)
+	outDir           string // explicit -out dir, for the gain-recommendation sidecar
 	surveyAudioDir   string
 	maxDwellSeconds  float64
 	identifyMinConf  float64
@@ -174,6 +179,7 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 			rep.Fatal(1, fmt.Errorf("live survey: %w", err))
 		}
 		printSurvey(sv)
+		maybeAutoGain(ctx, src, p, lockedControlChannels(sv.System, sv))
 		return sv.System, sv, reports
 	}
 
@@ -181,7 +187,137 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 	if err != nil {
 		rep.Fatal(1, fmt.Errorf("live hunt: %w", err))
 	}
+	maybeAutoGain(ctx, src, p, lockedControlChannels(sys, nil))
 	return sys, nil, reports
+}
+
+// lockedControlChannels collects the control-channel frequencies worth a gain
+// sweep: every control channel of a discovered system, plus any survey carrier
+// that locked as a trunk control channel.
+func lockedControlChannels(sys *hunt.DiscoveredSystem, sv *hunt.SignalSurvey) []uint32 {
+	seen := map[uint32]struct{}{}
+	var out []uint32
+	add := func(hz uint32) {
+		if hz == 0 {
+			return
+		}
+		if _, ok := seen[hz]; !ok {
+			seen[hz] = struct{}{}
+			out = append(out, hz)
+		}
+	}
+	if sys != nil {
+		for _, st := range sys.Sites {
+			for _, ch := range st.ControlChannels {
+				if ch.IsControl {
+					add(ch.FrequencyHz)
+				}
+			}
+		}
+	}
+	if sv != nil {
+		for _, s := range sv.Signals {
+			if s.Class == survey.ClassTrunkControl {
+				add(s.FreqHz)
+			}
+		}
+	}
+	return out
+}
+
+// maybeAutoGain runs the optional gain sweep on the live SDR after a hunt/survey
+// and prints the per-channel recommendation. It restores the run's configured
+// gain afterwards and never applies a recommendation automatically.
+func maybeAutoGain(ctx context.Context, src *streamIQSource, p huntLiveParams, ccs []uint32) {
+	if !p.autoGain {
+		return
+	}
+	if len(ccs) == 0 {
+		fmt.Fprintln(os.Stderr, "auto-gain: no locked control channel to sweep")
+		return
+	}
+	gains, err := parseGainSetDB(p.autoGainSet)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "auto-gain: %v\n", err)
+		return
+	}
+	if len(gains) == 0 {
+		fmt.Fprintf(os.Stderr, "auto-gain: sweeping the default gain spread across %d control channel(s)…\n", len(ccs))
+	} else {
+		fmt.Fprintf(os.Stderr, "auto-gain: sweeping %d gain(s) across %d control channel(s)…\n", len(gains), len(ccs))
+	}
+	recs, err := hunt.AutoGainSweep(ctx, src, src, ccs, hunt.AutoGainOptions{
+		Gains:        gains,
+		Protocol:     p.protocol,
+		SampleRateHz: p.sampleRateHz,
+		AutoTune:     p.autoTune,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "auto-gain: %v\n", err)
+	}
+	// Restore the operator's configured gain (the sweep left the SDR on the last
+	// tried gain).
+	_ = src.SetGain(p.gain)
+
+	for _, rec := range recs {
+		if rec.BestGainTenthDB < 0 {
+			fmt.Fprintf(os.Stderr, "auto-gain: %.4f MHz — no usable decode at any gain\n", float64(rec.FreqHz)/1e6)
+			continue
+		}
+		lock := ""
+		if !rec.Locked {
+			lock = " (no lock — low confidence)"
+		}
+		fmt.Fprintf(os.Stderr, "auto-gain: %.4f MHz — recommend %.1f dB (err %.2f/ksym)%s\n",
+			float64(rec.FreqHz)/1e6, float64(rec.BestGainTenthDB)/10, rec.BestErrorRate, lock)
+	}
+	if p.outDir != "" && len(recs) > 0 {
+		writeGainRecommendation(p.outDir, recs)
+	}
+}
+
+// parseGainSetDB parses a comma-separated list of gains in dB into tenths of dB.
+// An empty string yields nil (the sweep uses its default spread).
+func parseGainSetDB(s string) ([]int, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	var out []int
+	for _, tok := range strings.Split(s, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		db, err := strconv.ParseFloat(tok, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid gain %q in -auto-gain-set", tok)
+		}
+		out = append(out, int(db*10))
+	}
+	return out, nil
+}
+
+// writeGainRecommendation writes the sweep result as JSON into the out dir.
+func writeGainRecommendation(outDir string, recs []hunt.GainRecommendation) {
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "auto-gain: %v\n", err)
+		return
+	}
+	path := filepath.Join(outDir, "gain-recommendation.json")
+	f, err := os.Create(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "auto-gain: %v\n", err)
+		return
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(recs); err != nil {
+		fmt.Fprintf(os.Stderr, "auto-gain: %v\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "auto-gain: wrote %s\n", path)
 }
 
 // printSurvey writes the classified signal inventory to stderr — the survey's

--- a/internal/hunt/accumulate_test.go
+++ b/internal/hunt/accumulate_test.go
@@ -139,6 +139,48 @@ func TestAccumulate_FoldsTopology(t *testing.T) {
 	}
 }
 
+func TestResolveNeighborFreqs(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	r := fakeResult(851012500, map[string]any{"NAC": uint16(0x293)}, 1000)
+	r.Topology = &siglab.TopologySnapshot{
+		RFSS: 1, Site: 2,
+		Neighbors: []siglab.NeighborRef{
+			{RFSS: 1, Site: 3, ChannelID: 1, ChannelNumber: 10}, // resolvable
+			{RFSS: 1, Site: 4}, // no coords ⇒ unresolved
+		},
+		BandPlan: []siglab.BandPlanSlot{
+			{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500},
+		},
+	}
+	Accumulate(sys, Observation{Protocol: "p25", Confidence: 0.9, Result: r})
+	sys.sortAll() // resolution runs at finish
+
+	nb := sys.Sites[0].Neighbors
+	// Sorted by (RFSS, Site): Site 3 first, then Site 4.
+	if len(nb) != 2 {
+		t.Fatalf("neighbors = %+v, want 2", nb)
+	}
+	if got := nb[0].FrequencyHz; got != 851_125_000 { // 851M + 10*12.5k
+		t.Errorf("neighbor site 3 freq = %d, want 851125000", got)
+	}
+	if nb[1].FrequencyHz != 0 {
+		t.Errorf("neighbor site 4 (no coords) should stay unresolved, got %d", nb[1].FrequencyHz)
+	}
+}
+
+func TestResolveNeighborFreqs_NoBandPlan(t *testing.T) {
+	sys := &DiscoveredSystem{
+		Sites: []DiscoveredSite{{
+			RFSS: 1, SiteID: 2,
+			Neighbors: []NeighborRef{{RFSS: 1, Site: 3, ChannelID: 1, ChannelNumber: 10}},
+		}},
+	}
+	sys.sortAll()
+	if sys.Sites[0].Neighbors[0].FrequencyHz != 0 {
+		t.Errorf("no band plan ⇒ neighbor must stay unresolved")
+	}
+}
+
 func TestAccumulate_TopologyDedupesAcrossObservations(t *testing.T) {
 	sys := &DiscoveredSystem{}
 	mk := func() Observation {

--- a/internal/hunt/autogain.go
+++ b/internal/hunt/autogain.go
@@ -1,0 +1,165 @@
+package hunt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// GainSettable is the optional gain-control capability the auto-gain sweep needs
+// beyond IQSource. The standalone live-device source implements it; the daemon's
+// shared-SDR broker source does not (changing gain would disrupt the daemon's
+// other consumers), so auto-gain is a standalone-live-SDR feature.
+type GainSettable interface {
+	// SetGain sets the front-end gain in tenths of a dB (-1 ⇒ AGC).
+	SetGain(tenthDB int) error
+}
+
+// defaultGainSet is a conservative spread (tenths of dB) used when the caller
+// doesn't supply one. RTL-SDR and Airspy gain ladders differ, so an operator
+// should pass a device-appropriate set; this spread is a reasonable blind probe.
+var defaultGainSet = []int{0, 87, 166, 240, 297, 370, 440, 496}
+
+// AutoGainOptions configures an auto-gain sweep.
+type AutoGainOptions struct {
+	Gains        []int             // tenths of dB to try; empty ⇒ defaultGainSet
+	DwellSeconds float64           // capture per (freq, gain); 0 ⇒ 1.0
+	Protocol     trunking.Protocol // force the decoder (skip identify) when known
+	SampleRateHz float64
+	AutoTune     bool
+	Log          *slog.Logger
+}
+
+// GainScore is the decode outcome at one (frequency, gain).
+type GainScore struct {
+	GainTenthDB int     `json:"gain_tenth_db"`
+	ErrorRate   float64 `json:"error_rate"`
+	Locked      bool    `json:"locked"`
+	Err         string  `json:"error,omitempty"`
+}
+
+// GainRecommendation is the best gain found for one control channel.
+type GainRecommendation struct {
+	FreqHz          uint32      `json:"freq_hz"`
+	BestGainTenthDB int         `json:"best_gain_tenth_db"`
+	BestErrorRate   float64     `json:"best_error_rate"`
+	Locked          bool        `json:"locked"`
+	PerGain         []GainScore `json:"per_gain"`
+}
+
+// AutoGainSweep sweeps each control channel across a set of gains and recommends
+// the gain that minimises the decode error rate (preferring a gain that locks).
+// It requires a gain-controllable live SDR and mutates the device gain as it
+// runs — the caller restores the desired gain afterwards. Recommendations are
+// advisory; nothing is applied automatically.
+func AutoGainSweep(ctx context.Context, src IQSource, gc GainSettable, ccs []uint32, opts AutoGainOptions) ([]GainRecommendation, error) {
+	if src == nil || gc == nil {
+		return nil, fmt.Errorf("hunt: auto-gain requires a gain-controllable live SDR")
+	}
+	if opts.SampleRateHz <= 0 {
+		return nil, fmt.Errorf("hunt: auto-gain needs a positive sample rate")
+	}
+	gains := opts.Gains
+	if len(gains) == 0 {
+		gains = defaultGainSet
+	}
+	dwell := opts.DwellSeconds
+	if dwell <= 0 {
+		dwell = 1.0
+	}
+	n := int(dwell * opts.SampleRateHz)
+
+	recs := make([]GainRecommendation, 0, len(ccs))
+	for _, freq := range ccs {
+		if err := ctx.Err(); err != nil {
+			return recs, err
+		}
+		rec := GainRecommendation{FreqHz: freq, BestGainTenthDB: -1, BestErrorRate: math.Inf(1)}
+		for _, g := range gains {
+			if err := ctx.Err(); err != nil {
+				return recs, err
+			}
+			rec.PerGain = append(rec.PerGain, scoreGain(ctx, src, gc, freq, g, n, opts))
+		}
+		if i := pickGain(rec.PerGain); i >= 0 {
+			rec.BestGainTenthDB = rec.PerGain[i].GainTenthDB
+			rec.BestErrorRate = rec.PerGain[i].ErrorRate
+			rec.Locked = rec.PerGain[i].Locked
+		}
+		recs = append(recs, rec)
+	}
+	return recs, nil
+}
+
+// scoreGain sets the gain, tunes the frequency (which drains the settle
+// transient, including the gain change), captures a short dwell, and decodes it,
+// returning the protocol-neutral decode error rate and whether it locked.
+func scoreGain(ctx context.Context, src IQSource, gc GainSettable, freq uint32, gain, n int, opts AutoGainOptions) GainScore {
+	sc := GainScore{GainTenthDB: gain}
+	if err := gc.SetGain(gain); err != nil {
+		sc.Err = fmt.Sprintf("set gain: %v", err)
+		return sc
+	}
+	if err := src.Tune(freq); err != nil {
+		sc.Err = fmt.Sprintf("tune: %v", err)
+		return sc
+	}
+	iq, err := captureN(ctx, src, n)
+	if err != nil {
+		sc.Err = fmt.Sprintf("capture: %v", err)
+		return sc
+	}
+	buf := siglab.EncodeCapture(iq, siglab.FormatF32)
+	rep := decodeAndAccumulate(&DiscoveredSystem{}, bytes.NewReader(buf),
+		fmt.Sprintf("%.4f MHz @ gain %.1f dB", float64(freq)/1e6, float64(gain)/10),
+		decodeParams{
+			Protocol:     opts.Protocol,
+			Format:       siglab.FormatF32,
+			SampleRateHz: opts.SampleRateHz,
+			FrequencyHz:  freq,
+			AutoTune:     opts.AutoTune,
+			Log:          opts.Log,
+		})
+	sc.ErrorRate = rep.ErrorRate
+	sc.Locked = rep.Locked
+	if rep.Error != "" {
+		sc.Err = rep.Error
+	}
+	return sc
+}
+
+// pickGain returns the index of the best score: prefer one that locked, then the
+// lowest error rate, then the lower gain (less front-end strain). Scores whose
+// capture/decode errored are ignored. Returns -1 when none are usable.
+func pickGain(scores []GainScore) int {
+	best := -1
+	for i := range scores {
+		s := scores[i]
+		if s.Err != "" {
+			continue
+		}
+		if best < 0 {
+			best = i
+			continue
+		}
+		b := scores[best]
+		switch {
+		case s.Locked != b.Locked:
+			if s.Locked {
+				best = i
+			}
+		case s.ErrorRate != b.ErrorRate:
+			if s.ErrorRate < b.ErrorRate {
+				best = i
+			}
+		case s.GainTenthDB < b.GainTenthDB:
+			best = i
+		}
+	}
+	return best
+}

--- a/internal/hunt/autogain_test.go
+++ b/internal/hunt/autogain_test.go
@@ -1,0 +1,111 @@
+package hunt
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPickGain(t *testing.T) {
+	tests := []struct {
+		name   string
+		scores []GainScore
+		want   int // index, or -1
+	}{
+		{"empty", nil, -1},
+		{"all errored", []GainScore{{GainTenthDB: 10, Err: "x"}, {GainTenthDB: 20, Err: "y"}}, -1},
+		{
+			"prefer locked over lower error",
+			[]GainScore{
+				{GainTenthDB: 100, ErrorRate: 0, Locked: false}, // 0 error but no lock
+				{GainTenthDB: 200, ErrorRate: 5, Locked: true},  // locked
+			},
+			1,
+		},
+		{
+			"min error among locked",
+			[]GainScore{
+				{GainTenthDB: 100, ErrorRate: 8, Locked: true},
+				{GainTenthDB: 200, ErrorRate: 3, Locked: true},
+				{GainTenthDB: 300, ErrorRate: 6, Locked: true},
+			},
+			1,
+		},
+		{
+			"tie on error ⇒ lower gain",
+			[]GainScore{
+				{GainTenthDB: 300, ErrorRate: 2, Locked: true},
+				{GainTenthDB: 100, ErrorRate: 2, Locked: true},
+			},
+			1,
+		},
+		{
+			"errored entries skipped",
+			[]GainScore{
+				{GainTenthDB: 100, Err: "capture"},
+				{GainTenthDB: 200, ErrorRate: 4, Locked: true},
+			},
+			1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pickGain(tc.scores); got != tc.want {
+				t.Errorf("pickGain = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// fakeGainSource is a FileIQSource that also records the gains SetGain was asked
+// to apply, so a test can drive AutoGainSweep without an SDR.
+type fakeGainSource struct {
+	*FileIQSource
+	gains []int
+}
+
+func (f *fakeGainSource) SetGain(tenthDB int) error {
+	f.gains = append(f.gains, tenthDB)
+	return nil
+}
+
+func TestAutoGainSweep_Orchestration(t *testing.T) {
+	// Zero IQ ⇒ siglab identify is inconclusive (no lock, error rate 0) at every
+	// gain, so the sweep exercises the SetGain→Tune→capture→decode loop and the
+	// tie-break picks the lowest gain.
+	src := &fakeGainSource{FileIQSource: NewFileIQSource(make([]complex64, 4800), 48_000)}
+	gains := []int{100, 300, 200}
+	recs, err := AutoGainSweep(context.Background(), src, src, []uint32{851_000_000}, AutoGainOptions{
+		Gains:        gains,
+		DwellSeconds: 0.05,
+		SampleRateHz: 48_000,
+	})
+	if err != nil {
+		t.Fatalf("AutoGainSweep: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("recs = %d, want 1", len(recs))
+	}
+	if len(recs[0].PerGain) != len(gains) {
+		t.Errorf("per-gain scores = %d, want %d", len(recs[0].PerGain), len(gains))
+	}
+	// Every requested gain was applied, in order.
+	if len(src.gains) != len(gains) {
+		t.Fatalf("SetGain calls = %v, want %v", src.gains, gains)
+	}
+	for i, g := range gains {
+		if src.gains[i] != g {
+			t.Errorf("SetGain[%d] = %d, want %d", i, src.gains[i], g)
+		}
+	}
+	// All scores tie at (no lock, 0 error) ⇒ lowest gain wins.
+	if recs[0].BestGainTenthDB != 100 {
+		t.Errorf("best gain = %d, want 100 (lowest on tie)", recs[0].BestGainTenthDB)
+	}
+}
+
+func TestAutoGainSweep_RequiresGainControl(t *testing.T) {
+	src := NewFileIQSource(make([]complex64, 16), 48_000)
+	if _, err := AutoGainSweep(context.Background(), src, nil, []uint32{1}, AutoGainOptions{SampleRateHz: 48_000}); err == nil {
+		t.Error("expected error when gain controller is nil")
+	}
+}

--- a/internal/hunt/decode.go
+++ b/internal/hunt/decode.go
@@ -119,6 +119,9 @@ func decodeAndAccumulate(sys *DiscoveredSystem, r io.ReadSeeker, source string, 
 	if res.Lock != nil {
 		rep.ControlHz = res.Lock.FrequencyHz
 	}
+	if res.Signal != nil {
+		rep.ErrorRate = res.Signal.DecodeErrorRate
+	}
 	rep.Talkgroups = len(sys.Talkgroups) - before
 	return rep
 }

--- a/internal/hunt/discover.go
+++ b/internal/hunt/discover.go
@@ -50,6 +50,10 @@ type CaptureReport struct {
 	Locked     bool    `json:"locked"`
 	ControlHz  uint32  `json:"control_hz,omitempty"`
 	Talkgroups int     `json:"talkgroups"`
+	// ErrorRate is the decode-error events per 1000 symbols from the decode
+	// (siglab Signal.DecodeErrorRate), a protocol-neutral demod-quality proxy.
+	// Zero when no signal analysis was produced. Used by the auto-gain sweep.
+	ErrorRate  float64 `json:"error_rate,omitempty"`
 	Skipped    bool    `json:"skipped"`
 	SkipReason string  `json:"skip_reason,omitempty"`
 	Error      string  `json:"error,omitempty"`

--- a/internal/hunt/export.go
+++ b/internal/hunt/export.go
@@ -3,6 +3,7 @@ package hunt
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 )
 
@@ -61,6 +62,13 @@ func ParseFormat(s string) (Format, error) {
 // Write serializes sys to w in the requested format. RRHints, when non-empty,
 // are rendered into the RR submission package (ignored by the other formats).
 func Write(w io.Writer, sys *DiscoveredSystem, f Format, hints []DuplicateHint) error {
+	return WriteWithRRDiff(w, sys, f, hints, nil)
+}
+
+// WriteWithRRDiff is Write with an optional cross-reference diff against an
+// existing RadioReference system, rendered into the RR submission package
+// (ignored by the other formats). diff == nil is identical to Write.
+func WriteWithRRDiff(w io.Writer, sys *DiscoveredSystem, f Format, hints []DuplicateHint, diff *RRDiff) error {
 	sys.sortAll()
 	switch f {
 	case FormatBundle:
@@ -68,10 +76,116 @@ func Write(w io.Writer, sys *DiscoveredSystem, f Format, hints []DuplicateHint) 
 	case FormatTrunkRecorder:
 		return writeTrunkRecorder(w, sys)
 	case FormatRR:
-		return writeRR(w, sys, hints)
+		return writeRR(w, sys, hints, diff)
 	default:
 		return fmt.Errorf("hunt: unsupported format %d", f)
 	}
+}
+
+// FreqOffset is a discovered frequency that matched a RadioReference frequency
+// within tolerance but not exactly — likely a tuning/PPM offset worth checking.
+type FreqOffset struct {
+	DiscoveredHz uint32 `json:"discovered_hz"`
+	RRHz         uint32 `json:"rr_hz"`
+	DeltaHz      int64  `json:"delta_hz"` // discovered - RR
+}
+
+// RRDiff is the cross-reference of a discovered system against the matched
+// RadioReference system: frequencies/talkgroups that differ or are new. It
+// upgrades the RR step from "is this a duplicate?" to "what's new or off here?".
+type RRDiff struct {
+	SID               int          `json:"sid"`
+	Name              string       `json:"name"`
+	FreqOffsets       []FreqOffset `json:"freq_offsets,omitempty"`
+	FreqsNotInRR      []uint32     `json:"freqs_not_in_rr,omitempty"`
+	TalkgroupsNotInRR []uint32     `json:"talkgroups_not_in_rr,omitempty"`
+}
+
+// Empty reports whether the diff found nothing worth reporting.
+func (d *RRDiff) Empty() bool {
+	return d == nil || (len(d.FreqOffsets) == 0 && len(d.FreqsNotInRR) == 0 && len(d.TalkgroupsNotInRR) == 0)
+}
+
+// rrFreqToleranceHz is how far a discovered control/voice frequency may sit from
+// a RadioReference frequency and still be considered the same channel (PPM drift
+// + RR rounding). 5 kHz stays below the tight 6.25 kHz channel raster so adjacent
+// channels aren't paired.
+const rrFreqToleranceHz = 5_000
+
+// DiffAgainstRR compares the system's discovered control/secondary frequencies
+// and talkgroups against a flattened RadioReference frequency/talkgroup list
+// (the CLI flattens FullSystem into these slices, keeping this package free of
+// the radioreference import). Frequencies are paired greedily by nearest unused
+// RR frequency: an exact pair is silent, a pair within rrFreqToleranceHz is an
+// offset, and anything farther (or unmatched) is "not in RR".
+func DiffAgainstRR(sys *DiscoveredSystem, sid int, name string, rrFreqs, rrTGs []uint32) RRDiff {
+	diff := RRDiff{SID: sid, Name: name}
+
+	// Discovered frequencies: control channels + secondary control channels.
+	seen := map[uint32]struct{}{}
+	var disc []uint32
+	add := func(hz uint32) {
+		if hz == 0 {
+			return
+		}
+		if _, ok := seen[hz]; !ok {
+			seen[hz] = struct{}{}
+			disc = append(disc, hz)
+		}
+	}
+	for _, st := range sys.Sites {
+		for _, ch := range st.ControlChannels {
+			if ch.IsControl {
+				add(ch.FrequencyHz)
+			}
+		}
+		for _, s := range st.Secondary {
+			add(s)
+		}
+	}
+	sort.Slice(disc, func(i, j int) bool { return disc[i] < disc[j] })
+
+	rr := append([]uint32(nil), rrFreqs...)
+	sort.Slice(rr, func(i, j int) bool { return rr[i] < rr[j] })
+	used := make([]bool, len(rr))
+	for _, d := range disc {
+		best := -1
+		var bestAbs int64 = -1
+		var bestDelta int64
+		for i, f := range rr {
+			if used[i] {
+				continue
+			}
+			delta := int64(d) - int64(f)
+			ad := delta
+			if ad < 0 {
+				ad = -ad
+			}
+			if best < 0 || ad < bestAbs {
+				best, bestAbs, bestDelta = i, ad, delta
+			}
+		}
+		switch {
+		case best < 0 || bestAbs > rrFreqToleranceHz:
+			diff.FreqsNotInRR = append(diff.FreqsNotInRR, d)
+		case bestAbs == 0:
+			used[best] = true // exact match — nothing to report
+		default:
+			used[best] = true
+			diff.FreqOffsets = append(diff.FreqOffsets, FreqOffset{DiscoveredHz: d, RRHz: rr[best], DeltaHz: bestDelta})
+		}
+	}
+
+	rrtg := make(map[uint32]struct{}, len(rrTGs))
+	for _, tg := range rrTGs {
+		rrtg[tg] = struct{}{}
+	}
+	for _, tg := range sys.Talkgroups {
+		if _, ok := rrtg[tg.Dec]; !ok {
+			diff.TalkgroupsNotInRR = append(diff.TalkgroupsNotInRR, tg.Dec)
+		}
+	}
+	return diff
 }
 
 // DuplicateHint is a possible pre-existing RadioReference system match,

--- a/internal/hunt/export_rr.go
+++ b/internal/hunt/export_rr.go
@@ -7,6 +7,43 @@ import (
 	"strings"
 )
 
+// writeRRDiff renders the cross-reference against an existing RadioReference
+// system: control/voice frequencies that are offset or new, and talkgroups
+// observed on-air but not yet in RR. A nil/empty diff renders nothing.
+func writeRRDiff(p *errWriter, diff *RRDiff) {
+	if diff.Empty() {
+		return
+	}
+	p.printf("## Differences vs RadioReference (SID %d", diff.SID)
+	if diff.Name != "" {
+		p.printf(" — %s", diff.Name)
+	}
+	p.printf(")\n\n")
+
+	if len(diff.FreqOffsets) > 0 {
+		p.printf("### Frequency offsets (within %g kHz — verify tuning/PPM)\n\n", float64(rrFreqToleranceHz)/1e3)
+		p.printf("| Discovered | RadioReference | Δ (kHz) |\n|---|---|---|\n")
+		for _, o := range diff.FreqOffsets {
+			p.printf("| %s | %s | %+.3f |\n", formatMHz(o.DiscoveredHz), formatMHz(o.RRHz), float64(o.DeltaHz)/1e3)
+		}
+		p.printf("\n")
+	}
+	if len(diff.FreqsNotInRR) > 0 {
+		p.printf("### Frequencies not in RadioReference\n\n")
+		for _, hz := range diff.FreqsNotInRR {
+			p.printf("- %s\n", formatMHz(hz))
+		}
+		p.printf("\n")
+	}
+	if len(diff.TalkgroupsNotInRR) > 0 {
+		p.printf("### Talkgroups on-air but not in RadioReference\n\n")
+		for _, dec := range diff.TalkgroupsNotInRR {
+			p.printf("- %d (0x%X)\n", dec, dec)
+		}
+		p.printf("\n")
+	}
+}
+
 // rrSubmitURL is the RadioReference "submit a new system" entry point.
 // RadioReference has no public write API — new systems go through this web
 // form, reviewed by Global administrators — so the submission package links
@@ -17,12 +54,14 @@ const rrSubmitURL = "https://www.radioreference.com/db/submit/"
 // (Markdown) the operator can paste into the RR Submit form. When hints are
 // supplied (from the optional read-only RR API duplicate check) they are
 // surfaced at the top so the operator doesn't submit a duplicate.
-func writeRR(w io.Writer, sys *DiscoveredSystem, hints []DuplicateHint) error {
+func writeRR(w io.Writer, sys *DiscoveredSystem, hints []DuplicateHint, diff *RRDiff) error {
 	p := &errWriter{w: w}
 
 	p.printf("# RadioReference submission: %s\n\n", sys.DisplayName())
 	p.printf("_Discovered by GopherTrunk. Review every field before submitting; " +
 		"a blind discovery cannot name talkgroups or confirm site geography._\n\n")
+
+	writeRRDiff(p, diff)
 
 	// Duplicate warnings first.
 	if len(hints) > 0 {

--- a/internal/hunt/export_rr.go
+++ b/internal/hunt/export_rr.go
@@ -101,7 +101,11 @@ func writeRR(w io.Writer, sys *DiscoveredSystem, hints []DuplicateHint) error {
 			p.printf("\nAdjacent sites: ")
 			refs := make([]string, 0, len(st.Neighbors))
 			for _, n := range st.Neighbors {
-				refs = append(refs, fmt.Sprintf("RFSS %d/Site %d", n.RFSS, n.Site))
+				ref := fmt.Sprintf("RFSS %d/Site %d", n.RFSS, n.Site)
+				if n.FrequencyHz != 0 {
+					ref += " @ " + formatMHz(n.FrequencyHz)
+				}
+				refs = append(refs, ref)
 			}
 			p.printf("%s\n", strings.Join(refs, ", "))
 		}

--- a/internal/hunt/export_test.go
+++ b/internal/hunt/export_test.go
@@ -144,6 +144,59 @@ func TestWriteRR_WithAndWithoutHints(t *testing.T) {
 	}
 }
 
+func TestDiffAgainstRR(t *testing.T) {
+	sys := &DiscoveredSystem{
+		Sites: []DiscoveredSite{{
+			RFSS: 1, SiteID: 1,
+			ControlChannels: []DiscoveredChannel{
+				{FrequencyHz: 851012500, IsControl: true}, // exact match to RR
+				{FrequencyHz: 851025000, IsControl: true}, // +500 Hz vs RR 851024500
+				{FrequencyHz: 860000000, IsControl: true}, // nothing near in RR
+			},
+		}},
+		Talkgroups: []DiscoveredTalkgroup{{Dec: 100}, {Dec: 200}},
+	}
+	rrFreqs := []uint32{851012500, 851024500, 770000000}
+	rrTGs := []uint32{100}
+
+	d := DiffAgainstRR(sys, 42, "RR Sys", rrFreqs, rrTGs)
+
+	if len(d.FreqOffsets) != 1 || d.FreqOffsets[0].DiscoveredHz != 851025000 ||
+		d.FreqOffsets[0].RRHz != 851024500 || d.FreqOffsets[0].DeltaHz != 500 {
+		t.Errorf("FreqOffsets = %+v, want one +500 Hz pairing", d.FreqOffsets)
+	}
+	if len(d.FreqsNotInRR) != 1 || d.FreqsNotInRR[0] != 860000000 {
+		t.Errorf("FreqsNotInRR = %v, want [860000000]", d.FreqsNotInRR)
+	}
+	if len(d.TalkgroupsNotInRR) != 1 || d.TalkgroupsNotInRR[0] != 200 {
+		t.Errorf("TalkgroupsNotInRR = %v, want [200]", d.TalkgroupsNotInRR)
+	}
+	if d.Empty() {
+		t.Error("diff should not be empty")
+	}
+
+	// Render path: the diff section appears in the RR package.
+	var buf bytes.Buffer
+	if err := WriteWithRRDiff(&buf, sampleSystem(), FormatRR, nil, &d); err != nil {
+		t.Fatalf("WriteWithRRDiff: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Differences vs RadioReference", "Frequency offsets", "Frequencies not in RadioReference", "200 (0xC8)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("RR diff section missing %q:\n%s", want, out)
+		}
+	}
+
+	// An all-matching system yields an empty diff (nothing to render).
+	empty := DiffAgainstRR(&DiscoveredSystem{
+		Sites:      []DiscoveredSite{{ControlChannels: []DiscoveredChannel{{FrequencyHz: 851012500, IsControl: true}}}},
+		Talkgroups: []DiscoveredTalkgroup{{Dec: 100}},
+	}, 42, "RR Sys", []uint32{851012500}, []uint32{100})
+	if !empty.Empty() {
+		t.Errorf("fully-matching system should diff empty, got %+v", empty)
+	}
+}
+
 func TestFormatMHz(t *testing.T) {
 	cases := map[uint32]string{
 		851012500: "851.0125",

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -56,6 +56,10 @@ type LiveHuntOptions struct {
 	// all decoding (trunking identify, paging, analog tone scan) for a fast
 	// inventory.
 	ClassifyOnly bool
+	// SkipFreqs, when non-empty, drops candidate carriers whose center
+	// frequency is already present (a resumed survey reads these from the
+	// existing NDJSON output so it doesn't re-survey carriers it already has).
+	SkipFreqs map[uint32]struct{}
 	// SurveyDeep hands narrowband carriers the blind classifier called analog
 	// (am/nbfm/wfm ≤ NBFM bandwidth) to the authoritative siglab identify before
 	// the analog tone scan, so a trunked DMR/TETRA/MPT control channel the blind

--- a/internal/hunt/livesurvey.go
+++ b/internal/hunt/livesurvey.go
@@ -350,7 +350,7 @@ func surveyCandidates(ctx context.Context, opts LiveHuntOptions, log *slog.Logge
 		for _, f := range opts.Candidates {
 			out = append(out, Candidate{FreqHz: f})
 		}
-		return out, nil
+		return skipSurveyed(out, opts.SkipFreqs), nil
 	}
 	sw, err := NewSweeper(SweepOptions{
 		Source:     opts.Source,
@@ -365,10 +365,30 @@ func surveyCandidates(ctx context.Context, opts LiveHuntOptions, log *slog.Logge
 		return nil, err
 	}
 	progress(LiveHuntProgress{Phase: PhaseSweeping, Detail: "scanning bands"})
-	return sw.Sweep(ctx, func(centerHz uint32, peaks []Peak) {
+	cands, err := sw.Sweep(ctx, func(centerHz uint32, peaks []Peak) {
 		progress(LiveHuntProgress{Phase: PhaseSweeping, CenterHz: centerHz,
 			Detail: fmt.Sprintf("%d peak(s)", len(peaks))})
 	})
+	if err != nil {
+		return nil, err
+	}
+	return skipSurveyed(cands, opts.SkipFreqs), nil
+}
+
+// skipSurveyed drops candidates whose frequency is already in skip (a resumed
+// survey), preserving order. A nil/empty skip set is a no-op.
+func skipSurveyed(cands []Candidate, skip map[uint32]struct{}) []Candidate {
+	if len(skip) == 0 {
+		return cands
+	}
+	out := cands[:0]
+	for _, c := range cands {
+		if _, done := skip[c.FreqHz]; done {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
 }
 
 // finishSurvey stamps the finish time, sorts the inventory, and clears an empty

--- a/internal/hunt/ndjson.go
+++ b/internal/hunt/ndjson.go
@@ -1,0 +1,88 @@
+package hunt
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+// NDJSONSink appends one DetectedSignal per line to a newline-delimited JSON
+// file, fsyncing after each record so an interrupted survey leaves a complete,
+// resumable trail on disk (the per-record durability the end-of-run survey.json
+// can't offer). It is the streaming peer of WriteSurvey: WriteSurvey snapshots
+// the whole inventory at the end, NDJSONSink records each carrier as it is
+// classified, via the survey's OnSignal hook.
+type NDJSONSink struct {
+	mu sync.Mutex
+	f  *os.File
+}
+
+// OpenNDJSONSink opens (creating if needed) path for append. The caller must
+// Close it when the run ends.
+func OpenNDJSONSink(path string) (*NDJSONSink, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	return &NDJSONSink{f: f}, nil
+}
+
+// Write marshals ds to one line and fsyncs. Safe for concurrent callers (the
+// daemon invokes OnSignal from a single goroutine, but the lock keeps it sound
+// regardless).
+func (s *NDJSONSink) Write(ds DetectedSignal) error {
+	b, err := json.Marshal(ds)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := s.f.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	return s.f.Sync()
+}
+
+// Close closes the underlying file.
+func (s *NDJSONSink) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.f.Close()
+}
+
+// LoadSurveyedFreqs reads the frequencies already recorded in an NDJSON survey
+// file so a resumed run can skip them. A missing file yields an empty set and no
+// error (first run). Unparseable lines (e.g. a record half-written before a
+// crash) are skipped rather than failing the load.
+func LoadSurveyedFreqs(path string) (map[uint32]struct{}, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[uint32]struct{}{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	out := map[uint32]struct{}{}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var rec struct {
+			FreqHz uint32 `json:"freq_hz"`
+		}
+		if err := json.Unmarshal(line, &rec); err != nil || rec.FreqHz == 0 {
+			continue
+		}
+		out[rec.FreqHz] = struct{}{}
+	}
+	if err := sc.Err(); err != nil {
+		return out, err
+	}
+	return out, nil
+}

--- a/internal/hunt/ndjson_test.go
+++ b/internal/hunt/ndjson_test.go
@@ -1,0 +1,111 @@
+package hunt
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func TestNDJSONSinkRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "survey.ndjson")
+	sink, err := OpenNDJSONSink(path)
+	if err != nil {
+		t.Fatalf("OpenNDJSONSink: %v", err)
+	}
+	freqs := []uint32{451_000_000, 452_125_000, 453_250_000}
+	for _, f := range freqs {
+		if err := sink.Write(DetectedSignal{FreqHz: f, Class: survey.ClassNBFM}); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+	if err := sink.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// One JSON object per line.
+	raw, _ := os.ReadFile(path)
+	if got := countLines(raw); got != len(freqs) {
+		t.Errorf("line count = %d, want %d", got, len(freqs))
+	}
+
+	set, err := LoadSurveyedFreqs(path)
+	if err != nil {
+		t.Fatalf("LoadSurveyedFreqs: %v", err)
+	}
+	if len(set) != len(freqs) {
+		t.Fatalf("loaded %d freqs, want %d", len(set), len(freqs))
+	}
+	for _, f := range freqs {
+		if _, ok := set[f]; !ok {
+			t.Errorf("freq %d missing from resume set", f)
+		}
+	}
+}
+
+func TestLoadSurveyedFreqs_MissingFileAndJunk(t *testing.T) {
+	// Missing file ⇒ empty set, no error.
+	set, err := LoadSurveyedFreqs(filepath.Join(t.TempDir(), "nope.ndjson"))
+	if err != nil || len(set) != 0 {
+		t.Fatalf("missing file: set=%v err=%v, want empty/no error", set, err)
+	}
+
+	// A half-written trailing line (crash) is skipped, valid lines still load.
+	path := filepath.Join(t.TempDir(), "partial.ndjson")
+	os.WriteFile(path, []byte(`{"freq_hz":451000000}`+"\n"+`{"freq_hz":4520`), 0o644)
+	set, err = LoadSurveyedFreqs(path)
+	if err != nil {
+		t.Fatalf("LoadSurveyedFreqs: %v", err)
+	}
+	if len(set) != 1 {
+		t.Errorf("loaded %d, want 1 (junk line skipped)", len(set))
+	}
+}
+
+// TestRunLiveSurvey_ResumeSkips verifies a resumed survey skips candidates whose
+// frequency is in SkipFreqs — they are never tuned and produce no signal.
+func TestRunLiveSurvey_ResumeSkips(t *testing.T) {
+	const a, b = 451_000_000, 452_000_000
+	// Two candidates; map gives each a flat (analog-ish) buffer.
+	buf := make([]complex64, 48_000)
+	for i := range buf {
+		buf[i] = complex(0.2, 0)
+	}
+	src := NewMappedIQSource(map[uint32][]complex64{a: buf, b: buf}, 48_000)
+
+	var seen []uint32
+	sv, _, err := RunLiveSurvey(context.Background(), LiveHuntOptions{
+		Source:       src,
+		Candidates:   []uint32{a, b},
+		DwellSeconds: float64(len(buf)) / 48_000,
+		ClassifyOnly: true,
+		SkipFreqs:    map[uint32]struct{}{a: {}}, // resume: a already done
+		OnSignal:     func(ds DetectedSignal) { seen = append(seen, ds.FreqHz) },
+	})
+	if err != nil {
+		t.Fatalf("RunLiveSurvey: %v", err)
+	}
+	if len(sv.Signals) != 1 || sv.Signals[0].FreqHz != b {
+		t.Errorf("signals = %+v, want only %d", sv.Signals, b)
+	}
+	if len(seen) != 1 || seen[0] != b {
+		t.Errorf("OnSignal freqs = %v, want [%d]", seen, b)
+	}
+	for _, f := range src.TuneCalls() {
+		if f == a {
+			t.Errorf("skipped freq %d was tuned", a)
+		}
+	}
+}
+
+func countLines(b []byte) int {
+	n := 0
+	for _, c := range b {
+		if c == '\n' {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/hunt/system.go
+++ b/internal/hunt/system.go
@@ -98,6 +98,10 @@ type NeighborRef struct {
 	Site          uint8  `json:"site"`
 	ChannelID     uint8  `json:"channel_id,omitempty"`
 	ChannelNumber uint16 `json:"channel_number,omitempty"`
+	// FrequencyHz is the neighbour's control-channel frequency, resolved from
+	// (ChannelID, ChannelNumber) against the system band plan at finish. Zero
+	// when the band plan doesn't cover the channel (e.g. no IDEN_UP seen yet).
+	FrequencyHz uint32 `json:"frequency_hz,omitempty"`
 }
 
 // BandPlanEntry is one P25 IDEN_UP-equivalent band-plan mapping.
@@ -224,4 +228,48 @@ func (s *DiscoveredSystem) sortAll() {
 	}
 	sort.Slice(s.Talkgroups, func(i, j int) bool { return s.Talkgroups[i].Dec < s.Talkgroups[j].Dec })
 	sort.Slice(s.BandPlan, func(i, j int) bool { return s.BandPlan[i].ChannelID < s.BandPlan[j].ChannelID })
+	// Resolve neighbour control-channel frequencies now that the band plan is
+	// fully accumulated (it may be incomplete on any single observation).
+	s.resolveNeighborFreqs()
+}
+
+// bandPlanFreq resolves a (channelID, channelNumber) pair to a downlink
+// frequency using the accumulated band plan, mirroring P25's IDEN_UP math
+// (BaseHz + channelNumber*SpacingHz). It deliberately does not apply TxOffsetHz
+// — that is the uplink offset; a control-channel reference is the downlink.
+// Returns false when no band-plan entry covers channelID or the result is out
+// of range.
+func (s *DiscoveredSystem) bandPlanFreq(channelID uint8, channelNumber uint16) (uint32, bool) {
+	for _, e := range s.BandPlan {
+		if e.ChannelID != channelID {
+			continue
+		}
+		hz := e.BaseHz + uint64(channelNumber)*uint64(e.SpacingHz)
+		if hz == 0 || hz > 0xFFFFFFFF {
+			return 0, false
+		}
+		return uint32(hz), true
+	}
+	return 0, false
+}
+
+// resolveNeighborFreqs fills in NeighborRef.FrequencyHz for every neighbour
+// whose (ChannelID, ChannelNumber) the band plan can resolve. It is idempotent
+// (a neighbour already carrying a frequency is left untouched), so it is safe to
+// call from sortAll on every finish/export.
+func (s *DiscoveredSystem) resolveNeighborFreqs() {
+	if len(s.BandPlan) == 0 {
+		return
+	}
+	for i := range s.Sites {
+		for j := range s.Sites[i].Neighbors {
+			n := &s.Sites[i].Neighbors[j]
+			if n.FrequencyHz != 0 || (n.ChannelID == 0 && n.ChannelNumber == 0) {
+				continue
+			}
+			if hz, ok := s.bandPlanFreq(n.ChannelID, n.ChannelNumber); ok {
+				n.FrequencyHz = hz
+			}
+		}
+	}
 }


### PR DESCRIPTION
Two independent improvements to the hunt/survey feature, adapted from ideas in
the p25-survey tool (reimplemented; no code copied).

Neighbor frequency resolution: adjacent sites were stored as
(RFSS, Site, ChannelID, ChannelNumber) without a frequency. Resolve them against
the accumulated band plan (BaseHz + ChannelNumber*SpacingHz, downlink) at finish
via sortAll, surfacing NeighborRef.FrequencyHz in JSON and the RR report.

NDJSON streaming + resume: new -survey-ndjson <file> appends each classified
carrier to a newline-delimited JSON file with fsync per record (crash-safe),
wired through the existing OnSignal hook. -resume preloads the frequencies
already recorded and skips them, so an interrupted survey continues where it
stopped.