### PR TITLE
api: scrub non-finite floats at the JSON wire boundary (#648)

### DIFF
--- a/internal/api/handlers_siglab.go
+++ b/internal/api/handlers_siglab.go
@@ -421,7 +421,9 @@ func (s *Server) handleSiglabIdentify(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, out)
+	// Strip any non-finite metric (SNR/EVM/confidence on a marginal carrier) so
+	// the response can't fail mid-encode after the 200 header (issue #648).
+	writeJSON(w, http.StatusOK, scrubNonFinite(out))
 }
 
 // handleSiglabWideband surveys a staged wideband capture: it builds the
@@ -492,7 +494,7 @@ func (s *Server) handleSiglabWideband(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, "siglab: "+err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, out)
+	writeJSON(w, http.StatusOK, scrubNonFinite(out))
 }
 
 // siglabSynthRequest is the body of POST /api/v1/siglab/synthesize. It mirrors

--- a/internal/api/sanitize.go
+++ b/internal/api/sanitize.go
@@ -1,0 +1,149 @@
+package api
+
+import (
+	"encoding"
+	"encoding/json"
+	"math"
+	"reflect"
+)
+
+// finiteOr0 returns f unless it is NaN or ±Inf, in which case it returns 0.
+// encoding/json cannot represent non-finite floats, so a stray Inf/NaN from a
+// divide-by-zero or log-of-zero on a dead/marginal carrier would otherwise fail
+// json.Marshal and break the event stream the moment it was encoded (issue #648).
+// Mirrors hunt.finiteOr0; kept local so package api need not depend on hunt.
+func finiteOr0(f float64) float64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return f
+}
+
+var (
+	jsonMarshalerType = reflect.TypeOf((*json.Marshaler)(nil)).Elem()
+	textMarshalerType = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
+)
+
+// scrubNonFinite returns a JSON-safe copy of v in which every float64/float32
+// that is NaN or ±Inf is replaced by 0. It is the categorical wire-boundary net
+// for issue #648: the live event stream and the siglab REST responses carry
+// floats computed across many protocols (SNR, EVM, confidence, dB power, …), any
+// of which can go non-finite on a marginal carrier, and encoding/json rejects
+// those — tearing down the WebSocket the moment one reaches the encoder.
+//
+// It copies as it descends, so the caller's value — which for a passed-through
+// event payload is shared with every other bus subscriber, the NDJSON sink and
+// the canonical store — is never mutated. On any unexpected reflection panic it
+// falls back to returning v unchanged; the marshal-first guard at the WS/SSE
+// boundary then logs and skips that one frame rather than crashing the stream.
+func scrubNonFinite(v any) (out any) {
+	defer func() {
+		if recover() != nil {
+			out = v
+		}
+	}()
+	if v == nil {
+		return nil
+	}
+	return scrubValue(reflect.ValueOf(v)).Interface()
+}
+
+// scrubValue is the reflection core. It returns a fresh value of the same type
+// as rv with non-finite floats zeroed, allocating new containers as it descends
+// so it never writes through to rv.
+func scrubValue(rv reflect.Value) reflect.Value {
+	t := rv.Type()
+
+	// Types that marshal themselves (time.Time, etc.) or are non-float scalars
+	// cannot expose a JSON-visible non-finite float — return them untouched and
+	// skip the descent. This keeps the common int/string-only events cheap.
+	if t.Implements(jsonMarshalerType) || t.Implements(textMarshalerType) ||
+		reflect.PointerTo(t).Implements(jsonMarshalerType) ||
+		reflect.PointerTo(t).Implements(textMarshalerType) {
+		return rv
+	}
+
+	switch rv.Kind() {
+	case reflect.Float64, reflect.Float32:
+		out := reflect.New(t).Elem()
+		out.SetFloat(finiteOr0(rv.Float()))
+		return out
+
+	case reflect.Pointer:
+		if rv.IsNil() {
+			return rv
+		}
+		out := reflect.New(t.Elem())
+		out.Elem().Set(scrubValue(rv.Elem()))
+		return out
+
+	case reflect.Interface:
+		if rv.IsNil() {
+			return rv
+		}
+		out := reflect.New(t).Elem()
+		out.Set(scrubValue(rv.Elem()))
+		return out
+
+	case reflect.Struct:
+		out := reflect.New(t).Elem()
+		out.Set(rv) // verbatim copy first (incl. unexported fields)
+		scrubFieldsInPlace(out)
+		return out
+
+	case reflect.Slice:
+		if rv.IsNil() {
+			return rv
+		}
+		out := reflect.MakeSlice(t, rv.Len(), rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			out.Index(i).Set(scrubValue(rv.Index(i)))
+		}
+		return out
+
+	case reflect.Array:
+		out := reflect.New(t).Elem()
+		for i := 0; i < rv.Len(); i++ {
+			out.Index(i).Set(scrubValue(rv.Index(i)))
+		}
+		return out
+
+	case reflect.Map:
+		if rv.IsNil() {
+			return rv
+		}
+		out := reflect.MakeMapWithSize(t, rv.Len())
+		for iter := rv.MapRange(); iter.Next(); {
+			out.SetMapIndex(iter.Key(), scrubValue(iter.Value()))
+		}
+		return out
+
+	default:
+		return rv
+	}
+}
+
+// scrubFieldsInPlace zeroes non-finite floats in the settable fields of the
+// addressable struct value sv (a freshly-allocated copy — never the caller's
+// original). It is split out so it can also reach the promoted exported fields
+// of an embedded unexported struct, which encoding/json marshals even though the
+// embedded field itself is not directly settable.
+func scrubFieldsInPlace(sv reflect.Value) {
+	t := sv.Type()
+	for i := 0; i < t.NumField(); i++ {
+		f := sv.Field(i)
+		if f.CanSet() {
+			f.Set(scrubValue(f))
+			continue
+		}
+		// Unexported field. If it is an embedded value struct, json promotes its
+		// exported fields — its exported sub-fields are settable through f even
+		// though f itself is not — so descend to scrub them. Plain unexported
+		// fields (and embedded unexported pointers) are left as the verbatim copy:
+		// json ignores the former, and the marshal-first guard covers the latter
+		// exotic shared-pointer case.
+		if t.Field(i).Anonymous && f.Kind() == reflect.Struct {
+			scrubFieldsInPlace(f)
+		}
+	}
+}

