### PR TITLE
hunt: snap swept candidates to channel grid; harden MPT1327 lock

### DIFF
--- a/internal/hunt/grid.go
+++ b/internal/hunt/grid.go
@@ -1,0 +1,95 @@
+package hunt
+
+import "math"
+
+// standardChannelSteps are the trunking channel rasters inferGrid tests, finest
+// first. They are the channel steps used by real P25/DMR/MPT/analog land-mobile
+// systems worldwide; 11.6 kHz and friends are measurement artifacts, not real
+// channel plans.
+var standardChannelSteps = []uint32{6_250, 12_500, 25_000}
+
+// gridFitThreshold is the minimum mean-resultant-length (circular concentration,
+// 0..1) a candidate raster must reach for its residuals to count as "clustered
+// on a grid". 0.8 keeps a genuine raster (residuals piled at one phase) while
+// rejecting frequencies scattered across the step.
+const gridFitThreshold = 0.8
+
+// minGridCandidates is the fewest candidates inferGrid needs before it trusts a
+// detected raster; below it there isn't enough evidence to pick a step, so the
+// caller falls back to the finest standard step (which still corrects sub-step
+// bin jitter).
+const minGridCandidates = 3
+
+// inferGrid picks the channel raster (step, phase in Hz) that best explains the
+// candidate frequencies. For each standard step it treats the residuals
+// (f mod step) as points on a circle and measures their concentration (mean
+// resultant length); the raster fits when the residuals pile up at one phase.
+// It returns the coarsest step whose residuals are tightly clustered — the
+// coarsest raster the channels genuinely sit on — and that cluster's phase.
+//
+// With too few candidates, or no step clustering tightly, it falls back to the
+// finest standard step at phase 0: a lone carrier (the 440.125 MHz repro) then
+// still snaps to the nearest 6.25 kHz point, correcting the FFT-bin offset.
+func inferGrid(cands []Candidate) (stepHz, phaseHz uint32) {
+	if len(cands) < minGridCandidates {
+		return standardChannelSteps[0], 0
+	}
+	bestStep, bestPhase := uint32(0), uint32(0)
+	for _, step := range standardChannelSteps {
+		phase, r := gridFit(cands, step)
+		if r >= gridFitThreshold {
+			// Coarsest qualifying step wins: standardChannelSteps is finest-first,
+			// so keep overwriting as we walk to coarser steps that still fit.
+			bestStep, bestPhase = step, phase
+		}
+	}
+	if bestStep == 0 {
+		return standardChannelSteps[0], 0
+	}
+	return bestStep, bestPhase
+}
+
+// gridFit returns the cluster phase (Hz) and the mean resultant length (0..1) of
+// the candidate frequencies' residuals modulo step. A resultant length near 1
+// means the residuals pile up at one phase (the carriers sit on this raster);
+// near 0 means they are spread across the step (this raster doesn't explain them).
+func gridFit(cands []Candidate, step uint32) (phaseHz uint32, resultant float64) {
+	var sumSin, sumCos float64
+	for _, c := range cands {
+		theta := 2 * math.Pi * float64(c.FreqHz%step) / float64(step)
+		sumSin += math.Sin(theta)
+		sumCos += math.Cos(theta)
+	}
+	n := float64(len(cands))
+	resultant = math.Hypot(sumCos, sumSin) / n
+	mean := math.Atan2(sumSin, sumCos)
+	if mean < 0 {
+		mean += 2 * math.Pi
+	}
+	phaseHz = uint32(math.Round(mean/(2*math.Pi)*float64(step))) % step
+	return phaseHz, resultant
+}
+
+// snapHz snaps f to the nearest point on the (step, phase) grid, but only when
+// that point is within maxCorrectionHz of f — so a small FFT-bin quantization
+// error is corrected to the true channel centre while a carrier that genuinely
+// sits off the raster (e.g. an analog channel on a different plan) is left where
+// it is. maxCorrectionHz == 0, or step == 0, disables snapping.
+func snapHz(f, step, phase, maxCorrectionHz uint32) uint32 {
+	if step == 0 || maxCorrectionHz == 0 {
+		return f
+	}
+	k := math.Round((float64(f) - float64(phase)) / float64(step))
+	nearest := int64(phase) + int64(k)*int64(step)
+	if nearest < 0 {
+		return f
+	}
+	d := int64(f) - nearest
+	if d < 0 {
+		d = -d
+	}
+	if d <= int64(maxCorrectionHz) {
+		return uint32(nearest)
+	}
+	return f
+}

