### PR TITLE
tetra: recover the BSCH colour code under any π/4-DQPSK rotation

### DIFF
--- a/docs/decoder-capture-needs.md
+++ b/docs/decoder-capture-needs.md
@@ -62,6 +62,21 @@ real-air confirmation**. A single labeled capture closes each one.
 - **Cross-check:** telive 1.5 / osmo-tetra.
 - **Pass bar:** CC lock < 5 s, ≥ 90% frame recovery, Viterbi correction
   depth p95 ≤ 8 / p99 ≤ 12 bit-errors per 116-bit block.
+- **Verification progress (live 468.5 MHz / 1 Msps captures):** two
+  blockers found and one fixed. (1) The captured front-end was
+  **spectrum-inverted** — set `iq_invert: true` (or replay with
+  `-conjugate`); with that the normal-burst demod is clean (NTS1 at
+  Hamming distance 0). (2) A real-air decoder bug: the BSCH colour-code
+  recovery only correlated the rotation-0 orientation of the
+  synchronisation training sequence, but π/4-DQPSK's residual-CFO term
+  rotates the whole dibit stream — now fixed to try all four rotations
+  (`internal/radio/tetra/process.go`, guarded by
+  `TestRecoverColourCodeUnderRotation` +
+  `TestProcessLearnsColourCodeFromSBBurstUnderRotation`). Still open:
+  the supplied clips are only ≈3.3 s each (too few frame-18 SB slots)
+  and their SB region does not demodulate cleanly, so no `cc.locked`
+  fires yet. Closing this needs a **≥30 s** cleartext capture spanning
+  several clean synchronisation bursts. See `samples/tetra/README.md`.
 
 ### YSF (Yaesu System Fusion, DN mode)
 - **What to capture:** A YSF carrier (Pi-Star/reflector or a keyed HT).

