### PR TITLE
Add download, support, and community CTAs to non-home pages

### DIFF
--- a/docs/_includes/join-cta.html
+++ b/docs/_includes/join-cta.html
@@ -1,0 +1,27 @@
+{%- comment -%}
+  "Join the conversation" call-to-action band, rendered by the default
+  layout at the bottom of the content, above the site footer. Shown on every
+  non-home page (the homepage hero already carries these community links) and
+  suppressed by `hide_ctas: true`. Links carry data-cta-event for gtag
+  measurement (handled in assets/js/site.js).
+{%- endcomment -%}
+{%- unless page.hide_ctas or page.url == "/" -%}
+<section class="join-cta" aria-label="Join the community">
+  <div class="container join-cta__inner">
+    <div class="join-cta__copy">
+      <h2 class="join-cta__title">Join the conversation</h2>
+      <p class="join-cta__lede">Questions, signal IDs, feature ideas? Swap notes with other GopherTrunk users on Discord and Reddit.</p>
+    </div>
+    <div class="join-cta__actions">
+      <a class="btn btn--discord" href="https://discord.gg/x49Hr62uH" rel="noopener" data-cta-event="cta_join_discord">
+        {% include icons/discord.svg %}
+        <span>Join the Discord</span>
+      </a>
+      <a class="btn btn--reddit" href="https://www.reddit.com/r/GopherTrunk" rel="noopener" data-cta-event="cta_join_reddit">
+        {% include icons/reddit.svg %}
+        <span>r/GopherTrunk</span>
+      </a>
+    </div>
+  </div>
+</section>
+{%- endunless -%}

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -1,0 +1,26 @@
+{%- comment -%}
+Resolve the version string the download links should point at, and the
+release-asset base URL. Assigned variables (`ver`, `rel_url`) persist into
+the including page's scope because Jekyll's {% include %} shares scope.
+
+Three-tier resolution so callers stay useful no matter the release state:
+
+  1. site.github.latest_release — GitHub's "latest stable" endpoint.
+     Excludes prereleases, so this returns null while every release
+     is a v0.x.y (which release.yml flags prerelease per SemVer §4).
+     Once v1.0.0+ ships stable, this is the right answer.
+  2. site.github.releases[0] — the most recent release of any kind,
+     prereleases included. Drives callers through the pre-1.0 window.
+  3. Hardcoded tag — last-ditch fallback if the GitHub metadata API call
+     fails during the Pages build (rare). Bump on each release as a
+     defensive matter, but it should never be the value users actually see.
+{%- endcomment -%}
+{%- assign ver = nil -%}
+{%- if site.github.latest_release and site.github.latest_release.tag_name -%}
+  {%- assign ver = site.github.latest_release.tag_name -%}
+{%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
+  {%- assign ver = site.github.releases[0].tag_name -%}
+{%- else -%}
+  {%- assign ver = "v0.4.4" -%}
+{%- endif -%}
+{%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/_includes/page-ctas.html
+++ b/docs/_includes/page-ctas.html
@@ -1,0 +1,37 @@
+{%- comment -%}
+  In-content call-to-action sections rendered on non-home page bodies.
+
+  Rendered as the last children of the content host ([data-cta-host]); on
+  capable browsers assets/js/site.js relocates them to ~1/3 ("try") and
+  ~2/3 ("support") down the content. With JS off they remain here, at the
+  end of the content — still functional.
+
+  Suppressed per-page with `hide_ctas: true` in front matter (set on the
+  download/install/support pages where these would be redundant).
+
+  Every link carries data-cta-event so site.js can fire a gtag 'cta_click'
+  event — lets us measure whether these CTAs convert.
+{%- endcomment -%}
+{%- unless page.hide_ctas -%}
+{%- include latest-version.html -%}
+<aside class="page-cta page-cta--try" data-cta="try" aria-label="Try GopherTrunk">
+  <h2 class="page-cta__title">Have you tried GopherTrunk?</h2>
+  <p class="page-cta__lede">A pure-Go digital-trunking scanner engine for RTL-SDR — P25, DMR, TETRA, NXDN and more, in a single static binary. Grab the latest build and start scanning.</p>
+  <div class="page-cta__actions">
+    <a class="btn btn--primary" href="{{ '/downloads.html' | relative_url }}" data-cta-event="cta_try_download">Download GopherTrunk {{ ver }} &rarr;</a>
+  </div>
+</aside>
+
+<aside class="page-cta page-cta--support" data-cta="support" aria-label="Support GopherTrunk">
+  <h2 class="page-cta__title">Enjoying GopherTrunk?</h2>
+  <p class="page-cta__lede">GopherTrunk is free and open source, built in spare time. If it's useful to you, a small contribution helps keep the features and docs coming.</p>
+  <div class="page-cta__actions">
+    <a class="btn btn--primary" href="https://www.buymeacoffee.com/Mrcheramie" rel="noopener" data-cta-event="cta_support_bmc">Buy me a coffee</a>
+    <a class="btn btn--ghost" href="https://github.com/sponsors/MattCheramie" rel="noopener" data-cta-event="cta_support_sponsors">
+      {% include icons/heart.svg %}
+      <span>GitHub Sponsors</span>
+    </a>
+  </div>
+</aside>
+<script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="Mrcheramie" data-description="Support me on Buy me a coffee!" data-message="Help support more content like this!" data-color="#5F7FFF" data-position="Right" data-x_margin="18" data-y_margin="18"></script>
+{%- endunless -%}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -7,6 +7,7 @@
     <a class="skip-link" href="#content">Skip to content</a>
     {%- include nav.html -%}
     {{ content }}
+    {%- include join-cta.html -%}
     {%- include footer.html -%}
     <script defer src="{{ '/assets/js/site.js' | relative_url }}"></script>
   </body>

--- a/docs/_layouts/learn-hub.html
+++ b/docs/_layouts/learn-hub.html
@@ -12,7 +12,7 @@ layout: default
 {%- for mod in learn.modules -%}{%- assign total = total | plus: mod.lessons.size -%}{%- endfor -%}
 
 <main id="content" class="page" role="main">
-  <div class="container">
+  <div class="container" data-cta-host>
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <ol>
         <li><a href="{{ '/' | relative_url }}">Home</a></li>
@@ -81,6 +81,8 @@ layout: default
         </ol>
       </section>
     </div>
+
+    {%- include page-ctas.html -%}
   </div>
 </main>
 

--- a/docs/_layouts/lesson.html
+++ b/docs/_layouts/lesson.html
@@ -73,7 +73,10 @@ layout: default
         {%- endif -%}
       </header>
 
-      {{ content }}
+      <div class="lesson__body" data-cta-host>
+        {{ content }}
+        {%- include page-ctas.html -%}
+      </div>
 
       {%- if page.faq and page.faq.size > 0 -%}
         <section class="lesson__faq" aria-label="Frequently asked questions">

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -15,8 +15,9 @@ layout: default
       </nav>
     {%- endif -%}
 
-    <article class="prose">
+    <article class="prose" data-cta-host>
       {{ content }}
+      {%- include page-ctas.html -%}
     </article>
 
     {%- if page.path -%}

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -37,8 +37,9 @@ layout: default
         </p>
       </header>
 
-      <div itemprop="articleBody">
+      <div itemprop="articleBody" data-cta-host>
         {{ content }}
+        {%- include page-ctas.html -%}
       </div>
 
       {%- if page.tags and page.tags.size > 0 -%}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1233,3 +1233,60 @@ a.category-chip:hover {
   .site-search__form { width: 100%; }
   .site-search__input { width: 100%; }
 }
+
+/* ---------- In-content CTAs (try / support) ---------- */
+.page-cta {
+  margin: 2.25rem 0;
+  padding: 1.25rem 1.5rem;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--accent);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+.page-cta--support { border-left-color: #5f7fff; }
+.page-cta__title {
+  margin: 0 0 0.4rem;
+  font-size: 1.2rem;
+  border: none;
+  padding: 0;
+}
+.page-cta__lede {
+  margin: 0 0 1rem;
+  color: var(--fg-muted);
+  font-size: 0.97rem;
+}
+.page-cta__actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+/* ---------- "Join the conversation" band (above the footer) ---------- */
+.join-cta {
+  border-top: 1px solid var(--border);
+  background:
+    radial-gradient(ellipse at top, var(--accent-soft), transparent 70%),
+    var(--bg);
+}
+.join-cta__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  padding-top: 2.5rem;
+  padding-bottom: 2.5rem;
+}
+.join-cta__copy { flex: 1 1 18rem; }
+.join-cta__title { margin: 0 0 0.35rem; font-size: 1.4rem; }
+.join-cta__lede { margin: 0; color: var(--fg-muted); }
+.join-cta__actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+@media (max-width: 600px) {
+  .join-cta__actions { width: 100%; }
+  .join-cta__actions .btn { flex: 1 1 auto; justify-content: center; }
+}

--- a/docs/assets/js/site.js
+++ b/docs/assets/js/site.js
@@ -48,6 +48,51 @@
     }
   }
 