--- a/internal/hunt/grid_test.go
+++ b/internal/hunt/grid_test.go
@@ -1,0 +1,70 @@
+package hunt
+
+import "testing"
+
+// TestSnapLoneCarrierCorrectsBinOffset: the field repro — a P25 trunk really on
+// 440.125000 MHz reported a few hundred Hz off by FFT-bin quantization must snap
+// back to the true channel centre (so it tunes dead-on and locks). A single
+// candidate falls back to the finest standard step (6.25 kHz, phase 0).
+func TestSnapLoneCarrierCorrectsBinOffset(t *testing.T) {
+	const rate, fft = 2_400_000, 4096 // binHz ≈ 586
+	in := []Candidate{{FreqHz: 440_124_700, SNRDb: 20}}
+	out := snapCandidatesToGrid(in, rate, fft)
+	if len(out) != 1 {
+		t.Fatalf("got %d candidates, want 1", len(out))
+	}
+	if out[0].FreqHz != 440_125_000 {
+		t.Errorf("snapped to %d Hz, want 440125000", out[0].FreqHz)
+	}
+}
+
+// TestInferGridPicksTwelveAndHalf: a set of carriers on a 12.5 kHz raster is
+// detected as a 12.5 kHz step (not the finer 6.25 kHz, which also fits — the
+// coarsest tightly-clustered raster wins).
+func TestInferGridPicksTwelveAndHalf(t *testing.T) {
+	base := uint32(851_012_500)
+	var cands []Candidate
+	for i := uint32(0); i < 6; i++ {
+		cands = append(cands, Candidate{FreqHz: base + i*12_500})
+	}
+	step, phase := inferGrid(cands)
+	if step != 12_500 {
+		t.Errorf("inferred step %d Hz, want 12500", step)
+	}
+	if phase != base%12_500 {
+		t.Errorf("inferred phase %d Hz, want %d", phase, base%12_500)
+	}
+}
+
+// TestSnapMergesJitteredDuplicates: two bin-jittered detections of the same
+// channel collapse to one snapped candidate, strongest SNR winning.
+func TestSnapMergesJitteredDuplicates(t *testing.T) {
+	const rate, fft = 2_400_000, 4096
+	in := []Candidate{
+		{FreqHz: 460_000_300, SNRDb: 12}, // +300 above 460.000 (within one bin)
+		{FreqHz: 459_999_500, SNRDb: 18}, // -500 below 460.000 (stronger, within one bin)
+	}
+	out := snapCandidatesToGrid(in, rate, fft)
+	if len(out) != 1 {
+		t.Fatalf("got %d candidates, want 1 (merged)", len(out))
+	}
+	if out[0].FreqHz != 460_000_000 {
+		t.Errorf("merged candidate at %d Hz, want 460000000", out[0].FreqHz)
+	}
+	if out[0].SNRDb != 18 {
+		t.Errorf("merged SNR %.0f, want 18 (strongest)", out[0].SNRDb)
+	}
+}
+
+// TestSnapLeavesFarOffGridCarrier: a carrier more than one FFT bin off any grid
+// point is genuinely off-raster and must be kept untouched (snap-only, never
+// fabricate a frequency).
+func TestSnapLeavesFarOffGridCarrier(t *testing.T) {
+	const rate, fft = 2_400_000, 4096 // binHz ≈ 586
+	// 3 kHz off the nearest 6.25 kHz point — far beyond one bin.
+	in := []Candidate{{FreqHz: 462_003_000, SNRDb: 10}}
+	out := snapCandidatesToGrid(in, rate, fft)
+	if len(out) != 1 || out[0].FreqHz != 462_003_000 {
+		t.Errorf("off-grid carrier changed to %v, want unchanged 462003000", out)
+	}
+}

