### PR TITLE
Clock voice chains from the DDC's actual resampled rate

### DIFF
--- a/internal/sdr/wbvoice/tuner.go
+++ b/internal/sdr/wbvoice/tuner.go
@@ -33,6 +33,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"sync"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
@@ -67,6 +68,19 @@ type VirtualTuner struct {
 	broker     *iqtap.Broker
 	widebandHz uint32
 	inRateHz   uint32
+
+	// actualOutHz is the per-tap rate the DDC *actually* emits for this
+	// input rate, which is not always exactly NarrowbandRateHz: the
+	// rational resampler can only hit the nearest representable L/M ratio,
+	// so e.g. an input rate whose 48000/in ratio trips the resampler's
+	// L≤64 / M≤8192 caps lands a fraction of a percent off 48 kHz (issue
+	// #550). Computed once in New from inRateHz alone — the DDC's output
+	// rate is independent of the tap offset — and reported via
+	// SampleRateExactHz so the composer clocks the voice symbol-recovery
+	// loop at the true rate instead of the nominal target. A nominal-rate
+	// symbol clock drifts off the true symbol phase and periodically slips,
+	// which surfaces as voice spikes/glitches.
+	actualOutHz float64
 
 	tunerMu  sync.Mutex
 	targetHz uint32 // 0 ⇒ no SetCenterFreq yet
@@ -116,12 +130,23 @@ func New(opts Options) (*VirtualTuner, error) {
 	if log == nil {
 		log = slog.Default()
 	}
+	// Pre-compute the rate the DDC will actually emit for this input rate.
+	// A no-tap DDCBank only reduces the L/M ratio and stores it; the
+	// expensive Kaiser FIR prototype is built per-tap in AddTap, which we
+	// don't call here — so this is cheap and allocation-light, and it
+	// matches the args StreamIQ uses to build the live bank, so the rate
+	// reported here is exactly the rate the stream is clocked at.
+	actualOutHz := tuner.NewDDCBank(
+		float64(opts.SDRSampleRateHz), float64(NarrowbandRateHz), GuardFrac,
+	).OutputRateHz()
+
 	return &VirtualTuner{
-		serial:     opts.Serial,
-		log:        log.With("wbvoice", opts.Serial),
-		broker:     opts.Broker,
-		widebandHz: opts.WidebandCenterHz,
-		inRateHz:   opts.SDRSampleRateHz,
+		serial:      opts.Serial,
+		log:         log.With("wbvoice", opts.Serial),
+		broker:      opts.Broker,
+		widebandHz:  opts.WidebandCenterHz,
+		inRateHz:    opts.SDRSampleRateHz,
+		actualOutHz: actualOutHz,
 	}, nil
 }
 
@@ -129,12 +154,24 @@ func New(opts Options) (*VirtualTuner, error) {
 // daemon registered with the voice pool + composer.FindBySerial.
 func (v *VirtualTuner) Serial() string { return v.serial }
 
-// SampleRateHz reports the per-tap rate this source emits. The
-// composer reads it once per call to size its decimator; for a
-// virtual tuner the rate is already the chain's intermediate
-// rate (48 kHz), so the composer's decimation collapses to a
-// pass-through.
-func (v *VirtualTuner) SampleRateHz() uint32 { return NarrowbandRateHz }
+// SampleRateHz reports the per-tap rate this source emits, rounded to an
+// integer. The composer reads it once per call to size its decimator; for
+// a virtual tuner the rate is ~48 kHz (the chain's intermediate rate), so
+// the composer's decimation collapses to a pass-through. The rate is
+// usually exactly NarrowbandRateHz but can land a fraction of a percent
+// off when the resampler can't hit the target exactly (see actualOutHz);
+// callers that clock a symbol-recovery loop should use SampleRateExactHz
+// instead so they don't drift on the fractional part.
+func (v *VirtualTuner) SampleRateHz() uint32 { return uint32(math.Round(v.actualOutHz)) }
+
+// SampleRateExactHz reports the per-tap rate this source actually emits,
+// with the fractional part preserved. This is the rate the DDC's rational
+// resampler truly produces (DDCBank.OutputRateHz), which is not always
+// exactly NarrowbandRateHz. Voice chains clock their symbol-recovery loop
+// from this so the loop tracks the true symbol phase instead of drifting
+// off a rounded nominal — the parity fix the control-channel path already
+// has (issue #550; widebandt2 builds its receivers from OutputRateHz).
+func (v *VirtualTuner) SampleRateExactHz() float64 { return v.actualOutHz }
 
 // CanTune reports whether hz lies inside the wideband dongle's usable
 // IQ window. The trunking pool consults this before calling

--- a/internal/sdr/wbvoice/tuner_test.go
+++ b/internal/sdr/wbvoice/tuner_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
 )
@@ -111,6 +112,48 @@ func TestSampleRateHzReports48k(t *testing.T) {
 	})
 	if got := v.SampleRateHz(); got != NarrowbandRateHz {
 		t.Errorf("SampleRateHz = %d, want %d", got, NarrowbandRateHz)
+	}
+	// At an exact-divisor input rate the fractional accessor agrees exactly.
+	if got := v.SampleRateExactHz(); got != float64(NarrowbandRateHz) {
+		t.Errorf("SampleRateExactHz = %v, want %v", got, float64(NarrowbandRateHz))
+	}
+}
+
+// TestSampleRateExactHzMatchesDDCBank verifies the virtual tuner reports the
+// DDC's *actual* per-tap output rate (fractional part preserved), not the
+// rounded nominal 48 kHz, so the composer can clock the voice symbol-recovery
+// loop at the true rate. 390625 Hz (a 6.25 MS/s ÷16 polyphase bin rate) is the
+// issue #550 case: 48000/390625 reduces to L=384/M=3125, trips the resampler's
+// L≤64 cap, and the bank lands a fraction of a percent off 48 kHz — the exact
+// regime where clocking the receiver at a rounded 48000 would slip symbols and
+// produce voice spikes/glitches.
+func TestSampleRateExactHzMatchesDDCBank(t *testing.T) {
+	const fractionalRate = 390_625
+	broker := iqtap.New(newFakeDevice(), 0, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	v, err := New(Options{
+		Serial: "tap-0", Broker: broker,
+		WidebandCenterHz: 851_500_000, SDRSampleRateHz: fractionalRate,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Must equal exactly what a bank built with the StreamIQ args reports —
+	// the rate the live stream is actually clocked at.
+	want := tuner.NewDDCBank(float64(fractionalRate), float64(NarrowbandRateHz), GuardFrac).OutputRateHz()
+	if got := v.SampleRateExactHz(); got != want {
+		t.Errorf("SampleRateExactHz = %v, want %v (DDCBank.OutputRateHz)", got, want)
+	}
+	// And it must be the fractional rate, not the nominal target: a symbol
+	// clock built from 48000 here would drift off the true symbol phase.
+	if want == float64(NarrowbandRateHz) {
+		t.Fatalf("test input rate %d did not produce a fractional output rate; pick one that trips the resampler caps", fractionalRate)
+	}
+	if got := v.SampleRateExactHz(); got == float64(NarrowbandRateHz) {
+		t.Errorf("SampleRateExactHz = %v, want a fractional rate ≠ %d", got, NarrowbandRateHz)
+	}
+	// The rounded integer accessor still rounds to the nearest Hz.
+	if got, want := v.SampleRateHz(), uint32(math.Round(want)); got != want {
+		t.Errorf("SampleRateHz = %d, want %d (rounded actual rate)", got, want)
 	}
 }
 

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -74,6 +74,20 @@ type IQSource interface {
 	SampleRateHz() uint32
 }
 
+// exactRateSource is an optional capability an IQSource may implement to
+// report its delivered rate with the fractional part preserved. A
+// wideband-derived virtual voice tuner's DDC resampler does not always
+// land exactly on 48 kHz; the integer SampleRateHz rounds that away, but a
+// symbol-recovery loop clocked at the rounded rate drifts off the true
+// symbol phase and periodically slips, surfacing as voice spikes/glitches.
+// Sources that know their exact rate implement this so the digital voice
+// chains clock their receivers at the true rate. Physical SDRs (exact
+// integer rates) need not implement it — the composer falls back to
+// SampleRateHz. Mirrors the control-channel fix in widebandt2 (issue #550).
+type exactRateSource interface {
+	SampleRateExactHz() float64
+}
+
 // Devices resolves a Voice-role IQ source by its serial. The daemon
 // supplies a wrapper around sdr.Pool; tests use a map.
 type Devices interface {
@@ -423,6 +437,18 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 	if rateHz == 0 {
 		rateHz = c.iqHz
 	}
+	// Prefer the source's exact (fractional) rate when it exposes one, so
+	// the digital voice chains clock their symbol-recovery loop at the true
+	// rate rather than a rounded nominal — a nominal-rate clock drifts and
+	// slips, which the listener hears as spikes/glitches (issue #550 parity
+	// for the voice path). Physical SDRs don't implement this and fall back
+	// to the exact integer rate above.
+	rateHzF := float64(rateHz)
+	if exact, ok := src.(exactRateSource); ok {
+		if r := exact.SampleRateExactHz(); r > 0 {
+			rateHzF = r
+		}
+	}
 	ch := &chain{cancel: cancel, done: make(chan struct{})}
 	c.mu.Lock()
 	c.chains[cs.DeviceSerial] = ch
@@ -438,7 +464,7 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 				"device", cs.DeviceSerial, "system", cs.Grant.System,
 				"group", cs.Grant.GroupID)
 		}
-		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, cs.Grant.GroupID, cs.Grant.DMRInterleavedVoice, ch.done)
+		go c.runDMRVoiceChain(chainCtx, cs.DeviceSerial, iqCh, rateHzF, cs.Grant.GroupID, cs.Grant.DMRInterleavedVoice, ch.done)
 	case isP25P2Voice:
 		macCfg := p25p2.MACDecodeConfig{
 			Trellis:    p25p2.TrellisMode(cs.Grant.P25Phase2Decode.Trellis),
@@ -447,11 +473,13 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 			Scrambler:  p25p2.ScramblerMode(cs.Grant.P25Phase2Decode.Scrambler),
 			Seed:       cs.Grant.P25Phase2Decode.Seed,
 		}
-		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, macCfg, iqCh, rateHz, ch.done)
+		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, macCfg, iqCh, rateHzF, ch.done)
 	case isP25P1Voice:
