### PR TITLE
Add stream_mtu config for SoapyRemote endpoints

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -877,6 +877,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					DeviceArgs:     args,
 					Format:         s.Format,
 					StreamProtocol: s.StreamProtocol,
+					StreamMTU:      s.StreamMTU,
 					ConnectTimeout: time.Duration(s.ConnectTimeoutMs) * time.Millisecond,
 				})
 				if s.Serial != "" {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -371,6 +371,11 @@ sdr:
   #     role: control               # control | voice | auto
   #     format: "CS16"              # CS16 (16-bit, default) or CF32 (float)
   #     stream_protocol: "tcp"      # tcp (default/only for now)
+  #     stream_mtu: 0               # stream endpoint MTU in bytes, sent as the
+  #                                 #  remote:mtu stream arg (NOT a make() arg,
+  #                                 #  so it can't go in args). 0 = SoapyRemote
+  #                                 #  default 1500; raise (e.g. 8192) on
+  #                                 #  jumbo-frame / high-throughput links.
   #     ppm: 0                      # best-effort (driver-dependent)
   #     gain: "auto"                # "auto" or tenths-of-dB ("300" = 30.0 dB)
   #     bias_tee: false             # best-effort (driver-dependent)

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -590,6 +590,7 @@ sdr:
       role: control               # control | voice | auto
       format: "CS16"              # CS16 (16-bit, default) or CF32 (float)
       stream_protocol: "tcp"      # tcp (default/only for now)
+      stream_mtu: 0               # stream endpoint MTU in bytes; 0 = default 1500
       ppm: 0                      # best-effort (driver-dependent)
       gain: "auto"                # "auto" or tenths-of-dB ("300" = 30.0 dB)
       bias_tee: false             # best-effort (driver-dependent)
@@ -607,6 +608,13 @@ broker / fan-out path.
   (`stream_protocol: tcp`), which opens two sockets to the server (a stream
   socket and a status socket, matching `SoapySDRServer`'s setup). UDP
   streaming with the windowed flow-control is a planned follow-up.
+- `stream_mtu` sets the SoapyRemote stream endpoint MTU in bytes. It is sent
+  to the server as the `remote:mtu` *stream* argument (the equivalent of
+  `SoapySDR`'s `remote:mtu` knob) and used to size the client's flow-control
+  window so both ends agree. Because it's a stream argument, not a `make()`
+  kwarg, it cannot be expressed via `args`. Leave it `0` for SoapyRemote's
+  default of 1500; raise it (e.g. `8192`) on jumbo-frame or high-throughput
+  links.
 - `args` passes extra SoapySDR device kwargs to the remote `make()` as a
   `"key=value,key2=value2"` string, merged with `driver` (an explicit
   `driver=` in `args` wins). Use it for server-side device selection and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -768,6 +768,14 @@ type SoapyRemoteConfig struct {
 	// StreamProtocol selects the stream transport. Only "tcp" (the
 	// default) is currently implemented.
 	StreamProtocol string `yaml:"stream_protocol"`
+	// StreamMTU sets the SoapyRemote stream endpoint MTU in bytes. It is
+	// forwarded to the server's setupStream as the "remote:mtu" stream arg
+	// and used to size the client's flow-control window so both ends agree.
+	// This is a stream argument, distinct from the device make() kwargs in
+	// Args, so it cannot be expressed there. Zero leaves SoapyRemote's
+	// default (1500); raise it (e.g. 8192) on jumbo-frame / high-throughput
+	// links.
+	StreamMTU int `yaml:"stream_mtu"`
 	// PPM is the frequency-correction tuning applied on open (best-effort;
 	// ignored by SoapySDR drivers without frequency-correction support).
 	PPM int `yaml:"ppm"`
@@ -1717,6 +1725,12 @@ func validateSoapyFields(i int, s SoapyRemoteConfig) error {
 	case "", "tcp":
 	default:
 		return fmt.Errorf("sdr.soapy_remote[%d]: stream_protocol must be tcp", i)
+	}
+	// stream_mtu is in bytes; 0 means SoapyRemote's default (1500). Reject
+	// values that can't be a real endpoint MTU — too small to hold a useful
+	// frame, or above the driver's 4 MiB per-transfer read guard.
+	if s.StreamMTU != 0 && (s.StreamMTU < 64 || s.StreamMTU > 1<<20) {
+		return fmt.Errorf("sdr.soapy_remote[%d]: stream_mtu %d out of range (64..1048576 bytes, 0 = default 1500)", i, s.StreamMTU)
 	}
 	if _, err := s.DeviceArgs(); err != nil {
 		return fmt.Errorf("sdr.soapy_remote[%d]: args: %w", i, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -317,6 +317,11 @@ func TestValidate(t *testing.T) {
 		// soapy_remote args: SoapySDR make() kwargs as "k=v,k=v" (issue #542).
 		{"soapy args ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "rx_subdev_spec=A:0,antenna=RX1"}}}}, false},
 		{"soapy args malformed", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "rx_subdev_spec"}}}}, true},
+		// soapy_remote stream_mtu: 0 = default; a real MTU is fine; out-of-range fails.
+		{"soapy stream_mtu zero ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1"}}}}, false},
+		{"soapy stream_mtu valid", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 8192}}}}, false},
+		{"soapy stream_mtu too small", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 10}}}}, true},
+		{"soapy stream_mtu too large", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 1 << 21}}}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -124,6 +124,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SoapyRemoteConfig.Role":             {Help: "Pool role hint: control / voice / auto.", Options: roleOpts()},
 	"SoapyRemoteConfig.Format":           {Help: "Wire sample format: CS16 (16-bit, default) or CF32 (32-bit float).", Options: opts("", "(default)", "CS16", "CS16", "CF32", "CF32")},
 	"SoapyRemoteConfig.StreamProtocol":   {Help: "Stream transport. Only tcp is implemented.", Options: opts("", "(default)", "tcp", "tcp")},
