### PR TITLE
Add stream_window config for SoapyRemote endpoints

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -878,6 +878,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					Format:         s.Format,
 					StreamProtocol: s.StreamProtocol,
 					StreamMTU:      s.StreamMTU,
+					StreamWindow:   s.StreamWindow,
 					ConnectTimeout: time.Duration(s.ConnectTimeoutMs) * time.Millisecond,
 				})
 				if s.Serial != "" {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -376,6 +376,11 @@ sdr:
   #                                 #  so it can't go in args). 0 = SoapyRemote
   #                                 #  default 1500; raise (e.g. 8192) on
   #                                 #  jumbo-frame / high-throughput links.
+  #     stream_window: 0            # stream flow-control window in bytes, sent
+  #                                 #  as the remote:window stream arg (also not
+  #                                 #  a make() arg). 0 = client default 8 MiB;
+  #                                 #  raise on high-latency / high-bandwidth
+  #                                 #  links. Must be >= stream_mtu.
   #     ppm: 0                      # best-effort (driver-dependent)
   #     gain: "auto"                # "auto" or tenths-of-dB ("300" = 30.0 dB)
   #     bias_tee: false             # best-effort (driver-dependent)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -776,6 +776,15 @@ type SoapyRemoteConfig struct {
 	// default (1500); raise it (e.g. 8192) on jumbo-frame / high-throughput
 	// links.
 	StreamMTU int `yaml:"stream_mtu"`
+	// StreamWindow sets the SoapyRemote stream flow-control window in bytes.
+	// It is forwarded to the server's setupStream as the "remote:window"
+	// stream arg (sizing its socket buffers) and used as the client's
+	// in-flight credit ceiling, advertised as window/stream_mtu sequences, so
+	// both ends agree. Like StreamMTU this is a stream argument and cannot be
+	// expressed in Args. Zero uses the client default (8 MiB); raise it on
+	// high-latency / high-bandwidth links where a larger in-flight window
+	// keeps the pipe full.
+	StreamWindow int `yaml:"stream_window"`
 	// PPM is the frequency-correction tuning applied on open (best-effort;
 	// ignored by SoapySDR drivers without frequency-correction support).
 	PPM int `yaml:"ppm"`
@@ -1731,6 +1740,22 @@ func validateSoapyFields(i int, s SoapyRemoteConfig) error {
 	// frame, or above the driver's 4 MiB per-transfer read guard.
 	if s.StreamMTU != 0 && (s.StreamMTU < 64 || s.StreamMTU > 1<<20) {
 		return fmt.Errorf("sdr.soapy_remote[%d]: stream_mtu %d out of range (64..1048576 bytes, 0 = default 1500)", i, s.StreamMTU)
+	}
+	// stream_window is in bytes; 0 means the client default (8 MiB). Bound it
+	// to a sane socket-buffer range, and require it to hold at least one MTU so
+	// the advertised credit (window/mtu) is never zero (which would starve the
+	// server's sender).
+	if s.StreamWindow != 0 {
+		if s.StreamWindow < 1<<16 || s.StreamWindow > 256<<20 {
+			return fmt.Errorf("sdr.soapy_remote[%d]: stream_window %d out of range (65536..268435456 bytes, 0 = default 8 MiB)", i, s.StreamWindow)
+		}
+		mtu := s.StreamMTU
+		if mtu == 0 {
+			mtu = 1500
+		}
+		if s.StreamWindow < mtu {
+			return fmt.Errorf("sdr.soapy_remote[%d]: stream_window %d must be >= stream_mtu %d", i, s.StreamWindow, mtu)
+		}
 	}
 	if _, err := s.DeviceArgs(); err != nil {
 		return fmt.Errorf("sdr.soapy_remote[%d]: args: %w", i, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -322,6 +322,13 @@ func TestValidate(t *testing.T) {
 		{"soapy stream_mtu valid", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 8192}}}}, false},
 		{"soapy stream_mtu too small", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 10}}}}, true},
 		{"soapy stream_mtu too large", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 1 << 21}}}}, true},
+		// soapy_remote stream_window: 0 = default; a real window is fine;
+		// out-of-range or below the MTU fails.
+		{"soapy stream_window zero ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1"}}}}, false},
+		{"soapy stream_window valid", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamWindow: 16 << 20}}}}, false},
+		{"soapy stream_window too small", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamWindow: 1024}}}}, true},
+		{"soapy stream_window too large", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamWindow: 512 << 20}}}}, true},
+		{"soapy stream_window below mtu", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 1 << 20, StreamWindow: 1 << 16}}}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -125,6 +125,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SoapyRemoteConfig.Format":           {Help: "Wire sample format: CS16 (16-bit, default) or CF32 (32-bit float).", Options: opts("", "(default)", "CS16", "CS16", "CF32", "CF32")},
 	"SoapyRemoteConfig.StreamProtocol":   {Help: "Stream transport. Only tcp is implemented.", Options: opts("", "(default)", "tcp", "tcp")},
 	"SoapyRemoteConfig.StreamMTU":        {Label: "Stream MTU", Help: "Stream endpoint MTU in bytes (sent as the remote:mtu stream arg). 0 = SoapyRemote default 1500. Raise for jumbo-frame / high-throughput links. This is a stream arg, so it cannot go in Args."},
