### PR TITLE
p25/phase1: validate C4FM control-channel demod on a live UHF capture

### DIFF
--- a/cmd/gophertrunk/p25_make_fixture_test.go
+++ b/cmd/gophertrunk/p25_make_fixture_test.go
@@ -1,0 +1,95 @@
+//go:build integration
+
+package main
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// TestGenerateP25Fixture channelises a wideband real-air P25 Phase 1 capture
+// down to the production 48 kHz baseband and writes it as a small GNU Radio
+// f32 cfile, so a multi-megabyte 2 MSPS recording becomes a commit-sized
+// regression fixture (the shape of testdata/mmr-s9-cc.cfile / mmr-city-cc.cfile).
+//
+// It is a one-shot operator tool, not a CI gate: it only runs under the
+// `integration` build tag AND when P25_GEN_SRC points at the raw capture, so
+// the normal suite never touches it. The down-conversion reuses the exact DDC
+// the live/replay pipeline uses (ccdecoder.NewDownconverterWithOffset →
+// dsp.Resampler, rational L/M to land on 48000 Hz exactly), so the fixture is
+// channelised identically to how the receiver would see the signal on the air.
+//
+// The default output lands in samples/p25/ — which is git-ignored (capture
+// binaries are never committed, see samples/.gitignore). So this regenerates
+// the local capture the demod-quality harness (TestReplayP25RealCaptureMetrics)
+// grades against; the committed record of that grading is the metadata sidecar.
+//
+// Usage:
+//
+//	P25_GEN_SRC=/path/to/p25_450500center_2msps.cfile \
+//	P25_GEN_OFFSET_HZ=-625000 \
+//	go test -tags integration -run TestGenerateP25Fixture ./cmd/gophertrunk/
+//
+// Defaults: offset -625000 Hz (the 449.875 MHz control channel inside a
+// 450.500 MHz-centred 2 MSPS capture), output ../../samples/p25/p25-450875-cc.cfile.
+func TestGenerateP25Fixture(t *testing.T) {
+	src := os.Getenv("P25_GEN_SRC")
+	if src == "" {
+		t.Skip("P25_GEN_SRC unset — set it to a raw 2 MSPS P25 .cfile to (re)generate the fixture")
+	}
+	out := os.Getenv("P25_GEN_OUT")
+	if out == "" {
+		out = "../../samples/p25/p25-450875-cc.cfile"
+	}
+	const (
+		inRateHz  = 2_000_000.0
+		targetHz  = 48_000.0
+		defOffset = -625_000.0 // 449.875 MHz CC within a 450.500 MHz-centred capture
+	)
+	offsetHz := defOffset
+	if s := os.Getenv("P25_GEN_OFFSET_HZ"); s != "" {
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			t.Fatalf("P25_GEN_OFFSET_HZ=%q: %v", s, err)
+		}
+		offsetHz = v
+	}
+
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	pairs := len(raw) / 8
+	if pairs == 0 {
+		t.Fatalf("%s has no samples", src)
+	}
+	iq := make([]complex64, pairs)
+	dec, _ := siglab.FormatF32.Decoder()
+	dec(raw[:pairs*8], iq)
+
+	ddc := ccdecoder.NewDownconverterWithOffset(inRateHz, targetHz, offsetHz)
+	var chan48 []complex64
+	var scratch []complex64
+	const chunk = 65536
+	for off := 0; off < len(iq); off += chunk {
+		end := off + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		scratch = ddc.Process(scratch, iq[off:end])
+		chan48 = append(chan48, scratch...) // copy out: scratch is reused next chunk
+	}
+	if len(chan48) == 0 {
+		t.Fatalf("down-conversion produced no samples")
+	}
+
+	if err := siglab.WriteCapture(out, chan48, siglab.FormatF32); err != nil {
+		t.Fatalf("write %s: %v", out, err)
+	}
+	t.Logf("wrote %s: %d samples @ %.0f Hz (%.2f s, %d bytes) from %s offset=%.0f Hz",
+		out, len(chan48), ddc.OutRateHz(), float64(len(chan48))/ddc.OutRateHz(), len(chan48)*8, src, offsetHz)
+}

--- a/docs/decoder-capture-needs.md
+++ b/docs/decoder-capture-needs.md
@@ -224,7 +224,18 @@ false-positive coverage but **not blocking**.
 - **MDC1200** — over-the-air FEC redundancy isn't exploited yet, but
   that's a decode-improvement follow-up, not a capture gap.
 - **P25 Phase 1 / Phase 2** — full TIA-102 chains ship and decode to
-  audio; Phase 2 inner FEC (trellis / RS / PN44) is closed.
+  audio; Phase 2 inner FEC (trellis / RS / PN44) is closed. The Phase 1
+  C4FM control-channel demod is now confirmed on real air: a live UHF
+  capture (449.875 MHz, NAC 0x2C1) was channelised to 48 kHz and run
+  through the `samples/p25/` demod-quality harness
+  (`TestReplayP25RealCaptureMetrics`), which grades it at EVM ≈ 12.7%,
+  SNR ≈ 14.5 dB, NID 31/0, TSBK 36/0. The capture binary is **not**
+  committed (per `samples/.gitignore`); the committed record is the
+  `samples/p25/p25-450875-cc.metadata.json` sidecar, and the capture is
+  reproducible locally via `TestGenerateP25Fixture`. (The Tier 2 IMBE
+  *voice*-level calibration above is a separate gap — it needs raw IMBE
+  frames + a DSD-FME reference WAV, which a control-channel IQ capture
+  does not provide.)
 - **EDACS, LTR, Motorola Type II, dPMR control** — control chains ship;
   FEC is on by default with no outstanding capture.
 