--- a/internal/radio/tetra/process.go
+++ b/internal/radio/tetra/process.go
@@ -12,11 +12,14 @@ type processState struct {
 	pduDibits    []uint8
 	matchScratch []int
 
-	// SB-burst (synchronisation burst) path: a separate detector for
-	// the synchronisation training sequence plus a rolling dibit buffer
-	// with look-back (to the BSCH before the STS) and look-ahead (to the
-	// BNCH after it). See processSB.
-	stsDet     *SyncDetector
+	// SB-burst (synchronisation burst) path: a detector for the
+	// synchronisation training sequence under each of the four π/4-DQPSK
+	// constellation rotations (a residual CFO rotates the whole dibit
+	// stream by an unknown 0..3, so a single fixed-orientation correlator
+	// misses the SB on real air), plus a rolling dibit buffer with
+	// look-back (to the BSCH before the STS) and look-ahead (to the BNCH
+	// after it). See processSB.
+	stsDets    [4]*SyncDetector
 	stsScratch []int
 	buf        []uint8     // rolling dibit window
 	softBuf    []complex64 // per-dibit soft differential, parallel to buf (nil ⇒ hard-only)
@@ -89,11 +92,15 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	c.mu.Unlock()
 
 	if c.proc == nil {
-		c.proc = &processState{
+		sts := SyncTrainingDibits()
+		ps := &processState{
 			det:       NewSyncDetector(NormalSyncDibits(), 3),
-			stsDet:    NewSyncDetector(SyncTrainingDibits(), 3),
 			pduDibits: make([]uint8, 0, channelDibitCount(ChannelSCHF)),
 		}
+		for r := range ps.stsDets {
+			ps.stsDets[r] = NewSyncDetector(rotateDibits(sts, uint8(r)), 3)
+		}
+		c.proc = ps
 	}
 	p := c.proc
 
@@ -192,10 +199,27 @@ func (c *ControlChannel) processSB(p *processState, dibits []uint8, diffs []comp
 		p.softBuf = p.softBuf[:0]
 	}
 
-	var hits []int
-	hits, _ = p.stsDet.Process(p.stsScratch[:0], dibits, baseIdx)
-	for _, trailing := range hits {
-		p.pendingSTS = append(p.pendingSTS, trailing-(stsDibits-1)) // leading index L
+	// Correlate the STS under each constellation rotation; a hit from any
+	// orientation enqueues the burst (decodeSB re-tries all four rotations
+	// when decoding the BSCH/BNCH, so the firing detector's rotation need
+	// not be carried through). De-duplicate trailing indices so a sequence
+	// that matches under two rotations is only decoded once.
+	for r := range p.stsDets {
+		var hits []int
+		hits, _ = p.stsDets[r].Process(p.stsScratch[:0], dibits, baseIdx)
+		for _, trailing := range hits {
+			L := trailing - (stsDibits - 1) // leading index L
+			dup := false
+			for _, q := range p.pendingSTS {
+				if q == L {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				p.pendingSTS = append(p.pendingSTS, L)
+			}
+		}
 	}
 
 	bufEnd := p.bufBase + len(p.buf)
@@ -357,21 +381,35 @@ func hammingBits(a, b []byte) int {
 // sequence itself rather than relying on the live Process state machine.
 func RecoverColourCode(stream []uint8) (uint32, bool) {
 	sts := SyncTrainingDibits()
-	det := NewSyncDetector(sts, 3)
-	hits, _ := det.Process(nil, stream, 0)
-	for _, trailing := range hits {
-		L := trailing - (len(sts) - 1) // leading dibit index of the STS
-		if L-sbBSCHDibits < 0 || L > len(stream) {
-			continue // BSCH look-back runs off the front of the buffer
+	// π/4-DQPSK carries data in the differential phase, so a residual carrier
+	// frequency offset adds a constant 90°/dibit term to the whole stream —
+	// the demodulated dibits arrive cyclically rotated by an unknown 0..3. On
+	// real air this rotation is essentially never zero, so the synchronisation
+	// training sequence only matches once the stream is de-rotated to the
+	// reference orientation. The synthesised fixtures demod at rotation 0,
+	// which is why a rotation-blind correlator passed in tests yet recovered
+	// no colour code on air. Try all four rotations of the stream.
+	for srot := uint8(0); srot < 4; srot++ {
+		rs := stream
+		if srot != 0 {
+			rs = rotateDibits(stream, srot)
 		}
-		bsch := stream[L-sbBSCHDibits : L]
-		for rot := uint8(0); rot < 4; rot++ {
-			recovered, ok := DecodeBSCH(TetraDibitsToBits(rotateDibits(bsch, rot)))
-			if !ok {
-				continue
+		det := NewSyncDetector(sts, 3)
+		hits, _ := det.Process(nil, rs, 0)
+		for _, trailing := range hits {
+			L := trailing - (len(sts) - 1) // leading dibit index of the STS
+			if L-sbBSCHDibits < 0 || L > len(rs) {
+				continue // BSCH look-back runs off the front of the buffer
 			}
-			if s, ok := ParseSyncPDU(recovered); ok {
-				return s.ExtendedColourCode(), true
+			bsch := rs[L-sbBSCHDibits : L]
+			for rot := uint8(0); rot < 4; rot++ {
+				recovered, ok := DecodeBSCH(TetraDibitsToBits(rotateDibits(bsch, rot)))
+				if !ok {
+					continue
+				}
+				if s, ok := ParseSyncPDU(recovered); ok {
+					return s.ExtendedColourCode(), true
+				}
 			}
 		}
 	}

--- a/internal/radio/tetra/process_test.go
+++ b/internal/radio/tetra/process_test.go
@@ -45,6 +45,47 @@ func TestRecoverColourCode(t *testing.T) {
 	}
 }
 
+// TestRecoverColourCodeUnderRotation reproduces the real-air failure mode that
+// the rotation-0 synthetic fixtures masked: π/4-DQPSK carries data in the
+// differential phase, so a residual carrier offset adds a constant 90°/dibit
+// term that cyclically rotates the entire demodulated stream by an unknown
+// 0..3. Live captures essentially never sit at rotation 0 (the supplied 468.5
+// MHz TETRA captures landed at rotation 1), so a rotation-blind STS correlator
+// never fires and no colour code is recovered — exactly what was observed on
+// air. RecoverColourCode must de-rotate and recover under every orientation.
+func TestRecoverColourCodeUnderRotation(t *testing.T) {
+	const (
+		cc6        = 0x2D
+		mcc uint16 = 0x0CE
+		mnc uint16 = 0x1234
+	)
+	want := ExtendedColourCode(mcc, mnc, cc6)
+
+	syncInfo := make([]byte, 60)
+	putBits(syncInfo, 4, 6, cc6)
+	putBits(syncInfo, 31, 10, uint32(mcc))
+	putBits(syncInfo, 41, 14, uint32(mnc))
+	bschDibits := TetraBitsToDibits(EncodeBSCH(syncInfo))
+
+	var base []uint8
+	base = append(base, make([]uint8, 23)...)    // leading filler
+	base = append(base, bschDibits...)           // BSCH
+	base = append(base, SyncTrainingDibits()...) // STS
+	base = append(base, make([]uint8, 40)...)    // trailing pad
+
+	for rot := uint8(0); rot < 4; rot++ {
+		stream := rotateDibits(base, rot)
+		got, ok := RecoverColourCode(stream)
+		if !ok {
+			t.Errorf("rot=%d: RecoverColourCode found no BSCH in a rotated SB burst", rot)
+			continue
+		}
+		if got != want {
+			t.Errorf("rot=%d: recovered colour code = %#x, want %#x", rot, got, want)
+		}
+	}
+}
+
 // TestProcessLocksOnSystemBroadcastAfterSync builds a dibit stream
 // of 50 padding dibits + 38 normal training-sequence dibits + 48
 // dibits whose raw bits decode to an MLE-SYSINFO PDU with known

--- a/internal/radio/tetra/sync_pdu_test.go
+++ b/internal/radio/tetra/sync_pdu_test.go
@@ -150,3 +150,76 @@ func TestProcessLearnsColourCodeFromSBBurst(t *testing.T) {
 		t.Errorf("lock LocationArea = %#x, want %#x (BNCH SYSINFO not decoded with the learned colour)", ls.LocationArea, la)
 	}
 }
+
+// TestProcessLearnsColourCodeFromSBBurstUnderRotation is the live-path
+// counterpart to TestRecoverColourCodeUnderRotation: it drives the full
+// ControlChannel.Process state machine with a synchronisation burst whose
+// dibit stream is globally rotated (the residual-CFO orientation real air
+// always carries), and asserts the SB detector still fires, the colour code
+// is learned from the BSCH, and the BNCH SYSINFO descrambles to a lock.
+// Before the per-rotation STS detectors landed, a non-zero rotation slipped
+// straight past the single fixed-orientation correlator and never locked.
+func TestProcessLearnsColourCodeFromSBBurstUnderRotation(t *testing.T) {
+	const (
+		cc6        = 0x2D
+		mcc uint16 = 0x0CE
+		mnc uint16 = 0x1234
+		la  uint16 = 0x2B7
+	)
+	ext := ExtendedColourCode(mcc, mnc, cc6)
+
+	syncInfo := make([]byte, 60)
+	putBits(syncInfo, 4, 6, cc6)
+	putBits(syncInfo, 31, 10, uint32(mcc))
+	putBits(syncInfo, 41, 14, uint32(mnc))
+	bschDibits := TetraBitsToDibits(EncodeBSCH(syncInfo))
+
+	payload := make([]byte, 11)
+	payload[3] = byte((la >> 6) & 0xFF)
+	payload[4] = byte((la & 0x3F) << 2)
+	pdu := PDU{Disc: DiscMLE, Type: uint8(MLESystemInfo), Payload: payload}
+	bnchDibits := TetraBitsToDibits(EncodeSCHHD(pduToType1Bits(pdu, 124), ext))
+
+	var burst []uint8
+	burst = append(burst, bschDibits...)
+	burst = append(burst, SyncTrainingDibits()...)
+	burst = append(burst, make([]uint8, 15)...)
+	burst = append(burst, bnchDibits...)
+
+	base := make([]uint8, 30)
+	for r := 0; r < 4; r++ {
+		base = append(base, burst...)
+		base = append(base, make([]uint8, 40)...)
+	}
+
+	for rot := uint8(1); rot < 4; rot++ {
+		stream := rotateDibits(base, rot)
+
+		bus := events.NewBus(16)
+		sub := bus.Subscribe()
+		cc := New(Options{Bus: bus, Log: slog.New(slog.NewTextHandler(io.Discard, nil)), SystemName: "Sys", FrequencyHz: 412_000_000})
+		cc.SetChannelCoding(ChannelCodingOn)
+		cc.Process(stream, 0)
+
+		if got := cc.ColourCode(); got != ext {
+			t.Errorf("rot=%d: learned colour code = %#x, want %#x", rot, got, ext)
+		}
+		var locked bool
+		for {
+			select {
+			case ev := <-sub.C:
+				if ev.Kind == events.KindCCLocked {
+					locked = true
+				}
+				continue
+			default:
+			}
+			break
+		}
+		if !locked {
+			t.Errorf("rot=%d: no cc.locked from the rotated SB burst", rot)
+		}
+		sub.Close()
+		bus.Close()
+	}
+}

--- a/samples/tetra/README.md
+++ b/samples/tetra/README.md
@@ -97,6 +97,45 @@ follow-up. Such a capture ships with a `.metadata.json` sidecar (schema
 above) and the realair test above starts asserting against it
 automatically.
 
+### What a second live capture set taught us (468.5 MHz, 1 Msps)
+
+A second batch of live downlink captures (seven `*.cfile` clips,
+≈3.3 s each, 1 Msps, centre 468.475 MHz; carrier ≈119 kHz off centre)
+was replayed through the production pipeline. They are **not** committed
+(per `samples/.gitignore`), but they surfaced two concrete findings:
+
+1. **The front-end was spectrum-inverted (issue #264).** Raw, the
+   π/4-DQPSK differential decode is garbled (dibit histogram ≈
+   34/29/18/19 %). With the spectrum de-inverted (`gophertrunk replay
+   -conjugate …`, or `iq_invert: true` on the device) the dibits snap
+   to a uniform 25/25/25/25 % and the **normal** training sequence
+   (NTS1) correlates at Hamming distance **0** over hundreds of bursts —
+   i.e. the normal-burst demod is provably clean once the spectrum is
+   corrected.
+
+2. **A real-air decoder bug: the colour-code recovery was
+   rotation-blind.** π/4-DQPSK carries data in the differential phase,
+   so a residual carrier offset rotates the whole demodulated dibit
+   stream by an unknown 0..3 (these captures sat at rotation 1). The
+   synchronisation-training-sequence (STS) correlator that gates BSCH
+   recovery matched only the rotation-0 orientation, so on air it never
+   fired — which is almost certainly why the reference carrier above
+   recovered no colour code either. `RecoverColourCode` and the live
+   `processSB` STS detection are now tried under all four rotations
+   (regression: `TestRecoverColourCodeUnderRotation`,
+   `TestProcessLearnsColourCodeFromSBBurstUnderRotation`).
+
+Even with both addressed these particular clips still do **not** lock:
+the synchronisation burst itself never demodulates cleanly (best STS
+match ≈5/19 mismatches vs. 0/19 for the normal bursts, and the
+near-misses do not sit on the ~18 360-symbol multiframe grid). Each clip
+is only ≈3.3 s — a synchronisation burst recurs only once per ≈1.02 s
+multiframe — so they span too few SB opportunities, and the SB region
+appears further disrupted (likely the frequency-correction field pulling
+the carrier/timing loop). A **≥30 s** cleartext capture that includes
+several clean frame-18 SB slots is still what closes the lock + Viterbi
+histogram criteria.
+
 ## Recommended sources
 
 - **telive / osmo-tetra** — produces both IQ recordings and a


### PR DESCRIPTION
Verifying the live 468.5 MHz / 1 Msps TETRA downlink captures against the
production pipeline surfaced two issues behind the never-closing Tier-1
"confirm CC decode on air" item.

First, the captured front-end is spectrum-inverted: raw, the differential
decode is garbled (dibit histogram ~34/29/18/19%); de-inverted (replay
-conjugate / device iq_invert) the dibits go uniform and the normal
training sequence correlates at Hamming distance 0. So the normal-burst
demod is provably clean once the spectrum is corrected.

Second — and the real bug — the BSCH colour-code recovery was
rotation-blind. π/4-DQPSK carries data in the differential phase, so a
residual carrier offset adds a constant 90°/dibit term that cyclically
rotates the whole demodulated stream by an unknown 0..3. The
synchronisation-training-sequence correlator that gates BSCH recovery
matched only the rotation-0 orientation, so on real air (these captures
sat at rotation 1) it never fired and no colour code was learned — which
also explains why the committed reference carrier never locked. The
synthesised fixtures all demod at rotation 0, masking it in tests.

RecoverColourCode and the live processSB STS detection now correlate the
sync training sequence under all four rotations (decodeSB already retries
the BSCH/BNCH under every rotation, so only the detector gate needed
fixing). Regression guards: TestRecoverColourCodeUnderRotation and
TestProcessLearnsColourCodeFromSBBurstUnderRotation (both fail on the old
rotation-blind path).

Still open: the supplied clips are only ~3.3 s each (too few frame-18 SB
slots) and their SB region does not demodulate cleanly, so no cc.locked
fires yet — closing the lock + Viterbi-histogram criteria still needs a
>=30 s cleartext capture spanning several clean synchronisation bursts.
Findings recorded in samples/tetra/README.md and
docs/decoder-capture-needs.md.

https://claude.ai/code/session_01HKofhKio91SXPYSVnc4Gkp