+  // In-content CTAs: relocate the "try" / "support" call-outs to roughly
+  // 1/3 and 2/3 down the content. They render at the end of the host as a
+  // no-JS fallback; here we move them into the reading flow by pixel height.
+  var ctaHost = document.querySelector('[data-cta-host]');
+  if (ctaHost) {
+    var tryCta = ctaHost.querySelector(':scope > [data-cta="try"]');
+    var supportCta = ctaHost.querySelector(':scope > [data-cta="support"]');
+    if (tryCta && supportCta) {
+      var blocks = Array.prototype.filter.call(ctaHost.children, function (el) {
+        return el !== tryCta && el !== supportCta;
+      });
+      if (blocks.length >= 2) {
+        var hostTop = ctaHost.getBoundingClientRect().top;
+        var hostHeight = ctaHost.offsetHeight;
+        // First block whose top crosses the given fraction of the content.
+        var blockAt = function (fraction) {
+          var target = hostTop + hostHeight * fraction;
+          for (var i = 0; i < blocks.length; i++) {
+            if (blocks[i].getBoundingClientRect().top >= target) return blocks[i];
+          }
+          return null;
+        };
+        var tryRef = blockAt(1 / 3);
+        var supportRef = blockAt(2 / 3);
+        // Guarantee support lands after try even when both resolve to the
+        // same (or no) reference block.
+        if (supportRef === tryRef) supportRef = null;
+        if (tryRef) ctaHost.insertBefore(tryCta, tryRef);
+        if (supportRef) ctaHost.insertBefore(supportCta, supportRef);
+        else ctaHost.appendChild(supportCta);
+      }
+    }
+  }
+
+  // Google Analytics: fire a gtag event whenever a CTA link is clicked, so
+  // we can measure whether these call-to-actions convert.
+  document.addEventListener('click', function (e) {
+    var link = e.target.closest && e.target.closest('[data-cta-event]');
+    if (!link || typeof window.gtag !== 'function') return;
+    window.gtag('event', 'cta_click', {
+      cta_id: link.getAttribute('data-cta-event'),
+      page_path: location.pathname
+    });
+  });
+
   // Mobile: tap a group label to expand its submenu (desktop uses :hover/:focus-within)
   var isCoarse = window.matchMedia('(max-width: 800px)').matches;
   if (isCoarse) {

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -3,34 +3,15 @@ layout: page
 title: Downloads
 description: Install GopherTrunk on Linux, macOS, or Windows
 nav_group: Install
+hide_ctas: true
 ---
 
 {%- comment -%}
-Resolve the version string the download cards should point at.
-Three-tier resolution so the page stays useful no matter what the
-release state looks like:
-
-  1. site.github.latest_release — GitHub's "latest stable" endpoint.
-     Excludes prereleases, so this returns null while every release
-     is a v0.x.y (which release.yml flags prerelease per SemVer §4).
-     Once v1.0.0+ ships stable, this is the right answer.
-  2. site.github.releases[0] — the most recent release of any kind,
-     prereleases included. Drives the page through the pre-1.0
-     window.
-  3. Hardcoded tag — last-ditch fallback if the GitHub metadata
-     API call fails during the Pages build (rare). Bump on each
-     release as a defensive matter, but it should never be the
-     value users actually see.
+Resolve `ver` (release tag) and `rel_url` (release-asset base URL) via the
+shared three-tier resolution in _includes/latest-version.html. The assigned
+variables persist into this page's scope after the include.
 {%- endcomment -%}
-{%- assign ver = nil -%}
-{%- if site.github.latest_release and site.github.latest_release.tag_name -%}
-  {%- assign ver = site.github.latest_release.tag_name -%}
-{%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
-  {%- assign ver = site.github.releases[0].tag_name -%}
-{%- else -%}
-  {%- assign ver = "v0.4.4" -%}
-{%- endif -%}
-{%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}
+{%- include latest-version.html -%}
 
 # Download GopherTrunk
 

--- a/docs/install-linux.md
+++ b/docs/install-linux.md
@@ -3,6 +3,7 @@ layout: page
 title: Linux install
 description: Five-minute path from a fresh download to a working gophertrunk sdr list on Linux
 nav_group: Install
+hide_ctas: true
 ---
 
 # Installing GopherTrunk on Linux

--- a/docs/install-macos.md
+++ b/docs/install-macos.md
@@ -3,6 +3,7 @@ layout: page
 title: macOS install
 description: Five-minute path from a fresh download to a working gophertrunk sdr list on macOS
 nav_group: Install
+hide_ctas: true
 ---
 
 # Installing GopherTrunk on macOS

--- a/docs/install-windows.md
+++ b/docs/install-windows.md
@@ -3,6 +3,7 @@ layout: page
 title: Windows install
 description: Five-minute path from a fresh download to a working gophertrunk sdr list on Windows 11
 nav_group: Install
+hide_ctas: true
 ---
 
 # Installing GopherTrunk on Windows 11

--- a/docs/support.md
+++ b/docs/support.md
@@ -3,6 +3,7 @@ layout: page
 title: Support
 description: Help keep GopherTrunk going
 nav_group: Support
+hide_ctas: true
 ---
 
 # Support GopherTrunk


### PR DESCRIPTION
Inject call-to-action sections into every non-homepage page body:

- A "Have you tried GopherTrunk?" CTA at ~1/3 with a button to the
  downloads page showing the dynamically-resolved latest version.
- An "Enjoying GopherTrunk?" support CTA at ~2/3 with a Buy Me a Coffee
  link, a GitHub Sponsors link, and the floating Buy Me a Coffee widget.
- A "Join the conversation" band (Discord + Reddit) at the bottom of the
  content, above the footer.

The in-content CTAs render at the end of the content as a no-JS fallback;
site.js relocates them to ~1/3 and ~2/3 down by pixel height. Every CTA
link carries a data-cta-event attribute, and a delegated click handler
fires a gtag 'cta_click' event so conversions can be measured.

Version resolution is extracted from downloads.md into a shared
_includes/latest-version.html and reused by the CTA. CTAs are suppressed
via hide_ctas front matter on the downloads, install, and support pages
where they would be redundant.