### PR TITLE
hunt: sanitize non-finite floats so the live survey stream survives (#648)

### DIFF
--- a/internal/api/ws.go
+++ b/internal/api/ws.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
@@ -81,8 +82,17 @@ func (s *Server) handleWS(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			dto := eventToDTO(ev)
+			// Marshal first (like the SSE handler) so a payload that can't be
+			// encoded — e.g. a stray non-finite float — is logged and skipped
+			// rather than tearing the whole connection down or, worse, flushing
+			// a half-written frame via conn.WriteJSON (issue #648).
+			payload, err := json.Marshal(dto)
+			if err != nil {
+				s.log.Warn("api: WS encode failed", "kind", ev.Kind, "err", err)
+				continue
+			}
 			_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-			if err := conn.WriteJSON(dto); err != nil {
+			if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
 				s.log.Debug("api: WS write failed", "err", err)
 				return
 			}

--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// TestEventToDTOHuntCandidateFinite confirms a normal hunt candidate marshals
+// over the WS/SSE envelope. The hunt feature publishes hunt.DetectedSignal under
+// events.KindHuntLiveCandidate, which eventToDTO passes straight through, so its
+// floats must always be encodable.
+func TestEventToDTOHuntCandidateFinite(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindHuntLiveCandidate,
+		Payload: hunt.DetectedSignal{
+			FreqHz: 440_087_400, SNRDb: 28.0, Class: survey.ClassNBFM, Confidence: 0.8,
+			Analog: &survey.AnalogReport{Active: true, PowerDbFS: -12.5, CTCSSHz: 67.0},
+		},
+	})
+	if _, err := json.Marshal(dto); err != nil {
+		t.Fatalf("marshal finite hunt candidate: %v", err)
+	}
+}
+
+// TestEventToDTONonFiniteIsUnsupported documents the failure mode behind issue
+// #648: a payload carrying a non-finite float (here +Inf, as the field report's
+// "json: unsupported value: +Inf" showed) is rejected by encoding/json. The WS
+// handler must therefore skip such a frame rather than tear the connection down,
+// and the survey now sanitizes its signals so this can't reach the wire in
+// practice. This test pins both halves of that contract.
+func TestEventToDTONonFiniteIsUnsupported(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindHuntLiveCandidate,
+		Payload: hunt.DetectedSignal{
+			FreqHz: 468_475_000, Class: survey.ClassPSK,
+			Features: survey.ClassFeatures{SNRDb: math.Inf(1)},
+		},
+	})
+	_, err := json.Marshal(dto)
+	if err == nil {
+		t.Fatal("expected json.Marshal to reject a non-finite payload")
+	}
+	var ue *json.UnsupportedValueError
+	if !errors.As(err, &ue) {
+		t.Fatalf("error = %v, want *json.UnsupportedValueError", err)
+	}
+}

--- a/internal/hunt/livesurvey.go
+++ b/internal/hunt/livesurvey.go
@@ -228,6 +228,10 @@ func classifyAndRoute(sys *DiscoveredSystem, fullIQ []complex64, fullRate uint32
 		chIQ: chIQ, chRate: chRate,
 		cand: cand, opts: opts, log: log,
 	})
+	// Guarantee the signal is JSON-encodable before it is stored, published on
+	// the event bus, or written to NDJSON — a non-finite measurement must not be
+	// able to break the live survey's wire stream (issue #648).
+	ds.sanitize()
 	return ds, rep
 }
 

