### PR TITLE
docs: post-release v0.4.3 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,117 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.4.3] — 2026-06-15
+
+This release is **Signal Lab wide-band tooling**, paired with a TETRA
+real-air fix and two decode-validation milestones. Offline auto-tune used to
+chase only the single loudest carrier, so a control channel that was both
+**off-centre and not dominant** in a wide capture was missed; siglab and Hunt
+now rank every carrier in the band and prefer the one that actually *locks*,
+fixing the live P25 captures that previously mis-latched (#678). Building on
+that, a new **wide-band multi-carrier survey** takes one IQ grab, finds every
+carrier, decodes each, and recognises a DMR Tier III trunked system in a
+single shot — exposed as a siglab library call, an offline `hunt -wideband`
+path, a `POST /api/v1/siglab/wideband` endpoint, and a matplotlib-style
+*Wideband* panel in the web console (#677, #679). A new **`gophertrunk
+spectrum`** subcommand prints the band RMS power, Welch-averaged spectrum, and
+detected carriers as text / JSON / CSV — the Python-free analog of
+`numpy.fft` + `matplotlib` (#680). Signal Lab's Results-view PSD and
+spectrogram now compute **server-side in Go**, letting the heavy
+**TensorFlow.js** browser dependency be dropped entirely (#680). On the decode
+side, TETRA control channels now **recover the BSCH colour code under any
+π/4-DQPSK rotation** so real-air downlinks (which sit at a non-zero rotation)
+actually learn their colour code (#681, #648), with a new differential-phase
+*rotation tracker* viz to make the rotation visible (#682). Finally, live
+captures **confirm DMR BPTC/RS Full-LC and P25 Phase 1 C4FM control-channel
+decode on air**, closing two long-standing real-air validation gaps (#675,
+#676, #527).
+
+### Added
+
+- **`gophertrunk spectrum` subcommand.** A Python-free, no-server analog of
+  `numpy.fft` + `matplotlib`: given a recorded capture it prints the band RMS
+  power, the Welch-averaged spectrum, and the detected carriers as text, JSON,
+  or CSV — absolute frequencies with `-freq`, otherwise offsets from DC. On the
+  delivered P25 captures it lists the 449.875 MHz control channel at SNR
+  ≈47 dB. (#680)
+- **Signal Lab wide-band multi-carrier survey.** `siglab.SurveyWideband` /
+  `SurveyWidebandIQ` take a wide-band IQ buffer, find every carrier (Welch
+  spectrum → peak detection → power-weighted centring of wide C4FM humps →
+  grid-snap), down-convert and identify each, then cluster the results into
+  control-vs-voice system rollups — recognising a DMR Tier III trunked system
+  in one shot rather than auto-tuning to a single dominant carrier. Reused by a
+  new offline `hunt -wideband -in <capture>` path that folds every DMR carrier
+  into one discovered system. (#677)
+- **Wide-band survey over REST + web.** `POST /api/v1/siglab/wideband` surveys
+  a staged capture and returns the averaged band spectrum, per-carrier results,
+  and system rollups (spectrum collection gated so the offline path stays
+  lean). A new *Wideband* panel in `web/siglab` renders the averaged spectrum
+  with each detected carrier marked by control/voice role alongside the
+  trunked-system rollup table. (#679)
+- **Hunt / siglab auto-identify of off-centre, non-dominant control channels.**
+  Offline auto-tune now detects and ranks multiple carrier candidates
+  (`dsp.EstimateCarrierCandidatesHz`) and, under `-auto-tune`, tries each —
+  preferring a carrier whose decoder actually *locks* over a louder one that
+  merely looks plausible — so a control channel under a louder neighbour is
+  found automatically (13/13 live P25 segments now lock, was 11/13). Hunt gains
+  a `-detect-carriers` flag that FFT-averages a recorded buffer and sweeps every
+  detected carrier through the classify/decode body, inventorying a whole band
+  from one capture with no SDR. (#678)
+- **π/4-DQPSK rotation tracker viz.** Signal Lab's Results view gains a
+  `RotationTracker` plot of per-symbol differential phase against the ideal
+  ±π/4 / ±3π/4 rails (populated on the CQPSK path), making constellation
+  rotation directly visible. Backed by new native-Go DSP helper packages
+  (`internal/dsp/stats`, `internal/dsp/phase`) consolidated from previously
+  inlined numpy/scipy-style operations. (#682)
+
+### Changed
+
+- **Signal Lab computes the Results-view PSD and spectrogram server-side; drops
+  TensorFlow.js.** New `GET /api/v1/siglab/jobs/{id}/psd` and `/spectrogram`
+  endpoints compute the spectra in Go from the job's captured IQ
+  (`spectrum.AverageDB` / `Spectrogram`); the PSD, Spectrogram, and Compare
+  overlay views now fetch the server-computed spectrum by job id instead of
+  computing it in-browser. The `@tensorflow/tfjs` dependency — used only for
+  that in-browser compute — is removed from `web/siglab`, shrinking the bundle.
+  Plotly, Chart.js, and D3 are unaffected. (#680)
+- **Wide-band survey DSP primitives promoted into shared, tested functions.**
+  The Welch-averaged spectrum (`spectrum.AverageDB`), boxcar smoothing, robust
+  percentile noise floor, power-weighted carrier centroid, RMS / dB helpers,
+  and an STFT spectrogram now live in `internal/dsp/spectrum` and
+  `internal/carriers` instead of being inlined and duplicated across siglab and
+  hunt. Behaviour-preserving refactor guarded by the existing survey tests.
+  (#679, #680, #682)
+
+### Fixed
+
+- **TETRA BSCH colour-code recovery was rotation-blind** (#648). π/4-DQPSK
+  carries data in the differential phase, so a residual carrier offset
+  cyclically rotates the whole demodulated stream by an unknown 0–3; the
+  synchronisation-training-sequence correlator that gates BSCH colour-code
+  recovery matched only the rotation-0 orientation, so real-air downlinks
+  (which sat at rotation 1) never learned a colour code and the reference
+  carrier never locked — while the synthesised fixtures, all at rotation 0,
+  hid the bug. `RecoverColourCode` and the live STS detector now correlate the
+  sync training sequence under all four rotations. (#681)
+
+### Validated
+
+- **DMR BPTC/RS Full-LC decode confirmed on real air** (#527 follow-up). Live
+  441 MHz / 2 MS/s DMR Tier III captures replayed through the production
+  receiver decode the `BPTC(196,96) → RS(12,9) → Full LC` chain cleanly
+  (Terminator-with-LC recovers a stable RS-validated FLC; control-channel CSBKs
+  pass BPTC + CRC and the Tier III control channel locks), refuting the
+  "real-air BPTC/RS is broken" hypothesis. Captured as no-build-tag regression
+  tests with committed channelised fixtures. (#675)
+- **P25 Phase 1 C4FM control-channel demod validated on a live UHF capture**
+  (#676). Thirteen live 450.500 MHz / 2 MSPS captures of a real UHF P25 system
+  all decode to NAC `0x2C1`, with C4FM consistently out-decoding CQPSK; the
+  cleanest segment reads EVM 12.7 %, SNR ≈14.5 dB, NID trusted 31 / failed 0,
+  TSBK 36 with zero CRC/trellis failures. Recorded as a demod-quality gate
+  (`samples/p25/p25-450875-cc.metadata.json`) with floors below the measured
+  values. (#676)
+
 ## [v0.4.2] — 2026-06-14
 
 This release is mostly **hunt / survey maturation**, with TETRA blind identify

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.4.2
+VERSION=v0.4.3
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/announcements/v0.4.3.md
+++ b/docs/announcements/v0.4.3.md
@@ -1,0 +1,53 @@
+# GopherTrunk v0.4.3 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.4.3 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.3
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.4.3 — Signal Lab wide-band survey (find + decode every carrier in one grab), a new `gophertrunk spectrum` CLI, server-side PSD/spectrogram (TensorFlow.js gone), and TETRA colour-code recovery under any π/4-DQPSK rotation
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.4.3 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.4.2:**
+
+* **Signal Lab wide-band multi-carrier survey** (#677, #679) — one wide IQ grab, find every carrier, decode each, and recognize a DMR Tier III trunked system in a single shot (instead of auto-tuning to just the loudest carrier). Available as an offline `hunt -wideband` path, a `POST /api/v1/siglab/wideband` endpoint, and a matplotlib-style *Wideband* panel in the web console that marks each carrier by control/voice role.
+* **Auto-identify off-centre, non-dominant control channels** (#678) — offline auto-tune now ranks every carrier in the band and prefers the one that actually *locks* over a louder neighbour, so a CC hiding under a stronger signal is found automatically (13/13 live P25 segments lock now, was 11/13). Plus a `-detect-carriers` flag that inventories a whole band from one recorded capture, no SDR needed.
+* **New `gophertrunk spectrum` CLI** (#680) — the Python-free analog of `numpy.fft` + `matplotlib`: prints band RMS power, the Welch-averaged spectrum, and detected carriers as text / JSON / CSV.
+* **Server-side PSD / spectrogram, TensorFlow.js dropped** (#680) — Signal Lab's Results-view PSD and spectrogram now compute in Go (`/api/v1/siglab/jobs/{id}/psd` + `/spectrogram`), so the heavy `@tensorflow/tfjs` browser dependency is gone and the bundle is smaller.
+* **TETRA colour-code recovery under any π/4-DQPSK rotation** (#681, #648) — π/4-DQPSK rotates the whole demodulated stream by an unknown 0–3, and the BSCH colour-code correlator only matched rotation 0, so real-air downlinks never learned a colour code. It now correlates the sync training sequence under all four rotations. New differential-phase *rotation tracker* viz makes the rotation visible (#682).
+* **Real-air decode validation** (#675, #676, #527) — live captures confirm DMR `BPTC(196,96) → RS(12,9) → Full LC` decode and P25 Phase 1 C4FM control-channel demod (13 captures, NAC 0x2C1, EVM 12.7%, zero CRC/trellis failures), closing two long-standing validation gaps.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.3
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.4.3 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.4.2:**
+- **Signal Lab wide-band survey** (#677, #679) — one wide IQ grab → find + decode every carrier → recognize a DMR Tier III system in one shot. Offline `hunt -wideband`, a `/api/v1/siglab/wideband` endpoint, and a *Wideband* web panel that marks carriers by control/voice role.
+- **Auto-identify off-centre, non-dominant CCs** (#678) — auto-tune ranks every carrier and prefers the one that *locks* over a louder neighbour (13/13 live P25 segments lock now, was 11/13); `-detect-carriers` inventories a whole band from one capture with no SDR.
+- **New `gophertrunk spectrum` CLI** (#680) — the Python-free `numpy.fft` + `matplotlib` analog: band RMS power, Welch spectrum, detected carriers as text/JSON/CSV.
+- **Server-side PSD/spectrogram** (#680) — Results-view spectra now compute in Go → `@tensorflow/tfjs` dropped, smaller bundle.
+- **TETRA colour-code under any π/4-DQPSK rotation** (#681, #648) — BSCH recovery now correlates the sync sequence under all four rotations, so real-air downlinks actually learn their colour code; new rotation-tracker viz (#682).
+- **Real-air validation** (#675, #676) — live captures confirm DMR BPTC/RS Full-LC and P25 P1 C4FM control-channel decode on air.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.3>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -28,7 +28,7 @@ release state looks like:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.4.2" -%}
+  {%- assign ver = "v0.4.3" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
 


### PR DESCRIPTION
Now that the daily release workflow tagged v0.4.3, sync the docs:

- CHANGELOG: promote [Unreleased] to [v0.4.3] (2026-06-15) with a release
  summary and backfill the user-visible changes that shipped without a
  changelog entry — the Signal Lab wide-band multi-carrier survey
  (siglab lib + offline hunt -wideband + REST + web Wideband panel)
  (#677, #679); auto-identify of off-centre, non-dominant control
  channels + the -detect-carriers offline sweep (#678); the new
  gophertrunk spectrum CLI (#680); server-side PSD/spectrogram with
  TensorFlow.js dropped from web/siglab (#680); the shared DSP-primitive
  promotion (#679, #680, #682); the TETRA BSCH colour-code rotation fix
  + rotation-tracker viz (#681, #682, #648); and the DMR + P25 Phase 1
  real-air decode validation milestones (#675, #676, #527).
- README: bump the Linux quick-install VERSION to v0.4.3.
- downloads.md: bump the GitHub Pages fallback version to v0.4.3.
- announcements: add the v0.4.3 social blurb drafts.

https://claude.ai/code/session_01P62J1hWR8uar3ENTpAiVyD