### PR TITLE
siglab: recover TETRA colour code from the BSCH during blind identify (#648)

### DIFF
--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -315,6 +315,37 @@ func (c *ControlChannel) decodeSB(p *processState, L int) {
 	c.maybeLock(ls)
 }
 
+// RecoverColourCode scans a dibit stream for a synchronisation burst and
+// returns the cell's extended (30-bit) colour code recovered from its BSCH.
+// The BSCH is scrambled with colour code 0 (§8.2.5.2), so this works with no
+// prior knowledge of the cell — it is how a cold receiver (and the blind
+// identify scorer) learns the scrambling code needed to descramble the SCH/HD
+// SYSINFO bursts that follow. Returns false when no SB burst with a CRC-valid
+// BSCH is present. Stateless: it correlates the synchronisation training
+// sequence itself rather than relying on the live Process state machine.
+func RecoverColourCode(stream []uint8) (uint32, bool) {
+	sts := SyncTrainingDibits()
+	det := NewSyncDetector(sts, 3)
+	hits, _ := det.Process(nil, stream, 0)
+	for _, trailing := range hits {
+		L := trailing - (len(sts) - 1) // leading dibit index of the STS
+		if L-sbBSCHDibits < 0 || L > len(stream) {
+			continue // BSCH look-back runs off the front of the buffer
+		}
+		bsch := stream[L-sbBSCHDibits : L]
+		for rot := uint8(0); rot < 4; rot++ {
+			recovered, ok := DecodeBSCH(TetraDibitsToBits(rotateDibits(bsch, rot)))
+			if !ok {
+				continue
+			}
+			if s, ok := ParseSyncPDU(recovered); ok {
+				return s.ExtendedColourCode(), true
+			}
+		}
+	}
+	return 0, false
+}
+
 // dispatchSlice turns the collected post-sync dibit slice into a
 // PDU and forwards it to Ingest. Under ChannelCodingOff the
 // slice is interpreted as raw type-1 bits; under ChannelCodingOn

--- a/internal/radio/tetra/process_test.go
+++ b/internal/radio/tetra/process_test.go
@@ -8,6 +8,43 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 )
 
+// TestRecoverColourCode builds a synchronisation burst (BSCH + STS) carrying a
+// known cell colour code and confirms RecoverColourCode pulls the extended
+// colour code back out with no prior configuration — the path blind identify
+// relies on to descramble SCH/HD (issue #648).
+func TestRecoverColourCode(t *testing.T) {
+	const (
+		cc6        = 0x2D
+		mcc uint16 = 0x0CE
+		mnc uint16 = 0x1234
+	)
+	want := ExtendedColourCode(mcc, mnc, cc6)
+
+	syncInfo := make([]byte, 60)
+	putBits(syncInfo, 4, 6, cc6)
+	putBits(syncInfo, 31, 10, uint32(mcc))
+	putBits(syncInfo, 41, 14, uint32(mnc))
+	bschDibits := TetraBitsToDibits(EncodeBSCH(syncInfo))
+
+	var stream []uint8
+	stream = append(stream, bschDibits...)           // [0,60) BSCH
+	stream = append(stream, SyncTrainingDibits()...) // [60,79) STS
+	stream = append(stream, make([]uint8, 40)...)    // trailing pad
+
+	got, ok := RecoverColourCode(stream)
+	if !ok {
+		t.Fatal("RecoverColourCode found no BSCH in a clean SB burst")
+	}
+	if got != want {
+		t.Errorf("recovered colour code = %#x, want %#x", got, want)
+	}
+
+	// A stream with no synchronisation burst yields nothing.
+	if _, ok := RecoverColourCode(make([]uint8, 200)); ok {
+		t.Error("RecoverColourCode reported a colour code on an empty stream")
+	}
+}
+
 // TestProcessLocksOnSystemBroadcastAfterSync builds a dibit stream
 // of 50 padding dibits + 38 normal training-sequence dibits + 48
 // dibits whose raw bits decode to an MLE-SYSINFO PDU with known

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -503,7 +503,12 @@ func newTETRAPipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		cc.SetExpectedChannel(ch)
 		cc.SetColourCode(opts.System.TETRAColourCode)
 		if opts.System.TETRAColourCode == 0 && ch != tetra.ChannelBSCH {
-			opts.Log.Warn("ccdecoder: tetra_channel_coding=on with zero tetra_colour_code on non-BSCH channel; descrambler will not lock",
+			// Not fatal: the decoder auto-acquires the colour code from a BSCH
+			// synchronisation burst (scrambled with colour 0) and then descrambles
+			// the SCH/HD stream (issue #553). Setting tetra_colour_code only avoids
+			// the cold-start wait for the first SB burst. Debug, not Warn — this is
+			// the normal state during blind identify (#648).
+			opts.Log.Debug("ccdecoder: tetra zero colour code; will auto-acquire from the BSCH synchronisation burst",
 				"system", opts.SystemName, "channel", opts.System.TETRAChannel)
 		}
 	}

--- a/internal/siglab/fec.go
+++ b/internal/siglab/fec.go
@@ -248,6 +248,16 @@ func tetraFEC(stream []uint8, land *SyncLandscape, sys trunking.System) []FECSta
 	const schDibits = 108 // 216 type-5 bits
 	syncLen := land.SyncLen
 	cc := sys.TETRAColourCode
