### PR TITLE
p25/phase1: make CC talker-alias decode observable + capture unhandled-TSBK payloads (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ for tagged releases.
 
 ### Changed
 
+- **P25 Phase 1 unhandled-TSBK diagnostic now dumps the raw payload (#376).**
+  The first round of CBD/Mt Anakie field diagnostics confirmed the alias is
+  *not* arriving as our control-channel working-model fragment (vendor opcode
+  `0x15`, plain ASCII): zero `cc talker alias`/`fragment` lines fired on either
+  system, even the cleanly-decoding one. The census instead named candidate
+  opcodes (Motorola `0x90` opcode `0x16`; standard `0x15`/`0x16`/`0x30`) but we
+  couldn't tell which carries the alias from the opcode number alone. The
+  `p25: unhandled tsbk` census line now also prints the **numeric** opcode
+  (`Opcode.String()` mislabels vendor opcodes with standard names), and a new
+  `p25: unhandled tsbk payload` line logs the raw 8-byte payload hex, capped at
+  8 samples per distinct `(MFID, opcode)` so a multi-block alias sequence can be
+  captured and reversed against known RIDs / alias strings without flooding a
+  busy control channel.
 - **P25 Phase 1 control-channel talker-alias decode is now observable in the
   daemon log (#376).** A new field-tested system (CBD) locks and populates RIDs
   but shows blank talker aliases, with heavy TSBK CRC loss on the control

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -124,15 +124,17 @@ type ControlChannel struct {
 	// is broken" from "demod is fine but one frame in N is corrupt".
 	stats CCStats
 
-	// diagSeen rate-limits one-shot diagnostic Info lines to the first
-	// occurrence of a given key, so a field tester sees the census of
-	// what a site emits without the per-frame flood that keeps the
-	// per-opcode detail at Debug. Keys: unhandled (MFID,opcode) pairs
-	// and first-seen talker-alias source units. Written only from the
-	// dispatchTSBK path, which runs on the single Process goroutine
-	// (the sole writer of decode state), so no lock is needed — unlike
-	// stats, this is never read off-goroutine. Issue #376 (CBD).
-	diagSeen map[uint32]struct{}
+	// diagSeen counts, per diagnostic key, how many times the key has
+	// been observed, so one-shot census lines fire on the first sight
+	// and payload samples are capped — letting a field tester see what
+	// a site emits (including the raw bytes of opcodes we don't decode)
+	// without the per-frame flood that keeps the per-opcode detail at
+	// Debug. Keys: unhandled (MFID,opcode) pairs and first-seen
+	// talker-alias source units (namespaced by the high byte). Written
+	// only from the dispatchTSBK path, which runs on the single Process
+	// goroutine (the sole writer of decode state), so no lock is needed
+	// — unlike stats, this is never read off-goroutine. Issue #376 (CBD).
+	diagSeen map[uint32]int
 }
 
 // CCStats is the snapshot Stats() returns. All counters are
@@ -305,7 +307,7 @@ func New(opts Options) *ControlChannel {
 		bandPlan:            bp,
 		now:                 now,
 		aliasAsm:            NewTalkerAliasAssembler(now),
-		diagSeen:            make(map[uint32]struct{}),
+		diagSeen:            make(map[uint32]int),
 		rotations:           resolveRotations(opts.Rotations),
 		nidSearchSpan:       span,
 		p25Phase1DemodMode:  opts.P25Phase1DemodMode,
@@ -1037,13 +1039,10 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 	case OpUnitRegistrationResponse:
 		c.publishUnitRegistration(ParseUnitRegistrationResponse(t.Payload), nac)
 	default:
-		// One Info census line per distinct (MFID,opcode) — a standard
-		// opcode we don't dispatch could be (or carry) the alias
-		// transport a given site uses; the bulk per-frame detail stays
-		// at Debug. Issue #376 (CBD).
-		if c.diagFirst(diagUnhandledTSBK | uint32(t.MFID)<<8 | uint32(t.Opcode)) {
-			c.log.Info("p25: unhandled tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
-		}
+		// Census + raw-payload sample — a standard opcode we don't
+		// dispatch could be (or carry) the alias transport a given site
+		// uses; the bulk per-frame detail stays at Debug. Issue #376 (CBD).
+		c.logUnhandledTSBK(t, nac)
 		c.log.Debug("tsbk decoded",
 			"opcode", t.Opcode, "lb", t.LB, "metric", metric, "nac", nac)
 	}
@@ -1084,12 +1083,10 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 		}
 		return
 	}
-	// Unrecognised vendor opcode: log one Info census line per distinct
-	// (MFID,opcode) so a field test names any alias-bearing transport we
-	// don't yet decode, while the per-frame detail stays at Debug.
-	if c.diagFirst(diagUnhandledTSBK | uint32(t.MFID)<<8 | uint32(t.Opcode)) {
-		c.log.Info("p25: unhandled tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
-	}
+	// Unrecognised vendor opcode: census + raw-payload sample so a field
+	// test can name and reverse any alias-bearing transport we don't yet
+	// decode, while the per-frame detail stays at Debug.
+	c.logUnhandledTSBK(t, nac)
 	c.log.Debug("p25: vendor tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
 }
 
@@ -1101,15 +1098,40 @@ const (
 	diagAliasSrc      uint32 = 2 << 24
 )
 
+// maxUnhandledSamples caps how many raw payloads are logged per distinct
+// (MFID,opcode) so a busy CC stays bounded; 8 is enough to catch a full
+// multi-block alias sequence on a candidate opcode. Issue #376 (CBD).
+const maxUnhandledSamples = 8
+
 // diagFirst reports whether key is being seen for the first time,
 // recording it so subsequent calls return false. Single-writer
 // (Process goroutine) — see diagSeen.
 func (c *ControlChannel) diagFirst(key uint32) bool {
-	if _, seen := c.diagSeen[key]; seen {
-		return false
+	n := c.diagSeen[key]
+	c.diagSeen[key] = n + 1
+	return n == 0
+}
+
+// logUnhandledTSBK emits the field diagnostics for a TSBK we don't
+// dispatch: one Info census line per distinct (MFID,opcode) — with the
+// numeric opcode, since Opcode.String() mislabels vendor opcodes with
+// standard names — plus up to maxUnhandledSamples raw-payload lines so a
+// field tester can capture the bytes of a candidate alias transport and
+// cross-check them against known RIDs / alias strings. Issue #376 (CBD).
+func (c *ControlChannel) logUnhandledTSBK(t TSBK, nac uint16) {
+	key := diagUnhandledTSBK | uint32(t.MFID)<<8 | uint32(t.Opcode)
+	n := c.diagSeen[key]
+	c.diagSeen[key] = n + 1
+	if n == 0 {
+		c.log.Info("p25: unhandled tsbk",
+			"mfid", t.MFID, "opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
+			"name", t.Opcode, "nac", nac)
 	}
-	c.diagSeen[key] = struct{}{}
-	return true
+	if n < maxUnhandledSamples {
+		c.log.Info("p25: unhandled tsbk payload",
+			"mfid", t.MFID, "opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
+			"lb", t.LB, "payload", fmt.Sprintf("%x", t.Payload[:]), "nac", nac)
+	}
 }
 
 // publishPatch publishes an events.KindPatch for a vendor patch /

--- a/internal/radio/p25/phase1/tsbk_vendor_test.go
+++ b/internal/radio/p25/phase1/tsbk_vendor_test.go
@@ -204,7 +204,8 @@ func TestDiagFirst(t *testing.T) {
 // TestControlChannelCensusesUnhandledTSBK confirms an undecoded vendor
 // opcode produces exactly one Info census line per distinct (MFID,opcode)
 // — the signal a CBD-class field test needs to name an alias transport we
-// don't yet decode (issue #376) — and that a handled opcode does not.
+// don't yet decode (issue #376) — plus a capped run of raw-payload sample
+// lines carrying the bytes, so the transport can be reverse-engineered.
 func TestControlChannelCensusesUnhandledTSBK(t *testing.T) {
 	var buf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -212,13 +213,33 @@ func TestControlChannelCensusesUnhandledTSBK(t *testing.T) {
 	defer bus.Close()
 	cc := New(Options{Bus: bus, Log: log, SystemName: "S"})
 
-	// An unknown Motorola opcode (not patch/delete/alias) twice.
-	unknown := TSBK{Opcode: 0x3F, MFID: MFIDMotorola, Payload: [8]byte{}}
-	cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, unknown), 0)
-	cc.Process(buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, unknown), 1<<20)
+	// An unknown Motorola opcode (not patch/delete/alias) seen more times
+	// than the payload-sample cap, with a recognisable payload.
+	unknown := TSBK{Opcode: 0x3F, MFID: MFIDMotorola,
+		Payload: [8]byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04}}
+	const fires = maxUnhandledSamples + 3
+	for i := 0; i < fires; i++ {
+		lead := 0
+		if i == 0 {
+			lead = 10 // establish lock on the first frame
+		}
+		cc.Process(buildLockedStreamWithTSBK(lead, 0x293, DUIDTrunkingSignaling, unknown), i<<20)
+	}
 
-	if n := strings.Count(buf.String(), "p25: unhandled tsbk"); n != 1 {
+	out := buf.String()
+	// The summary message is a prefix of the payload message, so match the
+	// closing quote slog adds around the (space-containing) msg value.
+	if n := strings.Count(out, `msg="p25: unhandled tsbk"`); n != 1 {
 		t.Errorf("unhandled-tsbk census lines = %d, want 1 (one per distinct opcode)", n)
+	}
+	if n := strings.Count(out, `msg="p25: unhandled tsbk payload"`); n != maxUnhandledSamples {
+		t.Errorf("unhandled-tsbk payload lines = %d, want %d (capped)", n, maxUnhandledSamples)
+	}
+	if !strings.Contains(out, "deadbeef01020304") {
+		t.Error("payload sample line missing the raw payload hex")
+	}
+	if !strings.Contains(out, "opcode=0x3F") {
+		t.Error("diagnostic missing numeric opcode (Opcode.String mislabels vendor opcodes)")
 	}
 }
 


### PR DESCRIPTION
Field-debug slice for #376 (P25 Talker Alias / RID not appearing), continuing the issue's diagnose→decode loop. Two commits, both confined to the Phase 1 control-channel decoder + a test + CHANGELOG.

## Why

A new field-tested system (**CBD**, an MMR-class Phase 1 CC with Phase 2 TDMA traffic) locks and populates RIDs but shows blank talker aliases. The Phase 1 CC alias path was fully wired (vendor-TSBK `0x15` → reassembly → `KindTalkerAlias` → `/rids`) but **logged only at `Debug`**, so a field tester couldn't tell whether aliases were arriving, completing, or riding a transport we don't decode — and there was no on-air capture to reason from.

## What changed

**Commit 1 — make the path observable.** Promote three diagnostics to `Info`, mirroring the per-`(opcode,MFID)` census the Phase 2 voice composer already emits:
- `p25: cc talker alias` — on full alias reassembly
- `p25: cc talker alias fragment` — first vendor-TSBK fragment per source (so "fragments arrive but never complete" is distinguishable from "no fragments at all")
- `p25: unhandled tsbk` — one line per distinct `(MFID, opcode)` we don't dispatch, naming any alias-bearing transport a site uses but we miss

Also threads the system name into the Phase 1 voice-channel `KindTalkerAlias` publish (was leaving the `/rids` System column and `TALKER-ALIAS` log line systemless).

**Commit 2 — capture the bytes.** The field run came back with **zero** `cc talker alias` lines on two sites (including a cleanly-decoding one) — proving the alias is not our working-model fragment — and a census of candidate opcodes (Motorola `0x90` op `0x16`; standard `0x15`/`0x16`/`0x30`) whose *payloads* we couldn't see. So the `unhandled tsbk` census now prints the **numeric** opcode (the stringer mislabels vendor opcodes with standard names), and a new `p25: unhandled tsbk payload` line dumps the raw 8-byte payload hex, capped at 8 samples per `(MFID, opcode)` so a multi-block alias sequence can be reconstructed and cross-checked against known RIDs / alias strings without flooding a busy CC.

These are diagnostics, not a blind decoder: vendor alias formats are reverse-engineered against real on-air data, and the captured payloads (cross-checked against SDRTrunk's known RID↔alias pairs) drive the next slice — either reversing the CC opcode that carries the alias, or confirming it rides the Phase 2 traffic channel (#403/#413 path) instead.

## Testing

- `go build ./...`, `go vet`, and `go test ./internal/radio/p25/phase1/... ./internal/voice/composer/...` all pass.
- New unit tests: `TestDiagFirst`, `TestControlChannelCensusesUnhandledTSBK` (asserts one summary line, payload-sample cap, payload hex, numeric opcode); existing `TestControlChannelPublishesTalkerAlias` still green.
- Field verification (the real verifier): grep the new `Info` lines against the existing CBD `.cfile` replay — instructions and the RID-hex/ASCII cross-check are in the issue thread.

Closes nothing yet — keeps #376 open for the field tester's next payload paste.

https://claude.ai/code/session_01NM1XgSWaCc2hkbzdgsunHN

---
_Generated by [Claude Code](https://claude.ai/code/session_01NM1XgSWaCc2hkbzdgsunHN)_