--- a/internal/api/sanitize_test.go
+++ b/internal/api/sanitize_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// scrubFloats is a payload type the api package has no DTO case for, so it
+// exercises the eventToDTO default passthrough — the path the TETRA identify
+// events take.
+type scrubFloats struct {
+	F64 float64 `json:"f64"`
+	F32 float32 `json:"f32"`
+	OK  float64 `json:"ok"`
+	S   string  `json:"s"`
+	N   int     `json:"n"`
+}
+
+type scrubEmbedExported struct {
+	A float64 `json:"a"`
+}
+
+type scrubNested struct {
+	scrubEmbedExported                    // embedded
+	Ptr                *float64           `json:"ptr"`
+	Slice              []float64          `json:"slice"`
+	Map                map[string]float64 `json:"map"`
+	Inner              scrubFloats        `json:"inner"`
+}
+
+// scrubUnexported has an unexported pointer field, mirroring siglab structs that
+// stash a reused result (e.g. CandidateScore.result). The scrubber must not
+// panic reaching it and must preserve it.
+type scrubUnexported struct {
+	X   float64 `json:"x"`
+	ptr *int
+}
+
+func TestEventToDTODefaultPassthroughIsZeroed(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind:    events.Kind("test/unrecognized"),
+		Payload: scrubFloats{F64: math.Inf(1), F32: float32(math.Inf(-1)), OK: 3.5},
+	})
+	b, err := json.Marshal(dto)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got struct {
+		Payload scrubFloats `json:"payload"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Payload.F64 != 0 || got.Payload.F32 != 0 {
+		t.Errorf("non-finite floats not zeroed: %+v", got.Payload)
+	}
+	if got.Payload.OK != 3.5 {
+		t.Errorf("finite float altered: got %v, want 3.5", got.Payload.OK)
+	}
+}
+
+func TestScrubNonFiniteDoesNotMutateOriginal(t *testing.T) {
+	orig := &scrubFloats{F64: math.Inf(1)}
+	dto := eventToDTO(events.Event{Kind: events.Kind("test/x"), Payload: orig})
+	b, err := json.Marshal(dto)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// The shared original — held by other bus subscribers / the store — must be
+	// untouched, while the wire copy is zeroed.
+	if !math.IsInf(orig.F64, 1) {
+		t.Errorf("scrub mutated the shared original: F64 = %v, want +Inf", orig.F64)
+	}
+	var got struct {
+		Payload scrubFloats `json:"payload"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Payload.F64 != 0 {
+		t.Errorf("wire copy not zeroed: F64 = %v", got.Payload.F64)
+	}
+}
+
+func TestScrubNonFiniteNestedContainers(t *testing.T) {
+	inf := math.Inf(1)
+	v := scrubNested{
+		scrubEmbedExported: scrubEmbedExported{A: math.Inf(1)},
+		Ptr:                &inf,
+		Slice:              []float64{math.Inf(-1), 2.0},
+		Map:                map[string]float64{"bad": math.NaN(), "good": 1.0},
+		Inner:              scrubFloats{F64: math.NaN(), OK: 7},
+	}
+	b, err := json.Marshal(scrubNonFinite(v))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got scrubNested
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.A != 0 || got.Ptr == nil || *got.Ptr != 0 || got.Slice[0] != 0 || got.Inner.F64 != 0 || got.Map["bad"] != 0 {
+		t.Errorf("nested non-finite not zeroed: %s", b)
+	}
+	if got.Slice[1] != 2.0 || got.Map["good"] != 1.0 || got.Inner.OK != 7 {
+		t.Errorf("nested finite values altered: %s", b)
+	}
+}
+
+func TestScrubNonFiniteUnexportedFieldSafe(t *testing.T) {
+	n := 42
+	v := scrubUnexported{X: math.Inf(1), ptr: &n}
+	out := scrubNonFinite(v) // must not panic on the unexported pointer
+	got, ok := out.(scrubUnexported)
+	if !ok {
+		t.Fatalf("unexpected type %T", out)
+	}
+	if got.X != 0 {
+		t.Errorf("exported float not zeroed: %v", got.X)
+	}
+	if got.ptr != &n {
+		t.Errorf("unexported field not preserved")
+	}
+}
+
+func TestScrubNonFiniteLeavesEdgeTypesUnchanged(t *testing.T) {
+	now := time.Now()
+	if got := scrubNonFinite(now); !got.(time.Time).Equal(now) {
+		t.Errorf("time.Time changed: %v != %v", got, now)
+	}
+	if got := scrubNonFinite(json.Number("3.14")); got.(json.Number) != "3.14" {
+		t.Errorf("json.Number changed: %v", got)
+	}
+	c := complex(1.0, 2.0)
+	if got := scrubNonFinite(c); got.(complex128) != c {
+		t.Errorf("complex128 changed: %v", got)
+	}
+	if got := scrubNonFinite(nil); got != nil {
+		t.Errorf("nil changed: %v", got)
+	}
+}
+
+func TestScrubNonFiniteIdentifyResult(t *testing.T) {
+	res := &siglab.IdentifyResult{
+		Confidence:   math.Inf(1),
+		SampleRateHz: 48000,
+		TuneHz:       math.Inf(-1),
+		Candidates: []siglab.CandidateScore{
+			{Protocol: "tetra", Score: math.NaN(), FECPassRate: math.Inf(1), LockLatencySec: 1.2},
+		},
+	}
+	b, err := json.Marshal(scrubNonFinite(res))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got siglab.IdentifyResult
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Confidence != 0 || got.TuneHz != 0 || got.Candidates[0].Score != 0 || got.Candidates[0].FECPassRate != 0 {
+		t.Errorf("identify non-finite not zeroed: %s", b)
+	}
+	if got.SampleRateHz != 48000 || got.Candidates[0].LockLatencySec != 1.2 {
+		t.Errorf("identify finite values altered: %s", b)
+	}
+}

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -109,5 +109,11 @@ func eventToDTO(ev events.Event) EventDTO {
 		// explicit DTO for yet.
 		dto.Payload = p
 	}