-		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHz, cs.Grant.P25Phase1DemodMode, cs.Grant.GroupID, cs.Grant.PatchedGroups, ch.done)
+		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.P25Phase1DemodMode, cs.Grant.GroupID, cs.Grant.PatchedGroups, ch.done)
 	default:
-		go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, rateHz, ch.done)
+		// Analog FM has no symbol clock to drift, so the rounded integer
+		// rate is fine; keep its uint32 signature unchanged.
+		go c.runFMChain(chainCtx, cs.DeviceSerial, iqCh, uint32(math.Round(rateHzF)), ch.done)
 	}
 }
 

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,11 @@ import (
 type fakeSource struct {
 	mu  sync.Mutex
 	chs []chan []complex64
+	// baseHz / exactHz let a test drive a per-source rate. Both default to
+	// 0 so existing tests keep the daemon-wide fallback; exactHz>0 exercises
+	// the fractional-rate path the digital voice chains clock from.
+	baseHz  uint32
+	exactHz float64
 }
 
 func newFakeSource() *fakeSource { return &fakeSource{} }
@@ -35,7 +41,13 @@ func (f *fakeSource) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	return ch, nil
 }
 
-func (f *fakeSource) SampleRateHz() uint32 { return 0 }
+func (f *fakeSource) SampleRateHz() uint32 { return f.baseHz }
+
+// SampleRateExactHz implements the optional exactRateSource capability so a
+// test can drive a fractional delivered rate into the voice chains. Returns 0
+// (no override) unless exactHz was set, preserving the daemon-wide fallback
+// for the existing tests.
+func (f *fakeSource) SampleRateExactHz() float64 { return f.exactHz }
 
 func (f *fakeSource) SendIQ(samples []complex64) {
 	f.mu.Lock()
@@ -517,5 +529,99 @@ func TestCloseIsIdempotent(t *testing.T) {
 	}
 	if err := c.Close(); err != nil {
 		t.Errorf("second Close: %v", err)
+	}
+}
+
+// attrCaptureHandler is a minimal slog.Handler that records the float64 value
+// of a named attribute the first time a record with a given message is logged.
+// Used to observe the rate the voice chains clock their receiver at, which is
+// otherwise internal to the chain goroutine.
+type attrCaptureHandler struct {
+	mu      sync.Mutex
+	wantMsg string
+	wantKey string
+	got     float64
+	seen    bool
+}
+
+func (h *attrCaptureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *attrCaptureHandler) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h *attrCaptureHandler) WithGroup(string) slog.Handler            { return h }
+func (h *attrCaptureHandler) Handle(_ context.Context, r slog.Record) error {
+	if r.Message != h.wantMsg {
+		return nil
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		if a.Key == h.wantKey {
+			h.mu.Lock()
+			h.got = a.Value.Float64()
+			h.seen = true
+			h.mu.Unlock()
+			return false
+		}
+		return true
+	})
+	return nil
+}
+func (h *attrCaptureHandler) value() (float64, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.got, h.seen
+}
+
+// narrowbandHzForTest mirrors the wbvoice virtual-tuner nominal rate so the
+// test's source advertises a realistic integer base rate alongside its exact
+// fractional rate.
+const narrowbandHzForTest = 48_000
+
+// TestP25P1ChainClocksAtExactSourceRate verifies the P25 Phase 1 voice chain
+// clocks its receiver from the source's exact fractional rate, not the rounded
+// integer one — the parity-with-control-channel fix (issue #550) that keeps a
+// symbol clock from drifting and slipping (audible spikes/glitches). The chain
+// logs the rate it builds the receiver at as "symbol_rate_hz"; we assert it
+// equals the fractional rate the source advertised.
+func TestP25P1ChainClocksAtExactSourceRate(t *testing.T) {
+	const fractionalHz = 47983.5 // not an integer, and < 96 kHz so decim clamps to 1
+	capture := &attrCaptureHandler{
+		wantMsg: "composer: p25p1 voice chain started",
+		wantKey: "symbol_rate_hz",
+	}
+	src := newFakeSource()
+	src.baseHz = narrowbandHzForTest
+	src.exactHz = fractionalHz
+
+	bus := events.NewBus(8)
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          &recordingSink{},
+		Engine:        &fakeEngine{},
+		IQSampleRate:  2_400_000,
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+		Log:           slog.New(capture),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Run(ctx)
+	defer func() { cancel(); c.Close(); bus.Close() }()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "Alpha", Protocol: "p25",
+				GroupID: 100, FrequencyHz: 851_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, time.Second, func() bool { _, ok := capture.value(); return ok })
+	if got, _ := capture.value(); got != fractionalHz {
+		t.Errorf("receiver clocked at %v Hz, want the exact source rate %v Hz", got, fractionalHz)
 	}
 }

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -127,7 +128,7 @@ func (r *slotRouter) accept(sf dmrvoice.VoiceSuperframe) bool {
 	return false
 }
 
