### PR TITLE
siglab+hunt: wide-band multi-carrier survey & DMR Tier III system recognition

### DIFF
--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -42,6 +42,7 @@ func runHunt(args []string) {
 	autoTune := fs.Bool("auto-tune", false, "estimate the dominant carrier offset and tune it to 0 Hz before demod")
 	conjugate := fs.Bool("conjugate", false, "conjugate IQ (negate Q) before channelization (spectrum-inverted front-end)")
 	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation")
+	wideband := fs.Bool("wideband", false, "offline: treat each -in capture as a wide-band multi-carrier grab — survey it (spectrum → per-carrier DDC → identify), then group the carriers into one trunked system. -freq is the capture CENTER frequency.")
 	minConfidence := fs.Float64("min-confidence", 0.40, "skip auto-identified captures below this confidence (0..1)")
 
 	// Live-mode flags (no -in): sweep an SDR across operator-given band(s) or
@@ -126,6 +127,10 @@ EXAMPLES:
 
   # SURVEY (offline): classify + decode a recorded wideband capture, no SDR
   gophertrunk hunt -survey -in wideband.cfile -format f32 -sample-rate 2400000
+
+  # WIDEBAND (offline): split a wide-band capture into per-carrier streams and
+  # group them into one trunked system (-freq is the capture CENTER frequency)
+  gophertrunk hunt -wideband -in dmr-441MHz.cfile -freq 441000000 -format f32 -sample-rate 2000000
 
 FLAGS:`)
 		fs.PrintDefaults()
@@ -239,7 +244,22 @@ FLAGS:`)
 			captures = append(captures, ci)
 		}
 