+	// Categorically strip non-finite floats (±Inf/NaN) from whatever payload we
+	// settled on — known DTO copies and the raw passthrough alike — so a stray
+	// metric from a marginal carrier can never fail json.Marshal and tear down
+	// the live WS/SSE stream (issue #648). Operates on a copy; the bus payload,
+	// NDJSON sink and canonical store keep their original values.
+	dto.Payload = scrubNonFinite(dto.Payload)
 	return dto
 }

--- a/internal/api/ws_test.go
+++ b/internal/api/ws_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
 	"math"
 	"testing"
 
@@ -28,13 +27,11 @@ func TestEventToDTOHuntCandidateFinite(t *testing.T) {
 	}
 }
 
-// TestEventToDTONonFiniteIsUnsupported documents the failure mode behind issue
-// #648: a payload carrying a non-finite float (here +Inf, as the field report's
-// "json: unsupported value: +Inf" showed) is rejected by encoding/json. The WS
-// handler must therefore skip such a frame rather than tear the connection down,
-// and the survey now sanitizes its signals so this can't reach the wire in
-// practice. This test pins both halves of that contract.
-func TestEventToDTONonFiniteIsUnsupported(t *testing.T) {
+// TestEventToDTONonFiniteIsZeroed pins the issue #648 fix: eventToDTO strips a
+// non-finite float (here +Inf, the value the field report's "json: unsupported
+// value: +Inf" hit) from the payload, so json.Marshal now succeeds and the field
+// crosses the wire as 0 instead of tearing the live stream down.
+func TestEventToDTONonFiniteIsZeroed(t *testing.T) {
 	dto := eventToDTO(events.Event{
 		Kind: events.KindHuntLiveCandidate,
 		Payload: hunt.DetectedSignal{
@@ -42,12 +39,21 @@ func TestEventToDTONonFiniteIsUnsupported(t *testing.T) {
 			Features: survey.ClassFeatures{SNRDb: math.Inf(1)},
 		},
 	})
-	_, err := json.Marshal(dto)
-	if err == nil {
-		t.Fatal("expected json.Marshal to reject a non-finite payload")
+	b, err := json.Marshal(dto)
+	if err != nil {
+		t.Fatalf("marshal sanitized payload: %v", err)
 	}
-	var ue *json.UnsupportedValueError
-	if !errors.As(err, &ue) {
-		t.Fatalf("error = %v, want *json.UnsupportedValueError", err)
+	var got struct {
+		Payload struct {
+			Features struct {
+				SNRDb float64 `json:"snr_db"`
+			} `json:"features"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Payload.Features.SNRDb != 0 {
+		t.Errorf("features.snr_db = %v, want 0 (sanitized)", got.Payload.Features.SNRDb)
 	}
 }


### PR DESCRIPTION
Follow-up to the merged #648 work (#688 hunt sanitize, #690 finite SNR ceiling). The field still hit a hard stop the earlier fixes didn't cover.

## Problem

A live TETRA-zone survey could not finish — an identify-path metric went `+Inf`, reached the WebSocket JSON encoder (which cannot represent non-finite floats), and the stream tore down:

```
system=identify ... ccdecoder: tetra zero colour code; will auto-acquire from the BSCH synchronisation burst
api: WS write failed err="json: unsupported value: +Inf"
```

The merged `DetectedSignal.sanitize()` (#688) only covers one event payload type; these events come from the `system=identify` path. `+Inf`/`NaN` can arise from divide-by-zero or log-of-zero in any of many per-protocol metrics, so sanitizing each source is whack-a-mole. (Research ruled out the obvious individual sources: SNR is already capped, EVM is zero-guarded, the survey spectrum is floored before `log10`, IQ-imbalance is bounded.)

## Fix — a categorical wire-boundary net

New `internal/api/sanitize.go`: `scrubNonFinite`, a reflection-based **copy-on-descend** scrubber returning a JSON-safe copy of any payload with every `NaN`/`±Inf` `float64`/`float32` replaced by `0`. Applied at the two serialization chokepoints:

- `eventToDTO` — covers **both** the WS and SSE streams, every event kind.
- the siglab identify + wideband REST responses (`handlers_siglab.go`).

It copies as it descends, so shared bus payloads, the NDJSON sink and the canonical store keep their original values. It handles structs (including JSON-promoted fields of embedded unexported structs), pointers, interfaces, slices, arrays and maps; skips unexported fields (e.g. `CandidateScore.result`) and self-marshaling types (`time.Time`); and falls back to the original value on any reflection panic, leaving the marshal-first guard as the final net.

The upstream `DetectedSignal.sanitize()` (data-at-rest) and the WS/SSE marshal-first guards are kept as complementary layers.

## Tests

Inverts the now-obsolete `TestEventToDTONonFiniteIsUnsupported` to assert the field is zeroed, and adds a scrubber suite: default passthrough, mutation-safety (shared original untouched), nested containers, unexported fields, edge types (`time.Time`/`json.Number`/`complex128`), and a real `siglab.IdentifyResult`.

Verified: `go build ./...`, `go vet ./internal/api/...`, `go test ./internal/api/... ./internal/hunt/... ./internal/siglab/...` all pass.

https://claude.ai/code/session_01U2zwCZq1rZ5owK4ayPXfT3

---
_Generated by [Claude Code](https://claude.ai/code/session_01U2zwCZq1rZ5owK4ayPXfT3)_