+	"SoapyRemoteConfig.StreamMTU":        {Label: "Stream MTU", Help: "Stream endpoint MTU in bytes (sent as the remote:mtu stream arg). 0 = SoapyRemote default 1500. Raise for jumbo-frame / high-throughput links. This is a stream arg, so it cannot go in Args."},
 	"SoapyRemoteConfig.PPM":              {Label: "PPM", Help: "Frequency-correction applied on open (best-effort)."},
 	"SoapyRemoteConfig.Gain":             {Help: "Tuner gain: 'auto'/empty for AGC, else tenths of a dB."},
 	"SoapyRemoteConfig.BiasTee":          {Label: "Bias-tee", Help: "Toggle the remote device's bias-tee (best-effort)."},

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -39,6 +39,7 @@ import (
 	"log/slog"
 	"math"
 	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -84,6 +85,10 @@ type Spec struct {
 	Format string
 	// StreamProtocol selects the stream transport: "tcp" (default/only).
 	StreamProtocol string
+	// StreamMTU sets the stream endpoint MTU in bytes, sent to the server as
+	// the "remote:mtu" setupStream arg and used to size the client's
+	// flow-control window. Zero (or <=0) uses SoapyRemote's default (1500).
+	StreamMTU int
 	// ConnectTimeout overrides DefaultConnectTimeout when non-zero.
 	ConnectTimeout time.Duration
 }
@@ -153,17 +158,29 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 	}
 	addr := withDefaultPort(spec.Addr)
 
