### PR TITLE
Add native DSP numerical helpers and π/4-DQPSK rotation viz

### DIFF
--- a/internal/dsp/carrier.go
+++ b/internal/dsp/carrier.go
@@ -4,6 +4,8 @@ import (
 	"math"
 	"math/cmplx"
 	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/stats"
 )
 
 // CarrierCandidate is one detected narrowband carrier: its offset from DC
@@ -95,31 +97,26 @@ func EstimateCarrierCandidatesHz(iq []complex64, sampleRateHz, searchHz, minSpac
 		powers[i] = avgPowerNorm(x, freqs[i], coarseWin, 256)
 	}
 
-	// Collect local maxima (endpoints included, so a carrier at the band edge
-	// — and always the global max — is a candidate).
-	type pk struct{ f, p float64 }
-	var peaks []pk
-	for i := 0; i < coarseN; i++ {
-		left := i == 0 || powers[i] > powers[i-1]
-		right := i == coarseN-1 || powers[i] >= powers[i+1]
-		if left && right {
-			peaks = append(peaks, pk{freqs[i], powers[i]})
-		}
-	}
-	if len(peaks) == 0 {
+	// Collect local maxima above a relative-power floor, strongest first
+	// (endpoints included, so a carrier at the band edge — and always the
+	// global max — is a candidate). The floor drops noise bins ≥
+	// carrierCandidateFloorDb below the strongest carrier.
+	floorRatio := math.Pow(10, -carrierCandidateFloorDb/10)
+	peakIdx := stats.FindPeaks(powers, stats.PeakOpts{
+		RelHeight:   floorRatio,
+		IncludeEnds: true,
+	})
+	if len(peakIdx) == 0 {
 		return nil
 	}
-	sort.Slice(peaks, func(a, b int) bool { return peaks[a].p > peaks[b].p })
 
-	// Min-spacing suppression + relative-power floor.
+	// Min-spacing suppression in frequency units: a weaker peak within
+	// minSpacingN of an already-kept stronger one is a sidelobe, not a carrier.
+	type pk struct{ f, p float64 }
 	minSpacingN := minSpacingHz / sampleRateHz
-	floorRatio := math.Pow(10, -carrierCandidateFloorDb/10)
-	pMax := peaks[0].p
 	var kept []pk
-	for _, c := range peaks {
-		if c.p < pMax*floorRatio {
-			continue
-		}
+	for _, idx := range peakIdx {
+		c := pk{freqs[idx], powers[idx]}
 		tooClose := false
 		for _, k := range kept {
 			if math.Abs(c.f-k.f) < minSpacingN {

--- a/internal/dsp/phase/phase.go
+++ b/internal/dsp/phase/phase.go
@@ -1,0 +1,62 @@
+// Package phase holds the small phase-domain helpers the rotation analyses use
+// — the native Go equivalents of numpy.unwrap and the per-symbol differential
+// phase that makes a π/4-DQPSK constellation's rotation visible. They are
+// stdlib-only and operate on plain float64 / complex128 slices.
+package phase
+
+import (
+	"math"
+	"math/cmplx"
+)
+
+// Unwrap removes 2π discontinuities from a sequence of phase angles in radians,
+// matching numpy.unwrap with the default discontinuity of π: wherever the step
+// between consecutive samples exceeds π in magnitude, a multiple of 2π is added
+// to bring it back into (-π, π]. The first sample is left untouched. Returns a
+// new slice; the input is not modified.
+func Unwrap(p []float64) []float64 {
+	out := make([]float64, len(p))
+	copy(out, p)
+	if len(p) < 2 {
+		return out
+	}
+	correction := 0.0
+	for i := 1; i < len(p); i++ {
+		d := p[i] - p[i-1]
+		// Remainder maps d into [-π, π]; nudge the -π boundary to +π for a
+		// positive jump so the result lies in (-π, π], as numpy does.
+		wrapped := math.Remainder(d, 2*math.Pi)
+		if wrapped == -math.Pi && d > 0 {
+			wrapped = math.Pi
+		}
+		correction += wrapped - d
+		out[i] = p[i] + correction
+	}
+	return out
+}
+
+// FromComplex returns the wrapped instantaneous phase (atan2(Im, Re), in
+// (-π, π]) of each sample in z. Returns a new slice.
+func FromComplex(z []complex128) []float64 {
+	out := make([]float64, len(z))
+	for i, v := range z {
+		out[i] = math.Atan2(imag(v), real(v))
+	}
+	return out
+}
+
+// Diff returns the per-sample differential phase angle(z[i]·conj(z[i-1])) in
+// (-π, π] — the rotation between consecutive samples, i.e. the π/4-DQPSK
+// rotation signal. The output has length len(z)-1; it is nil when z has fewer
+// than two samples.
+func Diff(z []complex128) []float64 {
+	if len(z) < 2 {
+		return nil
+	}
+	out := make([]float64, len(z)-1)
+	for i := 1; i < len(z); i++ {
+		d := z[i] * cmplx.Conj(z[i-1])
+		out[i-1] = math.Atan2(imag(d), real(d))
+	}
+	return out
+}

--- a/internal/dsp/phase/phase_test.go
+++ b/internal/dsp/phase/phase_test.go
@@ -1,0 +1,79 @@
+package phase
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+func TestUnwrapRamp(t *testing.T) {
+	// A phase ramp of +0.6π per step wraps in the raw (atan2-style) sequence
+	// but must come out monotonic and continuous after unwrapping.
+	stepTrue := 0.6 * math.Pi
+	n := 12
+	wrapped := make([]float64, n)
+	for i := range wrapped {
+		// Wrap the true phase into (-π, π].
+		wrapped[i] = math.Atan2(math.Sin(stepTrue*float64(i)), math.Cos(stepTrue*float64(i)))
+	}
+	got := Unwrap(wrapped)
+	for i := 1; i < n; i++ {
+		d := got[i] - got[i-1]
+		if math.Abs(d-stepTrue) > 1e-9 {
+			t.Errorf("step %d = %v, want %v (continuous ramp)", i, d, stepTrue)
+		}
+	}
+}
+
+func TestUnwrapShortInputs(t *testing.T) {
+	if got := Unwrap(nil); len(got) != 0 {
+		t.Errorf("Unwrap(nil) len = %d, want 0", len(got))
+	}
+	if got := Unwrap([]float64{1.5}); len(got) != 1 || got[0] != 1.5 {
+		t.Errorf("Unwrap singleton = %v, want [1.5]", got)
+	}
+}
+
+func TestUnwrapDoesNotMutateInput(t *testing.T) {
+	in := []float64{3, -3, 3}
+	_ = Unwrap(in)
+	if in[1] != -3 {
+		t.Errorf("Unwrap mutated its input: %v", in)
+	}
+}
+
+func TestDiffConstantRotation(t *testing.T) {
+	// A phasor rotating by a fixed step has a constant differential phase.
+	step := math.Pi / 4
+	n := 8
+	z := make([]complex128, n)
+	for i := range z {
+		z[i] = cmplx.Exp(complex(0, step*float64(i)))
+	}
+	d := Diff(z)
+	if len(d) != n-1 {
+		t.Fatalf("Diff len = %d, want %d", len(d), n-1)
+	}
+	for i, v := range d {
+		if math.Abs(v-step) > 1e-9 {
+			t.Errorf("Diff[%d] = %v, want %v", i, v, step)
+		}
+	}
+}
+
+func TestFromComplex(t *testing.T) {
+	z := []complex128{complex(1, 0), complex(0, 1), complex(-1, 0)}
+	got := FromComplex(z)
+	want := []float64{0, math.Pi / 2, math.Pi}
+	for i := range want {
+		if math.Abs(got[i]-want[i]) > 1e-12 {
+			t.Errorf("FromComplex[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDiffShort(t *testing.T) {
+	if got := Diff([]complex128{complex(1, 0)}); got != nil {
+		t.Errorf("Diff of one sample = %v, want nil", got)
+	}
+}

--- a/internal/dsp/spectrum/welch.go
+++ b/internal/dsp/spectrum/welch.go
@@ -1,0 +1,77 @@
+package spectrum
+
+import (
+	"math"
+	"math/cmplx"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+)
+
+// Welch returns the averaged power spectral density (dBFS) of in — the native
+// Go equivalent of scipy.signal.welch. It splits in into overlapping segments
+// of length len(win), windows and FFTs each, and averages their periodograms in
+// linear power before a single conversion to dB. Averaging trades frequency
+// resolution for a far lower-variance noise floor than the single-shot PowerDB
+// periodogram, which is what makes a weak carrier legible against noise.
+//
+// win is the analysis window (length n, a power of two) and winSum is Σ(win²),
+// precomputed once by the caller; plan must be fft.New(n). noverlap is the
+// number of samples shared between consecutive segments (0 ≤ noverlap < n; a
+// common choice is n/2). Bins are FFT-shifted so dst[0] is -Fs/2 and dst[n/2]
+// is DC, identical to PowerDB / Frame. Normalization matches PowerDB
+// (power = |X|²/(n·Σw²)), so a unit-amplitude tone reads ~0 dBFS.
+//
+// The returned slice is freshly allocated (length n). When in is shorter than
+// one segment, no periodogram can be formed and every bin reads the clamp
+// floor.
+func Welch(plan fft.Plan, win []float64, winSum float64, in []complex64, noverlap int) []float32 {
+	n := len(win)
+	dst := make([]float32, n)
+	floor := float32(10 * math.Log10(1e-30))
+	if n == 0 {
+		return dst
+	}
+	step := n - noverlap
+	if step < 1 {
+		step = n
+	}
+
+	bufIn := make([]complex128, n)
+	bufOut := make([]complex128, n)
+	acc := make([]float64, n) // linear power, already FFT-shifted
+	norm := 1.0 / (float64(n) * winSum)
+	half := n / 2
+
+	segs := 0
+	for off := 0; off+n <= len(in); off += step {
+		seg := in[off : off+n]
+		for i := 0; i < n; i++ {
+			s := seg[i]
+			w := win[i]
+			bufIn[i] = complex(float64(real(s))*w, float64(imag(s))*w)
+		}
+		out := plan.Forward(bufOut, bufIn)
+		for i := 0; i < n; i++ {
+			dstIdx := (i + half) % n
+			mag := cmplx.Abs(out[i])
+			acc[dstIdx] += mag * mag * norm
+		}
+		segs++
+	}
+
+	if segs == 0 {
+		for i := range dst {
+			dst[i] = floor
+		}
+		return dst
+	}
+	inv := 1.0 / float64(segs)
+	for i := 0; i < n; i++ {
+		power := acc[i] * inv
+		if power < 1e-30 {
+			power = 1e-30
+		}
+		dst[i] = float32(10 * math.Log10(power))
+	}
+	return dst
+}

--- a/internal/dsp/spectrum/welch_test.go
+++ b/internal/dsp/spectrum/welch_test.go
@@ -1,0 +1,115 @@
+package spectrum
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/window"
+)
+
+func hannSum(win []float64) float64 {
+	var s float64
+	for _, v := range win {
+		s += v * v
+	}
+	return s
+}
+
+func TestWelchPeaksAtTone(t *testing.T) {
+	const (
+		size     = 256
+		sampleHz = 48000.0
+		toneHz   = 6000.0
+		segments = 8
+	)
+	plan := fft.New(size)
+	win := window.Hann(size)
+	winSum := hannSum(win)
+
+	// A full tone spanning several overlapping segments.
+	total := size * segments / 2 // 50% overlap → ~segments periodograms
+	in := make([]complex64, total)
+	w := 2 * math.Pi * toneHz / sampleHz
+	for n := 0; n < total; n++ {
+		in[n] = complex64(complex(math.Cos(w*float64(n)), math.Sin(w*float64(n))))
+	}
+
+	dst := Welch(plan, win, winSum, in, size/2)
+	if len(dst) != size {
+		t.Fatalf("Welch len = %d, want %d", len(dst), size)
+	}
+
+	center := size / 2
+	wantBin := center + int(math.Round(toneHz*size/sampleHz))
+	peak, peakVal := 0, float32(math.Inf(-1))
+	for i, v := range dst {
+		if v > peakVal {
+			peak, peakVal = i, v
+		}
+	}
+	if peak != wantBin {
+		t.Errorf("Welch peak bin = %d, want %d", peak, wantBin)
+	}
+	if peakVal < -3 || peakVal > 1 {
+		t.Errorf("Welch peak level = %.2f dBFS, want ~0", peakVal)
+	}
+}
+
+func TestWelchAveragingLowersNoiseVariance(t *testing.T) {
+	const (
+		size = 256
+	)
+	plan := fft.New(size)
+	win := window.Hann(size)
+	winSum := hannSum(win)
+
+	// White complex noise long enough for many segments.
+	rng := rand.New(rand.NewSource(1))
+	const total = size * 32
+	noise := make([]complex64, total)
+	for i := range noise {
+		noise[i] = complex64(complex(rng.NormFloat64(), rng.NormFloat64()))
+	}
+
+	// Single periodogram (one segment) vs averaged Welch over all segments.
+	single := Welch(plan, win, winSum, noise[:size], 0)
+	avg := Welch(plan, win, winSum, noise, size/2)
+
+	varOf := func(x []float32) float64 {
+		var mean float64
+		for _, v := range x {
+			mean += float64(v)
+		}
+		mean /= float64(len(x))
+		var ss float64
+		for _, v := range x {
+			d := float64(v) - mean
+			ss += d * d
+		}
+		return ss / float64(len(x))
+	}
+
+	if varOf(avg) >= varOf(single) {
+		t.Errorf("averaged PSD variance %.3f not below single-segment %.3f",
+			varOf(avg), varOf(single))
+	}
+}
+
+func TestWelchTooShortReturnsFloor(t *testing.T) {
+	const size = 64
+	plan := fft.New(size)
+	win := window.Hann(size)
+	winSum := hannSum(win)
+
+	dst := Welch(plan, win, winSum, make([]complex64, size-1), 0)
+	if len(dst) != size {
+		t.Fatalf("len = %d, want %d", len(dst), size)
+	}
+	for i, v := range dst {
+		if v > -200 {
+			t.Errorf("bin %d = %v, want the clamp floor for an empty average", i, v)
+		}
+	}
+}

--- a/internal/dsp/stats/correlate.go
+++ b/internal/dsp/stats/correlate.go
@@ -1,0 +1,55 @@
+package stats
+
+import "math"
+
+// Correlate returns the full normalized cross-correlation of a and b
+// (numpy.correlate / scipy.signal.correlate, mode="full"), together with the
+// lag of its peak. Each output sample is divided by sqrt(Σa²·Σb²), so a
+// sequence correlated against itself peaks at exactly 1.0.
+//
+// The output has length len(a)+len(b)-1. Index k corresponds to lag
+// s = k-(len(b)-1): the value is Σ a[i]·b[i-s] over the overlapping region.
+// peakLag is the lag s maximizing the correlation — equivalently, the offset
+// into a at which b best aligns (so a pattern b embedded in a at index p peaks
+// at peakLag == p). Returns (nil, 0) when either input is empty.
+func Correlate(a, b []float64) (corr []float64, peakLag int) {
+	na, nb := len(a), len(b)
+	if na == 0 || nb == 0 {
+		return nil, 0
+	}
+	var ea, eb float64
+	for _, v := range a {
+		ea += v * v
+	}
+	for _, v := range b {
+		eb += v * v
+	}
+	norm := math.Sqrt(ea * eb)
+
+	corr = make([]float64, na+nb-1)
+	bestIdx, bestVal := 0, math.Inf(-1)
+	for k := range corr {
+		s := k - (nb - 1)
+		// i ranges over indices where both a[i] and b[i-s] exist.
+		iLo := 0
+		if s > 0 {
+			iLo = s
+		}
+		iHi := na
+		if s+nb < iHi {
+			iHi = s + nb
+		}
+		var acc float64
+		for i := iLo; i < iHi; i++ {
+			acc += a[i] * b[i-s]
+		}
+		if norm > 0 {
+			acc /= norm
+		}
+		corr[k] = acc
+		if acc > bestVal {
+			bestVal, bestIdx = acc, k
+		}
+	}
+	return corr, bestIdx - (nb - 1)
+}

--- a/internal/dsp/stats/correlate_test.go
+++ b/internal/dsp/stats/correlate_test.go
@@ -1,0 +1,47 @@
+package stats
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCorrelateAutocorrPeak(t *testing.T) {
+	a := []float64{1, -2, 3, 0, 1}
+	corr, lag := Correlate(a, a)
+	if lag != 0 {
+		t.Errorf("autocorrelation peak lag = %d, want 0", lag)
+	}
+	// Normalized autocorrelation peaks at exactly 1.0 at zero lag.
+	peak := corr[len(corr)/2]
+	if math.Abs(peak-1.0) > 1e-12 {
+		t.Errorf("autocorrelation peak = %v, want 1.0", peak)
+	}
+	for _, v := range corr {
+		if v > peak+1e-12 {
+			t.Errorf("found correlation %v exceeding the zero-lag peak %v", v, peak)
+		}
+	}
+}
+
+func TestCorrelateRecoversShift(t *testing.T) {
+	// The pattern b sits inside a starting at index 3.
+	b := []float64{1, 2, 3}
+	a := []float64{0, 0, 0, 1, 2, 3, 0}
+	_, lag := Correlate(a, b)
+	if lag != 3 {
+		t.Errorf("peak lag = %d, want 3 (pattern start index)", lag)
+	}
+}
+
+func TestCorrelateEmpty(t *testing.T) {
+	if c, lag := Correlate(nil, []float64{1}); c != nil || lag != 0 {
+		t.Errorf("Correlate(nil,_) = (%v,%v), want (nil,0)", c, lag)
+	}
+}
+
+func TestCorrelateLength(t *testing.T) {
+	corr, _ := Correlate([]float64{1, 2}, []float64{1, 2, 3})
+	if len(corr) != 2+3-1 {
+		t.Errorf("len(corr) = %d, want %d", len(corr), 2+3-1)
+	}
+}

--- a/internal/dsp/stats/peaks.go
+++ b/internal/dsp/stats/peaks.go
@@ -1,0 +1,96 @@
+package stats
+
+import "sort"
+
+// PeakOpts constrains FindPeaks, mirroring a minimal subset of
+// scipy.signal.find_peaks. A zero value finds every interior local maximum.
+type PeakOpts struct {
+	// Height is an absolute minimum: peaks with y < Height are dropped. 0
+	// disables the absolute floor.
+	Height float64
+	// RelHeight keeps only peaks at least RelHeight·max(peak) tall (a relative
+	// floor, e.g. 0.01 ≈ 20 dB down). 0 disables it. When both Height and
+	// RelHeight are set the stricter threshold wins.
+	RelHeight float64
+	// MinDistance is the minimum index spacing between kept peaks. When peaks
+	// are closer, the taller one wins (greedy, strongest first). 0 disables
+	// spacing suppression.
+	MinDistance int
+	// IncludeEnds treats the first and last samples as candidate maxima (a peak
+	// at a band edge still qualifies). When false they are never peaks, matching
+	// scipy's default.
+	IncludeEnds bool
+}
+
+// FindPeaks returns the indices of the local maxima in y that satisfy opts,
+// sorted by descending height (strongest first). A sample is a local maximum
+// when it is strictly greater than its left neighbour and greater than or equal
+// to its right neighbour (the ">=" right rule keeps the left-most index of a
+// flat top, matching the carrier-search convention this generalises). Returns
+// nil for empty input or when no peak clears the thresholds.
+func FindPeaks(y []float64, opts PeakOpts) []int {
+	n := len(y)
+	if n == 0 {
+		return nil
+	}
+	var idx []int
+	for i := 0; i < n; i++ {
+		if (i == 0 || i == n-1) && !opts.IncludeEnds {
+			continue
+		}
+		left := i == 0 || y[i] > y[i-1]
+		right := i == n-1 || y[i] >= y[i+1]
+		if left && right {
+			idx = append(idx, i)
+		}
+	}
+	if len(idx) == 0 {
+		return nil
+	}
+
+	// Threshold: the stricter of the absolute and relative floors.
+	threshold := opts.Height
+	if opts.RelHeight > 0 {
+		var maxPeak float64
+		for j, i := range idx {
+			if j == 0 || y[i] > maxPeak {
+				maxPeak = y[i]
+			}
+		}
+		if rt := opts.RelHeight * maxPeak; rt > threshold {
+			threshold = rt
+		}
+	}
+	kept := make([]int, 0, len(idx))
+	for _, i := range idx {
+		if y[i] >= threshold {
+			kept = append(kept, i)
+		}
+	}
+	sort.SliceStable(kept, func(a, b int) bool { return y[kept[a]] > y[kept[b]] })
+
+	if opts.MinDistance > 0 {
+		var out []int
+		for _, i := range kept {
+			ok := true
+			for _, j := range out {
+				d := i - j
+				if d < 0 {
+					d = -d
+				}
+				if d < opts.MinDistance {
+					ok = false
+					break
+				}
+			}
+			if ok {
+				out = append(out, i)
+			}
+		}
+		kept = out
+	}
+	if len(kept) == 0 {
+		return nil
+	}
+	return kept
+}

--- a/internal/dsp/stats/peaks_test.go
+++ b/internal/dsp/stats/peaks_test.go
@@ -1,0 +1,64 @@
+package stats
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFindPeaksBasic(t *testing.T) {
+	// Interior maxima at indices 2 (value 5) and 5 (value 4).
+	y := []float64{0, 1, 5, 1, 2, 4, 0}
+	got := FindPeaks(y, PeakOpts{})
+	want := []int{2, 5} // strongest first
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindPeaks = %v, want %v", got, want)
+	}
+}
+
+func TestFindPeaksExcludesEndsByDefault(t *testing.T) {
+	y := []float64{9, 1, 5, 1, 9}
+	got := FindPeaks(y, PeakOpts{})
+	if !reflect.DeepEqual(got, []int{2}) {
+		t.Errorf("FindPeaks (no ends) = %v, want [2]", got)
+	}
+	withEnds := FindPeaks(y, PeakOpts{IncludeEnds: true})
+	// Both endpoints (value 9) outrank the interior peak (value 5).
+	if len(withEnds) != 3 || withEnds[2] != 2 {
+		t.Errorf("FindPeaks (ends) = %v, want the two endpoints then index 2", withEnds)
+	}
+}
+
+func TestFindPeaksRelHeightFloor(t *testing.T) {
+	y := []float64{0, 10, 0, 0.5, 0, 9, 0}
+	// RelHeight 0.5 keeps only peaks ≥ 5; the 0.5-tall bump at index 3 drops.
+	got := FindPeaks(y, PeakOpts{RelHeight: 0.5})
+	if !reflect.DeepEqual(got, []int{1, 5}) {
+		t.Errorf("FindPeaks RelHeight = %v, want [1 5]", got)
+	}
+}
+
+func TestFindPeaksMinDistance(t *testing.T) {
+	y := []float64{0, 8, 0, 9, 0, 1, 0}
+	// Peaks at 1,3,5; min distance 3 keeps the strongest (3) then 5 is too
+	// close to nothing kept yet... index 5 is distance 2 from 3, suppressed;
+	// index 1 is distance 2 from 3, suppressed. Only the strongest survives.
+	got := FindPeaks(y, PeakOpts{MinDistance: 3})
+	if !reflect.DeepEqual(got, []int{3}) {
+		t.Errorf("FindPeaks MinDistance = %v, want [3]", got)
+	}
+}
+
+func TestFindPeaksFlatTopTakesLeft(t *testing.T) {
+	// A flat top spanning indices 2..3: the ">=" right rule keeps the left one.
+	y := []float64{0, 1, 5, 5, 1, 0}
+	got := FindPeaks(y, PeakOpts{})
+	if !reflect.DeepEqual(got, []int{2}) {
+		t.Errorf("FindPeaks flat top = %v, want [2]", got)
+	}
+}
+
+func TestFindPeaksEmpty(t *testing.T) {
+	if got := FindPeaks(nil, PeakOpts{}); got != nil {
+		t.Errorf("FindPeaks(nil) = %v, want nil", got)
+	}
+}

--- a/internal/dsp/stats/stats.go
+++ b/internal/dsp/stats/stats.go
@@ -1,0 +1,173 @@
+// Package stats provides small, dependency-free numerical helpers — the
+// descriptive statistics, histogram, mode, argmax, normalized
+// cross-correlation and peak-finding that the signal-analysis paths reach for.
+// They are the native Go equivalents of the handful of numpy/scipy routines
+// the demod and sync-landscape analyses lean on (numpy.mean/std/histogram,
+// numpy.argmax, scipy.signal.find_peaks, scipy.signal.correlate), so those
+// operations live in one tested place instead of being re-derived inline.
+//
+// Everything is float64/int and stdlib-only, matching the sibling leaf
+// packages (window, fft) — no gonum, no CGO.
+package stats
+
+import (
+	"math"
+	"sort"
+)
+
+// Mean returns the arithmetic mean of x (numpy.mean), or 0 for empty input.
+func Mean(x []float64) float64 {
+	if len(x) == 0 {
+		return 0
+	}
+	var sum float64
+	for _, v := range x {
+		sum += v
+	}
+	return sum / float64(len(x))
+}
+
+// Variance returns the variance of x. When sample is true it applies Bessel's
+// correction (divide by n-1, ddof=1, numpy.var(ddof=1)); otherwise it is the
+// population variance (divide by n). Returns 0 when there are too few points
+// for the requested estimator.
+func Variance(x []float64, sample bool) float64 {
+	n := len(x)
+	if n == 0 || (sample && n < 2) {
+		return 0
+	}
+	m := Mean(x)
+	var ss float64
+	for _, v := range x {
+		d := v - m
+		ss += d * d
+	}
+	denom := float64(n)
+	if sample {
+		denom = float64(n - 1)
+	}
+	return ss / denom
+}
+
+// StdDev returns the standard deviation of x (sqrt of Variance), honouring the
+// same sample/population choice as Variance.
+func StdDev(x []float64, sample bool) float64 {
+	return math.Sqrt(Variance(x, sample))
+}
+
+// Min returns the smallest value in x and its index, or (0, -1) for empty input.
+func Min(x []float64) (val float64, idx int) {
+	if len(x) == 0 {
+		return 0, -1
+	}
+	val, idx = x[0], 0
+	for i, v := range x {
+		if v < val {
+			val, idx = v, i
+		}
+	}
+	return val, idx
+}
+
+// Max returns the largest value in x and its index, or (0, -1) for empty input.
+func Max(x []float64) (val float64, idx int) {
+	if len(x) == 0 {
+		return 0, -1
+	}
+	val, idx = x[0], 0
+	for i, v := range x {
+		if v > val {
+			val, idx = v, i
+		}
+	}
+	return val, idx
+}
+
+// ArgMax returns the index of the largest value in x (numpy.argmax), or -1 for
+// empty input. Ties resolve to the first (lowest) index.
+func ArgMax(x []float64) int {
+	_, idx := Max(x)
+	return idx
+}
+
+// ArgMin returns the index of the smallest value in x (numpy.argmin), or -1 for
+// empty input. Ties resolve to the first (lowest) index.
+func ArgMin(x []float64) int {
+	_, idx := Min(x)
+	return idx
+}
+
+// ArgMaxInt returns the index of the largest value in an integer slice, or -1
+// for empty input. Ties resolve to the first (lowest) index. It generalises the
+// "pick the winner by hit count" selection in the sync-landscape analysis.
+func ArgMaxInt(x []int) int {
+	if len(x) == 0 {
+		return -1
+	}
+	best := 0
+	for i, v := range x {
+		if v > x[best] {
+			best = i
+		}
+	}
+	return best
+}
+
+// Histogram bins x into nbins equal-width bins spanning [min(x), max(x)]
+// (numpy.histogram). It returns the per-bin counts (length nbins) and the
+// nbins+1 bin edges. Values equal to the right-most edge fall in the last bin,
+// matching numpy. Returns (nil, nil) when nbins < 1 or x is empty.
+func Histogram(x []float64, nbins int) (counts []int, edges []float64) {
+	if nbins < 1 || len(x) == 0 {
+		return nil, nil
+	}
+	lo, _ := Min(x)
+	hi, _ := Max(x)
+	edges = make([]float64, nbins+1)
+	counts = make([]int, nbins)
+	if lo == hi {
+		// Degenerate range: numpy widens it to [lo-0.5, hi+0.5].
+		lo, hi = lo-0.5, hi+0.5
+	}
+	width := (hi - lo) / float64(nbins)
+	for i := 0; i <= nbins; i++ {
+		edges[i] = lo + width*float64(i)
+	}
+	for _, v := range x {
+		b := int((v - lo) / width)
+		if b == nbins { // right edge folds into the last bin
+			b = nbins - 1
+		}
+		if b >= 0 && b < nbins {
+			counts[b]++
+		}
+	}
+	return counts, edges
+}
+
+// ModeInt returns the most frequent value in x. Ties resolve toward the
+// smaller value, matching the sync-landscape modal-spacing convention it
+// generalises. Returns 0 for empty input.
+func ModeInt(x []int) int {
+	if len(x) == 0 {
+		return 0
+	}
+	s := append([]int(nil), x...)
+	sort.Ints(s)
+	bestVal, bestCount := s[0], 1
+	curVal, curCount := s[0], 1
+	for i := 1; i < len(s); i++ {
+		if s[i] == curVal {
+			curCount++
+		} else {
+			if curCount > bestCount {
+				bestVal, bestCount = curVal, curCount
+			}
+			curVal, curCount = s[i], 1
+		}
+	}
+	if curCount > bestCount {
+		bestVal = curVal
+	}
+	return bestVal
+}

--- a/internal/dsp/stats/stats_test.go
+++ b/internal/dsp/stats/stats_test.go
@@ -1,0 +1,168 @@
+package stats
+
+import (
+	"math"
+	"reflect"
+	"testing"
+)
+
+func almost(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestMeanVarianceStdDev(t *testing.T) {
+	x := []float64{2, 4, 4, 4, 5, 5, 7, 9}
+	if got := Mean(x); !almost(got, 5) {
+		t.Errorf("Mean = %v, want 5", got)
+	}
+	// Population variance of this classic set is 4, sample variance 32/7.
+	if got := Variance(x, false); !almost(got, 4) {
+		t.Errorf("population Variance = %v, want 4", got)
+	}
+	if got := Variance(x, true); !almost(got, 32.0/7.0) {
+		t.Errorf("sample Variance = %v, want %v", got, 32.0/7.0)
+	}
+	if got := StdDev(x, false); !almost(got, 2) {
+		t.Errorf("population StdDev = %v, want 2", got)
+	}
+}
+
+func TestStatsEmptyAndSingleton(t *testing.T) {
+	if got := Mean(nil); got != 0 {
+		t.Errorf("Mean(nil) = %v, want 0", got)
+	}
+	if got := Variance([]float64{3}, true); got != 0 {
+		t.Errorf("sample Variance of one point = %v, want 0", got)
+	}
+	if got := Variance([]float64{3}, false); got != 0 {
+		t.Errorf("population Variance of one point = %v, want 0", got)
+	}
+}
+
+func TestMinMaxArg(t *testing.T) {
+	x := []float64{3, -1, 7, 7, 2}
+	if v, i := Min(x); v != -1 || i != 1 {
+		t.Errorf("Min = (%v,%v), want (-1,1)", v, i)
+	}
+	if v, i := Max(x); v != 7 || i != 2 {
+		t.Errorf("Max = (%v,%v), want (7,2) (first of a tie)", v, i)
+	}
+	if got := ArgMax(x); got != 2 {
+		t.Errorf("ArgMax = %v, want 2", got)
+	}
+	if got := ArgMin(x); got != 1 {
+		t.Errorf("ArgMin = %v, want 1", got)
+	}
+	if got := ArgMax(nil); got != -1 {
+		t.Errorf("ArgMax(nil) = %v, want -1", got)
+	}
+}
+
+func TestArgMaxInt(t *testing.T) {
+	if got := ArgMaxInt([]int{1, 5, 5, 2}); got != 1 {
+		t.Errorf("ArgMaxInt = %v, want 1 (first of a tie)", got)
+	}
+	if got := ArgMaxInt(nil); got != -1 {
+		t.Errorf("ArgMaxInt(nil) = %v, want -1", got)
+	}
+}
+
+func TestHistogram(t *testing.T) {
+	x := []float64{0, 1, 2, 3, 4}
+	counts, edges := Histogram(x, 5)
+	wantEdges := []float64{0, 0.8, 1.6, 2.4, 3.2, 4}
+	if len(edges) != 6 {
+		t.Fatalf("edges len = %d, want 6", len(edges))
+	}
+	for i := range wantEdges {
+		if !almost(edges[i], wantEdges[i]) {
+			t.Errorf("edge %d = %v, want %v", i, edges[i], wantEdges[i])
+		}
+	}
+	// Each integer lands in its own bin; total count is preserved and the
+	// right-most value folds into the last bin.
+	total := 0
+	for _, c := range counts {
+		total += c
+	}
+	if total != len(x) {
+		t.Errorf("count total = %d, want %d", total, len(x))
+	}
+	if counts[len(counts)-1] < 1 {
+		t.Errorf("last bin should hold the right-edge value, counts=%v", counts)
+	}
+	if c, _ := Histogram(nil, 4); c != nil {
+		t.Errorf("Histogram(nil) counts = %v, want nil", c)
+	}
+}
+
+func TestModeInt(t *testing.T) {
+	if got := ModeInt([]int{4, 2, 4, 2, 4}); got != 4 {
+		t.Errorf("ModeInt = %v, want 4", got)
+	}
+	// Tie between 2 and 5 (one each besides) resolves toward the smaller value.
+	if got := ModeInt([]int{5, 2, 5, 2}); got != 2 {
+		t.Errorf("ModeInt tie = %v, want 2 (smaller)", got)
+	}
+	if got := ModeInt(nil); got != 0 {
+		t.Errorf("ModeInt(nil) = %v, want 0", got)
+	}
+}
+
+// TestModeIntMatchesLegacy pins ModeInt to the behaviour of the original
+// inline modal-spacing scan it replaced, including the tie rule.
+func TestModeIntMatchesLegacy(t *testing.T) {
+	cases := [][]int{
+		{18, 18, 18, 9, 18},
+		{1, 2, 3, 4},
+		{7, 7, 3, 3, 1},
+		{5},
+	}
+	for _, c := range cases {
+		if got, want := ModeInt(c), legacyMode(c); got != want {
+			t.Errorf("ModeInt(%v) = %d, legacy = %d", c, got, want)
+		}
+	}
+}
+
+// legacyMode is the pre-refactor inline implementation, kept here as the oracle.
+func legacyMode(deltas []int) int {
+	if len(deltas) == 0 {
+		return 0
+	}
+	s := append([]int(nil), deltas...)
+	for i := 1; i < len(s); i++ { // insertion sort, mirrors sort.Ints result
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+	bestVal, bestCount := s[0], 1
+	curVal, curCount := s[0], 1
+	for i := 1; i < len(s); i++ {
+		if s[i] == curVal {
+			curCount++
+		} else {
+			if curCount > bestCount {
+				bestVal, bestCount = curVal, curCount
+			}
+			curVal, curCount = s[i], 1
+		}
+	}
+	if curCount > bestCount {
+		bestVal = curVal
+	}
+	return bestVal
+}
+
+func TestHistogramDegenerateRange(t *testing.T) {
+	// All-equal input must not divide by a zero-width range.
+	counts, edges := Histogram([]float64{3, 3, 3}, 2)
+	if !reflect.DeepEqual(counts, []int{0, 3}) && !reflect.DeepEqual(counts, []int{3, 0}) {
+		t.Logf("counts=%v edges=%v", counts, edges)
+	}
+	total := 0
+	for _, c := range counts {
+		total += c
+	}
+	if total != 3 {
+		t.Errorf("degenerate histogram lost counts: %v", counts)
+	}
+}

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -398,6 +398,12 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 			res.IQTaps.SymbolSoft = s
 			res.IQTaps.SymbolCardinality = an.cardinality
 		}
+		// Per-symbol differential phase (the π/4-DQPSK rotation signal) for the
+		// rotation-tracker viz. Populated only on the CQPSK path, which is the
+		// only one that buffers complex constellation points.
+		if an != nil && len(an.constBuf) > 1 {
+			res.IQTaps.DiffPhase = diffPhaseSeries(an.constBuf, cfg.captureIQMaxPoints())
+		}
 	}
 	return res, nil
 }

--- a/internal/siglab/iqtaps.go
+++ b/internal/siglab/iqtaps.go
@@ -1,5 +1,7 @@
 package siglab
 
+import "github.com/MattCheramie/GopherTrunk/internal/dsp/phase"
+
 // IQPoint is one complex sample on the wire. Float32 keeps the captured
 // stream compact; web consumers render it directly without conversion. The
 // JSON tags match internal/api's IQPoint (the live Constellation panel) so
@@ -46,6 +48,14 @@ type IQTaps struct {
 	// SymbolCardinality is 4 for the dibit (4-level) protocols, 2 for the
 	// bit (2-level) protocols.
 	SymbolCardinality int `json:"symbol_cardinality,omitempty" yaml:"symbol_cardinality,omitempty"`
+
+	// DiffPhase is the per-symbol differential phase (radians, in (-π, π]) of
+	// the complex constellation — angle(z[i]·conj(z[i-1])) — decimated to the
+	// same cap as the IQ. It is the rotation signal that backs the offline
+	// rotation-tracker viz: a π/4-DQPSK control channel clusters these around
+	// ±π/4 and ±3π/4. Populated only on the CQPSK / π4-DQPSK path (the deep
+	// constellation buffer); empty for C4FM and the 2-level paths.
+	DiffPhase []float32 `json:"diff_phase,omitempty" yaml:"diff_phase,omitempty"`
 }
 
 // decimateSymbolSeries stride-decimates an aligned dibit + soft stream
@@ -69,6 +79,30 @@ func decimateSymbolSeries(dibits []uint8, soft []float32, maxPoints int) (outD [
 		}
 	}
 	return outD, outS
+}
+
+// diffPhaseSeries computes the per-symbol differential phase of a complex
+// constellation buffer — the π/4-DQPSK rotation signal — and decimates it to
+// at most maxPoints points. It returns nil when there are too few points to
+// form a rotation (need at least two constellation samples) or maxPoints ≤ 0.
+func diffPhaseSeries(constBuf []complex64, maxPoints int) []float32 {
+	if len(constBuf) < 2 || maxPoints <= 0 {
+		return nil
+	}
+	z := make([]complex128, len(constBuf))
+	for i, c := range constBuf {
+		z[i] = complex(float64(real(c)), float64(imag(c)))
+	}
+	d := phase.Diff(z) // len == len(z)-1, wrapped to (-π, π]
+	stride := 1
+	if len(d) > maxPoints {
+		stride = (len(d) + maxPoints - 1) / maxPoints
+	}
+	out := make([]float32, 0, (len(d)+stride-1)/stride)
+	for i := 0; i < len(d); i += stride {
+		out = append(out, float32(d[i]))
+	}
+	return out
 }
 
 // iqTapBuffer accumulates the decimated channelized IQ and soft samples for

--- a/internal/siglab/iqtaps_test.go
+++ b/internal/siglab/iqtaps_test.go
@@ -1,0 +1,51 @@
+package siglab
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+func TestDiffPhaseSeriesRotation(t *testing.T) {
+	// A constellation rotating by a fixed π/4 step per symbol — the canonical
+	// π/4-DQPSK rotation — must yield a constant differential phase of π/4.
+	const step = math.Pi / 4
+	n := 200
+	pts := make([]complex64, n)
+	for i := range pts {
+		pts[i] = complex64(cmplx.Exp(complex(0, step*float64(i))))
+	}
+	got := diffPhaseSeries(pts, 1000)
+	if len(got) != n-1 {
+		t.Fatalf("len = %d, want %d", len(got), n-1)
+	}
+	for i, v := range got {
+		if math.Abs(float64(v)-step) > 1e-5 {
+			t.Errorf("diff[%d] = %v, want %v", i, v, step)
+		}
+	}
+}
+
+func TestDiffPhaseSeriesDecimationCap(t *testing.T) {
+	pts := make([]complex64, 5000)
+	for i := range pts {
+		pts[i] = complex64(cmplx.Exp(complex(0, 0.3*float64(i))))
+	}
+	const cap = 500
+	got := diffPhaseSeries(pts, cap)
+	if len(got) == 0 {
+		t.Fatal("expected a decimated diff-phase series")
+	}
+	if len(got) > cap {
+		t.Errorf("diff-phase series exceeds cap: %d > %d", len(got), cap)
+	}
+}
+
+func TestDiffPhaseSeriesTooShort(t *testing.T) {
+	if got := diffPhaseSeries([]complex64{complex(1, 0)}, 100); got != nil {
+		t.Errorf("diffPhaseSeries of one point = %v, want nil", got)
+	}
+	if got := diffPhaseSeries(nil, 100); got != nil {
+		t.Errorf("diffPhaseSeries(nil) = %v, want nil", got)
+	}
+}

--- a/internal/siglab/synclandscape.go
+++ b/internal/siglab/synclandscape.go
@@ -1,6 +1,6 @@
 package siglab
 
-import "sort"
+import "github.com/MattCheramie/GopherTrunk/internal/dsp/stats"
 
 // SyncVariant is one named candidate sync pattern (e.g. one of DMR's 9 ETSI
 // sync words, or a protocol's single FSW), as a slice of symbols (dibits in
@@ -123,7 +123,8 @@ func computeSyncLandscape(stream []uint8, variants []SyncVariant, cardinality, t
 }
 
 // modalSpacing returns the most-frequent delta between consecutive positions
-// (0 when fewer than two positions).
+// (0 when fewer than two positions). The mode itself is computed by
+// stats.ModeInt, which breaks ties toward the smaller spacing.
 func modalSpacing(positions []int) int {
 	if len(positions) < 2 {
 		return 0
@@ -132,23 +133,7 @@ func modalSpacing(positions []int) int {
 	for i := 1; i < len(positions); i++ {
 		deltas = append(deltas, positions[i]-positions[i-1])
 	}
-	sort.Ints(deltas)
-	bestVal, bestCount := deltas[0], 1
-	curVal, curCount := deltas[0], 1
-	for i := 1; i < len(deltas); i++ {
-		if deltas[i] == curVal {
-			curCount++
-		} else {
-			if curCount > bestCount {
-				bestVal, bestCount = curVal, curCount
-			}
-			curVal, curCount = deltas[i], 1
-		}
-	}
-	if curCount > bestCount {
-		bestVal = curVal
-	}
-	return bestVal
+	return stats.ModeInt(deltas)
 }
 
 // dibitVariants / bitVariants wrap fixed patterns as single-variant slices.

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -17,6 +17,9 @@ export interface IQTaps {
   symbol_dibits?: number[];
   symbol_soft?: number[];
   symbol_cardinality?: number;
+  // Per-symbol differential phase (radians) of the complex constellation —
+  // the π/4-DQPSK rotation signal. Present only on the CQPSK path.
+  diff_phase?: number[];
 }
 
 export interface LockInfo {

--- a/web/siglab/src/panels/Results.tsx
+++ b/web/siglab/src/panels/Results.tsx
@@ -8,6 +8,7 @@ import { PSD } from "../viz/PSD";
 import { Spectrogram } from "../viz/Spectrogram";
 import { EyeDiagram } from "../viz/EyeDiagram";
 import { SymbolScope } from "../viz/SymbolScope";
+import { RotationTracker } from "../viz/RotationTracker";
 import { SyncLandscape } from "../viz/SyncLandscape";
 import { ReceiverStates } from "../viz/ReceiverStates";
 import { GrantsTable, EventTimeline } from "../viz/Tables";
@@ -140,6 +141,9 @@ function VizGrid({ r, iq }: { r: Result; iq?: Result["iq_taps"] }) {
           dibits={iq.symbol_dibits ?? []}
           cardinality={iq.symbol_cardinality}
         />
+      )}
+      {iq && (iq.diff_phase?.length ?? 0) > 0 && (
+        <RotationTracker phase={iq.diff_phase ?? []} />
       )}
       {detail.sync && <SyncLandscape sync={detail.sync} />}
       {detail.receiver_states && detail.receiver_states.length > 0 && (

--- a/web/siglab/src/viz/RotationTracker.tsx
+++ b/web/siglab/src/viz/RotationTracker.tsx
@@ -1,0 +1,83 @@
+import { Line } from "react-chartjs-2";
+import { ensureChart } from "./chartSetup";
+
+ensureChart();
+
+// The four ideal π/4-DQPSK symbol rotations. A clean CQPSK control channel's
+// per-symbol differential phase clusters tightly on these levels; carrier or
+// timing error smears it between them.
+const IDEAL = [Math.PI / 4, (3 * Math.PI) / 4, -Math.PI / 4, (-3 * Math.PI) / 4];
+
+// RotationTracker plots the per-symbol differential phase (the rotation between
+// consecutive constellation points) over symbol index — the matplotlib-style
+// view of π/4-DQPSK rotation that the BSCH colour-code recovery hinges on. The
+// data is IQTaps.diff_phase, computed natively in the analyzer via
+// dsp/phase.Diff; it is populated only on the CQPSK path.
+export function RotationTracker({ phase }: { phase: number[] }) {
+  if (phase.length === 0) return null;
+
+  // Decimate to keep the chart responsive on long captures.
+  const max = 4000;
+  const step = Math.max(1, Math.floor(phase.length / max));
+  const labels: number[] = [];
+  const series: number[] = [];
+  for (let i = 0; i < phase.length; i += step) {
+    labels.push(i);
+    series.push(phase[i]);
+  }
+
+  // Flat reference lines at each ideal rotation level.
+  const railDatasets = IDEAL.map((lvl) => ({
+    label: `${(lvl / Math.PI).toFixed(2)}π`,
+    data: labels.map(() => lvl),
+    borderColor: "rgba(148,163,184,0.35)",
+    borderWidth: 1,
+    borderDash: [4, 4],
+    pointRadius: 0,
+    fill: false,
+  }));
+
+  return (
+    <div className="card">
+      <h3 className="mb-2 text-sm font-semibold">
+        Rotation tracker (π/4-DQPSK differential phase)
+      </h3>
+      <Line
+        data={{
+          labels,
+          datasets: [
+            {
+              label: "Δφ (rad)",
+              data: series,
+              borderColor: "rgba(56,189,248,0.9)",
+              backgroundColor: "rgba(56,189,248,0.9)",
+              showLine: false,
+              pointRadius: 1.2,
+            },
+            ...railDatasets,
+          ],
+        }}
+        options={{
+          responsive: true,
+          interaction: { mode: "index", intersect: false },
+          plugins: {
+            legend: { display: false },
+            title: { display: false },
+          },
+          scales: {
+            x: { title: { display: true, text: "symbol index" } },
+            y: {
+              title: { display: true, text: "Δφ (rad)" },
+              min: -Math.PI,
+              max: Math.PI,
+            },
+          },
+        }}
+      />
+      <p className="mt-2 text-xs text-muted">
+        Per-symbol differential phase. Tight clustering on the dashed ±π/4 / ±3π/4
+        rails means a clean rotation; smearing means carrier or timing error.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The BSCH rotation-recovery work hand-rolled several numpy/scipy/matplotlib-style operations inline. This consolidates them into reusable, tested **native Go** packages (no CGO, stdlib-only where the existing leaf packages are), refactors the existing inline copies onto them, and surfaces the π/4-DQPSK rotation story in the siglab frontend.

## New Go packages

- **`internal/dsp/stats`** — `Mean`, `Variance`/`StdDev` (population + Bessel), `Min`/`Max`, `ArgMax`/`ArgMin`/`ArgMaxInt`, `Histogram` (numpy.histogram), `ModeInt`, `Correlate` (normalized cross-correlation + peak lag, scipy.signal.correlate), and `FindPeaks` (scipy.signal.find_peaks subset).
- **`internal/dsp/phase`** — `Unwrap` (numpy.unwrap), `FromComplex`, and `Diff` (per-symbol differential phase).
- **`spectrum.Welch`** — averaged overlapped-segment PSD (scipy.signal.welch), built on the existing `window` + `fft.Plan`, mirroring `PowerDB`'s normalization.

## Behavior-preserving refactors

Existing tests pass unchanged — the gates `TestEstimateCarrierCandidates*` and `TestComputeSyncLandscape*` stay green:

- `carrier.go` `EstimateCarrierCandidatesHz` now uses `stats.FindPeaks` for local-maxima detection + relative floor; the frequency-domain spacing loop is kept verbatim.
- `synclandscape.go` `modalSpacing` delegates to `stats.ModeInt`.

The sync-landscape winner-selection loop is deliberately left alone: its `BestDist` tiebreak is fused into the correlation loop and doesn't map cleanly onto `ArgMaxInt` without risking the tie semantics that `detail_test.go` pins, so only `modalSpacing` was extracted there.

## Rotation visualization (Go data + JS viz)

- `IQTaps` gains a `DiffPhase` field, computed in the engine from the CQPSK constellation buffer via `phase.Diff`. It is populated only on the CQPSK path (C4FM uses the soft buffer), so it is naturally gated to the protocols where rotation is meaningful.
- New `web/siglab/src/viz/RotationTracker.tsx` (Chart.js, modeled on `ReceiverStates`) plots per-symbol differential phase against the ideal ±π/4 / ±3π/4 rails, wired into `Results.tsx`'s `VizGrid`.

## Verification

- `go build ./...` and `go vet ./...` clean.
- Go tests pass: `stats`, `phase`, `spectrum`, `dsp`, `siglab`, `api`.
- Web (`web/siglab`): `npm run typecheck`, `npm run build`, and `npm test` (vitest) all pass.

https://claude.ai/code/session_01HKofhKio91SXPYSVnc4Gkp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HKofhKio91SXPYSVnc4Gkp)_