-func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz uint32, groupID uint32, interleaved bool, done chan<- struct{}) {
+func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-chan []complex64, iqHz float64, groupID uint32, interleaved bool, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-dmr:"+serial, nil)
 
@@ -137,17 +138,17 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 	bt := c.newBoundaryTracker(serial, 0, nil)
 	go bt.run(ctx)
 
-	decim := int(iqHz) / dmrVoiceIntermediateHz
+	decim := int(math.Round(iqHz)) / dmrVoiceIntermediateHz
 	if decim < 1 {
 		decim = 1
 	}
-	symbolHz := float64(iqHz) / float64(decim)
+	symbolHz := iqHz / float64(decim)
 
 	// Front-end LPF: doubles as the anti-aliasing filter for the
 	// decimation, so it is only needed when the IQ is actually
 	// decimated (the live multi-MS/s path; decim == 1 only in tests
 	// that feed IQ already at the intermediate rate).
-	cutoff := float64(c.bw) / float64(iqHz)
+	cutoff := float64(c.bw) / iqHz
 	if cutoff > 0.45 {
 		cutoff = 0.45
 	}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"context"
 	"errors"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -56,7 +57,7 @@ func (c *Composer) resolveP25Phase1DemodMode(serial, mode string) p25p1rx.DemodM
 // The recorder maps protocol "p25" to the pure-Go IMBE vocoder
 // (voice.DefaultVocoderForProtocol), so WriteRawFrame here decodes each
 // 11-byte frame to PCM and into the call's WAV.
-func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system string, iqCh <-chan []complex64, iqHz uint32, demodMode string, grantTG uint32, patched []uint32, done chan<- struct{}) {
+func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system string, iqCh <-chan []complex64, iqHz float64, demodMode string, grantTG uint32, patched []uint32, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-p25p1:"+serial, nil)
 
@@ -66,11 +67,11 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	bt := c.newBoundaryTracker(serial, grantTG, patched)
 	go bt.run(ctx)
 
-	decim := int(iqHz) / p25p1VoiceIntermediateHz
+	decim := int(math.Round(iqHz)) / p25p1VoiceIntermediateHz
 	if decim < 1 {
 		decim = 1
 	}
-	symbolHz := float64(iqHz) / float64(decim)
+	symbolHz := iqHz / float64(decim)
 
 	mode := c.resolveP25Phase1DemodMode(serial, demodMode)
 
@@ -90,7 +91,7 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	// decimation, so it is only needed when the IQ is actually
 	// decimated (decim == 1 only in tests that feed IQ already at the
 	// intermediate rate).
-	cutoff := float64(c.bw) / float64(iqHz)
+	cutoff := float64(c.bw) / iqHz
 	if cutoff > 0.45 {
 		cutoff = 0.45
 	}

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -44,7 +45,7 @@ const p25p2VoiceGardnerGain = 0.005
 // vocoder (voice.DefaultVocoderForProtocol), so WriteRawFrame here
 // decodes each 7-byte frame to PCM and into the call's WAV — unlike the
 // DMR chain, whose pre-FEC frames the vocoder cannot consume.
-func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, system string, macCfg p25p2.MACDecodeConfig, iqCh <-chan []complex64, iqHz uint32, done chan<- struct{}) {
+func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, system string, macCfg p25p2.MACDecodeConfig, iqCh <-chan []complex64, iqHz float64, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-p25p2:"+serial, nil)
 
@@ -89,17 +90,17 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 			"scrambler", macCfg.Scrambler, "rs", macCfg.RS, "seed", macCfg.Seed)
 	}
 