--- a/internal/hunt/livesurvey.go
+++ b/internal/hunt/livesurvey.go
@@ -170,7 +170,11 @@ func classifyAndRoute(sys *DiscoveredSystem, fullIQ []complex64, fullRate uint32
 	cls := survey.ClassifyWith(chIQ, float64(chRate), wideBw, wideSnr, opts.ClassifyConfig)
 	ds.Class = cls.Class
 	ds.Confidence = cls.Confidence
-	ds.OccupiedBwHz = cls.OccupiedBwHz
+	// Report the bandwidth normalised to the nearest real channel width (so a
+	// 12.5 kHz channel reads as 12.5 kHz, not the off-centre-skewed "11.6 kHz");
+	// the raw measurement stays on ds.Features for diagnostics, and the
+	// classifier's own decision already ran on the raw value above.
+	ds.OccupiedBwHz = survey.SnapChannelBandwidth(cls.OccupiedBwHz)
 	ds.BaudHz = cls.Features.BaudHz
 	ds.Features = cls.Features
 

--- a/internal/hunt/sweeper.go
+++ b/internal/hunt/sweeper.go
@@ -185,8 +185,37 @@ func (s *Sweeper) Sweep(ctx context.Context, onStep OnStep) ([]Candidate, error)
 	for _, c := range best {
 		out = append(out, c)
 	}
+	out = snapCandidatesToGrid(out, rate, s.fftSize)
 	sort.Slice(out, func(i, j int) bool { return out[i].SNRDb > out[j].SNRDb })
 	return out, nil
+}
+
+// snapCandidatesToGrid corrects the FFT-bin quantization offset in the swept
+// candidates: it infers the channel raster the carriers sit on (auto-detected
+// from their frequencies) and snaps each candidate to the nearest grid point
+// within one FFT bin, so a carrier the bins reported a few hundred Hz off (e.g.
+// 440.1247 MHz for a P25 trunk really on 440.125000) tunes to the true centre
+// and actually locks. Snapping is bounded to one bin, so a carrier that
+// genuinely sits off the raster is kept untouched. Candidates that collapse to
+// the same snapped frequency merge, strongest SNR winning.
+func snapCandidatesToGrid(cands []Candidate, rate uint32, fftSize int) []Candidate {
+	if len(cands) == 0 || fftSize <= 0 {
+		return cands
+	}
+	step, phase := inferGrid(cands)
+	binHz := uint32(math.Round(float64(rate) / float64(fftSize)))
+	merged := make(map[uint32]Candidate, len(cands))
+	for _, c := range cands {
+		c.FreqHz = snapHz(c.FreqHz, step, phase, binHz)
+		if cur, ok := merged[c.FreqHz]; !ok || c.SNRDb > cur.SNRDb {
+			merged[c.FreqHz] = c
+		}
+	}
+	out := make([]Candidate, 0, len(merged))
+	for _, c := range merged {
+		out = append(out, c)
+	}
+	return out
 }
 
 // captureFrame captures framesPerStep FFT frames at the current center and

--- a/internal/radio/mpt1327/control.go
+++ b/internal/radio/mpt1327/control.go
@@ -56,6 +56,47 @@ type ControlChannel struct {
 	strictValidation bool
 	bchMode          BCHMode
 	cwscTolerance    int
+
+	// confirmed counts the recognised Address codewords seen so far; minConfirm
+	// is how many must arrive before a lock is trusted. minConfirm <= 0 means
+	// lock on the first (the legacy / in-package-fixture default); the ccdecoder
+	// connector raises it for production so a single chance codeword — a
+	// cross-protocol false parse of an off-channel P25/DMR carrier — can't
+	// declare an MPT 1327 lock.
+	confirmed  int
+	minConfirm int
+}
+
+// SetMinConfirm sets how many recognised Address codewords must be ingested
+// before the control channel publishes a lock. n <= 1 restores the legacy
+// lock-on-first-codeword behaviour. The production default (set by the ccdecoder
+// connector) is 2: a real control channel streams codewords continuously, so the
+// extra confirmation costs negligible latency while removing single-codeword
+// false locks.
+func (c *ControlChannel) SetMinConfirm(n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.minConfirm = n
+}
+
+// MinConfirm returns the configured confirmation threshold.
+func (c *ControlChannel) MinConfirm() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.minConfirm
+}
+
+// noteConfirmation records one recognised Address codeword and reports whether
+// enough have now arrived to trust a lock.
+func (c *ControlChannel) noteConfirmation() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	need := c.minConfirm
+	if need < 1 {
+		need = 1
+	}
+	c.confirmed++
+	return c.confirmed >= need
 }
 
 // SetStrictValidation toggles the strict frame-validity filter on
@@ -254,14 +295,22 @@ func (c *ControlChannel) Ingest(w Codeword) {
 		// follow at the trunking layer.
 		return
 	}
