### PR TITLE
Fix missing types/node module

### DIFF
--- a/web/siglab/package-lock.json
+++ b/web/siglab/package-lock.json
@@ -26,6 +26,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/d3": "^7.4.3",
+        "@types/node": "^25.9.3",
         "@types/plotly.js-dist-min": "^2.3.4",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -6960,9 +6961,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"

--- a/web/siglab/package.json
+++ b/web/siglab/package.json
@@ -31,6 +31,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/d3": "^7.4.3",
+    "@types/node": "^25.9.3",
     "@types/plotly.js-dist-min": "^2.3.4",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",


### PR DESCRIPTION
Commit addresses the following error:

vite.config.ts:2:31 - error TS2307: Cannot find module 'node:url' or its corresponding type declarations.

<!--
Thanks for the PR. Please fill in the sections below. If a section
doesn't apply, write "n/a" rather than deleting it — that makes review
go faster.

PR scoping rules live in CONTRIBUTING.md. Briefly: one logical change
per PR; bug fixes ship with a regression test; refactors stay separate
from behaviour changes.
-->

## Summary

Add missing types/node module to Developer dependencies to corerct make dist build failure

## Changes

cd web/sigint && npm install -D types/node
-

## Test plan

<!-- How did you verify this? Which tests cover the new behaviour? Any
     manual smoke tests against hardware? -->

- [x] `make vet test` is green locally
- [x] ` make dest` is green locally
## Breaking changes
N/A
## Docs / CHANGELOG

- [ N/A ] Added a `## [Unreleased]` bullet to [`CHANGELOG.md`](../CHANGELOG.md)
      if this is user-visible
- [ N/A ] Updated [`README.md`](../README.md) or [`docs/`](../docs/) if
      operator-facing behaviour changed

## Linked issues

Closes #684 
