### PR TITLE
siglab: promote wideband survey DSP primitives + add spectrum API/web viz

### DIFF
--- a/internal/api/handlers_siglab.go
+++ b/internal/api/handlers_siglab.go
@@ -424,6 +424,77 @@ func (s *Server) handleSiglabIdentify(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
+// handleSiglabWideband surveys a staged wideband capture: it builds the
+// Welch-averaged band spectrum, detects every carrier, identifies each, and
+// clusters them into trunked-system verdicts. The response carries the spectrum
+// (for plotting), the per-carrier results, and the system rollups. Runs
+// synchronously — a wideband grab is bounded and the survey is in-memory.
+func (s *Server) handleSiglabWideband(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		CaptureID    string  `json:"capture_id"`
+		SampleRateHz float64 `json:"sample_rate_hz"`
+		CenterHz     uint32  `json:"center_hz"`
+		Format       string  `json:"format"`
+		FFTSize      int     `json:"fft_size"`
+		ChannelRate  float64 `json:"channel_rate_hz"`
+		ThresholdDb  float32 `json:"peak_threshold_db"`
+		Strategy     string  `json:"tuner_strategy"`
+		Conjugate    bool    `json:"conjugate"`
+		IQCorrect    bool    `json:"iq_correct"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
+		return
+	}
+	cap, ok := s.siglab.getCapture(req.CaptureID)
+	if !ok {
+		s.writeError(w, http.StatusNotFound, "siglab: capture not found")
+		return
+	}
+	formatStr := req.Format
+	if formatStr == "" {
+		formatStr = cap.Format.String()
+	}
+	format, err := siglab.ParseSampleFormat(formatStr)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
+		return
+	}
+	rate := req.SampleRateHz
+	if rate <= 0 {
+		rate = cap.SampleRateHz
+	}
+	if rate <= 0 {
+		s.writeError(w, http.StatusBadRequest, "siglab: sample_rate_hz is required")
+		return
+	}
+
+	f, err := os.Open(cap.Path)
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, "siglab: open capture: "+err.Error())
+		return
+	}
+	defer f.Close()
+
+	out, err := siglab.SurveyWideband(f, cap.Name, siglab.WidebandConfig{
+		SampleRateHz:    rate,
+		CenterHz:        req.CenterHz,
+		Format:          format,
+		FFTSize:         req.FFTSize,
+		ChannelRateHz:   req.ChannelRate,
+		PeakThresholdDb: req.ThresholdDb,
+		TunerStrategy:   req.Strategy,
+		Conjugate:       req.Conjugate,
+		IQCorrect:       req.IQCorrect,
+		CollectSpectrum: true,
+	})
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
 // siglabSynthRequest is the body of POST /api/v1/siglab/synthesize. It mirrors
 // the `gen` CLI surface.
 type siglabSynthRequest struct {

--- a/internal/api/handlers_siglab_test.go
+++ b/internal/api/handlers_siglab_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"math"
+	"math/cmplx"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -165,5 +168,89 @@ func TestSiglabRunMissingCapture(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// TestSiglabWideband uploads a synthetic two-carrier wideband capture and
+// surveys it, asserting the endpoint returns the averaged band spectrum (for
+// plotting) and detects both planted carriers.
+func TestSiglabWideband(t *testing.T) {
+	ts := newSiglabTestServer(t)
+
+	// Two complex tones over a noise floor in a 2 MS/s band, ~400 Hz off the
+	// 12.5 kHz raster (mirrors the siglab wideband detector test).
+	const rate = 2_000_000.0
+	const center = 441_000_000
+	n := 1 << 16
+	iq := make([]complex64, n)
+	seed := uint64(1)
+	rnd := func() float64 { // tiny LCG → ~uniform in [-0.5,0.5)
+		seed = seed*6364136223846793005 + 1442695040888963407
+		return float64(seed>>11)/float64(1<<53) - 0.5
+	}
+	for i := range iq {
+		iq[i] = complex(float32(rnd()*0.04), float32(rnd()*0.04))
+	}
+	addTone := func(freqHz, amp float64) {
+		step := cmplx.Exp(complex(0, 2*math.Pi*freqHz/rate))
+		ph := complex(1, 0)
+		for i := range iq {
+			iq[i] += complex64(complex(amp, 0) * ph)
+			ph *= step
+		}
+	}
+	addTone(300_000+400, 1.0)
+	addTone(-250_000+400, 0.7)
+
+	// Upload the capture as raw f32 via the multipart endpoint.
+	raw := siglab.EncodeCapture(iq, siglab.FormatF32)
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", "wide.cf32")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := fw.Write(raw); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	_ = mw.WriteField("format", "f32")
+	_ = mw.WriteField("sample_rate_hz", "2000000")
+	_ = mw.Close()
+
+	upResp, err := http.Post(ts.URL+"/api/v1/siglab/captures", mw.FormDataContentType(), &buf)
+	if err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+	defer upResp.Body.Close()
+	if upResp.StatusCode != http.StatusOK {
+		t.Fatalf("upload status = %d, want 200", upResp.StatusCode)
+	}
+	var cap siglabCaptureDTO
+	if err := json.NewDecoder(upResp.Body).Decode(&cap); err != nil {
+		t.Fatalf("decode upload: %v", err)
+	}
+
+	// Survey the staged capture.
+	body := `{"capture_id":"` + cap.ID + `","center_hz":441000000}`
+	wbResp, err := http.Post(ts.URL+"/api/v1/siglab/wideband", "application/json", bytes.NewBufferString(body))
+	if err != nil {
+		t.Fatalf("wideband: %v", err)
+	}
+	defer wbResp.Body.Close()
+	if wbResp.StatusCode != http.StatusOK {
+		t.Fatalf("wideband status = %d, want 200", wbResp.StatusCode)
+	}
+	var got siglab.WidebandResult
+	if err := json.NewDecoder(wbResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode wideband: %v", err)
+	}
+	if got.Spectrum == nil || len(got.Spectrum.Bins) == 0 {
+		t.Fatal("expected a spectrum with bins for plotting")
+	}
+	if got.Spectrum.CenterHz != center {
+		t.Errorf("spectrum center = %d, want %d", got.Spectrum.CenterHz, center)
+	}
+	if got.DetectedCount < 2 {
+		t.Errorf("detected_count = %d, want >= 2", got.DetectedCount)
 	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1063,6 +1063,7 @@ func (s *Server) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/siglab/jobs/{id}/iq", s.handleSiglabJobIQ)
 		mux.HandleFunc("GET /api/v1/siglab/jobs/{id}/export", s.handleSiglabExport)
 		mux.HandleFunc("POST /api/v1/siglab/identify", s.gate(s.handleSiglabIdentify))
+		mux.HandleFunc("POST /api/v1/siglab/wideband", s.gate(s.handleSiglabWideband))
 		mux.HandleFunc("POST /api/v1/siglab/synthesize", s.gate(s.handleSiglabSynthesize))
 		// Live raw-IQ capture off a tuner: list devices (read), record a
 		// fixed-length capture (gated mutation — it spends an SDR + CPU),

--- a/internal/carriers/peaks.go
+++ b/internal/carriers/peaks.go
@@ -68,7 +68,7 @@ func DetectPeaks(frame spectrum.Frame, opts PeakOptions) []Peak {
 		}
 	}
 
-	floor := percentile(frame.Bins, noiseFloorPercentile)
+	floor := spectrum.Percentile(frame.Bins, noiseFloorPercentile)
 	binHz := float64(frame.SampleRate) / float64(n)
 	dcBin := n / 2 // FFT-shifted: DC sits in the middle (see spectrum.frame)
 
@@ -115,25 +115,6 @@ func DetectPeaks(frame spectrum.Frame, opts PeakOptions) []Peak {
 func binToHz(frame spectrum.Frame, bin int, binHz float64) uint32 {
 	base := float64(frame.CenterHz) - float64(frame.SampleRate)/2
 	return uint32(math.Round(base + float64(bin)*binHz))
-}
-
-// percentile returns the p-quantile (0..1) of bins using a copy+sort. Used for
-// the robust noise-floor estimate.
-func percentile(bins []float32, p float64) float32 {
-	if len(bins) == 0 {
-		return 0
-	}
-	cp := make([]float32, len(bins))
-	copy(cp, bins)
-	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
-	idx := int(p * float64(len(cp)-1))
-	if idx < 0 {
-		idx = 0
-	}
-	if idx >= len(cp) {
-		idx = len(cp) - 1
-	}
-	return cp[idx]
 }
 
 func absDiff(a, b uint32) uint32 {

--- a/internal/dsp/spectrum/average.go
+++ b/internal/dsp/spectrum/average.go
@@ -1,0 +1,56 @@
+package spectrum
+
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
+)
+
+// AverageDB builds a Welch-averaged dBFS spectrum over the whole of iq,
+// returning a Frame ready for peak detection or display. It is the offline,
+// one-shot analog of the streaming Producer: rather than emitting frames at a
+// fixed rate it walks iq in non-overlapping n-sample windows, computes the
+// dBFS power spectrum of each via PowerDB, and averages the per-bin dB values
+// across all windows (scipy.signal.welch with a Hann window and zero overlap).
+//
+// n must be a power of two. When iq holds fewer than n samples a single
+// zero-padded window is taken so a short capture still yields a frame. The
+// returned Frame's CenterHz/SampleRate carry centerHz and the rounded
+// sampleRateHz so callers can map bins back to absolute frequency.
+func AverageDB(iq []complex64, centerHz uint32, sampleRateHz float64, n int) Frame {
+	plan := fft.New(n)
+	win := window.Hann(n)
+	var winSum float64
+	for _, w := range win {
+		winSum += w * w
+	}
+
+	acc := make([]float64, n)
+	bufIn := make([]complex128, n)
+	bufOut := make([]complex128, n)
+	dst := make([]float32, n)
+	frames := 0
+	for off := 0; off+n <= len(iq); off += n {
+		PowerDB(plan, win, winSum, iq[off:off+n], bufIn, bufOut, dst)
+		for i, v := range dst {
+			acc[i] += float64(v)
+		}
+		frames++
+	}
+
+	bins := make([]float32, n)
+	if frames == 0 {
+		// Fewer than one FFT window: single padded pass so a short carrier
+		// still produces a frame.
+		pad := make([]complex64, n)
+		copy(pad, iq)
+		PowerDB(plan, win, winSum, pad, bufIn, bufOut, dst)
+		copy(bins, dst)
+	} else {
+		for i := range bins {
+			bins[i] = float32(acc[i] / float64(frames))
+		}
+	}
+	return Frame{CenterHz: centerHz, SampleRate: uint32(math.Round(sampleRateHz)), Bins: bins}
+}

--- a/internal/dsp/spectrum/average_test.go
+++ b/internal/dsp/spectrum/average_test.go
@@ -1,0 +1,79 @@
+package spectrum
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+// A unit-amplitude complex tone should read ~0 dBFS in the bin it lands on and
+// well below that elsewhere, matching PowerDB's normalization.
+func TestAverageDBTonePeaksAtZeroDBFS(t *testing.T) {
+	const n = 256
+	const rate = 48_000.0
+	// Place the tone four bins above DC so it sits on an exact FFT bin.
+	const k = 4
+	iq := make([]complex64, n*8)
+	for i := range iq {
+		ph := 2 * math.Pi * float64(k) * float64(i) / float64(n)
+		iq[i] = complex64(cmplx.Exp(complex(0, ph)))
+	}
+
+	frame := AverageDB(iq, 100_000_000, rate, n)
+	if len(frame.Bins) != n {
+		t.Fatalf("Bins len = %d, want %d", len(frame.Bins), n)
+	}
+	if frame.SampleRate != uint32(rate) {
+		t.Errorf("SampleRate = %d, want %d", frame.SampleRate, uint32(rate))
+	}
+
+	// FFT-shifted: DC is at n/2, so the tone lands at n/2 + k. With a Hann
+	// window the main lobe spreads the tone across ~3 bins, so the peak bin
+	// reads a couple dB below 0 dBFS — PowerDB documents "~0 dBFS at its bin".
+	peakBin := n/2 + k
+	if frame.Bins[peakBin] < -3 || frame.Bins[peakBin] > 1 {
+		t.Errorf("tone bin = %.2f dBFS, want ~0", frame.Bins[peakBin])
+	}
+	// A bin far from the tone should be deep in the noise floor.
+	if frame.Bins[n/2-40] > -40 {
+		t.Errorf("off-tone bin = %.2f dBFS, want < -40", frame.Bins[n/2-40])
+	}
+}
+
+// Averaging identical windows must equal a single window: the per-bin dB mean
+// of N copies of the same frame is that frame.
+func TestAverageDBStableAcrossIdenticalWindows(t *testing.T) {
+	const n = 128
+	one := make([]complex64, n)
+	for i := range one {
+		ph := 2 * math.Pi * 3 * float64(i) / float64(n)
+		one[i] = complex64(cmplx.Exp(complex(0, ph)))
+	}
+	// Tile the same window eight times.
+	many := make([]complex64, 0, n*8)
+	for j := 0; j < 8; j++ {
+		many = append(many, one...)
+	}
+
+	single := AverageDB(one, 0, 48_000, n)
+	avg := AverageDB(many, 0, 48_000, n)
+	for i := range single.Bins {
+		if d := math.Abs(float64(single.Bins[i] - avg.Bins[i])); d > 1e-3 {
+			t.Fatalf("bin %d: single=%.4f avg=%.4f differ by %.4g", i, single.Bins[i], avg.Bins[i], d)
+		}
+	}
+}
+
+// Fewer than one FFT window still yields a full-length frame via the padded
+// single pass.
+func TestAverageDBShortBufferPads(t *testing.T) {
+	const n = 64
+	short := make([]complex64, 10) // < n
+	for i := range short {
+		short[i] = complex(1, 0)
+	}
+	frame := AverageDB(short, 0, 48_000, n)
+	if len(frame.Bins) != n {
+		t.Fatalf("Bins len = %d, want %d (padded pass)", len(frame.Bins), n)
+	}
+}

--- a/internal/dsp/spectrum/stat.go
+++ b/internal/dsp/spectrum/stat.go
@@ -1,0 +1,90 @@
+package spectrum
+
+import (
+	"math"
+	"sort"
+)
+
+// Smooth returns bins convolved with a centered boxcar of half-width w (total
+// window 2w+1), the discrete uniform filter used to tame per-bin noise before
+// peak picking (np.convolve with a normalized rectangular kernel). w<=0 returns
+// a copy. Windows are clipped at the array edges so the output keeps the input
+// length without wrap-around.
+func Smooth(bins []float32, w int) []float32 {
+	out := make([]float32, len(bins))
+	if w <= 0 {
+		copy(out, bins)
+		return out
+	}
+	for i := range bins {
+		lo, hi := i-w, i+w
+		if lo < 0 {
+			lo = 0
+		}
+		if hi >= len(bins) {
+			hi = len(bins) - 1
+		}
+		var s float32
+		for j := lo; j <= hi; j++ {
+			s += bins[j]
+		}
+		out[i] = s / float32(hi-lo+1)
+	}
+	return out
+}
+
+// Percentile returns the p-quantile (p in 0..1) of bins via copy+sort, the
+// robust noise-floor estimate (np.percentile with nearest-rank interpolation).
+// An empty slice returns 0; p is clamped into range.
+func Percentile(bins []float32, p float64) float32 {
+	if len(bins) == 0 {
+		return 0
+	}
+	cp := make([]float32, len(bins))
+	copy(cp, bins)
+	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+	idx := int(p * float64(len(cp)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(cp) {
+		idx = len(cp) - 1
+	}
+	return cp[idx]
+}
+
+// WeightedCentroidHz returns the power-weighted mean frequency of the carrier
+// hump around peakBin: the contiguous band of bins within ±halfWidth, each
+// weighted by its linear power (dB → power via DBToLinearPower). This finds the
+// true center of a wide carrier whose single strongest bin is noisy
+// (np.average of the bin frequencies weighted by power). baseHz is the absolute
+// frequency of bin 0 and binHz the bin spacing. Bins at or below floorDb are
+// excluded; when no bin clears the floor the peak bin's frequency is returned.
+func WeightedCentroidHz(binsDb []float32, peakBin, halfWidth int, floorDb float32, baseHz, binHz float64) float64 {
+	lo, hi := peakBin-halfWidth, peakBin+halfWidth
+	if lo < 0 {
+		lo = 0
+	}
+	if hi >= len(binsDb) {
+		hi = len(binsDb) - 1
+	}
+	var wsum, psum float64
+	for j := lo; j <= hi; j++ {
+		if binsDb[j] <= floorDb {
+			continue
+		}
+		p := dbToLinearPower(float64(binsDb[j]))
+		freq := baseHz + float64(j)*binHz
+		wsum += p * freq
+		psum += p
+	}
+	if psum == 0 {
+		return baseHz + float64(peakBin)*binHz
+	}
+	return wsum / psum
+}
+
+// dbToLinearPower mirrors dsp.DBToLinearPower; spectrum sits below dsp's
+// top-level package so the conversion is duplicated here to avoid an import
+// cycle. Keep the two in sync.
+func dbToLinearPower(db float64) float64 { return math.Pow(10, db/10) }

--- a/internal/dsp/spectrum/stat_test.go
+++ b/internal/dsp/spectrum/stat_test.go
@@ -1,0 +1,83 @@
+package spectrum
+
+import (
+	"math"
+	"sort"
+	"testing"
+)
+
+func TestSmoothCopiesWhenWidthNonPositive(t *testing.T) {
+	in := []float32{1, 2, 3, 4}
+	out := Smooth(in, 0)
+	if &out[0] == &in[0] {
+		t.Fatal("Smooth(w<=0) must return a copy, not the same backing array")
+	}
+	for i := range in {
+		if out[i] != in[i] {
+			t.Fatalf("bin %d: got %v want %v", i, out[i], in[i])
+		}
+	}
+}
+
+func TestSmoothBoxAverage(t *testing.T) {
+	// Half-width 1 ⇒ centered 3-wide mean, clipped at the edges.
+	in := []float32{0, 3, 6, 9}
+	out := Smooth(in, 1)
+	want := []float32{
+		(0 + 3) / 2.0,     // edge: bins 0,1
+		(0 + 3 + 6) / 3.0, // bins 0,1,2
+		(3 + 6 + 9) / 3.0, // bins 1,2,3
+		(6 + 9) / 2.0,     // edge: bins 2,3
+	}
+	for i := range want {
+		if math.Abs(float64(out[i]-want[i])) > 1e-5 {
+			t.Errorf("bin %d: got %v want %v", i, out[i], want[i])
+		}
+	}
+}
+
+func TestPercentileMatchesSortedReference(t *testing.T) {
+	bins := []float32{9, 1, 7, 3, 5, 2, 8, 4, 6, 0}
+	for _, p := range []float64{0, 0.25, 0.5, 0.9, 1} {
+		cp := append([]float32(nil), bins...)
+		sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+		idx := int(p * float64(len(cp)-1))
+		want := cp[idx]
+		if got := Percentile(bins, p); got != want {
+			t.Errorf("Percentile(p=%.2f) = %v, want %v", p, got, want)
+		}
+	}
+}
+
+func TestPercentileEmpty(t *testing.T) {
+	if got := Percentile(nil, 0.5); got != 0 {
+		t.Errorf("Percentile(nil) = %v, want 0", got)
+	}
+}
+
+// A symmetric hump's power-weighted centroid is its geometric center.
+func TestWeightedCentroidHzSymmetricHump(t *testing.T) {
+	// Bins in dB: a triangular hump peaking at bin 5, floor elsewhere.
+	bins := make([]float32, 11)
+	for i := range bins {
+		bins[i] = -60 // below floor
+	}
+	bins[3], bins[4], bins[5], bins[6], bins[7] = -20, -10, 0, -10, -20
+	const baseHz, binHz = 100_000.0, 1_000.0
+	got := WeightedCentroidHz(bins, 5, 4, -30, baseHz, binHz)
+	want := baseHz + 5*binHz // symmetric ⇒ center bin
+	if math.Abs(got-want) > 1.0 {
+		t.Errorf("centroid = %.1f Hz, want %.1f", got, want)
+	}
+}
+
+// When no bin clears the floor the centroid falls back to the peak bin's
+// frequency.
+func TestWeightedCentroidHzAllBelowFloor(t *testing.T) {
+	bins := []float32{-90, -90, -90, -90, -90}
+	const baseHz, binHz = 0.0, 500.0
+	got := WeightedCentroidHz(bins, 2, 2, -30, baseHz, binHz)
+	if want := baseHz + 2*binHz; got != want {
+		t.Errorf("centroid = %.1f, want fallback %.1f", got, want)
+	}
+}

--- a/internal/siglab/wideband.go
+++ b/internal/siglab/wideband.go
@@ -5,13 +5,10 @@ import (
 	"io"
 	"log/slog"
 	"math"
-	"sort"
 
 	"github.com/MattCheramie/GopherTrunk/internal/carriers"
-	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
-	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -51,7 +48,11 @@ type WidebandConfig struct {
 	MaxCarriers        int                 // defensive cap on taps; 0 ⇒ no cap
 	Conjugate          bool                //
 	IQCorrect          bool                //
-	Log                *slog.Logger        //
+	// CollectSpectrum retains the Welch-averaged power spectrum on the result
+	// (WidebandResult.Spectrum) so callers can plot the band with the detected
+	// carriers overlaid. Off by default to keep the offline hunt path lean.
+	CollectSpectrum bool         //
+	Log             *slog.Logger //
 }
 
 // CarrierRole labels a surveyed carrier within a trunked system.
@@ -103,6 +104,17 @@ type SystemRollup struct {
 	Verdict      string `json:"verdict" yaml:"verdict"`
 }
 
+// SurveySpectrum is the Welch-averaged power spectrum of the whole band, in
+// the same FFT-shifted dBFS layout as spectrum.Frame: Bins[0] is the lowest
+// frequency (CenterHz - SampleRateHz/2) and successive bins step by
+// SampleRateHz/len(Bins). Populated only when WidebandConfig.CollectSpectrum is
+// set; it lets a UI plot the band with the detected carriers marked.
+type SurveySpectrum struct {
+	CenterHz     uint32    `json:"center_hz" yaml:"center_hz"`
+	SampleRateHz uint32    `json:"sample_rate_hz" yaml:"sample_rate_hz"`
+	Bins         []float32 `json:"bins" yaml:"bins"`
+}
+
 // WidebandResult is the full survey outcome.
 type WidebandResult struct {
 	Source        string  `json:"source" yaml:"source"`
@@ -110,6 +122,9 @@ type WidebandResult struct {
 	CenterHz      uint32  `json:"center_hz" yaml:"center_hz"`
 	ChannelRateHz float64 `json:"channel_rate_hz" yaml:"channel_rate_hz"`
 	Strategy      string  `json:"strategy" yaml:"strategy"`
+	// Spectrum is the averaged band power spectrum for display; nil unless
+	// WidebandConfig.CollectSpectrum was set.
+	Spectrum *SurveySpectrum `json:"spectrum,omitempty" yaml:"spectrum,omitempty"`
 	// DetectedCount is the number of spectral carrier peaks before the
 	// per-carrier identify filter dropped the ones that didn't decode to a
 	// real protocol (leakage / noise peaks).
@@ -185,7 +200,14 @@ func SurveyWidebandIQ(iq []complex64, source string, cfg WidebandConfig) (*Wideb
 	}
 
 	// 1-3. Spectrum → peaks → grid-snap.
-	cands := detectCarriers(iq, cfg, fftSize, guard)
+	frame, cands := detectCarriers(iq, cfg, fftSize, guard)
+	if cfg.CollectSpectrum {
+		out.Spectrum = &SurveySpectrum{
+			CenterHz:     frame.CenterHz,
+			SampleRateHz: frame.SampleRate,
+			Bins:         frame.Bins,
+		}
+	}
 	out.DetectedCount = len(cands)
 	if len(cands) == 0 {
 		return out, nil
@@ -287,32 +309,34 @@ func keepCarrier(c CarrierResult) bool {
 // carrier collapses to one bump, (b) finds the bumps with the shared peak
 // detector, (c) refines each centre to the power-weighted centroid of its hump,
 // and only then snaps to the channel raster.
-func detectCarriers(iq []complex64, cfg WidebandConfig, fftSize int, guard float64) []detectedCarrier {
-	frame := averageSpectrum(iq, cfg.CenterHz, cfg.SampleRateHz, fftSize)
+// detectCarriers returns the Welch-averaged band spectrum (for optional
+// display) alongside the snapped carrier candidates found in it.
+func detectCarriers(iq []complex64, cfg WidebandConfig, fftSize int, guard float64) (spectrum.Frame, []detectedCarrier) {
+	frame := spectrum.AverageDB(iq, cfg.CenterHz, cfg.SampleRateHz, fftSize)
 	binHzF := cfg.SampleRateHz / float64(fftSize)
 
 	// Smooth over ~half the tightest channel so a wide carrier reads as a
 	// single bump instead of many noisy local maxima.
 	smoothBins := int(math.Round(6_250.0 / 2.0 / binHzF))
 	smoothed := frame
-	smoothed.Bins = movingAverage(frame.Bins, smoothBins)
+	smoothed.Bins = spectrum.Smooth(frame.Bins, smoothBins)
 
 	peaks := carriers.DetectPeaks(smoothed, carriers.PeakOptions{
 		ThresholdDb:  cfg.PeakThresholdDb,
 		MinSpacingHz: cfg.MinSpacingHz,
 	})
 	if len(peaks) == 0 {
-		return nil
+		return frame, nil
 	}
 
-	floor := percentile25(smoothed.Bins)
+	floor := spectrum.Percentile(smoothed.Bins, 0.25)
 	base := float64(cfg.CenterHz) - cfg.SampleRateHz/2
 	halfWidthBins := int(math.Round(12_500.0 / binHzF)) // ±one channel
 	freqs := make([]uint32, len(peaks))
 	centers := make([]uint32, len(peaks))
 	for i, p := range peaks {
 		bin := int(math.Round((float64(p.FreqHz) - base) / binHzF))
-		centerHz := centroidHz(smoothed.Bins, bin, halfWidthBins, floor, base, binHzF)
+		centerHz := spectrum.WeightedCentroidHz(smoothed.Bins, bin, halfWidthBins, floor, base, binHzF)
 		centers[i] = uint32(math.Round(centerHz))
 		freqs[i] = centers[i]
 	}
@@ -348,108 +372,7 @@ func detectCarriers(iq []complex64, cfg WidebandConfig, fftSize int, guard float
 			break
 		}
 	}
-	return cands
-}
-
-// movingAverage smooths bins with a centered box filter of half-width w (total
-// window 2w+1). w<=0 returns a copy.
-func movingAverage(bins []float32, w int) []float32 {
-	out := make([]float32, len(bins))
-	if w <= 0 {
-		copy(out, bins)
-		return out
-	}
-	for i := range bins {
-		lo, hi := i-w, i+w
-		if lo < 0 {
-			lo = 0
-		}
-		if hi >= len(bins) {
-			hi = len(bins) - 1
-		}
-		var s float32
-		for j := lo; j <= hi; j++ {
-			s += bins[j]
-		}
-		out[i] = s / float32(hi-lo+1)
-	}
-	return out
-}
-
-// centroidHz returns the power-weighted mean frequency of the carrier hump
-// around peakBin: the contiguous run of above-floor bins within ±halfWidth,
-// weighted by linear power. This finds the true centre of a wide C4FM carrier
-// whose strongest single bin is noisy.
-func centroidHz(binsDb []float32, peakBin, halfWidth int, floor float32, base, binHz float64) float64 {
-	lo, hi := peakBin-halfWidth, peakBin+halfWidth
-	if lo < 0 {
-		lo = 0
-	}
-	if hi >= len(binsDb) {
-		hi = len(binsDb) - 1
-	}
-	var wsum, psum float64
-	for j := lo; j <= hi; j++ {
-		if binsDb[j] <= floor {
-			continue
-		}
-		p := math.Pow(10, float64(binsDb[j])/10) // dB → linear power
-		freq := base + float64(j)*binHz
-		wsum += p * freq
-		psum += p
-	}
-	if psum == 0 {
-		return base + float64(peakBin)*binHz
-	}
-	return wsum / psum
-}
-
-// percentile25 is the 25th-percentile (robust noise floor) of a dB-bin slice.
-func percentile25(bins []float32) float32 {
-	if len(bins) == 0 {
-		return 0
-	}
-	cp := make([]float32, len(bins))
-	copy(cp, bins)
-	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
-	idx := int(0.25 * float64(len(cp)-1))
-	return cp[idx]
-}
-
-// averageSpectrum builds a Welch-averaged dBFS frame over the whole buffer.
-func averageSpectrum(iq []complex64, centerHz uint32, sampleRateHz float64, n int) spectrum.Frame {
-	plan := fft.New(n)
-	win := window.Hann(n)
-	var winSum float64
-	for _, w := range win {
-		winSum += w * w
-	}
-	acc := make([]float64, n)
-	bufIn := make([]complex128, n)
-	bufOut := make([]complex128, n)
-	dst := make([]float32, n)
-	frames := 0
-	for off := 0; off+n <= len(iq); off += n {
-		spectrum.PowerDB(plan, win, winSum, iq[off:off+n], bufIn, bufOut, dst)
-		for i, v := range dst {
-			acc[i] += float64(v)
-		}
-		frames++
-	}
-	bins := make([]float32, n)
-	if frames == 0 {
-		// Fewer than one FFT window: single padded pass so a short carrier
-		// still produces a frame.
-		pad := make([]complex64, n)
-		copy(pad, iq)
-		spectrum.PowerDB(plan, win, winSum, pad, bufIn, bufOut, dst)
-		copy(bins, dst)
-	} else {
-		for i := range bins {
-			bins[i] = float32(acc[i] / float64(frames))
-		}
-	}
-	return spectrum.Frame{CenterHz: centerHz, SampleRate: uint32(math.Round(sampleRateHz)), Bins: bins}
+	return frame, cands
 }
 
 // newBank builds the per-carrier channelizer, mirroring widebandt2.pickStrategy

--- a/internal/siglab/wideband_test.go
+++ b/internal/siglab/wideband_test.go
@@ -64,7 +64,7 @@ func TestSurveyWidebandFindsAndSnapsTones(t *testing.T) {
 	tone(300_000+400, 1.0)  // ~400 Hz off a 12.5 kHz grid point
 	tone(-250_000+400, 0.7) //
 
-	cands := detectCarriers(iq, WidebandConfig{SampleRateHz: rate, CenterHz: center}, 4096, 0.05)
+	_, cands := detectCarriers(iq, WidebandConfig{SampleRateHz: rate, CenterHz: center}, 4096, 0.05)
 	if len(cands) < 2 {
 		t.Fatalf("detected %d carriers, want >= 2", len(cands))
 	}

--- a/web/siglab/src/App.tsx
+++ b/web/siglab/src/App.tsx
@@ -5,12 +5,14 @@ import { Captures } from "./panels/Captures";
 import { Results } from "./panels/Results";
 import { Synthesize } from "./panels/Synthesize";
 import { Identify } from "./panels/Identify";
+import { Wideband } from "./panels/Wideband";
 import { Compare } from "./panels/Compare";
 
 const tabs = [
   { to: "/captures", label: "Captures" },
   { to: "/synthesize", label: "Synthesize" },
   { to: "/identify", label: "Identify" },
+  { to: "/wideband", label: "Wideband" },
   { to: "/compare", label: "Compare" },
 ];
 
@@ -54,6 +56,7 @@ export function App() {
           <Route path="/results/:captureId" element={<Results />} />
           <Route path="/synthesize" element={<Synthesize />} />
           <Route path="/identify" element={<Identify />} />
+          <Route path="/wideband" element={<Wideband />} />
           <Route path="/compare" element={<Compare />} />
           <Route path="*" element={<Navigate to="/captures" replace />} />
         </Routes>

--- a/web/siglab/src/api/client.ts
+++ b/web/siglab/src/api/client.ts
@@ -14,6 +14,8 @@ import type {
   ProtocolsDTO,
   RunConfig,
   SynthRequest,
+  WidebandRequest,
+  WidebandResult,
 } from "./types";
 
 export interface ClientConfig {
@@ -126,6 +128,11 @@ export const api = {
       capture_id: captureID,
       ...opts,
     }),
+
+  // wideband surveys a staged multi-carrier capture: averaged band spectrum +
+  // per-carrier identification + trunked-system rollups.
+  wideband: (c: ClientConfig, body: WidebandRequest) =>
+    req<WidebandResult>(c, "POST", "/api/v1/siglab/wideband", body),
 
   // synthesize stages an idealized/impaired capture and returns its DTO.
   synthesize: (c: ClientConfig, body: SynthRequest) =>

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -278,6 +278,73 @@ export interface RunConfig {
   collect_receiver_state?: boolean;
 }
 
+// WidebandRequest is the body of POST /api/v1/siglab/wideband. center_hz is the
+// absolute tuner center of the wideband grab; the survey maps detected carriers
+// to absolute frequencies from it.
+export interface WidebandRequest {
+  capture_id: string;
+  center_hz?: number;
+  sample_rate_hz?: number;
+  format?: string;
+  fft_size?: number;
+  channel_rate_hz?: number;
+  peak_threshold_db?: number;
+  tuner_strategy?: string;
+  conjugate?: boolean;
+  iq_correct?: boolean;
+}
+
+// SurveySpectrum is the Welch-averaged band power spectrum (dBFS), FFT-shifted
+// so bins[0] is center_hz - sample_rate_hz/2. Mirrors siglab.SurveySpectrum.
+export interface SurveySpectrum {
+  center_hz: number;
+  sample_rate_hz: number;
+  bins: number[];
+}
+
+// WidebandCarrier is one surveyed carrier. role is "control" | "voice" | "".
+export interface WidebandCarrier {
+  offset_hz: number;
+  freq_hz: number;
+  snr_db: number;
+  protocol: string;
+  confidence: number;
+  inconclusive: boolean;
+  locked: boolean;
+  role: string;
+  color_code?: number;
+  system_id?: number;
+  grants?: GrantRecord[];
+  score: number;
+}
+
+// WidebandSystem clusters carriers into one trunked-system verdict.
+export interface WidebandSystem {
+  protocol: string;
+  tier3: boolean;
+  system_id?: number;
+  color_code?: number;
+  control_count: number;
+  voice_count: number;
+  lo_hz: number;
+  hi_hz: number;
+  carrier_idx: number[];
+  verdict: string;
+}
+
+// WidebandResult mirrors siglab.WidebandResult.
+export interface WidebandResult {
+  source: string;
+  sample_rate_hz: number;
+  center_hz: number;
+  channel_rate_hz: number;
+  strategy: string;
+  spectrum?: SurveySpectrum;
+  detected_count: number;
+  carriers: WidebandCarrier[];
+  systems: WidebandSystem[];
+}
+
 export interface SynthRequest {
   protocol: string;
   format: string;

--- a/web/siglab/src/panels/Wideband.tsx
+++ b/web/siglab/src/panels/Wideband.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { useStore } from "../store/shared";
+import { WidebandSurvey } from "../viz/WidebandSurvey";
+import type { WidebandResult } from "../api/types";
+
+// Wideband surveys a multi-carrier capture: it splits the band into carriers,
+// identifies each, and rolls them into trunked-system verdicts (siglab
+// SurveyWideband). center_hz is the absolute tuner center of the grab.
+export function Wideband() {
+  const captures = useStore((s) => s.captures);
+  const wideband = useStore((s) => s.wideband);
+  const [captureId, setCaptureId] = useState("");
+  const [centerMHz, setCenterMHz] = useState("");
+  const [result, setResult] = useState<WidebandResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onSurvey() {
+    if (!captureId) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const centerHz = centerMHz ? Math.round(parseFloat(centerMHz) * 1e6) : undefined;
+      setResult(await wideband(captureId, { center_hz: centerHz }));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4">
+      <div className="card flex flex-wrap items-end gap-3">
+        <div className="flex-1">
+          <label className="label">Capture</label>
+          <select
+            className="input"
+            value={captureId}
+            onChange={(e) => setCaptureId(e.target.value)}
+          >
+            <option value="">— select —</option>
+            {captures.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="label">Center (MHz)</label>
+          <input
+            className="input w-32"
+            value={centerMHz}
+            placeholder="441.0"
+            onChange={(e) => setCenterMHz(e.target.value)}
+          />
+        </div>
+        <button className="btn" disabled={busy || !captureId} onClick={onSurvey}>
+          {busy ? "Surveying…" : "Survey"}
+        </button>
+      </div>
+      {err && <div className="card text-xs text-err">{err}</div>}
+
+      {result && <WidebandSurvey result={result} />}
+    </div>
+  );
+}

--- a/web/siglab/src/store/shared.ts
+++ b/web/siglab/src/store/shared.ts
@@ -11,6 +11,8 @@ import type {
   Result,
   RunConfig,
   SynthRequest,
+  WidebandRequest,
+  WidebandResult,
 } from "../api/types";
 
 // Analysis is the per-capture run state: the job id, live-streamed events,
@@ -51,6 +53,7 @@ interface Store {
   run: (captureId: string, config: RunConfig) => Promise<void>;
   fetchIQ: (captureId: string) => Promise<IQTaps | undefined>;
   identify: (captureId: string, sampleRateHz?: number) => Promise<IdentifyResult>;
+  wideband: (captureId: string, opts: Partial<WidebandRequest>) => Promise<WidebandResult>;
 }
 
 export const useStore = create<Store>((set, get) => ({
@@ -172,6 +175,16 @@ export const useStore = create<Store>((set, get) => ({
     return api.identify(get().config, captureId, {
       sample_rate_hz: sampleRateHz ?? cap?.sample_rate_hz,
       format: cap?.format,
+    });
+  },
+
+  wideband: async (captureId, opts) => {
+    const cap = get().captures.find((c) => c.id === captureId);
+    return api.wideband(get().config, {
+      capture_id: captureId,
+      sample_rate_hz: cap?.sample_rate_hz,
+      format: cap?.format,
+      ...opts,
     });
   },
 }));

--- a/web/siglab/src/viz/WidebandSurvey.test.tsx
+++ b/web/siglab/src/viz/WidebandSurvey.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// jsdom has no canvas; stub the chart so the component renders its tables.
+vi.mock("react-chartjs-2", () => ({
+  Line: () => <div data-testid="chart" />,
+}));
+
+import { WidebandSurvey } from "./WidebandSurvey";
+import type { WidebandResult } from "../api/types";
+
+function sampleResult(): WidebandResult {
+  return {
+    source: "wide.cf32",
+    sample_rate_hz: 2_000_000,
+    center_hz: 441_000_000,
+    channel_rate_hz: 48_000,
+    strategy: "ddc",
+    spectrum: { center_hz: 441_000_000, sample_rate_hz: 2_000_000, bins: [-80, -40, -10, -50] },
+    detected_count: 2,
+    carriers: [
+      {
+        offset_hz: 48_000,
+        freq_hz: 441_048_000,
+        snr_db: 22.5,
+        protocol: "dmr",
+        confidence: 0.9,
+        inconclusive: false,
+        locked: true,
+        role: "control",
+        color_code: 1,
+        system_id: 7,
+        grants: [],
+        score: 1.2,
+      },
+      {
+        offset_hz: -48_000,
+        freq_hz: 440_952_000,
+        snr_db: 18.0,
+        protocol: "dmr",
+        confidence: 0.8,
+        inconclusive: false,
+        locked: false,
+        role: "voice",
+        color_code: 1,
+        grants: [
+          {
+            offset_sec: 0,
+            group_id: 1,
+            source_id: 2,
+            channel_id: 0,
+            channel_num: 0,
+            timeslot: 1,
+            frequency_hz: 440_952_000,
+            encrypted: false,
+            emergency: false,
+          },
+        ],
+        score: 0.9,
+      },
+    ],
+    systems: [
+      {
+        protocol: "dmr",
+        tier3: true,
+        system_id: 7,
+        color_code: 1,
+        control_count: 1,
+        voice_count: 1,
+        lo_hz: 440_952_000,
+        hi_hz: 441_048_000,
+        carrier_idx: [0, 1],
+        verdict: "DMR Tier III system",
+      },
+    ],
+  };
+}
+
+describe("WidebandSurvey", () => {
+  it("renders the survey summary, system rollup, and carrier rows", () => {
+    render(<WidebandSurvey result={sampleResult()} />);
+
+    expect(screen.getByTestId("chart")).toBeInTheDocument();
+    expect(screen.getByText(/2 carrier peaks/)).toBeInTheDocument();
+
+    // System rollup.
+    expect(screen.getByText(/DMR Tier III system/)).toBeInTheDocument();
+    expect(screen.getByText("440.9520–441.0480")).toBeInTheDocument();
+
+    // Carrier rows with roles and absolute frequencies.
+    expect(screen.getByText("441.0480")).toBeInTheDocument();
+    expect(screen.getByText("440.9520")).toBeInTheDocument();
+    expect(screen.getByText("control")).toBeInTheDocument();
+    expect(screen.getByText("voice")).toBeInTheDocument();
+  });
+
+  it("handles a survey with no carriers", () => {
+    const empty: WidebandResult = {
+      ...sampleResult(),
+      detected_count: 0,
+      carriers: [],
+      systems: [],
+    };
+    render(<WidebandSurvey result={empty} />);
+    expect(screen.getByText(/0 identified/)).toBeInTheDocument();
+  });
+});

--- a/web/siglab/src/viz/WidebandSurvey.tsx
+++ b/web/siglab/src/viz/WidebandSurvey.tsx
@@ -1,0 +1,190 @@
+import { Line } from "react-chartjs-2";
+import type { ChartDataset } from "chart.js";
+import type { WidebandResult, WidebandCarrier } from "../api/types";
+import { ensureChart } from "./chartSetup";
+
+ensureChart();
+
+// roleColor maps a carrier's role to its marker color: control channels carry
+// the system identity (amber), voice carriers carry grants (green), and
+// unclassified carriers are muted (sky).
+function roleColor(role: string): string {
+  switch (role) {
+    case "control":
+      return "#f59e0b";
+    case "voice":
+      return "#22c55e";
+    default:
+      return "#38bdf8";
+  }
+}
+
+// binDbAt returns the spectrum dB value nearest carrier frequency f, so a marker
+// pins to the peak it represents. Bins are FFT-shifted: bins[0] is
+// center - rate/2, stepping by rate/len.
+function binDbAt(
+  bins: number[],
+  centerHz: number,
+  rateHz: number,
+  f: number,
+): number {
+  if (bins.length === 0) return 0;
+  const base = centerHz - rateHz / 2;
+  const step = rateHz / bins.length;
+  let idx = Math.round((f - base) / step);
+  if (idx < 0) idx = 0;
+  if (idx >= bins.length) idx = bins.length - 1;
+  return bins[idx];
+}
+
+// WidebandSurvey renders the matplotlib-style view of a wide-band survey: the
+// Welch-averaged band spectrum with each detected carrier marked (colored by
+// control/voice role), the trunked-system rollups, and the per-carrier table.
+export function WidebandSurvey({ result }: { result: WidebandResult }) {
+  const spec = result.spectrum;
+  const datasets: ChartDataset<"line">[] = [];
+
+  if (spec && spec.bins.length > 0) {
+    const base = spec.center_hz - spec.sample_rate_hz / 2;
+    const step = spec.sample_rate_hz / spec.bins.length;
+    datasets.push({
+      label: "PSD (dBFS)",
+      data: spec.bins.map((db, i) => ({ x: (base + i * step) / 1e6, y: db })),
+      borderColor: "#64748b",
+      pointRadius: 0,
+      borderWidth: 1,
+    });
+    if (result.carriers.length > 0) {
+      datasets.push({
+        type: "scatter",
+        label: "carriers",
+        data: result.carriers.map((c) => ({
+          x: c.freq_hz / 1e6,
+          y: binDbAt(spec.bins, spec.center_hz, spec.sample_rate_hz, c.freq_hz),
+        })),
+        pointBackgroundColor: result.carriers.map((c) => roleColor(c.role)),
+        pointBorderColor: result.carriers.map((c) => roleColor(c.role)),
+        pointRadius: 5,
+        pointStyle: "triangle",
+      } as unknown as ChartDataset<"line">);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="card">
+        <h3 className="mb-2 text-sm font-semibold">
+          Wide-band survey · {result.detected_count} carrier peaks ·{" "}
+          {result.carriers.length} identified
+        </h3>
+        {spec && spec.bins.length > 0 ? (
+          <Line
+            data={{ datasets }}
+            options={{
+              responsive: true,
+              plugins: {
+                legend: { display: false },
+                tooltip: {
+                  callbacks: {
+                    label: (ctx) => {
+                      if (ctx.dataset.label !== "carriers") {
+                        return `${(ctx.parsed.y ?? 0).toFixed(1)} dBFS`;
+                      }
+                      const c = result.carriers[ctx.dataIndex];
+                      const id =
+                        c.system_id != null && c.system_id !== 0
+                          ? ` · sys ${c.system_id}`
+                          : "";
+                      return `${(c.freq_hz / 1e6).toFixed(4)} MHz · ${
+                        c.protocol || "?"
+                      } · ${c.role || "unknown"}${id}`;
+                    },
+                  },
+                },
+              },
+              scales: {
+                x: {
+                  type: "linear",
+                  title: { display: true, text: "MHz" },
+                  ticks: { maxTicksLimit: 12 },
+                },
+                y: { title: { display: true, text: "dBFS" } },
+              },
+            }}
+          />
+        ) : (
+          <p className="text-xs text-muted">No spectrum returned.</p>
+        )}
+      </div>
+
+      {result.systems.length > 0 && (
+        <div className="card">
+          <h3 className="mb-2 text-sm font-semibold">Systems</h3>
+          <table className="w-full text-left text-xs">
+            <thead className="text-muted">
+              <tr>
+                <th className="pr-3">Verdict</th>
+                <th className="pr-3">Protocol</th>
+                <th className="pr-3">Control</th>
+                <th className="pr-3">Voice</th>
+                <th className="pr-3">System</th>
+                <th className="pr-3">CC</th>
+                <th>Span (MHz)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.systems.map((sys, i) => (
+                <tr key={i} className="border-t border-white/5">
+                  <td className="py-1 pr-3">
+                    {sys.tier3 && <span className="text-accent">★ </span>}
+                    {sys.verdict}
+                  </td>
+                  <td className="pr-3 uppercase">{sys.protocol}</td>
+                  <td className="pr-3">{sys.control_count}</td>
+                  <td className="pr-3">{sys.voice_count}</td>
+                  <td className="pr-3">{sys.system_id || "—"}</td>
+                  <td className="pr-3">{sys.color_code || "—"}</td>
+                  <td>
+                    {(sys.lo_hz / 1e6).toFixed(4)}–{(sys.hi_hz / 1e6).toFixed(4)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {result.carriers.length > 0 && (
+        <div className="card">
+          <h3 className="mb-2 text-sm font-semibold">Carriers</h3>
+          <table className="w-full text-left text-xs">
+            <thead className="text-muted">
+              <tr>
+                <th className="pr-3">Freq (MHz)</th>
+                <th className="pr-3">Role</th>
+                <th className="pr-3">Protocol</th>
+                <th className="pr-3">SNR (dB)</th>
+                <th className="pr-3">Locked</th>
+                <th>Grants</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.carriers.map((c: WidebandCarrier, i) => (
+                <tr key={i} className="border-t border-white/5">
+                  <td className="py-1 pr-3">{(c.freq_hz / 1e6).toFixed(4)}</td>
+                  <td className="pr-3" style={{ color: roleColor(c.role) }}>
+                    {c.role || "unknown"}
+                  </td>
+                  <td className="pr-3">{c.protocol || "—"}</td>
+                  <td className="pr-3">{c.snr_db.toFixed(1)}</td>
+                  <td className="pr-3">{c.locked ? "✓" : ""}</td>
+                  <td>{c.grants?.length ?? 0}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What this adds

A follow-up to the wide-band survey (#677, now on `main`). That review asked which
external numpy/scipy/matplotlib functions the feature relied on. The answer: **none** —
it added zero dependencies and runs on Go stdlib + GopherTrunk's own `internal/dsp`.
But it *inlined* several numpy/scipy-style primitives that weren't reusable, **duplicated**
one (`percentile` lived in both `siglab/wideband.go` and `carriers/peaks.go`), and never
surfaced the survey for viewing. This PR fixes all three.

## Changes

**`internal/dsp/spectrum` — promote the inlined primitives into tested, shared functions**
- `AverageDB` — Welch-averaged dBFS spectrum (the `scipy.signal.welch` analog); the one
  genuine gap in the DSP surface.
- `Smooth` (boxcar / `np.convolve`), `Percentile` (robust noise floor / `np.percentile`),
  `WeightedCentroidHz` (power-weighted carrier center / weighted `np.average`).
- Rewired `siglab/wideband.go` and `carriers/peaks.go` to the shared funcs and deleted the
  inline/duplicate copies. Pure refactor — the existing survey tests are the regression guard.

**API — expose the survey over REST**
- `WidebandResult` gains an optional `Spectrum` (gated by `WidebandConfig.CollectSpectrum`
  so the offline `hunt` path stays lean and its exports don't bloat).
- `POST /api/v1/siglab/wideband` surveys a staged capture and returns the averaged band
  spectrum + per-carrier results + system rollups.

**web/siglab — matplotlib-style survey view**
- New **Wideband** panel + `WidebandSurvey` viz: the averaged band spectrum with each
  detected carrier marked (colored by control/voice role) and the trunked-system rollup
  table. Reuses the existing Chart.js PSD/table patterns.

## Notes
- I deliberately did **not** add an exported `dsp.DBToLinearPower`: the existing dB↔linear
  sites use inconsistent `/10` (power) vs `/20` (amplitude) conventions, so a new uncalled
  export wasn't justified; the conversion stays local to `spectrum`.

## Verification
- `gofmt`/`go vet` clean; **all Go packages pass** (`go test ./...`).
- web/siglab typechecks, builds, and the new component/handler/unit tests pass.
- New tests at each layer: `spectrum` primitive unit tests, the `/wideband` handler test
  (synthetic two-carrier upload → survey), and the `WidebandSurvey` component test.

https://claude.ai/code/session_01PNxDvNBvMWMxLGzfjKWnFA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNxDvNBvMWMxLGzfjKWnFA)_