+	// A recognised Address codeword is lock evidence; require minConfirm of them
+	// before trusting an Aloha / AhoyChan as a genuine control channel.
+	confirmed := false
+	if codewordKindIsRecognised(w) {
+		confirmed = c.noteConfirmation()
+	}
 	switch w.Kind() {
 	case KindAloha:
-		c.maybeLock(LockState{
-			FrequencyHz: c.freqHz,
-			Prefix:      w.Prefix,
-		})
+		if confirmed {
+			c.maybeLock(LockState{
+				FrequencyHz: c.freqHz,
+				Prefix:      w.Prefix,
+			})
+		}
 	case KindAhoyChan:
-		if a, ok := w.AsAhoyChannel(); ok {
+		if a, ok := w.AsAhoyChannel(); ok && confirmed {
 			c.maybeLock(LockState{
 				FrequencyHz: c.freqHz,
 				SystemID:    a.System,

--- a/internal/radio/mpt1327/minconfirm_test.go
+++ b/internal/radio/mpt1327/minconfirm_test.go
@@ -1,0 +1,63 @@
+package mpt1327
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// countCCLocked drains the subscription and returns how many cc.locked events
+// were published.
+func countCCLocked(sub *events.Subscription) int {
+	got := 0
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCCLocked {
+				got++
+			}
+		default:
+			return got
+		}
+	}
+}
+
+// TestMinConfirmSuppressesSingleCodewordLock: with the production confirmation
+// threshold a lone recognised codeword (a cross-protocol false parse) must not
+// declare a lock; the second confirms it.
+func TestMinConfirmSuppressesSingleCodewordLock(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetMinConfirm(2)
+
+	cc.Ingest(alohaCodeword(0x3))
+	if got := countCCLocked(sub); got != 0 {
+		t.Fatalf("after 1 codeword with minConfirm=2: got %d CCLocked, want 0", got)
+	}
+
+	cc.Ingest(alohaCodeword(0x3))
+	if got := countCCLocked(sub); got != 1 {
+		t.Fatalf("after 2 codewords with minConfirm=2: got %d CCLocked, want 1", got)
+	}
+}
+
+// TestMinConfirmDefaultLocksOnFirst: the zero-value (in-package fixture) default
+// keeps the legacy lock-on-first behaviour so existing fixtures still lock.
+func TestMinConfirmDefaultLocksOnFirst(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+
+	cc.Ingest(alohaCodeword(0x3))
+	if got := countCCLocked(sub); got != 1 {
+		t.Fatalf("default minConfirm: got %d CCLocked on first codeword, want 1", got)
+	}
+}

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -1072,6 +1072,12 @@ func (p *ltrPipeline) Close() error           { return nil }
 // 64-bit on-air codeword's BCH(63,38) FEC + de-interleaving are
 // follow-ups; without them the adapter works on noise-free test
 // fixtures but typically fails on captured MPT 1327 traffic.
+// mpt1327ProdMinConfirm is the production confirmation threshold for an MPT 1327
+// lock: how many recognised Address codewords must arrive before the control
+// channel publishes cc.locked. 2 removes single-codeword false locks at
+// negligible latency on a continuously-broadcasting real control channel.
+const mpt1327ProdMinConfirm = 2
+
 func newMPT1327Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 	cc := mpt1327.New(mpt1327.Options{
 		Bus:         opts.Bus,
@@ -1091,6 +1097,11 @@ func newMPT1327Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 			"system", opts.SystemName, "value", opts.System.MPT1327CWSCTolerance)
 	}
 	cc.SetCWSCTolerance(cwscTol)
+	// Require a couple of recognised codewords before an MPT 1327 lock: a real
+	// control channel streams them continuously, so this is near-instant on a
+	// genuine CC but stops a single cross-protocol false parse (e.g. an
+	// off-channel P25/DMR carrier handed to the identifier) from locking MPT.
+	cc.SetMinConfirm(mpt1327ProdMinConfirm)
 	rx := mpt1327rx.New(mpt1327rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		BitSink: func(bits []byte, baseIdx int) {

--- a/internal/survey/classify.go
+++ b/internal/survey/classify.go
@@ -556,6 +556,30 @@ func boxSmooth3(v []float64) []float64 {
 	return out
 }
 
+// standardChannelWidths are the occupied bandwidths of real narrowband
+// land-mobile channels. A measured width close to one of these is the channel;
+// off-grid values like 11.6 kHz are measurement artifacts (an off-centre carrier
+// skews the outward DC walk), not bandwidths any system actually uses.
+var standardChannelWidths = []uint32{6_250, 12_500, 25_000}
+
+// SnapChannelBandwidth normalises a measured occupied bandwidth for reporting:
+// when bwHz lands within ±20% of a standard narrowband channel width it returns
+// that width (so a carrier reads as the 12.5 kHz channel it is, not "11.6 kHz");
+// otherwise it returns bwHz unchanged so a genuinely wideband signal (broadcast
+// FM, a wideband data carrier) is reported as-measured. This only adjusts the
+// displayed width — the raw measurement stays on ClassFeatures.OccupiedBwHz.
+func SnapChannelBandwidth(bwHz uint32) uint32 {
+	const tol = 0.20
+	for _, w := range standardChannelWidths {
+		lo := float64(w) * (1 - tol)
+		hi := float64(w) * (1 + tol)
+		if float64(bwHz) >= lo && float64(bwHz) <= hi {
+			return w
+		}
+	}
+	return bwHz
+}
+
 // IsPagingBaud reports whether baud is close to a POCSAG/FLEX signalling rate.
 // The router uses it to decide whether a digital FSK carrier is worth a paging
 // decode attempt before the (more expensive) trunking identify.

--- a/internal/survey/snapbw_test.go
+++ b/internal/survey/snapbw_test.go
@@ -1,0 +1,26 @@
+package survey
+
+import "testing"
+
+func TestSnapChannelBandwidth(t *testing.T) {
+	cases := []struct {
+		name string
+		in   uint32
+		want uint32
+	}{
+		{"the 11.6 kHz artifact reads as a 12.5 kHz channel", 11_600, 12_500},
+		{"13.5 kHz reads as 12.5 kHz", 13_500, 12_500},
+		{"6.0 kHz reads as 6.25 kHz", 6_000, 6_250},
+		{"23 kHz reads as 25 kHz", 23_000, 25_000},
+		{"exactly 12.5 kHz is unchanged", 12_500, 12_500},
+		{"a genuinely wideband signal is left as-measured", 150_000, 150_000},
+		{"an in-between value with no nearby standard is unchanged", 18_000, 18_000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SnapChannelBandwidth(tc.in); got != tc.want {
+				t.Errorf("SnapChannelBandwidth(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Field report on `hunt`/`survey`: zero P25/DMR detection, false MPT1327 locks, and bogus "11.6 kHz" bandwidths — repro: a P25 trunk at 440.125 MHz goes undetected because its detected frequency "was offset".

## Root cause

The sweep reports carriers at FFT-bin centres (~586 Hz bins at 2.4 MS/s), so a real 440.125000 MHz carrier is reported a few hundred Hz off. The survey tunes the SDR to that offset and feeds it to the decoders: P25/DMR (4800-baud) can't lock off-centre, while MPT1327 (1200-baud FFSK, permissive alignment, lock-on-first-codeword) false-locks and wins the identify. There was no channel-grid snapping and `-auto-tune` defaults off (and is unsafe here — it searches the whole sweep span). The off-centre carrier also skews the occupied-bandwidth measurement off the true 12.5 kHz.

## Fix

- **Snap swept candidates to the channel raster.** `inferGrid` auto-detects the step (6.25/12.5/25 kHz) from the candidates via circular clustering, falling back to 6.25 kHz for a lone carrier; `snapHz` corrects each candidate within one FFT bin (440.1247 → 440.125000) without moving genuinely off-grid carriers. Jittered detections of one channel merge.
- **Normalise reported occupied bandwidth** to the nearest standard channel width (`SnapChannelBandwidth`), so a 12.5 kHz channel reads as 12.5 kHz, not the skewed "11.6 kHz"; the raw measurement stays on `Features`.
- **Harden the MPT1327 lock**: require a couple of recognised codewords (`SetMinConfirm`) before publishing a lock. A real CC streams them continuously (near-zero latency), but a single cross-protocol false parse can no longer lock. `New` keeps lock-on-first for in-package fixtures; the ccdecoder connector sets the production threshold to 2.

Adds unit tests for grid inference/snapping, bandwidth snapping, and the MPT confirmation gate. `go vet` clean; full `go test ./...` green (incl. the P25/DMR/MPT1327 integration captures).

Note: this corrects FFT-bin quantization but assumes roughly-calibrated PPM; a large uncorrected PPM offset still needs `-ppm`.

https://claude.ai/code/session_014NzS3HiMsCwpAsGJ1U2ATh

---
_Generated by [Claude Code](https://claude.ai/code/session_014NzS3HiMsCwpAsGJ1U2ATh)_