+	"SoapyRemoteConfig.StreamWindow":     {Label: "Stream window", Help: "Stream flow-control window in bytes (sent as the remote:window stream arg). 0 = client default 8 MiB. Raise on high-latency / high-bandwidth links to keep the pipe full. Must be >= stream MTU. This is a stream arg, so it cannot go in Args."},
 	"SoapyRemoteConfig.PPM":              {Label: "PPM", Help: "Frequency-correction applied on open (best-effort)."},
 	"SoapyRemoteConfig.Gain":             {Help: "Tuner gain: 'auto'/empty for AGC, else tenths of a dB."},
 	"SoapyRemoteConfig.BiasTee":          {Label: "Bias-tee", Help: "Toggle the remote device's bias-tee (best-effort)."},

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -89,6 +89,11 @@ type Spec struct {
 	// the "remote:mtu" setupStream arg and used to size the client's
 	// flow-control window. Zero (or <=0) uses SoapyRemote's default (1500).
 	StreamMTU int
+	// StreamWindow sets the stream flow-control window in bytes, sent to the
+	// server as the "remote:window" setupStream arg and used as the client's
+	// in-flight credit ceiling (advertised as window/StreamMTU sequences).
+	// Zero (or <=0) uses the client default (streamWindowBytes, 8 MiB).
+	StreamWindow int
 	// ConnectTimeout overrides DefaultConnectTimeout when non-zero.
 	ConnectTimeout time.Duration
 }
@@ -165,7 +170,11 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 	if mtu <= 0 {
 		mtu = streamMTU
 	}
-	windowSeqs := uint32(streamWindowBytes / mtu)
+	window := spec.StreamWindow
+	if window <= 0 {
+		window = streamWindowBytes
+	}
+	windowSeqs := uint32(window / mtu)
 
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
@@ -179,6 +188,7 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		conn:       conn,
 		log:        d.log,
 		mtu:        mtu,
