### PR TITLE
docs(p25): record SDRTrunk ground truth for #376 alias decode paths

### DIFF
--- a/internal/radio/p25/phase1/link_control.go
+++ b/internal/radio/p25/phase1/link_control.go
@@ -49,15 +49,20 @@ type LinkControl struct {
 const lcContentOctets = 9
 
 // Standard TIA-102.AABF Link Control Opcodes the talker-alias path
-// needs. These three LCOs carry a radio's display name across an
-// active voice channel (LDU1) as a HEADER + two BLOCK fragments —
-// distinct from the Motorola vendor TSBK alias format the control
-// channel already handles (see tsbk_vendor.go's OpVendorTalkerAlias).
+// needs. These LCOs carry a radio's display name across an active
+// voice channel as a HEADER + data BLOCK fragments — distinct from
+// the Motorola vendor TSBK alias format the control channel already
+// handles (see tsbk_vendor.go's OpVendorTalkerAlias).
 //
-// Today GopherTrunk only decodes the vendor TSBK form; standard
-// voice-channel alias dispatch is a documented follow-up (issue
-// #376 audit). The constants live here so consumers can recognise
-// the opcodes when the LC is parsed and surface them in logs.
+// The LDU1 voice-channel form is decoded today: p25p1_voice.go
+// dispatches IsTalkerAliasLCO LCs into MotorolaTalkerAliasBuf. The
+// remaining #376 gap is the TDULC carriage — field reports
+// (SDRTrunk ground truth on Victorian MMR) show Phase 1 systems
+// emit the same 0x15/0x17 alias LCs in the TERMINATOR (TDULC, DUID
+// 0xF) link control, NOT LDU1, so the voice chain misses them: it
+// returns at the terminator before parsing the TDULC LC, and no
+// TDULC LC extractor exists yet. The constants live here so
+// consumers can recognise the opcodes when the LC is parsed.
 const (
 	LCOGroupVoiceChannelUser = 0x00 // the common LCO carrying TG + SRC
 	LCOTalkerAliasHeader     = 0x15 // first frame: char-set + total length

--- a/internal/radio/p25/phase1/motorola_alias.go
+++ b/internal/radio/p25/phase1/motorola_alias.go
@@ -17,6 +17,14 @@ import "time"
 // form; if a voice chain ever observes one, this assembler ignores
 // it.
 //
+// Carriage note (#376): SDRTrunk ground truth on Victorian MMR shows
+// these 0x15/0x17 LCs ride primarily in the TERMINATOR link control
+// (TDULC, DUID 0xF), not LDU1. p25p1_voice.go currently feeds this
+// buffer only from LDU1 and returns early on the terminator, so the
+// TDULC-borne aliases are missed until a TDULC LC extractor is added
+// — fixture-backed follow-up. This buffer's reassembly is carriage-
+// independent, so the future TDULC path can reuse it unchanged.
+//
 // The 9-octet LC content layouts (HEADER + DATA BLOCK), the message
 // framing (WACN + System + RadioID + encoded alias + CRC), and the
 // per-byte obfuscation cipher are documented publicly in the
@@ -53,7 +61,11 @@ import "time"
 //	bits 20..31  : System ID
 //	bits 32..55  : Radio (subscriber) ID
 //	bits 56..end-16 : encoded alias bytes
-//	last 16 bits : CRC-16/GSM (currently informational; not verified)
+//	last 16 bits : CRC-16/GSM (currently informational; not verified).
+//	               Validating it would reject the junk alias a
+//	               partial/garbled block sequence can otherwise surface
+//	               (#376) — a fixture-backed hardening, pending a real
+//	               frame to confirm the CRC parameters.
 //
 // Encoded alias bytes are byte-aligned starting at bit 56. Each
 // encoded byte passes through the cipher (see decodeAliasBytes) to

--- a/internal/radio/p25/phase2/mac_vendor.go
+++ b/internal/radio/p25/phase2/mac_vendor.go
@@ -37,6 +37,16 @@ const (
 	// OpVendorTalkerAlias carries one fragment of a radio's display
 	// name (talker alias). Both Motorola (MFID 0x90) and Harris
 	// (MFID 0xA4) emit it; AsTalkerAliasFragment decodes either.
+	//
+	// CORRECTION PENDING (#376): this 0x82 value and the plain-ASCII
+	// payload in talker_alias.go are a speculative working model. On-air
+	// SDRTrunk decode of Victorian MMR shows the real Motorola Phase 2
+	// alias rides on FACCH-S during hangtime as a HEADER opcode 0x91 +
+	// DATA opcodes 0x95 (MFID 0x90), cipher-obfuscated (the same
+	// Motorola alias cipher as phase1/motorola_alias_cipher.go) with a
+	// CRC-16 tail, and carries the source RID inline in the header.
+	// Correct the opcode + framing here against the fixtures before
+	// trusting any Phase 2 alias decode.
 	OpVendorTalkerAlias Opcode = 0x82
 	// OpMotorolaPatchDelete is the Motorola group-regroup delete
 	// command (MOT_GRG_DEL_CMD, MFID 0x90): it cancels a patch

--- a/internal/radio/p25/phase2/talker_alias.go
+++ b/internal/radio/p25/phase2/talker_alias.go
@@ -20,6 +20,17 @@ import (
 // in the data. All wire detail is confined here; the assembler logic
 // (per-source buffering, completion, staleness eviction) is
 // encoding-independent and tolerant of reordered or missing fragments.
+//
+// CORRECTION PENDING (#376): the working model above does not match the
+// real Motorola Phase 2 alias observed on-air (SDRTrunk, Victorian MMR).
+// The real form rides on FACCH-S during hangtime with a HEADER opcode
+// 0x91 + DATA opcodes 0x95 (see mac_vendor.go), the fragments are run
+// through the Motorola alias cipher (port phase1/motorola_alias_cipher.go)
+// not read as plain ASCII, there is a CRC-16 tail to validate, and the
+// source RID is carried inline in the header rather than supplied
+// separately. The encoding-independent assembler below should survive
+// the correction; AsTalkerAliasFragment + cleanAlias are what change.
+// Implement against the fixtures before trusting the output.
 
 // TalkerAliasFragment is one numbered piece of a radio's talker alias.
 type TalkerAliasFragment struct {


### PR DESCRIPTION
The RID/talker-alias entity plumbing is already complete; the open #376
work is the decode path. Capture the two proprietary Motorola alias
forms confirmed via SDRTrunk against Victorian MMR, where the code's
working models live, so the fixture-backed implementation has the
transport named:

- phase1 link_control.go: LDU1 alias dispatch already exists; the
  remaining gap is the TDULC carriage (0x15/0x17 LCs ride in the
  terminator LC, not LDU1, which the voice chain returns before).
- phase1 motorola_alias.go: note the TDULC carriage and that CRC-16/GSM
  validation would reject garbled-block junk aliases.
- phase2 mac_vendor.go + talker_alias.go: the speculative 0x82 plain-
  ASCII model does not match on-air traffic — the real form is FACCH-S
  header 0x91 / data 0x95, Motorola-cipher obfuscated, CRC-16 tail, with
  the source RID inline in the header.

Comment-only; no behavioral change.