### PR TITLE
hunt: generalize p25-survey features across protocols + wire them into the web

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2022,9 +2022,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		// is possible; the REST/TUI/web cockpit drives it.
 		if d.pool != nil && len(d.iqBrokers) > 0 {
 			if mgr, err := hunt.NewManager(hunt.ManagerOptions{
-				Acquire: d.buildHuntAcquirer(),
-				Bus:     d.bus,
-				Log:     log,
+				Acquire:   d.buildHuntAcquirer(),
+				Bus:       d.bus,
+				Log:       log,
+				SurveyDir: huntSurveyDir(cfg.Storage.Path),
 			}); err != nil {
 				log.Warn("daemon: hunt manager not started", "err", err)
 			} else {

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2029,7 +2029,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				log.Warn("daemon: hunt manager not started", "err", err)
 			} else {
 				d.huntMgr = mgr
-				opts.Hunt = huntCockpit{mgr: mgr, cfgPath: d.cfgPath}
+				opts.Hunt = huntCockpit{mgr: mgr, cfgPath: d.cfgPath, rrAuth: radioreference.ResolveAuth(radioreference.Auth{
+					AppKey:   firstNonEmptyStr(os.Getenv("GOPHERTRUNK_RR_KEY"), cfg.RadioReference.APIKey),
+					Username: firstNonEmptyStr(os.Getenv("GOPHERTRUNK_RR_USER"), cfg.RadioReference.Username),
+					Password: firstNonEmptyStr(os.Getenv("GOPHERTRUNK_RR_PASS"), cfg.RadioReference.Password),
+				})}
 			}
 		}
 		if d.player != nil || d.recorder != nil {

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/huntrr"
 	"github.com/MattCheramie/GopherTrunk/internal/radioreference"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/survey"
@@ -462,112 +463,28 @@ func gatherRRHints(sys *hunt.DiscoveredSystem, opts rrOptions) ([]hunt.Duplicate
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Collect candidate existing systems: explicit SIDs first, then every
-	// system registered in the given county (enriched with its identity).
-	var existing []radioreference.System
-	seen := map[int]bool{}
-	addDetails := func(sid int) {
-		if sid == 0 || seen[sid] {
-			return
-		}
-		seen[sid] = true
-		d, derr := client.GetTrsDetails(ctx, sid)
-		if derr != nil {
-			fmt.Fprintf(os.Stderr, "hunt: RadioReference getTrsDetails(%d): %v\n", sid, derr)
-			return
-		}
-		existing = append(existing, d)
-	}
+	checkSIDs := make([]int, 0, len(opts.checkSIDs))
 	for _, s := range opts.checkSIDs {
 		if sid, perr := strconv.Atoi(strings.TrimSpace(s)); perr == nil {
-			addDetails(sid)
-		}
-	}
-	if opts.countyID != 0 {
-		briefs, cerr := client.GetCountyInfo(ctx, opts.countyID)
-		if cerr != nil {
-			fmt.Fprintf(os.Stderr, "hunt: RadioReference getCountyInfo(%d): %v\n", opts.countyID, cerr)
-		}
-		for _, b := range briefs {
-			addDetails(b.SID)
+			checkSIDs = append(checkSIDs, sid)
 		}
 	}
 
-	cand := radioreference.Candidate{
-		WACN:     sys.WACN,
-		SystemID: sys.SystemID,
-		Name:     sys.DisplayName(),
+	res := huntrr.Gather(ctx, client, sys, opts.countyID, checkSIDs, func(err error) {
+		fmt.Fprintf(os.Stderr, "hunt: RadioReference %v\n", err)
+	})
+	if len(res.Hints) == 0 {
+		fmt.Fprintf(os.Stderr, "hunt: RadioReference check found no existing match among %d system(s)\n", res.Compared)
+		return nil, res.Diff
 	}
-	for _, st := range sys.Sites {
-		for _, ch := range st.ControlChannels {
-			if ch.IsControl {
-				cand.ControlChannels = append(cand.ControlChannels, ch.FrequencyHz)
-			}
-		}
-	}
-
-	rrHints := radioreference.MatchAgainst(cand, existing)
-	if len(rrHints) == 0 {
-		fmt.Fprintf(os.Stderr, "hunt: RadioReference check found no existing match among %d system(s)\n", len(existing))
-		return nil, nil
-	}
-	out := make([]hunt.DuplicateHint, 0, len(rrHints))
-	for _, h := range rrHints {
+	for _, h := range res.Hints {
 		fmt.Fprintf(os.Stderr, "hunt: possible duplicate — RR SID %d (%s): %s\n", h.SID, h.Name, h.Reason)
-		out = append(out, hunt.DuplicateHint{SID: h.SID, Name: h.Name, Reason: h.Reason, Confidence: h.Confidence})
 	}
-
-	// Cross-reference: for the strongest confident match, pull the full RR system
-	// and diff our discovered freqs/talkgroups against it (offsets + new items).
-	diff := buildRRDiff(ctx, client, sys, rrHints)
-	return out, diff
-}
-
-// rrDiffMinConfidence is the match confidence above which a diff is worth
-// fetching the full RR system for (the WACN+SYSID / control-overlap tiers).
-const rrDiffMinConfidence = 0.80
-
-// buildRRDiff fetches the strongest confident hint's full RR system and diffs
-// the discovered system against it. Returns nil on any error or when no hint is
-// confident enough (the diff is best-effort, never fatal).
-func buildRRDiff(ctx context.Context, client *radioreference.Client, sys *hunt.DiscoveredSystem, hints []radioreference.Hint) *hunt.RRDiff {
-	var top radioreference.Hint
-	for _, h := range hints {
-		if h.SID != 0 && h.Confidence >= rrDiffMinConfidence && h.Confidence > top.Confidence {
-			top = h
-		}
+	if d := res.Diff; d != nil {
+		fmt.Fprintf(os.Stderr, "hunt: RadioReference diff — %d offset(s), %d new freq(s), %d new talkgroup(s)\n",
+			len(d.FreqOffsets), len(d.FreqsNotInRR), len(d.TalkgroupsNotInRR))
 	}
-	if top.SID == 0 {
-		return nil
-	}
-	fs, err := client.GetFullSystem(ctx, top.SID)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "hunt: RadioReference getFullSystem(%d): %v\n", top.SID, err)
-		return nil
-	}
-	var rrFreqs []uint32
-	for _, st := range fs.Sites {
-		rrFreqs = append(rrFreqs, st.Frequencies...)
-	}
-	rrTGs := make([]uint32, 0, len(fs.Talkgroups))
-	for _, tg := range fs.Talkgroups {
-		rrTGs = append(rrTGs, tg.Dec)
-	}
-	d := hunt.DiffAgainstRR(sys, top.SID, nonEmptyName(fs.Name, top.Name), rrFreqs, rrTGs)
-	if d.Empty() {
-		return nil
-	}
-	fmt.Fprintf(os.Stderr, "hunt: RadioReference diff vs SID %d — %d offset(s), %d new freq(s), %d new talkgroup(s)\n",
-		top.SID, len(d.FreqOffsets), len(d.FreqsNotInRR), len(d.TalkgroupsNotInRR))
-	return &d
-}
-
-// nonEmptyName returns a if non-empty, else b.
-func nonEmptyName(a, b string) string {
-	if a != "" {
-		return a
-	}
-	return b
+	return res.Hints, res.Diff
 }
 
 // slugName lowercases a display name into a filesystem-safe stem.

--- a/cmd/gophertrunk/hunt_acquire.go
+++ b/cmd/gophertrunk/hunt_acquire.go
@@ -81,6 +81,12 @@ func (d *Daemon) buildHuntAcquirer() hunt.Acquirer {
 		}
 		broker := d.iqBrokers[serial]
 		src, sub := newBrokerIQSource(broker)
+		// Gain control is only safe when the hunt holds the SDR exclusively (a
+		// dedicated spare). On the borrowed control SDR, changing gain would
+		// disrupt the daemon's other consumers, so auto-gain stays unavailable.
+		if !borrow {
+			src.setGain = broker.SetGain
+		}
 
 		if borrow && d.cchuntSup != nil {
 			d.cchuntSup.PauseAll()

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/api"
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/huntrr"
+	"github.com/MattCheramie/GopherTrunk/internal/radioreference"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -17,6 +21,28 @@ import (
 type huntCockpit struct {
 	mgr     *hunt.Manager
 	cfgPath string
+	rrAuth  radioreference.Auth // RadioReference credentials for the cross-reference endpoint
+}
+
+// RadioReference cross-references a run's discovered system against
+// RadioReference (duplicate hints + frequency/talkgroup diff), using the
+// daemon's configured credentials and the caller-supplied comparison targets.
+func (c huntCockpit) RadioReference(id, countyID int, checkSIDs []int) (api.HuntRRReport, error) {
+	sys, ok, err := c.runSystem(id)
+	if err != nil {
+		return api.HuntRRReport{}, err
+	}
+	if !ok {
+		return api.HuntRRReport{}, fmt.Errorf("hunt: no discovered system to cross-reference yet")
+	}
+	client, err := radioreference.NewClient(c.rrAuth)
+	if err != nil {
+		return api.HuntRRReport{}, fmt.Errorf("hunt: RadioReference credentials not configured (set radioreference.* or GOPHERTRUNK_RR_KEY/USER/PASS): %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	res := huntrr.Gather(ctx, client, sys, countyID, checkSIDs, nil)
+	return api.HuntRRReport{Hints: res.Hints, Diff: res.Diff, Compared: res.Compared}, nil
 }
 
 // Status builds the REST snapshot from the manager's run state + latest map.

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -61,6 +61,9 @@ func (c huntCockpit) Status() api.HuntStatus {
 		SystemName: st.SystemName,
 		Signals:    st.Signals,
 		Error:      st.Error,
+
+		GainRecommendations: st.GainRecommendations,
+		GainNote:            st.GainNote,
 	}
 	if sys, reports, ok := c.mgr.Current(); ok {
 		out.System = sys
@@ -85,6 +88,10 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 	if req.NoSweep {
 		bands = nil
 	}
+	gainSet, err := parseGainSetDB(req.AutoGainSet)
+	if err != nil {
+		return 0, err
+	}
 
 	var proto trunking.Protocol
 	if req.Protocol != "" {
@@ -102,6 +109,8 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 		ClassifyOnly:    req.ClassifyOnly,
 		PersistSurvey:   req.PersistSurvey,
 		Resume:          req.Resume,
+		AutoGain:        req.AutoGain,
+		AutoGainSet:     gainSet,
 		MaxDwellSeconds: req.MaxDwellSeconds,
 		Serial:          req.Serial,
 		FFTSize:         req.FFTSize,

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -99,6 +100,8 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 		Protocol:        proto,
 		Survey:          req.Survey,
 		ClassifyOnly:    req.ClassifyOnly,
+		PersistSurvey:   req.PersistSurvey,
+		Resume:          req.Resume,
 		MaxDwellSeconds: req.MaxDwellSeconds,
 		Serial:          req.Serial,
 		FFTSize:         req.FFTSize,
@@ -120,6 +123,16 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 }
 
 func (c huntCockpit) Stop() bool { return c.mgr.Stop() }
+
+// huntSurveyDir derives the directory for daemon survey NDJSON persistence from
+// the configured storage path (survey files sit alongside the DB). An empty
+// storage path disables persistence (returns "").
+func huntSurveyDir(storagePath string) string {
+	if storagePath == "" {
+		return ""
+	}
+	return filepath.Dir(storagePath)
+}
 
 // ExportSurvey serializes a run's classified signal inventory in the requested
 // format (json|csv).

--- a/internal/api/handlers_hunt.go
+++ b/internal/api/handlers_hunt.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 // handleHuntStatus returns the live system-discovery snapshot. Always 200 —
@@ -160,6 +161,42 @@ func (s *Server) handleHuntCommit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "dry_run": req.DryRun, "changes": changes})
+}
+
+// handleHuntRadioReference cross-references a run's discovered system against
+// RadioReference. Query params: county_id (a RadioReference ctid) and check_sid
+// (a system id, repeatable) select the existing systems to compare against.
+func (s *Server) handleHuntRadioReference(w http.ResponseWriter, r *http.Request) {
+	if s.hunt == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "hunt not wired")
+		return
+	}
+	id, ok := huntRunID(r)
+	if !ok {
+		s.writeError(w, http.StatusBadRequest, "invalid run id")
+		return
+	}
+	countyID, _ := strconv.Atoi(r.URL.Query().Get("county_id"))
+	var checkSIDs []int
+	for _, raw := range r.URL.Query()["check_sid"] {
+		if sid, err := strconv.Atoi(strings.TrimSpace(raw)); err == nil && sid != 0 {
+			checkSIDs = append(checkSIDs, sid)
+		}
+	}
+	if countyID == 0 && len(checkSIDs) == 0 {
+		s.writeError(w, http.StatusBadRequest, "provide county_id or check_sid to compare against")
+		return
+	}
+	rep, err := s.hunt.RadioReference(id, countyID, checkSIDs)
+	if err != nil {
+		status := http.StatusBadGateway
+		if isHuntNoSuchRun(err) {
+			status = http.StatusNotFound
+		}
+		s.writeError(w, status, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, rep)
 }
 
 // huntRunID parses the optional {id} path value; empty ⇒ 0 (current). ok=false

--- a/internal/api/handlers_hunt_test.go
+++ b/internal/api/handlers_hunt_test.go
@@ -20,6 +20,8 @@ type fakeHuntCockpit struct {
 	exportErr  error
 	commitChg  []string
 	commitErr  error
+	rrReport   HuntRRReport
+	rrErr      error
 
 	lastStart  HuntStartRequest
 	lastFormat string
@@ -45,6 +47,11 @@ func (f *fakeHuntCockpit) ExportSurvey(id int, format string) ([]byte, string, e
 func (f *fakeHuntCockpit) Commit(id int, force, dryRun bool) ([]string, error) {
 	f.lastID = id
 	return f.commitChg, f.commitErr
+}
+
+func (f *fakeHuntCockpit) RadioReference(id, countyID int, checkSIDs []int) (HuntRRReport, error) {
+	f.lastID = id
+	return f.rrReport, f.rrErr
 }
 
 func TestHuntStatus_NoCockpitReturnsIdle(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -130,6 +130,12 @@ type HuntCockpit interface {
 	// Commit merges a run's discovered system into config.yaml (id 0 = latest),
 	// returning a human-readable list of changes.
 	Commit(id int, force, dryRun bool) (changes []string, err error)
+	// RadioReference cross-references a run's discovered system against
+	// RadioReference (id 0 = latest): duplicate-system hints plus a
+	// frequency/talkgroup diff. countyID and checkSIDs select the existing
+	// systems to compare against. Returns an error when RR credentials are not
+	// configured or no system has been discovered yet.
+	RadioReference(id, countyID int, checkSIDs []int) (HuntRRReport, error)
 }
 
 // ScannerCockpit is the API surface for the police-scanner subsystem:
@@ -977,6 +983,8 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/hunt/survey", s.handleHuntSurveyExport)
 	mux.HandleFunc("GET /api/v1/hunt/{id}/survey", s.handleHuntSurveyExport)
 	mux.HandleFunc("POST /api/v1/hunt/commit", s.gate(s.handleHuntCommit))
+	mux.HandleFunc("GET /api/v1/hunt/radioreference", s.handleHuntRadioReference)
+	mux.HandleFunc("GET /api/v1/hunt/{id}/radioreference", s.handleHuntRadioReference)
 	mux.HandleFunc("POST /api/v1/hunt/{id}/commit", s.gate(s.handleHuntCommit))
 
 	mux.HandleFunc("GET /api/v1/scanner", s.handleScannerStatus)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -45,8 +45,10 @@ type HuntStartRequest struct {
 	Bands           []string  `json:"bands,omitempty"`      // "low:high" MHz
 	Candidates      []float64 `json:"candidates,omitempty"` // MHz
 	NoSweep         bool      `json:"no_sweep,omitempty"`
-	Survey          bool      `json:"survey,omitempty"`        // classify+decode every carrier, not just trunking CCs
-	ClassifyOnly    bool      `json:"classify_only,omitempty"` // survey: classify, skip decoding
+	Survey          bool      `json:"survey,omitempty"`         // classify+decode every carrier, not just trunking CCs
+	ClassifyOnly    bool      `json:"classify_only,omitempty"`  // survey: classify, skip decoding
+	PersistSurvey   bool      `json:"persist_survey,omitempty"` // survey: stream carriers to NDJSON (crash-safe, resumable)
+	Resume          bool      `json:"resume,omitempty"`         // survey: skip frequencies already in the NDJSON file
 	MaxDwellSeconds float64   `json:"max_dwell_seconds,omitempty"`
 	Protocol        string    `json:"protocol,omitempty"`
 	DwellSeconds    float64   `json:"dwell_seconds,omitempty"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -26,6 +26,9 @@ type HuntStatus struct {
 	Error   string                 `json:"error,omitempty"`
 	System  *hunt.DiscoveredSystem `json:"system,omitempty"`
 	Reports []hunt.CaptureReport   `json:"reports,omitempty"`
+	// GainRecommendations / GainNote carry the result of an -auto-gain run.
+	GainRecommendations []hunt.GainRecommendation `json:"gain_recommendations,omitempty"`
+	GainNote            string                    `json:"gain_note,omitempty"`
 }
 
 // HuntRRReport is the GET /api/v1/hunt/radioreference response: the
@@ -49,6 +52,8 @@ type HuntStartRequest struct {
 	ClassifyOnly    bool      `json:"classify_only,omitempty"`  // survey: classify, skip decoding
 	PersistSurvey   bool      `json:"persist_survey,omitempty"` // survey: stream carriers to NDJSON (crash-safe, resumable)
 	Resume          bool      `json:"resume,omitempty"`         // survey: skip frequencies already in the NDJSON file
+	AutoGain        bool      `json:"auto_gain,omitempty"`      // post-run: sweep gains on locked CCs, recommend the best
+	AutoGainSet     string    `json:"auto_gain_set,omitempty"`  // optional comma-separated gain ladder in dB (e.g. "0,8.7,16.6")
 	MaxDwellSeconds float64   `json:"max_dwell_seconds,omitempty"`
 	Protocol        string    `json:"protocol,omitempty"`
 	DwellSeconds    float64   `json:"dwell_seconds,omitempty"`

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -28,6 +28,15 @@ type HuntStatus struct {
 	Reports []hunt.CaptureReport   `json:"reports,omitempty"`
 }
 
+// HuntRRReport is the GET /api/v1/hunt/radioreference response: the
+// RadioReference cross-reference of a run's discovered system — ranked
+// duplicate-system hints and a frequency/talkgroup diff vs the strongest match.
+type HuntRRReport struct {
+	Hints    []hunt.DuplicateHint `json:"hints,omitempty"`
+	Diff     *hunt.RRDiff         `json:"diff,omitempty"`
+	Compared int                  `json:"compared"` // existing RR systems compared against
+}
+
 // HuntStartRequest is the POST /api/v1/hunt/start body. Frequencies are in MHz
 // for operator convenience. With Bands set the hunt sweeps; with Candidates +
 // NoSweep it probes the listed control channels directly.

--- a/internal/hunt/accumulate.go
+++ b/internal/hunt/accumulate.go
@@ -110,6 +110,7 @@ func Accumulate(dst *DiscoveredSystem, obs Observation) {
 				Site:          n.Site,
 				ChannelID:     n.ChannelID,
 				ChannelNumber: n.ChannelNumber,
+				FrequencyHz:   n.FrequencyHz,
 			})
 		}
 		if len(t.Secondary) > 0 {

--- a/internal/hunt/accumulate_test.go
+++ b/internal/hunt/accumulate_test.go
@@ -168,6 +168,51 @@ func TestResolveNeighborFreqs(t *testing.T) {
 	}
 }
 
+// TestNeighbor_DecoderResolvedFreqSurfaces covers the protocol-generic path:
+// a decoder that resolves its neighbour frequency itself (DMR/EDACS/Motorola set
+// TopoNeighborRef.FrequencyHz; there is no advertised band plan) must have that
+// frequency carried through to the discovered system.
+func TestNeighbor_DecoderResolvedFreqSurfaces(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	r := fakeResult(440_000_000, map[string]any{"ColorCode": uint16(1)}, 100)
+	r.Topology = &siglab.TopologySnapshot{
+		RFSS: 0, Site: 2,
+		Neighbors: []siglab.NeighborRef{
+			{Site: 5, ChannelNumber: 7, FrequencyHz: 441_250_000}, // decoder-resolved
+		},
+	}
+	Accumulate(sys, Observation{Protocol: "dmr", Confidence: 0.9, Result: r})
+	sys.sortAll()
+	if got := sys.Sites[0].Neighbors[0].FrequencyHz; got != 441_250_000 {
+		t.Errorf("decoder-resolved neighbor freq = %d, want 441250000", got)
+	}
+}
+
+// TestNeighbor_FreqBackfilledAcrossObservations: the first sighting of a
+// neighbour had no resolver (freq 0); a later sighting resolved it. The merge
+// keeps the identity but backfills the frequency.
+func TestNeighbor_FreqBackfilledAcrossObservations(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	mk := func(freq uint32) *siglab.Result {
+		r := fakeResult(440_000_000, map[string]any{"ColorCode": uint16(1)}, 100)
+		r.Topology = &siglab.TopologySnapshot{
+			Site:      2,
+			Neighbors: []siglab.NeighborRef{{Site: 5, ChannelNumber: 7, FrequencyHz: freq}},
+		}
+		return r
+	}
+	Accumulate(sys, Observation{Protocol: "dmr", Confidence: 0.9, Result: mk(0)})
+	Accumulate(sys, Observation{Protocol: "dmr", Confidence: 0.9, Result: mk(441_250_000)})
+	sys.sortAll()
+	nb := sys.Sites[0].Neighbors
+	if len(nb) != 1 {
+		t.Fatalf("neighbors = %+v, want 1 (deduped)", nb)
+	}
+	if nb[0].FrequencyHz != 441_250_000 {
+		t.Errorf("neighbor freq not backfilled: got %d", nb[0].FrequencyHz)
+	}
+}
+
 func TestResolveNeighborFreqs_NoBandPlan(t *testing.T) {
 	sys := &DiscoveredSystem{
 		Sites: []DiscoveredSite{{

--- a/internal/hunt/export.go
+++ b/internal/hunt/export.go
@@ -192,8 +192,8 @@ func DiffAgainstRR(sys *DiscoveredSystem, sid int, name string, rrFreqs, rrTGs [
 // surfaced by an optional read-only RR API lookup. It is rendered into the RR
 // submission package so an operator doesn't submit a duplicate.
 type DuplicateHint struct {
-	SID        int     // RadioReference system id
-	Name       string  // existing system name
-	Reason     string  // why it matched (WACN+SYSID, overlapping CC, name/county)
-	Confidence float64 // 0..1
+	SID        int     `json:"sid"`        // RadioReference system id
+	Name       string  `json:"name"`       // existing system name
+	Reason     string  `json:"reason"`     // why it matched (WACN+SYSID, overlapping CC, name/county)
+	Confidence float64 `json:"confidence"` // 0..1
 }

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -68,6 +68,14 @@ type LiveHuntOptions struct {
 	// Resume, with PersistSurvey, preloads the frequencies already in the run's
 	// NDJSON file into SkipFreqs so an interrupted survey continues.
 	Resume bool
+	// AutoGain requests a post-run gain sweep: after the hunt/survey, each locked
+	// control channel is decoded across a set of front-end gains and the gain
+	// minimising the decode error rate is recommended (advisory; nothing is
+	// applied). Requires a gain-controllable, exclusively-held SDR — a no-op with
+	// a clear note when the SDR is shared (the daemon's borrowed control SDR).
+	AutoGain bool
+	// AutoGainSet is the gain ladder to sweep (tenths of dB); empty uses a default.
+	AutoGainSet []int
 	// SurveyDeep hands narrowband carriers the blind classifier called analog
 	// (am/nbfm/wfm ≤ NBFM bandwidth) to the authoritative siglab identify before
 	// the analog tone scan, so a trunked DMR/TETRA/MPT control channel the blind

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -60,6 +60,14 @@ type LiveHuntOptions struct {
 	// frequency is already present (a resumed survey reads these from the
 	// existing NDJSON output so it doesn't re-survey carriers it already has).
 	SkipFreqs map[uint32]struct{}
+	// PersistSurvey requests the daemon Manager stream this survey run's
+	// classified carriers to a crash-safe NDJSON file (in ManagerOptions.SurveyDir),
+	// so it can be resumed. Ignored for a plain (non-survey) hunt or when no
+	// SurveyDir is configured. The CLI persists via its own -survey-ndjson flag.
+	PersistSurvey bool
+	// Resume, with PersistSurvey, preloads the frequencies already in the run's
+	// NDJSON file into SkipFreqs so an interrupted survey continues.
+	Resume bool
 	// SurveyDeep hands narrowband carriers the blind classifier called analog
 	// (am/nbfm/wfm ≤ NBFM bandwidth) to the authoritative siglab identify before
 	// the analog tone scan, so a trunked DMR/TETRA/MPT control channel the blind

--- a/internal/hunt/manager.go
+++ b/internal/hunt/manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
 )
 
 // surveyRunKey derives a stable filename key from a run's band set / candidate
@@ -82,6 +83,8 @@ type Manager struct {
 	survey     *SignalSurvey
 	reports    []CaptureReport
 	err        string
+	gainRecs   []GainRecommendation
+	gainNote   string
 	startedAt  time.Time
 	finishedAt time.Time
 	cancel     context.CancelFunc
@@ -135,6 +138,12 @@ type RunStatus struct {
 	Signals []DetectedSignal `json:"signals,omitempty"`
 	Error   string           `json:"error,omitempty"`
 
+	// GainRecommendations is the per-control-channel result of an -auto-gain run
+	// (nil when auto-gain wasn't requested or no CC locked). GainNote explains
+	// why auto-gain produced nothing (e.g. the SDR is shared).
+	GainRecommendations []GainRecommendation `json:"gain_recommendations,omitempty"`
+	GainNote            string               `json:"gain_note,omitempty"`
+
 	StartedAt  time.Time `json:"started_at,omitempty"`
 	FinishedAt time.Time `json:"finished_at,omitempty"`
 }
@@ -159,6 +168,8 @@ func (m *Manager) Start(opts LiveHuntOptions) (int, error) {
 	m.survey = nil
 	m.reports = nil
 	m.err = ""
+	m.gainRecs = nil
+	m.gainNote = ""
 	m.startedAt = time.Now()
 	m.finishedAt = time.Time{}
 	m.sink = nil
@@ -237,13 +248,93 @@ func (m *Manager) run(ctx context.Context, id int, opts LiveHuntOptions) {
 	defer release()
 	opts.Source = src
 
+	var (
+		sys     *DiscoveredSystem
+		sv      *SignalSurvey
+		reports []CaptureReport
+		runErr  error
+	)
 	if opts.Survey {
-		sv, reports, serr := RunLiveSurvey(ctx, opts)
-		m.finish(id, surveySystem(sv), sv, reports, serr)
+		sv, reports, runErr = RunLiveSurvey(ctx, opts)
+		sys = surveySystem(sv)
+	} else {
+		sys, reports, runErr = RunLiveHunt(ctx, opts)
+	}
+
+	// Optional post-run gain sweep on the locked control channels (advisory).
+	if opts.AutoGain && runErr == nil && ctx.Err() == nil {
+		m.runAutoGain(ctx, src, opts, lockedControlChannels(sys, sv))
+	}
+
+	m.finish(id, sys, sv, reports, runErr)
+}
+
+// runAutoGain sweeps front-end gains on the locked control channels and stores
+// the recommendations (or a note explaining why none were produced). It needs a
+// gain-controllable, exclusively-held SDR; a shared SDR's source reports gain
+// control unavailable, which becomes a user-facing note rather than an error.
+func (m *Manager) runAutoGain(ctx context.Context, src IQSource, opts LiveHuntOptions, ccs []uint32) {
+	note := func(s string) {
+		m.mu.Lock()
+		m.gainNote = s
+		m.mu.Unlock()
+	}
+	if len(ccs) == 0 {
+		note("auto-gain: no locked control channel to sweep")
 		return
 	}
-	sys, reports, err := RunLiveHunt(ctx, opts)
-	m.finish(id, sys, nil, reports, err)
+	gc, ok := src.(GainSettable)
+	if !ok {
+		note("auto-gain: gain control unavailable on this SDR")
+		return
+	}
+	recs, err := AutoGainSweep(ctx, src, gc, ccs, AutoGainOptions{
+		Gains:        opts.AutoGainSet,
+		Protocol:     opts.Protocol,
+		SampleRateHz: float64(src.SampleRateHz()),
+		Log:          m.log,
+	})
+	if err != nil {
+		note(fmt.Sprintf("auto-gain unavailable: %v", err))
+		return
+	}
+	m.mu.Lock()
+	m.gainRecs = recs
+	m.mu.Unlock()
+}
+
+// lockedControlChannels collects the control-channel frequencies a run locked,
+// from the discovered system's sites and (for a survey) the trunk-control
+// signals — protocol-neutral, the input to the auto-gain sweep.
+func lockedControlChannels(sys *DiscoveredSystem, sv *SignalSurvey) []uint32 {
+	seen := map[uint32]struct{}{}
+	var out []uint32
+	add := func(hz uint32) {
+		if hz == 0 {
+			return
+		}
+		if _, ok := seen[hz]; !ok {
+			seen[hz] = struct{}{}
+			out = append(out, hz)
+		}
+	}
+	if sys != nil {
+		for _, st := range sys.Sites {
+			for _, ch := range st.ControlChannels {
+				if ch.IsControl {
+					add(ch.FrequencyHz)
+				}
+			}
+		}
+	}
+	if sv != nil {
+		for _, s := range sv.Signals {
+			if s.Class == survey.ClassTrunkControl {
+				add(s.FreqHz)
+			}
+		}
+	}
+	return out
 }
 
 // surveySystem safely extracts the discovered system from a (possibly nil)
@@ -335,6 +426,8 @@ func (m *Manager) statusLocked() RunStatus {
 	if m.survey != nil {
 		st.Signals = m.survey.Signals
 	}
+	st.GainRecommendations = m.gainRecs
+	st.GainNote = m.gainNote
 	return st
 }
 

--- a/internal/hunt/manager.go
+++ b/internal/hunt/manager.go
@@ -4,14 +4,31 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log/slog"
+	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/storage"
 )
+
+// surveyRunKey derives a stable filename key from a run's band set / candidate
+// list / forced protocol so a resumed survey reuses the same NDJSON file.
+func surveyRunKey(opts LiveHuntOptions) string {
+	h := fnv.New64a()
+	for _, b := range opts.Bands {
+		fmt.Fprintf(h, "b%d:%d;", b.LowHz, b.HighHz)
+	}
+	for _, c := range opts.Candidates {
+		fmt.Fprintf(h, "c%d;", c)
+	}
+	fmt.Fprintf(h, "p%d;", opts.Protocol)
+	return strconv.FormatUint(h.Sum64(), 16)
+}
 
 // RunState is the lifecycle of a live hunt run, surfaced to the cockpit/REST.
 type RunState string
@@ -39,6 +56,10 @@ type ManagerOptions struct {
 	Acquire Acquirer
 	Bus     *events.Bus
 	Log     *slog.Logger
+	// SurveyDir, when set, is the directory the manager streams a survey run's
+	// classified carriers into as crash-safe NDJSON (one file per band set), so a
+	// web survey can resume after an interruption. Empty disables persistence.
+	SurveyDir string
 }
 
 // Manager owns the daemon's single live-hunt run: it acquires an SDR, runs the
@@ -46,11 +67,13 @@ type ManagerOptions struct {
 // and holds the latest discovered system for export/commit. Safe for
 // concurrent use by the REST/TUI cockpit.
 type Manager struct {
-	acquire Acquirer
-	bus     *events.Bus
-	log     *slog.Logger
+	acquire   Acquirer
+	bus       *events.Bus
+	log       *slog.Logger
+	surveyDir string
 
 	mu         sync.Mutex
+	sink       *NDJSONSink // active survey persistence sink (nil when off)
 	runID      int
 	state      RunState
 	runSurvey  bool // the active/last run is a survey (drives RunStatus.Mode)
@@ -94,7 +117,7 @@ func NewManager(opts ManagerOptions) (*Manager, error) {
 	if log == nil {
 		log = slog.New(slog.DiscardHandler)
 	}
-	return &Manager{acquire: opts.Acquire, bus: opts.Bus, log: log, state: StateRunIdle}, nil
+	return &Manager{acquire: opts.Acquire, bus: opts.Bus, log: log, surveyDir: opts.SurveyDir, state: StateRunIdle}, nil
 }
 
 // RunStatus is the read snapshot the cockpit/REST renders.
@@ -138,7 +161,37 @@ func (m *Manager) Start(opts LiveHuntOptions) (int, error) {
 	m.err = ""
 	m.startedAt = time.Now()
 	m.finishedAt = time.Time{}
+	m.sink = nil
 	m.mu.Unlock()
+
+	// Survey persistence + resume: stream classified carriers to a per-band-set
+	// NDJSON file, and (when resuming) skip frequencies already recorded there.
+	var sink *NDJSONSink
+	if opts.PersistSurvey && opts.Survey && m.surveyDir != "" {
+		path := filepath.Join(m.surveyDir, "hunt-survey-"+surveyRunKey(opts)+".ndjson")
+		if opts.Resume {
+			if done, err := LoadSurveyedFreqs(path); err != nil {
+				m.log.Warn("hunt: survey resume load failed", "path", path, "err", err)
+			} else if len(done) > 0 {
+				if opts.SkipFreqs == nil {
+					opts.SkipFreqs = done
+				} else {
+					for f := range done {
+						opts.SkipFreqs[f] = struct{}{}
+					}
+				}
+				m.log.Info("hunt: resuming survey", "path", path, "skip", len(done))
+			}
+		}
+		if s, err := OpenNDJSONSink(path); err != nil {
+			m.log.Warn("hunt: survey persistence disabled", "path", path, "err", err)
+		} else {
+			sink = s
+			m.mu.Lock()
+			m.sink = s
+			m.mu.Unlock()
+		}
+	}
 
 	// Wire progress events onto the bus + the live snapshot.
 	opts.Log = m.log
@@ -154,6 +207,11 @@ func (m *Manager) Start(opts LiveHuntOptions) (int, error) {
 	// exactly like a dedicated paging receiver's.
 	opts.OnSignal = func(ds DetectedSignal) {
 		m.publish(events.KindHuntLiveCandidate, ds)
+		if sink != nil {
+			if err := sink.Write(ds); err != nil {
+				m.log.Warn("hunt: survey NDJSON write failed", "err", err)
+			}
+		}
 		for _, pg := range ds.Pages {
 			m.publish(events.KindPagerMessage, storage.PagerMessage{
 				ReceivedAt: time.Now(),
@@ -207,6 +265,10 @@ func (m *Manager) finish(id int, sys *DiscoveredSystem, sv *SignalSurvey, report
 	}
 	m.finishedAt = time.Now()
 	m.cancel = nil
+	if m.sink != nil {
+		_ = m.sink.Close()
+		m.sink = nil
+	}
 	switch {
 	case err != nil && errors.Is(err, context.Canceled):
 		m.state = StateRunStopped

--- a/internal/hunt/manager_test.go
+++ b/internal/hunt/manager_test.go
@@ -149,6 +149,34 @@ func TestManager_SurveyPersistAndResume(t *testing.T) {
 	}
 }
 
+// TestManager_AutoGainUnavailableNote: with AutoGain on a source that can't set
+// gain (the file source / a borrowed shared SDR), the run completes and records
+// a user-facing note rather than failing.
+func TestManager_AutoGainUnavailableNote(t *testing.T) {
+	src, dwell := p25Source(t)
+	mgr, err := NewManager(ManagerOptions{
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) { return src, func() {}, nil },
+		Bus:     events.NewBus(256),
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	if _, err := mgr.Start(LiveHuntOptions{
+		Survey: true, AutoGain: true,
+		Candidates: []uint32{851_000_000}, DwellSeconds: dwell, MinConfidence: 0.3,
+	}); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitUntil(t, 15*time.Second, func() bool { return !mgr.Status().Running })
+	st := mgr.Status()
+	if st.State != StateRunDone {
+		t.Fatalf("state = %q, want done", st.State)
+	}
+	if st.GainNote == "" {
+		t.Error("expected a gain note when gain control is unavailable")
+	}
+}
+
 func TestManager_StartRunsAndMapsSystem(t *testing.T) {
 	bus := events.NewBus(256)
 	sub := bus.Subscribe()

--- a/internal/hunt/manager_test.go
+++ b/internal/hunt/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -96,6 +97,55 @@ func TestManager_SurveyModeReportsSignals(t *testing.T) {
 	}
 	if !sawCandidate {
 		t.Error("expected a KindHuntLiveCandidate event on the bus")
+	}
+}
+
+// TestManager_SurveyPersistAndResume runs a survey with PersistSurvey into a
+// SurveyDir, confirms an NDJSON file is written, then runs again with Resume and
+// confirms the already-surveyed candidate is skipped.
+func TestManager_SurveyPersistAndResume(t *testing.T) {
+	dir := t.TempDir()
+	src, dwell := p25Source(t)
+	mgr, err := NewManager(ManagerOptions{
+		Acquire:   func(context.Context, LiveHuntOptions) (IQSource, func(), error) { return src, func() {}, nil },
+		Bus:       events.NewBus(256),
+		SurveyDir: dir,
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	opts := LiveHuntOptions{
+		Survey: true, PersistSurvey: true,
+		Candidates: []uint32{851_000_000}, DwellSeconds: dwell, MinConfidence: 0.3,
+	}
+	if _, err := mgr.Start(opts); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitUntil(t, 15*time.Second, func() bool { return !mgr.Status().Running })
+
+	files, _ := filepath.Glob(filepath.Join(dir, "hunt-survey-*.ndjson"))
+	if len(files) != 1 {
+		t.Fatalf("ndjson files = %v, want exactly 1", files)
+	}
+	done, err := LoadSurveyedFreqs(files[0])
+	if err != nil {
+		t.Fatalf("LoadSurveyedFreqs: %v", err)
+	}
+	if _, ok := done[851_000_000]; !ok {
+		t.Fatalf("surveyed freqs = %v, want 851000000 recorded", done)
+	}
+
+	// Resume: the same band/candidate set keys the same file; the lone candidate
+	// is already surveyed, so the run skips it and reports no signals.
+	src2, _ := p25Source(t)
+	mgr.acquire = func(context.Context, LiveHuntOptions) (IQSource, func(), error) { return src2, func() {}, nil }
+	opts.Resume = true
+	if _, err := mgr.Start(opts); err != nil {
+		t.Fatalf("Start resume: %v", err)
+	}
+	waitUntil(t, 15*time.Second, func() bool { return !mgr.Status().Running })
+	if n := len(mgr.Status().Signals); n != 0 {
+		t.Errorf("resumed run surveyed %d signal(s), want 0 (candidate already done)", n)
 	}
 }
 

--- a/internal/hunt/system.go
+++ b/internal/hunt/system.go
@@ -187,8 +187,14 @@ func (s *DiscoveredSystem) addTalkgroup(dec uint32, encrypted bool, at time.Time
 // the neighbor's (RFSS, Site).
 func (s *DiscoveredSystem) addNeighbor(rfss, siteID uint8, n NeighborRef) {
 	site := s.site(rfss, siteID)
-	for _, e := range site.Neighbors {
-		if e.RFSS == n.RFSS && e.Site == n.Site {
+	for i := range site.Neighbors {
+		if site.Neighbors[i].RFSS == n.RFSS && site.Neighbors[i].Site == n.Site {
+			// First identity wins, but backfill a frequency once a later
+			// observation resolves one (the decoder may not have had a band-plan
+			// resolver on the first sighting).
+			if site.Neighbors[i].FrequencyHz == 0 && n.FrequencyHz != 0 {
+				site.Neighbors[i].FrequencyHz = n.FrequencyHz
+			}
 			return
 		}
 	}

--- a/internal/huntrr/huntrr.go
+++ b/internal/huntrr/huntrr.go
@@ -1,0 +1,127 @@
+// Package huntrr cross-references a discovered trunked system against
+// RadioReference: duplicate-system hints plus a frequency/talkgroup diff
+// (offsets and items not yet in RR). It bridges the hunt package (which must
+// stay free of the radioreference import) and the radioreference client, so the
+// CLI and the daemon/web run identical logic. The diff math itself lives in
+// hunt (DiffAgainstRR, over primitive slices); this package only orchestrates
+// the RR lookups and flattening.
+package huntrr
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/radioreference"
+)
+
+// diffMinConfidence is the match confidence above which fetching the full RR
+// system for a detailed diff is worthwhile (the WACN+SYSID / control-overlap
+// tiers of radioreference.MatchAgainst).
+const diffMinConfidence = 0.80
+
+// Result is the RadioReference cross-reference for one discovered system.
+type Result struct {
+	Hints    []hunt.DuplicateHint // ranked possible existing systems
+	Diff     *hunt.RRDiff         // freq/talkgroup diff vs the strongest match, or nil
+	Compared int                  // how many existing RR systems were compared against
+}
+
+// Gather collects candidate existing systems (the explicit checkSIDs first,
+// then every system registered in countyID when non-zero), matches the
+// discovered system against them, and — for the strongest confident match —
+// fetches its full detail and diffs frequencies/talkgroups. Every RR call is
+// best-effort: a per-call error is passed to onErr (which may be nil) and that
+// source is skipped, never aborting the whole gather.
+func Gather(ctx context.Context, client *radioreference.Client, sys *hunt.DiscoveredSystem, countyID int, checkSIDs []int, onErr func(error)) Result {
+	report := func(err error) {
+		if onErr != nil && err != nil {
+			onErr(err)
+		}
+	}
+
+	var existing []radioreference.System
+	seen := map[int]bool{}
+	add := func(sid int) {
+		if sid == 0 || seen[sid] {
+			return
+		}
+		seen[sid] = true
+		d, err := client.GetTrsDetails(ctx, sid)
+		if err != nil {
+			report(fmt.Errorf("getTrsDetails(%d): %w", sid, err))
+			return
+		}
+		existing = append(existing, d)
+	}
+	for _, sid := range checkSIDs {
+		add(sid)
+	}
+	if countyID != 0 {
+		briefs, err := client.GetCountyInfo(ctx, countyID)
+		if err != nil {
+			report(fmt.Errorf("getCountyInfo(%d): %w", countyID, err))
+		}
+		for _, b := range briefs {
+			add(b.SID)
+		}
+	}
+
+	cand := radioreference.Candidate{
+		WACN:     sys.WACN,
+		SystemID: sys.SystemID,
+		Name:     sys.DisplayName(),
+	}
+	for _, st := range sys.Sites {
+		for _, ch := range st.ControlChannels {
+			if ch.IsControl {
+				cand.ControlChannels = append(cand.ControlChannels, ch.FrequencyHz)
+			}
+		}
+	}
+
+	hints := radioreference.MatchAgainst(cand, existing)
+	res := Result{Compared: len(existing)}
+	for _, h := range hints {
+		res.Hints = append(res.Hints, hunt.DuplicateHint{SID: h.SID, Name: h.Name, Reason: h.Reason, Confidence: h.Confidence})
+	}
+	res.Diff = buildDiff(ctx, client, sys, hints, report)
+	return res
+}
+
+// buildDiff fetches the strongest confident hint's full RR system and diffs the
+// discovered system against it. Returns nil on any error, when no hint clears
+// diffMinConfidence, or when the diff is empty.
+func buildDiff(ctx context.Context, client *radioreference.Client, sys *hunt.DiscoveredSystem, hints []radioreference.Hint, report func(error)) *hunt.RRDiff {
+	var top radioreference.Hint
+	for _, h := range hints {
+		if h.SID != 0 && h.Confidence >= diffMinConfidence && h.Confidence > top.Confidence {
+			top = h
+		}
+	}
+	if top.SID == 0 {
+		return nil
+	}
+	fs, err := client.GetFullSystem(ctx, top.SID)
+	if err != nil {
+		report(fmt.Errorf("getFullSystem(%d): %w", top.SID, err))
+		return nil
+	}
+	var rrFreqs []uint32
+	for _, st := range fs.Sites {
+		rrFreqs = append(rrFreqs, st.Frequencies...)
+	}
+	rrTGs := make([]uint32, 0, len(fs.Talkgroups))
+	for _, tg := range fs.Talkgroups {
+		rrTGs = append(rrTGs, tg.Dec)
+	}
+	name := fs.Name
+	if name == "" {
+		name = top.Name
+	}
+	d := hunt.DiffAgainstRR(sys, top.SID, name, rrFreqs, rrTGs)
+	if d.Empty() {
+		return nil
+	}
+	return &d
+}

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -369,6 +369,26 @@ func (c *ControlChannel) resolveLCN(lcn uint16) (uint32, bool) {
 	return freq, true
 }
 
+// NeighborFrequency resolves an adjacent-site LCN to its downlink frequency
+// using the configured band-plan resolver, quietly: unlike resolveLCN, an
+// unresolved neighbour is informational (not a dropped grant) so no decode.error
+// event is published. Returns false when no resolver is set or the LCN is
+// outside the plan. The hunt topology snapshot uses this to surface neighbour
+// control-channel frequencies.
+func (c *ControlChannel) NeighborFrequency(lcn uint16) (uint32, bool) {
+	c.resolverMu.RLock()
+	resolver := c.resolver
+	c.resolverMu.RUnlock()
+	if resolver == nil {
+		return 0, false
+	}
+	freq, err := resolver.Frequency(lcn)
+	if err != nil {
+		return 0, false
+	}
+	return freq, true
+}
+
 func (c *ControlChannel) maybeLock(s LockState) {
 	if !c.locked || c.last != s {
 		c.locked = true

--- a/internal/radio/edacs/control.go
+++ b/internal/radio/edacs/control.go
@@ -206,6 +206,22 @@ func (c *ControlChannel) Ingest(w CCW) {
 // sites) accumulated from the control channel, for the hunt/discovery layer.
 func (c *ControlChannel) Topology() TopologyConfig { return c.topo.snapshot() }
 
+// NeighborFrequency resolves an adjacent-site LCN to its downlink frequency via
+// the configured band-plan resolver, quietly (no log/event on a miss — an
+// unresolved neighbour is informational). Returns false when no resolver is set
+// or the LCN is outside the plan. The hunt topology snapshot uses this to
+// surface neighbour control-channel frequencies.
+func (c *ControlChannel) NeighborFrequency(lcn uint8) (uint32, bool) {
+	if c.resolver == nil {
+		return 0, false
+	}
+	hz, err := c.resolver.Frequency(lcn)
+	if err != nil {
+		return 0, false
+	}
+	return hz, true
+}
+
 func (c *ControlChannel) publishGrant(g GroupVoiceGrant) {
 	if c.bus == nil {
 		return

--- a/internal/radio/motorola/control.go
+++ b/internal/radio/motorola/control.go
@@ -145,6 +145,22 @@ func (c *ControlChannel) Ingest(o OSW) {
 // sites) accumulated from the control channel, for the hunt/discovery layer.
 func (c *ControlChannel) Topology() TopologyConfig { return c.topo.snapshot() }
 
+// NeighborFrequency resolves an adjacent-site LCN to its downlink frequency via
+// the configured band-plan resolver, quietly (no log/event on a miss — an
+// unresolved neighbour is informational). Returns false when no resolver is set
+// or the LCN is outside the plan. The hunt topology snapshot uses this to
+// surface neighbour control-channel frequencies.
+func (c *ControlChannel) NeighborFrequency(lcn uint16) (uint32, bool) {
+	if c.resolver == nil {
+		return 0, false
+	}
+	hz, err := c.resolver.Frequency(lcn)
+	if err != nil {
+		return 0, false
+	}
+	return hz, true
+}
+
 func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant) {
 	if c.bus == nil {
 		return

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -707,10 +707,14 @@ func (p *dmrPipeline) TopologySnapshot() *trunking.TopologySnapshot {
 		ColorCode: t.ColorCode,
 	}
 	for _, n := range t.Neighbors {
-		snap.Neighbors = append(snap.Neighbors, trunking.TopoNeighborRef{
+		ref := trunking.TopoNeighborRef{
 			Site:          uint8(n.SiteID),
 			ChannelNumber: n.LCN,
-		})
+		}
+		if hz, ok := p.cc.NeighborFrequency(n.LCN); ok {
+			ref.FrequencyHz = hz
+		}
+		snap.Neighbors = append(snap.Neighbors, ref)
 	}
 	return snap
 }
@@ -914,10 +918,14 @@ func (p *edacsPipeline) TopologySnapshot() *trunking.TopologySnapshot {
 	t := p.cc.Topology()
 	snap := &trunking.TopologySnapshot{SystemID: uint32(t.SystemID)}
 	for _, n := range t.Neighbors {
-		snap.Neighbors = append(snap.Neighbors, trunking.TopoNeighborRef{
+		ref := trunking.TopoNeighborRef{
 			Site:          uint8(n.SiteID),
 			ChannelNumber: uint16(n.LCN),
-		})
+		}
+		if hz, ok := p.cc.NeighborFrequency(n.LCN); ok {
+			ref.FrequencyHz = hz
+		}
+		snap.Neighbors = append(snap.Neighbors, ref)
 	}
 	return snap
 }
@@ -973,10 +981,14 @@ func (p *motorolaPipeline) TopologySnapshot() *trunking.TopologySnapshot {
 	t := p.cc.Topology()
 	snap := &trunking.TopologySnapshot{SystemID: uint32(t.SystemID)}
 	for _, n := range t.Neighbors {
-		snap.Neighbors = append(snap.Neighbors, trunking.TopoNeighborRef{
+		ref := trunking.TopoNeighborRef{
 			Site:          uint8(n.SiteID),
 			ChannelNumber: n.LCN,
-		})
+		}
+		if hz, ok := p.cc.NeighborFrequency(n.LCN); ok {
+			ref.FrequencyHz = hz
+		}
+		snap.Neighbors = append(snap.Neighbors, ref)
 	}
 	return snap
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   ConfigListResponse,
   DeviceDTO,
   Health,
+  HuntRRReport,
   HuntStatus,
   Mutations,
   RIDDTO,
@@ -198,6 +199,15 @@ export const api = {
   scanner: (c: ClientConfig) =>
     request<ScannerStatusDTO>(c, "GET", "/api/v1/scanner"),
   hunt: (c: ClientConfig) => request<HuntStatus>(c, "GET", "/api/v1/hunt"),
+  huntRadioReference: (
+    c: ClientConfig,
+    params: { countyID?: number; checkSIDs?: number[] },
+  ) => {
+    const q = new URLSearchParams();
+    if (params.countyID) q.set("county_id", String(params.countyID));
+    for (const sid of params.checkSIDs ?? []) q.append("check_sid", String(sid));
+    return request<HuntRRReport>(c, "GET", `/api/v1/hunt/radioreference?${q.toString()}`);
+  },
   audio: (c: ClientConfig) =>
     request<AudioStatusDTO>(c, "GET", "/api/v1/audio"),
   metricsText: (c: ClientConfig) =>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -183,6 +183,29 @@ export interface DiscoveredSite {
   neighbors?: NeighborRef[];
 }
 
+// HuntRRReport mirrors api.HuntRRReport — the RadioReference cross-reference of
+// a discovered system: duplicate-system hints + a frequency/talkgroup diff.
+export interface HuntRRReport {
+  hints?: DuplicateHint[];
+  diff?: RRDiff;
+  compared: number;
+}
+
+export interface DuplicateHint {
+  sid: number;
+  name: string;
+  reason: string;
+  confidence: number;
+}
+
+export interface RRDiff {
+  sid: number;
+  name: string;
+  freq_offsets?: { discovered_hz: number; rr_hz: number; delta_hz: number }[];
+  freqs_not_in_rr?: number[];
+  talkgroups_not_in_rr?: number[];
+}
+
 // NeighborRef mirrors hunt.NeighborRef — an adjacent site advertised by the
 // control channel. frequency_hz is set once the band plan / LCN resolver maps
 // the channel to a downlink frequency.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -265,6 +265,8 @@ export interface HuntStartRequest {
   no_sweep?: boolean;
   survey?: boolean;
   classify_only?: boolean;
+  persist_survey?: boolean;
+  resume?: boolean;
   max_dwell_seconds?: number;
   protocol?: string;
   dwell_seconds?: number;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -146,6 +146,17 @@ export interface HuntStatus {
   // Per-capture decode results from the live run, so the Hunt panel can
   // show what each surveyed candidate decoded to (or why it was skipped).
   reports?: CaptureReport[];
+  gain_recommendations?: GainRecommendation[];
+  gain_note?: string;
+}
+
+// GainRecommendation mirrors hunt.GainRecommendation — the best front-end gain
+// found for one control channel by an auto-gain sweep.
+export interface GainRecommendation {
+  freq_hz: number;
+  best_gain_tenth_db: number;
+  best_error_rate: number;
+  locked: boolean;
 }
 
 // CaptureReport mirrors hunt.CaptureReport — one candidate's decode outcome
@@ -267,6 +278,8 @@ export interface HuntStartRequest {
   classify_only?: boolean;
   persist_survey?: boolean;
   resume?: boolean;
+  auto_gain?: boolean;
+  auto_gain_set?: string;
   max_dwell_seconds?: number;
   protocol?: string;
   dwell_seconds?: number;

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -179,6 +179,19 @@ export interface DiscoveredSite {
   site_name?: string;
   county?: string;
   control_channels?: { frequency_hz: number; is_control?: boolean; confidence?: number }[];
+  secondary?: number[];
+  neighbors?: NeighborRef[];
+}
+
+// NeighborRef mirrors hunt.NeighborRef — an adjacent site advertised by the
+// control channel. frequency_hz is set once the band plan / LCN resolver maps
+// the channel to a downlink frequency.
+export interface NeighborRef {
+  rfss?: number;
+  site?: number;
+  channel_id?: number;
+  channel_number?: number;
+  frequency_hz?: number;
 }
 
 // DMRGrantObservedDTO mirrors api.DMRGrantObservedDTO — a raw DMR Tier III

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -79,6 +79,7 @@ export function Hunt() {
   const [classifyOnly, setClassifyOnly] = useState(false);
   const [persistSurvey, setPersistSurvey] = useState(false);
   const [resume, setResume] = useState(false);
+  const [autoGain, setAutoGain] = useState(false);
   const [sortBy, setSortBy] = useState<"freq" | "class" | "snr">("freq");
   const [rrCounty, setRRCounty] = useState("");
   const [rrSID, setRRSID] = useState("");
@@ -121,6 +122,7 @@ export function Hunt() {
         classify_only: (survey && classifyOnly) || undefined,
         persist_survey: (survey && persistSurvey) || undefined,
         resume: (survey && persistSurvey && resume) || undefined,
+        auto_gain: autoGain || undefined,
         name: name || undefined,
         state: stateCode || undefined,
         county: county || undefined,
@@ -362,6 +364,10 @@ export function Hunt() {
             Resume — skip frequencies already surveyed in that file
           </label>
         ) : null}
+        <label className="hunt-survey-toggle">
+          <input type="checkbox" checked={autoGain} onChange={(e) => setAutoGain(e.target.checked)} />
+          Auto-gain — after the run, recommend the best front-end gain (needs a dedicated SDR)
+        </label>
         <div className="hunt-buttons">
           <button onClick={start} disabled={!canMutate || running}>
             Start hunt
@@ -458,6 +464,33 @@ export function Hunt() {
           ) : null}
         </section>
       ) : null}
+
+      {status?.gain_recommendations && status.gain_recommendations.length > 0 ? (
+        <section className="hunt-gain">
+          <h3>Auto-gain recommendations</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Control channel</th>
+                <th>Best gain (dB)</th>
+                <th>Error rate</th>
+                <th>Locked</th>
+              </tr>
+            </thead>
+            <tbody>
+              {status.gain_recommendations.map((g, i) => (
+                <tr key={i}>
+                  <td>{(g.freq_hz / 1e6).toFixed(4)} MHz</td>
+                  <td>{(g.best_gain_tenth_db / 10).toFixed(1)}</td>
+                  <td>{g.best_error_rate.toFixed(3)}</td>
+                  <td>{g.locked ? "yes" : "no"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
+      {status?.gain_note ? <p className="hint">Auto-gain: {status.gain_note}</p> : null}
 
       {!canMutate ? (
         <p className="hint">Mutations are read-only on this connection (no auth token).</p>

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -77,6 +77,8 @@ export function Hunt() {
   const [protocol, setProtocol] = useState("");
   const [survey, setSurvey] = useState(false);
   const [classifyOnly, setClassifyOnly] = useState(false);
+  const [persistSurvey, setPersistSurvey] = useState(false);
+  const [resume, setResume] = useState(false);
   const [sortBy, setSortBy] = useState<"freq" | "class" | "snr">("freq");
   const [rrCounty, setRRCounty] = useState("");
   const [rrSID, setRRSID] = useState("");
@@ -117,6 +119,8 @@ export function Hunt() {
         no_sweep: candList.length > 0 && bandList.length === 0,
         survey: survey || undefined,
         classify_only: (survey && classifyOnly) || undefined,
+        persist_survey: (survey && persistSurvey) || undefined,
+        resume: (survey && persistSurvey && resume) || undefined,
         name: name || undefined,
         state: stateCode || undefined,
         county: county || undefined,
@@ -340,6 +344,22 @@ export function Hunt() {
               onChange={(e) => setClassifyOnly(e.target.checked)}
             />
             Classify only — skip decoding (fast inventory)
+          </label>
+        ) : null}
+        {survey ? (
+          <label className="hunt-survey-toggle">
+            <input
+              type="checkbox"
+              checked={persistSurvey}
+              onChange={(e) => setPersistSurvey(e.target.checked)}
+            />
+            Persist survey — stream carriers to a crash-safe NDJSON file
+          </label>
+        ) : null}
+        {survey && persistSurvey ? (
+          <label className="hunt-survey-toggle">
+            <input type="checkbox" checked={resume} onChange={(e) => setResume(e.target.checked)} />
+            Resume — skip frequencies already surveyed in that file
           </label>
         ) : null}
         <div className="hunt-buttons">

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -170,6 +170,7 @@ export function Hunt() {
                 <th>Site</th>
                 <th>RFSS</th>
                 <th>Control channels</th>
+                <th>Neighbors</th>
               </tr>
             </thead>
             <tbody>
@@ -181,6 +182,18 @@ export function Hunt() {
                     {site.control_channels && site.control_channels.length > 0
                       ? site.control_channels
                           .map((c) => `${(c.frequency_hz / 1e6).toFixed(4)}${c.is_control ? "*" : ""}`)
+                          .join(", ")
+                      : "—"}
+                  </td>
+                  <td>
+                    {site.neighbors && site.neighbors.length > 0
+                      ? site.neighbors
+                          .map((n) => {
+                            const id = `${n.rfss ?? 0}/${n.site ?? 0}`;
+                            return n.frequency_hz
+                              ? `${id} @ ${(n.frequency_hz / 1e6).toFixed(4)}`
+                              : id;
+                          })
                           .join(", ")
                       : "—"}
                   </td>

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import { writes } from "../api/write";
-import type { CaptureReport, DetectedSignal, HuntStatus } from "../api/types";
+import type {
+  CaptureReport,
+  DetectedSignal,
+  HuntRRReport,
+  HuntStatus,
+} from "../api/types";
 import { selectCanMutate, selectClientConfig, useShared } from "../store/shared";
 
 const POLL_INTERVAL_MS = 2_000;
@@ -73,6 +78,10 @@ export function Hunt() {
   const [survey, setSurvey] = useState(false);
   const [classifyOnly, setClassifyOnly] = useState(false);
   const [sortBy, setSortBy] = useState<"freq" | "class" | "snr">("freq");
+  const [rrCounty, setRRCounty] = useState("");
+  const [rrSID, setRRSID] = useState("");
+  const [rrReport, setRRReport] = useState<HuntRRReport | null>(null);
+  const [rrBusy, setRRBusy] = useState(false);
 
   useEffect(() => {
     let cancel = false;
@@ -124,6 +133,28 @@ export function Hunt() {
       await writes.huntStop(cfg);
     } catch (e: unknown) {
       setError(e instanceof Error ? `stop hunt failed: ${e.message}` : "stop hunt failed");
+    }
+  }
+
+  async function checkRR() {
+    setRRBusy(true);
+    try {
+      const countyID = parseInt(rrCounty.trim(), 10);
+      const checkSIDs = rrSID
+        .split(",")
+        .map((s) => parseInt(s.trim(), 10))
+        .filter((n) => Number.isFinite(n) && n > 0);
+      const rep = await api.huntRadioReference(cfg, {
+        countyID: Number.isFinite(countyID) && countyID > 0 ? countyID : undefined,
+        checkSIDs,
+      });
+      setRRReport(rep);
+    } catch (e: unknown) {
+      setError(
+        e instanceof Error ? `RadioReference check failed: ${e.message}` : "RadioReference check failed",
+      );
+    } finally {
+      setRRBusy(false);
     }
   }
 
@@ -335,6 +366,76 @@ export function Hunt() {
           <span>Survey:</span>
           <a href={`${cfg.baseURL}/api/v1/hunt/survey?format=json`}>signals JSON</a>
           <a href={`${cfg.baseURL}/api/v1/hunt/survey?format=csv`}>signals CSV</a>
+        </section>
+      ) : null}
+
+      {status?.system_name ? (
+        <section className="hunt-rr">
+          <h3>RadioReference</h3>
+          <div className="hunt-rr-controls">
+            <label>
+              County id (ctid)
+              <input value={rrCounty} onChange={(e) => setRRCounty(e.target.value)} placeholder="e.g. 1234" />
+            </label>
+            <label>
+              or System id(s)
+              <input value={rrSID} onChange={(e) => setRRSID(e.target.value)} placeholder="comma-separated SIDs" />
+            </label>
+            <button onClick={checkRR} disabled={rrBusy || (!rrCounty.trim() && !rrSID.trim())}>
+              {rrBusy ? "Checking…" : "Cross-reference"}
+            </button>
+          </div>
+          {rrReport ? (
+            <div className="hunt-rr-result">
+              {rrReport.hints && rrReport.hints.length > 0 ? (
+                <>
+                  <h4>Possible existing systems</h4>
+                  <ul>
+                    {rrReport.hints.map((h, i) => (
+                      <li key={i}>
+                        SID {h.sid} — {h.name} ({(h.confidence * 100).toFixed(0)}%): {h.reason}
+                      </li>
+                    ))}
+                  </ul>
+                </>
+              ) : (
+                <p>No existing match among {rrReport.compared} system(s).</p>
+              )}
+              {rrReport.diff ? (
+                <>
+                  <h4>
+                    Differences vs RadioReference (SID {rrReport.diff.sid}, {rrReport.diff.name})
+                  </h4>
+                  {rrReport.diff.freq_offsets && rrReport.diff.freq_offsets.length > 0 ? (
+                    <div>
+                      <strong>Frequency offsets:</strong>
+                      <ul>
+                        {rrReport.diff.freq_offsets.map((o, i) => (
+                          <li key={i}>
+                            {(o.discovered_hz / 1e6).toFixed(4)} vs {(o.rr_hz / 1e6).toFixed(4)} MHz (
+                            {o.delta_hz > 0 ? "+" : ""}
+                            {(o.delta_hz / 1e3).toFixed(2)} kHz)
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                  {rrReport.diff.freqs_not_in_rr && rrReport.diff.freqs_not_in_rr.length > 0 ? (
+                    <div>
+                      <strong>Frequencies not in RadioReference:</strong>{" "}
+                      {rrReport.diff.freqs_not_in_rr.map((f) => (f / 1e6).toFixed(4)).join(", ")} MHz
+                    </div>
+                  ) : null}
+                  {rrReport.diff.talkgroups_not_in_rr && rrReport.diff.talkgroups_not_in_rr.length > 0 ? (
+                    <div>
+                      <strong>Talkgroups not in RadioReference:</strong>{" "}
+                      {rrReport.diff.talkgroups_not_in_rr.join(", ")}
+                    </div>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+          ) : null}
         </section>
       ) : null}
 


### PR DESCRIPTION
Generalizes the three p25-survey-derived hunt features (neighbor resolution, NDJSON/resume, RR diff, auto-gain) beyond P25 and wires them into the web UI.

## Protocol genericity
- Neighbor frequency resolution now works for **DMR Tier III, EDACS, and Motorola** (each via its existing band-plan `Resolver`), not just P25; `addNeighbor` carries/backfills decoder-resolved frequencies. **TETRA** has no neighbor-cell accumulation yet (documented); the generic path picks it up once that decoding is added.
- Auto-gain and the RR diff were already protocol-neutral.

## Web interface
- Sites table renders resolved neighbor sites.
- **RadioReference cross-reference**: shared `internal/huntrr` package (CLI + daemon use it), new `GET /api/v1/hunt/radioreference` endpoint, Hunt-panel section (duplicate hints + offset / not-in-RR / new-talkgroup diff).
- **Daemon survey persistence** (crash-safe NDJSON) + **resume**, with panel toggles.
- **Auto-gain** usable from a web hunt, guarded by SDR exclusivity (gain control only on a dedicated SDR; a clear note on the shared control SDR); recommendations surface on `HuntStatus` and in the panel.

## Verification
`gofmt` / `go vet ./...` / `go build ./...` clean; `go test ./...` green; `web/` `tsc --noEmit` clean. New tests: cross-protocol neighbor resolution + backfill, daemon NDJSON persist/resume, auto-gain unavailable-note path.

Licensing: p25-survey is GPLv3, GopherTrunk is Apache-2.0 — this is an independent reimplementation of the ideas, no code copied.

https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK

---
_Generated by [Claude Code](https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK)_