### PR TITLE
Add RF & SDR learning hub to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Completed calls stream to Broadcastify Calls, RdioScanner, OpenMHz,
 and live Icecast / ShoutCast mountpoints out of the box. Why does
 this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html)**.
 
+> **New to radio or SDR?** Start with the **[Learn RF & SDR path](https://gophertrunk.org/learn/)** —
+> a free, structured course that takes you from "what is a radio wave?" to decoding
+> digital trunked systems with GopherTrunk, one short lesson at a time.
+
 ## Quick start
 
 ```sh

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -42,6 +42,16 @@ defaults:
       type: pages
     values:
       layout: page
+  # Learning-path pages under /learn/ get the lesson layout and nav group
+  # automatically, so individual lessons only declare slug/title/description.
+  # The hub (learn/index.md) overrides layout back to `page`.
+  - scope:
+      path: "learn"
+      type: pages
+    values:
+      layout: lesson
+      nav_group: Learn RF & SDR
+      permalink: /learn/:basename/
   # Per-category post URLs scoped to posts only — a global `permalink`
   # in _config.yml would also rewrite every existing /foo.html page to
   # /foo/ and break the data-driven nav.

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -1,0 +1,249 @@
+# GopherTrunk RF & SDR Learning Path — single source of truth.
+#
+# This file drives three things at once, so they never drift apart:
+#   1. The hub landing page grid           (docs/learn/index.md)
+#   2. The in-lesson sidebar / module list (docs/_layouts/lesson.html)
+#   3. Prev / next path navigation         (docs/_includes/learn-path-nav.html)
+#
+# Adding a lesson:
+#   1. Append an entry under the right module's `lessons:` list below.
+#   2. Create docs/learn/<slug>.md with front matter `slug: <slug>` and a
+#      title/description. The `learn` defaults scope in _config.yml gives it
+#      the lesson layout and nav_group automatically.
+#   3. Keep `slug` stable once published — it is the page URL (/learn/<slug>/).
+#
+# Fields per lesson:
+#   slug         URL slug -> /learn/<slug>/   (append-only; renaming breaks links)
+#   title        Lesson title (also the card heading)
+#   summary      One-line description for cards, sidebar, and llms.txt
+#   minutes      Estimated reading time (integer; shown on cards)
+#   level        beginner | intermediate | advanced  (badge + filtering)
+#   status       full | stub   (stub = outline published, body still being written)
+#
+# `intro` on the path itself and `blurb` on each module feed the hub page.
+
+intro: >
+  A guided path from complete newcomer to confident GopherTrunk operator. Start
+  with what a radio wave actually is, learn how software-defined radios turn the
+  airwaves into numbers, then follow the signal all the way to decoded digital
+  voice — and put it to work in GopherTrunk.
+
+modules:
+  - id: rf-fundamentals
+    label: "Module 1 — RF Fundamentals"
+    blurb: "The physics every operator leans on: waves, frequency, power, antennas, and how signals travel."
+    lessons:
+      - slug: radio-waves
+        title: What is a radio wave?
+        summary: Frequency, wavelength, amplitude, and the electromagnetic spectrum — the one idea everything else builds on.
+        minutes: 9
+        level: beginner
+        status: full
+      - slug: frequency-and-spectrum
+        title: Frequency, bands & the spectrum
+        summary: Hz to GHz, the HF/VHF/UHF bands, and how spectrum is carved up into band plans.
+        minutes: 8
+        level: beginner
+        status: stub
+      - slug: decibels
+        title: Decibels & signal power
+        summary: dB, dBm, and dBFS demystified — gain, path loss, the noise floor, and why radio lives in logarithms.
+        minutes: 10
+        level: beginner
+        status: full
+      - slug: antennas
+        title: Antennas 101
+        summary: Resonance, polarization, gain, SWR, and the connectors that join your antenna to your SDR.
+        minutes: 9
+        level: beginner
+        status: stub
+      - slug: propagation
+        title: How signals travel
+        summary: Line of sight, multipath, fading, and why where you put the antenna matters more than the radio.
+        minutes: 8
+        level: beginner
+        status: stub
+
+  - id: signals-modulation
+    label: "Module 2 — Signals & Modulation"
+    blurb: How information rides on a carrier — from analog AM/FM to the digital constellations GopherTrunk decodes.
+    lessons:
+      - slug: signal-anatomy
+        title: Anatomy of a signal
+        summary: Carrier, bandwidth, and the difference between a spectrum view and a waterfall.
+        minutes: 7
+        level: beginner
+        status: stub
+      - slug: analog-modulation
+        title: Analog modulation — AM, FM, SSB
+        summary: The three classic ways to put a voice on a carrier, and where you still hear them today.
+        minutes: 8
+        level: beginner
+        status: stub
+      - slug: digital-modulation
+        title: Digital modulation & constellations
+        summary: FSK, PSK, QAM, and C4FM — how bits become symbols, and how to read a constellation and eye diagram.
+        minutes: 12
+        level: intermediate
+        status: full
+      - slug: symbols-and-baud
+        title: Symbols, baud & bitrate
+        summary: Why a 4800-baud C4FM signal carries 9600 bits per second, and what that means for capture.
+        minutes: 7
+        level: intermediate
+        status: stub
+
+  - id: sdr
+    label: "Module 3 — Software-Defined Radio"
+    blurb: What an SDR actually is, how it samples the air into IQ data, and how to set it up without overloading it.
+    lessons:
+      - slug: what-is-sdr
+        title: What is software-defined radio?
+        summary: The core idea — move the radio into software — and why one cheap dongle can decode dozens of systems.
+        minutes: 9
+        level: beginner
+        status: full
+      - slug: sdr-receiver
+        title: How an SDR receiver works
+        summary: Antenna to tuner to ADC — the signal chain that turns radio waves into a stream of samples.
+        minutes: 9
+        level: intermediate
+        status: stub
+      - slug: iq-data
+        title: IQ data & complex signals
+        summary: Why SDRs output pairs of numbers, what "I" and "Q" mean, and how they capture both amplitude and phase.
+        minutes: 9
+        level: intermediate
+        status: stub
+      - slug: sample-rate-nyquist
+        title: Sample rate, bandwidth & Nyquist
+        summary: How much spectrum you can see at once, the Nyquist limit, and the bandwidth/CPU trade-off.
+        minutes: 8
+        level: intermediate
+        status: stub
+      - slug: gain-and-agc
+        title: Gain, AGC & avoiding overload
+        summary: Set gain too low and you lose weak signals; too high and you drown in distortion. Finding the sweet spot.
+        minutes: 8
+        level: intermediate
+        status: stub
+      - slug: sdr-hardware
+        title: SDR hardware — RTL-SDR, HackRF, Airspy
+        summary: Picking a dongle for the job and how each one maps to GopherTrunk's supported hardware.
+        minutes: 9
+        level: beginner
+        status: stub
+
+  - id: dsp
+    label: "Module 4 — DSP Essentials"
+    blurb: The digital signal processing that lives between IQ samples and decoded bits — explained without the heavy math.
+    lessons:
+      - slug: fft-and-waterfall
+        title: The FFT & reading a waterfall
+        summary: How the Fourier transform turns samples into a spectrum, and how to read GopherTrunk's waterfall.
+        minutes: 9
+        level: intermediate
+        status: stub
+      - slug: filtering-decimation
+        title: Filtering & decimation
+        summary: Zooming in on one channel, throwing away the rest, and keeping the CPU happy.
+        minutes: 8
+        level: intermediate
+        status: stub
+      - slug: demodulation-pipeline
+        title: The demodulation pipeline
+        summary: "The stages every signal passes through: tune, filter, demodulate, recover symbols, decode."
+        minutes: 9
+        level: advanced
+        status: stub
+      - slug: clock-recovery
+        title: Clock recovery & symbol timing
+        summary: How a receiver finds the beat of a digital signal so it samples each symbol at the right instant.
+        minutes: 8
+        level: advanced
+        status: stub
+
+  - id: digital-voice-trunking
+    label: "Module 5 — Digital Voice & Trunked Radio"
+    blurb: From vocoded voice to control channels — the systems GopherTrunk was built to follow.
+    lessons:
+      - slug: digital-voice
+        title: Analog vs. digital voice
+        summary: Why public-safety radio went digital, and what a vocoder gives up to fit a voice in a few kbps.
+        minutes: 8
+        level: intermediate
+        status: stub
+      - slug: vocoders
+        title: Vocoders — IMBE & AMBE+2
+        summary: The speech codecs behind P25 and DMR, and how GopherTrunk turns their frames back into audio.
+        minutes: 8
+        level: advanced
+        status: stub
+      - slug: what-is-trunking
+        title: What is trunked radio?
+        summary: Control channels, voice channels, and affiliation — how a fleet shares a handful of frequencies.
+        minutes: 11
+        level: intermediate
+        status: full
+      - slug: protocol-landscape
+        title: The digital protocol landscape
+        summary: P25, DMR, NXDN, TETRA, Motorola, EDACS, and friends — who uses what, and how to tell them apart.
+        minutes: 10
+        level: intermediate
+        status: stub
+      - slug: encryption
+        title: Encryption & what you can decode
+        summary: Why some talkgroups are silent, what GopherTrunk can and can't do, and how to spot encryption.
+        minutes: 7
+        level: intermediate
+        status: stub
+      - slug: other-signals
+        title: Other signals you'll meet
+        summary: Paging, AIS, ADS-B, and APRS — the non-trunked signals GopherTrunk can also decode.
+        minutes: 8
+        level: beginner
+        status: stub
+
+  - id: gophertrunk
+    label: "Module 6 — Putting It Together with GopherTrunk"
+    blurb: "Everything you've learned, applied: from a bare antenna to decoded calls, and how to fix it when it won't lock."
+    lessons:
+      - slug: antenna-to-audio
+        title: From antenna to audio
+        summary: The complete GopherTrunk signal path, tracing one call from RF in the air to a WAV on disk.
+        minutes: 11
+        level: intermediate
+        status: full
+      - slug: finding-systems
+        title: Finding & identifying systems
+        summary: Using Hunt and online databases to discover what's on the air near you and add it to GopherTrunk.
+        minutes: 9
+        level: intermediate
+        status: stub
+      - slug: tuning-with-scopes
+        title: Tuning for a clean lock
+        summary: Reading the constellation, eye diagram, and symbol scope to dial in a marginal signal.
+        minutes: 9
+        level: advanced
+        status: stub
+      - slug: calibration-troubleshooting
+        title: Calibration & troubleshooting
+        summary: PPM and voice calibration, plus a checklist for the usual reasons a control channel won't decode.
+        minutes: 9
+        level: advanced
+        status: stub
+      - slug: legal-ethical
+        title: Legal & ethical monitoring
+        summary: Knowing what's legal to receive where you live, and the etiquette of the scanner hobby.
+        minutes: 6
+        level: beginner
+        status: stub
+
+# Standalone reference, not part of the sequential path (no prev/next slot).
+glossary:
+  slug: glossary
+  title: Glossary of RF & SDR terms
+  summary: Plain-language definitions for every term in the learning path, cross-linked to the lessons.
+  minutes: 12
+  level: beginner
+  status: full

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -44,7 +44,7 @@ modules:
         summary: Hz to GHz, the HF/VHF/UHF bands, and how spectrum is carved up into band plans.
         minutes: 8
         level: beginner
-        status: stub
+        status: full
       - slug: decibels
         title: Decibels & signal power
         summary: dB, dBm, and dBFS demystified — gain, path loss, the noise floor, and why radio lives in logarithms.
@@ -56,13 +56,13 @@ modules:
         summary: Resonance, polarization, gain, SWR, and the connectors that join your antenna to your SDR.
         minutes: 9
         level: beginner
-        status: stub
+        status: full
       - slug: propagation
         title: How signals travel
         summary: Line of sight, multipath, fading, and why where you put the antenna matters more than the radio.
         minutes: 8
         level: beginner
-        status: stub
+        status: full
 
   - id: signals-modulation
     label: "Module 2 — Signals & Modulation"
@@ -73,13 +73,13 @@ modules:
         summary: Carrier, bandwidth, and the difference between a spectrum view and a waterfall.
         minutes: 7
         level: beginner
-        status: stub
+        status: full
       - slug: analog-modulation
         title: Analog modulation — AM, FM, SSB
         summary: The three classic ways to put a voice on a carrier, and where you still hear them today.
         minutes: 8
         level: beginner
-        status: stub
+        status: full
       - slug: digital-modulation
         title: Digital modulation & constellations
         summary: FSK, PSK, QAM, and C4FM — how bits become symbols, and how to read a constellation and eye diagram.
@@ -91,7 +91,7 @@ modules:
         summary: Why a 4800-baud C4FM signal carries 9600 bits per second, and what that means for capture.
         minutes: 7
         level: intermediate
-        status: stub
+        status: full
 
   - id: sdr
     label: "Module 3 — Software-Defined Radio"
@@ -108,31 +108,31 @@ modules:
         summary: Antenna to tuner to ADC — the signal chain that turns radio waves into a stream of samples.
         minutes: 9
         level: intermediate
-        status: stub
+        status: full
       - slug: iq-data
         title: IQ data & complex signals
         summary: Why SDRs output pairs of numbers, what "I" and "Q" mean, and how they capture both amplitude and phase.
         minutes: 9
         level: intermediate
-        status: stub
+        status: full
       - slug: sample-rate-nyquist
         title: Sample rate, bandwidth & Nyquist
         summary: How much spectrum you can see at once, the Nyquist limit, and the bandwidth/CPU trade-off.
         minutes: 8
         level: intermediate
-        status: stub
+        status: full
       - slug: gain-and-agc
         title: Gain, AGC & avoiding overload
         summary: Set gain too low and you lose weak signals; too high and you drown in distortion. Finding the sweet spot.
         minutes: 8
         level: intermediate
-        status: stub
+        status: full
       - slug: sdr-hardware
         title: SDR hardware — RTL-SDR, HackRF, Airspy
         summary: Picking a dongle for the job and how each one maps to GopherTrunk's supported hardware.
         minutes: 9
         level: beginner
-        status: stub
+        status: full
 
   - id: dsp
     label: "Module 4 — DSP Essentials"
@@ -143,25 +143,25 @@ modules:
         summary: How the Fourier transform turns samples into a spectrum, and how to read GopherTrunk's waterfall.
         minutes: 9
         level: intermediate
-        status: stub
+        status: full
       - slug: filtering-decimation
         title: Filtering & decimation
         summary: Zooming in on one channel, throwing away the rest, and keeping the CPU happy.
         minutes: 8
         level: intermediate
-        status: stub
+        status: full
       - slug: demodulation-pipeline
         title: The demodulation pipeline
         summary: "The stages every signal passes through: tune, filter, demodulate, recover symbols, decode."
         minutes: 9
         level: advanced
-        status: stub
+        status: full
       - slug: clock-recovery
         title: Clock recovery & symbol timing
         summary: How a receiver finds the beat of a digital signal so it samples each symbol at the right instant.
         minutes: 8
         level: advanced
-        status: stub
+        status: full
 
   - id: digital-voice-trunking
     label: "Module 5 — Digital Voice & Trunked Radio"
@@ -172,13 +172,13 @@ modules:
         summary: Why public-safety radio went digital, and what a vocoder gives up to fit a voice in a few kbps.
         minutes: 8
         level: intermediate
-        status: stub
+        status: full
       - slug: vocoders
         title: Vocoders — IMBE & AMBE+2
         summary: The speech codecs behind P25 and DMR, and how GopherTrunk turns their frames back into audio.
         minutes: 8
         level: advanced
-        status: stub
+        status: full
       - slug: what-is-trunking
         title: What is trunked radio?
         summary: Control channels, voice channels, and affiliation — how a fleet shares a handful of frequencies.
@@ -190,19 +190,19 @@ modules:
         summary: P25, DMR, NXDN, TETRA, Motorola, EDACS, and friends — who uses what, and how to tell them apart.
         minutes: 10
         level: intermediate
-        status: stub
+        status: full
       - slug: encryption
         title: Encryption & what you can decode
         summary: Why some talkgroups are silent, what GopherTrunk can and can't do, and how to spot encryption.
         minutes: 7
         level: intermediate
-        status: stub
+        status: full
       - slug: other-signals
         title: Other signals you'll meet
         summary: Paging, AIS, ADS-B, and APRS — the non-trunked signals GopherTrunk can also decode.
         minutes: 8
         level: beginner
-        status: stub
+        status: full
 
   - id: gophertrunk
     label: "Module 6 — Putting It Together with GopherTrunk"
@@ -219,25 +219,25 @@ modules:
         summary: Using Hunt and online databases to discover what's on the air near you and add it to GopherTrunk.
         minutes: 9
         level: intermediate
-        status: stub
+        status: full
       - slug: tuning-with-scopes
         title: Tuning for a clean lock
         summary: Reading the constellation, eye diagram, and symbol scope to dial in a marginal signal.
         minutes: 9
         level: advanced
-        status: stub
+        status: full
       - slug: calibration-troubleshooting
         title: Calibration & troubleshooting
         summary: PPM and voice calibration, plus a checklist for the usual reasons a control channel won't decode.
         minutes: 9
         level: advanced
-        status: stub
+        status: full
       - slug: legal-ethical
         title: Legal & ethical monitoring
         summary: Knowing what's legal to receive where you live, and the etiquette of the scanner hobby.
         minutes: 6
         level: beginner
-        status: stub
+        status: full
 
 # Standalone reference, not part of the sequential path (no prev/next slot).
 glossary:

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -11,6 +11,24 @@ groups:
         url: /guide-intermediate.html
       - title: Advanced
         url: /guide-advanced.html
+  - label: Learn RF & SDR
+    items:
+      - title: Learning path overview
+        url: /learn/
+      - title: 1 · RF fundamentals
+        url: /learn/#rf-fundamentals
+      - title: 2 · Signals & modulation
+        url: /learn/#signals-modulation
+      - title: 3 · Software-defined radio
+        url: /learn/#sdr
+      - title: 4 · DSP essentials
+        url: /learn/#dsp
+      - title: 5 · Digital voice & trunking
+        url: /learn/#digital-voice-trunking
+      - title: 6 · Using GopherTrunk
+        url: /learn/#gophertrunk
+      - title: Glossary
+        url: /learn/glossary/
   - label: About
     items:
       - title: The Story of GopherTrunk

--- a/docs/_includes/icons/search.svg
+++ b/docs/_includes/icons/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>

--- a/docs/_includes/learn-path-nav.html
+++ b/docs/_includes/learn-path-nav.html
@@ -1,0 +1,38 @@
+{%- comment -%}
+  Prev / next navigation for the learning path. Expects:
+    all_lessons — flat ordered array of lesson objects (slug, title)
+    idx         — index of the current lesson, or -1 if not in the path
+  Wired up by _layouts/lesson.html.
+{%- endcomment -%}
+{%- if include.idx >= 0 -%}
+  {%- assign prev_i = include.idx | minus: 1 -%}
+  {%- assign next_i = include.idx | plus: 1 -%}
+  <nav class="path-nav" aria-label="Learning path">
+    {%- if include.idx > 0 -%}
+      {%- assign prev = include.all_lessons[prev_i] -%}
+      <a class="path-nav__link path-nav__link--prev" href="{{ '/learn/' | append: prev.slug | append: '/' | relative_url }}">
+        <span class="path-nav__dir">&larr; Previous</span>
+        <span class="path-nav__title">{{ prev.title }}</span>
+      </a>
+    {%- else -%}
+      <a class="path-nav__link path-nav__link--prev" href="{{ '/learn/' | relative_url }}">
+        <span class="path-nav__dir">&larr; Path overview</span>
+        <span class="path-nav__title">Start of the path</span>
+      </a>
+    {%- endif -%}
+
+    {%- assign last = include.total | minus: 1 -%}
+    {%- if include.idx < last -%}
+      {%- assign next = include.all_lessons[next_i] -%}
+      <a class="path-nav__link path-nav__link--next" href="{{ '/learn/' | append: next.slug | append: '/' | relative_url }}">
+        <span class="path-nav__dir">Next &rarr;</span>
+        <span class="path-nav__title">{{ next.title }}</span>
+      </a>
+    {%- else -%}
+      <a class="path-nav__link path-nav__link--next" href="{{ '/learn/glossary/' | relative_url }}">
+        <span class="path-nav__dir">You finished! &rarr;</span>
+        <span class="path-nav__title">Browse the glossary</span>
+      </a>
+    {%- endif -%}
+  </nav>
+{%- endif -%}

--- a/docs/_includes/learn-schema.html
+++ b/docs/_includes/learn-schema.html
@@ -1,0 +1,74 @@
+{%- comment -%}
+  Structured data for learning-path pages. Emits:
+    - TechArticle           (the lesson itself, with learning metadata)
+    - BreadcrumbList        (Home › Learn › Lesson)
+    - FAQPage               (only when the page defines a `faq:` list)
+  Kept out of head.html so the homepage SoftwareApplication entity stays clean.
+  Expects include.idx / include.total from the lesson layout.
+{%- endcomment -%}
+{%- assign page_url = page.url | absolute_url -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": {{ page.title | jsonify }},
+  "description": {{ page.description | jsonify }},
+  "url": {{ page_url | jsonify }},
+  "image": {{ site.url | append: site.image | jsonify }},
+  "inLanguage": "en",
+  "isPartOf": {
+    "@type": "Course",
+    "name": "GopherTrunk RF & SDR Learning Path",
+    "url": {{ '/learn/' | absolute_url | jsonify }}
+  },
+  {%- if page.level -%}
+  "educationalLevel": {{ page.level | jsonify }},
+  {%- endif -%}
+  {%- if page.keywords -%}
+  "keywords": {{ page.keywords | jsonify }},
+  {%- endif -%}
+  "author": {
+    "@type": "Person",
+    "name": {{ site.author.name | jsonify }},
+    "url": {{ site.author.url | jsonify }}
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": {{ site.title | jsonify }},
+    "url": {{ site.url | jsonify }},
+    "logo": {
+      "@type": "ImageObject",
+      "url": {{ site.url | append: site.image | jsonify }}
+    }
+  },
+  "mainEntityOfPage": { "@type": "WebPage", "@id": {{ page_url | jsonify }} }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": {{ '/' | absolute_url | jsonify }} },
+    { "@type": "ListItem", "position": 2, "name": "Learn RF & SDR", "item": {{ '/learn/' | absolute_url | jsonify }} },
+    { "@type": "ListItem", "position": 3, "name": {{ page.title | jsonify }}, "item": {{ page_url | jsonify }} }
+  ]
+}
+</script>
+{%- if page.faq and page.faq.size > 0 -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {%- for qa in page.faq -%}
+    {
+      "@type": "Question",
+      "name": {{ qa.q | jsonify }},
+      "acceptedAnswer": { "@type": "Answer", "text": {{ qa.a | jsonify }} }
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ]
+}
+</script>
+{%- endif -%}

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -33,6 +33,12 @@
       </ul>
 
       <ul class="site-nav__external">
+        <li class="site-search">
+          <form class="site-search__form" role="search" action="{{ '/search/' | relative_url }}" method="get">
+            <span class="site-search__icon" aria-hidden="true">{% include icons/search.svg %}</span>
+            <input class="site-search__input" type="search" name="q" placeholder="Search…" aria-label="Search docs and lessons" autocomplete="off">
+          </form>
+        </li>
         {%- for link in site.data.nav.external -%}
           <li>
             <a href="{{ link.url }}" rel="noopener" aria-label="{{ link.title }}" title="{{ link.title }}">

--- a/docs/_layouts/learn-hub.html
+++ b/docs/_layouts/learn-hub.html
@@ -1,0 +1,127 @@
+---
+layout: default
+---
+{%- comment -%}
+  Landing page for the RF & SDR learning path. Renders the module/lesson
+  grid from _data/learn.yml and a localStorage-backed progress bar
+  (progressively enhanced by assets/js/learn.js). Emits Course + ItemList
+  structured data for SEO / AI search.
+{%- endcomment -%}
+{%- assign learn = site.data.learn -%}
+{%- assign total = 0 -%}
+{%- for mod in learn.modules -%}{%- assign total = total | plus: mod.lessons.size -%}{%- endfor -%}
+
+<main id="content" class="page" role="main">
+  <div class="container">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="{{ '/' | relative_url }}">Home</a></li>
+        <li><span aria-current="page">Learn RF &amp; SDR</span></li>
+      </ol>
+    </nav>
+
+    <header class="learn-hero">
+      <h1 class="learn-hero__title">{{ page.title }}</h1>
+      <p class="learn-hero__lede">{{ learn.intro }}</p>
+      <div class="learn-hero__cta">
+        <a class="btn btn--primary" href="{{ '/learn/radio-waves/' | relative_url }}">Start lesson 1 &rarr;</a>
+        <a class="btn btn--ghost" href="{{ '/learn/glossary/' | relative_url }}">Jump to glossary</a>
+      </div>
+
+      <div class="progress" data-progress data-total="{{ total }}" hidden>
+        <div class="progress__track"><div class="progress__bar" data-progress-bar></div></div>
+        <p class="progress__label"><span data-progress-count>0</span> of {{ total }} lessons complete · <button type="button" class="progress__reset" data-progress-reset>reset</button></p>
+      </div>
+    </header>
+
+    <article class="prose prose--wide learn-intro">
+      {{ content }}
+    </article>
+
+    <div class="learn-modules">
+      {%- for mod in learn.modules -%}
+        <section class="learn-module" id="{{ mod.id }}">
+          <div class="learn-module__head">
+            <h2 class="learn-module__title">{{ mod.label }}</h2>
+            <p class="learn-module__blurb">{{ mod.blurb }}</p>
+          </div>
+          <ol class="learn-grid">
+            {%- for lesson in mod.lessons -%}
+              {%- assign lesson_url = '/learn/' | append: lesson.slug | append: '/' -%}
+              <li class="learn-card{% if lesson.status == 'stub' %} learn-card--stub{% endif %}" data-lesson="{{ lesson.slug }}">
+                <a class="learn-card__link" href="{{ lesson_url | relative_url }}">
+                  <span class="learn-card__check" data-lesson-check aria-hidden="true"></span>
+                  <span class="learn-card__body">
+                    <span class="learn-card__title">{{ lesson.title }}</span>
+                    <span class="learn-card__summary">{{ lesson.summary }}</span>
+                    <span class="learn-card__meta">
+                      <span class="lesson__badge lesson__badge--{{ lesson.level }}">{{ lesson.level }}</span>
+                      <span class="learn-card__time">{{ lesson.minutes }} min</span>
+                      {%- if lesson.status == 'stub' -%}<span class="learn-card__tag">outline</span>{%- endif -%}
+                    </span>
+                  </span>
+                </a>
+              </li>
+            {%- endfor -%}
+          </ol>
+        </section>
+      {%- endfor -%}
+
+      <section class="learn-module" id="glossary-card">
+        <ol class="learn-grid">
+          <li class="learn-card learn-card--glossary" data-lesson="{{ learn.glossary.slug }}">
+            <a class="learn-card__link" href="{{ '/learn/glossary/' | relative_url }}">
+              <span class="learn-card__check" data-lesson-check aria-hidden="true"></span>
+              <span class="learn-card__body">
+                <span class="learn-card__title">{{ learn.glossary.title }}</span>
+                <span class="learn-card__summary">{{ learn.glossary.summary }}</span>
+              </span>
+            </a>
+          </li>
+        </ol>
+      </section>
+    </div>
+  </div>
+</main>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Course",
+  "name": {{ page.title | jsonify }},
+  "description": {{ learn.intro | strip_newlines | jsonify }},
+  "url": {{ '/learn/' | absolute_url | jsonify }},
+  "provider": {
+    "@type": "Organization",
+    "name": {{ site.title | jsonify }},
+    "url": {{ site.url | jsonify }}
+  },
+  "hasCourseInstance": {
+    "@type": "CourseInstance",
+    "courseMode": "online",
+    "courseWorkload": "PT6H"
+  }
+}
+</script>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "GopherTrunk RF & SDR lessons",
+  "itemListElement": [
+    {%- assign n = 0 -%}
+    {%- for mod in learn.modules -%}
+      {%- for lesson in mod.lessons -%}
+        {%- assign n = n | plus: 1 -%}
+        {
+          "@type": "ListItem",
+          "position": {{ n }},
+          "name": {{ lesson.title | jsonify }},
+          "url": {{ '/learn/' | append: lesson.slug | append: '/' | absolute_url | jsonify }}
+        }{%- unless n == total -%},{%- endunless -%}
+      {%- endfor -%}
+    {%- endfor -%}
+  ]
+}
+</script>
+<script defer src="{{ '/assets/js/learn.js' | relative_url }}"></script>

--- a/docs/_layouts/lesson.html
+++ b/docs/_layouts/lesson.html
@@ -1,0 +1,117 @@
+---
+layout: default
+---
+{%- comment -%}
+  Lesson layout for the RF & SDR learning path.
+
+  Flattens site.data.learn.modules into one ordered list so it can compute
+  the lesson's position, its module, and prev/next links from a single
+  source (_data/learn.yml). The page identifies itself with `slug:` in
+  front matter. The glossary (page.lesson_standalone) skips path nav.
+{%- endcomment -%}
+
+{%- assign all_lessons = "" | split: "" -%}
+{%- assign module_labels = "" | split: "" -%}
+{%- for mod in site.data.learn.modules -%}
+  {%- for lesson in mod.lessons -%}
+    {%- assign all_lessons = all_lessons | push: lesson -%}
+    {%- assign module_labels = module_labels | push: mod.label -%}
+  {%- endfor -%}
+{%- endfor -%}
+{%- assign total = all_lessons | size -%}
+
+{%- assign idx = -1 -%}
+{%- for lesson in all_lessons -%}
+  {%- if lesson.slug == page.slug -%}{%- assign idx = forloop.index0 -%}{%- endif -%}
+{%- endfor -%}
+
+{%- assign words = content | number_of_words -%}
+{%- assign read_minutes = words | divided_by: 200 | plus: 1 -%}
+
+<main id="content" class="page" role="main">
+  <div class="container page__container">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="{{ '/' | relative_url }}">Home</a></li>
+        <li><a href="{{ '/learn/' | relative_url }}">Learn RF &amp; SDR</a></li>
+        {%- if idx >= 0 -%}
+          <li><span class="breadcrumb__group">{{ module_labels[idx] }}</span></li>
+        {%- endif -%}
+        <li><span aria-current="page">{{ page.title }}</span></li>
+      </ol>
+    </nav>
+
+    <article class="prose lesson">
+      <header class="lesson__head">
+        <p class="lesson__meta">
+          {%- if idx >= 0 -%}
+            <span class="lesson__step">Lesson {{ idx | plus: 1 }} of {{ total }}</span>
+            <span class="lesson__sep" aria-hidden="true">·</span>
+          {%- endif -%}
+          {%- if page.level -%}
+            <span class="lesson__badge lesson__badge--{{ page.level }}">{{ page.level }}</span>
+            <span class="lesson__sep" aria-hidden="true">·</span>
+          {%- endif -%}
+          <span class="lesson__time">{{ read_minutes }} min read</span>
+        </p>
+
+        {%- if page.status == "stub" -%}
+          <p class="lesson__draft" role="note">
+            <strong>Draft outline.</strong> This lesson is part of the published learning
+            path but its full write-up is still in progress. The headings below map out what
+            it will cover. Want to help? <a href="https://github.com/MattCheramie/GopherTrunk/blob/main/{{ page.path }}" rel="noopener">Edit it on GitHub</a>.
+          </p>
+        {%- endif -%}
+
+        {%- if page.prereq and page.prereq.size > 0 -%}
+          <p class="lesson__prereq"><span class="lesson__prereq-label">Before this:</span>
+            {%- for slug in page.prereq -%}
+              {%- assign p = all_lessons | where: "slug", slug | first -%}
+              {%- if p -%}<a class="lesson__chip" href="{{ '/learn/' | append: slug | append: '/' | relative_url }}">{{ p.title }}</a>{%- endif -%}
+            {%- endfor -%}
+          </p>
+        {%- endif -%}
+      </header>
+
+      {{ content }}
+
+      {%- if page.faq and page.faq.size > 0 -%}
+        <section class="lesson__faq" aria-label="Frequently asked questions">
+          <h2 id="faq">Frequently asked questions</h2>
+          {%- for qa in page.faq -%}
+            <details class="lesson__faq-item">
+              <summary>{{ qa.q }}</summary>
+              <div class="lesson__faq-answer">{{ qa.a | markdownify }}</div>
+            </details>
+          {%- endfor -%}
+        </section>
+      {%- endif -%}
+
+      {%- if page.gophertrunk_links and page.gophertrunk_links.size > 0 -%}
+        <aside class="lesson__apply" aria-label="Use this in GopherTrunk">
+          <h2 class="lesson__apply-title">Use this in GopherTrunk</h2>
+          <ul>
+            {%- for link in page.gophertrunk_links -%}
+              <li><a href="{{ link.url | relative_url }}">{{ link.title }}</a> — {{ link.note }}</li>
+            {%- endfor -%}
+          </ul>
+        </aside>
+      {%- endif -%}
+    </article>
+
+    {%- unless page.lesson_standalone -%}
+      {%- include learn-path-nav.html all_lessons=all_lessons idx=idx total=total -%}
+    {%- endunless -%}
+
+    {%- if page.path -%}
+      <footer class="page__edit">
+        <a href="https://github.com/MattCheramie/GopherTrunk/blob/main/{{ page.path }}" rel="noopener">
+          Edit this page on GitHub &rarr;
+        </a>
+      </footer>
+    {%- endif -%}
+  </div>
+</main>
+
+{%- include learn-schema.html idx=idx total=total -%}
+<script defer src="{{ '/assets/js/learn.js' | relative_url }}"></script>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -788,3 +788,366 @@ a.category-chip:hover {
   color: var(--fg-muted);
   font-size: 0.95rem;
 }
+
+/* ====================================================================
+   Learning path (RF & SDR knowledge base)
+   ==================================================================== */
+
+/* ---------- Hub hero ---------- */
+.learn-hero {
+  text-align: center;
+  padding: 2.5rem 0 1.5rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 2rem;
+}
+.learn-hero__title {
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.75rem;
+}
+.learn-hero__lede {
+  max-width: 44rem;
+  margin: 0 auto 1.5rem;
+  color: var(--fg-muted);
+  font-size: 1.1rem;
+}
+.learn-hero__cta {
+  display: flex;
+  justify-content: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+.learn-intro { margin: 0 auto 2.5rem; }
+
+/* ---------- Progress bar ---------- */
+.progress {
+  max-width: 32rem;
+  margin: 1.75rem auto 0;
+}
+.progress__track {
+  height: 8px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.progress__bar {
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  border-radius: 999px;
+  transition: width 0.3s ease;
+}
+.progress__label {
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+}
+.progress__reset {
+  background: none;
+  border: none;
+  color: var(--link);
+  padding: 0;
+  font-size: inherit;
+  text-decoration: underline;
+}
+
+/* ---------- Module + card grid ---------- */
+.learn-modules { margin-bottom: 2rem; }
+.learn-module { margin: 0 0 2.5rem; }
+.learn-module__head { margin-bottom: 1rem; }
+.learn-module__title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0 0 0.3rem;
+}
+.learn-module__blurb {
+  margin: 0;
+  color: var(--fg-muted);
+  max-width: 46rem;
+}
+.learn-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
+  gap: 0.85rem;
+  counter-reset: none;
+}
+.learn-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  transition: transform 0.08s ease, border-color 0.12s ease;
+}
+.learn-card:hover { transform: translateY(-2px); border-color: var(--accent); }
+.learn-card__link {
+  display: flex;
+  gap: 0.7rem;
+  padding: 1rem;
+  color: var(--fg);
+  text-decoration: none;
+  height: 100%;
+}
+.learn-card__link:hover { text-decoration: none; color: var(--fg); }
+.learn-card__check {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  margin-top: 0.15rem;
+  border: 2px solid var(--border);
+  border-radius: 999px;
+  position: relative;
+}
+.learn-card.is-done .learn-card__check {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.learn-card.is-done .learn-card__check::after {
+  content: "";
+  position: absolute;
+  left: 5px;
+  top: 1px;
+  width: 5px;
+  height: 10px;
+  border: solid var(--accent-fg);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+}
+.learn-card__body { display: flex; flex-direction: column; gap: 0.3rem; }
+.learn-card__title { font-weight: 600; font-size: 1.02rem; }
+.learn-card__summary { color: var(--fg-muted); font-size: 0.9rem; line-height: 1.45; }
+.learn-card__meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+  font-size: 0.78rem;
+  color: var(--fg-muted);
+}
+.learn-card__tag {
+  border: 1px dashed var(--border);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 0.7rem;
+}
+.learn-card--stub { opacity: 0.92; }
+.learn-card--glossary { border-style: dashed; }
+
+/* ---------- Lesson page chrome ---------- */
+.lesson__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--fg-muted);
+  font-size: 0.88rem;
+  margin: 0 0 1rem;
+}
+.lesson__sep { opacity: 0.5; }
+.lesson__badge {
+  text-transform: capitalize;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.1rem 0.55rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+.lesson__badge--beginner { color: #1a7f37; border-color: #1a7f3733; background: #1a7f3714; }
+.lesson__badge--intermediate { color: #9a6700; border-color: #9a670033; background: #9a670014; }
+.lesson__badge--advanced { color: #a40e26; border-color: #a40e2633; background: #a40e2614; }
+:root.dark .lesson__badge--beginner { color: #3fb950; }
+:root.dark .lesson__badge--intermediate { color: #d29922; }
+:root.dark .lesson__badge--advanced { color: #f85149; }
+
+.lesson__draft {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-soft);
+  padding: 0.7rem 1rem;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  font-size: 0.92rem;
+}
+.lesson__prereq {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+.lesson__prereq-label { color: var(--fg-muted); }
+.lesson__chip {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-elev);
+  font-size: 0.85rem;
+}
+.lesson__chip:hover { border-color: var(--accent); text-decoration: none; }
+
+/* TL;DR / key-takeaways callout */
+.tldr {
+  border: 1px solid var(--accent);
+  background: var(--accent-soft);
+  border-radius: var(--radius);
+  padding: 1rem 1.2rem;
+  margin: 1.5rem 0;
+}
+.tldr > strong:first-child,
+.tldr .tldr__label {
+  display: block;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.78rem;
+  color: var(--accent);
+  margin-bottom: 0.35rem;
+}
+.tldr p:last-child { margin-bottom: 0; }
+
+/* Diagram figure captions */
+.figure {
+  margin: 1.5rem 0;
+  text-align: center;
+}
+.figure svg, .figure img {
+  margin: 0 auto;
+  max-width: 100%;
+}
+.figure figcaption {
+  margin-top: 0.5rem;
+  color: var(--fg-muted);
+  font-size: 0.88rem;
+}
+
+/* Glossary term back-links */
+.term { border-bottom: 1px dotted var(--link); }
+
+/* ---------- Apply / GopherTrunk links box ---------- */
+.lesson__apply {
+  margin: 2.5rem 0 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  padding: 1rem 1.25rem;
+}
+.lesson__apply-title { margin-top: 0 !important; font-size: 1.15rem !important; border: none !important; }
+.lesson__apply ul { margin-bottom: 0; }
+
+/* ---------- FAQ ---------- */
+.lesson__faq { margin-top: 2.5rem; }
+.lesson__faq-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 1rem;
+  margin: 0.6rem 0;
+  background: var(--bg);
+}
+.lesson__faq-item summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+.lesson__faq-answer { margin-top: 0.5rem; color: var(--fg); }
+
+/* ---------- Knowledge-check widgets ---------- */
+.knowledge-check {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  padding: 1.1rem 1.25rem;
+  margin: 1.75rem 0;
+}
+.knowledge-check__q { font-weight: 600; margin: 0 0 0.75rem; }
+.quiz__options { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.5rem; }
+.quiz__option {
+  text-align: left;
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.85rem;
+  color: var(--fg);
+}
+.quiz__option:hover { border-color: var(--accent); }
+.quiz__option.is-correct { border-color: #1a7f37; background: #1a7f3714; }
+.quiz__option.is-wrong { border-color: #a40e26; background: #a40e2614; }
+.quiz__feedback { margin: 0.75rem 0 0; font-size: 0.92rem; }
+.quiz__feedback.is-correct { color: #1a7f37; }
+.quiz__feedback.is-wrong { color: #a40e26; }
+:root.dark .quiz__feedback.is-correct { color: #3fb950; }
+:root.dark .quiz__feedback.is-wrong { color: #f85149; }
+
+/* ---------- Calculators ---------- */
+.calc {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  padding: 1.1rem 1.25rem;
+  margin: 1.75rem 0;
+}
+.calc__title { margin: 0 0 0.75rem; font-weight: 600; }
+.calc__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+.calc__row label { min-width: 8rem; font-size: 0.92rem; }
+.calc input, .calc select {
+  font: inherit;
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--fg);
+  max-width: 9rem;
+}
+.calc__out {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--accent);
+}
+.calc__note { margin: 0.6rem 0 0; font-size: 0.82rem; color: var(--fg-muted); }
+
+/* ---------- Mark-complete control ---------- */
+.lesson-complete { margin: 2.5rem 0 0; }
+.lesson-complete__btn.is-done {
+  border-color: #1a7f37;
+  color: #1a7f37;
+}
+:root.dark .lesson-complete__btn.is-done { color: #3fb950; border-color: #3fb950; }
+
+/* ---------- Prev / next path nav ---------- */
+.path-nav {
+  display: flex;
+  gap: 0.85rem;
+  margin: 2rem 0 0;
+  flex-wrap: wrap;
+}
+.path-nav__link {
+  flex: 1 1 0;
+  min-width: 12rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  color: var(--fg);
+}
+.path-nav__link:hover { border-color: var(--accent); text-decoration: none; color: var(--fg); }
+.path-nav__link--next { text-align: right; }
+.path-nav__dir { font-size: 0.8rem; color: var(--fg-muted); }
+.path-nav__title { font-weight: 600; }
+
+@media (max-width: 560px) {
+  .path-nav { flex-direction: column; }
+  .path-nav__link--next { text-align: left; }
+}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1151,3 +1151,85 @@ a.category-chip:hover {
   .path-nav { flex-direction: column; }
   .path-nav__link--next { text-align: left; }
 }
+
+/* ====================================================================
+   Site-wide search
+   ==================================================================== */
+
+/* ---------- Nav search box ---------- */
+.site-search { display: flex; align-items: center; }
+.site-search__form { position: relative; display: flex; align-items: center; }
+.site-search__icon {
+  position: absolute;
+  left: 0.5rem;
+  display: inline-flex;
+  color: var(--fg-muted);
+  pointer-events: none;
+}
+.site-search__icon svg { width: 15px; height: 15px; }
+.site-search__input {
+  font: inherit;
+  font-size: 0.9rem;
+  width: 11rem;
+  padding: 0.4rem 0.55rem 0.4rem 1.85rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elev);
+  color: var(--fg);
+}
+.site-search__input::placeholder { color: var(--fg-muted); }
+.site-search__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg);
+}
+
+/* ---------- Search results page ---------- */
+.search-page__form { margin: 0 0 1rem; }
+.search-page__input {
+  font: inherit;
+  font-size: 1.05rem;
+  width: 100%;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--fg);
+}
+.search-page__input:focus { outline: none; border-color: var(--accent); box-shadow: var(--shadow); }
+.search-page__status { color: var(--fg-muted); font-size: 0.92rem; margin: 0 0 1rem; }
+
+.search-results { list-style: none; margin: 0; padding: 0; display: grid; gap: 0.6rem; }
+.search-result {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+.search-result:hover { border-color: var(--accent); background: var(--bg-elev); }
+.search-result__link { display: block; padding: 0.85rem 1rem; color: var(--fg); text-decoration: none; }
+.search-result__link:hover { text-decoration: none; color: var(--fg); }
+.search-result__title { display: block; font-weight: 600; color: var(--link); margin-bottom: 0.2rem; }
+.search-result__group {
+  display: inline-block;
+  font-size: 0.72rem;
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+  margin-bottom: 0.3rem;
+}
+.search-result__excerpt { display: block; font-size: 0.9rem; color: var(--fg-muted); line-height: 1.45; }
+.search-result mark, .search-result__title mark {
+  background: var(--accent-soft);
+  color: inherit;
+  border-radius: 0.15rem;
+  padding: 0 0.1rem;
+}
+
+/* ---------- Mobile: full-width search in the nav overlay ---------- */
+@media (max-width: 800px) {
+  .site-search { width: 100%; order: -1; margin-bottom: 0.5rem; }
+  .site-search__form { width: 100%; }
+  .site-search__input { width: 100%; }
+}

--- a/docs/assets/js/learn.js
+++ b/docs/assets/js/learn.js
@@ -1,0 +1,168 @@
+/*
+ * GopherTrunk learning-path enhancements. Progressive: every page is fully
+ * usable with this file absent or blocked. Adds, when JS is available:
+ *   - a "mark complete" control on lessons, persisted in localStorage
+ *   - a progress bar + per-card checkmarks on the hub
+ *   - frequency <-> wavelength and dB/dBm calculators
+ *   - self-check quizzes
+ */
+(function () {
+  'use strict';
+
+  var STORE = 'gt-learn-progress';
+
+  function load() {
+    try {
+      var raw = localStorage.getItem(STORE);
+      var arr = raw ? JSON.parse(raw) : [];
+      return Array.isArray(arr) ? arr : [];
+    } catch (e) { return []; }
+  }
+  function save(list) {
+    try { localStorage.setItem(STORE, JSON.stringify(list)); } catch (e) {}
+  }
+  function has(slug) { return load().indexOf(slug) !== -1; }
+  function setDone(slug, done) {
+    var list = load();
+    var i = list.indexOf(slug);
+    if (done && i === -1) list.push(slug);
+    if (!done && i !== -1) list.splice(i, 1);
+    save(list);
+  }
+  function currentSlug() {
+    var m = location.pathname.match(/\/learn\/([^/]+)\/?$/);
+    return m ? m[1] : null;
+  }
+
+  /* ---- Lesson page: mark complete ---- */
+  function initLessonComplete() {
+    var slug = currentSlug();
+    if (!slug || slug === 'glossary') return;
+    var nav = document.querySelector('.path-nav');
+    var article = document.querySelector('.lesson');
+    if (!article) return;
+
+    var wrap = document.createElement('div');
+    wrap.className = 'lesson-complete';
+    var btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'btn btn--secondary lesson-complete__btn';
+    wrap.appendChild(btn);
+
+    function render() {
+      var done = has(slug);
+      btn.setAttribute('aria-pressed', done ? 'true' : 'false');
+      btn.classList.toggle('is-done', done);
+      btn.textContent = done ? '✓ Completed — click to undo' : 'Mark this lesson complete';
+    }
+    btn.addEventListener('click', function () {
+      setDone(slug, !has(slug));
+      render();
+    });
+    render();
+
+    if (nav && nav.parentNode) nav.parentNode.insertBefore(wrap, nav);
+    else article.appendChild(wrap);
+  }
+
+  /* ---- Hub page: progress bar + card checks ---- */
+  function initHubProgress() {
+    var box = document.querySelector('[data-progress]');
+    if (!box) return;
+    var total = parseInt(box.getAttribute('data-total'), 10) || 0;
+    var bar = box.querySelector('[data-progress-bar]');
+    var count = box.querySelector('[data-progress-count]');
+    var reset = box.querySelector('[data-progress-reset]');
+
+    function paint() {
+      var done = load();
+      var cards = document.querySelectorAll('[data-lesson]');
+      var n = 0;
+      cards.forEach(function (card) {
+        var slug = card.getAttribute('data-lesson');
+        var isDone = done.indexOf(slug) !== -1;
+        card.classList.toggle('is-done', isDone);
+        if (isDone && slug !== 'glossary') n++;
+      });
+      var pct = total ? Math.round((n / total) * 100) : 0;
+      if (bar) bar.style.width = pct + '%';
+      if (count) count.textContent = n;
+    }
+    box.hidden = false;
+    if (reset) reset.addEventListener('click', function () { save([]); paint(); });
+    paint();
+  }
+
+  /* ---- Calculators ---- */
+  var C = 299792458; // speed of light, m/s
+
+  function fmt(n) {
+    if (!isFinite(n)) return '—';
+    if (n !== 0 && (Math.abs(n) < 1e-3 || Math.abs(n) >= 1e6)) return n.toExponential(3);
+    return (Math.round(n * 1000) / 1000).toString();
+  }
+
+  function initFreqCalc(el) {
+    var freq = el.querySelector('[data-freq]');
+    var unit = el.querySelector('[data-freq-unit]');
+    var out = el.querySelector('[data-wavelength]');
+    if (!freq || !out) return;
+    function calc() {
+      var mult = unit ? parseFloat(unit.value) : 1e6;
+      var hz = parseFloat(freq.value) * mult;
+      var lambda = C / hz; // metres
+      var disp = lambda >= 1 ? fmt(lambda) + ' m' : fmt(lambda * 100) + ' cm';
+      out.textContent = isFinite(lambda) && hz > 0 ? disp : '—';
+    }
+    freq.addEventListener('input', calc);
+    if (unit) unit.addEventListener('change', calc);
+    calc();
+  }
+
+  function initDbCalc(el) {
+    var watts = el.querySelector('[data-watts]');
+    var dbm = el.querySelector('[data-dbm]');
+    if (!watts || !dbm) return;
+    function fromWatts() {
+      var w = parseFloat(watts.value);
+      if (!(w > 0)) { dbm.value = ''; return; }
+      dbm.value = fmt(10 * Math.log10(w * 1000));
+    }
+    function fromDbm() {
+      var d = parseFloat(dbm.value);
+      if (isNaN(d)) { watts.value = ''; return; }
+      watts.value = fmt(Math.pow(10, d / 10) / 1000);
+    }
+    watts.addEventListener('input', fromWatts);
+    dbm.addEventListener('input', fromDbm);
+    fromWatts();
+  }
+
+  /* ---- Quizzes ---- */
+  function initQuiz(el) {
+    var options = el.querySelectorAll('[data-answer]');
+    var feedback = el.querySelector('[data-quiz-feedback]');
+    options.forEach(function (opt) {
+      opt.addEventListener('click', function () {
+        var correct = opt.getAttribute('data-answer') === 'correct';
+        options.forEach(function (o) { o.classList.remove('is-correct', 'is-wrong'); });
+        opt.classList.add(correct ? 'is-correct' : 'is-wrong');
+        if (feedback) {
+          feedback.hidden = false;
+          feedback.textContent = correct
+            ? '✓ ' + (el.getAttribute('data-correct-msg') || 'Correct!')
+            : '✗ Not quite — try again.';
+          feedback.className = 'quiz__feedback ' + (correct ? 'is-correct' : 'is-wrong');
+        }
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    initLessonComplete();
+    initHubProgress();
+    document.querySelectorAll('[data-calc="freq"]').forEach(initFreqCalc);
+    document.querySelectorAll('[data-calc="db"]').forEach(initDbCalc);
+    document.querySelectorAll('[data-quiz]').forEach(initQuiz);
+  });
+})();

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -1,0 +1,145 @@
+/*
+ * Client-side site search. Fetches /search.json (built by Jekyll) once and
+ * filters it in the browser — no server, no external service. Progressive:
+ * the page works without this script (the form just submits ?q= to /search/).
+ */
+(function () {
+  'use strict';
+
+  var input = document.getElementById('gt-search-input');
+  var results = document.getElementById('gt-search-results');
+  var status = document.getElementById('gt-search-status');
+  if (!input || !results) return;
+
+  var index = null;
+  var pending = null;
+
+  function esc(s) {
+    return String(s).replace(/[&<>"]/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+    });
+  }
+
+  function terms(q) {
+    return q.toLowerCase().split(/\s+/).filter(Boolean);
+  }
+
+  // Highlight each term in an escaped snippet.
+  function highlight(text, ts) {
+    var out = esc(text);
+    ts.forEach(function (t) {
+      var re = new RegExp('(' + t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + ')', 'ig');
+      out = out.replace(re, '<mark>$1</mark>');
+    });
+    return out;
+  }
+
+  // Build a ~160-char snippet centred on the first term match in the body.
+  function snippet(item, ts) {
+    var desc = item.desc || '';
+    if (desc) return desc;
+    var body = item.body || '';
+    var low = body.toLowerCase();
+    var at = -1;
+    for (var i = 0; i < ts.length; i++) {
+      var p = low.indexOf(ts[i]);
+      if (p !== -1) { at = p; break; }
+    }
+    if (at === -1) return body.slice(0, 160);
+    var start = Math.max(0, at - 60);
+    return (start > 0 ? '…' : '') + body.slice(start, start + 160) + '…';
+  }
+
+  function score(item, ts) {
+    var title = (item.title || '').toLowerCase();
+    var kw = (item.kw || '').toLowerCase();
+    var group = (item.group || '').toLowerCase();
+    var desc = (item.desc || '').toLowerCase();
+    var body = (item.body || '').toLowerCase();
+    var total = 0;
+    for (var i = 0; i < ts.length; i++) {
+      var t = ts[i], hit = 0;
+      if (title.indexOf(t) !== -1) hit += 10;
+      if (kw.indexOf(t) !== -1) hit += 5;
+      if (group.indexOf(t) !== -1) hit += 4;
+      if (desc.indexOf(t) !== -1) hit += 2;
+      if (body.indexOf(t) !== -1) hit += 1;
+      if (hit === 0) return 0; // every term must match somewhere (AND)
+      total += hit;
+    }
+    if (title.indexOf(ts.join(' ')) === 0) total += 8; // title prefix boost
+    return total;
+  }
+
+  function render(q) {
+    var ts = terms(q);
+    results.innerHTML = '';
+    if (!ts.length) {
+      status.textContent = index ? 'Type to search ' + index.length + ' pages.' : '';
+      return;
+    }
+    if (!index) { status.textContent = 'Loading the search index…'; return; }
+
+    var hits = [];
+    for (var i = 0; i < index.length; i++) {
+      var s = score(index[i], ts);
+      if (s > 0) hits.push({ s: s, item: index[i] });
+    }
+    hits.sort(function (a, b) {
+      return b.s - a.s || a.item.title.localeCompare(b.item.title);
+    });
+
+    if (!hits.length) {
+      status.textContent = 'No results for “' + q + '”. Try a broader term.';
+      return;
+    }
+    status.textContent = hits.length + (hits.length === 1 ? ' result' : ' results') + ' for “' + q + '”';
+
+    var frag = document.createDocumentFragment();
+    hits.slice(0, 40).forEach(function (h) {
+      var li = document.createElement('li');
+      li.className = 'search-result';
+      var groupHtml = h.item.group
+        ? '<span class="search-result__group">' + esc(h.item.group) + '</span>'
+        : '';
+      li.innerHTML =
+        '<a class="search-result__link" href="' + esc(h.item.url) + '">' +
+          '<span class="search-result__title">' + highlight(h.item.title, ts) + '</span>' +
+          groupHtml +
+          '<span class="search-result__excerpt">' + highlight(snippet(h.item, ts), ts) + '</span>' +
+        '</a>';
+      frag.appendChild(li);
+    });
+    results.appendChild(frag);
+  }
+
+  function getQ() {
+    var m = location.search.match(/[?&]q=([^&]*)/);
+    return m ? decodeURIComponent(m[1].replace(/\+/g, ' ')) : '';
+  }
+
+  function onInput() {
+    var q = input.value.trim();
+    if (pending) clearTimeout(pending);
+    pending = setTimeout(function () {
+      render(q);
+      var url = q ? '?q=' + encodeURIComponent(q) : location.pathname;
+      try { history.replaceState(null, '', url); } catch (e) {}
+    }, 120);
+  }
+
+  input.addEventListener('input', onInput);
+
+  // Load the index, then run any ?q= already in the URL.
+  fetch('/search.json', { credentials: 'same-origin' })
+    .then(function (r) { return r.json(); })
+    .then(function (data) {
+      index = data;
+      var q = getQ();
+      if (q && !input.value) input.value = q;
+      render(input.value.trim());
+    })
+    .catch(function () {
+      status.textContent = 'Could not load the search index. Please reload the page.';
+    });
+})();

--- a/docs/learn/analog-modulation.md
+++ b/docs/learn/analog-modulation.md
@@ -68,6 +68,13 @@ That's why FM sounds clean and is everywhere: **FM broadcast** (wide deviation,
 the digital voice systems GopherTrunk decodes. FM also has a *capture effect*: the
 strongest signal on a channel takes over, suppressing weaker ones.
 
+How wide is an FM signal? A handy estimate (Carson's rule) is *bandwidth ≈ 2 ×
+(deviation + top audio frequency)*. Narrowband two-way FM with ~2.5 kHz deviation and
+3 kHz audio works out to *2 × (2.5 + 3) = 11 kHz* — which is why it fits a 12.5 kHz
+[channel](/learn/frequency-and-spectrum/). Wide-deviation FM broadcast (~75 kHz
+deviation, 15 kHz audio) needs *2 × (75 + 15) = 180 kHz* — hence the ~200 kHz channels.
+More deviation buys better noise immunity at the cost of bandwidth.
+
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 440 170" role="img" aria-label="Three rows. A message wave on top. AM below it shown as a wave whose height follows the message. FM shown as a wave whose spacing tightens and loosens with the message." xmlns="http://www.w3.org/2000/svg">
   <text x="6" y="22" font-size="10" fill="currentColor">message</text>

--- a/docs/learn/analog-modulation.md
+++ b/docs/learn/analog-modulation.md
@@ -1,0 +1,24 @@
+---
+slug: analog-modulation
+title: Analog modulation — AM, FM, SSB
+description: The three classic analog modulations explained — amplitude modulation (AM), frequency modulation (FM), and single sideband (SSB) — how each puts voice on a carrier and where you still hear them.
+level: beginner
+status: stub
+prereq:
+  - radio-waves
+  - signal-anatomy
+---
+
+# Analog modulation — AM, FM, SSB
+
+Digital modes build on ideas first used in analog radio. This lesson covers the classics.
+
+## Amplitude modulation (AM)
+
+## Frequency modulation (FM) and deviation
+
+## Single sideband (SSB) and why it is efficient
+
+## How each sounds and looks on a waterfall
+
+## Where analog still lives today

--- a/docs/learn/analog-modulation.md
+++ b/docs/learn/analog-modulation.md
@@ -1,24 +1,133 @@
 ---
 slug: analog-modulation
 title: Analog modulation — AM, FM, SSB
-description: The three classic analog modulations explained — amplitude modulation (AM), frequency modulation (FM), and single sideband (SSB) — how each puts voice on a carrier and where you still hear them.
+description: The three classic analog modulations explained — amplitude modulation (AM), frequency modulation (FM), and single sideband (SSB). How each puts a voice on a carrier, how they sound and look on a waterfall, and where you still hear them today.
+keywords: analog modulation, AM, FM, SSB, single sideband, amplitude modulation, frequency modulation, deviation, airband AM, narrowband FM
 level: beginner
-status: stub
+status: full
 prereq:
   - radio-waves
   - signal-anatomy
+faq:
+  - q: What is the difference between AM and FM?
+    a: AM (amplitude modulation) varies the carrier's strength to carry the audio, keeping its frequency fixed. FM (frequency modulation) varies the carrier's frequency instead, keeping its strength fixed. FM is more resistant to amplitude noise (static), which is why it sounds cleaner for voice and music; AM is simpler and still used where many signals share a band, like aviation.
+  - q: Why does aviation still use AM?
+    a: Aircraft VHF airband uses AM partly for historical reasons and partly because of a useful property — when two stations transmit at once, AM lets you hear both (a "heterodyne"), so a controller notices a collision. With FM, the stronger signal would simply capture the channel and mask the weaker one.
+  - q: What is SSB and why is it efficient?
+    a: SSB (single sideband) is a refined form of AM that removes the carrier and one of the two redundant sidebands, transmitting only what's needed. That puts all the power into the information and uses about half the bandwidth, so SSB carries far over HF with modest power. The trade-off is that the receiver must be tuned precisely or the voice sounds distorted.
+  - q: How can I tell AM, FM, and SSB apart on a waterfall?
+    a: AM shows a central carrier spike with symmetric sidebands. FM is a wider block whose width depends on deviation. SSB is an offset blob of energy with no carrier spike, sitting to one side of where the carrier would be. With practice each has a recognisable footprint.
+gophertrunk_links:
+  - title: Plots (signal scopes)
+    url: /plots.html
+    note: see AM/FM/SSB footprints on the live spectrum.
+  - title: ADS-B
+    url: /adsb.html
+    note: aviation's data side, alongside the AM airband voice.
 ---
 
 # Analog modulation — AM, FM, SSB
 
-Digital modes build on ideas first used in analog radio. This lesson covers the classics.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Analog modulation puts a voice on a [carrier](/learn/signal-anatomy/) by varying one
+of its properties. **AM** varies the carrier's **amplitude** (simple, used for
+aviation and shortwave). **FM** varies its **frequency** (noise-resistant, used for
+broadcast and most analog two-way voice). **SSB** strips AM down to a single sideband
+with no carrier — half the bandwidth, all the power on the information, the backbone of
+long-distance HF voice. The same three properties — amplitude, frequency, phase —
+return as the basis of [digital modulation](/learn/digital-modulation/).
+</div>
+
+Digital modes are built on ideas first used in analog radio, so it pays to meet the
+classics. All three change the carrier in step with the audio; they differ in *which*
+property they change.
 
 ## Amplitude modulation (AM)
 
-## Frequency modulation (FM) and deviation
+In **AM**, the audio rides on the carrier's **amplitude** (strength) while its
+frequency stays put. Louder audio → bigger swings in carrier height. It's the oldest
+and simplest scheme — easy to build and easy to demodulate.
 
-## Single sideband (SSB) and why it is efficient
+Its weakness is that noise and interference are *also* amplitude variations, so AM
+picks up static readily. Yet it survives where simplicity or a special property
+matters: **shortwave broadcast** and **aviation VHF airband**. Aviation keeps AM
+partly because if two aircraft transmit at once you hear both (a beat tone), alerting
+the controller — whereas FM would let the stronger one silently mask the other.
 
-## How each sounds and looks on a waterfall
+## Frequency modulation (FM)
 
-## Where analog still lives today
+In **FM**, the audio varies the carrier's **frequency** while amplitude stays
+constant. The amount the frequency swings is the **deviation** — wider deviation
+carries louder/richer audio but uses more bandwidth.
+
+Because the information is in frequency, not amplitude, FM can **ignore amplitude
+noise** — a receiver just tracks the frequency wiggle and discards strength changes.
+That's why FM sounds clean and is everywhere: **FM broadcast** (wide deviation,
+~200 kHz wide) and **narrowband FM** two-way voice (~12.5 kHz), the analog cousin of
+the digital voice systems GopherTrunk decodes. FM also has a *capture effect*: the
+strongest signal on a channel takes over, suppressing weaker ones.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 170" role="img" aria-label="Three rows. A message wave on top. AM below it shown as a wave whose height follows the message. FM shown as a wave whose spacing tightens and loosens with the message." xmlns="http://www.w3.org/2000/svg">
+  <text x="6" y="22" font-size="10" fill="currentColor">message</text>
+  <path d="M70 20 Q120 0 170 20 T270 20 T370 20" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="6" y="78" font-size="10" fill="currentColor">AM</text>
+  <path d="M70 75 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0 q5 -12 10 0 q5 -8 10 0 q5 -12 10 0 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0 q5 -12 10 0 q5 -8 10 0 q5 -12 10 0 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="6" y="138" font-size="10" fill="currentColor">FM</text>
+  <path d="M70 135 q4 -16 8 0 q4 -16 8 0 q6 -16 12 0 q7 -16 14 0 q8 -16 16 0 q7 -16 14 0 q6 -16 12 0 q4 -16 8 0 q4 -16 8 0 q4 -16 8 0 q6 -16 12 0 q7 -16 14 0 q8 -16 16 0 q7 -16 14 0 q6 -16 12 0" fill="none" stroke="currentColor" stroke-width="1.3"/>
+</svg>
+<figcaption>AM follows the message in the wave's <em>height</em>; FM follows it in the wave's <em>spacing</em> (frequency). FM's amplitude stays constant, which is why it shrugs off static.</figcaption>
+</figure>
+
+## Single sideband (SSB)
+
+A plain AM signal is wasteful: it sends a carrier (no information) plus *two* mirror-
+image sidebands (the same information twice). **SSB** throws away the carrier and one
+sideband, transmitting just **one sideband** — either upper (USB) or lower (LSB).
+
+The payoff is big: about **half the bandwidth** and **all the power on the
+information**, so a modest SSB transmitter reaches across continents on
+[HF](/learn/frequency-and-spectrum/). That's why amateurs and long-distance services
+favour it. The cost is precision — without a carrier to lock onto, the receiver must
+be tuned exactly, or voices sound like Donald Duck.
+
+## How they look and sound
+
+| Mode | On the waterfall | Sounds like |
+|------|------------------|-------------|
+| AM | Central carrier spike + symmetric sidebands | Voice with audible static |
+| FM | A wider block (width follows deviation) | Clean voice, hiss when no signal |
+| SSB | Offset blob, no carrier spike | Clear voice only when tuned exactly |
+
+Recognising these footprints on the [spectrum and waterfall](/learn/signal-anatomy/)
+is a practical skill — it tells you what you've found before you decode it.
+
+## Where analog still lives
+
+Despite the move to digital, analog is far from gone: **FM broadcast**, **aviation AM
+airband**, **marine VHF FM**, **amateur SSB on HF**, **weather radio**, and plenty of
+legacy two-way **narrowband FM**. Many of these aren't GopherTrunk's trunked-voice
+specialty, but understanding them makes the [digital](/learn/digital-modulation/)
+versions — which vary the very same carrier properties — far easier to grasp.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — FM puts the information in frequency, so amplitude noise is ignored." markdown="0">
+  <p class="knowledge-check__q">Quick check: why does FM resist static better than AM?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses less bandwidth</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Its information is in frequency, not amplitude, so amplitude noise is discarded</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It transmits with more power</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **AM** varies amplitude — simple, static-prone, used for aviation and shortwave.
+- **FM** varies frequency — noise-resistant, used for broadcast and analog two-way.
+- **SSB** is AM with the carrier and one sideband removed — half the bandwidth, ideal
+  for long-distance HF.
+- Each has a recognisable **waterfall footprint** and sound.
+- The same amplitude/frequency/phase ideas power digital modulation next.
+
+Next: the bridge to digital — how symbol rate (baud) relates to bitrate.

--- a/docs/learn/antenna-to-audio.md
+++ b/docs/learn/antenna-to-audio.md
@@ -1,0 +1,190 @@
+---
+slug: antenna-to-audio
+title: From antenna to audio — the GopherTrunk signal path
+description: Follow one trunked-radio call end to end through GopherTrunk — antenna, SDR, IQ samples, demodulation, symbol recovery, trunking logic, vocoder, and a WAV on disk. The capstone that ties the whole RF and SDR learning path together.
+keywords: SDR signal path, how GopherTrunk works, IQ to audio, demodulation pipeline, trunked radio decoding, vocoder, control channel following, end to end SDR
+level: intermediate
+status: full
+prereq:
+  - what-is-sdr
+  - digital-modulation
+  - what-is-trunking
+faq:
+  - q: How does GopherTrunk turn a radio signal into an audio recording?
+    a: "GopherTrunk runs a pipeline: the antenna feeds an SDR that digitises spectrum into IQ samples; software filters and tunes to the control channel, demodulates its 4FSK into symbols, and decodes the trunking protocol; when a call starts, it tunes a receiver to the assigned voice channel, demodulates and decodes that, runs the vocoder frames through a speech decoder to produce audio, and writes the result to a WAV file with metadata."
+  - q: What is the role of the vocoder in the signal path?
+    a: Digital voice systems don't send raw audio — they compress speech into tiny data frames using a vocoder such as IMBE (P25) or AMBE+2 (DMR). At the end of the receive chain, GopherTrunk feeds those decoded frames into a matching vocoder to reconstruct an audible waveform you can listen to and save.
+  - q: Can GopherTrunk follow several calls at once?
+    a: Yes. By continuously decoding the control channel, GopherTrunk knows every voice-channel assignment as it happens and can task receivers to capture multiple simultaneous calls across the system, then mix or queue them for playback and recording according to your priorities.
+  - q: Where can a call be lost in the signal path?
+    a: A call can fail at any stage — too little signal above the noise floor, gain set so high the ADC clips, a tuning or clock error smearing the constellation, the wrong protocol or parameters, or encryption you can't decode. Most troubleshooting is about finding which stage in the chain broke.
+gophertrunk_links:
+  - title: Architecture
+    url: /architecture.html
+    note: the engineering view of the same pipeline described here.
+  - title: Web console
+    url: /web.html
+    note: where you watch each stage of the path happen live.
+  - title: Tuning for a clean lock
+    url: /learn/tuning-with-scopes/
+    note: diagnose which stage broke when a call doesn't decode.
+---
+
+# From antenna to audio
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+This is the capstone: one trunked call traced end to end through GopherTrunk.
+The **antenna** feeds an **SDR** that digitises spectrum into **IQ samples**.
+Software **tunes and filters** to the **control channel**, **demodulates** its
+4FSK into **symbols**, and **decodes** the trunking protocol. When a call starts,
+GopherTrunk tunes a receiver to the assigned **voice channel**, recovers its
+symbols, feeds the **vocoder** frames to a speech decoder, and writes an **audio
+file**. Every concept from the earlier lessons is one link in this chain — and
+troubleshooting is just finding which link broke.
+</div>
+
+You've met every piece on its own. Now let's assemble them. We'll follow a single
+police dispatch call from radio waves in the air to a `.wav` on your disk, naming
+the lesson behind each step so you can see how the whole path fits together.
+
+## Stage 1 — Antenna: catching the wave
+
+It starts with a **[radio wave](/learn/radio-waves/)** arriving at your antenna, which
+converts the wave's electric field back into a tiny electrical signal — typically a
+faint **[−80 to −110 dBm](/learn/decibels/)**. Antenna choice and placement set the ceiling
+for everything downstream: if the signal doesn't arrive with enough strength above
+the **noise floor**, no amount of clever software can recover it. This is why "where
+you put the antenna matters more than the radio."
+
+## Stage 2 — SDR hardware: spectrum becomes IQ
+
+The signal travels down the coax into your **[SDR](/learn/what-is-sdr/)**. There it's
+amplified, shifted down in frequency, and handed to an **analog-to-digital
+converter** that samples it millions of times a second. The output is a stream of
+**[IQ samples](/learn/iq-data/)** — pairs of numbers capturing the amplitude *and* phase of
+a whole slice of spectrum at once.
+
+Two settings rule this stage. **[Sample rate](/learn/sample-rate-nyquist/)** sets how much
+spectrum you capture in one go (and how hard the CPU works).
+**[Gain](/learn/gain-and-agc/)** sets how strong the signal is when it hits the ADC — too
+low and weak signals vanish into the noise; too high and the ADC **clips** at
+0 dBFS, spraying distortion everywhere. Getting these right is most of "setting up"
+an SDR.
+
+## Stage 3 — Tune and filter: zoom in on the control channel
+
+Now we're in software. The IQ firehose covers far more spectrum than one channel, so
+GopherTrunk **digitally tunes** to the **[control channel](/learn/what-is-trunking/)** and
+**[filters](/learn/filtering-decimation/)** away everything else, keeping just that narrow
+slice. This is the SDR equivalent of turning the dial — except it happens in code and
+can be done for several channels in parallel from the same sample stream.
+
+## Stage 4 — Demodulate: recover the symbols
+
+The isolated control-channel signal is still a modulated waveform. GopherTrunk
+**[demodulates](/learn/demodulation-pipeline/)** it — for P25 and DMR, reading the
+**[4FSK](/learn/digital-modulation/)** frequency shifts — and runs **[clock
+recovery](/learn/clock-recovery/)** to sample each **symbol** at exactly the right instant.
+This is the stage you can *watch*: the **[constellation, eye diagram, and symbol
+scope](/learn/tuning-with-scopes/)** all visualise these recovered symbols, so a smeared
+constellation here tells you the demodulator is struggling before any data is lost.
+
+## Stage 5 — Decode the trunking protocol: read the map
+
+The symbols become bits, and the bits become **control-channel messages**. Decoding
+the [trunking protocol](/learn/protocol-landscape/) is where GopherTrunk reads the system's
+running commentary: registrations, requests, and — crucially — **channel
+assignments**. The moment it sees *"talkgroup 101 → voice channel 3,"* it knows a
+call is starting and exactly where. You can watch this raw stream in the
+**[CC Activity](/cc-activity.html)** panel.
+
+## Stage 6 — Follow the call: capture the voice channel
+
+GopherTrunk now tasks a receiver to tune to **voice channel 3** and runs stages 3–5
+again on *that* channel — filter, demodulate, recover symbols, decode. Because it's
+still reading the control channel in parallel, it can follow this call *and* catch
+the next assignment elsewhere, capturing **multiple simultaneous calls** across the
+system. It's also reading the transmitting **[radio ID](/radio-ids.html)**, so the
+recording is labelled with *who* spoke, not just which talkgroup.
+
+## Stage 7 — Vocoder: frames become sound
+
+The voice channel doesn't carry audio — it carries **[vocoder](/learn/vocoders/)** frames,
+speech compressed to a few kilobits per second by a codec like **IMBE** (P25) or
+**AMBE+2** (DMR). GopherTrunk feeds those frames into a matching speech decoder,
+which **reconstructs an audible waveform**. This is the step that turns abstract bits
+back into a human voice — the [analog-vs-digital-voice](/learn/digital-voice/) trade-off in
+action.
+
+## Stage 8 — Audio out: playback and a WAV on disk
+
+Finally, the reconstructed audio is played live in the console and written to a
+**`.wav` file**, tagged with the talkgroup, radio ID, timestamp, and system. From
+here GopherTrunk can also stream it onward to services like Broadcastify or
+RdioScanner. The call that began as a faint ripple at your antenna is now a labelled
+recording you can replay — and the engine is already following the next one.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 110" role="img" aria-label="The full pipeline as a row of boxes: antenna, SDR, tune and filter, demodulate, decode protocol, follow voice, vocoder, audio file." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9.5" fill="currentColor" text-anchor="middle">
+    <g>
+      <rect x="8"   y="40" width="56" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="36" y="60">antenna</text>
+      <rect x="74"  y="40" width="56" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="102" y="60">SDR</text>
+      <rect x="140" y="40" width="56" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="168" y="57">tune/</text><text x="168" y="68">filter</text>
+      <rect x="206" y="40" width="56" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="234" y="60">demod</text>
+      <rect x="272" y="40" width="56" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="300" y="57">decode</text><text x="300" y="68">protocol</text>
+      <rect x="338" y="40" width="56" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="366" y="57">follow</text><text x="366" y="68">voice</text>
+      <rect x="404" y="40" width="56" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="432" y="60">vocoder</text>
+      <rect x="470" y="40" width="62" height="34" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="501" y="57">audio</text><text x="501" y="68">.wav</text>
+    </g>
+    <g stroke="currentColor" stroke-width="1.2">
+      <line x1="64" y1="57" x2="73" y2="57"/><line x1="130" y1="57" x2="139" y2="57"/><line x1="196" y1="57" x2="205" y2="57"/>
+      <line x1="262" y1="57" x2="271" y2="57"/><line x1="328" y1="57" x2="337" y2="57"/><line x1="394" y1="57" x2="403" y2="57"/><line x1="460" y1="57" x2="469" y2="57"/>
+    </g>
+    <text x="102" y="92" font-size="9">IQ samples →</text>
+    <text x="300" y="22" font-size="9">control channel reads the map ↑</text>
+  </g>
+</svg>
+<figcaption>The complete GopherTrunk path. Stages 3–6 run continuously on the control channel and again on each voice channel a call is assigned to.</figcaption>
+</figure>
+
+## Why this map is your best troubleshooting tool
+
+When a call *doesn't* decode, the chain tells you where to look. Walk it in order:
+
+| Symptom | Likely stage | Where to look |
+|---------|--------------|---------------|
+| Nothing at all, flat spectrum | Antenna / gain | signal below noise floor, or too little gain |
+| Spectrum looks "smeared" or distorted | SDR / gain | ADC clipping — reduce gain |
+| Control channel won't lock | Demodulate | smeared constellation, [clock/timing](/learn/clock-recovery/) |
+| Locks but no calls | Decode protocol | wrong system parameters or protocol |
+| Calls listed but silent | Vocoder / encryption | [encrypted](/learn/encryption/) talkgroup, or wrong vocoder |
+
+That's the real payoff of this whole learning path: you're no longer poking settings
+at random. You have a mental model of every stage, so you can reason about *which*
+one broke — exactly what the [calibration and
+troubleshooting](/learn/calibration-troubleshooting/) lesson builds on.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — vocoder frames are decoded into an audible waveform at the end of the chain." markdown="0">
+  <p class="knowledge-check__q">Quick check: a system is locked and calls are listed, but they play back silent. Which stage is the prime suspect?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The antenna</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The digital tuner</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The vocoder — or the talkgroup is encrypted</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A call flows: **antenna → SDR → IQ → tune/filter → demodulate → decode protocol →
+  follow voice → vocoder → audio**.
+- The **control channel** is decoded continuously so the engine knows where every
+  call goes and can follow several at once.
+- Each stage maps to an earlier lesson — this is where the whole path comes together.
+- The pipeline doubles as a **troubleshooting checklist**: find the stage that broke.
+
+You've now seen the entire chain. The remaining lessons in this module make you
+fluent at *operating* it — finding systems, tuning a clean lock, and calibrating —
+and the [glossary](/learn/glossary/) is there whenever a term needs a refresher.

--- a/docs/learn/antennas.md
+++ b/docs/learn/antennas.md
@@ -58,6 +58,13 @@ Recall *λ ≈ 300 ÷ MHz* from [lesson 1](/learn/radio-waves/): plug in the fre
 take a quarter or half. A whip cut for the band you care about will dramatically
 out-perform a random "telescopic" antenna left at the wrong length.
 
+**Worked example — sizing a whip for an 800 MHz P25 system.** Wavelength is
+*300 ÷ 800 = 0.375 m* (37.5 cm). A quarter-wave whip is a quarter of that:
+*0.375 ÷ 4 ≈ 0.094 m*, or about **9.4 cm**. (In practice you trim slightly shorter —
+roughly 95% — to account for the antenna's electrical vs. physical length, so ~9 cm.)
+That tiny stub is why 800 MHz scanner antennas are so short, and why a long telescopic
+whip left fully extended is *wrong* for this band — it's resonant somewhere far lower.
+
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 360 150" role="img" aria-label="A vertical dipole antenna: two rods, each a quarter wavelength, fed in the middle, radiating a doughnut-shaped pattern around it." xmlns="http://www.w3.org/2000/svg">
   <line x1="180" y1="20" x2="180" y2="68" stroke="currentColor" stroke-width="3"/>

--- a/docs/learn/antennas.md
+++ b/docs/learn/antennas.md
@@ -1,28 +1,150 @@
 ---
 slug: antennas
 title: Antennas 101
-description: Antenna basics for SDR — resonance and length, polarization, gain and directivity, SWR, feedline loss, and the connectors that join an antenna to your software-defined radio.
+description: Antenna basics for SDR — why length follows wavelength, resonance and bandwidth, vertical vs horizontal polarization, gain and directivity, SWR, feedline loss, and the SMA/BNC/N connectors that join an antenna to your software-defined radio.
+keywords: SDR antenna, antenna basics, dipole, antenna length wavelength, polarization, antenna gain, SWR, coax loss, SMA BNC connector, discone antenna
 level: beginner
-status: stub
+status: full
 prereq:
   - radio-waves
   - decibels
+faq:
+  - q: What size antenna do I need for a frequency?
+    a: Antenna size follows wavelength. A common design, the half-wave dipole, is about half a wavelength long; a quarter-wave whip is a quarter. Since wavelength ≈ 300 ÷ frequency-in-MHz metres, a 150 MHz antenna's quarter-wave is about 0.5 m, and a 460 MHz one about 0.16 m. Match the antenna to the band you want and it will work far better than a random whip.
+  - q: Does antenna placement matter more than the antenna itself?
+    a: Often yes. VHF and UHF are line-of-sight, so height and a clear view of the horizon usually help more than a fancier antenna. Getting the antenna outside, up high, and away from obstructions and electrical noise typically beats any upgrade you could make at the radio.
+  - q: What is SWR and why does it matter?
+    a: SWR (standing wave ratio) measures how well your antenna is matched to your radio and feedline at a given frequency. A good match (low SWR, near 1:1) means most energy is transferred; a poor match reflects energy back. For receive-only SDR use it's less critical than for transmitting, but a badly matched antenna still costs you signal.
+  - q: What connector does an RTL-SDR use?
+    a: Most RTL-SDR dongles use an SMA or MCX connector. Many antennas and adapters use SMA, BNC, or N connectors. You'll often need a small adapter to join a given antenna to your dongle. Keep adapters and coax runs short and good-quality to minimise loss.
+gophertrunk_links:
+  - title: Hardware guide
+    url: /hardware.html
+    note: antenna and dongle pairing notes for GopherTrunk.
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: compare antennas by watching live signal level and SNR.
 ---
 
 # Antennas 101
 
-The antenna sets the ceiling on everything downstream. This lesson covers just enough to choose and place one well.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The antenna sets the ceiling on everything downstream — no software can recover a
+signal the antenna never caught. Antenna **size follows wavelength** (a quarter-wave
+whip is *λ/4*), so match it to your band. **Polarization** (usually vertical for
+scanning) should match the transmitter. **Gain** trades coverage for directivity.
+**SWR** measures how well the antenna is matched, and **coax/connectors** quietly eat
+[decibels](/learn/decibels/). For VHF/UHF, *placement and height usually beat a
+fancier antenna.*
+</div>
 
-## Why antenna length follows wavelength
+You've learned what a wave is and how power is measured. The antenna is where the
+two meet: it turns waves in the air into the faint signal your [SDR](/learn/what-is-sdr/)
+digitises. Get it wrong and everything after struggles.
 
-## Resonance and bandwidth
+## Why does antenna length follow wavelength?
 
-## Polarization (vertical vs. horizontal)
+An antenna works best when its size is a specific fraction of the **wavelength** of
+the signal — because the wave's electric field has to "fit" the conductor to drive a
+strong current. Two classic designs:
 
-## Gain, directivity, and radiation patterns
+| Design | Length | 150 MHz | 460 MHz |
+|--------|--------|---------|---------|
+| Quarter-wave whip (λ/4) | a quarter wavelength | ~0.5 m | ~0.16 m |
+| Half-wave dipole (λ/2) | half a wavelength | ~1.0 m | ~0.33 m |
 
-## SWR and impedance matching
+Recall *λ ≈ 300 ÷ MHz* from [lesson 1](/learn/radio-waves/): plug in the frequency,
+take a quarter or half. A whip cut for the band you care about will dramatically
+out-perform a random "telescopic" antenna left at the wrong length.
 
-## Feedline, connectors (SMA, BNC, N), and loss
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 360 150" role="img" aria-label="A vertical dipole antenna: two rods, each a quarter wavelength, fed in the middle, radiating a doughnut-shaped pattern around it." xmlns="http://www.w3.org/2000/svg">
+  <line x1="180" y1="20" x2="180" y2="68" stroke="currentColor" stroke-width="3"/>
+  <line x1="180" y1="82" x2="180" y2="130" stroke="currentColor" stroke-width="3"/>
+  <circle cx="180" cy="75" r="3" fill="currentColor"/>
+  <text x="190" y="48" font-size="11" fill="currentColor">λ/4</text>
+  <text x="190" y="112" font-size="11" fill="currentColor">λ/4</text>
+  <ellipse cx="180" cy="75" rx="120" ry="30" fill="none" stroke="currentColor" stroke-opacity="0.4" stroke-dasharray="4 3"/>
+  <text x="250" y="75" font-size="11" fill="currentColor">radiation</text>
+</svg>
+<figcaption>A vertical half-wave dipole. It's most sensitive broadside (around it), least off the ends — which is why a vertical antenna favours signals on the horizon.</figcaption>
+</figure>
 
-## Practical picks for scanning
+## What is resonance and bandwidth?
+
+An antenna is **resonant** at the frequency its length is tuned for, where it's most
+efficient. Move away from that frequency and efficiency drops. The span over which it
+stays "good enough" is its **bandwidth**. A simple whip is fairly narrow; **broadband
+antennas** like a *discone* trade a little peak efficiency for coverage across a huge
+range — handy for scanning many bands with one antenna.
+
+## What is polarization, and why match it?
+
+**Polarization** is the orientation of the wave's electric field — set by how the
+transmitting antenna is mounted. A vertical antenna radiates **vertically polarized**
+waves; a horizontal one, horizontal. If your receive antenna's polarization doesn't
+match the transmitter's, you can lose a lot of signal (theoretically ~20 dB for a
+full mismatch).
+
+Most land-mobile and public-safety radio is **vertical**, so a vertical scanner
+antenna is the safe default. FM broadcast is often horizontal or circular.
+
+## What do gain and directivity mean?
+
+Antenna **gain** (in dBi) doesn't create energy — it *focuses* it. A high-gain
+antenna squeezes its pattern into a narrower shape, giving more signal in the favoured
+direction at the cost of coverage elsewhere:
+
+- An **omnidirectional** vertical hears all compass directions roughly equally —
+  ideal when systems surround you.
+- A **directional** antenna (Yagi) adds gain toward where it's pointed — great for
+  pulling in one distant system, useless for everything off to the side.
+
+For general trunk-tracking, omnidirectional is usually right. Reach for directional
+only when chasing a specific weak, distant system.
+
+## What is SWR and feedline loss?
+
+**SWR (standing wave ratio)** measures how well the antenna is matched to your radio
+and coax at a frequency. A good match (near 1:1) transfers most energy; a poor match
+reflects some back. For receive-only SDR it matters less than for transmitting, but a
+badly matched antenna still costs you signal.
+
+Then there's the cable. Every metre of **coax** and every **connector/adapter** eats
+a fraction of a [decibel](/learn/decibels/) — more at higher frequencies. Keep runs
+short, use decent coax, and minimise adapter stacks. A long, lossy cable can quietly
+undo a good antenna.
+
+## Connectors you'll meet
+
+| Connector | Where |
+|-----------|-------|
+| SMA | Most RTL-SDR dongles, small antennas |
+| MCX | Some RTL-SDR dongles |
+| BNC | Scanners, lab gear (quick twist-lock) |
+| N | Larger outdoor antennas, low loss |
+
+You'll often need a small **adapter** (e.g. SMA-to-BNC) to join a given antenna to
+your dongle. See the [Hardware guide](/hardware.html) for specifics.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — a quarter-wave at 150 MHz is roughly 0.5 m." markdown="0">
+  <p class="knowledge-check__q">Quick check: roughly how long is a quarter-wave whip for 150 MHz?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">About 5 cm</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">About 50 cm</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">About 5 m</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Antenna **size follows wavelength**; cut it for your band (λ/4 or λ/2).
+- **Resonance** sets the best frequency; broadband antennas (discone) cover more.
+- Match **polarization** to the transmitter — vertical for most scanning.
+- **Gain** focuses the pattern; omnidirectional for general use, directional to chase.
+- Mind **SWR** and **coax/connector loss** — and remember placement and height often
+  matter most.
+
+Next: where you put that antenna — how signals actually travel from transmitter to you.

--- a/docs/learn/antennas.md
+++ b/docs/learn/antennas.md
@@ -1,0 +1,28 @@
+---
+slug: antennas
+title: Antennas 101
+description: Antenna basics for SDR — resonance and length, polarization, gain and directivity, SWR, feedline loss, and the connectors that join an antenna to your software-defined radio.
+level: beginner
+status: stub
+prereq:
+  - radio-waves
+  - decibels
+---
+
+# Antennas 101
+
+The antenna sets the ceiling on everything downstream. This lesson covers just enough to choose and place one well.
+
+## Why antenna length follows wavelength
+
+## Resonance and bandwidth
+
+## Polarization (vertical vs. horizontal)
+
+## Gain, directivity, and radiation patterns
+
+## SWR and impedance matching
+
+## Feedline, connectors (SMA, BNC, N), and loss
+
+## Practical picks for scanning

--- a/docs/learn/calibration-troubleshooting.md
+++ b/docs/learn/calibration-troubleshooting.md
@@ -60,6 +60,33 @@ roughly constant per dongle, though it **drifts with temperature** — let the d
 up for a few minutes before calibrating. A correct PPM is exactly what cures the
 *rotating constellation* from the [tuning lesson](/learn/tuning-with-scopes/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="Two channel grids. Before correction, the received signal sits a few kHz off the channel centre between two channels. After PPM correction, it lands exactly on the channel." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <!-- before -->
+    <text x="120" y="20" font-weight="600">before — 14 kHz off</text>
+    <line x1="30" y1="90" x2="220" y2="90" stroke="currentColor" stroke-opacity="0.4"/>
+    <g stroke="currentColor" stroke-opacity="0.4"><line x1="70" y1="84" x2="70" y2="96"/><line x1="125" y1="84" x2="125" y2="96"/><line x1="180" y1="84" x2="180" y2="96"/></g>
+    <text x="125" y="110" font-size="8">channel centre</text>
+    <path d="M95 90 L101 50 L107 90 Z" fill="currentColor" fill-opacity="0.4" stroke="currentColor"/>
+    <text x="101" y="44" font-size="8">signal</text>
+    <line x1="101" y1="68" x2="124" y2="68" stroke="currentColor" stroke-dasharray="3 2"/>
+    <text x="112" y="62" font-size="7">✗ between channels</text>
+    <!-- after -->
+    <text x="400" y="20" font-weight="600">after PPM correction</text>
+    <line x1="300" y1="90" x2="490" y2="90" stroke="currentColor" stroke-opacity="0.4"/>
+    <g stroke="currentColor" stroke-opacity="0.4"><line x1="340" y1="84" x2="340" y2="96"/><line x1="395" y1="84" x2="395" y2="96"/><line x1="450" y1="84" x2="450" y2="96"/></g>
+    <text x="395" y="110" font-size="8">channel centre</text>
+    <path d="M389 90 L395 50 L401 90 Z" fill="currentColor" fill-opacity="0.4" stroke="currentColor"/>
+    <text x="395" y="44" font-size="8">signal</text>
+    <text x="395" y="130" font-size="7">✓ on channel — locks</text>
+    <line x1="225" y1="70" x2="298" y2="70" stroke="currentColor" stroke-width="1.2" marker-end="url(#pp)"/>
+  </g>
+  <defs><marker id="pp" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An uncorrected dongle lands the signal off the channel centre (here ~14 kHz at UHF) — between channels, so it won't lock. The right PPM value shifts it back onto the channel.</figcaption>
+</figure>
+
 ## Voice calibration for clean audio
 
 Once a system locks, [voice calibration](/voice-calibration.html) dials in the **decoded

--- a/docs/learn/calibration-troubleshooting.md
+++ b/docs/learn/calibration-troubleshooting.md
@@ -1,0 +1,26 @@
+---
+slug: calibration-troubleshooting
+title: Calibration & troubleshooting
+description: Calibrate and troubleshoot your SDR setup — PPM frequency correction, voice calibration, and a stage-by-stage checklist for the usual reasons a control channel will not decode.
+level: advanced
+status: stub
+prereq:
+  - antenna-to-audio
+  - gain-and-agc
+---
+
+# Calibration & troubleshooting
+
+When it will not work, this lesson helps you find the broken stage and fix it.
+
+## PPM: correcting frequency error
+
+## Voice calibration for clean audio
+
+## The troubleshooting checklist (by pipeline stage)
+
+## Common failure modes and fixes
+
+## When to suspect hardware vs. config
+
+See [Voice calibration](/voice-calibration.html) for the audio side.

--- a/docs/learn/calibration-troubleshooting.md
+++ b/docs/learn/calibration-troubleshooting.md
@@ -1,26 +1,125 @@
 ---
 slug: calibration-troubleshooting
 title: Calibration & troubleshooting
-description: Calibrate and troubleshoot your SDR setup — PPM frequency correction, voice calibration, and a stage-by-stage checklist for the usual reasons a control channel will not decode.
+description: Calibrate and troubleshoot your SDR setup — PPM frequency-error correction, voice calibration for clean audio, and a stage-by-stage checklist for the usual reasons a control channel won't decode.
+keywords: PPM correction, SDR calibration, frequency offset, voice calibration, troubleshoot SDR, control channel won't decode, no audio, SDR not working, scanner troubleshooting
 level: advanced
-status: stub
+status: full
 prereq:
   - antenna-to-audio
   - gain-and-agc
+faq:
+  - q: What is PPM correction on an SDR?
+    a: PPM (parts per million) correction compensates for the small frequency error in an SDR's reference oscillator. Cheap dongles can be off by tens of parts per million, which at UHF means the signal lands a few kHz away from where you tuned. Setting the right PPM value shifts the radio so signals appear at their true frequency, which is essential for a clean digital lock.
+  - q: How do I find the right PPM value?
+    a: Tune to a known, stable reference signal and adjust PPM until it sits exactly on its correct frequency, or use a tool that measures the offset against a known signal. Once set, the value is roughly constant for that dongle (it can drift slightly with temperature, so let the dongle warm up first).
+  - q: My control channel won't decode — what should I check?
+    a: Work the signal path in order — antenna and placement, gain (too low or clipping), frequency/PPM offset, then system parameters. Confirm there's actually signal above the noise floor, that gain isn't clipping the ADC, that PPM is correct so the signal is on frequency, and that you have the right control-channel frequency and system type. The scopes pinpoint where it breaks.
+  - q: Calls are listed but there's no audio — is that a hardware fault?
+    a: Usually not. Listed calls with no audio most often means the talkgroup is encrypted, or the wrong vocoder/voice settings, rather than a hardware problem. Check whether other talkgroups produce audio; if they do, the system and hardware are fine and the silent one is likely encrypted.
+gophertrunk_links:
+  - title: Voice calibration
+    url: /voice-calibration.html
+    note: tune decoded audio level and clarity.
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: the meters you watch while calibrating.
+  - title: Hardware guide
+    url: /hardware.html
+    note: rule out a hardware fault when config and signal check out.
 ---
 
 # Calibration & troubleshooting
 
-When it will not work, this lesson helps you find the broken stage and fix it.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Two calibrations matter most: **PPM correction** (compensating the dongle's small
+frequency error so signals land on their true frequency) and **[voice
+calibration](/voice-calibration.html)** (clean, correctly-levelled audio). When a control
+channel won't decode, **walk the [signal path](/learn/antenna-to-audio/) in order** —
+antenna/placement, gain (too low or clipping), PPM/frequency, then system parameters —
+using the [scopes](/learn/tuning-with-scopes/) to pinpoint the broken stage. And remember:
+**calls listed but silent is usually [encryption](/learn/encryption/), not a fault.**
+</div>
 
-## PPM: correcting frequency error
+This is the practical payoff of the whole path. Because you understand every
+[stage](/learn/antenna-to-audio/), you can troubleshoot by reasoning instead of guessing.
+We start with the one calibration newcomers most often miss.
+
+## PPM — correcting frequency error
+
+Every SDR has a reference oscillator, and cheap ones aren't perfectly accurate. The
+error is measured in **PPM (parts per million)**. It sounds tiny, but at UHF a 30 PPM
+error at 460 MHz is about **14 kHz** — more than a channel's width, so your signal lands
+in the wrong place and won't lock.
+
+**PPM correction** tells GopherTrunk to shift by that amount so signals appear at their
+**true frequency**. To find your value: tune to a **known, stable reference** and adjust
+PPM until it sits exactly where it should, or use a measurement tool. The value is
+roughly constant per dongle, though it **drifts with temperature** — let the dongle warm
+up for a few minutes before calibrating. A correct PPM is exactly what cures the
+*rotating constellation* from the [tuning lesson](/learn/tuning-with-scopes/).
 
 ## Voice calibration for clean audio
 
+Once a system locks, [voice calibration](/voice-calibration.html) dials in the **decoded
+audio** — levels and clarity — so recordings and live playback sound right. This is
+separate from getting a lock: a perfectly locked system can still need its audio tuned.
+Follow the [Voice calibration](/voice-calibration.html) guide for the specifics.
+
 ## The troubleshooting checklist (by pipeline stage)
+
+When something's wrong, march down the [signal path](/learn/antenna-to-audio/) — the
+failure almost always lives at one identifiable stage:
+
+| Symptom | Stage | Check |
+|---------|-------|-------|
+| Flat spectrum, nothing | Antenna / gain | Antenna connected? Up and clear? [Gain](/learn/gain-and-agc/) high enough? Signal above [noise floor](/learn/decibels/)? |
+| Smeared/distorted spectrum, ghosts | Gain | ADC **clipping** — reduce gain |
+| Signal present, constellation rotating | Frequency | Set/correct **PPM** |
+| Constellation fuzzy despite strong meter | SNR | Improve [antenna/placement](/learn/propagation/); check for nearby overload |
+| Control channel won't lock | Demod/params | Right control-channel frequency and [system type](/learn/protocol-landscape/)? |
+| Locks but no calls | Decode/params | Correct system parameters; right talkgroups not all locked out |
+| Calls listed but silent | Vocoder/encryption | Other talkgroups OK? If yes, likely **[encrypted](/learn/encryption/)** |
+
+The [scopes](/learn/tuning-with-scopes/) turn most of these from guesswork into a glance.
 
 ## Common failure modes and fixes
 
+- **Wrong PPM** → rotating constellation, no lock → calibrate PPM.
+- **Gain too high** → clipping, ghost signals → reduce gain.
+- **Gain too low / poor antenna** → buried in noise → improve SNR.
+- **Wrong control-channel frequency or system type** → no lock → re-check the
+  [system details](/learn/finding-systems/).
+- **Encrypted talkgroup** → silent calls with visible metadata → expected, not fixable.
+- **USB issues at high sample rate** → dropped samples, glitches → lower
+  [sample rate](/learn/sample-rate-nyquist/) or use a better USB port/cable.
+
 ## When to suspect hardware vs. config
 
-See [Voice calibration](/voice-calibration.html) for the audio side.
+Most problems are **configuration or signal**, not hardware. Suspect **hardware** only
+after the basics check out: try a **different USB port/cable** (power and data issues are
+common), let the dongle **warm up** (drift), test a **known-good system** to prove the
+chain, and watch for **overheating** on long runs. If a known-good system decodes
+elsewhere but not on this dongle, *then* consider the hardware. Otherwise, it's almost
+always antenna, gain, PPM, or parameters — in that order.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — PPM corrects the dongle's frequency error so signals land on frequency." markdown="0">
+  <p class="knowledge-check__q">Quick check: a strong signal shows a slowly rotating constellation and won't lock. The fix?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Increase the gain</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Set the correct PPM frequency correction</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Buy a bigger antenna</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **PPM correction** aligns the dongle to true frequency — cures rotating constellations.
+- **Voice calibration** dials in clean decoded audio, separate from getting a lock.
+- Troubleshoot by **walking the signal path**: antenna → gain → PPM → parameters.
+- **Calls listed but silent** is usually [encryption](/learn/encryption/), not a fault.
+- Suspect **hardware last**, after antenna, gain, PPM, and config check out.
+
+Last lesson: the rules and etiquette that make all of this responsible.

--- a/docs/learn/clock-recovery.md
+++ b/docs/learn/clock-recovery.md
@@ -1,23 +1,145 @@
 ---
 slug: clock-recovery
 title: Clock recovery & symbol timing
-description: Symbol timing and clock recovery explained — how a receiver finds the rhythm of a digital signal so it samples each symbol at the right instant, and what timing error does to decoding.
+description: Symbol timing and clock recovery explained — how a receiver finds the rhythm of a digital signal so it samples each symbol at the right instant, why timing error closes the eye diagram, and what loss of symbol lock looks like in GopherTrunk.
+keywords: clock recovery, symbol timing, symbol synchronization, timing error, eye diagram, symbol clock, timing recovery loop, symbol lock, digital demodulation
 level: advanced
-status: stub
+status: full
 prereq:
   - demodulation-pipeline
+faq:
+  - q: What is clock recovery in a digital receiver?
+    a: Clock recovery is the process of working out the exact timing of a digital signal's symbols from the signal itself, since the transmitter's clock isn't shared with the receiver. Once recovered, the receiver knows when each symbol starts and can sample it at its centre, where the value is clearest. Without it, the receiver wouldn't know where one symbol ends and the next begins.
+  - q: Why does symbol timing matter so much?
+    a: A digital symbol is only a clean, distinct value for a brief instant at its centre. Sample too early or too late and you catch the transition between symbols, where the value is ambiguous, causing errors. Good symbol timing samples right at the centre of each symbol, where the eye diagram is most open and the decision is easiest.
+  - q: What does the eye diagram have to do with clock recovery?
+    a: The eye diagram shows the demodulated signal overlaid over one symbol period; the open part of the "eye" is where sampling gives a clear value. Clock recovery aims to sample at the widest point of the eye. If timing drifts, the sampling point moves off-centre and the eye appears to close, which is a visible sign of timing trouble.
+  - q: What happens when clock recovery loses lock?
+    a: When the receiver can't track the symbol timing — usually because the signal is too weak, noisy, or smeared by multipath — symbols are sampled at the wrong moments and bit errors climb past what error correction can fix. In practice the decode breaks up or drops, and GopherTrunk's symbol-based scopes show a collapsing, unstable pattern.
+gophertrunk_links:
+  - title: Eye diagram
+    url: /eye-diagram.html
+    note: watch the eye open or close as timing locks or drifts.
+  - title: Symbol scope
+    url: /symbol-scope.html
+    note: see recovered symbols — steady when locked, jittery when not.
 ---
 
 # Clock recovery & symbol timing
 
-The receiver has to find the beat of the signal before it can read the symbols. Here is how.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The transmitter never sends its clock, so the receiver must **recover the symbol
+timing from the signal itself** — that's **clock recovery**. It matters because a
+[symbol](/learn/digital-modulation/) is only a clean value for an instant at its
+**centre**; sampling off-centre catches the ambiguous transitions and causes errors.
+Clock recovery aims to sample at the **widest point of the [eye
+diagram](/learn/digital-modulation/)**. When the signal is too weak or smeared, timing
+loses lock, the eye **closes**, and the decode breaks up — visible in GopherTrunk's
+symbol scope and eye diagram.
+</div>
+
+This is the timing trick at the heart of stage 4 of the
+[demodulation pipeline](/learn/demodulation-pipeline/). It's why a signal with plenty of
+strength can still fail to decode — and why the scopes are such powerful diagnostic
+tools.
 
 ## Why symbol timing matters
 
+A digital signal carries one [symbol](/learn/digital-modulation/) after another at a
+fixed [symbol rate](/learn/symbols-and-baud/). But each symbol is only a clean, distinct
+value for a **brief instant at its centre**. Between symbols, the signal *transitions*
+from one value to the next, passing through ambiguous in-between levels.
+
+The receiver therefore has to sample **right at the centre** of every symbol. Sample a
+little early or late and you catch a transition instead of a symbol, reading a value
+that's neither one thing nor the other — an error. At 4800 [baud](/learn/symbols-and-baud/),
+those instants are about 200 microseconds apart, and the receiver must hit each one.
+
 ## The clock-recovery problem
+
+Here's the catch: the transmitter and receiver run on **separate clocks**, and the
+transmitter doesn't send a "tick here" signal. The receiver only has the incoming
+waveform. So it must **deduce the symbol timing from the signal itself** — figuring out
+the rhythm purely from where the signal's transitions fall.
+
+Worse, the two clocks drift slightly relative to each other, so the timing isn't a
+one-time guess — it has to be **continuously tracked**.
 
 ## How a receiver locks to the symbol rate
 
+A **timing-recovery loop** solves it. In essence the receiver:
+
+1. Makes an initial estimate of the symbol period (it knows the nominal
+   [baud](/learn/symbols-and-baud/)).
+2. Watches where the signal's **transitions** actually occur — transitions should fall
+   *between* symbols, so their position reveals whether the current sampling point is
+   early or late.
+3. **Nudges** the sampling instant to keep it centred, repeating forever to track drift.
+
+When this loop has settled onto the right rhythm, the receiver has **symbol lock** —
+it's sampling each symbol at its centre, and the symbols come out clean.
+
 ## Timing error and the eye diagram
 
+The [eye diagram](/learn/digital-modulation/) makes timing visible. It overlays many
+symbol periods so the open "eyes" between levels stack up. The **centre of the eye is
+the widest, clearest place to sample**:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 150" role="img" aria-label="An eye diagram with an open eye shape. A vertical dashed line at the centre marks the ideal sampling instant where the eye is widest; arrows show that sampling off to the side hits the narrow, closing part." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" stroke-opacity="0.8">
+    <path d="M40 30 C120 30 120 120 200 120 C280 120 280 30 360 30"/>
+    <path d="M40 120 C120 120 120 30 200 30 C280 30 280 120 360 120"/>
+    <path d="M40 30 C120 30 120 120 200 120"/>
+    <path d="M200 30 C280 30 280 120 360 120"/>
+  </g>
+  <line x1="200" y1="20" x2="200" y2="130" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="200" y="146" text-anchor="middle" font-size="10" fill="currentColor">sample here (eye widest)</text>
+  <text x="70" y="18" font-size="10" fill="currentColor">off-centre = errors →</text>
+</svg>
+<figcaption>Clock recovery aims the sampling instant at the centre of the eye. If timing drifts off-centre, the usable opening shrinks and bit errors rise.</figcaption>
+</figure>
+
+If timing drifts off-centre, the effective opening shrinks — the eye appears to
+**close** — and decisions get error-prone even though the signal strength hasn't
+changed. A closing eye is therefore a direct, visual symptom of a timing (or noise)
+problem.
+
 ## What loss of lock looks like in GopherTrunk
+
+When the signal is too weak, too noisy, or smeared by [multipath](/learn/propagation/),
+the timing loop can't keep up and **loses lock**. Symbols get sampled at the wrong
+moments, bit errors outrun [error correction](/learn/demodulation-pipeline/), and the
+decode breaks up or drops out. On the scopes you'll see it clearly:
+
+- The **[eye diagram](/eye-diagram.html)** closes and blurs.
+- The **[symbol scope](/symbol-scope.html)** goes from steady, well-separated levels to
+  a jittery, collapsing mess.
+- The **[constellation](/constellation.html)** smears or rotates.
+
+Recognising these is the core skill of [tuning for a clean
+lock](/learn/tuning-with-scopes/) — often the fix is more SNR (better antenna/placement,
+right [gain](/learn/gain-and-agc/)) so the timing loop has a clean signal to track.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — sample at the centre of the eye, where the symbol value is clearest." markdown="0">
+  <p class="knowledge-check__q">Quick check: where should the receiver sample each symbol?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">At the transition between symbols</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">At the centre of the symbol, where the eye is widest</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It doesn't matter when</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The transmitter's clock isn't shared, so the receiver must **recover symbol timing**
+  from the signal.
+- Sample at the **symbol centre** (widest eye); off-centre sampling causes errors.
+- A **timing-recovery loop** tracks the rhythm and follows clock drift.
+- **Losing lock** closes the eye and breaks the decode — visible on GopherTrunk's scopes.
+- The usual cure is more **SNR** so the loop has a clean signal.
+
+That completes Module 4. Next module reaches the systems GopherTrunk was built for —
+starting with why voice went digital.

--- a/docs/learn/clock-recovery.md
+++ b/docs/learn/clock-recovery.md
@@ -1,0 +1,23 @@
+---
+slug: clock-recovery
+title: Clock recovery & symbol timing
+description: Symbol timing and clock recovery explained — how a receiver finds the rhythm of a digital signal so it samples each symbol at the right instant, and what timing error does to decoding.
+level: advanced
+status: stub
+prereq:
+  - demodulation-pipeline
+---
+
+# Clock recovery & symbol timing
+
+The receiver has to find the beat of the signal before it can read the symbols. Here is how.
+
+## Why symbol timing matters
+
+## The clock-recovery problem
+
+## How a receiver locks to the symbol rate
+
+## Timing error and the eye diagram
+
+## What loss of lock looks like in GopherTrunk

--- a/docs/learn/clock-recovery.md
+++ b/docs/learn/clock-recovery.md
@@ -66,6 +66,13 @@ the rhythm purely from where the signal's transitions fall.
 Worse, the two clocks drift slightly relative to each other, so the timing isn't a
 one-time guess — it has to be **continuously tracked**.
 
+How much drift? A cheap dongle's clock might be off by **20 ppm** — 20 parts per
+million. At 4800 [baud](/learn/symbols-and-baud/) that's only about 0.1 symbol of slip
+per second, which sounds negligible. But a digital frame is thousands of symbols long,
+so left uncorrected the sampling point would wander right out of the symbol within a
+fraction of a second and the decode would collapse. That's why clock recovery is a
+*loop* that nudges constantly, not a one-time measurement.
+
 ## How a receiver locks to the symbol rate
 
 A **timing-recovery loop** solves it. In essence the receiver:

--- a/docs/learn/decibels.md
+++ b/docs/learn/decibels.md
@@ -183,6 +183,28 @@ dB over a few kilometres) and **antenna gain** (a directional antenna concentrat
 energy, adding several dB in its favoured direction). Master this and you can
 predict, roughly, whether a system will be receivable before you ever tune to it.
 
+### Worked example: "will I hear it?"
+
+Put it all together. A repeater transmits **+47 dBm** (about 50 W). You're far
+enough away that **path loss** is **−120 dB**. Your antenna adds **+3 dB**, but coax
+and connectors cost **−4 dB**. Just add them up:
+
+```
+  +47 dBm   transmitter power
+  -120 dB   path loss
+   +3 dB    antenna gain
+   -4 dB    feedline + connector loss
+  ----------
+  -74 dBm   signal at the SDR
+```
+
+Now compare against the **noise floor**. If yours is around **−100 dBm**, your
+**SNR ≈ −74 − (−100) = 26 dB** — comfortably above what any digital voice mode
+needs, so it'll decode cleanly. Drop to a worse antenna (−74 → say −90 dBm signal)
+and SNR falls to 10 dB — still workable, but closer to the edge. This back-of-the-
+envelope sum, done entirely in decibels, is exactly how you reason about whether a
+system is worth chasing and what a better antenna or location would buy you.
+
 <div class="knowledge-check" data-quiz data-correct-msg="Exactly — +20 dB is two 10x steps, so 100x the power." markdown="0">
   <p class="knowledge-check__q">Quick check: how much more power is −60 dBm than −80 dBm?</p>
   <ul class="quiz__options">

--- a/docs/learn/decibels.md
+++ b/docs/learn/decibels.md
@@ -1,0 +1,207 @@
+---
+slug: decibels
+title: Decibels & signal power
+description: Understand decibels for radio — dB, dBm, and dBFS explained simply. Learn gain, path loss, the noise floor, signal-to-noise ratio, and why every SDR measurement lives in logarithms.
+keywords: decibels, dB, dBm, dBFS, signal power, noise floor, SNR, signal to noise ratio, gain, path loss, RF power
+level: beginner
+status: full
+prereq:
+  - radio-waves
+faq:
+  - q: What is the difference between dB, dBm, and dBFS?
+    a: "dB is a ratio between two powers — it expresses a change, like \"6 dB of gain.\" dBm is an absolute power referenced to one milliwatt, so it names an actual signal strength, like \"-95 dBm.\" dBFS is decibels relative to digital full scale, used inside the SDR to describe how close a sample is to clipping the analog-to-digital converter; 0 dBFS is the maximum and real signals sit below it as negative numbers."
+  - q: Why does radio use decibels instead of plain numbers?
+    a: Radio signals span an enormous range — a strong local signal can be a trillion times more powerful than the faint one you're straining to hear. Decibels compress that range with a logarithm, so instead of writing 0.000000000001 watts you write a tidy -90 dBm. Logarithms also turn the multiplication of gains and losses along a signal path into simple addition.
+  - q: What is the noise floor?
+    a: The noise floor is the background level of random RF energy and receiver noise that's always present, measured in dBm. A signal must rise above the noise floor to be usable. The gap between your signal and the noise floor is the signal-to-noise ratio (SNR), and digital modes need a minimum SNR to decode cleanly.
+  - q: Is a signal of -80 dBm stronger or weaker than -100 dBm?
+    a: -80 dBm is stronger. Because these are negative numbers, the one closer to zero is larger. -80 dBm is 100 times (20 dB) more powerful than -100 dBm. A useful rule — every 10 dB is a 10x change in power, and every 3 dB is roughly a doubling or halving.
+gophertrunk_links:
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: read live power, noise floor, and SNR while you tune a control channel.
+  - title: Gain, AGC & avoiding overload
+    url: /learn/gain-and-agc/
+    note: set gain by watching dBFS so you don't clip the ADC.
+---
+
+# Decibels & signal power
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **decibel (dB)** is a logarithmic way to express a ratio of power. **dBm** pins
+that ratio to a real reference (1 milliwatt) so it names an absolute signal
+strength; **dBFS** does the same against a digital maximum inside your SDR. Radio
+uses decibels because signals span a trillion-to-one range and logarithms make
+that manageable — and because gains and losses along a path simply **add up**.
+The numbers that matter most: every **10 dB = 10× power**, every **3 dB ≈ 2×**,
+and a signal is only usable when it sits well above the **noise floor**.
+</div>
+
+Decibels trip up almost every newcomer, because they're negative, logarithmic, and
+come in confusing flavours. Spend ten minutes here and they'll click — after which
+GopherTrunk's signal meters turn from noise into a clear story about whether a
+signal is good enough to decode.
+
+## Why does radio measure everything in decibels?
+
+The signals you care about cover an absurd dynamic range. A handheld radio across
+the street might deliver a billion times more power to your antenna than a repeater
+on a distant hilltop. Writing those values in watts means juggling numbers like
+`0.000000000002` — error-prone and unreadable.
+
+A **decibel** solves this by taking the *logarithm* of the ratio between two powers:
+
+> **dB = 10 × log₁₀(P₁ ÷ P₂)**
+
+The logarithm squashes that trillion-to-one span into a friendly range of about
+120 units. Two consequences fall out of this and they're the whole reason engineers
+love decibels:
+
+1. **Multiplication becomes addition.** An amplifier that multiplies power by 4 and
+   a cable that cuts it in half become "+6 dB" and "-3 dB" — you just add them:
+   net +3 dB. Tracing a signal through a chain of gains and losses is arithmetic you
+   can do in your head.
+2. **It matches how we perceive change.** A 10× jump in power "feels" like one step,
+   whether you're going from weak to medium or medium to strong.
+
+## What do the magic numbers 3 dB and 10 dB mean?
+
+You don't need a calculator for most day-to-day decibel thinking — just two
+anchors:
+
+| Change in dB | Change in power | Mnemonic |
+|--------------|-----------------|----------|
+| +3 dB | ×2 (double) | "3 to double" |
+| −3 dB | ÷2 (half) | |
+| +10 dB | ×10 | "10 for ten-fold" |
+| +20 dB | ×100 | |
+| +30 dB | ×1000 | |
+
+Combine them: +13 dB is ×10 then ×2 = ×20. −6 dB is half and half again = ¼. This
+mental arithmetic is enough to reason about almost any antenna, amplifier, or cable
+spec you'll meet.
+
+## What is dBm, and how is it different from dB?
+
+Plain **dB** is only a *ratio* — it tells you about a change, not an actual level.
+"This amplifier gives 15 dB of gain" says nothing about how strong the output is
+until you know the input.
+
+**dBm** fixes a reference: it's decibels relative to **1 milliwatt**. That turns it
+into an absolute unit of power, so it can name a real signal strength on its own:
+
+| dBm | Power | Typical meaning |
+|-----|-------|-----------------|
+| 0 dBm | 1 mW | A reference point |
+| −30 dBm | 1 µW | A very strong received signal |
+| −80 dBm | 10 pW | A solid, easy-to-decode signal |
+| −100 dBm | 0.1 pW | A weak signal, near many noise floors |
+| −120 dBm | 1 fW | Often buried in the noise |
+
+Two things to internalise. First, **received signals are negative** — they're tiny
+fractions of a milliwatt. Second, **closer to zero is stronger**: −80 dBm beats
+−100 dBm by 20 dB, which is 100× the power.
+
+<div class="calc" data-calc="db" markdown="0">
+  <p class="calc__title">Power ↔ dBm converter</p>
+  <div class="calc__row">
+    <label for="db-w">Power (watts)</label>
+    <input id="db-w" type="number" data-watts value="0.001" min="0" step="any" inputmode="decimal">
+  </div>
+  <div class="calc__row">
+    <label for="db-dbm">Power (dBm)</label>
+    <input id="db-dbm" type="number" data-dbm step="any" inputmode="decimal">
+  </div>
+  <p class="calc__note">Edit either field. 1 W = 30 dBm; 1 mW = 0 dBm; a 5 W handheld transmits at +37 dBm.</p>
+</div>
+
+## What is the noise floor, and why does it decide what you can hear?
+
+No receiver sees pure silence. There's always a background hiss — thermal noise in
+the electronics plus random RF energy from the environment. That background level
+is the **noise floor**, and like signal strength it's measured in dBm (often around
+−110 to −90 dBm for an SDR, depending on bandwidth and surroundings).
+
+A signal is only useful if it pokes up *above* the noise floor. The gap between the
+two is the **signal-to-noise ratio (SNR)**, measured in dB:
+
+> **SNR (dB) = signal level (dBm) − noise floor (dBm)**
+
+A signal at −85 dBm with a noise floor at −105 dBm has 20 dB of SNR — plenty.
+Digital voice modes each need a minimum SNR to decode; drop below it and the
+decoder starts dropping symbols and you get gaps or silence. This is why, in
+GopherTrunk's [tuning meters](/tuning.html), you watch not just the raw signal but
+how far it stands above the noise.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 180" role="img" aria-label="A spectrum plot with a noisy baseline labelled noise floor and a tall peak labelled signal, with the gap between them labelled SNR." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="150" x2="500" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="40" y1="20" x2="40" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="14" y="28" font-size="11" fill="currentColor">dBm</text>
+  <path d="M40 120 L70 124 L100 116 L130 122 L160 118 L185 119 L210 121 L240 117 L300 120 L340 118 L400 121 L450 117 L500 120" fill="none" stroke="currentColor" stroke-width="1.5" stroke-opacity="0.6"/>
+  <line x1="40" y1="120" x2="500" y2="120" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.5"/>
+  <text x="360" y="135" font-size="11" fill="currentColor">noise floor</text>
+  <path d="M250 120 L262 50 L274 120 Z" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.5"/>
+  <text x="262" y="44" text-anchor="middle" font-size="11" fill="currentColor">signal</text>
+  <line x1="295" y1="50" x2="295" y2="120" stroke="currentColor" stroke-width="1.5"/>
+  <text x="302" y="88" font-size="12" fill="currentColor">SNR</text>
+</svg>
+<figcaption>SNR is the height of the signal above the noise floor. Below a mode's minimum SNR, the decoder can't recover the bits.</figcaption>
+</figure>
+
+## What is dBFS, and where does it show up?
+
+Inside the SDR, after the antenna signal is digitised, levels are measured against
+the maximum number the **analog-to-digital converter (ADC)** can represent. That
+scale is **dBFS** — decibels relative to **full scale**. Here **0 dBFS is the
+ceiling**, and every real sample sits below it as a negative number, like −12 dBFS.
+
+dBFS matters for one practical reason: if a signal (or the sum of all signals in
+your bandwidth) reaches 0 dBFS, the ADC **clips** — it can't go higher, so the
+waveform is flattened and distortion sprays across the spectrum, wrecking nearby
+decodes. The fix is setting **[gain](/learn/gain-and-agc/)** so strong signals peak
+comfortably below 0 dBFS. dBm describes the world outside the radio; dBFS describes
+the digital world inside it.
+
+## How do gain and path loss add up along a signal path?
+
+Here's where decibels pay off. Walk a signal from antenna to decoder and every
+stage is just a number you add:
+
+```
+  -70 dBm   antenna picks up the signal
+  +20 dB    low-noise amplifier (LNA)
+   -2 dB    coax cable loss
+  ----------
+  -52 dBm   at the SDR input
+```
+
+No multiplying microwatts — just running addition. The same logic covers **path
+loss** (the signal weakening as it spreads from the transmitter, which can be 100+
+dB over a few kilometres) and **antenna gain** (a directional antenna concentrating
+energy, adding several dB in its favoured direction). Master this and you can
+predict, roughly, whether a system will be receivable before you ever tune to it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Exactly — +20 dB is two 10x steps, so 100x the power." markdown="0">
+  <p class="knowledge-check__q">Quick check: how much more power is −60 dBm than −80 dBm?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">2× the power</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">20× the power</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">100× the power</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **dB** is a logarithmic *ratio* of power; **+10 dB = ×10**, **+3 dB ≈ ×2**.
+- **dBm** is absolute power vs. 1 mW; received signals are negative, and closer to
+  zero is stronger.
+- **dBFS** is the digital scale inside the SDR; 0 dBFS is the clipping ceiling.
+- The **noise floor** sets the bar a signal must clear; **SNR** is how far it clears
+  it, and decoders need a minimum.
+- Gains and losses along a path **add**, which is the whole point of decibels.
+
+Next, we'll look at how the spectrum is divided into bands — and then start putting
+information *onto* these waves with modulation.

--- a/docs/learn/demodulation-pipeline.md
+++ b/docs/learn/demodulation-pipeline.md
@@ -1,0 +1,28 @@
+---
+slug: demodulation-pipeline
+title: The demodulation pipeline
+description: The SDR demodulation pipeline stage by stage — tune, filter, demodulate, recover symbols, and decode — the chain that turns IQ samples into usable bits.
+level: advanced
+status: stub
+prereq:
+  - filtering-decimation
+  - digital-modulation
+---
+
+# The demodulation pipeline
+
+A map of the stages every signal passes through inside an SDR decoder.
+
+## The pipeline overview
+
+## Stage 1: digital tuning
+
+## Stage 2: channel filtering and decimation
+
+## Stage 3: demodulation (FM/FSK/PSK)
+
+## Stage 4: symbol recovery
+
+## Stage 5: framing and decoding
+
+## How GopherTrunk runs many pipelines at once

--- a/docs/learn/demodulation-pipeline.md
+++ b/docs/learn/demodulation-pipeline.md
@@ -126,6 +126,19 @@ plus each active [voice channel](/learn/antenna-to-audio/) — and runs them con
 One radio, many simultaneous decodes. The [Architecture](/architecture.html) page shows
 how this is wired in practice.
 
+Notice how the **data rate collapses** as you move down the pipeline — which is why the
+expensive early stages are shared and the cheap late stages are many:
+
+| Stage | Roughly how much data |
+|-------|-----------------------|
+| Raw IQ in | ~2.4 M complex samples/s (the whole band) |
+| After filter + decimate | ~24 k samples/s (one channel) |
+| After symbol recovery | 4800 symbols/s |
+| After decode | 9600 bits/s, then a handful of [vocoder](/learn/vocoders/) frames |
+
+A million-to-one reduction from antenna to message — each stage throwing away what the
+next doesn't need.
+
 <div class="knowledge-check" data-quiz data-correct-msg="Right — demodulation recovers the waveform; decoding interprets the resulting bits." markdown="0">
   <p class="knowledge-check__q">Quick check: which stage applies forward error correction and extracts the message?</p>
   <ul class="quiz__options">

--- a/docs/learn/demodulation-pipeline.md
+++ b/docs/learn/demodulation-pipeline.md
@@ -1,28 +1,147 @@
 ---
 slug: demodulation-pipeline
 title: The demodulation pipeline
-description: The SDR demodulation pipeline stage by stage — tune, filter, demodulate, recover symbols, and decode — the chain that turns IQ samples into usable bits.
+description: The SDR demodulation pipeline stage by stage — digital tuning, channel filtering and decimation, demodulation of FM/FSK/PSK, symbol recovery, and framing and decoding — the chain that turns IQ samples into usable bits and audio.
+keywords: demodulation pipeline, SDR signal chain, digital tuning, channel filter, demodulation, symbol recovery, framing, FEC decoding, DSP pipeline
 level: advanced
-status: stub
+status: full
 prereq:
   - filtering-decimation
   - digital-modulation
+faq:
+  - q: What are the stages of an SDR demodulation pipeline?
+    a: A typical pipeline has five stages — digital tuning to shift the wanted channel to centre, channel filtering and decimation to isolate it at a low sample rate, demodulation to recover the modulating information (FM, FSK, or PSK), symbol recovery to time and slice that into symbols, and framing and decoding to turn symbols into error-corrected bits and finally usable data or audio.
+  - q: What is the difference between demodulation and decoding?
+    a: Demodulation recovers the raw modulating signal from the carrier — for example turning frequency shifts back into a stream of levels. Decoding is the later step that interprets the resulting symbols and bits — finding frame boundaries, applying error correction, and extracting the actual message. Demodulation deals with the waveform; decoding deals with the data.
+  - q: Why does each channel need its own pipeline?
+    a: Each signal you follow needs to be individually tuned, filtered, demodulated, and decoded. Because the SDR captures a wide block of spectrum as shared IQ, software can run a separate pipeline per channel from that one stream — which is how a single radio can decode a control channel and several voice channels simultaneously.
+  - q: Where in the pipeline do most decode failures happen?
+    a: Usually at demodulation and symbol recovery, when the signal is too weak or smeared for the symbols to be told apart cleanly, or at decoding when error correction can no longer fix the resulting bit errors. The constellation and eye-diagram views show problems at the demod/symbol stage before the failure reaches the decoded output.
+gophertrunk_links:
+  - title: Architecture
+    url: /architecture.html
+    note: GopherTrunk's real pipeline, end to end.
+  - title: Status
+    url: /status.html
+    note: the decoders this pipeline feeds, and their coverage.
 ---
 
 # The demodulation pipeline
 
-A map of the stages every signal passes through inside an SDR decoder.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Turning [IQ samples](/learn/iq-data/) into usable bits is a five-stage **pipeline**:
+**(1) digital tuning** shifts your channel to centre; **(2) filter + decimate**
+isolates it cheaply; **(3) demodulation** recovers the modulating signal (FM/FSK/PSK);
+**(4) symbol recovery** times and slices it into [symbols](/learn/digital-modulation/);
+**(5) framing + decoding** applies error correction and extracts the message.
+*Demodulation* handles the waveform; *decoding* handles the data. One shared IQ stream
+feeds **one pipeline per channel**, which is how GopherTrunk tracks many calls at once.
+</div>
+
+You've met the pieces — [IQ](/learn/iq-data/), [modulation](/learn/digital-modulation/),
+[filtering](/learn/filtering-decimation/). This lesson assembles them into the chain that
+every signal passes through inside an SDR decoder. It's the detailed version of the
+[antenna-to-audio](/learn/antenna-to-audio/) story.
 
 ## The pipeline overview
 
-## Stage 1: digital tuning
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 90" role="img" aria-label="Five boxes left to right: digital tuning, filter and decimate, demodulate, symbol recovery, frame and decode, with IQ in on the left and bits out on the right." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="22" y="48">IQ →</text>
+    <rect x="44" y="30" width="78" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="83" y="44">1 · digital</text><text x="83" y="55">tuning</text>
+    <rect x="134" y="30" width="86" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="177" y="44">2 · filter +</text><text x="177" y="55">decimate</text>
+    <rect x="232" y="30" width="80" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="272" y="50">3 · demod</text>
+    <rect x="324" y="30" width="86" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="367" y="44">4 · symbol</text><text x="367" y="55">recovery</text>
+    <rect x="422" y="30" width="82" height="34" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="463" y="44">5 · frame +</text><text x="463" y="55">decode</text>
+    <text x="520" y="48">→ bits</text>
+    <g stroke="currentColor" stroke-width="1.1">
+      <line x1="122" y1="47" x2="133" y2="47"/><line x1="220" y1="47" x2="231" y2="47"/><line x1="312" y1="47" x2="323" y2="47"/><line x1="410" y1="47" x2="421" y2="47"/>
+    </g>
+  </g>
+</svg>
+<figcaption>The five stages every channel passes through. The first two are the front-end DSP; the last three turn a waveform into a message.</figcaption>
+</figure>
 
-## Stage 2: channel filtering and decimation
+## Stage 1 — Digital tuning
 
-## Stage 3: demodulation (FM/FSK/PSK)
+The captured [IQ](/learn/iq-data/) covers a whole band, but your channel sits somewhere
+off-centre. **Digital tuning** multiplies the IQ by a rotating tone to **shift your
+channel down to zero frequency** (baseband), so the next stage's simple low-pass filter
+can isolate it. It's the software equivalent of fine-tuning the dial — and, unlike
+hardware, you can do it for many channels at once from the same samples.
 
-## Stage 4: symbol recovery
+## Stage 2 — Channel filtering and decimation
 
-## Stage 5: framing and decoding
+With the channel centred, a **channel filter** keeps just its narrow bandwidth and
+rejects neighbours and noise; **decimation** then drops the sample rate to suit that
+narrow signal. This is the [filtering & decimation](/learn/filtering-decimation/) step,
+and it's what makes the rest cheap enough to run in parallel.
+
+## Stage 3 — Demodulation
+
+Now the channel is isolated at a manageable rate, **demodulation** recovers the
+*modulating signal* from the carrier, according to the
+[modulation type](/learn/digital-modulation/):
+
+- **FM/FSK** — track the instantaneous frequency; for 4FSK (P25/DMR) the output is a
+  stream of four levels.
+- **PSK** — track the phase angle of each [IQ](/learn/iq-data/) sample.
+
+The output isn't symbols yet — it's a continuous, noisy stream that *contains* the
+symbols. This is the stage the [constellation](/constellation.html) visualises.
+
+## Stage 4 — Symbol recovery
+
+The demodulated stream has to be sliced into discrete [symbols](/learn/digital-modulation/)
+at exactly the right instants. That requires knowing the signal's rhythm —
+**[clock recovery](/learn/clock-recovery/)** — so the decoder samples each symbol at its
+centre, where the [eye diagram](/learn/digital-modulation/) is most open. Get the timing
+right and the four levels resolve into clean symbols; get it wrong and symbols smear
+into their neighbours.
+
+## Stage 5 — Framing and decoding
+
+Symbols become **bits**, but raw bits aren't the message. **Framing** finds where
+packets begin (using known sync patterns), and **decoding** applies **forward error
+correction (FEC)** to fix the inevitable bit errors, then extracts the payload — a
+[control-channel message](/learn/what-is-trunking/), or [vocoder](/learn/vocoders/) frames
+for voice. *Demodulation gave us a waveform; decoding gives us meaning.*
+
+## Demodulation vs. decoding, and where failures live
+
+It's worth nailing the distinction: **demodulation** works on the *waveform* (stages
+3–4), **decoding** works on the *data* (stage 5). Most failures show up at the boundary
+— a signal too weak or smeared for symbol recovery produces bit errors that FEC can't
+fix. Because the [constellation and eye diagram](/learn/tuning-with-scopes/) watch stage
+3–4, they warn you *before* the decoded output fails, which is what makes them such good
+[tuning tools](/learn/tuning-with-scopes/).
 
 ## How GopherTrunk runs many pipelines at once
+
+Since every stage is arithmetic on the shared [IQ stream](/learn/iq-data/), GopherTrunk
+instantiates **one pipeline per channel** — the [control channel](/learn/what-is-trunking/)
+plus each active [voice channel](/learn/antenna-to-audio/) — and runs them concurrently.
+One radio, many simultaneous decodes. The [Architecture](/architecture.html) page shows
+how this is wired in practice.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — demodulation recovers the waveform; decoding interprets the resulting bits." markdown="0">
+  <p class="knowledge-check__q">Quick check: which stage applies forward error correction and extracts the message?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Digital tuning</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Demodulation</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Framing and decoding</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The pipeline: **tune → filter/decimate → demodulate → recover symbols → frame/decode**.
+- **Demodulation** recovers the waveform; **decoding** (with FEC) recovers the message.
+- Symbol recovery needs **clock recovery** to sample at the right instant.
+- Failures cluster at demod/symbol-recovery — which the scopes reveal early.
+- One IQ stream feeds **many parallel pipelines**.
+
+Next: the timing trick at the heart of stage 4 — clock recovery.

--- a/docs/learn/digital-modulation.md
+++ b/docs/learn/digital-modulation.md
@@ -78,6 +78,21 @@ voice: **P25 Phase 1 (C4FM)** and **DMR** both use 4FSK, where the carrier sits 
 one of four small frequency offsets (deviations) for each symbol. FSK is popular
 because it tolerates the cheap, efficient amplifiers used in handhelds.
 
+Concretely, C4FM's four symbols are four exact frequency **deviations** from the
+channel centre — and each maps to a fixed 2-bit pair (a *dibit*):
+
+| Deviation | Symbol level | Bits (dibit) |
+|-----------|--------------|--------------|
+| +1800 Hz | +3 | 01 |
+| +600 Hz | +1 | 00 |
+| −600 Hz | −1 | 10 |
+| −1800 Hz | −3 | 11 |
+
+When you watch the [symbol scope](/symbol-scope.html), those four levels are
+literally these deviations; on the [constellation](/learn/iq-data/) they're four
+points. A clean signal lands every symbol on one of the four — anything in between
+is the receiver guessing.
+
 ### PSK — phase-shift keying
 
 The carrier's **phase** (its timing offset) jumps between fixed angles while

--- a/docs/learn/digital-modulation.md
+++ b/docs/learn/digital-modulation.md
@@ -1,0 +1,180 @@
+---
+slug: digital-modulation
+title: Digital modulation & constellations
+description: How digital radio puts bits on a carrier — FSK, PSK, QAM, and the C4FM/CQPSK modes behind P25 and DMR. Learn to read a constellation diagram and an eye diagram the way GopherTrunk shows them.
+keywords: digital modulation, FSK, PSK, QPSK, QAM, C4FM, CQPSK, constellation diagram, eye diagram, symbols, 4FSK, P25 modulation, DMR modulation
+level: intermediate
+status: full
+prereq:
+  - radio-waves
+faq:
+  - q: What is digital modulation?
+    a: Digital modulation is the process of putting digital data — ones and zeros — onto a radio carrier by switching the carrier between a fixed set of states. Each state, called a symbol, stands for one or more bits. The receiver measures which state arrived and maps it back to bits. Common families are FSK (switching frequency), PSK (switching phase), and QAM (switching both amplitude and phase).
+  - q: What is a constellation diagram?
+    a: A constellation diagram is a plot of a digital signal's symbols on a 2-D plane, where each point's position encodes the carrier's phase (angle) and amplitude (distance from centre). A clean signal shows tight, well-separated dots at the expected symbol positions; noise, mistuning, or distortion smears the dots, and when they blur together the decoder starts making errors.
+  - q: What is the difference between a symbol and a bit?
+    a: A bit is a single 0 or 1. A symbol is one transmitted state of the carrier, which can carry several bits at once. For example, 4-level FSK (used by P25 and DMR) has four symbols, so each symbol carries 2 bits. That's why a 4800-symbol-per-second signal moves 9600 bits per second.
+  - q: What modulation do P25 and DMR use?
+    a: "P25 Phase 1 uses C4FM, a four-level frequency-shift keying (4FSK) where the carrier sits at one of four frequency deviations per symbol. DMR uses 4FSK as well. P25 Phase 2 uses H-DQPSK, a phase-shift variant. GopherTrunk's constellation, symbol-scope, and eye-diagram panels let you see these symbols directly."
+gophertrunk_links:
+  - title: Constellation
+    url: /constellation.html
+    note: see the live IQ constellation of the signal you're decoding.
+  - title: Symbol scope
+    url: /symbol-scope.html
+    note: watch the recovered symbol levels stream past in real time.
+  - title: Eye diagram
+    url: /eye-diagram.html
+    note: judge timing and noise margin at a glance.
+---
+
+# Digital modulation & constellations
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Digital modulation** sends data by switching a carrier between a fixed set of
+states called **symbols**, each carrying one or more **bits**. The three families
+are **FSK** (switch the frequency), **PSK** (switch the phase), and **QAM** (switch
+both phase and amplitude). A **constellation diagram** plots those symbols on a
+2-D plane so you can *see* signal quality: tight, separated dots mean a clean
+signal; smeared dots mean errors are coming. P25 and DMR use four-level FSK
+(**C4FM**), which GopherTrunk visualises live in its constellation, symbol-scope,
+and eye-diagram panels.
+</div>
+
+In [lesson 1](/learn/radio-waves/) you saw that information rides on a wave by changing
+its amplitude, frequency, or phase. Analog modes vary those smoothly. **Digital**
+modes do something cleaner: they snap the carrier to a few *predefined* states, so
+the receiver only has to decide *which* state arrived — far more robust against
+noise. This lesson is where the scopes in GopherTrunk finally make sense.
+
+## What is a symbol, and how is it different from a bit?
+
+A **bit** is a single 0 or 1. A **symbol** is one state the transmitter actually
+puts on the air, and a symbol can stand for more than one bit at a time.
+
+If a scheme has only two states, each symbol carries one bit. If it has four states,
+each symbol carries two bits (00, 01, 10, 11). Eight states → three bits, and so on.
+This is why the *symbol rate* (symbols per second, called **baud**) and the *bit
+rate* (bits per second) are different numbers:
+
+> **bit rate = symbol rate × bits per symbol**
+
+P25 Phase 1 runs at **4800 baud** with **4 states (2 bits each)**, giving
+**9600 bits per second**. That distinction — explored further in
+[Symbols, baud & bitrate](/learn/symbols-and-baud/) — matters when you size capture
+buffers and reason about how much SNR a mode needs.
+
+## What are the three families of digital modulation?
+
+Every digital mode you'll meet varies one of the wave's three properties — exactly
+the three from lesson 1.
+
+### FSK — frequency-shift keying
+
+The carrier jumps between a set of **frequencies**, one per symbol. Two frequencies
+gives **2FSK**; four gives **4FSK**. This is the workhorse of land-mobile digital
+voice: **P25 Phase 1 (C4FM)** and **DMR** both use 4FSK, where the carrier sits at
+one of four small frequency offsets (deviations) for each symbol. FSK is popular
+because it tolerates the cheap, efficient amplifiers used in handhelds.
+
+### PSK — phase-shift keying
+
+The carrier's **phase** (its timing offset) jumps between fixed angles while
+amplitude stays constant. Two phases is **BPSK**; four is **QPSK** (2 bits/symbol).
+**P25 Phase 2** uses a PSK variant. PSK is spectrally efficient and shows up
+everywhere from satellites to digital broadcast.
+
+### QAM — quadrature amplitude modulation
+
+QAM varies **both phase and amplitude**, packing many states into the plane —
+16-QAM (4 bits/symbol), 64-QAM, and higher. More bits per symbol means more data in
+the same bandwidth, but the states sit closer together, so QAM needs a higher
+[SNR](/learn/decibels/) to decode. You'll meet it in Wi-Fi, cable, and LTE rather than
+scanner traffic, but the same constellation idea applies.
+
+## What is a constellation diagram, and how do I read one?
+
+A **constellation diagram** is the single most useful picture in digital radio. It
+plots each received symbol as a point on a 2-D plane built from the SDR's
+**[IQ data](/learn/iq-data/)**: the horizontal axis (**I**) and vertical axis (**Q**)
+together encode the carrier's phase as the point's *angle* and its amplitude as the
+point's *distance from the centre*.
+
+A perfect signal places every symbol exactly on its ideal spot, so you see a few
+tight clusters. Real signals scatter around those spots, and *how much* they
+scatter is a direct read on quality:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="Two constellation diagrams side by side. The left shows four tight clusters of dots labelled clean signal. The right shows four smeared clouds of dots overlapping, labelled noisy signal." xmlns="http://www.w3.org/2000/svg">
+  <!-- clean -->
+  <g>
+    <line x1="20" y1="100" x2="180" y2="100" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="100" y1="20" x2="100" y2="180" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor">
+      <circle cx="60" cy="60" r="2.5"/><circle cx="58" cy="62" r="2.5"/><circle cx="62" cy="59" r="2.5"/>
+      <circle cx="140" cy="60" r="2.5"/><circle cx="138" cy="62" r="2.5"/><circle cx="141" cy="58" r="2.5"/>
+      <circle cx="60" cy="140" r="2.5"/><circle cx="62" cy="138" r="2.5"/><circle cx="59" cy="141" r="2.5"/>
+      <circle cx="140" cy="140" r="2.5"/><circle cx="138" cy="139" r="2.5"/><circle cx="142" cy="141" r="2.5"/>
+    </g>
+    <text x="100" y="196" text-anchor="middle" font-size="12" fill="currentColor">clean — easy to decode</text>
+  </g>
+  <!-- noisy -->
+  <g>
+    <line x1="280" y1="100" x2="440" y2="100" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="360" y1="20" x2="360" y2="180" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor" fill-opacity="0.7">
+      <circle cx="320" cy="62" r="2.5"/><circle cx="312" cy="70" r="2.5"/><circle cx="328" cy="54" r="2.5"/><circle cx="318" cy="78" r="2.5"/><circle cx="332" cy="66" r="2.5"/>
+      <circle cx="398" cy="60" r="2.5"/><circle cx="404" cy="72" r="2.5"/><circle cx="392" cy="52" r="2.5"/><circle cx="410" cy="64" r="2.5"/>
+      <circle cx="322" cy="138" r="2.5"/><circle cx="314" cy="146" r="2.5"/><circle cx="330" cy="132" r="2.5"/><circle cx="318" cy="150" r="2.5"/>
+      <circle cx="400" cy="140" r="2.5"/><circle cx="392" cy="148" r="2.5"/><circle cx="408" cy="132" r="2.5"/><circle cx="404" cy="150" r="2.5"/>
+    </g>
+    <text x="360" y="196" text-anchor="middle" font-size="12" fill="currentColor">noisy — errors creep in</text>
+  </g>
+</svg>
+<figcaption>A 4-state (QPSK-like) constellation. Tight, separated clusters decode reliably; as noise, mistuning, or distortion smear them toward each other, the decoder starts guessing wrong.</figcaption>
+</figure>
+
+In GopherTrunk, the **[Constellation panel](/constellation.html)** draws this live.
+When you're chasing a marginal signal, a constellation that's collapsing toward the
+centre or rotating tells you exactly what's wrong — too little SNR, a tuning error,
+or a clock problem — long before you'd guess it from the audio.
+
+## What is an eye diagram, and what does it tell me?
+
+Where the constellation shows symbols in the IQ *plane*, an **eye diagram** shows
+them against *time*. It overlays many short snippets of the recovered signal so they
+stack up, and the result has open "eye" shapes between the symbol levels. The
+**wider and taller the eye opening**, the more margin the decoder has to sample each
+symbol correctly. A closing eye means noise or timing jitter is eating that margin.
+
+For the 4-level FSK in P25 and DMR you'll see **three stacked eyes** (four levels →
+three gaps). GopherTrunk's **[Eye diagram](/eye-diagram.html)** and
+**[Symbol scope](/symbol-scope.html)** panels let you watch this directly — together
+with the constellation, they're your toolkit for [tuning a clean
+lock](/learn/tuning-with-scopes/) later in the path.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — 4 states means 2 bits per symbol, so 4800 × 2 = 9600 bps." markdown="0">
+  <p class="knowledge-check__q">Quick check: a 4-level (4FSK) signal at 4800 baud carries how many bits per second?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">2400 bps</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">4800 bps</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">9600 bps</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Digital modulation switches the carrier between fixed **symbols**; each symbol
+  carries one or more **bits**.
+- **FSK** switches frequency (P25 C4FM, DMR), **PSK** switches phase (P25 Phase 2),
+  **QAM** switches both for higher data rates.
+- A **constellation** plots symbols in the IQ plane — tight clusters = clean,
+  smeared = errors.
+- An **eye diagram** plots them against time — a wide-open eye means healthy margin.
+- GopherTrunk shows all three views live, which is how you diagnose a shaky signal.
+
+Next in this module: how symbol rate and bit rate relate, and why it matters for
+capture. Or jump ahead to [what software-defined radio actually
+is](/learn/what-is-sdr/) to see where these symbols come from.

--- a/docs/learn/digital-voice.md
+++ b/docs/learn/digital-voice.md
@@ -1,23 +1,138 @@
 ---
 slug: digital-voice
 title: Analog vs. digital voice
-description: Analog versus digital voice radio — why public safety moved to digital, how a vocoder compresses speech into a few kilobits per second, and the trade-offs in quality and range.
+description: Analog versus digital voice radio explained — how analog FM voice works, why public safety moved to digital, the role of the vocoder, the digital "cliff effect" on range, and what it all means for monitoring with an SDR.
+keywords: digital voice radio, analog vs digital, P25 vs analog, vocoder, cliff effect, digital radio quality, why public safety went digital, narrowband
 level: intermediate
-status: stub
+status: full
 prereq:
   - digital-modulation
+faq:
+  - q: Why did public safety move from analog to digital voice?
+    a: Digital voice lets more channels fit in the same spectrum, supports trunking and talkgroups, carries data like unit IDs alongside the audio, allows encryption, and keeps voice clear right out to the edge of coverage rather than fading into static. Regulators also pushed narrower channels, which digital handles well. The trade-offs are codec artefacts and an abrupt loss of audio when the signal gets too weak.
+  - q: What is the cliff effect in digital radio?
+    a: The cliff effect is digital radio's all-or-nothing behaviour at the edge of coverage. As long as the signal is decodable, audio is clear; once it drops below the threshold the error correction can handle, the audio doesn't gradually fade like analog — it breaks up and then cuts out abruptly, as if falling off a cliff.
+  - q: Does digital voice sound better than analog?
+    a: It sounds clearer in good-to-marginal conditions because there's no background hiss, but it can sound robotic or watery because the vocoder reconstructs speech from a compressed model rather than reproducing the original waveform. Analog degrades gracefully into static; digital stays crisp until it suddenly fails.
+  - q: What does digital voice mean for monitoring?
+    a: You need software that can demodulate the digital signal and run the matching vocoder to produce audio — which is exactly what GopherTrunk does. You also get metadata like talkgroups and radio IDs for free, but you'll hit the cliff effect on weak signals and you can't hear encrypted talkgroups at all.
+gophertrunk_links:
+  - title: Vocoders
+    url: /vocoders.html
+    note: the codecs that make digital voice possible.
+  - title: Voice calibration
+    url: /voice-calibration.html
+    note: tune GopherTrunk for the cleanest decoded audio.
 ---
 
 # Analog vs. digital voice
 
-Why did public-safety radio go digital, and what did it give up? This lesson sets the stage.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Analog voice** (FM) sends the speech waveform directly and **fades gracefully** into
+static as it weakens. **Digital voice** compresses speech with a **[vocoder](/learn/vocoders/)**
+into a few kilobits per second, then sends it as [digital
+modulation](/learn/digital-modulation/) — gaining spectrum efficiency, trunking,
+talkgroups, embedded IDs, and optional encryption, at the cost of a robotic timbre and
+the **cliff effect** (clear audio that *abruptly* cuts out at the coverage edge instead
+of fading). For monitoring, you need software that demodulates *and* vocodes — which is
+what GopherTrunk does.
+</div>
+
+Module 5 reaches the systems GopherTrunk was built for. Before the trunking protocols
+themselves, it's worth understanding what changed when voice went from analog to digital
+— because it shapes everything about how these systems sound and behave.
 
 ## How analog voice radio works
 
+Traditional two-way radio uses **[FM](/learn/analog-modulation/)**: the audio directly
+varies the carrier's frequency, and the receiver turns that back into sound. It's
+simple, robust, and **degrades gracefully** — as the signal weakens you get more hiss,
+then more, until the voice is buried, but you can often still make out words deep into
+the noise. One conversation occupies one channel.
+
 ## Why systems moved to digital
+
+Agencies and regulators pushed to digital for several concrete reasons:
+
+- **Spectrum efficiency** — narrower channels and, with [trunking](/learn/what-is-trunking/),
+  many groups sharing few frequencies.
+- **Talkgroups and features** — virtual channels, priority, and selective calling.
+- **Embedded data** — radio IDs, talkgroup numbers, and status ride alongside the voice.
+- **Clear audio across coverage** — no hiss; voice stays crisp until the signal fails.
+- **Encryption** — optional [privacy](/learn/encryption/) on sensitive talkgroups.
+
+The catch is that digital introduces a codec (the vocoder) and a sharp failure edge,
+both covered below.
 
 ## The role of the vocoder
 
+You can't send full-quality audio in the tiny [bitrate](/learn/symbols-and-baud/) a
+narrow digital channel provides. The solution is a **[vocoder](/learn/vocoders/)** (voice
+coder): instead of transmitting the speech *waveform*, it transmits a compact
+*description* of the speech — enough parameters for the receiver to **reconstruct**
+something that sounds like the talker. This squeezes a voice into a few kbps, which is
+the whole reason digital voice fits. The next lesson is devoted to how vocoders do this.
+
 ## Quality, range, and the cliff effect
 
+Two perceptual differences fall out of going digital:
+
+- **Timbre.** Because the vocoder *models* speech rather than reproducing it, digital
+  voice can sound slightly robotic or "watery," especially on a marginal signal. In
+  good conditions it's clean and hiss-free.
+- **The cliff effect.** This is the big one. Analog fades smoothly; digital is
+  **all-or-nothing**. As long as [error correction](/learn/demodulation-pipeline/) can
+  fix the bit errors, audio is perfect. Once the signal drops below that threshold,
+  audio doesn't gently fade — it **breaks into burbles and then cuts out abruptly**, as
+  if walking off a cliff.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 150" role="img" aria-label="Two curves of audio quality versus signal strength. Analog declines as a smooth downward slope. Digital stays flat and high, then drops off a vertical cliff at the threshold." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="120" x2="420" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="40" y1="20" x2="40" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="230" y="140" text-anchor="middle" font-size="10" fill="currentColor">signal strength →</text>
+  <text x="20" y="70" font-size="10" fill="currentColor" transform="rotate(-90 20 70)">quality</text>
+  <path d="M60 118 C160 100 300 60 410 35" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="360" y="30" font-size="10" fill="currentColor">analog</text>
+  <path d="M150 118 L150 45 L410 45" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="360" y="40" font-size="10" fill="currentColor">digital</text>
+  <text x="150" y="100" font-size="9" fill="currentColor" text-anchor="middle">cliff</text>
+</svg>
+<figcaption>Analog quality slides down gradually; digital stays clear, then falls off a cliff once the signal can no longer be decoded.</figcaption>
+</figure>
+
 ## What this means for monitoring
+
+For SDR monitoring, the consequences are practical:
+
+- You need software that can both **demodulate** the digital signal and run the matching
+  **vocoder** to make sound — GopherTrunk does both (see
+  [antenna-to-audio](/learn/antenna-to-audio/)).
+- You get **metadata for free** — talkgroups, radio IDs — that analog never carried.
+- The **cliff effect** means a marginal system is either decoding well or not at all;
+  improving [SNR](/learn/decibels/) (antenna, placement, [gain](/learn/gain-and-agc/)) is
+  what moves you back from the cliff edge.
+- **Encrypted** talkgroups are silent no matter how strong the signal — that's the
+  [next-but-one lesson](/learn/encryption/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — digital is clear until it abruptly fails at the cliff." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does digital voice behave as the signal weakens toward the edge of coverage?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It gradually fades into hiss like analog</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It stays clear, then breaks up and cuts out abruptly</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It gets louder</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Analog FM** sends the waveform and **fades gracefully**; **digital** sends vocoded
+  speech and is **all-or-nothing**.
+- Digital won for **spectrum efficiency, trunking, embedded data, and encryption**.
+- The **[vocoder](/learn/vocoders/)** compresses speech into a few kbps.
+- The **cliff effect** means marginal = clean or nothing; raise SNR to back off the edge.
+- Monitoring needs demod **and** vocoder; you gain metadata but lose encrypted traffic.
+
+Next: a closer look at the vocoders themselves — IMBE and AMBE+2.

--- a/docs/learn/digital-voice.md
+++ b/docs/learn/digital-voice.md
@@ -1,0 +1,23 @@
+---
+slug: digital-voice
+title: Analog vs. digital voice
+description: Analog versus digital voice radio — why public safety moved to digital, how a vocoder compresses speech into a few kilobits per second, and the trade-offs in quality and range.
+level: intermediate
+status: stub
+prereq:
+  - digital-modulation
+---
+
+# Analog vs. digital voice
+
+Why did public-safety radio go digital, and what did it give up? This lesson sets the stage.
+
+## How analog voice radio works
+
+## Why systems moved to digital
+
+## The role of the vocoder
+
+## Quality, range, and the cliff effect
+
+## What this means for monitoring

--- a/docs/learn/digital-voice.md
+++ b/docs/learn/digital-voice.md
@@ -74,6 +74,14 @@ coder): instead of transmitting the speech *waveform*, it transmits a compact
 something that sounds like the talker. This squeezes a voice into a few kbps, which is
 the whole reason digital voice fits. The next lesson is devoted to how vocoders do this.
 
+The scale of the squeeze is dramatic. Uncompressed phone-quality audio is about
+**64 kbps**; an MP3 music stream, 128+ kbps. A P25 voice channel carries the actual
+speech in roughly **4.4 kbps** — and that has to share the channel with error
+correction and signalling. That's better than a **10:1** reduction versus a plain phone
+call, achievable *only* because the vocoder models speech rather than storing sound.
+Squeeze that hard and some fidelity is unavoidably lost — the source of digital voice's
+characteristic timbre.
+
 ## Quality, range, and the cliff effect
 
 Two perceptual differences fall out of going digital:

--- a/docs/learn/encryption.md
+++ b/docs/learn/encryption.md
@@ -72,6 +72,26 @@ GopherTrunk demodulates and decodes the signal perfectly; it simply hands you sc
 payload because that's all that was transmitted. **It does not attempt to defeat
 encryption**, which is both impractical and, in many places, specifically prohibited.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A call's data split into two parts. The control-channel metadata — talkgroup and radio ID — is readable. The voice payload is shown locked and scrambled, marked not decodable." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <rect x="30" y="40" width="200" height="70" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="130" y="34" text-anchor="middle" font-size="9">control channel — readable</text>
+    <text x="46" y="64">✓ Talkgroup 101</text>
+    <text x="46" y="84">✓ Radio ID 4471</text>
+    <text x="46" y="104">✓ Voice channel 3</text>
+    <rect x="290" y="40" width="200" height="70" rx="6" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="5 3"/>
+    <text x="390" y="34" text-anchor="middle" font-size="9">voice payload — encrypted</text>
+    <text x="306" y="74" font-family="monospace" font-size="11" fill="currentColor" opacity="0.7">9f3a c1d8 7b22 e0…</text>
+    <text x="306" y="98" font-size="9">✗ not decodable (no key)</text>
+    <text x="390" y="128" text-anchor="middle" font-size="9">🔒 scrambled</text>
+    <line x1="230" y1="75" x2="289" y2="75" stroke="currentColor" stroke-width="1.2" marker-end="url(#en)"/>
+  </g>
+  <defs><marker id="en" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Encryption scrambles the <em>voice</em>, not the <em>traffic</em>. You still see the talkgroup, radio ID, and channel from the control channel — only the audio payload is locked.</figcaption>
+</figure>
+
 ## How to recognise encryption in GopherTrunk
 
 Signs you're dealing with encryption rather than a weak or unsupported signal:

--- a/docs/learn/encryption.md
+++ b/docs/learn/encryption.md
@@ -1,0 +1,25 @@
+---
+slug: encryption
+title: Encryption & what you can decode
+description: Radio encryption explained for scanner users — why some talkgroups are silent, the difference between encryption and protocol support, and how to recognize encrypted traffic.
+level: intermediate
+status: stub
+prereq:
+  - what-is-trunking
+---
+
+# Encryption & what you can decode
+
+Why are some talkgroups silent even with a perfect signal? Usually encryption. Here is the reality.
+
+## Encryption vs. an unsupported protocol
+
+## Why encrypted voice cannot be decoded
+
+## How to recognize encryption in GopherTrunk
+
+## What you *can* still see (metadata, IDs)
+
+## A note on legality and expectations
+
+See also [DMR encryption](/dmr-encryption.html).

--- a/docs/learn/encryption.md
+++ b/docs/learn/encryption.md
@@ -1,25 +1,131 @@
 ---
 slug: encryption
 title: Encryption & what you can decode
-description: Radio encryption explained for scanner users — why some talkgroups are silent, the difference between encryption and protocol support, and how to recognize encrypted traffic.
+description: Radio encryption explained for scanner users — why some talkgroups are silent even with a perfect signal, the difference between encryption and an unsupported protocol, how to recognise encrypted traffic in GopherTrunk, and what metadata you can still see.
+keywords: radio encryption, encrypted talkgroup, P25 encryption, DMR encryption, AES DES radio, why is my scanner silent, decode encrypted radio, monitoring encryption
 level: intermediate
-status: stub
+status: full
 prereq:
   - what-is-trunking
+faq:
+  - q: Why is a talkgroup silent even though my signal is perfect?
+    a: The most common reason is encryption. If a talkgroup is encrypted, the voice data is scrambled with a key you don't have, so even a flawless decode produces no intelligible audio. A strong signal and a locked control channel can't help — encryption is a deliberate barrier, not a reception problem.
+  - q: Can GopherTrunk decode encrypted voice?
+    a: No. Encryption is designed to be unbreakable without the key, and GopherTrunk does not attempt to defeat it — nor should any tool you'd use. You can still see the call happening and its metadata, but the audio itself stays scrambled. Encrypted talkgroups are simply not listenable.
+  - q: How do I know if traffic is encrypted versus just unsupported?
+    a: An unsupported protocol means the software can't decode the signal at all. Encryption means the protocol decodes fine — you see the call, talkgroup, and radio ID on the control channel — but the voice payload is scrambled and plays as silence, noise, or a brief digital chirp. Seeing healthy call metadata with no usable audio points to encryption.
+  - q: Is it legal to listen to encrypted radio?
+    a: You generally cannot listen to encrypted radio at all without the key, so the question is usually moot. Separately, what you may legally receive varies by country and region, and attempting to defeat encryption is often specifically prohibited. Always follow the laws where you live — see the legal and ethical monitoring lesson.
+gophertrunk_links:
+  - title: DMR encryption
+    url: /dmr-encryption.html
+    note: how encryption appears in DMR specifically.
+  - title: CC Activity
+    url: /cc-activity.html
+    note: encrypted calls still show as control-channel activity.
 ---
 
 # Encryption & what you can decode
 
-Why are some talkgroups silent even with a perfect signal? Usually encryption. Here is the reality.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+If a talkgroup is **silent despite a perfect signal**, the usual cause is
+**encryption** — the voice payload is scrambled with a key you don't have, so even a
+flawless [decode](/learn/antenna-to-audio/) yields no audio. This is different from an
+**unsupported protocol** (where nothing decodes at all): with encryption the
+[control channel](/learn/what-is-trunking/) decodes fine, so you still see the **call,
+talkgroup, and radio ID** — just no listenable voice. GopherTrunk **does not** break
+encryption, and neither should any tool. Knowing the difference saves hours of
+fruitless troubleshooting.
+</div>
+
+This lesson answers the question every new digital-monitoring user eventually asks: *my
+signal is great, the system is locked, so why is this talkgroup silent?* Usually the
+answer isn't a reception problem at all.
 
 ## Encryption vs. an unsupported protocol
 
-## Why encrypted voice cannot be decoded
+These two produce different symptoms, and telling them apart is the key skill:
 
-## How to recognize encryption in GopherTrunk
+| | Unsupported protocol | Encryption |
+|--|----------------------|------------|
+| Control channel | May not decode | **Decodes fine** |
+| Call metadata (TG, ID) | Often missing | **Visible** |
+| Voice audio | Nothing / garbage | **Silent / noise** |
+| Cause | Software can't read this signal | Payload deliberately scrambled |
+| Fixable? | Maybe (add support, settings) | **No — by design** |
 
-## What you *can* still see (metadata, IDs)
+So if GopherTrunk is happily showing you the [control-channel
+activity](/cc-activity.html), the talkgroup, and the transmitting [radio
+ID](/radio-ids.html) — but the call plays as silence — you're almost certainly looking
+at **encryption**, not a decode failure.
+
+## Why encrypted voice can't be decoded
+
+Once the system has the voice digitised as [vocoder](/learn/vocoders/) frames, an
+encrypted system **scrambles those bits with a cipher** (such as AES or, on older
+systems, DES) using a secret **key**. Only radios holding the matching key can
+unscramble them. Modern ciphers are designed so that *without* the key, recovering the
+audio is computationally infeasible — that's the entire point.
+
+GopherTrunk demodulates and decodes the signal perfectly; it simply hands you scrambled
+payload because that's all that was transmitted. **It does not attempt to defeat
+encryption**, which is both impractical and, in many places, specifically prohibited.
+
+## How to recognise encryption in GopherTrunk
+
+Signs you're dealing with encryption rather than a weak or unsupported signal:
+
+- The **system locks** and other (unencrypted) talkgroups decode normally.
+- The encrypted talkgroup's calls **appear** in the activity and history — with
+  talkgroup and radio ID — but produce **no intelligible audio** (silence, noise, or a
+  short digital chirp).
+- Many protocols flag encryption in the signalling, so the call may be **marked
+  encrypted**.
+- It's **consistent** for that talkgroup regardless of signal strength — unlike the
+  [cliff effect](/learn/digital-voice/), which varies with SNR.
+
+The [DMR encryption](/dmr-encryption.html) page covers how this looks for DMR
+specifically.
+
+## What you can still see
+
+Encryption hides the *voice*, not the *traffic*. The control channel is typically **not**
+encrypted, so you can still observe a lot:
+
+- **Which talkgroups are active** and how busy the system is.
+- **Radio IDs** affiliating and transmitting.
+- **Call patterns** and timing.
+
+For many monitoring purposes — understanding a system's structure, activity levels, and
+units — this metadata is valuable even when the audio is locked away.
 
 ## A note on legality and expectations
 
-See also [DMR encryption](/dmr-encryption.html).
+Set expectations realistically: **encrypted talkgroups are not listenable**, full stop.
+Trying to circumvent encryption is often explicitly illegal and outside the spirit of
+the hobby. What you may legally *receive* in the first place also varies by jurisdiction
+— the [legal & ethical monitoring](/learn/legal-ethical/) lesson covers that. The healthy
+mindset: enjoy the open systems and the metadata, and treat encrypted talkgroups as
+simply off-limits.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — visible metadata but no audio is the signature of encryption." markdown="0">
+  <p class="knowledge-check__q">Quick check: the system is locked, you see the talkgroup and radio ID, but the call is silent. Most likely cause?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Weak signal / cliff effect</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The talkgroup is encrypted</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The antenna is unplugged</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **silent talkgroup with a perfect signal** is usually **encryption**.
+- Encryption ≠ unsupported protocol: with encryption the **control channel and metadata
+  decode**, only the **voice** is scrambled.
+- GopherTrunk **cannot and does not** break encryption — it's infeasible by design.
+- You can still see **talkgroups, radio IDs, and activity**.
+- Respect the **law and the hobby** — encrypted talkgroups are off-limits.
+
+Next: the many non-trunked signals your SDR can also decode.

--- a/docs/learn/fft-and-waterfall.md
+++ b/docs/learn/fft-and-waterfall.md
@@ -1,0 +1,26 @@
+---
+slug: fft-and-waterfall
+title: The FFT & reading a waterfall
+description: The Fast Fourier Transform explained without the math — how an FFT turns IQ samples into a spectrum, and how to read GopherTrunk's waterfall to spot and identify signals.
+level: intermediate
+status: stub
+prereq:
+  - iq-data
+  - signal-anatomy
+---
+
+# The FFT & reading a waterfall
+
+The FFT is the engine behind every spectrum display. You can use it well without the calculus.
+
+## From samples to spectrum: what the FFT does
+
+## Bins, resolution, and frame rate
+
+## Reading the spectrum view
+
+## Reading the waterfall view
+
+## Identifying signals by their footprint
+
+## Tips for spotting a control channel

--- a/docs/learn/fft-and-waterfall.md
+++ b/docs/learn/fft-and-waterfall.md
@@ -1,26 +1,144 @@
 ---
 slug: fft-and-waterfall
 title: The FFT & reading a waterfall
-description: The Fast Fourier Transform explained without the math — how an FFT turns IQ samples into a spectrum, and how to read GopherTrunk's waterfall to spot and identify signals.
+description: The Fast Fourier Transform explained without the math — how an FFT turns IQ samples into a spectrum, what bins and resolution mean, and how to read GopherTrunk's spectrum and waterfall to spot, identify, and find control channels.
+keywords: FFT, fast fourier transform, spectrum analyzer, waterfall display, reading a waterfall, FFT bins, frequency resolution, find control channel, SDR spectrum
 level: intermediate
-status: stub
+status: full
 prereq:
   - iq-data
   - signal-anatomy
+faq:
+  - q: What does an FFT do in an SDR?
+    a: An FFT (Fast Fourier Transform) converts a block of time-domain IQ samples into a frequency-domain spectrum — it measures how much energy is present at each frequency across the captured band. That spectrum is what an SDR draws as the peaks-and-valleys display and, stacked over time, as the waterfall. It's how raw samples become a picture you can read.
+  - q: What are FFT bins and resolution?
+    a: An FFT splits the captured bandwidth into a number of equal slices called bins; each bin reports the energy at one narrow frequency range. More bins (a larger FFT) give finer frequency resolution but update less often and cost more CPU. The resolution is roughly the sample rate divided by the FFT size.
+  - q: How do I read a waterfall display?
+    a: Frequency runs across the horizontal axis and time scrolls vertically; brightness or colour shows signal strength. A bright vertical stripe is a signal present at that frequency; how it behaves over time — steady, bursty, or patterned — tells you what kind of signal it is. A steady, fixed-width stripe is often a control channel.
+  - q: How do I find a control channel on the waterfall?
+    a: Look for a continuous, fixed-width digital signal that's always on, usually in the band your target system uses. Voice channels flicker on and off as calls come and go, but the control channel transmits constantly. Its steady presence is its signature, and tools like GopherTrunk's Hunt automate the search.
+gophertrunk_links:
+  - title: Plots (signal scopes)
+    url: /plots.html
+    note: GopherTrunk's live spectrum and waterfall.
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: automatically scan a band for steady control channels.
 ---
 
 # The FFT & reading a waterfall
 
-The FFT is the engine behind every spectrum display. You can use it well without the calculus.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The **FFT (Fast Fourier Transform)** turns a block of [IQ samples](/learn/iq-data/) into
+a **spectrum** — energy at each frequency across the band. Stack spectra over time and
+you get the **waterfall**. The FFT splits the band into **bins**; more bins = finer
+**resolution** but slower updates and more CPU. You read a waterfall by **frequency
+(across), time (scrolling), strength (brightness)** — and a **steady, fixed-width
+stripe** is the tell-tale of a [control channel](/learn/what-is-trunking/). No calculus
+required.
+</div>
 
-## From samples to spectrum: what the FFT does
+The FFT is the engine behind every spectrum display you'll ever use, and the waterfall
+is how you'll actually *find* signals. You can use both expertly without touching the
+underlying math — here's the working understanding.
+
+## What the FFT does (without the math)
+
+Your SDR produces [IQ samples](/learn/iq-data/) over *time*. But to *see* signals you
+want them organised by *frequency*. The **FFT** does exactly that conversion: feed it a
+block of samples and it tells you **how much energy sits at each frequency** across the
+captured [bandwidth](/learn/sample-rate-nyquist/). 
+
+Think of it as a prism for radio: a jumble of samples goes in, and out comes a tidy
+breakdown of "this much at 851.0 MHz, this much at 851.2 MHz…". Draw that as height
+versus frequency and you have the [spectrum view](/learn/signal-anatomy/); the FFT runs
+many times a second to keep it live.
 
 ## Bins, resolution, and frame rate
 
+The FFT divides the band into a fixed number of equal slices called **bins**. Each bin
+reports the energy in one narrow frequency range. The number of bins is the **FFT
+size** (512, 1024, 4096…), and it sets a trade-off:
+
+| Bigger FFT | Smaller FFT |
+|------------|-------------|
+| Finer frequency **resolution** | Coarser resolution |
+| Slower updates (more samples per frame) | Faster, smoother updates |
+| More CPU | Less CPU |
+
+As a rule, **resolution ≈ sample rate ÷ FFT size**. So at 2.4 MSa/s a 2048-point FFT
+gives bins about 1.2 kHz wide — fine enough to separate adjacent channels. You don't
+usually set this by hand, but knowing it explains why a display can look "blocky" (too
+few bins) or sluggish (too many).
+
 ## Reading the spectrum view
+
+The spectrum is a snapshot: **frequency across, strength up.** Peaks are signals; the
+restless baseline is the [noise floor](/learn/decibels/). The **height of a peak above
+that floor is its SNR at a glance** — the taller it stands, the better it'll
+[decode](/learn/antenna-to-audio/). Width tells you roughly what kind of signal it is
+(narrow voice channel vs. wide broadcast), as covered in
+[anatomy of a signal](/learn/signal-anatomy/).
 
 ## Reading the waterfall view
 
+The **waterfall** plots that same spectrum **over time**: frequency across, time
+scrolling, and **brightness/colour for strength**. Because it keeps history, it reveals
+behaviour the snapshot can't:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 150" role="img" aria-label="A waterfall: frequency across, time down. One bright continuous vertical stripe labelled control channel, and two short bright blocks at another frequency labelled voice calls." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="380" height="110" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-opacity="0.3"/>
+  <rect x="130" y="20" width="12" height="110" fill="currentColor" fill-opacity="0.6"/>
+  <text x="136" y="14" text-anchor="middle" font-size="9" fill="currentColor">control</text>
+  <rect x="300" y="28" width="12" height="26" fill="currentColor" fill-opacity="0.6"/>
+  <rect x="300" y="78" width="12" height="20" fill="currentColor" fill-opacity="0.6"/>
+  <text x="306" y="14" text-anchor="middle" font-size="9" fill="currentColor">voice</text>
+  <text x="230" y="146" text-anchor="middle" font-size="10" fill="currentColor">frequency →</text>
+  <text x="30" y="75" font-size="10" fill="currentColor" transform="rotate(-90 30 75)">time ↓</text>
+</svg>
+<figcaption>On a waterfall, a control channel is a continuous stripe (always on); voice calls are intermittent blocks that come and go.</figcaption>
+</figure>
+
 ## Identifying signals by their footprint
 
+Each signal type has a recognisable look on the waterfall:
+
+- **Control channel** — continuous, fixed-width, *always on*.
+- **Voice calls** — intermittent blocks that appear and vanish.
+- **FM broadcast** — wide, constant, with audio "texture."
+- **Pagers** — periodic bursts.
+
+This is pattern recognition, and it comes fast with practice. The waterfall becomes a
+map of what's on the air before you decode a single bit.
+
 ## Tips for spotting a control channel
+
+To bring a trunked system into GopherTrunk you first need its
+[control channel](/learn/what-is-trunking/):
+
+1. Tune to the [band](/learn/frequency-and-spectrum/) the system uses.
+2. Scan the waterfall for a **steady, fixed-width digital stripe that never turns off** —
+   voice channels flicker, the control channel doesn't.
+3. Confirm by checking it against a [systems database](/learn/finding-systems/).
+4. Or let **[Hunt](/hunt.html)** sweep the band and surface candidates automatically.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the control channel is the one that's always on." markdown="0">
+  <p class="knowledge-check__q">Quick check: on a waterfall, which signal is most likely the control channel?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A block that appears for a few seconds then vanishes</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A steady, fixed-width stripe that's always present</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The widest signal on screen</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **FFT** converts IQ samples into a **spectrum** (energy vs. frequency).
+- **Bins/FFT size** set **resolution** vs. update speed vs. CPU (resolution ≈ rate ÷ size).
+- Read the **spectrum** for strength/SNR and width; read the **waterfall** for behaviour over time.
+- Signals have **footprints**; a **steady fixed-width stripe** flags a control channel.
+
+Next: how software zooms in on just one of those channels — filtering and decimation.

--- a/docs/learn/filtering-decimation.md
+++ b/docs/learn/filtering-decimation.md
@@ -1,23 +1,128 @@
 ---
 slug: filtering-decimation
 title: Filtering & decimation
-description: Digital filtering and decimation for SDR — how software zooms in on a single channel, removes everything else, and lowers the sample rate to keep the CPU manageable.
+description: Digital filtering and decimation for SDR explained — how software zooms in on a single channel, removes everything else with low-pass and band-pass filters, and lowers the sample rate to keep the CPU manageable.
+keywords: digital filter, decimation, channelization, low-pass filter, band-pass filter, downsampling, SDR DSP, filter then decimate, channel filter
 level: intermediate
-status: stub
+status: full
 prereq:
   - sample-rate-nyquist
+faq:
+  - q: What is decimation in DSP?
+    a: Decimation is reducing a signal's sample rate by keeping only every Nth sample after filtering out the frequencies that would otherwise alias. It's how an SDR narrows a wide capture down to just one channel's worth of bandwidth, which dramatically cuts the amount of data the rest of the pipeline has to process.
+  - q: Why filter before decimating?
+    a: Decimation lowers the sample rate, which shrinks the bandwidth that can be represented. Any energy outside that new, smaller bandwidth would fold back as aliasing and corrupt the signal. Filtering first removes that out-of-band energy, so decimation only throws away samples you no longer need. Filter-then-decimate is the standard order for this reason.
+  - q: What does a digital filter actually do?
+    a: A digital filter passes some frequencies and attenuates others, working on the stream of samples with arithmetic. A low-pass filter keeps low frequencies and removes high ones; a band-pass filter keeps a chosen band and rejects everything outside it. In an SDR, a channel filter isolates one narrow signal from a wide capture.
+  - q: How does an SDR follow many channels from one capture?
+    a: It channelises — for each channel of interest, it digitally shifts that channel to centre, applies a filter to isolate it, and decimates to a low sample rate suited to that one signal. Because this is just math on the shared IQ stream, the SDR can run several of these in parallel, which is how GopherTrunk follows a control channel and multiple voice channels at once.
+gophertrunk_links:
+  - title: Architecture
+    url: /architecture.html
+    note: how GopherTrunk channelises one IQ stream into many decoders.
+  - title: Mixer
+    url: /mixer.html
+    note: the frequency-shift step that centres a channel before filtering.
 ---
 
 # Filtering & decimation
 
-How does software pull one narrow channel out of a wide capture? Filtering and decimation.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A wide [IQ capture](/learn/sample-rate-nyquist/) contains far more than the one channel
+you want. **Digital filtering** keeps a chosen slice of spectrum and rejects the rest;
+**decimation** then lowers the sample rate to match that narrow slice, slashing the data
+the rest of the pipeline must handle. The order matters — **filter first, then
+decimate** — or out-of-band energy [aliases](/learn/sample-rate-nyquist/) back in. Doing
+this per channel ("channelising") is how one SDR feeds **many decoders at once**.
+</div>
+
+You've captured a couple of megahertz of [IQ](/learn/iq-data/). Now you need one
+12.5 kHz channel out of it, running cheaply enough to do several at a time. That's
+filtering and decimation — the first real DSP step in the
+[demodulation pipeline](/learn/demodulation-pipeline/).
 
 ## What a digital filter does
 
-## Low-pass, band-pass, and channel filters
+A **digital filter** is just arithmetic on the sample stream that **passes some
+frequencies and attenuates others**. No physical components — it's math applied to the
+IQ. The two kinds you'll meet:
+
+- **Low-pass** — keeps frequencies below a cutoff, removes those above.
+- **Band-pass** — keeps a chosen band, rejects everything outside it.
+
+In an SDR, the workhorse is a **channel filter**: a narrow filter that isolates *one*
+signal (say, a single control channel) and discards its neighbours and the noise around
+them. To centre the channel first, the SDR digitally **shifts** it to zero frequency
+(the [mixer](/mixer.html) step) so a simple low-pass filter can do the isolating.
 
 ## Decimation: lowering the sample rate
 
-## Why filter-then-decimate saves CPU
+Once you've filtered down to a narrow channel, you no longer need millions of samples a
+second to represent it — a 12.5 kHz channel needs only a small fraction of the original
+rate. **Decimation** drops the rate by keeping, say, every 100th sample. The result is
+a much smaller stream that still contains your channel in full.
+
+Why bother? Because every later stage —
+[demodulation](/learn/demodulation-pipeline/), [clock recovery](/learn/clock-recovery/),
+decoding — does work *per sample*. Fewer samples = far less CPU.
+
+## Why filter before decimating?
+
+Order is everything. Decimation **reduces the representable bandwidth** (it's the
+[Nyquist](/learn/sample-rate-nyquist/) limit in reverse). If any energy still sits
+outside that smaller bandwidth when you decimate, it **folds back as aliasing** and
+contaminates your channel — a phantom signal landing right on top of the one you want.
+
+So you **filter first** to remove everything outside the channel, *then* decimate to
+throw away the now-unnecessary samples. Filter-then-decimate is the universal pattern.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="Left: a wide spectrum with several signals and a filter window around one. Middle arrow filter. Right: only the selected channel remains, at a lower sample rate." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <line x1="20" y1="90" x2="190" y2="90" stroke="currentColor" stroke-opacity="0.3"/>
+    <path d="M40 90 L46 55 L52 90 Z" fill="currentColor" fill-opacity="0.3" stroke="currentColor"/>
+    <path d="M95 90 L101 45 L107 90 Z" fill="currentColor" fill-opacity="0.3" stroke="currentColor"/>
+    <path d="M150 90 L156 65 L162 90 Z" fill="currentColor" fill-opacity="0.3" stroke="currentColor"/>
+    <rect x="86" y="35" width="30" height="60" fill="none" stroke="currentColor" stroke-dasharray="3 2"/>
+    <text x="101" y="110">filter window</text>
+    <text x="105" y="28">wide capture</text>
+    <line x1="205" y1="70" x2="245" y2="70" stroke="currentColor" stroke-width="1.5" marker-end="url(#fd)"/>
+    <text x="225" y="62">filter +</text><text x="225" y="84">decimate</text>
+    <line x1="270" y1="90" x2="440" y2="90" stroke="currentColor" stroke-opacity="0.3"/>
+    <path d="M345 90 L351 40 L357 90 Z" fill="currentColor" fill-opacity="0.4" stroke="currentColor"/>
+    <text x="351" y="28">one channel, low rate</text>
+  </g>
+  <defs><marker id="fd" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Isolate one channel with a filter, then decimate to a low sample rate. The rest of the pipeline now has far less data to chew on.</figcaption>
+</figure>
 
 ## How this fits the demodulation pipeline
+
+Filtering and decimation are the **front of every channel's
+[demodulation pipeline](/learn/demodulation-pipeline/)**: shift the channel to centre,
+filter it, decimate. Because it's all arithmetic on the shared
+[IQ stream](/learn/iq-data/), GopherTrunk runs **many of these in parallel** — one for
+the [control channel](/learn/what-is-trunking/) and one for each
+[voice channel](/learn/antenna-to-audio/) it's following — from a single capture. That
+parallel channelising is exactly how it can track several calls at once.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — filter first so out-of-band energy can't alias when you decimate." markdown="0">
+  <p class="knowledge-check__q">Quick check: why must you filter before decimating?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To make the signal louder</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">So out-of-band energy doesn't alias back into the channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Decimation only works on filtered audio</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Digital filters** keep a chosen band and reject the rest (low-pass, band-pass, channel).
+- **Decimation** lowers the sample rate to match a narrow channel, saving CPU.
+- Always **filter then decimate** to avoid aliasing.
+- **Channelising** the shared IQ lets one SDR feed **many parallel decoders**.
+
+Next: the whole chain assembled — the demodulation pipeline from tune to decoded bits.

--- a/docs/learn/filtering-decimation.md
+++ b/docs/learn/filtering-decimation.md
@@ -1,0 +1,23 @@
+---
+slug: filtering-decimation
+title: Filtering & decimation
+description: Digital filtering and decimation for SDR — how software zooms in on a single channel, removes everything else, and lowers the sample rate to keep the CPU manageable.
+level: intermediate
+status: stub
+prereq:
+  - sample-rate-nyquist
+---
+
+# Filtering & decimation
+
+How does software pull one narrow channel out of a wide capture? Filtering and decimation.
+
+## What a digital filter does
+
+## Low-pass, band-pass, and channel filters
+
+## Decimation: lowering the sample rate
+
+## Why filter-then-decimate saves CPU
+
+## How this fits the demodulation pipeline

--- a/docs/learn/filtering-decimation.md
+++ b/docs/learn/filtering-decimation.md
@@ -67,6 +67,13 @@ Why bother? Because every later stage —
 [demodulation](/learn/demodulation-pipeline/), [clock recovery](/learn/clock-recovery/),
 decoding — does work *per sample*. Fewer samples = far less CPU.
 
+**Worked example.** Capture at **2.4 MSa/s** but you only need a single 12.5 kHz
+channel. Filter to that channel, then decimate by a factor of **100** to **24 kSa/s** —
+still well above [Nyquist](/learn/sample-rate-nyquist/) for a 12.5 kHz signal, but a
+hundredth of the data. Run that for ten channels at once and you're still processing
+far less than the single raw stream. The decimation factor is yours to choose: just
+keep the result comfortably wider than the channel you kept.
+
 ## Why filter before decimating?
 
 Order is everything. Decimation **reduces the representable bandwidth** (it's the

--- a/docs/learn/finding-systems.md
+++ b/docs/learn/finding-systems.md
@@ -46,6 +46,24 @@ Module 6 puts the whole path to work. The very first practical task is finding s
 to listen to — specifically, a system's [control channel](/learn/what-is-trunking/), the
 key that unlocks everything else.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 96" role="img" aria-label="A four-step workflow: look up a database or run Hunt, find the control channel, identify the system, then add or import it into GopherTrunk." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9.5" fill="currentColor" text-anchor="middle">
+    <rect x="12" y="34" width="108" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="66" y="49">database / Hunt</text><text x="66" y="61" font-size="8">where to look</text>
+    <rect x="148" y="34" width="108" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="202" y="49">control channel</text><text x="202" y="61" font-size="8">the steady stripe</text>
+    <rect x="284" y="34" width="108" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="338" y="49">identify</text><text x="338" y="61" font-size="8">protocol &amp; params</text>
+    <rect x="420" y="34" width="108" height="34" rx="6" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="474" y="49">add / import</text><text x="474" y="61" font-size="8">into GopherTrunk</text>
+    <g stroke="currentColor" stroke-width="1.2">
+      <line x1="120" y1="51" x2="147" y2="51" marker-end="url(#fs)"/>
+      <line x1="256" y1="51" x2="283" y2="51" marker-end="url(#fs)"/>
+      <line x1="392" y1="51" x2="419" y2="51" marker-end="url(#fs)"/>
+    </g>
+  </g>
+  <defs><marker id="fs" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The find-and-add workflow: locate a candidate (database or Hunt), confirm the control channel, identify the system, and bring it into GopherTrunk.</figcaption>
+</figure>
+
 ## Online databases — start here
 
 The easiest way to find systems is to look them up. **RadioReference** (and similar

--- a/docs/learn/finding-systems.md
+++ b/docs/learn/finding-systems.md
@@ -1,26 +1,126 @@
 ---
 slug: finding-systems
 title: Finding & identifying systems
-description: How to find trunked radio systems near you — using online databases and GopherTrunk's Hunt feature to discover control channels, identify systems, and add them to your config.
+description: How to find trunked radio systems near you — using online databases like RadioReference, scanning a band for control channels on the waterfall, using GopherTrunk's Hunt feature, identifying a system, and adding it to your configuration.
+keywords: find trunked system, RadioReference, find control channel, scan for systems, GopherTrunk Hunt, identify radio system, add system config, what can I receive
 level: intermediate
-status: stub
+status: full
 prereq:
   - what-is-trunking
   - fft-and-waterfall
+faq:
+  - q: How do I find trunked radio systems near me?
+    a: Start with an online database such as RadioReference, which lists known systems, their control-channel frequencies, talkgroups, and types by location. Cross-check by looking at the waterfall for a steady control-channel signal in the listed band. If a system isn't in a database, you can scan the band yourself or use GopherTrunk's Hunt feature to discover active control channels.
+  - q: What is a control channel frequency and where do I get it?
+    a: A trunked system's control channel is the always-on data frequency that coordinates it. You get it from a database listing for the system, or by finding the steady, fixed-width digital signal on the waterfall in the system's band. GopherTrunk needs at least one working control-channel frequency to start following a system.
+  - q: What does GopherTrunk's Hunt feature do?
+    a: Hunt sweeps a frequency range looking for active control channels, helping you discover systems you don't already have frequencies for. It surfaces candidate control channels so you can identify and add them, which is especially useful for unknown or undocumented systems in your area.
+  - q: How do I add a found system to GopherTrunk?
+    a: Once you have a system's control-channel frequency (and ideally its type and talkgroup list), you add it to your GopherTrunk configuration, or import details from CSV or a database export. GopherTrunk then locks the control channel, reads the system parameters, and starts following calls.
+gophertrunk_links:
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: sweep a band to find control channels automatically.
+  - title: Import (PDF / CSV)
+    url: /import.html
+    note: bring in system and talkgroup data in bulk.
+  - title: Bookmarks
+    url: /bookmarks.html
+    note: save frequencies and systems you've found.
 ---
 
 # Finding & identifying systems
 
-Before you can monitor a system, you have to find its control channel. Here is how.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+To monitor a [trunked system](/learn/what-is-trunking/) you first need its **control-
+channel frequency**. The fastest route is an **online database** (like RadioReference)
+that lists systems, control channels, talkgroups, and types by location. Cross-check on
+the **[waterfall](/learn/fft-and-waterfall/)** by spotting the steady, always-on control
+channel. For unknown systems, **GopherTrunk's [Hunt](/hunt.html)** sweeps a band to
+discover active control channels. Then **add or [import](/import.html)** the system and
+GopherTrunk locks on and follows calls.
+</div>
 
-## Online databases (RadioReference and friends)
+Module 6 puts the whole path to work. The very first practical task is finding something
+to listen to — specifically, a system's [control channel](/learn/what-is-trunking/), the
+key that unlocks everything else.
+
+## Online databases — start here
+
+The easiest way to find systems is to look them up. **RadioReference** (and similar
+regional databases) catalogue known systems by location, listing:
+
+- the **system type** ([P25, DMR, etc.](/learn/protocol-landscape/)),
+- the **control-channel frequencies**,
+- the **talkgroups** and what they're used for,
+- and often **radio IDs** and notes.
+
+For most populated areas, your local systems are already documented. Grab the
+control-channel frequency and system details, and you're 90% of the way there. This
+beats blind scanning almost every time.
 
 ## Scanning a band for control channels
 
-## Using GopherTrunk Hunt to discover systems
+When a system *isn't* documented, or you want to confirm one, look on the
+[waterfall](/learn/fft-and-waterfall/). In the [band](/learn/frequency-and-spectrum/) the
+system uses, hunt for the tell-tale **control-channel footprint**:
+
+- **continuous** — it's always transmitting, unlike voice channels that flicker on/off;
+- **fixed width** — a narrow, consistent digital signal;
+- **steady strength** — it doesn't come and go.
+
+That always-on stripe among intermittent voice bursts is your candidate.
+
+## Using GopherTrunk Hunt
+
+Scanning by eye is slow. **[Hunt](/hunt.html)** automates it: point it at a frequency
+range and it sweeps for active control channels, surfacing candidates for you to
+identify and add. This is the tool for **unknown or undocumented systems** — it turns
+"is there anything here?" into a list of real signals to investigate.
 
 ## Identifying a system from its control channel
 
+Once you've locked a candidate control channel, the **signalling identifies the system**.
+GopherTrunk reads the control-channel data to determine the protocol and system
+parameters (system ID, etc.), so you can confirm what you've found and match it against a
+database entry. The [protocol landscape](/learn/protocol-landscape/) lesson helps you
+interpret what you're seeing.
+
 ## Adding a system to your configuration
 
-See the [Hunt guide](/hunt.html) and [Import](/import.html).
+With a confirmed control channel (and ideally its talkgroup list), you bring it into
+GopherTrunk:
+
+1. **Add** the system and its control-channel frequency to your configuration.
+2. **[Import](/import.html)** talkgroups and details in bulk from CSV or a database
+   export, rather than typing them.
+3. **[Bookmark](/bookmarks.html)** frequencies and systems you've found for later.
+
+GopherTrunk then locks the control channel, reads its [running
+commentary](/learn/what-is-trunking/), and begins following calls — exactly the
+[antenna-to-audio](/learn/antenna-to-audio/) flow, now pointed at a real system you
+found. If the control channel won't hold a clean lock, the next two lessons —
+[tuning with scopes](/learn/tuning-with-scopes/) and
+[calibration & troubleshooting](/learn/calibration-troubleshooting/) — are where you go.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the control channel is the always-on data signal you need first." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the single most important frequency to find for a trunked system?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Any one voice channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The control-channel frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The FM broadcast band</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- You need a system's **control-channel frequency** above all.
+- **Databases** (RadioReference) are the fastest source of systems, control channels, and
+  talkgroups.
+- Confirm on the **waterfall** by the control channel's **steady, always-on** footprint.
+- **Hunt** discovers undocumented systems automatically.
+- **Add or import** the system, then GopherTrunk locks on and follows calls.
+
+Next: when a control channel is marginal, how to read the scopes and dial in a clean lock.

--- a/docs/learn/finding-systems.md
+++ b/docs/learn/finding-systems.md
@@ -1,0 +1,26 @@
+---
+slug: finding-systems
+title: Finding & identifying systems
+description: How to find trunked radio systems near you — using online databases and GopherTrunk's Hunt feature to discover control channels, identify systems, and add them to your config.
+level: intermediate
+status: stub
+prereq:
+  - what-is-trunking
+  - fft-and-waterfall
+---
+
+# Finding & identifying systems
+
+Before you can monitor a system, you have to find its control channel. Here is how.
+
+## Online databases (RadioReference and friends)
+
+## Scanning a band for control channels
+
+## Using GopherTrunk Hunt to discover systems
+
+## Identifying a system from its control channel
+
+## Adding a system to your configuration
+
+See the [Hunt guide](/hunt.html) and [Import](/import.html).

--- a/docs/learn/frequency-and-spectrum.md
+++ b/docs/learn/frequency-and-spectrum.md
@@ -1,0 +1,25 @@
+---
+slug: frequency-and-spectrum
+title: Frequency, bands & the spectrum
+description: How the radio spectrum is measured and divided — Hz to GHz, the HF, VHF, and UHF bands, and how regulators carve spectrum into band plans for broadcast, public safety, and amateur radio.
+level: beginner
+status: stub
+prereq:
+  - radio-waves
+---
+
+# Frequency, bands & the spectrum
+
+This lesson maps out the radio spectrum so you know *where* to look for the systems you want to receive.
+
+## Measuring frequency: Hz, kHz, MHz, GHz
+
+## The named bands: VLF, LF, MF, HF, VHF, UHF, SHF
+
+## What each band is good for (and why)
+
+## Band plans: how spectrum gets allocated
+
+## Where common systems live (public safety, aviation, marine, amateur)
+
+## How this maps to your SDR's tuning range

--- a/docs/learn/frequency-and-spectrum.md
+++ b/docs/learn/frequency-and-spectrum.md
@@ -75,6 +75,26 @@ Notice the wavelength column — it's just *λ ≈ 300 ÷ MHz* from the last les
 shrinks as you climb, which is why a UHF antenna is a handspan while an HF antenna
 can be metres long.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 120" role="img" aria-label="A horizontal map of the radio spectrum from VLF on the left to SHF on the right, with the VHF and UHF bands highlighted as the main scanning range." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="60" x2="520" y2="60" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <g stroke="currentColor" stroke-width="1">
+      <line x1="20" y1="55" x2="20" y2="65"/><line x1="92" y1="55" x2="92" y2="65"/>
+      <line x1="164" y1="55" x2="164" y2="65"/><line x1="236" y1="55" x2="236" y2="65"/>
+      <line x1="308" y1="55" x2="308" y2="65"/><line x1="452" y1="55" x2="452" y2="65"/><line x1="520" y1="55" x2="520" y2="65"/>
+    </g>
+    <rect x="308" y="48" width="144" height="24" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/>
+    <text x="56" y="46">VLF</text><text x="128" y="46">LF</text><text x="200" y="46">MF</text><text x="272" y="46">HF</text>
+    <text x="344" y="44" font-weight="600">VHF</text><text x="416" y="44" font-weight="600">UHF</text><text x="486" y="46">SHF</text>
+    <text x="56" y="84" font-size="8">3 kHz</text><text x="272" y="84" font-size="8">3 MHz</text>
+    <text x="380" y="98" font-size="9" font-weight="600">← most scanning lives here →</text>
+    <text x="500" y="84" font-size="8">30 GHz</text>
+  </g>
+</svg>
+<figcaption>The radio spectrum at a glance. Frequency rises left to right; each band is a ten-fold step. VHF and UHF (highlighted) carry the bulk of scanner and trunked-radio traffic.</figcaption>
+</figure>
+
 ## Why does the band change how a signal behaves?
 
 The band sets the *propagation* — how far and by what path a signal travels (the
@@ -113,6 +133,25 @@ A rough tour of where common things live (exact allocations vary by country):
 You don't memorise this — you look up specific systems in a database. But knowing the
 *shape* of the band plan means that when you see a signal on the
 [waterfall](/learn/fft-and-waterfall/), you already have a guess about what it is.
+
+### Channel spacing: the grid within a band
+
+Zoom into an allocation and it's divided again into evenly spaced **channels**. The
+spacing is the step between adjacent channel centres, and it tells you how wide each
+signal is allowed to be:
+
+| Channel spacing | Era / use | Example |
+|-----------------|-----------|---------|
+| 25 kHz | Older "wideband" land-mobile | Legacy analog FM |
+| 12.5 kHz | Modern "narrowband" | P25 Phase 1, DMR, NXDN (wider) |
+| 6.25 kHz | Very narrow | NXDN, dPMR |
+
+So a P25 control channel listed as 851.0125 MHz sits on a **12.5 kHz grid** — the
+adjacent channels are at 851.000 and 851.025. This matters in practice: it sets the
+[filter width](/learn/filtering-decimation/) GopherTrunk needs and explains why
+mistuning by even a few kilohertz lands you between channels. Regulators have steadily
+pushed users from 25 → 12.5 kHz (and narrower) to fit more systems in the same band —
+a big reason analog gave way to [digital](/learn/digital-voice/).
 
 ## How does this map to my SDR?
 

--- a/docs/learn/frequency-and-spectrum.md
+++ b/docs/learn/frequency-and-spectrum.md
@@ -1,25 +1,145 @@
 ---
 slug: frequency-and-spectrum
 title: Frequency, bands & the spectrum
-description: How the radio spectrum is measured and divided — Hz to GHz, the HF, VHF, and UHF bands, and how regulators carve spectrum into band plans for broadcast, public safety, and amateur radio.
+description: How the radio spectrum is measured and divided — Hz to GHz, the VLF through SHF bands, HF/VHF/UHF, and how regulators carve spectrum into band plans for broadcast, public safety, aviation, marine, and amateur radio.
+keywords: radio spectrum, frequency bands, HF VHF UHF, band plan, spectrum allocation, kHz MHz GHz, public safety frequencies, where to scan
 level: beginner
-status: stub
+status: full
 prereq:
   - radio-waves
+faq:
+  - q: What are the main radio frequency bands?
+    a: The radio spectrum is split into bands by frequency. The common ones are VLF (3–30 kHz), LF (30–300 kHz), MF (300 kHz–3 MHz), HF (3–30 MHz), VHF (30–300 MHz), UHF (300 MHz–3 GHz), and SHF (3–30 GHz). Each has different propagation behaviour and is allocated to different uses. Most scanner and trunked-radio activity lives in VHF and UHF.
+  - q: What frequencies do police and fire use?
+    a: It varies by country and region, but public-safety radio commonly sits in VHF (around 150–174 MHz), UHF (around 450–470 MHz), and the 700/800 MHz bands, increasingly as digital trunked systems. There is no single answer — you look up the specific system in a database like RadioReference for your area.
+  - q: What is a band plan?
+    a: A band plan is the agreed division of a frequency band into channels and uses. Regulators (like the FCC in the US or Ofcom in the UK) and standards bodies publish band plans so broadcasters, public safety, aviation, marine, amateur, and other users do not interfere with each other. It tells you what kind of signal to expect at a given frequency.
+  - q: Why does the band matter for what I can receive?
+    a: Different bands propagate differently and need different antennas. HF can bounce off the ionosphere and travel worldwide; VHF and UHF are mostly line-of-sight. The band also tells you what is there — aircraft on VHF airband, marine on VHF marine, trunked public safety on UHF and 700/800 MHz — so knowing the band plan tells you where to point your SDR.
+gophertrunk_links:
+  - title: Hardware guide
+    url: /hardware.html
+    note: check your dongle covers the band your target systems live in.
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: sweep a band to find active control channels.
 ---
 
 # Frequency, bands & the spectrum
 
-This lesson maps out the radio spectrum so you know *where* to look for the systems you want to receive.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The radio spectrum runs from a few kilohertz to hundreds of gigahertz, divided into
+**bands** — VLF, LF, MF, **HF**, **VHF**, **UHF**, SHF — each with its own
+propagation behaviour and uses. Regulators publish **band plans** that say what
+lives where: broadcast, aviation, marine, public safety, amateur. Knowing the band
+plan tells you *where to point your SDR* and *what to expect*. Most trunked-radio
+scanning happens in **VHF, UHF, and the 700/800 MHz bands**.
+</div>
 
-## Measuring frequency: Hz, kHz, MHz, GHz
+In [lesson 1](/learn/radio-waves/) you learned that frequency is how fast a wave
+cycles. This lesson zooms out: how the whole spectrum is measured, named, and carved
+up — so you know which slice of it to go looking in.
 
-## The named bands: VLF, LF, MF, HF, VHF, UHF, SHF
+## How is frequency measured?
 
-## What each band is good for (and why)
+Frequency is counted in **hertz (Hz)** — cycles per second — but radio frequencies
+are large, so we lean on prefixes:
 
-## Band plans: how spectrum gets allocated
+| Prefix | Hertz | Example |
+|--------|-------|---------|
+| kHz (kilo) | 1,000 | AM broadcast, navigation beacons |
+| MHz (mega) | 1,000,000 | FM radio, airband, public safety |
+| GHz (giga) | 1,000,000,000 | Wi-Fi, GPS, satellite, radar |
 
-## Where common systems live (public safety, aviation, marine, amateur)
+When you set GopherTrunk to **460.025 MHz**, you're naming a precise point on this
+ruler. The spectrum is continuous, but in practice it's organised into the named
+bands below.
 
-## How this maps to your SDR's tuning range
+## What are the radio bands?
+
+Each band spans a decade of frequency (a ten-fold range) and behaves differently.
+The names are an international convention:
+
+| Band | Range | Wavelength | Typical uses |
+|------|-------|------------|--------------|
+| VLF | 3–30 kHz | 100–10 km | Submarine comms, time signals |
+| LF | 30–300 kHz | 10–1 km | Longwave broadcast, navigation |
+| MF | 300 kHz–3 MHz | 1 km–100 m | AM broadcast, marine |
+| **HF** | 3–30 MHz | 100–10 m | Shortwave, amateur, long-distance |
+| **VHF** | 30–300 MHz | 10–1 m | FM radio, airband, marine, public safety |
+| **UHF** | 300 MHz–3 GHz | 1 m–10 cm | TV, cellular, public-safety trunking, GPS |
+| SHF | 3–30 GHz | 10–1 cm | Wi-Fi, satellite, radar |
+
+Notice the wavelength column — it's just *λ ≈ 300 ÷ MHz* from the last lesson. It
+shrinks as you climb, which is why a UHF antenna is a handspan while an HF antenna
+can be metres long.
+
+## Why does the band change how a signal behaves?
+
+The band sets the *propagation* — how far and by what path a signal travels (the
+[next lesson](/learn/propagation/) goes deeper):
+
+- **HF** waves can refract off the ionosphere and skip thousands of kilometres —
+  that's how shortwave reaches across oceans.
+- **VHF and UHF** are essentially **line-of-sight**: they travel to the radio
+  horizon and don't bend far around the Earth. Local public-safety, airband, and
+  marine all live here because they're meant to cover a region, not the globe.
+- **SHF** is even more line-of-sight and easily blocked, but carries huge bandwidth.
+
+For GopherTrunk the practical upshot: the trunked systems you'll follow are regional,
+so they live in the line-of-sight VHF/UHF/700/800 MHz range.
+
+## What is a band plan, and why should I care?
+
+Within each band, regulators and standards bodies divide the spectrum into
+**channels and allocations** — a **band plan**. It's the master map that keeps
+broadcasters, aircraft, ships, police, and hams from stepping on each other.
+
+A rough tour of where common things live (exact allocations vary by country):
+
+| Roughly | What you'll find |
+|---------|------------------|
+| 88–108 MHz | FM broadcast radio |
+| 108–137 MHz | Aircraft (VHF airband, AM) |
+| 144–148 MHz | Amateur 2-metre (APRS, repeaters) |
+| 156–162 MHz | Marine VHF (and AIS at 161.975 / 162.025) |
+| 150–174 MHz | VHF public safety / business |
+| 420–450 MHz | Amateur 70-cm |
+| 450–470 MHz | UHF public safety / business |
+| 700 / 800 MHz | Digital trunked public safety (P25, etc.) |
+| 1090 MHz | Aircraft ADS-B transponders |
+
+You don't memorise this — you look up specific systems in a database. But knowing the
+*shape* of the band plan means that when you see a signal on the
+[waterfall](/learn/fft-and-waterfall/), you already have a guess about what it is.
+
+## How does this map to my SDR?
+
+Every SDR has a **frequency range** it can tune. A basic RTL-SDR covers roughly
+24 MHz–1.7 GHz — enough for nearly all VHF/UHF trunked scanning, airband, marine, and
+ADS-B, but *not* the HF shortwave bands (you'd want an Airspy HF+ or an upconverter
+for those). Matching your hardware's range to the band your targets live in is the
+first hardware decision — see the [SDR hardware lesson](/learn/sdr-hardware/) and the
+[Hardware guide](/hardware.html).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — VHF/UHF are line-of-sight, ideal for regional systems." markdown="0">
+  <p class="knowledge-check__q">Quick check: a regional police trunked system is most likely found in which bands?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">VLF and LF</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">VHF, UHF, and 700/800 MHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">SHF only</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Frequency is measured in **Hz**, scaled by kHz / MHz / GHz.
+- The spectrum is divided into **bands** (VLF…SHF); **VHF and UHF** carry most
+  scanner traffic.
+- The band sets **propagation** — HF can skip worldwide; VHF/UHF are line-of-sight.
+- A **band plan** tells you what lives where, so you know where to look.
+- Match your SDR's tuning range to the band your targets are in.
+
+Next: why two antennas at the same frequency can perform completely differently.

--- a/docs/learn/gain-and-agc.md
+++ b/docs/learn/gain-and-agc.md
@@ -1,0 +1,26 @@
+---
+slug: gain-and-agc
+title: Gain, AGC & avoiding overload
+description: How to set SDR gain correctly — the trade-off between sensitivity and overload, what ADC clipping looks like, dBFS headroom, and when to use automatic gain control (AGC).
+level: intermediate
+status: stub
+prereq:
+  - decibels
+  - sdr-receiver
+---
+
+# Gain, AGC & avoiding overload
+
+Gain is the setting newcomers get wrong most often. Here is how to get it right.
+
+## What the gain control actually does
+
+## Too low: weak signals lost in the noise
+
+## Too high: ADC clipping and distortion
+
+## Reading dBFS and keeping headroom
+
+## Manual gain vs. AGC
+
+## A practical gain-setting routine

--- a/docs/learn/gain-and-agc.md
+++ b/docs/learn/gain-and-agc.md
@@ -100,6 +100,14 @@ peaks somewhere comfortably below 0 — leaving **headroom** for bursts and the 
 local transmitters. GopherTrunk's [tuning meters](/tuning.html) show level and SNR live,
 so you can watch this directly rather than guess.
 
+**Worked example.** Say your strongest local signal currently peaks at **−18 dBFS**.
+That's 18 dB of headroom — plenty, and you could raise gain to pull up weaker signals.
+Add 12 dB of gain and it now peaks at **−6 dBFS**: still safe, but close. Add another
+10 dB and it hits **+4 dBFS** — impossible, so it **clips**, and the band fills with
+[spurious signals](/learn/sample-rate-nyquist/). The sweet spot here was the **−6 dBFS**
+setting: weak signals lifted as far as possible while the strong one keeps a few dB of
+margin below the ceiling.
+
 ## Manual gain vs. AGC
 
 **AGC (automatic gain control)** adjusts gain on its own to chase the current signal.

--- a/docs/learn/gain-and-agc.md
+++ b/docs/learn/gain-and-agc.md
@@ -1,26 +1,144 @@
 ---
 slug: gain-and-agc
 title: Gain, AGC & avoiding overload
-description: How to set SDR gain correctly — the trade-off between sensitivity and overload, what ADC clipping looks like, dBFS headroom, and when to use automatic gain control (AGC).
+description: How to set SDR gain correctly — the trade-off between sensitivity and overload, what ADC clipping looks like, reading dBFS headroom, manual gain vs automatic gain control (AGC), and a practical gain-setting routine for clean decoding.
+keywords: SDR gain, set RTL-SDR gain, ADC clipping, overload, dBFS, headroom, AGC automatic gain control, gain too high, intermodulation, best gain setting
 level: intermediate
-status: stub
+status: full
 prereq:
   - decibels
   - sdr-receiver
+faq:
+  - q: How do I set the gain on an SDR?
+    a: Start low, raise the gain until weak signals appear and the signal-to-noise ratio stops improving, then back off slightly so strong signals don't push the ADC into clipping. The goal is the highest gain that keeps your strongest signal comfortably below 0 dBFS. Watch the dBFS level or the spectrum for distortion as you adjust.
+  - q: What happens if SDR gain is too high?
+    a: Too much gain drives the analog-to-digital converter past its maximum (0 dBFS), causing clipping. The waveform is flattened and distortion spreads across the spectrum as spurious signals and a raised noise floor — often making nearby channels undecodable. Strong nearby transmitters can also cause intermodulation. The fix is to reduce gain.
+  - q: What happens if SDR gain is too low?
+    a: Too little gain leaves weak signals buried in the receiver's own noise. The signal-to-noise ratio suffers and faint systems won't decode even though there's plenty of headroom at the ADC. The right gain is high enough to lift weak signals clear of the noise but not so high that strong ones clip.
+  - q: Should I use AGC or manual gain?
+    a: For decoding digital trunked systems, manual gain set once for your environment is usually best — it's predictable and avoids the AGC pumping up and down as signals come and go. AGC can be handy for casual listening across varied signals, but for a fixed monitoring setup a well-chosen manual gain gives the most consistent results.
+gophertrunk_links:
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: watch live level, dBFS, and SNR while setting gain.
+  - title: Histogram (symbol)
+    url: /histogram.html
+    note: a clipped or starved signal shows in the symbol histogram too.
 ---
 
 # Gain, AGC & avoiding overload
 
-Gain is the setting newcomers get wrong most often. Here is how to get it right.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Gain** controls how strong the signal is when it reaches the
+[ADC](/learn/sdr-receiver/). Too **low** and weak signals stay buried in noise; too
+**high** and the ADC **clips** at 0 [dBFS](/learn/decibels/), spraying distortion across
+the band. The sweet spot is the **highest gain that keeps your strongest signal
+comfortably below 0 dBFS**. Set it by ear-of-the-meters: raise until SNR stops
+improving, then back off a touch. For a fixed monitoring rig, **manual gain usually
+beats AGC**.
+</div>
 
-## What the gain control actually does
+This is the setting beginners get wrong most, and it can make a perfectly good antenna
+and signal undecodable. The good news: once you understand what gain does, getting it
+right is a 30-second routine.
+
+## What does the gain control actually do?
+
+Gain is amplification — it boosts the signal somewhere along the
+[receive chain](/learn/sdr-receiver/) (front-end LNA, mixer, and/or baseband) before
+the **ADC** digitises it. The ADC can only measure within a fixed range. Gain decides
+**where your signals land inside that range**: turn it up and everything moves toward
+the top; turn it down and everything moves toward the bottom (the noise).
+
+The whole game is positioning your signals **high enough to clear the noise** but **not
+so high they hit the ceiling**.
 
 ## Too low: weak signals lost in the noise
 
+With gain too low, faint signals sit down near the receiver's own
+[noise floor](/learn/decibels/). Their [SNR](/learn/decibels/) is poor, so even though
+there's tons of unused ADC range above, the [demodulator](/learn/demodulation-pipeline/)
+can't reliably tell symbols apart. Symptom: weak/distant systems won't lock, while the
+spectrum looks "quiet" with lots of headroom.
+
 ## Too high: ADC clipping and distortion
+
+With gain too high, the strongest signal (or the *sum* of all signals in your
+[bandwidth](/learn/sample-rate-nyquist/)) reaches **0 dBFS** — the ADC's maximum — and
+**clips**. The waveform's peaks are flattened, which mathematically generates harmonics
+and **spurious signals** that spread across the spectrum and **raise the apparent noise
+floor**. A strong nearby transmitter can also cause **intermodulation** — false signals
+born from overload. Symptom: the band looks messy, ghost signals appear, and channels
+that should decode don't.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 130" role="img" aria-label="Three small waveforms. Left: a small wave low near a noise line, labelled too low. Middle: a healthy wave well within the ceiling, labelled good. Right: a wave with flattened tops hitting the ceiling, labelled clipping." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none">
+    <line x1="20" y1="20" x2="140" y2="20" stroke-dasharray="3 3" stroke-opacity="0.5"/>
+    <line x1="160" y1="20" x2="280" y2="20" stroke-dasharray="3 3" stroke-opacity="0.5"/>
+    <line x1="300" y1="20" x2="420" y2="20" stroke-dasharray="3 3" stroke-opacity="0.5"/>
+    <path d="M20 95 q15 -10 30 0 q15 -10 30 0 q15 -10 30 0 q15 -10 30 0" stroke-width="1.3"/>
+    <path d="M160 95 q15 -55 30 0 q15 -55 30 0 q15 -55 30 0 q15 -55 30 0" stroke-width="1.3"/>
+    <path d="M300 95 q15 -80 22 -75 l16 0 q14 -5 22 75 q15 -80 22 -75 l16 0 q14 -5 22 75" stroke-width="1.3"/>
+  </g>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <text x="80" y="120">too low (noise)</text>
+    <text x="220" y="120">good headroom</text>
+    <text x="360" y="120">clipping (0 dBFS)</text>
+    <text x="380" y="14">ceiling</text>
+  </g>
+</svg>
+<figcaption>Gain positions the signal in the ADC's range. Aim for the middle: clear of the noise, well under the 0 dBFS ceiling.</figcaption>
+</figure>
 
 ## Reading dBFS and keeping headroom
 
+[dBFS](/learn/decibels/) is the scale inside the SDR where **0 dBFS is the ceiling** and
+real samples are negative. The practical target: set gain so your **strongest** signal
+peaks somewhere comfortably below 0 — leaving **headroom** for bursts and the loudest
+local transmitters. GopherTrunk's [tuning meters](/tuning.html) show level and SNR live,
+so you can watch this directly rather than guess.
+
 ## Manual gain vs. AGC
 
+**AGC (automatic gain control)** adjusts gain on its own to chase the current signal.
+That sounds ideal but, for decoding a fixed trunked system, AGC can **pump** — ramping
+up during quiet moments (lifting the noise) and clamping down when a strong call hits —
+which destabilises the very levels the decoder relies on.
+
+For a stationary monitoring rig, **manual gain set once for your environment** is
+usually the better choice: predictable and consistent. AGC earns its keep more for
+casual hand-tuning across wildly varied signals.
+
 ## A practical gain-setting routine
+
+1. Tune to your [control channel](/learn/what-is-trunking/) (or strongest target).
+2. Start with **low gain**.
+3. Raise it step by step, watching **SNR** climb on the [tuning meters](/tuning.html).
+4. Keep going until SNR **stops improving** — past this, you're mostly amplifying noise.
+5. Check the spectrum for **distortion/ghost signals** and the level for **clipping**.
+6. **Back off** a step or two to leave headroom. Lock it in.
+
+If a strong local transmitter is overloading you, *lower* gain even if your target is
+weak — clearing the overload often helps more than the lost gain costs.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — clipping at 0 dBFS sprays distortion across the band." markdown="0">
+  <p class="knowledge-check__q">Quick check: the band suddenly shows ghost signals and a raised noise floor after you turned gain up. What happened?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The antenna got better</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The ADC is clipping — reduce gain</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The sample rate is too low</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Gain positions your signals in the **ADC's range**.
+- **Too low** → buried in noise; **too high** → **clipping** and spurious signals.
+- Aim for the **highest gain that keeps the strongest signal below 0 dBFS**.
+- **Manual gain** is usually best for a fixed decoding setup; AGC can pump.
+- Routine: raise until SNR plateaus, check for clipping, back off for headroom.
+
+Next: choosing the hardware that all of this runs on.

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -1,0 +1,203 @@
+---
+slug: glossary
+title: Glossary of RF & SDR terms
+description: Plain-language definitions of radio and software-defined-radio terms — frequency, dBm, IQ, FSK, control channel, vocoder, and dozens more — each cross-linked to the GopherTrunk learning path.
+keywords: SDR glossary, RF terms, radio glossary, dBm definition, IQ data, control channel, talkgroup, FSK, vocoder, P25 DMR terms, SDR dictionary
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of RF & SDR terms
+
+Every term used across the [learning path](/learn/), defined in plain language and
+linked to the lesson where it's explained in full. Skim it as a refresher, or use
+your browser's find (Ctrl/Cmd-F) to jump to a word. Terms are grouped by theme and
+ordered roughly from fundamentals to systems.
+
+## Radio wave fundamentals
+
+**Amplitude** — The strength or "height" of a radio wave; more amplitude means a
+stronger signal. Your SDR reports it as a power level. See
+[What is a radio wave?](/learn/radio-waves/)
+
+**Carrier** — A plain, steady radio wave with no information on it yet. Modulation
+changes the carrier to carry a message. See [What is a radio wave?](/learn/radio-waves/)
+
+**Electromagnetic spectrum** — The full range of electromagnetic waves, from radio
+through light to X-rays. Radio occupies roughly 3 kHz–300 GHz. See
+[What is a radio wave?](/learn/radio-waves/)
+
+**Frequency** — How many times per second a wave cycles, measured in **hertz (Hz)**.
+Higher frequency = shorter wavelength. See [What is a radio wave?](/learn/radio-waves/)
+
+**Hertz (Hz)** — The unit of frequency: one cycle per second. Common multiples are
+kHz (thousand), MHz (million), and GHz (billion). See
+[Frequency, bands & the spectrum](/learn/frequency-and-spectrum/)
+
+**Modulation** — Deliberately varying a carrier's amplitude, frequency, or phase to
+encode information. See [Digital modulation & constellations](/learn/digital-modulation/)
+
+**Wavelength (λ)** — The physical length of one wave cycle, in metres. Approximated
+for radio by *λ ≈ 300 ÷ frequency in MHz*. See [What is a radio wave?](/learn/radio-waves/)
+
+**Band** — A defined, contiguous range of frequencies assigned to a use (e.g. the FM
+broadcast band). See [Frequency, bands & the spectrum](/learn/frequency-and-spectrum/)
+
+**HF / VHF / UHF** — Conventional names for frequency ranges: High Frequency
+(3–30 MHz), Very High Frequency (30–300 MHz), Ultra High Frequency (300 MHz–3 GHz).
+See [Frequency, bands & the spectrum](/learn/frequency-and-spectrum/)
+
+## Power, noise & decibels
+
+**dB (decibel)** — A logarithmic *ratio* between two powers. +10 dB = ×10 power;
++3 dB ≈ ×2. Used for gain and loss. See [Decibels & signal power](/learn/decibels/)
+
+**dBm** — Absolute power referenced to 1 milliwatt. Received signals are negative
+numbers; closer to zero is stronger. See [Decibels & signal power](/learn/decibels/)
+
+**dBFS** — Decibels relative to digital full scale, used inside the SDR. 0 dBFS is
+the ADC's ceiling; real samples sit below it. See [Decibels & signal power](/learn/decibels/)
+
+**Gain** — Amplification, expressed in dB. Also the SDR setting that controls how
+strong the signal is at the ADC. See [Gain, AGC & avoiding overload](/learn/gain-and-agc/)
+
+**Noise floor** — The ever-present background level of receiver and environmental
+noise, in dBm. A signal must rise above it to be usable. See
+[Decibels & signal power](/learn/decibels/)
+
+**Path loss** — How much a signal weakens (in dB) as it travels from transmitter to
+receiver. See [Decibels & signal power](/learn/decibels/)
+
+**SNR (signal-to-noise ratio)** — The gap in dB between a signal and the noise floor.
+Digital modes need a minimum SNR to decode. See [Decibels & signal power](/learn/decibels/)
+
+## Signals & modulation
+
+**Baud (symbol rate)** — Symbols transmitted per second. Different from bit rate when
+each symbol carries multiple bits. See [Symbols, baud & bitrate](/learn/symbols-and-baud/)
+
+**Bit rate** — Bits per second = symbol rate × bits per symbol. See
+[Symbols, baud & bitrate](/learn/symbols-and-baud/)
+
+**Symbol** — One transmitted state of the carrier, carrying one or more bits. See
+[Digital modulation & constellations](/learn/digital-modulation/)
+
+**AM / FM / SSB** — Analog modulations that vary amplitude (AM), frequency (FM), or
+send a single sideband (SSB). See [Analog modulation](/learn/analog-modulation/)
+
+**FSK (frequency-shift keying)** — Digital modulation that switches the carrier
+between set frequencies. **4FSK** (four levels) underlies P25 C4FM and DMR. See
+[Digital modulation & constellations](/learn/digital-modulation/)
+
+**PSK (phase-shift keying)** — Digital modulation that switches the carrier's phase;
+QPSK uses four phases. See [Digital modulation & constellations](/learn/digital-modulation/)
+
+**QAM** — Modulation varying both phase and amplitude to pack many bits per symbol;
+needs higher SNR. See [Digital modulation & constellations](/learn/digital-modulation/)
+
+**C4FM** — The four-level FSK used by P25 Phase 1. See
+[Digital modulation & constellations](/learn/digital-modulation/)
+
+**Constellation diagram** — A plot of symbols in the IQ plane; tight clusters mean a
+clean signal. See [Digital modulation & constellations](/learn/digital-modulation/)
+
+**Eye diagram** — Overlaid symbol waveforms vs. time; a wide-open "eye" means good
+decoding margin. See [Digital modulation & constellations](/learn/digital-modulation/)
+
+## Software-defined radio
+
+**SDR (software-defined radio)** — A radio whose tuning, filtering, and demodulation
+happen in software. See [What is software-defined radio?](/learn/what-is-sdr/)
+
+**ADC (analog-to-digital converter)** — The chip that samples the analog signal into
+digital numbers. Clipping it causes distortion. See [What is SDR?](/learn/what-is-sdr/)
+
+**IQ samples** — Pairs of numbers (In-phase and Quadrature) that capture a signal's
+amplitude and phase together. The SDR's output. See [IQ data & complex signals](/learn/iq-data/)
+
+**Sample rate** — How many samples per second the SDR produces; sets how much
+spectrum (bandwidth) you can see at once. See
+[Sample rate, bandwidth & Nyquist](/learn/sample-rate-nyquist/)
+
+**Nyquist limit** — The rule that you must sample at least twice the bandwidth you
+want to capture. See [Sample rate, bandwidth & Nyquist](/learn/sample-rate-nyquist/)
+
+**Bandwidth** — The width of spectrum, in Hz, occupied by a signal or captured by a
+receiver. See [Sample rate, bandwidth & Nyquist](/learn/sample-rate-nyquist/)
+
+**AGC (automatic gain control)** — Circuitry or software that adjusts gain on its own.
+See [Gain, AGC & avoiding overload](/learn/gain-and-agc/)
+
+**PPM (parts per million)** — A measure of an SDR's frequency error; correcting it
+aligns the radio to true frequency. See [Calibration & troubleshooting](/learn/calibration-troubleshooting/)
+
+**RTL-SDR / HackRF / Airspy** — Common SDR hardware. RTL-SDR is the cheap entry
+point; HackRF and Airspy add bandwidth, sensitivity, or transmit. See
+[SDR hardware](/learn/sdr-hardware/) and the [Hardware guide](/hardware.html)
+
+## DSP
+
+**DSP (digital signal processing)** — Manipulating sampled signals with math:
+filtering, tuning, demodulating. See [The demodulation pipeline](/learn/demodulation-pipeline/)
+
+**FFT (Fast Fourier Transform)** — The algorithm that turns IQ samples into a
+spectrum view; the basis of the waterfall. See [The FFT & reading a waterfall](/learn/fft-and-waterfall/)
+
+**Waterfall** — A scrolling spectrum display showing signal strength across frequency
+over time. See [The FFT & reading a waterfall](/learn/fft-and-waterfall/)
+
+**Filtering** — Keeping a chosen slice of spectrum and discarding the rest. See
+[Filtering & decimation](/learn/filtering-decimation/)
+
+**Decimation** — Reducing the sample rate after filtering to save CPU. See
+[Filtering & decimation](/learn/filtering-decimation/)
+
+**Demodulation** — Recovering the original message from a modulated signal. See
+[The demodulation pipeline](/learn/demodulation-pipeline/)
+
+**Clock recovery** — Finding the timing of a digital signal so each symbol is sampled
+at the right instant. See [Clock recovery & symbol timing](/learn/clock-recovery/)
+
+## Digital voice & trunked radio
+
+**Vocoder** — A speech codec that compresses voice into tiny data frames; IMBE (P25)
+and AMBE+2 (DMR) are common. See [Vocoders](/learn/vocoders/) and the
+[Vocoders reference](/vocoders.html)
+
+**Trunked radio** — A system that shares a pool of frequencies, assigning a channel
+per call. See [What is trunked radio?](/learn/what-is-trunking/)
+
+**Conventional radio** — Non-trunked radio where each group uses a fixed frequency.
+See [What is trunked radio?](/learn/what-is-trunking/)
+
+**Control channel** — The data-only frequency that coordinates a trunked system and
+announces channel assignments. GopherTrunk decodes it first. See
+[What is trunked radio?](/learn/what-is-trunking/)
+
+**Voice channel** — A frequency temporarily assigned to carry a call. See
+[What is trunked radio?](/learn/what-is-trunking/)
+
+**Talkgroup** — A virtual channel identifying a group of users; you follow talkgroups,
+not frequencies. See [What is trunked radio?](/learn/what-is-trunking/)
+
+**Affiliation** — A radio registering with the trunked system over the control
+channel. See [What is trunked radio?](/learn/what-is-trunking/)
+
+**Radio ID** — The unique identifier of an individual radio transmitting on a system.
+See the [Radio IDs panel](/radio-ids.html)
+
+**P25 / DMR / NXDN / TETRA** — Digital land-mobile-radio standards GopherTrunk
+decodes. See [The digital protocol landscape](/learn/protocol-landscape/)
+
+**Encryption** — Scrambling that prevents voice from being decoded; encrypted
+talkgroups stay silent. See [Encryption & what you can decode](/learn/encryption/)
+
+**APRS / AIS / ADS-B** — Non-trunked data signals (amateur position, ship tracking,
+aircraft tracking) GopherTrunk can also decode. See [Other signals you'll meet](/learn/other-signals/)
+
+---
+
+Didn't find a term? It's probably explained in one of the
+[learning-path lessons](/learn/) — or open an
+[issue on GitHub](https://github.com/MattCheramie/GopherTrunk/issues) and we'll add it.

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -1,0 +1,26 @@
+---
+layout: learn-hub
+title: Learn RF & SDR — from newbie to expert
+description: A free, structured learning path covering radio and software-defined-radio (SDR) fundamentals — frequency, modulation, IQ data, DSP, and digital trunked radio — taking you from complete beginner to confident GopherTrunk operator.
+keywords: SDR tutorial, software defined radio for beginners, RF fundamentals, learn radio, P25 DMR trunking, IQ data, RTL-SDR guide, GopherTrunk
+permalink: /learn/
+---
+
+Radio can feel like a wall of jargon — dBm, IQ, FSK, control channels, vocoders.
+It isn't. Every one of those ideas is simple once it's explained in order, and
+that's exactly what this path does. We start with what a radio wave *is* and
+build, one short lesson at a time, until you can take a bare antenna and a $30
+dongle and decode digital voice off a trunked radio system with **GopherTrunk**.
+
+**Who this is for.** Total newcomers welcome — no math, electronics, or licence
+required. If you already know some RF, use the module list to jump straight to
+the gaps. Every lesson is self-contained and cross-linked, so you can read
+top-to-bottom or hop around.
+
+**How the path works.** Six modules take you from physics to practice. The first
+modules are vendor-neutral RF and SDR theory — knowledge that applies to *any*
+radio. The later modules connect each idea directly to running GopherTrunk, so
+you finish knowing not just *what* a constellation diagram is, but how to use the
+one in GopherTrunk to fix a signal that won't lock. Mark lessons complete as you
+go — your progress is saved in your browser. New here? **[Start with lesson 1:
+What is a radio wave?](radio-waves/)**

--- a/docs/learn/iq-data.md
+++ b/docs/learn/iq-data.md
@@ -1,0 +1,26 @@
+---
+slug: iq-data
+title: IQ data & complex signals
+description: IQ data explained for SDR beginners — what In-phase and Quadrature samples are, why radios output pairs of numbers, and how IQ captures both the amplitude and phase of a signal.
+level: intermediate
+status: stub
+prereq:
+  - what-is-sdr
+  - digital-modulation
+---
+
+# IQ data & complex signals
+
+IQ is the language an SDR speaks. Once it clicks, constellations and demodulation make sense.
+
+## Why one number per sample is not enough
+
+## In-phase (I) and Quadrature (Q) defined
+
+## How I and Q encode amplitude and phase
+
+## The complex plane and the constellation connection
+
+## Negative frequencies and why IQ allows them
+
+## How GopherTrunk uses IQ internally

--- a/docs/learn/iq-data.md
+++ b/docs/learn/iq-data.md
@@ -1,26 +1,140 @@
 ---
 slug: iq-data
 title: IQ data & complex signals
-description: IQ data explained for SDR beginners — what In-phase and Quadrature samples are, why radios output pairs of numbers, and how IQ captures both the amplitude and phase of a signal.
+description: IQ data explained for SDR beginners — what In-phase (I) and Quadrature (Q) samples are, why radios output pairs of numbers, how IQ captures both amplitude and phase, and how the complex plane connects directly to the constellation diagram.
+keywords: IQ data, IQ samples, in-phase quadrature, complex signal, IQ explained, amplitude and phase, complex plane, negative frequency, SDR baseband
 level: intermediate
-status: stub
+status: full
 prereq:
   - what-is-sdr
   - digital-modulation
+faq:
+  - q: What is IQ data in an SDR?
+    a: IQ data is the stream of paired numbers an SDR produces, where I is the "in-phase" component and Q is the "quadrature" component (90 degrees out of phase). Together each I/Q pair captures both the amplitude and the phase of the signal at that instant, which is everything needed to represent any modulation. Plotting I horizontally and Q vertically gives the complex plane used by constellation diagrams.
+  - q: Why does an SDR output two numbers per sample instead of one?
+    a: A single amplitude reading can't tell you phase — whether the wave is rising or falling, or which way it's rotating. By sampling two components 90 degrees apart (I and Q), the receiver captures amplitude and phase together, and can even distinguish frequencies above and below the tuned centre (positive vs negative frequencies). One number is ambiguous; the pair is complete.
+  - q: What do I and Q stand for?
+    a: I stands for In-phase and Q for Quadrature. They are two versions of the signal sampled 90 degrees apart in phase. Mathematically they're the real and imaginary parts of a complex number, which is why IQ samples are often called complex samples.
+  - q: How does IQ relate to the constellation diagram?
+    a: A constellation diagram is literally a plot of IQ samples — I on the horizontal axis, Q on the vertical. Each symbol's amplitude is its distance from the centre and its phase is its angle. So the constellation you see in GopherTrunk is a direct picture of the IQ data coming off your SDR.
+gophertrunk_links:
+  - title: Constellation
+    url: /constellation.html
+    note: a live plot of the IQ samples themselves.
+  - title: Architecture
+    url: /architecture.html
+    note: how GopherTrunk moves IQ through its pipeline.
 ---
 
 # IQ data & complex signals
 
-IQ is the language an SDR speaks. Once it clicks, constellations and demodulation make sense.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+SDRs output **IQ data** — pairs of numbers, **I** (in-phase) and **Q** (quadrature,
+90° apart). Together each pair captures the signal's **amplitude** *and* **phase** at
+that instant, which is everything needed to represent any modulation. Plot **I
+horizontally and Q vertically** and you get the **complex plane** — exactly the
+[constellation diagram](/learn/digital-modulation/). IQ also lets the receiver tell
+frequencies *above* the tuned centre from those *below* (positive vs. negative
+frequencies). One number is ambiguous; the **pair is complete**.
+</div>
 
-## Why one number per sample is not enough
+IQ is the language an SDR speaks, and it's the concept that ties
+[modulation](/learn/digital-modulation/), the [constellation](/constellation.html), and
+[demodulation](/learn/demodulation-pipeline/) together. It looks abstract for about
+five minutes, then it clicks.
 
-## In-phase (I) and Quadrature (Q) defined
+## Why isn't one number per sample enough?
+
+Imagine sampling a wave's height and getting "0.5." Is the wave rising or falling? Is
+it a 1 kHz tone above your tuned frequency or 1 kHz below? A single amplitude reading
+can't say — it's **ambiguous**. To fully describe a wave at an instant you need two
+things: how *strong* it is (amplitude) and *where in its cycle* it is (phase). One
+number gives you only one of those.
+
+## I and Q, defined
+
+The fix is to sample the signal **twice, 90° apart in phase**:
+
+- **I — In-phase:** the signal measured against a reference cosine.
+- **Q — Quadrature:** the same signal measured against a reference sine (90° shifted).
+
+The [quadrature-sampling receiver](/learn/sdr-receiver/) produces these two channels
+naturally when it mixes the signal down to baseband. Mathematically, I and Q are the
+**real and imaginary parts of a complex number**, which is why IQ samples are also
+called *complex samples* — but you don't need the math to use them.
 
 ## How I and Q encode amplitude and phase
 
-## The complex plane and the constellation connection
+Here's the payoff. Treat each sample as a point with coordinates (I, Q):
+
+- Its **distance from the origin** is the **amplitude** (how strong).
+- Its **angle** around the origin is the **phase** (where in the cycle).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 260 220" role="img" aria-label="The complex IQ plane: I on the horizontal axis, Q on the vertical. A point is shown with an arrow from the origin; its length is amplitude and its angle is phase." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="110" x2="240" y2="110" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="130" y1="20" x2="130" y2="200" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="232" y="124" font-size="11" fill="currentColor">I</text>
+  <text x="116" y="30" font-size="11" fill="currentColor">Q</text>
+  <line x1="130" y1="110" x2="195" y2="55" stroke="currentColor" stroke-width="2"/>
+  <circle cx="195" cy="55" r="4" fill="currentColor"/>
+  <path d="M160 110 A 36 36 0 0 0 150 84" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  <text x="150" y="104" font-size="10" fill="currentColor">phase</text>
+  <text x="150" y="70" font-size="10" fill="currentColor" transform="rotate(-40 165 80)">amplitude</text>
+</svg>
+<figcaption>An IQ sample as a point on the complex plane. Length = amplitude, angle = phase. A steady tone traces a circle; modulation moves the point to meaningful spots.</figcaption>
+</figure>
+
+A pure, steady tone makes this point **rotate** around the origin at a constant rate —
+the rotation speed *is* the frequency. [Modulation](/learn/digital-modulation/) nudges
+the point to specific places: amplitude modulation changes its distance, frequency
+modulation changes its rotation rate, phase modulation jumps its angle.
+
+## The constellation connection
+
+If a point's position encodes amplitude and phase, then plotting the **symbols** of a
+digital signal on the IQ plane shows exactly which state each one is — which is what a
+**[constellation diagram](/learn/digital-modulation/)** is. The constellation you watch
+in GopherTrunk's [Constellation panel](/constellation.html) is *literally a scatter
+plot of IQ samples*. Tight clusters = clean IQ; smeared clusters = noisy IQ. Now you
+know what's being plotted.
 
 ## Negative frequencies and why IQ allows them
 
-## How GopherTrunk uses IQ internally
+Because IQ captures *direction of rotation*, the receiver can tell a signal **above**
+the tuned centre frequency from one **below** it — "positive" vs. "negative"
+frequencies relative to the centre. A single real number can't distinguish the two
+(they'd look identical), but the I/Q pair can, because they rotate opposite ways. This
+is why an SDR can show and process the **whole** captured band, both sides of the
+centre, at once.
+
+## How GopherTrunk uses IQ
+
+Everything GopherTrunk does starts from the IQ stream off your SDR. It digitally
+[tunes and filters](/learn/filtering-decimation/) within that IQ to isolate a channel,
+[demodulates](/learn/demodulation-pipeline/) it by tracking amplitude/phase over time,
+and renders the [constellation](/constellation.html) and other scopes straight from the
+IQ so you can *see* signal quality. IQ isn't a detail of the hardware — it's the raw
+material of the entire pipeline.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — distance from the origin is amplitude, angle is phase." markdown="0">
+  <p class="knowledge-check__q">Quick check: on the IQ plane, what does a sample's <em>angle</em> represent?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Its amplitude</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Its phase</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Its sample rate</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **IQ data** = paired **I** (in-phase) and **Q** (quadrature, 90° apart) samples.
+- Together they capture **amplitude (distance)** and **phase (angle)** — the full state
+  of the wave.
+- The IQ plane *is* the **constellation diagram**.
+- IQ distinguishes **positive vs. negative** frequencies, so the whole band is usable.
+- GopherTrunk's entire pipeline runs on IQ.
+
+Next: how much spectrum that IQ stream actually covers — sample rate, bandwidth, and Nyquist.

--- a/docs/learn/iq-data.md
+++ b/docs/learn/iq-data.md
@@ -91,6 +91,19 @@ the rotation speed *is* the frequency. [Modulation](/learn/digital-modulation/) 
 the point to specific places: amplitude modulation changes its distance, frequency
 modulation changes its rotation rate, phase modulation jumps its angle.
 
+To make it concrete, a few sample values and what they mean:
+
+| I | Q | Amplitude (√(I²+Q²)) | Phase (angle) |
+|---|---|----------------------|----------------|
+| 1.0 | 0.0 | 1.0 | 0° (pointing right) |
+| 0.0 | 1.0 | 1.0 | 90° (straight up) |
+| 0.71 | 0.71 | 1.0 | 45° |
+| 0.5 | 0.0 | 0.5 | 0°, but half as strong |
+
+Notice rows 1–3 have the **same amplitude** but different **phase** — a single
+real number couldn't tell them apart, yet the I/Q pair does. That's the whole reason
+SDRs work in pairs.
+
 ## The constellation connection
 
 If a point's position encodes amplitude and phase, then plotting the **symbols** of a

--- a/docs/learn/legal-ethical.md
+++ b/docs/learn/legal-ethical.md
@@ -67,6 +67,23 @@ questions**.
 | **Divulging** | Sharing the contents with others, recording, or republishing |
 | **Acting** | Using what you heard — especially for gain or to interfere |
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 96" role="img" aria-label="Three escalating steps: receiving, then divulging, then acting — each more likely to be restricted than the last." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="46" width="150" height="34" rx="6" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.2"/><text x="95" y="61">Receiving</text><text x="95" y="73" font-size="8">often permitted</text>
+    <rect x="185" y="38" width="150" height="34" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="260" y="53">Divulging</text><text x="260" y="65" font-size="8">often restricted</text>
+    <rect x="350" y="30" width="150" height="34" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="425" y="45">Acting</text><text x="425" y="57" font-size="8">most restricted</text>
+    <g stroke="currentColor" stroke-width="1.2">
+      <line x1="170" y1="60" x2="184" y2="56" marker-end="url(#le)"/>
+      <line x1="335" y1="52" x2="349" y2="48" marker-end="url(#le)"/>
+    </g>
+    <text x="260" y="14" font-size="9">more likely to be restricted →</text>
+  </g>
+  <defs><marker id="le" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Three separate questions, each typically more regulated than the last. "Allowed to listen" doesn't imply "allowed to share or act."</figcaption>
+</figure>
+
 In several places, receiving may be tolerated while **divulging or acting** on the
 content is restricted or illegal. So "I'm allowed to listen" does not automatically mean
 "I'm allowed to share or use it." Check each separately.

--- a/docs/learn/legal-ethical.md
+++ b/docs/learn/legal-ethical.md
@@ -1,0 +1,23 @@
+---
+slug: legal-ethical
+title: Legal & ethical monitoring
+description: Know the rules before you listen — how monitoring laws vary by country and region, what is legal to receive, and the etiquette and ethics of the radio-scanning hobby.
+level: beginner
+status: stub
+---
+
+# Legal & ethical monitoring
+
+Receiving radio is a privilege with responsibilities. Know the rules where you live.
+
+## Monitoring laws vary by country and region
+
+## Receiving vs. divulging vs. acting on content
+
+## Encryption and the expectation of privacy
+
+## Scanner etiquette and good-neighbour practice
+
+## Resources for checking your local rules
+
+> This lesson is general information, not legal advice. Always check the rules for your own jurisdiction.

--- a/docs/learn/legal-ethical.md
+++ b/docs/learn/legal-ethical.md
@@ -1,23 +1,127 @@
 ---
 slug: legal-ethical
 title: Legal & ethical monitoring
-description: Know the rules before you listen — how monitoring laws vary by country and region, what is legal to receive, and the etiquette and ethics of the radio-scanning hobby.
+description: Know the rules before you listen — how radio-monitoring laws vary by country and region, the difference between receiving and divulging or acting on content, encryption and privacy, and the etiquette of the scanner hobby.
+keywords: scanner laws, is it legal to listen to police, radio monitoring law, receiving vs divulging, scanner etiquette, encryption legality, responsible monitoring
 level: beginner
-status: stub
+status: full
+faq:
+  - q: Is it legal to listen to police and other radio with an SDR?
+    a: It depends entirely on where you live. Some countries and regions permit receiving many transmissions, others restrict or prohibit it, and rules can differ for using a scanner in a vehicle or acting on what you hear. There is no universal answer, so you must check the specific laws for your country, state, or region before monitoring.
+  - q: What's the difference between receiving and divulging?
+    a: Many legal frameworks distinguish passively receiving a transmission from divulging its contents to others or acting on it for gain. In several places receiving may be tolerated while sharing, recording, or using the content is restricted. Treat receiving, divulging, and acting as separate questions, each governed by your local rules.
+  - q: Is it legal to try to decode encrypted radio?
+    a: Attempting to defeat encryption is commonly prohibited and is outside the spirit of the hobby — and in practice it isn't feasible without the key anyway. The safe and standard position is to treat encrypted talkgroups as off-limits and never attempt to circumvent the encryption.
+  - q: What is good scanner etiquette?
+    a: Listen respectfully, don't interfere, never use what you hear to obstruct emergency responders or invade privacy, be careful about sharing sensitive information (like personal details or live tactical movements), and follow your local laws. The hobby's good standing depends on enthusiasts behaving responsibly.
+gophertrunk_links:
+  - title: Encryption & what you can decode
+    url: /learn/encryption/
+    note: why some traffic is — and should stay — off-limits.
+  - title: The Story of GopherTrunk
+    url: /story.html
+    note: the project's perspective and values.
 ---
 
 # Legal & ethical monitoring
 
-Receiving radio is a privilege with responsibilities. Know the rules where you live.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Receiving radio is a privilege with responsibilities, and the **rules vary widely by
+country and region** — there is no universal answer, so **check your local laws**. Many
+frameworks separate **receiving** from **divulging or acting on** what you hear. Treat
+**[encrypted](/learn/encryption/)** traffic as off-limits and never try to defeat it. And
+beyond the law, follow basic **etiquette**: don't interfere, don't invade privacy, and be
+careful what you share. The hobby's good standing depends on responsible enthusiasts.
+</div>
+
+You've reached the end of the path — and the most important non-technical lesson. None of
+the skills you've learned matter if they're used irresponsibly or illegally. This lesson
+is short on purpose, but please don't skip it.
+
+> **This lesson is general information, not legal advice.** Laws differ everywhere and
+> change over time. Always check the rules for **your own jurisdiction** before you
+> monitor.
 
 ## Monitoring laws vary by country and region
 
-## Receiving vs. divulging vs. acting on content
+What you may legally receive depends entirely on **where you are**:
+
+- Some countries broadly permit receiving many transmissions.
+- Others restrict or prohibit monitoring certain services (or any not addressed to you).
+- Rules can differ further for **using a scanner in a vehicle**, **recording**, or
+  **public-safety** traffic specifically.
+
+Because there's no global standard, the only correct first step is to **look up the laws
+for your country, state, or region**. Don't assume your local rules match what you've seen
+online from somewhere else.
+
+## Receiving vs. divulging vs. acting
+
+A distinction that appears in many legal frameworks: these are **three separate
+questions**.
+
+| Action | What it means |
+|--------|---------------|
+| **Receiving** | Passively listening to a transmission |
+| **Divulging** | Sharing the contents with others, recording, or republishing |
+| **Acting** | Using what you heard — especially for gain or to interfere |
+
+In several places, receiving may be tolerated while **divulging or acting** on the
+content is restricted or illegal. So "I'm allowed to listen" does not automatically mean
+"I'm allowed to share or use it." Check each separately.
 
 ## Encryption and the expectation of privacy
 
+Where traffic is [encrypted](/learn/encryption/), the operator has chosen privacy, and the
+law often backs that choice. **Attempting to defeat encryption is commonly prohibited**
+(and, as you learned, infeasible without the key). The standard, safe position — and
+GopherTrunk's — is to treat encrypted talkgroups as **simply off-limits** and never
+attempt to circumvent them. Enjoy the open systems; leave the closed ones closed.
+
 ## Scanner etiquette and good-neighbour practice
+
+Beyond the letter of the law, the hobby runs on good behaviour:
+
+- **Don't interfere** — receiving is passive; never transmit on systems you don't have
+  rights to.
+- **Respect privacy** — be very careful with personal details or anything that could harm
+  or expose individuals.
+- **Don't obstruct responders** — never use monitored information to get in the way of
+  emergency services or to gain unfair advantage.
+- **Be thoughtful about sharing** — live tactical movements or sensitive data can cause
+  real harm; just because you *can* share doesn't mean you *should*.
+- **Follow the rules** — the freedom enthusiasts enjoy depends on the community staying
+  responsible.
 
 ## Resources for checking your local rules
 
-> This lesson is general information, not legal advice. Always check the rules for your own jurisdiction.
+- Your **national telecommunications regulator** (e.g. the FCC, Ofcom, ACMA, and their
+  equivalents) publishes the governing rules.
+- **Local amateur-radio and scanner clubs** often summarise the practical situation in
+  your area.
+- **Reputable hobby communities** and databases discuss regional norms — but verify
+  against the actual regulator, not just forum lore.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — there's no universal rule; always check your own jurisdiction." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the correct first step before monitoring in your area?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Assume the rules match what you read online from elsewhere</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Look up the laws for your own country, state, or region</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only worry about it if you share what you hear</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Monitoring law **varies by jurisdiction** — there's no universal rule; check yours.
+- **Receiving, divulging, and acting** are distinct questions, governed separately.
+- Treat **encrypted** traffic as off-limits; never attempt to defeat it.
+- Follow **etiquette**: don't interfere, respect privacy, share thoughtfully.
+- The hobby's freedom depends on **responsible** enthusiasts.
+
+🎉 **That's the whole path** — from [what a radio wave is](/learn/radio-waves/) to
+operating GopherTrunk responsibly. Keep the [glossary](/learn/glossary/) handy, and put
+your skills to work: head to [Get started](/getting-started-setup.html) and decode your
+first call.

--- a/docs/learn/other-signals.md
+++ b/docs/learn/other-signals.md
@@ -89,6 +89,25 @@ Smaller signalling systems are everywhere:
 These add identity and control data to otherwise analog systems, and GopherTrunk can
 surface them.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 130" role="img" aria-label="A frequency line from about 144 MHz to 1090 MHz with markers for APRS at 144.39, marine AIS near 162, paging in the VHF/UHF range, and ADS-B at 1090 MHz." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="80" x2="510" y2="80" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <g stroke="currentColor" stroke-width="1.2">
+      <line x1="70" y1="74" x2="70" y2="86"/><line x1="150" y1="74" x2="150" y2="86"/>
+      <line x1="250" y1="74" x2="250" y2="86"/><line x1="480" y1="74" x2="480" y2="86"/>
+    </g>
+    <text x="70" y="66">APRS</text><text x="70" y="100" font-size="8">144.39</text>
+    <text x="150" y="66">AIS</text><text x="150" y="100" font-size="8">~162</text>
+    <text x="250" y="66">paging</text><text x="250" y="100" font-size="8">VHF/UHF</text>
+    <text x="480" y="66">ADS-B</text><text x="480" y="100" font-size="8">1090</text>
+    <text x="30" y="118" font-size="8" text-anchor="start">144 MHz</text>
+    <text x="510" y="118" font-size="8" text-anchor="end">1090 MHz →</text>
+  </g>
+</svg>
+<figcaption>A rough map of where these signals live. Each is in range of a basic RTL-SDR — only the antenna and software change.</figcaption>
+</figure>
+
 ## Why this matters for your learning
 
 Every one of these uses the **exact concepts** from this path — a

--- a/docs/learn/other-signals.md
+++ b/docs/learn/other-signals.md
@@ -1,25 +1,130 @@
 ---
 slug: other-signals
 title: Other signals you'll meet
-description: Beyond trunked voice — the other signals an SDR and GopherTrunk can decode, including POCSAG/FLEX paging, AIS ship tracking, ADS-B aircraft, and APRS amateur position reports.
+description: Beyond trunked voice — the other signals an SDR and GopherTrunk can decode, including POCSAG and FLEX paging, AIS ship tracking, ADS-B aircraft tracking, APRS amateur position reports, and signalling like DSC and MDC1200.
+keywords: POCSAG, FLEX, paging, AIS, ADS-B, APRS, AX.25, DSC, MDC1200, SDR decode, non-voice signals, data modes
 level: beginner
-status: stub
+status: full
 prereq:
   - what-is-sdr
+faq:
+  - q: What else can an SDR decode besides voice?
+    a: A lot. Common data signals include POCSAG and FLEX pagers, AIS ship-position reports, ADS-B aircraft transponders, APRS amateur position and telemetry, marine DSC calling, and signalling like MDC1200. Because the SDR just provides IQ samples, the same hardware can decode any of these given the right software — and GopherTrunk supports many of them.
+  - q: What is ADS-B?
+    a: ADS-B (Automatic Dependent Surveillance–Broadcast) is a system where aircraft continuously broadcast their identity, position, altitude, and velocity on 1090 MHz. An SDR can receive these and plot live aircraft on a map. GopherTrunk can decode ADS-B alongside its trunked-radio work.
+  - q: What is AIS?
+    a: AIS (Automatic Identification System) is the maritime equivalent of ADS-B — ships broadcast their identity, position, course, and speed on VHF marine frequencies (around 162 MHz). An SDR can receive and plot them, giving a live picture of nearby vessel traffic.
+  - q: What is APRS?
+    a: APRS (Automatic Packet Reporting System) is an amateur-radio data mode, usually on 144.39 MHz in North America, carrying position reports, weather, messages, and telemetry over AX.25 packet. An SDR can decode APRS to see station locations and data.
+gophertrunk_links:
+  - title: POCSAG paging
+    url: /pocsag.html
+    note: decode pager messages with GopherTrunk.
+  - title: AIS
+    url: /ais.html
+    note: track ships on VHF marine.
+  - title: ADS-B
+    url: /adsb.html
+    note: plot aircraft on 1090 MHz.
+  - title: APRS / AX.25
+    url: /aprs.html
+    note: amateur position and packet data.
 ---
 
 # Other signals you'll meet
 
-Trunked voice is only part of the picture. Your SDR can decode many other signals.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Trunked voice is only part of what's on the air. Because an [SDR](/learn/what-is-sdr/)
+just delivers [IQ samples](/learn/iq-data/), the *same* hardware can decode many other
+signals with the right software — and GopherTrunk supports a range of them: **POCSAG/FLEX
+paging**, **AIS** ship tracking, **ADS-B** aircraft tracking, **APRS** amateur position
+data, plus signalling like **DSC** and **MDC1200**. Most are **data, not voice**, and
+many can be plotted on a map. They're a great way to see results even where voice systems
+are quiet or encrypted.
+</div>
+
+You've followed the path toward trunked digital voice — but the spectrum is full of other
+useful, decodable signals. This lesson is a quick tour, each with a pointer to
+GopherTrunk's reference page, so you know what else your dongle can do.
 
 ## Paging (POCSAG / FLEX)
 
-## AIS: tracking ships
+Pagers are far from dead — hospitals, fire services, and industry still use them.
+**POCSAG** and the faster **FLEX** are [FSK](/learn/digital-modulation/) paging protocols
+carrying short text and numeric messages. They're easy to decode and a satisfying first
+data mode. GopherTrunk decodes [POCSAG](/pocsag.html); you'll see messages stream in as
+they're transmitted.
 
-## ADS-B: tracking aircraft
+## AIS — tracking ships
+
+**AIS (Automatic Identification System)** is how ships broadcast their **identity,
+position, course, and speed** on VHF marine frequencies (around 161.975 / 162.025 MHz).
+Decode it and you get a **live map of vessel traffic** near any coast or waterway.
+GopherTrunk's [AIS](/ais.html) support turns these bursts into plotted ships.
+
+## ADS-B — tracking aircraft
+
+**ADS-B (Automatic Dependent Surveillance–Broadcast)** is the aviation counterpart:
+aircraft continuously transmit **position, altitude, velocity, and identity** on
+**1090 MHz**. It's one of the most popular SDR applications — plot live aircraft overhead
+in real time. See [ADS-B](/adsb.html) for GopherTrunk's decoder (note 1090 MHz is within
+RTL-SDR range, though a tuned antenna helps).
 
 ## APRS and AX.25
 
+**APRS (Automatic Packet Reporting System)** is an amateur-radio data network — usually
+**144.39 MHz** in North America — carrying **position reports, weather, telemetry, and
+messages** over **AX.25** packet. Decoding it shows you nearby ham stations, weather
+sensors, and mobile trackers. GopherTrunk handles [APRS / AX.25](/aprs.html).
+
 ## DSC, MDC1200, and more
 
-GopherTrunk references: [POCSAG](/pocsag.html), [AIS](/ais.html), [ADS-B](/adsb.html), [APRS](/aprs.html).
+Smaller signalling systems are everywhere:
+
+- **DSC (Digital Selective Calling)** — marine distress and calling on VHF/HF.
+- **MDC1200** — a Motorola signalling format that sends a unit ID as a quick data burst
+  at the start/end of an analog transmission (PTT IDs).
+
+These add identity and control data to otherwise analog systems, and GopherTrunk can
+surface them.
+
+## Why this matters for your learning
+
+Every one of these uses the **exact concepts** from this path — a
+[carrier](/learn/signal-anatomy/) carrying [modulated](/learn/digital-modulation/) data,
+captured as [IQ](/learn/iq-data/), pulled out by [filtering](/learn/filtering-decimation/),
+and [demodulated and decoded](/learn/demodulation-pipeline/). Learning trunked voice gave
+you a toolkit that *generalises*. And practically, these data modes are a great way to
+**see immediate results** — a map filling with ships or planes — even when local voice
+systems are quiet or [encrypted](/learn/encryption/).
+
+| Signal | Roughly where | What you get |
+|--------|---------------|--------------|
+| POCSAG / FLEX | VHF/UHF paging allocations | Text/numeric pages |
+| AIS | ~162 MHz | Ship positions |
+| ADS-B | 1090 MHz | Aircraft positions |
+| APRS | 144.39 MHz (NA) | Ham positions, weather |
+| DSC | VHF/HF marine | Marine calling/distress |
+| MDC1200 | On analog voice channels | Radio unit IDs |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — ADS-B aircraft transponders broadcast on 1090 MHz." markdown="0">
+  <p class="knowledge-check__q">Quick check: on which frequency do aircraft broadcast ADS-B?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">144.39 MHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">162 MHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">1090 MHz</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- One SDR decodes far more than voice — the difference is **software**, not hardware.
+- **POCSAG/FLEX** (paging), **AIS** (ships), **ADS-B** (aircraft), **APRS** (ham data),
+  plus **DSC** and **MDC1200** signalling.
+- Many are **mappable data modes** — quick, visible wins.
+- They all reuse the same path concepts, so your skills **generalise**.
+
+That completes Module 5. The final module puts everything to work — starting with finding
+systems to monitor.

--- a/docs/learn/other-signals.md
+++ b/docs/learn/other-signals.md
@@ -1,0 +1,25 @@
+---
+slug: other-signals
+title: Other signals you'll meet
+description: Beyond trunked voice — the other signals an SDR and GopherTrunk can decode, including POCSAG/FLEX paging, AIS ship tracking, ADS-B aircraft, and APRS amateur position reports.
+level: beginner
+status: stub
+prereq:
+  - what-is-sdr
+---
+
+# Other signals you'll meet
+
+Trunked voice is only part of the picture. Your SDR can decode many other signals.
+
+## Paging (POCSAG / FLEX)
+
+## AIS: tracking ships
+
+## ADS-B: tracking aircraft
+
+## APRS and AX.25
+
+## DSC, MDC1200, and more
+
+GopherTrunk references: [POCSAG](/pocsag.html), [AIS](/ais.html), [ADS-B](/adsb.html), [APRS](/aprs.html).

--- a/docs/learn/propagation.md
+++ b/docs/learn/propagation.md
@@ -55,6 +55,13 @@ horizon out. A transmitter on a tall tower or hilltop reaches far; a receiver up
 with a clear view hears far. This is why repeaters live on towers and why getting your
 antenna up and outside helps so much.
 
+**A rough number.** The radio horizon in kilometres is about *4.1 × √(height in
+metres)*. An antenna at **2 m** reaches ~5.8 km to the horizon; lift it to **10 m**
+and it reaches ~13 km; a repeater at **100 m** reaches ~41 km. Two stations each see
+to their own horizon, so their ranges *add* — which is why a hilltop repeater can
+link two handhelds that could never hear each other directly. Every metre of height
+you add literally extends how far you can receive.
+
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 420 150" role="img" aria-label="A curved Earth with a tall transmitter tower and a receiver. A straight line of sight reaches over the curve to the horizon; an obstacle blocks a low path." xmlns="http://www.w3.org/2000/svg">
   <path d="M10 140 Q210 90 410 140" fill="none" stroke="currentColor" stroke-opacity="0.4" stroke-width="1.5"/>

--- a/docs/learn/propagation.md
+++ b/docs/learn/propagation.md
@@ -1,24 +1,140 @@
 ---
 slug: propagation
 title: How signals travel
-description: RF propagation for beginners — line-of-sight, the radio horizon, multipath and fading, and why antenna placement matters more than the radio for reliable reception.
+description: RF propagation for beginners — line-of-sight and the radio horizon, how terrain and buildings attenuate signals, multipath and fading, how propagation changes with frequency, and practical antenna-placement tips for a scanner setup.
+keywords: RF propagation, line of sight, radio horizon, multipath, fading, signal attenuation, antenna placement, VHF UHF propagation, scanner reception tips
 level: beginner
-status: stub
+status: full
 prereq:
   - radio-waves
   - antennas
+faq:
+  - q: Why can't I receive a station that isn't far away?
+    a: At VHF and UHF, radio is mostly line-of-sight. Hills, buildings, and even dense trees between you and the transmitter block or weaken the signal. A station only a few kilometres away can be unreachable if terrain is in the way, while a more distant one on a hilltop comes in clearly. Height and a clear path matter more than raw distance.
+  - q: What is the radio horizon?
+    a: The radio horizon is the farthest point a line-of-sight signal reaches before the curvature of the Earth blocks it. It's slightly farther than the visual horizon because the atmosphere bends radio waves a little. Raising the antenna extends the radio horizon, which is why height helps so much for VHF/UHF reception.
+  - q: What is multipath?
+    a: Multipath is when a signal reaches your antenna by several paths at once — directly and via reflections off buildings, terrain, or vehicles. The copies arrive slightly out of step and can reinforce or cancel each other, causing fading and, for digital signals, decoding errors. Moving the antenna a little can change multipath dramatically.
+  - q: How do I improve reception?
+    a: Get the antenna higher and outdoors with a clear view toward the systems you want, match its polarization (usually vertical), keep coax short, and move it away from sources of electrical noise like computers, chargers, and LED lighting. For VHF/UHF, placement and height usually beat buying a better radio.
+gophertrunk_links:
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: watch SNR change live as you reposition the antenna.
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: find which systems actually reach your location.
 ---
 
 # How signals travel
 
-Where you put the antenna usually matters more than which radio you buy. Here is why.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+At the VHF/UHF frequencies most scanning uses, radio is essentially
+**line-of-sight** — it travels to the **radio horizon** and stops, blocked by hills,
+buildings, and the Earth's curve. Reflections create **multipath**, which causes
+**fading** and decoding errors. Lower frequencies travel and penetrate better; higher
+ones are blocked more easily. The single biggest lever you control is **antenna
+placement**: height, a clear path, matched polarization, and distance from noise
+usually beat any radio upgrade.
+</div>
 
-## Line of sight and the radio horizon
+You've got an [antenna](/learn/antennas/) sized for your band. Where you put it, and
+what's between it and the transmitter, decides whether a system comes in clean or not
+at all. This lesson explains why.
 
-## How buildings, terrain, and trees attenuate signals
+## What is line-of-sight and the radio horizon?
 
-## Multipath and fading
+At VHF and UHF, radio waves travel in nearly straight lines — **line-of-sight**. They
+don't bend far around the Earth, so they reach a limit called the **radio horizon**,
+where the planet's curvature gets in the way. It's a bit beyond the *visual* horizon
+because the atmosphere refracts radio slightly.
 
-## How propagation changes with frequency
+The key consequence: **height extends range.** Raising either antenna pushes the
+horizon out. A transmitter on a tall tower or hilltop reaches far; a receiver up high
+with a clear view hears far. This is why repeaters live on towers and why getting your
+antenna up and outside helps so much.
 
-## Practical placement tips for a scanner setup
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 420 150" role="img" aria-label="A curved Earth with a tall transmitter tower and a receiver. A straight line of sight reaches over the curve to the horizon; an obstacle blocks a low path." xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 140 Q210 90 410 140" fill="none" stroke="currentColor" stroke-opacity="0.4" stroke-width="1.5"/>
+  <line x1="70" y1="120" x2="70" y2="60" stroke="currentColor" stroke-width="2"/>
+  <text x="50" y="52" font-size="10" fill="currentColor">TX</text>
+  <line x1="350" y1="118" x2="350" y2="88" stroke="currentColor" stroke-width="2"/>
+  <text x="338" y="80" font-size="10" fill="currentColor">RX</text>
+  <line x1="70" y1="60" x2="350" y2="88" stroke="currentColor" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="180" y="62" font-size="10" fill="currentColor">line of sight</text>
+  <rect x="205" y="100" width="14" height="20" fill="currentColor" fill-opacity="0.3"/>
+  <text x="200" y="135" font-size="9" fill="currentColor">obstacle</text>
+</svg>
+<figcaption>Line-of-sight reaches to the radio horizon; height extends it. An obstacle in the path blocks or weakens the signal.</figcaption>
+</figure>
+
+## How do terrain and buildings weaken signals?
+
+Anything in the path **attenuates** (weakens) the signal. Hills and large buildings
+can block it entirely (a "shadow"). Walls, foliage, and even rain take their toll —
+more so at higher frequencies. This is why a station only a few kilometres away can be
+unreachable if a ridge or tower block sits between you, while a more distant hilltop
+system comes in fine. **Distance is only part of the story; the path matters more.**
+
+## What are multipath and fading?
+
+A signal rarely takes just one route to your antenna. It also bounces off buildings,
+terrain, and vehicles, so several copies arrive — slightly delayed relative to each
+other. That's **multipath**. Because the copies are out of step, they can add up or
+partly cancel, making the signal level **fade** up and down, sometimes as things
+(like traffic) move.
+
+For analog you hear this as flutter; for **digital** signals multipath smears the
+[symbols](/learn/digital-modulation/) and can push decoding past its error limit.
+Often the fix is simply to **move the antenna** a short distance — even tens of
+centimetres can swap a deep fade for a strong spot.
+
+## How does propagation change with frequency?
+
+As a rule of thumb, lower frequencies travel and penetrate better:
+
+| Band | Behaviour |
+|------|-----------|
+| HF | Can refract off the ionosphere — worldwide "skip" |
+| VHF | Line-of-sight, bends slightly, decent building penetration |
+| UHF | Line-of-sight, more easily blocked, but good in urban multipath |
+| SHF | Very line-of-sight, blocked by almost anything |
+
+The trunked systems GopherTrunk follows sit in VHF/UHF/700-800 MHz, so think
+**line-of-sight with multipath** — height and a clear path are your friends.
+
+## Practical placement tips
+
+- **Go up and out.** Higher and outdoors beats low and indoors almost every time.
+- **Clear the path** toward the systems you want; aim around big obstructions.
+- **Match polarization** — vertical for most land-mobile (see [antennas](/learn/antennas/)).
+- **Keep coax short** to limit loss.
+- **Escape noise.** Computers, USB hubs, chargers, and LED/CFL lighting raise your
+  [noise floor](/learn/decibels/); distance from them improves SNR more than you'd
+  expect.
+
+Watch the effect live in GopherTrunk's [tuning meters](/tuning.html): reposition the
+antenna and see SNR rise or fall in real time.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — at VHF/UHF a clear, high path matters more than raw distance." markdown="0">
+  <p class="knowledge-check__q">Quick check: a system 3 km away won't decode, but one 30 km away on a hilltop does. The likeliest reason?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The far system transmits on a lower frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Terrain/buildings block the near one; the far one has line-of-sight</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Closer signals are always weaker</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- VHF/UHF radio is **line-of-sight**, limited by the **radio horizon**; height extends it.
+- **Terrain and buildings** attenuate or block signals — path beats distance.
+- **Multipath** causes **fading** and digital errors; moving the antenna often helps.
+- Lower frequencies travel/penetrate better; the trunked bands are line-of-sight.
+- **Placement** — height, clear path, polarization, low noise — is your biggest lever.
+
+That wraps Module 1. Next module: how information is actually put onto these waves,
+starting with the anatomy of a signal on screen.

--- a/docs/learn/propagation.md
+++ b/docs/learn/propagation.md
@@ -1,0 +1,24 @@
+---
+slug: propagation
+title: How signals travel
+description: RF propagation for beginners — line-of-sight, the radio horizon, multipath and fading, and why antenna placement matters more than the radio for reliable reception.
+level: beginner
+status: stub
+prereq:
+  - radio-waves
+  - antennas
+---
+
+# How signals travel
+
+Where you put the antenna usually matters more than which radio you buy. Here is why.
+
+## Line of sight and the radio horizon
+
+## How buildings, terrain, and trees attenuate signals
+
+## Multipath and fading
+
+## How propagation changes with frequency
+
+## Practical placement tips for a scanner setup

--- a/docs/learn/protocol-landscape.md
+++ b/docs/learn/protocol-landscape.md
@@ -1,0 +1,27 @@
+---
+slug: protocol-landscape
+title: The digital protocol landscape
+description: A field guide to digital radio protocols — P25, DMR, NXDN, TETRA, Motorola, EDACS, and more — who uses each, how they differ, and how to tell them apart on the air.
+level: intermediate
+status: stub
+prereq:
+  - what-is-trunking
+---
+
+# The digital protocol landscape
+
+A guided tour of the digital systems you will encounter, and how to recognize each.
+
+## P25 (Phase 1 and Phase 2)
+
+## DMR (Tier II and Tier III)
+
+## NXDN and dPMR
+
+## TETRA
+
+## Legacy: Motorola Type II, EDACS, LTR, MPT 1327
+
+## How to tell them apart on a waterfall
+
+See the [Status reference](/status.html) for GopherTrunk decoder coverage.

--- a/docs/learn/protocol-landscape.md
+++ b/docs/learn/protocol-landscape.md
@@ -50,6 +50,32 @@ each call its own frequency. **TDMA** (time-division) splits one frequency into 
 **time slots**, so two or more calls share it by taking turns. TDMA doubles capacity in
 the same spectrum, which is why newer standards adopt it. Keep this in mind as we go.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 180" role="img" aria-label="Two grids of frequency versus time. FDMA on the left gives each call its own horizontal frequency lane. TDMA on the right fits two calls on one frequency by alternating time slots." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <!-- FDMA -->
+    <text x="110" y="18" text-anchor="middle" font-weight="600">FDMA</text>
+    <line x1="40" y1="150" x2="200" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+    <line x1="40" y1="30" x2="40" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+    <text x="120" y="170" text-anchor="middle" font-size="9">time →</text>
+    <text x="30" y="90" font-size="9" transform="rotate(-90 30 90)">freq →</text>
+    <rect x="44" y="50" width="152" height="26" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="0.8"/><text x="120" y="67" text-anchor="middle" font-size="9">call A — channel 1</text>
+    <rect x="44" y="86" width="152" height="26" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="0.8"/><text x="120" y="103" text-anchor="middle" font-size="9">call B — channel 2</text>
+    <!-- TDMA -->
+    <text x="400" y="18" text-anchor="middle" font-weight="600">TDMA</text>
+    <line x1="330" y1="150" x2="490" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+    <line x1="330" y1="30" x2="330" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+    <text x="410" y="170" text-anchor="middle" font-size="9">time →</text>
+    <rect x="334" y="68" width="38" height="44" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="0.8"/><text x="353" y="94" text-anchor="middle" font-size="9">A</text>
+    <rect x="372" y="68" width="38" height="44" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="0.8"/><text x="391" y="94" text-anchor="middle" font-size="9">B</text>
+    <rect x="410" y="68" width="38" height="44" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="0.8"/><text x="429" y="94" text-anchor="middle" font-size="9">A</text>
+    <rect x="448" y="68" width="38" height="44" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="0.8"/><text x="467" y="94" text-anchor="middle" font-size="9">B</text>
+    <text x="410" y="128" text-anchor="middle" font-size="8">one frequency, alternating slots</text>
+  </g>
+</svg>
+<figcaption>FDMA gives each call its own frequency lane; TDMA fits two calls (A and B) on one frequency by taking turns in time slots — twice the capacity in the same channel.</figcaption>
+</figure>
+
 ## P25 (Phase 1 and Phase 2)
 
 **P25** is the open standard for **North-American public safety**:

--- a/docs/learn/protocol-landscape.md
+++ b/docs/learn/protocol-landscape.md
@@ -1,27 +1,140 @@
 ---
 slug: protocol-landscape
 title: The digital protocol landscape
-description: A field guide to digital radio protocols — P25, DMR, NXDN, TETRA, Motorola, EDACS, and more — who uses each, how they differ, and how to tell them apart on the air.
+description: A field guide to digital radio protocols — P25 Phase 1 and 2, DMR Tier II/III, NXDN, dPMR, TETRA, and legacy systems like Motorola Type II, EDACS, LTR, and MPT 1327 — who uses each, how they differ, and how to tell them apart.
+keywords: P25, DMR, NXDN, TETRA, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, digital radio protocols, trunking standards, identify radio system
 level: intermediate
-status: stub
+status: full
 prereq:
   - what-is-trunking
+faq:
+  - q: What is the difference between P25 and DMR?
+    a: Both are digital land-mobile-radio standards using 4-level FSK, but P25 is a North-American public-safety standard (Phase 1 is FDMA at 12.5 kHz; Phase 2 is TDMA for double capacity) using IMBE/AMBE+2 vocoders. DMR is an ETSI standard widely used in business and amateur radio, using two-slot TDMA in a 12.5 kHz channel with the AMBE+2 vocoder. P25 dominates US public safety; DMR dominates commercial and ham digital.
+  - q: How can I tell which protocol a system uses?
+    a: Start with a database like RadioReference, which lists the system type for known systems. On the air, the modulation and channel width give clues, and decoder software identifies the protocol once it locks onto the control channel. GopherTrunk recognises the protocol from the control-channel signalling once it's decoding.
+  - q: What is the difference between FDMA and TDMA?
+    a: FDMA (frequency-division multiple access) gives each call its own frequency channel. TDMA (time-division multiple access) splits one frequency into time slots so several calls share it, alternating in rapid turns. P25 Phase 1 is FDMA; P25 Phase 2 and DMR are TDMA, which is how they fit more conversations into the same spectrum.
+  - q: Are old analog trunking systems still around?
+    a: Yes. Legacy systems like Motorola Type II, EDACS, LTR, and MPT 1327 still operate in places, often with analog voice but a data control channel for trunking. Newer deployments are overwhelmingly digital (P25, DMR), but a scanner enthusiast still encounters legacy systems, and GopherTrunk supports a range of them.
+gophertrunk_links:
+  - title: Status
+    url: /status.html
+    note: which protocols GopherTrunk decodes and how completely.
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: identify an unknown system from its control channel.
 ---
 
 # The digital protocol landscape
 
-A guided tour of the digital systems you will encounter, and how to recognize each.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The digital airwaves are a patchwork of standards. **P25** dominates North-American
+public safety (**Phase 1** = FDMA 12.5 kHz; **Phase 2** = TDMA, double capacity).
+**DMR** rules business and amateur digital (two-slot TDMA, [AMBE+2](/learn/vocoders/)).
+**NXDN/dPMR** are narrowband alternatives; **TETRA** is common in Europe. Older
+**Motorola Type II, EDACS, LTR, MPT 1327** still linger. Most use
+[4FSK](/learn/digital-modulation/); they differ in how they pack calls (**FDMA vs.
+TDMA**) and signal their [control channel](/learn/what-is-trunking/). GopherTrunk
+identifies the protocol once it locks on.
+</div>
+
+You understand [trunking](/learn/what-is-trunking/) in the abstract; this is the field
+guide to the actual standards you'll meet, what's behind each name, and how they relate.
+The [Status reference](/status.html) tracks GopherTrunk's coverage of them.
+
+## FDMA vs. TDMA — the key axis
+
+One distinction explains a lot of the family tree. **FDMA** (frequency-division) gives
+each call its own frequency. **TDMA** (time-division) splits one frequency into rapid
+**time slots**, so two or more calls share it by taking turns. TDMA doubles capacity in
+the same spectrum, which is why newer standards adopt it. Keep this in mind as we go.
 
 ## P25 (Phase 1 and Phase 2)
 
+**P25** is the open standard for **North-American public safety**:
+
+- **Phase 1** — **FDMA**, 12.5 kHz channels, **[C4FM](/learn/digital-modulation/)** 4FSK,
+  **[IMBE](/learn/vocoders/)** vocoder. The workhorse for police/fire.
+- **Phase 2** — **TDMA**, two voice slots per channel for double capacity, a PSK-family
+  modulation, **AMBE+2** vocoder.
+
+If you're in the US tracking emergency services, P25 is what you'll see most.
+
 ## DMR (Tier II and Tier III)
+
+**DMR** (Digital Mobile Radio) is an **ETSI** standard huge in **business and amateur**
+radio. It's **two-slot TDMA** in a 12.5 kHz channel using **AMBE+2**:
+
+- **Tier II** — conventional (non-trunked) two-slot DMR; very common commercially and on
+  ham repeaters.
+- **Tier III** — **trunked** DMR with a [control channel](/learn/what-is-trunking/).
+
+DMR's low cost made it ubiquitous outside public safety.
 
 ## NXDN and dPMR
 
+**NXDN** (used by Kenwood/Icom systems) and **dPMR** are **narrowband** standards (often
+6.25 kHz) using 4FSK, found in business, transport, and utilities. They trade some audio
+quality for very efficient spectrum use, and both come in conventional and trunked
+flavours.
+
 ## TETRA
 
-## Legacy: Motorola Type II, EDACS, LTR, MPT 1327
+**TETRA** (Terrestrial Trunked Radio) is a European-rooted standard widespread in
+**public safety and transport outside North America**. It uses a four-slot TDMA scheme
+with π/4-DQPSK modulation and is a complete trunked system with strong feature support.
 
-## How to tell them apart on a waterfall
+## Legacy systems
 
-See the [Status reference](/status.html) for GopherTrunk decoder coverage.
+Plenty of older systems still run, frequently with **analog voice** but a **data control
+channel** for trunking:
+
+| System | Notes |
+|--------|-------|
+| Motorola Type II | Classic analog trunking, widespread legacy |
+| EDACS | GE/Ericsson trunking |
+| LTR | Logic Trunked Radio, simple business trunking |
+| MPT 1327 | Analog trunking common outside the US |
+
+They're fading as agencies migrate to P25/DMR, but a scanner enthusiast still meets
+them.
+
+## How to tell them apart
+
+1. **Database first.** [RadioReference](/learn/finding-systems/) lists the system type for
+   known systems in your area — by far the easiest route.
+2. **On the air.** Channel width and [modulation](/learn/digital-modulation/) footprint on
+   the [waterfall](/learn/fft-and-waterfall/) narrow it down; TDMA vs. FDMA behaviour
+   (one slot vs. shared) is a clue.
+3. **Let the decoder say.** Once GopherTrunk locks a [control
+   channel](/learn/what-is-trunking/), the signalling identifies the protocol and system
+   parameters for you.
+
+| Standard | Access | Typical use | Vocoder |
+|----------|--------|-------------|---------|
+| P25 Phase 1 | FDMA | US public safety | IMBE |
+| P25 Phase 2 | TDMA | US public safety (high capacity) | AMBE+2 |
+| DMR | TDMA (2-slot) | Business, amateur | AMBE+2 |
+| NXDN / dPMR | FDMA (narrow) | Business, utilities | AMBE+ variants |
+| TETRA | TDMA (4-slot) | Public safety (EU and beyond) | ACELP |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — TDMA shares one frequency across time slots to carry more calls." markdown="0">
+  <p class="knowledge-check__q">Quick check: P25 Phase 2 and DMR both use TDMA. What does TDMA let them do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Transmit on every frequency at once</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Fit more calls in the same spectrum via time slots</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Avoid needing a control channel</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The big axis is **FDMA** (a frequency per call) vs. **TDMA** (time slots share a frequency).
+- **P25** = US public safety (Phase 1 FDMA, Phase 2 TDMA); **DMR** = business/amateur (2-slot TDMA).
+- **NXDN/dPMR** are narrowband; **TETRA** is common in Europe; legacy Motorola/EDACS/LTR/MPT linger.
+- Identify systems via a **database**, their **on-air footprint**, or by letting the
+  decoder read the **control channel**.
+
+Next: the reason some talkgroups stay silent no matter what — encryption.

--- a/docs/learn/radio-waves.md
+++ b/docs/learn/radio-waves.md
@@ -1,0 +1,177 @@
+---
+slug: radio-waves
+title: What is a radio wave?
+description: A plain-language introduction to radio waves — frequency, wavelength, amplitude, and the electromagnetic spectrum. The one foundational idea every SDR and scanner skill builds on.
+keywords: radio wave, what is a radio wave, frequency, wavelength, amplitude, electromagnetic spectrum, hertz, RF basics
+level: beginner
+status: full
+faq:
+  - q: What is a radio wave in simple terms?
+    a: A radio wave is an invisible ripple of electric and magnetic energy that travels through space at the speed of light. A transmitter shakes electrons in an antenna, and that motion radiates outward as a wave that a distant antenna can pick up. Radio waves carry information — voice, data, video — by varying the wave's height (amplitude), rate (frequency), or timing (phase).
+  - q: What is the difference between frequency and wavelength?
+    a: Frequency is how many times per second a wave cycles, measured in hertz (Hz). Wavelength is the physical distance the wave covers in one cycle, measured in metres. They are inversely related — higher frequency means shorter wavelength. For radio you can convert between them with wavelength (m) = 300 / frequency (MHz).
+  - q: How fast do radio waves travel?
+    a: Radio waves travel at the speed of light — about 299,792,458 metres per second (roughly 300,000 km/s) in a vacuum, and very slightly slower in air. This is why you can think of "the speed of light" and "the speed of radio" as the same thing.
+  - q: Why do I need to understand radio waves to use an SDR?
+    a: Every setting on a software-defined radio — the frequency you tune to, the bandwidth you capture, the antenna you choose — is a direct consequence of how radio waves behave. Once frequency, wavelength, and amplitude click, the rest of SDR stops feeling like magic and starts feeling like cause and effect.
+gophertrunk_links:
+  - title: Hardware guide
+    url: /hardware.html
+    note: pick a dongle whose frequency range covers the waves you want to receive.
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: watch live signal levels — amplitude — as you tune across a band.
+---
+
+# What is a radio wave?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **radio wave** is energy that travels through space as a vibrating electric and
+magnetic field, moving at the speed of light. It is described by three numbers:
+**frequency** (how fast it cycles, in hertz), **wavelength** (how long one cycle
+is, in metres), and **amplitude** (how strong it is). Radio is just the slow,
+long-wavelength part of the same electromagnetic spectrum that includes light.
+Get these three numbers straight and every other SDR idea follows.
+</div>
+
+This is lesson 1 of the path, and it's the one everything else leans on. By the
+end you'll be able to look at "460.025 MHz" and know roughly how long that wave
+is, why it behaves the way it does, and how it connects to the dials you'll turn
+in GopherTrunk.
+
+## What exactly is a radio wave?
+
+A radio wave is a ripple of **electromagnetic energy**. When a transmitter pushes
+electrical current back and forth in an antenna, it creates a changing electric
+field, which creates a changing magnetic field, which creates a changing electric
+field — and that self-sustaining pattern races away from the antenna at the speed
+of light. No wires, no medium required; radio waves cross empty space happily.
+
+It's the same physics as visible light, microwaves, and X-rays. The only thing
+that separates "radio" from "light" is how fast the field vibrates. Radio waves
+vibrate slowly enough (thousands to billions of times per second) that we can
+build electronics to generate and detect them directly — which is exactly what
+your SDR does.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 160" role="img" aria-label="A sine wave showing one wavelength from crest to crest and amplitude as height from the centre line." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="80" x2="500" y2="80" stroke="currentColor" stroke-opacity="0.3" stroke-width="1"/>
+  <path d="M20 80 C 70 0, 130 0, 180 80 S 290 160, 340 80 S 450 0, 500 80" fill="none" stroke="currentColor" stroke-width="2.5"/>
+  <line x1="180" y1="30" x2="340" y2="30" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="260" y="22" text-anchor="middle" font-size="13" fill="currentColor">one wavelength (λ)</text>
+  <line x1="100" y1="80" x2="100" y2="22" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="108" y="50" font-size="13" fill="currentColor">amplitude</text>
+</svg>
+<figcaption>One cycle of a wave: <strong>wavelength</strong> is the distance between repeats; <strong>amplitude</strong> is its height; <strong>frequency</strong> is how many cycles pass each second.</figcaption>
+</figure>
+
+## What is frequency, and why is it measured in hertz?
+
+**Frequency** is how many complete cycles the wave makes every second. The unit is
+the **hertz (Hz)** — one cycle per second. Radio frequencies are big numbers, so we
+use prefixes:
+
+| Unit | Cycles per second | You'll see it for |
+|------|-------------------|-------------------|
+| 1 kHz (kilohertz) | 1,000 | Long-wave broadcast, navigation |
+| 1 MHz (megahertz) | 1,000,000 | FM radio, public-safety, scanners |
+| 1 GHz (gigahertz) | 1,000,000,000 | Wi-Fi, GPS, cellular, satellite |
+
+When you tell GopherTrunk to listen on **851.0125 MHz**, you're telling it to look
+for a wave cycling about 851 million times every second. Tune to the wrong
+frequency and you simply won't hear the signal — it's like dialing the wrong phone
+number.
+
+## What is wavelength, and how do I calculate it?
+
+**Wavelength** (the Greek letter λ, "lambda") is the physical length of one cycle —
+the distance from one crest to the next. Because all radio waves travel at the same
+speed, frequency and wavelength are two sides of the same coin: the faster a wave
+cycles, the less distance it covers per cycle, so the **shorter** its wavelength.
+
+The exact relationship is *wavelength = speed of light ÷ frequency*. For everyday
+radio there's a shortcut worth memorising:
+
+> **λ (metres) ≈ 300 ÷ frequency (MHz)**
+
+So a 150 MHz signal is about 2 metres long; a 460 MHz signal is about 0.65 m; a
+1.2 GHz signal is just 25 cm. This isn't trivia — wavelength decides how big your
+**[antenna](/learn/antennas/)** needs to be (antennas are sized to a fraction of a
+wavelength) and how the wave bends around buildings and hills.
+
+<div class="calc" data-calc="freq" markdown="0">
+  <p class="calc__title">Frequency ↔ wavelength calculator</p>
+  <div class="calc__row">
+    <label for="rw-freq">Frequency</label>
+    <input id="rw-freq" type="number" data-freq value="460" min="0" step="any" inputmode="decimal">
+    <select data-freq-unit aria-label="Frequency unit">
+      <option value="1000">kHz</option>
+      <option value="1000000" selected>MHz</option>
+      <option value="1000000000">GHz</option>
+    </select>
+  </div>
+  <div class="calc__row">
+    <label>Wavelength</label>
+    <span class="calc__out" data-wavelength>—</span>
+  </div>
+  <p class="calc__note">Uses the exact speed of light (299,792,458 m/s). The “300 ÷ MHz” rule is a handy approximation of the same formula.</p>
+</div>
+
+## What is amplitude, and how does it relate to signal strength?
+
+**Amplitude** is the height of the wave — how much energy it carries. A bigger
+amplitude means a stronger signal. As a radio wave spreads out from a transmitter
+and travels past obstacles, its amplitude shrinks, which is why a distant repeater
+is harder to hear than a nearby one.
+
+Your SDR doesn't measure amplitude in metres of wave height; it reports it as a
+**power level** in decibels (you'll meet **[dBm and the noise floor](/learn/decibels/)**
+in the next-but-one lesson). For now, hold onto the intuition: *amplitude = how
+loud the signal is at your antenna*, and a digital decoder needs enough amplitude
+above the background noise to recover the data.
+
+## How does information ride on a radio wave?
+
+A plain, unchanging wave — a **carrier** — carries no information by itself. To send
+something, the transmitter deliberately *changes* one of the wave's three
+properties in step with the message:
+
+- Vary the **amplitude** → that's **AM** (and the basis of many data modes).
+- Vary the **frequency** → that's **FM** (and digital cousins like FSK).
+- Vary the **phase** (the wave's timing) → the basis of **PSK** and the digital
+  voice modes GopherTrunk decodes.
+
+That deliberate changing is called **modulation**, and it's the whole subject of
+[Module 2](/learn/#signals-modulation). For now, just know that the radio wave is the
+*envelope* and modulation is the *message written on it*.
+
+## Where do radio waves sit in the bigger picture?
+
+Radio is the low-frequency end of the **electromagnetic spectrum** — the same
+family as microwaves, infrared, visible light, and X-rays, just vibrating far more
+slowly. "Radio" conventionally spans about **3 kHz to 300 GHz**. Within that range,
+governments carve the spectrum into **bands** and assign them to uses — broadcast,
+aviation, public safety, amateur radio, satellite. That's the subject of the next
+lesson, [Frequency, bands & the spectrum](/learn/frequency-and-spectrum/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — higher frequency means a shorter wave." markdown="0">
+  <p class="knowledge-check__q">Quick check: a 900 MHz signal compared with a 150 MHz signal has a…</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">longer wavelength</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">shorter wavelength</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">the same wavelength</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A radio wave is electromagnetic energy travelling at the speed of light.
+- **Frequency** (Hz) is how fast it cycles; **wavelength** (m) is how long one cycle
+  is; they're linked by *λ ≈ 300 ÷ MHz*.
+- **Amplitude** is its strength, which your SDR reports as a power level.
+- **Modulation** changes the wave to carry information.
+- Radio is just the slow part of the same spectrum as light.
+
+Next up: how that spectrum is divided into the bands you'll actually tune to.

--- a/docs/learn/sample-rate-nyquist.md
+++ b/docs/learn/sample-rate-nyquist.md
@@ -1,0 +1,25 @@
+---
+slug: sample-rate-nyquist
+title: Sample rate, bandwidth & Nyquist
+description: Sample rate, bandwidth, and the Nyquist theorem made simple — how much spectrum an SDR can capture at once, what aliasing is, and the bandwidth-versus-CPU trade-off.
+level: intermediate
+status: stub
+prereq:
+  - iq-data
+---
+
+# Sample rate, bandwidth & Nyquist
+
+How wide a slice of the spectrum can you see at once? This lesson answers that.
+
+## Sample rate and what it buys you
+
+## The Nyquist limit in plain terms
+
+## Bandwidth = how much spectrum you capture
+
+## Aliasing and why it matters
+
+## The bandwidth vs. CPU trade-off
+
+## Choosing a sample rate for trunk-tracking

--- a/docs/learn/sample-rate-nyquist.md
+++ b/docs/learn/sample-rate-nyquist.md
@@ -1,25 +1,141 @@
 ---
 slug: sample-rate-nyquist
 title: Sample rate, bandwidth & Nyquist
-description: Sample rate, bandwidth, and the Nyquist theorem made simple — how much spectrum an SDR can capture at once, what aliasing is, and the bandwidth-versus-CPU trade-off.
+description: Sample rate, bandwidth, and the Nyquist theorem made simple — how much spectrum an SDR captures at once, why sample rate equals IQ bandwidth, what aliasing is, the bandwidth-versus-CPU trade-off, and choosing a rate for trunk-tracking.
+keywords: sample rate, Nyquist theorem, bandwidth, aliasing, IQ bandwidth, SDR sample rate, decimation, sample rate vs CPU, RTL-SDR sample rate
 level: intermediate
-status: stub
+status: full
 prereq:
   - iq-data
+faq:
+  - q: How much spectrum can an SDR capture at once?
+    a: With IQ (complex) sampling, the captured bandwidth roughly equals the sample rate. An RTL-SDR running at 2.4 million samples per second captures about 2.4 MHz of spectrum at once. To see or decode signals across a wider span you either raise the sample rate (if the hardware allows) or retune to a different centre frequency.
+  - q: What is the Nyquist theorem in simple terms?
+    a: The Nyquist theorem says you must sample at least twice as fast as the highest frequency you want to represent, or you lose information. For SDRs using IQ sampling, the practical version is that the usable bandwidth is about equal to the sample rate. Sample too slowly for the bandwidth you're capturing and signals fold back as aliases.
+  - q: What is aliasing?
+    a: Aliasing is when a signal outside the bandwidth your sample rate can represent gets "folded" back into your captured spectrum, appearing at the wrong frequency. It looks like a real signal but isn't where it seems. Anti-aliasing filtering and choosing an adequate sample rate prevent it.
+  - q: Does a higher sample rate always help?
+    a: No. A higher sample rate captures more spectrum but produces more data, so it uses more USB bandwidth and more CPU to process. For trunk-tracking you only need enough sample rate to cover the channels you're following. Capturing a huge span you don't use just wastes CPU and can stress the hardware.
+gophertrunk_links:
+  - title: Architecture
+    url: /architecture.html
+    note: how GopherTrunk channelises a wideband IQ stream.
+  - title: Hardware guide
+    url: /hardware.html
+    note: typical sample rates for each supported radio.
 ---
 
 # Sample rate, bandwidth & Nyquist
 
-How wide a slice of the spectrum can you see at once? This lesson answers that.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An SDR's **sample rate** (samples per second) sets how much spectrum it captures at
+once: with [IQ sampling](/learn/iq-data/), **captured bandwidth ≈ sample rate**. The
+**Nyquist theorem** is the rule behind this — sample too slowly for the bandwidth and
+signals **alias** (fold back to the wrong frequency). Higher sample rate = more
+spectrum but **more data, more CPU, more USB load**. For trunk-tracking you want *just
+enough* rate to cover the channels you follow — not the widest possible span.
+</div>
+
+You know the SDR streams [IQ samples](/learn/iq-data/). How wide a slice of spectrum do
+those samples represent, and how fast must they come? That's this lesson — and it
+directly sets one of the few numbers you'll configure.
 
 ## Sample rate and what it buys you
 
-## The Nyquist limit in plain terms
+The **sample rate** is how many [IQ samples](/learn/iq-data/) per second the ADC
+produces, in samples/second (Sa/s) or, loosely, "MHz." Its headline effect is simple:
 
-## Bandwidth = how much spectrum you capture
+> With complex (IQ) sampling, the **captured bandwidth is approximately equal to the
+> sample rate.**
 
-## Aliasing and why it matters
+So an RTL-SDR at **2.4 MSa/s** shows you about **2.4 MHz** of spectrum at once, centred
+on whatever frequency the [LO](/learn/sdr-receiver/) is tuned to. Want to see more than
+that span? Raise the rate (within hardware limits) or **retune** the centre frequency
+to a different chunk.
+
+## The Nyquist theorem, plainly
+
+The **Nyquist theorem** is the law underneath that rule of thumb. In its general form:
+*to represent a signal faithfully you must sample at least twice its highest
+frequency.* For SDRs doing IQ sampling, the practical takeaway is the one above —
+**usable bandwidth ≈ sample rate**. Try to capture more bandwidth than your sample rate
+supports and the information doesn't just vanish; it corrupts your data through
+aliasing.
+
+## What is aliasing?
+
+**Aliasing** is when energy outside the bandwidth your sample rate can represent gets
+**folded** back into your captured spectrum, showing up at a *wrong* frequency. It can
+look exactly like a genuine signal — a phantom that isn't really there (or is really
+somewhere else). 
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 140" role="img" aria-label="A captured band between two dashed Nyquist edges. A real signal sits inside; an out-of-band signal beyond the edge is shown folding back to appear inside as an alias." xmlns="http://www.w3.org/2000/svg">
+  <line x1="60" y1="110" x2="420" y2="110" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="110" y1="20" x2="110" y2="120" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.6"/>
+  <line x1="330" y1="20" x2="330" y2="120" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.6"/>
+  <text x="220" y="134" text-anchor="middle" font-size="10" fill="currentColor">captured bandwidth (≈ sample rate)</text>
+  <path d="M170 110 L180 60 L190 110 Z" fill="currentColor" fill-opacity="0.3" stroke="currentColor"/>
+  <text x="180" y="52" text-anchor="middle" font-size="9" fill="currentColor">real</text>
+  <path d="M360 110 L370 75 L380 110 Z" fill="none" stroke="currentColor" stroke-opacity="0.5"/>
+  <text x="370" y="68" text-anchor="middle" font-size="9" fill="currentColor">out of band</text>
+  <path d="M260 110 L270 80 L280 110 Z" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-dasharray="3 2"/>
+  <text x="270" y="73" text-anchor="middle" font-size="9" fill="currentColor">alias!</text>
+  <path d="M370 78 q-50 -30 -100 0" fill="none" stroke="currentColor" stroke-opacity="0.5" stroke-dasharray="2 2"/>
+</svg>
+<figcaption>A signal beyond the captured bandwidth folds back ("aliases") to appear at a false position inside it. Anti-alias filtering and adequate sample rate prevent this.</figcaption>
+</figure>
+
+SDR front ends include **anti-aliasing filtering**, and choosing an adequate sample
+rate keeps real signals safely inside the usable window. The edges of that window can be
+less clean, so it's common to keep your target a little away from the very edge.
 
 ## The bandwidth vs. CPU trade-off
 
+It's tempting to crank the sample rate to "see everything," but more bandwidth has
+costs:
+
+| Higher sample rate | Consequence |
+|--------------------|-------------|
+| More spectrum captured | Good — more channels at once |
+| More samples/second | More **USB bandwidth** (can cause dropped samples) |
+| More data to process | More **CPU** for FFTs, filtering, demod |
+| Cheap-tuner edge quality | Wider spans expose front-end limits |
+
+GopherTrunk takes a wide IQ stream and **channelises** it — digitally
+[filtering and decimating](/learn/filtering-decimation/) out each narrow channel it
+needs. So the question isn't "how wide can I go" but "how wide do I *need*."
+
 ## Choosing a sample rate for trunk-tracking
+
+A trunked system's [control channel](/learn/what-is-trunking/) and its voice channels
+may be spread across some span of a band. You want a sample rate (and centre frequency)
+that **covers the channels you actually follow**, with a little margin, and no more:
+
+- If all your channels fit within ~2 MHz, an RTL-SDR's 2.4 MSa/s is plenty.
+- If they're spread wider, you may need a wider-bandwidth radio (Airspy) or a second
+  dongle covering another chunk.
+- Avoid maxing the rate "just in case" — it risks dropped samples and wastes CPU you
+  could spend [decoding more calls](/learn/antenna-to-audio/).
+
+The [Hardware guide](/hardware.html) lists practical rates per radio.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — with IQ sampling, captured bandwidth ≈ sample rate." markdown="0">
+  <p class="knowledge-check__q">Quick check: an RTL-SDR runs at 2.4 MSa/s. Roughly how much spectrum does it capture at once?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">About 1.2 kHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">About 2.4 MHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The entire VHF band</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Sample rate ≈ captured bandwidth** for IQ sampling.
+- **Nyquist** is the rule behind it; under-sampling causes **aliasing** (false signals).
+- Higher rate = more spectrum but **more USB/CPU load** and possible dropped samples.
+- For trunk-tracking, pick a rate that **just covers your channels**, with margin.
+
+Next: the setting people get wrong most — gain — and how to avoid overloading the ADC.

--- a/docs/learn/sample-rate-nyquist.md
+++ b/docs/learn/sample-rate-nyquist.md
@@ -107,6 +107,13 @@ GopherTrunk takes a wide IQ stream and **channelises** it — digitally
 [filtering and decimating](/learn/filtering-decimation/) out each narrow channel it
 needs. So the question isn't "how wide can I go" but "how wide do I *need*."
 
+**Worked example.** Suppose a system's control channel is at 851.0 MHz and its voice
+channels span up to 853.4 MHz — a 2.4 MHz spread. Centre an RTL-SDR at 852.2 MHz and
+run it at **2.4 MSa/s**: the whole system fits in one capture, with no retuning.
+Each 12.5 kHz channel is then filtered out and decimated down to perhaps **24 kSa/s**
+— a **100×** reduction — before demodulation. That's the magic: you sample the *band*
+fast, but each *channel* slowly, so a modest CPU can follow many at once.
+
 ## Choosing a sample rate for trunk-tracking
 
 A trunked system's [control channel](/learn/what-is-trunking/) and its voice channels

--- a/docs/learn/sdr-hardware.md
+++ b/docs/learn/sdr-hardware.md
@@ -1,27 +1,137 @@
 ---
 slug: sdr-hardware
 title: SDR hardware — RTL-SDR, HackRF, Airspy
-description: A practical SDR hardware buying guide — RTL-SDR, HackRF, and Airspy compared on bandwidth, frequency range, sensitivity, and price, and how each maps to GopherTrunk support.
+description: A practical SDR hardware buying guide — RTL-SDR, HackRF, Airspy R2/Mini and HF+ compared on frequency range, bandwidth, sensitivity, and price, plus remote backends, and how each maps to GopherTrunk's supported hardware.
+keywords: SDR hardware, RTL-SDR, HackRF One, Airspy, Airspy HF+, best SDR for scanning, SDR comparison, rtl_tcp, SoapyRemote, which SDR to buy
 level: beginner
-status: stub
+status: full
 prereq:
   - what-is-sdr
+faq:
+  - q: What is the best SDR for beginners?
+    a: An RTL-SDR (a modern RTL2832U dongle, ideally a quality "v3/v4"-class unit) is the best starting point. It costs around $30, covers roughly 24 MHz to 1.7 GHz, captures about 2.4 MHz of bandwidth, and is enough to follow most VHF/UHF trunked systems with GopherTrunk. You can always step up later.
+  - q: What's the difference between RTL-SDR, HackRF, and Airspy?
+    a: RTL-SDR is the cheap, receive-only entry point with modest bandwidth. Airspy radios offer better sensitivity and wider bandwidth for more demanding reception, and the Airspy HF+ specialises in the lower (HF) bands. HackRF One is a wideband transceiver that can also transmit and covers a very large frequency range, but isn't needed for scanning. For trunk-tracking, RTL-SDR or Airspy are the usual picks.
+  - q: How much SDR bandwidth do I need for trunked radio?
+    a: Enough to cover the channels you follow. If a system's control and voice channels fit within about 2 MHz, an RTL-SDR is sufficient. If they're spread wider, an Airspy's larger bandwidth — or a second dongle covering another chunk — helps. GopherTrunk can drive a pool of radios for exactly this reason.
+  - q: Can the SDR be on a different computer from GopherTrunk?
+    a: Yes. Remote backends like rtl_tcp and SoapyRemote let the radio live on one machine (say, a Raspberry Pi at the antenna) and stream IQ to GopherTrunk on another. This keeps the dongle close to the antenna with a short coax run while you run the decoder elsewhere.
+gophertrunk_links:
+  - title: Hardware guide
+    url: /hardware.html
+    note: the authoritative list of GopherTrunk-supported radios and notes.
+  - title: Downloads
+    url: /downloads.html
+    note: get GopherTrunk once you've picked a radio.
+  - title: Get started
+    url: /getting-started-setup.html
+    note: go from dongle to first decoded call.
 ---
 
 # SDR hardware — RTL-SDR, HackRF, Airspy
 
-Which dongle should you buy? This lesson compares the common options for trunk-tracking.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+For trunk-tracking, an **RTL-SDR** (~$30, ~24 MHz–1.7 GHz, ~2.4 MHz bandwidth,
+receive-only) is the best place to start and enough for most systems. **Airspy** adds
+sensitivity and [bandwidth](/learn/sample-rate-nyquist/); the **Airspy HF+** targets the
+lower bands. **HackRF One** is a wideband transceiver (can transmit) but overkill for
+scanning. The radio mostly sets your **frequency range** and **how much spectrum you
+capture at once** — and GopherTrunk can drive a **pool** of radios, even
+[remote](/learn/what-is-sdr/) ones, at the same time.
+</div>
 
-## What actually matters: range, bandwidth, sensitivity
+[What is SDR?](/learn/what-is-sdr/) made the case that the software does the clever part
+and the hardware is almost interchangeable. "Almost" — there are real differences worth
+knowing before you buy. This lesson keeps it practical.
 
-## RTL-SDR: the cheap entry point
+## What actually matters
+
+When comparing SDRs for trunk-tracking, three specs dominate:
+
+- **Frequency range** — can it tune the [band](/learn/frequency-and-spectrum/) your
+  targets live in? (VHF/UHF/700-800 MHz for most trunked systems.)
+- **Bandwidth** — how much spectrum it captures at once
+  ([sample rate](/learn/sample-rate-nyquist/)); more lets you follow channels spread
+  further apart from one radio.
+- **Sensitivity & dynamic range** — how well it hears weak signals without overloading
+  on strong ones (tied to [gain](/learn/gain-and-agc/) headroom).
+
+Price and "receive vs. transmit" round it out. For *receiving* trunked voice, you never
+need transmit.
+
+## RTL-SDR — the cheap entry point
+
+The **RTL-SDR** (an RTL2832U-based dongle, originally a TV tuner) is the reason this
+hobby exploded. A good modern unit costs around **$30**, tunes roughly **24 MHz–1.7
+GHz**, and captures about **2.4 MHz**. It's **receive-only** with modest dynamic range —
+but it's more than enough to learn on and to follow most VHF/UHF trunked systems in
+GopherTrunk. Buy a reputable one (quality varies); cheap no-name clones can drift and
+overload.
 
 ## Airspy R2 / Mini and HF+
 
+**Airspy R2** and the smaller **Airspy Mini** offer better front ends, higher
+sensitivity, and **wider bandwidth** (R2 up to ~10 MHz) than an RTL-SDR — useful when a
+system's channels are spread across a band, or in tough RF environments. The **Airspy
+HF+** is a different beast, optimised for the **lower bands (HF and low VHF)** with
+excellent dynamic range — the one to reach for if shortwave or low-band is your goal
+(an RTL-SDR can't reach HF without a direct-sampling mode or upconverter).
+
 ## HackRF One
 
-## Remote backends (rtl_tcp, SoapyRemote)
+**HackRF One** is a wideband **transceiver**: a huge range (~1 MHz–6 GHz) and the
+ability to *transmit*. That breadth is great for experimentation, but for *receiving*
+trunked voice it's overkill, has only 8-bit sampling (less dynamic range than Airspy),
+and transmit is irrelevant to scanning. Worth it if you have broader SDR ambitions;
+not the obvious trunk-tracking pick.
 
-## Matching hardware to your target systems
+## Comparison at a glance
 
-See also the [Hardware guide](/hardware.html) for GopherTrunk-specific details.
+| Radio | Range | Bandwidth | TX? | Best for |
+|-------|-------|-----------|-----|----------|
+| RTL-SDR | ~24 MHz–1.7 GHz | ~2.4 MHz | No | Starting out, most trunked systems |
+| Airspy Mini/R2 | ~24 MHz–1.8 GHz | up to ~6–10 MHz | No | Wider spans, weak signals |
+| Airspy HF+ | HF–low VHF | ~0.66 MHz | No | HF / low-band reception |
+| HackRF One | ~1 MHz–6 GHz | up to ~20 MHz | Yes | Wideband experimentation |
+
+## Remote backends
+
+The radio doesn't have to sit next to the computer running GopherTrunk. **rtl_tcp** and
+**SoapyRemote** stream [IQ](/learn/iq-data/) over the network, so you can put a dongle on
+a **Raspberry Pi right at the antenna** (short coax = less [loss](/learn/antennas/)) and
+decode on a beefier machine elsewhere. GopherTrunk treats these like any other radio.
+
+## Matching hardware to your targets
+
+1. **Identify your systems' bands** (see [finding systems](/learn/finding-systems/)).
+2. **Check coverage** — an RTL-SDR covers nearly all VHF/UHF trunked work.
+3. **Check span** — if your channels fit in ~2 MHz, RTL-SDR is fine; wider may want
+   Airspy or a second dongle.
+4. **Going to HF?** Choose Airspy HF+.
+5. **Start cheap.** An RTL-SDR teaches you everything; upgrade only when you hit a real
+   limit.
+
+The [Hardware guide](/hardware.html) is the authoritative, GopherTrunk-specific list of
+supported radios and gotchas.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an RTL-SDR covers VHF/UHF and is the ideal starting radio." markdown="0">
+  <p class="knowledge-check__q">Quick check: you want to follow a local 800 MHz P25 system on a budget. Best first radio?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">An RTL-SDR</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">An Airspy HF+ (HF-focused)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing under $500 will work</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The radio mainly sets **frequency range** and **capture bandwidth**.
+- **RTL-SDR** is the ideal, cheap starting point for VHF/UHF trunk-tracking.
+- **Airspy** adds sensitivity/bandwidth; **HF+** for the low bands; **HackRF** for wideband/TX.
+- **Remote backends** let the dongle live at the antenna.
+- Match the radio to your targets' band and span — and start cheap.
+
+That completes Module 3. Next module digs into the DSP that turns IQ into bits —
+starting with the FFT and the waterfall.

--- a/docs/learn/sdr-hardware.md
+++ b/docs/learn/sdr-hardware.md
@@ -1,0 +1,27 @@
+---
+slug: sdr-hardware
+title: SDR hardware — RTL-SDR, HackRF, Airspy
+description: A practical SDR hardware buying guide — RTL-SDR, HackRF, and Airspy compared on bandwidth, frequency range, sensitivity, and price, and how each maps to GopherTrunk support.
+level: beginner
+status: stub
+prereq:
+  - what-is-sdr
+---
+
+# SDR hardware — RTL-SDR, HackRF, Airspy
+
+Which dongle should you buy? This lesson compares the common options for trunk-tracking.
+
+## What actually matters: range, bandwidth, sensitivity
+
+## RTL-SDR: the cheap entry point
+
+## Airspy R2 / Mini and HF+
+
+## HackRF One
+
+## Remote backends (rtl_tcp, SoapyRemote)
+
+## Matching hardware to your target systems
+
+See also the [Hardware guide](/hardware.html) for GopherTrunk-specific details.

--- a/docs/learn/sdr-hardware.md
+++ b/docs/learn/sdr-hardware.md
@@ -95,6 +95,28 @@ not the obvious trunk-tracking pick.
 | Airspy HF+ | HF–low VHF | ~0.66 MHz | No | HF / low-band reception |
 | HackRF One | ~1 MHz–6 GHz | up to ~20 MHz | Yes | Wideband experimentation |
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 170" role="img" aria-label="Frequency coverage bars for four SDRs against a log frequency axis from 1 MHz to 6 GHz. A shaded band marks the VHF/UHF/700-800 MHz trunked-radio range." xmlns="http://www.w3.org/2000/svg">
+  <rect x="206" y="20" width="150" height="120" fill="currentColor" fill-opacity="0.08"/>
+  <text x="281" y="16" text-anchor="middle" font-size="9" fill="currentColor">trunked-radio range</text>
+  <g font-size="9" fill="currentColor">
+    <text x="10" y="44">RTL-SDR</text>
+    <rect x="120" y="36" width="250" height="12" rx="3" fill="currentColor" fill-opacity="0.4"/>
+    <text x="10" y="74">Airspy R2</text>
+    <rect x="120" y="66" width="255" height="12" rx="3" fill="currentColor" fill-opacity="0.4"/>
+    <text x="10" y="104">Airspy HF+</text>
+    <rect x="60" y="96" width="80" height="12" rx="3" fill="currentColor" fill-opacity="0.4"/>
+    <text x="10" y="134">HackRF</text>
+    <rect x="95" y="126" width="420" height="12" rx="3" fill="currentColor" fill-opacity="0.4"/>
+  </g>
+  <line x1="40" y1="150" x2="520" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <text x="60" y="162">1 MHz</text><text x="206" y="162">30 MHz</text><text x="356" y="162">1 GHz</text><text x="515" y="162">6 GHz</text>
+  </g>
+</svg>
+<figcaption>Coverage at a glance (frequency axis is roughly logarithmic). Most radios comfortably cover the trunked-radio range; the HF+ trades reach for low-band excellence, and HackRF spans the most.</figcaption>
+</figure>
+
 ## Remote backends
 
 The radio doesn't have to sit next to the computer running GopherTrunk. **rtl_tcp** and

--- a/docs/learn/sdr-receiver.md
+++ b/docs/learn/sdr-receiver.md
@@ -1,25 +1,143 @@
 ---
 slug: sdr-receiver
 title: How an SDR receiver works
-description: Inside an SDR receiver — the signal chain from antenna through low-noise amplifier, mixer and local oscillator, to the analog-to-digital converter that turns radio waves into samples.
+description: Inside an SDR receiver — the signal chain from antenna through low-noise amplifier, mixer and local oscillator, to the analog-to-digital converter that turns radio waves into IQ samples, plus direct vs quadrature sampling.
+keywords: SDR receiver, how SDR works, LNA, mixer, local oscillator, ADC, downconversion, direct sampling, quadrature sampling, RTL-SDR architecture
 level: intermediate
-status: stub
+status: full
 prereq:
   - what-is-sdr
+faq:
+  - q: What are the main parts of an SDR receiver?
+    a: An SDR receiver chains a few stages — front-end filtering and a low-noise amplifier (LNA) to boost the faint antenna signal, a mixer driven by a local oscillator that shifts the band of interest down to a lower frequency, and an analog-to-digital converter (ADC) that samples it into numbers. The output is a stream of IQ samples for software to process.
+  - q: What does the mixer and local oscillator do?
+    a: The mixer combines the incoming signal with a pure tone from the local oscillator (LO) to shift the frequency you care about down to a low "intermediate" frequency or to baseband, where the ADC can handle it. Tuning the SDR is really just changing the LO frequency so a different part of the spectrum lands in the ADC's range.
+  - q: What is the difference between direct sampling and quadrature sampling?
+    a: Direct sampling digitises the radio signal straight away with a fast ADC, no mixer — simple but it needs a very fast converter and is usually limited to lower frequencies. Quadrature sampling first mixes the signal down to baseband as two channels (I and Q), so a slower ADC can capture a chosen slice of spectrum at any tuned frequency. Most VHF/UHF SDRs use quadrature sampling.
+  - q: Why does the front end need a low-noise amplifier?
+    a: Signals at the antenna can be extremely weak, and every stage adds some noise. A low-noise amplifier boosts the signal early, before later stages can swamp it with their own noise, setting the receiver's sensitivity. Its noise figure largely determines how weak a signal the whole receiver can usefully detect.
+gophertrunk_links:
+  - title: Hardware guide
+    url: /hardware.html
+    note: how GopherTrunk's supported radios implement this chain.
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: the live receiver telemetry from this signal chain.
 ---
 
 # How an SDR receiver works
 
-Opening up the box: the stages that turn a faint antenna signal into a clean stream of samples.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+An [SDR](/learn/what-is-sdr/) receiver is a short chain: **front-end filter + low-noise
+amplifier (LNA)** boost the faint antenna signal; a **mixer** driven by a **local
+oscillator (LO)** shifts your chosen band down to a low frequency; and an
+**analog-to-digital converter (ADC)** samples it into numbers — emitting
+[IQ samples](/learn/iq-data/). **Tuning is just changing the LO.** Most VHF/UHF SDRs
+use **quadrature sampling** (mix to baseband, then digitise), while some use **direct
+sampling** (digitise the RF straight away).
+</div>
+
+[Last lesson](/learn/what-is-sdr/) said the SDR's job is to turn a slice of spectrum
+into samples. Now let's open the box and see the stages that do it — because knowing
+them makes [gain](/learn/gain-and-agc/), [sample rate](/learn/sample-rate-nyquist/), and
+troubleshooting far more intuitive.
 
 ## The receive chain at a glance
 
-## Low-noise amplifier (LNA) and front-end filtering
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 110" role="img" aria-label="Signal chain: antenna, filter, low-noise amplifier, mixer fed by a local oscillator, then ADC, then IQ samples out." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <path d="M30 70 v-26 m-9 0 l9 -12 l9 12" fill="none" stroke="currentColor" stroke-width="2"/>
+    <text x="30" y="88">antenna</text>
+    <rect x="70" y="42" width="60" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="100" y="62">filter</text>
+    <rect x="146" y="42" width="60" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="176" y="62">LNA</text>
+    <rect x="222" y="42" width="60" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="252" y="62">mixer</text>
+    <rect x="222" y="92" width="60" height="0" /><text x="252" y="100" font-size="9">LO</text>
+    <circle cx="252" cy="92" r="3" fill="currentColor"/>
+    <line x1="252" y1="76" x2="252" y2="89" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="320" y="42" width="60" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="350" y="62">ADC</text>
+    <rect x="408" y="42" width="84" height="34" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="450" y="62">IQ samples</text>
+    <g stroke="currentColor" stroke-width="1.2">
+      <line x1="40" y1="59" x2="69" y2="59"/><line x1="130" y1="59" x2="145" y2="59"/><line x1="206" y1="59" x2="221" y2="59"/><line x1="282" y1="59" x2="319" y2="59"/><line x1="380" y1="59" x2="407" y2="59"/>
+    </g>
+  </g>
+</svg>
+<figcaption>The receive chain. Each stage has a job — and each is a place a signal can be lost or distorted, which is why this map helps troubleshooting.</figcaption>
+</figure>
+
+## Front-end filtering and the low-noise amplifier
+
+The antenna delivers a faint, messy mix of everything in the band. A **front-end
+filter** trims the worst out-of-band energy so it can't overload later stages. Then a
+**low-noise amplifier (LNA)** boosts the wanted signal **early** — this matters because
+every later stage adds noise, and you want the signal strong before that happens. The
+LNA's quality (its *noise figure*) largely sets how weak a signal the whole receiver
+can detect — its **sensitivity**.
 
 ## Mixing down with a local oscillator
 
+The ADC can't directly digitise, say, an 850 MHz signal cheaply. So a **mixer**
+combines the incoming signal with a pure tone from a **local oscillator (LO)**,
+shifting your chosen band **down** to a low frequency the ADC can handle (baseband or a
+low intermediate frequency). 
+
+The beautiful part: **tuning the radio is just changing the LO frequency.** Want a
+different part of the spectrum? Move the LO so that part lands in the ADC's window.
+There are no mechanical dials — just a number.
+
 ## The analog-to-digital converter (ADC)
 
-## Direct sampling vs. quadrature sampling
+The **ADC** measures the down-shifted signal millions of times a second, turning the
+continuous wave into a stream of numbers. Two ADC properties shape everything
+downstream:
 
-## How this maps to real RTL-SDR / Airspy hardware
+- **Sample rate** — how fast it measures, which sets how much
+  [bandwidth](/learn/sample-rate-nyquist/) you capture.
+- **Bit depth / range** — how finely and over what span it can measure, which is why
+  [gain](/learn/gain-and-agc/) must be set so strong signals don't exceed the ADC's
+  ceiling (**clipping** at 0 dBFS).
+
+## Direct vs. quadrature sampling
+
+Two ways to get the signal into the ADC:
+
+| Approach | How | Trade-off |
+|----------|-----|-----------|
+| **Quadrature sampling** | Mix down to baseband as two channels — **I and Q** — then digitise | Works at any tuned frequency with a modest ADC; the norm for VHF/UHF SDRs |
+| **Direct sampling** | Digitise the RF immediately with a very fast ADC, no mixer | Simple, but needs a fast/expensive ADC and is usually limited to lower bands |
+
+Quadrature sampling is why SDR output comes as **pairs** of numbers — the I and Q that
+the [next lesson](/learn/iq-data/) is all about.
+
+## How this maps to real hardware
+
+- An **RTL-SDR** uses a tuner chip (the mixer + LO) feeding the RTL2832U's ADC,
+  outputting IQ — classic quadrature sampling across ~24 MHz–1.7 GHz. (Some support a
+  direct-sampling mode for HF.)
+- **Airspy** radios use higher-quality front ends and faster ADCs for better
+  sensitivity and bandwidth; the **Airspy HF+** is optimised for the lower bands.
+- **HackRF** is a wideband quadrature transceiver (it can transmit too).
+
+The [Hardware guide](/hardware.html) and the [SDR hardware lesson](/learn/sdr-hardware/)
+cover which to choose; here, the point is that they all implement this same chain.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — tuning an SDR just changes the local oscillator frequency." markdown="0">
+  <p class="knowledge-check__q">Quick check: what actually changes when you "tune" an SDR to a new frequency?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The antenna length</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The local oscillator frequency feeding the mixer</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The ADC's bit depth</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The chain is **filter → LNA → mixer (LO) → ADC → IQ samples**.
+- The **LNA** sets sensitivity; **tuning = changing the LO**.
+- The **ADC** sets capture bandwidth (sample rate) and the clipping ceiling.
+- **Quadrature sampling** (mix to I/Q) is standard; **direct sampling** digitises RF
+  directly.
+
+Next: those pairs of numbers — what I and Q actually mean.

--- a/docs/learn/sdr-receiver.md
+++ b/docs/learn/sdr-receiver.md
@@ -1,0 +1,25 @@
+---
+slug: sdr-receiver
+title: How an SDR receiver works
+description: Inside an SDR receiver — the signal chain from antenna through low-noise amplifier, mixer and local oscillator, to the analog-to-digital converter that turns radio waves into samples.
+level: intermediate
+status: stub
+prereq:
+  - what-is-sdr
+---
+
+# How an SDR receiver works
+
+Opening up the box: the stages that turn a faint antenna signal into a clean stream of samples.
+
+## The receive chain at a glance
+
+## Low-noise amplifier (LNA) and front-end filtering
+
+## Mixing down with a local oscillator
+
+## The analog-to-digital converter (ADC)
+
+## Direct sampling vs. quadrature sampling
+
+## How this maps to real RTL-SDR / Airspy hardware

--- a/docs/learn/sdr-receiver.md
+++ b/docs/learn/sdr-receiver.md
@@ -86,6 +86,12 @@ The beautiful part: **tuning the radio is just changing the LO frequency.** Want
 different part of the spectrum? Move the LO so that part lands in the ADC's window.
 There are no mechanical dials — just a number.
 
+**Worked example.** To receive an 851.0 MHz control channel, the tuner sets its LO so
+that 851.0 MHz mixes down to baseband (0 Hz at the centre of the capture). To jump to
+770.0 MHz instead, it simply moves the LO down by 81 MHz — the same hardware, a
+different number. Whatever sits within ±half the [sample rate](/learn/sample-rate-nyquist/)
+of the LO appears in your captured band, ready for software to [channelise](/learn/filtering-decimation/).
+
 ## The analog-to-digital converter (ADC)
 
 The **ADC** measures the down-shifted signal millions of times a second, turning the

--- a/docs/learn/signal-anatomy.md
+++ b/docs/learn/signal-anatomy.md
@@ -69,6 +69,13 @@ you need to capture the whole thing (a theme that returns in
 Wider isn't "better" — it's a trade. More bandwidth carries more data but uses more
 spectrum and demands more of your receiver and CPU.
 
+This is why bandwidth is the *first* number to know about a signal: it sets how much
+receiver bandwidth you must capture. To decode a 12.5 kHz P25 channel you only need to
+[filter](/learn/filtering-decimation/) out ~12.5 kHz around it — but to capture a whole
+FM broadcast station you need ~200 kHz, sixteen times as much. Capture too little and
+you clip the signal's edges and lose data; the bandwidth tells you exactly how wide to
+open the window.
+
 ## The spectrum view vs. the waterfall
 
 SDRs give you two windows onto the same data:

--- a/docs/learn/signal-anatomy.md
+++ b/docs/learn/signal-anatomy.md
@@ -1,0 +1,23 @@
+---
+slug: signal-anatomy
+title: Anatomy of a signal
+description: Understand the parts of a radio signal — carrier, bandwidth, and the difference between a spectrum (frequency) view and a waterfall (frequency-over-time) display in an SDR.
+level: beginner
+status: stub
+prereq:
+  - radio-waves
+---
+
+# Anatomy of a signal
+
+Before modulation makes sense, it helps to picture what a signal looks like on screen.
+
+## The carrier and its sidebands
+
+## Bandwidth: how wide a signal is
+
+## The spectrum view vs. the waterfall view
+
+## Reading signal strength off a display
+
+## Spotting different signals by their shape

--- a/docs/learn/signal-anatomy.md
+++ b/docs/learn/signal-anatomy.md
@@ -1,23 +1,136 @@
 ---
 slug: signal-anatomy
 title: Anatomy of a signal
-description: Understand the parts of a radio signal — carrier, bandwidth, and the difference between a spectrum (frequency) view and a waterfall (frequency-over-time) display in an SDR.
+description: Learn the parts of a radio signal — carrier and sidebands, bandwidth, and the difference between the spectrum (frequency) view and the waterfall (frequency-over-time) display — so you can recognise signals on an SDR before you decode them.
+keywords: radio signal, carrier, sidebands, bandwidth, spectrum analyzer, waterfall display, reading a waterfall, signal shape, SDR display
 level: beginner
-status: stub
+status: full
 prereq:
   - radio-waves
+faq:
+  - q: What is the bandwidth of a signal?
+    a: Bandwidth is how wide a signal is in frequency — the span of spectrum it occupies, measured in hertz. A narrow FM voice channel might be ~12.5 kHz wide; an FM broadcast station ~200 kHz; Wi-Fi tens of megahertz. Wider signals can carry more data but take up more spectrum and need more receiver bandwidth to capture.
+  - q: What is the difference between a spectrum view and a waterfall?
+    a: A spectrum view plots signal strength against frequency right now — a snapshot, like a row of peaks. A waterfall plots the same information over time, scrolling, so each horizontal line is one moment and brightness shows strength. The spectrum shows the instant; the waterfall shows history, which makes intermittent signals and patterns easy to spot.
+  - q: What are sidebands?
+    a: When you modulate a carrier to add information, the energy spreads out into sidebands on either side of the carrier frequency. The width of those sidebands is essentially the signal's bandwidth. A bare unmodulated carrier is a single spike; a modulated signal is a wider shape because of its sidebands.
+  - q: How do I recognise a signal type on a waterfall?
+    a: By its shape and behaviour — width, whether it's continuous or bursty, and any structure. A control channel is usually a steady, fixed-width digital signal; voice calls come and go; FM broadcast is wide and constant. With practice the waterfall becomes a visual fingerprint of what's on the air.
+gophertrunk_links:
+  - title: Plots (signal scopes)
+    url: /plots.html
+    note: GopherTrunk's spectrum and waterfall views.
+  - title: Web console
+    url: /web.html
+    note: where the live spectrum and waterfall appear.
 ---
 
 # Anatomy of a signal
 
-Before modulation makes sense, it helps to picture what a signal looks like on screen.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A real signal is a **carrier** plus the **sidebands** that modulation spreads around
+it; together they occupy a width of spectrum called **bandwidth**. An SDR shows
+signals two ways: the **spectrum view** plots strength vs. frequency *right now*,
+while the **waterfall** plots the same thing *over time*, scrolling, with brightness
+for strength. Learning to read these — by a signal's width, shape, and whether it's
+steady or bursty — lets you *recognise* what's on the air before decoding it.
+</div>
 
-## The carrier and its sidebands
+Before we get into modulation, it helps to picture what a signal actually looks like
+on an SDR screen — because that's how you'll find and identify everything for the rest
+of the path.
 
-## Bandwidth: how wide a signal is
+## Carrier and sidebands
 
-## The spectrum view vs. the waterfall view
+A bare **carrier** — a steady wave at one frequency — appears as a single tall spike.
+But a carrier with no changes carries no information. The moment you
+[modulate](/learn/digital-modulation/) it (vary its amplitude, frequency, or phase),
+the energy spreads into **sidebands** on either side of the carrier. The richer or
+faster the information, the wider those sidebands — and the wider the signal.
 
-## Reading signal strength off a display
+So on screen, an idle carrier is a thin spike; an active, modulated signal is a wider
+shape. That width has a name.
 
-## Spotting different signals by their shape
+## What is bandwidth?
+
+**Bandwidth** is how much spectrum a signal occupies, in hertz. It's one of the most
+important numbers about any signal because it determines how much receiver bandwidth
+you need to capture the whole thing (a theme that returns in
+[sample rate & Nyquist](/learn/sample-rate-nyquist/)).
+
+| Signal | Typical bandwidth |
+|--------|-------------------|
+| Narrowband FM voice | ~12.5 kHz |
+| P25 / DMR digital voice | ~12.5 kHz |
+| FM broadcast station | ~200 kHz |
+| Wi-Fi channel | 20–80 MHz |
+
+Wider isn't "better" — it's a trade. More bandwidth carries more data but uses more
+spectrum and demands more of your receiver and CPU.
+
+## The spectrum view vs. the waterfall
+
+SDRs give you two windows onto the same data:
+
+- The **spectrum view** (or "FFT view") plots **signal strength against frequency** at
+  this instant. Peaks are signals; the wiggly baseline is the
+  [noise floor](/learn/decibels/). It's a live snapshot — great for *how strong* and
+  *how wide* right now.
+- The **waterfall** plots that same spectrum **over time**, scrolling downward (or
+  up). Each horizontal line is one moment; **brightness or colour shows strength**.
+  Because it keeps history, the waterfall makes intermittent signals, bursts, and
+  repeating patterns jump out.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 190" role="img" aria-label="Top: a spectrum plot with a noisy baseline and two peaks. Bottom: a waterfall showing the same two signals as vertical stripes scrolling over time, one continuous and one bursty." xmlns="http://www.w3.org/2000/svg">
+  <text x="6" y="14" font-size="10" fill="currentColor">spectrum (now)</text>
+  <path d="M20 70 L60 66 L100 68 L130 66 L160 30 L175 66 L240 67 L290 66 L320 40 L335 66 L420 68" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="20" y1="80" x2="420" y2="80" stroke="currentColor" stroke-opacity="0.3"/>
+  <text x="6" y="100" font-size="10" fill="currentColor">waterfall (over time)</text>
+  <rect x="20" y="105" width="400" height="75" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-opacity="0.3"/>
+  <rect x="160" y="105" width="14" height="75" fill="currentColor" fill-opacity="0.55"/>
+  <rect x="316" y="105" width="14" height="22" fill="currentColor" fill-opacity="0.55"/>
+  <rect x="316" y="150" width="14" height="18" fill="currentColor" fill-opacity="0.55"/>
+  <text x="150" y="190" font-size="9" fill="currentColor">continuous</text>
+  <text x="305" y="190" font-size="9" fill="currentColor">bursty</text>
+</svg>
+<figcaption>The spectrum shows the instant; the waterfall shows history. A steady control channel is a continuous stripe; voice calls come and go as bursts.</figcaption>
+</figure>
+
+## Reading signal strength and shape
+
+On the spectrum, **height above the noise floor** is your [SNR](/learn/decibels/) at a
+glance — the taller a peak stands over the baseline, the better it'll decode. On the
+waterfall, that's **brightness**.
+
+Beyond strength, the *shape and behaviour* identify a signal:
+
+- **Width** — narrow voice channel vs. wide broadcast.
+- **Continuous vs. bursty** — a trunked [control channel](/learn/what-is-trunking/) is
+  a steady, fixed-width digital signal; individual voice calls flicker on and off.
+- **Structure** — some signals have a distinctive look (evenly spaced tones, a flat
+  digital "block," etc.).
+
+With a little practice the waterfall becomes a **visual fingerprint**: you'll spot a
+control channel, a pager burst, or an FM station without decoding anything — exactly
+the skill you'll use in [finding systems](/learn/finding-systems/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the waterfall adds the time axis, revealing bursts and patterns." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a waterfall show that a plain spectrum view doesn't?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Higher frequencies</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">How signals change over time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The exact modulation type</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A signal is a **carrier** plus **sidebands**; their span is its **bandwidth**.
+- **Bandwidth** sets how much receiver bandwidth you need to capture a signal.
+- The **spectrum view** shows strength vs. frequency now; the **waterfall** adds time.
+- **Height/brightness** ≈ SNR; **width, burstiness, and structure** identify the type.
+
+Next: the classic analog ways to put a voice on a carrier — AM, FM, and SSB.

--- a/docs/learn/symbols-and-baud.md
+++ b/docs/learn/symbols-and-baud.md
@@ -1,0 +1,23 @@
+---
+slug: symbols-and-baud
+title: Symbols, baud & bitrate
+description: The difference between baud (symbol rate) and bitrate explained — why a 4800-baud 4FSK signal like P25 carries 9600 bits per second, and what symbol rate means for SDR capture.
+level: intermediate
+status: stub
+prereq:
+  - digital-modulation
+---
+
+# Symbols, baud & bitrate
+
+A small but important distinction that clears up a lot of confusion about digital signals.
+
+## Symbols vs. bits, revisited
+
+## Baud (symbol rate) defined
+
+## Bits per symbol and the bitrate formula
+
+## Worked example: P25 and DMR at 4800 baud
+
+## Why symbol rate sets your capture and SNR needs

--- a/docs/learn/symbols-and-baud.md
+++ b/docs/learn/symbols-and-baud.md
@@ -75,6 +75,24 @@ So the same signal can be described two ways without contradiction: its **symbol
 (baud) and its **bitrate** (bps). They diverge whenever there's more than one bit per
 symbol.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A four-level signal over time. Each step sits at one of four levels and is labelled with the two bits it represents: 00, 01, 10, 11." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-opacity="0.25">
+    <line x1="40" y1="30" x2="500" y2="30"/><line x1="40" y1="60" x2="500" y2="60"/>
+    <line x1="40" y1="90" x2="500" y2="90"/><line x1="40" y1="120" x2="500" y2="120"/>
+  </g>
+  <g font-size="9" fill="currentColor" text-anchor="end">
+    <text x="36" y="33">+3 (11)</text><text x="36" y="63">+1 (10)</text><text x="36" y="93">−1 (01)</text><text x="36" y="123">−3 (00)</text>
+  </g>
+  <polyline points="50,90 110,90 110,30 170,30 170,120 230,120 230,60 290,60 290,30 350,30 350,90 410,90 410,120 470,120" fill="none" stroke="currentColor" stroke-width="2"/>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="80" y="105">01</text><text x="140" y="22">11</text><text x="200" y="135">00</text><text x="260" y="52">10</text><text x="320" y="22">11</text><text x="380" y="105">01</text><text x="440" y="135">00</text>
+  </g>
+  <text x="270" y="148" text-anchor="middle" font-size="9" fill="currentColor">one symbol per step · each carries 2 bits →</text>
+</svg>
+<figcaption>A 4-level (4FSK/C4FM) signal. Each step is one <strong>symbol</strong> at one of four levels, and each carries <strong>2 bits</strong> — so the bitrate is twice the symbol rate.</figcaption>
+</figure>
+
 ## Worked example: P25 and DMR
 
 P25 Phase 1 uses **C4FM**, a four-level [FSK](/learn/digital-modulation/):
@@ -87,6 +105,21 @@ That's why you'll see both "4800 symbols/s" and "9600 bps" quoted for P25 — th
 the symbol rate and the bitrate of the very same signal. DMR likewise uses 4-level FSK
 at 4800 baud, organised into two time slots. When someone says a system is "9600,"
 they usually mean its bitrate; "4800" is its baud.
+
+### Two ways to send more data
+
+Say you want to double a system's data rate. The bitrate formula shows there are
+exactly two levers — and each has a cost:
+
+| Lever | What changes | The cost |
+|-------|--------------|----------|
+| **Raise the symbol rate** (e.g. 4800 → 9600 baud) | More symbols per second | Wider [bandwidth](/learn/sample-rate-nyquist/) — the signal occupies more spectrum |
+| **More bits per symbol** (e.g. 4 → 16 states) | Each symbol carries more | Higher [SNR](/learn/decibels/) needed — the states crowd closer, so noise causes errors sooner |
+
+This is the fundamental trade-off behind every digital mode. Narrowband public-safety
+systems can't just widen their channel (the [12.5 kHz grid](/learn/frequency-and-spectrum/)
+forbids it), so to gain capacity they lean on cleverer schemes and time slots rather
+than raw bandwidth — which is exactly why [P25 Phase 2 and DMR use TDMA](/learn/protocol-landscape/).
 
 ## Why symbol rate matters for capture
 

--- a/docs/learn/symbols-and-baud.md
+++ b/docs/learn/symbols-and-baud.md
@@ -1,23 +1,127 @@
 ---
 slug: symbols-and-baud
 title: Symbols, baud & bitrate
-description: The difference between baud (symbol rate) and bitrate explained — why a 4800-baud 4FSK signal like P25 carries 9600 bits per second, and what symbol rate means for SDR capture.
+description: The difference between baud (symbol rate) and bitrate explained simply — why a 4800-baud 4FSK signal like P25 carries 9600 bits per second, how bits-per-symbol works, and what symbol rate means for SDR capture and SNR.
+keywords: baud rate, symbol rate, bitrate, bits per symbol, baud vs bitrate, 4FSK 4800 baud, P25 9600 bps, symbol rate explained
 level: intermediate
-status: stub
+status: full
 prereq:
   - digital-modulation
+faq:
+  - q: What is the difference between baud and bitrate?
+    a: Baud (the symbol rate) is how many symbols are sent per second. Bitrate is how many bits per second. They're equal only when each symbol carries one bit. When a symbol carries multiple bits — as in 4-level modulation — the bitrate is higher than the baud. The formula is bitrate = baud × bits per symbol.
+  - q: Why does a 4800-baud P25 signal carry 9600 bits per second?
+    a: P25 Phase 1 uses C4FM, a four-level modulation, so each symbol represents 2 bits (four states = 2 bits). At 4800 symbols per second, that's 4800 × 2 = 9600 bits per second. The symbol rate is 4800 baud but the bitrate is 9600 bps.
+  - q: Does a higher symbol rate need more bandwidth?
+    a: Yes. Roughly, the faster you send symbols, the more bandwidth the signal occupies. To carry more data you can either raise the symbol rate (more bandwidth) or pack more bits into each symbol (more states, which needs a higher SNR to tell the states apart). It's always a trade-off between bandwidth, data rate, and required signal quality.
+  - q: Why does symbol rate matter for capturing a signal with an SDR?
+    a: Your SDR has to sample fast enough and capture enough bandwidth to represent every symbol cleanly, and the signal needs enough SNR for the demodulator to distinguish the states. Knowing a system's symbol rate tells you the minimum bandwidth to capture and helps you reason about why a marginal signal drops symbols.
+gophertrunk_links:
+  - title: Symbol scope
+    url: /symbol-scope.html
+    note: watch recovered symbols stream past at the system's symbol rate.
+  - title: Status
+    url: /status.html
+    note: the protocols (and their rates) GopherTrunk decodes.
 ---
 
 # Symbols, baud & bitrate
 
-A small but important distinction that clears up a lot of confusion about digital signals.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Baud** is the **symbol rate** — symbols per second. **Bitrate** is **bits per
+second**. They're the same only when each symbol carries one bit; with multi-level
+modulation a symbol carries several bits, so **bitrate = baud × bits-per-symbol**.
+P25's C4FM runs at **4800 baud** with **4 states (2 bits each) = 9600 bps**. Raising
+the symbol rate widens the signal's bandwidth; packing more bits per symbol needs more
+[SNR](/learn/decibels/). Knowing a system's symbol rate tells you how much bandwidth to
+capture.
+</div>
+
+This is a short, sharp distinction that clears up a surprising amount of confusion —
+and it's the reason "4800" and "9600" both get quoted for the same P25 signal.
 
 ## Symbols vs. bits, revisited
 
+From [digital modulation](/learn/digital-modulation/): a **bit** is a single 0 or 1; a
+**symbol** is one state the transmitter actually puts on the air, and a symbol can
+encode more than one bit. The number of bits per symbol depends on how many states the
+modulation has:
+
+| States | Bits per symbol | Example |
+|--------|-----------------|---------|
+| 2 | 1 | 2FSK, BPSK |
+| 4 | 2 | 4FSK / C4FM (P25, DMR), QPSK |
+| 8 | 3 | 8PSK |
+| 16 | 4 | 16-QAM |
+
+More states pack more bits into each symbol — but the states sit closer together, so
+the receiver needs a cleaner signal (more SNR) to tell them apart.
+
 ## Baud (symbol rate) defined
 
-## Bits per symbol and the bitrate formula
+**Baud** is simply how many symbols are transmitted each second. A signal "at
+4800 baud" sends 4800 distinct states per second, whatever each state means. Baud is a
+property of the *channel timing* — it's the metronome the
+[symbol scope](/symbol-scope.html) is ticking to.
 
-## Worked example: P25 and DMR at 4800 baud
+## The bitrate formula
 
-## Why symbol rate sets your capture and SNR needs
+Put the two together and you get the only formula you need here:
+
+> **bitrate (bps) = baud (symbols/s) × bits-per-symbol**
+
+So the same signal can be described two ways without contradiction: its **symbol rate**
+(baud) and its **bitrate** (bps). They diverge whenever there's more than one bit per
+symbol.
+
+## Worked example: P25 and DMR
+
+P25 Phase 1 uses **C4FM**, a four-level [FSK](/learn/digital-modulation/):
+
+- 4 states → **2 bits per symbol**
+- Symbol rate → **4800 baud**
+- Bitrate → 4800 × 2 = **9600 bps**
+
+That's why you'll see both "4800 symbols/s" and "9600 bps" quoted for P25 — they're
+the symbol rate and the bitrate of the very same signal. DMR likewise uses 4-level FSK
+at 4800 baud, organised into two time slots. When someone says a system is "9600,"
+they usually mean its bitrate; "4800" is its baud.
+
+## Why symbol rate matters for capture
+
+Two practical consequences for SDR work:
+
+1. **Bandwidth.** Faster symbols spread the signal wider. The symbol rate sets a floor
+   on how much [bandwidth](/learn/sample-rate-nyquist/) you must capture to represent
+   every symbol cleanly — capture too little and you mangle the edges of the signal.
+2. **SNR and reliability.** The demodulator has to land a decision on *each* symbol. As
+   the signal weakens or smears (multipath, low SNR), it starts mis-judging symbols —
+   first a few errors that forward error correction hides, then audible drops. A
+   four-level signal is harder to keep clean than a two-level one because its states are
+   closer together.
+
+Knowing the rate, in other words, tells you both the *minimum bandwidth* to set and
+*why* a marginal signal degrades the way it does — groundwork for
+[tuning a clean lock](/learn/tuning-with-scopes/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — 4 states = 2 bits/symbol, so 9600 × ... no: 4800 baud × 2 = 9600 bps." markdown="0">
+  <p class="knowledge-check__q">Quick check: a 4-level signal runs at 3600 baud. What's its bitrate?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">1800 bps</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">3600 bps</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">7200 bps</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Baud** = symbols/second; **bitrate** = bits/second.
+- They differ when a symbol carries more than one bit: **bitrate = baud × bits/symbol**.
+- P25/DMR: **4800 baud × 2 bits = 9600 bps**.
+- Faster symbols → more **bandwidth**; more bits/symbol → more **SNR** needed.
+- The symbol rate tells you the minimum capture bandwidth and explains degradation.
+
+That completes Module 2. Next module opens up the SDR itself — starting with what
+software-defined radio is and how the receiver turns waves into samples.

--- a/docs/learn/tuning-with-scopes.md
+++ b/docs/learn/tuning-with-scopes.md
@@ -64,6 +64,43 @@ A healthy decode has a recognisable signature across the scopes:
 If you see that, you're done — leave it alone. When you don't, the *way* it's wrong is
 the clue.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 180" role="img" aria-label="Healthy versus degraded scopes. On the left, a constellation with four tight clusters and a wide-open eye diagram. On the right, smeared constellation clusters and a closing eye diagram." xmlns="http://www.w3.org/2000/svg">
+  <text x="130" y="16" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">healthy lock</text>
+  <text x="390" y="16" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">degraded</text>
+  <!-- healthy constellation -->
+  <g fill="currentColor">
+    <circle cx="60" cy="60" r="2.5"/><circle cx="58" cy="62" r="2.5"/><circle cx="62" cy="59" r="2.5"/>
+    <circle cx="110" cy="60" r="2.5"/><circle cx="108" cy="62" r="2.5"/><circle cx="112" cy="58" r="2.5"/>
+    <circle cx="60" cy="100" r="2.5"/><circle cx="62" cy="98" r="2.5"/><circle cx="59" cy="101" r="2.5"/>
+    <circle cx="110" cy="100" r="2.5"/><circle cx="108" cy="99" r="2.5"/><circle cx="112" cy="101" r="2.5"/>
+  </g>
+  <text x="85" y="124" text-anchor="middle" font-size="8" fill="currentColor">tight clusters</text>
+  <!-- healthy eye -->
+  <g stroke="currentColor" fill="none" stroke-width="1.1" stroke-opacity="0.85">
+    <path d="M160 45 C185 45 185 100 210 100 C235 100 235 45 260 45"/>
+    <path d="M160 100 C185 100 185 45 210 45 C235 45 235 100 260 100"/>
+  </g>
+  <text x="210" y="124" text-anchor="middle" font-size="8" fill="currentColor">open eye</text>
+  <!-- degraded constellation -->
+  <g fill="currentColor" fill-opacity="0.7">
+    <circle cx="318" cy="58" r="2.5"/><circle cx="310" cy="66" r="2.5"/><circle cx="326" cy="52" r="2.5"/><circle cx="320" cy="72" r="2.5"/>
+    <circle cx="372" cy="60" r="2.5"/><circle cx="380" cy="70" r="2.5"/><circle cx="366" cy="54" r="2.5"/><circle cx="384" cy="64" r="2.5"/>
+    <circle cx="320" cy="100" r="2.5"/><circle cx="312" cy="106" r="2.5"/><circle cx="328" cy="96" r="2.5"/>
+    <circle cx="374" cy="100" r="2.5"/><circle cx="382" cy="106" r="2.5"/><circle cx="366" cy="96" r="2.5"/>
+  </g>
+  <text x="345" y="124" text-anchor="middle" font-size="8" fill="currentColor">smeared</text>
+  <!-- degraded eye -->
+  <g stroke="currentColor" fill="none" stroke-width="1.1" stroke-opacity="0.85">
+    <path d="M420 55 C445 60 445 90 470 90 C495 90 495 60 520 55"/>
+    <path d="M420 90 C445 85 445 60 470 60 C495 60 495 85 520 90"/>
+  </g>
+  <text x="470" y="124" text-anchor="middle" font-size="8" fill="currentColor">closing eye</text>
+  <line x1="290" y1="30" x2="290" y2="135" stroke="currentColor" stroke-opacity="0.25"/>
+</svg>
+<figcaption>The same signal, healthy vs. degraded. Tight clusters and an open eye decode cleanly; smeared clusters and a closing eye are about to drop symbols.</figcaption>
+</figure>
+
 ## Reading the constellation for SNR and tuning
 
 The [constellation](/constellation.html) is your first stop. Two failure modes have

--- a/docs/learn/tuning-with-scopes.md
+++ b/docs/learn/tuning-with-scopes.md
@@ -1,26 +1,131 @@
 ---
 slug: tuning-with-scopes
 title: Tuning for a clean lock
-description: Use GopherTrunk's constellation, eye diagram, and symbol scope to dial in a marginal signal — reading each scope to diagnose SNR, tuning error, and clock problems for a clean lock.
+description: Use GopherTrunk's constellation, eye diagram, symbol scope, and histogram to dial in a marginal signal — reading each scope to diagnose SNR, tuning error, and clock problems, with a step-by-step routine for a clean lock.
+keywords: tune SDR, clean lock, constellation diagram, eye diagram, symbol scope, symbol histogram, diagnose signal, SNR tuning, frequency offset, P25 DMR tuning
 level: advanced
-status: stub
+status: full
 prereq:
   - digital-modulation
   - antenna-to-audio
+faq:
+  - q: How do I get a clean lock on a control channel?
+    a: Maximise SNR first — a good antenna, placement, and correct gain — then use the scopes to fine-tune. A clean lock shows tight, well-separated clusters on the constellation, a wide-open eye diagram, and steady, distinct levels on the symbol scope. If those look smeared or rotating, work the cause (low SNR, frequency offset, or clipping) rather than guessing.
+  - q: What does a smeared constellation mean?
+    a: Smearing means the symbols aren't landing cleanly on their ideal positions, so the decoder is starting to make errors. Common causes are low signal-to-noise ratio (the whole pattern fuzzes outward), a frequency/tuning offset (the pattern rotates or spins), or ADC clipping from too much gain (distortion). The shape of the smear points to the cause.
+  - q: Why is my signal strong but still not decoding?
+    a: Strength isn't everything. A strong signal can still fail from a frequency offset (needs PPM correction), too much gain causing clipping, multipath smearing the symbols, or simply being the wrong system/parameters. The scopes separate these — a rotating constellation suggests frequency offset; distortion suggests clipping; general fuzz suggests low SNR despite the strong meter.
+  - q: What's the difference between the constellation, eye diagram, and symbol scope?
+    a: They show the same recovered symbols three ways. The constellation plots symbols on the IQ plane (amplitude and phase). The eye diagram plots them against time to show timing margin. The symbol scope streams the recovered symbol levels so you can watch stability. Together they let you tell an SNR problem from a timing problem from a tuning problem.
+gophertrunk_links:
+  - title: Constellation
+    url: /constellation.html
+    note: the IQ-plane view for SNR and frequency offset.
+  - title: Eye diagram
+    url: /eye-diagram.html
+    note: timing margin at a glance.
+  - title: Symbol scope
+    url: /symbol-scope.html
+    note: live recovered symbol levels.
+  - title: Symbol histogram
+    url: /histogram.html
+    note: confirm symbol levels are crisp and centred.
 ---
 
 # Tuning for a clean lock
 
-You have the scopes from Module 2; now use them to fix a signal that will not lock.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+When a control channel is marginal, GopherTrunk's scopes tell you *why*. The
+**[constellation](/constellation.html)** shows SNR and frequency offset (tight clusters =
+good; fuzzy = low SNR; rotating = tuning offset). The
+**[eye diagram](/eye-diagram.html)** shows timing margin (open eye = good). The
+**[symbol scope](/symbol-scope.html)** and **[histogram](/histogram.html)** show whether
+recovered levels are crisp and centred. The routine: **maximise SNR first**
+([antenna](/learn/antennas/), [placement](/learn/propagation/),
+[gain](/learn/gain-and-agc/)), then read the scopes to fix what's left.
+</div>
+
+You've assembled the whole [signal path](/learn/antenna-to-audio/). This lesson is the
+applied skill that separates frustration from success: using the scopes you met in
+[digital modulation](/learn/digital-modulation/) to diagnose and fix a signal that won't
+lock cleanly.
 
 ## What a good lock looks like
 
+A healthy decode has a recognisable signature across the scopes:
+
+- **Constellation** — a few **tight, well-separated clusters** at the expected symbol
+  positions (four for [4FSK/C4FM](/learn/digital-modulation/)).
+- **Eye diagram** — **wide-open eyes** with clear gaps between levels.
+- **Symbol scope** — steady, **distinct levels** that don't wander.
+- **Histogram** — sharp **peaks centred** on each symbol level.
+
+If you see that, you're done — leave it alone. When you don't, the *way* it's wrong is
+the clue.
+
 ## Reading the constellation for SNR and tuning
+
+The [constellation](/constellation.html) is your first stop. Two failure modes have
+distinct looks:
+
+| What you see | Likely cause | Fix |
+|--------------|--------------|-----|
+| Clusters fuzz outward, evenly | **Low SNR** | More signal: [antenna](/learn/antennas/)/[placement](/learn/propagation/), correct [gain](/learn/gain-and-agc/) |
+| Pattern **rotates or spins** | **Frequency/tuning offset** | [PPM correction](/learn/calibration-troubleshooting/) |
+| Clusters distorted, smeared unevenly + ghost signals | **ADC clipping** (too much gain) | Reduce [gain](/learn/gain-and-agc/) |
+
+So a *rotating* constellation isn't a strength problem at all — it's a tuning problem,
+solved by [calibration](/learn/calibration-troubleshooting/), not a better antenna.
 
 ## Reading the eye diagram for timing
 
+The [eye diagram](/eye-diagram.html) reveals [timing](/learn/clock-recovery/) and noise
+margin. A **wide-open** eye means the [symbol-recovery](/learn/demodulation-pipeline/)
+stage has plenty of room to sample each symbol correctly. A **closing or blurred** eye
+means margin is being eaten — by low SNR or a timing problem — and errors are imminent.
+For 4-level signals you'll see **three stacked eyes**; all three should be open.
+
 ## Using the symbol scope and histogram
+
+The [symbol scope](/symbol-scope.html) streams the recovered symbol levels in real time —
+when locked, they sit at steady, well-separated values; when struggling, they jitter and
+collapse together. The [symbol histogram](/histogram.html) is the statistical view:
+**sharp, centred peaks** at each level mean clean symbols; smeared or shifted peaks
+confirm SNR or offset problems. Together they corroborate what the constellation hints.
 
 ## A step-by-step tuning routine
 
-GopherTrunk panels: [Constellation](/constellation.html), [Eye diagram](/eye-diagram.html), [Symbol scope](/symbol-scope.html), [Tuning](/tuning.html).
+1. **Maximise SNR first.** Most lock problems are really signal problems. Get the
+   [antenna](/learn/antennas/) up and clear ([placement](/learn/propagation/)), and set
+   [gain](/learn/gain-and-agc/) by the routine in that lesson. Watch SNR on the
+   [tuning meters](/tuning.html).
+2. **Check the constellation.** Fuzzy → keep improving SNR. Rotating → suspect a
+   **frequency offset**; apply [PPM correction](/learn/calibration-troubleshooting/).
+   Distorted with ghosts → **reduce gain** (clipping).
+3. **Check the eye.** If SNR is good but the eye won't open, suspect
+   [timing/clock](/learn/clock-recovery/) — usually still cured by more SNR.
+4. **Confirm with symbol scope/histogram.** Steady levels and crisp peaks = a solid lock.
+5. **Lock it in** and let GopherTrunk follow calls.
+
+Work the scopes in that order and you stop guessing — each view rules a cause in or out.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a rotating/spinning constellation points to a frequency offset." markdown="0">
+  <p class="knowledge-check__q">Quick check: the constellation clusters are tight but the whole pattern is slowly rotating. What's the likely cause?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Low SNR — get a better antenna</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A frequency/tuning offset — apply PPM correction</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The system is encrypted</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The scopes diagnose *why* a signal won't lock — each view rules a cause in or out.
+- **Constellation:** fuzzy = low SNR; rotating = frequency offset; distorted = clipping.
+- **Eye diagram:** open = healthy timing margin; closing = trouble.
+- **Symbol scope/histogram:** steady, crisp levels confirm a clean lock.
+- Routine: **maximise SNR first**, then read the scopes in order and fix the specific cause.
+
+Next: the calibration behind that frequency offset, and a full troubleshooting checklist.

--- a/docs/learn/tuning-with-scopes.md
+++ b/docs/learn/tuning-with-scopes.md
@@ -1,0 +1,26 @@
+---
+slug: tuning-with-scopes
+title: Tuning for a clean lock
+description: Use GopherTrunk's constellation, eye diagram, and symbol scope to dial in a marginal signal — reading each scope to diagnose SNR, tuning error, and clock problems for a clean lock.
+level: advanced
+status: stub
+prereq:
+  - digital-modulation
+  - antenna-to-audio
+---
+
+# Tuning for a clean lock
+
+You have the scopes from Module 2; now use them to fix a signal that will not lock.
+
+## What a good lock looks like
+
+## Reading the constellation for SNR and tuning
+
+## Reading the eye diagram for timing
+
+## Using the symbol scope and histogram
+
+## A step-by-step tuning routine
+
+GopherTrunk panels: [Constellation](/constellation.html), [Eye diagram](/eye-diagram.html), [Symbol scope](/symbol-scope.html), [Tuning](/tuning.html).

--- a/docs/learn/vocoders.md
+++ b/docs/learn/vocoders.md
@@ -1,0 +1,25 @@
+---
+slug: vocoders
+title: Vocoders — IMBE & AMBE+2
+description: How radio vocoders work — IMBE (P25) and AMBE+2 (DMR) speech codecs explained, why digital voice fits in a few kbps, and how GopherTrunk turns vocoder frames back into audio.
+level: advanced
+status: stub
+prereq:
+  - digital-voice
+---
+
+# Vocoders — IMBE & AMBE+2
+
+Vocoders are the speech codecs behind digital voice. This lesson explains what they do.
+
+## What a vocoder is
+
+## Modeling speech instead of recording it
+
+## IMBE and the P25 connection
+
+## AMBE+2 and DMR / NXDN
+
+## How GopherTrunk decodes vocoder frames to audio
+
+See also the [Vocoders reference](/vocoders.html) and [Voice calibration](/voice-calibration.html).

--- a/docs/learn/vocoders.md
+++ b/docs/learn/vocoders.md
@@ -66,6 +66,28 @@ them into a matching synthesiser — *recreating* a voice that sounds like the t
 rather than replaying a recording. The codecs in P25 and DMR belong to the **MBE
 (Multi-Band Excitation)** family, which is a refined version of this idea.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 150" role="img" aria-label="The source-plus-filter speech model. A pitch source and a noise source feed a vocal-tract filter to produce speech. The vocoder measures pitch, voicing, and spectral shape and sends them as a tiny frame, which the receiver synthesises back into audio." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="14" y="24" width="86" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="57" y="41">pitch (buzz)</text>
+    <rect x="14" y="74" width="86" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="57" y="91">noise (hiss)</text>
+    <rect x="140" y="48" width="96" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="188" y="62">vocal-tract</text><text x="188" y="73" font-size="8">filter (spectral shape)</text>
+    <line x1="100" y1="37" x2="139" y2="58" stroke="currentColor" stroke-width="1.1"/>
+    <line x1="100" y1="87" x2="139" y2="68" stroke="currentColor" stroke-width="1.1"/>
+    <text x="188" y="98" font-size="8">= speech</text>
+    <rect x="276" y="48" width="74" height="30" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="313" y="60">tiny frame</text><text x="313" y="71" font-size="8">few kbps</text>
+    <line x1="236" y1="63" x2="275" y2="63" stroke="currentColor" stroke-width="1.2" marker-end="url(#vc)"/>
+    <text x="256" y="42" font-size="8">measure</text>
+    <rect x="392" y="48" width="96" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="440" y="62">synthesise</text><text x="440" y="73" font-size="8">(receiver)</text>
+    <line x1="350" y1="63" x2="391" y2="63" stroke="currentColor" stroke-width="1.2" marker-end="url(#vc)"/>
+    <text x="505" y="66" text-anchor="start">audio</text>
+    <line x1="488" y1="63" x2="500" y2="63" stroke="currentColor" stroke-width="1.2" marker-end="url(#vc)"/>
+  </g>
+  <defs><marker id="vc" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Source + filter: a vocoder measures the pitch/voicing source and the vocal-tract filter, sends just those parameters as a tiny frame, and the receiver re-builds the voice from them.</figcaption>
+</figure>
+
 ## IMBE and the P25 connection
 
 **IMBE — Improved Multi-Band Excitation** — is the vocoder of **P25 Phase 1**. It runs

--- a/docs/learn/vocoders.md
+++ b/docs/learn/vocoders.md
@@ -1,25 +1,127 @@
 ---
 slug: vocoders
 title: Vocoders — IMBE & AMBE+2
-description: How radio vocoders work — IMBE (P25) and AMBE+2 (DMR) speech codecs explained, why digital voice fits in a few kbps, and how GopherTrunk turns vocoder frames back into audio.
+description: How radio vocoders work — IMBE (P25) and AMBE+2 (DMR/NXDN) speech codecs explained, why modelling speech lets digital voice fit in a few kbps, and how GopherTrunk turns vocoder frames back into audio.
+keywords: vocoder, IMBE, AMBE+2, AMBE, speech codec, P25 vocoder, DMR vocoder, half-rate full-rate, digital voice codec, MBE
 level: advanced
-status: stub
+status: full
 prereq:
   - digital-voice
+faq:
+  - q: What is a vocoder in digital radio?
+    a: A vocoder (voice coder) is a speech codec that compresses spoken audio into a very low bitrate by modelling how speech is produced rather than recording the waveform. It extracts parameters like pitch and the spectral shape of each short slice of speech, sends just those, and the receiver synthesises audio from them. This lets a voice fit in a few kilobits per second.
+  - q: What vocoder does P25 use?
+    a: P25 Phase 1 uses IMBE (Improved Multi-Band Excitation) at about 7.2 kbps including error correction (4.4 kbps of voice). P25 Phase 2 and many DMR systems use AMBE+2, a more efficient successor. Both come from the MBE family of codecs. GopherTrunk includes vocoder implementations to turn these frames back into audio.
+  - q: What is the difference between IMBE and AMBE+2?
+    a: Both are multi-band excitation vocoders from the same lineage. IMBE is the older codec used by P25 Phase 1. AMBE+2 is newer and more efficient, used by P25 Phase 2, DMR, and NXDN, and supports lower bitrates (half-rate) so systems can fit two voice streams where one used to go. AMBE+2 generally sounds better at a given bitrate.
+  - q: Why does digital voice sometimes sound robotic?
+    a: Because the vocoder reconstructs speech from a compact model of pitch and spectral shape rather than reproducing the original sound. When the model can't perfectly capture a voice — or when bit errors corrupt the parameters on a weak signal — the synthesised audio takes on a robotic, watery, or warbling quality.
+gophertrunk_links:
+  - title: Vocoders (reference)
+    url: /vocoders.html
+    note: GopherTrunk's vocoder implementations and details.
+  - title: Voice calibration
+    url: /voice-calibration.html
+    note: tune decoded audio levels and clarity.
 ---
 
 # Vocoders — IMBE & AMBE+2
 
-Vocoders are the speech codecs behind digital voice. This lesson explains what they do.
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **vocoder** (voice coder) is the speech codec that makes [digital
+voice](/learn/digital-voice/) possible. Instead of sending the speech *waveform*, it
+**models how speech is produced** — pitch, energy, spectral shape — and sends just those
+parameters, squeezing a voice into a few kbps. **IMBE** powers P25 Phase 1; **AMBE+2**
+(its more efficient successor) powers P25 Phase 2, **DMR**, and **NXDN**. The receiver
+**re-synthesises** audio from the parameters, which is why digital voice can sound
+slightly robotic. GopherTrunk ships vocoder implementations to turn these frames back
+into sound.
+</div>
+
+The [last lesson](/learn/digital-voice/) said a vocoder compresses speech into a few
+kbps. This lesson explains *how* — and names the specific codecs you'll meet on the air.
+It's the stage-7 detail of [antenna-to-audio](/learn/antenna-to-audio/).
 
 ## What a vocoder is
 
-## Modeling speech instead of recording it
+A **vocoder** is a codec specialised for *speech*. General audio compression (like MP3)
+tries to reproduce any sound faithfully. A vocoder cheats brilliantly: it assumes the
+sound is a human voice, so it only needs to capture the things that make speech
+*intelligible* — and can throw away everything else. That assumption is what gets the
+bitrate down to a few kbps, low enough to fit a narrow digital channel.
+
+## Modelling speech instead of recording it
+
+Human speech is produced by the vocal cords (a pitched buzz, or noisy hiss for sounds
+like "s") shaped by the throat and mouth (a filter). A vocoder mirrors this **source +
+filter** model. Many times a second, for each short slice of speech, it measures:
+
+- **Pitch** — how fast the vocal cords vibrate (or whether the sound is unvoiced).
+- **Voicing/energy** — how loud, and voiced vs. unvoiced across frequency bands.
+- **Spectral shape** — the resonances the mouth and throat impose.
+
+It transmits only these compact parameters as a **vocoder frame**. The receiver feeds
+them into a matching synthesiser — *recreating* a voice that sounds like the talker
+rather than replaying a recording. The codecs in P25 and DMR belong to the **MBE
+(Multi-Band Excitation)** family, which is a refined version of this idea.
 
 ## IMBE and the P25 connection
 
+**IMBE — Improved Multi-Band Excitation** — is the vocoder of **P25 Phase 1**. It runs
+at about **7.2 kbps** over the air, of which roughly **4.4 kbps** is voice and the rest
+is [forward error correction](/learn/demodulation-pipeline/) to protect the parameters
+against bit errors (important, because a corrupted parameter sounds much worse than a
+corrupted audio sample). IMBE is the classic public-safety digital-voice codec.
+
 ## AMBE+2 and DMR / NXDN
+
+**AMBE+2** is IMBE's more efficient successor from the same family. It's used by **P25
+Phase 2**, **DMR**, and **NXDN**, and it supports **lower (half-rate) bitrates**, which
+is part of how DMR fits *two* voice timeslots in a channel and how P25 Phase 2 doubles
+capacity. At a given bitrate AMBE+2 generally sounds cleaner than IMBE.
+
+| Codec | Used by | Notes |
+|-------|---------|-------|
+| IMBE | P25 Phase 1 | ~7.2 kbps (incl. FEC); the original |
+| AMBE+2 | P25 Phase 2, DMR, NXDN | More efficient; supports half-rate |
+
+## Why it can sound robotic
+
+Because the audio is **synthesised from a model**, not reproduced, it carries the
+model's limitations: voices can sound slightly **robotic, watery, or warbling**,
+especially when the speaker's voice doesn't fit the model well. And on a weak signal,
+**bit errors corrupt the parameters** — a wrong pitch or spectral value makes a
+distinctly digital "burble," the audible face of the [cliff
+effect](/learn/digital-voice/).
 
 ## How GopherTrunk decodes vocoder frames to audio
 
-See also the [Vocoders reference](/vocoders.html) and [Voice calibration](/voice-calibration.html).
+In the [pipeline](/learn/demodulation-pipeline/), once a voice channel is demodulated and
+decoded, the result is a stream of **vocoder frames**. GopherTrunk feeds them into its
+built-in vocoder — the **matching** decoder for the system (IMBE for P25 Phase 1, AMBE+2
+elsewhere) — which **synthesises the audio waveform**. That audio is then played live and
+written to a [WAV file](/learn/antenna-to-audio/). The [Vocoders reference](/vocoders.html)
+covers GopherTrunk's implementations, and [Voice calibration](/voice-calibration.html)
+helps you dial in clean output.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a vocoder sends a model of the speech, not the waveform." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does a vocoder fit a voice into a few kbps?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">By recording the waveform at very low quality</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">By sending parameters of a speech model the receiver re-synthesises</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">By speeding up the audio</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **vocoder** compresses speech by **modelling how it's produced**, not recording it.
+- It sends **pitch, voicing, and spectral shape** as compact frames; the receiver
+  re-synthesises audio.
+- **IMBE** → P25 Phase 1; **AMBE+2** → P25 Phase 2, DMR, NXDN (more efficient, half-rate).
+- Synthesis from a model is why digital voice can sound **robotic**, worse on weak signals.
+- GopherTrunk runs the matching vocoder to turn frames into playable, recordable audio.
+
+Next: the wider family of digital protocols and how to tell them apart.

--- a/docs/learn/what-is-sdr.md
+++ b/docs/learn/what-is-sdr.md
@@ -1,0 +1,170 @@
+---
+slug: what-is-sdr
+title: What is software-defined radio?
+description: A beginner's guide to software-defined radio (SDR) — what it is, how it differs from a traditional radio, why one cheap dongle can decode dozens of systems, and how GopherTrunk turns IQ samples into decoded calls.
+keywords: software defined radio, what is SDR, SDR explained, RTL-SDR, IQ samples, SDR vs traditional radio, SDR for beginners, how does SDR work
+level: beginner
+status: full
+prereq:
+  - radio-waves
+faq:
+  - q: What is software-defined radio in simple terms?
+    a: Software-defined radio (SDR) is a radio where the parts that used to be fixed hardware — the tuning, filtering, and demodulation — are done in software instead. The hardware just converts a slice of the radio spectrum into a stream of digital samples, and a program decides what to do with them. That means one device can receive AM, FM, digital voice, pagers, aircraft transponders, and more, by changing software rather than swapping parts.
+  - q: How is an SDR different from a normal radio?
+    a: A traditional radio has dedicated circuits built for one job — an FM broadcast radio can only do FM broadcast. An SDR digitises the raw signal early and leaves the actual decoding to software, so the same hardware can be reconfigured for completely different modes. The flexibility comes from moving the radio's "brains" into code.
+  - q: Why can one cheap SDR dongle decode so many different systems?
+    a: Because the dongle's only job is to hand the computer a chunk of spectrum as IQ samples. Everything that distinguishes one system from another — the modulation, the protocol, the error correction — is handled in software like GopherTrunk. Add support for a new protocol in code and the same hardware can suddenly decode it, no new equipment required.
+  - q: Do I need an expensive SDR to get started?
+    a: No. An RTL-SDR dongle costing around $30 is enough to follow most of this learning path and to run GopherTrunk on many trunked systems. More expensive radios like HackRF or Airspy add wider bandwidth, better sensitivity, or transmit capability, but they aren't required to start learning.
+gophertrunk_links:
+  - title: What is GopherTrunk?
+    url: /getting-started.html
+    note: see how GopherTrunk fits the "software" half of software-defined radio.
+  - title: Hardware guide
+    url: /hardware.html
+    note: the dongles GopherTrunk drives, from RTL-SDR to Airspy.
+  - title: Get started
+    url: /getting-started-setup.html
+    note: go from a dongle to your first decoded call.
+---
+
+# What is software-defined radio?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Software-defined radio (SDR)** moves the "brains" of a radio out of fixed
+circuits and into software. The hardware does just one thing: it converts a slice
+of the radio spectrum into a stream of digital numbers — **IQ samples**. A program
+then tunes, filters, and demodulates those samples to recover whatever's on the
+air. That's why a single ~$30 dongle can decode FM, digital voice, pagers, and
+aircraft transponders: change the software, not the hardware. **GopherTrunk is the
+software half** — it turns IQ samples from your dongle into decoded trunked-radio
+calls.
+</div>
+
+You now know what a radio wave is and how digital data rides on it. This lesson
+introduces the device that catches those waves for a computer — and the single
+idea that makes the whole hobby possible.
+
+## What does "software-defined" actually mean?
+
+In a **traditional radio**, every function is a dedicated piece of hardware. There's
+a circuit that tunes to a frequency, a circuit that filters out everything else, and
+a circuit that demodulates the result into sound. Those circuits are built for one
+job — an FM broadcast receiver can *only* receive FM broadcast, forever.
+
+A **software-defined radio** keeps the hardware to a bare minimum: just enough to
+grab a chunk of spectrum and turn it into digital samples. Everything after that —
+the tuning fine-tune, the filtering, the demodulation, the protocol decoding — is
+done by a *program* running on a computer. Want to receive a different mode? You
+don't rewire anything; you run different software.
+
+That's the whole revolution in one sentence: **the radio becomes code.**
+
+## How does an SDR turn radio waves into numbers?
+
+At a high level, an SDR receiver does three things, which we'll unpack across
+[Module 3](/learn/#sdr):
+
+1. **Tune** — an oscillator shifts the band you care about down to a low frequency
+   the rest of the chain can handle.
+2. **Digitise** — an **analog-to-digital converter (ADC)** measures the signal
+   millions of times per second, turning the smooth wave into a stream of numbers.
+3. **Deliver IQ** — those numbers come out in pairs called **[IQ samples](/learn/iq-data/)**,
+   which together capture both the amplitude *and* the phase of the signal — exactly
+   the two things you need to reconstruct any modulation.
+
+The output isn't audio. It's a firehose of IQ samples — a faithful digital copy of a
+whole slice of the airwaves. What you *do* with that firehose is up to software.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 130" role="img" aria-label="A signal chain: antenna into SDR hardware which outputs IQ samples into software which outputs decoded audio and data." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="12" fill="currentColor" text-anchor="middle">
+    <path d="M40 80 v-30 m-10 0 l10 -14 l10 14" fill="none" stroke="currentColor" stroke-width="2"/>
+    <text x="40" y="100">antenna</text>
+    <rect x="90" y="40" width="110" height="44" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="145" y="60">SDR hardware</text>
+    <text x="145" y="76" font-size="10">tune · digitise</text>
+    <rect x="270" y="40" width="120" height="44" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="330" y="60">software</text>
+    <text x="330" y="76" font-size="10">(GopherTrunk)</text>
+    <rect x="455" y="40" width="70" height="44" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="490" y="60">audio</text>
+    <text x="490" y="76">&amp; data</text>
+    <line x1="52" y1="62" x2="88" y2="62" stroke="currentColor" stroke-width="1.5" marker-end="url(#a)"/>
+    <line x1="200" y1="62" x2="268" y2="62" stroke="currentColor" stroke-width="1.5" marker-end="url(#a)"/>
+    <text x="234" y="34" font-size="10">IQ samples</text>
+    <line x1="390" y1="62" x2="453" y2="62" stroke="currentColor" stroke-width="1.5" marker-end="url(#a)"/>
+  </g>
+  <defs><marker id="a" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The SDR pipeline: hardware grabs spectrum and emits IQ samples; software does the rest. The hardware boundary is where flexibility comes from.</figcaption>
+</figure>
+
+## Why can one cheap dongle decode dozens of systems?
+
+Because the dongle doesn't *care* what it's receiving. Its only job is to deliver
+IQ samples for a slice of spectrum. The thing that distinguishes a police P25 system
+from a pager network from an aircraft transponder is the **modulation and protocol**
+— and all of that lives in software.
+
+So when GopherTrunk adds support for a new protocol, your *existing* hardware can
+suddenly decode it. The same RTL-SDR that follows a trunked system can, with
+different software, watch aircraft, plot ships, or read pager traffic. This is the
+payoff of "the radio becomes code": capabilities arrive as updates, not as new
+equipment.
+
+It's also why this learning path spends its early modules on *fundamentals* rather
+than any one device. The RF concepts — frequency, modulation, IQ, SNR — are what you
+actually configure. The hardware is almost interchangeable.
+
+## Where does GopherTrunk fit?
+
+GopherTrunk is the **software half** of a software-defined radio, specialised for
+**digital trunked-radio** systems. It takes the IQ samples from your dongle and runs
+the full chain you'll learn in this path: it tunes to a control channel, filters and
+demodulates the [4FSK signal](/learn/digital-modulation/), recovers the symbols, decodes
+the trunking protocol to learn which voice channel a call jumped to, follows it,
+decodes the [vocoded voice](/learn/vocoders/), and writes you a WAV file — all in real time,
+across many channels at once.
+
+You don't need to understand every stage to *run* it. But you'll operate it far
+better once you do — which is exactly what the rest of this path builds toward, and
+what the [From antenna to audio](/learn/antenna-to-audio/) lesson ties together at the end.
+
+## What hardware do I need to start?
+
+Not much. A basic **RTL-SDR** dongle (around $30) is enough to follow this path and
+run GopherTrunk on many systems. Step-up radios add capability you may grow into:
+
+| Class | Examples | What it adds |
+|-------|----------|--------------|
+| Entry | RTL-SDR (RTL2832U) | Cheap, ~2.4 MHz bandwidth, receive only — perfect to learn on |
+| Wideband | Airspy R2 / Mini | More bandwidth and sensitivity |
+| HF-capable | Airspy HF+ | Strong performance on lower bands |
+| Transmit-capable | HackRF One | Wide range and TX (not needed for scanning) |
+
+The [Hardware guide](/hardware.html) covers exactly which radios GopherTrunk drives
+and how to pick one. The [SDR hardware lesson](/learn/sdr-hardware/) later in this module
+goes deeper on the trade-offs.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the hardware just delivers IQ samples; software does the decoding." markdown="0">
+  <p class="knowledge-check__q">Quick check: in an SDR, what decides whether you're decoding FM, P25, or pagers?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A switch on the dongle</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The software processing the IQ samples</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A different antenna for each mode</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- An **SDR** moves tuning, filtering, and demodulation from fixed hardware into
+  software.
+- The hardware's only job is to digitise a slice of spectrum into **IQ samples**.
+- One dongle decodes many systems because the differences live in *code*, not parts.
+- **GopherTrunk** is the software that turns those samples into decoded trunked calls.
+- An ~$30 RTL-SDR is enough to begin.
+
+Next, we'll open up the receiver and trace how those IQ samples are actually made.

--- a/docs/learn/what-is-trunking.md
+++ b/docs/learn/what-is-trunking.md
@@ -1,0 +1,171 @@
+---
+slug: what-is-trunking
+title: What is trunked radio?
+description: Trunked radio explained for beginners — control channels, voice channels, talkgroups, and affiliation. Understand how systems like P25 and DMR share a few frequencies across a whole fleet, and why GopherTrunk follows the control channel.
+keywords: trunked radio, trunking explained, control channel, voice channel, talkgroup, affiliation, P25 trunking, DMR trunking, what is a control channel, conventional vs trunked
+level: intermediate
+status: full
+prereq:
+  - radio-waves
+  - digital-modulation
+faq:
+  - q: What is trunked radio?
+    a: Trunked radio is a system where many user groups share a small pool of radio channels automatically. Instead of each group having its own permanent frequency, a computer assigns a free channel for the duration of each call, then releases it. A dedicated control channel coordinates everything, telling radios where to go for each conversation. This packs far more users onto the same spectrum than giving everyone a fixed frequency.
+  - q: What is a control channel?
+    a: A control channel is one frequency in a trunked system that continuously carries data rather than voice. It manages the system — handling radios registering, requesting calls, and being told which voice channel to switch to. To monitor a trunked system you decode the control channel first, because it's the map that tells you where every call goes.
+  - q: What is a talkgroup?
+    a: A talkgroup is a virtual channel — a label that identifies a group of users, like "Police Dispatch" or "Fire Ground 2." Members of a talkgroup hear each other regardless of which physical frequency the system assigns to a given call. In a trunked system you follow talkgroups, not frequencies, because the frequency changes call to call.
+  - q: What is the difference between conventional and trunked radio?
+    a: In conventional radio, each group has a fixed frequency it always uses. In trunked radio, frequencies are shared and assigned on demand by a control channel. Conventional is simple to scan — just listen to the frequency. Trunked needs you to decode the control channel to follow conversations as they hop between voice channels.
+  - q: Why does GopherTrunk follow the control channel?
+    a: Because the control channel is where the system announces every call and the voice channel it's assigned to. By decoding it in real time, GopherTrunk knows the instant a talkgroup starts a call and which frequency to tune a receiver to in order to capture the audio — then it follows the next call, and the next, across the whole system.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch the raw control-channel messages GopherTrunk decodes in real time.
+  - title: Radio IDs
+    url: /radio-ids.html
+    note: see which radios are affiliating and transmitting on the system.
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: find a control channel when you don't know the system's frequencies yet.
+---
+
+# What is trunked radio?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Trunked radio** lets many user groups share a small pool of frequencies by
+assigning a free channel to each call on demand, then reclaiming it. A dedicated
+**control channel** carries data — not voice — and orchestrates the whole system,
+announcing every call and the **voice channel** it's been assigned. Users belong to
+**talkgroups** (virtual channels), so you follow *who's talking*, not a fixed
+frequency. This is why **GopherTrunk decodes the control channel first**: it's the
+map that tells the software where each call goes so it can follow them across the
+system.
+</div>
+
+This is the idea GopherTrunk was built around. Once trunking clicks, the whole
+design of the software — control channels, talkgroups, the activity panels — turns
+from jargon into something obvious.
+
+## What problem does trunking solve?
+
+Radio spectrum is scarce and expensive. Imagine a county with 40 agencies — police,
+fire, public works, transit, schools. Give each its own permanent frequency and
+you've burned 40 channels, most sitting *silent* most of the time while a few are
+congested. That's **conventional** radio: simple, but wasteful.
+
+**Trunking** fixes the waste by sharing. The agencies pool, say, 10 frequencies, and
+a central computer hands out a free one *per call*, just for that call's duration,
+then takes it back. Because real conversations are short and bursty, 10 shared
+channels can serve all 40 groups with almost no waiting. It's the same logic as a
+bank with one queue feeding several tellers instead of a separate line per teller.
+
+## How does a trunked call actually work?
+
+The magic is coordination, and it happens on the **control channel** — one frequency
+that carries a constant stream of *data* (never voice). Here's a single call,
+step by step:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 210" role="img" aria-label="A diagram showing a control channel at top sending assignment messages, and a pool of voice channels below being assigned to different talkgroups." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="460" height="40" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+  <text x="270" y="38" text-anchor="middle" font-size="13" fill="currentColor" font-weight="600">Control channel (data only)</text>
+  <text x="270" y="53" text-anchor="middle" font-size="10" fill="currentColor">“Talkgroup 101 → go to channel 3”</text>
+  <g font-size="11" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="110" width="90" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="85" y="132">Voice 1</text>
+    <rect x="150" y="110" width="90" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="195" y="132">Voice 2</text>
+    <rect x="260" y="110" width="90" height="36" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.5"/>
+    <text x="305" y="127">Voice 3</text>
+    <text x="305" y="140" font-size="9">TG 101 active</text>
+    <rect x="370" y="110" width="90" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="415" y="132">Voice 4</text>
+  </g>
+  <line x1="270" y1="60" x2="305" y2="108" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#tg)"/>
+  <text x="270" y="190" text-anchor="middle" font-size="11" fill="currentColor">A free voice channel is assigned per call, then released.</text>
+  <defs><marker id="tg" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The control channel assigns a free voice channel for each call. Follow the control channel and you know where every conversation is.</figcaption>
+</figure>
+
+1. A user keys up. Their radio sends a request on the **control channel**.
+2. The system computer finds a **free voice channel** and broadcasts an *assignment*
+   on the control channel: "Talkgroup 101, go to voice channel 3."
+3. Every radio affiliated with talkgroup 101 hears that data message and instantly
+   retunes to voice channel 3 to listen.
+4. The call happens on channel 3. When it ends, the channel is released back into the
+   pool for the next call — maybe a completely different talkgroup.
+
+The next call from the same talkgroup might land on channel 7, then channel 2. The
+*frequency is never fixed* — which is exactly why you can't scan a trunked system the
+old-fashioned way.
+
+## What is a talkgroup?
+
+Because the physical frequency keeps changing, trunked systems give users a stable
+*virtual* identity: the **talkgroup**. A talkgroup is just a number with a label —
+"Police Dispatch," "Fire Ground 2," "City Transit." Everyone in a talkgroup hears
+each other's calls no matter which voice channel the system happens to assign.
+
+So when you monitor a trunked system, **you follow talkgroups, not frequencies**.
+In GopherTrunk you'll lock, prioritise, or mute *talkgroups* — and the software
+handles the frequency-hopping underneath. Each transmitting radio also has its own
+**[radio ID](/radio-ids.html)**, so you can see individual units, not just groups.
+
+## What is affiliation?
+
+**Affiliation** is how the system keeps track of who's listening to what. When a
+radio is turned on or switches to a talkgroup, it *registers* (affiliates) with the
+system over the control channel. That lets the system route calls efficiently and,
+helpfully for monitoring, it means the control channel is a constant source of
+information about which radios and talkgroups are active — visible in GopherTrunk's
+**[Radio IDs](/radio-ids.html)** and **[CC Activity](/cc-activity.html)** panels.
+
+## Why does GopherTrunk decode the control channel first?
+
+Everything above runs through the control channel, so it is the **single most
+important thing to decode**. By locking onto it and reading its data stream in real
+time, GopherTrunk learns:
+
+- the instant any talkgroup starts a call,
+- which voice channel that call was assigned to,
+- which radio ID is transmitting, and
+- the system's identity and parameters.
+
+With that map, GopherTrunk can point a receiver at the right voice channel at the
+right moment, capture the audio, and immediately be ready for the next assignment —
+following dozens of conversations as they scatter across the channel pool. Lose the
+control channel and you're blind; that's why so much of operating GopherTrunk comes
+down to getting a [clean, solid lock](/learn/tuning-with-scopes/) on it.
+
+The control-channel data itself is sent using the [digital
+modulation](/learn/digital-modulation/) you met earlier — for P25 and DMR, that's the 4FSK
+whose symbols you can watch in the constellation and eye-diagram panels. Different
+systems package this differently, which is the subject of [the protocol
+landscape](/learn/protocol-landscape/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — you follow the talkgroup; the system moves it across voice channels." markdown="0">
+  <p class="knowledge-check__q">Quick check: on a trunked system, what do you follow to hear a particular group of users?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A single fixed frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Their talkgroup</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The control channel's audio</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Trunking** shares a small pool of frequencies across many groups by assigning a
+  channel per call.
+- The **control channel** carries data and orchestrates everything — it's the map.
+- **Talkgroups** are virtual channels; you follow them, not frequencies.
+- **Affiliation** registers radios so the system (and you) know who's active.
+- **GopherTrunk decodes the control channel first** so it can follow every call.
+
+Next, we'll survey the actual protocols — P25, DMR, NXDN and friends — and how to
+tell them apart. Or see the whole chain assembled in [From antenna to
+audio](/learn/antenna-to-audio/).

--- a/docs/learn/what-is-trunking.md
+++ b/docs/learn/what-is-trunking.md
@@ -103,6 +103,23 @@ The next call from the same talkgroup might land on channel 7, then channel 2. T
 *frequency is never fixed* — which is exactly why you can't scan a trunked system the
 old-fashioned way.
 
+### Watching the pool churn
+
+To see why this defeats an old scanner, follow ten seconds on a busy system —
+this is exactly the stream GopherTrunk reads on the control channel:
+
+| Time | Control-channel message | What a follower does |
+|------|-------------------------|----------------------|
+| 0.0 s | TG 101 (Dispatch) → channel 3 | Tune a receiver to ch 3, record |
+| 1.2 s | TG 250 (Fire) → channel 7 | Tune a *second* receiver to ch 7 |
+| 3.8 s | TG 101 ends; ch 3 released | Free ch 3 back to the pool |
+| 4.1 s | TG 101 (Dispatch) → channel 2 | The *same* talkgroup, a *new* channel |
+| 5.5 s | TG 412 (Transit) → channel 3 | Reuse ch 3, now a different group |
+
+An old scanner parked on "channel 3" would hear Dispatch, then silence, then Transit
+— a meaningless jumble. A trunk-tracker following the *control channel* knows who's on
+each channel at every instant, which is the whole point of decoding it first.
+
 ## What is a talkgroup?
 
 Because the physical frequency keeps changing, trunked systems give users a stable

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,35 @@
+---
+permalink: /llms.txt
+layout: null
+sitemap: false
+---
+# GopherTrunk
+
+> GopherTrunk is a pure-Go software-defined-radio (SDR) scanner engine that follows
+> and decodes digital trunked-radio voice calls (P25, DMR, TETRA, NXDN, Motorola,
+> EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF) from RTL-SDR, HackRF, and Airspy hardware.
+> The site also hosts a free, structured learning path that teaches radio and SDR
+> fundamentals from beginner to expert.
+
+## Learn RF & SDR (learning path)
+
+A guided curriculum taking a complete newcomer to a confident GopherTrunk operator.
+Start: {{ '/learn/' | absolute_url }}
+{% for mod in site.data.learn.modules %}
+### {{ mod.label }}
+{{ mod.blurb }}
+{% for lesson in mod.lessons %}- [{{ lesson.title }}]({{ '/learn/' | append: lesson.slug | append: '/' | absolute_url }}): {{ lesson.summary }}
+{% endfor %}{% endfor %}
+### Reference
+- [{{ site.data.learn.glossary.title }}]({{ '/learn/glossary/' | absolute_url }}): {{ site.data.learn.glossary.summary }}
+
+## Getting started with GopherTrunk
+- [What is GopherTrunk?]({{ '/getting-started.html' | absolute_url }}): conceptual overview of the scanner and its interfaces.
+- [Get started]({{ '/getting-started-setup.html' | absolute_url }}): from a dongle to your first decoded call.
+- [Hardware]({{ '/hardware.html' | absolute_url }}): supported SDR dongles.
+- [Downloads]({{ '/downloads.html' | absolute_url }}): builds for Linux, macOS, and Windows.
+
+## Reference
+- [Architecture]({{ '/architecture.html' | absolute_url }}): how the engine is built.
+- [Vocoders]({{ '/vocoders.html' | absolute_url }}): IMBE and AMBE+2 voice decoding.
+- [Status]({{ '/status.html' | absolute_url }}): protocol and decoder coverage.

--- a/docs/search.json
+++ b/docs/search.json
@@ -1,0 +1,31 @@
+---
+permalink: /search.json
+layout: null
+sitemap: false
+---
+{%- comment -%}
+  Client-side search index. Built once at Jekyll build time and fetched by
+  assets/js/search.js. Covers every HTML page (top-level docs + /learn/
+  lessons) and blog posts. site.html_pages excludes raw files like this one
+  and llms.txt automatically. Skip the search page itself and any page that
+  sets `search: false`. The leading-comma flag keeps the JSON valid even
+  when items are skipped.
+{%- endcomment -%}
+{%- assign items = site.html_pages | concat: site.posts -%}
+[
+{%- assign first = true -%}
+{%- for item in items -%}
+  {%- if item.title and item.url != "/search/" and item.search != false -%}
+    {%- unless first %},{% endunless -%}
+    {%- assign first = false -%}
+    {
+      "title": {{ item.title | jsonify }},
+      "url": {{ item.url | relative_url | jsonify }},
+      "desc": {{ item.description | default: item.summary | default: "" | jsonify }},
+      "kw": {{ item.keywords | default: "" | jsonify }},
+      "group": {{ item.nav_group | default: item.category | default: "" | jsonify }},
+      "body": {{ item.content | strip_html | normalize_whitespace | truncatewords: 100 | jsonify }}
+    }
+  {%- endif -%}
+{%- endfor -%}
+]

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,36 @@
+---
+permalink: /search/
+title: Search
+description: Search the GopherTrunk documentation and the RF & SDR learning path — pages, lessons, and reference, all from one box.
+nav_group: Learn RF & SDR
+sitemap: false
+search: false
+---
+
+# Search
+
+<div class="search-page">
+  <form class="search-page__form" role="search" action="{{ '/search/' | relative_url }}" method="get">
+    <input
+      type="search"
+      id="gt-search-input"
+      name="q"
+      class="search-page__input"
+      placeholder="Search docs and lessons — e.g. P25, decibels, IQ, control channel"
+      autocomplete="off"
+      autocapitalize="off"
+      spellcheck="false"
+      aria-label="Search query"
+      autofocus>
+  </form>
+  <p class="search-page__status" id="gt-search-status" aria-live="polite">Loading the search index…</p>
+  <ul class="search-results" id="gt-search-results"></ul>
+</div>
+
+<noscript>
+Search needs JavaScript. You can still browse the
+[learning path](/learn/), the [glossary](/learn/glossary/), or use your
+browser's find on any page.
+</noscript>
+
+<script defer src="{{ '/assets/js/search.js' | relative_url }}"></script>


### PR DESCRIPTION
Introduce a structured, SEO- and AI-search-optimized learning path at
/learn/ that takes a reader from complete SDR newbie to confident
GopherTrunk operator. Vendor-neutral RF fundamentals funnel into
GopherTrunk specifics across six modules and a glossary.

- New data-driven curriculum (_data/learn.yml) powering a hub landing
  page, in-lesson metadata, and prev/next path navigation.
- Lesson + hub layouts with breadcrumbs, reading time, level badges,
  prerequisite chips, and "use this in GopherTrunk" links.
- Per-lesson JSON-LD (TechArticle, BreadcrumbList, FAQPage) and a
  Course/ItemList on the hub; visible FAQ sections mirror the schema.
- Progressive-enhancement JS: localStorage progress tracker, freq<->
  wavelength and dB/dBm calculators, and self-check quizzes (pages stay
  fully usable with JS off).
- 8 fully written cornerstone lessons (radio waves, decibels, digital
  modulation, what is SDR, trunking, antenna-to-audio, hub, glossary)
  plus 22 navigable outline stubs covering the full path.
- Nav group, /learn/ pretty URLs, llms.txt for AI crawlers, and a
  homepage callout from the README.

Verified with a local Jekyll build: site compiles, 105 JSON-LD blocks
parse, and internal links resolve.