--- a/internal/hunt/sanitize_test.go
+++ b/internal/hunt/sanitize_test.go
@@ -1,0 +1,97 @@
+package hunt
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// TestDetectedSignalSanitize asserts that a signal whose measurements went
+// non-finite — an infinite SNR from a noise-free residual, an infinite siglab
+// confidence, a -Inf analog power from log(0), NaN classifier features — is
+// clamped to finite values and becomes JSON-encodable. Before the fix the same
+// payload broke json.Marshal with "unsupported value: +Inf", which on the
+// WebSocket event stream tore the live survey's connection down (issue #648).
+func TestDetectedSignalSanitize(t *testing.T) {
+	ds := DetectedSignal{
+		FreqHz:     440_087_400,
+		SNRDb:      float32(math.Inf(1)),
+		Class:      survey.ClassPSK,
+		Confidence: math.NaN(),
+		BaudHz:     math.Inf(-1),
+		Trunking:   &TrunkingRef{Protocol: "tetra", Confidence: math.Inf(1)},
+		Analog:     &survey.AnalogReport{Active: true, PowerDbFS: math.Inf(-1), CTCSSHz: math.NaN()},
+		Features: survey.ClassFeatures{
+			SNRDb:          math.Inf(1),
+			EnvelopeCV:     math.NaN(),
+			IFStd:          math.Inf(-1),
+			IFKurtosis:     math.NaN(),
+			BaudHz:         math.Inf(1),
+			BaudProminence: math.Inf(1),
+		},
+	}
+
+	// The raw signal must fail to marshal — that is the bug we are guarding.
+	if _, err := json.Marshal(ds); err == nil {
+		t.Fatal("expected json.Marshal to fail on the un-sanitized non-finite signal")
+	}
+
+	ds.sanitize()
+
+	finite := []struct {
+		name string
+		v    float64
+	}{
+		{"SNRDb", float64(ds.SNRDb)},
+		{"Confidence", ds.Confidence},
+		{"BaudHz", ds.BaudHz},
+		{"Trunking.Confidence", ds.Trunking.Confidence},
+		{"Analog.PowerDbFS", ds.Analog.PowerDbFS},
+		{"Analog.CTCSSHz", ds.Analog.CTCSSHz},
+		{"Features.SNRDb", ds.Features.SNRDb},
+		{"Features.EnvelopeCV", ds.Features.EnvelopeCV},
+		{"Features.IFStd", ds.Features.IFStd},
+		{"Features.IFKurtosis", ds.Features.IFKurtosis},
+		{"Features.BaudHz", ds.Features.BaudHz},
+		{"Features.BaudProminence", ds.Features.BaudProminence},
+	}
+	for _, f := range finite {
+		if math.IsNaN(f.v) || math.IsInf(f.v, 0) {
+			t.Errorf("%s = %v, want finite after sanitize", f.name, f.v)
+		}
+	}
+
+	if _, err := json.Marshal(ds); err != nil {
+		t.Fatalf("json.Marshal after sanitize: %v", err)
+	}
+}
+
+// TestDetectedSignalSanitizePreservesFinite makes sure sanitize only touches
+// non-finite values and leaves real measurements alone.
+func TestDetectedSignalSanitizePreservesFinite(t *testing.T) {
+	ds := DetectedSignal{
+		FreqHz:     440_260_000,
+		SNRDb:      61.6,
+		Confidence: 0.85,
+		BaudHz:     4800,
+		Trunking:   &TrunkingRef{Protocol: "dmr", Confidence: 0.7},
+		Analog:     &survey.AnalogReport{PowerDbFS: -12.5, CTCSSHz: 67.0},
+		Features:   survey.ClassFeatures{SNRDb: 61.6, BaudProminence: 22.5},
+	}
+	ds.sanitize()
+
+	if ds.SNRDb != 61.6 || ds.Confidence != 0.85 || ds.BaudHz != 4800 {
+		t.Errorf("sanitize altered finite top-level fields: %+v", ds)
+	}
+	if ds.Trunking.Confidence != 0.7 {
+		t.Errorf("Trunking.Confidence = %v, want 0.7", ds.Trunking.Confidence)
+	}
+	if ds.Analog.PowerDbFS != -12.5 || ds.Analog.CTCSSHz != 67.0 {
+		t.Errorf("sanitize altered finite analog fields: %+v", ds.Analog)
+	}
+	if ds.Features.SNRDb != 61.6 || ds.Features.BaudProminence != 22.5 {
+		t.Errorf("sanitize altered finite feature fields: %+v", ds.Features)
+	}
+}

