### PR TITLE
p25/phase1: dump raw payload of unhandled TSBKs for alias hunt (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Changed
+
+- **P25 Phase 1 unhandled-TSBK diagnostic now dumps the raw payload (#376).**
+  The first round of CBD/Mt Anakie field diagnostics confirmed the alias is
+  *not* arriving as our control-channel working-model fragment (vendor opcode
+  `0x15`, plain ASCII): zero `cc talker alias`/`fragment` lines fired on either
+  system, even the cleanly-decoding one. The census instead named candidate
+  opcodes (Motorola `0x90` opcode `0x16`; standard `0x15`/`0x16`/`0x30`) but we
+  couldn't tell which carries the alias from the opcode number alone. The
+  `p25: unhandled tsbk` census line now also prints the **numeric** opcode
+  (`Opcode.String()` mislabels vendor opcodes with standard names), and a new
+  `p25: unhandled tsbk payload` line logs the raw 8-byte payload hex, capped at
+  8 samples per distinct `(MFID, opcode)` so a multi-block alias sequence can be
+  captured and reversed against known RIDs / alias strings without flooding a
+  busy control channel. The prior diagnostic round shipped only on an unmerged
+  branch, so a field replay built against `main` saw no payload lines; this
+  lands it on `main`.
+
 ## [v0.4.3] — 2026-06-15
 
 This release is **Signal Lab wide-band tooling**, paired with a TETRA

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -124,15 +124,17 @@ type ControlChannel struct {
 	// is broken" from "demod is fine but one frame in N is corrupt".
 	stats CCStats
 
-	// diagSeen rate-limits one-shot diagnostic Info lines to the first
-	// occurrence of a given key, so a field tester sees the census of
-	// what a site emits without the per-frame flood that keeps the
-	// per-opcode detail at Debug. Keys: unhandled (MFID,opcode) pairs
-	// and first-seen talker-alias source units. Written only from the
-	// dispatchTSBK path, which runs on the single Process goroutine
-	// (the sole writer of decode state), so no lock is needed — unlike
-	// stats, this is never read off-goroutine. Issue #376 (CBD).
-	diagSeen map[uint32]struct{}
+	// diagSeen counts, per diagnostic key, how many times the key has
+	// been observed, so one-shot census lines fire on the first sight
+	// and payload samples are capped — letting a field tester see what
+	// a site emits (including the raw bytes of opcodes we don't decode)
+	// without the per-frame flood that keeps the per-opcode detail at
+	// Debug. Keys: unhandled (MFID,opcode) pairs and first-seen
+	// talker-alias source units (namespaced by the high byte). Written
+	// only from the dispatchTSBK path, which runs on the single Process
+	// goroutine (the sole writer of decode state), so no lock is needed
+	// — unlike stats, this is never read off-goroutine. Issue #376 (CBD).
+	diagSeen map[uint32]int
 }
 
 // CCStats is the snapshot Stats() returns. All counters are
@@ -305,7 +307,7 @@ func New(opts Options) *ControlChannel {
 		bandPlan:            bp,
 		now:                 now,
 		aliasAsm:            NewTalkerAliasAssembler(now),
-		diagSeen:            make(map[uint32]struct{}),
+		diagSeen:            make(map[uint32]int),
 		rotations:           resolveRotations(opts.Rotations),
 		nidSearchSpan:       span,
 		p25Phase1DemodMode:  opts.P25Phase1DemodMode,
@@ -1037,13 +1039,10 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 	case OpUnitRegistrationResponse:
 		c.publishUnitRegistration(ParseUnitRegistrationResponse(t.Payload), nac)
 	default:
-		// One Info census line per distinct (MFID,opcode) — a standard
-		// opcode we don't dispatch could be (or carry) the alias
-		// transport a given site uses; the bulk per-frame detail stays
-		// at Debug. Issue #376 (CBD).
-		if c.diagFirst(diagUnhandledTSBK | uint32(t.MFID)<<8 | uint32(t.Opcode)) {
-			c.log.Info("p25: unhandled tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
-		}
+		// Census + raw-payload sample — a standard opcode we don't
+		// dispatch could be (or carry) the alias transport a given site
+		// uses; the bulk per-frame detail stays at Debug. Issue #376 (CBD).
+		c.logUnhandledTSBK(t, nac)
 		c.log.Debug("tsbk decoded",
 			"opcode", t.Opcode, "lb", t.LB, "metric", metric, "nac", nac)
 	}
@@ -1084,12 +1083,10 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 		}
 		return
 	}
-	// Unrecognised vendor opcode: log one Info census line per distinct
-	// (MFID,opcode) so a field test names any alias-bearing transport we
-	// don't yet decode, while the per-frame detail stays at Debug.
-	if c.diagFirst(diagUnhandledTSBK | uint32(t.MFID)<<8 | uint32(t.Opcode)) {
-		c.log.Info("p25: unhandled tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
-	}
+	// Unrecognised vendor opcode: census + raw-payload sample so a field
+	// test can name and reverse any alias-bearing transport we don't yet
+	// decode, while the per-frame detail stays at Debug.
+	c.logUnhandledTSBK(t, nac)
 	c.log.Debug("p25: vendor tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
 }
 
@@ -1101,15 +1098,40 @@ const (
 	diagAliasSrc      uint32 = 2 << 24
 )
 
+// maxUnhandledSamples caps how many raw payloads are logged per distinct
+// (MFID,opcode) so a busy CC stays bounded; 8 is enough to catch a full
+// multi-block alias sequence on a candidate opcode. Issue #376 (CBD).
+const maxUnhandledSamples = 8
+
 // diagFirst reports whether key is being seen for the first time,
 // recording it so subsequent calls return false. Single-writer
 // (Process goroutine) — see diagSeen.
 func (c *ControlChannel) diagFirst(key uint32) bool {
-	if _, seen := c.diagSeen[key]; seen {
-		return false
+	n := c.diagSeen[key]
+	c.diagSeen[key] = n + 1
+	return n == 0
+}
+
+// logUnhandledTSBK emits the field diagnostics for a TSBK we don't
+// dispatch: one Info census line per distinct (MFID,opcode) — with the
+// numeric opcode, since Opcode.String() mislabels vendor opcodes with
+// standard names — plus up to maxUnhandledSamples raw-payload lines so a
+// field tester can capture the bytes of a candidate alias transport and
+// cross-check them against known RIDs / alias strings. Issue #376 (CBD).
+func (c *ControlChannel) logUnhandledTSBK(t TSBK, nac uint16) {
+	key := diagUnhandledTSBK | uint32(t.MFID)<<8 | uint32(t.Opcode)
+	n := c.diagSeen[key]
+	c.diagSeen[key] = n + 1
+	if n == 0 {
+		c.log.Info("p25: unhandled tsbk",
+			"mfid", t.MFID, "opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
+			"name", t.Opcode, "nac", nac)
 	}
-	c.diagSeen[key] = struct{}{}
-	return true
+	if n < maxUnhandledSamples {
+		c.log.Info("p25: unhandled tsbk payload",
+			"mfid", t.MFID, "opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
+			"lb", t.LB, "payload", fmt.Sprintf("%x", t.Payload[:]), "nac", nac)
+	}
 }
 
 // publishPatch publishes an events.KindPatch for a vendor patch /

--- a/internal/radio/p25/phase1/tsbk_vendor_test.go
+++ b/internal/radio/p25/phase1/tsbk_vendor_test.go
@@ -204,7 +204,8 @@ func TestDiagFirst(t *testing.T) {
 // TestControlChannelCensusesUnhandledTSBK confirms an undecoded vendor
 // opcode produces exactly one Info census line per distinct (MFID,opcode)
 // — the signal a CBD-class field test needs to name an alias transport we
-// don't yet decode (issue #376) — and that a handled opcode does not.
+// don't yet decode (issue #376) — plus a capped run of raw-payload sample
+// lines carrying the bytes, so the transport can be reverse-engineered.
 func TestControlChannelCensusesUnhandledTSBK(t *testing.T) {
 	var buf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -212,13 +213,33 @@ func TestControlChannelCensusesUnhandledTSBK(t *testing.T) {
 	defer bus.Close()
 	cc := New(Options{Bus: bus, Log: log, SystemName: "S"})
 
-	// An unknown Motorola opcode (not patch/delete/alias) twice.
-	unknown := TSBK{Opcode: 0x3F, MFID: MFIDMotorola, Payload: [8]byte{}}
-	cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, unknown), 0)
-	cc.Process(buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, unknown), 1<<20)
+	// An unknown Motorola opcode (not patch/delete/alias) seen more times
+	// than the payload-sample cap, with a recognisable payload.
+	unknown := TSBK{Opcode: 0x3F, MFID: MFIDMotorola,
+		Payload: [8]byte{0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03, 0x04}}
+	const fires = maxUnhandledSamples + 3
+	for i := 0; i < fires; i++ {
+		lead := 0
+		if i == 0 {
+			lead = 10 // establish lock on the first frame
+		}
+		cc.Process(buildLockedStreamWithTSBK(lead, 0x293, DUIDTrunkingSignaling, unknown), i<<20)
+	}
 
-	if n := strings.Count(buf.String(), "p25: unhandled tsbk"); n != 1 {
+	out := buf.String()
+	// The summary message is a prefix of the payload message, so match the
+	// closing quote slog adds around the (space-containing) msg value.
+	if n := strings.Count(out, `msg="p25: unhandled tsbk"`); n != 1 {
 		t.Errorf("unhandled-tsbk census lines = %d, want 1 (one per distinct opcode)", n)
+	}
+	if n := strings.Count(out, `msg="p25: unhandled tsbk payload"`); n != maxUnhandledSamples {
+		t.Errorf("unhandled-tsbk payload lines = %d, want %d (capped)", n, maxUnhandledSamples)
+	}
+	if !strings.Contains(out, "deadbeef01020304") {
+		t.Error("payload sample line missing the raw payload hex")
+	}
+	if !strings.Contains(out, "opcode=0x3F") {
+		t.Error("diagnostic missing numeric opcode (Opcode.String mislabels vendor opcodes)")
 	}
 }
 


### PR DESCRIPTION
The CBD/Mt Anakie field diagnostics confirmed the talker alias is not
arriving as our control-channel working-model fragment (vendor opcode
0x15, plain ASCII): zero cc-talker-alias lines fired on either system,
even the cleanly-decoding one. The census named candidate opcodes
(Motorola 0x90/0x16, standard 0x15/0x16/0x30) but the opcode number
alone can't tell us which carries the alias.

Extend the unhandled-TSBK diagnostic to capture the bytes:
- the census line now prints the numeric opcode (Opcode.String mislabels
  vendor opcodes with standard names)
- a new "p25: unhandled tsbk payload" line logs the raw 8-byte payload
  hex, capped at 8 samples per distinct (MFID,opcode) so a multi-block
  alias sequence can be reconstructed and cross-checked against known
  RIDs / alias strings without flooding a busy CC

diagSeen becomes a per-key counter to drive the cap; diagFirst keeps its
first-occurrence semantics for the alias-fragment gating.

This diagnostic previously shipped only on an unmerged branch, so a field
replay built against main saw no payload lines (issue #376, 2026-06-15);
this lands it on main.

https://claude.ai/code/session_01LzdxG4TMYB7FxP9vBjXaDK