--- a/samples/p25/README.md
+++ b/samples/p25/README.md
@@ -10,6 +10,14 @@ the **field truth** — it runs the real signal through the receiver and reports
 the pre-FEC error rate, EVM, estimated SNR, and FSW sync-margin so a weak-decode
 report becomes a number you can act on.
 
+**Status:** validated against a live UHF C4FM site (449.875 MHz, NAC 0x2C1) —
+see `p25-450875-cc.metadata.json`. The harness graded it at EVM ≈ 12.7%,
+SNR ≈ 14.5 dB, sync-margin min=3/median=5, NID trusted=31/failed=0, TSBK
+decoded=36/CRC-failed=0. The `.cfile` itself is git-ignored (capture binaries
+are never committed); the committed metadata sidecar carries the result, and
+the capture is reproducible from the raw 2 MSPS recording via
+`TestGenerateP25Fixture` (`cmd/gophertrunk/p25_make_fixture_test.go`).
+
 Two captures are most valuable, and you can drop either or both:
 
 - a **C4FM** site (the FM-discriminator path — the one the harness shows is the

--- a/samples/p25/p25-450875-cc.metadata.json
+++ b/samples/p25/p25-450875-cc.metadata.json
@@ -1,0 +1,16 @@
+{
+  "source": "OTA RTL-SDR @ 450.500 MHz center, 2 MSPS; control channel at -625 kHz (449.875 MHz), channelised to 48 kHz",
+  "tool_cross_check": "",
+  "sample_rate_hz": 48000,
+  "center_freq_hz": 449875000,
+  "expected": {
+    "demod_mode": "c4fm",
+    "nac": "0x2C1",
+    "min_nid_trusted": 24,
+    "min_tsbk": 28,
+    "max_evm_pct": 18.0,
+    "min_snr_db": 11.0,
+    "min_sync_margin": 2
+  },
+  "notes": "Live UHF P25 Phase 1 C4FM control channel, NAC 0x2C1. Clean decode. Measured 2026-06-14: EVM 12.7%, SNR 14.5 dB, sync-margin min=3/median=5 (hits=31), NID trusted=31/failed=0, TSBK decoded=36/CRC-failed=0. Bounds are floors below the measured values; tighten as the demod improves."
+}


### PR DESCRIPTION
## Summary

Closes the P25 Phase 1 real-air validation gap using **13 live over-the-air captures** (450.500 MHz center, 2 MSPS) of a real UHF P25 system. The repo's skip-gated `samples/p25/` demod-quality harness had been waiting on exactly this kind of capture.

**Result:** all 13 captures decode to the same system — **NAC `0x2C1`**. The control channel sits at **−625 kHz (449.875 MHz)** inside the captured band, and **C4FM consistently out-decodes CQPSK** (this is a normal, non-simulcast site). The cleanest capture decodes with **NID trusted 31 / failed 0, TSBK 36, zero CRC/trellis failures**.

Measured demod quality (via `TestReplayP25RealCaptureMetrics`):

| Metric | Value |
| --- | --- |
| EVM | 12.7% |
| SNR | ≈14.5 dB |
| Sync-margin | min=3 / median=5 (hits=31) |
| NID | trusted=31, failed=0 |
| TSBK | decoded=36, CRC-failed=0, trellis-failed=0 |
| NAC | 0x2C1 |

## No capture binaries committed

Per `samples/.gitignore`, capture `.cfile`s are never committed. The committed record of the validation is:

- **`samples/p25/p25-450875-cc.metadata.json`** — feeds the demod-quality harness; bounds (`max_evm_pct`, `min_snr_db`, `min_sync_margin`, `min_nid_trusted`, `min_tsbk`) are set as floors below the measured values so the harness asserts a real pass/fail gate.
- **`TestGenerateP25Fixture`** (`cmd/gophertrunk/p25_make_fixture_test.go`) — an integration-gated, env-driven generator that reuses `ccdecoder`'s production DDC (`NewDownconverterWithOffset` → `dsp.Resampler`, rational L/M landing exactly on 48 kHz) + `siglab` to channelise a wideband 2 MSPS capture down to the centred 48 kHz baseband the harness reads. Its default output lands in the git-ignored `samples/p25/` path, so running it never risks committing a capture.

## Docs

- `docs/decoder-capture-needs.md` — record the P25 Phase 1 real-air validation and the measured metrics.
- `samples/p25/README.md` — add a Status line.
- Both note the Tier-2 **IMBE voice-level calibration** remains open: it needs raw IMBE frames + a DSD-FME reference WAV, which a control-channel IQ capture does not provide.

## Verification

```
go build ./...                                                        # clean
go vet -tags integration ./cmd/gophertrunk/...                       # clean
go test ./cmd/gophertrunk/...                                        # ok
go test -tags integration -run TestReplayP25RealCaptureMetrics ./cmd/gophertrunk/   # ok (bounds asserted)
```

https://claude.ai/code/session_01Ej6yTsbb8okPyhJww3MQe4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ej6yTsbb8okPyhJww3MQe4)_