-		if *surveyMode {
+		if *wideband {
+			// Offline wide-band survey: split each capture into per-carrier
+			// streams and group the DMR carriers into one trunked system.
+			fmt.Fprintf(os.Stderr, "wideband: surveying %d capture(s)…\n", len(captures))
+			var derr error
+			sys, reports, derr = hunt.DiscoverWideband(captures, hunt.DiscoverConfig{
+				Name:          *name,
+				State:         *state,
+				County:        *county,
+				Location:      *location,
+				MinConfidence: *minConfidence,
+			})
+			if derr != nil {
+				rep.Fatal(1, derr)
+			}
+		} else if *surveyMode {
 			// Offline survey: classify + route every capture, not just trunking.
 			fmt.Fprintf(os.Stderr, "survey: classifying %d capture(s)…\n", len(captures))
 			sv, sreports, serr := hunt.RunOfflineSurvey(captures, hunt.LiveHuntOptions{
@@ -318,6 +338,9 @@ func finishHunt(rep *diag.Reporter, sys *hunt.DiscoveredSystem, reports []hunt.C
 		default:
 			fmt.Fprintf(os.Stderr, "hunt:   %s — %s, locked=%v, +%d talkgroups\n",
 				r.Path, r.Protocol, r.Locked, r.Talkgroups)
+			if r.Verdict != "" {
+				fmt.Fprintf(os.Stderr, "hunt:     ↳ %s\n", r.Verdict)
+			}
 		}
 	}
 	// Resolve the output directory up front so the survey inventory and any

--- a/internal/carriers/carriers_test.go
+++ b/internal/carriers/carriers_test.go
@@ -1,0 +1,52 @@
+package carriers
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+)
+
+func TestDetectPeaksFindsTonesAndSorts(t *testing.T) {
+	const n, center, rate = 1024, 851_000_000, 2_048_000
+	bins := make([]float32, n)
+	for i := range bins {
+		bins[i] = -80
+	}
+	bins[300] = -20 // strongest
+	bins[800] = -30
+	frame := spectrum.Frame{CenterHz: center, SampleRate: rate, Bins: bins}
+
+	peaks := DetectPeaks(frame, PeakOptions{ThresholdDb: 10})
+	if len(peaks) != 2 {
+		t.Fatalf("len(peaks) = %d, want 2: %+v", len(peaks), peaks)
+	}
+	step := float64(rate) / n
+	base := float64(center) - float64(rate)/2
+	want300 := uint32(base + 300*step)
+	if absDiff(peaks[0].FreqHz, want300) > uint32(step) {
+		t.Errorf("peaks[0] = %d Hz, want strongest near %d Hz", peaks[0].FreqHz, want300)
+	}
+}
+
+func TestInferGridPicksTwelveAndHalfAndSnaps(t *testing.T) {
+	base := uint32(851_012_500)
+	freqs := make([]uint32, 0, 6)
+	for i := uint32(0); i < 6; i++ {
+		freqs = append(freqs, base+i*12_500)
+	}
+	step, phase := InferGrid(freqs)
+	if step != 12_500 {
+		t.Fatalf("inferred step %d Hz, want 12500", step)
+	}
+	if phase != base%12_500 {
+		t.Errorf("inferred phase %d Hz, want %d", phase, base%12_500)
+	}
+	// A carrier ~300 Hz off the raster snaps back within one bin's correction.
+	if got := SnapHz(base+12_500+300, step, phase, 586); got != base+12_500 {
+		t.Errorf("SnapHz = %d, want %d", got, base+12_500)
+	}
+	// A carrier 3 kHz off-raster is left untouched.
+	if got := SnapHz(base+3_000, step, phase, 586); got != base+3_000 {
+		t.Errorf("far-off-grid carrier changed to %d, want unchanged", got)
+	}
+}

--- a/internal/carriers/grid.go
+++ b/internal/carriers/grid.go
@@ -1,0 +1,95 @@
+package carriers
+
+import "math"
+
+// standardChannelSteps are the trunking channel rasters InferGrid tests, finest
+// first. They are the channel steps used by real P25/DMR/MPT/analog land-mobile
+// systems worldwide; 11.6 kHz and friends are measurement artifacts, not real
+// channel plans.
+var standardChannelSteps = []uint32{6_250, 12_500, 25_000}
+
+// gridFitThreshold is the minimum mean-resultant-length (circular concentration,
+// 0..1) a candidate raster must reach for its residuals to count as "clustered
+// on a grid". 0.8 keeps a genuine raster (residuals piled at one phase) while
+// rejecting frequencies scattered across the step.
+const gridFitThreshold = 0.8
+
+// minGridCandidates is the fewest candidates InferGrid needs before it trusts a
+// detected raster; below it there isn't enough evidence to pick a step, so the
+// caller falls back to the finest standard step (which still corrects sub-step
+// bin jitter).
+const minGridCandidates = 3
+
+// InferGrid picks the channel raster (step, phase in Hz) that best explains the
+// candidate frequencies. For each standard step it treats the residuals
+// (f mod step) as points on a circle and measures their concentration (mean
+// resultant length); the raster fits when the residuals pile up at one phase.
+// It returns the coarsest step whose residuals are tightly clustered — the
+// coarsest raster the channels genuinely sit on — and that cluster's phase.
+//
+// With too few candidates, or no step clustering tightly, it falls back to the
+// finest standard step at phase 0: a lone carrier (the 440.125 MHz repro) then
+// still snaps to the nearest 6.25 kHz point, correcting the FFT-bin offset.
+func InferGrid(freqs []uint32) (stepHz, phaseHz uint32) {
+	if len(freqs) < minGridCandidates {
+		return standardChannelSteps[0], 0
+	}
+	bestStep, bestPhase := uint32(0), uint32(0)
+	for _, step := range standardChannelSteps {
+		phase, r := gridFit(freqs, step)
+		if r >= gridFitThreshold {
+			// Coarsest qualifying step wins: standardChannelSteps is finest-first,
+			// so keep overwriting as we walk to coarser steps that still fit.
+			bestStep, bestPhase = step, phase
+		}
+	}
+	if bestStep == 0 {
+		return standardChannelSteps[0], 0
+	}
+	return bestStep, bestPhase
+}
+
+// gridFit returns the cluster phase (Hz) and the mean resultant length (0..1) of
+// the candidate frequencies' residuals modulo step. A resultant length near 1
+// means the residuals pile up at one phase (the carriers sit on this raster);
+// near 0 means they are spread across the step (this raster doesn't explain them).
+func gridFit(freqs []uint32, step uint32) (phaseHz uint32, resultant float64) {
+	var sumSin, sumCos float64
+	for _, f := range freqs {
+		theta := 2 * math.Pi * float64(f%step) / float64(step)
+		sumSin += math.Sin(theta)
+		sumCos += math.Cos(theta)
+	}
+	n := float64(len(freqs))
+	resultant = math.Hypot(sumCos, sumSin) / n
+	mean := math.Atan2(sumSin, sumCos)
+	if mean < 0 {
+		mean += 2 * math.Pi
+	}
+	phaseHz = uint32(math.Round(mean/(2*math.Pi)*float64(step))) % step
+	return phaseHz, resultant
+}
+
+// SnapHz snaps f to the nearest point on the (step, phase) grid, but only when
+// that point is within maxCorrectionHz of f — so a small FFT-bin quantization
+// error is corrected to the true channel centre while a carrier that genuinely
+// sits off the raster (e.g. an analog channel on a different plan) is left where
+// it is. maxCorrectionHz == 0, or step == 0, disables snapping.
+func SnapHz(f, step, phase, maxCorrectionHz uint32) uint32 {
+	if step == 0 || maxCorrectionHz == 0 {
+		return f
+	}
+	k := math.Round((float64(f) - float64(phase)) / float64(step))
+	nearest := int64(phase) + int64(k)*int64(step)
+	if nearest < 0 {
+		return f
+	}
+	d := int64(f) - nearest
+	if d < 0 {
+		d = -d
+	}
+	if d <= int64(maxCorrectionHz) {
+		return uint32(nearest)
+	}
+	return f
+}

--- a/internal/carriers/peaks.go
+++ b/internal/carriers/peaks.go
@@ -1,0 +1,144 @@
+// Package carriers holds protocol-neutral carrier-discovery primitives: finding
+// candidate carriers in a power spectrum and snapping them onto the standard
+// land-mobile channel rasters. It sits below both internal/hunt (the live
+// sweeper) and internal/siglab (the offline wideband survey) so the two share
+// one implementation of the peak detector and channel-grid logic rather than
+// drifting copies — the import direction is carriers ← {hunt, siglab}, never
+// the reverse.
+package carriers
+
+import (
+	"math"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+)
+
+// Peak is a candidate carrier found in a spectrum frame: its absolute
+// frequency, its power, and how far it stands above the estimated noise floor.
+type Peak struct {
+	FreqHz    uint32
+	PowerDbFS float32
+	SNRDb     float32
+}
+
+// PeakOptions tune the carrier detector.
+type PeakOptions struct {
+	// ThresholdDb is the minimum power above the estimated noise floor for a
+	// local maximum to count as a carrier. 0 ⇒ a sensible default (10 dB).
+	ThresholdDb float32
+	// MinSpacingHz is the minimum separation between reported peaks; when two
+	// maxima fall closer than this the stronger one wins. 0 ⇒ 6.25 kHz (the
+	// tightest trunking channel step).
+	MinSpacingHz uint32
+	// GuardBins drops this many bins at each band edge (rolloff) from
+	// consideration. 0 ⇒ a default proportional to the FFT size.
+	GuardBins int
+}
+
+// noiseFloorPercentile is the percentile of bin powers used as the noise-floor
+// estimate. The low quartile is robust to strong carriers occupying the upper
+// tail, unlike a mean.
+const noiseFloorPercentile = 0.25
+
+// DetectPeaks finds candidate carriers in a spectrum frame. It estimates a
+// robust noise floor (low-quartile of the bin powers), keeps local maxima that
+// stand ThresholdDb above it, drops the DC bin and the band-edge guard bins,
+// and enforces a minimum carrier spacing (stronger peak wins). Bin indices are
+// mapped to absolute Hz using the frame's center and sample rate. Returned
+// peaks are sorted by descending SNR.
+func DetectPeaks(frame spectrum.Frame, opts PeakOptions) []Peak {
+	n := len(frame.Bins)
+	if n < 8 || frame.SampleRate == 0 {
+		return nil
+	}
+	threshold := opts.ThresholdDb
+	if threshold <= 0 {
+		threshold = 10
+	}
+	minSpacing := opts.MinSpacingHz
+	if minSpacing == 0 {
+		minSpacing = 6_250
+	}
+	guard := opts.GuardBins
+	if guard <= 0 {
+		guard = n / 64 // ~1.5% of the band at each edge
+		if guard < 1 {
+			guard = 1
+		}
+	}
+
+	floor := percentile(frame.Bins, noiseFloorPercentile)
+	binHz := float64(frame.SampleRate) / float64(n)
+	dcBin := n / 2 // FFT-shifted: DC sits in the middle (see spectrum.frame)
+
+	var peaks []Peak
+	for i := guard; i < n-guard; i++ {
+		if i == dcBin {
+			continue
+		}
+		v := frame.Bins[i]
+		if v-floor < threshold {
+			continue
+		}
+		// Strict local maximum against immediate neighbors.
+		if v <= frame.Bins[i-1] || v < frame.Bins[i+1] {
+			continue
+		}
+		peaks = append(peaks, Peak{
+			FreqHz:    binToHz(frame, i, binHz),
+			PowerDbFS: v,
+			SNRDb:     v - floor,
+		})
+	}
+
+	// Strongest-first, then suppress weaker peaks within MinSpacingHz.
+	sort.Slice(peaks, func(a, b int) bool { return peaks[a].SNRDb > peaks[b].SNRDb })
+	var kept []Peak
+	for _, p := range peaks {
+		ok := true
+		for _, k := range kept {
+			if absDiff(p.FreqHz, k.FreqHz) < minSpacing {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			kept = append(kept, p)
+		}
+	}
+	return kept
+}
+
+// binToHz maps an FFT-shifted bin index to its absolute center frequency.
+// Bins[0] = CenterHz - SampleRate/2; step = SampleRate/N.
+func binToHz(frame spectrum.Frame, bin int, binHz float64) uint32 {
+	base := float64(frame.CenterHz) - float64(frame.SampleRate)/2
+	return uint32(math.Round(base + float64(bin)*binHz))
+}
+
+// percentile returns the p-quantile (0..1) of bins using a copy+sort. Used for
+// the robust noise-floor estimate.
+func percentile(bins []float32, p float64) float32 {
+	if len(bins) == 0 {
+		return 0
+	}
+	cp := make([]float32, len(bins))
+	copy(cp, bins)
+	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+	idx := int(p * float64(len(cp)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(cp) {
+		idx = len(cp) - 1
+	}
+	return cp[idx]
+}
+
+func absDiff(a, b uint32) uint32 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/internal/hunt/discover.go
+++ b/internal/hunt/discover.go
@@ -57,6 +57,9 @@ type CaptureReport struct {
 	Skipped    bool    `json:"skipped"`
 	SkipReason string  `json:"skip_reason,omitempty"`
 	Error      string  `json:"error,omitempty"`
+	// Verdict is the wideband survey's system-level summary line (set only by
+	// DiscoverWideband). Empty for single-carrier captures.
+	Verdict string `json:"verdict,omitempty"`
 }
 
 // Discover folds every capture into a single DiscoveredSystem. Captures whose

--- a/internal/hunt/grid.go
+++ b/internal/hunt/grid.go
@@ -1,95 +1,20 @@
 package hunt
 
-import "math"
+import "github.com/MattCheramie/GopherTrunk/internal/carriers"
 
-// standardChannelSteps are the trunking channel rasters inferGrid tests, finest
-// first. They are the channel steps used by real P25/DMR/MPT/analog land-mobile
-// systems worldwide; 11.6 kHz and friends are measurement artifacts, not real
-// channel plans.
-var standardChannelSteps = []uint32{6_250, 12_500, 25_000}
+// inferGrid + snapHz wrap the channel-grid helpers in internal/carriers so the
+// sweeper (snapCandidatesToGrid) keeps calling them with hunt's Candidate type
+// while the implementation lives in the neutral carriers package, shared with
+// the siglab wideband survey.
 
-// gridFitThreshold is the minimum mean-resultant-length (circular concentration,
-// 0..1) a candidate raster must reach for its residuals to count as "clustered
-// on a grid". 0.8 keeps a genuine raster (residuals piled at one phase) while
-// rejecting frequencies scattered across the step.
-const gridFitThreshold = 0.8
-
-// minGridCandidates is the fewest candidates inferGrid needs before it trusts a
-// detected raster; below it there isn't enough evidence to pick a step, so the
-// caller falls back to the finest standard step (which still corrects sub-step
-// bin jitter).
-const minGridCandidates = 3
-
-// inferGrid picks the channel raster (step, phase in Hz) that best explains the
-// candidate frequencies. For each standard step it treats the residuals
-// (f mod step) as points on a circle and measures their concentration (mean
-// resultant length); the raster fits when the residuals pile up at one phase.
-// It returns the coarsest step whose residuals are tightly clustered — the
-// coarsest raster the channels genuinely sit on — and that cluster's phase.
-//
-// With too few candidates, or no step clustering tightly, it falls back to the
-// finest standard step at phase 0: a lone carrier (the 440.125 MHz repro) then
-// still snaps to the nearest 6.25 kHz point, correcting the FFT-bin offset.
 func inferGrid(cands []Candidate) (stepHz, phaseHz uint32) {
-	if len(cands) < minGridCandidates {
-		return standardChannelSteps[0], 0
+	freqs := make([]uint32, len(cands))
+	for i, c := range cands {
+		freqs[i] = c.FreqHz
 	}
-	bestStep, bestPhase := uint32(0), uint32(0)
-	for _, step := range standardChannelSteps {
-		phase, r := gridFit(cands, step)
-		if r >= gridFitThreshold {
-			// Coarsest qualifying step wins: standardChannelSteps is finest-first,
-			// so keep overwriting as we walk to coarser steps that still fit.
-			bestStep, bestPhase = step, phase
-		}
-	}
-	if bestStep == 0 {
-		return standardChannelSteps[0], 0
-	}
-	return bestStep, bestPhase
+	return carriers.InferGrid(freqs)
 }
 
-// gridFit returns the cluster phase (Hz) and the mean resultant length (0..1) of
-// the candidate frequencies' residuals modulo step. A resultant length near 1
-// means the residuals pile up at one phase (the carriers sit on this raster);
-// near 0 means they are spread across the step (this raster doesn't explain them).
-func gridFit(cands []Candidate, step uint32) (phaseHz uint32, resultant float64) {
-	var sumSin, sumCos float64
-	for _, c := range cands {
-		theta := 2 * math.Pi * float64(c.FreqHz%step) / float64(step)
-		sumSin += math.Sin(theta)
-		sumCos += math.Cos(theta)
-	}
-	n := float64(len(cands))
-	resultant = math.Hypot(sumCos, sumSin) / n
-	mean := math.Atan2(sumSin, sumCos)
-	if mean < 0 {
-		mean += 2 * math.Pi
-	}
-	phaseHz = uint32(math.Round(mean/(2*math.Pi)*float64(step))) % step
-	return phaseHz, resultant
-}
-
-// snapHz snaps f to the nearest point on the (step, phase) grid, but only when
-// that point is within maxCorrectionHz of f — so a small FFT-bin quantization
-// error is corrected to the true channel centre while a carrier that genuinely
-// sits off the raster (e.g. an analog channel on a different plan) is left where
-// it is. maxCorrectionHz == 0, or step == 0, disables snapping.
 func snapHz(f, step, phase, maxCorrectionHz uint32) uint32 {
-	if step == 0 || maxCorrectionHz == 0 {
-		return f
-	}
-	k := math.Round((float64(f) - float64(phase)) / float64(step))
-	nearest := int64(phase) + int64(k)*int64(step)
-	if nearest < 0 {
-		return f
-	}
-	d := int64(f) - nearest
-	if d < 0 {
-		d = -d
-	}
-	if d <= int64(maxCorrectionHz) {
-		return uint32(nearest)
-	}
-	return f
+	return carriers.SnapHz(f, step, phase, maxCorrectionHz)
 }

--- a/internal/hunt/peaks.go
+++ b/internal/hunt/peaks.go
@@ -1,134 +1,26 @@
 package hunt
 
 import (
-	"math"
-	"sort"
-
+	"github.com/MattCheramie/GopherTrunk/internal/carriers"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
 )
 
-// Peak is a candidate carrier found in a spectrum frame: its absolute
-// frequency, its power, and how far it stands above the estimated noise floor.
-type Peak struct {
-	FreqHz    uint32
-	PowerDbFS float32
-	SNRDb     float32
-}
+// Peak and PeakOptions are re-exported from internal/carriers so the live
+// sweeper keeps its existing public surface while the peak detector itself
+// lives in the neutral carriers package (shared with the siglab wideband
+// survey). See internal/carriers for the implementation.
+type Peak = carriers.Peak
+type PeakOptions = carriers.PeakOptions
 
-// PeakOptions tune the carrier detector.
-type PeakOptions struct {
-	// ThresholdDb is the minimum power above the estimated noise floor for a
-	// local maximum to count as a carrier. 0 ⇒ a sensible default (10 dB).
-	ThresholdDb float32
-	// MinSpacingHz is the minimum separation between reported peaks; when two
-	// maxima fall closer than this the stronger one wins. 0 ⇒ 6.25 kHz (the
-	// tightest trunking channel step).
-	MinSpacingHz uint32
-	// GuardBins drops this many bins at each band edge (rolloff) from
-	// consideration. 0 ⇒ a default proportional to the FFT size.
-	GuardBins int
-}
-
-// noiseFloorPercentile is the percentile of bin powers used as the noise-floor
-// estimate. The low quartile is robust to strong carriers occupying the upper
-// tail, unlike a mean.
-const noiseFloorPercentile = 0.25
-
-// DetectPeaks finds candidate carriers in a spectrum frame. It estimates a
-// robust noise floor (low-quartile of the bin powers), keeps local maxima that
-// stand ThresholdDb above it, drops the DC bin and the band-edge guard bins,
-// and enforces a minimum carrier spacing (stronger peak wins). Bin indices are
-// mapped to absolute Hz using the frame's center and sample rate. Returned
-// peaks are sorted by descending SNR.
+// DetectPeaks finds candidate carriers in a spectrum frame. Thin wrapper over
+// carriers.DetectPeaks (kept for the sweeper's call sites).
 func DetectPeaks(frame spectrum.Frame, opts PeakOptions) []Peak {
-	n := len(frame.Bins)
-	if n < 8 || frame.SampleRate == 0 {
-		return nil
-	}
-	threshold := opts.ThresholdDb
-	if threshold <= 0 {
-		threshold = 10
-	}
-	minSpacing := opts.MinSpacingHz
-	if minSpacing == 0 {
-		minSpacing = 6_250
-	}
-	guard := opts.GuardBins
-	if guard <= 0 {
-		guard = n / 64 // ~1.5% of the band at each edge
-		if guard < 1 {
-			guard = 1
-		}
-	}
-
-	floor := percentile(frame.Bins, noiseFloorPercentile)
-	binHz := float64(frame.SampleRate) / float64(n)
-	dcBin := n / 2 // FFT-shifted: DC sits in the middle (see spectrum.frame)
-
-	var peaks []Peak
-	for i := guard; i < n-guard; i++ {
-		if i == dcBin {
-			continue
-		}
-		v := frame.Bins[i]
-		if v-floor < threshold {
-			continue
-		}
-		// Strict local maximum against immediate neighbors.
-		if v <= frame.Bins[i-1] || v < frame.Bins[i+1] {
-			continue
-		}
-		peaks = append(peaks, Peak{
-			FreqHz:    binToHz(frame, i, binHz),
-			PowerDbFS: v,
-			SNRDb:     v - floor,
-		})
-	}
-
-	// Strongest-first, then suppress weaker peaks within MinSpacingHz.
-	sort.Slice(peaks, func(a, b int) bool { return peaks[a].SNRDb > peaks[b].SNRDb })
-	var kept []Peak
-	for _, p := range peaks {
-		ok := true
-		for _, k := range kept {
-			if absDiff(p.FreqHz, k.FreqHz) < minSpacing {
-				ok = false
-				break
-			}
-		}
-		if ok {
-			kept = append(kept, p)
-		}
-	}
-	return kept
+	return carriers.DetectPeaks(frame, opts)
 }
 
-// binToHz maps an FFT-shifted bin index to its absolute center frequency.
-// Bins[0] = CenterHz - SampleRate/2; step = SampleRate/N.
-func binToHz(frame spectrum.Frame, bin int, binHz float64) uint32 {
-	base := float64(frame.CenterHz) - float64(frame.SampleRate)/2
-	return uint32(math.Round(base + float64(bin)*binHz))
-}
-
-// percentile returns the p-quantile (0..1) of bins using a copy+sort. Used for
-// the robust noise-floor estimate.
-func percentile(bins []float32, p float64) float32 {
-	if len(bins) == 0 {
-		return 0
-	}
-	cp := make([]float32, len(bins))
-	copy(cp, bins)
-	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
-	idx := int(p * float64(len(cp)-1))
-	if idx < 0 {
-		idx = 0
-	}
-	if idx >= len(cp) {
-		idx = len(cp) - 1
-	}
-	return cp[idx]
-}
-
+// absDiff is the |a-b| helper the sweeper + peak tests use. carriers has its
+// own copy for DetectPeaks; this one stays so the hunt-package tests and
+// sweeper logic don't depend on the carriers internal.
 func absDiff(a, b uint32) uint32 {
 	if a > b {
 		return a - b

--- a/internal/hunt/wideband.go
+++ b/internal/hunt/wideband.go
@@ -1,0 +1,114 @@
+package hunt
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// DiscoverWideband folds wideband multi-carrier captures into a single
+// DiscoveredSystem. Each capture is surveyed (siglab.SurveyWideband splits it
+// into per-carrier baseband streams, identifies each, and recognizes a DMR
+// Tier III trunked system), and every DMR carrier of the capture is accumulated
+// into the same system — so the control channels register their identity +
+// frequencies and the voice carriers' grants become talkgroups, all under one
+// discovered system. It is the offline-hunt counterpart of Discover for the
+// `hunt -wideband -in <capture>` path.
+//
+// Each capture's CaptureInput.FrequencyHz is the capture CENTER frequency (the
+// dongle's tuned center), not a single carrier; the per-carrier absolute
+// frequencies fall out of the survey's spectral offsets.
+func DiscoverWideband(captures []CaptureInput, cfg DiscoverConfig) (*DiscoveredSystem, []CaptureReport, error) {
+	log := cfg.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+
+	sys := &DiscoveredSystem{
+		Name:     cfg.Name,
+		State:    cfg.State,
+		County:   cfg.County,
+		Location: cfg.Location,
+	}
+	reports := make([]CaptureReport, 0, len(captures))
+
+	for _, cap := range captures {
+		f, err := os.Open(cap.Path)
+		if err != nil {
+			reports = append(reports, CaptureReport{Path: cap.Path, Error: fmt.Sprintf("open: %v", err)})
+			continue
+		}
+		wr, err := siglab.SurveyWideband(f, cap.Path, siglab.WidebandConfig{
+			SampleRateHz: cap.SampleRateHz,
+			CenterHz:     cap.FrequencyHz,
+			Format:       cap.Format,
+			Conjugate:    cap.Conjugate,
+			IQCorrect:    cap.IQCorrect,
+			Log:          log,
+		})
+		f.Close()
+		if err != nil {
+			reports = append(reports, CaptureReport{Path: cap.Path, Error: fmt.Sprintf("survey: %v", err)})
+			continue
+		}
+		reports = append(reports, accumulateSurvey(sys, cap.Path, wr))
+	}
+
+	sys.sortAll()
+	return sys, reports, nil
+}
+
+// accumulateSurvey folds every DMR carrier of one wideband survey into sys and
+// returns a one-line report for the capture.
+func accumulateSurvey(sys *DiscoveredSystem, path string, wr *siglab.WidebandResult) CaptureReport {
+	before := len(sys.Talkgroups)
+	rep := CaptureReport{Path: path}
+
+	var controls, voices int
+	var bestConf float64
+	for _, c := range wr.Carriers {
+		if c.Role != siglab.RoleControl && c.Role != siglab.RoleVoice {
+			continue // not a DMR member of a trunked system
+		}
+		res := c.Result()
+		if res == nil {
+			continue
+		}
+		Accumulate(sys, Observation{
+			Protocol:       c.Protocol,
+			Confidence:     c.Confidence,
+			Result:         res,
+			FallbackFreqHz: c.FreqHz,
+			At:             time.Now(),
+		})
+		switch c.Role {
+		case siglab.RoleControl:
+			controls++
+			if c.Locked {
+				rep.Locked = true
+			}
+			if rep.ControlHz == 0 {
+				rep.ControlHz = c.FreqHz
+			}
+		case siglab.RoleVoice:
+			voices++
+		}
+		if c.Confidence > bestConf {
+			bestConf = c.Confidence
+		}
+	}
+
+	rep.Protocol = sys.Protocol
+	rep.Confidence = bestConf
+	rep.Talkgroups = len(sys.Talkgroups) - before
+	if len(wr.Systems) > 0 {
+		rep.Verdict = wr.Systems[0].Verdict
+	} else if controls == 0 && voices == 0 {
+		rep.Skipped = true
+		rep.SkipReason = fmt.Sprintf("no DMR carriers recognized among %d detected", wr.DetectedCount)
+	}
+	return rep
+}

--- a/internal/hunt/wideband_test.go
+++ b/internal/hunt/wideband_test.go
@@ -1,0 +1,110 @@
+package hunt
+
+import (
+	"encoding/binary"
+	"math"
+	"math/cmplx"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// buildWidebandFixture plants the two committed 48 kHz DMR fixtures (the Tier
+// III control channel and a voice carrier) into one synthetic 192 kHz
+// wide-band capture at ±48 kHz and writes it as an f32 .cfile. Returns the path
+// and the capture center frequency.
+func buildWidebandFixture(t *testing.T) (path string, centerHz uint32) {
+	t.Helper()
+	const wideRate = 192_000.0
+	centerHz = 441_000_000
+	load := func(name string) []complex64 {
+		raw, err := os.ReadFile(filepath.Join("..", "..", "cmd", "gophertrunk", "testdata", name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		p := len(raw) / 8
+		iq := make([]complex64, p)
+		dec, _ := siglab.FormatF32.Decoder()
+		dec(raw[:p*8], iq)
+		return iq
+	}
+	upshift := func(in []complex64, offsetHz float64) []complex64 {
+		rs := dsp.NewResampler(4, 1, 16, 9.0)
+		up := rs.Process(nil, in)
+		step := cmplx.Exp(complex(0, 2*math.Pi*offsetHz/wideRate))
+		ph := complex(1, 0)
+		out := make([]complex64, len(up))
+		for i, s := range up {
+			out[i] = complex64(complex128(s) * ph)
+			ph *= step
+		}
+		return out
+	}
+	ctrl := upshift(load("dmr-t3-cc.cfile"), +48_000)
+	vox := upshift(load("dmr-voice-term.cfile"), -48_000)
+	n := len(ctrl)
+	if len(vox) < n {
+		n = len(vox)
+	}
+	buf := make([]byte, n*8)
+	for i := 0; i < n; i++ {
+		s := ctrl[i] + vox[i]
+		binary.LittleEndian.PutUint32(buf[i*8:], math.Float32bits(real(s)))
+		binary.LittleEndian.PutUint32(buf[i*8+4:], math.Float32bits(imag(s)))
+	}
+	path = filepath.Join(t.TempDir(), "dmr-t3-wideband.cfile")
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path, centerHz
+}
+
+// TestDiscoverWidebandGroupsTier3System asserts the offline wideband-hunt bridge
+// surveys a wideband capture, recognizes the DMR Tier III control channel, and
+// folds it into one DiscoveredSystem carrying the real SystemID.
+func TestDiscoverWidebandGroupsTier3System(t *testing.T) {
+	path, center := buildWidebandFixture(t)
+
+	sys, reports, err := DiscoverWideband([]CaptureInput{{
+		Path:         path,
+		Format:       siglab.FormatF32,
+		SampleRateHz: 192_000,
+		FrequencyHz:  center,
+	}}, DiscoverConfig{Name: "wb-test"})
+	if err != nil {
+		t.Fatalf("DiscoverWideband: %v", err)
+	}
+
+	if len(reports) != 1 {
+		t.Fatalf("got %d reports, want 1", len(reports))
+	}
+	rep := reports[0]
+	t.Logf("report: proto=%s locked=%v controlHz=%d tgs=%d verdict=%q",
+		rep.Protocol, rep.Locked, rep.ControlHz, rep.Talkgroups, rep.Verdict)
+	if rep.Error != "" {
+		t.Fatalf("report error: %s", rep.Error)
+	}
+	if !rep.Locked {
+		t.Errorf("report not locked; want the Tier III control channel locked")
+	}
+	if rep.ControlHz == 0 {
+		t.Errorf("report has no control-channel frequency")
+	}
+	if !strings.Contains(rep.Verdict, "DMR Tier III trunked system") {
+		t.Errorf("verdict = %q, want it to name the Tier III system", rep.Verdict)
+	}
+
+	if sys.Protocol != "dmr" {
+		t.Errorf("system protocol = %q, want dmr", sys.Protocol)
+	}
+	if sys.SystemID != 61760 {
+		t.Errorf("system SystemID = %d, want 61760", sys.SystemID)
+	}
+	if len(sys.Sites) == 0 {
+		t.Errorf("system has no sites; want at least the camped control-channel site")
+	}
+}

--- a/internal/siglab/wideband.go
+++ b/internal/siglab/wideband.go
@@ -65,18 +65,18 @@ const (
 
 // CarrierResult is one detected carrier surveyed end-to-end.
 type CarrierResult struct {
-	OffsetHz     float64     `json:"offset_hz" yaml:"offset_hz"`
-	FreqHz       uint32      `json:"freq_hz" yaml:"freq_hz"`
-	SNRDb        float32     `json:"snr_db" yaml:"snr_db"`
-	Protocol     string      `json:"protocol" yaml:"protocol"`
-	Confidence   float64     `json:"confidence" yaml:"confidence"`
-	Inconclusive bool        `json:"inconclusive" yaml:"inconclusive"`
-	Locked       bool        `json:"locked" yaml:"locked"`
-	Role         CarrierRole `json:"role" yaml:"role"`
-	ColorCode    uint8       `json:"color_code,omitempty" yaml:"color_code,omitempty"`
-	SystemID     uint32      `json:"system_id,omitempty" yaml:"system_id,omitempty"`
+	OffsetHz     float64       `json:"offset_hz" yaml:"offset_hz"`
+	FreqHz       uint32        `json:"freq_hz" yaml:"freq_hz"`
+	SNRDb        float32       `json:"snr_db" yaml:"snr_db"`
+	Protocol     string        `json:"protocol" yaml:"protocol"`
+	Confidence   float64       `json:"confidence" yaml:"confidence"`
+	Inconclusive bool          `json:"inconclusive" yaml:"inconclusive"`
+	Locked       bool          `json:"locked" yaml:"locked"`
+	Role         CarrierRole   `json:"role" yaml:"role"`
+	ColorCode    uint8         `json:"color_code,omitempty" yaml:"color_code,omitempty"`
+	SystemID     uint32        `json:"system_id,omitempty" yaml:"system_id,omitempty"`
 	Grants       []GrantRecord `json:"grants,omitempty" yaml:"grants,omitempty"`
-	Score        float64     `json:"score" yaml:"score"`
+	Score        float64       `json:"score" yaml:"score"`
 
 	identify *IdentifyResult // retained for the hunt bridge
 	result   *Result         // full Run of the winning protocol
@@ -105,11 +105,11 @@ type SystemRollup struct {
 
 // WidebandResult is the full survey outcome.
 type WidebandResult struct {
-	Source        string          `json:"source" yaml:"source"`
-	SampleRateHz  float64         `json:"sample_rate_hz" yaml:"sample_rate_hz"`
-	CenterHz      uint32          `json:"center_hz" yaml:"center_hz"`
-	ChannelRateHz float64         `json:"channel_rate_hz" yaml:"channel_rate_hz"`
-	Strategy      string          `json:"strategy" yaml:"strategy"`
+	Source        string  `json:"source" yaml:"source"`
+	SampleRateHz  float64 `json:"sample_rate_hz" yaml:"sample_rate_hz"`
+	CenterHz      uint32  `json:"center_hz" yaml:"center_hz"`
+	ChannelRateHz float64 `json:"channel_rate_hz" yaml:"channel_rate_hz"`
+	Strategy      string  `json:"strategy" yaml:"strategy"`
 	// DetectedCount is the number of spectral carrier peaks before the
 	// per-carrier identify filter dropped the ones that didn't decode to a
 	// real protocol (leakage / noise peaks).

--- a/internal/siglab/wideband.go
+++ b/internal/siglab/wideband.go
@@ -1,0 +1,511 @@
+package siglab
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/carriers"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Wideband-survey defaults. The channelization constants mirror
+// internal/scanner/widebandt2 so the offline survey decimates each carrier the
+// same way the live wide-band engine does.
+const (
+	wbDefaultFFTSize       = 4096
+	wbDefaultChannelRateHz = 48_000.0
+	wbDefaultGuardFrac     = 0.05
+	wbDefaultPeakThreshDb  = 10.0
+	wbDefaultMinSpacingHz  = 6_250
+
+	// pickStrategy mirror (widebandt2): DDC ≤ 6 taps, polyphase above.
+	wbStrategyAutoThreshold = 6
+	wbChannelizerBins       = 16
+	wbChannelizerTaps       = 16
+	wbChannelizerKaiserBeta = 9.0
+)
+
+// WidebandConfig configures a wideband multi-carrier survey: the whole-capture
+// sample rate + format, the channel rate each carrier is decimated to, and the
+// per-carrier identify knobs.
+type WidebandConfig struct {
+	SampleRateHz       float64             // wideband input rate (required)
+	CenterHz           uint32              // absolute capture center (0 ⇒ offsets only)
+	Format             SampleFormat        //
+	ChannelRateHz      float64             // per-carrier target; 0 ⇒ 48 kHz
+	FFTSize            int                 // spectrum FFT; 0 ⇒ 4096
+	GuardFrac          float64             // band-edge guard; 0 ⇒ 0.05
+	PeakThresholdDb    float32             // 0 ⇒ 10
+	MinSpacingHz       uint32              // 0 ⇒ 6.25 kHz
+	TunerStrategy      string              // "" | "auto" | "ddc" | "polyphase"
+	Candidates         []trunking.Protocol // per-carrier identify set; nil ⇒ all
+	IdentifyMaxSamples int64               // per-carrier identify cap; 0 ⇒ whole carrier
+	MaxCarriers        int                 // defensive cap on taps; 0 ⇒ no cap
+	Conjugate          bool                //
+	IQCorrect          bool                //
+	Log                *slog.Logger        //
+}
+
+// CarrierRole labels a surveyed carrier within a trunked system.
+type CarrierRole string
+
+const (
+	RoleUnknown CarrierRole = ""
+	RoleControl CarrierRole = "control"
+	RoleVoice   CarrierRole = "voice"
+)
+
+// CarrierResult is one detected carrier surveyed end-to-end.
+type CarrierResult struct {
+	OffsetHz     float64     `json:"offset_hz" yaml:"offset_hz"`
+	FreqHz       uint32      `json:"freq_hz" yaml:"freq_hz"`
+	SNRDb        float32     `json:"snr_db" yaml:"snr_db"`
+	Protocol     string      `json:"protocol" yaml:"protocol"`
+	Confidence   float64     `json:"confidence" yaml:"confidence"`
+	Inconclusive bool        `json:"inconclusive" yaml:"inconclusive"`
+	Locked       bool        `json:"locked" yaml:"locked"`
+	Role         CarrierRole `json:"role" yaml:"role"`
+	ColorCode    uint8       `json:"color_code,omitempty" yaml:"color_code,omitempty"`
+	SystemID     uint32      `json:"system_id,omitempty" yaml:"system_id,omitempty"`
+	Grants       []GrantRecord `json:"grants,omitempty" yaml:"grants,omitempty"`
+	Score        float64     `json:"score" yaml:"score"`
+
+	identify *IdentifyResult // retained for the hunt bridge
+	result   *Result         // full Run of the winning protocol
+}
+
+// Result returns the winning protocol's full run Result (topology + grants),
+// or nil. Used by the offline hunt bridge to fold each carrier into a system.
+func (c *CarrierResult) Result() *Result { return c.result }
+
+// Identify returns the carrier's ranked identification.
+func (c *CarrierResult) Identify() *IdentifyResult { return c.identify }
+
+// SystemRollup clusters carriers into one trunked-system verdict.
+type SystemRollup struct {
+	Protocol     string `json:"protocol" yaml:"protocol"`
+	Tier3        bool   `json:"tier3" yaml:"tier3"`
+	SystemID     uint32 `json:"system_id,omitempty" yaml:"system_id,omitempty"`
+	ColorCode    uint8  `json:"color_code,omitempty" yaml:"color_code,omitempty"`
+	ControlCount int    `json:"control_count" yaml:"control_count"`
+	VoiceCount   int    `json:"voice_count" yaml:"voice_count"`
+	LoHz         uint32 `json:"lo_hz" yaml:"lo_hz"`
+	HiHz         uint32 `json:"hi_hz" yaml:"hi_hz"`
+	CarrierIdx   []int  `json:"carrier_idx" yaml:"carrier_idx"`
+	Verdict      string `json:"verdict" yaml:"verdict"`
+}
+
+// WidebandResult is the full survey outcome.
+type WidebandResult struct {
+	Source        string          `json:"source" yaml:"source"`
+	SampleRateHz  float64         `json:"sample_rate_hz" yaml:"sample_rate_hz"`
+	CenterHz      uint32          `json:"center_hz" yaml:"center_hz"`
+	ChannelRateHz float64         `json:"channel_rate_hz" yaml:"channel_rate_hz"`
+	Strategy      string          `json:"strategy" yaml:"strategy"`
+	// DetectedCount is the number of spectral carrier peaks before the
+	// per-carrier identify filter dropped the ones that didn't decode to a
+	// real protocol (leakage / noise peaks).
+	DetectedCount int             `json:"detected_count" yaml:"detected_count"`
+	Carriers      []CarrierResult `json:"carriers" yaml:"carriers"`
+	Systems       []SystemRollup  `json:"systems" yaml:"systems"`
+}
+
+// detectedCarrier is a snapped spectral peak before identification.
+type detectedCarrier struct {
+	offsetHz float64
+	freqHz   uint32
+	snr      float32
+}
+
+// SurveyWideband decodes the whole capture from r into memory and surveys it.
+func SurveyWideband(r io.ReadSeeker, source string, cfg WidebandConfig) (*WidebandResult, error) {
+	if cfg.SampleRateHz <= 0 {
+		return nil, fmt.Errorf("siglab: wideband sample rate must be > 0")
+	}
+	decode, bytesPerSample := cfg.Format.Decoder()
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("siglab: read wideband capture: %w", err)
+	}
+	pairs := len(raw) / bytesPerSample
+	if pairs == 0 {
+		return nil, fmt.Errorf("siglab: wideband capture %s has no samples", source)
+	}
+	iq := make([]complex64, pairs)
+	decode(raw[:pairs*bytesPerSample], iq)
+	return SurveyWidebandIQ(iq, source, cfg)
+}
+
+// SurveyWidebandIQ surveys an already-decoded wideband buffer: averaged power
+// spectrum → carrier peaks → grid-snap → per-carrier DDC → per-carrier identify
+// → cluster into systems. It is the in-memory core the hunt bridge and tests
+// share.
+func SurveyWidebandIQ(iq []complex64, source string, cfg WidebandConfig) (*WidebandResult, error) {
+	if cfg.SampleRateHz <= 0 {
+		return nil, fmt.Errorf("siglab: wideband sample rate must be > 0")
+	}
+	log := cfg.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	if cfg.Conjugate {
+		for i, s := range iq {
+			iq[i] = complex(real(s), -imag(s))
+		}
+	}
+	if cfg.IQCorrect {
+		rtlsdr.NewIQImbalanceCorrector().Process(iq)
+	}
+
+	chRate := cfg.ChannelRateHz
+	if chRate <= 0 {
+		chRate = wbDefaultChannelRateHz
+	}
+	guard := cfg.GuardFrac
+	if guard <= 0 {
+		guard = wbDefaultGuardFrac
+	}
+	fftSize := cfg.FFTSize
+	if fftSize <= 0 {
+		fftSize = wbDefaultFFTSize
+	}
+
+	out := &WidebandResult{
+		Source:       baseName(source),
+		SampleRateHz: cfg.SampleRateHz,
+		CenterHz:     cfg.CenterHz,
+	}
+
+	// 1-3. Spectrum → peaks → grid-snap.
+	cands := detectCarriers(iq, cfg, fftSize, guard)
+	out.DetectedCount = len(cands)
+	if len(cands) == 0 {
+		return out, nil
+	}
+
+	// 4. Per-carrier extraction via a tuner Bank (reuse dsp/tuner).
+	bank, strategy := newBank(cfg.TunerStrategy, len(cands), cfg.SampleRateHz, chRate, guard)
+	out.Strategy = strategy
+	bufs := make([][]complex64, len(cands))
+	taps := make([]int, 0, len(cands)) // cand index per registered tap
+	for i, c := range cands {
+		i := i
+		err := bank.AddTap(c.offsetHz, func(o []complex64) {
+			if len(o) > 0 {
+				bufs[i] = append(bufs[i], o...) // copy: the bank reuses o
+			}
+		})
+		if err != nil {
+			log.Debug("siglab/wideband: drop carrier", "offset_hz", c.offsetHz, "err", err)
+			continue
+		}
+		taps = append(taps, i)
+	}
+	chOut := bank.OutputRateHz()
+	out.ChannelRateHz = chOut
+
+	const chunk = 8192
+	for off := 0; off < len(iq); off += chunk {
+		end := off + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		bank.Process(iq[off:end])
+	}
+
+	// 5+6. Identify each carrier; the winner's full Run carries topology/grants.
+	// Carriers that don't decode to any real protocol (leakage / noise peaks
+	// the spectral detector picked up) are dropped here so the reported list is
+	// only genuine carriers.
+	for _, i := range taps {
+		c := cands[i]
+		buf := bufs[i]
+		if len(buf) == 0 {
+			continue
+		}
+		cr := CarrierResult{OffsetHz: c.offsetHz, FreqHz: c.freqHz, SNRDb: c.snr}
+		idr, err := IdentifyIQ(buf, fmt.Sprintf("%s@%+.0fkHz", baseName(source), c.offsetHz/1000), IdentifyConfig{
+			SampleRateHz: chOut,
+			Format:       FormatF32,
+			Candidates:   cfg.Candidates,
+			MaxSamples:   cfg.IdentifyMaxSamples,
+			Log:          cfg.Log,
+		})
+		if err != nil {
+			log.Debug("siglab/wideband: identify failed", "offset_hz", c.offsetHz, "err", err)
+			continue
+		}
+		cr.identify = idr
+		cr.Protocol = idr.Winner
+		cr.Confidence = idr.Confidence
+		cr.Inconclusive = idr.Inconclusive
+		if res := idr.WinnerResult(); res != nil {
+			cr.result = res
+			cr.Locked = res.Locked
+			cr.Grants = res.Grants
+			cr.ColorCode, cr.SystemID = carrierIdentity(res)
+		}
+		if win := winnerScore(idr); win != nil {
+			cr.Score = win.Score
+		}
+		cr.Role = roleForCarrier(cr)
+		if !keepCarrier(cr) {
+			continue
+		}
+		out.Carriers = append(out.Carriers, cr)
+	}
+
+	out.Systems = clusterSystems(out.Carriers, cfg.CenterHz, cfg.SampleRateHz, chRate)
+	return out, nil
+}
+
+// keepCarrier filters the spectral detections down to genuine carriers: a DMR
+// member, anything that locked a decoder, or a confident non-DMR
+// identification. Inconclusive noise/leakage peaks are dropped.
+func keepCarrier(c CarrierResult) bool {
+	if isDMRMember(c) || c.Locked {
+		return true
+	}
+	return !c.Inconclusive && c.Confidence >= dmrMemberConfidence
+}
+
+// detectCarriers runs the spectrum → peak → centroid-refine → grid-snap front
+// end and returns the in-band snapped carrier offsets, strongest first.
+//
+// Digital land-mobile carriers (C4FM/π4-DQPSK) are 6.25–25 kHz wide with a
+// rounded, noisy top, so the single strongest FFT bin can sit hundreds of Hz
+// off the true centre — enough to break the per-carrier decode. The detector
+// therefore (a) smooths the averaged spectrum over ~half a channel so each
+// carrier collapses to one bump, (b) finds the bumps with the shared peak
+// detector, (c) refines each centre to the power-weighted centroid of its hump,
+// and only then snaps to the channel raster.
+func detectCarriers(iq []complex64, cfg WidebandConfig, fftSize int, guard float64) []detectedCarrier {
+	frame := averageSpectrum(iq, cfg.CenterHz, cfg.SampleRateHz, fftSize)
+	binHzF := cfg.SampleRateHz / float64(fftSize)
+
+	// Smooth over ~half the tightest channel so a wide carrier reads as a
+	// single bump instead of many noisy local maxima.
+	smoothBins := int(math.Round(6_250.0 / 2.0 / binHzF))
+	smoothed := frame
+	smoothed.Bins = movingAverage(frame.Bins, smoothBins)
+
+	peaks := carriers.DetectPeaks(smoothed, carriers.PeakOptions{
+		ThresholdDb:  cfg.PeakThresholdDb,
+		MinSpacingHz: cfg.MinSpacingHz,
+	})
+	if len(peaks) == 0 {
+		return nil
+	}
+
+	floor := percentile25(smoothed.Bins)
+	base := float64(cfg.CenterHz) - cfg.SampleRateHz/2
+	halfWidthBins := int(math.Round(12_500.0 / binHzF)) // ±one channel
+	freqs := make([]uint32, len(peaks))
+	centers := make([]uint32, len(peaks))
+	for i, p := range peaks {
+		bin := int(math.Round((float64(p.FreqHz) - base) / binHzF))
+		centerHz := centroidHz(smoothed.Bins, bin, halfWidthBins, floor, base, binHzF)
+		centers[i] = uint32(math.Round(centerHz))
+		freqs[i] = centers[i]
+	}
+
+	step, phase := carriers.InferGrid(freqs)
+	binHz := uint32(math.Round(binHzF))
+	half := cfg.SampleRateHz * (0.5 - guard)
+
+	// Centroid refinement collapses every smoothed sub-maximum of one wide
+	// carrier toward its centre, so re-dedup the refined centres: a second
+	// detection within one channel width (12.5 kHz) of an already-kept,
+	// stronger carrier is the same carrier's shoulder, not a new one.
+	const mergeHz = 12_500
+	var cands []detectedCarrier
+	for i := range peaks {
+		snapped := carriers.SnapHz(centers[i], step, phase, binHz)
+		offsetHz := float64(snapped) - float64(cfg.CenterHz)
+		if math.Abs(offsetHz) > half {
+			continue // outside the usable (guard-banded) IQ window
+		}
+		dup := false
+		for _, k := range cands {
+			if absU32(snapped, k.freqHz) < mergeHz {
+				dup = true
+				break
+			}
+		}
+		if dup {
+			continue
+		}
+		cands = append(cands, detectedCarrier{offsetHz: offsetHz, freqHz: snapped, snr: peaks[i].SNRDb})
+		if cfg.MaxCarriers > 0 && len(cands) >= cfg.MaxCarriers {
+			break
+		}
+	}
+	return cands
+}
+
+// movingAverage smooths bins with a centered box filter of half-width w (total
+// window 2w+1). w<=0 returns a copy.
+func movingAverage(bins []float32, w int) []float32 {
+	out := make([]float32, len(bins))
+	if w <= 0 {
+		copy(out, bins)
+		return out
+	}
+	for i := range bins {
+		lo, hi := i-w, i+w
+		if lo < 0 {
+			lo = 0
+		}
+		if hi >= len(bins) {
+			hi = len(bins) - 1
+		}
+		var s float32
+		for j := lo; j <= hi; j++ {
+			s += bins[j]
+		}
+		out[i] = s / float32(hi-lo+1)
+	}
+	return out
+}
+
+// centroidHz returns the power-weighted mean frequency of the carrier hump
+// around peakBin: the contiguous run of above-floor bins within ±halfWidth,
+// weighted by linear power. This finds the true centre of a wide C4FM carrier
+// whose strongest single bin is noisy.
+func centroidHz(binsDb []float32, peakBin, halfWidth int, floor float32, base, binHz float64) float64 {
+	lo, hi := peakBin-halfWidth, peakBin+halfWidth
+	if lo < 0 {
+		lo = 0
+	}
+	if hi >= len(binsDb) {
+		hi = len(binsDb) - 1
+	}
+	var wsum, psum float64
+	for j := lo; j <= hi; j++ {
+		if binsDb[j] <= floor {
+			continue
+		}
+		p := math.Pow(10, float64(binsDb[j])/10) // dB → linear power
+		freq := base + float64(j)*binHz
+		wsum += p * freq
+		psum += p
+	}
+	if psum == 0 {
+		return base + float64(peakBin)*binHz
+	}
+	return wsum / psum
+}
+
+// percentile25 is the 25th-percentile (robust noise floor) of a dB-bin slice.
+func percentile25(bins []float32) float32 {
+	if len(bins) == 0 {
+		return 0
+	}
+	cp := make([]float32, len(bins))
+	copy(cp, bins)
+	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+	idx := int(0.25 * float64(len(cp)-1))
+	return cp[idx]
+}
+
+// averageSpectrum builds a Welch-averaged dBFS frame over the whole buffer.
+func averageSpectrum(iq []complex64, centerHz uint32, sampleRateHz float64, n int) spectrum.Frame {
+	plan := fft.New(n)
+	win := window.Hann(n)
+	var winSum float64
+	for _, w := range win {
+		winSum += w * w
+	}
+	acc := make([]float64, n)
+	bufIn := make([]complex128, n)
+	bufOut := make([]complex128, n)
+	dst := make([]float32, n)
+	frames := 0
+	for off := 0; off+n <= len(iq); off += n {
+		spectrum.PowerDB(plan, win, winSum, iq[off:off+n], bufIn, bufOut, dst)
+		for i, v := range dst {
+			acc[i] += float64(v)
+		}
+		frames++
+	}
+	bins := make([]float32, n)
+	if frames == 0 {
+		// Fewer than one FFT window: single padded pass so a short carrier
+		// still produces a frame.
+		pad := make([]complex64, n)
+		copy(pad, iq)
+		spectrum.PowerDB(plan, win, winSum, pad, bufIn, bufOut, dst)
+		copy(bins, dst)
+	} else {
+		for i := range bins {
+			bins[i] = float32(acc[i] / float64(frames))
+		}
+	}
+	return spectrum.Frame{CenterHz: centerHz, SampleRate: uint32(math.Round(sampleRateHz)), Bins: bins}
+}
+
+// newBank builds the per-carrier channelizer, mirroring widebandt2.pickStrategy
+// (DDC ≤ 6 taps, polyphase above; explicit override honored).
+func newBank(strategy string, nTaps int, inRateHz, outRateHz, guardFrac float64) (tuner.Bank, string) {
+	usePoly := false
+	switch strategy {
+	case "polyphase":
+		usePoly = true
+	case "ddc":
+		usePoly = false
+	default: // "" | "auto"
+		usePoly = nTaps > wbStrategyAutoThreshold
+	}
+	if usePoly {
+		return tuner.NewChannelizerBank(inRateHz, outRateHz, guardFrac,
+			wbChannelizerBins, wbChannelizerTaps, wbChannelizerKaiserBeta), "polyphase"
+	}
+	return tuner.NewDDCBank(inRateHz, outRateHz, guardFrac), "ddc"
+}
+
+// carrierIdentity pulls (colorCode, systemID) from a DMR run Result: the lock
+// payload (tier3 Aloha lock carries both) first, then any grant's channel-id
+// (color code) as a fallback for voice carriers.
+func carrierIdentity(res *Result) (colorCode uint8, systemID uint32) {
+	if res.Lock != nil {
+		if v, ok := res.Lock.Fields["ColorCode"]; ok {
+			colorCode = uint8(toUint32(v))
+		}
+		if v, ok := res.Lock.Fields["SystemID"]; ok {
+			systemID = toUint32(v)
+		}
+	}
+	if colorCode == 0 && len(res.Grants) > 0 {
+		colorCode = res.Grants[0].ChannelID
+	}
+	return colorCode, systemID
+}
+
+// winnerScore returns the winning candidate's score record.
+func winnerScore(idr *IdentifyResult) *CandidateScore {
+	for i := range idr.Candidates {
+		if idr.Candidates[i].Protocol == idr.Winner {
+			return &idr.Candidates[i]
+		}
+	}
+	return nil
+}
+
+// baseName returns the path's final element without importing path/filepath in
+// the hot survey loop (labels only).
+func baseName(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' {
+			return p[i+1:]
+		}
+	}
+	return p
+}

--- a/internal/siglab/wideband_rollup.go
+++ b/internal/siglab/wideband_rollup.go
@@ -1,0 +1,194 @@
+package siglab
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// dmrMemberConfidence is the floor below which a non-locked DMR identification
+// is too weak to count as a real carrier of the system. A locked carrier always
+// counts regardless of confidence.
+const dmrMemberConfidence = 0.30
+
+// isDMRProtocol reports whether an identify winner is a DMR-family protocol.
+func isDMRProtocol(p string) bool {
+	return p == "dmr" || p == "dmr-tier2" || p == "dmr-tier1"
+}
+
+// isDMRMember reports whether a surveyed carrier is a real DMR carrier of a
+// trunked system — a DMR-family winner that either locked or cleared the
+// confidence floor.
+func isDMRMember(c CarrierResult) bool {
+	if !isDMRProtocol(c.Protocol) {
+		return false
+	}
+	return c.Locked || (!c.Inconclusive && c.Confidence >= dmrMemberConfidence)
+}
+
+// roleForCarrier classifies a DMR carrier as control vs voice. A control
+// channel locks the Tier III state machine and carries an Aloha SystemID; a
+// voice carrier is any other DMR member (traffic channel — it may carry grants
+// or just the BS sync + slot type of an in-progress call).
+func roleForCarrier(c CarrierResult) CarrierRole {
+	if !isDMRMember(c) {
+		return RoleUnknown
+	}
+	if c.Protocol == "dmr" && c.Locked && c.SystemID != 0 {
+		return RoleControl
+	}
+	return RoleVoice
+}
+
+// clusterSystems groups DMR members into trunked-system rollups. Carriers are
+// grouped by the SystemID of their nearest control channel; when no control
+// carries a SystemID they fold into a single unidentified DMR system. Each
+// system yields the verdict string.
+func clusterSystems(cs []CarrierResult, centerHz uint32, sampleRateHz, channelRateHz float64) []SystemRollup {
+	type cluster struct {
+		systemID  uint32
+		colorCode uint8
+		idx       []int
+		control   int
+		voice     int
+		lo, hi    uint32
+	}
+
+	// Distinct control SystemIDs anchor the systems.
+	controls := []int{}
+	for i, c := range cs {
+		if c.Role == RoleControl {
+			controls = append(controls, i)
+		}
+	}
+
+	clusters := map[uint32]*cluster{}
+	keyForVoice := func(c CarrierResult) uint32 {
+		// Attach a voice carrier to the control with the nearest frequency.
+		if len(controls) == 0 {
+			return 0
+		}
+		best, bestD := controls[0], absU32(c.FreqHz, cs[controls[0]].FreqHz)
+		for _, ci := range controls[1:] {
+			if d := absU32(c.FreqHz, cs[ci].FreqHz); d < bestD {
+				best, bestD = ci, d
+			}
+		}
+		return cs[best].SystemID
+	}
+
+	get := func(key uint32) *cluster {
+		cl := clusters[key]
+		if cl == nil {
+			cl = &cluster{systemID: key, lo: ^uint32(0)}
+			clusters[key] = cl
+		}
+		return cl
+	}
+
+	for i, c := range cs {
+		if !isDMRMember(c) {
+			continue
+		}
+		var key uint32
+		if c.Role == RoleControl {
+			key = c.SystemID
+		} else {
+			key = keyForVoice(c)
+		}
+		cl := get(key)
+		cl.idx = append(cl.idx, i)
+		if c.Role == RoleControl {
+			cl.control++
+			if cl.systemID == 0 {
+				cl.systemID = c.SystemID
+			}
+			if cl.colorCode == 0 {
+				cl.colorCode = c.ColorCode
+			}
+		} else {
+			cl.voice++
+		}
+		if c.FreqHz != 0 {
+			if c.FreqHz < cl.lo {
+				cl.lo = c.FreqHz
+			}
+			if c.FreqHz > cl.hi {
+				cl.hi = c.FreqHz
+			}
+		}
+	}
+
+	// Stable order: most control channels first, then by SystemID.
+	keys := make([]uint32, 0, len(clusters))
+	for k := range clusters {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(a, b int) bool {
+		ca, cb := clusters[keys[a]], clusters[keys[b]]
+		if ca.control != cb.control {
+			return ca.control > cb.control
+		}
+		return keys[a] < keys[b]
+	})
+
+	var out []SystemRollup
+	for _, k := range keys {
+		cl := clusters[k]
+		if cl.lo == ^uint32(0) {
+			cl.lo = 0
+		}
+		sr := SystemRollup{
+			Protocol:     "dmr",
+			Tier3:        cl.control >= 1,
+			SystemID:     cl.systemID,
+			ColorCode:    cl.colorCode,
+			ControlCount: cl.control,
+			VoiceCount:   cl.voice,
+			LoHz:         cl.lo,
+			HiHz:         cl.hi,
+			CarrierIdx:   cl.idx,
+		}
+		sr.Verdict = verdictString(sr, centerHz, sampleRateHz)
+		out = append(out, sr)
+	}
+	return out
+}
+
+// verdictString renders the operator-facing one-liner.
+func verdictString(sr SystemRollup, centerHz uint32, sampleRateHz float64) string {
+	var b strings.Builder
+	if sr.Tier3 {
+		b.WriteString("DMR Tier III trunked system")
+	} else {
+		b.WriteString("DMR carriers (no control channel locked)")
+	}
+	if centerHz != 0 {
+		fmt.Fprintf(&b, " at %.4f MHz / %.1f MS/s wideband", float64(centerHz)/1e6, sampleRateHz/1e6)
+	} else {
+		fmt.Fprintf(&b, " / %.1f MS/s wideband", sampleRateHz/1e6)
+	}
+	if sr.SystemID != 0 {
+		fmt.Fprintf(&b, ", SystemID=%d", sr.SystemID)
+	}
+	fmt.Fprintf(&b, ", CC=%d", sr.ColorCode)
+	fmt.Fprintf(&b, ", %d control + %d voice carrier%s", sr.ControlCount, sr.VoiceCount, plural(sr.ControlCount+sr.VoiceCount))
+	if sr.LoHz != 0 && sr.HiHz != 0 {
+		fmt.Fprintf(&b, " spanning %.4f–%.4f MHz", float64(sr.LoHz)/1e6, float64(sr.HiHz)/1e6)
+	}
+	return b.String()
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+func absU32(a, b uint32) uint32 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/internal/siglab/wideband_test.go
+++ b/internal/siglab/wideband_test.go
@@ -72,7 +72,7 @@ func TestSurveyWidebandFindsAndSnapsTones(t *testing.T) {
 	// the 12.5 kHz raster (offset divisible by 12.5 kHz from the 441 MHz centre).
 	for _, c := range cands[:2] {
 		rel := int64(c.freqHz) - center
-		if mod := ((rel%12_500)+12_500)%12_500; mod > 100 && mod < 12_400 {
+		if mod := ((rel % 12_500) + 12_500) % 12_500; mod > 100 && mod < 12_400 {
 			t.Errorf("carrier %d Hz (offset %d) not snapped to 12.5 kHz grid (residual %d)", c.freqHz, rel, mod)
 		}
 	}
@@ -128,7 +128,7 @@ func TestSurveyWidebandRecognizesDMRTier3(t *testing.T) {
 	cc := loadFixtureIQ(t, "dmr-t3-cc.cfile")
 	voice := loadFixtureIQ(t, "dmr-voice-term.cfile")
 
-	ctrl := upshift(cc, 4, 1, +48_000, wideRate)  // control at +48 kHz
+	ctrl := upshift(cc, 4, 1, +48_000, wideRate)   // control at +48 kHz
 	vox := upshift(voice, 4, 1, -48_000, wideRate) // voice at -48 kHz
 	n := len(ctrl)
 	if len(vox) < n {

--- a/internal/siglab/wideband_test.go
+++ b/internal/siglab/wideband_test.go
@@ -1,0 +1,190 @@
+package siglab
+
+import (
+	"math"
+	"math/cmplx"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+)
+
+// loadFixtureIQ reads one of the committed 48 kHz centred DMR fixtures.
+func loadFixtureIQ(t *testing.T, name string) []complex64 {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "cmd", "gophertrunk", "testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	pairs := len(raw) / 8
+	iq := make([]complex64, pairs)
+	dec, _ := FormatF32.Decoder()
+	dec(raw[:pairs*8], iq)
+	return iq
+}
+
+// upshift resamples a 48 kHz baseband stream to outRateHz and mixes it to the
+// given offset — the inverse of the survey's per-carrier DDC, used to plant a
+// known carrier inside a synthetic wide-band buffer.
+func upshift(in []complex64, l, m int, offsetHz, outRateHz float64) []complex64 {
+	rs := dsp.NewResampler(l, m, 16, 9.0)
+	up := rs.Process(nil, in)
+	step := cmplx.Exp(complex(0, 2*math.Pi*offsetHz/outRateHz))
+	ph := complex(1, 0)
+	out := make([]complex64, len(up))
+	for i, s := range up {
+		out[i] = complex64(complex128(s) * ph)
+		ph *= step
+	}
+	return out
+}
+
+// TestSurveyWidebandFindsAndSnapsTones checks the spectrum→peaks→grid-snap front
+// end (detectCarriers) on a synthetic two-tone buffer placed ~400 Hz off the
+// 12.5 kHz raster, over a realistic noise floor.
+func TestSurveyWidebandFindsAndSnapsTones(t *testing.T) {
+	const rate = 2_000_000.0
+	const center = 441_000_000
+	n := 1 << 18
+	rng := newLCG(1)
+	iq := make([]complex64, n)
+	for i := range iq { // white noise floor
+		iq[i] = complex(float32(rng.normal()*0.02), float32(rng.normal()*0.02))
+	}
+	tone := func(freqHz, amp float64) {
+		step := cmplx.Exp(complex(0, 2*math.Pi*freqHz/rate))
+		ph := complex(1, 0)
+		for i := range iq {
+			iq[i] += complex64(complex128(complex(amp, 0)) * ph)
+			ph *= step
+		}
+	}
+	tone(300_000+400, 1.0)  // ~400 Hz off a 12.5 kHz grid point
+	tone(-250_000+400, 0.7) //
+
+	cands := detectCarriers(iq, WidebandConfig{SampleRateHz: rate, CenterHz: center}, 4096, 0.05)
+	if len(cands) < 2 {
+		t.Fatalf("detected %d carriers, want >= 2", len(cands))
+	}
+	// The two strongest detections are the planted tones; both must snap onto
+	// the 12.5 kHz raster (offset divisible by 12.5 kHz from the 441 MHz centre).
+	for _, c := range cands[:2] {
+		rel := int64(c.freqHz) - center
+		if mod := ((rel%12_500)+12_500)%12_500; mod > 100 && mod < 12_400 {
+			t.Errorf("carrier %d Hz (offset %d) not snapped to 12.5 kHz grid (residual %d)", c.freqHz, rel, mod)
+		}
+	}
+	// The strongest two should be near the two planted carriers.
+	wantAbs := []int64{300_000, -250_000}
+	for _, w := range wantAbs {
+		found := false
+		for _, c := range cands[:min2(4, len(cands))] {
+			if absI64(int64(c.freqHz)-(center+w)) < 6_250 {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("no detected carrier near offset %d Hz; got %v", w, cands)
+		}
+	}
+}
+
+func absI64(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func min2(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// lcg is a tiny deterministic PRNG for test noise (no math/rand import churn).
+type lcg struct{ s uint64 }
+
+func newLCG(seed uint64) *lcg { return &lcg{s: seed*6364136223846793005 + 1} }
+func (g *lcg) f64() float64 {
+	g.s = g.s*6364136223846793005 + 1442695040888963407
+	return float64(g.s>>11) / float64(1<<53)
+}
+
+// normal returns an approximately-Gaussian sample (sum of 3 uniforms, zero mean).
+func (g *lcg) normal() float64 { return (g.f64() + g.f64() + g.f64() - 1.5) }
+
+// TestSurveyWidebandRecognizesDMRTier3 is the end-to-end proof: it plants the
+// real control-channel fixture (Aloha → Tier III lock + SystemID) and the real
+// voice fixture into one synthetic 192 kHz wide-band buffer at distinct
+// offsets, then asserts the survey recovers two carriers, classifies one as
+// control and one as voice, and rolls them into a single DMR Tier III system
+// with the verdict string.
+func TestSurveyWidebandRecognizesDMRTier3(t *testing.T) {
+	const wideRate = 192_000.0 // 4× the 48 kHz fixtures
+	const center = 441_000_000
+	cc := loadFixtureIQ(t, "dmr-t3-cc.cfile")
+	voice := loadFixtureIQ(t, "dmr-voice-term.cfile")
+
+	ctrl := upshift(cc, 4, 1, +48_000, wideRate)  // control at +48 kHz
+	vox := upshift(voice, 4, 1, -48_000, wideRate) // voice at -48 kHz
+	n := len(ctrl)
+	if len(vox) < n {
+		n = len(vox)
+	}
+	wide := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		wide[i] = ctrl[i] + vox[i]
+	}
+
+	res, err := SurveyWidebandIQ(wide, "dmr-t3-wideband", WidebandConfig{
+		SampleRateHz: wideRate, CenterHz: center,
+	})
+	if err != nil {
+		t.Fatalf("survey: %v", err)
+	}
+	t.Logf("strategy=%s carriers=%d", res.Strategy, len(res.Carriers))
+	for _, c := range res.Carriers {
+		t.Logf("  %d Hz (off %+0.0f) proto=%s conf=%.2f locked=%v role=%s cc=%d sysid=%d",
+			c.FreqHz, c.OffsetHz, c.Protocol, c.Confidence, c.Locked, c.Role, c.ColorCode, c.SystemID)
+	}
+
+	if len(res.Carriers) != 2 {
+		t.Fatalf("found %d carriers, want 2", len(res.Carriers))
+	}
+	var control, voiceN int
+	for _, c := range res.Carriers {
+		switch c.Role {
+		case RoleControl:
+			control++
+		case RoleVoice:
+			voiceN++
+		}
+	}
+	if control != 1 {
+		t.Errorf("control carriers = %d, want 1", control)
+	}
+	if voiceN != 1 {
+		t.Errorf("voice carriers = %d, want 1", voiceN)
+	}
+
+	if len(res.Systems) != 1 {
+		t.Fatalf("rolled up %d systems, want 1: %+v", len(res.Systems), res.Systems)
+	}
+	sys := res.Systems[0]
+	if !sys.Tier3 {
+		t.Errorf("system not recognized as Tier III: %+v", sys)
+	}
+	if sys.ControlCount != 1 || sys.VoiceCount != 1 {
+		t.Errorf("rollup control=%d voice=%d, want 1/1", sys.ControlCount, sys.VoiceCount)
+	}
+	if sys.SystemID != 61760 {
+		t.Errorf("SystemID = %d, want 61760 (Aloha)", sys.SystemID)
+	}
+	if !strings.Contains(sys.Verdict, "DMR Tier III trunked system") {
+		t.Errorf("verdict = %q, want it to name the Tier III system", sys.Verdict)
+	}
+	t.Logf("verdict: %s", sys.Verdict)
+}


### PR DESCRIPTION
## What this adds

Automates the manual pipeline used to verify the 441 MHz / 2 MS/s DMR
captures into a reusable feature: take a **wide-band IQ grab, find every
carrier, decode each, and recognize a "DMR Tier III trunked system"** —
exposed as a siglab library function and reused by the offline
`hunt -wideband` path.

Today `siglab.Identify` auto-tunes to **one dominant carrier only**, so a
wide-band capture with many carriers can't be surveyed in one shot. This
closes that gap.

## Changes

**`internal/carriers` (new package — resolves an import cycle)**
`hunt` imports `siglab`, so siglab can't reuse hunt's peak/grid helpers
directly. Moved `peaks.go`/`grid.go` down to a neutral `internal/carriers`
package (`DetectPeaks`, `InferGrid`, `SnapHz`); `hunt` keeps thin
alias/wrapper shims so its public surface is unchanged.

**`siglab.SurveyWideband` / `SurveyWidebandIQ`**
Averaged Welch spectrum → carrier peaks (`carriers.DetectPeaks`) →
smoothing + **power-weighted centroid centering** of wide C4FM humps (the
raw strongest bin sits ~900 Hz off-center, which breaks decode) →
grid-snap → per-carrier DDC via `dsp/tuner` (DDC ≤6 carriers, polyphase
above, mirroring `widebandt2.pickStrategy`) → per-carrier `IdentifyIQ` →
the DMR winner's full `Run` supplies lock / SystemID / ColorCode / grants.
Carriers cluster into `SystemRollup`s (control vs voice, SystemID, span)
with a one-line verdict; noise/leakage peaks that don't decode are filtered
out.

**`hunt.DiscoverWideband` + `hunt -wideband -in <capture>`**
Surveys each wide-band capture and folds every DMR carrier into one
`DiscoveredSystem` via the existing `Accumulate` — control channels register
identity + frequency, voice grants become talkgroups. `-freq` is the
capture center. `CaptureReport` gains a `Verdict` line.

## Verified end-to-end

Through the production CLI on a synthetic 2-carrier wide-band capture built
from the committed `dmr-t3-cc` / `dmr-voice-term` fixtures:

```
DMR Tier III trunked system at 441.0000 MHz / 2.0 MS/s wideband,
SystemID=61760, CC=0, 1 control + 1 voice carriers spanning 440.9521–441.0482 MHz
```

Tests at all three layers (carriers peak/grid; siglab two-tone detection +
end-to-end combined wide-band buffer; hunt `DiscoverWideband` grouping).
`go build ./...`, `go vet`, and the suites are green.

## Note on the diff

This branch is stacked on top of the DMR-capture-verification work in
**#675** (a force-push to split it cleanly was blocked by policy), so the
diff currently also shows that commit. The wide-band feature is the top
commit (`338b1ec`); once #675 merges to `main`, only the feature diff
remains. Review the top commit for this PR's scope.

https://claude.ai/code/session_01PNxDvNBvMWMxLGzfjKWnFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNxDvNBvMWMxLGzfjKWnFA)_