### PR TITLE
Finite SNR ceiling + issue #648 digital-vs-analog ground-truth harness

### DIFF
--- a/internal/radio/p25/phase1/metrics/estimator_test.go
+++ b/internal/radio/p25/phase1/metrics/estimator_test.go
@@ -95,6 +95,35 @@ func TestSNRResidualC4FM(t *testing.T) {
 	approx(t, got, want, 0.6, "C4FM residual SNR")
 }
 
+// TestSNRNoiseFreeIsFinite pins that a noise-free input never yields +Inf/NaN —
+// the estimate stays JSON-marshalable and threshold comparisons keep working
+// (issue #648 follow-up). The zero-EVM guard returns the finite ceiling exactly;
+// the residual estimators on float32-quantised clean inputs return a large but
+// finite value (the tiny quantisation residual keeps them off the exact-zero
+// branch), which is equally fine — the point is "finite, never infinity".
+func TestSNRNoiseFreeIsFinite(t *testing.T) {
+	cleanSoft := makeC4FMSoft(4000, 1.0, 0, 11)
+	cleanPts := makeQPSK(4000, 1.0, 0, 12)
+	cases := []struct {
+		name string
+		got  float64
+	}{
+		{"SNRFromEVM", SNRFromEVM(0)},
+		{"SNRResidualC4FM", SNRResidualC4FM(cleanSoft, 1.0)},
+		{"SNRResidualConstellation", SNRResidualConstellation(cleanPts)},
+		{"SNRM2M4Constellation", SNRM2M4Constellation(cleanPts)},
+	}
+	for _, c := range cases {
+		if math.IsInf(c.got, 0) || math.IsNaN(c.got) {
+			t.Errorf("%s returned non-finite %v, want a finite estimate", c.name, c.got)
+		}
+	}
+	// The directly-constructible zero-EVM guard returns the finite ceiling.
+	if got := SNRFromEVM(0); got != maxSNREstimateDB {
+		t.Errorf("SNRFromEVM(0) = %v, want maxSNREstimateDB (%v)", got, maxSNREstimateDB)
+	}
+}
+
 func TestSNRM2M4AgreesWithResidual(t *testing.T) {
 	// On a QPSK stream the moment estimator and the decision-directed
 	// residual estimator should land close.

--- a/internal/radio/p25/phase1/metrics/snr.go
+++ b/internal/radio/p25/phase1/metrics/snr.go
@@ -2,6 +2,12 @@ package metrics
 
 import "math"
 
+// maxSNREstimateDB is the finite ceiling reported for a noise-free input whose
+// residual is ~0 (SNR → +Inf). Returning a large finite number instead of an
+// infinity keeps the estimate JSON-marshalable and self-consistent; it mirrors
+// siglab's demodSNRCapDB so a value that flows through capSNR is unchanged.
+const maxSNREstimateDB = 99.0
+
 // SNRFromEVM converts an error-vector-magnitude percentage to an SNR in dB
 // under the standard assumption that the residual error vector is the noise:
 //
@@ -9,10 +15,10 @@ import "math"
 //
 // It is the quick cross-check on the residual-variance estimators below — they
 // should agree to within a fraction of a dB on a clean AWGN stream. Returns
-// +Inf for a zero EVM (a noise-free constellation).
+// maxSNREstimateDB (a finite ceiling) for a zero EVM (a noise-free constellation).
 func SNRFromEVM(evmPct float64) float64 {
 	if evmPct <= 0 {
-		return math.Inf(1)
+		return maxSNREstimateDB
 	}
 	return -20 * math.Log10(evmPct/100)
 }
@@ -27,7 +33,7 @@ func SNRFromEVM(evmPct float64) float64 {
 // outer is the outer-rail reference (see EstimateOuterRailC4FM when unknown).
 // This is modulation-aware (it knows the 4-level structure), so unlike a
 // blind moment estimator it stays unbiased on the non-constant-modulus C4FM
-// eye. Returns +Inf when the residual is zero and 0 for an empty input.
+// eye. Returns maxSNREstimateDB when the residual is zero and 0 for an empty input.
 func SNRResidualC4FM(soft []float32, outer float64) float64 {
 	if len(soft) == 0 || outer <= 0 {
 		return 0
@@ -50,7 +56,7 @@ func SNRResidualC4FM(soft []float32, outer float64) float64 {
 		noiseSq += best
 	}
 	if noiseSq <= 0 {
-		return math.Inf(1)
+		return maxSNREstimateDB
 	}
 	return 10 * math.Log10(sigSq/noiseSq)
 }
@@ -59,14 +65,14 @@ func SNRResidualC4FM(soft []float32, outer float64) float64 {
 // in dB from the residual about the nearest ideal QPSK point. Signal power is
 // the reference radius squared (the RMS modulus); noise power is the mean
 // square distance to the assigned ideal point, in the same normalized units.
-// Returns +Inf for a zero residual and 0 for an empty input.
+// Returns maxSNREstimateDB for a zero residual and 0 for an empty input.
 func SNRResidualConstellation(points []complex64) float64 {
 	evm := EVMConstellation(points)
 	if evm <= 0 {
 		if len(points) == 0 {
 			return 0
 		}
-		return math.Inf(1)
+		return maxSNREstimateDB
 	}
 	return SNRFromEVM(evm)
 }
@@ -81,8 +87,8 @@ func SNRResidualConstellation(points []complex64) float64 {
 // It needs no decisions, so it cross-checks the decision-directed residual
 // estimator: the two should agree on a QPSK stream. It is *not* valid on the
 // non-constant-modulus C4FM soft axis (the kurtosis assumption breaks), so
-// there is deliberately no C4FM M2M4 variant. Returns 0 for an empty input or
-// when the moments fall outside the estimator's valid region.
+// there is deliberately no C4FM M2M4 variant. Returns 0 for an empty input and
+// maxSNREstimateDB when the moments fall in the noise-free region (disc/noise ≤ 0).
 func SNRM2M4Constellation(points []complex64) float64 {
 	n := len(points)
 	if n == 0 {
@@ -98,12 +104,12 @@ func SNRM2M4Constellation(points []complex64) float64 {
 	m4 /= float64(n)
 	disc := 2*m2*m2 - m4
 	if disc <= 0 {
-		return math.Inf(1) // essentially noise-free (M4 → M2²·... region)
+		return maxSNREstimateDB // essentially noise-free (M4 → M2²·... region)
 	}
 	s := math.Sqrt(disc)
 	noise := m2 - s
 	if noise <= 0 {
-		return math.Inf(1)
+		return maxSNREstimateDB
 	}
 	return 10 * math.Log10(s/noise)
 }

--- a/internal/survey/classify_digital_snr_test.go
+++ b/internal/survey/classify_digital_snr_test.go
@@ -1,0 +1,127 @@
+package survey
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+)
+
+// This file is the issue #648 ground-truth harness. It synthesises narrowband
+// DIGITAL FM (DMR Tier II / P25 C4FM at 4800 baud) and analog FM/AM voice at a
+// sweep of SNRs to (a) guard the regression the maintainer warned about — analog
+// voice must never be promoted to a digital class — and (b) characterise the SNR
+// at which a real digital carrier's cyclostationary 4800-baud line collapses to
+// the analog range, so any future tuning is done against measured ground truth
+// rather than blind.
+//
+// Measured finding (see the t.Log table from the characterisation test): a clean
+// C4FM carrier has a strong baud line (prominence ~50-65, well over the digital
+// gate of 15), but under AWGN the prominence falls into the 3-5 band — the same
+// band analog FM voice occupies — long before the carrier is otherwise unusable.
+// There is no feature in the current vector (BaudProminence, IFStd, EnvelopeCV,
+// IFKurtosis) that separates a degraded C4FM carrier from analog voice, so the
+// blind classifier cannot recover it without false-positiving analog. The
+// authoritative recovery path is siglab identify (the survey's deep route), not
+// a classifier threshold change.
+
+const snrHarnessSamples = 24_000 // 0.5 s at 48 kHz
+
+// digitalSNRSweep is the set of AWGN SNRs (dB) the harness exercises, from clean
+// down to the marginal regime where the baud line is buried.
+var digitalSNRSweep = []float64{40, 30, 25, 20, 16, 12, 10, 8}
+
+// cleanP25 / cleanDMR build pristine (no-impairment) 4800-baud C4FM carriers.
+func cleanP25(seed int64) []complex64 {
+	return demod.ModulateP25C4FM(randDibits(snrHarnessSamples/10, seed), testRateHz, 1800)
+}
+
+func cleanDMR(seed int64) []complex64 {
+	return demod.ModulateC4FM(randDibits(snrHarnessSamples/10, seed), 10, 8, 0.2, testRateHz, 1944)
+}
+
+// noisyAnalogFM / noisyAM build analog voice carriers at the given AWGN SNR.
+func noisyAnalogFM(snrDB float64, seed int64) []complex64 {
+	clean := fmModulate(lowpassNoise(snrHarnessSamples, seed), testRateHz, 3000)
+	return demod.ApplyImpairments(clean, testRateHz, demod.Impairments{SNRdB: snrDB, Seed: seed})
+}
+
+func noisyAM(snrDB float64, seed int64) []complex64 {
+	clean := amModulate(lowpassNoise(snrHarnessSamples, seed), 0.95)
+	return demod.ApplyImpairments(clean, testRateHz, demod.Impairments{SNRdB: snrDB, Seed: seed})
+}
+
+// withAWGN adds AWGN at the given SNR to a clean carrier.
+func withAWGN(clean []complex64, snrDB float64, seed int64) []complex64 {
+	return demod.ApplyImpairments(clean, testRateHz, demod.Impairments{SNRdB: snrDB, Seed: seed})
+}
+
+// TestCleanDigitalReadsDigital is the synthesis sanity check: a pristine 4800-baud
+// C4FM carrier must classify digital (its baud line is strong at the source). If
+// this regresses, the harness fixtures or the modulators are broken.
+func TestCleanDigitalReadsDigital(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		iq   []complex64
+	}{
+		{"p25-c4fm", cleanP25(7)},
+		{"dmr-c4fm", cleanDMR(7)},
+	} {
+		cls := Classify(tc.iq, testRateHz)
+		if !IsDigital(cls.Class) {
+			t.Errorf("clean %s read %q, want a digital class\n  features: %+v",
+				tc.name, cls.Class, cls.Features)
+		}
+	}
+}
+
+// TestAnalogNeverReadsDigitalAcrossSNR is the load-bearing regression guard for
+// issue #648: an analog FM or AM voice carrier must never be promoted to a
+// digital class, at any SNR. This is the failure mode a careless lowering of the
+// digital prominence gate would cause — the harness pins it so such a change
+// cannot land silently.
+func TestAnalogNeverReadsDigitalAcrossSNR(t *testing.T) {
+	analog := []struct {
+		name  string
+		build func(float64, int64) []complex64
+	}{
+		{"analog-fm", noisyAnalogFM},
+		{"am-voice", noisyAM},
+	}
+	for _, a := range analog {
+		for i, snr := range digitalSNRSweep {
+			cls := Classify(a.build(snr, int64(200+i)), testRateHz)
+			if IsDigital(cls.Class) {
+				t.Errorf("%s at %.0f dB read digital %q (false-positive regression)\n  features: %+v",
+					a.name, snr, cls.Class, cls.Features)
+			}
+		}
+	}
+}
+
+// TestDigitalBaudCollapseCharacterization logs the baud-line measurement for the
+// digital carriers from clean down through the SNR sweep, documenting where the
+// cyclostationary line falls into the analog prominence band. It is a
+// characterisation test (logs, no behavioural assertion past the clean sanity
+// check) — the data is what any future, capture-backed tuning is measured
+// against. Run `go test -run TestDigitalBaudCollapseCharacterization -v` to view.
+func TestDigitalBaudCollapseCharacterization(t *testing.T) {
+	gate := DefaultClassifyConfig().DigitalProminence
+	for _, d := range []struct {
+		name  string
+		clean []complex64
+	}{
+		{"p25", cleanP25(7)},
+		{"dmr", cleanDMR(7)},
+	} {
+		c := Classify(d.clean, testRateHz)
+		t.Logf("%s CLEAN    → baud=%6.0f prom=%5.1f (gate %.0f) ifstd=%.3f modality=%d class=%s",
+			d.name, c.Features.BaudHz, c.Features.BaudProminence, gate,
+			c.Features.IFStd, c.Features.IFModality, c.Class)
+		for _, snr := range digitalSNRSweep {
+			cc := Classify(withAWGN(d.clean, snr, 7), testRateHz)
+			f := cc.Features
+			t.Logf("%s SNR=%3.0f → baud=%6.0f prom=%5.1f (gate %.0f) ifstd=%.3f modality=%d class=%s",
+				d.name, snr, f.BaudHz, f.BaudProminence, gate, f.IFStd, f.IFModality, cc.Class)
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to the issue #648 wire-boundary sanitize. Two self-contained changes plus the measured finding that parks a blind classifier fix.

## A — Finite SNR ceiling (`p25/metrics`)

The four SNR estimators returned `math.Inf(1)` on noise-free input. In production siglab's `capSNR` already bounds these, but returning `+Inf` at the source is a latent footgun (`encoding/json` cannot emit it). They now return a finite `maxSNREstimateDB` (99.0 dB, mirroring siglab's `demodSNRCapDB`) so the estimate is self-consistent and JSON-marshalable; no caller keys off the value being exactly infinite. Pinned by `TestSNRNoiseFreeIsFinite`.

## B1 — Ground-truth harness (`survey`)

Synthesizes narrowband DMR Tier II / P25 C4FM (4800 baud) and analog FM/AM voice across an AWGN SNR sweep:

- `TestCleanDigitalReadsDigital` — synthesis sanity (clean C4FM is digital).
- `TestAnalogNeverReadsDigitalAcrossSNR` — load-bearing regression guard so a lowered digital prominence gate cannot silently promote analog voice.
- `TestDigitalBaudCollapseCharacterization` — logs where the cyclostationary 4800-baud line collapses into the analog prominence band.

## Why there is no classifier change

The harness quantitatively confirms the maintainer's warning. A clean C4FM baud line has prominence ~50–65 (well over the digital gate of 15), but under AWGN it falls into the 3–5 band that analog FM voice also occupies (analog is sometimes higher), with no other feature (`IFStd`, `EnvelopeCV`, `IFKurtosis`) separating them. So any prominence-gate change that recovers degraded DMR/P25 also false-positives analog voice — blind tuning trades one failure for another.

Per maintainer direction, this PR lands A + B1 and waits for real DMR/P25 IQ captures before attempting capture-backed tuning. The harness is the regression net for that work; the safe non-blind recovery path (the lock-only `-survey-deep` route in `livesurvey.go`) already exists if needed.

All affected packages (`survey`, `hunt`, `api`, `p25/phase1`, `siglab`) build and pass.

https://claude.ai/code/session_01U2zwCZq1rZ5owK4ayPXfT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2zwCZq1rZ5owK4ayPXfT3)_