### PR TITLE
mpt1327: require a consistent prefix across confirmation codewords (#648)

### DIFF
--- a/internal/radio/mpt1327/control.go
+++ b/internal/radio/mpt1327/control.go
@@ -57,14 +57,17 @@ type ControlChannel struct {
 	bchMode          BCHMode
 	cwscTolerance    int
 
-	// confirmed counts the recognised Address codewords seen so far; minConfirm
-	// is how many must arrive before a lock is trusted. minConfirm <= 0 means
-	// lock on the first (the legacy / in-package-fixture default); the ccdecoder
-	// connector raises it for production so a single chance codeword — a
-	// cross-protocol false parse of an off-channel P25/DMR carrier — can't
-	// declare an MPT 1327 lock.
-	confirmed  int
-	minConfirm int
+	// confirmed counts the recognised Address codewords seen so far on a single
+	// system; minConfirm is how many must arrive before a lock is trusted, and
+	// confirmPrefix is the Prefix that run shares. minConfirm <= 0 means lock on
+	// the first (the legacy / in-package-fixture default); the ccdecoder connector
+	// raises it for production. The run must agree on one Prefix — the 7-bit system
+	// field every Aloha/AhoyChan carries — so a single chance codeword, or two
+	// inconsistent cross-protocol false parses of off-channel P25/DMR carriers
+	// (a different prefix each time), can't declare an MPT 1327 lock.
+	confirmed     int
+	confirmPrefix uint8
+	minConfirm    int
 }
 
 // SetMinConfirm sets how many recognised Address codewords must be ingested
@@ -86,16 +89,23 @@ func (c *ControlChannel) MinConfirm() int {
 	return c.minConfirm
 }
 
-// noteConfirmation records one recognised Address codeword and reports whether
-// enough have now arrived to trust a lock.
-func (c *ControlChannel) noteConfirmation() bool {
+// noteConfirmation records one recognised Address codeword carrying the given
+// Prefix and reports whether enough consistent ones have now arrived to trust a
+// lock. A codeword whose Prefix matches the run in progress corroborates it; a
+// new or changed Prefix restarts the count at one (this codeword), so an
+// inconsistent burst of cross-protocol false parses never accumulates to a lock.
+func (c *ControlChannel) noteConfirmation(prefix uint8) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	need := c.minConfirm
 	if need < 1 {
 		need = 1
 	}
-	c.confirmed++
+	if c.confirmed > 0 && prefix == c.confirmPrefix {
+		c.confirmed++
+	} else {
+		c.confirmed, c.confirmPrefix = 1, prefix
+	}
 	return c.confirmed >= need
 }
 
@@ -295,11 +305,12 @@ func (c *ControlChannel) Ingest(w Codeword) {
 		// follow at the trunking layer.
 		return
 	}
-	// A recognised Address codeword is lock evidence; require minConfirm of them
-	// before trusting an Aloha / AhoyChan as a genuine control channel.
+	// A recognised Address codeword is lock evidence; require minConfirm of them,
+	// all sharing one Prefix, before trusting an Aloha / AhoyChan as a genuine
+	// control channel.
 	confirmed := false
 	if codewordKindIsRecognised(w) {
-		confirmed = c.noteConfirmation()
+		confirmed = c.noteConfirmation(w.Prefix)
 	}
 	switch w.Kind() {
 	case KindAloha:

--- a/internal/radio/mpt1327/minconfirm_test.go
+++ b/internal/radio/mpt1327/minconfirm_test.go
@@ -61,3 +61,48 @@ func TestMinConfirmDefaultLocksOnFirst(t *testing.T) {
 		t.Fatalf("default minConfirm: got %d CCLocked on first codeword, want 1", got)
 	}
 }
+
+// TestMinConfirmRequiresConsistentIdentity: confirmations must share one Prefix.
+// Two recognised codewords carrying different prefixes (the inconsistent
+// cross-protocol false-parse case) must not lock — the changed prefix restarts
+// the count; a second codeword on the new prefix then confirms it.
+func TestMinConfirmRequiresConsistentIdentity(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetMinConfirm(2)
+
+	cc.Ingest(alohaCodeword(0x3))
+	cc.Ingest(alohaCodeword(0x5)) // different prefix: restarts the run, no lock
+	if got := countCCLocked(sub); got != 0 {
+		t.Fatalf("after 2 codewords with mismatched prefixes: got %d CCLocked, want 0", got)
+	}
+
+	cc.Ingest(alohaCodeword(0x5)) // second on prefix 0x5: now confirmed
+	if got := countCCLocked(sub); got != 1 {
+		t.Fatalf("after 2 consistent codewords on prefix 0x5: got %d CCLocked, want 1", got)
+	}
+}
+
+// TestMinConfirmAlternatingIdentityNeverLocks: a stream that never repeats a
+// prefix twice in a row (random cross-protocol parses) must never reach the
+// confirmation threshold, however long it runs.
+func TestMinConfirmAlternatingIdentityNeverLocks(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Sys"})
+	cc.SetMinConfirm(2)
+
+	for i := 0; i < 20; i++ {
+		cc.Ingest(alohaCodeword(uint8(i%2 + 1))) // 1,2,1,2,… never two alike in a row
+	}
+	if got := countCCLocked(sub); got != 0 {
+		t.Fatalf("alternating prefixes: got %d CCLocked, want 0", got)
+	}
+}


### PR DESCRIPTION
## Problem

Issue #648's four-point retest reported **false MPT 1327 locks** — `468.4316 MHz … locked · conf 63%`, `468.6953 MHz … conf 67%`, and repeated `mpt1327 cc locked freq=0 sys=… prefix=…` lines whose system IDs were **garbage and changed every time**.

PR #669 added a confirmation gate (`SetMinConfirm`, production default 2) so a lock needs more than one recognised Address codeword. But `noteConfirmation` counts codewords **regardless of identity** — so two *inconsistent* cross-protocol false parses (a different `Prefix` each, exactly the retest signature) still reach the count and lock.

## Change

Make the gate identity-aware: the confirming codewords must agree on `Prefix`.

- A codeword whose 7-bit `Prefix` matches the run in progress corroborates it (`confirmed++`); a new or changed `Prefix` restarts the count at one. An inconsistent burst of random parses therefore never accumulates to a lock.
- Keys on `Prefix` rather than `System` because `System` only exists on AhoyChan, whereas `Prefix` is the stable field carried by every Aloha **and** AhoyChan — so a genuine control channel's mixed codeword stream still confirms within a couple of codewords (negligible added latency on a continuously-broadcasting CC).

Single-file change to `internal/radio/mpt1327/control.go` plus tests.

## Tests

- `TestMinConfirmRequiresConsistentIdentity` — mismatched-prefix pair does **not** lock; a consistent second codeword on the new prefix then does.
- `TestMinConfirmAlternatingIdentityNeverLocks` — alternating prefixes never reach the threshold.
- Existing `TestMinConfirmSuppressesSingleCodewordLock` and `TestMinConfirmDefaultLocksOnFirst` unchanged and green.

`gofmt`, `go vet ./...`, `go build ./...`, and `go test ./internal/radio/mpt1327/... ./internal/scanner/ccdecoder/...` all pass.

## Scope

Addresses **point 3** of #648. Points 1 & 2 (DMR/P25 carriers reading `nbfm`) remain pending the real-air IQ capture requested from the reporter in [#648 comment](https://github.com/MattCheramie/GopherTrunk/issues/648#issuecomment-4700144925); point 4 (TETRA lock) was addressed on `main` by #662 + #669.

https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK

---
_Generated by [Claude Code](https://claude.ai/code/session_014GYhNi3au44Sr2Ai9DJ7DK)_