-	decim := int(iqHz) / p25p2VoiceIntermediateHz
+	decim := int(math.Round(iqHz)) / p25p2VoiceIntermediateHz
 	if decim < 1 {
 		decim = 1
 	}
-	symbolHz := float64(iqHz) / float64(decim)
+	symbolHz := iqHz / float64(decim)
 
 	// Front-end LPF: doubles as the anti-aliasing filter for the
 	// decimation, so it is only needed when the IQ is actually
 	// decimated (decim == 1 only in tests that feed IQ already at the
 	// intermediate rate).
-	cutoff := float64(c.bw) / float64(iqHz)
+	cutoff := float64(c.bw) / iqHz
 	if cutoff > 0.45 {
 		cutoff = 0.45
 	}


### PR DESCRIPTION
P25/DMR voice grants tapped off a wideband SDR run through a per-call DDC
that frequency-translates and rationally resamples toward 48 kHz, then feed
a symbol-clock-recovery receiver. The receiver's samples-per-symbol is
derived from the rate it is told.

The rational resampler cannot always hit exactly 48000 Hz — at certain
input rates the reduced L/M ratio trips the resampler's caps and lands a
fraction of a percent off (e.g. ~48828 Hz at a 6.25 MS/s-derived bin rate;
issue #550). DDCBank.OutputRateHz() already reports the true emitted rate,
and its doc says consumers must clock their symbol loops from it, not the
nominal target. The control-channel wideband path was fixed to do this
(widebandt2 builds receivers from bank.OutputRateHz). The voice path was
not: wbvoice.VirtualTuner.SampleRateHz() hardcoded the nominal 48000, which
flowed through the composer into every digital voice chain, so the receiver
was told 48000 even when the stream ran slightly off. A symbol clock told
the wrong rate drifts off the true symbol phase, periodically slips, and the
vocoder conceals the burst with a click — audible voice spikes/glitches.

Surface the DDC's actual fractional output rate from the virtual tuner
through the composer to the receiver, mirroring the control-channel fix:

- wbvoice: compute the actual per-tap rate once in New (a no-tap DDCBank
  only reduces the ratio; no expensive FIR is built) and expose it via a new
  SampleRateExactHz(). SampleRateHz() now returns the rounded actual rate.
- composer: add an optional exactRateSource capability; when a source
  implements it, clock the chains from the fractional rate. Physical SDRs
  don't implement it and keep their exact integer rate.
- p25p1 / p25p2 / dmr voice chains: take the rate as float64 so the
  fractional part reaches the receiver's symbol clock intact.

Physical-SDR sources are unchanged (exact integer rate -> integer
decimation -> symbolHz stays exactly 48000).

Tests: wbvoice asserts SampleRateExactHz matches DDCBank.OutputRateHz and is
fractional at a cap-tripping input rate; the composer asserts the P25P1 chain
clocks its receiver at the source's exact fractional rate.

https://claude.ai/code/session_01UXKMNTbYu6DuSdhVWHTYzg