### PR TITLE
p25/phase1: decode Motorola patch-group channel grant / update (#376)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+
+- **P25 Phase 1 decodes Motorola patch-group channel grant / update (#376).**
+  Field captures from a Motorola system (MMR, sites CBD/Mt Anakie) emit
+  manufacturer-specific (MFID `0x90`) TSBKs at opcodes `0x02` and `0x03` that
+  GopherTrunk logged as unhandled — the raw-payload diagnostic confirmed they
+  are patch-group (super-group) **voice channel grant** and **grant-update**
+  messages, not talker aliases. They now decode through the same band-plan /
+  Phase 2 TDMA routing as the standard grant/update opcodes. The `0x02` form
+  carries the source RID and the service-options encryption bit, so the
+  patch-group calls that previously arrived `src=0` / `enc=false` now surface
+  their radio ID and encryption, and GopherTrunk follows the super-group voice
+  calls it was dropping. (The unidentified `0x90` opcode `0x16` is left in the
+  unhandled-TSBK census pending ground truth.)
+
 ### Changed
 
 - **P25 Phase 1 unhandled-TSBK diagnostic now dumps the raw payload (#376).**

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1068,6 +1068,30 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 		c.publishPatch(uint32(hr.RegroupGroup), nil, "harris", true)
 		return
 	}
+	if g, ok := t.AsMotorolaPatchGroupChannelGrant(); ok {
+		// Patch-group voice channel grant — mirrors the standard
+		// OpGroupVoiceChannelGrant path. The 0x02 form carries the
+		// source RID + service-options encryption bit, so this backfills
+		// the src=0/enc=false patch-group calls MMR/CBD was dropping
+		// (issue #376); super-group attribution is handled downstream.
+		c.publishGroupGrant(g, nac)
+		return
+	}
+	if u, ok := t.AsMotorolaPatchGroupChannelGrantUpdate(); ok {
+		// Two (channel, super-group) activity pairs — mirrors the
+		// standard OpGroupVoiceChannelUpdate path. Issue #376.
+		c.publishVoiceGrant(voiceGrant{
+			groupID: uint32(u.GroupAddressA), channelID: u.ChannelAID,
+			channelNumber: u.ChannelANumber,
+		}, nac)
+		if u.GroupAddressB != 0 {
+			c.publishVoiceGrant(voiceGrant{
+				groupID: uint32(u.GroupAddressB), channelID: u.ChannelBID,
+				channelNumber: u.ChannelBNumber,
+			}, nac)
+		}
+		return
+	}
 	if f, ok := t.AsTalkerAliasFragment(); ok {
 		// Surface the first fragment seen per source at Info so a field
 		// tester can tell aliases are arriving on the CC even when the

--- a/internal/radio/p25/phase1/tsbk_vendor.go
+++ b/internal/radio/p25/phase1/tsbk_vendor.go
@@ -28,6 +28,14 @@ const (
 	// ("patch") add and cancel commands under MFID 0x90.
 	OpMotorolaPatchGroupAdd    Opcode = 0x00
 	OpMotorolaPatchGroupDelete Opcode = 0x01
+	// OpMotorolaPatchGroupChannelGrant / Update are the Motorola
+	// patch-group (super-group) voice channel grant and grant-update
+	// commands under MFID 0x90. Their payload layout matches the
+	// standard group voice channel grant / update respectively, but the
+	// group address is a Motorola super-group (patch) address — the same
+	// one OpMotorolaPatchGroupAdd aggregates member talkgroups under.
+	OpMotorolaPatchGroupChannelGrant       Opcode = 0x02
+	OpMotorolaPatchGroupChannelGrantUpdate Opcode = 0x03
 	// OpHarrisRegroup is the Harris dynamic-regroup command under
 	// MFID 0xA4.
 	OpHarrisRegroup Opcode = 0x00
@@ -142,6 +150,34 @@ func AssembleHarrisRegroup(r HarrisRegroup) [8]byte {
 	binary.BigEndian.PutUint16(p[0:2], r.RegroupGroup)
 	p[2], p[3], p[4] = byte(r.TargetID>>16), byte(r.TargetID>>8), byte(r.TargetID)
 	return p
+}
+
+// AsMotorolaPatchGroupChannelGrant returns the patch-group voice channel
+// grant if the TSBK is a Motorola patch-group channel grant (MFID 0x90,
+// opcode 0x02), otherwise (zero, false). The on-wire payload layout is
+// identical to the standard group voice channel grant — service options,
+// channel, group, 24-bit source — so it reuses ParseGroupVoiceChannelGrant;
+// the group address is a Motorola super-group (patch) address. Confirmed
+// against MMR/CBD field captures (issue #376): e.g. payload
+// 401001006904e2cc → enc grant on group 105, source 320204.
+func (t TSBK) AsMotorolaPatchGroupChannelGrant() (GroupVoiceChannelGrant, bool) {
+	if t.MFID != MFIDMotorola || t.Opcode != OpMotorolaPatchGroupChannelGrant {
+		return GroupVoiceChannelGrant{}, false
+	}
+	return ParseGroupVoiceChannelGrant(t.Payload), true
+}
+
+// AsMotorolaPatchGroupChannelGrantUpdate returns the patch-group voice
+// channel grant-update if the TSBK is a Motorola patch-group channel
+// grant-update (MFID 0x90, opcode 0x03), otherwise (zero, false). The
+// payload carries two (channel, super-group) activity pairs in the same
+// layout as the standard group voice channel update, so it reuses
+// ParseGroupVoiceChannelUpdate. Issue #376 (MMR/CBD).
+func (t TSBK) AsMotorolaPatchGroupChannelGrantUpdate() (GroupVoiceChannelUpdate, bool) {
+	if t.MFID != MFIDMotorola || t.Opcode != OpMotorolaPatchGroupChannelGrantUpdate {
+		return GroupVoiceChannelUpdate{}, false
+	}
+	return ParseGroupVoiceChannelUpdate(t.Payload), true
 }
 
 // AsTalkerAliasFragment returns one talker-alias fragment if the TSBK

--- a/internal/radio/p25/phase1/tsbk_vendor_test.go
+++ b/internal/radio/p25/phase1/tsbk_vendor_test.go
@@ -243,6 +243,106 @@ func TestControlChannelCensusesUnhandledTSBK(t *testing.T) {
 	}
 }
 
+// TestAsMotorolaPatchGroupChannelGrant pins the decode against the real
+// MMR/CBD field capture (issue #376): Motorola opcode 0x02 payload
+// 401001006904e2cc is a patch-group voice channel grant — encrypted
+// (service-options 0x40), channel (ID 1, number 1), super-group 105,
+// source RID 320204 (0x04e2cc). A standard-MFID TSBK with the same
+// opcode must not match (it would be a different message).
+func TestAsMotorolaPatchGroupChannelGrant(t *testing.T) {
+	payload := [8]byte{0x40, 0x10, 0x01, 0x00, 0x69, 0x04, 0xE2, 0xCC}
+	tsbk := TSBK{Opcode: OpMotorolaPatchGroupChannelGrant, MFID: MFIDMotorola, Payload: payload}
+	got, ok := tsbk.AsMotorolaPatchGroupChannelGrant()
+	if !ok {
+		t.Fatal("AsMotorolaPatchGroupChannelGrant returned !ok")
+	}
+	if got.ServiceOptions != 0x40 || got.ChannelID != 1 || got.ChannelNumber != 1 ||
+		got.GroupAddress != 105 || got.SourceID != 0x04E2CC {
+		t.Errorf("grant = %+v, want svc=0x40 chan=1.1 group=105 source=0x04e2cc", got)
+	}
+	tsbk.MFID = MFIDStandard
+	if _, ok := tsbk.AsMotorolaPatchGroupChannelGrant(); ok {
+		t.Error("AsMotorolaPatchGroupChannelGrant matched a standard-MFID TSBK")
+	}
+}
+
+// TestAsMotorolaPatchGroupChannelGrantUpdate pins the decode against the
+// real MMR/CBD capture (issue #376): Motorola opcode 0x03 payload
+// 5090019131942710 carries two (channel, super-group) activity pairs —
+// (ID 5, number 0x090, group 401) and (ID 3, number 0x194, group 10000).
+func TestAsMotorolaPatchGroupChannelGrantUpdate(t *testing.T) {
+	payload := [8]byte{0x50, 0x90, 0x01, 0x91, 0x31, 0x94, 0x27, 0x10}
+	tsbk := TSBK{Opcode: OpMotorolaPatchGroupChannelGrantUpdate, MFID: MFIDMotorola, Payload: payload}
+	got, ok := tsbk.AsMotorolaPatchGroupChannelGrantUpdate()
+	if !ok {
+		t.Fatal("AsMotorolaPatchGroupChannelGrantUpdate returned !ok")
+	}
+	if got.ChannelAID != 5 || got.ChannelANumber != 0x090 || got.GroupAddressA != 401 ||
+		got.ChannelBID != 3 || got.ChannelBNumber != 0x194 || got.GroupAddressB != 10000 {
+		t.Errorf("update = %+v, want A=(5.0x090,401) B=(3.0x194,10000)", got)
+	}
+	tsbk.MFID = MFIDStandard
+	if _, ok := tsbk.AsMotorolaPatchGroupChannelGrantUpdate(); ok {
+		t.Error("AsMotorolaPatchGroupChannelGrantUpdate matched a standard-MFID TSBK")
+	}
+}
+
+// TestControlChannelDispatchesMotorolaPatchGroupGrant confirms a Motorola
+// patch-group channel grant (opcode 0x02) resolves through the band plan
+// and publishes a KindGrant carrying its source RID + encryption — the
+// MMR/CBD calls that previously arrived src=0/enc=false (issue #376) — and
+// that it is no longer logged as an unhandled TSBK.
+func TestControlChannelDispatchesMotorolaPatchGroupGrant(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	identTSBK := TSBK{Opcode: OpIdentifierUpdate,
+		Payload: AssembleIdentifierUpdate(IdentifierUpdate{
+			ChannelID: 1, SpacingHz: 12_500, BaseHz: 851_000_000,
+		})}
+	// Real CBD opcode-0x02 payload: enc grant, channel (1, 1), group 105,
+	// source 0x04e2cc.
+	grantTSBK := TSBK{LB: true, Opcode: OpMotorolaPatchGroupChannelGrant, MFID: MFIDMotorola,
+		Payload: [8]byte{0x40, 0x10, 0x01, 0x00, 0x69, 0x04, 0xE2, 0xCC}}
+
+	stream1 := buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, identTSBK)
+	stream2 := buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, grantTSBK)
+
+	cc := New(Options{Bus: bus, Log: log, SystemName: "S", FrequencyHz: 851_000_000})
+	cc.Process(stream1, 0)
+	cc.Process(stream2, len(stream1))
+
+	var got *trunking.Grant
+	deadline := time.After(time.Second)
+	for got == nil {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g := ev.Payload.(trunking.Grant)
+				got = &g
+			}
+		case <-deadline:
+			t.Fatal("no grant event published for Motorola patch-group channel grant")
+		}
+	}
+	if got.GroupID != 105 || got.SourceID != 0x04E2CC {
+		t.Errorf("group/source = %d/%#x, want 105/0x04e2cc", got.GroupID, got.SourceID)
+	}
+	if got.FrequencyHz != 851_012_500 {
+		t.Errorf("freq = %d, want 851_012_500", got.FrequencyHz)
+	}
+	if !got.Encrypted || got.Emergency {
+		t.Errorf("flags = enc=%v emer=%v, want enc only", got.Encrypted, got.Emergency)
+	}
+	if strings.Contains(buf.String(), "p25: unhandled tsbk") {
+		t.Error("Motorola patch-group channel grant was logged as unhandled")
+	}
+}
+
 func TestControlChannelPublishesTalkerAlias(t *testing.T) {
 	bus := events.NewBus(16)
 	defer bus.Close()


### PR DESCRIPTION
## What

Decodes the two Motorola-vendor (MFID `0x90`) P25 Phase 1 control-channel TSBKs that GopherTrunk was logging as **unhandled** on a Motorola system (MMR, sites CBD/Mt Anakie): opcode `0x02` (patch-group voice channel **grant**) and `0x03` (patch-group voice channel **grant-update**).

## Why

The previous slice's raw-payload diagnostic (merged via #689) let the field tester capture the bytes. Cross-referencing them against the decoder layouts shows they are **not** talker aliases — they're patch-group (super-group) channel grant/update broadcasts:

- `0x02` `401001006904e2cc` → service-options `0x40` (encryption bit) · channel `(ID 1, num 1)` · super-group `105` · source RID `320204` (`0x04e2cc`) — exact `GroupVoiceChannelGrant` layout.
- `0x03` `5090019131942710` → two `(channel, super-group)` activity pairs `(5/0x090, 401)` and `(3/0x194, 10000)` — exact `GroupVoiceChannelUpdate` layout.

This **closes the "alias on the control channel" fork** of #376 (the alias rides the Phase 2 traffic channel, which a CC-only replay structurally can't reveal). Decoding these is independently valuable: `0x02` carries the **source RID + encryption bit**, so the patch-group calls that previously arrived `src=0` / `enc=false` now surface their radio ID and encryption, and GopherTrunk **follows the super-group voice calls it was dropping** — a prerequisite to ever decoding their voice-channel aliases.

## Changes (all in `internal/radio/p25/phase1/`)

- **`tsbk_vendor.go`** — two opcode constants (`OpMotorolaPatchGroupChannelGrant` = 0x02, `...Update` = 0x03) and two MFID-guarded accessors that reuse the existing `ParseGroupVoiceChannelGrant` / `ParseGroupVoiceChannelUpdate` parsers (the on-wire layout is identical to the standard grant/update).
- **`control.go`** — `dispatchVendorTSBK` handles the two opcodes via the existing `publishGroupGrant` / `publishVoiceGrant` paths, inheriting band-plan resolution, **Phase 2 TDMA routing**, encryption-from-service-options, source-ID, and pending-grant queueing for free. Mirrors the standard `OpGroupVoiceChannelGrant` / `OpGroupVoiceChannelUpdate` dispatch.
- **`tsbk_vendor_test.go`** — two accessor tests pinned to the real CBD bytes + an end-to-end `ControlChannel` dispatch test asserting a `KindGrant` with the decoded source/group/freq/encryption and that the message is no longer logged as `p25: unhandled tsbk`.
- **`CHANGELOG.md`** — entry under `[Unreleased] / Added`.

The unidentified `0x90` opcode `0x16` (`c23f..ffff0000`, not a grant shape) is **left in the unhandled-TSBK census** pending ground truth rather than guessed.

## Verification

- `gofmt -l internal/radio/p25/phase1/` clean; `go build ./...` OK.
- `go test ./internal/radio/p25/phase1/` passes (incl. the 3 new tests and the existing vendor/census tests); downstream `internal/trunking/...` and `internal/voice/...` consumer suites pass.

## Follow-up (not in this PR)

The remaining alias work is the Phase 2 traffic-channel path — it needs a **voice-following capture** (voice tuner attached), grepping `composer: p25p2 voice chain started | p25p2 mac pdu | p25p2 talker alias`. No speculative alias decode until those bytes name the transport.

https://claude.ai/code/session_01LzdxG4TMYB7FxP9vBjXaDK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzdxG4TMYB7FxP9vBjXaDK)_