+		window:     window,
 		windowSeqs: windowSeqs,
 		ackTrigger: windowSeqs / streamNumBuffs,
 		info: sdr.Info{
@@ -219,10 +229,12 @@ type device struct {
 	info    sdr.Info
 
 	// mtu is the effective stream endpoint MTU (defaults to streamMTU when
-	// unset). windowSeqs is the in-flight credit advertised to the server in
-	// each flow-control ACK (streamWindowBytes/mtu); ackTrigger is how many
+	// unset). window is the effective flow-control window in bytes (defaults
+	// to streamWindowBytes). windowSeqs is the in-flight credit advertised to
+	// the server in each flow-control ACK (window/mtu); ackTrigger is how many
 	// received datagrams elapse between gratuitous ACKs (windowSeqs/numBuffs).
 	mtu        int
+	window     int
 	windowSeqs uint32
 	ackTrigger uint32
 
@@ -459,11 +471,15 @@ func (d *device) setupStreamTCP() (streamID int32, dataConn, statusConn net.Conn
 	p.char(dirRX)
 	p.str(d.format.soapyName())
 	p.sizeList([]int{0})
-	// Stream args. remote:mtu is only sent when a non-default MTU is
-	// configured, keeping the default setup frame byte-identical to before.
+	// Stream args. remote:mtu / remote:window are only sent when configured to
+	// a non-default value, keeping the default setup frame byte-identical to
+	// before.
 	streamArgs := map[string]string{"remote:prot": "tcp"}
 	if d.mtu != streamMTU {
 		streamArgs["remote:mtu"] = strconv.Itoa(d.mtu)
+	}
+	if d.window != streamWindowBytes {
+		streamArgs["remote:window"] = strconv.Itoa(d.window)
 	}
 	p.kwargs(streamArgs)
 	p.str("0")

--- a/internal/sdr/soapyremote/driver_test.go
+++ b/internal/sdr/soapyremote/driver_test.go
@@ -631,6 +631,47 @@ func TestStreamMTU(t *testing.T) {
 	}
 }
 
+// TestStreamWindow verifies a configured stream_window both reaches the server
+// as the remote:window setup arg and resizes the client's advertised
+// flow-control credit (window/mtu) instead of the default streamWindowBytes.
+func TestStreamWindow(t *testing.T) {
+	const window = 2 * 1024 * 1024 // 2097152
+	srv := newFakeSoapyServer(t)
+	srv.streamSamples = []complex64{complex(0.5, -0.5), complex(0.25, 0.25)}
+	drv := New([]Spec{{Addr: srv.Addr(), Format: "CS16", StreamWindow: window}}, testLogger())
+	dev, err := drv.Open(0)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer dev.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for IQ")
+	}
+
+	if kw := srv.recordedSetupKwargs(); kw["remote:window"] != "2097152" {
+		t.Errorf("setup kwargs remote:window = %q, want \"2097152\" (kwargs=%v)", kw["remote:window"], kw)
+	}
+
+	acks := srv.recordedACKs()
+	if len(acks) == 0 {
+		t.Fatal("server did not receive any flow-control ACK from client")
+	}
+	// Default MTU (1500) with the configured window: credit = window/mtu.
+	wantWindow := int32(window / streamMTU)
+	if acks[0].elems != wantWindow {
+		t.Errorf("initial ACK elems = %d, want %d (window/mtu)", acks[0].elems, wantWindow)
+	}
+}
+
 func TestOpenRejectsUDP(t *testing.T) {
 	srv := newFakeSoapyServer(t)
 	drv := New([]Spec{{Addr: srv.Addr(), StreamProtocol: "udp"}}, testLogger())

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -91,6 +91,7 @@ export interface SoapyRemoteConfig {
   Format: string;
   StreamProtocol: string;
   StreamMTU: number;
+  StreamWindow: number;
   PPM: number;
   Gain: string;
   BiasTee: boolean;

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -121,7 +121,7 @@ export function SDRSection() {
           label="soapy_remote endpoints"
           items={cfg.SoapyRemote}
           onChange={(x) => set({ ...cfg, SoapyRemote: x })}
-          makeNew={() => ({ Addr: "", Driver: "", Args: "", MasterClockHz: 0, Serial: "", Role: "", Format: "", StreamProtocol: "", StreamMTU: 0, PPM: 0, Gain: "auto", BiasTee: false, ConnectTimeoutMs: 0 })}
+          makeNew={() => ({ Addr: "", Driver: "", Args: "", MasterClockHz: 0, Serial: "", Role: "", Format: "", StreamProtocol: "", StreamMTU: 0, StreamWindow: 0, PPM: 0, Gain: "auto", BiasTee: false, ConnectTimeoutMs: 0 })}
           itemTitle={(s) => s.Addr || "soapy_remote"}
           emptyHint="SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, …)."
           renderItem={(s, set) => (
@@ -152,6 +152,7 @@ export function SDRSection() {
                 ]}
               />
               <NumberField label="Stream MTU (bytes)" value={s.StreamMTU} onChange={(v) => set({ ...s, StreamMTU: v })} placeholder="0 = default 1500" />
+              <NumberField label="Stream window (bytes)" value={s.StreamWindow} onChange={(v) => set({ ...s, StreamWindow: v })} placeholder="0 = default 8 MiB" />
               <TextField label="Gain" value={s.Gain} onChange={(v) => set({ ...s, Gain: v })} placeholder="auto or tenths-dB" />
               <NumberField label="PPM" value={s.PPM} onChange={(v) => set({ ...s, PPM: v })} />
               <NumberField label="Connect timeout (ms)" value={s.ConnectTimeoutMs} onChange={(v) => set({ ...s, ConnectTimeoutMs: v })} />


### PR DESCRIPTION
## Summary

Follow-up to the `stream_mtu` support (#664). The SoapyRemote stream flow-control window (`remote:window`) is, like the MTU, a `setupStream` **stream argument** rather than a device `make()` kwarg — so it could not be set via the existing `soapy_remote.args` field. This adds a per-endpoint `stream_window` knob, plumbed identically to `stream_mtu`.

When set, it:
- sends `remote:window` in `SETUP_STREAM` (the default setup frame stays byte-identical when unset), and
- sizes the client's in-flight credit ceiling (`window / mtu`) from the same value, so both ends agree.

## Changes
- **`internal/config/config.go`** — new `StreamWindow int` (`yaml:"stream_window"`) field + validation: range `65536..268435456` bytes, and must be `>= stream_mtu` so the advertised credit (`window/mtu`) is never zero (which would starve the server's sender).
- **`internal/sdr/soapyremote/driver.go`** — `Spec.StreamWindow`; the device's flow-control state now uses the effective window (`windowSeqs = window/mtu`), and `setupStreamTCP` emits `remote:window` only when non-default.
- **`cmd/gophertrunk/daemon.go`** — config → Spec wiring.
- **`internal/configbuilder/fieldmeta.go`**, **`web/configbuilder/src/api/types.ts`**, **`web/configbuilder/src/sections/SDR.tsx`** — surfaced in the WebUI config builder.
- **`config.example.yaml`** — documented next to `stream_mtu`.

## Tests
- New `TestStreamWindow` asserts a configured `stream_window` both reaches the server as `remote:window` and resizes the client's advertised ACK credit (`window/mtu`).
- New config-validation cases (zero/default, valid, too small, too large, below MTU).

## Verification
- `gofmt` / `go vet` / `go build ./...` clean.
- `go test -race` passes for `internal/sdr/soapyremote`, `internal/config`, `internal/configbuilder`, `cmd/gophertrunk`.
- `web/configbuilder`: `tsc --noEmit` + `vite build` pass.

https://claude.ai/code/session_01J18B4C2KQTE18Bf8MrDWrU

---
_Generated by [Claude Code](https://claude.ai/code/session_01J18B4C2KQTE18Bf8MrDWrU)_