+	// Blind identify has no configured colour code, but SCH/HD is scrambled
+	// with the cell's colour code — descrambling with 0 fails on every real
+	// cell, forfeiting TETRA's whole FEC score (issue #648). The BSCH (colour 0)
+	// carries the code, so recover it from a synchronisation burst in the same
+	// stream and descramble SCH/HD with it.
+	if cc == 0 {
+		if recovered, ok := tetra.RecoverColourCode(stream); ok {
+			cc = recovered
+		}
+	}
 	for _, pos := range land.positions {
 		start := pos + syncLen
 		if start+schDibits > len(stream) {

--- a/internal/siglab/fec_test.go
+++ b/internal/siglab/fec_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -128,6 +129,59 @@ func TestFECTallyNXDN(t *testing.T) {
 	}
 	if cac.CRCPass == 0 {
 		t.Errorf("NXDN CAC: no frames passed CRC (frames=%d)", cac.Frames)
+	}
+}
+
+// TestTetraFECRecoversColourCode covers issue #648: under blind identify there
+// is no configured colour code, so descrambling SCH/HD with 0 fails on every
+// real cell and TETRA forfeits its 30% FEC score. tetraFEC must recover the
+// colour code from the BSCH of a synchronisation burst in the stream and use it.
+func TestTetraFECRecoversColourCode(t *testing.T) {
+	const (
+		cc6        = 0x2D
+		mcc uint16 = 0x0CE
+		mnc uint16 = 0x1234
+	)
+	colour := tetra.ExtendedColourCode(mcc, mnc, cc6)
+
+	// Synchronisation burst: BSCH (colour 0 on the wire, carrying the code) + STS.
+	set := func(bits []byte, off, n int, v uint32) {
+		for i := 0; i < n; i++ {
+			bits[off+i] = byte((v >> uint(n-1-i)) & 1)
+		}
+	}
+	syncInfo := make([]byte, 60)
+	set(syncInfo, 4, 6, cc6)
+	set(syncInfo, 31, 10, uint32(mcc))
+	set(syncInfo, 41, 14, uint32(mnc))
+	var sb []uint8
+	sb = append(sb, tetra.TetraBitsToDibits(tetra.EncodeBSCH(syncInfo))...) // BSCH [0,60)
+	sb = append(sb, tetra.SyncTrainingDibits()...)                          // STS  [60,79)
+	sb = append(sb, make([]uint8, 15)...)                                   // trailing pad
+
+	variants := []SyncVariant{
+		{Name: "nts1", Pattern: tetra.NormalSyncDibits()},
+		{Name: "nts2", Pattern: tetra.NormalSyncDibits2()},
+		{Name: "extended", Pattern: tetra.ExtendedSyncDibits()},
+		{Name: "sync", Pattern: tetra.SyncTrainingDibits()},
+	}
+
+	// SB burst + SCH/HD SYSINFO bursts scrambled with the cell's colour code.
+	sch := buildTETRASCHHDStream(8, colour, 0x2B7)
+	stream := append(append([]uint8{}, sb...), sch...)
+	land := computeSyncLandscape(stream, variants, 4, 2)
+
+	// Blind identify (zero configured colour code) must still tally CRC passes.
+	got := tetraFEC(stream, land, trunking.System{})
+	if len(got) == 0 || got[0].CRCPass == 0 {
+		t.Fatalf("tetraFEC tallied no SCH/HD CRC passes after colour-code recovery: %+v", got)
+	}
+
+	// Control: with no BSCH to recover from, colour 0 can't descramble the
+	// cell's SCH/HD, so nothing passes — proving the recovery is what helped.
+	noSB := computeSyncLandscape(sch, variants, 4, 2)
+	if s := tetraFEC(sch, noSB, trunking.System{}); len(s) > 0 && s[0].CRCPass != 0 {
+		t.Errorf("expected 0 CRC passes without a BSCH to recover the colour code, got %d", s[0].CRCPass)
 	}
 }
 


### PR DESCRIPTION
## Issue #648 — TETRA control channels never lock during blind survey

The latest retests on #648 show good progress (TETRA is now recognised — carriers read `trunk-voice | tetra`, bandwidths and classes are sane), but the TETRA **control channel never locks**: `skipped — no trunked control channel above confidence 0.40 (best: tetra @ 0.16)` / `tetra | no lock`, so no system or talkgroups are mapped.

### Root cause
The TETRA identify confidence is `0.45·sync + 0.25·locked + 0.30·FEC`. The FEC term (`tetraFEC`) descrambles the SCH/HD bursts with `sys.TETRAColourCode` — but blind identify has **no configured colour code (0)**. Colour code 0 is wrong for any real cell, so every SCH/HD CRC fails and TETRA **forfeits its entire 30% FEC weight**. Combined with no SB-burst lock, the score lands at ~0.16, under the 0.40 gate.

The BSCH is scrambled with colour code 0 (always decodable) and carries the cell's colour code — but the FEC scorer never consulted it.

### Fix
- **`tetra.RecoverColourCode`** — correlates the synchronisation training sequence, decodes the colour‑0 BSCH, and returns the extended colour code (mirrors the live `decodeSB`/`#553` cold-start path).
- **`tetraFEC`** now recovers the colour code from a BSCH in the stream when none is configured, and descrambles SCH/HD with it — so a real TETRA control channel earns its FEC score and clears the gate.
- **Corrected the stale `ccdecoder` warning** that claimed a zero colour code means *"descrambler will not lock"* — the decoder auto-acquires it from the BSCH (#553), so it is informational, not fatal. Demoted to Debug (the normal state during blind identify). The reporter pasted this warning believing it was the failure cause.

### Tests
- `TestRecoverColourCode` (tetra): round-trips a colour code through a synthesised SB burst, plus a no-burst negative case.
- `TestTetraFECRecoversColourCode` (siglab): SCH/HD CRC passes under a **zero** configured colour code when a BSCH is present, with a control proving nothing passes without one.

`go build ./...`, `go vet`, and `go test ./...` are green.

Note: this is orthogonal to the AM-gate work (#657) and stacks cleanly on top of it.

https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK

---
_Generated by [Claude Code](https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK)_