### PR TITLE
Add RF &amp; SDR learning hub, encyclopedia reference, and site search to the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,10 @@
 # occasionally drop secrets here while iterating on streaming creds).
 .env
 .env.*
+# Jekyll build output and caches for the docs site (docs/). The site is
+# built and deployed by .github/workflows/pages.yml; the generated
+# _site/ is an artifact and must never be committed.
+docs/_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -52,6 +52,15 @@ defaults:
       layout: lesson
       nav_group: Learn RF & SDR
       permalink: /learn/:basename/
+  # Encyclopedia articles under /reference/ get the reference layout and nav
+  # group automatically. The hub (reference/index.md) overrides to reference-hub.
+  - scope:
+      path: "reference"
+      type: pages
+    values:
+      layout: reference
+      nav_group: Reference
+      permalink: /reference/:basename/
   # Per-category post URLs scoped to posts only — a global `permalink`
   # in _config.yml would also rewrite every existing /foo.html page to
   # /foo/ and break the data-driven nav.

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -29,6 +29,32 @@ groups:
         url: /learn/#gophertrunk
       - title: Glossary
         url: /learn/glossary/
+  - label: Reference
+    items:
+      - title: Encyclopedia overview
+        url: /reference/
+      - title: RF & signal fundamentals
+        url: /reference/#rf-fundamentals
+      - title: Modulation
+        url: /reference/#modulation
+      - title: SDR & DSP
+        url: /reference/#sdr-dsp
+      - title: Algorithms
+        url: /reference/#algorithms
+      - title: Trunked radio
+        url: /reference/#trunked-radio
+      - title: Protocols & standards
+        url: /reference/#protocols
+      - title: Voice coding
+        url: /reference/#voice-coding
+      - title: Hardware
+        url: /reference/#hardware
+      - title: People
+        url: /reference/#people
+      - title: Organizations
+        url: /reference/#organizations
+      - title: A–Z index
+        url: /reference/#a-z
   - label: About
     items:
       - title: The Story of GopherTrunk
@@ -95,7 +121,7 @@ groups:
         url: /rigctld.html
       - title: Hardening
         url: /hardening.html
-  - label: Reference
+  - label: Technical docs
     items:
       - title: Architecture
         url: /architecture.html

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -1,0 +1,227 @@
+# GopherTrunk Reference — encyclopedia single source of truth.
+#
+# Drives: the reference hub (docs/reference/index.md) category grid + A–Z index,
+# the article breadcrumb category label (docs/_layouts/reference.html), and the
+# "Reference" section of docs/llms.txt.
+#
+# Adding an entry:
+#   1. Append it under the right category's `entries:` list below.
+#   2. Create docs/reference/<slug>.md with front matter: slug, title,
+#      entry_type, category (= the category id), description, and (optionally)
+#      aka / infobox / see_also / related_lessons / external / autolink.
+#   3. The `reference` defaults scope in _config.yml gives it layout + nav_group.
+#   4. Set `autolink: true` in the article front matter to include the term in
+#      the site-wide autolinker (docs/reference-terms.json). Omit it for common
+#      words (frequency, gain, phase, …) to avoid noisy false matches.
+#
+# Keep `slug` stable once published — it is the URL (/reference/<slug>/).
+
+intro: >
+  The GopherTrunk Reference is a plain-language encyclopedia of the terms,
+  technologies, algorithms, people, hardware, and organizations behind radio and
+  software-defined radio. Each article is a standalone, long-form definition — no
+  lesson order, no exercises, just information — cross-linked to related entries
+  and to the learning path. Browse by category or jump to the A–Z index.
+
+categories:
+  - id: rf-fundamentals
+    label: RF & signal fundamentals
+    blurb: The physical quantities and units that describe radio waves and signal power.
+    entries:
+      - { slug: electromagnetic-spectrum, title: Electromagnetic spectrum, type: term }
+      - { slug: radio-wave, title: Radio wave, type: term }
+      - { slug: frequency, title: Frequency, type: term }
+      - { slug: wavelength, title: Wavelength, type: term }
+      - { slug: amplitude, title: Amplitude, type: term }
+      - { slug: phase, title: Phase, type: term }
+      - { slug: carrier-wave, title: Carrier wave, type: term }
+      - { slug: modulation, title: Modulation, type: term }
+      - { slug: bandwidth, title: Bandwidth, type: term }
+      - { slug: decibel, title: Decibel (dB), type: term }
+      - { slug: dbm, title: dBm, type: term }
+      - { slug: dbfs, title: dBFS, type: term }
+      - { slug: signal-to-noise-ratio, title: Signal-to-noise ratio (SNR), type: term }
+      - { slug: noise-floor, title: Noise floor, type: term }
+      - { slug: attenuation, title: Attenuation, type: term }
+      - { slug: path-loss, title: Path loss, type: term }
+      - { slug: frequency-bands, title: Frequency bands (HF/VHF/UHF), type: term }
+
+  - id: antennas-propagation
+    label: Antennas & propagation
+    blurb: How energy radiates from an antenna and travels to your receiver.
+    entries:
+      - { slug: antenna, title: Antenna, type: term }
+      - { slug: dipole-antenna, title: Dipole antenna, type: term }
+      - { slug: antenna-gain, title: Antenna gain, type: term }
+      - { slug: polarization, title: Polarization, type: term }
+      - { slug: standing-wave-ratio, title: Standing wave ratio (SWR), type: term }
+      - { slug: radio-propagation, title: Radio propagation, type: term }
+      - { slug: multipath-propagation, title: Multipath propagation, type: term }
+      - { slug: radio-horizon, title: Radio horizon, type: term }
+      - { slug: ionospheric-propagation, title: Ionospheric propagation, type: term }
+
+  - id: modulation
+    label: Modulation
+    blurb: The schemes that put information onto a carrier — analog and digital.
+    entries:
+      - { slug: amplitude-modulation, title: Amplitude modulation (AM), type: technology }
+      - { slug: frequency-modulation, title: Frequency modulation (FM), type: technology }
+      - { slug: single-sideband, title: Single sideband (SSB), type: technology }
+      - { slug: frequency-shift-keying, title: Frequency-shift keying (FSK), type: technology }
+      - { slug: phase-shift-keying, title: Phase-shift keying (PSK), type: technology }
+      - { slug: quadrature-amplitude-modulation, title: Quadrature amplitude modulation (QAM), type: technology }
+      - { slug: c4fm, title: C4FM, type: technology }
+      - { slug: cqpsk, title: CQPSK, type: technology }
+      - { slug: gmsk, title: GMSK, type: technology }
+      - { slug: afsk, title: AFSK, type: technology }
+      - { slug: ffsk, title: FFSK, type: technology }
+      - { slug: symbol-rate, title: Symbol rate (baud), type: term }
+      - { slug: constellation-diagram, title: Constellation diagram, type: term }
+      - { slug: eye-diagram, title: Eye diagram, type: term }
+
+  - id: sdr-dsp
+    label: SDR & DSP
+    blurb: Software-defined radio and the digital signal processing between IQ and bits.
+    entries:
+      - { slug: software-defined-radio, title: Software-defined radio (SDR), type: technology }
+      - { slug: iq-data, title: IQ data, type: term }
+      - { slug: analog-to-digital-converter, title: Analog-to-digital converter (ADC), type: term }
+      - { slug: sample-rate, title: Sample rate, type: term }
+      - { slug: nyquist-theorem, title: Nyquist–Shannon sampling theorem, type: term }
+      - { slug: aliasing, title: Aliasing, type: term }
+      - { slug: superheterodyne-receiver, title: Superheterodyne receiver, type: term }
+      - { slug: local-oscillator, title: Local oscillator, type: term }
+      - { slug: digital-down-converter, title: Digital down-converter (DDC), type: term }
+      - { slug: decimation, title: Decimation, type: term }
+      - { slug: digital-filter, title: Digital filter, type: term }
+      - { slug: cic-filter, title: CIC filter, type: algorithm }
+      - { slug: root-raised-cosine-filter, title: Root-raised-cosine filter, type: algorithm }
+      - { slug: matched-filter, title: Matched filter, type: algorithm }
+      - { slug: automatic-gain-control, title: Automatic gain control (AGC), type: term }
+      - { slug: demodulation, title: Demodulation, type: term }
+      - { slug: clock-recovery, title: Clock recovery, type: term }
+      - { slug: costas-loop, title: Costas loop, type: algorithm }
+      - { slug: cma-equalizer, title: CMA equalizer, type: algorithm }
+      - { slug: ppm-frequency-correction, title: PPM frequency correction, type: term }
+
+  - id: algorithms
+    label: Transforms & algorithms
+    blurb: The mathematics of spectra, error correction, and timing recovery.
+    entries:
+      - { slug: fourier-transform, title: Fourier transform, type: algorithm }
+      - { slug: fast-fourier-transform, title: Fast Fourier transform (FFT), type: algorithm }
+      - { slug: viterbi-algorithm, title: Viterbi algorithm, type: algorithm }
+      - { slug: convolutional-code, title: Convolutional code, type: algorithm }
+      - { slug: reed-solomon-code, title: Reed–Solomon code, type: algorithm }
+      - { slug: bch-code, title: BCH code, type: algorithm }
+      - { slug: golay-code, title: Golay code, type: algorithm }
+      - { slug: hamming-code, title: Hamming code, type: algorithm }
+      - { slug: cyclic-redundancy-check, title: Cyclic redundancy check (CRC), type: algorithm }
+      - { slug: trellis-coded-modulation, title: Trellis-coded modulation, type: algorithm }
+      - { slug: forward-error-correction, title: Forward error correction (FEC), type: term }
+      - { slug: interleaving, title: Interleaving, type: algorithm }
+      - { slug: scrambling, title: Scrambling (whitening), type: algorithm }
+      - { slug: gardner-timing-recovery, title: Gardner timing recovery, type: algorithm }
+      - { slug: mueller-muller-timing-recovery, title: Mueller–Müller timing recovery, type: algorithm }
+      - { slug: multi-band-excitation, title: Multi-band excitation (MBE), type: algorithm }
+      - { slug: compact-position-reporting, title: Compact position reporting (CPR), type: algorithm }
+      - { slug: rc4-cipher, title: RC4 (ARC4) cipher, type: algorithm }
+
+  - id: trunked-radio
+    label: Trunked radio
+    blurb: The concepts that let many users share a pool of channels.
+    entries:
+      - { slug: trunked-radio, title: Trunked radio, type: term }
+      - { slug: conventional-radio, title: Conventional radio, type: term }
+      - { slug: control-channel, title: Control channel, type: term }
+      - { slug: voice-channel, title: Voice channel, type: term }
+      - { slug: talkgroup, title: Talkgroup, type: term }
+      - { slug: affiliation, title: Affiliation, type: term }
+      - { slug: fdma, title: FDMA, type: term }
+      - { slug: tdma, title: TDMA, type: term }
+      - { slug: channel-grant, title: Channel grant, type: term }
+      - { slug: radio-id, title: Radio ID, type: term }
+
+  - id: protocols
+    label: Protocols & standards
+    blurb: The digital and analog systems GopherTrunk decodes, in one uniform format.
+    entries:
+      - { slug: project-25, title: "Project 25 (P25)", type: protocol }
+      - { slug: p25-phase-1, title: P25 Phase 1, type: protocol }
+      - { slug: p25-phase-2, title: P25 Phase 2, type: protocol }
+      - { slug: dmr, title: Digital Mobile Radio (DMR), type: protocol }
+      - { slug: dmr-tier-1, title: DMR Tier I, type: protocol }
+      - { slug: dmr-tier-2, title: DMR Tier II, type: protocol }
+      - { slug: dmr-tier-3, title: DMR Tier III, type: protocol }
+      - { slug: nxdn, title: NXDN, type: protocol }
+      - { slug: dpmr, title: dPMR, type: protocol }
+      - { slug: tetra, title: TETRA, type: protocol }
+      - { slug: motorola-type-ii, title: Motorola Type II, type: protocol }
+      - { slug: edacs, title: EDACS, type: protocol }
+      - { slug: ltr, title: LTR (Logic Trunked Radio), type: protocol }
+      - { slug: mpt-1327, title: MPT 1327, type: protocol }
+      - { slug: d-star, title: D-STAR, type: protocol }
+      - { slug: system-fusion-ysf, title: System Fusion (YSF), type: protocol }
+      - { slug: m17, title: M17, type: protocol }
+      - { slug: pocsag, title: POCSAG, type: protocol }
+      - { slug: flex, title: FLEX, type: protocol }
+      - { slug: ais, title: Automatic Identification System (AIS), type: protocol }
+      - { slug: ads-b, title: ADS-B, type: protocol }
+      - { slug: aprs, title: APRS, type: protocol }
+      - { slug: ax25, title: AX.25, type: protocol }
+      - { slug: dsc, title: Digital Selective Calling (DSC), type: protocol }
+      - { slug: mdc1200, title: MDC-1200, type: protocol }
+
+  - id: voice-coding
+    label: Voice coding
+    blurb: The vocoders that compress speech into a few kilobits per second.
+    entries:
+      - { slug: vocoder, title: Vocoder, type: technology }
+      - { slug: imbe, title: IMBE, type: technology }
+      - { slug: ambe, title: AMBE, type: technology }
+      - { slug: ambe-plus-2, title: AMBE+2, type: technology }
+      - { slug: codec2, title: Codec 2, type: technology }
+
+  - id: hardware
+    label: Hardware
+    blurb: SDR dongles, tuner chips, and front-end components.
+    entries:
+      - { slug: rtl-sdr, title: RTL-SDR, type: hardware }
+      - { slug: rtl2832u, title: RTL2832U, type: hardware }
+      - { slug: r820t-tuner, title: R820T / R820T2 tuner, type: hardware }
+      - { slug: hackrf, title: HackRF One, type: hardware }
+      - { slug: airspy, title: Airspy, type: hardware }
+      - { slug: airspy-hf-plus, title: Airspy HF+, type: hardware }
+      - { slug: upconverter, title: Upconverter, type: hardware }
+      - { slug: low-noise-amplifier, title: Low-noise amplifier (LNA), type: hardware }
+      - { slug: bias-tee, title: Bias tee, type: hardware }
+      - { slug: soapysdr, title: SoapySDR, type: technology }
+      - { slug: rtl-tcp, title: rtl_tcp, type: technology }
+
+  - id: people
+    label: People
+    blurb: Scientists and engineers whose work underpins radio and SDR.
+    entries:
+      - { slug: heinrich-hertz, title: Heinrich Hertz, type: person }
+      - { slug: james-clerk-maxwell, title: James Clerk Maxwell, type: person }
+      - { slug: guglielmo-marconi, title: Guglielmo Marconi, type: person }
+      - { slug: joseph-fourier, title: Joseph Fourier, type: person }
+      - { slug: harry-nyquist, title: Harry Nyquist, type: person }
+      - { slug: claude-shannon, title: Claude Shannon, type: person }
+      - { slug: edwin-armstrong, title: Edwin Armstrong, type: person }
+      - { slug: andrew-viterbi, title: Andrew Viterbi, type: person }
+      - { slug: richard-hamming, title: Richard Hamming, type: person }
+      - { slug: reginald-fessenden, title: Reginald Fessenden, type: person }
+
+  - id: organizations
+    label: Organizations & standards bodies
+    blurb: The bodies that allocate spectrum and write the standards.
+    entries:
+      - { slug: itu, title: International Telecommunication Union (ITU), type: organization }
+      - { slug: fcc, title: Federal Communications Commission (FCC), type: organization }
+      - { slug: etsi, title: ETSI, type: organization }
+      - { slug: tia, title: Telecommunications Industry Association (TIA), type: organization }
+      - { slug: apco-international, title: APCO International, type: organization }
+      - { slug: icao, title: ICAO, type: organization }
+      - { slug: dvsi, title: Digital Voice Systems (DVSI), type: organization }
+      - { slug: m17-project, title: M17 Project, type: organization }

--- a/docs/_includes/reference-schema.html
+++ b/docs/_includes/reference-schema.html
@@ -1,0 +1,52 @@
+{%- comment -%}
+  Structured data for reference entries. Person for people; otherwise DefinedTerm
+  inside the "GopherTrunk Reference" DefinedTermSet. Always a BreadcrumbList.
+  `external` links become sameAs for authority. Kept out of head.html so the
+  homepage SoftwareApplication entity stays clean.
+{%- endcomment -%}
+{%- assign page_url = page.url | absolute_url -%}
+{%- capture sameas -%}
+  {%- if page.external and page.external.size > 0 -%}
+    "sameAs": [{% for x in page.external %}{{ x.url | jsonify }}{% unless forloop.last %},{% endunless %}{% endfor %}],
+  {%- endif -%}
+{%- endcapture -%}
+{%- if page.entry_type == "person" -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": {{ page.title | jsonify }},
+  "description": {{ page.description | jsonify }},
+  "url": {{ page_url | jsonify }},
+  {{ sameas }}
+  "mainEntityOfPage": { "@type": "WebPage", "@id": {{ page_url | jsonify }} }
+}
+</script>
+{%- else -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "DefinedTerm",
+  "name": {{ page.title | jsonify }},
+  "description": {{ page.description | jsonify }},
+  "url": {{ page_url | jsonify }},
+  {{ sameas }}
+  "inDefinedTermSet": {
+    "@type": "DefinedTermSet",
+    "name": "GopherTrunk Reference",
+    "url": {{ '/reference/' | absolute_url | jsonify }}
+  }
+}
+</script>
+{%- endif -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "name": "Home", "item": {{ '/' | absolute_url | jsonify }} },
+    { "@type": "ListItem", "position": 2, "name": "Reference", "item": {{ '/reference/' | absolute_url | jsonify }} },
+    { "@type": "ListItem", "position": 3, "name": {{ page.title | jsonify }}, "item": {{ page_url | jsonify }} }
+  ]
+}
+</script>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -9,5 +9,6 @@
     {{ content }}
     {%- include footer.html -%}
     <script defer src="{{ '/assets/js/site.js' | relative_url }}"></script>
+    <script defer src="{{ '/assets/js/autolink.js' | relative_url }}"></script>
   </body>
 </html>

--- a/docs/_layouts/reference-hub.html
+++ b/docs/_layouts/reference-hub.html
@@ -1,0 +1,84 @@
+---
+layout: default
+---
+{%- comment -%}
+  Landing page for the GopherTrunk Reference encyclopedia. Renders a category
+  index and a generated A–Z index from _data/reference.yml, plus DefinedTermSet
+  + ItemList structured data.
+{%- endcomment -%}
+{%- assign ref = site.data.reference -%}
+{%- assign all_entries = "" | split: "" -%}
+{%- for cat in ref.categories -%}
+  {%- for e in cat.entries -%}{%- assign all_entries = all_entries | push: e -%}{%- endfor -%}
+{%- endfor -%}
+{%- assign sorted = all_entries | sort_natural: "title" -%}
+{%- assign total = all_entries | size -%}
+
+<main id="content" class="page" role="main">
+  <div class="container">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="{{ '/' | relative_url }}">Home</a></li>
+        <li><span aria-current="page">Reference</span></li>
+      </ol>
+    </nav>
+
+    <header class="ref-hero">
+      <p class="ref-eyebrow">Encyclopedia</p>
+      <h1 class="ref-hero__title">{{ page.title }}</h1>
+      <p class="ref-hero__lede">{{ ref.intro }}</p>
+      <p class="ref-hero__meta">{{ total }} entries · <a href="#a-z">A–Z index</a> · <a href="{{ '/learn/' | relative_url }}">Learning path</a> · <a href="{{ '/learn/glossary/' | relative_url }}">Glossary</a></p>
+    </header>
+
+    <article class="prose prose--wide ref-intro">{{ content }}</article>
+
+    <div class="ref-categories">
+      {%- for cat in ref.categories -%}
+        <section class="ref-category" id="{{ cat.id }}">
+          <div class="ref-category__head">
+            <h2 class="ref-category__title">{{ cat.label }}</h2>
+            <p class="ref-category__blurb">{{ cat.blurb }}</p>
+          </div>
+          <ul class="ref-grid">
+            {%- for e in cat.entries -%}
+              <li class="ref-card">
+                <a href="{{ '/reference/' | append: e.slug | append: '/' | relative_url }}">
+                  <span class="ref-card__title">{{ e.title }}</span>
+                  <span class="ref-tag ref-tag--{{ e.type }}">{{ e.type }}</span>
+                </a>
+              </li>
+            {%- endfor -%}
+          </ul>
+        </section>
+      {%- endfor -%}
+    </div>
+
+    <section class="ref-az" id="a-z">
+      <h2>A–Z index</h2>
+      <ul class="ref-az__list">
+        {%- for e in sorted -%}
+          <li><a href="{{ '/reference/' | append: e.slug | append: '/' | relative_url }}">{{ e.title }}</a></li>
+        {%- endfor -%}
+      </ul>
+    </section>
+  </div>
+</main>
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "DefinedTermSet",
+  "name": "GopherTrunk Reference",
+  "description": {{ ref.intro | strip_newlines | jsonify }},
+  "url": {{ '/reference/' | absolute_url | jsonify }},
+  "hasDefinedTerm": [
+    {%- for e in sorted -%}
+    {
+      "@type": "DefinedTerm",
+      "name": {{ e.title | jsonify }},
+      "url": {{ '/reference/' | append: e.slug | append: '/' | absolute_url | jsonify }}
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ]
+}
+</script>

--- a/docs/_layouts/reference.html
+++ b/docs/_layouts/reference.html
@@ -1,0 +1,107 @@
+---
+layout: default
+---
+{%- comment -%}
+  Encyclopedia article layout for the GopherTrunk Reference. Deliberately
+  distinct from the learning hub: a definition-first article with a right-hand
+  infobox, category breadcrumb, "See also", "Related lessons", and an external
+  "References" list — no prev/next, reading time, TL;DR, or quizzes.
+
+  Front matter consumed: slug, title, entry_type, category, description, aka,
+  infobox (ordered list of {label,value}), see_also (slugs), related_lessons
+  ({title,url}), external ({title,url}).
+{%- endcomment -%}
+
+{%- assign all_entries = "" | split: "" -%}
+{%- assign cat_label = "" -%}
+{%- for cat in site.data.reference.categories -%}
+  {%- if cat.id == page.category -%}{%- assign cat_label = cat.label -%}{%- endif -%}
+  {%- for e in cat.entries -%}{%- assign all_entries = all_entries | push: e -%}{%- endfor -%}
+{%- endfor -%}
+{%- assign is_protocol = false -%}
+{%- if page.entry_type == "protocol" -%}{%- assign is_protocol = true -%}{%- endif -%}
+
+<main id="content" class="page" role="main">
+  <div class="container page__container">
+    <nav class="breadcrumb" aria-label="Breadcrumb">
+      <ol>
+        <li><a href="{{ '/' | relative_url }}">Home</a></li>
+        <li><a href="{{ '/reference/' | relative_url }}">Reference</a></li>
+        {%- if cat_label != "" -%}
+          <li><a href="{{ '/reference/#' | append: page.category | relative_url }}">{{ cat_label }}</a></li>
+        {%- endif -%}
+        <li><span aria-current="page">{{ page.title }}</span></li>
+      </ol>
+    </nav>
+
+    <p class="ref-eyebrow">Reference{% if page.entry_type %} · <span class="ref-eyebrow__type">{{ page.entry_type }}</span>{% endif %}</p>
+
+    <div class="ref-layout">
+      <article class="prose ref-article">
+        {%- if page.aka and page.aka.size > 0 -%}
+          <p class="ref-aka">Also known as: {% for a in page.aka %}<span>{{ a }}</span>{% unless forloop.last %}, {% endunless %}{% endfor %}</p>
+        {%- endif -%}
+
+        {{ content }}
+
+        {%- if page.see_also and page.see_also.size > 0 -%}
+          <section class="ref-seealso" aria-label="See also">
+            <h2>See also</h2>
+            <ul>
+              {%- for slug in page.see_also -%}
+                {%- assign target = all_entries | where: "slug", slug | first -%}
+                {%- if target -%}<li><a href="{{ '/reference/' | append: slug | append: '/' | relative_url }}">{{ target.title }}</a></li>{%- endif -%}
+              {%- endfor -%}
+            </ul>
+          </section>
+        {%- endif -%}
+
+        {%- if page.related_lessons and page.related_lessons.size > 0 -%}
+          <section class="ref-related" aria-label="Related lessons">
+            <h2>Learn it step by step</h2>
+            <ul>
+              {%- for l in page.related_lessons -%}
+                <li><a href="{{ l.url | relative_url }}">{{ l.title }}</a></li>
+              {%- endfor -%}
+            </ul>
+          </section>
+        {%- endif -%}
+
+        {%- if page.external and page.external.size > 0 -%}
+          <section class="ref-refs" aria-label="References and external links">
+            <h2>References &amp; external links</h2>
+            <ul>
+              {%- for x in page.external -%}
+                <li><a href="{{ x.url }}" rel="noopener nofollow">{{ x.title }}</a></li>
+              {%- endfor -%}
+            </ul>
+          </section>
+        {%- endif -%}
+      </article>
+
+      {%- if page.infobox and page.infobox.size > 0 -%}
+        <aside class="ref-infobox{% if is_protocol %} ref-infobox--protocol{% endif %}" aria-label="Quick facts">
+          <p class="ref-infobox__title">{{ page.title }}</p>
+          <dl>
+            {%- for row in page.infobox -%}
+              <div class="ref-infobox__row">
+                <dt>{{ row.label }}</dt>
+                <dd>{{ row.value }}</dd>
+              </div>
+            {%- endfor -%}
+          </dl>
+        </aside>
+      {%- endif -%}
+    </div>
+
+    {%- if page.path -%}
+      <footer class="page__edit">
+        <a href="https://github.com/MattCheramie/GopherTrunk/blob/main/{{ page.path }}" rel="noopener">
+          Edit this page on GitHub &rarr;
+        </a>
+      </footer>
+    {%- endif -%}
+  </div>
+</main>
+
+{%- include reference-schema.html cat_label=cat_label -%}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1233,3 +1233,127 @@ a.category-chip:hover {
   .site-search__form { width: 100%; }
   .site-search__input { width: 100%; }
 }
+
+/* ====================================================================
+   Reference (encyclopedia) — visually distinct from the learning hub
+   ==================================================================== */
+
+.ref-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--accent);
+  margin: 0 0 0.4rem;
+}
+.ref-eyebrow__type { color: var(--fg-muted); font-weight: 600; }
+
+/* ---------- Hub ---------- */
+.ref-hero {
+  padding: 2.25rem 0 1.25rem;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 1.75rem;
+}
+.ref-hero__title {
+  font-size: clamp(1.9rem, 4vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.6rem;
+}
+.ref-hero__lede { max-width: 46rem; color: var(--fg-muted); font-size: 1.08rem; margin: 0 0 0.75rem; }
+.ref-hero__meta { font-size: 0.92rem; color: var(--fg-muted); margin: 0; }
+.ref-intro { margin: 0 auto 2rem; }
+
+.ref-categories { margin-bottom: 2.5rem; }
+.ref-category { margin: 0 0 2rem; }
+.ref-category__head { margin-bottom: 0.75rem; }
+.ref-category__title { font-size: 1.3rem; font-weight: 600; margin: 0 0 0.2rem; }
+.ref-category__blurb { margin: 0; color: var(--fg-muted); }
+.ref-grid {
+  list-style: none; margin: 0; padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+  gap: 0.5rem;
+}
+.ref-card a {
+  display: flex; align-items: center; justify-content: space-between; gap: 0.5rem;
+  padding: 0.6rem 0.8rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--fg);
+  text-decoration: none;
+}
+.ref-card a:hover { border-color: var(--accent); background: var(--bg-elev); text-decoration: none; }
+.ref-card__title { font-weight: 500; }
+
+/* Category/type tag — squared (vs. the learning hub's pill badges) */
+.ref-tag {
+  flex-shrink: 0;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  background: var(--bg-elev);
+}
+.ref-tag--protocol { color: var(--accent); border-color: var(--accent); }
+.ref-tag--person { font-style: italic; }
+
+/* ---------- A–Z index ---------- */
+.ref-az { border-top: 1px solid var(--border); padding-top: 1.5rem; }
+.ref-az__list {
+  list-style: none; margin: 0.5rem 0 0; padding: 0;
+  columns: 4 11rem;
+  column-gap: 1.5rem;
+  font-size: 0.92rem;
+}
+.ref-az__list li { break-inside: avoid; margin: 0.15rem 0; }
+
+/* ---------- Article: two-column with infobox ---------- */
+.ref-layout { display: block; }
+.ref-article { max-width: var(--maxw-prose); }
+.ref-aka { color: var(--fg-muted); font-size: 0.92rem; font-style: italic; margin-top: 0; }
+.ref-aka span { font-style: normal; }
+
+.ref-infobox {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  padding: 0.9rem 1rem;
+  margin: 0 0 1.5rem;
+  font-size: 0.9rem;
+}
+.ref-infobox__title { font-weight: 700; margin: 0 0 0.6rem; font-size: 1rem; }
+.ref-infobox dl { margin: 0; }
+.ref-infobox__row { display: grid; grid-template-columns: 8rem 1fr; gap: 0.5rem; padding: 0.3rem 0; border-top: 1px solid var(--border); }
+.ref-infobox__row:first-of-type { border-top: none; }
+.ref-infobox dt { color: var(--fg-muted); font-weight: 600; }
+.ref-infobox dd { margin: 0; }
+.ref-infobox--protocol { border-color: var(--accent); }
+.ref-infobox--protocol .ref-infobox__title { color: var(--accent); }
+
+@media (min-width: 60rem) {
+  .ref-layout {
+    display: grid;
+    grid-template-columns: 1fr 17rem;
+    gap: 2rem;
+    align-items: start;
+  }
+  .ref-infobox { margin-top: 0.5rem; position: sticky; top: 72px; }
+}
+
+/* ---------- See also / related / references ---------- */
+.ref-seealso, .ref-related, .ref-refs { margin-top: 2rem; }
+.ref-seealso h2, .ref-related h2, .ref-refs h2 { font-size: 1.15rem; }
+.ref-seealso ul, .ref-related ul, .ref-refs ul { margin: 0.5rem 0 0; }
+
+/* ---------- Auto-links (site-wide) ---------- */
+.ref-autolink {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--link);
+}
+.ref-autolink:hover { color: var(--link); border-bottom-style: solid; text-decoration: none; }

--- a/docs/assets/js/autolink.js
+++ b/docs/assets/js/autolink.js
@@ -1,0 +1,116 @@
+/*
+ * Site-wide reference auto-linker. Progressive enhancement: with this file
+ * absent or blocked, pages render normally. When present, it links the first
+ * mention (per page) of each curated reference term to its /reference/ article.
+ *
+ * Safety rules: only inside .prose; never inside a/code/pre/headings/svg or the
+ * infobox; whole-word (alnum-boundary) matching; longest term first; one link
+ * per term per page; never self-link the current article. Terms come from
+ * /reference-terms.json (only entries with `autolink: true`).
+ */
+(function () {
+  'use strict';
+
+  var SKIP_TAGS = { A: 1, CODE: 1, PRE: 1, H1: 1, H2: 1, H3: 1, H4: 1, H5: 1, H6: 1, SCRIPT: 1, STYLE: 1, svg: 1, BUTTON: 1, SUMMARY: 1 };
+
+  function escapeRe(s) { return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+
+  function currentPath() {
+    return location.pathname.replace(/\/$/, '');
+  }
+
+  function inSkippedAncestor(node) {
+    for (var el = node.parentNode; el && el !== document.body; el = el.parentNode) {
+      if (el.nodeType !== 1) continue;
+      var tag = el.tagName;
+      if (SKIP_TAGS[tag] || SKIP_TAGS[tag && tag.toLowerCase()]) return true;
+      if (el.classList && (el.classList.contains('ref-infobox') || el.classList.contains('no-autolink'))) return true;
+    }
+    return false;
+  }
+
+  function run(terms) {
+    if (!terms || !terms.length) return;
+    var here = currentPath();
+
+    // Build candidates: {token, url}. Use aka synonyms plus the title with any
+    // "(…)" abbreviation stripped. Drop candidates pointing at the current page.
+    var candidates = [];
+    terms.forEach(function (t) {
+      var url = (t.url || '').replace(/\/$/, '');
+      if (!url || url === here) return;            // never self-link
+      var tokens = (t.aka || []).slice();
+      var base = (t.term || '').replace(/\s*\(.*?\)\s*/g, ' ').trim();
+      if (base) tokens.push(base);
+      tokens.forEach(function (tok) {
+        tok = (tok || '').trim();
+        if (tok.length < 3) return;                // skip ambiguous short tokens
+        candidates.push({ token: tok, url: t.url });
+      });
+    });
+    if (!candidates.length) return;
+
+    // Longest token first so multi-word terms win over their substrings.
+    candidates.sort(function (a, b) { return b.token.length - a.token.length; });
+
+    var used = {};                                  // url -> true (one link per term/page)
+    var parts = candidates.map(function (c) { return escapeRe(c.token); });
+    var re;
+    try {
+      re = new RegExp('(?<![A-Za-z0-9])(' + parts.join('|') + ')(?![A-Za-z0-9])', 'i');
+    } catch (e) {
+      return;                                       // lookbehind unsupported — bail quietly
+    }
+    var byToken = {};
+    candidates.forEach(function (c) { byToken[c.token.toLowerCase()] = c.url; });
+
+    // Collect target text nodes first (don't mutate while walking).
+    var containers = document.querySelectorAll('.prose');
+    var nodes = [];
+    containers.forEach(function (root) {
+      var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+      var n;
+      while ((n = walker.nextNode())) {
+        if (n.nodeValue.trim().length >= 3 && !inSkippedAncestor(n)) nodes.push(n);
+      }
+    });
+
+    nodes.forEach(function (node) {
+      var text = node.nodeValue;
+      var m = re.exec(text);
+      if (!m) return;
+      var frag = document.createDocumentFragment();
+      var last = 0;
+      // Iterate matches within this node with a global, sticky-ish scan.
+      var g = new RegExp(re.source, 'gi');
+      var match;
+      while ((match = g.exec(text))) {
+        var token = match[1];
+        var url = byToken[token.toLowerCase()];
+        if (!url || used[url]) continue;
+        used[url] = true;
+        if (match.index > last) frag.appendChild(document.createTextNode(text.slice(last, match.index)));
+        var a = document.createElement('a');
+        a.className = 'ref-autolink';
+        a.href = url;
+        a.textContent = token;
+        a.title = 'Reference: ' + token;
+        frag.appendChild(a);
+        last = match.index + token.length;
+      }
+      if (last > 0) {
+        if (last < text.length) frag.appendChild(document.createTextNode(text.slice(last)));
+        node.parentNode.replaceChild(frag, node);
+      }
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    if (!document.querySelector('.prose')) return;
+    var url = (document.documentElement.getAttribute('data-baseurl') || '') + '/reference-terms.json';
+    fetch('/reference-terms.json')
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (terms) { if (terms) run(terms); })
+      .catch(function () {});
+  });
+})();

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -15,6 +15,10 @@ linked to the lesson where it's explained in full. Skim it as a refresher, or us
 your browser's find (Ctrl/Cmd-F) to jump to a word. Terms are grouped by theme and
 ordered roughly from fundamentals to systems.
 
+> **Want the long version?** Many of these terms have a full, encyclopedia-style
+> article in the [GopherTrunk Reference](/reference/) — and the first mention of a
+> covered term on any page links straight to it.
+
 ## Radio wave fundamentals
 
 **Amplitude** — The strength or "height" of a radio wave; more amplitude means a

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -23,13 +23,22 @@ Start: {{ '/learn/' | absolute_url }}
 ### Reference
 - [{{ site.data.learn.glossary.title }}]({{ '/learn/glossary/' | absolute_url }}): {{ site.data.learn.glossary.summary }}
 
+## Reference (encyclopedia)
+
+Long-form, encyclopedia-style articles defining radio and SDR terms, technologies,
+algorithms, people, hardware, and organizations. Browse: {{ '/reference/' | absolute_url }}
+{% for cat in site.data.reference.categories %}
+### {{ cat.label }}
+{% for e in cat.entries %}- [{{ e.title }}]({{ '/reference/' | append: e.slug | append: '/' | absolute_url }}){% endfor %}
+{% endfor %}
+
 ## Getting started with GopherTrunk
 - [What is GopherTrunk?]({{ '/getting-started.html' | absolute_url }}): conceptual overview of the scanner and its interfaces.
 - [Get started]({{ '/getting-started-setup.html' | absolute_url }}): from a dongle to your first decoded call.
 - [Hardware]({{ '/hardware.html' | absolute_url }}): supported SDR dongles.
 - [Downloads]({{ '/downloads.html' | absolute_url }}): builds for Linux, macOS, and Windows.
 
-## Reference
+## Technical docs
 - [Architecture]({{ '/architecture.html' | absolute_url }}): how the engine is built.
 - [Vocoders]({{ '/vocoders.html' | absolute_url }}): IMBE and AMBE+2 voice decoding.
 - [Status]({{ '/status.html' | absolute_url }}): protocol and decoder coverage.

--- a/docs/reference-terms.json
+++ b/docs/reference-terms.json
@@ -1,0 +1,24 @@
+---
+permalink: /reference-terms.json
+layout: null
+sitemap: false
+---
+{%- comment -%}
+  Term -> reference-URL map for the site-wide autolinker (assets/js/autolink.js).
+  Includes only reference pages that set `autolink: true` in front matter, so
+  common words (frequency, gain, phase, …) are excluded. `aka` adds synonyms and
+  abbreviations to match.
+{%- endcomment -%}
+[
+{%- assign first = true -%}
+{%- for p in site.pages -%}
+  {%- if p.entry_type and p.autolink == true and p.title and p.url -%}
+    {%- unless first -%},{%- endunless -%}{%- assign first = false -%}
+    {
+      "term": {{ p.title | jsonify }},
+      "aka": {% if p.aka %}{{ p.aka | jsonify }}{% else %}[]{% endif %},
+      "url": {{ p.url | relative_url | jsonify }}
+    }
+  {%- endif -%}
+{%- endfor -%}
+]

--- a/docs/reference/ads-b.md
+++ b/docs/reference/ads-b.md
@@ -1,0 +1,63 @@
+---
+slug: ads-b
+title: ADS-B
+entry_type: protocol
+category: protocols
+description: ADS-B (Automatic Dependent Surveillance–Broadcast) is an aviation system in which aircraft broadcast identity, position, altitude, and velocity on 1090 MHz using pulse-position modulation.
+keywords: ADS-B, Mode S, 1090 MHz, aircraft tracking, pulse position modulation, CPR, Extended Squitter, DO-260
+aka: [ADS-B, ADSB]
+autolink: true
+infobox:
+  - { label: Type, value: Aviation surveillance broadcast }
+  - { label: Standards body, value: ICAO / RTCA / EUROCAE }
+  - { label: Frequency, value: 1090 MHz (also 978 MHz UAT) }
+  - { label: Modulation, value: PPM (Mode S Extended Squitter) }
+  - { label: Bit rate, value: 1 Mbps }
+  - { label: Position coding, value: Compact Position Reporting (CPR) }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [ais, compact-position-reporting, cyclic-redundancy-check, icao]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Automatic Dependent Surveillance–Broadcast (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast }
+  - { title: "GopherTrunk ADS-B decoder", url: /adsb.html }
+---
+
+**ADS-B** (**Automatic Dependent Surveillance–Broadcast**) is an aviation
+surveillance system in which aircraft continuously broadcast their **identity,
+position, altitude, and velocity** on **1090 MHz** (and 978 MHz UAT in the U.S.). It
+is the aeronautical counterpart to [AIS](/reference/ais/) and one of the most popular
+SDR applications.
+
+## Overview
+
+ADS-B rides on Mode S Extended Squitter messages, modulated with **pulse-position
+modulation** at 1 Mbps. Latitude/longitude are encoded with
+[Compact Position Reporting](/reference/compact-position-reporting/), which resolves
+to a precise position from a pair of even/odd messages.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Frequency | 1090 MHz (978 MHz UAT) |
+| Modulation | PPM (Mode S) |
+| Bit rate | 1 Mbps |
+| Integrity | CRC-24 |
+| Position | CPR even/odd encoding |
+
+## History
+
+Standardised by [ICAO](/reference/icao/) with MOPS from RTCA (DO-260) and EUROCAE
+(ED-102); mandated for most controlled airspace through the 2010s–2020s.
+
+## Deployment
+
+Commercial and general aviation worldwide; widely received by hobbyists feeding
+flight-tracking networks.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk detects the 1090 MHz squitters in the magnitude domain, validates the
+[CRC-24](/reference/cyclic-redundancy-check/), and decodes aircraft state. See the
+[ADS-B decoder](/adsb.html) page.

--- a/docs/reference/ads-b.md
+++ b/docs/reference/ads-b.md
@@ -29,6 +29,16 @@ position, altitude, and velocity** on **1090 MHz** (and 978 MHz UAT in the U.S.)
 is the aeronautical counterpart to [AIS](/reference/ais/) and one of the most popular
 SDR applications.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="An aircraft broadcasting position and identity bursts on 1090 MHz to a ground receiver." xmlns="http://www.w3.org/2000/svg">
+  <path d="M60 40 l40 10 l-10 -18 m10 18 l18 -14 m-58 4 l-14 -10" stroke="currentColor" stroke-width="1.4" fill="none"/>
+  <g fill="none" stroke="currentColor" stroke-opacity="0.5"><path d="M75 60 A 30 30 0 0 1 75 110"/><path d="M90 55 A 50 50 0 0 1 90 115"/></g>
+  <path d="M380 100 v-20 m-8 0 l8 -10 l8 10" stroke="currentColor" stroke-width="1.6" fill="none"/><text x="380" y="115" text-anchor="middle" font-size="8" fill="currentColor">receiver</text>
+  <text x="220" y="40" text-anchor="middle" font-size="9" fill="currentColor">1090 MHz position/ID squitters</text>
+</svg>
+<figcaption>ADS-B aircraft continuously broadcast position, altitude, and identity on 1090 MHz.</figcaption>
+</figure>
+
 ## Overview
 
 ADS-B rides on Mode S Extended Squitter messages, modulated with **pulse-position

--- a/docs/reference/affiliation.md
+++ b/docs/reference/affiliation.md
@@ -23,6 +23,17 @@ external:
 [control channel](/reference/control-channel/) when it powers on or changes
 [talkgroup](/reference/talkgroup/), so the system can route calls efficiently.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A radio sending a registration request to the system, which records it as affiliated." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="45" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="75" y="66" text-anchor="middle" font-size="9" fill="currentColor">radio 4567</text>
+  <rect x="340" y="45" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="385" y="66" text-anchor="middle" font-size="9" fill="currentColor">system</text>
+  <line x1="122" y1="56" x2="338" y2="56" stroke="currentColor" stroke-width="1.1" marker-end="url(#afar)"/><text x="230" y="50" text-anchor="middle" font-size="8.5" fill="currentColor">"register on TG 101"</text>
+  <line x1="338" y1="70" x2="122" y2="70" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 3" marker-end="url(#afar)"/><text x="230" y="84" text-anchor="middle" font-size="8.5" fill="currentColor">acknowledged · affiliated</text>
+  <defs><marker id="afar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Affiliation is a radio registering with the system over the control channel so calls can be routed to it.</figcaption>
+</figure>
+
 ## How it works
 
 Affiliation messages name the [radio ID](/reference/radio-id/) and talkgroup, giving the

--- a/docs/reference/affiliation.md
+++ b/docs/reference/affiliation.md
@@ -1,0 +1,35 @@
+---
+slug: affiliation
+title: Affiliation
+entry_type: term
+category: trunked-radio
+description: Affiliation is the process by which a radio registers with a trunked system over the control channel, letting the system route calls and track which units are active.
+keywords: affiliation, registration, control channel, radio ID, trunking
+aka: [affiliation]
+autolink: true
+infobox:
+  - { label: Type, value: Trunking registration event }
+  - { label: Carried on, value: Control channel }
+  - { label: Reveals, value: Active radios and talkgroups }
+see_also: [control-channel, radio-id, talkgroup, trunked-radio]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+---
+
+**Affiliation** is the process by which a radio **registers** with a
+[trunked radio](/reference/trunked-radio/) system over the
+[control channel](/reference/control-channel/) when it powers on or changes
+[talkgroup](/reference/talkgroup/), so the system can route calls efficiently.
+
+## How it works
+
+Affiliation messages name the [radio ID](/reference/radio-id/) and talkgroup, giving the
+control channel a constant stream of information about which units and groups are
+active.
+
+## Relevance to SDR
+
+Affiliation data lets GopherTrunk populate its Radio IDs and activity views even before
+a call begins, showing who is on the system.

--- a/docs/reference/afsk.md
+++ b/docs/reference/afsk.md
@@ -23,6 +23,17 @@ modulate a radio (usually FM). The classic case is the Bell 202 standard — 120
 2200 Hz tones — carrying 1200 bps [APRS](/reference/aprs/) packet over
 [AX.25](/reference/ax25/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="An audio waveform alternating between a low-pitch tone for one bit value and a high-pitch tone for the other." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 60 q15 -26 30 0 t30 0 t30 0
+            M110 60 q8 -26 16 0 t16 0 t16 0 t16 0 t16 0 t10 0
+            M230 60 q15 -26 30 0 t30 0 t30 0
+            M320 60 q8 -26 16 0 t16 0 t16 0 t16 0 t16 0 t16 0 t8 0" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g font-size="9" fill="currentColor"><text x="55" y="100">space tone</text><text x="150" y="100">mark tone</text></g>
+</svg>
+<figcaption>AFSK sends data as two audio tones over an FM channel — the scheme behind APRS (Bell 202).</figcaption>
+</figure>
+
 ## How it works
 
 Because the keying is at audio frequencies, AFSK can pass through an ordinary FM voice

--- a/docs/reference/afsk.md
+++ b/docs/reference/afsk.md
@@ -1,0 +1,35 @@
+---
+slug: afsk
+title: AFSK
+entry_type: technology
+category: modulation
+description: AFSK (audio frequency-shift keying) sends digital data as audio tones that then modulate a radio, classically the Bell 202 tones used by 1200 bps APRS packet.
+keywords: AFSK, audio frequency shift keying, Bell 202, 1200 baud, APRS, packet radio, mark space tones
+aka: [AFSK]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation (audio FSK) }
+  - { label: Classic form, value: Bell 202 (1200/2200 Hz) }
+  - { label: Used by, value: APRS / packet radio }
+see_also: [frequency-shift-keying, aprs, ax25, ffsk]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Frequency-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-shift_keying }
+---
+
+**AFSK** (audio frequency-shift keying) represents bits as **audio tones** that then
+modulate a radio (usually FM). The classic case is the Bell 202 standard — 1200 Hz and
+2200 Hz tones — carrying 1200 bps [APRS](/reference/aprs/) packet over
+[AX.25](/reference/ax25/).
+
+## How it works
+
+Because the keying is at audio frequencies, AFSK can pass through an ordinary FM voice
+channel. A receiver demodulates the FM to audio, then detects which tone is present per
+bit.
+
+## Relevance to SDR
+
+GopherTrunk decodes AFSK as part of its APRS pipeline, detecting the mark/space tones
+after FM demodulation.

--- a/docs/reference/airspy-hf-plus.md
+++ b/docs/reference/airspy-hf-plus.md
@@ -22,6 +22,16 @@ external:
 optimised for the **HF and low-VHF** [bands](/reference/frequency-bands/), with
 excellent dynamic range for receiving shortwave and weak low-band signals.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for Airspy HF+ (HF + low VHF) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="430" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="30" y="86">0</text><text x="163" y="86">2 GHz</text><text x="296" y="86">4 GHz</text><text x="430" y="86">6 GHz</text></g>
+  <rect x="30" y="40" width="18" height="20" rx="3" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="28" text-anchor="middle" font-size="10" fill="currentColor">Airspy HF+ (HF + low VHF) coverage</text>
+</svg>
+<figcaption>The Airspy HF+ is optimised for the lower bands (HF and low VHF) with excellent dynamic range.</figcaption>
+</figure>
+
 ## Overview
 
 Where a basic [RTL-SDR](/reference/rtl-sdr/) cannot tune HF directly (needing an

--- a/docs/reference/airspy-hf-plus.md
+++ b/docs/reference/airspy-hf-plus.md
@@ -1,0 +1,34 @@
+---
+slug: airspy-hf-plus
+title: Airspy HF+
+entry_type: hardware
+category: hardware
+description: Airspy HF+ is a software-defined radio optimised for the HF and low-VHF bands, with excellent dynamic range for receiving shortwave and weak low-band signals.
+keywords: Airspy HF+, HF SDR, shortwave receiver, dynamic range, Discovery, low VHF
+aka: [Airspy HF+, Airspy HF plus]
+autolink: true
+infobox:
+  - { label: Type, value: HF / low-VHF SDR receiver }
+  - { label: Strength, value: High dynamic range on low bands }
+  - { label: Range, value: ~9 kHz – 31 MHz, 60–260 MHz }
+see_also: [airspy, rtl-sdr, upconverter, ionospheric-propagation, frequency-bands]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/sdr-hardware/ }
+external:
+  - { title: "Airspy (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio }
+---
+
+**Airspy HF+** is a [software-defined radio](/reference/software-defined-radio/)
+optimised for the **HF and low-VHF** [bands](/reference/frequency-bands/), with
+excellent dynamic range for receiving shortwave and weak low-band signals.
+
+## Overview
+
+Where a basic [RTL-SDR](/reference/rtl-sdr/) cannot tune HF directly (needing an
+[upconverter](/reference/upconverter/) or direct-sampling mode), the HF+ is purpose-built
+for it — ideal for [ionospheric](/reference/ionospheric-propagation/) shortwave
+reception.
+
+## Relevance to SDR
+
+Choose the HF+ when HF or low-band is your target; GopherTrunk supports it as a receiver.

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -24,6 +24,16 @@ external:
 smaller Mini) offering better sensitivity, dynamic range, and wider
 [bandwidth](/reference/bandwidth/) than an [RTL-SDR](/reference/rtl-sdr/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for Airspy R2/Mini (~24 MHz–1.8 GHz) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="430" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="30" y="86">0</text><text x="163" y="86">2 GHz</text><text x="296" y="86">4 GHz</text><text x="430" y="86">6 GHz</text></g>
+  <rect x="32" y="40" width="120" height="20" rx="3" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="28" text-anchor="middle" font-size="10" fill="currentColor">Airspy R2/Mini (~24 MHz–1.8 GHz) coverage</text>
+</svg>
+<figcaption>Airspy adds sensitivity and bandwidth over RTL-SDR across VHF/UHF.</figcaption>
+</figure>
+
 ## Overview
 
 Airspy R2 captures up to ~10 MHz, useful when a system's channels are spread across a

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -1,0 +1,36 @@
+---
+slug: airspy
+title: Airspy
+entry_type: hardware
+category: hardware
+description: Airspy is a line of high-performance VHF/UHF software-defined radio receivers (R2 and Mini) offering better sensitivity and wider bandwidth than RTL-SDR.
+keywords: Airspy, Airspy R2, Airspy Mini, high performance SDR, VHF UHF receiver
+aka: [Airspy]
+autolink: true
+infobox:
+  - { label: Type, value: VHF/UHF SDR receiver }
+  - { label: Models, value: Airspy R2, Airspy Mini }
+  - { label: Range, value: ~24 MHz – 1.8 GHz }
+  - { label: Bandwidth, value: up to ~10 MHz (R2) }
+see_also: [rtl-sdr, airspy-hf-plus, hackrf, software-defined-radio]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/sdr-hardware/ }
+external:
+  - { title: "Airspy (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio }
+---
+
+**Airspy** is a line of high-performance VHF/UHF
+[software-defined radio](/reference/software-defined-radio/) receivers (the R2 and the
+smaller Mini) offering better sensitivity, dynamic range, and wider
+[bandwidth](/reference/bandwidth/) than an [RTL-SDR](/reference/rtl-sdr/).
+
+## Overview
+
+Airspy R2 captures up to ~10 MHz, useful when a system's channels are spread across a
+band or in tough RF environments. For the lower bands, the
+[Airspy HF+](/reference/airspy-hf-plus/) is the specialised choice.
+
+## Relevance to SDR
+
+GopherTrunk supports Airspy receivers for demanding reception where an RTL-SDR's
+bandwidth or sensitivity falls short.

--- a/docs/reference/ais.md
+++ b/docs/reference/ais.md
@@ -29,6 +29,16 @@ VHF marine frequencies. It uses [GMSK](/reference/gmsk/) modulation in a
 self-organising [TDMA](/reference/tdma/) scheme so many vessels share two channels
 without a central controller.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="Ships transmitting short position bursts in assigned time slots on a shared marine VHF channel." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="80" x2="430" y2="80" stroke="currentColor" stroke-opacity="0.4"/>
+  <g fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1"><rect x="50" y="50" width="22" height="30"/><rect x="120" y="50" width="22" height="30"/><rect x="210" y="50" width="22" height="30"/><rect x="300" y="50" width="22" height="30"/><rect x="370" y="50" width="22" height="30"/></g>
+  <text x="230" y="100" text-anchor="middle" font-size="8.5" fill="currentColor">~162 MHz · GMSK · self-organising time slots (SOTDMA)</text>
+  <text x="230" y="28" text-anchor="middle" font-size="9" fill="currentColor">each ship broadcasts position bursts</text>
+</svg>
+<figcaption>AIS ships broadcast short position bursts in self-organising time slots on shared marine VHF channels.</figcaption>
+</figure>
+
 ## Overview
 
 Each station transmits position reports keyed to its MMSI identifier on 161.975 MHz

--- a/docs/reference/ais.md
+++ b/docs/reference/ais.md
@@ -1,0 +1,59 @@
+---
+slug: ais
+title: Automatic Identification System (AIS)
+entry_type: protocol
+category: protocols
+description: AIS (Automatic Identification System) is a maritime VHF data system in which ships broadcast identity, position, course, and speed using GMSK in a self-organising TDMA scheme.
+keywords: AIS, Automatic Identification System, marine tracking, GMSK, SOTDMA, 161.975 162.025, vessel position, NMEA
+aka: [AIS]
+autolink: true
+infobox:
+  - { label: Type, value: Maritime data broadcast }
+  - { label: Standards body, value: ITU / IMO }
+  - { label: Band, value: VHF marine (161.975 / 162.025 MHz) }
+  - { label: Access, value: Self-organising TDMA (SOTDMA) }
+  - { label: Modulation, value: GMSK, 9600 bps }
+  - { label: Content, value: MMSI, position, course, speed }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [ads-b, gmsk, tdma, itu, dsc]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Automatic identification system (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_identification_system }
+  - { title: "GopherTrunk AIS decoder", url: /ais.html }
+---
+
+**AIS** (**Automatic Identification System**) is a maritime safety system in which
+ships and shore stations broadcast their **identity, position, course, and speed** on
+VHF marine frequencies. It uses [GMSK](/reference/gmsk/) modulation in a
+self-organising [TDMA](/reference/tdma/) scheme so many vessels share two channels
+without a central controller.
+
+## Overview
+
+Each station transmits position reports keyed to its MMSI identifier on 161.975 MHz
+(AIS 1) and 162.025 MHz (AIS 2). Receiving AIS gives a live map of nearby vessel
+traffic, the maritime counterpart to [ADS-B](/reference/ads-b/).
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Band | VHF marine, ~162 MHz |
+| Access | SOTDMA |
+| Modulation | GMSK, 9600 bps |
+| Framing | HDLC-style with CRC-16 |
+
+## History
+
+Standardised by the [ITU](/reference/itu/) and mandated by the IMO for SOLAS vessels
+from the early 2000s to improve collision avoidance and traffic monitoring.
+
+## Deployment
+
+Commercial shipping, port authorities, vessel-traffic services, and hobbyist tracking.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk demodulates the GMSK bursts, frames them, and decodes position reports.
+See the [AIS decoder](/ais.html) page.

--- a/docs/reference/aliasing.md
+++ b/docs/reference/aliasing.md
@@ -1,0 +1,34 @@
+---
+slug: aliasing
+title: Aliasing
+entry_type: term
+category: sdr-dsp
+description: Aliasing is the appearance of out-of-band energy at a false frequency when a signal is sampled too slowly for its bandwidth; anti-alias filtering and adequate sample rate prevent it.
+keywords: aliasing, fold-back, anti-alias filter, undersampling, false signal, Nyquist
+aka: [aliasing]
+autolink: true
+infobox:
+  - { label: Type, value: Sampling artefact }
+  - { label: Cause, value: Sampling below Nyquist for the bandwidth }
+  - { label: Prevented by, value: Anti-alias filter + adequate rate }
+see_also: [nyquist-theorem, sample-rate, decimation, digital-filter]
+related_lessons:
+  - { title: "Sample rate, bandwidth & Nyquist", url: /learn/sample-rate-nyquist/ }
+external:
+  - { title: "Aliasing (Wikipedia)", url: https://en.wikipedia.org/wiki/Aliasing }
+---
+
+**Aliasing** is when energy outside the bandwidth a [sample rate](/reference/sample-rate/)
+can represent gets **folded** back into the captured spectrum, appearing at a wrong
+frequency — a phantom that looks like a real signal.
+
+## How it works
+
+It is the [Nyquist theorem](/reference/nyquist-theorem/) violated. SDR front-ends include
+anti-alias filtering, and choosing an adequate sample rate keeps real signals safely
+inside the usable window. It also constrains the order of
+[filtering and decimation](/reference/decimation/).
+
+## Relevance to SDR
+
+Recognising an alias prevents chasing signals that are not really where they appear.

--- a/docs/reference/aliasing.md
+++ b/docs/reference/aliasing.md
@@ -22,6 +22,20 @@ external:
 can represent gets **folded** back into the captured spectrum, appearing at a wrong
 frequency — a phantom that looks like a real signal.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A captured band between Nyquist edges with a real signal inside and an out-of-band signal folding back to a false position." xmlns="http://www.w3.org/2000/svg">
+  <line x1="60" y1="105" x2="420" y2="105" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="110" y1="20" x2="110" y2="115" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.6"/>
+  <line x1="330" y1="20" x2="330" y2="115" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.6"/>
+  <text x="220" y="125" text-anchor="middle" font-size="9" fill="currentColor">captured bandwidth</text>
+  <path d="M160 105 L170 55 L180 105 Z" fill="currentColor" fill-opacity="0.3" stroke="currentColor"/><text x="170" y="48" text-anchor="middle" font-size="8" fill="currentColor">real</text>
+  <path d="M360 105 L370 70 L380 105 Z" fill="none" stroke="currentColor" stroke-opacity="0.5"/><text x="372" y="63" text-anchor="middle" font-size="8" fill="currentColor">out of band</text>
+  <path d="M255 105 L265 78 L275 105 Z" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-dasharray="3 2"/><text x="265" y="71" text-anchor="middle" font-size="8" fill="currentColor">alias!</text>
+  <path d="M368 73 q-50 -28 -100 0" fill="none" stroke="currentColor" stroke-opacity="0.5" stroke-dasharray="2 2"/>
+</svg>
+<figcaption>Aliasing: energy beyond the captured bandwidth folds back to a false position inside it.</figcaption>
+</figure>
+
 ## How it works
 
 It is the [Nyquist theorem](/reference/nyquist-theorem/) violated. SDR front-ends include

--- a/docs/reference/ambe-plus-2.md
+++ b/docs/reference/ambe-plus-2.md
@@ -24,6 +24,18 @@ external:
 [P25 Phase 2](/reference/p25-phase-2/), [DMR](/reference/dmr/), and
 [NXDN](/reference/nxdn/), and supports **half-rate** operation.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A 12.5 kHz channel split into two TDMA slots, each carrying a half-rate AMBE+2 voice stream." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="40" width="380" height="40" fill="none" stroke="currentColor" stroke-width="1.2"/>
+  <line x1="230" y1="40" x2="230" y2="80" stroke="currentColor" stroke-width="1.2"/>
+  <text x="135" y="64" text-anchor="middle" font-size="9" fill="currentColor">slot 1 · AMBE+2</text>
+  <text x="325" y="64" text-anchor="middle" font-size="9" fill="currentColor">slot 2 · AMBE+2</text>
+  <text x="230" y="28" text-anchor="middle" font-size="9" fill="currentColor">one 12.5 kHz channel</text>
+  <text x="230" y="100" text-anchor="middle" font-size="9" fill="currentColor">half-rate coding fits two voices where one used to go</text>
+</svg>
+<figcaption>AMBE+2 is a more efficient successor used by P25 Phase 2, DMR, and NXDN, supporting half-rate streams.</figcaption>
+</figure>
+
 ## How it works
 
 Half-rate AMBE+2 is part of how [DMR](/reference/dmr/) fits two voice

--- a/docs/reference/ambe-plus-2.md
+++ b/docs/reference/ambe-plus-2.md
@@ -1,0 +1,36 @@
+---
+slug: ambe-plus-2
+title: AMBE+2
+entry_type: technology
+category: voice-coding
+description: AMBE+2 is an efficient successor to IMBE/AMBE from DVSI, used by P25 Phase 2, DMR, and NXDN, and supporting half-rate operation for higher capacity.
+keywords: AMBE+2, AMBE plus 2, DVSI, DMR, P25 Phase 2, NXDN, half-rate vocoder
+aka: [AMBE+2]
+autolink: true
+infobox:
+  - { label: Type, value: Speech vocoder (MBE family) }
+  - { label: Developer, value: DVSI }
+  - { label: Used by, value: P25 Phase 2, DMR, NXDN }
+  - { label: Feature, value: Half-rate operation }
+see_also: [vocoder, imbe, ambe, dmr, p25-phase-2, nxdn, dvsi]
+related_lessons:
+  - { title: "Vocoders — IMBE & AMBE+2", url: /learn/vocoders/ }
+external:
+  - { title: "Multi-Band Excitation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+---
+
+**AMBE+2** is the efficient successor to [IMBE](/reference/imbe/) and
+[AMBE](/reference/ambe/) from [DVSI](/reference/dvsi/). It powers
+[P25 Phase 2](/reference/p25-phase-2/), [DMR](/reference/dmr/), and
+[NXDN](/reference/nxdn/), and supports **half-rate** operation.
+
+## How it works
+
+Half-rate AMBE+2 is part of how [DMR](/reference/dmr/) fits two voice
+[timeslots](/reference/tdma/) in one channel and how P25 Phase 2 doubles capacity. At a
+given bitrate it generally sounds cleaner than IMBE.
+
+## Relevance to SDR
+
+GopherTrunk runs AMBE+2 decoding to produce audio from the most common modern digital
+voice systems.

--- a/docs/reference/ambe.md
+++ b/docs/reference/ambe.md
@@ -24,6 +24,15 @@ external:
 [D-STAR](/reference/d-star/) and EDACS ProVoice, and is the basis for the more efficient
 [AMBE+2](/reference/ambe-plus-2/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A stream of small AMBE voice frames each carrying voice bits plus error-correction bits." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2" fill="none"><rect x="40" y="40" width="90" height="32"/><rect x="140" y="40" width="90" height="32"/><rect x="240" y="40" width="90" height="32"/><rect x="340" y="40" width="90" height="32"/></g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="85" y="60">voice+FEC</text><text x="185" y="60">voice+FEC</text><text x="285" y="60">voice+FEC</text><text x="385" y="60">voice+FEC</text></g>
+  <text x="230" y="24" text-anchor="middle" font-size="9" fill="currentColor">compact frames, ~20 ms each</text>
+</svg>
+<figcaption>AMBE is the multi-band excitation vocoder family behind many digital-voice systems.</figcaption>
+</figure>
+
 ## How it works
 
 Like other MBE vocoders, AMBE separates voiced (pitched) and unvoiced (noisy) bands and

--- a/docs/reference/ambe.md
+++ b/docs/reference/ambe.md
@@ -1,0 +1,36 @@
+---
+slug: ambe
+title: AMBE
+entry_type: technology
+category: voice-coding
+description: AMBE (Advanced Multi-Band Excitation) is a family of low-bitrate speech vocoders from DVSI used across digital voice radio, including D-STAR and as the basis for AMBE+2.
+keywords: AMBE, Advanced Multi-Band Excitation, DVSI, D-STAR, vocoder, low bitrate speech
+aka: [AMBE]
+autolink: true
+infobox:
+  - { label: Type, value: Speech vocoder family (MBE) }
+  - { label: Developer, value: DVSI }
+  - { label: Used by, value: D-STAR, ProVoice; basis of AMBE+2 }
+see_also: [vocoder, imbe, ambe-plus-2, multi-band-excitation, d-star, dvsi]
+related_lessons:
+  - { title: "Vocoders — IMBE & AMBE+2", url: /learn/vocoders/ }
+external:
+  - { title: "Multi-Band Excitation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+---
+
+**AMBE** (**Advanced Multi-Band Excitation**) is a family of low-bitrate speech
+[vocoders](/reference/vocoder/) from [DVSI](/reference/dvsi/), building on the
+[MBE](/reference/multi-band-excitation/) model. It is used by
+[D-STAR](/reference/d-star/) and EDACS ProVoice, and is the basis for the more efficient
+[AMBE+2](/reference/ambe-plus-2/).
+
+## How it works
+
+Like other MBE vocoders, AMBE separates voiced (pitched) and unvoiced (noisy) bands and
+transmits compact spectral parameters, reconstructing speech at the receiver from a few
+kbps.
+
+## Relevance to SDR
+
+GopherTrunk implements AMBE-family decoding in pure Go to render digital voice without
+proprietary hardware.

--- a/docs/reference/amplitude-modulation.md
+++ b/docs/reference/amplitude-modulation.md
@@ -1,0 +1,36 @@
+---
+slug: amplitude-modulation
+title: Amplitude modulation (AM)
+entry_type: technology
+category: modulation
+description: Amplitude modulation (AM) encodes information by varying a carrier's amplitude; it is simple, prone to noise, and still used for shortwave broadcast and aviation voice.
+keywords: amplitude modulation, AM, carrier, sidebands, aviation airband, shortwave
+aka: [amplitude modulation]
+autolink: true
+infobox:
+  - { label: Type, value: Analog modulation }
+  - { label: Varies, value: Carrier amplitude }
+  - { label: Used for, value: Shortwave broadcast, aviation airband }
+see_also: [modulation, frequency-modulation, single-sideband, carrier-wave]
+related_lessons:
+  - { title: "Analog modulation — AM, FM, SSB", url: /learn/analog-modulation/ }
+external:
+  - { title: "Amplitude modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Amplitude_modulation }
+---
+
+**Amplitude modulation** (**AM**) encodes information by varying the
+[amplitude](/reference/amplitude/) of a [carrier wave](/reference/carrier-wave/) while
+its [frequency](/reference/frequency/) stays fixed. It is the oldest and simplest
+[modulation](/reference/modulation/) scheme.
+
+## How it works
+
+Louder audio produces larger swings in carrier height, creating two mirror-image
+sidebands around the carrier. Because noise is also an amplitude variation, AM is
+relatively noise-prone.
+
+## Relevance to SDR
+
+AM survives where simplicity or a useful property matters — shortwave broadcast, and
+aviation VHF airband (where overlapping transmissions beat together so a controller
+notices). An SDR demodulates AM by tracking the envelope.

--- a/docs/reference/amplitude-modulation.md
+++ b/docs/reference/amplitude-modulation.md
@@ -23,6 +23,15 @@ external:
 its [frequency](/reference/frequency/) stays fixed. It is the oldest and simplest
 [modulation](/reference/modulation/) scheme.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A carrier whose amplitude envelope follows a slower message waveform." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 65 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0 q5 -12 10 0 q5 -8 10 0 q5 -12 10 0 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0 q5 -12 10 0 q5 -8 10 0 q5 -12 10 0 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0 q5 -12 10 0 q5 -8 10 0 q5 -12 10 0 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0" fill="none" stroke="currentColor" stroke-width="1.4"/>
+  <path d="M20 65 C 80 18, 140 18, 200 65 S 320 112, 380 65 S 440 30, 440 65" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+  <text x="20" y="118" font-size="10" fill="currentColor">the envelope carries the message</text>
+</svg>
+<figcaption>AM varies the carrier's amplitude in step with the message; the dashed envelope is the audio.</figcaption>
+</figure>
+
 ## How it works
 
 Louder audio produces larger swings in carrier height, creating two mirror-image

--- a/docs/reference/amplitude.md
+++ b/docs/reference/amplitude.md
@@ -1,0 +1,35 @@
+---
+slug: amplitude
+title: Amplitude
+entry_type: term
+category: rf-fundamentals
+description: Amplitude is the magnitude or strength of a wave; in radio it corresponds to signal power and is the quantity varied by amplitude modulation.
+keywords: amplitude, signal strength, magnitude, power, AM
+infobox:
+  - { label: Type, value: Wave property }
+  - { label: Represents, value: Strength / power }
+  - { label: Reported as, value: Power level (dBm / dBFS) }
+see_also: [phase, decibel, dbm, amplitude-modulation, signal-to-noise-ratio]
+related_lessons:
+  - { title: "What is a radio wave?", url: /learn/radio-waves/ }
+external:
+  - { title: "Amplitude (Wikipedia)", url: https://en.wikipedia.org/wiki/Amplitude }
+---
+
+**Amplitude** is the magnitude — the "height" — of a wave. For a
+[radio wave](/reference/radio-wave/) it corresponds to signal strength, which a
+receiver reports as a power level in [dBm](/reference/dbm/) or
+[dBFS](/reference/dbfs/).
+
+## How it works
+
+A larger amplitude carries more power. As a signal spreads from a transmitter and
+passes obstacles, its amplitude falls ([path loss](/reference/path-loss/)), which is
+why distant signals are weaker.
+
+## Relevance to SDR
+
+Varying amplitude is the basis of [amplitude modulation](/reference/amplitude-modulation/)
+and part of what an [IQ](/reference/iq-data/) sample encodes (its distance from the
+origin). A signal's amplitude relative to the [noise floor](/reference/noise-floor/)
+sets its [SNR](/reference/signal-to-noise-ratio/).

--- a/docs/reference/amplitude.md
+++ b/docs/reference/amplitude.md
@@ -21,6 +21,17 @@ external:
 receiver reports as a power level in [dBm](/reference/dbm/) or
 [dBFS](/reference/dbfs/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A larger-amplitude sine wave and a smaller-amplitude sine wave sharing a centre line." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="70" x2="440" y2="70" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 70 q35 -48 70 0 t70 0 t70 0 t70 0 t70 0 t50 0" fill="none" stroke="currentColor" stroke-width="2"/>
+  <path d="M20 70 q35 -16 70 0 t70 0 t70 0 t70 0 t70 0 t50 0" fill="none" stroke="currentColor" stroke-width="1.6" stroke-opacity="0.6"/>
+  <line x1="90" y1="70" x2="90" y2="22" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="98" y="40" font-size="11" fill="currentColor">larger amplitude = stronger signal</text>
+</svg>
+<figcaption>Amplitude is the height of the wave; greater amplitude delivers more power to the receiver.</figcaption>
+</figure>
+
 ## How it works
 
 A larger amplitude carries more power. As a signal spreads from a transmitter and

--- a/docs/reference/analog-to-digital-converter.md
+++ b/docs/reference/analog-to-digital-converter.md
@@ -22,6 +22,17 @@ An **analog-to-digital converter** (**ADC**) measures a continuous signal many t
 second, turning it into a stream of numbers. In an SDR it produces the
 [IQ](/reference/iq-data/) samples software works on.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A smooth analog wave overlaid with a stair-step series of sampled values taken at regular intervals." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="70" x2="440" y2="70" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 70 C 90 15, 160 15, 230 70 S 370 125, 440 70" fill="none" stroke="currentColor" stroke-width="1.4" stroke-opacity="0.6"/>
+  <polyline points="20,70 50,52 80,33 110,28 140,40 170,58 200,70 230,70 260,82 290,98 320,103 350,95 380,80 410,70 440,62" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <g fill="currentColor"><circle cx="50" cy="52" r="2.5"/><circle cx="110" cy="28" r="2.5"/><circle cx="170" cy="58" r="2.5"/><circle cx="290" cy="98" r="2.5"/><circle cx="350" cy="95" r="2.5"/></g>
+  <text x="20" y="118" font-size="9" fill="currentColor">regular samples turn the continuous wave into numbers</text>
+</svg>
+<figcaption>The ADC measures the signal at a fixed rate, converting the continuous waveform into digital samples.</figcaption>
+</figure>
+
 ## How it works
 
 Its [sample rate](/reference/sample-rate/) sets how much

--- a/docs/reference/analog-to-digital-converter.md
+++ b/docs/reference/analog-to-digital-converter.md
@@ -1,0 +1,35 @@
+---
+slug: analog-to-digital-converter
+title: Analog-to-digital converter (ADC)
+entry_type: term
+category: sdr-dsp
+description: An analog-to-digital converter samples a continuous signal into discrete numbers; in an SDR its sample rate sets capture bandwidth and its full scale sets the clipping ceiling.
+keywords: ADC, analog to digital converter, sampling, quantization, bit depth, clipping, dBFS
+aka: [analog-to-digital converter, ADC]
+autolink: true
+infobox:
+  - { label: Type, value: Sampling device }
+  - { label: Sets, value: Capture bandwidth (rate), clipping (full scale) }
+  - { label: Overflow, value: Clipping at 0 dBFS }
+see_also: [sample-rate, nyquist-theorem, dbfs, automatic-gain-control, software-defined-radio]
+related_lessons:
+  - { title: "How an SDR receiver works", url: /learn/sdr-receiver/ }
+external:
+  - { title: "Analog-to-digital converter (Wikipedia)", url: https://en.wikipedia.org/wiki/Analog-to-digital_converter }
+---
+
+An **analog-to-digital converter** (**ADC**) measures a continuous signal many times per
+second, turning it into a stream of numbers. In an SDR it produces the
+[IQ](/reference/iq-data/) samples software works on.
+
+## How it works
+
+Its [sample rate](/reference/sample-rate/) sets how much
+[bandwidth](/reference/bandwidth/) can be captured (per the
+[Nyquist theorem](/reference/nyquist-theorem/)), and its range defines full scale —
+exceed it and the signal **clips** at 0 [dBFS](/reference/dbfs/).
+
+## Relevance to SDR
+
+Setting [gain](/reference/automatic-gain-control/) so strong signals stay below the ADC's
+ceiling, without burying weak ones in noise, is central to clean reception.

--- a/docs/reference/andrew-viterbi.md
+++ b/docs/reference/andrew-viterbi.md
@@ -1,0 +1,38 @@
+---
+slug: andrew-viterbi
+title: Andrew Viterbi
+entry_type: person
+category: people
+description: Andrew Viterbi (b. 1935) is an American engineer who devised the Viterbi algorithm for decoding convolutional codes and co-founded Qualcomm.
+keywords: Andrew Viterbi, Viterbi algorithm, convolutional codes, Qualcomm, CDMA
+aka: [Andrew Viterbi]
+autolink: true
+infobox:
+  - { label: Born, value: "1935" }
+  - { label: Field, value: Electrical engineering }
+  - { label: Known for, value: Viterbi algorithm; co-founding Qualcomm }
+see_also: [viterbi-algorithm, convolutional-code, forward-error-correction]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Andrew Viterbi (Wikipedia)", url: https://en.wikipedia.org/wiki/Andrew_Viterbi }
+---
+
+**Andrew Viterbi** (born 1935) is an American electrical engineer who devised the
+**[Viterbi algorithm](/reference/viterbi-algorithm/)** for maximum-likelihood decoding of
+[convolutional codes](/reference/convolutional-code/), and co-founded Qualcomm.
+
+## Life and work
+
+Viterbi introduced his algorithm in 1967 as a practical way to decode convolutional
+codes; it became foundational to digital communications and storage.
+
+## Contribution
+
+His algorithm makes strong [forward error correction](/reference/forward-error-correction/)
+practical, improving reception at low SNR.
+
+## Legacy
+
+Viterbi decoding appears throughout modern radio, from amateur [M17](/reference/m17/) to
+cellular systems.

--- a/docs/reference/andrew-viterbi.md
+++ b/docs/reference/andrew-viterbi.md
@@ -22,6 +22,16 @@ external:
 **[Viterbi algorithm](/reference/viterbi-algorithm/)** for maximum-likelihood decoding of
 [convolutional codes](/reference/convolutional-code/), and co-founded Qualcomm.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A trellis with one highlighted most-likely path, the Viterbi algorithm." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor"><circle cx="40" cy="40" r="3"/><circle cx="40" cy="95" r="3"/><circle cx="160" cy="40" r="3"/><circle cx="160" cy="95" r="3"/><circle cx="280" cy="40" r="3"/><circle cx="280" cy="95" r="3"/><circle cx="400" cy="40" r="3"/><circle cx="400" cy="95" r="3"/></g>
+  <g stroke="currentColor" stroke-opacity="0.3"><line x1="40" y1="40" x2="160" y2="40"/><line x1="40" y1="40" x2="160" y2="95"/><line x1="40" y1="95" x2="160" y2="40"/><line x1="40" y1="95" x2="160" y2="95"/><line x1="160" y1="40" x2="280" y2="40"/><line x1="160" y1="95" x2="280" y2="40"/><line x1="160" y1="95" x2="280" y2="95"/><line x1="280" y1="40" x2="400" y2="95"/><line x1="280" y1="95" x2="400" y2="95"/></g>
+  <polyline points="40,95 160,40 280,40 400,95" fill="none" stroke="currentColor" stroke-width="2.4"/>
+  <text x="220" y="122" text-anchor="middle" font-size="9" fill="currentColor">the Viterbi algorithm</text>
+</svg>
+<figcaption>Viterbi devised the maximum-likelihood decoding algorithm now used to decode convolutional codes everywhere.</figcaption>
+</figure>
+
 ## Life and work
 
 Viterbi introduced his algorithm in 1967 as a practical way to decode convolutional

--- a/docs/reference/antenna-gain.md
+++ b/docs/reference/antenna-gain.md
@@ -23,6 +23,18 @@ energy in a preferred direction compared with a reference. It is given in
 [decibels](/reference/decibel/): **dBi** relative to an isotropic radiator, or **dBd**
 relative to a [dipole](/reference/dipole-antenna/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="An omnidirectional circular pattern on the left and a focused directional lobe on the right." xmlns="http://www.w3.org/2000/svg">
+  <circle cx="110" cy="75" r="45" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.4"/>
+  <circle cx="110" cy="75" r="2.5" fill="currentColor"/>
+  <text x="110" y="140" text-anchor="middle" font-size="9" fill="currentColor">omnidirectional</text>
+  <path d="M330 75 C 330 35, 430 45, 440 75 C 430 105, 330 115, 330 75 Z" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.4"/>
+  <circle cx="330" cy="75" r="2.5" fill="currentColor"/>
+  <text x="360" y="140" text-anchor="middle" font-size="9" fill="currentColor">directional (gain)</text>
+</svg>
+<figcaption>Antenna gain doesn't create energy — it focuses the pattern, trading all-round coverage for reach.</figcaption>
+</figure>
+
 ## How it works
 
 Gain does not create energy; it focuses it. A high-gain antenna trades coverage for

--- a/docs/reference/antenna-gain.md
+++ b/docs/reference/antenna-gain.md
@@ -1,0 +1,35 @@
+---
+slug: antenna-gain
+title: Antenna gain
+entry_type: term
+category: antennas-propagation
+description: Antenna gain is the degree to which an antenna concentrates radiated or received energy in a preferred direction, expressed in dBi or dBd.
+keywords: antenna gain, dBi, dBd, directivity, radiation pattern, Yagi
+aka: [antenna gain]
+autolink: true
+infobox:
+  - { label: Type, value: Antenna property }
+  - { label: Units, value: dBi (vs isotropic), dBd (vs dipole) }
+  - { label: Trade-off, value: More gain = narrower pattern }
+see_also: [antenna, dipole-antenna, decibel, radio-propagation]
+related_lessons:
+  - { title: "Antennas 101", url: /learn/antennas/ }
+external:
+  - { title: "Antenna gain (Wikipedia)", url: https://en.wikipedia.org/wiki/Antenna_gain }
+---
+
+**Antenna gain** measures how strongly an [antenna](/reference/antenna/) concentrates
+energy in a preferred direction compared with a reference. It is given in
+[decibels](/reference/decibel/): **dBi** relative to an isotropic radiator, or **dBd**
+relative to a [dipole](/reference/dipole-antenna/).
+
+## How it works
+
+Gain does not create energy; it focuses it. A high-gain antenna trades coverage for
+reach — an omnidirectional vertical hears all directions, while a directional Yagi adds
+gain toward where it points at the expense of the sides.
+
+## Relevance to SDR
+
+For general scanning, an omnidirectional antenna is usually best; a directional,
+high-gain antenna helps pull in one specific distant system.

--- a/docs/reference/antenna.md
+++ b/docs/reference/antenna.md
@@ -1,0 +1,37 @@
+---
+slug: antenna
+title: Antenna
+entry_type: term
+category: antennas-propagation
+description: An antenna is a conductor that converts electrical signals into radio waves and back; its dimensions, sized to the wavelength, set the reception of an SDR system.
+keywords: antenna, aerial, radiator, resonance, reception
+aka: [antenna, aerial]
+autolink: true
+infobox:
+  - { label: Type, value: Transducer (RF ↔ current) }
+  - { label: Sized to, value: Wavelength (e.g. λ/4, λ/2) }
+  - { label: Key specs, value: Resonance, gain, polarization, SWR }
+see_also: [dipole-antenna, antenna-gain, polarization, standing-wave-ratio, wavelength]
+related_lessons:
+  - { title: "Antennas 101", url: /learn/antennas/ }
+external:
+  - { title: "Antenna (radio) (Wikipedia)", url: https://en.wikipedia.org/wiki/Antenna_(radio) }
+---
+
+An **antenna** is a conductor that converts electrical signals into
+[radio waves](/reference/radio-wave/) and, on receive, converts passing radio waves
+back into a tiny current. It sets the ceiling on everything downstream — no receiver
+can recover a signal the antenna never captured.
+
+## How it works
+
+An antenna works best when its dimensions are a fraction of the signal's
+[wavelength](/reference/wavelength/) (a quarter-wave whip is λ/4). Its key properties
+are resonance/[bandwidth](/reference/bandwidth/), [gain](/reference/antenna-gain/),
+[polarization](/reference/polarization/), and impedance match
+([SWR](/reference/standing-wave-ratio/)).
+
+## Relevance to SDR
+
+Choosing an antenna cut for the target [band](/reference/frequency-bands/) and placing
+it high with a clear path usually improves reception more than any change at the radio.

--- a/docs/reference/antenna.md
+++ b/docs/reference/antenna.md
@@ -23,6 +23,16 @@ An **antenna** is a conductor that converts electrical signals into
 back into a tiny current. It sets the ceiling on everything downstream — no receiver
 can recover a signal the antenna never captured.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 150" role="img" aria-label="A vertical antenna element with concentric arcs radiating outward to represent transmitted or received waves." xmlns="http://www.w3.org/2000/svg">
+  <line x1="150" y1="120" x2="150" y2="40" stroke="currentColor" stroke-width="2.5"/>
+  <line x1="120" y1="120" x2="180" y2="120" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="none" stroke="currentColor" stroke-opacity="0.5"><path d="M150 80 A 40 40 0 0 1 190 80"/><path d="M150 80 A 70 70 0 0 1 220 80"/><path d="M150 80 A 40 40 0 0 0 110 80"/><path d="M150 80 A 70 70 0 0 0 80 80"/></g>
+  <text x="150" y="140" text-anchor="middle" font-size="9" fill="currentColor">converts between waves and current</text>
+</svg>
+<figcaption>An antenna couples radio waves to and from the receiver; its size follows the wavelength it works at.</figcaption>
+</figure>
+
 ## How it works
 
 An antenna works best when its dimensions are a fraction of the signal's

--- a/docs/reference/apco-international.md
+++ b/docs/reference/apco-international.md
@@ -23,6 +23,19 @@ professional association for public-safety communications. With the
 [TIA](/reference/tia/) it drove the creation of [Project 25](/reference/project-25/),
 sometimes called **APCO-25**.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="APCO defines public-safety requirements that shaped P25." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="100" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="70" y="61">APCO</text>
+    <rect x="170" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="225" y="61">requirements</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">P25 (public safety)</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="120" y1="58" x2="169" y2="58" marker-end="url(#rel_apco-international)"/><line x1="280" y1="58" x2="329" y2="58" marker-end="url(#rel_apco-international)"/></g>
+  </g>
+  <defs><marker id="rel_apco-international" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>APCO International represents public-safety communications and drove the P25 requirements.</figcaption>
+</figure>
+
 ## Overview
 
 APCO represents dispatchers, radio managers, and agencies, and championed an open digital

--- a/docs/reference/apco-international.md
+++ b/docs/reference/apco-international.md
@@ -1,0 +1,33 @@
+---
+slug: apco-international
+title: APCO International
+entry_type: organization
+category: organizations
+description: APCO International is the association of public-safety communications professionals that, with the TIA, drove the creation of the Project 25 (P25) standards.
+keywords: APCO, APCO International, public safety communications, P25, Project 25, APCO-25
+aka: [APCO, APCO International]
+autolink: true
+infobox:
+  - { label: Type, value: Professional association }
+  - { label: Focus, value: Public-safety communications }
+  - { label: Role, value: Co-driver of P25 (APCO-25) }
+see_also: [project-25, tia, trunked-radio]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "APCO International (Wikipedia)", url: https://en.wikipedia.org/wiki/Association_of_Public-Safety_Communications_Officials-International }
+---
+
+**APCO International** (the Association of Public-Safety Communications Officials) is the
+professional association for public-safety communications. With the
+[TIA](/reference/tia/) it drove the creation of [Project 25](/reference/project-25/),
+sometimes called **APCO-25**.
+
+## Overview
+
+APCO represents dispatchers, radio managers, and agencies, and championed an open digital
+standard for interoperability among emergency services.
+
+## Relevance to SDR
+
+APCO's role explains the "APCO-25"/"P25" naming and the standard's public-safety focus.

--- a/docs/reference/aprs.md
+++ b/docs/reference/aprs.md
@@ -28,6 +28,15 @@ real-time tactical information — **position, weather, telemetry, and messaging
 is carried as [AX.25](/reference/ax25/) packet frames using
 [AFSK](/reference/afsk/), most commonly on 144.390 MHz in North America.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="An APRS packet carrying a callsign and position payload over AX.25 on 144.39 MHz." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1"><rect x="30" y="40" width="90" height="28" fill="currentColor" fill-opacity="0.12"/><rect x="120" y="40" width="220" height="28" fill="currentColor" fill-opacity="0.22"/><rect x="340" y="40" width="90" height="28" fill="none"/></g>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle"><text x="75" y="58">callsign</text><text x="230" y="58">position / weather / message</text><text x="385" y="58">FCS</text></g>
+  <text x="230" y="88" text-anchor="middle" font-size="8" fill="currentColor">AFSK over AX.25 · 144.39 MHz (NA)</text>
+</svg>
+<figcaption>APRS carries position and telemetry in AX.25 packets, usually via 1200-baud AFSK on 144.39 MHz.</figcaption>
+</figure>
+
 ## Overview
 
 Stations beacon their position (often from GPS), and digipeaters relay packets so

--- a/docs/reference/aprs.md
+++ b/docs/reference/aprs.md
@@ -1,0 +1,59 @@
+---
+slug: aprs
+title: APRS
+entry_type: protocol
+category: protocols
+description: APRS (Automatic Packet Reporting System) is an amateur-radio data network for real-time position, weather, telemetry, and messaging, carried over AX.25 packet using AFSK.
+keywords: APRS, Automatic Packet Reporting System, amateur radio, 144.390, AX.25, AFSK, Bob Bruninga, position reporting
+aka: [APRS]
+autolink: true
+infobox:
+  - { label: Type, value: Amateur data network }
+  - { label: Created by, value: Bob Bruninga (WB4APR) }
+  - { label: Band, value: 144.390 MHz (North America) }
+  - { label: Link layer, value: AX.25 (UI frames) }
+  - { label: Modulation, value: 1200 bps AFSK (Bell 202) }
+  - { label: Content, value: Position, weather, telemetry, messages }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [ax25, afsk, mueller-muller-timing-recovery, cyclic-redundancy-check]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Automatic Packet Reporting System (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_Packet_Reporting_System }
+  - { title: "GopherTrunk APRS decoder", url: /aprs.html }
+---
+
+**APRS** (**Automatic Packet Reporting System**) is an amateur-radio data network for
+real-time tactical information — **position, weather, telemetry, and messaging**. It
+is carried as [AX.25](/reference/ax25/) packet frames using
+[AFSK](/reference/afsk/), most commonly on 144.390 MHz in North America.
+
+## Overview
+
+Stations beacon their position (often from GPS), and digipeaters relay packets so
+local activity propagates across a region; internet gateways (igates) bridge RF to the
+global APRS-IS network. The result is a live map of amateur stations, weather sensors,
+and mobile trackers.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Link layer | AX.25 UI frames |
+| Modulation | 1200 bps AFSK (Bell 202 tones) |
+| Integrity | FCS / CRC-16 |
+| Content | Position, weather, telemetry, messages |
+
+## History
+
+Created by Bob Bruninga (WB4APR) in the 1980s–90s; it remains one of amateur radio's
+most active data modes.
+
+## Deployment
+
+Amateur radio worldwide via beacons, digipeaters, igates, and the APRS-IS network.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk demodulates the AFSK, recovers AX.25 frames, and decodes APRS payloads.
+See the [APRS / AX.25 decoder](/aprs.html) page.

--- a/docs/reference/attenuation.md
+++ b/docs/reference/attenuation.md
@@ -22,6 +22,16 @@ external:
 cable, connector, or obstacle. It is expressed in [decibels](/reference/decibel/) and
 subtracts directly from a power budget.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A sine wave whose amplitude shrinks steadily from left to right as it is attenuated." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="65" x2="440" y2="65" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 65 q15 -40 30 0 t30 0 q15 -30 30 0 t30 0 q15 -20 30 0 t30 0 q15 -12 30 0 t30 0 q15 -7 30 0 t30 0 q15 -4 30 0 t20 0" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="30" y="115" font-size="10" fill="currentColor">transmitter</text>
+  <text x="430" y="115" font-size="10" fill="currentColor" text-anchor="end">weaker at receiver</text>
+</svg>
+<figcaption>Attenuation is the loss of signal strength as energy spreads out and is absorbed along the path.</figcaption>
+</figure>
+
 ## How it works
 
 Every metre of coax, every connector, and every wall or tree adds loss — generally more

--- a/docs/reference/attenuation.md
+++ b/docs/reference/attenuation.md
@@ -1,0 +1,34 @@
+---
+slug: attenuation
+title: Attenuation
+entry_type: term
+category: rf-fundamentals
+description: Attenuation is the reduction in signal strength as it passes through a medium, cable, or obstacle, expressed in decibels.
+keywords: attenuation, loss, dB, coax loss, signal weakening
+aka: [attenuation]
+autolink: true
+infobox:
+  - { label: Type, value: Signal loss }
+  - { label: Unit, value: Decibels (dB) }
+  - { label: Causes, value: Distance, cable, obstacles, filters }
+see_also: [path-loss, decibel, radio-propagation, antenna]
+related_lessons:
+  - { title: "How signals travel", url: /learn/propagation/ }
+external:
+  - { title: "Attenuation (Wikipedia)", url: https://en.wikipedia.org/wiki/Attenuation }
+---
+
+**Attenuation** is the reduction of signal strength as energy passes through a medium,
+cable, connector, or obstacle. It is expressed in [decibels](/reference/decibel/) and
+subtracts directly from a power budget.
+
+## How it works
+
+Every metre of coax, every connector, and every wall or tree adds loss — generally more
+at higher [frequencies](/reference/frequency/). Free-space spreading is a specific kind
+of attenuation called [path loss](/reference/path-loss/).
+
+## Relevance to SDR
+
+Keeping cable runs short and connectors clean minimises attenuation between
+[antenna](/reference/antenna/) and receiver, preserving [SNR](/reference/signal-to-noise-ratio/).

--- a/docs/reference/automatic-gain-control.md
+++ b/docs/reference/automatic-gain-control.md
@@ -23,6 +23,16 @@ level — high enough above the [noise floor](/reference/noise-floor/) but below
 [ADC](/reference/analog-to-digital-converter/)'s clipping ceiling (0
 [dBFS](/reference/dbfs/)).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="An input whose amplitude varies wildly, and an output of roughly constant amplitude after AGC." xmlns="http://www.w3.org/2000/svg">
+  <text x="20" y="22" font-size="9" fill="currentColor">input (varying level)</text>
+  <path d="M20 45 q6 -6 12 0 t12 0 q6 -22 12 0 t12 0 q6 -22 12 0 t12 0 q6 -4 12 0 t12 0 q6 -4 12 0 t12 0 q6 -16 12 0 t12 0 q6 -16 12 0 t12 0" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="20" y="95" font-size="9" fill="currentColor">output (levelled)</text>
+  <path d="M20 118 q6 -13 12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0" fill="none" stroke="currentColor" stroke-width="1.3"/>
+</svg>
+<figcaption>AGC continuously adjusts gain so the output level stays roughly constant despite a fading input.</figcaption>
+</figure>
+
 ## How it works
 
 AGC can live in the tuner hardware or in software. For decoding a fixed system it can

--- a/docs/reference/automatic-gain-control.md
+++ b/docs/reference/automatic-gain-control.md
@@ -1,0 +1,35 @@
+---
+slug: automatic-gain-control
+title: Automatic gain control (AGC)
+entry_type: term
+category: sdr-dsp
+description: Automatic gain control adjusts amplification to keep a signal at a usable level; in SDR it can be hardware or software, and is often set manually for stable decoding.
+keywords: AGC, automatic gain control, gain, headroom, clipping, pumping
+aka: [automatic gain control, AGC]
+autolink: true
+infobox:
+  - { label: Type, value: Gain-management technique }
+  - { label: Goal, value: Keep level usable, avoid clipping }
+  - { label: Note, value: Manual gain often best for decoding }
+see_also: [dbfs, analog-to-digital-converter, noise-floor, ppm-frequency-correction]
+related_lessons:
+  - { title: "Gain, AGC & avoiding overload", url: /learn/gain-and-agc/ }
+external:
+  - { title: "Automatic gain control (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_gain_control }
+---
+
+**Automatic gain control** (**AGC**) adjusts amplification to keep a signal at a usable
+level — high enough above the [noise floor](/reference/noise-floor/) but below the
+[ADC](/reference/analog-to-digital-converter/)'s clipping ceiling (0
+[dBFS](/reference/dbfs/)).
+
+## How it works
+
+AGC can live in the tuner hardware or in software. For decoding a fixed system it can
+"pump" — ramping up in quiet moments and clamping on strong bursts — which is why a
+well-chosen **manual gain** is often preferred.
+
+## Relevance to SDR
+
+Setting gain correctly is the single setting beginners most often get wrong; see the
+gain lesson for a practical routine.

--- a/docs/reference/ax25.md
+++ b/docs/reference/ax25.md
@@ -26,6 +26,21 @@ external:
 adapts the telecom **HDLC** frame format with amateur **callsign addressing**, and is
 the link layer beneath [APRS](/reference/aprs/) and traditional packet networks.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="An AX.25 HDLC frame: flag, address, control, PID, information, frame-check sequence, flag." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1" font-size="7.5" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="36" height="26" fill="currentColor" fill-opacity="0.12"/><text x="38" y="58">flag</text>
+    <rect x="56" y="42" width="70" height="26" fill="none"/><text x="91" y="58">address</text>
+    <rect x="126" y="42" width="46" height="26" fill="none"/><text x="149" y="58">control</text>
+    <rect x="172" y="42" width="34" height="26" fill="none"/><text x="189" y="58">PID</text>
+    <rect x="206" y="42" width="150" height="26" fill="currentColor" fill-opacity="0.22"/><text x="281" y="58">information</text>
+    <rect x="356" y="42" width="50" height="26" fill="none"/><text x="381" y="58">FCS</text>
+    <rect x="406" y="42" width="34" height="26" fill="currentColor" fill-opacity="0.12"/><text x="423" y="58">flag</text>
+  </g>
+</svg>
+<figcaption>AX.25 is the amateur packet link layer: an HDLC frame delimited by flags, with addresses, payload, and an FCS.</figcaption>
+</figure>
+
 ## Overview
 
 AX.25 frames are delimited by flag bytes, bit-stuffed, and protected by a frame check

--- a/docs/reference/ax25.md
+++ b/docs/reference/ax25.md
@@ -1,0 +1,58 @@
+---
+slug: ax25
+title: AX.25
+entry_type: protocol
+category: protocols
+description: AX.25 is the data-link-layer protocol for amateur packet radio, adapting the HDLC frame format with amateur callsign addressing, and is the link layer beneath APRS.
+keywords: AX.25, packet radio, HDLC, amateur data link, UI frame, callsign addressing, FCS, NRZI
+aka: [AX.25, AX25]
+autolink: true
+infobox:
+  - { label: Type, value: Data-link-layer protocol }
+  - { label: Based on, value: HDLC }
+  - { label: Addressing, value: Amateur callsigns + SSID }
+  - { label: Framing, value: Flag-delimited, bit-stuffed, FCS }
+  - { label: Line coding, value: NRZI }
+  - { label: Used by, value: APRS and packet BBS/networks }
+  - { label: GopherTrunk support, value: Decoded (via APRS) }
+see_also: [aprs, afsk, cyclic-redundancy-check]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "AX.25 (Wikipedia)", url: https://en.wikipedia.org/wiki/AX.25 }
+---
+
+**AX.25** is the **data-link-layer** protocol used in amateur **packet radio**. It
+adapts the telecom **HDLC** frame format with amateur **callsign addressing**, and is
+the link layer beneath [APRS](/reference/aprs/) and traditional packet networks.
+
+## Overview
+
+AX.25 frames are delimited by flag bytes, bit-stuffed, and protected by a frame check
+sequence ([CRC](/reference/cyclic-redundancy-check/)). They carry source and
+destination callsigns (with SSIDs) plus an optional digipeater path. APRS uses
+connectionless "UI" (unnumbered information) frames; classic packet BBS use connected
+modes.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Frame format | HDLC-derived, flag-delimited |
+| Addressing | Callsign + SSID, digipeater path |
+| Error check | 16-bit FCS |
+| Line coding | NRZI over AFSK/FSK |
+
+## History
+
+Developed by the amateur community in the 1980s as a radio adaptation of X.25/HDLC for
+packet networks and bulletin-board systems.
+
+## Deployment
+
+Amateur packet radio, APRS, and store-and-forward networks.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk recovers AX.25 frames as part of its [APRS](/reference/aprs/) pipeline. See
+the [APRS / AX.25](/aprs.html) page.

--- a/docs/reference/bandwidth.md
+++ b/docs/reference/bandwidth.md
@@ -1,0 +1,35 @@
+---
+slug: bandwidth
+title: Bandwidth
+entry_type: term
+category: rf-fundamentals
+description: Bandwidth is the width of the frequency range a signal occupies or a receiver captures, measured in hertz; it bounds data rate and sets capture requirements.
+keywords: bandwidth, Hz, channel width, occupied bandwidth, capture bandwidth
+infobox:
+  - { label: Symbol, value: B }
+  - { label: Unit, value: Hertz (Hz) }
+  - { label: Determines, value: Data capacity, capture needs }
+see_also: [sample-rate, nyquist-theorem, frequency, signal-to-noise-ratio]
+related_lessons:
+  - { title: "Anatomy of a signal", url: /learn/signal-anatomy/ }
+  - { title: "Sample rate, bandwidth & Nyquist", url: /learn/sample-rate-nyquist/ }
+external:
+  - { title: "Bandwidth (signal processing) (Wikipedia)", url: https://en.wikipedia.org/wiki/Bandwidth_(signal_processing) }
+---
+
+**Bandwidth** is the width, in hertz, of the [frequency](/reference/frequency/) range a
+signal occupies or that a receiver captures. A narrowband voice channel may be ~12.5
+kHz wide; an FM broadcast station ~200 kHz; Wi-Fi tens of megahertz.
+
+## How it works
+
+Wider bandwidth can carry more information but uses more spectrum and demands a higher
+[sample rate](/reference/sample-rate/) to capture (per the
+[Nyquist theorem](/reference/nyquist-theorem/)). It also admits more noise, affecting
+[SNR](/reference/signal-to-noise-ratio/).
+
+## Relevance to SDR
+
+An SDR's capture bandwidth (≈ its sample rate) sets how much spectrum you see at once.
+[Filtering and decimation](/reference/decimation/) narrow a wide capture down to a
+single channel's bandwidth.

--- a/docs/reference/bandwidth.md
+++ b/docs/reference/bandwidth.md
@@ -21,6 +21,21 @@ external:
 signal occupies or that a receiver captures. A narrowband voice channel may be ~12.5
 kHz wide; an FM broadcast station ~200 kHz; Wi-Fi tens of megahertz.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A spectrum bump occupying a span of frequency, with the width of the occupied span labelled bandwidth." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="100" x2="440" y2="100" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M150 100 C 190 100, 195 35, 230 35 C 265 35, 270 100, 310 100" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.6"/>
+  <line x1="150" y1="55" x2="310" y2="55" stroke="currentColor" marker-start="url(#bws)" marker-end="url(#bwe)"/>
+  <text x="230" y="48" text-anchor="middle" font-size="11" fill="currentColor">bandwidth</text>
+  <text x="230" y="118" text-anchor="middle" font-size="10" fill="currentColor">frequency →</text>
+  <defs>
+    <marker id="bws" markerWidth="8" markerHeight="8" refX="2" refY="3" orient="auto"><path d="M6 0 L0 3 L6 6 z" fill="currentColor"/></marker>
+    <marker id="bwe" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker>
+  </defs>
+</svg>
+<figcaption>Bandwidth is the span of frequency a signal occupies — wider signals carry more data but use more spectrum.</figcaption>
+</figure>
+
 ## How it works
 
 Wider bandwidth can carry more information but uses more spectrum and demands a higher

--- a/docs/reference/bch-code.md
+++ b/docs/reference/bch-code.md
@@ -1,0 +1,34 @@
+---
+slug: bch-code
+title: BCH code
+entry_type: algorithm
+category: algorithms
+description: BCH codes are a class of cyclic block error-correction codes that can be designed to correct a chosen number of bit errors; POCSAG and DSC use BCH codes.
+keywords: BCH code, Bose Chaudhuri Hocquenghem, cyclic code, error correction, POCSAG, DSC
+aka: [BCH code]
+autolink: true
+infobox:
+  - { label: Type, value: Cyclic block code }
+  - { label: Designed for, value: A target error-correction capability }
+  - { label: Used by, value: POCSAG, FLEX, DSC }
+see_also: [forward-error-correction, hamming-code, reed-solomon-code, pocsag, dsc]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "BCH code (Wikipedia)", url: https://en.wikipedia.org/wiki/BCH_code }
+---
+
+**BCH codes** (Bose–Chaudhuri–Hocquenghem) are a class of cyclic block
+[error-correction](/reference/forward-error-correction/) codes that can be constructed to
+correct a chosen number of bit errors.
+
+## How it works
+
+A BCH codeword adds algebraically structured parity bits; the decoder computes a syndrome
+to locate and fix errors. [POCSAG](/reference/pocsag/) uses BCH(31,21), and
+[DSC](/reference/dsc/) uses a small BCH code.
+
+## Relevance to SDR
+
+BCH decoding lets GopherTrunk recover paging and signalling messages even when a few bits
+are corrupted.

--- a/docs/reference/bch-code.md
+++ b/docs/reference/bch-code.md
@@ -22,6 +22,15 @@ external:
 [error-correction](/reference/forward-error-correction/) codes that can be constructed to
 correct a chosen number of bit errors.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="A BCH codeword shown as a block of message bits followed by parity-check bits." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="40" width="230" height="30" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="155" y="59" text-anchor="middle" font-size="9" fill="currentColor">message bits (k)</text>
+  <rect x="270" y="40" width="150" height="30" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/><text x="345" y="59" text-anchor="middle" font-size="9" fill="currentColor">parity (n−k)</text>
+  <text x="230" y="90" text-anchor="middle" font-size="9" fill="currentColor">e.g. BCH(31,21) in POCSAG</text>
+</svg>
+<figcaption>BCH codes append algebraically-computed parity bits that correct multiple bit errors per codeword.</figcaption>
+</figure>
+
 ## How it works
 
 A BCH codeword adds algebraically structured parity bits; the decoder computes a syndrome

--- a/docs/reference/bias-tee.md
+++ b/docs/reference/bias-tee.md
@@ -1,0 +1,33 @@
+---
+slug: bias-tee
+title: Bias tee
+entry_type: hardware
+category: hardware
+description: A bias tee injects DC power onto the coax feeding an antenna-mounted device such as an LNA, while passing the RF signal through to the receiver.
+keywords: bias tee, bias-T, DC injection, LNA power, phantom power, coax
+aka: [bias tee, bias-T]
+autolink: true
+infobox:
+  - { label: Type, value: RF/DC combining network }
+  - { label: Function, value: DC power up the coax, RF through }
+  - { label: Powers, value: Antenna-mounted LNA / active antenna }
+see_also: [low-noise-amplifier, antenna, rtl-sdr]
+related_lessons:
+  - { title: "How an SDR receiver works", url: /learn/sdr-receiver/ }
+external:
+  - { title: "Bias tee (Wikipedia)", url: https://en.wikipedia.org/wiki/Bias_tee }
+---
+
+A **bias tee** is a small network that injects **DC power onto the coax** feeding an
+antenna-mounted device — typically a [low-noise amplifier](/reference/low-noise-amplifier/)
+— while passing the RF signal through to the receiver unaffected.
+
+## How it works
+
+It combines a DC path and an RF path so a single cable carries both. Many SDRs (including
+some [RTL-SDR](/reference/rtl-sdr/) models) have a built-in switchable bias tee.
+
+## Relevance to SDR
+
+A bias tee lets you power a mast-mounted LNA without a separate cable, keeping the
+amplifier close to the [antenna](/reference/antenna/) where it does the most good.

--- a/docs/reference/bias-tee.md
+++ b/docs/reference/bias-tee.md
@@ -22,6 +22,17 @@ A **bias tee** is a small network that injects **DC power onto the coax** feedin
 antenna-mounted device — typically a [low-noise amplifier](/reference/low-noise-amplifier/)
 — while passing the RF signal through to the receiver unaffected.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A bias tee injecting DC power onto the coax while passing RF through to the receiver." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="55" x2="200" y2="55" stroke="currentColor" stroke-width="1.4"/><text x="60" y="46" font-size="8" fill="currentColor">RF + DC</text>
+  <line x1="200" y1="55" x2="420" y2="55" stroke="currentColor" stroke-width="1.4"/><text x="360" y="46" font-size="8" fill="currentColor">RF to RX</text>
+  <line x1="200" y1="55" x2="200" y2="95" stroke="currentColor" stroke-width="1.4"/><text x="200" y="108" font-size="8" fill="currentColor" text-anchor="middle">DC supply</text>
+  <circle cx="200" cy="55" r="3" fill="currentColor"/>
+  <text x="230" y="30" font-size="9" fill="currentColor">powers a remote LNA over the coax</text>
+</svg>
+<figcaption>A bias tee feeds DC up the coax to power a mast-mounted LNA while passing the RF through.</figcaption>
+</figure>
+
 ## How it works
 
 It combines a DC path and an RF path so a single cable carries both. Many SDRs (including

--- a/docs/reference/c4fm.md
+++ b/docs/reference/c4fm.md
@@ -24,6 +24,16 @@ external:
 The carrier sits at one of four frequency deviations per [symbol](/reference/symbol-rate/),
 carrying 2 bits each.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="Four horizontal deviation levels labelled with dibits, and a stepped trace moving between them over time." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-opacity="0.35"><line x1="60" y1="30" x2="430" y2="30"/><line x1="60" y1="60" x2="430" y2="60"/><line x1="60" y1="90" x2="430" y2="90"/><line x1="60" y1="120" x2="430" y2="120"/></g>
+  <g font-size="9" fill="currentColor" text-anchor="end"><text x="55" y="33">+3 (01)</text><text x="55" y="63">+1 (00)</text><text x="55" y="93">-1 (10)</text><text x="55" y="123">-3 (11)</text></g>
+  <polyline points="70,60 110,30 150,90 190,90 230,120 270,30 310,60 350,120 390,90 430,30" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="240" y="142" text-anchor="middle" font-size="9" fill="currentColor">time → (one dibit per symbol, 4800 baud)</text>
+</svg>
+<figcaption>C4FM is four-level FSK: each symbol sits at one of four frequency deviations, carrying two bits.</figcaption>
+</figure>
+
 ## How it works
 
 C4FM runs at 4800 baud (9600 bps) and is paired with [CQPSK](/reference/cqpsk/): the two

--- a/docs/reference/c4fm.md
+++ b/docs/reference/c4fm.md
@@ -1,0 +1,37 @@
+---
+slug: c4fm
+title: C4FM
+entry_type: technology
+category: modulation
+description: C4FM is the four-level continuous-phase FSK modulation used by P25 Phase 1 and Yaesu System Fusion, carrying 2 bits per symbol at 4800 baud.
+keywords: C4FM, four-level FSK, 4FSK, P25 Phase 1, System Fusion, 4800 baud, CQPSK
+aka: [C4FM]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation (4-level FSK) }
+  - { label: Symbol rate, value: 4800 baud (9600 bps) }
+  - { label: Used by, value: P25 Phase 1, System Fusion }
+see_also: [frequency-shift-keying, cqpsk, project-25, p25-phase-1, system-fusion-ysf, symbol-rate]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+---
+
+**C4FM** (compatible four-level FM) is the four-level
+[FSK](/reference/frequency-shift-keying/) modulation used by
+[P25 Phase 1](/reference/p25-phase-1/) and [System Fusion](/reference/system-fusion-ysf/).
+The carrier sits at one of four frequency deviations per [symbol](/reference/symbol-rate/),
+carrying 2 bits each.
+
+## How it works
+
+C4FM runs at 4800 baud (9600 bps) and is paired with [CQPSK](/reference/cqpsk/): the two
+are designed so a single receiver detects both transmit paths. Its four levels appear as
+four clusters on a [constellation](/reference/constellation-diagram/) and three stacked
+eyes on an [eye diagram](/reference/eye-diagram/).
+
+## Relevance to SDR
+
+Recognising healthy C4FM symbols is central to decoding P25 Phase 1 and Fusion; the
+scopes reveal SNR, tuning, and timing problems at a glance.

--- a/docs/reference/carrier-wave.md
+++ b/docs/reference/carrier-wave.md
@@ -1,0 +1,36 @@
+---
+slug: carrier-wave
+title: Carrier wave
+entry_type: term
+category: rf-fundamentals
+description: A carrier wave is a steady radio-frequency signal that carries no information by itself until it is modulated, varying its amplitude, frequency, or phase to convey a message.
+keywords: carrier wave, carrier, modulation, unmodulated, RF
+aka: [carrier wave, carrier]
+autolink: true
+infobox:
+  - { label: Type, value: Reference signal }
+  - { label: Carries info via, value: Modulation }
+  - { label: Appears as, value: Single spectral spike (unmodulated) }
+see_also: [modulation, radio-wave, frequency, amplitude-modulation]
+related_lessons:
+  - { title: "Anatomy of a signal", url: /learn/signal-anatomy/ }
+external:
+  - { title: "Carrier wave (Wikipedia)", url: https://en.wikipedia.org/wiki/Carrier_wave }
+---
+
+A **carrier wave** is a steady [radio-frequency](/reference/radio-wave/) signal at a
+single [frequency](/reference/frequency/) that conveys no information on its own. It
+becomes useful only when [modulation](/reference/modulation/) varies one of its
+properties in step with a message.
+
+## How it works
+
+An unmodulated carrier appears on a spectrum display as a single narrow spike.
+Modulation spreads energy into sidebands around it, and the width of those sidebands is
+essentially the signal's [bandwidth](/reference/bandwidth/).
+
+## Relevance to SDR
+
+Receivers tune to a carrier's frequency and then demodulate the variations around it.
+A residual carrier at zero frequency after downconversion is the familiar "DC spike"
+seen on SDR spectra.

--- a/docs/reference/carrier-wave.md
+++ b/docs/reference/carrier-wave.md
@@ -23,6 +23,16 @@ single [frequency](/reference/frequency/) that conveys no information on its own
 becomes useful only when [modulation](/reference/modulation/) varies one of its
 properties in step with a message.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A steady unmodulated carrier wave on top, and the same carrier amplitude-modulated by a message below." xmlns="http://www.w3.org/2000/svg">
+  <text x="20" y="20" font-size="10" fill="currentColor">unmodulated carrier</text>
+  <path d="M20 45 q10 -18 20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <text x="20" y="95" font-size="10" fill="currentColor">modulated (carries information)</text>
+  <path d="M20 120 q10 -8 20 0 t20 0 q10 -22 20 0 t20 0 q10 -22 20 0 t20 0 q10 -8 20 0 t20 0 q10 -4 20 0 t20 0 q10 -8 20 0 t20 0 q10 -22 20 0 t20 0 q10 -22 20 0 t20 0 q10 -8 20 0 t20 0" fill="none" stroke="currentColor" stroke-width="1.6"/>
+</svg>
+<figcaption>A bare carrier carries no information until modulation varies its amplitude, frequency, or phase.</figcaption>
+</figure>
+
 ## How it works
 
 An unmodulated carrier appears on a spectrum display as a single narrow spike.

--- a/docs/reference/channel-grant.md
+++ b/docs/reference/channel-grant.md
@@ -23,6 +23,16 @@ assigns a [talkgroup](/reference/talkgroup/)'s call to a specific
 [voice channel](/reference/voice-channel/) (and timeslot on
 [TDMA](/reference/tdma/) systems).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="The control channel issuing a grant message that causes affiliated radios to retune to a voice channel." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="40" width="120" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="90" y="61" text-anchor="middle" font-size="9" fill="currentColor">control channel</text>
+  <line x1="152" y1="57" x2="290" y2="57" stroke="currentColor" stroke-width="1.1" marker-end="url(#cgar)"/><text x="221" y="50" text-anchor="middle" font-size="8.5" fill="currentColor">grant: TG 101 → ch 3</text>
+  <rect x="300" y="40" width="130" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="365" y="56" text-anchor="middle" font-size="9" fill="currentColor">radios retune</text><text x="365" y="68" text-anchor="middle" font-size="8" fill="currentColor">to voice channel 3</text>
+  <defs><marker id="cgar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A channel grant is the control-channel message assigning a talkgroup to a specific voice channel.</figcaption>
+</figure>
+
 ## How it works
 
 The grant names the talkgroup and the channel; affiliated radios and monitors retune to

--- a/docs/reference/channel-grant.md
+++ b/docs/reference/channel-grant.md
@@ -1,0 +1,35 @@
+---
+slug: channel-grant
+title: Channel grant
+entry_type: term
+category: trunked-radio
+description: A channel grant is the control-channel message that assigns a talkgroup's call to a specific voice channel (and timeslot), telling radios and monitors where to tune.
+keywords: channel grant, grant, control channel message, voice channel assignment, trunking
+aka: [channel grant]
+autolink: true
+infobox:
+  - { label: Type, value: Control-channel message }
+  - { label: Contains, value: Talkgroup, voice channel, (slot) }
+  - { label: Triggers, value: Radios retune to the call }
+see_also: [control-channel, voice-channel, talkgroup, trunked-radio]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+---
+
+A **channel grant** is the [control-channel](/reference/control-channel/) message that
+assigns a [talkgroup](/reference/talkgroup/)'s call to a specific
+[voice channel](/reference/voice-channel/) (and timeslot on
+[TDMA](/reference/tdma/) systems).
+
+## How it works
+
+The grant names the talkgroup and the channel; affiliated radios and monitors retune to
+follow the call. It is the moment a monitor learns that a call is starting and exactly
+where.
+
+## Relevance to SDR
+
+GopherTrunk reads grants in real time to task a receiver to the right channel/slot,
+which is how it follows conversations as they scatter across the channel pool.

--- a/docs/reference/cic-filter.md
+++ b/docs/reference/cic-filter.md
@@ -1,0 +1,34 @@
+---
+slug: cic-filter
+title: CIC filter
+entry_type: algorithm
+category: sdr-dsp
+description: A cascaded integrator–comb (CIC) filter is a multiplier-free filter ideal for efficient large-ratio decimation or interpolation in SDR hardware and software.
+keywords: CIC filter, cascaded integrator comb, decimation, interpolation, multiplier-free, Hogenauer
+aka: [CIC filter]
+autolink: true
+infobox:
+  - { label: Type, value: Decimation/interpolation filter }
+  - { label: Feature, value: No multipliers (adds/delays only) }
+  - { label: Use, value: Large-ratio rate change }
+see_also: [decimation, digital-filter, sample-rate, digital-down-converter]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Cascaded integrator–comb filter (Wikipedia)", url: https://en.wikipedia.org/wiki/Cascaded_integrator%E2%80%93comb_filter }
+---
+
+A **CIC filter** (cascaded integrator–comb) is a [digital filter](/reference/digital-filter/)
+built from only integrators and combs — **no multipliers** — making it very efficient for
+large-ratio [decimation](/reference/decimation/) or interpolation.
+
+## How it works
+
+Integrator stages run at the high rate and comb stages at the low rate, changing the
+[sample rate](/reference/sample-rate/) cheaply. Its gentle passband is usually followed by
+a short compensation FIR filter.
+
+## Relevance to SDR
+
+CIC filters are common in the front of an SDR channeliser, where huge decimation ratios
+must be done with minimal computation.

--- a/docs/reference/cic-filter.md
+++ b/docs/reference/cic-filter.md
@@ -22,6 +22,21 @@ A **CIC filter** (cascaded integrator–comb) is a [digital filter](/reference/d
 built from only integrators and combs — **no multipliers** — making it very efficient for
 large-ratio [decimation](/reference/decimation/) or interpolation.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A cascaded integrator-comb block diagram: integrators, a rate change, then comb stages." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="45" width="50" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="55" y="64">∫</text>
+    <rect x="90" y="45" width="50" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="115" y="64">∫</text>
+    <rect x="155" y="45" width="60" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="185" y="63">↓ R</text>
+    <rect x="230" y="45" width="50" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="255" y="64">comb</text>
+    <rect x="290" y="45" width="50" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="315" y="64">comb</text>
+    <text x="385" y="64">efficient<tspan x="385" dy="12">decimator</tspan></text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="80" y1="60" x2="89" y2="60"/><line x1="140" y1="60" x2="154" y2="60"/><line x1="215" y1="60" x2="229" y2="60"/><line x1="280" y1="60" x2="289" y2="60"/><line x1="340" y1="60" x2="350" y2="60"/></g>
+  </g>
+</svg>
+<figcaption>A CIC filter uses only adders and delays (no multipliers), making it a cheap high-ratio decimator.</figcaption>
+</figure>
+
 ## How it works
 
 Integrator stages run at the high rate and comb stages at the low rate, changing the

--- a/docs/reference/claude-shannon.md
+++ b/docs/reference/claude-shannon.md
@@ -21,6 +21,20 @@ external:
 **Claude Shannon** (1916–2001) was an American mathematician and engineer who founded
 **information theory**, defining how much information a noisy channel can carry.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="An information source passing through a noisy channel to a destination, with the channel-capacity formula." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="40" width="60" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="59">source</text>
+    <rect x="150" y="40" width="80" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="190" y="53">noisy</text><text x="190" y="64" font-size="8">channel</text>
+    <rect x="290" y="40" width="80" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="330" y="59">destination</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="90" y1="55" x2="149" y2="55" marker-end="url(#shar)"/><line x1="230" y1="55" x2="289" y2="55" marker-end="url(#shar)"/></g>
+  </g>
+  <text x="230" y="98" text-anchor="middle" font-size="10" fill="currentColor">C = B · log₂(1 + SNR)</text>
+  <defs><marker id="shar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Shannon founded information theory, defining the maximum error-free data rate of a noisy channel.</figcaption>
+</figure>
+
 ## Life and work
 
 His 1948 paper "A Mathematical Theory of Communication" introduced channel capacity,

--- a/docs/reference/claude-shannon.md
+++ b/docs/reference/claude-shannon.md
@@ -1,0 +1,39 @@
+---
+slug: claude-shannon
+title: Claude Shannon
+entry_type: person
+category: people
+description: Claude Shannon (1916–2001) was an American mathematician who founded information theory, defining channel capacity and the limits of reliable communication over noisy channels.
+keywords: Claude Shannon, information theory, channel capacity, Shannon limit, entropy, Bell Labs
+aka: [Claude Shannon, Shannon]
+autolink: true
+infobox:
+  - { label: Lived, value: "1916–2001" }
+  - { label: Field, value: Mathematics / engineering }
+  - { label: Known for, value: Information theory }
+see_also: [nyquist-theorem, harry-nyquist, signal-to-noise-ratio, forward-error-correction]
+related_lessons:
+  - { title: "Sample rate, bandwidth & Nyquist", url: /learn/sample-rate-nyquist/ }
+external:
+  - { title: "Claude Shannon (Wikipedia)", url: https://en.wikipedia.org/wiki/Claude_Shannon }
+---
+
+**Claude Shannon** (1916–2001) was an American mathematician and engineer who founded
+**information theory**, defining how much information a noisy channel can carry.
+
+## Life and work
+
+His 1948 paper "A Mathematical Theory of Communication" introduced channel capacity,
+entropy, and the limits that bound any communication system — including the role of
+[SNR](/reference/signal-to-noise-ratio/).
+
+## Contribution
+
+Shannon's capacity theorem sets the ultimate target that
+[forward error correction](/reference/forward-error-correction/) strives toward, and his
+work with [Nyquist](/reference/harry-nyquist/)'s underlies the
+[sampling theorem](/reference/nyquist-theorem/).
+
+## Legacy
+
+Information theory governs the design of every modern digital radio.

--- a/docs/reference/clock-recovery.md
+++ b/docs/reference/clock-recovery.md
@@ -1,0 +1,35 @@
+---
+slug: clock-recovery
+title: Clock recovery
+entry_type: term
+category: sdr-dsp
+description: Clock recovery determines a digital signal's symbol timing from the signal itself, so the receiver samples each symbol at its centre where the eye is widest.
+keywords: clock recovery, symbol timing, timing recovery, symbol synchronization, Gardner, Mueller-Muller
+aka: [clock recovery, symbol timing]
+autolink: true
+infobox:
+  - { label: Type, value: Timing-synchronisation stage }
+  - { label: Recovers, value: Symbol timing from the signal }
+  - { label: Algorithms, value: Gardner, Mueller–Müller }
+see_also: [gardner-timing-recovery, mueller-muller-timing-recovery, symbol-rate, eye-diagram, demodulation]
+related_lessons:
+  - { title: "Clock recovery & symbol timing", url: /learn/clock-recovery/ }
+external:
+  - { title: "Clock recovery (Wikipedia)", url: https://en.wikipedia.org/wiki/Clock_recovery }
+---
+
+**Clock recovery** determines a digital signal's [symbol](/reference/symbol-rate/) timing
+from the signal itself, since the transmitter's clock is not shared. It lets the receiver
+sample each symbol at its **centre**, where the [eye](/reference/eye-diagram/) is widest.
+
+## How it works
+
+A timing-recovery loop watches where transitions fall and nudges the sampling instant to
+stay centred, tracking small clock drift. Common algorithms are
+[Gardner](/reference/gardner-timing-recovery/) and
+[Mueller–Müller](/reference/mueller-muller-timing-recovery/).
+
+## Relevance to SDR
+
+Loss of symbol lock — from low SNR or [multipath](/reference/multipath-propagation/) —
+closes the eye and breaks the decode, a key thing the scopes reveal.

--- a/docs/reference/clock-recovery.md
+++ b/docs/reference/clock-recovery.md
@@ -22,6 +22,18 @@ external:
 from the signal itself, since the transmitter's clock is not shared. It lets the receiver
 sample each symbol at its **centre**, where the [eye](/reference/eye-diagram/) is widest.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 140" role="img" aria-label="An eye diagram with a dashed line at the centre showing where clock recovery aims the sampling instant." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.1" stroke-opacity="0.85">
+    <path d="M40 30 C120 30 120 110 200 110 C280 110 280 30 360 30"/>
+    <path d="M40 110 C120 110 120 30 200 30 C280 30 280 110 360 110"/>
+  </g>
+  <line x1="200" y1="20" x2="200" y2="120" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="200" y="136" text-anchor="middle" font-size="10" fill="currentColor">recovered clock samples at the eye centre</text>
+</svg>
+<figcaption>Clock recovery finds the symbol rhythm from the signal itself so each symbol is sampled at its centre.</figcaption>
+</figure>
+
 ## How it works
 
 A timing-recovery loop watches where transitions fall and nudges the sampling instant to

--- a/docs/reference/cma-equalizer.md
+++ b/docs/reference/cma-equalizer.md
@@ -1,0 +1,35 @@
+---
+slug: cma-equalizer
+title: CMA equalizer
+entry_type: algorithm
+category: sdr-dsp
+description: A constant-modulus-algorithm (CMA) equalizer is a blind adaptive filter that counteracts multipath distortion without a training sequence, improving digital decoding.
+keywords: CMA, constant modulus algorithm, blind equalizer, multipath, adaptive filter, intersymbol interference
+aka: [CMA equalizer, constant-modulus algorithm]
+autolink: true
+infobox:
+  - { label: Type, value: Blind adaptive equalizer }
+  - { label: Counteracts, value: Multipath / intersymbol interference }
+  - { label: Blind, value: No training sequence required }
+see_also: [multipath-propagation, demodulation, clock-recovery, constellation-diagram]
+related_lessons:
+  - { title: "Tuning for a clean lock", url: /learn/tuning-with-scopes/ }
+external:
+  - { title: "Constant modulus algorithm (Wikipedia)", url: https://en.wikipedia.org/wiki/Constant_modulus_algorithm }
+---
+
+A **CMA equalizer** uses the **constant-modulus algorithm** — a blind adaptive
+[filter](/reference/digital-filter/) — to counteract
+[multipath](/reference/multipath-propagation/) distortion without needing a known training
+sequence.
+
+## How it works
+
+It adjusts its taps to drive the output toward a constant modulus (the property of
+constant-envelope modulations), undoing intersymbol interference and tightening the
+[constellation](/reference/constellation-diagram/).
+
+## Relevance to SDR
+
+A CMA equalizer can rescue decoding in reflective urban environments where multipath
+otherwise smears the symbols.

--- a/docs/reference/cma-equalizer.md
+++ b/docs/reference/cma-equalizer.md
@@ -23,6 +23,20 @@ A **CMA equalizer** uses the **constant-modulus algorithm** — a blind adaptive
 [multipath](/reference/multipath-propagation/) distortion without needing a known training
 sequence.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="A smeared constellation on the left and a tightened constellation on the right after equalisation." xmlns="http://www.w3.org/2000/svg">
+  <g><line x1="20" y1="95" x2="170" y2="95" stroke="currentColor" stroke-opacity="0.3"/><line x1="95" y1="30" x2="95" y2="160" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor" fill-opacity="0.7"><circle cx="58" cy="60" r="2.5"/><circle cx="50" cy="68" r="2.5"/><circle cx="66" cy="54" r="2.5"/><circle cx="132" cy="62" r="2.5"/><circle cx="124" cy="70" r="2.5"/><circle cx="58" cy="130" r="2.5"/><circle cx="66" cy="122" r="2.5"/><circle cx="132" cy="130" r="2.5"/></g>
+    <text x="95" y="180" text-anchor="middle" font-size="9" fill="currentColor">multipath-smeared</text></g>
+  <line x1="195" y1="95" x2="235" y2="95" stroke="currentColor" marker-end="url(#eqar)"/>
+  <g><line x1="280" y1="95" x2="440" y2="95" stroke="currentColor" stroke-opacity="0.3"/><line x1="360" y1="30" x2="360" y2="160" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor"><circle cx="325" cy="62" r="2.5"/><circle cx="395" cy="62" r="2.5"/><circle cx="325" cy="128" r="2.5"/><circle cx="395" cy="128" r="2.5"/></g>
+    <text x="360" y="180" text-anchor="middle" font-size="9" fill="currentColor">equalised</text></g>
+  <defs><marker id="eqar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A CMA equaliser blindly undoes channel distortion (multipath), pulling smeared symbols back to tight clusters.</figcaption>
+</figure>
+
 ## How it works
 
 It adjusts its taps to drive the output toward a constant modulus (the property of

--- a/docs/reference/codec2.md
+++ b/docs/reference/codec2.md
@@ -1,0 +1,36 @@
+---
+slug: codec2
+title: Codec 2
+entry_type: technology
+category: voice-coding
+description: Codec 2 is an open-source, royalty-free low-bitrate speech vocoder by David Rowe, used by the M17 protocol and FreeDV as a patent-free alternative to AMBE.
+keywords: Codec 2, open source vocoder, David Rowe, M17, FreeDV, royalty-free, low bitrate speech
+aka: [Codec 2, Codec2]
+autolink: true
+infobox:
+  - { label: Type, value: Open-source speech vocoder }
+  - { label: Author, value: David Rowe }
+  - { label: Licensing, value: Royalty-free (LGPL) }
+  - { label: Used by, value: M17, FreeDV }
+see_also: [vocoder, m17, ambe-plus-2, m17-project]
+related_lessons:
+  - { title: "Vocoders — IMBE & AMBE+2", url: /learn/vocoders/ }
+external:
+  - { title: "Codec 2 (Wikipedia)", url: https://en.wikipedia.org/wiki/Codec_2 }
+---
+
+**Codec 2** is an open-source, **royalty-free** low-bitrate speech
+[vocoder](/reference/vocoder/) created by David Rowe. It provides intelligible voice
+from roughly 700 bps to 3200 bps and is the patent-free alternative to
+[AMBE](/reference/ambe/)-family codecs.
+
+## How it works
+
+Like other vocoders it models speech with pitch and spectral parameters, but its
+open licence lets anyone implement it freely — the reason [M17](/reference/m17/) and
+the FreeDV digital-voice mode adopted it.
+
+## Relevance to SDR
+
+Codec 2 lets fully open decoders (including M17 support) render digital voice without
+proprietary vocoder licensing.

--- a/docs/reference/codec2.md
+++ b/docs/reference/codec2.md
@@ -24,6 +24,17 @@ external:
 from roughly 700 bps to 3200 bps and is the patent-free alternative to
 [AMBE](/reference/ambe/)-family codecs.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A royalty-free Codec 2 frame shown at a very low bit rate compared with a larger uncompressed audio block." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="40" width="200" height="34" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.5"/><text x="140" y="61" text-anchor="middle" font-size="9" fill="currentColor">raw audio (large)</text>
+  <line x1="250" y1="57" x2="290" y2="57" stroke="currentColor" marker-end="url(#c2ar)"/>
+  <rect x="300" y="44" width="56" height="26" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="328" y="61" text-anchor="middle" font-size="8" fill="currentColor">~1.2–3.2 kbps</text>
+  <text x="400" y="61" font-size="9" fill="currentColor">open</text>
+  <defs><marker id="c2ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Codec 2 is an open, royalty-free low-bitrate speech codec — the vocoder used by M17.</figcaption>
+</figure>
+
 ## How it works
 
 Like other vocoders it models speech with pitch and spectral parameters, but its

--- a/docs/reference/compact-position-reporting.md
+++ b/docs/reference/compact-position-reporting.md
@@ -1,0 +1,33 @@
+---
+slug: compact-position-reporting
+title: Compact position reporting (CPR)
+entry_type: algorithm
+category: algorithms
+description: Compact position reporting is the ADS-B encoding that conveys aircraft latitude and longitude in few bits, resolved to a precise position from a pair of even/odd messages.
+keywords: CPR, compact position reporting, ADS-B, latitude longitude, even odd, Mode S
+aka: [compact position reporting, CPR]
+autolink: true
+infobox:
+  - { label: Type, value: Position-encoding scheme }
+  - { label: Used by, value: ADS-B }
+  - { label: Resolves from, value: Even/odd message pair }
+see_also: [ads-b, cyclic-redundancy-check, icao]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Compact Position Reporting", url: https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast }
+---
+
+**Compact position reporting** (**CPR**) is the encoding [ADS-B](/reference/ads-b/) uses to
+convey an aircraft's latitude and longitude in few bits, trading a small amount of
+ambiguity for compactness.
+
+## How it works
+
+CPR encodes position relative to a grid of zones. A globally unambiguous fix is recovered
+from a matched pair of **even** and **odd** format messages, or locally from a known
+reference position.
+
+## Relevance to SDR
+
+An ADS-B decoder must implement CPR to turn raw messages into mappable aircraft positions.

--- a/docs/reference/compact-position-reporting.md
+++ b/docs/reference/compact-position-reporting.md
@@ -22,6 +22,19 @@ external:
 convey an aircraft's latitude and longitude in few bits, trading a small amount of
 ambiguity for compactness.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="An even frame and an odd frame combined to resolve a globally unambiguous latitude and longitude on a grid." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="40" width="70" height="26" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="65" y="57" text-anchor="middle" font-size="9" fill="currentColor">even</text>
+  <rect x="30" y="74" width="70" height="26" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/><text x="65" y="91" text-anchor="middle" font-size="9" fill="currentColor">odd</text>
+  <line x1="104" y1="70" x2="150" y2="70" stroke="currentColor" marker-end="url(#cprar)"/>
+  <g stroke="currentColor" stroke-opacity="0.4"><rect x="170" y="30" width="120" height="80" fill="none"/><line x1="210" y1="30" x2="210" y2="110"/><line x1="250" y1="30" x2="250" y2="110"/><line x1="170" y1="57" x2="290" y2="57"/><line x1="170" y1="83" x2="290" y2="83"/></g>
+  <circle cx="230" cy="70" r="4" fill="currentColor"/>
+  <text x="360" y="74" text-anchor="middle" font-size="9" fill="currentColor">unambiguous lat/lon</text>
+  <defs><marker id="cprar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Compact position reporting (ADS-B) combines an even and odd message to pin down a position with few bits.</figcaption>
+</figure>
+
 ## How it works
 
 CPR encodes position relative to a grid of zones. A globally unambiguous fix is recovered

--- a/docs/reference/constellation-diagram.md
+++ b/docs/reference/constellation-diagram.md
@@ -24,6 +24,18 @@ on the [IQ](/reference/iq-data/) plane: the horizontal axis is I and the vertica
 is Q, so each point's angle is its [phase](/reference/phase/) and its distance from the
 origin is its [amplitude](/reference/amplitude/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="Two four-point constellations: tight clusters labelled clean on the left, smeared clusters labelled noisy on the right." xmlns="http://www.w3.org/2000/svg">
+  <g><line x1="20" y1="100" x2="180" y2="100" stroke="currentColor" stroke-opacity="0.3"/><line x1="100" y1="25" x2="100" y2="175" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor"><circle cx="60" cy="60" r="2.5"/><circle cx="58" cy="62" r="2.5"/><circle cx="62" cy="59" r="2.5"/><circle cx="140" cy="60" r="2.5"/><circle cx="138" cy="62" r="2.5"/><circle cx="60" cy="140" r="2.5"/><circle cx="62" cy="138" r="2.5"/><circle cx="140" cy="140" r="2.5"/><circle cx="138" cy="141" r="2.5"/></g>
+    <text x="100" y="192" text-anchor="middle" font-size="10" fill="currentColor">clean</text></g>
+  <g><line x1="280" y1="100" x2="440" y2="100" stroke="currentColor" stroke-opacity="0.3"/><line x1="360" y1="25" x2="360" y2="175" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor" fill-opacity="0.7"><circle cx="320" cy="62" r="2.5"/><circle cx="312" cy="70" r="2.5"/><circle cx="330" cy="54" r="2.5"/><circle cx="318" cy="78" r="2.5"/><circle cx="400" cy="60" r="2.5"/><circle cx="408" cy="72" r="2.5"/><circle cx="392" cy="52" r="2.5"/><circle cx="322" cy="140" r="2.5"/><circle cx="330" cy="132" r="2.5"/><circle cx="400" cy="140" r="2.5"/><circle cx="392" cy="148" r="2.5"/></g>
+    <text x="360" y="192" text-anchor="middle" font-size="10" fill="currentColor">noisy</text></g>
+</svg>
+<figcaption>A constellation plots symbols on the IQ plane; tight clusters decode reliably, smeared clusters bring errors.</figcaption>
+</figure>
+
 ## How it works
 
 A clean signal places symbols in tight, well-separated clusters at their ideal points.

--- a/docs/reference/constellation-diagram.md
+++ b/docs/reference/constellation-diagram.md
@@ -1,0 +1,36 @@
+---
+slug: constellation-diagram
+title: Constellation diagram
+entry_type: term
+category: modulation
+description: A constellation diagram plots a digital signal's symbols on the IQ plane, where position encodes phase and amplitude; tight clusters indicate a clean signal.
+keywords: constellation diagram, IQ plane, symbols, signal quality, EVM, modulation
+aka: [constellation diagram, constellation]
+autolink: true
+infobox:
+  - { label: Type, value: Signal-quality display }
+  - { label: Axes, value: I (in-phase) and Q (quadrature) }
+  - { label: Reads, value: Phase (angle), amplitude (radius) }
+see_also: [iq-data, eye-diagram, phase-shift-keying, quadrature-amplitude-modulation, phase]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+  - { title: "Tuning for a clean lock", url: /learn/tuning-with-scopes/ }
+external:
+  - { title: "Constellation diagram (Wikipedia)", url: https://en.wikipedia.org/wiki/Constellation_diagram }
+---
+
+A **constellation diagram** plots a digital signal's [symbols](/reference/symbol-rate/)
+on the [IQ](/reference/iq-data/) plane: the horizontal axis is I and the vertical axis
+is Q, so each point's angle is its [phase](/reference/phase/) and its distance from the
+origin is its [amplitude](/reference/amplitude/).
+
+## How it works
+
+A clean signal places symbols in tight, well-separated clusters at their ideal points.
+Noise fuzzes the clusters, a tuning offset rotates them, and clipping distorts them —
+so the *shape* of the scatter diagnoses the problem.
+
+## Relevance to SDR
+
+GopherTrunk's constellation panel draws this live, making it the first tool for
+[tuning a clean lock](/learn/tuning-with-scopes/).

--- a/docs/reference/control-channel.md
+++ b/docs/reference/control-channel.md
@@ -23,6 +23,21 @@ The **control channel** is the **data-only** frequency that coordinates a
 signalling — never voice — managing registrations, call requests, and
 [channel grants](/reference/channel-grant/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A steady always-on control channel stripe issuing messages that point radios to voice channels." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="30" width="400" height="28" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="48" text-anchor="middle" font-size="10" fill="currentColor">control channel — continuous data, never voice</text>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <text x="100" y="86">grant</text><text x="100" y="98" font-size="7.5">→ ch 3</text>
+    <text x="230" y="86">affiliation</text><text x="230" y="98" font-size="7.5">radio 4567</text>
+    <text x="360" y="86">grant</text><text x="360" y="98" font-size="7.5">→ ch 7</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1"><line x1="100" y1="58" x2="100" y2="74"/><line x1="230" y1="58" x2="230" y2="74"/><line x1="360" y1="58" x2="360" y2="74"/></g>
+  <text x="230" y="120" text-anchor="middle" font-size="9" fill="currentColor">decode this first — it's the map to every call</text>
+</svg>
+<figcaption>The control channel carries the system's running commentary — affiliations, requests, and channel grants.</figcaption>
+</figure>
+
 ## How it works
 
 When a call starts, the control channel broadcasts a grant naming the

--- a/docs/reference/control-channel.md
+++ b/docs/reference/control-channel.md
@@ -1,0 +1,35 @@
+---
+slug: control-channel
+title: Control channel
+entry_type: term
+category: trunked-radio
+description: The control channel is the data-only frequency of a trunked radio system that coordinates it, announcing channel grants, registrations, and system parameters.
+keywords: control channel, trunking signalling, channel grant, affiliation, data channel
+aka: [control channel]
+autolink: true
+infobox:
+  - { label: Type, value: Trunking signalling channel }
+  - { label: Carries, value: Data only (no voice) }
+  - { label: Announces, value: Grants, affiliations, system info }
+see_also: [trunked-radio, voice-channel, channel-grant, affiliation, talkgroup]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+---
+
+The **control channel** is the **data-only** frequency that coordinates a
+[trunked radio](/reference/trunked-radio/) system. It carries a continuous stream of
+signalling — never voice — managing registrations, call requests, and
+[channel grants](/reference/channel-grant/).
+
+## How it works
+
+When a call starts, the control channel broadcasts a grant naming the
+[talkgroup](/reference/talkgroup/) and the assigned [voice channel](/reference/voice-channel/);
+affiliated radios retune to listen. It also conveys the system identity and parameters.
+
+## Relevance to SDR
+
+Decoding the control channel is the key to monitoring a trunked system — it is the map
+that tells GopherTrunk where every call goes, so it can follow them all.

--- a/docs/reference/conventional-radio.md
+++ b/docs/reference/conventional-radio.md
@@ -1,0 +1,35 @@
+---
+slug: conventional-radio
+title: Conventional radio
+entry_type: term
+category: trunked-radio
+description: Conventional radio assigns each user group a fixed frequency, unlike trunked radio; it is simple to scan because conversations always occur on the same channel.
+keywords: conventional radio, non-trunked, fixed frequency, simplex, repeater
+aka: [conventional radio]
+autolink: true
+infobox:
+  - { label: Type, value: Radio-system architecture }
+  - { label: Channel use, value: Fixed frequency per group }
+  - { label: Contrast, value: Trunked radio }
+see_also: [trunked-radio, voice-channel, frequency]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Two-way radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Two-way_radio }
+---
+
+**Conventional radio** assigns each user group its own **fixed frequency**, in contrast
+to [trunked radio](/reference/trunked-radio/). A conversation always happens on the same
+channel, so there is no [control channel](/reference/control-channel/) to coordinate
+assignments.
+
+## How it works
+
+Groups simply transmit on their assigned simplex frequency or repeater pair. This is
+simple and robust but uses spectrum inefficiently, since each channel sits idle when its
+group is quiet.
+
+## Relevance to SDR
+
+Conventional channels are scanned directly by tuning to the known frequency — no
+grant-following required. [DMR Tier II](/reference/dmr-tier-2/) is a digital example.

--- a/docs/reference/conventional-radio.md
+++ b/docs/reference/conventional-radio.md
@@ -23,6 +23,25 @@ to [trunked radio](/reference/trunked-radio/). A conversation always happens on 
 channel, so there is no [control channel](/reference/control-channel/) to coordinate
 assignments.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="On the left, conventional radio with each group on its own fixed channel; on the right, trunked radio sharing a pool." xmlns="http://www.w3.org/2000/svg">
+  <text x="115" y="20" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">conventional</text>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="34" width="150" height="22" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="115" y="49">Police → ch A (always)</text>
+    <rect x="40" y="60" width="150" height="22" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="115" y="75">Fire → ch B (always)</text>
+    <rect x="40" y="86" width="150" height="22" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="115" y="101">Public works → ch C</text>
+  </g>
+  <text x="345" y="20" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">trunked</text>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <rect x="270" y="34" width="150" height="22" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="345" y="49">shared pool of channels</text>
+    <rect x="270" y="60" width="70" height="22" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="305" y="75">any group</text>
+    <rect x="350" y="60" width="70" height="22" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="75">on demand</text>
+  </g>
+  <text x="230" y="135" text-anchor="middle" font-size="9" fill="currentColor">fixed assignment vs. assigned-per-call</text>
+</svg>
+<figcaption>Conventional radio gives each group a permanent frequency; trunking shares a pool on demand.</figcaption>
+</figure>
+
 ## How it works
 
 Groups simply transmit on their assigned simplex frequency or repeater pair. This is

--- a/docs/reference/convolutional-code.md
+++ b/docs/reference/convolutional-code.md
@@ -1,0 +1,34 @@
+---
+slug: convolutional-code
+title: Convolutional code
+entry_type: algorithm
+category: algorithms
+description: A convolutional code is a forward-error-correction code that encodes data as a sliding function of recent input bits, typically decoded with the Viterbi algorithm.
+keywords: convolutional code, FEC, constraint length, Viterbi, trellis, puncturing
+aka: [convolutional code]
+autolink: true
+infobox:
+  - { label: Type, value: Error-correction code }
+  - { label: Encodes, value: Sliding window of input bits }
+  - { label: Decoded by, value: Viterbi algorithm }
+see_also: [viterbi-algorithm, forward-error-correction, trellis-coded-modulation, m17]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Convolutional code (Wikipedia)", url: https://en.wikipedia.org/wiki/Convolutional_code }
+---
+
+A **convolutional code** is a [forward-error-correction](/reference/forward-error-correction/)
+code in which each output depends on a sliding window of recent input bits, set by the
+*constraint length*.
+
+## How it works
+
+The encoder adds structured redundancy; the receiver uses the
+[Viterbi algorithm](/reference/viterbi-algorithm/) to find the most likely original
+sequence. Puncturing can raise the code rate by omitting some output bits.
+
+## Relevance to SDR
+
+Convolutional coding (K=5) protects [M17](/reference/m17/) and appears in other digital
+radio links to recover from bit errors.

--- a/docs/reference/convolutional-code.md
+++ b/docs/reference/convolutional-code.md
@@ -22,6 +22,19 @@ A **convolutional code** is a [forward-error-correction](/reference/forward-erro
 code in which each output depends on a sliding window of recent input bits, set by the
 *constraint length*.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A shift register of memory cells whose taps are XOR-combined to produce two output bits per input bit." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.3" fill="none"><rect x="60" y="40" width="40" height="30"/><rect x="110" y="40" width="40" height="30"/><rect x="160" y="40" width="40" height="30"/></g>
+  <text x="35" y="59" font-size="9" fill="currentColor">in</text><line x1="44" y1="55" x2="59" y2="55" stroke="currentColor"/>
+  <circle cx="260" cy="35" r="10" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="260" y="39" text-anchor="middle" font-size="10" fill="currentColor">⊕</text>
+  <circle cx="260" cy="95" r="10" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="260" y="99" text-anchor="middle" font-size="10" fill="currentColor">⊕</text>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.7"><line x1="80" y1="40" x2="80" y2="35" /><line x1="80" y1="35" x2="250" y2="35"/><line x1="180" y1="40" x2="180" y2="35"/><line x1="130" y1="70" x2="130" y2="95"/><line x1="130" y1="95" x2="250" y2="95"/><line x1="180" y1="70" x2="180" y2="95"/></g>
+  <line x1="270" y1="35" x2="320" y2="35" stroke="currentColor"/><text x="330" y="39" font-size="9" fill="currentColor">out1</text>
+  <line x1="270" y1="95" x2="320" y2="95" stroke="currentColor"/><text x="330" y="99" font-size="9" fill="currentColor">out2</text>
+</svg>
+<figcaption>A convolutional code outputs parity bits computed from the current and recent input bits via a shift register.</figcaption>
+</figure>
+
 ## How it works
 
 The encoder adds structured redundancy; the receiver uses the

--- a/docs/reference/costas-loop.md
+++ b/docs/reference/costas-loop.md
@@ -23,6 +23,22 @@ A **Costas loop** is a phase-locked feedback structure that recovers the
 [demodulation](/reference/demodulation/) of [PSK](/reference/phase-shift-keying/) and
 related signals.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A feedback loop: input to a phase detector, to a loop filter, to a controlled oscillator that feeds back to the phase detector." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="60" y="40" width="70" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="95" y="54">phase</text><text x="95" y="65">detector</text>
+    <rect x="180" y="40" width="70" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="215" y="54">loop</text><text x="215" y="65">filter</text>
+    <rect x="300" y="40" width="80" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="340" y="54">controlled</text><text x="340" y="65">oscillator</text>
+    <line x1="20" y1="56" x2="59" y2="56" stroke="currentColor" stroke-width="1.1"/><text x="38" y="48">in</text>
+    <line x1="130" y1="56" x2="179" y2="56" stroke="currentColor" stroke-width="1.1" marker-end="url(#clar)"/>
+    <line x1="250" y1="56" x2="299" y2="56" stroke="currentColor" stroke-width="1.1" marker-end="url(#clar)"/>
+    <path d="M340 72 V 105 H 95 V 73" fill="none" stroke="currentColor" stroke-width="1.1" marker-end="url(#clar)"/>
+  </g>
+  <defs><marker id="clar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A Costas loop recovers a PSK carrier by feeding a phase-error estimate back to a controlled oscillator.</figcaption>
+</figure>
+
 ## How it works
 
 It compares in-phase and quadrature error to drive an oscillator that locks to the

--- a/docs/reference/costas-loop.md
+++ b/docs/reference/costas-loop.md
@@ -1,0 +1,36 @@
+---
+slug: costas-loop
+title: Costas loop
+entry_type: algorithm
+category: sdr-dsp
+description: A Costas loop is a feedback circuit that recovers a suppressed carrier's phase and frequency, enabling coherent demodulation of PSK and other phase-modulated signals.
+keywords: Costas loop, carrier recovery, phase locked loop, PSK, coherent demodulation, John Costas
+aka: [Costas loop]
+autolink: true
+infobox:
+  - { label: Type, value: Carrier-recovery loop }
+  - { label: Recovers, value: Carrier phase and frequency }
+  - { label: Used for, value: PSK/QAM coherent demodulation }
+see_also: [phase-shift-keying, phase, demodulation, cma-equalizer, ppm-frequency-correction]
+related_lessons:
+  - { title: "Tuning for a clean lock", url: /learn/tuning-with-scopes/ }
+external:
+  - { title: "Costas loop (Wikipedia)", url: https://en.wikipedia.org/wiki/Costas_loop }
+---
+
+A **Costas loop** is a phase-locked feedback structure that recovers the
+[phase](/reference/phase/) and frequency of a suppressed carrier, enabling **coherent**
+[demodulation](/reference/demodulation/) of [PSK](/reference/phase-shift-keying/) and
+related signals.
+
+## How it works
+
+It compares in-phase and quadrature error to drive an oscillator that locks to the
+carrier, removing residual frequency offset so the
+[constellation](/reference/constellation-diagram/) stops rotating. It is named for John P.
+Costas.
+
+## Relevance to SDR
+
+Carrier recovery via a Costas loop is essential to decoding phase-modulated systems and
+to stabilising a constellation that would otherwise spin.

--- a/docs/reference/cqpsk.md
+++ b/docs/reference/cqpsk.md
@@ -23,6 +23,17 @@ external:
 [C4FM](/reference/c4fm/) used on [P25](/reference/project-25/). It produces the **same
 symbol stream** as C4FM so a single demodulator can receive either.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 210" role="img" aria-label="A QPSK constellation with four points and arcs showing the linear phase transitions between them." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="105" x2="270" y2="105" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="150" y1="20" x2="150" y2="190" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M205 55 A 78 78 0 0 1 205 155" fill="none" stroke="currentColor" stroke-opacity="0.4" stroke-dasharray="3 3"/>
+  <g fill="currentColor"><circle cx="205" cy="55" r="5"/><circle cx="95" cy="55" r="5"/><circle cx="95" cy="155" r="5"/><circle cx="205" cy="155" r="5"/></g>
+  <text x="150" y="205" text-anchor="middle" font-size="9" fill="currentColor">linear phase transitions (compatible with C4FM detection)</text>
+</svg>
+<figcaption>CQPSK conveys the same symbols as C4FM on a linear (phase) path, so one receiver design handles both.</figcaption>
+</figure>
+
 ## How it works
 
 CQPSK uses a linear amplifier and shapes the signal so its phase trajectory matches

--- a/docs/reference/cqpsk.md
+++ b/docs/reference/cqpsk.md
@@ -1,0 +1,35 @@
+---
+slug: cqpsk
+title: CQPSK
+entry_type: technology
+category: modulation
+description: CQPSK (compatible QPSK) is the linear phase-modulation counterpart to C4FM used on P25, producing the same symbols so one demodulator can handle both transmit paths.
+keywords: CQPSK, compatible QPSK, LSM, linear simulcast modulation, P25, phase modulation
+aka: [CQPSK]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation (phase) }
+  - { label: Related to, value: C4FM (same symbols) }
+  - { label: Used by, value: P25 (linear/simulcast path) }
+see_also: [phase-shift-keying, c4fm, project-25, constellation-diagram]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+---
+
+**CQPSK** (compatible QPSK, also linear simulcast modulation, LSM) is the linear
+[phase-modulation](/reference/phase-shift-keying/) counterpart to
+[C4FM](/reference/c4fm/) used on [P25](/reference/project-25/). It produces the **same
+symbol stream** as C4FM so a single demodulator can receive either.
+
+## How it works
+
+CQPSK uses a linear amplifier and shapes the signal so its phase trajectory matches
+C4FM's four levels. Simulcast systems favour it because linear modulation behaves
+better when overlapping transmitters are received together.
+
+## Relevance to SDR
+
+A P25 receiver can demodulate both C4FM and CQPSK; on the
+[constellation](/reference/constellation-diagram/) the recovered symbols look alike.

--- a/docs/reference/cyclic-redundancy-check.md
+++ b/docs/reference/cyclic-redundancy-check.md
@@ -22,6 +22,18 @@ A **cyclic redundancy check** (**CRC**) is an error-*detection* code that append
 checksum computed by polynomial division over the data. A mismatch on receive flags a
 corrupted frame.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A data frame with a CRC value appended, and a check at the receiver that flags pass or fail." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="40" width="220" height="30" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="140" y="59" text-anchor="middle" font-size="9" fill="currentColor">data frame</text>
+  <rect x="250" y="40" width="80" height="30" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/><text x="290" y="59" text-anchor="middle" font-size="9" fill="currentColor">CRC</text>
+  <line x1="334" y1="55" x2="370" y2="55" stroke="currentColor" marker-end="url(#crcar)"/>
+  <text x="410" y="50" font-size="9" fill="currentColor">recompute</text><text x="410" y="63" font-size="9" fill="currentColor">→ pass/fail</text>
+  <text x="180" y="92" text-anchor="middle" font-size="9" fill="currentColor">detects (not corrects) errors</text>
+  <defs><marker id="crcar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A CRC appends a checksum so the receiver can detect whether a frame arrived intact.</figcaption>
+</figure>
+
 ## How it works
 
 Unlike [forward error correction](/reference/forward-error-correction/), a CRC detects

--- a/docs/reference/cyclic-redundancy-check.md
+++ b/docs/reference/cyclic-redundancy-check.md
@@ -1,0 +1,34 @@
+---
+slug: cyclic-redundancy-check
+title: Cyclic redundancy check (CRC)
+entry_type: algorithm
+category: algorithms
+description: A cyclic redundancy check is an error-detection code that appends a checksum computed by polynomial division; it detects corrupted frames in AIS, ADS-B, AX.25, and more.
+keywords: CRC, cyclic redundancy check, checksum, error detection, FCS, polynomial, CRC-24
+aka: [cyclic redundancy check, CRC]
+autolink: true
+infobox:
+  - { label: Type, value: Error-detection code }
+  - { label: Method, value: Polynomial division checksum }
+  - { label: Used by, value: AIS, ADS-B (CRC-24), AX.25, M17 }
+see_also: [forward-error-correction, ads-b, ais, ax25]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Cyclic redundancy check (Wikipedia)", url: https://en.wikipedia.org/wiki/Cyclic_redundancy_check }
+---
+
+A **cyclic redundancy check** (**CRC**) is an error-*detection* code that appends a
+checksum computed by polynomial division over the data. A mismatch on receive flags a
+corrupted frame.
+
+## How it works
+
+Unlike [forward error correction](/reference/forward-error-correction/), a CRC detects
+but does not correct errors. Frames failing the CRC are discarded.
+[ADS-B](/reference/ads-b/) uses CRC-24; [AIS](/reference/ais/) and
+[AX.25](/reference/ax25/) use CRC-16 (FCS).
+
+## Relevance to SDR
+
+CRC validation ensures GopherTrunk only reports data frames that arrived intact.

--- a/docs/reference/d-star.md
+++ b/docs/reference/d-star.md
@@ -1,0 +1,57 @@
+---
+slug: d-star
+title: D-STAR
+entry_type: protocol
+category: protocols
+description: D-STAR (Digital Smart Technologies for Amateur Radio) is an amateur digital-voice and data standard developed by the JARL and popularised by Icom, using GMSK and an AMBE-family vocoder.
+keywords: D-STAR, amateur digital voice, JARL, Icom, GMSK, AMBE, DV, reflectors
+aka: [D-STAR, DSTAR]
+autolink: true
+infobox:
+  - { label: Type, value: Amateur digital voice + data }
+  - { label: Developer, value: JARL (popularised by Icom) }
+  - { label: Access, value: FDMA }
+  - { label: Channel spacing, value: 6.25 kHz (DV) }
+  - { label: Modulation, value: GMSK (4800 bps) }
+  - { label: Vocoder, value: AMBE (DV mode) }
+  - { label: GopherTrunk support, value: See Status }
+see_also: [system-fusion-ysf, m17, gmsk, ambe, vocoder]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "D-STAR (Wikipedia)", url: https://en.wikipedia.org/wiki/D-STAR }
+---
+
+**D-STAR** (**Digital Smart Technologies for Amateur Radio**) is an amateur-radio
+digital voice and data standard developed by the Japan Amateur Radio League (JARL)
+and widely implemented by **Icom**. It uses [GMSK](/reference/gmsk/) modulation and an
+[AMBE](/reference/ambe/)-family [vocoder](/reference/vocoder/) for its digital-voice
+(DV) mode.
+
+## Overview
+
+D-STAR carries digital voice plus a low-rate data stream, and is known for its
+internet-linked **reflectors** and gateways that connect repeaters worldwide. DV mode
+fits in a narrow 6.25 kHz channel.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | [FDMA](/reference/fdma/) |
+| Modulation | GMSK, 4800 bps |
+| Vocoder | AMBE (DV) |
+| Data | Low-rate data alongside voice |
+
+## History
+
+Specified by the JARL around 2001 and brought to market by Icom; one of the earliest
+mainstream amateur digital-voice systems.
+
+## Deployment
+
+Amateur radio worldwide, via DV repeaters, hotspots, and networked reflectors.
+
+## Decoding it with GopherTrunk
+
+See [Status](/status.html) for GopherTrunk's D-STAR link-layer and voice coverage.

--- a/docs/reference/d-star.md
+++ b/docs/reference/d-star.md
@@ -28,6 +28,20 @@ and widely implemented by **Icom**. It uses [GMSK](/reference/gmsk/) modulation 
 [AMBE](/reference/ambe/)-family [vocoder](/reference/vocoder/) for its digital-voice
 (DV) mode.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 110" role="img" aria-label="D-STAR digital voice from radio to repeater to internet gateways." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="44" width="70" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="65" y="63">radio</text>
+    <rect x="150" y="44" width="80" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="190" y="63">repeater</text>
+    <rect x="290" y="44" width="120" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="350" y="58">internet</text><text x="350" y="69" font-size="8">reflectors/gateways</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="100" y1="59" x2="149" y2="59" marker-end="url(#am_d-star)"/><line x1="230" y1="59" x2="289" y2="59" marker-end="url(#am_d-star)"/></g>
+    <text x="65" y="30" font-size="8">GMSK · AMBE</text>
+  </g>
+  <defs><marker id="am_d-star" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>D-STAR carries digital voice and data and links repeaters worldwide via internet reflectors.</figcaption>
+</figure>
+
 ## Overview
 
 D-STAR carries digital voice plus a low-rate data stream, and is known for its

--- a/docs/reference/dbfs.md
+++ b/docs/reference/dbfs.md
@@ -23,6 +23,19 @@ of an SDR. Here **0 dBFS is the ceiling** — the largest value the
 [ADC](/reference/analog-to-digital-converter/) can represent — and real samples sit
 below it as negative numbers.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 150" role="img" aria-label="A vertical scale with 0 dBFS at the top as the ADC ceiling, a signal sitting below it with headroom, and the noise near the bottom." xmlns="http://www.w3.org/2000/svg">
+  <rect x="120" y="20" width="60" height="110" fill="none" stroke="currentColor" stroke-opacity="0.5"/>
+  <line x1="120" y1="30" x2="180" y2="30" stroke="currentColor" stroke-width="2"/>
+  <text x="190" y="33" font-size="10" fill="currentColor">0 dBFS (clip)</text>
+  <rect x="120" y="55" width="60" height="55" fill="currentColor" fill-opacity="0.2"/>
+  <text x="190" y="58" font-size="10" fill="currentColor">headroom</text>
+  <text x="190" y="85" font-size="10" fill="currentColor">signal</text>
+  <text x="190" y="125" font-size="10" fill="currentColor">noise</text>
+</svg>
+<figcaption>dBFS is the digital scale inside the SDR; 0 dBFS is the ADC's ceiling, so real samples sit below it.</figcaption>
+</figure>
+
 ## How it works
 
 If a signal reaches 0 dBFS the converter **clips**, flattening peaks and spraying

--- a/docs/reference/dbfs.md
+++ b/docs/reference/dbfs.md
@@ -1,0 +1,35 @@
+---
+slug: dbfs
+title: dBFS
+entry_type: term
+category: rf-fundamentals
+description: dBFS is level expressed in decibels relative to digital full scale, used inside an SDR; 0 dBFS is the ADC's maximum, and exceeding it causes clipping.
+keywords: dBFS, decibels full scale, ADC, clipping, headroom, digital level
+aka: [dBFS]
+autolink: true
+infobox:
+  - { label: Type, value: Digital level unit }
+  - { label: Reference, value: ADC full scale (0 dBFS max) }
+  - { label: Risk at 0 dBFS, value: Clipping / distortion }
+see_also: [decibel, dbm, analog-to-digital-converter, automatic-gain-control]
+related_lessons:
+  - { title: "Gain, AGC & avoiding overload", url: /learn/gain-and-agc/ }
+external:
+  - { title: "dBFS (Wikipedia)", url: https://en.wikipedia.org/wiki/DBFS }
+---
+
+**dBFS** (decibels relative to **full scale**) measures level inside the digital domain
+of an SDR. Here **0 dBFS is the ceiling** — the largest value the
+[ADC](/reference/analog-to-digital-converter/) can represent — and real samples sit
+below it as negative numbers.
+
+## How it works
+
+If a signal reaches 0 dBFS the converter **clips**, flattening peaks and spraying
+distortion across the spectrum. Leaving headroom below 0 dBFS keeps the signal clean.
+
+## Relevance to SDR
+
+[Gain](/reference/automatic-gain-control/) should be set so the strongest signal peaks
+comfortably under 0 dBFS. dBm describes the world outside the radio;
+[dBFS](/reference/dbfs/) describes the world inside it.

--- a/docs/reference/dbm.md
+++ b/docs/reference/dbm.md
@@ -1,0 +1,34 @@
+---
+slug: dbm
+title: dBm
+entry_type: term
+category: rf-fundamentals
+description: dBm is power expressed in decibels relative to one milliwatt, giving an absolute signal-strength figure; received radio signals are negative dBm values.
+keywords: dBm, decibel milliwatt, absolute power, received signal strength
+aka: [dBm]
+autolink: true
+infobox:
+  - { label: Type, value: Absolute power unit }
+  - { label: Reference, value: 1 milliwatt }
+  - { label: Examples, value: "0 dBm = 1 mW; −80 dBm ≈ solid signal" }
+see_also: [decibel, dbfs, noise-floor, signal-to-noise-ratio]
+related_lessons:
+  - { title: "Decibels & signal power", url: /learn/decibels/ }
+external:
+  - { title: "dBm (Wikipedia)", url: https://en.wikipedia.org/wiki/DBm }
+---
+
+**dBm** is power expressed in [decibels](/reference/decibel/) relative to **one
+milliwatt**, making it an *absolute* measure of signal strength rather than a mere
+ratio. 0 dBm equals 1 mW; +30 dBm is 1 watt.
+
+## How it works
+
+Because received radio signals are tiny fractions of a milliwatt, they are **negative**
+dBm values — and the one closer to zero is stronger (−70 dBm beats −90 dBm by 100×).
+
+## Relevance to SDR
+
+Receiver meters report signal and [noise-floor](/reference/noise-floor/) levels in dBm;
+their difference is the [SNR](/reference/signal-to-noise-ratio/) that determines whether
+a signal decodes.

--- a/docs/reference/dbm.md
+++ b/docs/reference/dbm.md
@@ -22,6 +22,19 @@ external:
 milliwatt**, making it an *absolute* measure of signal strength rather than a mere
 ratio. 0 dBm equals 1 mW; +30 dBm is 1 watt.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A dBm scale showing reference points from +30 dBm (1 watt) down to -120 dBm, with received signals in the negative range." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="60" x2="440" y2="60" stroke="currentColor" stroke-opacity="0.5"/>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <line x1="80" y1="54" x2="80" y2="66" stroke="currentColor"/><text x="80" y="80">+30</text><text x="80" y="44">1 W</text>
+    <line x1="170" y1="54" x2="170" y2="66" stroke="currentColor"/><text x="170" y="80">0</text><text x="170" y="44">1 mW</text>
+    <line x1="280" y1="54" x2="280" y2="66" stroke="currentColor"/><text x="280" y="80">-80</text><text x="280" y="44">strong RX</text>
+    <line x1="400" y1="54" x2="400" y2="66" stroke="currentColor"/><text x="400" y="80">-120 dBm</text><text x="400" y="44">in the noise</text>
+  </g>
+</svg>
+<figcaption>dBm is absolute power referenced to 1 mW. Received signals are negative; closer to zero is stronger.</figcaption>
+</figure>
+
 ## How it works
 
 Because received radio signals are tiny fractions of a milliwatt, they are **negative**

--- a/docs/reference/decibel.md
+++ b/docs/reference/decibel.md
@@ -22,6 +22,23 @@ The **decibel** (**dB**) is a logarithmic unit expressing the ratio between two 
 levels: *dB = 10·log₁₀(P₁/P₂)*. Radio relies on it because signal powers span an
 enormous range and because gains and losses then simply **add**.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A ladder showing that each +10 dB step multiplies power by ten and +3 dB roughly doubles it." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <line x1="60" y1="20" x2="60" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+    <text x="70" y="30">+30 dB = ×1000</text>
+    <text x="70" y="58">+20 dB = ×100</text>
+    <text x="70" y="86">+10 dB = ×10</text>
+    <text x="70" y="114">+3 dB ≈ ×2</text>
+    <line x1="55" y1="26" x2="65" y2="26" stroke="currentColor"/>
+    <line x1="55" y1="54" x2="65" y2="54" stroke="currentColor"/>
+    <line x1="55" y1="82" x2="65" y2="82" stroke="currentColor"/>
+    <line x1="55" y1="110" x2="65" y2="110" stroke="currentColor"/>
+  </g>
+</svg>
+<figcaption>Decibels are logarithmic: every +10 dB is ten times the power, and gains and losses simply add.</figcaption>
+</figure>
+
 ## How it works
 
 Two anchors cover most mental arithmetic: **+3 dB ≈ double the power**, and **+10 dB =

--- a/docs/reference/decibel.md
+++ b/docs/reference/decibel.md
@@ -1,0 +1,35 @@
+---
+slug: decibel
+title: Decibel (dB)
+entry_type: term
+category: rf-fundamentals
+description: The decibel is a logarithmic unit expressing the ratio between two power levels; in radio it makes gains, losses, and huge dynamic ranges easy to add and compare.
+keywords: decibel, dB, logarithmic, ratio, gain, loss, power
+aka: [decibel, dB]
+autolink: true
+infobox:
+  - { label: Type, value: Logarithmic ratio unit }
+  - { label: Formula, value: "dB = 10·log10(P1/P2)" }
+  - { label: Rules, value: "+3 dB ≈ ×2, +10 dB = ×10" }
+see_also: [dbm, dbfs, signal-to-noise-ratio, noise-floor, path-loss, antenna-gain]
+related_lessons:
+  - { title: "Decibels & signal power", url: /learn/decibels/ }
+external:
+  - { title: "Decibel (Wikipedia)", url: https://en.wikipedia.org/wiki/Decibel }
+---
+
+The **decibel** (**dB**) is a logarithmic unit expressing the ratio between two power
+levels: *dB = 10·log₁₀(P₁/P₂)*. Radio relies on it because signal powers span an
+enormous range and because gains and losses then simply **add**.
+
+## How it works
+
+Two anchors cover most mental arithmetic: **+3 dB ≈ double the power**, and **+10 dB =
+ten times**. A chain of amplifier gains and cable losses becomes a running sum in dB.
+
+## Relevance to SDR
+
+Absolute power is given in [dBm](/reference/dbm/); digital headroom in
+[dBFS](/reference/dbfs/). [Antenna gain](/reference/antenna-gain/),
+[path loss](/reference/path-loss/), and [SNR](/reference/signal-to-noise-ratio/) are
+all expressed in decibels.

--- a/docs/reference/decimation.md
+++ b/docs/reference/decimation.md
@@ -1,0 +1,34 @@
+---
+slug: decimation
+title: Decimation
+entry_type: term
+category: sdr-dsp
+description: Decimation reduces a signal's sample rate by keeping every Nth sample after low-pass filtering, shrinking the data rate once a channel has been isolated.
+keywords: decimation, downsampling, sample rate reduction, filter then decimate, CPU
+aka: [decimation]
+autolink: true
+infobox:
+  - { label: Type, value: DSP operation }
+  - { label: Does, value: Lower sample rate after filtering }
+  - { label: Order, value: Filter, then decimate }
+see_also: [digital-filter, cic-filter, sample-rate, aliasing, digital-down-converter]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Decimation (signal processing) (Wikipedia)", url: https://en.wikipedia.org/wiki/Downsampling_(signal_processing) }
+---
+
+**Decimation** reduces a signal's [sample rate](/reference/sample-rate/) by keeping only
+every Nth sample, after a low-pass [filter](/reference/digital-filter/) removes the
+frequencies that would otherwise [alias](/reference/aliasing/).
+
+## How it works
+
+The order matters: **filter first, then decimate**, so out-of-band energy cannot fold
+back. Once a narrow channel is isolated, decimating dramatically cuts the data the rest of
+the pipeline must process.
+
+## Relevance to SDR
+
+Decimation is what makes running [many channels](/reference/digital-down-converter/) from
+one capture computationally feasible.

--- a/docs/reference/decimation.md
+++ b/docs/reference/decimation.md
@@ -22,6 +22,18 @@ external:
 every Nth sample, after a low-pass [filter](/reference/digital-filter/) removes the
 frequencies that would otherwise [alias](/reference/aliasing/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A dense row of samples reduced to a sparse row by keeping every fourth sample after filtering." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor"><circle cx="30" cy="40" r="3"/><circle cx="55" cy="40" r="3"/><circle cx="80" cy="40" r="3"/><circle cx="105" cy="40" r="3"/><circle cx="130" cy="40" r="3"/><circle cx="155" cy="40" r="3"/><circle cx="180" cy="40" r="3"/><circle cx="205" cy="40" r="3"/><circle cx="230" cy="40" r="3"/><circle cx="255" cy="40" r="3"/><circle cx="280" cy="40" r="3"/><circle cx="305" cy="40" r="3"/></g>
+  <text x="350" y="44" font-size="9" fill="currentColor">high rate</text>
+  <line x1="160" y1="55" x2="160" y2="78" stroke="currentColor" marker-end="url(#dcar)"/><text x="200" y="72" font-size="9" fill="currentColor">keep every 4th (÷4)</text>
+  <g fill="currentColor"><circle cx="30" cy="95" r="3"/><circle cx="130" cy="95" r="3"/><circle cx="230" cy="95" r="3"/><circle cx="330" cy="95" r="3"/></g>
+  <text x="370" y="99" font-size="9" fill="currentColor">low rate</text>
+  <defs><marker id="dcar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Decimation lowers the sample rate after filtering, cutting the data the rest of the pipeline must process.</figcaption>
+</figure>
+
 ## How it works
 
 The order matters: **filter first, then decimate**, so out-of-band energy cannot fold

--- a/docs/reference/demodulation.md
+++ b/docs/reference/demodulation.md
@@ -24,6 +24,19 @@ external:
 tracks instantaneous frequency; for [PSK](/reference/phase-shift-keying/) it tracks
 [phase](/reference/phase/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A modulated waveform entering a demodulator block and the recovered message waveform leaving it." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 55 q5 -16 10 0 q5 -22 10 0 q5 -16 10 0 q5 -8 10 0 q5 -16 10 0 q5 -22 10 0 q5 -16 10 0 q5 -8 10 0 q5 -16 10 0 q5 -22 10 0" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <rect x="200" y="38" width="74" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="237" y="59" font-size="9" fill="currentColor" text-anchor="middle">demod</text>
+  <line x1="120" y1="55" x2="199" y2="55" stroke="currentColor" stroke-width="1.1"/>
+  <path d="M290 55 Q 330 30 370 55 T 440 55" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <line x1="274" y1="55" x2="289" y2="55" stroke="currentColor" stroke-width="1.1" marker-end="url(#dmar)"/>
+  <text x="365" y="92" font-size="9" fill="currentColor">recovered message</text>
+  <defs><marker id="dmar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Demodulation recovers the original modulating signal from the carrier — the step before decoding bits.</figcaption>
+</figure>
+
 ## How it works
 
 The demodulator outputs a continuous, noisy stream that *contains* the

--- a/docs/reference/demodulation.md
+++ b/docs/reference/demodulation.md
@@ -1,0 +1,37 @@
+---
+slug: demodulation
+title: Demodulation
+entry_type: term
+category: sdr-dsp
+description: Demodulation recovers the original modulating information from a carrier; for digital signals it produces the symbol stream that decoding then turns into bits.
+keywords: demodulation, demodulator, FM PSK FSK, symbol recovery, decoding, pipeline
+aka: [demodulation]
+autolink: true
+infobox:
+  - { label: Type, value: DSP stage }
+  - { label: Recovers, value: Modulating signal from carrier }
+  - { label: Followed by, value: Symbol recovery, decoding }
+see_also: [modulation, clock-recovery, costas-loop, constellation-diagram, software-defined-radio]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Demodulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Demodulation }
+---
+
+**Demodulation** recovers the original modulating information from a
+[carrier](/reference/carrier-wave/) — the inverse of
+[modulation](/reference/modulation/). For FM/[FSK](/reference/frequency-shift-keying/) it
+tracks instantaneous frequency; for [PSK](/reference/phase-shift-keying/) it tracks
+[phase](/reference/phase/).
+
+## How it works
+
+The demodulator outputs a continuous, noisy stream that *contains* the
+[symbols](/reference/symbol-rate/); [clock recovery](/reference/clock-recovery/) then
+slices it into discrete symbols, which decoding turns into bits. Demodulation handles the
+waveform; decoding handles the data.
+
+## Relevance to SDR
+
+Choosing the matching demodulator for a signal's modulation is the core of recovering it;
+the [constellation](/reference/constellation-diagram/) visualises this stage.

--- a/docs/reference/digital-down-converter.md
+++ b/docs/reference/digital-down-converter.md
@@ -1,0 +1,35 @@
+---
+slug: digital-down-converter
+title: Digital down-converter (DDC)
+entry_type: term
+category: sdr-dsp
+description: A digital down-converter shifts a channel within a wideband IQ stream to baseband using a numerically controlled oscillator, then filters and decimates it for processing.
+keywords: digital down converter, DDC, NCO, channelizer, mixing, decimation
+aka: [digital down-converter, DDC]
+autolink: true
+infobox:
+  - { label: Type, value: DSP block }
+  - { label: Does, value: Shift channel to baseband, filter, decimate }
+  - { label: Uses, value: Numerically controlled oscillator }
+see_also: [local-oscillator, decimation, digital-filter, iq-data, demodulation]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Digital down converter (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_down_converter }
+---
+
+A **digital down-converter** (**DDC**) shifts a chosen channel within a wideband
+[IQ](/reference/iq-data/) stream to baseband using a numerically controlled oscillator
+(a software [local oscillator](/reference/local-oscillator/)), then
+[filters](/reference/digital-filter/) and [decimates](/reference/decimation/) it.
+
+## How it works
+
+Multiplying the IQ by a rotating tone centres the target channel at zero frequency; a
+low-pass filter isolates it and decimation lowers the rate. Many DDCs can run in parallel
+from one capture.
+
+## Relevance to SDR
+
+The DDC is how GopherTrunk extracts a control channel and multiple voice channels from a
+single wideband capture.

--- a/docs/reference/digital-down-converter.md
+++ b/docs/reference/digital-down-converter.md
@@ -23,6 +23,20 @@ A **digital down-converter** (**DDC**) shifts a chosen channel within a wideband
 (a software [local oscillator](/reference/local-oscillator/)), then
 [filters](/reference/digital-filter/) and [decimates](/reference/decimation/) it.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 110" role="img" aria-label="Wideband IQ into a numerically controlled oscillator mixer, then a low-pass filter, then decimation, producing one narrow channel." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="40" y="63">wide IQ</text>
+    <circle cx="120" cy="58" r="20" fill="none" stroke="currentColor" stroke-width="1.3"/><path d="M106 44 L134 72 M134 44 L106 72" stroke="currentColor" stroke-width="1.1"/><text x="120" y="96" font-size="8">NCO</text><line x1="120" y1="92" x2="120" y2="78" stroke="currentColor"/>
+    <rect x="172" y="44" width="74" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="209" y="62">low-pass</text>
+    <rect x="278" y="44" width="84" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="320" y="62">decimate</text>
+    <rect x="394" y="44" width="96" height="28" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="442" y="62">one channel</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="70" y1="58" x2="100" y2="58"/><line x1="140" y1="58" x2="171" y2="58"/><line x1="246" y1="58" x2="277" y2="58"/><line x1="362" y1="58" x2="393" y2="58"/></g>
+  </g>
+</svg>
+<figcaption>A digital down-converter shifts a channel to baseband (NCO), filters it, and decimates — the heart of channelising.</figcaption>
+</figure>
+
 ## How it works
 
 Multiplying the IQ by a rotating tone centres the target channel at zero frequency; a

--- a/docs/reference/digital-filter.md
+++ b/docs/reference/digital-filter.md
@@ -1,0 +1,36 @@
+---
+slug: digital-filter
+title: Digital filter
+entry_type: term
+category: sdr-dsp
+description: A digital filter passes some frequencies and attenuates others by arithmetic on a sample stream; low-pass, band-pass, and channel filters isolate signals in an SDR.
+keywords: digital filter, FIR, IIR, low-pass, band-pass, channel filter, DSP
+aka: [digital filter]
+autolink: true
+infobox:
+  - { label: Type, value: DSP operation }
+  - { label: Kinds, value: FIR, IIR; low-pass, band-pass }
+  - { label: Use, value: Isolate a channel, shape pulses }
+see_also: [decimation, cic-filter, root-raised-cosine-filter, matched-filter, digital-down-converter]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Digital filter (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_filter }
+---
+
+A **digital filter** passes some frequencies and attenuates others by performing
+arithmetic on a stream of samples — no physical components. The main families are FIR
+(finite impulse response) and IIR (infinite impulse response).
+
+## How it works
+
+A low-pass filter keeps frequencies below a cutoff; a band-pass keeps a chosen range. In
+an SDR a narrow **channel filter** isolates one signal from a wide capture, often paired
+with [decimation](/reference/decimation/).
+
+## Relevance to SDR
+
+Filtering is fundamental to channelising the [IQ](/reference/iq-data/) stream and to pulse
+shaping; specialised forms include the [CIC](/reference/cic-filter/),
+[root-raised-cosine](/reference/root-raised-cosine-filter/), and
+[matched](/reference/matched-filter/) filters.

--- a/docs/reference/digital-filter.md
+++ b/docs/reference/digital-filter.md
@@ -22,6 +22,18 @@ A **digital filter** passes some frequencies and attenuates others by performing
 arithmetic on a stream of samples — no physical components. The main families are FIR
 (finite impulse response) and IIR (infinite impulse response).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A frequency-response curve that passes a band of frequencies and attenuates those outside it." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="110" x2="440" y2="110" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="40" y1="20" x2="40" y2="110" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M40 95 L150 95 C 180 95, 180 35, 210 35 L 270 35 C 300 35, 300 95, 330 95 L 440 95" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.8"/>
+  <text x="240" y="28" text-anchor="middle" font-size="10" fill="currentColor">passband</text>
+  <text x="90" y="86" font-size="9" fill="currentColor">rejected</text><text x="390" y="86" font-size="9" fill="currentColor">rejected</text>
+  <text x="240" y="130" text-anchor="middle" font-size="9" fill="currentColor">frequency →</text>
+</svg>
+<figcaption>A digital filter passes a chosen band of frequencies and attenuates the rest — isolating one channel.</figcaption>
+</figure>
+
 ## How it works
 
 A low-pass filter keeps frequencies below a cutoff; a band-pass keeps a chosen range. In

--- a/docs/reference/dipole-antenna.md
+++ b/docs/reference/dipole-antenna.md
@@ -1,0 +1,35 @@
+---
+slug: dipole-antenna
+title: Dipole antenna
+entry_type: term
+category: antennas-propagation
+description: A dipole is a simple resonant antenna of two conductors fed at the centre, typically a half wavelength long, with an omnidirectional pattern broadside to its axis.
+keywords: dipole, half-wave dipole, resonant antenna, radiation pattern, balun
+aka: [dipole antenna, dipole]
+autolink: true
+infobox:
+  - { label: Type, value: Resonant antenna }
+  - { label: Length, value: ~λ/2 (half-wave) }
+  - { label: Pattern, value: Omnidirectional broadside }
+see_also: [antenna, antenna-gain, polarization, wavelength]
+related_lessons:
+  - { title: "Antennas 101", url: /learn/antennas/ }
+external:
+  - { title: "Dipole antenna (Wikipedia)", url: https://en.wikipedia.org/wiki/Dipole_antenna }
+---
+
+A **dipole antenna** is a simple resonant [antenna](/reference/antenna/) made of two
+conductors fed at the centre, classically a **half [wavelength](/reference/wavelength/)**
+long. It is the reference against which other antennas' [gain](/reference/antenna-gain/)
+is often compared.
+
+## How it works
+
+A half-wave dipole radiates most strongly broadside (perpendicular to its axis) and
+least off the ends, giving an omnidirectional doughnut pattern around a vertical
+dipole. Its [polarization](/reference/polarization/) follows its orientation.
+
+## Relevance to SDR
+
+A dipole (or its grounded cousin, the quarter-wave whip) cut for the target band is a
+cheap, effective receive antenna for scanning.

--- a/docs/reference/dipole-antenna.md
+++ b/docs/reference/dipole-antenna.md
@@ -23,6 +23,18 @@ conductors fed at the centre, classically a **half [wavelength](/reference/wavel
 long. It is the reference against which other antennas' [gain](/reference/antenna-gain/)
 is often compared.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 320 150" role="img" aria-label="A centre-fed dipole with two quarter-wave rods and a doughnut-shaped radiation pattern around it." xmlns="http://www.w3.org/2000/svg">
+  <line x1="160" y1="20" x2="160" y2="68" stroke="currentColor" stroke-width="3"/>
+  <line x1="160" y1="82" x2="160" y2="130" stroke="currentColor" stroke-width="3"/>
+  <circle cx="160" cy="75" r="3" fill="currentColor"/>
+  <text x="172" y="48" font-size="10" fill="currentColor">λ/4</text><text x="172" y="112" font-size="10" fill="currentColor">λ/4</text>
+  <ellipse cx="160" cy="75" rx="110" ry="28" fill="none" stroke="currentColor" stroke-opacity="0.4" stroke-dasharray="4 3"/>
+  <text x="250" y="75" font-size="9" fill="currentColor">pattern</text>
+</svg>
+<figcaption>A half-wave dipole is two quarter-wave rods fed in the middle, most sensitive broadside to its length.</figcaption>
+</figure>
+
 ## How it works
 
 A half-wave dipole radiates most strongly broadside (perpendicular to its axis) and

--- a/docs/reference/dmr-tier-1.md
+++ b/docs/reference/dmr-tier-1.md
@@ -27,6 +27,15 @@ external:
 defined by [ETSI](/reference/etsi/) for low-power, short-range consumer and light
 commercial use without an individual user licence.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 360 110" role="img" aria-label="A single licence-free DMR Tier I channel at low power." xmlns="http://www.w3.org/2000/svg">
+  <rect x="60" y="40" width="240" height="34" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/>
+  <text x="180" y="61" text-anchor="middle" font-size="9" fill="currentColor">fixed low-power channel</text>
+  <text x="180" y="96" text-anchor="middle" font-size="9" fill="currentColor">licence-free, no trunking</text>
+</svg>
+<figcaption>DMR Tier I uses fixed, low-power licence-free channels with no system planning or trunking.</figcaption>
+</figure>
+
 ## Overview
 
 Tier I targets the same role as licence-free analog radios, but digital. It uses

--- a/docs/reference/dmr-tier-1.md
+++ b/docs/reference/dmr-tier-1.md
@@ -1,0 +1,59 @@
+---
+slug: dmr-tier-1
+title: DMR Tier I
+entry_type: protocol
+category: protocols
+description: DMR Tier I is the licence-free tier of the ETSI DMR standard, intended for low-power consumer and light commercial use without an individual licence.
+keywords: DMR Tier I, DMR Tier 1, licence-free, PMR446, dPMR, consumer radio
+aka: [DMR Tier I, DMR Tier 1]
+autolink: true
+infobox:
+  - { label: Type, value: Digital land-mobile radio }
+  - { label: Part of, value: DMR (ETSI) }
+  - { label: Licensing, value: Licence-free / low power }
+  - { label: Access, value: TDMA-capable (often single-slot use) }
+  - { label: Channel spacing, value: 12.5 kHz }
+  - { label: Modulation, value: 4FSK }
+  - { label: Vocoder, value: AMBE+2 }
+  - { label: GopherTrunk support, value: As conventional DMR }
+see_also: [dmr, dmr-tier-2, dmr-tier-3, frequency-shift-keying, etsi]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+---
+
+**DMR Tier I** is the **licence-free** tier of the [DMR](/reference/dmr/) standard,
+defined by [ETSI](/reference/etsi/) for low-power, short-range consumer and light
+commercial use without an individual user licence.
+
+## Overview
+
+Tier I targets the same role as licence-free analog radios, but digital. It uses
+fixed low power and a small set of designated channels, so no system planning or
+trunking is involved. Equipment is simple and inexpensive.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Licensing | Licence-free, limited power |
+| Access | Conventional (TDMA-capable hardware) |
+| Channel | 12.5 kHz |
+| Modulation | [4FSK](/reference/frequency-shift-keying/) |
+| Vocoder | [AMBE+2](/reference/ambe-plus-2/) |
+
+## History
+
+Tier I was specified alongside the other tiers in ETSI's DMR documents to cover the
+unlicensed consumer segment.
+
+## Deployment
+
+Found in inexpensive consumer handhelds in regions that allocate licence-free DMR
+channels; less common than Tier II in North America.
+
+## Decoding it with GopherTrunk
+
+Tier I traffic is conventional DMR and decodes like any [Tier II](/reference/dmr-tier-2/)
+conventional channel once tuned. See [Status](/status.html).

--- a/docs/reference/dmr-tier-2.md
+++ b/docs/reference/dmr-tier-2.md
@@ -27,6 +27,16 @@ external:
 standard. It is non-trunked — each repeater pair uses fixed frequencies — but carries
 **two voice timeslots** per 12.5 kHz channel via [TDMA](/reference/tdma/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 140" role="img" aria-label="Two TDMA slots in a conventional DMR Tier II channel." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="105" x2="360" y2="105" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#ta_dmr2)"/>
+  <text x="195" y="128" text-anchor="middle" font-size="9" fill="currentColor">time → · one 12.5 kHz channel, 2 slots</text>
+  <g stroke="currentColor" stroke-width="1.1"><rect x="40" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="92" y="40" width="52" height="50" fill="none"/><rect x="144" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="196" y="40" width="52" height="50" fill="none"/><rect x="248" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="300" y="40" width="52" height="50" fill="none"/></g><g font-size="9" fill="currentColor" text-anchor="middle"><text x="66" y="69">1</text><text x="118" y="69">2</text><text x="170" y="69">1</text><text x="222" y="69">2</text><text x="274" y="69">1</text><text x="326" y="69">2</text></g>
+  <defs><marker id="ta_dmr2" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>DMR Tier II is conventional two-slot TDMA — two calls per fixed channel.</figcaption>
+</figure>
+
 ## Overview
 
 Tier II is the workhorse of commercial DMR and the basis of amateur DMR repeaters.

--- a/docs/reference/dmr-tier-2.md
+++ b/docs/reference/dmr-tier-2.md
@@ -1,0 +1,59 @@
+---
+slug: dmr-tier-2
+title: DMR Tier II
+entry_type: protocol
+category: protocols
+description: DMR Tier II is the licensed conventional tier of the ETSI DMR standard, using two-slot TDMA in 12.5 kHz channels — the most common commercial and amateur DMR mode.
+keywords: DMR Tier II, DMR Tier 2, conventional DMR, MOTOTRBO, two-slot TDMA, AMBE+2
+aka: [DMR Tier II, DMR Tier 2]
+autolink: true
+infobox:
+  - { label: Type, value: Digital land-mobile radio }
+  - { label: Part of, value: DMR (ETSI) }
+  - { label: Licensing, value: Licensed conventional }
+  - { label: Access, value: Two-slot TDMA }
+  - { label: Channel spacing, value: 12.5 kHz }
+  - { label: Modulation, value: 4FSK (9600 bps) }
+  - { label: Vocoder, value: AMBE+2 }
+  - { label: GopherTrunk support, value: Decoded (both slots) }
+see_also: [dmr, dmr-tier-1, dmr-tier-3, tdma, ambe-plus-2]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+---
+
+**DMR Tier II** is the **licensed, conventional** tier of the [DMR](/reference/dmr/)
+standard. It is non-trunked — each repeater pair uses fixed frequencies — but carries
+**two voice timeslots** per 12.5 kHz channel via [TDMA](/reference/tdma/).
+
+## Overview
+
+Tier II is the workhorse of commercial DMR and the basis of amateur DMR repeaters.
+Because it is conventional, you tune directly to a known frequency rather than
+following a [control channel](/reference/control-channel/); the two timeslots still
+allow two simultaneous conversations.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | Two-slot TDMA |
+| Channel | 12.5 kHz |
+| Modulation | [4FSK](/reference/frequency-shift-keying/), 9600 bps |
+| Vocoder | [AMBE+2](/reference/ambe-plus-2/) |
+
+## History
+
+Tier II was the first widely commercialised DMR tier, popularised by Motorola's
+MOTOTRBO line from the late 2000s.
+
+## Deployment
+
+Extremely common in business, utility, and amateur radio. Amateur networks bridge
+Tier II repeaters and hotspots over the internet.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk decodes both timeslots of a Tier II channel and renders AMBE+2 audio. For
+trunked DMR, see [Tier III](/reference/dmr-tier-3/). See [Status](/status.html).

--- a/docs/reference/dmr-tier-3.md
+++ b/docs/reference/dmr-tier-3.md
@@ -29,6 +29,17 @@ adds a [control channel](/reference/control-channel/) and trunking signalling so
 [talkgroups](/reference/talkgroup/) can share a pool of two-slot
 [TDMA](/reference/tdma/) channels, assigned on demand.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 150" role="img" aria-label="A DMR Tier III control channel assigning two-slot TDMA traffic channels from a pool." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="300" height="26" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="190" y="37" text-anchor="middle" font-size="9" fill="currentColor">control channel (CSBK)</text>
+  <g stroke="currentColor" stroke-width="1.1"><rect x="40" y="80" width="90" height="40" fill="none"/><line x1="85" y1="80" x2="85" y2="120"/><rect x="150" y="80" width="90" height="40" fill="none"/><line x1="195" y1="80" x2="195" y2="120"/><rect x="260" y="80" width="80" height="40" fill="currentColor" fill-opacity="0.18"/><line x1="300" y1="80" x2="300" y2="120"/></g>
+  <text x="190" y="138" text-anchor="middle" font-size="8.5" fill="currentColor">two-slot TDMA traffic pool, assigned on demand</text>
+  <line x1="190" y1="46" x2="300" y2="78" stroke="currentColor" stroke-dasharray="3 3" marker-end="url(#t3ar)"/>
+  <defs><marker id="t3ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>DMR Tier III adds a control channel that assigns two-slot TDMA traffic channels — trunked DMR.</figcaption>
+</figure>
+
 ## Overview
 
 Where [Tier II](/reference/dmr-tier-2/) is conventional, Tier III is a full

--- a/docs/reference/dmr-tier-3.md
+++ b/docs/reference/dmr-tier-3.md
@@ -1,0 +1,64 @@
+---
+slug: dmr-tier-3
+title: DMR Tier III
+entry_type: protocol
+category: protocols
+description: DMR Tier III is the trunked tier of the ETSI DMR standard, adding a control channel and signalling (CSBK) so many talkgroups share a pool of two-slot TDMA channels.
+keywords: DMR Tier III, DMR Tier 3, trunked DMR, Capacity Plus, control channel, CSBK, talkgroup
+aka: [DMR Tier III, DMR Tier 3]
+autolink: true
+infobox:
+  - { label: Type, value: Digital trunked radio }
+  - { label: Part of, value: DMR (ETSI) }
+  - { label: Licensing, value: Licensed trunked }
+  - { label: Access, value: Two-slot TDMA + control channel }
+  - { label: Channel spacing, value: 12.5 kHz }
+  - { label: Signalling, value: CSBK (control signalling block) }
+  - { label: Vocoder, value: AMBE+2 }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [dmr, dmr-tier-2, trunked-radio, control-channel, talkgroup, channel-grant, tdma]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+---
+
+**DMR Tier III** is the **trunked** tier of the [DMR](/reference/dmr/) standard. It
+adds a [control channel](/reference/control-channel/) and trunking signalling so many
+[talkgroups](/reference/talkgroup/) can share a pool of two-slot
+[TDMA](/reference/tdma/) channels, assigned on demand.
+
+## Overview
+
+Where [Tier II](/reference/dmr-tier-2/) is conventional, Tier III is a full
+[trunked-radio](/reference/trunked-radio/) system. Radios register
+([affiliate](/reference/affiliation/)) and request calls over the control channel,
+which issues [channel grants](/reference/channel-grant/) pointing them to a traffic
+channel and slot. (Motorola's proprietary Capacity Plus offers similar trunking
+outside the strict Tier III standard.)
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | Two-slot TDMA + dedicated control channel |
+| Signalling | CSBK control messages |
+| Channel | 12.5 kHz |
+| Vocoder | [AMBE+2](/reference/ambe-plus-2/) |
+
+## History
+
+Tier III trunking was standardised by [ETSI](/reference/etsi/) to give DMR a
+multi-site, high-capacity option competing with P25 and TETRA in the commercial
+market.
+
+## Deployment
+
+Used by larger commercial, utility, and transport operators needing trunked capacity
+at lower cost than [TETRA](/reference/tetra/) or [P25](/reference/project-25/).
+
+## Decoding it with GopherTrunk
+
+GopherTrunk locks the Tier III control channel, follows CSBK channel grants to the
+assigned channel/slot, and decodes the voice. See [Status](/status.html).

--- a/docs/reference/dmr.md
+++ b/docs/reference/dmr.md
@@ -31,6 +31,16 @@ places **two timeslots** ([TDMA](/reference/tdma/)) in a 12.5 kHz channel using
 [4FSK](/reference/frequency-shift-keying/) modulation and the
 [AMBE+2](/reference/ambe-plus-2/) vocoder.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 140" role="img" aria-label="Two TDMA slots in a 12.5 kHz DMR channel." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="105" x2="360" y2="105" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#ta_dmr)"/>
+  <text x="195" y="128" text-anchor="middle" font-size="9" fill="currentColor">time → · one 12.5 kHz channel, 2 slots</text>
+  <g stroke="currentColor" stroke-width="1.1"><rect x="40" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="92" y="40" width="52" height="50" fill="none"/><rect x="144" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="196" y="40" width="52" height="50" fill="none"/><rect x="248" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="300" y="40" width="52" height="50" fill="none"/></g><g font-size="9" fill="currentColor" text-anchor="middle"><text x="66" y="69">1</text><text x="118" y="69">2</text><text x="170" y="69">1</text><text x="222" y="69">2</text><text x="274" y="69">1</text><text x="326" y="69">2</text></g>
+  <defs><marker id="ta_dmr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>DMR divides each 12.5 kHz channel into two TDMA timeslots.</figcaption>
+</figure>
+
 ## Overview
 
 DMR's low cost and ETSI openness made it ubiquitous outside public safety. It is

--- a/docs/reference/dmr.md
+++ b/docs/reference/dmr.md
@@ -1,0 +1,70 @@
+---
+slug: dmr
+title: Digital Mobile Radio (DMR)
+entry_type: protocol
+category: protocols
+description: Digital Mobile Radio (DMR) is an ETSI open standard for digital two-way radio using two-slot TDMA in a 12.5 kHz channel with the AMBE+2 vocoder, defined in three tiers.
+keywords: DMR, Digital Mobile Radio, ETSI, two-slot TDMA, AMBE+2, Tier I II III, MOTOTRBO
+aka: [DMR, Digital Mobile Radio]
+autolink: true
+infobox:
+  - { label: Type, value: Digital land-mobile radio }
+  - { label: Standards body, value: ETSI }
+  - { label: Introduced, value: "2005" }
+  - { label: Access, value: TDMA (2 slots) }
+  - { label: Channel spacing, value: 12.5 kHz }
+  - { label: Modulation, value: 4FSK (4800 baud, 9600 bps) }
+  - { label: Vocoder, value: AMBE+2 }
+  - { label: Tiers, value: I (licence-free), II (conventional), III (trunked) }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [dmr-tier-1, dmr-tier-2, dmr-tier-3, ambe-plus-2, tdma, etsi, control-channel]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+---
+
+**Digital Mobile Radio** (**DMR**) is an open digital two-way-radio standard from
+[ETSI](/reference/etsi/), widely used in business, commercial, and amateur radio. It
+places **two timeslots** ([TDMA](/reference/tdma/)) in a 12.5 kHz channel using
+[4FSK](/reference/frequency-shift-keying/) modulation and the
+[AMBE+2](/reference/ambe-plus-2/) vocoder.
+
+## Overview
+
+DMR's low cost and ETSI openness made it ubiquitous outside public safety. It is
+defined in three tiers of increasing capability:
+[Tier I](/reference/dmr-tier-1/) (licence-free), [Tier II](/reference/dmr-tier-2/)
+(licensed conventional), and [Tier III](/reference/dmr-tier-3/) (trunked with a
+[control channel](/reference/control-channel/)). Motorola's MOTOTRBO is the
+best-known commercial implementation.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | Two-slot TDMA |
+| Channel | 12.5 kHz |
+| Modulation | 4FSK, 4800 [baud](/reference/symbol-rate/) (9600 bps) |
+| Vocoder | AMBE+2 |
+| Error correction | Golay, Hamming, BPTC, Reed–Solomon (by burst) |
+
+Two-slot TDMA effectively yields 6.25 kHz-equivalent efficiency, letting two calls
+share one frequency.
+
+## History
+
+ETSI published the DMR standard in 2005, with commercial radios following soon after.
+Amateur DMR grew rapidly in the 2010s via networked repeaters and hotspots.
+
+## Deployment
+
+DMR dominates commercial/business radio and is popular with amateurs. Trunked
+deployments use Tier III; most conventional business and ham systems are Tier II.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk decodes both DMR timeslots, follows Tier III trunking, and renders AMBE+2
+audio. Optional known-key [DMR encryption](/dmr-encryption.html) handling is
+documented separately. See [Status](/status.html).

--- a/docs/reference/dpmr.md
+++ b/docs/reference/dpmr.md
@@ -1,0 +1,57 @@
+---
+slug: dpmr
+title: dPMR
+entry_type: protocol
+category: protocols
+description: dPMR (digital private mobile radio) is an ETSI narrowband 4FSK standard using 6.25 kHz FDMA channels, closely related to NXDN, for licence-free and licensed business radio.
+keywords: dPMR, digital private mobile radio, ETSI, 6.25 kHz, narrowband, FDMA, 4FSK
+aka: [dPMR]
+autolink: true
+infobox:
+  - { label: Type, value: Digital land-mobile radio }
+  - { label: Standards body, value: ETSI }
+  - { label: Access, value: FDMA }
+  - { label: Channel spacing, value: 6.25 kHz }
+  - { label: Modulation, value: 4FSK (2400 baud) }
+  - { label: Vocoder, value: AMBE+2 }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [nxdn, frequency-shift-keying, ambe-plus-2, etsi, fdma]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "dPMR (Wikipedia)", url: https://en.wikipedia.org/wiki/DPMR }
+---
+
+**dPMR** (**digital private mobile radio**) is an [ETSI](/reference/etsi/) narrowband
+standard using **6.25 kHz** [FDMA](/reference/fdma/) channels with
+[4FSK](/reference/frequency-shift-keying/) modulation. It is technically close to
+[NXDN](/reference/nxdn/) and serves the same low-cost, spectrum-efficient niche.
+
+## Overview
+
+dPMR comes in licence-free (Mode 1) and licensed conventional/trunked variants. Its
+6.25 kHz channelisation packs more users into a band than 12.5 kHz systems.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | FDMA |
+| Channel | 6.25 kHz |
+| Modulation | 4FSK, 2400 baud |
+| Vocoder | [AMBE+2](/reference/ambe-plus-2/) |
+
+## History
+
+Standardised by ETSI in parallel with the narrowbanding push of the late 2000s as an
+open alternative for low-tier business radio.
+
+## Deployment
+
+Used in European and international business radio; less common in North America than
+[DMR](/reference/dmr/) or [NXDN](/reference/nxdn/).
+
+## Decoding it with GopherTrunk
+
+dPMR decodes similarly to NXDN given its shared narrowband 4FSK design. See
+[Status](/status.html).

--- a/docs/reference/dpmr.md
+++ b/docs/reference/dpmr.md
@@ -27,6 +27,19 @@ standard using **6.25 kHz** [FDMA](/reference/fdma/) channels with
 [4FSK](/reference/frequency-shift-keying/) modulation. It is technically close to
 [NXDN](/reference/nxdn/) and serves the same low-cost, spectrum-efficient niche.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 360 150" role="img" aria-label="Narrow 6.25 kHz FDMA channels for dPMR." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="135" x2="40" y2="20" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#fa_dpmr)"/>
+  <text x="22" y="80" font-size="9" fill="currentColor" transform="rotate(-90 22 80)">frequency</text>
+  <g fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1">
+    <rect x="50" y="28" width="260" height="22"/><rect x="50" y="60" width="260" height="22"/><rect x="50" y="92" width="260" height="22"/>
+  </g>
+  <g font-size="8.5" fill="currentColor"><text x="180" y="43" text-anchor="middle">one call per channel (6.25 kHz)</text><text x="180" y="75" text-anchor="middle">one call per channel</text><text x="180" y="107" text-anchor="middle">one call per channel</text></g>
+  <defs><marker id="fa_dpmr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>dPMR uses 6.25 kHz FDMA channels, like its close relative NXDN.</figcaption>
+</figure>
+
 ## Overview
 
 dPMR comes in licence-free (Mode 1) and licensed conventional/trunked variants. Its

--- a/docs/reference/dsc.md
+++ b/docs/reference/dsc.md
@@ -1,0 +1,59 @@
+---
+slug: dsc
+title: Digital Selective Calling (DSC)
+entry_type: protocol
+category: protocols
+description: DSC (Digital Selective Calling) is a maritime calling and distress-alerting protocol, sending FSK data bursts on VHF channel 70 and HF to address specific stations or signal emergencies.
+keywords: DSC, Digital Selective Calling, GMDSS, VHF channel 70, distress alert, MMSI, FFSK, maritime
+aka: [DSC]
+autolink: true
+infobox:
+  - { label: Type, value: Maritime calling / distress alerting }
+  - { label: Standards body, value: ITU (GMDSS) }
+  - { label: Band, value: VHF Ch 70 (156.525 MHz) + HF }
+  - { label: Modulation, value: FSK data burst }
+  - { label: Addressing, value: MMSI (selective calling) }
+  - { label: Error correction, value: Symbol repetition + parity }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [ais, ffsk, frequency-shift-keying, itu]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Digital selective calling (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_selective_calling }
+  - { title: "GopherTrunk DSC decoder", url: /dsc.html }
+---
+
+**DSC** (**Digital Selective Calling**) is a maritime protocol for **calling specific
+stations and broadcasting distress alerts**. Part of the Global Maritime Distress and
+Safety System (GMDSS), it sends short [FSK](/reference/frequency-shift-keying/) data
+bursts on **VHF channel 70** (156.525 MHz) and on HF.
+
+## Overview
+
+A DSC message carries the sender's and (for selective calls) recipient's MMSI, a
+category (routine, safety, urgency, distress), and optional position. A distress alert
+automatically conveys identity and, if interfaced, GPS position. DSC complements
+[AIS](/reference/ais/) on the safety side.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Band | VHF Ch 70 + HF DSC frequencies |
+| Modulation | FSK burst |
+| Addressing | MMSI |
+| Error control | Symbol repetition + parity |
+
+## History
+
+Standardised by the [ITU](/reference/itu/) and mandated within GMDSS from the 1990s to
+modernise distress alerting beyond voice calling.
+
+## Deployment
+
+SOLAS and recreational vessels, coast stations, and rescue coordination centres.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk demodulates the FSK, applies the symbol-repetition error control, and
+decodes DSC messages. See the [DSC decoder](/dsc.html) page.

--- a/docs/reference/dsc.md
+++ b/docs/reference/dsc.md
@@ -28,6 +28,15 @@ stations and broadcasting distress alerts**. Part of the Global Maritime Distres
 Safety System (GMDSS), it sends short [FSK](/reference/frequency-shift-keying/) data
 bursts on **VHF channel 70** (156.525 MHz) and on HF.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="A short Digital Selective Calling burst carrying a call type and the sender's maritime identity." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1"><rect x="40" y="40" width="70" height="28" fill="currentColor" fill-opacity="0.12"/><rect x="110" y="40" width="120" height="28" fill="currentColor" fill-opacity="0.22"/><rect x="230" y="40" width="120" height="28" fill="none"/><rect x="350" y="40" width="70" height="28" fill="none"/></g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="75" y="58">dotting</text><text x="170" y="58">format / MMSI</text><text x="290" y="58">distress / call</text><text x="385" y="58">ECC</text></g>
+  <text x="230" y="88" text-anchor="middle" font-size="8" fill="currentColor">FFSK · VHF Ch 70 (and HF)</text>
+</svg>
+<figcaption>DSC sends short FFSK bursts on VHF channel 70 for distress and routine calling, carrying the sender's MMSI.</figcaption>
+</figure>
+
 ## Overview
 
 A DSC message carries the sender's and (for selective calls) recipient's MMSI, a

--- a/docs/reference/dvsi.md
+++ b/docs/reference/dvsi.md
@@ -1,0 +1,35 @@
+---
+slug: dvsi
+title: Digital Voice Systems (DVSI)
+entry_type: organization
+category: organizations
+description: Digital Voice Systems, Inc. (DVSI) is the company that develops and licenses the IMBE and AMBE vocoder families used by P25, DMR, NXDN, and D-STAR.
+keywords: DVSI, Digital Voice Systems, IMBE, AMBE, AMBE+2, vocoder licensing, patents
+aka: [DVSI, Digital Voice Systems]
+autolink: true
+infobox:
+  - { label: Type, value: Company }
+  - { label: Products, value: IMBE, AMBE, AMBE+2 vocoders }
+  - { label: Note, value: Patented/licensed codecs }
+see_also: [vocoder, imbe, ambe, ambe-plus-2, multi-band-excitation]
+related_lessons:
+  - { title: "Vocoders — IMBE & AMBE+2", url: /learn/vocoders/ }
+external:
+  - { title: "Digital Voice Systems (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+---
+
+**Digital Voice Systems, Inc.** (**DVSI**) is the company that develops and licenses the
+[IMBE](/reference/imbe/) and [AMBE](/reference/ambe/) / [AMBE+2](/reference/ambe-plus-2/)
+[vocoder](/reference/vocoder/) families based on
+[multi-band excitation](/reference/multi-band-excitation/).
+
+## Overview
+
+DVSI's codecs are used by [P25](/reference/project-25/), [DMR](/reference/dmr/),
+[NXDN](/reference/nxdn/), and [D-STAR](/reference/d-star/). Their patented, licensed nature
+is why open alternatives like [Codec 2](/reference/codec2/) exist.
+
+## Relevance to SDR
+
+GopherTrunk implements the relevant vocoders in pure Go to decode digital voice, while
+respecting the patent/licensing landscape DVSI created.

--- a/docs/reference/dvsi.md
+++ b/docs/reference/dvsi.md
@@ -23,6 +23,19 @@ external:
 [vocoder](/reference/vocoder/) families based on
 [multi-band excitation](/reference/multi-band-excitation/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="DVSI develops and licenses the AMBE and IMBE vocoders used by digital systems." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="100" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="70" y="61">DVSI</text>
+    <rect x="170" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="225" y="61">licenses</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">AMBE · IMBE</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="120" y1="58" x2="169" y2="58" marker-end="url(#rel_dvsi)"/><line x1="280" y1="58" x2="329" y2="58" marker-end="url(#rel_dvsi)"/></g>
+  </g>
+  <defs><marker id="rel_dvsi" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>DVSI develops and licenses the patented AMBE and IMBE vocoders.</figcaption>
+</figure>
+
 ## Overview
 
 DVSI's codecs are used by [P25](/reference/project-25/), [DMR](/reference/dmr/),

--- a/docs/reference/edacs.md
+++ b/docs/reference/edacs.md
@@ -27,6 +27,17 @@ M-A-COM). It uses a **dedicated [control channel](/reference/control-channel/)**
 continuously coordinates the system, with analog FM voice or the digital **ProVoice**
 ([AMBE](/reference/ambe/)) option.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 140" role="img" aria-label="EDACS dedicated control channel assigning analog or ProVoice channels." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="300" height="26" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="190" y="37" text-anchor="middle" font-size="9" fill="currentColor">dedicated control channel</text>
+  <g stroke="currentColor" stroke-width="1.1" fill="none"><rect x="40" y="80" width="90" height="34"/><rect x="150" y="80" width="90" height="34"/><rect x="260" y="80" width="80" height="34" fill="currentColor" fill-opacity="0.18"/></g>
+  <text x="190" y="130" text-anchor="middle" font-size="8.5" fill="currentColor">analog FM voice channels (assigned on demand)</text>
+  <line x1="190" y1="46" x2="300" y2="78" stroke="currentColor" stroke-dasharray="3 3" marker-end="url(#lg_edacs)"/>
+  <defs><marker id="lg_edacs" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>EDACS uses a dedicated control channel to assign analog FM (or digital ProVoice) channels.</figcaption>
+</figure>
+
 ## Overview
 
 EDACS is known for fast call setup via its always-on control channel and tightly

--- a/docs/reference/edacs.md
+++ b/docs/reference/edacs.md
@@ -1,0 +1,56 @@
+---
+slug: edacs
+title: EDACS
+entry_type: protocol
+category: protocols
+description: EDACS (Enhanced Digital Access Communications System) is a trunked-radio system from GE/Ericsson/M-A-COM using a dedicated control channel, with analog and ProVoice digital variants.
+keywords: EDACS, Ericsson, GE, M/A-COM, trunked radio, ProVoice, control channel, legacy
+aka: [EDACS]
+autolink: true
+infobox:
+  - { label: Type, value: Trunked radio (analog & digital) }
+  - { label: Developer, value: GE / Ericsson / M-A-COM }
+  - { label: Era, value: 1980s–2000s }
+  - { label: Access, value: FDMA with dedicated control channel }
+  - { label: Voice, value: Analog FM or ProVoice (AMBE) }
+  - { label: GopherTrunk support, value: See Status }
+see_also: [trunked-radio, control-channel, motorola-type-ii, ltr, mpt-1327]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Enhanced Digital Access Communications System (Wikipedia)", url: https://en.wikipedia.org/wiki/Enhanced_Digital_Access_Communications_System }
+---
+
+**EDACS** (**Enhanced Digital Access Communications System**) is a
+[trunked-radio](/reference/trunked-radio/) system developed by GE/Ericsson (later
+M-A-COM). It uses a **dedicated [control channel](/reference/control-channel/)** that
+continuously coordinates the system, with analog FM voice or the digital **ProVoice**
+([AMBE](/reference/ambe/)) option.
+
+## Overview
+
+EDACS is known for fast call setup via its always-on control channel and tightly
+specified channel numbering. Systems can be wide-area (multi-site) and were a primary
+competitor to [Motorola Type II](/reference/motorola-type-ii/).
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | [FDMA](/reference/fdma/) |
+| Control channel | Dedicated, continuous |
+| Voice | Analog FM or ProVoice (digital) |
+
+## History
+
+Deployed from the 1980s by GE/Ericsson and M-A-COM for public-safety and utility
+fleets; gradually displaced by [P25](/reference/project-25/).
+
+## Deployment
+
+Legacy public-safety, utility, and transportation systems, some still operating.
+
+## Decoding it with GopherTrunk
+
+See the [Status](/status.html) page for GopherTrunk's EDACS coverage (control-channel
+following and supported voice modes).

--- a/docs/reference/edwin-armstrong.md
+++ b/docs/reference/edwin-armstrong.md
@@ -1,0 +1,38 @@
+---
+slug: edwin-armstrong
+title: Edwin Armstrong
+entry_type: person
+category: people
+description: Edwin Armstrong (1890–1954) was an American engineer who invented the regenerative and superheterodyne receivers and wide-band frequency modulation (FM).
+keywords: Edwin Armstrong, FM, frequency modulation, superheterodyne, regeneration, radio inventor
+aka: [Edwin Armstrong, Edwin Howard Armstrong]
+autolink: true
+infobox:
+  - { label: Lived, value: "1890–1954" }
+  - { label: Field, value: Electrical engineering }
+  - { label: Known for, value: FM, superheterodyne receiver }
+see_also: [frequency-modulation, superheterodyne-receiver, radio-wave]
+related_lessons:
+  - { title: "Analog modulation — AM, FM, SSB", url: /learn/analog-modulation/ }
+external:
+  - { title: "Edwin Howard Armstrong (Wikipedia)", url: https://en.wikipedia.org/wiki/Edwin_Howard_Armstrong }
+---
+
+**Edwin Armstrong** (1890–1954) was an American electrical engineer who invented several
+cornerstones of radio, most notably wide-band **[frequency modulation](/reference/frequency-modulation/)**.
+
+## Life and work
+
+Armstrong devised the regenerative receiver, the
+[superheterodyne receiver](/reference/superheterodyne-receiver/) architecture still used
+today, and FM broadcasting, which dramatically improved audio quality and noise immunity.
+
+## Contribution
+
+The superheterodyne principle underlies almost every receiver — including the front end of
+an SDR — and FM remains central to analog and digital voice.
+
+## Legacy
+
+Armstrong's inventions shaped 20th-century radio; the superheterodyne is arguably the most
+important receiver architecture ever devised.

--- a/docs/reference/edwin-armstrong.md
+++ b/docs/reference/edwin-armstrong.md
@@ -21,6 +21,15 @@ external:
 **Edwin Armstrong** (1890–1954) was an American electrical engineer who invented several
 cornerstones of radio, most notably wide-band **[frequency modulation](/reference/frequency-modulation/)**.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="An FM waveform whose cycle spacing varies with the message at constant amplitude, contrasted with noisy AM." xmlns="http://www.w3.org/2000/svg">
+  <text x="20" y="22" font-size="9" fill="currentColor">FM (Armstrong)</text>
+  <path d="M20 50 q4 -20 8 0 q4 -20 8 0 q6 -20 12 0 q8 -20 16 0 q8 -20 16 0 q6 -20 12 0 q4 -20 8 0 q4 -20 8 0 q4 -20 8 0 q6 -20 12 0 q8 -20 16 0 q8 -20 16 0 q6 -20 12 0 q4 -20 8 0" fill="none" stroke="currentColor" stroke-width="1.4"/>
+  <text x="20" y="92" font-size="9" fill="currentColor">resists amplitude noise → clear audio</text>
+</svg>
+<figcaption>Armstrong invented FM (and the superheterodyne and regenerative receivers), giving radio static-free audio.</figcaption>
+</figure>
+
 ## Life and work
 
 Armstrong devised the regenerative receiver, the

--- a/docs/reference/electromagnetic-spectrum.md
+++ b/docs/reference/electromagnetic-spectrum.md
@@ -1,0 +1,38 @@
+---
+slug: electromagnetic-spectrum
+title: Electromagnetic spectrum
+entry_type: term
+category: rf-fundamentals
+description: The electromagnetic spectrum is the full range of electromagnetic radiation by frequency, from radio waves through microwaves, infrared, visible light, and on to X-rays and gamma rays.
+keywords: electromagnetic spectrum, EM spectrum, radio waves, frequency range, light, microwaves
+aka: [electromagnetic spectrum, EM spectrum]
+autolink: true
+infobox:
+  - { label: Type, value: Physical concept }
+  - { label: Radio portion, value: ~3 kHz – 300 GHz }
+  - { label: Travels at, value: Speed of light }
+see_also: [radio-wave, frequency, wavelength, frequency-bands]
+related_lessons:
+  - { title: "What is a radio wave?", url: /learn/radio-waves/ }
+external:
+  - { title: "Electromagnetic spectrum (Wikipedia)", url: https://en.wikipedia.org/wiki/Electromagnetic_spectrum }
+---
+
+The **electromagnetic spectrum** is the full range of electromagnetic radiation
+ordered by frequency (or, equivalently, wavelength). It spans from low-frequency
+[radio waves](/reference/radio-wave/) through microwaves, infrared, visible light,
+ultraviolet, X-rays, and gamma rays — all the same phenomenon vibrating at different
+rates.
+
+## Overview
+
+Every part of the spectrum is electromagnetic energy travelling at the speed of light;
+only the [frequency](/reference/frequency/) (and thus [wavelength](/reference/wavelength/))
+differs. Radio occupies the low-frequency end, conventionally about **3 kHz to 300
+GHz**, which is slow enough that electronics can generate and detect it directly.
+
+## Relevance to SDR
+
+Software-defined radios operate within the radio portion of the spectrum. Where a
+signal sits in that range — its [band](/reference/frequency-bands/) — determines how it
+propagates, what antenna it needs, and what equipment can receive it.

--- a/docs/reference/electromagnetic-spectrum.md
+++ b/docs/reference/electromagnetic-spectrum.md
@@ -24,6 +24,26 @@ ordered by frequency (or, equivalently, wavelength). It spans from low-frequency
 ultraviolet, X-rays, and gamma rays — all the same phenomenon vibrating at different
 rates.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 110" role="img" aria-label="The electromagnetic spectrum from radio waves through microwaves, infrared, visible light, ultraviolet, X-rays and gamma rays, with the radio portion highlighted." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="30" width="60" height="26" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/>
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <rect x="80" y="30" width="60" height="26"/><rect x="140" y="30" width="60" height="26"/>
+    <rect x="200" y="30" width="60" height="26"/><rect x="260" y="30" width="60" height="26"/>
+    <rect x="320" y="30" width="60" height="26"/><rect x="380" y="30" width="80" height="26"/>
+  </g>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <text x="50" y="47">Radio</text><text x="110" y="47">Micro</text><text x="170" y="47">IR</text>
+    <text x="230" y="47">Visible</text><text x="290" y="47">UV</text><text x="350" y="47">X-ray</text><text x="420" y="47">Gamma</text>
+  </g>
+  <text x="20" y="78" font-size="9" fill="currentColor">lower frequency · longer wavelength</text>
+  <text x="460" y="78" font-size="9" fill="currentColor" text-anchor="end">higher frequency</text>
+  <line x1="20" y1="66" x2="460" y2="66" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#emar)"/>
+  <defs><marker id="emar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Radio occupies the low-frequency, long-wavelength end of the same electromagnetic spectrum as light and X-rays.</figcaption>
+</figure>
+
 ## Overview
 
 Every part of the spectrum is electromagnetic energy travelling at the speed of light;

--- a/docs/reference/etsi.md
+++ b/docs/reference/etsi.md
@@ -1,0 +1,34 @@
+---
+slug: etsi
+title: ETSI
+entry_type: organization
+category: organizations
+description: ETSI, the European Telecommunications Standards Institute, is the standards body behind DMR, dPMR, and TETRA, among many telecommunications standards.
+keywords: ETSI, European Telecommunications Standards Institute, DMR, dPMR, TETRA, standards
+aka: [ETSI, European Telecommunications Standards Institute]
+autolink: true
+infobox:
+  - { label: Type, value: Standards organization }
+  - { label: Region, value: Europe (global influence) }
+  - { label: Standards, value: DMR, dPMR, TETRA }
+see_also: [dmr, dpmr, tetra, itu]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "ETSI (Wikipedia)", url: https://en.wikipedia.org/wiki/ETSI }
+---
+
+**ETSI** (the **European Telecommunications Standards Institute**) is an independent,
+not-for-profit standards organization whose work is used worldwide. In land-mobile radio
+it authored [DMR](/reference/dmr/), [dPMR](/reference/dpmr/), and
+[TETRA](/reference/tetra/).
+
+## Overview
+
+ETSI's open standards let many vendors build interoperable equipment, which is a large
+part of why DMR became so widespread and inexpensive.
+
+## Relevance to SDR
+
+Several digital systems GopherTrunk decodes are ETSI standards, and their published
+specifications inform how decoders are built.

--- a/docs/reference/etsi.md
+++ b/docs/reference/etsi.md
@@ -23,6 +23,19 @@ not-for-profit standards organization whose work is used worldwide. In land-mobi
 it authored [DMR](/reference/dmr/), [dPMR](/reference/dpmr/), and
 [TETRA](/reference/tetra/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="ETSI publishes standards that radio systems implement." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="100" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="70" y="61">ETSI</text>
+    <rect x="170" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="225" y="61">publishes</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">DMR · TETRA · dPMR</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="120" y1="58" x2="169" y2="58" marker-end="url(#rel_etsi)"/><line x1="280" y1="58" x2="329" y2="58" marker-end="url(#rel_etsi)"/></g>
+  </g>
+  <defs><marker id="rel_etsi" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>ETSI is the European standards body behind DMR, TETRA, and dPMR.</figcaption>
+</figure>
+
 ## Overview
 
 ETSI's open standards let many vendors build interoperable equipment, which is a large

--- a/docs/reference/eye-diagram.md
+++ b/docs/reference/eye-diagram.md
@@ -23,6 +23,19 @@ An **eye diagram** overlays many short segments of a demodulated signal, each on
 symbol period long, so they stack into characteristic "eye" shapes between the symbol
 levels.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 150" role="img" aria-label="An eye diagram with an open eye shape and a dashed vertical line marking the ideal sampling instant at its widest point." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="none" stroke-width="1.2" stroke-opacity="0.85">
+    <path d="M40 30 C120 30 120 120 200 120 C280 120 280 30 360 30"/>
+    <path d="M40 120 C120 120 120 30 200 30 C280 30 280 120 360 120"/>
+    <path d="M40 30 C120 30 120 120 200 120"/><path d="M200 30 C280 30 280 120 360 120"/>
+  </g>
+  <line x1="200" y1="20" x2="200" y2="130" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="200" y="146" text-anchor="middle" font-size="10" fill="currentColor">sample here (eye widest)</text>
+</svg>
+<figcaption>An eye diagram overlays symbol periods; a wide-open eye means good timing and noise margin.</figcaption>
+</figure>
+
 ## How it works
 
 The **wider and taller the eye opening**, the more margin the decoder has to sample

--- a/docs/reference/eye-diagram.md
+++ b/docs/reference/eye-diagram.md
@@ -1,0 +1,36 @@
+---
+slug: eye-diagram
+title: Eye diagram
+entry_type: term
+category: modulation
+description: An eye diagram overlays many symbol periods of a demodulated signal against time; a wide-open "eye" indicates good timing and noise margin for decoding.
+keywords: eye diagram, eye pattern, symbol timing, noise margin, jitter, 4FSK
+aka: [eye diagram, eye pattern]
+autolink: true
+infobox:
+  - { label: Type, value: Signal-quality display }
+  - { label: Axes, value: Amplitude vs. time (overlaid) }
+  - { label: Open eye, value: Good timing/noise margin }
+see_also: [constellation-diagram, clock-recovery, symbol-rate, c4fm]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+  - { title: "Tuning for a clean lock", url: /learn/tuning-with-scopes/ }
+external:
+  - { title: "Eye pattern (Wikipedia)", url: https://en.wikipedia.org/wiki/Eye_pattern }
+---
+
+An **eye diagram** overlays many short segments of a demodulated signal, each one
+symbol period long, so they stack into characteristic "eye" shapes between the symbol
+levels.
+
+## How it works
+
+The **wider and taller the eye opening**, the more margin the decoder has to sample
+each [symbol](/reference/symbol-rate/) correctly. Noise and timing
+[jitter](/reference/clock-recovery/) close the eye. A 4-level signal like
+[C4FM](/reference/c4fm/) shows three stacked eyes.
+
+## Relevance to SDR
+
+GopherTrunk's eye-diagram panel shows timing and noise margin at a glance, complementing
+the [constellation](/reference/constellation-diagram/) for diagnosing a marginal signal.

--- a/docs/reference/fast-fourier-transform.md
+++ b/docs/reference/fast-fourier-transform.md
@@ -22,6 +22,20 @@ The **fast Fourier transform** (**FFT**) is an efficient algorithm for computing
 discrete [Fourier transform](/reference/fourier-transform/), reducing the work enough to
 run many times a second in real time.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A block of time samples feeding an FFT block that outputs a row of frequency bins." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor"><circle cx="30" cy="40" r="2.5"/><circle cx="30" cy="55" r="2.5"/><circle cx="30" cy="70" r="2.5"/><circle cx="30" cy="85" r="2.5"/></g>
+  <text x="30" y="105" text-anchor="middle" font-size="8" fill="currentColor">samples</text>
+  <rect x="70" y="35" width="80" height="60" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="110" y="69" text-anchor="middle" font-size="11" fill="currentColor">FFT</text>
+  <line x1="150" y1="65" x2="190" y2="65" stroke="currentColor" marker-end="url(#fftar)"/>
+  <line x1="200" y1="100" x2="440" y2="100" stroke="currentColor" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-width="3"><line x1="220" y1="100" x2="220" y2="80"/><line x1="250" y1="100" x2="250" y2="55"/><line x1="280" y1="100" x2="280" y2="40"/><line x1="310" y1="100" x2="310" y2="70"/><line x1="340" y1="100" x2="340" y2="85"/><line x1="370" y1="100" x2="370" y2="60"/><line x1="400" y1="100" x2="400" y2="90"/></g>
+  <text x="320" y="118" text-anchor="middle" font-size="8" fill="currentColor">frequency bins</text>
+  <defs><marker id="fftar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The FFT computes the spectrum efficiently, splitting the band into equal frequency bins — the basis of the waterfall.</figcaption>
+</figure>
+
 ## How it works
 
 It splits the captured [bandwidth](/reference/bandwidth/) into a number of **bins** (the

--- a/docs/reference/fast-fourier-transform.md
+++ b/docs/reference/fast-fourier-transform.md
@@ -1,0 +1,34 @@
+---
+slug: fast-fourier-transform
+title: Fast Fourier transform (FFT)
+entry_type: algorithm
+category: algorithms
+description: The fast Fourier transform is an efficient algorithm for computing the discrete Fourier transform, making real-time spectrum and waterfall displays practical.
+keywords: FFT, fast Fourier transform, DFT, spectrum, waterfall, bins, Cooley-Tukey
+aka: [fast Fourier transform, FFT]
+autolink: true
+infobox:
+  - { label: Type, value: Algorithm }
+  - { label: Computes, value: Discrete Fourier transform efficiently }
+  - { label: Output, value: Spectrum (bins) }
+see_also: [fourier-transform, bandwidth, sample-rate, iq-data]
+related_lessons:
+  - { title: "The FFT & reading a waterfall", url: /learn/fft-and-waterfall/ }
+external:
+  - { title: "Fast Fourier transform (Wikipedia)", url: https://en.wikipedia.org/wiki/Fast_Fourier_transform }
+---
+
+The **fast Fourier transform** (**FFT**) is an efficient algorithm for computing the
+discrete [Fourier transform](/reference/fourier-transform/), reducing the work enough to
+run many times a second in real time.
+
+## How it works
+
+It splits the captured [bandwidth](/reference/bandwidth/) into a number of **bins** (the
+FFT size); resolution ≈ [sample rate](/reference/sample-rate/) ÷ FFT size. More bins give
+finer resolution but slower updates and more CPU.
+
+## Relevance to SDR
+
+The FFT drives the spectrum and waterfall displays used to find signals and spot a steady
+[control channel](/reference/control-channel/).

--- a/docs/reference/fcc.md
+++ b/docs/reference/fcc.md
@@ -1,0 +1,35 @@
+---
+slug: fcc
+title: Federal Communications Commission (FCC)
+entry_type: organization
+category: organizations
+description: The FCC is the United States regulator of interstate communications, allocating spectrum, licensing users, and setting technical rules including the narrowbanding mandates that drove digital radio.
+keywords: FCC, Federal Communications Commission, spectrum, licensing, narrowbanding, US regulator
+aka: [FCC, Federal Communications Commission]
+autolink: true
+infobox:
+  - { label: Type, value: US government regulator }
+  - { label: Founded, value: "1934" }
+  - { label: Role, value: US spectrum allocation and licensing }
+see_also: [itu, tia, apco-international, frequency-bands]
+related_lessons:
+  - { title: "Frequency, bands & the spectrum", url: /learn/frequency-and-spectrum/ }
+  - { title: "Legal & ethical monitoring", url: /learn/legal-ethical/ }
+external:
+  - { title: "Federal Communications Commission (Wikipedia)", url: https://en.wikipedia.org/wiki/Federal_Communications_Commission }
+---
+
+The **Federal Communications Commission** (**FCC**) is the United States regulator of
+interstate radio, television, wire, satellite, and cable. It allocates US spectrum,
+licenses users, and sets technical rules.
+
+## Overview
+
+FCC band plans determine where US public-safety, business, and amateur services operate,
+within the global framework of the [ITU](/reference/itu/). Its narrowbanding mandates
+helped push land-mobile radio toward efficient digital systems.
+
+## Relevance to SDR
+
+US monitoring laws and band allocations stem from the FCC; what you may legally receive
+varies by jurisdiction (see the legal lesson).

--- a/docs/reference/fcc.md
+++ b/docs/reference/fcc.md
@@ -23,6 +23,18 @@ The **Federal Communications Commission** (**FCC**) is the United States regulat
 interstate radio, television, wire, satellite, and cable. It allocates US spectrum,
 licenses users, and sets technical rules.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="The FCC dividing the US radio spectrum into allocated service blocks." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="62" x2="430" y2="62" stroke="currentColor" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-width="1.1">
+    <rect x="40" y="44" width="70" height="18" fill="currentColor" fill-opacity="0.12"/><rect x="110" y="44" width="60" height="18" fill="currentColor" fill-opacity="0.22"/><rect x="170" y="44" width="80" height="18" fill="currentColor" fill-opacity="0.12"/><rect x="250" y="44" width="60" height="18" fill="currentColor" fill-opacity="0.22"/><rect x="310" y="44" width="110" height="18" fill="currentColor" fill-opacity="0.12"/>
+  </g>
+  <text x="230" y="30" text-anchor="middle" font-size="9" fill="currentColor">US spectrum allocations &amp; licensing</text>
+  <text x="230" y="86" text-anchor="middle" font-size="8.5" fill="currentColor">allocates the spectrum into services</text>
+</svg>
+<figcaption>The FCC allocates and licenses radio spectrum in the United States.</figcaption>
+</figure>
+
 ## Overview
 
 FCC band plans determine where US public-safety, business, and amateur services operate,

--- a/docs/reference/fdma.md
+++ b/docs/reference/fdma.md
@@ -21,6 +21,19 @@ external:
 **FDMA** (**frequency-division multiple access**) is a channel-access method in which
 each call occupies its own [frequency](/reference/frequency/) channel.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 200" role="img" aria-label="A frequency axis split into separate stacked channels, each carrying one continuous call." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="170" x2="40" y2="20" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#fdar)"/>
+  <text x="20" y="95" font-size="9" fill="currentColor" transform="rotate(-90 20 95)">frequency</text>
+  <g fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1">
+    <rect x="50" y="30" width="220" height="28"/><rect x="50" y="66" width="220" height="28"/><rect x="50" y="102" width="220" height="28"/><rect x="50" y="138" width="220" height="28"/>
+  </g>
+  <g font-size="9" fill="currentColor"><text x="160" y="49" text-anchor="middle">call A</text><text x="160" y="85" text-anchor="middle">call B</text><text x="160" y="121" text-anchor="middle">call C</text><text x="160" y="157" text-anchor="middle">call D</text></g>
+  <defs><marker id="fdar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>FDMA gives each call its own frequency channel — the access method of P25 Phase 1.</figcaption>
+</figure>
+
 ## How it works
 
 Capacity scales with the number of frequencies available; adding conversations means

--- a/docs/reference/fdma.md
+++ b/docs/reference/fdma.md
@@ -1,0 +1,34 @@
+---
+slug: fdma
+title: FDMA
+entry_type: term
+category: trunked-radio
+description: FDMA (frequency-division multiple access) gives each call its own frequency channel; P25 Phase 1 and NXDN use FDMA.
+keywords: FDMA, frequency division multiple access, channel access, P25 Phase 1, NXDN
+aka: [FDMA]
+autolink: true
+infobox:
+  - { label: Type, value: Channel-access method }
+  - { label: Principle, value: One call per frequency }
+  - { label: Used by, value: P25 Phase 1, NXDN, dPMR }
+see_also: [tdma, trunked-radio, p25-phase-1, nxdn]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Frequency-division multiple access (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-division_multiple_access }
+---
+
+**FDMA** (**frequency-division multiple access**) is a channel-access method in which
+each call occupies its own [frequency](/reference/frequency/) channel.
+
+## How it works
+
+Capacity scales with the number of frequencies available; adding conversations means
+adding channels. [P25 Phase 1](/reference/p25-phase-1/), [NXDN](/reference/nxdn/), and
+[dPMR](/reference/dpmr/) use FDMA.
+
+## Relevance to SDR
+
+On an FDMA system each [voice channel](/reference/voice-channel/) is a separate
+frequency the receiver tunes to; contrast with [TDMA](/reference/tdma/), which shares one
+frequency across time slots.

--- a/docs/reference/ffsk.md
+++ b/docs/reference/ffsk.md
@@ -1,0 +1,35 @@
+---
+slug: ffsk
+title: FFSK
+entry_type: technology
+category: modulation
+description: FFSK (fast frequency-shift keying) is a coherent audio FSK where tone frequencies are integer multiples of the bit rate; used by MDC1200, DSC, and MPT 1327 signalling.
+keywords: FFSK, fast frequency shift keying, MDC1200, DSC, MPT 1327, 1200 bps signalling
+aka: [FFSK]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation (coherent audio FSK) }
+  - { label: Property, value: Tones are integer multiples of bit rate }
+  - { label: Used by, value: MDC1200, DSC, MPT 1327 }
+see_also: [afsk, frequency-shift-keying, mdc1200, dsc, mpt-1327]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Frequency-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-shift_keying }
+---
+
+**FFSK** (fast frequency-shift keying) is a coherent form of audio
+[FSK](/reference/frequency-shift-keying/) in which the mark and space tones are exact
+integer multiples of the bit rate, so each bit contains a whole number of cycles. This
+makes detection clean and bit timing easy.
+
+## How it works
+
+The phase-continuous, integer-cycle tones suit short data bursts over analog FM. FFSK
+carries [MDC1200](/reference/mdc1200/) unit IDs, [DSC](/reference/dsc/) maritime calls,
+and [MPT 1327](/reference/mpt-1327/) control signalling, typically at 1200 bps.
+
+## Relevance to SDR
+
+GopherTrunk detects FFSK bursts on analog channels to decode signalling such as PTT
+IDs and trunking control data.

--- a/docs/reference/ffsk.md
+++ b/docs/reference/ffsk.md
@@ -23,6 +23,17 @@ external:
 integer multiples of the bit rate, so each bit contains a whole number of cycles. This
 makes detection clean and bit timing easy.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A fast two-tone FSK waveform with phase-continuous transitions between mark and space tones." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 60 q10 -26 20 0 t20 0 t20 0 t20 0
+            M120 60 q15 -26 30 0 t30 0 t30 0
+            M240 60 q10 -26 20 0 t20 0 t20 0 t20 0 t20 0
+            M360 60 q15 -26 30 0 t30 0 t20 0" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="20" y="100" font-size="9" fill="currentColor">phase-continuous mark/space tones (e.g. 1200/1800 Hz)</text>
+</svg>
+<figcaption>FFSK (fast FSK) is phase-continuous tone signalling used by MDC-1200 and DSC.</figcaption>
+</figure>
+
 ## How it works
 
 The phase-continuous, integer-cycle tones suit short data bursts over analog FM. FFSK

--- a/docs/reference/flex.md
+++ b/docs/reference/flex.md
@@ -1,0 +1,57 @@
+---
+slug: flex
+title: FLEX
+entry_type: protocol
+category: protocols
+description: FLEX is a high-speed one-way paging protocol developed by Motorola, using 4-level FSK at up to 6400 bps with strong synchronisation and error correction for reliable wide-area paging.
+keywords: FLEX paging, Motorola FLEX, 4-FSK, high-speed pager, 1600 3200 6400 bps, simulcast paging
+aka: [FLEX]
+autolink: true
+infobox:
+  - { label: Type, value: One-way paging protocol }
+  - { label: Developer, value: Motorola }
+  - { label: Modulation, value: 2- or 4-level FSK }
+  - { label: Bit rates, value: 1600 / 3200 / 6400 bps }
+  - { label: Error correction, value: BCH + interleaving }
+  - { label: GopherTrunk support, value: See Status }
+see_also: [pocsag, frequency-shift-keying, bch-code, interleaving]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "FLEX (Wikipedia)", url: https://en.wikipedia.org/wiki/FLEX_(protocol) }
+---
+
+**FLEX** is a high-speed one-way **paging** protocol developed by **Motorola** to
+succeed [POCSAG](/reference/pocsag/). It uses 2- or 4-level
+[FSK](/reference/frequency-shift-keying/) at up to 6400 bps, with robust
+synchronisation and [interleaving](/reference/interleaving/) that make it resilient on
+wide-area simulcast networks.
+
+## Overview
+
+FLEX organises traffic into precisely timed frames and phases, allowing high capacity
+and good battery life for pagers. Its time-synchronised structure suits large
+simulcast paging systems covering whole regions.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Modulation | 2-FSK or 4-FSK |
+| Bit rates | 1600, 3200, 6400 bps |
+| Coding | BCH + bit interleaving |
+| Framing | Time-synchronised frames/phases |
+
+## History
+
+Introduced by Motorola in the 1990s as paging demand outgrew POCSAG's capacity; widely
+deployed by commercial paging carriers.
+
+## Deployment
+
+Commercial wide-area paging, healthcare, and emergency notification networks.
+
+## Decoding it with GopherTrunk
+
+FLEX shares the FSK paging family with POCSAG; see [Status](/status.html) for current
+coverage and the [POCSAG decoder](/pocsag.html) page for the paging pipeline.

--- a/docs/reference/flex.md
+++ b/docs/reference/flex.md
@@ -27,6 +27,17 @@ succeed [POCSAG](/reference/pocsag/). It uses 2- or 4-level
 synchronisation and [interleaving](/reference/interleaving/) that make it resilient on
 wide-area simulcast networks.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="A FLEX frame with sync and time-multiplexed blocks, at higher rates than POCSAG." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1">
+    <rect x="30" y="40" width="60" height="28" fill="currentColor" fill-opacity="0.12"/><rect x="90" y="40" width="85" height="28" fill="none"/><rect x="175" y="40" width="85" height="28" fill="none"/><rect x="260" y="40" width="85" height="28" fill="none"/><rect x="345" y="40" width="85" height="28" fill="none"/>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="60" y="58">sync</text><text x="132" y="58">block</text><text x="217" y="58">block</text><text x="302" y="58">block</text><text x="387" y="58">block</text></g>
+  <text x="230" y="88" text-anchor="middle" font-size="8" fill="currentColor">multi-level FSK · up to 6400 bps</text>
+</svg>
+<figcaption>FLEX is a higher-rate paging protocol using time-multiplexed frames and multi-level FSK.</figcaption>
+</figure>
+
 ## Overview
 
 FLEX organises traffic into precisely timed frames and phases, allowing high capacity

--- a/docs/reference/forward-error-correction.md
+++ b/docs/reference/forward-error-correction.md
@@ -22,6 +22,19 @@ external:
 the receiver can **correct** errors on its own, without asking for retransmission —
 essential for broadcast and one-way radio links.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="Data plus added redundancy is transmitted; a bit is flipped in transit, and the receiver corrects it without retransmission." xmlns="http://www.w3.org/2000/svg">
+  <g font-family="monospace" font-size="11" fill="currentColor"><text x="40" y="45">1011</text><text x="100" y="45" fill-opacity="0.6">+ parity</text></g>
+  <line x1="180" y1="40" x2="240" y2="40" stroke="currentColor" marker-end="url(#fecar)"/><text x="210" y="32" text-anchor="middle" font-size="8" fill="currentColor">error</text>
+  <g font-family="monospace" font-size="11" fill="currentColor"><text x="255" y="45">1<tspan fill="currentColor" font-weight="bold">1</tspan>11</text></g>
+  <line x1="320" y1="40" x2="380" y2="40" stroke="currentColor" marker-end="url(#fecar)"/>
+  <g font-family="monospace" font-size="11" fill="currentColor"><text x="395" y="45">1011</text></g>
+  <text x="230" y="90" text-anchor="middle" font-size="9" fill="currentColor">redundancy lets the receiver fix errors with no retransmission</text>
+  <defs><marker id="fecar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Forward error correction adds redundancy so the receiver can repair bit errors on its own.</figcaption>
+</figure>
+
 ## How it works
 
 Encoders such as [Reed–Solomon](/reference/reed-solomon-code/),

--- a/docs/reference/forward-error-correction.md
+++ b/docs/reference/forward-error-correction.md
@@ -1,0 +1,35 @@
+---
+slug: forward-error-correction
+title: Forward error correction (FEC)
+entry_type: term
+category: algorithms
+description: Forward error correction adds structured redundancy to transmitted data so the receiver can detect and correct errors without retransmission — essential for one-way radio links.
+keywords: forward error correction, FEC, redundancy, error correcting code, coding gain
+aka: [forward error correction, FEC]
+autolink: true
+infobox:
+  - { label: Type, value: Error-control strategy }
+  - { label: Adds, value: Redundancy for correction }
+  - { label: Examples, value: Reed–Solomon, BCH, Golay, convolutional }
+see_also: [reed-solomon-code, bch-code, golay-code, hamming-code, convolutional-code, interleaving]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Forward error correction (Wikipedia)", url: https://en.wikipedia.org/wiki/Error_correction_code }
+---
+
+**Forward error correction** (**FEC**) adds structured redundancy to transmitted data so
+the receiver can **correct** errors on its own, without asking for retransmission —
+essential for broadcast and one-way radio links.
+
+## How it works
+
+Encoders such as [Reed–Solomon](/reference/reed-solomon-code/),
+[BCH](/reference/bch-code/), [Golay](/reference/golay-code/), and
+[convolutional](/reference/convolutional-code/) codes add parity that lets the decoder fix
+a bounded number of errors, often aided by [interleaving](/reference/interleaving/).
+
+## Relevance to SDR
+
+FEC is why a digital signal stays perfect until it abruptly fails (the "cliff effect"):
+the decoder fixes errors until it can't, after which audio drops out.

--- a/docs/reference/fourier-transform.md
+++ b/docs/reference/fourier-transform.md
@@ -1,0 +1,34 @@
+---
+slug: fourier-transform
+title: Fourier transform
+entry_type: algorithm
+category: algorithms
+description: The Fourier transform decomposes a signal into its constituent frequencies, converting between the time and frequency domains; it is the mathematical basis of spectrum analysis.
+keywords: Fourier transform, frequency domain, time domain, spectrum, Joseph Fourier
+aka: [Fourier transform]
+autolink: true
+infobox:
+  - { label: Type, value: Mathematical transform }
+  - { label: Converts, value: Time domain ↔ frequency domain }
+  - { label: Named for, value: Joseph Fourier }
+see_also: [fast-fourier-transform, joseph-fourier, bandwidth, software-defined-radio]
+related_lessons:
+  - { title: "The FFT & reading a waterfall", url: /learn/fft-and-waterfall/ }
+external:
+  - { title: "Fourier transform (Wikipedia)", url: https://en.wikipedia.org/wiki/Fourier_transform }
+---
+
+The **Fourier transform** decomposes a signal into the frequencies that compose it,
+converting between the time and frequency domains. It is the mathematical foundation of
+spectrum analysis, named for [Joseph Fourier](/reference/joseph-fourier/).
+
+## How it works
+
+Any signal can be expressed as a sum of sinusoids; the transform reports how much energy
+exists at each frequency. Its discrete, efficient form is the
+[FFT](/reference/fast-fourier-transform/).
+
+## Relevance to SDR
+
+Turning [IQ](/reference/iq-data/) samples into a spectrum — and thus a waterfall — is a
+Fourier transform, the reason you can *see* signals on an SDR.

--- a/docs/reference/fourier-transform.md
+++ b/docs/reference/fourier-transform.md
@@ -22,6 +22,19 @@ The **Fourier transform** decomposes a signal into the frequencies that compose 
 converting between the time and frequency domains. It is the mathematical foundation of
 spectrum analysis, named for [Joseph Fourier](/reference/joseph-fourier/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A complex time-domain waveform on the left transforms into a set of frequency peaks on the right." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 60 q10 -22 20 0 q10 18 20 0 q10 -28 20 0 q10 24 20 0 q10 -16 20 0 q10 20 20 0 q10 -22 20 0" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="100" y="105" text-anchor="middle" font-size="9" fill="currentColor">time domain</text>
+  <line x1="225" y1="60" x2="265" y2="60" stroke="currentColor" marker-end="url(#ftar)"/><text x="245" y="50" text-anchor="middle" font-size="8" fill="currentColor">FT</text>
+  <line x1="290" y1="90" x2="440" y2="90" stroke="currentColor" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-width="2"><line x1="320" y1="90" x2="320" y2="55"/><line x1="360" y1="90" x2="360" y2="35"/><line x1="400" y1="90" x2="400" y2="68"/></g>
+  <text x="365" y="105" text-anchor="middle" font-size="9" fill="currentColor">frequency domain</text>
+  <defs><marker id="ftar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The Fourier transform expresses a signal as a sum of frequencies — converting time into spectrum.</figcaption>
+</figure>
+
 ## How it works
 
 Any signal can be expressed as a sum of sinusoids; the transform reports how much energy

--- a/docs/reference/frequency-bands.md
+++ b/docs/reference/frequency-bands.md
@@ -1,0 +1,36 @@
+---
+slug: frequency-bands
+title: Frequency bands (HF/VHF/UHF)
+entry_type: term
+category: rf-fundamentals
+description: Frequency bands are conventional divisions of the radio spectrum — VLF, LF, MF, HF, VHF, UHF, SHF — each with characteristic propagation and uses.
+keywords: frequency bands, HF, VHF, UHF, SHF, band plan, spectrum allocation
+aka: [VHF, UHF, SHF]
+autolink: true
+infobox:
+  - { label: Type, value: Spectrum divisions }
+  - { label: HF, value: "3–30 MHz" }
+  - { label: VHF, value: "30–300 MHz" }
+  - { label: UHF, value: "300 MHz – 3 GHz" }
+see_also: [electromagnetic-spectrum, frequency, radio-propagation, ionospheric-propagation]
+related_lessons:
+  - { title: "Frequency, bands & the spectrum", url: /learn/frequency-and-spectrum/ }
+external:
+  - { title: "Radio spectrum (Wikipedia)", url: https://en.wikipedia.org/wiki/Radio_spectrum }
+---
+
+**Frequency bands** are the conventional decade-wide divisions of the radio
+[spectrum](/reference/electromagnetic-spectrum/): VLF, LF, MF, **HF** (3–30 MHz),
+**VHF** (30–300 MHz), **UHF** (300 MHz–3 GHz), and SHF (3–30 GHz). Each behaves
+differently and is allocated to different uses.
+
+## How it works
+
+HF can refract off the [ionosphere](/reference/ionospheric-propagation/) for worldwide
+"skip", while VHF and UHF are essentially line-of-sight. Regulators publish band plans
+assigning slices to broadcast, aviation, marine, public safety, and amateur use.
+
+## Relevance to SDR
+
+Most trunked-radio scanning happens in VHF, UHF, and the 700/800 MHz bands. Matching
+an SDR's tuning range to the target band is the first hardware decision.

--- a/docs/reference/frequency-bands.md
+++ b/docs/reference/frequency-bands.md
@@ -24,6 +24,28 @@ external:
 **VHF** (30–300 MHz), **UHF** (300 MHz–3 GHz), and SHF (3–30 GHz). Each behaves
 differently and is allocated to different uses.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 110" role="img" aria-label="A ruler of radio bands from VLF through SHF, with VHF and UHF highlighted as the main scanner bands." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2">
+    <rect x="20" y="34" width="55" height="24" fill="none"/>
+    <rect x="75" y="34" width="55" height="24" fill="none"/>
+    <rect x="130" y="34" width="55" height="24" fill="none"/>
+    <rect x="185" y="34" width="55" height="24" fill="none"/>
+    <rect x="240" y="34" width="80" height="24" fill="currentColor" fill-opacity="0.22"/>
+    <rect x="320" y="34" width="80" height="24" fill="currentColor" fill-opacity="0.22"/>
+    <rect x="400" y="34" width="60" height="24" fill="none"/>
+  </g>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="47" y="50">VLF</text><text x="102" y="50">LF</text><text x="157" y="50">MF</text><text x="212" y="50">HF</text>
+    <text x="280" y="50">VHF</text><text x="360" y="50">UHF</text><text x="430" y="50">SHF</text>
+  </g>
+  <text x="20" y="80" font-size="9" fill="currentColor">3 kHz</text>
+  <text x="460" y="80" font-size="9" fill="currentColor" text-anchor="end">300 GHz</text>
+  <text x="320" y="94" text-anchor="middle" font-size="9" fill="currentColor">most scanning lives in VHF/UHF</text>
+</svg>
+<figcaption>The radio spectrum divided into bands; VHF and UHF carry most scanner and trunked-radio traffic.</figcaption>
+</figure>
+
 ## How it works
 
 HF can refract off the [ionosphere](/reference/ionospheric-propagation/) for worldwide

--- a/docs/reference/frequency-modulation.md
+++ b/docs/reference/frequency-modulation.md
@@ -23,6 +23,14 @@ external:
 [amplitude](/reference/amplitude/) stays constant. The amount of swing is the
 *deviation*.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A carrier whose cycle spacing tightens and loosens with the message, at constant amplitude." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 60 q4 -28 8 0 q4 -28 8 0 q6 -28 12 0 q7 -28 14 0 q8 -28 16 0 q7 -28 14 0 q6 -28 12 0 q4 -28 8 0 q4 -28 8 0 q4 -28 8 0 q6 -28 12 0 q7 -28 14 0 q8 -28 16 0 q7 -28 14 0 q6 -28 12 0 q4 -28 8 0 q4 -28 8 0 q4 -28 8 0 q6 -28 12 0 q7 -28 14 0 q8 -28 16 0" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="20" y="105" font-size="10" fill="currentColor">constant amplitude — information is in the spacing (frequency)</text>
+</svg>
+<figcaption>FM varies the carrier's frequency while amplitude stays constant, which is why it shrugs off amplitude noise.</figcaption>
+</figure>
+
 ## How it works
 
 Because the information lives in frequency, not amplitude, an FM receiver can ignore

--- a/docs/reference/frequency-modulation.md
+++ b/docs/reference/frequency-modulation.md
@@ -1,0 +1,36 @@
+---
+slug: frequency-modulation
+title: Frequency modulation (FM)
+entry_type: technology
+category: modulation
+description: Frequency modulation (FM) encodes information by varying a carrier's frequency; it resists amplitude noise and is used for broadcast and analog two-way voice.
+keywords: frequency modulation, FM, deviation, capture effect, narrowband FM, broadcast
+aka: [frequency modulation]
+autolink: true
+infobox:
+  - { label: Type, value: Analog modulation }
+  - { label: Varies, value: Carrier frequency (deviation) }
+  - { label: Used for, value: FM broadcast, analog two-way voice }
+see_also: [modulation, amplitude-modulation, single-sideband, frequency-shift-keying]
+related_lessons:
+  - { title: "Analog modulation — AM, FM, SSB", url: /learn/analog-modulation/ }
+external:
+  - { title: "Frequency modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency_modulation }
+---
+
+**Frequency modulation** (**FM**) encodes information by varying a
+[carrier](/reference/carrier-wave/)'s [frequency](/reference/frequency/) while its
+[amplitude](/reference/amplitude/) stays constant. The amount of swing is the
+*deviation*.
+
+## How it works
+
+Because the information lives in frequency, not amplitude, an FM receiver can ignore
+amplitude noise, giving clean audio. FM also shows a *capture effect* — the strongest
+signal dominates a channel.
+
+## Relevance to SDR
+
+FM broadcast (wide deviation) and narrowband FM two-way voice are everywhere; the
+latter is the analog cousin of the digital [FSK](/reference/frequency-shift-keying/)
+voice modes GopherTrunk decodes.

--- a/docs/reference/frequency-shift-keying.md
+++ b/docs/reference/frequency-shift-keying.md
@@ -1,0 +1,36 @@
+---
+slug: frequency-shift-keying
+title: Frequency-shift keying (FSK)
+entry_type: technology
+category: modulation
+description: Frequency-shift keying (FSK) is digital modulation that switches a carrier between discrete frequencies; four-level FSK (4FSK) underlies P25 C4FM, DMR, and NXDN.
+keywords: FSK, frequency shift keying, 2FSK, 4FSK, C4FM, digital modulation, mark space
+aka: [frequency-shift keying, FSK, 4FSK]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation }
+  - { label: Varies, value: Carrier frequency (discrete) }
+  - { label: Used by, value: P25, DMR, NXDN, paging }
+see_also: [phase-shift-keying, quadrature-amplitude-modulation, c4fm, gmsk, afsk, ffsk, symbol-rate]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "Frequency-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-shift_keying }
+---
+
+**Frequency-shift keying** (**FSK**) is digital [modulation](/reference/modulation/)
+that switches a [carrier](/reference/carrier-wave/) between a fixed set of frequencies,
+one per [symbol](/reference/symbol-rate/). Two frequencies gives 2FSK; four gives 4FSK.
+
+## How it works
+
+Each frequency offset (deviation) represents a symbol. **4FSK** carries 2 bits per
+symbol and is the workhorse of digital land-mobile voice — [C4FM](/reference/c4fm/) in
+[P25](/reference/project-25/), and the modulation of [DMR](/reference/dmr/) and
+[NXDN](/reference/nxdn/) — because it tolerates efficient, non-linear amplifiers.
+
+## Relevance to SDR
+
+An FSK demodulator tracks instantaneous frequency; the resulting symbol levels appear
+on the [symbol scope](/reference/eye-diagram/) and as clusters on a
+[constellation](/reference/constellation-diagram/).

--- a/docs/reference/frequency-shift-keying.md
+++ b/docs/reference/frequency-shift-keying.md
@@ -22,6 +22,18 @@ external:
 that switches a [carrier](/reference/carrier-wave/) between a fixed set of frequencies,
 one per [symbol](/reference/symbol-rate/). Two frequencies gives 2FSK; four gives 4FSK.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A bit stream above, and below it a carrier that switches between a low frequency for zeros and a high frequency for ones." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="11" fill="currentColor" font-family="monospace"><text x="40" y="24">1</text><text x="140" y="24">0</text><text x="240" y="24">1</text><text x="340" y="24">0</text></g>
+  <path d="M30 80 q6 -26 12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0
+            M130 80 q12 -26 24 0 t24 0 t24 0 t24 0
+            M230 80 q6 -26 12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0 t12 0
+            M330 80 q12 -26 24 0 t24 0 t24 0 t24 0" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="30" y="115" font-size="9" fill="currentColor">each bit picks a frequency (here 2FSK; 4FSK uses four)</text>
+</svg>
+<figcaption>FSK switches the carrier between set frequencies; four-level 4FSK underlies P25 C4FM and DMR.</figcaption>
+</figure>
+
 ## How it works
 
 Each frequency offset (deviation) represents a symbol. **4FSK** carries 2 bits per

--- a/docs/reference/frequency.md
+++ b/docs/reference/frequency.md
@@ -21,6 +21,16 @@ external:
 in **hertz (Hz)**. For a [radio wave](/reference/radio-wave/) it is the quantity you
 tune to, and it is inversely related to [wavelength](/reference/wavelength/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="Two sine waves: a low-frequency wave with few cycles on top and a high-frequency wave with many cycles below." xmlns="http://www.w3.org/2000/svg">
+  <text x="20" y="24" font-size="10" fill="currentColor">low frequency</text>
+  <path d="M20 50 q30 -28 60 0 t60 0 t60 0 t60 0 t60 0 t60 0 t40 0" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="20" y="100" font-size="10" fill="currentColor">high frequency</text>
+  <path d="M20 122 q12 -26 24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0" fill="none" stroke="currentColor" stroke-width="2"/>
+</svg>
+<figcaption>Frequency is how many cycles pass each second; higher frequency packs more cycles into the same time (and means a shorter wavelength).</figcaption>
+</figure>
+
 ## How it works
 
 One hertz is one cycle per second. Radio frequencies are large, so they are scaled in

--- a/docs/reference/frequency.md
+++ b/docs/reference/frequency.md
@@ -1,0 +1,35 @@
+---
+slug: frequency
+title: Frequency
+entry_type: term
+category: rf-fundamentals
+description: Frequency is the number of cycles a wave completes per second, measured in hertz (Hz); for radio it sets the tuning point and, inversely, the wavelength.
+keywords: frequency, hertz, Hz, cycles per second, kHz MHz GHz
+infobox:
+  - { label: Symbol, value: f }
+  - { label: Unit, value: Hertz (Hz) }
+  - { label: Relation, value: "wavelength = c / frequency" }
+see_also: [wavelength, frequency-bands, electromagnetic-spectrum, radio-wave]
+related_lessons:
+  - { title: "What is a radio wave?", url: /learn/radio-waves/ }
+  - { title: "Frequency, bands & the spectrum", url: /learn/frequency-and-spectrum/ }
+external:
+  - { title: "Frequency (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency }
+---
+
+**Frequency** is the number of cycles a periodic wave completes each second, measured
+in **hertz (Hz)**. For a [radio wave](/reference/radio-wave/) it is the quantity you
+tune to, and it is inversely related to [wavelength](/reference/wavelength/).
+
+## How it works
+
+One hertz is one cycle per second. Radio frequencies are large, so they are scaled in
+kilohertz (kHz), megahertz (MHz), and gigahertz (GHz). Because all radio waves travel
+at the speed of light *c*, frequency and wavelength satisfy *wavelength = c /
+frequency*.
+
+## Relevance to SDR
+
+Tuning an SDR sets the centre frequency its [local oscillator](/reference/local-oscillator/)
+mixes down to baseband. The chosen frequency, within a [band](/reference/frequency-bands/),
+determines what signal you receive.

--- a/docs/reference/gardner-timing-recovery.md
+++ b/docs/reference/gardner-timing-recovery.md
@@ -23,6 +23,16 @@ external:
 half-symbol instants. A useful property is that it works **independently of carrier
 phase**.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A symbol waveform sampled twice per symbol — at the midpoint and the peak — to estimate timing error." xmlns="http://www.w3.org/2000/svg">
+  <path d="M30 90 C 90 90 90 40 150 40 C 210 40 210 90 270 90 C 330 90 330 40 390 40" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <g fill="currentColor"><circle cx="90" cy="65" r="3"/><circle cx="150" cy="40" r="3"/><circle cx="210" cy="65" r="3"/><circle cx="270" cy="90" r="3"/></g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="150" y="30">peak</text><text x="90" y="80">mid</text></g>
+  <text x="230" y="118" text-anchor="middle" font-size="9" fill="currentColor">two samples per symbol estimate the timing error</text>
+</svg>
+<figcaption>Gardner timing recovery uses two samples per symbol (midpoint and peak) to track symbol timing.</figcaption>
+</figure>
+
 ## How it works
 
 Its timing-error detector drives a loop that nudges the sampling instant toward the centre

--- a/docs/reference/gardner-timing-recovery.md
+++ b/docs/reference/gardner-timing-recovery.md
@@ -1,0 +1,35 @@
+---
+slug: gardner-timing-recovery
+title: Gardner timing recovery
+entry_type: algorithm
+category: algorithms
+description: Gardner timing recovery is a feedback algorithm that estimates symbol timing error from samples taken at the symbol and half-symbol points, without needing carrier phase.
+keywords: Gardner timing recovery, symbol timing, timing error detector, clock recovery, non-data-aided
+aka: [Gardner timing recovery, Gardner]
+autolink: true
+infobox:
+  - { label: Type, value: Symbol-timing algorithm }
+  - { label: Feature, value: Independent of carrier phase }
+  - { label: Use, value: Clock recovery for digital modems }
+see_also: [clock-recovery, mueller-muller-timing-recovery, symbol-rate, demodulation]
+related_lessons:
+  - { title: "Clock recovery & symbol timing", url: /learn/clock-recovery/ }
+external:
+  - { title: "Gardner (timing recovery) (Wikipedia)", url: https://en.wikipedia.org/wiki/Symbol_synchronization }
+---
+
+**Gardner timing recovery** is a feedback algorithm that estimates
+[symbol-timing](/reference/clock-recovery/) error using samples at the symbol and
+half-symbol instants. A useful property is that it works **independently of carrier
+phase**.
+
+## How it works
+
+Its timing-error detector drives a loop that nudges the sampling instant toward the centre
+of each [symbol](/reference/symbol-rate/), where the [eye](/reference/eye-diagram/) is
+widest, tracking small clock drift.
+
+## Relevance to SDR
+
+Gardner recovery is a common choice in SDR demodulators for locking symbol timing on PSK
+and QAM signals.

--- a/docs/reference/gmsk.md
+++ b/docs/reference/gmsk.md
@@ -1,0 +1,35 @@
+---
+slug: gmsk
+title: GMSK
+entry_type: technology
+category: modulation
+description: GMSK (Gaussian minimum-shift keying) is a continuous-phase FSK variant with a Gaussian pulse-shaping filter, giving a compact spectrum; used by AIS, GSM, and D-STAR.
+keywords: GMSK, Gaussian minimum shift keying, continuous phase, AIS, GSM, D-STAR, pulse shaping
+aka: [GMSK]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation (CPM) }
+  - { label: Feature, value: Gaussian-filtered, compact spectrum }
+  - { label: Used by, value: AIS, GSM, D-STAR }
+see_also: [frequency-shift-keying, ais, d-star, root-raised-cosine-filter]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "Minimum-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Minimum-shift_keying }
+---
+
+**GMSK** (Gaussian minimum-shift keying) is a continuous-phase
+[FSK](/reference/frequency-shift-keying/) variant in which the data is passed through a
+Gaussian filter before modulation, smoothing phase transitions for a **compact
+spectrum** and constant envelope.
+
+## How it works
+
+The constant envelope suits efficient non-linear amplifiers, while the Gaussian shaping
+limits bandwidth. These traits made GMSK the choice for GSM cellular and for
+[AIS](/reference/ais/) and [D-STAR](/reference/d-star/).
+
+## Relevance to SDR
+
+A GMSK demodulator recovers the underlying frequency/phase transitions; GopherTrunk
+uses one in its AIS pipeline.

--- a/docs/reference/gmsk.md
+++ b/docs/reference/gmsk.md
@@ -23,6 +23,15 @@ external:
 Gaussian filter before modulation, smoothing phase transitions for a **compact
 spectrum** and constant envelope.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A smooth continuous phase trajectory with no abrupt jumps, illustrating Gaussian-filtered MSK." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="60" x2="440" y2="60" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 60 C 60 30, 90 30, 120 60 S 180 90, 220 75 C 260 62, 270 35, 310 35 S 380 80, 440 55" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="20" y="100" font-size="10" fill="currentColor">phase is continuous and smoothly filtered — compact spectrum</text>
+</svg>
+<figcaption>GMSK is continuous-phase FSK with Gaussian pulse shaping, giving a narrow spectrum; AIS uses it.</figcaption>
+</figure>
+
 ## How it works
 
 The constant envelope suits efficient non-linear amplifiers, while the Gaussian shaping

--- a/docs/reference/golay-code.md
+++ b/docs/reference/golay-code.md
@@ -22,6 +22,15 @@ The **Golay code** is a remarkably efficient block
 [error-correction](/reference/forward-error-correction/) code. The binary Golay(23,12)
 and extended Golay(24,12) correct up to three bit errors in a short codeword.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="A Golay (24,12) codeword: twelve data bits and twelve parity bits of equal size." xmlns="http://www.w3.org/2000/svg">
+  <rect x="60" y="40" width="170" height="30" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="145" y="59" text-anchor="middle" font-size="9" fill="currentColor">12 data bits</text>
+  <rect x="230" y="40" width="170" height="30" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/><text x="315" y="59" text-anchor="middle" font-size="9" fill="currentColor">12 parity bits</text>
+  <text x="230" y="90" text-anchor="middle" font-size="9" fill="currentColor">Golay(24,12) corrects up to 3 bit errors</text>
+</svg>
+<figcaption>The Golay(24,12) code protects critical fields (e.g. in DMR, P25, and M17) against several bit errors.</figcaption>
+</figure>
+
 ## How it works
 
 Its mathematical structure (a perfect code in the binary case) packs strong correction

--- a/docs/reference/golay-code.md
+++ b/docs/reference/golay-code.md
@@ -1,0 +1,33 @@
+---
+slug: golay-code
+title: Golay code
+entry_type: algorithm
+category: algorithms
+description: The Golay code is a highly efficient perfect/near-perfect block code; the binary Golay(23,12) and extended Golay(24,12) correct up to three errors and appear in DMR, P25, and M17.
+keywords: Golay code, Golay(23,12), Golay(24,12), block code, three-error correcting, DMR, M17
+aka: [Golay code]
+autolink: true
+infobox:
+  - { label: Type, value: Perfect/near-perfect block code }
+  - { label: Corrects, value: Up to 3 errors (binary Golay) }
+  - { label: Used by, value: DMR, P25, M17 }
+see_also: [forward-error-correction, hamming-code, reed-solomon-code, dmr, m17]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Binary Golay code (Wikipedia)", url: https://en.wikipedia.org/wiki/Binary_Golay_code }
+---
+
+The **Golay code** is a remarkably efficient block
+[error-correction](/reference/forward-error-correction/) code. The binary Golay(23,12)
+and extended Golay(24,12) correct up to three bit errors in a short codeword.
+
+## How it works
+
+Its mathematical structure (a perfect code in the binary case) packs strong correction
+into few bits, making it ideal for small but critical control fields.
+
+## Relevance to SDR
+
+Golay coding protects link-control and signalling fields in [DMR](/reference/dmr/),
+[P25](/reference/project-25/), and [M17](/reference/m17/).

--- a/docs/reference/guglielmo-marconi.md
+++ b/docs/reference/guglielmo-marconi.md
@@ -23,6 +23,16 @@ external:
 [Hertz](/reference/heinrich-hertz/)'s laboratory waves into **practical long-distance
 radiotelegraphy**.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A signal arcing across a curved ocean from a transmitter in Europe to a receiver in North America." xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 120 Q230 70 450 120" fill="none" stroke="currentColor" stroke-opacity="0.4" stroke-width="1.4"/>
+  <line x1="80" y1="108" x2="80" y2="60" stroke="currentColor" stroke-width="2"/><text x="80" y="124" text-anchor="middle" font-size="8" fill="currentColor">Europe</text>
+  <line x1="380" y1="108" x2="380" y2="60" stroke="currentColor" stroke-width="2"/><text x="380" y="124" text-anchor="middle" font-size="8" fill="currentColor">N. America</text>
+  <path d="M80 60 Q230 10 380 60" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="5 3"/>
+</svg>
+<figcaption>Marconi pioneered practical wireless telegraphy, achieving the first transatlantic radio transmission in 1901.</figcaption>
+</figure>
+
 ## Life and work
 
 Building on others' discoveries, Marconi engineered and commercialised wireless

--- a/docs/reference/guglielmo-marconi.md
+++ b/docs/reference/guglielmo-marconi.md
@@ -1,0 +1,40 @@
+---
+slug: guglielmo-marconi
+title: Guglielmo Marconi
+entry_type: person
+category: people
+description: Guglielmo Marconi (1874–1937) was an Italian inventor and entrepreneur who developed practical long-distance radiotelegraphy and shared the 1909 Nobel Prize in Physics.
+keywords: Guglielmo Marconi, wireless telegraphy, radio pioneer, transatlantic, Nobel Prize
+aka: [Guglielmo Marconi, Marconi]
+autolink: true
+infobox:
+  - { label: Lived, value: "1874–1937" }
+  - { label: Field, value: Radio engineering / business }
+  - { label: Known for, value: Practical wireless telegraphy }
+  - { label: Honour, value: "Nobel Prize in Physics (1909)" }
+see_also: [heinrich-hertz, reginald-fessenden, radio-wave]
+related_lessons:
+  - { title: "What is a radio wave?", url: /learn/radio-waves/ }
+external:
+  - { title: "Guglielmo Marconi (Wikipedia)", url: https://en.wikipedia.org/wiki/Guglielmo_Marconi }
+---
+
+**Guglielmo Marconi** (1874–1937) was an Italian inventor and entrepreneur who turned
+[Hertz](/reference/heinrich-hertz/)'s laboratory waves into **practical long-distance
+radiotelegraphy**.
+
+## Life and work
+
+Building on others' discoveries, Marconi engineered and commercialised wireless
+telegraphy, famously achieving transatlantic signalling in 1901 and founding companies
+that spread the technology worldwide.
+
+## Contribution
+
+He demonstrated that radio could span oceans, launching the wireless communications
+industry.
+
+## Legacy
+
+Marconi shared the 1909 Nobel Prize in Physics and is widely regarded as a father of
+radio communication.

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -1,0 +1,37 @@
+---
+slug: hackrf
+title: HackRF One
+entry_type: hardware
+category: hardware
+description: HackRF One is an open-source wideband half-duplex software-defined radio transceiver covering 1 MHz to 6 GHz with up to 20 MHz of bandwidth and transmit capability.
+keywords: HackRF One, Great Scott Gadgets, wideband SDR, transceiver, 1 MHz 6 GHz, transmit
+aka: [HackRF, HackRF One]
+autolink: true
+infobox:
+  - { label: Type, value: Wideband SDR transceiver }
+  - { label: Vendor, value: Great Scott Gadgets }
+  - { label: Range, value: 1 MHz – 6 GHz }
+  - { label: Bandwidth, value: up to ~20 MHz }
+  - { label: TX, value: Yes (half-duplex) }
+see_also: [rtl-sdr, airspy, software-defined-radio]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/sdr-hardware/ }
+external:
+  - { title: "HackRF (Wikipedia)", url: https://en.wikipedia.org/wiki/HackRF_One }
+---
+
+**HackRF One** is an open-source, wideband, half-duplex
+[software-defined radio](/reference/software-defined-radio/) transceiver from Great Scott
+Gadgets, covering **1 MHz to 6 GHz** with up to ~20 MHz bandwidth and the ability to
+**transmit**.
+
+## Overview
+
+Its huge range and TX capability make it popular for experimentation, but it uses 8-bit
+sampling (less dynamic range than [Airspy](/reference/airspy/)) and transmit is
+irrelevant to receive-only scanning.
+
+## Relevance to SDR
+
+For decoding trunked voice, HackRF is overkill; an [RTL-SDR](/reference/rtl-sdr/) or
+Airspy is usually the better fit, but GopherTrunk can use it as a receiver.

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -25,6 +25,16 @@ external:
 Gadgets, covering **1 MHz to 6 GHz** with up to ~20 MHz bandwidth and the ability to
 **transmit**.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for HackRF One (~1 MHz–6 GHz) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="430" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="30" y="86">0</text><text x="163" y="86">2 GHz</text><text x="296" y="86">4 GHz</text><text x="430" y="86">6 GHz</text></g>
+  <rect x="30" y="40" width="400" height="20" rx="3" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="28" text-anchor="middle" font-size="10" fill="currentColor">HackRF One (~1 MHz–6 GHz) coverage</text>
+</svg>
+<figcaption>HackRF spans a huge range and can transmit, but with lower dynamic range — overkill for scanning.</figcaption>
+</figure>
+
 ## Overview
 
 Its huge range and TX capability make it popular for experimentation, but it uses 8-bit

--- a/docs/reference/hamming-code.md
+++ b/docs/reference/hamming-code.md
@@ -22,6 +22,18 @@ external:
 codes that correct **single-bit** errors (and detect two) using a handful of parity-check
 bits. They are named for [Richard Hamming](/reference/richard-hamming/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="Data bits interspersed with parity bits, with brackets showing each parity bit covering a set of data bits." xmlns="http://www.w3.org/2000/svg">
+  <g font-family="monospace" font-size="11" fill="currentColor" text-anchor="middle">
+    <text x="60" y="55">P</text><text x="100" y="55">P</text><text x="140" y="55">D</text><text x="180" y="55">P</text><text x="220" y="55">D</text><text x="260" y="55">D</text><text x="300" y="55">D</text>
+  </g>
+  <path d="M60 65 q40 18 80 0" fill="none" stroke="currentColor" stroke-opacity="0.6"/>
+  <path d="M100 70 q60 22 120 0" fill="none" stroke="currentColor" stroke-opacity="0.6"/>
+  <text x="230" y="100" text-anchor="middle" font-size="9" fill="currentColor">each parity bit (P) checks a set of data bits (D)</text>
+</svg>
+<figcaption>A Hamming code interleaves parity bits that locate and correct a single bit error per block.</figcaption>
+</figure>
+
 ## How it works
 
 Parity bits cover overlapping subsets of the data so that the pattern of failed checks (the

--- a/docs/reference/hamming-code.md
+++ b/docs/reference/hamming-code.md
@@ -1,0 +1,34 @@
+---
+slug: hamming-code
+title: Hamming code
+entry_type: algorithm
+category: algorithms
+description: Hamming codes are simple block codes that correct single-bit errors using parity check bits; they are a foundational error-correction scheme named for Richard Hamming.
+keywords: Hamming code, single error correction, parity bits, block code, Richard Hamming, FEC
+aka: [Hamming code]
+autolink: true
+infobox:
+  - { label: Type, value: Single-error-correcting block code }
+  - { label: Uses, value: Parity check bits }
+  - { label: Named for, value: Richard Hamming }
+see_also: [forward-error-correction, golay-code, bch-code, richard-hamming, cyclic-redundancy-check]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Hamming code (Wikipedia)", url: https://en.wikipedia.org/wiki/Hamming_code }
+---
+
+**Hamming codes** are simple block [error-correction](/reference/forward-error-correction/)
+codes that correct **single-bit** errors (and detect two) using a handful of parity-check
+bits. They are named for [Richard Hamming](/reference/richard-hamming/).
+
+## How it works
+
+Parity bits cover overlapping subsets of the data so that the pattern of failed checks (the
+syndrome) points directly at the erroneous bit. Variants such as Hamming(20,8) appear in
+digital radio link control.
+
+## Relevance to SDR
+
+Hamming coding protects small control fields in several digital protocols, contributing to
+robust decoding.

--- a/docs/reference/harry-nyquist.md
+++ b/docs/reference/harry-nyquist.md
@@ -22,6 +22,16 @@ external:
 the maximum signalling rate of a channel underlies the
 [sampling theorem](/reference/nyquist-theorem/) at the heart of digital radio.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A sine wave sampled at just over two points per cycle, illustrating the Nyquist sampling rate." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="60" x2="440" y2="60" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 60 C 70 20, 130 20, 180 60 S 290 100, 340 60 S 440 30, 440 60" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <g fill="currentColor"><circle cx="50" cy="40" r="3"/><circle cx="115" cy="32" r="3"/><circle cx="180" cy="60" r="3"/><circle cx="245" cy="88" r="3"/><circle cx="310" cy="80" r="3"/><circle cx="375" cy="48" r="3"/></g>
+  <text x="230" y="108" text-anchor="middle" font-size="9" fill="currentColor">sample at ≥ 2× the highest frequency</text>
+</svg>
+<figcaption>Nyquist established the sampling limit at the heart of all digital radio; the Nyquist rate bears his name.</figcaption>
+</figure>
+
 ## Life and work
 
 Nyquist studied how fast pulses could be sent over a channel without interference,

--- a/docs/reference/harry-nyquist.md
+++ b/docs/reference/harry-nyquist.md
@@ -1,0 +1,39 @@
+---
+slug: harry-nyquist
+title: Harry Nyquist
+entry_type: person
+category: people
+description: Harry Nyquist (1889–1976) was a Swedish-American engineer at Bell Labs whose work on sampling and signalling underlies the sampling theorem central to all digital radio.
+keywords: Harry Nyquist, Nyquist rate, sampling theorem, Bell Labs, signal processing
+aka: [Harry Nyquist, Nyquist]
+autolink: true
+infobox:
+  - { label: Lived, value: "1889–1976" }
+  - { label: Field, value: Electrical engineering }
+  - { label: Known for, value: Sampling and signalling theory }
+see_also: [nyquist-theorem, sample-rate, claude-shannon, aliasing]
+related_lessons:
+  - { title: "Sample rate, bandwidth & Nyquist", url: /learn/sample-rate-nyquist/ }
+external:
+  - { title: "Harry Nyquist (Wikipedia)", url: https://en.wikipedia.org/wiki/Harry_Nyquist }
+---
+
+**Harry Nyquist** (1889–1976) was a Swedish-American engineer at Bell Labs whose work on
+the maximum signalling rate of a channel underlies the
+[sampling theorem](/reference/nyquist-theorem/) at the heart of digital radio.
+
+## Life and work
+
+Nyquist studied how fast pulses could be sent over a channel without interference,
+establishing the relationship between [bandwidth](/reference/bandwidth/) and
+[sample rate](/reference/sample-rate/) later formalised with
+[Claude Shannon](/reference/claude-shannon/).
+
+## Contribution
+
+The Nyquist rate — sampling at twice the bandwidth — tells engineers how fast an
+[ADC](/reference/analog-to-digital-converter/) must run.
+
+## Legacy
+
+His name marks the boundary every SDR respects to avoid [aliasing](/reference/aliasing/).

--- a/docs/reference/heinrich-hertz.md
+++ b/docs/reference/heinrich-hertz.md
@@ -23,6 +23,16 @@ external:
 **demonstrated electromagnetic waves**, experimentally confirming
 [James Clerk Maxwell](/reference/james-clerk-maxwell/)'s theory.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A spark gap on the left radiating waves to a loop receiver on the right, illustrating Hertz's proof of radio waves." xmlns="http://www.w3.org/2000/svg">
+  <line x1="50" y1="40" x2="50" y2="62" stroke="currentColor" stroke-width="2"/><line x1="50" y1="72" x2="50" y2="94" stroke="currentColor" stroke-width="2"/>
+  <text x="50" y="110" text-anchor="middle" font-size="8" fill="currentColor">spark gap</text>
+  <g fill="none" stroke="currentColor" stroke-opacity="0.5"><path d="M70 67 A 30 30 0 0 1 100 67"/><path d="M70 67 A 60 60 0 0 1 130 67"/><path d="M70 67 A 90 90 0 0 1 160 67"/></g>
+  <circle cx="400" cy="67" r="22" fill="none" stroke="currentColor" stroke-width="2"/><text x="400" y="110" text-anchor="middle" font-size="8" fill="currentColor">loop receiver</text>
+</svg>
+<figcaption>Hertz experimentally proved electromagnetic waves exist; the unit of frequency, the hertz, is named for him.</figcaption>
+</figure>
+
 ## Life and work
 
 In the late 1880s Hertz built spark-gap transmitters and resonant receivers, showing

--- a/docs/reference/heinrich-hertz.md
+++ b/docs/reference/heinrich-hertz.md
@@ -1,0 +1,40 @@
+---
+slug: heinrich-hertz
+title: Heinrich Hertz
+entry_type: person
+category: people
+description: Heinrich Hertz (1857–1894) was a German physicist who first conclusively demonstrated the existence of electromagnetic waves, confirming Maxwell's theory; the unit of frequency is named after him.
+keywords: Heinrich Hertz, electromagnetic waves, hertz unit, radio history, Maxwell
+aka: [Heinrich Hertz]
+autolink: true
+infobox:
+  - { label: Lived, value: "1857–1894" }
+  - { label: Field, value: Physics }
+  - { label: Known for, value: Proving EM waves exist }
+  - { label: Legacy, value: The hertz (Hz) unit }
+see_also: [james-clerk-maxwell, guglielmo-marconi, radio-wave, frequency, electromagnetic-spectrum]
+related_lessons:
+  - { title: "What is a radio wave?", url: /learn/radio-waves/ }
+external:
+  - { title: "Heinrich Hertz (Wikipedia)", url: https://en.wikipedia.org/wiki/Heinrich_Hertz }
+---
+
+**Heinrich Hertz** (1857–1894) was a German physicist who first conclusively
+**demonstrated electromagnetic waves**, experimentally confirming
+[James Clerk Maxwell](/reference/james-clerk-maxwell/)'s theory.
+
+## Life and work
+
+In the late 1880s Hertz built spark-gap transmitters and resonant receivers, showing
+that invisible waves travelled across his laboratory, reflected, and refracted like
+light — proving they were electromagnetic.
+
+## Contribution
+
+His experiments turned Maxwell's mathematics into observed fact, opening the door to
+radio communication.
+
+## Legacy
+
+The SI unit of [frequency](/reference/frequency/), the **hertz (Hz)**, is named in his
+honour — fitting, given he proved the [radio wave](/reference/radio-wave/) exists.

--- a/docs/reference/icao.md
+++ b/docs/reference/icao.md
@@ -22,6 +22,19 @@ external:
 that standardises international civil aviation, including the
 **[ADS-B](/reference/ads-b/)** surveillance system and Mode S transponders.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="ICAO sets aviation standards including ADS-B." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="100" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="70" y="61">ICAO</text>
+    <rect x="170" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="225" y="61">standards</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">ADS-B (aviation)</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="120" y1="58" x2="169" y2="58" marker-end="url(#rel_icao)"/><line x1="280" y1="58" x2="329" y2="58" marker-end="url(#rel_icao)"/></g>
+  </g>
+  <defs><marker id="rel_icao" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>ICAO sets international civil-aviation standards, including ADS-B.</figcaption>
+</figure>
+
 ## Overview
 
 ICAO sets the framework that regional bodies (RTCA in the US, EUROCAE in Europe) detail

--- a/docs/reference/icao.md
+++ b/docs/reference/icao.md
@@ -1,0 +1,32 @@
+---
+slug: icao
+title: ICAO
+entry_type: organization
+category: organizations
+description: ICAO, the International Civil Aviation Organization, is the UN agency that standardises aviation, including the ADS-B surveillance system and Mode S transponders.
+keywords: ICAO, International Civil Aviation Organization, ADS-B, Mode S, aviation standards
+aka: [ICAO, International Civil Aviation Organization]
+autolink: true
+infobox:
+  - { label: Type, value: UN specialised agency }
+  - { label: Focus, value: Civil aviation standards }
+  - { label: Standards, value: ADS-B, Mode S }
+see_also: [ads-b, compact-position-reporting, itu]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "International Civil Aviation Organization (Wikipedia)", url: https://en.wikipedia.org/wiki/International_Civil_Aviation_Organization }
+---
+
+**ICAO** (the **International Civil Aviation Organization**) is the United Nations agency
+that standardises international civil aviation, including the
+**[ADS-B](/reference/ads-b/)** surveillance system and Mode S transponders.
+
+## Overview
+
+ICAO sets the framework that regional bodies (RTCA in the US, EUROCAE in Europe) detail
+into the MOPS aircraft must meet, driving the worldwide rollout of ADS-B.
+
+## Relevance to SDR
+
+ICAO standards define the 1090 MHz signals an SDR receives when tracking aircraft.

--- a/docs/reference/imbe.md
+++ b/docs/reference/imbe.md
@@ -23,6 +23,16 @@ external:
 [P25 Phase 1](/reference/p25-phase-1/), part of the
 [MBE](/reference/multi-band-excitation/) codec family from [DVSI](/reference/dvsi/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A speech spectrum split into frequency bands, each marked voiced or unvoiced, as in multi-band excitation." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="90" x2="430" y2="90" stroke="currentColor" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-width="1.2"><line x1="90" y1="90" x2="90" y2="35"/><line x1="150" y1="90" x2="150" y2="50"/><line x1="210" y1="90" x2="210" y2="42"/><line x1="270" y1="90" x2="270" y2="60"/><line x1="330" y1="90" x2="330" y2="48"/></g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="90" y="105">V</text><text x="150" y="105">V</text><text x="210" y="105">U</text><text x="270" y="105">V</text><text x="330" y="105">U</text></g>
+  <text x="230" y="24" text-anchor="middle" font-size="9" fill="currentColor">each band marked voiced (V) or unvoiced (U)</text>
+</svg>
+<figcaption>IMBE (used by P25 Phase 1) is a multi-band excitation codec that labels each spectral band voiced or unvoiced.</figcaption>
+</figure>
+
 ## How it works
 
 IMBE runs at about **7.2 kbps** over the air, of which roughly 4.4 kbps is voice and the

--- a/docs/reference/imbe.md
+++ b/docs/reference/imbe.md
@@ -1,0 +1,36 @@
+---
+slug: imbe
+title: IMBE
+entry_type: technology
+category: voice-coding
+description: IMBE (Improved Multi-Band Excitation) is the vocoder used by P25 Phase 1, encoding voice at about 7.2 kbps including error correction.
+keywords: IMBE, Improved Multi-Band Excitation, P25 Phase 1, vocoder, DVSI, 7200 bps
+aka: [IMBE]
+autolink: true
+infobox:
+  - { label: Type, value: Speech vocoder (MBE family) }
+  - { label: Bit rate, value: ~7.2 kbps (incl. FEC) }
+  - { label: Used by, value: P25 Phase 1 }
+  - { label: Licensor, value: DVSI }
+see_also: [vocoder, ambe, ambe-plus-2, multi-band-excitation, p25-phase-1, dvsi]
+related_lessons:
+  - { title: "Vocoders — IMBE & AMBE+2", url: /learn/vocoders/ }
+external:
+  - { title: "Multi-Band Excitation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+---
+
+**IMBE** (**Improved Multi-Band Excitation**) is the [vocoder](/reference/vocoder/) of
+[P25 Phase 1](/reference/p25-phase-1/), part of the
+[MBE](/reference/multi-band-excitation/) codec family from [DVSI](/reference/dvsi/).
+
+## How it works
+
+IMBE runs at about **7.2 kbps** over the air, of which roughly 4.4 kbps is voice and the
+rest is [forward error correction](/reference/forward-error-correction/) protecting the
+parameters — important because a corrupted parameter sounds far worse than a corrupted
+audio sample.
+
+## Relevance to SDR
+
+GopherTrunk decodes IMBE frames from P25 Phase 1 and synthesises audio. Its successor,
+[AMBE+2](/reference/ambe-plus-2/), is used by newer systems.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,13 @@
+---
+layout: reference-hub
+title: GopherTrunk Reference — RF & SDR encyclopedia
+description: A plain-language encyclopedia of radio and software-defined-radio terms, technologies, algorithms, people, hardware, and organizations — long-form reference articles, cross-linked and browsable by category or A–Z.
+keywords: RF encyclopedia, SDR reference, radio terms, P25 DMR TETRA reference, vocoder, IQ data, modulation, trunked radio, DefinedTerm
+permalink: /reference/
+autolink: false
+---
+
+Looking for a quick definition? The [glossary](/learn/glossary/) has one-line
+entries. Want to *learn* in order? Start the [learning path](/learn/). This
+**reference** is the long-form, neutral encyclopedia: each article defines and
+explains one topic in depth and links to everything related.

--- a/docs/reference/interleaving.md
+++ b/docs/reference/interleaving.md
@@ -22,6 +22,23 @@ external:
 receive, so that a **burst** of errors (from fading or interference) is spread thinly
 across many codewords rather than overwhelming one.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="Bits written into a matrix by rows and read out by columns, so that a burst of errors is spread across many codewords." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1" fill="none">
+    <rect x="60" y="30" width="120" height="80"/>
+    <line x1="60" y1="50" x2="180" y2="50"/><line x1="60" y1="70" x2="180" y2="70"/><line x1="60" y1="90" x2="180" y2="90"/>
+    <line x1="90" y1="30" x2="90" y2="110"/><line x1="120" y1="30" x2="120" y2="110"/><line x1="150" y1="30" x2="150" y2="110"/>
+  </g>
+  <text x="120" y="125" text-anchor="middle" font-size="8" fill="currentColor">write rows → read columns</text>
+  <line x1="200" y1="70" x2="250" y2="70" stroke="currentColor" marker-end="url(#ilar)"/>
+  <text x="360" y="60" text-anchor="middle" font-size="9" fill="currentColor">a burst of errors is</text>
+  <text x="360" y="74" text-anchor="middle" font-size="9" fill="currentColor">spread thin across</text>
+  <text x="360" y="88" text-anchor="middle" font-size="9" fill="currentColor">many codewords</text>
+  <defs><marker id="ilar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Interleaving reorders bits so a burst of errors is scattered, letting the error-correction code cope.</figcaption>
+</figure>
+
 ## How it works
 
 Because [FEC](/reference/forward-error-correction/) codes correct only a limited number of

--- a/docs/reference/interleaving.md
+++ b/docs/reference/interleaving.md
@@ -1,0 +1,34 @@
+---
+slug: interleaving
+title: Interleaving
+entry_type: algorithm
+category: algorithms
+description: Interleaving reorders bits or symbols before transmission so that a burst of errors is spread across multiple codewords, letting error-correction codes recover it.
+keywords: interleaving, de-interleaving, burst error, FEC, fading, robustness
+aka: [interleaving]
+autolink: true
+infobox:
+  - { label: Type, value: Error-resilience technique }
+  - { label: Spreads, value: Burst errors across codewords }
+  - { label: Paired with, value: FEC codes }
+see_also: [forward-error-correction, reed-solomon-code, bch-code, multipath-propagation]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Interleaving (Wikipedia)", url: https://en.wikipedia.org/wiki/Interleaving_(data) }
+---
+
+**Interleaving** reorders bits or symbols before transmission and restores their order on
+receive, so that a **burst** of errors (from fading or interference) is spread thinly
+across many codewords rather than overwhelming one.
+
+## How it works
+
+Because [FEC](/reference/forward-error-correction/) codes correct only a limited number of
+errors per codeword, distributing a burst lets each codeword's correction cope. The
+receiver de-interleaves before decoding.
+
+## Relevance to SDR
+
+Interleaving makes digital radio robust to [multipath](/reference/multipath-propagation/)
+fading and short interference bursts.

--- a/docs/reference/ionospheric-propagation.md
+++ b/docs/reference/ionospheric-propagation.md
@@ -23,6 +23,18 @@ external:
 layers of the upper atmosphere, allowing signals to "skip" over the horizon for
 hundreds or thousands of kilometres.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="An HF signal leaving a transmitter, refracting off the ionosphere layer, and returning to a distant receiver." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="120" x2="440" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="20" y1="35" x2="440" y2="35" stroke="currentColor" stroke-opacity="0.4" stroke-dasharray="6 4"/><text x="20" y="28" font-size="9" fill="currentColor">ionosphere</text>
+  <line x1="60" y1="118" x2="60" y2="100" stroke="currentColor" stroke-width="2"/><text x="60" y="135" text-anchor="middle" font-size="8" fill="currentColor">TX</text>
+  <line x1="400" y1="118" x2="400" y2="100" stroke="currentColor" stroke-width="2"/><text x="400" y="135" text-anchor="middle" font-size="8" fill="currentColor">RX (far)</text>
+  <path d="M60 100 L230 38 L400 100" fill="none" stroke="currentColor" stroke-width="1.5" marker-end="url(#ioar)"/>
+  <defs><marker id="ioar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>HF signals can refract off the ionosphere and "skip" thousands of kilometres beyond the horizon.</figcaption>
+</figure>
+
 ## How it works
 
 The ionosphere's electron density varies with the sun, so HF skip changes with time of

--- a/docs/reference/ionospheric-propagation.md
+++ b/docs/reference/ionospheric-propagation.md
@@ -1,0 +1,36 @@
+---
+slug: ionospheric-propagation
+title: Ionospheric propagation
+entry_type: term
+category: antennas-propagation
+description: Ionospheric propagation is the refraction of HF radio waves by charged layers of the upper atmosphere, enabling long-distance "skip" communication around the world.
+keywords: ionosphere, skip, skywave, HF propagation, shortwave, refraction
+aka: [ionospheric propagation, skywave]
+autolink: true
+infobox:
+  - { label: Type, value: HF propagation mode }
+  - { label: Mechanism, value: Refraction by ionosphere }
+  - { label: Enables, value: Worldwide HF "skip" }
+see_also: [radio-propagation, frequency-bands, airspy-hf-plus]
+related_lessons:
+  - { title: "Frequency, bands & the spectrum", url: /learn/frequency-and-spectrum/ }
+external:
+  - { title: "Skywave (Wikipedia)", url: https://en.wikipedia.org/wiki/Skywave }
+---
+
+**Ionospheric propagation** (skywave) is the refraction of
+[HF](/reference/frequency-bands/) [radio waves](/reference/radio-wave/) by ionised
+layers of the upper atmosphere, allowing signals to "skip" over the horizon for
+hundreds or thousands of kilometres.
+
+## How it works
+
+The ionosphere's electron density varies with the sun, so HF skip changes with time of
+day, season, and the solar cycle. Higher bands (VHF and up) generally pass through the
+ionosphere rather than reflecting, so they stay line-of-sight.
+
+## Relevance to SDR
+
+Receiving HF skip needs an HF-capable radio such as the
+[Airspy HF+](/reference/airspy-hf-plus/) or an [upconverter](/reference/upconverter/),
+since a basic [RTL-SDR](/reference/rtl-sdr/) does not tune HF directly.

--- a/docs/reference/iq-data.md
+++ b/docs/reference/iq-data.md
@@ -1,0 +1,35 @@
+---
+slug: iq-data
+title: IQ data
+entry_type: term
+category: sdr-dsp
+description: IQ data is the stream of paired in-phase (I) and quadrature (Q) samples an SDR produces, capturing both the amplitude and phase of a signal and enabling negative frequencies.
+keywords: IQ data, in-phase quadrature, complex samples, amplitude phase, baseband, constellation
+aka: [IQ data, IQ samples]
+autolink: true
+infobox:
+  - { label: Type, value: Complex sample stream }
+  - { label: Components, value: I (in-phase), Q (quadrature, 90°) }
+  - { label: Encodes, value: Amplitude (radius) + phase (angle) }
+see_also: [software-defined-radio, phase, amplitude, constellation-diagram, sample-rate]
+related_lessons:
+  - { title: "IQ data & complex signals", url: /learn/iq-data/ }
+external:
+  - { title: "In-phase and quadrature components (Wikipedia)", url: https://en.wikipedia.org/wiki/In-phase_and_quadrature_components }
+---
+
+**IQ data** is the stream of paired numbers an SDR produces — **I** (in-phase) and **Q**
+(quadrature, 90° apart). Together each pair captures both the
+[amplitude](/reference/amplitude/) and [phase](/reference/phase/) of the signal at that
+instant.
+
+## How it works
+
+Treating each sample as a point (I, Q), its distance from the origin is amplitude and its
+angle is phase — the basis of the [constellation diagram](/reference/constellation-diagram/).
+IQ also lets a receiver distinguish frequencies above and below the tuned centre.
+
+## Relevance to SDR
+
+Everything GopherTrunk does begins with the IQ stream from the radio: tuning, filtering,
+demodulation, and the scopes all operate on it.

--- a/docs/reference/iq-data.md
+++ b/docs/reference/iq-data.md
@@ -23,6 +23,19 @@ external:
 [amplitude](/reference/amplitude/) and [phase](/reference/phase/) of the signal at that
 instant.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 260 220" role="img" aria-label="The IQ plane with I horizontal and Q vertical; an arrow to a point shows amplitude as length and phase as angle." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="110" x2="240" y2="110" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="130" y1="20" x2="130" y2="200" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="232" y="124" font-size="11" fill="currentColor">I</text><text x="116" y="30" font-size="11" fill="currentColor">Q</text>
+  <line x1="130" y1="110" x2="195" y2="55" stroke="currentColor" stroke-width="2"/><circle cx="195" cy="55" r="4" fill="currentColor"/>
+  <path d="M165 110 A 36 36 0 0 0 150 84" fill="none" stroke="currentColor" stroke-opacity="0.6"/>
+  <text x="150" y="104" font-size="10" fill="currentColor">phase</text>
+  <text x="150" y="70" font-size="10" fill="currentColor" transform="rotate(-40 165 80)">amplitude</text>
+</svg>
+<figcaption>Each IQ sample is a point on the complex plane: distance from the origin is amplitude, angle is phase.</figcaption>
+</figure>
+
 ## How it works
 
 Treating each sample as a point (I, Q), its distance from the origin is amplitude and its

--- a/docs/reference/itu.md
+++ b/docs/reference/itu.md
@@ -1,0 +1,35 @@
+---
+slug: itu
+title: International Telecommunication Union (ITU)
+entry_type: organization
+category: organizations
+description: The ITU is the United Nations agency for information and communication technologies, allocating the global radio spectrum and publishing radio regulations and standards.
+keywords: ITU, International Telecommunication Union, spectrum allocation, radio regulations, United Nations
+aka: [ITU, International Telecommunication Union]
+autolink: true
+infobox:
+  - { label: Type, value: UN specialised agency }
+  - { label: Founded, value: "1865" }
+  - { label: Role, value: Global spectrum allocation, standards }
+see_also: [fcc, etsi, icao, frequency-bands]
+related_lessons:
+  - { title: "Frequency, bands & the spectrum", url: /learn/frequency-and-spectrum/ }
+external:
+  - { title: "International Telecommunication Union (Wikipedia)", url: https://en.wikipedia.org/wiki/International_Telecommunication_Union }
+---
+
+The **International Telecommunication Union** (**ITU**) is the United Nations specialised
+agency for information and communication technologies. It coordinates the **global radio
+[spectrum](/reference/frequency-bands/)** and publishes the Radio Regulations.
+
+## Overview
+
+The ITU divides the world into regions and allocates bands to services (broadcast,
+maritime, aviation, amateur, and more), providing the framework national regulators like
+the [FCC](/reference/fcc/) implement. ITU recommendations also define systems such as
+[AIS](/reference/ais/) and [DSC](/reference/dsc/).
+
+## Relevance to SDR
+
+The ITU's allocations are why specific signals live in specific bands worldwide, shaping
+where you tune.

--- a/docs/reference/itu.md
+++ b/docs/reference/itu.md
@@ -22,6 +22,18 @@ The **International Telecommunication Union** (**ITU**) is the United Nations sp
 agency for information and communication technologies. It coordinates the **global radio
 [spectrum](/reference/frequency-bands/)** and publishes the Radio Regulations.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="The ITU dividing the radio spectrum into allocated service blocks worldwide." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="62" x2="430" y2="62" stroke="currentColor" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-width="1.1">
+    <rect x="40" y="44" width="70" height="18" fill="currentColor" fill-opacity="0.12"/><rect x="110" y="44" width="60" height="18" fill="currentColor" fill-opacity="0.22"/><rect x="170" y="44" width="80" height="18" fill="currentColor" fill-opacity="0.12"/><rect x="250" y="44" width="60" height="18" fill="currentColor" fill-opacity="0.22"/><rect x="310" y="44" width="110" height="18" fill="currentColor" fill-opacity="0.12"/>
+  </g>
+  <text x="230" y="30" text-anchor="middle" font-size="9" fill="currentColor">International spectrum allocations</text>
+  <text x="230" y="86" text-anchor="middle" font-size="8.5" fill="currentColor">allocates the spectrum into services</text>
+</svg>
+<figcaption>The ITU coordinates global spectrum allocation and radio regulations across all countries.</figcaption>
+</figure>
+
 ## Overview
 
 The ITU divides the world into regions and allocates bands to services (broadcast,

--- a/docs/reference/james-clerk-maxwell.md
+++ b/docs/reference/james-clerk-maxwell.md
@@ -23,6 +23,16 @@ external:
 electricity, magnetism, and light, **predicting electromagnetic waves** that travel at
 the speed of light.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="Oscillating electric and magnetic fields at right angles forming a travelling electromagnetic wave." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="60" x2="440" y2="60" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 60 q35 -34 70 0 t70 0 t70 0 t70 0 t70 0 t50 0" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <path d="M20 60 q35 22 70 0 t70 0 t70 0 t70 0 t70 0 t50 0" fill="none" stroke="currentColor" stroke-width="1.3" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+  <text x="120" y="28" font-size="9" fill="currentColor">electric field</text><text x="120" y="100" font-size="9" fill="currentColor">magnetic field</text>
+</svg>
+<figcaption>Maxwell's equations unified electricity and magnetism and predicted electromagnetic waves — the foundation of radio.</figcaption>
+</figure>
+
 ## Life and work
 
 In the 1860s Maxwell formulated the four equations that bear his name, showing that

--- a/docs/reference/james-clerk-maxwell.md
+++ b/docs/reference/james-clerk-maxwell.md
@@ -1,0 +1,39 @@
+---
+slug: james-clerk-maxwell
+title: James Clerk Maxwell
+entry_type: person
+category: people
+description: James Clerk Maxwell (1831–1879) was a Scottish physicist whose equations unified electricity and magnetism and predicted electromagnetic waves travelling at the speed of light.
+keywords: James Clerk Maxwell, Maxwell's equations, electromagnetism, electromagnetic waves, physics
+aka: [James Clerk Maxwell]
+autolink: true
+infobox:
+  - { label: Lived, value: "1831–1879" }
+  - { label: Field, value: Physics }
+  - { label: Known for, value: "Maxwell's equations" }
+  - { label: Predicted, value: Electromagnetic waves }
+see_also: [heinrich-hertz, electromagnetic-spectrum, radio-wave]
+related_lessons:
+  - { title: "What is a radio wave?", url: /learn/radio-waves/ }
+external:
+  - { title: "James Clerk Maxwell (Wikipedia)", url: https://en.wikipedia.org/wiki/James_Clerk_Maxwell }
+---
+
+**James Clerk Maxwell** (1831–1879) was a Scottish physicist whose equations unified
+electricity, magnetism, and light, **predicting electromagnetic waves** that travel at
+the speed of light.
+
+## Life and work
+
+In the 1860s Maxwell formulated the four equations that bear his name, showing that
+changing electric and magnetic fields sustain one another and propagate as waves.
+
+## Contribution
+
+His theory predicted the [electromagnetic spectrum](/reference/electromagnetic-spectrum/)
+decades before radio existed; [Heinrich Hertz](/reference/heinrich-hertz/) later proved it.
+
+## Legacy
+
+Maxwell's equations remain the foundation of all radio engineering, including
+[software-defined radio](/reference/software-defined-radio/).

--- a/docs/reference/joseph-fourier.md
+++ b/docs/reference/joseph-fourier.md
@@ -1,0 +1,37 @@
+---
+slug: joseph-fourier
+title: Joseph Fourier
+entry_type: person
+category: people
+description: Joseph Fourier (1768–1830) was a French mathematician whose analysis showed that signals can be decomposed into sinusoids — the basis of the Fourier transform and all spectrum analysis.
+keywords: Joseph Fourier, Fourier series, Fourier transform, frequency analysis, mathematics
+aka: [Joseph Fourier, Fourier]
+autolink: true
+infobox:
+  - { label: Lived, value: "1768–1830" }
+  - { label: Field, value: Mathematics / physics }
+  - { label: Known for, value: Fourier series and analysis }
+see_also: [fourier-transform, fast-fourier-transform, frequency]
+related_lessons:
+  - { title: "The FFT & reading a waterfall", url: /learn/fft-and-waterfall/ }
+external:
+  - { title: "Joseph Fourier (Wikipedia)", url: https://en.wikipedia.org/wiki/Joseph_Fourier }
+---
+
+**Joseph Fourier** (1768–1830) was a French mathematician and physicist who showed that
+functions can be represented as sums of sinusoids — the insight behind the
+[Fourier transform](/reference/fourier-transform/).
+
+## Life and work
+
+Studying heat conduction, Fourier introduced what became Fourier series and analysis,
+decomposing complex signals into simple frequency components.
+
+## Contribution
+
+His mathematics is the bridge between the time and frequency domains — the very operation
+an [FFT](/reference/fast-fourier-transform/) performs.
+
+## Legacy
+
+Every spectrum display and waterfall in an SDR is, at heart, Fourier's idea made digital.

--- a/docs/reference/joseph-fourier.md
+++ b/docs/reference/joseph-fourier.md
@@ -22,6 +22,17 @@ external:
 functions can be represented as sums of sinusoids — the insight behind the
 [Fourier transform](/reference/fourier-transform/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A complex waveform shown as the sum of several simple sine waves." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 40 q20 -20 40 0 t40 0 t40 0 t40 0 t40 0 t40 0" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.6"/>
+  <path d="M20 65 q10 -12 20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0 t20 0" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.6"/>
+  <text x="300" y="50" font-size="14" fill="currentColor">= </text>
+  <path d="M330 95 q10 -22 20 0 q10 8 20 0 q10 -16 20 0 q10 14 20 0 q10 -10 20 0" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="120" y="110" text-anchor="middle" font-size="9" fill="currentColor">simple sines</text><text x="380" y="110" text-anchor="middle" font-size="9" fill="currentColor">sum</text>
+</svg>
+<figcaption>Fourier showed any signal can be expressed as a sum of sinusoids — the mathematics behind the FFT and spectra.</figcaption>
+</figure>
+
 ## Life and work
 
 Studying heat conduction, Fourier introduced what became Fourier series and analysis,

--- a/docs/reference/local-oscillator.md
+++ b/docs/reference/local-oscillator.md
@@ -1,0 +1,35 @@
+---
+slug: local-oscillator
+title: Local oscillator
+entry_type: term
+category: sdr-dsp
+description: A local oscillator is a tunable reference signal mixed with the incoming signal to shift a chosen band to a lower frequency; its setting is what "tuning" actually changes.
+keywords: local oscillator, LO, mixer, tuning, frequency reference, NCO
+aka: [local oscillator, LO]
+autolink: true
+infobox:
+  - { label: Type, value: Reference signal source }
+  - { label: Role, value: Sets the band shifted down by the mixer }
+  - { label: Digital form, value: Numerically controlled oscillator }
+see_also: [superheterodyne-receiver, digital-down-converter, frequency, ppm-frequency-correction]
+related_lessons:
+  - { title: "How an SDR receiver works", url: /learn/sdr-receiver/ }
+external:
+  - { title: "Local oscillator (Wikipedia)", url: https://en.wikipedia.org/wiki/Local_oscillator }
+---
+
+A **local oscillator** (**LO**) is a tunable reference signal mixed with the incoming
+signal to shift a chosen band down toward baseband. **Tuning a receiver is just changing
+the LO frequency.**
+
+## How it works
+
+In hardware the LO drives an analog mixer; in software a numerically controlled
+oscillator performs the same shift digitally inside a
+[digital down-converter](/reference/digital-down-converter/). LO inaccuracy shows up as a
+[PPM frequency error](/reference/ppm-frequency-correction/).
+
+## Relevance to SDR
+
+The LO sets which part of the spectrum lands in the ADC's window, so its accuracy and
+stability directly affect tuning.

--- a/docs/reference/local-oscillator.md
+++ b/docs/reference/local-oscillator.md
@@ -22,6 +22,20 @@ A **local oscillator** (**LO**) is a tunable reference signal mixed with the inc
 signal to shift a chosen band down toward baseband. **Tuning a receiver is just changing
 the LO frequency.**
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A mixer combining an incoming RF signal and a local-oscillator tone to produce a shifted lower frequency." xmlns="http://www.w3.org/2000/svg">
+  <text x="30" y="45" font-size="9" fill="currentColor">RF in</text>
+  <line x1="30" y1="55" x2="150" y2="55" stroke="currentColor" stroke-width="1.3"/>
+  <circle cx="175" cy="55" r="22" fill="none" stroke="currentColor" stroke-width="1.4"/><path d="M160 40 L190 70 M190 40 L160 70" stroke="currentColor" stroke-width="1.2"/>
+  <text x="175" y="100" font-size="9" fill="currentColor" text-anchor="middle">LO (tunable)</text><line x1="175" y1="92" x2="175" y2="78" stroke="currentColor"/>
+  <line x1="197" y1="55" x2="320" y2="55" stroke="currentColor" stroke-width="1.3" marker-end="url(#loar)"/>
+  <text x="330" y="51" font-size="9" fill="currentColor">shifted</text><text x="330" y="63" font-size="9" fill="currentColor">(IF/baseband)</text>
+  <text x="120" y="30" font-size="9" fill="currentColor" text-anchor="middle">tuning = changing the LO</text>
+  <defs><marker id="loar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The local oscillator sets the tuned frequency: the mixer shifts the chosen band down for digitising.</figcaption>
+</figure>
+
 ## How it works
 
 In hardware the LO drives an analog mixer; in software a numerically controlled

--- a/docs/reference/low-noise-amplifier.md
+++ b/docs/reference/low-noise-amplifier.md
@@ -23,6 +23,19 @@ A **low-noise amplifier** (**LNA**) boosts a weak [antenna](/reference/antenna/)
 noise as possible. Because later stages add their own noise, amplifying first preserves
 [SNR](/reference/signal-to-noise-ratio/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="Antenna into a low-noise amplifier early in the chain, boosting the weak signal before later stages add noise." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="35" y="55">antenna</text>
+    <path d="M120 38 L120 68 L160 53 Z" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="135" y="84" font-size="8">LNA</text>
+    <rect x="200" y="38" width="80" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="240" y="57">receiver</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="62" y1="53" x2="119" y2="53"/><line x1="160" y1="53" x2="199" y2="53"/></g>
+    <text x="330" y="49" font-size="8">boost early =</text><text x="330" y="61" font-size="8">best sensitivity</text>
+  </g>
+</svg>
+<figcaption>A low-noise amplifier boosts the faint antenna signal early, setting the receiver's sensitivity.</figcaption>
+</figure>
+
 ## How it works
 
 An LNA's *noise figure* largely determines how weak a signal the whole receiver can

--- a/docs/reference/low-noise-amplifier.md
+++ b/docs/reference/low-noise-amplifier.md
@@ -1,0 +1,35 @@
+---
+slug: low-noise-amplifier
+title: Low-noise amplifier (LNA)
+entry_type: hardware
+category: hardware
+description: A low-noise amplifier boosts a weak antenna signal early in the receive chain with minimal added noise, setting much of a receiver's sensitivity.
+keywords: LNA, low noise amplifier, noise figure, sensitivity, front end, preamp
+aka: [low-noise amplifier, LNA]
+autolink: true
+infobox:
+  - { label: Type, value: RF amplifier }
+  - { label: Placed, value: Early in receive chain (near antenna) }
+  - { label: Key spec, value: Noise figure }
+see_also: [noise-floor, signal-to-noise-ratio, superheterodyne-receiver, bias-tee, antenna]
+related_lessons:
+  - { title: "How an SDR receiver works", url: /learn/sdr-receiver/ }
+external:
+  - { title: "Low-noise amplifier (Wikipedia)", url: https://en.wikipedia.org/wiki/Low-noise_amplifier }
+---
+
+A **low-noise amplifier** (**LNA**) boosts a weak [antenna](/reference/antenna/) signal
+**early** in the [receive chain](/reference/superheterodyne-receiver/), adding as little
+noise as possible. Because later stages add their own noise, amplifying first preserves
+[SNR](/reference/signal-to-noise-ratio/).
+
+## How it works
+
+An LNA's *noise figure* largely determines how weak a signal the whole receiver can
+detect — its sensitivity. It is best mounted at the antenna, often powered through the
+coax by a [bias tee](/reference/bias-tee/).
+
+## Relevance to SDR
+
+An antenna-mounted LNA can meaningfully improve reception of weak signals, especially
+with lossy cable runs — but watch for overload from strong nearby transmitters.

--- a/docs/reference/ltr.md
+++ b/docs/reference/ltr.md
@@ -26,6 +26,15 @@ external:
 LTR is **distributed**: trunking data rides **subaudibly on each voice channel**, so
 every channel carries its own low-speed signalling.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 130" role="img" aria-label="Several LTR channels, each carrying analog voice plus its own embedded subaudible signalling — no dedicated control channel." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1" fill="none"><rect x="40" y="35" width="300" height="22"/><rect x="40" y="63" width="300" height="22"/><rect x="40" y="91" width="300" height="22"/></g>
+  <g font-size="8" fill="currentColor"><text x="50" y="50">voice + subaudible data</text><text x="50" y="78">voice + subaudible data</text><text x="50" y="106">voice + subaudible data</text></g>
+  <text x="190" y="128" text-anchor="middle" font-size="8" fill="currentColor">distributed — no dedicated control channel</text>
+</svg>
+<figcaption>LTR is distributed trunking: each channel carries its own subaudible signalling, with no separate control channel.</figcaption>
+</figure>
+
 ## Overview
 
 Because there is no separate control channel, radios monitor the embedded data

--- a/docs/reference/ltr.md
+++ b/docs/reference/ltr.md
@@ -1,0 +1,55 @@
+---
+slug: ltr
+title: LTR (Logic Trunked Radio)
+entry_type: protocol
+category: protocols
+description: LTR (Logic Trunked Radio) is a simple distributed trunking protocol by E.F. Johnson with no dedicated control channel — signalling is embedded subaudibly on each channel.
+keywords: LTR, Logic Trunked Radio, E.F. Johnson, distributed trunking, subaudible signalling, business radio
+aka: [LTR, Logic Trunked Radio]
+autolink: true
+infobox:
+  - { label: Type, value: Analog trunked radio }
+  - { label: Developer, value: E.F. Johnson }
+  - { label: Access, value: FDMA, distributed (no dedicated control channel) }
+  - { label: Signalling, value: Subaudible LCN data on each channel }
+  - { label: Voice, value: Analog FM }
+  - { label: GopherTrunk support, value: See Status }
+see_also: [trunked-radio, control-channel, motorola-type-ii, edacs, mpt-1327]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Logic Trunked Radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Logic_Trunked_Radio }
+---
+
+**LTR** (**Logic Trunked Radio**) is a simple, low-cost trunking protocol from
+**E.F. Johnson**. Unlike systems with a dedicated [control channel](/reference/control-channel/),
+LTR is **distributed**: trunking data rides **subaudibly on each voice channel**, so
+every channel carries its own low-speed signalling.
+
+## Overview
+
+Because there is no separate control channel, radios monitor the embedded data
+(logical channel numbers and home-repeater info) to follow calls. This makes LTR
+cheap to deploy but trickier to monitor than control-channel systems.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | [FDMA](/reference/fdma/), distributed |
+| Signalling | Subaudible data on each channel |
+| Voice | Analog FM |
+
+## History
+
+Introduced by E.F. Johnson and widely used for business/SMR trunking; variants
+include LTR-Net and PassPort.
+
+## Deployment
+
+Common in commercial/business shared systems (taxi, delivery, utilities), especially
+in North America.
+
+## Decoding it with GopherTrunk
+
+See [Status](/status.html) for GopherTrunk's handling of LTR's subaudible signalling.

--- a/docs/reference/m17-project.md
+++ b/docs/reference/m17-project.md
@@ -1,0 +1,34 @@
+---
+slug: m17-project
+title: M17 Project
+entry_type: organization
+category: organizations
+description: The M17 Project is an open-source community developing the royalty-free M17 amateur digital-voice protocol and associated open hardware and software.
+keywords: M17 Project, open source, amateur radio, Codec 2, royalty-free, digital voice
+aka: [M17 Project]
+autolink: true
+infobox:
+  - { label: Type, value: Open-source community project }
+  - { label: Develops, value: M17 protocol + open tools }
+  - { label: Ethos, value: Royalty-free, patent-free }
+see_also: [m17, codec2, vocoder]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "M17 Project", url: https://m17project.org/ }
+---
+
+The **M17 Project** is an open-source community that develops the royalty-free
+**[M17](/reference/m17/)** amateur digital-voice protocol along with open hardware and
+software implementations.
+
+## Overview
+
+Founded in 2019, the project set out to build a modern amateur protocol free of vocoder
+licensing constraints, adopting the open [Codec 2](/reference/codec2/)
+[vocoder](/reference/vocoder/) instead of patented alternatives.
+
+## Relevance to SDR
+
+The project's openness makes fully free M17 decoders possible, including GopherTrunk's
+link-layer support.

--- a/docs/reference/m17-project.md
+++ b/docs/reference/m17-project.md
@@ -22,6 +22,19 @@ The **M17 Project** is an open-source community that develops the royalty-free
 **[M17](/reference/m17/)** amateur digital-voice protocol along with open hardware and
 software implementations.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="The open-source M17 Project maintains the royalty-free M17 protocol." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="100" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="70" y="61">M17 Project</text>
+    <rect x="170" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="225" y="61">maintains</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">M17 (open)</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="120" y1="58" x2="169" y2="58" marker-end="url(#rel_m17-project)"/><line x1="280" y1="58" x2="329" y2="58" marker-end="url(#rel_m17-project)"/></g>
+  </g>
+  <defs><marker id="rel_m17-project" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The M17 Project is the open-source community that maintains the royalty-free M17 protocol.</figcaption>
+</figure>
+
 ## Overview
 
 Founded in 2019, the project set out to build a modern amateur protocol free of vocoder

--- a/docs/reference/m17.md
+++ b/docs/reference/m17.md
@@ -1,0 +1,61 @@
+---
+slug: m17
+title: M17
+entry_type: protocol
+category: protocols
+description: M17 is an open-source amateur digital-voice and data protocol using 4FSK modulation and the royalty-free Codec 2 vocoder, designed as a patent-free alternative to AMBE-based systems.
+keywords: M17, open source digital voice, Codec 2, 4FSK, amateur radio, royalty-free vocoder, convolutional code
+aka: [M17]
+autolink: true
+infobox:
+  - { label: Type, value: Amateur digital voice + data }
+  - { label: Developer, value: M17 Project (open source) }
+  - { label: Access, value: FDMA }
+  - { label: Modulation, value: 4FSK (9600 bps) }
+  - { label: Vocoder, value: Codec 2 (royalty-free) }
+  - { label: Error correction, value: Convolutional code + Golay }
+  - { label: GopherTrunk support, value: Decoded (link layer) }
+see_also: [codec2, frequency-shift-keying, convolutional-code, golay-code, m17-project]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+  - { title: "Vocoders — IMBE & AMBE+2", url: /learn/vocoders/ }
+external:
+  - { title: "M17 (Wikipedia)", url: https://en.wikipedia.org/wiki/M17_(amateur_radio) }
+  - { title: "M17 Project", url: https://m17project.org/ }
+---
+
+**M17** is an **open-source** amateur digital-voice and data protocol created by the
+[M17 Project](/reference/m17-project/). Its defining choice is the **royalty-free
+[Codec 2](/reference/codec2/)** vocoder, making it a fully patent-free alternative to
+[AMBE](/reference/ambe/)-based systems like [DMR](/reference/dmr/) and
+[D-STAR](/reference/d-star/).
+
+## Overview
+
+M17 uses [4FSK](/reference/frequency-shift-keying/) at 9600 bps and protects data with
+a [convolutional code](/reference/convolutional-code/) and
+[Golay](/reference/golay-code/) coding. It carries callsign metadata and supports both
+voice and packet/stream data, with internet reflectors for linking.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | [FDMA](/reference/fdma/) |
+| Modulation | 4FSK, 9600 bps |
+| Vocoder | Codec 2 |
+| Error correction | Convolutional (K=5) + Golay(24,12) |
+
+## History
+
+Started in 2019 as a community project to build a modern, open amateur protocol free
+of vocoder licensing constraints.
+
+## Deployment
+
+Growing amateur use via M17-capable firmware, hotspots, and reflectors.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk decodes the M17 link layer (callsigns, mode, stream metadata). See
+[M17 link layer](/m17.html) and [Status](/status.html).

--- a/docs/reference/m17.md
+++ b/docs/reference/m17.md
@@ -30,6 +30,17 @@ external:
 [AMBE](/reference/ambe/)-based systems like [DMR](/reference/dmr/) and
 [D-STAR](/reference/d-star/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="An M17 stream frame with sync, callsign metadata, and a Codec 2 voice payload." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1">
+    <rect x="30" y="40" width="50" height="30" fill="none"/><rect x="80" y="40" width="120" height="30" fill="currentColor" fill-opacity="0.12"/><rect x="200" y="40" width="230" height="30" fill="currentColor" fill-opacity="0.22"/>
+  </g>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle"><text x="55" y="59">sync</text><text x="140" y="59">callsigns (LICH)</text><text x="315" y="59">Codec 2 voice</text></g>
+  <text x="230" y="90" text-anchor="middle" font-size="8" fill="currentColor">4FSK · convolutional + Golay coded</text>
+</svg>
+<figcaption>An M17 frame carries sync, callsign metadata, and a royalty-free Codec 2 voice payload over 4FSK.</figcaption>
+</figure>
+
 ## Overview
 
 M17 uses [4FSK](/reference/frequency-shift-keying/) at 9600 bps and protects data with

--- a/docs/reference/matched-filter.md
+++ b/docs/reference/matched-filter.md
@@ -22,6 +22,19 @@ A **matched filter** is the linear filter that maximises
 [SNR](/reference/signal-to-noise-ratio/) against a *known* signal shape. Its impulse
 response is a time-reversed copy of the pulse it is matched to.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A noisy input on the left and a sharp correlation peak on the right after matched filtering." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 70 L40 64 L60 78 L80 60 L100 80 L120 66 L140 74 L160 62 L180 78 L200 68" fill="none" stroke="currentColor" stroke-width="1.3" stroke-opacity="0.6"/>
+  <text x="110" y="105" text-anchor="middle" font-size="9" fill="currentColor">noisy input</text>
+  <line x1="225" y1="65" x2="260" y2="65" stroke="currentColor" marker-end="url(#mfar)"/>
+  <line x1="280" y1="90" x2="440" y2="90" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M280 88 L350 88 L360 30 L370 88 L440 88" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="360" y="105" text-anchor="middle" font-size="9" fill="currentColor">correlation peak</text>
+  <defs><marker id="mfar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A matched filter maximises SNR for a known pulse shape, producing a sharp peak the detector can time on.</figcaption>
+</figure>
+
 ## How it works
 
 By correlating the incoming signal with the expected pulse, it concentrates energy at the

--- a/docs/reference/matched-filter.md
+++ b/docs/reference/matched-filter.md
@@ -1,0 +1,36 @@
+---
+slug: matched-filter
+title: Matched filter
+entry_type: algorithm
+category: sdr-dsp
+description: A matched filter is the optimal linear filter for maximising signal-to-noise ratio against a known pulse shape, used in receivers to sharpen symbol detection.
+keywords: matched filter, optimal filter, SNR, correlation, pulse shape, detection
+aka: [matched filter]
+autolink: true
+infobox:
+  - { label: Type, value: Optimal detection filter }
+  - { label: Maximises, value: SNR at the sampling instant }
+  - { label: Form, value: Time-reversed copy of the pulse }
+see_also: [root-raised-cosine-filter, digital-filter, signal-to-noise-ratio, demodulation]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Matched filter (Wikipedia)", url: https://en.wikipedia.org/wiki/Matched_filter }
+---
+
+A **matched filter** is the linear filter that maximises
+[SNR](/reference/signal-to-noise-ratio/) against a *known* signal shape. Its impulse
+response is a time-reversed copy of the pulse it is matched to.
+
+## How it works
+
+By correlating the incoming signal with the expected pulse, it concentrates energy at the
+ideal sampling instant, giving the cleanest possible symbol decision. For RRC-shaped
+signals, the receiver's [RRC](/reference/root-raised-cosine-filter/) is the matched
+filter.
+
+## Relevance to SDR
+
+Matched filtering is a standard receive step that improves
+[demodulation](/reference/demodulation/) of weak digital signals such as
+[AIS](/reference/ais/) and [APRS](/reference/aprs/).

--- a/docs/reference/mdc1200.md
+++ b/docs/reference/mdc1200.md
@@ -27,6 +27,16 @@ sends a short **1200 bps [FFSK](/reference/ffsk/)** data burst over an otherwise
 **analog FM** voice channel. It conveys a transmitting radio's unit ID (PTT
 ID / ANI), plus emergency and status signalling.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="An analog transmission with a short MDC-1200 data burst at the start carrying the unit ID." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="45" width="60" height="28" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/><text x="70" y="63" text-anchor="middle" font-size="8" fill="currentColor">MDC burst</text>
+  <rect x="100" y="45" width="320" height="28" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="260" y="63" text-anchor="middle" font-size="9" fill="currentColor">analog FM voice</text>
+  <text x="70" y="36" text-anchor="middle" font-size="8" fill="currentColor">unit ID</text>
+  <text x="230" y="98" text-anchor="middle" font-size="8" fill="currentColor">1200 bps FFSK at start (and optionally end) of PTT</text>
+</svg>
+<figcaption>MDC-1200 sends a brief FFSK data burst (the unit ID) at the start of an otherwise analog transmission.</figcaption>
+</figure>
+
 ## Overview
 
 When a user keys up, the radio can send a brief MDC burst at the start (and/or end) of

--- a/docs/reference/mdc1200.md
+++ b/docs/reference/mdc1200.md
@@ -1,0 +1,59 @@
+---
+slug: mdc1200
+title: MDC-1200
+entry_type: protocol
+category: protocols
+description: MDC-1200 is a Motorola in-band signalling system that sends a 1200 bps FFSK data burst over analog FM voice channels to convey unit IDs (PTT ID), emergency, and status.
+keywords: MDC-1200, MDC1200, Motorola signalling, PTT ID, FFSK, ANI, emergency, status, in-band
+aka: [MDC-1200, MDC1200]
+autolink: true
+infobox:
+  - { label: Type, value: In-band signalling (over analog FM) }
+  - { label: Developer, value: Motorola }
+  - { label: Modulation, value: 1200 bps FFSK (Fast FSK) }
+  - { label: Carries, value: Unit ID (ANI), emergency, status }
+  - { label: Error correction, value: Parity / repetition }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [ffsk, radio-id, frequency-shift-keying]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "MDC-1200 (Wikipedia)", url: https://en.wikipedia.org/wiki/MDC-1200 }
+  - { title: "GopherTrunk MDC1200 decoder", url: /mdc1200.html }
+---
+
+**MDC-1200** (Motorola Data Communications) is an **in-band signalling** system that
+sends a short **1200 bps [FFSK](/reference/ffsk/)** data burst over an otherwise
+**analog FM** voice channel. It conveys a transmitting radio's unit ID (PTT
+ID / ANI), plus emergency and status signalling.
+
+## Overview
+
+When a user keys up, the radio can send a brief MDC burst at the start (and/or end) of
+the transmission identifying the unit — giving an analog system some of the
+[radio-ID](/reference/radio-id/) visibility that digital systems carry natively.
+Emergency and status features ride on the same signalling.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Modulation | 1200 bps FFSK |
+| Carries | Unit ID, emergency, status |
+| Channel | Over analog FM voice |
+| Error control | Parity / repetition |
+
+## History
+
+Developed by Motorola for conventional and trunked analog systems as a lightweight
+data-signalling layer; widely used by public-safety and business fleets.
+
+## Deployment
+
+Analog FM systems needing unit identification and emergency signalling, including many
+public-safety conventional channels.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk detects the FFSK burst on analog channels and decodes the unit ID and
+flags. See the [MDC1200 decoder](/mdc1200.html) page.

--- a/docs/reference/modulation.md
+++ b/docs/reference/modulation.md
@@ -1,0 +1,37 @@
+---
+slug: modulation
+title: Modulation
+entry_type: term
+category: rf-fundamentals
+description: Modulation is the process of varying a carrier wave's amplitude, frequency, or phase to encode information for transmission over radio.
+keywords: modulation, AM FM PSK FSK, carrier, encoding information
+infobox:
+  - { label: Type, value: Signal-processing concept }
+  - { label: Varies, value: Amplitude, frequency, or phase }
+  - { label: Families, value: Analog (AM/FM/SSB), digital (FSK/PSK/QAM) }
+see_also: [carrier-wave, amplitude-modulation, frequency-modulation, phase-shift-keying, frequency-shift-keying, quadrature-amplitude-modulation]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+  - { title: "Analog modulation — AM, FM, SSB", url: /learn/analog-modulation/ }
+external:
+  - { title: "Modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Modulation }
+---
+
+**Modulation** is the process of varying a property of a
+[carrier wave](/reference/carrier-wave/) — its [amplitude](/reference/amplitude/),
+[frequency](/reference/frequency/), or [phase](/reference/phase/) — in step with a
+message so that information can travel over radio.
+
+## How it works
+
+Analog modulation varies a property continuously: [AM](/reference/amplitude-modulation/),
+[FM](/reference/frequency-modulation/), and [SSB](/reference/single-sideband/). Digital
+modulation switches the carrier between discrete states (symbols):
+[FSK](/reference/frequency-shift-keying/), [PSK](/reference/phase-shift-keying/), and
+[QAM](/reference/quadrature-amplitude-modulation/).
+
+## Relevance to SDR
+
+Choosing the matching demodulator for a signal's modulation is the heart of decoding.
+The same three carrier properties reappear as the axes of the
+[IQ](/reference/iq-data/) plane.

--- a/docs/reference/modulation.md
+++ b/docs/reference/modulation.md
@@ -22,6 +22,18 @@ external:
 [frequency](/reference/frequency/), or [phase](/reference/phase/) — in step with a
 message so that information can travel over radio.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A message wave, then an AM version whose height follows the message, then an FM version whose spacing follows the message." xmlns="http://www.w3.org/2000/svg">
+  <text x="6" y="22" font-size="10" fill="currentColor">message</text>
+  <path d="M70 20 Q120 0 170 20 T270 20 T370 20 T440 20" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="6" y="78" font-size="10" fill="currentColor">AM</text>
+  <path d="M70 75 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0 q5 -12 10 0 q5 -8 10 0 q5 -12 10 0 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0 q5 -12 10 0 q5 -8 10 0 q5 -12 10 0 q5 -22 10 0 q5 -28 10 0 q5 -22 10 0 q5 -12 10 0 q5 -8 10 0" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  <text x="6" y="140" font-size="10" fill="currentColor">FM</text>
+  <path d="M70 137 q4 -16 8 0 q4 -16 8 0 q6 -16 12 0 q7 -16 14 0 q8 -16 16 0 q7 -16 14 0 q6 -16 12 0 q4 -16 8 0 q4 -16 8 0 q4 -16 8 0 q6 -16 12 0 q7 -16 14 0 q8 -16 16 0 q7 -16 14 0 q6 -16 12 0 q4 -16 8 0 q4 -16 8 0" fill="none" stroke="currentColor" stroke-width="1.3"/>
+</svg>
+<figcaption>Modulation encodes a message by varying the carrier — its amplitude (AM), frequency (FM), or phase.</figcaption>
+</figure>
+
 ## How it works
 
 Analog modulation varies a property continuously: [AM](/reference/amplitude-modulation/),

--- a/docs/reference/motorola-type-ii.md
+++ b/docs/reference/motorola-type-ii.md
@@ -29,6 +29,17 @@ with **analog FM** voice channels. It was the dominant trunking technology for
 public-safety and business fleets before the migration to digital
 [P25](/reference/project-25/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 140" role="img" aria-label="Motorola Type II digital control channel assigning analog voice channels." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="300" height="26" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="190" y="37" text-anchor="middle" font-size="9" fill="currentColor">digital control channel (3600 bps)</text>
+  <g stroke="currentColor" stroke-width="1.1" fill="none"><rect x="40" y="80" width="90" height="34"/><rect x="150" y="80" width="90" height="34"/><rect x="260" y="80" width="80" height="34" fill="currentColor" fill-opacity="0.18"/></g>
+  <text x="190" y="130" text-anchor="middle" font-size="8.5" fill="currentColor">analog FM voice channels (assigned on demand)</text>
+  <line x1="190" y1="46" x2="300" y2="78" stroke="currentColor" stroke-dasharray="3 3" marker-end="url(#lg_motorola-type-ii)"/>
+  <defs><marker id="lg_motorola-type-ii" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Motorola Type II pairs a digital control channel with analog FM voice channels.</figcaption>
+</figure>
+
 ## Overview
 
 The control channel (a 3600 bps data stream) issues [channel grants](/reference/channel-grant/),

--- a/docs/reference/motorola-type-ii.md
+++ b/docs/reference/motorola-type-ii.md
@@ -1,0 +1,61 @@
+---
+slug: motorola-type-ii
+title: Motorola Type II
+entry_type: protocol
+category: protocols
+description: Motorola Type II is a classic analog trunked-radio system using a digital control channel to assign analog FM voice channels, widely deployed before the move to P25.
+keywords: Motorola Type II, SmartNet, SmartZone, analog trunking, control channel, fleet, public safety legacy
+aka: [Motorola Type II, SmartNet, SmartZone]
+autolink: true
+infobox:
+  - { label: Type, value: Analog trunked radio (digital control) }
+  - { label: Developer, value: Motorola }
+  - { label: Era, value: 1980s–2000s }
+  - { label: Access, value: FDMA with digital control channel }
+  - { label: Voice, value: Analog FM }
+  - { label: Control channel, value: 3600 bps digital }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [trunked-radio, control-channel, edacs, ltr, talkgroup, radio-id]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Motorola Type II (Wikipedia)", url: https://en.wikipedia.org/wiki/Motorola_Type_II }
+---
+
+**Motorola Type II** is a classic **analog trunked-radio** family (SmartNet /
+SmartZone) that pairs a **digital [control channel](/reference/control-channel/)**
+with **analog FM** voice channels. It was the dominant trunking technology for
+public-safety and business fleets before the migration to digital
+[P25](/reference/project-25/).
+
+## Overview
+
+The control channel (a 3600 bps data stream) issues [channel grants](/reference/channel-grant/),
+pointing radios in a [talkgroup](/reference/talkgroup/) to an analog voice frequency.
+This makes it a [trunked](/reference/trunked-radio/) system even though the voice
+itself is analog FM. Each transmitting radio carries a [radio ID](/reference/radio-id/).
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | [FDMA](/reference/fdma/) |
+| Control channel | 3600 bps digital |
+| Voice | Analog FM |
+| IDs | Talkgroups and radio IDs in control data |
+
+## History
+
+Introduced by Motorola in the 1980s (SmartNet), later extended with multi-site
+SmartZone, and ubiquitous through the 1990s–2000s.
+
+## Deployment
+
+Many legacy public-safety and commercial systems; steadily replaced by P25, though
+some remain in service.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk decodes the Type II control channel and follows grants to the analog
+voice channels. See [Status](/status.html).

--- a/docs/reference/mpt-1327.md
+++ b/docs/reference/mpt-1327.md
@@ -1,0 +1,57 @@
+---
+slug: mpt-1327
+title: MPT 1327
+entry_type: protocol
+category: protocols
+description: MPT 1327 is a British-originated analog trunking signalling standard with a dedicated control channel, widely used internationally for business and government radio.
+keywords: MPT 1327, MPT1327, analog trunking, control channel, FFSK signalling, business radio, international
+aka: [MPT 1327, MPT-1327, MPT1327]
+autolink: true
+infobox:
+  - { label: Type, value: Analog trunked radio }
+  - { label: Origin, value: UK (MPT series) }
+  - { label: Access, value: FDMA with dedicated control channel }
+  - { label: Control signalling, value: 1200 bps FFSK }
+  - { label: Voice, value: Analog FM }
+  - { label: GopherTrunk support, value: See Status }
+see_also: [trunked-radio, control-channel, ffsk, ltr, edacs]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "MPT-1327 (Wikipedia)", url: https://en.wikipedia.org/wiki/MPT-1327 }
+---
+
+**MPT 1327** is an analog [trunked-radio](/reference/trunked-radio/) signalling
+standard that originated in the United Kingdom. It uses a **dedicated
+[control channel](/reference/control-channel/)** carrying **1200 bps
+[FFSK](/reference/ffsk/)** data to manage analog FM voice channels, and became a
+common international trunking standard.
+
+## Overview
+
+MPT 1327 defines the control-channel signalling (call requests, grants, and
+identities) while voice remains analog FM on assigned channels. It was a widely
+adopted open alternative to proprietary systems like
+[Motorola Type II](/reference/motorola-type-ii/).
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | [FDMA](/reference/fdma/) |
+| Control signalling | 1200 bps FFSK |
+| Voice | Analog FM |
+
+## History
+
+Published in the UK in the 1980s; deployed across Europe, Asia, Africa, and
+Australasia for commercial and government trunking.
+
+## Deployment
+
+Business, transport, and government fleets internationally; declining as digital
+standards take over.
+
+## Decoding it with GopherTrunk
+
+See [Status](/status.html) for GopherTrunk's MPT 1327 control-channel support.

--- a/docs/reference/mpt-1327.md
+++ b/docs/reference/mpt-1327.md
@@ -27,6 +27,17 @@ standard that originated in the United Kingdom. It uses a **dedicated
 [FFSK](/reference/ffsk/)** data to manage analog FM voice channels, and became a
 common international trunking standard.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 140" role="img" aria-label="MPT 1327 FFSK control channel assigning analog voice channels." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="300" height="26" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="190" y="37" text-anchor="middle" font-size="9" fill="currentColor">control channel (1200 bps FFSK)</text>
+  <g stroke="currentColor" stroke-width="1.1" fill="none"><rect x="40" y="80" width="90" height="34"/><rect x="150" y="80" width="90" height="34"/><rect x="260" y="80" width="80" height="34" fill="currentColor" fill-opacity="0.18"/></g>
+  <text x="190" y="130" text-anchor="middle" font-size="8.5" fill="currentColor">analog FM voice channels (assigned on demand)</text>
+  <line x1="190" y1="46" x2="300" y2="78" stroke="currentColor" stroke-dasharray="3 3" marker-end="url(#lg_mpt-1327)"/>
+  <defs><marker id="lg_mpt-1327" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>MPT 1327 uses an FFSK control channel to manage analog FM voice channels.</figcaption>
+</figure>
+
 ## Overview
 
 MPT 1327 defines the control-channel signalling (call requests, grants, and

--- a/docs/reference/mueller-muller-timing-recovery.md
+++ b/docs/reference/mueller-muller-timing-recovery.md
@@ -21,6 +21,16 @@ external:
 **Mueller–Müller timing recovery** is a decision-directed symbol-timing algorithm that
 needs only **one sample per symbol**, making it computationally efficient.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A symbol waveform sampled once per symbol, with successive samples used to estimate and correct timing." xmlns="http://www.w3.org/2000/svg">
+  <path d="M30 90 C 90 90 90 40 150 40 C 210 40 210 90 270 90 C 330 90 330 40 390 40" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <g fill="currentColor"><circle cx="150" cy="40" r="3.5"/><circle cx="270" cy="90" r="3.5"/></g>
+  <line x1="150" y1="20" x2="150" y2="100" stroke="currentColor" stroke-dasharray="3 3" stroke-opacity="0.5"/><line x1="270" y1="20" x2="270" y2="100" stroke="currentColor" stroke-dasharray="3 3" stroke-opacity="0.5"/>
+  <text x="230" y="118" text-anchor="middle" font-size="9" fill="currentColor">one sample per symbol — lower rate than Gardner</text>
+</svg>
+<figcaption>Mueller–Müller timing recovery needs only one sample per symbol, using successive decisions to correct timing.</figcaption>
+</figure>
+
 ## How it works
 
 It uses current and previous symbol decisions to estimate the timing error and drive a

--- a/docs/reference/mueller-muller-timing-recovery.md
+++ b/docs/reference/mueller-muller-timing-recovery.md
@@ -1,0 +1,33 @@
+---
+slug: mueller-muller-timing-recovery
+title: Mueller–Müller timing recovery
+entry_type: algorithm
+category: algorithms
+description: Mueller–Müller timing recovery is a decision-directed symbol-timing algorithm that needs only one sample per symbol, making it efficient for many digital demodulators.
+keywords: Mueller-Muller, timing recovery, decision directed, symbol timing, clock recovery, one sample per symbol
+aka: [Mueller–Müller timing recovery, Mueller-Muller]
+autolink: true
+infobox:
+  - { label: Type, value: Symbol-timing algorithm }
+  - { label: Feature, value: One sample per symbol (decision-directed) }
+  - { label: Use, value: AIS, APRS, paging demodulators }
+see_also: [clock-recovery, gardner-timing-recovery, symbol-rate, ais, aprs]
+related_lessons:
+  - { title: "Clock recovery & symbol timing", url: /learn/clock-recovery/ }
+external:
+  - { title: "Symbol synchronization (Wikipedia)", url: https://en.wikipedia.org/wiki/Symbol_synchronization }
+---
+
+**Mueller–Müller timing recovery** is a decision-directed symbol-timing algorithm that
+needs only **one sample per symbol**, making it computationally efficient.
+
+## How it works
+
+It uses current and previous symbol decisions to estimate the timing error and drive a
+loop that keeps sampling at the symbol centre — at the cost of needing reasonably reliable
+decisions to start.
+
+## Relevance to SDR
+
+GopherTrunk uses Mueller–Müller recovery in decoders such as [AIS](/reference/ais/),
+[APRS](/reference/aprs/), and signalling pipelines.

--- a/docs/reference/multi-band-excitation.md
+++ b/docs/reference/multi-band-excitation.md
@@ -22,6 +22,16 @@ external:
 by its pitch and a decision, per frequency band, of whether that band is *voiced*
 (pitched) or *unvoiced* (noisy), plus the spectral envelope.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A speech spectrum divided into frequency bands, each independently declared voiced or unvoiced." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="90" x2="430" y2="90" stroke="currentColor" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-width="1.4"><line x1="80" y1="90" x2="80" y2="38"/><line x1="140" y1="90" x2="140" y2="52"/><line x1="200" y1="90" x2="200" y2="44"/><line x1="260" y1="90" x2="260" y2="62"/><line x1="320" y1="90" x2="320" y2="50"/><line x1="380" y1="90" x2="380" y2="70"/></g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="80" y="104">V</text><text x="140" y="104">V</text><text x="200" y="104">U</text><text x="260" y="104">V</text><text x="320" y="104">U</text><text x="380" y="104">V</text></g>
+  <text x="230" y="26" text-anchor="middle" font-size="9" fill="currentColor">voiced (V) / unvoiced (U) decision per band</text>
+</svg>
+<figcaption>Multi-band excitation models speech as a pitched spectrum with a voiced/unvoiced flag per band — the basis of IMBE/AMBE.</figcaption>
+</figure>
+
 ## How it works
 
 Transmitting these compact parameters lets the receiver re-synthesise intelligible speech

--- a/docs/reference/multi-band-excitation.md
+++ b/docs/reference/multi-band-excitation.md
@@ -1,0 +1,35 @@
+---
+slug: multi-band-excitation
+title: Multi-band excitation (MBE)
+entry_type: algorithm
+category: algorithms
+description: Multi-band excitation is a speech-modelling method that splits the spectrum into bands declared voiced or unvoiced; it underlies the IMBE and AMBE vocoder families.
+keywords: multi-band excitation, MBE, speech model, voiced unvoiced, IMBE, AMBE, vocoder
+aka: [multi-band excitation, MBE]
+autolink: true
+infobox:
+  - { label: Type, value: Speech-coding model }
+  - { label: Models, value: Pitch + per-band voicing + spectrum }
+  - { label: Underlies, value: IMBE, AMBE, AMBE+2 }
+see_also: [vocoder, imbe, ambe, ambe-plus-2, dvsi]
+related_lessons:
+  - { title: "Vocoders — IMBE & AMBE+2", url: /learn/vocoders/ }
+external:
+  - { title: "Multi-Band Excitation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+---
+
+**Multi-band excitation** (**MBE**) is a speech-modelling method that represents a voice
+by its pitch and a decision, per frequency band, of whether that band is *voiced*
+(pitched) or *unvoiced* (noisy), plus the spectral envelope.
+
+## How it works
+
+Transmitting these compact parameters lets the receiver re-synthesise intelligible speech
+at a few kbps. MBE underlies the [IMBE](/reference/imbe/) and [AMBE](/reference/ambe/) /
+[AMBE+2](/reference/ambe-plus-2/) [vocoders](/reference/vocoder/) from
+[DVSI](/reference/dvsi/).
+
+## Relevance to SDR
+
+Understanding MBE explains why decoded digital voice can sound robotic and why bit errors
+produce characteristic warbles.

--- a/docs/reference/multipath-propagation.md
+++ b/docs/reference/multipath-propagation.md
@@ -22,6 +22,18 @@ external:
 once — directly and via reflections off buildings, terrain, and vehicles. The copies
 arrive slightly out of step and add or cancel.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A transmitter and receiver with a direct path plus a reflected path bouncing off a building, arriving slightly delayed." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="110" x2="40" y2="70" stroke="currentColor" stroke-width="2"/><text x="40" y="125" text-anchor="middle" font-size="9" fill="currentColor">TX</text>
+  <line x1="420" y1="110" x2="420" y2="70" stroke="currentColor" stroke-width="2"/><text x="420" y="125" text-anchor="middle" font-size="9" fill="currentColor">RX</text>
+  <line x1="48" y1="75" x2="412" y2="75" stroke="currentColor" stroke-width="1.4" marker-end="url(#mpar)"/><text x="200" y="68" font-size="9" fill="currentColor">direct</text>
+  <rect x="225" y="20" width="40" height="24" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1"/>
+  <path d="M48 70 L245 44 L412 70" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#mpar)"/><text x="150" y="40" font-size="9" fill="currentColor">reflected (delayed)</text>
+  <defs><marker id="mpar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Multipath: copies arrive by direct and reflected paths and interfere, causing fading and decode errors.</figcaption>
+</figure>
+
 ## How it works
 
 The interference makes signal strength **fade** and smears digital

--- a/docs/reference/multipath-propagation.md
+++ b/docs/reference/multipath-propagation.md
@@ -1,0 +1,35 @@
+---
+slug: multipath-propagation
+title: Multipath propagation
+entry_type: term
+category: antennas-propagation
+description: Multipath propagation is the arrival of a signal via multiple reflected paths, causing fading and intersymbol interference that can degrade digital decoding.
+keywords: multipath, fading, reflections, intersymbol interference, equalizer
+aka: [multipath, multipath propagation]
+autolink: true
+infobox:
+  - { label: Type, value: Propagation impairment }
+  - { label: Causes, value: Reflections off terrain/buildings }
+  - { label: Effects, value: Fading, symbol smearing }
+see_also: [radio-propagation, cma-equalizer, clock-recovery, radio-horizon]
+related_lessons:
+  - { title: "How signals travel", url: /learn/propagation/ }
+external:
+  - { title: "Multipath propagation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multipath_propagation }
+---
+
+**Multipath propagation** occurs when a signal reaches the receiver by several paths at
+once — directly and via reflections off buildings, terrain, and vehicles. The copies
+arrive slightly out of step and add or cancel.
+
+## How it works
+
+The interference makes signal strength **fade** and smears digital
+[symbols](/reference/symbol-rate/) into one another (intersymbol interference),
+degrading decoding. Moving the antenna a short distance can change multipath markedly.
+
+## Relevance to SDR
+
+Multipath is a common reason a strong signal still won't decode; an
+[equalizer](/reference/cma-equalizer/) and good [clock recovery](/reference/clock-recovery/)
+help combat it.

--- a/docs/reference/noise-floor.md
+++ b/docs/reference/noise-floor.md
@@ -22,6 +22,16 @@ The **noise floor** is the constant background level of random energy present in
 receiver — thermal noise in the electronics plus environmental RF. It is measured in
 [dBm](/reference/dbm/) and sets the bar a signal must clear.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A wandering noisy baseline across frequency, marked as the noise floor, with no signal present." xmlns="http://www.w3.org/2000/svg">
+  <path d="M30 95 L60 90 L90 99 L120 88 L150 96 L180 86 L210 98 L240 90 L270 100 L300 88 L330 95 L360 87 L390 97 L420 91" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <line x1="30" y1="93" x2="430" y2="93" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.6"/>
+  <text x="30" y="40" font-size="11" fill="currentColor">noise floor — the level a signal must rise above</text>
+  <text x="230" y="118" text-anchor="middle" font-size="10" fill="currentColor">frequency →</text>
+</svg>
+<figcaption>The noise floor is the ever-present background from receiver and environmental noise.</figcaption>
+</figure>
+
 ## How it works
 
 Bandwidth, receiver quality, and local interference all raise or lower the floor. A

--- a/docs/reference/noise-floor.md
+++ b/docs/reference/noise-floor.md
@@ -1,0 +1,34 @@
+---
+slug: noise-floor
+title: Noise floor
+entry_type: term
+category: rf-fundamentals
+description: The noise floor is the ever-present background level of thermal and environmental noise in a receiver; a signal must rise above it to be usable.
+keywords: noise floor, thermal noise, background noise, sensitivity, dBm
+aka: [noise floor]
+autolink: true
+infobox:
+  - { label: Type, value: Background noise level }
+  - { label: Unit, value: dBm }
+  - { label: Sources, value: Thermal noise, environment, receiver }
+see_also: [signal-to-noise-ratio, dbm, low-noise-amplifier, attenuation]
+related_lessons:
+  - { title: "Decibels & signal power", url: /learn/decibels/ }
+external:
+  - { title: "Noise floor (Wikipedia)", url: https://en.wikipedia.org/wiki/Noise_floor }
+---
+
+The **noise floor** is the constant background level of random energy present in any
+receiver — thermal noise in the electronics plus environmental RF. It is measured in
+[dBm](/reference/dbm/) and sets the bar a signal must clear.
+
+## How it works
+
+Bandwidth, receiver quality, and local interference all raise or lower the floor. A
+signal is only useful when it pokes above it; the margin is the
+[SNR](/reference/signal-to-noise-ratio/).
+
+## Relevance to SDR
+
+A [low-noise amplifier](/reference/low-noise-amplifier/) and a quiet install lower the
+effective floor, while nearby electronics (USB, chargers, LED lighting) raise it.

--- a/docs/reference/nxdn.md
+++ b/docs/reference/nxdn.md
@@ -27,6 +27,19 @@ external:
 in very narrow 6.25 kHz channels (or 12.5 kHz) and the
 [AMBE+2](/reference/ambe-plus-2/) vocoder.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 360 150" role="img" aria-label="Narrow 6.25 kHz FDMA channels for NXDN." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="135" x2="40" y2="20" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#fa_nxdn)"/>
+  <text x="22" y="80" font-size="9" fill="currentColor" transform="rotate(-90 22 80)">frequency</text>
+  <g fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1">
+    <rect x="50" y="28" width="260" height="22"/><rect x="50" y="60" width="260" height="22"/><rect x="50" y="92" width="260" height="22"/>
+  </g>
+  <g font-size="8.5" fill="currentColor"><text x="180" y="43" text-anchor="middle">one call per channel (6.25 kHz)</text><text x="180" y="75" text-anchor="middle">one call per channel</text><text x="180" y="107" text-anchor="middle">one call per channel</text></g>
+  <defs><marker id="fa_nxdn" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>NXDN packs calls into very narrow 6.25 kHz (or 12.5 kHz) FDMA channels.</figcaption>
+</figure>
+
 ## Overview
 
 NXDN emphasises spectrum efficiency, fitting a channel into as little as 6.25 kHz —

--- a/docs/reference/nxdn.md
+++ b/docs/reference/nxdn.md
@@ -1,0 +1,59 @@
+---
+slug: nxdn
+title: NXDN
+entry_type: protocol
+category: protocols
+description: NXDN is a narrowband digital land-mobile radio standard by Kenwood and Icom, using 4FSK in 6.25 or 12.5 kHz channels with the AMBE+2 vocoder, in conventional and trunked forms.
+keywords: NXDN, NEXEDGE, IDAS, narrowband digital, 6.25 kHz, Kenwood, Icom, 4FSK
+aka: [NXDN, NEXEDGE, IDAS]
+autolink: true
+infobox:
+  - { label: Type, value: Digital land-mobile radio }
+  - { label: Developers, value: Kenwood & Icom }
+  - { label: Access, value: FDMA (conventional or trunked) }
+  - { label: Channel spacing, value: 6.25 kHz or 12.5 kHz }
+  - { label: Modulation, value: 4FSK (2400/4800 baud) }
+  - { label: Vocoder, value: AMBE+2 }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [dpmr, frequency-shift-keying, ambe-plus-2, trunked-radio, control-channel]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "NXDN (Wikipedia)", url: https://en.wikipedia.org/wiki/NXDN }
+---
+
+**NXDN** is a **narrowband** digital land-mobile radio standard jointly developed by
+**Kenwood** (NEXEDGE) and **Icom** (IDAS). It uses [4FSK](/reference/frequency-shift-keying/)
+in very narrow 6.25 kHz channels (or 12.5 kHz) and the
+[AMBE+2](/reference/ambe-plus-2/) vocoder.
+
+## Overview
+
+NXDN emphasises spectrum efficiency, fitting a channel into as little as 6.25 kHz —
+half the width of typical [DMR](/reference/dmr/) or [P25](/reference/project-25/)
+channels. It supports both conventional operation and trunking with a
+[control channel](/reference/control-channel/).
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | [FDMA](/reference/fdma/) |
+| Channel | 6.25 kHz (2400 baud) or 12.5 kHz (4800 baud) |
+| Modulation | 4FSK |
+| Vocoder | AMBE+2 |
+
+## History
+
+Introduced in the late 2000s as Kenwood and Icom's common air interface for
+narrowband digital business radio.
+
+## Deployment
+
+Common in business, transport, and utility fleets, especially where regulators reward
+6.25 kHz channelisation.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk decodes NXDN voice and follows trunked NXDN control channels. See
+[Status](/status.html).

--- a/docs/reference/nyquist-theorem.md
+++ b/docs/reference/nyquist-theorem.md
@@ -23,6 +23,16 @@ you must sample at least **twice its [bandwidth](/reference/bandwidth/)**. For I
 sampling, the practical takeaway is that usable bandwidth ≈
 [sample rate](/reference/sample-rate/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A fast wave sampled too slowly, with the sample dots tracing a slower false wave." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 60 q12 -30 24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0 t24 0" fill="none" stroke="currentColor" stroke-width="1.3" stroke-opacity="0.5"/>
+  <g fill="currentColor"><circle cx="20" cy="60" r="3"/><circle cx="92" cy="48" r="3"/><circle cx="164" cy="72" r="3"/><circle cx="236" cy="48" r="3"/><circle cx="308" cy="72" r="3"/><circle cx="380" cy="48" r="3"/><circle cx="430" cy="66" r="3"/></g>
+  <path d="M20 60 C 92 48, 92 48, 164 72 S 308 72, 380 48" fill="none" stroke="currentColor" stroke-width="1.8" stroke-dasharray="5 3"/>
+  <text x="20" y="112" font-size="9" fill="currentColor">too few samples → a false (aliased) low-frequency wave</text>
+</svg>
+<figcaption>Nyquist: sample at least twice the bandwidth, or fast signals fold back as false low-frequency aliases.</figcaption>
+</figure>
+
 ## How it works
 
 Sample too slowly for the bandwidth and information does not merely vanish — it corrupts

--- a/docs/reference/nyquist-theorem.md
+++ b/docs/reference/nyquist-theorem.md
@@ -1,0 +1,36 @@
+---
+slug: nyquist-theorem
+title: Nyquist–Shannon sampling theorem
+entry_type: term
+category: sdr-dsp
+description: The Nyquist–Shannon sampling theorem states that a signal must be sampled at least twice its bandwidth to be represented without loss; under-sampling causes aliasing.
+keywords: Nyquist theorem, sampling theorem, Nyquist rate, aliasing, bandwidth, Shannon
+aka: [Nyquist theorem, sampling theorem]
+autolink: true
+infobox:
+  - { label: Type, value: Sampling principle }
+  - { label: States, value: Sample ≥ 2× the bandwidth }
+  - { label: Named for, value: Harry Nyquist, Claude Shannon }
+see_also: [sample-rate, aliasing, bandwidth, harry-nyquist, claude-shannon]
+related_lessons:
+  - { title: "Sample rate, bandwidth & Nyquist", url: /learn/sample-rate-nyquist/ }
+external:
+  - { title: "Nyquist–Shannon sampling theorem (Wikipedia)", url: https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem }
+---
+
+The **Nyquist–Shannon sampling theorem** states that to represent a signal without loss
+you must sample at least **twice its [bandwidth](/reference/bandwidth/)**. For IQ
+sampling, the practical takeaway is that usable bandwidth ≈
+[sample rate](/reference/sample-rate/).
+
+## How it works
+
+Sample too slowly for the bandwidth and information does not merely vanish — it corrupts
+the data through [aliasing](/reference/aliasing/), folding out-of-band energy to false
+frequencies.
+
+## Relevance to SDR
+
+It is named for [Harry Nyquist](/reference/harry-nyquist/) and
+[Claude Shannon](/reference/claude-shannon/), and it sets the floor on the sample rate
+needed to capture a given channel.

--- a/docs/reference/p25-phase-1.md
+++ b/docs/reference/p25-phase-1.md
@@ -28,6 +28,19 @@ external:
 using **[FDMA](/reference/fdma/)** — one conversation per 12.5 kHz channel — with
 [C4FM](/reference/c4fm/) modulation and the [IMBE](/reference/imbe/) vocoder.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 360 150" role="img" aria-label="Stacked 12.5 kHz FDMA channels each carrying one P25 Phase 1 call." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="135" x2="40" y2="20" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#fa_p25-phase-1)"/>
+  <text x="22" y="80" font-size="9" fill="currentColor" transform="rotate(-90 22 80)">frequency</text>
+  <g fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1">
+    <rect x="50" y="28" width="260" height="22"/><rect x="50" y="60" width="260" height="22"/><rect x="50" y="92" width="260" height="22"/>
+  </g>
+  <g font-size="8.5" fill="currentColor"><text x="180" y="43" text-anchor="middle">one call per channel (12.5 kHz)</text><text x="180" y="75" text-anchor="middle">one call per channel</text><text x="180" y="107" text-anchor="middle">one call per channel</text></g>
+  <defs><marker id="fa_p25-phase-1" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>P25 Phase 1 is FDMA: each call occupies its own 12.5 kHz channel.</figcaption>
+</figure>
+
 ## Overview
 
 In Phase 1 each call occupies its own frequency. A trunked Phase 1 system uses a

--- a/docs/reference/p25-phase-1.md
+++ b/docs/reference/p25-phase-1.md
@@ -1,0 +1,68 @@
+---
+slug: p25-phase-1
+title: P25 Phase 1
+entry_type: protocol
+category: protocols
+description: P25 Phase 1 is the FDMA air interface of Project 25, using C4FM modulation at 4800 baud and the IMBE vocoder in 12.5 kHz channels for North American public-safety radio.
+keywords: P25 Phase 1, C4FM, IMBE, FDMA, 9600 bps, public safety, trunking
+aka: [P25 Phase 1, P25 Phase I, Phase 1 P25]
+autolink: true
+infobox:
+  - { label: Type, value: Digital land-mobile radio }
+  - { label: Part of, value: Project 25 }
+  - { label: Access, value: FDMA }
+  - { label: Channel spacing, value: 12.5 kHz }
+  - { label: Modulation, value: C4FM (4-level FSK) / CQPSK }
+  - { label: Symbol rate, value: 4800 baud (9600 bps) }
+  - { label: Vocoder, value: IMBE }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [project-25, p25-phase-2, c4fm, imbe, fdma, control-channel]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+---
+
+**P25 Phase 1** is the first-generation air interface of [Project 25](/reference/project-25/),
+using **[FDMA](/reference/fdma/)** — one conversation per 12.5 kHz channel — with
+[C4FM](/reference/c4fm/) modulation and the [IMBE](/reference/imbe/) vocoder.
+
+## Overview
+
+In Phase 1 each call occupies its own frequency. A trunked Phase 1 system uses a
+dedicated [control channel](/reference/control-channel/) to assign callers to voice
+channels; conventional Phase 1 simply transmits on a fixed frequency. It is the most
+widely deployed P25 variant and the baseline that Phase 2 builds on.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | FDMA |
+| Channel | 12.5 kHz |
+| Modulation | C4FM (4-level FSK); CQPSK on the linear path |
+| Symbol rate | 4800 [baud](/reference/symbol-rate/) → 9600 bps |
+| Vocoder | IMBE (7.2 kbps incl. FEC) |
+| Error correction | Golay, Hamming, Reed–Solomon, trellis (by field) |
+
+C4FM and CQPSK are designed to be detected by the same receiver, so a single
+demodulator can handle both transmit paths.
+
+## History
+
+Phase 1 documents were published by the [TIA](/reference/tia/) starting in the
+mid-1990s and saw broad public-safety adoption through the 2000s as agencies migrated
+from analog and proprietary systems.
+
+## Deployment
+
+Phase 1 underpins many statewide and municipal public-safety networks across North
+America, often alongside Phase 2 voice channels on the same system.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk demodulates the C4FM symbols, recovers the IMBE frames, and synthesises
+audio. The [constellation](/reference/constellation-diagram/) and
+[eye diagram](/reference/eye-diagram/) views help confirm a clean lock. See
+[Status](/status.html) for details.

--- a/docs/reference/p25-phase-2.md
+++ b/docs/reference/p25-phase-2.md
@@ -1,0 +1,66 @@
+---
+slug: p25-phase-2
+title: P25 Phase 2
+entry_type: protocol
+category: protocols
+description: P25 Phase 2 is the TDMA air interface of Project 25, placing two voice timeslots in a 12.5 kHz channel using H-DQPSK/H-CPM and the AMBE+2 vocoder for doubled spectrum efficiency.
+keywords: P25 Phase 2, TDMA, AMBE+2, H-DQPSK, two-slot, spectrum efficiency, public safety
+aka: [P25 Phase 2, P25 Phase II, Phase 2 P25]
+autolink: true
+infobox:
+  - { label: Type, value: Digital land-mobile radio }
+  - { label: Part of, value: Project 25 }
+  - { label: Access, value: TDMA (2 slots) }
+  - { label: Channel spacing, value: 12.5 kHz (6.25 kHz equivalent) }
+  - { label: Modulation, value: H-DQPSK / H-CPM }
+  - { label: Vocoder, value: AMBE+2 }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [project-25, p25-phase-1, ambe-plus-2, tdma, control-channel]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+  - { title: "Analog vs. digital voice", url: /learn/digital-voice/ }
+external:
+  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+---
+
+**P25 Phase 2** is the second-generation air interface of [Project 25](/reference/project-25/),
+using **two-slot [TDMA](/reference/tdma/)** to carry two simultaneous voice
+conversations in a single 12.5 kHz channel — effectively 6.25 kHz per call.
+
+## Overview
+
+Phase 2 was introduced to meet spectrum-efficiency goals. Where
+[Phase 1](/reference/p25-phase-1/) gives each call its own frequency, Phase 2 divides
+a traffic channel into two repeating timeslots, doubling capacity. It uses the more
+efficient [AMBE+2](/reference/ambe-plus-2/) vocoder and a phase-shift modulation
+(H-DQPSK on the outbound link, H-CPM on the inbound).
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | TDMA, 2 slots |
+| Channel | 12.5 kHz (6.25 kHz equivalent capacity) |
+| Modulation | H-DQPSK (outbound) / H-CPM (inbound) |
+| Vocoder | AMBE+2 (half-rate) |
+| Control channel | Usually a C4FM Phase 1 control channel |
+
+A common deployment keeps a [C4FM](/reference/c4fm/) Phase 1
+[control channel](/reference/control-channel/) while voice traffic uses Phase 2 TDMA
+slots.
+
+## History
+
+Phase 2 was standardised by the [TIA](/reference/tia/) to follow narrowbanding and
+spectrum-efficiency mandates, and has been deployed on large metropolitan and
+statewide systems since the early 2010s.
+
+## Deployment
+
+Phase 2 is widely used by busy urban public-safety systems where channel capacity is
+at a premium, frequently mixed with Phase 1 on the same network.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk follows the control channel, tunes to the assigned Phase 2 traffic
+channel and slot, and decodes the AMBE+2 voice. See [Status](/status.html).

--- a/docs/reference/p25-phase-2.md
+++ b/docs/reference/p25-phase-2.md
@@ -27,6 +27,16 @@ external:
 using **two-slot [TDMA](/reference/tdma/)** to carry two simultaneous voice
 conversations in a single 12.5 kHz channel — effectively 6.25 kHz per call.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 140" role="img" aria-label="Two TDMA slots in a 12.5 kHz channel for P25 Phase 2." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="105" x2="360" y2="105" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#ta_p2)"/>
+  <text x="195" y="128" text-anchor="middle" font-size="9" fill="currentColor">time → · one 12.5 kHz channel, 2 slots</text>
+  <g stroke="currentColor" stroke-width="1.1"><rect x="40" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="92" y="40" width="52" height="50" fill="none"/><rect x="144" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="196" y="40" width="52" height="50" fill="none"/><rect x="248" y="40" width="52" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="300" y="40" width="52" height="50" fill="none"/></g><g font-size="9" fill="currentColor" text-anchor="middle"><text x="66" y="69">1</text><text x="118" y="69">2</text><text x="170" y="69">1</text><text x="222" y="69">2</text><text x="274" y="69">1</text><text x="326" y="69">2</text></g>
+  <defs><marker id="ta_p2" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>P25 Phase 2 uses two-slot TDMA, fitting two calls in one 12.5 kHz channel.</figcaption>
+</figure>
+
 ## Overview
 
 Phase 2 was introduced to meet spectrum-efficiency goals. Where

--- a/docs/reference/path-loss.md
+++ b/docs/reference/path-loss.md
@@ -1,0 +1,37 @@
+---
+slug: path-loss
+title: Path loss
+entry_type: term
+category: rf-fundamentals
+description: Path loss is the attenuation a radio signal suffers travelling from transmitter to receiver, dominated by the spreading of energy over distance and obstacles in the way.
+keywords: path loss, free space loss, propagation loss, distance, dB
+aka: [path loss]
+autolink: true
+infobox:
+  - { label: Type, value: Propagation attenuation }
+  - { label: Unit, value: Decibels (dB) }
+  - { label: Grows with, value: Distance and frequency }
+see_also: [attenuation, radio-propagation, decibel, signal-to-noise-ratio]
+related_lessons:
+  - { title: "How signals travel", url: /learn/propagation/ }
+  - { title: "Decibels & signal power", url: /learn/decibels/ }
+external:
+  - { title: "Path loss (Wikipedia)", url: https://en.wikipedia.org/wiki/Path_loss }
+---
+
+**Path loss** is the [attenuation](/reference/attenuation/) a signal experiences
+travelling from transmitter to receiver. It is dominated by the spreading of energy
+over distance, plus losses from terrain, buildings, and foliage.
+
+## How it works
+
+In free space, power falls with the square of distance, and loss rises with
+[frequency](/reference/frequency/); real environments add much more. Path loss can
+total 100+ dB over a few kilometres, which is why link budgets are done in
+[decibels](/reference/decibel/).
+
+## Relevance to SDR
+
+Path loss explains why a distant or obstructed system arrives near the
+[noise floor](/reference/noise-floor/), and why antenna height and a clear path
+([propagation](/reference/radio-propagation/)) matter so much.

--- a/docs/reference/path-loss.md
+++ b/docs/reference/path-loss.md
@@ -23,6 +23,17 @@ external:
 travelling from transmitter to receiver. It is dominated by the spreading of energy
 over distance, plus losses from terrain, buildings, and foliage.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A curve of received power falling steeply with distance, illustrating path loss in decibels." xmlns="http://www.w3.org/2000/svg">
+  <line x1="50" y1="20" x2="50" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="50" y1="120" x2="440" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M55 28 C 120 70, 200 100, 435 115" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="20" y="70" font-size="10" fill="currentColor" transform="rotate(-90 20 70)">power (dB)</text>
+  <text x="240" y="140" text-anchor="middle" font-size="10" fill="currentColor">distance →</text>
+</svg>
+<figcaption>Path loss grows with distance (and frequency); it can exceed 100 dB over a few kilometres.</figcaption>
+</figure>
+
 ## How it works
 
 In free space, power falls with the square of distance, and loss rises with

--- a/docs/reference/phase-shift-keying.md
+++ b/docs/reference/phase-shift-keying.md
@@ -23,6 +23,17 @@ switches a [carrier](/reference/carrier-wave/)'s [phase](/reference/phase/) betw
 fixed angles while amplitude stays constant. Two phases is BPSK; four is QPSK (2 bits
 per symbol).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 220" role="img" aria-label="A QPSK constellation with four points at the diagonals of the IQ plane, each labelled with a two-bit value." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="110" x2="270" y2="110" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="150" y1="20" x2="150" y2="200" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="262" y="124" font-size="10" fill="currentColor">I</text><text x="136" y="30" font-size="10" fill="currentColor">Q</text>
+  <g fill="currentColor"><circle cx="210" cy="55" r="5"/><circle cx="90" cy="55" r="5"/><circle cx="90" cy="165" r="5"/><circle cx="210" cy="165" r="5"/></g>
+  <g font-size="10" fill="currentColor"><text x="218" y="50">01</text><text x="66" y="50">11</text><text x="66" y="182">10</text><text x="218" y="182">00</text></g>
+</svg>
+<figcaption>PSK encodes bits in the carrier's phase; QPSK uses four phase points (2 bits each). P25 Phase 2 uses a PSK variant.</figcaption>
+</figure>
+
 ## How it works
 
 Each symbol is a phase angle, read as a point on the [IQ](/reference/iq-data/) plane. A

--- a/docs/reference/phase-shift-keying.md
+++ b/docs/reference/phase-shift-keying.md
@@ -1,0 +1,36 @@
+---
+slug: phase-shift-keying
+title: Phase-shift keying (PSK)
+entry_type: technology
+category: modulation
+description: Phase-shift keying (PSK) is digital modulation that switches a carrier's phase between fixed angles; variants like QPSK and CQPSK appear in P25 Phase 2 and satellite links.
+keywords: PSK, phase shift keying, BPSK, QPSK, CQPSK, constellation, carrier recovery
+aka: [phase-shift keying, PSK, QPSK]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation }
+  - { label: Varies, value: Carrier phase (discrete angles) }
+  - { label: Used by, value: P25 Phase 2, satellite, broadcast }
+see_also: [frequency-shift-keying, quadrature-amplitude-modulation, cqpsk, phase, costas-loop, constellation-diagram]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "Phase-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Phase-shift_keying }
+---
+
+**Phase-shift keying** (**PSK**) is digital [modulation](/reference/modulation/) that
+switches a [carrier](/reference/carrier-wave/)'s [phase](/reference/phase/) between
+fixed angles while amplitude stays constant. Two phases is BPSK; four is QPSK (2 bits
+per symbol).
+
+## How it works
+
+Each symbol is a phase angle, read as a point on the [IQ](/reference/iq-data/) plane. A
+[Costas loop](/reference/costas-loop/) recovers the carrier phase so the
+[constellation](/reference/constellation-diagram/) lines up. PSK is spectrally
+efficient.
+
+## Relevance to SDR
+
+[P25 Phase 2](/reference/p25-phase-2/) uses a PSK variant, and many satellite and
+broadcast links are PSK; tracking phase accurately is key to decoding them.

--- a/docs/reference/phase.md
+++ b/docs/reference/phase.md
@@ -20,6 +20,17 @@ external:
 (0–360°) or radians. Two waves of the same [frequency](/reference/frequency/) can
 differ in phase, meaning one is shifted in time relative to the other.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Two identical sine waves offset horizontally, with the gap between them labelled phase difference." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="70" x2="440" y2="70" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 70 q35 -40 70 0 t70 0 t70 0 t70 0 t70 0 t50 0" fill="none" stroke="currentColor" stroke-width="2"/>
+  <path d="M55 70 q35 -40 70 0 t70 0 t70 0 t70 0 t70 0 t15 0" fill="none" stroke="currentColor" stroke-width="2" stroke-opacity="0.55" stroke-dasharray="5 3"/>
+  <line x1="20" y1="100" x2="55" y2="100" stroke="currentColor"/>
+  <text x="60" y="104" font-size="11" fill="currentColor">phase difference</text>
+</svg>
+<figcaption>Phase is where a wave sits in its cycle; shifting phase is the basis of PSK digital modulation.</figcaption>
+</figure>
+
 ## How it works
 
 On the [IQ](/reference/iq-data/) plane, a sample's **angle** is its phase and its

--- a/docs/reference/phase.md
+++ b/docs/reference/phase.md
@@ -1,0 +1,34 @@
+---
+slug: phase
+title: Phase
+entry_type: term
+category: rf-fundamentals
+description: Phase is the position of a point within a wave's cycle, measured in degrees or radians; shifting it carries information in phase-shift keying and is captured by IQ data.
+keywords: phase, phase shift, degrees, radians, PSK, IQ
+infobox:
+  - { label: Type, value: Wave property }
+  - { label: Unit, value: Degrees or radians }
+  - { label: Encoded by, value: IQ angle }
+see_also: [amplitude, iq-data, phase-shift-keying, constellation-diagram]
+related_lessons:
+  - { title: "IQ data & complex signals", url: /learn/iq-data/ }
+external:
+  - { title: "Phase (waves) (Wikipedia)", url: https://en.wikipedia.org/wiki/Phase_(waves) }
+---
+
+**Phase** is the position of a point within the cycle of a wave, expressed in degrees
+(0–360°) or radians. Two waves of the same [frequency](/reference/frequency/) can
+differ in phase, meaning one is shifted in time relative to the other.
+
+## How it works
+
+On the [IQ](/reference/iq-data/) plane, a sample's **angle** is its phase and its
+distance from the origin is its [amplitude](/reference/amplitude/). Deliberately
+jumping the phase between fixed values encodes data — the basis of
+[phase-shift keying](/reference/phase-shift-keying/).
+
+## Relevance to SDR
+
+Tracking phase is essential to demodulating PSK and QAM signals; a
+[Costas loop](/reference/costas-loop/) recovers the carrier phase so symbols land
+correctly on the [constellation](/reference/constellation-diagram/).

--- a/docs/reference/pocsag.md
+++ b/docs/reference/pocsag.md
@@ -27,6 +27,17 @@ protocol used worldwide to deliver numeric and alphanumeric messages to pagers. 
 a simple asynchronous **2-level [FSK](/reference/frequency-shift-keying/)** scheme,
 still in active use by hospitals, fire/EMS, and industry.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="A POCSAG transmission: preamble, sync codeword, then batches of address and message codewords." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1">
+    <rect x="20" y="40" width="70" height="28" fill="none"/><rect x="90" y="40" width="50" height="28" fill="currentColor" fill-opacity="0.12"/><rect x="140" y="40" width="80" height="28" fill="currentColor" fill-opacity="0.22"/><rect x="220" y="40" width="80" height="28" fill="none"/><rect x="300" y="40" width="80" height="28" fill="currentColor" fill-opacity="0.22"/><rect x="380" y="40" width="60" height="28" fill="none"/>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="55" y="58">preamble</text><text x="115" y="58">sync</text><text x="180" y="58">addr</text><text x="260" y="58">msg</text><text x="340" y="58">addr</text><text x="410" y="58">msg</text></g>
+  <text x="230" y="88" text-anchor="middle" font-size="8" fill="currentColor">2-FSK, one-way · 512/1200/2400 bps</text>
+</svg>
+<figcaption>POCSAG sends a preamble and sync, then batches of address and message codewords to pagers.</figcaption>
+</figure>
+
 ## Overview
 
 A POCSAG transmission begins with a preamble and sync codeword, then batches of

--- a/docs/reference/pocsag.md
+++ b/docs/reference/pocsag.md
@@ -1,0 +1,58 @@
+---
+slug: pocsag
+title: POCSAG
+entry_type: protocol
+category: protocols
+description: POCSAG (CCIR Radiopaging Code No. 1) is the classic asynchronous FSK paging protocol used worldwide for numeric and alphanumeric pager messages at 512, 1200, and 2400 bps.
+keywords: POCSAG, paging, CCIR 584, pager, FSK, numeric alphanumeric, DAPNET, fire EMS
+aka: [POCSAG]
+autolink: true
+infobox:
+  - { label: Type, value: One-way paging protocol }
+  - { label: Standard, value: CCIR Radiopaging Code No. 1 }
+  - { label: Modulation, value: 2-level FSK }
+  - { label: Bit rates, value: 512 / 1200 / 2400 bps }
+  - { label: Error correction, value: BCH(31,21) + parity }
+  - { label: GopherTrunk support, value: Decoded }
+see_also: [flex, frequency-shift-keying, bch-code, demodulation]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "POCSAG (Wikipedia)", url: https://en.wikipedia.org/wiki/POCSAG }
+  - { title: "GopherTrunk POCSAG decoder", url: /pocsag.html }
+---
+
+**POCSAG** (the **CCIR Radiopaging Code No. 1**) is the classic one-way **paging**
+protocol used worldwide to deliver numeric and alphanumeric messages to pagers. It is
+a simple asynchronous **2-level [FSK](/reference/frequency-shift-keying/)** scheme,
+still in active use by hospitals, fire/EMS, and industry.
+
+## Overview
+
+A POCSAG transmission begins with a preamble and sync codeword, then batches of
+address and message codewords. Each pager listens for its address (capcode). Messages
+are protected by a [BCH(31,21)](/reference/bch-code/) code plus a parity bit.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Modulation | 2-FSK (±4.5 kHz typical) |
+| Bit rates | 512, 1200, 2400 bps |
+| Coding | BCH(31,21) + even parity |
+| Content | Numeric or alphanumeric |
+
+## History
+
+Developed by the British Post Office and standardised by the CCIR in the early 1980s;
+it became the dominant global paging code.
+
+## Deployment
+
+Hospitals, emergency services, and industrial paging; the amateur DAPNET network also
+uses POCSAG.
+
+## Decoding it with GopherTrunk
+
+GopherTrunk demodulates the FSK, recovers codewords, and decodes numeric/alphanumeric
+messages. See the [POCSAG decoder](/pocsag.html) page.

--- a/docs/reference/polarization.md
+++ b/docs/reference/polarization.md
@@ -1,0 +1,34 @@
+---
+slug: polarization
+title: Polarization
+entry_type: term
+category: antennas-propagation
+description: Polarization is the orientation of a radio wave's electric field, set by the transmitting antenna; matching receive and transmit polarization avoids signal loss.
+keywords: polarization, vertical, horizontal, circular, cross-polarization, electric field
+aka: [polarization, polarisation]
+autolink: true
+infobox:
+  - { label: Type, value: Wave/antenna property }
+  - { label: Common kinds, value: Vertical, horizontal, circular }
+  - { label: Mismatch loss, value: Up to ~20 dB }
+see_also: [antenna, dipole-antenna, radio-propagation, antenna-gain]
+related_lessons:
+  - { title: "Antennas 101", url: /learn/antennas/ }
+external:
+  - { title: "Polarization (waves) (Wikipedia)", url: https://en.wikipedia.org/wiki/Polarization_(waves) }
+---
+
+**Polarization** is the orientation of a [radio wave](/reference/radio-wave/)'s
+electric field, determined by how the transmitting [antenna](/reference/antenna/) is
+mounted — vertical, horizontal, or circular.
+
+## How it works
+
+A receive antenna should match the transmitter's polarization; a full mismatch can
+cost on the order of 20 dB. Most land-mobile and public-safety radio is vertically
+polarized, while FM broadcast is often horizontal or circular.
+
+## Relevance to SDR
+
+A vertical antenna is the safe default for scanning land-mobile and trunked systems,
+matching their vertical polarization.

--- a/docs/reference/polarization.md
+++ b/docs/reference/polarization.md
@@ -22,6 +22,19 @@ external:
 electric field, determined by how the transmitting [antenna](/reference/antenna/) is
 mounted — vertical, horizontal, or circular.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A vertically oriented wave on the left and a horizontally oriented wave on the right, showing polarization." xmlns="http://www.w3.org/2000/svg">
+  <line x1="110" y1="20" x2="110" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M110 20 q -28 25 0 50 t0 50" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="110" y="135" text-anchor="middle" font-size="9" fill="currentColor">vertical</text>
+  <line x1="300" y1="70" x2="420" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M300 70 q 25 -28 50 0 t50 0" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="360" y="125" text-anchor="middle" font-size="9" fill="currentColor">horizontal</text>
+  <text x="230" y="70" text-anchor="middle" font-size="9" fill="currentColor">match the</text><text x="230" y="84" text-anchor="middle" font-size="9" fill="currentColor">transmitter</text>
+</svg>
+<figcaption>Polarization is the orientation of the wave's electric field; match it to the transmitter to avoid loss.</figcaption>
+</figure>
+
 ## How it works
 
 A receive antenna should match the transmitter's polarization; a full mismatch can

--- a/docs/reference/ppm-frequency-correction.md
+++ b/docs/reference/ppm-frequency-correction.md
@@ -1,0 +1,35 @@
+---
+slug: ppm-frequency-correction
+title: PPM frequency correction
+entry_type: term
+category: sdr-dsp
+description: PPM frequency correction compensates an SDR's reference-oscillator error, measured in parts per million, so signals appear at their true frequency and digital modes lock.
+keywords: PPM, parts per million, frequency error, oscillator drift, calibration, rotating constellation
+aka: [PPM correction, PPM]
+autolink: true
+infobox:
+  - { label: Type, value: Calibration parameter }
+  - { label: Corrects, value: Reference-oscillator error }
+  - { label: Symptom if wrong, value: Rotating constellation, no lock }
+see_also: [local-oscillator, frequency, costas-loop, constellation-diagram]
+related_lessons:
+  - { title: "Calibration & troubleshooting", url: /learn/calibration-troubleshooting/ }
+external:
+  - { title: "Frequency error (Wikipedia)", url: https://en.wikipedia.org/wiki/Clock_drift }
+---
+
+**PPM frequency correction** compensates for the small error in an SDR's reference
+oscillator, measured in **parts per million**, so signals land on their **true
+frequency**. At UHF a 30 PPM error is several kilohertz — more than a channel's width.
+
+## How it works
+
+Setting the right PPM shifts the [local oscillator](/reference/local-oscillator/) so a
+known reference sits exactly where it should. The error drifts a little with temperature,
+so warm-up matters.
+
+## Relevance to SDR
+
+A wrong PPM produces the classic *rotating
+[constellation](/reference/constellation-diagram/)* that won't lock — fixed by
+calibration, not a better antenna.

--- a/docs/reference/ppm-frequency-correction.md
+++ b/docs/reference/ppm-frequency-correction.md
@@ -22,6 +22,22 @@ external:
 oscillator, measured in **parts per million**, so signals land on their **true
 frequency**. At UHF a 30 PPM error is several kilohertz — more than a channel's width.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A signal sitting off the channel centre due to oscillator error, and the same signal centred after PPM correction." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="220" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="125" y1="30" x2="125" y2="78" stroke="currentColor" stroke-dasharray="3 3" stroke-opacity="0.6"/>
+  <path d="M150 70 L160 38 L170 70 Z" fill="currentColor" fill-opacity="0.25" stroke="currentColor"/>
+  <text x="125" y="95" text-anchor="middle" font-size="9" fill="currentColor">off-centre (uncorrected)</text>
+  <line x1="245" y1="55" x2="285" y2="55" stroke="currentColor" marker-end="url(#ppar)"/><text x="265" y="48" font-size="8" fill="currentColor" text-anchor="middle">+PPM</text>
+  <line x1="300" y1="70" x2="450" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="375" y1="30" x2="375" y2="78" stroke="currentColor" stroke-dasharray="3 3" stroke-opacity="0.6"/>
+  <path d="M365 70 L375 38 L385 70 Z" fill="currentColor" fill-opacity="0.25" stroke="currentColor"/>
+  <text x="375" y="95" text-anchor="middle" font-size="9" fill="currentColor">centred (corrected)</text>
+  <defs><marker id="ppar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>PPM correction compensates the dongle's oscillator error so signals land on their true frequency.</figcaption>
+</figure>
+
 ## How it works
 
 Setting the right PPM shifts the [local oscillator](/reference/local-oscillator/) so a

--- a/docs/reference/project-25.md
+++ b/docs/reference/project-25.md
@@ -32,6 +32,18 @@ North America. It defines how radios, repeaters, and trunked systems carry digit
 voice and data, with the explicit goal of interoperability between equipment from
 different manufacturers.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="P25 Phase 1 shown as FDMA channels and Phase 2 as two-slot TDMA." xmlns="http://www.w3.org/2000/svg">
+  <text x="115" y="22" text-anchor="middle" font-size="10" fill="currentColor">Phase 1 — FDMA</text>
+  <g fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"><rect x="40" y="34" width="150" height="20"/><rect x="40" y="60" width="150" height="20"/><rect x="40" y="86" width="150" height="20"/></g>
+  <text x="345" y="22" text-anchor="middle" font-size="10" fill="currentColor">Phase 2 — TDMA</text>
+  <g stroke="currentColor" stroke-width="1.1"><rect x="270" y="50" width="150" height="40" fill="none"/><line x1="345" y1="50" x2="345" y2="90"/></g>
+  <g font-size="9" fill="currentColor" text-anchor="middle"><text x="307" y="74">slot 1</text><text x="382" y="74">slot 2</text></g>
+  <text x="230" y="128" text-anchor="middle" font-size="9" fill="currentColor">Phase 2 doubles capacity in the same 12.5 kHz</text>
+</svg>
+<figcaption>P25 spans Phase 1 (FDMA, one call per channel) and Phase 2 (TDMA, two calls per channel).</figcaption>
+</figure>
+
 ## Overview
 
 P25 was created so that police, fire, and emergency-medical agencies could replace

--- a/docs/reference/project-25.md
+++ b/docs/reference/project-25.md
@@ -1,0 +1,78 @@
+---
+slug: project-25
+title: Project 25 (P25)
+entry_type: protocol
+category: protocols
+description: Project 25 (P25) is a suite of open standards for digital land-mobile radio used by public-safety agencies in North America, defining Phase 1 (FDMA) and Phase 2 (TDMA) air interfaces.
+keywords: P25, Project 25, APCO-25, public safety radio, digital trunking, C4FM, IMBE, AMBE+2
+aka: [P25, Project 25, APCO-25, APCO P25]
+autolink: true
+infobox:
+  - { label: Type, value: Digital land-mobile radio (voice + data) }
+  - { label: Standards body, value: TIA / APCO }
+  - { label: Introduced, value: "1995 (Phase 1)" }
+  - { label: Region, value: Primarily North America (public safety) }
+  - { label: Access, value: "FDMA (Phase 1), TDMA (Phase 2)" }
+  - { label: Channel spacing, value: 12.5 kHz (6.25 kHz equivalent in Phase 2) }
+  - { label: Modulation, value: "C4FM / CQPSK (P1), H-CPM/H-DQPSK (P2)" }
+  - { label: Vocoder, value: "IMBE (P1), AMBE+2 (P2)" }
+  - { label: GopherTrunk support, value: "Phase 1 and Phase 2 — see Status" }
+see_also: [p25-phase-1, p25-phase-2, c4fm, imbe, ambe-plus-2, trunked-radio, control-channel, tia, apco-international]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+  - { title: "GopherTrunk decoder status", url: /status.html }
+---
+
+**Project 25** (**P25**, also **APCO-25**) is a suite of open standards for
+**digital land-mobile radio** developed for public-safety and government users in
+North America. It defines how radios, repeaters, and trunked systems carry digital
+voice and data, with the explicit goal of interoperability between equipment from
+different manufacturers.
+
+## Overview
+
+P25 was created so that police, fire, and emergency-medical agencies could replace
+incompatible analog systems with a common digital standard. It specifies the air
+interface (how bits travel over the radio link), the [vocoder](/reference/vocoder/)
+used for voice, the trunking signalling, and inter-system interfaces. P25 comes in
+two air-interface generations: [Phase 1](/reference/p25-phase-1/), which uses
+[FDMA](/reference/fdma/), and [Phase 2](/reference/p25-phase-2/), which uses
+[TDMA](/reference/tdma/) to double channel capacity.
+
+## Technical characteristics
+
+| Property | Phase 1 | Phase 2 |
+|----------|---------|---------|
+| Access | FDMA | TDMA (2 slots) |
+| Channel | 12.5 kHz | 12.5 kHz / 2 = 6.25 kHz equiv. |
+| Modulation | [C4FM](/reference/c4fm/) (and CQPSK) | H-CPM / H-DQPSK |
+| Vocoder | [IMBE](/reference/imbe/) | [AMBE+2](/reference/ambe-plus-2/) |
+| Symbol rate | 4800 baud (9600 bps) | — |
+
+Both phases can be deployed conventionally or as a trunked system coordinated by a
+[control channel](/reference/control-channel/).
+
+## History
+
+P25 standardisation began in the late 1980s under [APCO](/reference/apco-international/),
+with Phase 1 documents published by the [TIA](/reference/tia/) from the mid-1990s.
+Phase 2 followed to address spectrum-efficiency mandates, introducing TDMA so two
+voice conversations could share one 12.5 kHz channel.
+
+## Deployment
+
+P25 is the dominant digital standard for U.S. state and federal public safety, and
+is used by many large metropolitan systems. Systems are catalogued in databases such
+as RadioReference, which list their [control-channel](/reference/control-channel/)
+frequencies and [talkgroups](/reference/talkgroup/).
+
+## Decoding it with GopherTrunk
+
+GopherTrunk decodes both P25 Phase 1 and Phase 2: it locks the control channel,
+follows channel grants to voice channels, and runs the matching vocoder to produce
+audio. See the [protocol landscape lesson](/learn/protocol-landscape/) for how P25
+compares with other systems, and the [Status](/status.html) page for current
+coverage.

--- a/docs/reference/quadrature-amplitude-modulation.md
+++ b/docs/reference/quadrature-amplitude-modulation.md
@@ -23,6 +23,21 @@ external:
 many states into the [IQ](/reference/iq-data/) plane — 16-QAM (4 bits/symbol), 64-QAM,
 and higher.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 240 240" role="img" aria-label="A 16-QAM constellation: a four-by-four grid of points on the IQ plane." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="120" x2="220" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="120" y1="20" x2="120" y2="220" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="212" y="134" font-size="10" fill="currentColor">I</text><text x="106" y="30" font-size="10" fill="currentColor">Q</text>
+  <g fill="currentColor">
+    <circle cx="60" cy="60" r="4"/><circle cx="100" cy="60" r="4"/><circle cx="140" cy="60" r="4"/><circle cx="180" cy="60" r="4"/>
+    <circle cx="60" cy="100" r="4"/><circle cx="100" cy="100" r="4"/><circle cx="140" cy="100" r="4"/><circle cx="180" cy="100" r="4"/>
+    <circle cx="60" cy="140" r="4"/><circle cx="100" cy="140" r="4"/><circle cx="140" cy="140" r="4"/><circle cx="180" cy="140" r="4"/>
+    <circle cx="60" cy="180" r="4"/><circle cx="100" cy="180" r="4"/><circle cx="140" cy="180" r="4"/><circle cx="180" cy="180" r="4"/>
+  </g>
+</svg>
+<figcaption>QAM varies both phase and amplitude; 16-QAM packs 4 bits per symbol but needs higher SNR to keep the points apart.</figcaption>
+</figure>
+
 ## How it works
 
 More bits per symbol means more data in the same [bandwidth](/reference/bandwidth/), but

--- a/docs/reference/quadrature-amplitude-modulation.md
+++ b/docs/reference/quadrature-amplitude-modulation.md
@@ -1,0 +1,35 @@
+---
+slug: quadrature-amplitude-modulation
+title: Quadrature amplitude modulation (QAM)
+entry_type: technology
+category: modulation
+description: QAM combines amplitude and phase modulation to pack many bits per symbol; higher-order QAM carries more data but needs a higher SNR to decode.
+keywords: QAM, quadrature amplitude modulation, 16-QAM, 64-QAM, constellation, bits per symbol
+aka: [quadrature amplitude modulation, QAM]
+autolink: true
+infobox:
+  - { label: Type, value: Digital modulation }
+  - { label: Varies, value: Phase and amplitude }
+  - { label: Used by, value: Wi-Fi, cable, LTE, broadcast }
+see_also: [phase-shift-keying, frequency-shift-keying, constellation-diagram, signal-to-noise-ratio, iq-data]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "Quadrature amplitude modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Quadrature_amplitude_modulation }
+---
+
+**Quadrature amplitude modulation** (**QAM**) varies **both** the
+[phase](/reference/phase/) and [amplitude](/reference/amplitude/) of a carrier, packing
+many states into the [IQ](/reference/iq-data/) plane — 16-QAM (4 bits/symbol), 64-QAM,
+and higher.
+
+## How it works
+
+More bits per symbol means more data in the same [bandwidth](/reference/bandwidth/), but
+the states sit closer together, so QAM needs a higher
+[SNR](/reference/signal-to-noise-ratio/) to tell them apart.
+
+## Relevance to SDR
+
+QAM appears in Wi-Fi, cable, and LTE rather than scanner voice traffic, but the same
+[constellation](/reference/constellation-diagram/) idea applies to reading its quality.

--- a/docs/reference/r820t-tuner.md
+++ b/docs/reference/r820t-tuner.md
@@ -1,0 +1,36 @@
+---
+slug: r820t-tuner
+title: R820T / R820T2 tuner
+entry_type: hardware
+category: hardware
+description: The Rafael Micro R820T and R820T2 are the most common tuner chips paired with the RTL2832U in RTL-SDR dongles, providing the RF front-end and mixer up to ~1.7 GHz.
+keywords: R820T, R820T2, R828D, Rafael Micro, tuner chip, RTL-SDR front end, mixer
+aka: [R820T, R820T2]
+autolink: true
+infobox:
+  - { label: Type, value: RF tuner IC }
+  - { label: Vendor, value: Rafael Micro }
+  - { label: Role, value: Front-end + mixer/LO }
+  - { label: Range, value: ~24 MHz – 1.7 GHz }
+see_also: [rtl-sdr, rtl2832u, superheterodyne-receiver, local-oscillator]
+related_lessons:
+  - { title: "How an SDR receiver works", url: /learn/sdr-receiver/ }
+external:
+  - { title: "RTL-SDR (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR }
+---
+
+The **R820T** and improved **R820T2** (and related R828D) from Rafael Micro are the most
+common tuner chips paired with the [RTL2832U](/reference/rtl2832u/) in
+[RTL-SDR](/reference/rtl-sdr/) dongles. They provide the RF front-end and
+mixer/[local oscillator](/reference/local-oscillator/).
+
+## Overview
+
+The tuner amplifies and shifts the selected band down to a low frequency the RTL2832U
+can digitise, covering roughly 24 MHz–1.7 GHz. Tuner quality affects sensitivity and
+overload behaviour.
+
+## Relevance to SDR
+
+The tuner sets the dongle's frequency range and much of its noise performance, important
+when chasing weak signals.

--- a/docs/reference/r820t-tuner.md
+++ b/docs/reference/r820t-tuner.md
@@ -24,6 +24,18 @@ common tuner chips paired with the [RTL2832U](/reference/rtl2832u/) in
 [RTL-SDR](/reference/rtl-sdr/) dongles. They provide the RF front-end and
 mixer/[local oscillator](/reference/local-oscillator/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="The tuner's role: RF in, mixed with a local oscillator, low-IF out to the ADC." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="35" y="55">RF in</text>
+    <rect x="80" y="36" width="120" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="140" y="50">R820T/R820T2</text><text x="140" y="62" font-size="7.5">LNA · mixer · LO</text>
+    <rect x="240" y="38" width="80" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="280" y="57">to ADC</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="60" y1="53" x2="79" y2="53"/><line x1="200" y1="53" x2="239" y2="53"/></g>
+  </g>
+</svg>
+<figcaption>The R820T/R820T2 is the most common RTL-SDR tuner chip — it amplifies and mixes RF down for the ADC.</figcaption>
+</figure>
+
 ## Overview
 
 The tuner amplifies and shifts the selected band down to a low frequency the RTL2832U

--- a/docs/reference/radio-horizon.md
+++ b/docs/reference/radio-horizon.md
@@ -22,6 +22,17 @@ The **radio horizon** is the farthest point a line-of-sight signal reaches befor
 Earth's curvature gets in the way. It lies slightly beyond the visual horizon because
 the atmosphere refracts radio waves a little.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A curved earth with a tall antenna whose line of sight reaches further around the curve than a short antenna." xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 140 Q230 80 450 140" fill="none" stroke="currentColor" stroke-opacity="0.4" stroke-width="1.4"/>
+  <line x1="120" y1="118" x2="120" y2="40" stroke="currentColor" stroke-width="2"/><text x="120" y="34" text-anchor="middle" font-size="8" fill="currentColor">tall</text>
+  <line x1="120" y1="40" x2="370" y2="106" stroke="currentColor" stroke-width="1.3" stroke-dasharray="5 3"/>
+  <circle cx="370" cy="106" r="3" fill="currentColor"/><text x="385" y="104" font-size="8" fill="currentColor">horizon</text>
+  <text x="230" y="135" text-anchor="middle" font-size="9" fill="currentColor">height extends the radio horizon</text>
+</svg>
+<figcaption>The radio horizon is the farthest line-of-sight point before the Earth's curve blocks it; raising the antenna extends it.</figcaption>
+</figure>
+
 ## How it works
 
 Raising either antenna pushes the radio horizon outward, which is why repeaters sit on

--- a/docs/reference/radio-horizon.md
+++ b/docs/reference/radio-horizon.md
@@ -1,0 +1,34 @@
+---
+slug: radio-horizon
+title: Radio horizon
+entry_type: term
+category: antennas-propagation
+description: The radio horizon is the farthest distance a line-of-sight signal reaches before the Earth's curvature blocks it, slightly beyond the visual horizon due to atmospheric refraction.
+keywords: radio horizon, line of sight, Earth curvature, antenna height, coverage range
+aka: [radio horizon]
+autolink: true
+infobox:
+  - { label: Type, value: Propagation limit }
+  - { label: Extended by, value: Antenna height }
+  - { label: Vs visual horizon, value: Slightly farther }
+see_also: [radio-propagation, frequency-bands, antenna]
+related_lessons:
+  - { title: "How signals travel", url: /learn/propagation/ }
+external:
+  - { title: "Radio horizon (Wikipedia)", url: https://en.wikipedia.org/wiki/Line-of-sight_propagation }
+---
+
+The **radio horizon** is the farthest point a line-of-sight signal reaches before the
+Earth's curvature gets in the way. It lies slightly beyond the visual horizon because
+the atmosphere refracts radio waves a little.
+
+## How it works
+
+Raising either antenna pushes the radio horizon outward, which is why repeaters sit on
+towers and hilltops and why getting a receive antenna up high extends range at
+[VHF/UHF](/reference/frequency-bands/).
+
+## Relevance to SDR
+
+For line-of-sight bands, antenna height is often the most effective way to reach more
+distant systems.

--- a/docs/reference/radio-id.md
+++ b/docs/reference/radio-id.md
@@ -1,0 +1,34 @@
+---
+slug: radio-id
+title: Radio ID
+entry_type: term
+category: trunked-radio
+description: A radio ID (unit ID) is the unique identifier of an individual radio on a system, revealed in control-channel signalling and in-band signalling such as MDC1200.
+keywords: radio ID, unit ID, ANI, subscriber ID, RID, source ID, MDC1200
+aka: [radio ID, unit ID]
+autolink: true
+infobox:
+  - { label: Type, value: Subscriber identifier }
+  - { label: Seen in, value: Control-channel data, MDC1200 }
+  - { label: Identifies, value: An individual radio/unit }
+see_also: [talkgroup, affiliation, control-channel, mdc1200]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+---
+
+A **radio ID** (unit ID) is the unique identifier of an individual radio on a system,
+distinct from the [talkgroup](/reference/talkgroup/) it is using. It appears in
+[control-channel](/reference/control-channel/) signalling and in analog in-band schemes
+like [MDC1200](/reference/mdc1200/).
+
+## How it works
+
+Each transmission and [affiliation](/reference/affiliation/) carries the source radio
+ID, so a monitor can see *which unit* is talking, not just which group.
+
+## Relevance to SDR
+
+GopherTrunk's Radio IDs view merges live radio IDs with any alias catalogue, letting you
+track individual units across a system.

--- a/docs/reference/radio-id.md
+++ b/docs/reference/radio-id.md
@@ -23,6 +23,18 @@ distinct from the [talkgroup](/reference/talkgroup/) it is using. It appears in
 [control-channel](/reference/control-channel/) signalling and in analog in-band schemes
 like [MDC1200](/reference/mdc1200/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A transmission burst tagged with a unique radio identifier and its talkgroup." xmlns="http://www.w3.org/2000/svg">
+  <rect x="60" y="40" width="340" height="30" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="60" text-anchor="middle" font-size="10" fill="currentColor">voice transmission</text>
+  <text x="120" y="30" font-size="9" fill="currentColor" text-anchor="middle">radio ID 4567</text>
+  <text x="330" y="30" font-size="9" fill="currentColor" text-anchor="middle">TG 101</text>
+  <g stroke="currentColor" stroke-width="1"><line x1="120" y1="33" x2="120" y2="40"/><line x1="330" y1="33" x2="330" y2="40"/></g>
+  <text x="230" y="92" text-anchor="middle" font-size="9" fill="currentColor">every transmission identifies the individual radio</text>
+</svg>
+<figcaption>A radio ID uniquely identifies the transmitting unit, so you see who is talking, not just which group.</figcaption>
+</figure>
+
 ## How it works
 
 Each transmission and [affiliation](/reference/affiliation/) carries the source radio

--- a/docs/reference/radio-propagation.md
+++ b/docs/reference/radio-propagation.md
@@ -1,0 +1,36 @@
+---
+slug: radio-propagation
+title: Radio propagation
+entry_type: term
+category: antennas-propagation
+description: Radio propagation is the behaviour of radio waves as they travel from transmitter to receiver — line-of-sight, reflection, diffraction, and atmospheric effects.
+keywords: radio propagation, line of sight, reflection, diffraction, fading, coverage
+aka: [radio propagation, propagation]
+autolink: true
+infobox:
+  - { label: Type, value: Wave-travel behaviour }
+  - { label: VHF/UHF, value: Mostly line-of-sight }
+  - { label: HF, value: Ionospheric skip possible }
+see_also: [multipath-propagation, radio-horizon, ionospheric-propagation, path-loss, frequency-bands]
+related_lessons:
+  - { title: "How signals travel", url: /learn/propagation/ }
+external:
+  - { title: "Radio propagation (Wikipedia)", url: https://en.wikipedia.org/wiki/Radio_propagation }
+---
+
+**Radio propagation** describes how [radio waves](/reference/radio-wave/) travel from
+transmitter to receiver, including line-of-sight travel, reflection, diffraction, and
+atmospheric effects.
+
+## How it works
+
+At VHF and UHF, propagation is essentially line-of-sight, bounded by the
+[radio horizon](/reference/radio-horizon/); reflections cause
+[multipath](/reference/multipath-propagation/). At HF, the
+[ionosphere](/reference/ionospheric-propagation/) can refract signals over great
+distances. Loss along the way is [path loss](/reference/path-loss/).
+
+## Relevance to SDR
+
+Understanding propagation explains why antenna height and a clear path often matter
+more than the radio, and why a distant hilltop system can beat a closer obstructed one.

--- a/docs/reference/radio-propagation.md
+++ b/docs/reference/radio-propagation.md
@@ -22,6 +22,17 @@ external:
 transmitter to receiver, including line-of-sight travel, reflection, diffraction, and
 atmospheric effects.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A curved earth with a tall transmitter tower and a receiver, a straight line-of-sight path, and an obstacle blocking a lower path." xmlns="http://www.w3.org/2000/svg">
+  <path d="M10 140 Q230 95 450 140" fill="none" stroke="currentColor" stroke-opacity="0.4" stroke-width="1.4"/>
+  <line x1="80" y1="122" x2="80" y2="55" stroke="currentColor" stroke-width="2"/><text x="62" y="48" font-size="9" fill="currentColor">TX</text>
+  <line x1="380" y1="120" x2="380" y2="88" stroke="currentColor" stroke-width="2"/><text x="368" y="80" font-size="9" fill="currentColor">RX</text>
+  <line x1="80" y1="55" x2="380" y2="88" stroke="currentColor" stroke-width="1.4" stroke-dasharray="5 3"/><text x="200" y="58" font-size="9" fill="currentColor">line of sight</text>
+  <rect x="225" y="100" width="14" height="22" fill="currentColor" fill-opacity="0.3"/>
+</svg>
+<figcaption>At VHF/UHF, propagation is line-of-sight; height and a clear path matter more than raw distance.</figcaption>
+</figure>
+
 ## How it works
 
 At VHF and UHF, propagation is essentially line-of-sight, bounded by the

--- a/docs/reference/radio-wave.md
+++ b/docs/reference/radio-wave.md
@@ -1,0 +1,36 @@
+---
+slug: radio-wave
+title: Radio wave
+entry_type: term
+category: rf-fundamentals
+description: A radio wave is electromagnetic radiation in the radio frequency range, used to carry information wirelessly by varying its amplitude, frequency, or phase.
+keywords: radio wave, electromagnetic radiation, RF, carrier, propagation
+aka: [radio wave, radio waves]
+autolink: true
+infobox:
+  - { label: Type, value: Electromagnetic radiation }
+  - { label: Frequency range, value: ~3 kHz – 300 GHz }
+  - { label: Speed, value: ~299,792,458 m/s (vacuum) }
+see_also: [electromagnetic-spectrum, frequency, wavelength, carrier-wave, modulation]
+related_lessons:
+  - { title: "What is a radio wave?", url: /learn/radio-waves/ }
+external:
+  - { title: "Radio wave (Wikipedia)", url: https://en.wikipedia.org/wiki/Radio_wave }
+---
+
+A **radio wave** is electromagnetic radiation whose [frequency](/reference/frequency/)
+lies in the radio range of the [electromagnetic spectrum](/reference/electromagnetic-spectrum/).
+Radio waves travel at the speed of light and carry information wirelessly when their
+[amplitude](/reference/amplitude/), frequency, or [phase](/reference/phase/) is varied
+— a process called [modulation](/reference/modulation/).
+
+## How it works
+
+A transmitter drives alternating current into an [antenna](/reference/antenna/),
+radiating a self-propagating electric and magnetic field. A distant antenna converts
+the passing field back into a tiny current that a receiver amplifies and decodes.
+
+## Relevance to SDR
+
+Radio waves are the raw input to any receiver. An SDR digitises a slice of them into
+[IQ data](/reference/iq-data/) for software to process.

--- a/docs/reference/radio-wave.md
+++ b/docs/reference/radio-wave.md
@@ -24,6 +24,18 @@ Radio waves travel at the speed of light and carry information wirelessly when t
 [amplitude](/reference/amplitude/), frequency, or [phase](/reference/phase/) is varied
 — a process called [modulation](/reference/modulation/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 150" role="img" aria-label="A sine wave with one wavelength marked between crests and amplitude marked as height from the centre line." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="80" x2="440" y2="80" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 80 C 60 10, 120 10, 160 80 S 260 150, 300 80 S 400 10, 440 80" fill="none" stroke="currentColor" stroke-width="2.2"/>
+  <line x1="160" y1="35" x2="300" y2="35" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="230" y="28" text-anchor="middle" font-size="12" fill="currentColor">wavelength (λ)</text>
+  <line x1="90" y1="80" x2="90" y2="25" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="98" y="52" font-size="12" fill="currentColor">amplitude</text>
+</svg>
+<figcaption>A radio wave is described by its wavelength, amplitude, and frequency (cycles per second).</figcaption>
+</figure>
+
 ## How it works
 
 A transmitter drives alternating current into an [antenna](/reference/antenna/),

--- a/docs/reference/rc4-cipher.md
+++ b/docs/reference/rc4-cipher.md
@@ -1,0 +1,35 @@
+---
+slug: rc4-cipher
+title: RC4 (ARC4) cipher
+entry_type: algorithm
+category: algorithms
+description: RC4 (ARC4) is a stream cipher that XORs data with a key-derived keystream; it provides the "Enhanced Privacy" encryption option in some DMR systems.
+keywords: RC4, ARC4, stream cipher, keystream, DMR Enhanced Privacy, encryption
+aka: [RC4, ARC4]
+autolink: true
+infobox:
+  - { label: Type, value: Stream cipher }
+  - { label: Method, value: XOR with key-derived keystream }
+  - { label: Seen in, value: DMR Enhanced Privacy }
+see_also: [scrambling, dmr, forward-error-correction]
+related_lessons:
+  - { title: "Encryption & what you can decode", url: /learn/encryption/ }
+external:
+  - { title: "RC4 (Wikipedia)", url: https://en.wikipedia.org/wiki/RC4 }
+---
+
+**RC4** (also **ARC4**) is a stream cipher that generates a pseudo-random keystream from a
+secret key and XORs it with the data. It provides the "Enhanced Privacy" encryption option
+on some [DMR](/reference/dmr/) systems.
+
+## How it works
+
+Only holders of the correct key can reproduce the keystream and recover the plaintext.
+Unlike [scrambling](/reference/scrambling/) (a public sequence), RC4's keystream is
+secret — so without the key the voice cannot be recovered.
+
+## Relevance to SDR
+
+RC4 illustrates the line between reversible whitening and true encryption: GopherTrunk can
+descramble whitening but cannot decode encrypted voice without the key. See
+[DMR encryption](/dmr-encryption.html).

--- a/docs/reference/rc4-cipher.md
+++ b/docs/reference/rc4-cipher.md
@@ -22,6 +22,20 @@ external:
 secret key and XORs it with the data. It provides the "Enhanced Privacy" encryption option
 on some [DMR](/reference/dmr/) systems.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A key generating a keystream that is XORed with plaintext to produce ciphertext." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="44" width="50" height="26" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="55" y="61" text-anchor="middle" font-size="9" fill="currentColor">key</text>
+  <line x1="80" y1="57" x2="120" y2="57" stroke="currentColor" marker-end="url(#rcar)"/>
+  <rect x="122" y="44" width="80" height="26" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="162" y="61" text-anchor="middle" font-size="8" fill="currentColor">keystream</text>
+  <circle cx="250" cy="57" r="12" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="250" y="61" text-anchor="middle" font-size="11" fill="currentColor">⊕</text>
+  <text x="250" y="92" text-anchor="middle" font-size="8" fill="currentColor">plaintext</text><line x1="250" y1="88" x2="250" y2="70" stroke="currentColor"/>
+  <line x1="202" y1="57" x2="238" y2="57" stroke="currentColor"/>
+  <line x1="262" y1="57" x2="320" y2="57" stroke="currentColor" marker-end="url(#rcar)"/><text x="370" y="61" font-size="9" fill="currentColor">ciphertext</text>
+  <defs><marker id="rcar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>RC4 is a stream cipher: a key seeds a keystream that is XORed with the data — used by DMR's basic privacy.</figcaption>
+</figure>
+
 ## How it works
 
 Only holders of the correct key can reproduce the keystream and recover the plaintext.

--- a/docs/reference/reed-solomon-code.md
+++ b/docs/reference/reed-solomon-code.md
@@ -22,6 +22,18 @@ external:
 that works on multi-bit **symbols** rather than individual bits, making it especially good
 at correcting **bursts** of errors.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A codeword of data symbols followed by parity symbols, with the parity able to correct a burst of damaged symbols." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1">
+    <rect x="30" y="40" width="34" height="30" fill="none"/><rect x="64" y="40" width="34" height="30" fill="none"/><rect x="98" y="40" width="34" height="30" fill="currentColor" fill-opacity="0.4"/><rect x="132" y="40" width="34" height="30" fill="currentColor" fill-opacity="0.4"/><rect x="166" y="40" width="34" height="30" fill="none"/><rect x="200" y="40" width="34" height="30" fill="none"/>
+    <rect x="250" y="40" width="34" height="30" fill="currentColor" fill-opacity="0.15"/><rect x="284" y="40" width="34" height="30" fill="currentColor" fill-opacity="0.15"/><rect x="318" y="40" width="34" height="30" fill="currentColor" fill-opacity="0.15"/>
+  </g>
+  <text x="132" y="90" text-anchor="middle" font-size="9" fill="currentColor">data symbols (shaded = damaged)</text>
+  <text x="301" y="90" text-anchor="middle" font-size="9" fill="currentColor">parity</text>
+</svg>
+<figcaption>Reed–Solomon adds parity symbols that correct bursts of damaged symbols — used across P25 and DMR.</figcaption>
+</figure>
+
 ## How it works
 
 It adds parity symbols so that a number of symbol errors can be located and corrected. It

--- a/docs/reference/reed-solomon-code.md
+++ b/docs/reference/reed-solomon-code.md
@@ -1,0 +1,35 @@
+---
+slug: reed-solomon-code
+title: Reed–Solomon code
+entry_type: algorithm
+category: algorithms
+description: Reed–Solomon is a block error-correction code that operates on symbols rather than bits, excelling at correcting bursts of errors; used in P25, DMR, storage, and broadcast.
+keywords: Reed-Solomon, RS code, block code, burst error, symbols, FEC
+aka: [Reed–Solomon code, Reed-Solomon]
+autolink: true
+infobox:
+  - { label: Type, value: Block error-correction code }
+  - { label: Operates on, value: Symbols (good vs bursts) }
+  - { label: Used by, value: P25, DMR, storage, broadcast }
+see_also: [forward-error-correction, bch-code, golay-code, interleaving]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Reed–Solomon error correction (Wikipedia)", url: https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction }
+---
+
+**Reed–Solomon** is a block [error-correction](/reference/forward-error-correction/) code
+that works on multi-bit **symbols** rather than individual bits, making it especially good
+at correcting **bursts** of errors.
+
+## How it works
+
+It adds parity symbols so that a number of symbol errors can be located and corrected. It
+is frequently paired with [interleaving](/reference/interleaving/) to spread burst errors
+across codewords.
+
+## Relevance to SDR
+
+Reed–Solomon protects parts of [P25](/reference/project-25/) and
+[DMR](/reference/dmr/) (and is ubiquitous in storage and broadcast), helping the decoder
+recover data on marginal signals.

--- a/docs/reference/reginald-fessenden.md
+++ b/docs/reference/reginald-fessenden.md
@@ -1,0 +1,38 @@
+---
+slug: reginald-fessenden
+title: Reginald Fessenden
+entry_type: person
+category: people
+description: Reginald Fessenden (1866–1932) was a Canadian-American inventor credited with the first audio radio transmissions, pioneering amplitude modulation and continuous-wave radio.
+keywords: Reginald Fessenden, AM radio, voice transmission, continuous wave, radio history, heterodyne
+aka: [Reginald Fessenden, Fessenden]
+autolink: true
+infobox:
+  - { label: Lived, value: "1866–1932" }
+  - { label: Field, value: Radio engineering }
+  - { label: Known for, value: Early voice (AM) transmission }
+see_also: [amplitude-modulation, guglielmo-marconi, carrier-wave]
+related_lessons:
+  - { title: "Analog modulation — AM, FM, SSB", url: /learn/analog-modulation/ }
+external:
+  - { title: "Reginald Fessenden (Wikipedia)", url: https://en.wikipedia.org/wiki/Reginald_Fessenden }
+---
+
+**Reginald Fessenden** (1866–1932) was a Canadian-American inventor credited with some of
+the first **audio radio transmissions**, moving radio beyond Morse code to voice using
+[amplitude modulation](/reference/amplitude-modulation/).
+
+## Life and work
+
+Where early wireless sent spark-gap pulses, Fessenden championed continuous-wave radio and
+the heterodyne principle, transmitting speech and music in the early 1900s.
+
+## Contribution
+
+His continuous-wave and AM techniques made broadcasting possible and influenced receiver
+design.
+
+## Legacy
+
+Fessenden is remembered as a pioneer of voice radio, complementing
+[Marconi](/reference/guglielmo-marconi/)'s telegraphy.

--- a/docs/reference/reginald-fessenden.md
+++ b/docs/reference/reginald-fessenden.md
@@ -22,6 +22,15 @@ external:
 the first **audio radio transmissions**, moving radio beyond Morse code to voice using
 [amplitude modulation](/reference/amplitude-modulation/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A carrier whose amplitude envelope follows a voice waveform, illustrating the first AM voice transmission." xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 60 q4 -16 8 0 q4 -22 8 0 q4 -16 8 0 q4 -8 8 0 q4 -16 8 0 q4 -22 8 0 q4 -16 8 0 q4 -8 8 0 q4 -16 8 0 q4 -22 8 0 q4 -16 8 0 q4 -8 8 0 q4 -16 8 0 q4 -22 8 0 q4 -16 8 0 q4 -8 8 0 q4 -16 8 0 q4 -22 8 0 q4 -16 8 0 q4 -8 8 0 q4 -16 8 0 q4 -22 8 0 q4 -16 8 0 q4 -8 8 0 q4 -16 8 0 q4 -22 8 0" fill="none" stroke="currentColor" stroke-width="1.2"/>
+  <path d="M20 60 C 90 20, 150 24, 210 60 S 330 96, 400 60 S 440 44, 440 60" fill="none" stroke="currentColor" stroke-width="1.3" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+  <text x="230" y="106" text-anchor="middle" font-size="9" fill="currentColor">voice on the amplitude envelope</text>
+</svg>
+<figcaption>Fessenden pioneered AM voice radio, credited with the first audio (voice and music) broadcast in 1906.</figcaption>
+</figure>
+
 ## Life and work
 
 Where early wireless sent spark-gap pulses, Fessenden championed continuous-wave radio and

--- a/docs/reference/richard-hamming.md
+++ b/docs/reference/richard-hamming.md
@@ -1,0 +1,38 @@
+---
+slug: richard-hamming
+title: Richard Hamming
+entry_type: person
+category: people
+description: Richard Hamming (1915–1998) was an American mathematician who created the first practical error-correcting codes, the Hamming codes, founding the field of coding theory.
+keywords: Richard Hamming, Hamming code, error correction, coding theory, Bell Labs, Hamming distance
+aka: [Richard Hamming]
+autolink: true
+infobox:
+  - { label: Lived, value: "1915–1998" }
+  - { label: Field, value: Mathematics }
+  - { label: Known for, value: Hamming codes, Hamming distance }
+see_also: [hamming-code, forward-error-correction, golay-code]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Richard Hamming (Wikipedia)", url: https://en.wikipedia.org/wiki/Richard_Hamming }
+---
+
+**Richard Hamming** (1915–1998) was an American mathematician who created the first
+practical **error-correcting codes** — the [Hamming codes](/reference/hamming-code/) —
+launching the field of coding theory.
+
+## Life and work
+
+Frustrated by computers halting on detected errors, Hamming devised codes that could
+*correct* single-bit errors automatically, and defined the "Hamming distance" measuring
+how many bits differ between codewords.
+
+## Contribution
+
+His work began the discipline of [forward error correction](/reference/forward-error-correction/)
+on which all reliable digital radio depends.
+
+## Legacy
+
+Hamming codes and their descendants protect data across radio, storage, and networking.

--- a/docs/reference/richard-hamming.md
+++ b/docs/reference/richard-hamming.md
@@ -22,6 +22,15 @@ external:
 practical **error-correcting codes** — the [Hamming codes](/reference/hamming-code/) —
 launching the field of coding theory.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="Data bits with interspersed parity bits that detect and correct a single error." xmlns="http://www.w3.org/2000/svg">
+  <g font-family="monospace" font-size="11" fill="currentColor" text-anchor="middle"><text x="60" y="50">P</text><text x="100" y="50">P</text><text x="140" y="50">D</text><text x="180" y="50">P</text><text x="220" y="50">D</text><text x="260" y="50">D</text><text x="300" y="50">D</text></g>
+  <path d="M60 60 q40 16 80 0" fill="none" stroke="currentColor" stroke-opacity="0.6"/><path d="M100 64 q60 20 120 0" fill="none" stroke="currentColor" stroke-opacity="0.6"/>
+  <text x="230" y="96" text-anchor="middle" font-size="9" fill="currentColor">parity bits locate and fix a single-bit error</text>
+</svg>
+<figcaption>Hamming created the first practical error-correcting codes, the ancestors of the FEC used in digital radio.</figcaption>
+</figure>
+
 ## Life and work
 
 Frustrated by computers halting on detected errors, Hamming devised codes that could

--- a/docs/reference/root-raised-cosine-filter.md
+++ b/docs/reference/root-raised-cosine-filter.md
@@ -1,0 +1,36 @@
+---
+slug: root-raised-cosine-filter
+title: Root-raised-cosine filter
+entry_type: algorithm
+category: sdr-dsp
+description: A root-raised-cosine (RRC) filter is a pulse-shaping filter used at both transmitter and receiver to limit bandwidth while minimising intersymbol interference.
+keywords: root raised cosine, RRC, pulse shaping, intersymbol interference, matched filter, roll-off
+aka: [root-raised-cosine filter, RRC filter]
+autolink: true
+infobox:
+  - { label: Type, value: Pulse-shaping filter }
+  - { label: Goal, value: Limit bandwidth, minimise ISI }
+  - { label: Used, value: TX and RX (matched pair) }
+see_also: [matched-filter, digital-filter, symbol-rate, eye-diagram]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Root-raised-cosine filter (Wikipedia)", url: https://en.wikipedia.org/wiki/Root-raised-cosine_filter }
+---
+
+A **root-raised-cosine** (**RRC**) filter is a pulse-shaping
+[filter](/reference/digital-filter/) applied at both transmitter and receiver. Split
+across the link, the two halves combine into a raised-cosine response that limits
+bandwidth while minimising **intersymbol interference**.
+
+## How it works
+
+The roll-off factor trades [bandwidth](/reference/bandwidth/) against pulse compactness.
+The receiver's RRC also acts as a [matched filter](/reference/matched-filter/),
+maximising SNR at the sampling instant — visible as a clean
+[eye diagram](/reference/eye-diagram/).
+
+## Relevance to SDR
+
+Applying the correct RRC is part of demodulating digital signals that use it, sharpening
+[symbol](/reference/symbol-rate/) decisions.

--- a/docs/reference/root-raised-cosine-filter.md
+++ b/docs/reference/root-raised-cosine-filter.md
@@ -23,6 +23,16 @@ A **root-raised-cosine** (**RRC**) filter is a pulse-shaping
 across the link, the two halves combine into a raised-cosine response that limits
 bandwidth while minimising **intersymbol interference**.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A root-raised-cosine pulse shape: a central peak with small symmetric ripples that cross zero at adjacent symbol instants." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="90" x2="440" y2="90" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 90 Q 70 96 110 90 Q 150 80 170 90 Q 200 105 230 35 Q 260 105 290 90 Q 310 80 350 90 Q 390 96 440 90" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <g fill="currentColor" fill-opacity="0.5"><circle cx="110" cy="90" r="2"/><circle cx="170" cy="90" r="2"/><circle cx="290" cy="90" r="2"/><circle cx="350" cy="90" r="2"/></g>
+  <text x="230" y="120" text-anchor="middle" font-size="9" fill="currentColor">zero at neighbouring symbol times → no inter-symbol interference</text>
+</svg>
+<figcaption>Root-raised-cosine shaping limits bandwidth while keeping symbols from smearing into their neighbours.</figcaption>
+</figure>
+
 ## How it works
 
 The roll-off factor trades [bandwidth](/reference/bandwidth/) against pulse compactness.

--- a/docs/reference/rtl-sdr.md
+++ b/docs/reference/rtl-sdr.md
@@ -25,6 +25,16 @@ external:
 receivers built around the [RTL2832U](/reference/rtl2832u/) chip — originally a DVB-T TV
 tuner that hobbyists discovered could stream raw [IQ](/reference/iq-data/) samples.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for RTL-SDR (~24 MHz–1.7 GHz) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="430" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="30" y="86">0</text><text x="163" y="86">2 GHz</text><text x="296" y="86">4 GHz</text><text x="430" y="86">6 GHz</text></g>
+  <rect x="32" y="40" width="113" height="20" rx="3" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="28" text-anchor="middle" font-size="10" fill="currentColor">RTL-SDR (~24 MHz–1.7 GHz) coverage</text>
+</svg>
+<figcaption>RTL-SDR covers most VHF/UHF scanning at low cost — receive only.</figcaption>
+</figure>
+
 ## Overview
 
 A typical RTL-SDR costs around $30, tunes roughly **24 MHz–1.7 GHz**, and captures about

--- a/docs/reference/rtl-sdr.md
+++ b/docs/reference/rtl-sdr.md
@@ -1,0 +1,38 @@
+---
+slug: rtl-sdr
+title: RTL-SDR
+entry_type: hardware
+category: hardware
+description: RTL-SDR is a family of low-cost USB software-defined radio receivers based on the RTL2832U chip, repurposed from DVB-T TV tuners, covering roughly 24 MHz to 1.7 GHz.
+keywords: RTL-SDR, RTL2832U, cheap SDR, DVB-T dongle, R820T, 24 MHz 1.7 GHz, receive only
+aka: [RTL-SDR, RTL SDR]
+autolink: true
+infobox:
+  - { label: Type, value: USB SDR receiver }
+  - { label: Bridge chip, value: RTL2832U }
+  - { label: Range, value: ~24 MHz – 1.7 GHz }
+  - { label: Bandwidth, value: ~2.4 MHz usable }
+  - { label: TX, value: No (receive only) }
+see_also: [rtl2832u, r820t-tuner, hackrf, airspy, upconverter, software-defined-radio]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/sdr-hardware/ }
+external:
+  - { title: "RTL-SDR (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR }
+  - { title: "GopherTrunk hardware guide", url: /hardware.html }
+---
+
+**RTL-SDR** is a family of inexpensive USB [software-defined radio](/reference/software-defined-radio/)
+receivers built around the [RTL2832U](/reference/rtl2832u/) chip — originally a DVB-T TV
+tuner that hobbyists discovered could stream raw [IQ](/reference/iq-data/) samples.
+
+## Overview
+
+A typical RTL-SDR costs around $30, tunes roughly **24 MHz–1.7 GHz**, and captures about
+2.4 MHz of [bandwidth](/reference/bandwidth/). It is receive-only with modest dynamic
+range, but more than enough to follow most VHF/UHF trunked systems.
+
+## Relevance to SDR
+
+The RTL-SDR is the ideal entry point and the baseline GopherTrunk targets. For HF, add an
+[upconverter](/reference/upconverter/) or use an [Airspy HF+](/reference/airspy-hf-plus/);
+see the [hardware guide](/hardware.html).

--- a/docs/reference/rtl-tcp.md
+++ b/docs/reference/rtl-tcp.md
@@ -22,6 +22,20 @@ external:
 [RTL-SDR](/reference/rtl-sdr/) over a **TCP** connection, letting the dongle be used from
 another machine on the network.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A dongle on a remote computer streaming IQ over the network to GopherTrunk on another machine." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <path d="M40 60 v-22 m-7 0 l7 -10 l7 10" fill="none" stroke="currentColor" stroke-width="1.6"/>
+    <rect x="70" y="44" width="92" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="116" y="58">Pi + dongle</text><text x="116" y="69" font-size="7.5">rtl_tcp server</text>
+    <rect x="300" y="44" width="110" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="355" y="63">GopherTrunk</text>
+    <line x1="162" y1="59" x2="299" y2="59" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#rtar)"/><text x="230" y="51">IQ over network</text>
+    <line x1="52" y1="59" x2="69" y2="59" stroke="currentColor" stroke-width="1.1"/>
+  </g>
+  <defs><marker id="rtar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>rtl_tcp streams IQ over the network, so the dongle can sit at the antenna while decoding runs elsewhere.</figcaption>
+</figure>
+
 ## Overview
 
 A common setup runs rtl_tcp on a Raspberry Pi right at the [antenna](/reference/antenna/)

--- a/docs/reference/rtl-tcp.md
+++ b/docs/reference/rtl-tcp.md
@@ -1,0 +1,33 @@
+---
+slug: rtl-tcp
+title: rtl_tcp
+entry_type: technology
+category: hardware
+description: rtl_tcp is a small server that streams raw IQ samples from an RTL-SDR over a TCP network connection, allowing the dongle to be used remotely.
+keywords: rtl_tcp, network SDR, remote RTL-SDR, IQ over TCP, Raspberry Pi SDR
+aka: [rtl_tcp]
+autolink: true
+infobox:
+  - { label: Type, value: Network IQ server }
+  - { label: Streams, value: Raw IQ from RTL-SDR over TCP }
+  - { label: Use, value: Dongle at antenna, decode elsewhere }
+see_also: [rtl-sdr, soapysdr, iq-data, software-defined-radio]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/sdr-hardware/ }
+external:
+  - { title: "rtl-sdr (osmocom)", url: https://osmocom.org/projects/rtl-sdr/wiki }
+---
+
+**rtl_tcp** is a small server that streams raw [IQ](/reference/iq-data/) samples from an
+[RTL-SDR](/reference/rtl-sdr/) over a **TCP** connection, letting the dongle be used from
+another machine on the network.
+
+## Overview
+
+A common setup runs rtl_tcp on a Raspberry Pi right at the [antenna](/reference/antenna/)
+— keeping the coax run short — while the decoder runs on a more capable host elsewhere.
+
+## Relevance to SDR
+
+GopherTrunk can attach to an rtl_tcp (or [SoapyRemote](/reference/soapysdr/)) source,
+treating a remote dongle like a local one.

--- a/docs/reference/rtl2832u.md
+++ b/docs/reference/rtl2832u.md
@@ -1,0 +1,35 @@
+---
+slug: rtl2832u
+title: RTL2832U
+entry_type: hardware
+category: hardware
+description: The RTL2832U is the Realtek demodulator/USB-bridge chip at the heart of RTL-SDR dongles, whose raw IQ output mode enabled low-cost software-defined radio.
+keywords: RTL2832U, Realtek, DVB-T demodulator, USB bridge, IQ output, RTL-SDR
+aka: [RTL2832U, RTL2832]
+autolink: true
+infobox:
+  - { label: Type, value: Demodulator / USB bridge IC }
+  - { label: Vendor, value: Realtek }
+  - { label: Role, value: ADC + USB streaming of IQ }
+  - { label: Paired tuner, value: R820T2, E4000, etc. }
+see_also: [rtl-sdr, r820t-tuner, analog-to-digital-converter]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/sdr-hardware/ }
+external:
+  - { title: "RTL-SDR (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR }
+---
+
+The **RTL2832U** is the Realtek demodulator and USB-bridge chip at the core of
+[RTL-SDR](/reference/rtl-sdr/) dongles. Its undocumented raw-[IQ](/reference/iq-data/)
+output mode is what turned cheap DVB-T tuners into software-defined radios.
+
+## Overview
+
+The RTL2832U contains the [ADC](/reference/analog-to-digital-converter/) and USB
+interface; it is paired with a separate tuner chip such as the
+[R820T2](/reference/r820t-tuner/) that handles RF front-end and mixing.
+
+## Relevance to SDR
+
+GopherTrunk drives RTL2832U-based devices through a pure-Go USB driver with no C
+dependencies.

--- a/docs/reference/rtl2832u.md
+++ b/docs/reference/rtl2832u.md
@@ -23,6 +23,20 @@ The **RTL2832U** is the Realtek demodulator and USB-bridge chip at the core of
 [RTL-SDR](/reference/rtl-sdr/) dongles. Its undocumented raw-[IQ](/reference/iq-data/)
 output mode is what turned cheap DVB-T tuners into software-defined radios.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="Block diagram: antenna into a tuner chip, into the RTL2832U ADC and demodulator, out over USB as IQ samples." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="35" y="55">antenna</text>
+    <rect x="78" y="38" width="74" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="115" y="57">tuner</text>
+    <rect x="172" y="38" width="96" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="220" y="51">RTL2832U</text><text x="220" y="62" font-size="7.5">ADC + DDC</text>
+    <rect x="290" y="38" width="70" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="325" y="57">USB</text>
+    <text x="405" y="55">IQ</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="62" y1="53" x2="77" y2="53"/><line x1="152" y1="53" x2="171" y2="53"/><line x1="268" y1="53" x2="289" y2="53"/><line x1="360" y1="53" x2="392" y2="53"/></g>
+  </g>
+</svg>
+<figcaption>The RTL2832U is the demodulator/ADC chip at the heart of RTL-SDR dongles, streaming IQ over USB.</figcaption>
+</figure>
+
 ## Overview
 
 The RTL2832U contains the [ADC](/reference/analog-to-digital-converter/) and USB

--- a/docs/reference/sample-rate.md
+++ b/docs/reference/sample-rate.md
@@ -1,0 +1,34 @@
+---
+slug: sample-rate
+title: Sample rate
+entry_type: term
+category: sdr-dsp
+description: Sample rate is the number of samples per second an SDR produces; with IQ sampling it approximately equals the captured bandwidth, trading spectrum coverage against CPU and USB load.
+keywords: sample rate, samples per second, capture bandwidth, IQ rate, decimation, CPU load
+aka: [sample rate]
+autolink: true
+infobox:
+  - { label: Symbol, value: Fs }
+  - { label: Unit, value: Samples/second (Sa/s) }
+  - { label: Rule, value: "captured bandwidth ≈ sample rate (IQ)" }
+see_also: [bandwidth, nyquist-theorem, aliasing, decimation, analog-to-digital-converter]
+related_lessons:
+  - { title: "Sample rate, bandwidth & Nyquist", url: /learn/sample-rate-nyquist/ }
+external:
+  - { title: "Sampling (signal processing) (Wikipedia)", url: https://en.wikipedia.org/wiki/Sampling_(signal_processing) }
+---
+
+**Sample rate** is how many [IQ](/reference/iq-data/) samples per second an SDR produces.
+With complex sampling, the **captured [bandwidth](/reference/bandwidth/) is approximately
+equal to the sample rate** — an RTL-SDR at 2.4 MSa/s sees about 2.4 MHz at once.
+
+## How it works
+
+Higher rates capture more spectrum but produce more data, raising CPU and USB load (and
+risking dropped samples). [Filtering and decimation](/reference/decimation/) narrow a wide
+capture down to one channel.
+
+## Relevance to SDR
+
+For trunk-tracking, choose a rate that just covers the channels you follow — not the
+widest possible span.

--- a/docs/reference/sample-rate.md
+++ b/docs/reference/sample-rate.md
@@ -22,6 +22,16 @@ external:
 With complex sampling, the **captured [bandwidth](/reference/bandwidth/) is approximately
 equal to the sample rate** — an RTL-SDR at 2.4 MSa/s sees about 2.4 MHz at once.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A sine wave with evenly spaced sample dots, captioned that captured bandwidth roughly equals the sample rate." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="55" x2="440" y2="55" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 55 C 80 15, 140 15, 200 55 S 320 95, 380 55 S 440 35, 440 55" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <g fill="currentColor"><circle cx="20" cy="55" r="3"/><circle cx="60" cy="28" r="3"/><circle cx="110" cy="28" r="3"/><circle cx="160" cy="44" r="3"/><circle cx="210" cy="58" r="3"/><circle cx="260" cy="78" r="3"/><circle cx="320" cy="86" r="3"/><circle cx="380" cy="55" r="3"/><circle cx="430" cy="40" r="3"/></g>
+  <text x="20" y="105" font-size="10" fill="currentColor">captured bandwidth ≈ sample rate (IQ sampling)</text>
+</svg>
+<figcaption>Sample rate sets how often the SDR measures the signal — and how much spectrum it captures at once.</figcaption>
+</figure>
+
 ## How it works
 
 Higher rates capture more spectrum but produce more data, raising CPU and USB load (and

--- a/docs/reference/scrambling.md
+++ b/docs/reference/scrambling.md
@@ -22,6 +22,19 @@ external:
 up long runs of identical bits, which helps [clock recovery](/reference/clock-recovery/)
 and keeps the spectrum balanced. It is **not** encryption.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A data stream XORed with a pseudo-random sequence to produce a whitened stream with no long runs." xmlns="http://www.w3.org/2000/svg">
+  <g font-family="monospace" font-size="11" fill="currentColor"><text x="30" y="50">data</text><text x="30" y="72">PRBS</text></g>
+  <circle cx="200" cy="58" r="12" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="200" y="62" text-anchor="middle" font-size="11" fill="currentColor">⊕</text>
+  <line x1="110" y1="48" x2="188" y2="55" stroke="currentColor" stroke-width="1"/><line x1="110" y1="70" x2="188" y2="62" stroke="currentColor" stroke-width="1"/>
+  <line x1="212" y1="58" x2="290" y2="58" stroke="currentColor" marker-end="url(#scar)"/>
+  <text x="350" y="62" font-size="10" fill="currentColor">whitened stream</text>
+  <text x="230" y="98" text-anchor="middle" font-size="9" fill="currentColor">balances 1s and 0s for reliable clock recovery</text>
+  <defs><marker id="scar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Scrambling (whitening) XORs data with a pseudo-random sequence to avoid long runs of identical bits.</figcaption>
+</figure>
+
 ## How it works
 
 Both ends know the same sequence, so the receiver de-scrambles by XORing again. This

--- a/docs/reference/scrambling.md
+++ b/docs/reference/scrambling.md
@@ -1,0 +1,33 @@
+---
+slug: scrambling
+title: Scrambling (whitening)
+entry_type: algorithm
+category: algorithms
+description: Scrambling, or whitening, XORs data with a pseudo-random sequence to remove long runs of identical bits, aiding clock recovery and spectral balance; it is not encryption.
+keywords: scrambling, whitening, pseudo-random, PRBS, clock recovery, DC balance, not encryption
+aka: [scrambling, whitening]
+autolink: true
+infobox:
+  - { label: Type, value: Data conditioning }
+  - { label: Method, value: XOR with pseudo-random sequence }
+  - { label: Not, value: Encryption (sequence is public) }
+see_also: [clock-recovery, rc4-cipher, forward-error-correction, demodulation]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Scrambler (Wikipedia)", url: https://en.wikipedia.org/wiki/Scrambler }
+---
+
+**Scrambling** (**whitening**) XORs data with a *public* pseudo-random sequence to break
+up long runs of identical bits, which helps [clock recovery](/reference/clock-recovery/)
+and keeps the spectrum balanced. It is **not** encryption.
+
+## How it works
+
+Both ends know the same sequence, so the receiver de-scrambles by XORing again. This
+guarantees frequent transitions for timing and avoids a DC bias, regardless of the data.
+
+## Relevance to SDR
+
+Recognising that whitening is reversible (unlike [RC4](/reference/rc4-cipher/) encryption)
+explains why a scrambled-but-unencrypted signal still decodes.

--- a/docs/reference/signal-to-noise-ratio.md
+++ b/docs/reference/signal-to-noise-ratio.md
@@ -1,0 +1,34 @@
+---
+slug: signal-to-noise-ratio
+title: Signal-to-noise ratio (SNR)
+entry_type: term
+category: rf-fundamentals
+description: Signal-to-noise ratio is the difference in decibels between a signal's power and the noise floor; digital modes require a minimum SNR to decode reliably.
+keywords: SNR, signal to noise ratio, noise floor, dB, decode threshold, SINAD
+aka: [signal-to-noise ratio, SNR]
+autolink: true
+infobox:
+  - { label: Symbol, value: SNR }
+  - { label: Unit, value: Decibels (dB) }
+  - { label: Formula, value: "signal (dBm) − noise floor (dBm)" }
+see_also: [noise-floor, decibel, dbm, demodulation]
+related_lessons:
+  - { title: "Decibels & signal power", url: /learn/decibels/ }
+external:
+  - { title: "Signal-to-noise ratio (Wikipedia)", url: https://en.wikipedia.org/wiki/Signal-to-noise_ratio }
+---
+
+**Signal-to-noise ratio** (**SNR**) is the gap, in [decibels](/reference/decibel/),
+between a signal's power and the [noise floor](/reference/noise-floor/). It is the
+single best predictor of whether a signal will decode.
+
+## How it works
+
+SNR = signal level − noise-floor level (both in [dBm](/reference/dbm/)). A signal at
+−85 dBm over a −105 dBm floor has 20 dB of SNR. Each digital mode has a minimum SNR
+below which [demodulation](/reference/demodulation/) starts dropping symbols.
+
+## Relevance to SDR
+
+Improving SNR — better antenna, placement, correct gain — is usually what moves a
+marginal signal from un-decodable to clean.

--- a/docs/reference/signal-to-noise-ratio.md
+++ b/docs/reference/signal-to-noise-ratio.md
@@ -22,6 +22,19 @@ external:
 between a signal's power and the [noise floor](/reference/noise-floor/). It is the
 single best predictor of whether a signal will decode.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 160" role="img" aria-label="A spectrum with a noisy baseline labelled noise floor and a tall peak labelled signal, with the gap between them labelled SNR." xmlns="http://www.w3.org/2000/svg">
+  <path d="M30 120 L70 124 L110 116 L150 122 L190 119 L240 121 L300 118 L360 121 L420 119" fill="none" stroke="currentColor" stroke-width="1.4" stroke-opacity="0.6"/>
+  <line x1="30" y1="120" x2="430" y2="120" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.5"/>
+  <text x="350" y="135" font-size="10" fill="currentColor">noise floor</text>
+  <path d="M210 120 L224 45 L238 120 Z" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.5"/>
+  <text x="224" y="38" text-anchor="middle" font-size="10" fill="currentColor">signal</text>
+  <line x1="260" y1="45" x2="260" y2="120" stroke="currentColor"/>
+  <text x="268" y="86" font-size="11" fill="currentColor">SNR</text>
+</svg>
+<figcaption>SNR is how far a signal rises above the noise floor; digital modes need a minimum SNR to decode.</figcaption>
+</figure>
+
 ## How it works
 
 SNR = signal level − noise-floor level (both in [dBm](/reference/dbm/)). A signal at

--- a/docs/reference/single-sideband.md
+++ b/docs/reference/single-sideband.md
@@ -23,6 +23,26 @@ external:
 [carrier](/reference/carrier-wave/) and one of the two redundant sidebands,
 transmitting only **one sideband** — upper (USB) or lower (LSB).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A double-sideband AM spectrum with carrier and two sidebands on the left, an arrow, and an SSB spectrum with only one sideband on the right." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.4">
+    <line x1="40" y1="100" x2="170" y2="100" stroke-opacity="0.4"/>
+    <line x1="105" y1="100" x2="105" y2="40"/>
+    <rect x="70" y="70" width="20" height="30" fill="currentColor" fill-opacity="0.2"/>
+    <rect x="120" y="70" width="20" height="30" fill="currentColor" fill-opacity="0.2"/>
+  </g>
+  <text x="105" y="118" text-anchor="middle" font-size="9" fill="currentColor">AM: carrier + 2 sidebands</text>
+  <line x1="195" y1="70" x2="235" y2="70" stroke="currentColor" marker-end="url(#ssbar)"/>
+  <g stroke="currentColor" stroke-width="1.4">
+    <line x1="280" y1="100" x2="430" y2="100" stroke-opacity="0.4"/>
+    <rect x="360" y="70" width="20" height="30" fill="currentColor" fill-opacity="0.3"/>
+  </g>
+  <text x="355" y="118" text-anchor="middle" font-size="9" fill="currentColor">SSB: one sideband only</text>
+  <defs><marker id="ssbar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>SSB removes the carrier and one redundant sideband — half the bandwidth, all the power on the information.</figcaption>
+</figure>
+
 ## How it works
 
 With the carrier and one sideband gone, SSB uses about **half the bandwidth** and puts

--- a/docs/reference/single-sideband.md
+++ b/docs/reference/single-sideband.md
@@ -1,0 +1,36 @@
+---
+slug: single-sideband
+title: Single sideband (SSB)
+entry_type: technology
+category: modulation
+description: Single sideband (SSB) is an efficient form of amplitude modulation that suppresses the carrier and one sideband, using half the bandwidth and concentrating power for long-distance HF voice.
+keywords: single sideband, SSB, USB, LSB, suppressed carrier, HF voice, amateur
+aka: [single sideband, SSB]
+autolink: true
+infobox:
+  - { label: Type, value: Analog modulation (AM variant) }
+  - { label: Sends, value: One sideband, suppressed carrier }
+  - { label: Used for, value: Long-distance HF voice, amateur }
+see_also: [amplitude-modulation, modulation, frequency-bands, ionospheric-propagation]
+related_lessons:
+  - { title: "Analog modulation — AM, FM, SSB", url: /learn/analog-modulation/ }
+external:
+  - { title: "Single-sideband modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Single-sideband_modulation }
+---
+
+**Single sideband** (**SSB**) is a refined form of
+[amplitude modulation](/reference/amplitude-modulation/) that removes the
+[carrier](/reference/carrier-wave/) and one of the two redundant sidebands,
+transmitting only **one sideband** — upper (USB) or lower (LSB).
+
+## How it works
+
+With the carrier and one sideband gone, SSB uses about **half the bandwidth** and puts
+all power into the information, so modest transmitters reach across continents on
+[HF](/reference/frequency-bands/). The cost is that the receiver must tune precisely or
+voices sound distorted.
+
+## Relevance to SDR
+
+SSB is the backbone of long-distance HF voice; receiving it needs an HF-capable SDR and
+accurate tuning to reinsert the missing carrier.

--- a/docs/reference/soapysdr.md
+++ b/docs/reference/soapysdr.md
@@ -1,0 +1,34 @@
+---
+slug: soapysdr
+title: SoapySDR
+entry_type: technology
+category: hardware
+description: SoapySDR is a vendor-neutral hardware abstraction library that provides a common API to many software-defined radios, including networked access via SoapyRemote.
+keywords: SoapySDR, SDR abstraction, SoapyRemote, hardware API, device support
+aka: [SoapySDR]
+autolink: true
+infobox:
+  - { label: Type, value: SDR hardware abstraction layer }
+  - { label: Provides, value: Common API across many SDRs }
+  - { label: Remote, value: SoapyRemote (network IQ) }
+see_also: [rtl-tcp, software-defined-radio, rtl-sdr, airspy]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/sdr-hardware/ }
+external:
+  - { title: "SoapySDR (project)", url: https://github.com/pothosware/SoapySDR }
+---
+
+**SoapySDR** is a vendor-neutral hardware-abstraction library that exposes a **common
+API** across many [software-defined radios](/reference/software-defined-radio/), so
+applications can support diverse devices without per-vendor code.
+
+## Overview
+
+Its **SoapyRemote** companion streams [IQ](/reference/iq-data/) over a network, letting a
+radio on one machine serve an application on another — useful for placing the dongle at
+the antenna.
+
+## Relevance to SDR
+
+SoapySDR-style remoting (alongside [rtl_tcp](/reference/rtl-tcp/)) lets GopherTrunk use
+radios that live on a separate host.

--- a/docs/reference/soapysdr.md
+++ b/docs/reference/soapysdr.md
@@ -22,6 +22,20 @@ external:
 API** across many [software-defined radios](/reference/software-defined-radio/), so
 applications can support diverse devices without per-vendor code.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="Applications calling a common SoapySDR layer that drives several different SDR devices through plugin modules." xmlns="http://www.w3.org/2000/svg">
+  <rect x="150" y="14" width="160" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="230" y="31" text-anchor="middle" font-size="9" fill="currentColor">applications</text>
+  <rect x="120" y="52" width="220" height="26" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="230" y="69" text-anchor="middle" font-size="9" fill="currentColor">SoapySDR (common API)</text>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <rect x="60" y="92" width="80" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="100" y="109">RTL-SDR</text>
+    <rect x="190" y="92" width="80" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="230" y="109">HackRF</text>
+    <rect x="320" y="92" width="80" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="360" y="109">Airspy</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1"><line x1="230" y1="40" x2="230" y2="52"/><line x1="100" y1="78" x2="100" y2="92"/><line x1="230" y1="78" x2="230" y2="92"/><line x1="360" y1="78" x2="360" y2="92"/></g>
+</svg>
+<figcaption>SoapySDR is a vendor-neutral abstraction layer: one API that drives many different SDR devices.</figcaption>
+</figure>
+
 ## Overview
 
 Its **SoapyRemote** companion streams [IQ](/reference/iq-data/) over a network, letting a

--- a/docs/reference/software-defined-radio.md
+++ b/docs/reference/software-defined-radio.md
@@ -1,0 +1,36 @@
+---
+slug: software-defined-radio
+title: Software-defined radio (SDR)
+entry_type: technology
+category: sdr-dsp
+description: Software-defined radio (SDR) is radio technology in which traditionally hardware functions — tuning, filtering, demodulation — are implemented in software operating on digitised IQ samples.
+keywords: software defined radio, SDR, IQ, digital radio, RTL-SDR, flexibility
+aka: [software-defined radio, SDR]
+autolink: true
+infobox:
+  - { label: Type, value: Radio architecture }
+  - { label: Idea, value: Move tuning/demod into software }
+  - { label: Hardware emits, value: IQ samples }
+  - { label: Examples, value: RTL-SDR, HackRF, Airspy }
+see_also: [iq-data, analog-to-digital-converter, superheterodyne-receiver, rtl-sdr, demodulation]
+related_lessons:
+  - { title: "What is software-defined radio?", url: /learn/what-is-sdr/ }
+external:
+  - { title: "Software-defined radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio }
+---
+
+**Software-defined radio** (**SDR**) moves the functions that were once fixed hardware —
+tuning, filtering, [demodulation](/reference/demodulation/) — into **software** operating
+on digitised [IQ samples](/reference/iq-data/). The hardware does only enough to convert a
+slice of spectrum into numbers.
+
+## How it works
+
+An SDR front-end amplifies, mixes, and digitises a band into IQ; software then does
+everything else. Because the differences between systems live in code, one device can
+decode many protocols.
+
+## Relevance to SDR
+
+GopherTrunk is the software half of an SDR, specialised for digital trunked radio. The
+hardware (e.g. [RTL-SDR](/reference/rtl-sdr/)) is almost interchangeable.

--- a/docs/reference/software-defined-radio.md
+++ b/docs/reference/software-defined-radio.md
@@ -24,6 +24,20 @@ tuning, filtering, [demodulation](/reference/demodulation/) — into **software*
 on digitised [IQ samples](/reference/iq-data/). The hardware does only enough to convert a
 slice of spectrum into numbers.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 110" role="img" aria-label="Antenna into SDR hardware which outputs IQ samples into software which outputs audio and data." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <path d="M40 78 v-28 m-9 0 l9 -12 l9 12" fill="none" stroke="currentColor" stroke-width="2"/><text x="40" y="96">antenna</text>
+    <rect x="86" y="44" width="104" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="138" y="58">SDR hardware</text><text x="138" y="71" font-size="8.5">tune · digitise</text>
+    <rect x="262" y="44" width="116" height="34" rx="6" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="320" y="58">software</text><text x="320" y="71" font-size="8.5">filter · demod · decode</text>
+    <rect x="450" y="44" width="78" height="34" rx="6" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.4"/><text x="489" y="64">audio &amp; data</text>
+    <text x="226" y="38" font-size="8.5">IQ samples</text>
+    <g stroke="currentColor" stroke-width="1.2"><line x1="52" y1="61" x2="85" y2="61"/><line x1="190" y1="61" x2="261" y2="61"/><line x1="378" y1="61" x2="449" y2="61"/></g>
+  </g>
+</svg>
+<figcaption>An SDR moves tuning, filtering, and demodulation into software; the hardware just delivers IQ samples.</figcaption>
+</figure>
+
 ## How it works
 
 An SDR front-end amplifies, mixes, and digitises a band into IQ; software then does

--- a/docs/reference/standing-wave-ratio.md
+++ b/docs/reference/standing-wave-ratio.md
@@ -1,0 +1,34 @@
+---
+slug: standing-wave-ratio
+title: Standing wave ratio (SWR)
+entry_type: term
+category: antennas-propagation
+description: SWR measures how well an antenna is impedance-matched to its feedline and radio at a frequency; a poor match reflects power instead of transferring it.
+keywords: SWR, VSWR, standing wave ratio, impedance match, reflection, return loss
+aka: [standing wave ratio, SWR, VSWR]
+autolink: true
+infobox:
+  - { label: Type, value: Impedance-match metric }
+  - { label: Ideal, value: 1:1 }
+  - { label: Effect of mismatch, value: Reflected power, lost signal }
+see_also: [antenna, dipole-antenna, attenuation]
+related_lessons:
+  - { title: "Antennas 101", url: /learn/antennas/ }
+external:
+  - { title: "Standing wave ratio (Wikipedia)", url: https://en.wikipedia.org/wiki/Standing_wave_ratio }
+---
+
+**Standing wave ratio** (**SWR**, often VSWR) measures how well an
+[antenna](/reference/antenna/) is impedance-matched to its feedline and radio at a
+given [frequency](/reference/frequency/). A perfect match is 1:1.
+
+## How it works
+
+When the match is poor, some energy is reflected back rather than transferred,
+creating standing waves on the feedline. For transmitting this can damage equipment;
+for receive-only SDR use it mainly costs a little signal.
+
+## Relevance to SDR
+
+A reasonably matched, resonant antenna delivers more signal to the SDR than a
+mismatched one, helping [SNR](/reference/signal-to-noise-ratio/).

--- a/docs/reference/standing-wave-ratio.md
+++ b/docs/reference/standing-wave-ratio.md
@@ -22,6 +22,16 @@ external:
 [antenna](/reference/antenna/) is impedance-matched to its feedline and radio at a
 given [frequency](/reference/frequency/). A perfect match is 1:1.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A forward wave travelling toward an antenna and a smaller reflected wave returning from a mismatch." xmlns="http://www.w3.org/2000/svg">
+  <rect x="380" y="45" width="50" height="40" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="405" y="70" text-anchor="middle" font-size="8" fill="currentColor">antenna</text>
+  <line x1="30" y1="50" x2="375" y2="50" stroke="currentColor" stroke-width="1.4" marker-end="url(#swf)"/><text x="60" y="42" font-size="9" fill="currentColor">forward</text>
+  <line x1="375" y1="80" x2="30" y2="80" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#swr)"/><text x="60" y="98" font-size="9" fill="currentColor">reflected (mismatch)</text>
+  <defs><marker id="swf" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker><marker id="swr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>SWR measures how well the antenna is matched; a poor match reflects energy back instead of radiating it.</figcaption>
+</figure>
+
 ## How it works
 
 When the match is poor, some energy is reflected back rather than transferred,

--- a/docs/reference/superheterodyne-receiver.md
+++ b/docs/reference/superheterodyne-receiver.md
@@ -23,6 +23,22 @@ A **superheterodyne receiver** uses a mixer driven by a
 fixed intermediate frequency (IF) — or to baseband — where it is easier to filter and
 detect.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 110" role="img" aria-label="Receiver chain: antenna, RF amplifier, mixer fed by a local oscillator, IF filter, then detector." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <path d="M28 70 v-24 m-8 0 l8 -11 l8 11" fill="none" stroke="currentColor" stroke-width="1.8"/>
+    <rect x="60" y="44" width="56" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="88" y="63">RF amp</text>
+    <rect x="140" y="44" width="56" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="168" y="63">mixer</text>
+    <circle cx="168" cy="96" r="3" fill="currentColor"/><line x1="168" y1="74" x2="168" y2="93" stroke="currentColor" stroke-width="1.2"/><text x="168" y="108" font-size="8">LO</text>
+    <rect x="220" y="44" width="64" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="252" y="60">IF filter</text>
+    <rect x="308" y="44" width="64" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="340" y="63">detector</text>
+    <rect x="396" y="44" width="64" height="30" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="428" y="63">output</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="36" y1="59" x2="59" y2="59"/><line x1="116" y1="59" x2="139" y2="59"/><line x1="196" y1="59" x2="219" y2="59"/><line x1="284" y1="59" x2="307" y2="59"/><line x1="372" y1="59" x2="395" y2="59"/></g>
+  </g>
+</svg>
+<figcaption>A superheterodyne receiver mixes the wanted signal down to a fixed intermediate frequency for easier filtering.</figcaption>
+</figure>
+
 ## How it works
 
 Tuning is just changing the local-oscillator frequency so the wanted band lands at the

--- a/docs/reference/superheterodyne-receiver.md
+++ b/docs/reference/superheterodyne-receiver.md
@@ -1,0 +1,35 @@
+---
+slug: superheterodyne-receiver
+title: Superheterodyne receiver
+entry_type: term
+category: sdr-dsp
+description: A superheterodyne receiver uses a mixer and local oscillator to shift a desired band down to a fixed intermediate frequency for easier filtering and detection; SDR front-ends apply the same principle.
+keywords: superheterodyne, superhet, mixer, local oscillator, intermediate frequency, IF, downconversion
+aka: [superheterodyne receiver, superhet]
+autolink: true
+infobox:
+  - { label: Type, value: Receiver architecture }
+  - { label: Key parts, value: Mixer + local oscillator }
+  - { label: Produces, value: Intermediate frequency / baseband }
+see_also: [local-oscillator, digital-down-converter, analog-to-digital-converter, software-defined-radio]
+related_lessons:
+  - { title: "How an SDR receiver works", url: /learn/sdr-receiver/ }
+external:
+  - { title: "Superheterodyne receiver (Wikipedia)", url: https://en.wikipedia.org/wiki/Superheterodyne_receiver }
+---
+
+A **superheterodyne receiver** uses a mixer driven by a
+[local oscillator](/reference/local-oscillator/) to shift a chosen band **down** to a
+fixed intermediate frequency (IF) — or to baseband — where it is easier to filter and
+detect.
+
+## How it works
+
+Tuning is just changing the local-oscillator frequency so the wanted band lands at the
+fixed IF. SDR quadrature front-ends apply the same idea, mixing to baseband as
+[IQ](/reference/iq-data/) before the [ADC](/reference/analog-to-digital-converter/).
+
+## Relevance to SDR
+
+Understanding the mixer/LO explains why "tuning" an SDR is simply setting a number, and
+how a [digital down-converter](/reference/digital-down-converter/) does it in software.

--- a/docs/reference/symbol-rate.md
+++ b/docs/reference/symbol-rate.md
@@ -21,6 +21,18 @@ external:
 **Symbol rate** (**baud**) is the number of modulation symbols transmitted per second.
 It differs from bit rate whenever each symbol carries more than one bit.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A row of symbol slots over time, each slot carrying two bits, showing baud versus bit rate." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <rect x="40" y="40" width="70" height="34"/><rect x="110" y="40" width="70" height="34"/><rect x="180" y="40" width="70" height="34"/><rect x="250" y="40" width="70" height="34"/><rect x="320" y="40" width="70" height="34"/>
+  </g>
+  <g font-size="11" fill="currentColor" text-anchor="middle" font-family="monospace"><text x="75" y="62">01</text><text x="145" y="62">11</text><text x="215" y="62">00</text><text x="285" y="62">10</text><text x="355" y="62">01</text></g>
+  <text x="215" y="26" text-anchor="middle" font-size="10" fill="currentColor">5 symbols (baud) × 2 bits = 10 bits</text>
+  <text x="215" y="96" text-anchor="middle" font-size="10" fill="currentColor">time → · bit rate = baud × bits-per-symbol</text>
+</svg>
+<figcaption>The symbol rate (baud) counts symbols per second; with 2 bits per symbol the bit rate is twice the baud.</figcaption>
+</figure>
+
 ## How it works
 
 The relationship is **bit rate = symbol rate × bits-per-symbol**. P25 and DMR run at

--- a/docs/reference/symbol-rate.md
+++ b/docs/reference/symbol-rate.md
@@ -1,0 +1,33 @@
+---
+slug: symbol-rate
+title: Symbol rate (baud)
+entry_type: term
+category: modulation
+description: Symbol rate, or baud, is the number of modulation symbols sent per second; the bit rate equals symbol rate times bits per symbol.
+keywords: symbol rate, baud, bit rate, bits per symbol, 4800 baud, 9600 bps
+aka: [symbol rate, baud]
+autolink: true
+infobox:
+  - { label: Symbol, value: Rs }
+  - { label: Unit, value: Baud (symbols/second) }
+  - { label: Relation, value: "bit rate = baud × bits/symbol" }
+see_also: [frequency-shift-keying, phase-shift-keying, quadrature-amplitude-modulation, bandwidth, clock-recovery]
+related_lessons:
+  - { title: "Symbols, baud & bitrate", url: /learn/symbols-and-baud/ }
+external:
+  - { title: "Symbol rate (Wikipedia)", url: https://en.wikipedia.org/wiki/Symbol_rate }
+---
+
+**Symbol rate** (**baud**) is the number of modulation symbols transmitted per second.
+It differs from bit rate whenever each symbol carries more than one bit.
+
+## How it works
+
+The relationship is **bit rate = symbol rate × bits-per-symbol**. P25 and DMR run at
+4800 baud with 4-level modulation (2 bits/symbol), giving 9600 bps. Higher symbol rates
+need more [bandwidth](/reference/bandwidth/).
+
+## Relevance to SDR
+
+The symbol rate sets the rhythm that [clock recovery](/reference/clock-recovery/) must
+lock to, and the minimum capture [bandwidth](/reference/bandwidth/) for a clean decode.

--- a/docs/reference/system-fusion-ysf.md
+++ b/docs/reference/system-fusion-ysf.md
@@ -1,0 +1,56 @@
+---
+slug: system-fusion-ysf
+title: System Fusion (YSF)
+entry_type: protocol
+category: protocols
+description: System Fusion (Yaesu System Fusion, YSF) is Yaesu's amateur C4FM digital-voice system, supporting digital and analog modes with an AMBE-family vocoder and internet-linked rooms.
+keywords: System Fusion, YSF, Yaesu, C4FM, amateur digital voice, Fusion, Wires-X, AMBE
+aka: [System Fusion, Yaesu System Fusion, YSF, Fusion]
+autolink: true
+infobox:
+  - { label: Type, value: Amateur digital voice }
+  - { label: Developer, value: Yaesu }
+  - { label: Access, value: FDMA }
+  - { label: Modulation, value: C4FM (4-level FSK) }
+  - { label: Vocoder, value: AMBE family }
+  - { label: GopherTrunk support, value: See Status }
+see_also: [d-star, m17, c4fm, ambe, vocoder]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "System Fusion (Wikipedia)", url: https://en.wikipedia.org/wiki/System_Fusion }
+---
+
+**System Fusion** (**Yaesu System Fusion**, **YSF**) is Yaesu's amateur digital-voice
+system, using [C4FM](/reference/c4fm/) modulation and an [AMBE](/reference/ambe/)-family
+[vocoder](/reference/vocoder/). It is notable for automatically mixing digital and
+analog users on the same repeater.
+
+## Overview
+
+Fusion repeaters can operate in modes that bridge analog FM and C4FM digital,
+smoothing the transition for clubs. The WIRES-X network links Fusion repeaters and
+"rooms" over the internet.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | [FDMA](/reference/fdma/) |
+| Modulation | C4FM |
+| Vocoder | AMBE family |
+| Modes | Digital voice, data, analog FM mix |
+
+## History
+
+Introduced by Yaesu in the mid-2010s as its entry into amateur digital voice,
+competing with [D-STAR](/reference/d-star/) and amateur [DMR](/reference/dmr/).
+
+## Deployment
+
+Amateur radio, via Fusion repeaters, hotspots, and WIRES-X rooms.
+
+## Decoding it with GopherTrunk
+
+YSF shares C4FM modulation with [P25 Phase 1](/reference/p25-phase-1/); see
+[Status](/status.html) for GopherTrunk's coverage.

--- a/docs/reference/system-fusion-ysf.md
+++ b/docs/reference/system-fusion-ysf.md
@@ -26,6 +26,20 @@ system, using [C4FM](/reference/c4fm/) modulation and an [AMBE](/reference/ambe/
 [vocoder](/reference/vocoder/). It is notable for automatically mixing digital and
 analog users on the same repeater.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 110" role="img" aria-label="System Fusion digital voice linked over WIRES-X rooms." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="44" width="70" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="65" y="63">radio</text>
+    <rect x="150" y="44" width="80" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="190" y="63">repeater</text>
+    <rect x="290" y="44" width="120" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="350" y="58">internet</text><text x="350" y="69" font-size="8">WIRES-X rooms</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="100" y1="59" x2="149" y2="59" marker-end="url(#am_system-fusion-ysf)"/><line x1="230" y1="59" x2="289" y2="59" marker-end="url(#am_system-fusion-ysf)"/></g>
+    <text x="65" y="30" font-size="8">C4FM</text>
+  </g>
+  <defs><marker id="am_system-fusion-ysf" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>System Fusion (YSF) uses C4FM and can bridge analog and digital users, linked via WIRES-X.</figcaption>
+</figure>
+
 ## Overview
 
 Fusion repeaters can operate in modes that bridge analog FM and C4FM digital,

--- a/docs/reference/talkgroup.md
+++ b/docs/reference/talkgroup.md
@@ -1,0 +1,35 @@
+---
+slug: talkgroup
+title: Talkgroup
+entry_type: term
+category: trunked-radio
+description: A talkgroup is a virtual channel in a trunked system identifying a group of users; members hear each other regardless of which physical frequency a call is assigned.
+keywords: talkgroup, TGID, virtual channel, trunking, dispatch, fleet
+aka: [talkgroup, talk group]
+autolink: true
+infobox:
+  - { label: Type, value: Virtual user channel }
+  - { label: Identified by, value: Talkgroup ID (TGID) }
+  - { label: You follow, value: Talkgroups, not frequencies }
+see_also: [trunked-radio, control-channel, voice-channel, radio-id, affiliation]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Talkgroup (Wikipedia)", url: https://en.wikipedia.org/wiki/Talkgroup }
+---
+
+A **talkgroup** is a virtual channel in a [trunked radio](/reference/trunked-radio/)
+system — a numbered label identifying a group of users such as "Police Dispatch."
+Members hear each other no matter which physical [voice channel](/reference/voice-channel/)
+the system assigns to a given call.
+
+## How it works
+
+Because the frequency changes call to call, the talkgroup provides a stable identity.
+Operators lock, prioritise, or mute *talkgroups*, and the system handles the
+frequency-hopping underneath.
+
+## Relevance to SDR
+
+In GopherTrunk you follow talkgroups, not frequencies; each is shown with the
+transmitting [radio ID](/reference/radio-id/).

--- a/docs/reference/talkgroup.md
+++ b/docs/reference/talkgroup.md
@@ -23,6 +23,19 @@ system — a numbered label identifying a group of users such as "Police Dispatc
 Members hear each other no matter which physical [voice channel](/reference/voice-channel/)
 the system assigns to a given call.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A single talkgroup whose successive calls appear on different physical voice channels over time." xmlns="http://www.w3.org/2000/svg">
+  <text x="230" y="22" text-anchor="middle" font-size="10" fill="currentColor">Talkgroup 101 (one virtual channel)</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="50" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="85" y="65">call 1</text><text x="85" y="78" font-size="8">on ch 3</text>
+    <rect x="185" y="50" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="230" y="65">call 2</text><text x="230" y="78" font-size="8">on ch 7</text>
+    <rect x="330" y="50" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="375" y="65">call 3</text><text x="375" y="78" font-size="8">on ch 2</text>
+  </g>
+  <text x="230" y="115" text-anchor="middle" font-size="9" fill="currentColor">you follow the talkgroup; the system moves it across channels</text>
+</svg>
+<figcaption>A talkgroup is a virtual channel: its calls hop across physical frequencies, but you follow the group.</figcaption>
+</figure>
+
 ## How it works
 
 Because the frequency changes call to call, the talkgroup provides a stable identity.

--- a/docs/reference/tdma.md
+++ b/docs/reference/tdma.md
@@ -22,6 +22,22 @@ external:
 into rapid, repeating **timeslots**, so two or more calls share the channel by taking
 turns.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 360 150" role="img" aria-label="A single frequency channel divided along time into repeating slots, alternating between two calls." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="110" x2="340" y2="110" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#tdar)"/>
+  <text x="185" y="135" text-anchor="middle" font-size="9" fill="currentColor">time →</text>
+  <g stroke="currentColor" stroke-width="1.1">
+    <rect x="40" y="40" width="50" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="90" y="40" width="50" height="50" fill="none"/>
+    <rect x="140" y="40" width="50" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="190" y="40" width="50" height="50" fill="none"/>
+    <rect x="240" y="40" width="50" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="290" y="40" width="50" height="50" fill="none"/>
+  </g>
+  <g font-size="9" fill="currentColor" text-anchor="middle"><text x="65" y="69">1</text><text x="115" y="69">2</text><text x="165" y="69">1</text><text x="215" y="69">2</text><text x="265" y="69">1</text><text x="315" y="69">2</text></g>
+  <text x="185" y="28" text-anchor="middle" font-size="9" fill="currentColor">one frequency, two calls share the slots</text>
+  <defs><marker id="tdar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>TDMA splits one frequency into time slots so several calls share it — used by P25 Phase 2 and DMR.</figcaption>
+</figure>
+
 ## How it works
 
 [P25 Phase 2](/reference/p25-phase-2/) and [DMR](/reference/dmr/) use two slots,

--- a/docs/reference/tdma.md
+++ b/docs/reference/tdma.md
@@ -1,0 +1,34 @@
+---
+slug: tdma
+title: TDMA
+entry_type: term
+category: trunked-radio
+description: TDMA (time-division multiple access) splits one frequency into repeating timeslots so several calls share it; P25 Phase 2, DMR, and TETRA use TDMA.
+keywords: TDMA, time division multiple access, timeslot, two-slot, P25 Phase 2, DMR, TETRA
+aka: [TDMA]
+autolink: true
+infobox:
+  - { label: Type, value: Channel-access method }
+  - { label: Principle, value: Calls share a frequency in time slots }
+  - { label: Used by, value: P25 Phase 2 (2), DMR (2), TETRA (4) }
+see_also: [fdma, trunked-radio, p25-phase-2, dmr, tetra]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Time-division multiple access (Wikipedia)", url: https://en.wikipedia.org/wiki/Time-division_multiple_access }
+---
+
+**TDMA** (**time-division multiple access**) splits one [frequency](/reference/frequency/)
+into rapid, repeating **timeslots**, so two or more calls share the channel by taking
+turns.
+
+## How it works
+
+[P25 Phase 2](/reference/p25-phase-2/) and [DMR](/reference/dmr/) use two slots,
+doubling capacity per channel; [TETRA](/reference/tetra/) uses four. A receiver must
+follow the correct slot as well as the frequency.
+
+## Relevance to SDR
+
+On a TDMA system a single granted [voice channel](/reference/voice-channel/) can carry
+two simultaneous calls, so GopherTrunk decodes the relevant slot of the assigned channel.

--- a/docs/reference/tetra.md
+++ b/docs/reference/tetra.md
@@ -30,6 +30,16 @@ professional users, especially in Europe and much of the world outside North Ame
 It uses **four-slot [TDMA](/reference/tdma/)** and π/4-DQPSK
 ([phase-shift keying](/reference/phase-shift-keying/)).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 140" role="img" aria-label="Four TDMA slots in a 25 kHz TETRA carrier." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="105" x2="360" y2="105" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#ta_tetra)"/>
+  <text x="195" y="128" text-anchor="middle" font-size="9" fill="currentColor">time → · one 25 kHz carrier, 4 slots</text>
+  <g stroke="currentColor" stroke-width="1.1"><rect x="40" y="40" width="40" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="80" y="40" width="40" height="50" fill="none"/><rect x="120" y="40" width="40" height="50" fill="currentColor" fill-opacity="0.12"/><rect x="160" y="40" width="40" height="50" fill="none" stroke-dasharray="3 2"/><rect x="200" y="40" width="40" height="50" fill="currentColor" fill-opacity="0.22"/><rect x="240" y="40" width="40" height="50" fill="none"/><rect x="280" y="40" width="40" height="50" fill="currentColor" fill-opacity="0.12"/><rect x="320" y="40" width="40" height="50" fill="none" stroke-dasharray="3 2"/></g><g font-size="9" fill="currentColor" text-anchor="middle"><text x="60" y="69">1</text><text x="100" y="69">2</text><text x="140" y="69">3</text><text x="180" y="69">4</text><text x="260" y="69">1</text><text x="300" y="69">2</text></g>
+  <defs><marker id="ta_tetra" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>TETRA uses four-slot TDMA on a 25 kHz carrier for high capacity.</figcaption>
+</figure>
+
 ## Overview
 
 TETRA is a complete system standard — not just an air interface — with rich features:

--- a/docs/reference/tetra.md
+++ b/docs/reference/tetra.md
@@ -1,0 +1,62 @@
+---
+slug: tetra
+title: TETRA
+entry_type: protocol
+category: protocols
+description: TETRA (Terrestrial Trunked Radio) is an ETSI digital trunked-radio standard using four-slot TDMA and π/4-DQPSK, widely used by public safety and transport outside North America.
+keywords: TETRA, Terrestrial Trunked Radio, ETSI, four-slot TDMA, pi/4-DQPSK, ACELP, public safety Europe
+aka: [TETRA, Terrestrial Trunked Radio]
+autolink: true
+infobox:
+  - { label: Type, value: Digital trunked radio }
+  - { label: Standards body, value: ETSI }
+  - { label: Introduced, value: "1995" }
+  - { label: Access, value: TDMA (4 slots) }
+  - { label: Channel spacing, value: 25 kHz }
+  - { label: Modulation, value: π/4-DQPSK }
+  - { label: Vocoder, value: ACELP }
+  - { label: GopherTrunk support, value: See Status }
+see_also: [trunked-radio, tdma, phase-shift-keying, control-channel, etsi]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Terrestrial Trunked Radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio }
+---
+
+**TETRA** (**Terrestrial Trunked Radio**) is an [ETSI](/reference/etsi/) digital
+[trunked-radio](/reference/trunked-radio/) standard built for public-safety and
+professional users, especially in Europe and much of the world outside North America.
+It uses **four-slot [TDMA](/reference/tdma/)** and π/4-DQPSK
+([phase-shift keying](/reference/phase-shift-keying/)).
+
+## Overview
+
+TETRA is a complete system standard — not just an air interface — with rich features:
+group and individual calls, direct mode, packet data, and strong security. Four
+timeslots per 25 kHz carrier give high capacity.
+
+## Technical characteristics
+
+| Property | Value |
+|----------|-------|
+| Access | TDMA, 4 slots |
+| Channel | 25 kHz |
+| Modulation | π/4-DQPSK (18 kbps gross) |
+| Vocoder | ACELP |
+
+## History
+
+Standardised by ETSI from the mid-1990s; adopted broadly by European emergency
+services, transport, and military/government users.
+
+## Deployment
+
+National public-safety networks across Europe, the Middle East, Asia, and elsewhere,
+plus transport and utilities. Rare in North America, where [P25](/reference/project-25/)
+dominates public safety.
+
+## Decoding it with GopherTrunk
+
+TETRA uses a distinct modulation and vocoder; consult the [Status](/status.html) page
+for GopherTrunk's current TETRA coverage.

--- a/docs/reference/tia.md
+++ b/docs/reference/tia.md
@@ -1,0 +1,33 @@
+---
+slug: tia
+title: Telecommunications Industry Association (TIA)
+entry_type: organization
+category: organizations
+description: The TIA is a US standards organization that, with APCO, develops the Project 25 (P25) suite of public-safety digital radio standards.
+keywords: TIA, Telecommunications Industry Association, P25, Project 25, standards, public safety
+aka: [TIA, Telecommunications Industry Association]
+autolink: true
+infobox:
+  - { label: Type, value: Standards organization }
+  - { label: Region, value: United States }
+  - { label: Standards, value: P25 (with APCO) }
+see_also: [project-25, apco-international, etsi]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Telecommunications Industry Association (Wikipedia)", url: https://en.wikipedia.org/wiki/Telecommunications_Industry_Association }
+---
+
+The **Telecommunications Industry Association** (**TIA**) is a US standards organization
+that, together with [APCO](/reference/apco-international/), develops the
+**[Project 25](/reference/project-25/)** suite of public-safety digital radio standards.
+
+## Overview
+
+TIA publishes the P25 documents defining its air interfaces, vocoders, and interfaces,
+enabling multi-vendor interoperability for North American public safety.
+
+## Relevance to SDR
+
+The TIA's P25 standards underpin the most common public-safety systems GopherTrunk
+decodes.

--- a/docs/reference/tia.md
+++ b/docs/reference/tia.md
@@ -22,6 +22,19 @@ The **Telecommunications Industry Association** (**TIA**) is a US standards orga
 that, together with [APCO](/reference/apco-international/), develops the
 **[Project 25](/reference/project-25/)** suite of public-safety digital radio standards.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="TIA publishes the TIA-102 standards that define P25." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="100" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="70" y="61">TIA</text>
+    <rect x="170" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="225" y="61">TIA-102 suite</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">P25 systems</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="120" y1="58" x2="169" y2="58" marker-end="url(#rel_tia)"/><line x1="280" y1="58" x2="329" y2="58" marker-end="url(#rel_tia)"/></g>
+  </g>
+  <defs><marker id="rel_tia" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The TIA publishes the TIA-102 standards suite that defines Project 25.</figcaption>
+</figure>
+
 ## Overview
 
 TIA publishes the P25 documents defining its air interfaces, vocoders, and interfaces,

--- a/docs/reference/trellis-coded-modulation.md
+++ b/docs/reference/trellis-coded-modulation.md
@@ -22,6 +22,20 @@ external:
 [convolutional coding](/reference/convolutional-code/) with the modulation symbol mapping,
 so coding gain is achieved without extra bandwidth.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A small trellis whose transitions map onto points of a constellation, combining coding and modulation." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor"><circle cx="40" cy="40" r="3"/><circle cx="40" cy="90" r="3"/><circle cx="150" cy="40" r="3"/><circle cx="150" cy="90" r="3"/></g>
+  <g stroke="currentColor" stroke-opacity="0.5"><line x1="40" y1="40" x2="150" y2="40"/><line x1="40" y1="40" x2="150" y2="90"/><line x1="40" y1="90" x2="150" y2="40"/><line x1="40" y1="90" x2="150" y2="90"/></g>
+  <text x="95" y="115" text-anchor="middle" font-size="8" fill="currentColor">trellis</text>
+  <line x1="175" y1="65" x2="215" y2="65" stroke="currentColor" marker-end="url(#tcmar)"/>
+  <line x1="240" y1="65" x2="430" y2="65" stroke="currentColor" stroke-opacity="0.3"/><line x1="335" y1="25" x2="335" y2="105" stroke="currentColor" stroke-opacity="0.3"/>
+  <g fill="currentColor"><circle cx="300" cy="45" r="3"/><circle cx="370" cy="45" r="3"/><circle cx="300" cy="90" r="3"/><circle cx="370" cy="90" r="3"/></g>
+  <text x="335" y="120" text-anchor="middle" font-size="8" fill="currentColor">constellation</text>
+  <defs><marker id="tcmar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Trellis-coded modulation combines error coding with the symbol mapping; P25 uses it on Phase 1 traffic.</figcaption>
+</figure>
+
 ## How it works
 
 The encoder constrains which symbol sequences are valid; the receiver uses the

--- a/docs/reference/trellis-coded-modulation.md
+++ b/docs/reference/trellis-coded-modulation.md
@@ -1,0 +1,35 @@
+---
+slug: trellis-coded-modulation
+title: Trellis-coded modulation
+entry_type: algorithm
+category: algorithms
+description: Trellis-coded modulation combines convolutional coding with modulation so error correction is built into the symbol mapping; P25 uses a trellis code on parts of its data.
+keywords: trellis coded modulation, TCM, convolutional, Viterbi, P25, coding gain
+aka: [trellis-coded modulation, TCM]
+autolink: true
+infobox:
+  - { label: Type, value: Coded-modulation scheme }
+  - { label: Combines, value: Coding + modulation mapping }
+  - { label: Decoded by, value: Viterbi over a trellis }
+see_also: [convolutional-code, viterbi-algorithm, forward-error-correction, project-25]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Trellis modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Trellis_modulation }
+---
+
+**Trellis-coded modulation** (**TCM**) integrates
+[convolutional coding](/reference/convolutional-code/) with the modulation symbol mapping,
+so coding gain is achieved without extra bandwidth.
+
+## How it works
+
+The encoder constrains which symbol sequences are valid; the receiver uses the
+[Viterbi algorithm](/reference/viterbi-algorithm/) over the resulting trellis to pick the
+most likely sequence. [P25](/reference/project-25/) applies a trellis code to parts of its
+data.
+
+## Relevance to SDR
+
+TCM improves decoding robustness on the protocols that use it, recovering data at lower
+SNR than uncoded modulation.

--- a/docs/reference/trunked-radio.md
+++ b/docs/reference/trunked-radio.md
@@ -1,0 +1,38 @@
+---
+slug: trunked-radio
+title: Trunked radio
+entry_type: term
+category: trunked-radio
+description: Trunked radio is a system that shares a small pool of frequencies among many user groups by assigning a channel to each call on demand, coordinated by a control channel.
+keywords: trunked radio, trunking, control channel, talkgroup, channel pool, public safety
+aka: [trunked radio, trunking]
+autolink: true
+infobox:
+  - { label: Type, value: Radio-system architecture }
+  - { label: Coordinated by, value: Control channel }
+  - { label: User identity, value: Talkgroup }
+  - { label: Examples, value: P25, DMR Tier III, TETRA }
+see_also: [conventional-radio, control-channel, voice-channel, talkgroup, channel-grant, fdma, tdma]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+---
+
+**Trunked radio** is a system architecture in which many user groups share a small pool
+of frequencies, with a computer assigning a free channel to each call for its duration
+and reclaiming it afterward. A [control channel](/reference/control-channel/)
+coordinates the whole system.
+
+## How it works
+
+When a user keys up, their radio requests a call on the control channel, which issues a
+[channel grant](/reference/channel-grant/) pointing the [talkgroup](/reference/talkgroup/)
+to a free [voice channel](/reference/voice-channel/). Because real traffic is bursty, a
+few channels can serve many groups.
+
+## Relevance to SDR
+
+To monitor a trunked system you decode the control channel first, then follow grants —
+exactly what GopherTrunk does for [P25](/reference/project-25/),
+[DMR Tier III](/reference/dmr-tier-3/), and others.

--- a/docs/reference/trunked-radio.md
+++ b/docs/reference/trunked-radio.md
@@ -24,6 +24,24 @@ of frequencies, with a computer assigning a free channel to each call for its du
 and reclaiming it afterward. A [control channel](/reference/control-channel/)
 coordinates the whole system.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 170" role="img" aria-label="A control channel at the top issuing an assignment, and a pool of voice channels below with one assigned to a talkgroup." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="20" width="400" height="34" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="35" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">control channel (data)</text>
+  <text x="230" y="48" text-anchor="middle" font-size="9" fill="currentColor">"TG 101 → channel 3"</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="100" width="86" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="73" y="120">voice 1</text>
+    <rect x="135" y="100" width="86" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="178" y="120">voice 2</text>
+    <rect x="240" y="100" width="86" height="32" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="283" y="116">voice 3</text><text x="283" y="128" font-size="8">TG 101</text>
+    <rect x="345" y="100" width="86" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="388" y="120">voice 4</text>
+  </g>
+  <line x1="230" y1="54" x2="283" y2="98" stroke="currentColor" stroke-dasharray="4 3" marker-end="url(#trar)"/>
+  <text x="230" y="155" text-anchor="middle" font-size="9" fill="currentColor">a free channel is assigned per call, then released</text>
+  <defs><marker id="trar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A trunked system shares a pool of channels; the control channel assigns a free one to each call.</figcaption>
+</figure>
+
 ## How it works
 
 When a user keys up, their radio requests a call on the control channel, which issues a

--- a/docs/reference/upconverter.md
+++ b/docs/reference/upconverter.md
@@ -1,0 +1,34 @@
+---
+slug: upconverter
+title: Upconverter
+entry_type: hardware
+category: hardware
+description: An upconverter shifts HF signals up into the tuning range of a VHF/UHF SDR such as an RTL-SDR, enabling shortwave reception on radios that cannot tune HF directly.
+keywords: upconverter, HF converter, Ham It Up, shortwave, RTL-SDR HF, frequency shifting
+aka: [upconverter]
+autolink: true
+infobox:
+  - { label: Type, value: External RF converter }
+  - { label: Function, value: Shifts HF up into VHF tuning range }
+  - { label: Enables, value: HF reception on VHF/UHF SDRs }
+see_also: [rtl-sdr, airspy-hf-plus, frequency-bands, local-oscillator]
+related_lessons:
+  - { title: "Frequency, bands & the spectrum", url: /learn/frequency-and-spectrum/ }
+external:
+  - { title: "Upconverter (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency_mixer }
+---
+
+An **upconverter** is an external device that **shifts HF signals up** into the tuning
+range of a VHF/UHF SDR such as an [RTL-SDR](/reference/rtl-sdr/), letting radios that
+cannot tune [HF](/reference/frequency-bands/) directly receive shortwave.
+
+## How it works
+
+It mixes the incoming HF signal with a fixed [local oscillator](/reference/local-oscillator/)
+(commonly 100–125 MHz), so a 7 MHz signal appears around 107–132 MHz where the dongle can
+tune. Software subtracts the offset to show true frequencies.
+
+## Relevance to SDR
+
+An upconverter is the budget route to HF on an RTL-SDR; a dedicated
+[Airspy HF+](/reference/airspy-hf-plus/) is the higher-performance alternative.

--- a/docs/reference/upconverter.md
+++ b/docs/reference/upconverter.md
@@ -22,6 +22,18 @@ An **upconverter** is an external device that **shifts HF signals up** into the 
 range of a VHF/UHF SDR such as an [RTL-SDR](/reference/rtl-sdr/), letting radios that
 cannot tune [HF](/reference/frequency-bands/) directly receive shortwave.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A low HF input shifted upward by a fixed offset into the RTL-SDR's tunable range." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="70" x2="430" y2="70" stroke="currentColor" stroke-opacity="0.4"/>
+  <rect x="40" y="55" width="30" height="15" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1.1"/><text x="55" y="90" font-size="8" fill="currentColor" text-anchor="middle">HF</text>
+  <line x1="80" y1="48" x2="250" y2="48" stroke="currentColor" stroke-dasharray="4 3" marker-end="url(#upar)"/><text x="165" y="42" font-size="8" fill="currentColor" text-anchor="middle">+125 MHz</text>
+  <rect x="260" y="55" width="30" height="15" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1.1"/><text x="275" y="90" font-size="8" fill="currentColor" text-anchor="middle">shifted</text>
+  <text x="360" y="62" font-size="8" fill="currentColor">RTL-SDR range</text>
+  <defs><marker id="upar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An upconverter shifts HF signals up into the RTL-SDR's tunable range, since the dongle can't reach HF directly.</figcaption>
+</figure>
+
 ## How it works
 
 It mixes the incoming HF signal with a fixed [local oscillator](/reference/local-oscillator/)

--- a/docs/reference/viterbi-algorithm.md
+++ b/docs/reference/viterbi-algorithm.md
@@ -23,6 +23,16 @@ trellis, given noisy observations. It is the standard way to decode
 [convolutional codes](/reference/convolutional-code/), named for
 [Andrew Viterbi](/reference/andrew-viterbi/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A trellis of states over time with many candidate paths and one highlighted most-likely surviving path." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor"><circle cx="40" cy="40" r="3"/><circle cx="40" cy="100" r="3"/><circle cx="150" cy="40" r="3"/><circle cx="150" cy="100" r="3"/><circle cx="260" cy="40" r="3"/><circle cx="260" cy="100" r="3"/><circle cx="370" cy="40" r="3"/><circle cx="370" cy="100" r="3"/></g>
+  <g stroke="currentColor" stroke-opacity="0.3" stroke-width="1"><line x1="40" y1="40" x2="150" y2="40"/><line x1="40" y1="40" x2="150" y2="100"/><line x1="40" y1="100" x2="150" y2="40"/><line x1="40" y1="100" x2="150" y2="100"/><line x1="150" y1="40" x2="260" y2="40"/><line x1="150" y1="40" x2="260" y2="100"/><line x1="150" y1="100" x2="260" y2="40"/><line x1="150" y1="100" x2="260" y2="100"/><line x1="260" y1="40" x2="370" y2="40"/><line x1="260" y1="40" x2="370" y2="100"/><line x1="260" y1="100" x2="370" y2="40"/><line x1="260" y1="100" x2="370" y2="100"/></g>
+  <polyline points="40,100 150,40 260,40 370,100" fill="none" stroke="currentColor" stroke-width="2.4"/>
+  <text x="205" y="130" text-anchor="middle" font-size="9" fill="currentColor">most-likely path through the trellis</text>
+</svg>
+<figcaption>The Viterbi algorithm finds the most-likely sequence through a trellis, decoding convolutional codes.</figcaption>
+</figure>
+
 ## How it works
 
 By keeping only the best path into each trellis state at each step, it avoids an

--- a/docs/reference/viterbi-algorithm.md
+++ b/docs/reference/viterbi-algorithm.md
@@ -1,0 +1,35 @@
+---
+slug: viterbi-algorithm
+title: Viterbi algorithm
+entry_type: algorithm
+category: algorithms
+description: The Viterbi algorithm efficiently finds the most likely sequence of states in a trellis, used to decode convolutional codes and improve digital reception.
+keywords: Viterbi algorithm, maximum likelihood, trellis, convolutional code, Andrew Viterbi, decoding
+aka: [Viterbi algorithm, Viterbi]
+autolink: true
+infobox:
+  - { label: Type, value: Maximum-likelihood decoder }
+  - { label: Decodes, value: Convolutional / trellis codes }
+  - { label: Named for, value: Andrew Viterbi }
+see_also: [convolutional-code, trellis-coded-modulation, forward-error-correction, andrew-viterbi, m17]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Viterbi algorithm (Wikipedia)", url: https://en.wikipedia.org/wiki/Viterbi_algorithm }
+---
+
+The **Viterbi algorithm** efficiently finds the most likely sequence of states through a
+trellis, given noisy observations. It is the standard way to decode
+[convolutional codes](/reference/convolutional-code/), named for
+[Andrew Viterbi](/reference/andrew-viterbi/).
+
+## How it works
+
+By keeping only the best path into each trellis state at each step, it avoids an
+exponential search while achieving maximum-likelihood decoding — recovering the
+transmitted bits even with errors.
+
+## Relevance to SDR
+
+Viterbi decoding is used in error-corrected digital systems such as
+[M17](/reference/m17/) and various trunked-radio components to drive down the error rate.

--- a/docs/reference/vocoder.md
+++ b/docs/reference/vocoder.md
@@ -1,0 +1,39 @@
+---
+slug: vocoder
+title: Vocoder
+entry_type: technology
+category: voice-coding
+description: A vocoder is a speech codec that compresses voice to a few kilobits per second by modelling how speech is produced rather than recording the waveform; it underpins all digital voice radio.
+keywords: vocoder, voice codec, speech coding, IMBE, AMBE, source filter model, digital voice
+aka: [vocoder]
+autolink: true
+infobox:
+  - { label: Type, value: Speech codec }
+  - { label: Approach, value: Model speech (pitch + spectrum) }
+  - { label: Bit rate, value: A few kbps }
+  - { label: Examples, value: IMBE, AMBE+2, Codec 2 }
+see_also: [imbe, ambe, ambe-plus-2, codec2, multi-band-excitation]
+related_lessons:
+  - { title: "Vocoders — IMBE & AMBE+2", url: /learn/vocoders/ }
+  - { title: "Analog vs. digital voice", url: /learn/digital-voice/ }
+external:
+  - { title: "Vocoder (Wikipedia)", url: https://en.wikipedia.org/wiki/Vocoder }
+  - { title: "GopherTrunk vocoders", url: /vocoders.html }
+---
+
+A **vocoder** (voice coder) is a speech codec that compresses voice into a few kilobits
+per second by **modelling how speech is produced** — pitch, voicing, and spectral shape
+— rather than recording the waveform. It is what makes
+[digital voice](/learn/digital-voice/) radio possible.
+
+## How it works
+
+Many times a second the vocoder extracts compact parameters of a short speech segment
+and transmits only those; the receiver re-synthesises an audible voice from them. This
+is why digital voice can sound slightly robotic, especially on a weak signal.
+
+## Relevance to SDR
+
+Decoding digital voice requires running the **matching** vocoder — [IMBE](/reference/imbe/)
+for [P25 Phase 1](/reference/p25-phase-1/), [AMBE+2](/reference/ambe-plus-2/) for DMR and
+P25 Phase 2, or [Codec 2](/reference/codec2/) for [M17](/reference/m17/).

--- a/docs/reference/vocoder.md
+++ b/docs/reference/vocoder.md
@@ -26,6 +26,20 @@ per second by **modelling how speech is produced** — pitch, voicing, and spect
 — rather than recording the waveform. It is what makes
 [digital voice](/learn/digital-voice/) radio possible.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 120" role="img" aria-label="Speech analysed into a source-and-filter model, sent as a tiny parameter frame, then re-synthesised back into speech." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="40" y="63">speech</text>
+    <rect x="78" y="44" width="86" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="121" y="58">analyse</text><text x="121" y="70" font-size="8">pitch · spectrum</text>
+    <rect x="200" y="48" width="90" height="26" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="245" y="65">~2–4 kbps frame</text>
+    <rect x="326" y="44" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="371" y="58">synthesise</text><text x="371" y="70" font-size="8">re-create voice</text>
+    <text x="470" y="63">audio</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="64" y1="61" x2="77" y2="61"/><line x1="164" y1="61" x2="199" y2="61"/><line x1="290" y1="61" x2="325" y2="61"/><line x1="416" y1="61" x2="448" y2="61"/></g>
+  </g>
+</svg>
+<figcaption>A vocoder models how speech is produced and sends only parameters, so a voice fits in a few kbps.</figcaption>
+</figure>
+
 ## How it works
 
 Many times a second the vocoder extracts compact parameters of a short speech segment

--- a/docs/reference/voice-channel.md
+++ b/docs/reference/voice-channel.md
@@ -22,6 +22,16 @@ A **voice channel** (or traffic channel) is a frequency that a
 [trunked radio](/reference/trunked-radio/) system **temporarily assigns** to carry one
 call. When the call ends, the channel returns to the pool for reuse.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A pool of voice channels over time, each lighting up briefly for a call then going idle." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor"><text x="20" y="35">ch 1</text><text x="20" y="65">ch 2</text><text x="20" y="95">ch 3</text></g>
+  <g stroke="currentColor" stroke-opacity="0.3"><line x1="55" y1="30" x2="440" y2="30"/><line x1="55" y1="60" x2="440" y2="60"/><line x1="55" y1="90" x2="440" y2="90"/></g>
+  <g fill="currentColor" fill-opacity="0.3"><rect x="70" y="22" width="80" height="16"/><rect x="250" y="22" width="60" height="16"/><rect x="120" y="52" width="100" height="16"/><rect x="180" y="82" width="70" height="16"/><rect x="330" y="82" width="90" height="16"/></g>
+  <text x="240" y="120" text-anchor="middle" font-size="9" fill="currentColor">time → (each call borrows a channel, then frees it)</text>
+</svg>
+<figcaption>Voice channels are assigned for the duration of a call, then returned to the shared pool.</figcaption>
+</figure>
+
 ## How it works
 
 The [control channel](/reference/control-channel/) issues a

--- a/docs/reference/voice-channel.md
+++ b/docs/reference/voice-channel.md
@@ -1,0 +1,35 @@
+---
+slug: voice-channel
+title: Voice channel
+entry_type: term
+category: trunked-radio
+description: A voice channel (traffic channel) is a frequency temporarily assigned by a trunked system to carry an individual call, released back to the pool when the call ends.
+keywords: voice channel, traffic channel, channel grant, trunking, call audio
+aka: [voice channel, traffic channel]
+autolink: true
+infobox:
+  - { label: Type, value: Assigned call-carrying channel }
+  - { label: Assigned by, value: Control channel (grant) }
+  - { label: Lifetime, value: Duration of one call }
+see_also: [control-channel, trunked-radio, channel-grant, talkgroup]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+---
+
+A **voice channel** (or traffic channel) is a frequency that a
+[trunked radio](/reference/trunked-radio/) system **temporarily assigns** to carry one
+call. When the call ends, the channel returns to the pool for reuse.
+
+## How it works
+
+The [control channel](/reference/control-channel/) issues a
+[grant](/reference/channel-grant/) directing a [talkgroup](/reference/talkgroup/) to a
+specific voice channel (and, on TDMA systems, a timeslot). The next call from that group
+may land on a different voice channel entirely.
+
+## Relevance to SDR
+
+GopherTrunk tunes a receiver to the granted voice channel to capture the audio, then
+returns to await the next assignment — following many calls from one capture.

--- a/docs/reference/wavelength.md
+++ b/docs/reference/wavelength.md
@@ -1,0 +1,35 @@
+---
+slug: wavelength
+title: Wavelength
+entry_type: term
+category: rf-fundamentals
+description: Wavelength is the physical distance a wave travels in one cycle; for radio it is inversely proportional to frequency and sets antenna dimensions.
+keywords: wavelength, lambda, antenna length, frequency relation
+aka: [wavelength]
+autolink: true
+infobox:
+  - { label: Symbol, value: λ (lambda) }
+  - { label: Unit, value: Metres }
+  - { label: Rule of thumb, value: "λ (m) ≈ 300 / f (MHz)" }
+see_also: [frequency, radio-wave, antenna, dipole-antenna]
+related_lessons:
+  - { title: "What is a radio wave?", url: /learn/radio-waves/ }
+external:
+  - { title: "Wavelength (Wikipedia)", url: https://en.wikipedia.org/wiki/Wavelength }
+---
+
+**Wavelength** (λ) is the physical distance a wave covers in one complete cycle. For a
+[radio wave](/reference/radio-wave/) it is inversely proportional to
+[frequency](/reference/frequency/): higher frequency means shorter wavelength.
+
+## How it works
+
+Since radio travels at the speed of light, *λ = c / f*. A handy approximation is
+**λ (metres) ≈ 300 ÷ frequency (MHz)** — so 150 MHz is about 2 m and 460 MHz about
+0.65 m.
+
+## Relevance to SDR
+
+Wavelength sets [antenna](/reference/antenna/) size (a quarter-wave whip is λ/4) and
+influences how signals bend around obstacles, making it central to antenna choice and
+[propagation](/reference/radio-propagation/).

--- a/docs/reference/wavelength.md
+++ b/docs/reference/wavelength.md
@@ -22,6 +22,21 @@ external:
 [radio wave](/reference/radio-wave/) it is inversely proportional to
 [frequency](/reference/frequency/): higher frequency means shorter wavelength.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A sine wave with the distance of one full cycle marked as the wavelength." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="75" x2="440" y2="75" stroke="currentColor" stroke-opacity="0.3"/>
+  <path d="M20 75 C 60 15, 120 15, 160 75 S 260 135, 300 75 S 400 15, 440 75" fill="none" stroke="currentColor" stroke-width="2.2"/>
+  <line x1="40" y1="30" x2="180" y2="30" stroke="currentColor" marker-start="url(#wls)" marker-end="url(#wle)"/>
+  <text x="110" y="24" text-anchor="middle" font-size="12" fill="currentColor">λ = one cycle</text>
+  <text x="20" y="118" font-size="11" fill="currentColor">λ (m) ≈ 300 ÷ frequency (MHz)</text>
+  <defs>
+    <marker id="wls" markerWidth="8" markerHeight="8" refX="2" refY="3" orient="auto"><path d="M6 0 L0 3 L6 6 z" fill="currentColor"/></marker>
+    <marker id="wle" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker>
+  </defs>
+</svg>
+<figcaption>Wavelength is the physical length of one cycle — inversely proportional to frequency.</figcaption>
+</figure>
+
 ## How it works
 
 Since radio travels at the speed of light, *λ = c / f*. A handy approximation is


### PR DESCRIPTION
## Summary

Turns the docs site into a full learning resource for radio and software-defined radio, alongside the existing product docs. Three interconnected, SEO/AI-optimized content modes are added — all built on the existing Jekyll + vanilla-JS + SCSS stack (no new build tooling, plugins, or services).

### 1. Learning hub — `/learn/`
A guided, newbie-to-expert **learning path**: 30 lessons across 6 modules plus a glossary, driven by `_data/learn.yml`.
- Pedagogical design: TL;DR key-takeaways, question-style headings, FAQ, knowledge-check quizzes, prerequisite chips, prev/next path nav, and a localStorage progress tracker.
- Light interactivity: frequency↔wavelength and dB/dBm calculators.
- Hand-authored, theme-aware inline **SVG diagrams** in every lesson.
- Per-lesson `TechArticle` + `BreadcrumbList` + `FAQPage` JSON-LD; `Course`/`ItemList` on the hub.

### 2. Reference encyclopedia — `/reference/`
A neutral, long-form, Wikipedia-style **encyclopedia** — a deliberately distinct page type from the learning hub (definition-first lead, right-hand infobox, "See also" / "Related lessons" / external references, category + A–Z index, no lesson chrome).
- **147 articles** across 11 categories: RF fundamentals, antennas/propagation, modulation, SDR &amp; DSP, algorithms, trunked radio, protocols, voice coding, hardware, people, organizations.
- **Uniform protocol profile** for P25, DMR (Tiers I–III), TETRA, NXDN, and the rest — same standardized infobox and section order.
- A **graphic on every content article** (147 well-formed SVGs): waveforms, constellations, signal-chain blocks, trellis/coding diagrams, protocol channel-structure diagrams, SDR coverage-bar charts, and concept diagrams for the people pages.
- `DefinedTerm` / `Person` / `DefinedTermSet` + `BreadcrumbList` JSON-LD.

### 3. Site-wide search &amp; auto-linking
- Dependency-free **client-side search** (`/search/`) over all pages, backed by a generated `search.json` (auto-indexes everything; no external service).
- **Auto-linking**: the first mention of a curated reference term anywhere on the site links to its `/reference/` page, via a generated term map + progressive-enhancement JS (skips code/headings/existing links, never self-links).

### Cross-cutting
- Glossary deep-links to full reference articles; `llms.txt` enumerates both knowledge sections for AI crawlers.
- Renamed the old "Reference" nav group to **"Technical docs"** so the encyclopedia can own the "Reference" name.
- Google Analytics is inherited site-wide; verified present on every generated HTML page.
- Added `docs/_site/` (and Jekyll caches) to `.gitignore`.

## Verification
Local Jekyll build is clean. All JSON-LD blocks parse (incl. 443 across the reference section), zero broken internal links, GA on every page, and all 147 reference SVGs validate as well-formed XML.

## Notes for reviewers
- Pure docs/content change under `docs/` — no Go or React-console code touched.
- Large diff by line count, but it's overwhelmingly Markdown content + inline SVG; the reusable infrastructure is a handful of layouts/includes/data files.

https://claude.ai/code/session_01FBZ8YkcJnbYzP5LuVMnpbs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBZ8YkcJnbYzP5LuVMnpbs)_