--- a/internal/hunt/survey.go
+++ b/internal/hunt/survey.go
@@ -1,6 +1,7 @@
 package hunt
 
 import (
+	"math"
 	"sort"
 	"time"
 
@@ -52,6 +53,42 @@ type TrunkingRef struct {
 	Confidence float64 `json:"confidence"`
 	Locked     bool    `json:"locked"`
 	ControlHz  uint32  `json:"control_hz,omitempty"`
+}
+
+// finiteOr0 returns f unless it is NaN or ±Inf, in which case it returns 0.
+// JSON has no encoding for non-finite floats, so a stray Inf/NaN from a
+// divide-by-zero or log-of-zero on a dead/marginal carrier would otherwise
+// break the whole event stream the moment it was marshaled (issue #648).
+func finiteOr0(f float64) float64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return f
+}
+
+// sanitize clamps every non-finite float (NaN / ±Inf) on the signal — including
+// the nested Features, Trunking, and Analog measurements — to 0 so the signal is
+// always JSON-encodable. A marginal or dead carrier can produce an infinite SNR
+// (noise-free residual), an infinite confidence (siglab scoring), or a -Inf
+// analog power (log of zero); any one of those would fail json.Marshal and, on
+// the WebSocket event stream, tear the live survey's connection down (issue #648).
+func (ds *DetectedSignal) sanitize() {
+	ds.SNRDb = float32(finiteOr0(float64(ds.SNRDb)))
+	ds.Confidence = finiteOr0(ds.Confidence)
+	ds.BaudHz = finiteOr0(ds.BaudHz)
+	ds.Features.SNRDb = finiteOr0(ds.Features.SNRDb)
+	ds.Features.EnvelopeCV = finiteOr0(ds.Features.EnvelopeCV)
+	ds.Features.IFStd = finiteOr0(ds.Features.IFStd)
+	ds.Features.IFKurtosis = finiteOr0(ds.Features.IFKurtosis)
+	ds.Features.BaudHz = finiteOr0(ds.Features.BaudHz)
+	ds.Features.BaudProminence = finiteOr0(ds.Features.BaudProminence)
+	if ds.Trunking != nil {
+		ds.Trunking.Confidence = finiteOr0(ds.Trunking.Confidence)
+	}
+	if ds.Analog != nil {
+		ds.Analog.PowerDbFS = finiteOr0(ds.Analog.PowerDbFS)
+		ds.Analog.CTCSSHz = finiteOr0(ds.Analog.CTCSSHz)
+	}
 }
 
 // sortSignals orders the inventory by frequency so the output is deterministic


### PR DESCRIPTION
A non-finite float (Inf/NaN) in a hunt signal broke the live WebSocket: the
TETRA-zone survey emitted a candidate whose payload contained +Inf, json.Marshal
failed with "unsupported value: +Inf", and the WS handler tore the connection
down on the write error, so the scan could never finish.

Two independent fixes:

- internal/hunt: clamp every non-finite float on DetectedSignal (top-level plus
  the nested Features/Trunking/Analog measurements) to 0 via a new sanitize()
  method, called once at the classifyAndRoute chokepoint every real signal flows
  through. This reaches the stored survey (REST GET /api/v1/hunt), the event-bus
  publish (WS/SSE), and the NDJSON sink, so a marginal/dead carrier's infinite
  SNR, infinite siglab confidence, or -Inf analog power can no longer reach the
  wire.

- internal/api/ws: marshal first and skip-on-error (mirroring the SSE handler)
  instead of conn.WriteJSON + return, so any future unencodable payload is logged
  and dropped for that one frame rather than killing the client's stream or
  flushing a half-written frame.

Adds regression tests covering sanitize() and the encode-skip contract.