+	// Resolve the effective stream MTU and derive the flow-control window the
+	// client advertises to the server. Defaulting to streamMTU keeps the
+	// wire frame and advertised window byte-identical when no MTU is set.
+	mtu := spec.StreamMTU
+	if mtu <= 0 {
+		mtu = streamMTU
+	}
+	windowSeqs := uint32(streamWindowBytes / mtu)
+
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
 		return nil, fmt.Errorf("soapyremote: dial %s: %w", addr, err)
 	}
 	dev := &device{
-		addr:    addr,
-		format:  format,
-		proto:   proto,
-		timeout: timeout,
-		conn:    conn,
-		log:     d.log,
+		addr:       addr,
+		format:     format,
+		proto:      proto,
+		timeout:    timeout,
+		conn:       conn,
+		log:        d.log,
+		mtu:        mtu,
+		windowSeqs: windowSeqs,
+		ackTrigger: windowSeqs / streamNumBuffs,
 		info: sdr.Info{
 			Driver:    DriverName,
 			Index:     idx,
@@ -200,6 +217,14 @@ type device struct {
 	timeout time.Duration
 	log     *slog.Logger
 	info    sdr.Info
+
+	// mtu is the effective stream endpoint MTU (defaults to streamMTU when
+	// unset). windowSeqs is the in-flight credit advertised to the server in
+	// each flow-control ACK (streamWindowBytes/mtu); ackTrigger is how many
+	// received datagrams elapse between gratuitous ACKs (windowSeqs/numBuffs).
+	mtu        int
+	windowSeqs uint32
+	ackTrigger uint32
 
 	mu         sync.Mutex
 	conn       net.Conn // RPC control socket
@@ -434,7 +459,13 @@ func (d *device) setupStreamTCP() (streamID int32, dataConn, statusConn net.Conn
 	p.char(dirRX)
 	p.str(d.format.soapyName())
 	p.sizeList([]int{0})
-	p.kwargs(map[string]string{"remote:prot": "tcp"})
+	// Stream args. remote:mtu is only sent when a non-default MTU is
+	// configured, keeping the default setup frame byte-identical to before.
+	streamArgs := map[string]string{"remote:prot": "tcp"}
+	if d.mtu != streamMTU {
+		streamArgs["remote:mtu"] = strconv.Itoa(d.mtu)
+	}
+	p.kwargs(streamArgs)
 	p.str("0")
 	p.str("0")
 	if err := p.writeTo(d.conn, streamSetupTimeout); err != nil {
@@ -506,7 +537,7 @@ func (d *device) setupStreamTCP() (streamID int32, dataConn, statusConn net.Conn
 // SoapyRemote requires these or the server never streams (see encodeStreamACK).
 func (d *device) sendStreamACK(conn net.Conn, seq uint32) error {
 	_ = conn.SetWriteDeadline(time.Now().Add(d.timeout))
-	_, err := conn.Write(encodeStreamACK(seq))
+	_, err := conn.Write(encodeStreamACK(seq, d.windowSeqs))
 	return err
 }
 
@@ -577,10 +608,10 @@ func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int
 			}
 		}
 		// Flow control: advance the acked sequence and send a gratuitous ACK
-		// every triggerAckWindow datagrams so the server keeps streaming. Done
+		// every d.ackTrigger datagrams so the server keeps streaming. Done
 		// for every datagram (including status codes), matching acquireRecv.
 		lastRecv = h.sequence + 1
-		if lastRecv-lastAck >= triggerAckWindow {
+		if lastRecv-lastAck >= d.ackTrigger {
 			if err := d.sendStreamACK(dataConn, lastRecv); err != nil {
 				d.log.Debug("soapyremote: stream ack", "addr", d.addr, "err", err)
 				return

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -29,6 +29,9 @@ type fakeSoapyServer struct {
 	// the stream socket (issue #542 follow-up). The first is the gratuitous
 	// initial ACK the server's waitSend() blocks on before streaming.
 	acks []streamHeader
+	// setupKwargs records the stream args the client sent in SETUP_STREAM
+	// (e.g. "remote:prot", "remote:mtu"), captured on the last setup call.
+	setupKwargs map[string]string
 
 	// samples streamed per datagram once activated.
 	streamSamples []complex64
@@ -87,6 +90,61 @@ func (s *fakeSoapyServer) recordedACKs() []streamHeader {
 	out := make([]streamHeader, len(s.acks))
 	copy(out, s.acks)
 	return out
+}
+
+func (s *fakeSoapyServer) recordedSetupKwargs() map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[string]string, len(s.setupKwargs))
+	for k, v := range s.setupKwargs {
+		out[k] = v
+	}
+	return out
+}
+
+// readSetupStreamKwargs parses a SETUP_STREAM request body (positioned just
+// past the call id) and returns its stream args. The layout mirrors the
+// client's setupStreamTCP packer: char(dir), str(format), sizeList(channels),
+// kwargs(streamArgs), str, str.
+func readSetupStreamKwargs(u *unpacker) (map[string]string, error) {
+	if _, err := u.char(); err != nil { // direction
+		return nil, err
+	}
+	if _, err := u.str(); err != nil { // format
+		return nil, err
+	}
+	if err := u.expect(tSizeList); err != nil { // channel list
+		return nil, err
+	}
+	n, err := u.i32()
+	if err != nil {
+		return nil, err
+	}
+	for i := int32(0); i < n; i++ {
+		if _, err := u.i32(); err != nil {
+			return nil, err
+		}
+	}
+	if err := u.expect(tKwargs); err != nil { // stream args
+		return nil, err
+	}
+	kn, err := u.i32()
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]string, kn)
+	for i := int32(0); i < kn; i++ {
+		k, err := u.str()
+		if err != nil {
+			return nil, err
+		}
+		v, err := u.str()
+		if err != nil {
+			return nil, err
+		}
+		m[k] = v
+	}
+	return m, nil
 }
 
 func (s *fakeSoapyServer) sawCall(id int32) bool {
@@ -169,6 +227,11 @@ func (s *fakeSoapyServer) handleRPC(conn net.Conn) {
 			}
 		case callSetupStream:
 			twoPhaseSetup = true
+			if kw, err := readSetupStreamKwargs(u); err == nil {
+				s.mu.Lock()
+				s.setupKwargs = kw
+				s.mu.Unlock()
+			}
 		case callActivateStream:
 			_, _ = u.i32() // streamId (int)
 			doActivate = true
@@ -504,6 +567,12 @@ func TestStreamIQ(t *testing.T) {
 		t.Errorf("initial ACK elems = %d, want %d (advertised window)", acks[0].elems, maxInFlightSeqs)
 	}
 
+	// With no stream_mtu configured the setup frame stays byte-identical to
+	// before: only remote:prot is sent, never remote:mtu.
+	if kw := srv.recordedSetupKwargs(); kw["remote:prot"] != "tcp" || kw["remote:mtu"] != "" {
+		t.Errorf("default setup kwargs = %v, want only remote:prot=tcp", kw)
+	}
+
 	// Cancelling the context must close the channel.
 	cancel()
 	drain := time.After(2 * time.Second)
@@ -516,6 +585,49 @@ func TestStreamIQ(t *testing.T) {
 		case <-drain:
 			t.Fatal("stream channel not closed after ctx cancel")
 		}
+	}
+}
+
+// TestStreamMTU verifies a configured stream_mtu both reaches the server as the
+// remote:mtu setup arg and resizes the client's advertised flow-control window
+// (streamWindowBytes/mtu), keeping both ends consistent.
+func TestStreamMTU(t *testing.T) {
+	const mtu = 3000
+	srv := newFakeSoapyServer(t)
+	srv.streamSamples = []complex64{complex(0.5, -0.5), complex(0.25, 0.25)}
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", StreamMTU: mtu}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			t.Fatal("stream channel closed before any data")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for IQ")
+	}
+
+	if kw := srv.recordedSetupKwargs(); kw["remote:mtu"] != "3000" {
+		t.Errorf("setup kwargs remote:mtu = %q, want \"3000\" (kwargs=%v)", kw["remote:mtu"], kw)
+	}
+
+	acks := srv.recordedACKs()
+	if len(acks) == 0 {
+		t.Fatal("server did not receive any flow-control ACK from client")
+	}
+	wantWindow := int32(streamWindowBytes / mtu)
+	if acks[0].elems != wantWindow {
+		t.Errorf("initial ACK elems = %d, want %d (streamWindowBytes/mtu)", acks[0].elems, wantWindow)
 	}
 }
 

--- a/internal/sdr/soapyremote/stream.go
+++ b/internal/sdr/soapyremote/stream.go
@@ -46,23 +46,24 @@ const (
 	// credit ceiling. The server gates its sender on the value we send, not on
 	// any local buffer, so this only needs to be comfortably large.
 	streamWindowBytes = 8 * 1024 * 1024
-	// maxInFlightSeqs is the credit window advertised to the server (the ACK's
-	// elems field); it gates how far ahead the server may stream (window/mtu).
+	// maxInFlightSeqs is the default credit window advertised to the server
+	// (the ACK's elems field); it gates how far ahead the server may stream
+	// (window/mtu). With a configured stream_mtu the device computes its own
+	// window as streamWindowBytes/mtu; this is the stream_mtu=0 default and the
+	// gratuitous-ACK cadence (window/numBuffs ≈699) follows from it.
 	maxInFlightSeqs = streamWindowBytes / streamMTU // ≈5592
-	// triggerAckWindow is how many received datagrams elapse between ACKs
-	// (_maxInFlightSeqs/_numBuffs), matching upstream's gratuitous-ACK cadence.
-	triggerAckWindow = maxInFlightSeqs / streamNumBuffs // ≈699
 )
 
 // encodeStreamACK builds the 24-byte flow-control ACK datagram: a bare,
 // payload-less header whose sequence is the last received sequence and whose
-// elems carries the advertised in-flight window. Big-endian, byte-matching
-// SoapyStreamEndpoint::sendACK.
-func encodeStreamACK(seq uint32) []byte {
+// elems carries the advertised in-flight window (window = streamWindowBytes/MTU,
+// passed in so a configured stream_mtu stays consistent on both ends).
+// Big-endian, byte-matching SoapyStreamEndpoint::sendACK.
+func encodeStreamACK(seq, window uint32) []byte {
 	b := make([]byte, streamHeaderSize)
 	binary.BigEndian.PutUint32(b[0:4], streamHeaderSize)
 	binary.BigEndian.PutUint32(b[4:8], seq)
-	binary.BigEndian.PutUint32(b[8:12], maxInFlightSeqs)
+	binary.BigEndian.PutUint32(b[8:12], window)
 	binary.BigEndian.PutUint32(b[12:16], 0)
 	binary.BigEndian.PutUint64(b[16:24], 0)
 	return b

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -90,6 +90,7 @@ export interface SoapyRemoteConfig {
   Role: string;
   Format: string;
   StreamProtocol: string;
+  StreamMTU: number;
   PPM: number;
   Gain: string;
   BiasTee: boolean;

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -121,7 +121,7 @@ export function SDRSection() {
           label="soapy_remote endpoints"
           items={cfg.SoapyRemote}
           onChange={(x) => set({ ...cfg, SoapyRemote: x })}
-          makeNew={() => ({ Addr: "", Driver: "", Args: "", MasterClockHz: 0, Serial: "", Role: "", Format: "", StreamProtocol: "", PPM: 0, Gain: "auto", BiasTee: false, ConnectTimeoutMs: 0 })}
+          makeNew={() => ({ Addr: "", Driver: "", Args: "", MasterClockHz: 0, Serial: "", Role: "", Format: "", StreamProtocol: "", StreamMTU: 0, PPM: 0, Gain: "auto", BiasTee: false, ConnectTimeoutMs: 0 })}
           itemTitle={(s) => s.Addr || "soapy_remote"}
           emptyHint="SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, …)."
           renderItem={(s, set) => (
@@ -151,6 +151,7 @@ export function SDRSection() {
                   { value: "tcp", label: "tcp" },
                 ]}
               />
+              <NumberField label="Stream MTU (bytes)" value={s.StreamMTU} onChange={(v) => set({ ...s, StreamMTU: v })} placeholder="0 = default 1500" />
               <TextField label="Gain" value={s.Gain} onChange={(v) => set({ ...s, Gain: v })} placeholder="auto or tenths-dB" />
               <NumberField label="PPM" value={s.PPM} onChange={(v) => set({ ...s, PPM: v })} />
               <NumberField label="Connect timeout (ms)" value={s.ConnectTimeoutMs} onChange={(v) => set({ ...s, ConnectTimeoutMs: v })} />


### PR DESCRIPTION
SoapyRemote's stream MTU is a stream argument (remote:mtu) read client-side
and forwarded to the server's setupStream, not a device make() kwarg, so it
could not be set via the existing soapy_remote.args field. Users who can only
start a session from a config file (then launch hunt from the WebUI) had no
way to configure it.

Add a per-endpoint stream_mtu knob that:
- sends remote:mtu in SETUP_STREAM when set (default frame unchanged at 1500),
- sizes the client's flow-control window (streamWindowBytes/mtu) from the same
  MTU so both ends agree.

Plumbed through SoapyRemoteConfig (with range validation), the driver Spec and
device flow-control state, the daemon wiring, the configbuilder field metadata,
the WebUI form, and docs/example config. encodeStreamACK now takes the window
as a parameter; the per-device window/ack-cadence default to the prior
constants. Adds tests covering the new wire arg, the resized ACK window, and
config validation.

https://claude.ai/code/session_01J18B4C2KQTE18Bf8MrDWrU