### PR TITLE
Reference: add 32 pages for audited terms that lacked one (with diagrams)

### DIFF
--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -78,6 +78,11 @@ categories:
       - { slug: symbol-rate, title: Symbol rate (baud), type: term }
       - { slug: constellation-diagram, title: Constellation diagram, type: term }
       - { slug: eye-diagram, title: Eye diagram, type: term }
+      - { slug: pi-4-dqpsk, title: π/4-DQPSK, type: technology }
+      - { slug: gfsk, title: GFSK, type: technology }
+      - { slug: nrzi, title: NRZI, type: term }
+      - { slug: dibit, title: Dibit, type: term }
+      - { slug: pulse-shaping, title: Pulse shaping, type: term }
 
   - id: sdr-dsp
     label: SDR & DSP
@@ -103,6 +108,15 @@ categories:
       - { slug: costas-loop, title: Costas loop, type: algorithm }
       - { slug: cma-equalizer, title: CMA equalizer, type: algorithm }
       - { slug: ppm-frequency-correction, title: PPM frequency correction, type: term }
+      - { slug: numerically-controlled-oscillator, title: Numerically controlled oscillator (NCO), type: term }
+      - { slug: fir-filter, title: FIR filter, type: algorithm }
+      - { slug: iir-filter, title: IIR filter, type: algorithm }
+      - { slug: intermediate-frequency, title: Intermediate frequency (IF), type: term }
+      - { slug: baseband, title: Baseband, type: term }
+      - { slug: channelizer, title: Channelizer, type: algorithm }
+      - { slug: resampler, title: Resampler, type: algorithm }
+      - { slug: automatic-frequency-control, title: Automatic frequency control (AFC), type: term }
+      - { slug: dc-offset, title: DC offset (DC spike), type: term }
 
   - id: algorithms
     label: Transforms & algorithms
@@ -126,6 +140,8 @@ categories:
       - { slug: multi-band-excitation, title: Multi-band excitation (MBE), type: algorithm }
       - { slug: compact-position-reporting, title: Compact position reporting (CPR), type: algorithm }
       - { slug: rc4-cipher, title: RC4 (ARC4) cipher, type: algorithm }
+      - { slug: bptc, title: BPTC, type: algorithm }
+      - { slug: dtmf, title: DTMF, type: term }
 
   - id: trunked-radio
     label: Trunked radio
@@ -141,6 +157,9 @@ categories:
       - { slug: tdma, title: TDMA, type: term }
       - { slug: channel-grant, title: Channel grant, type: term }
       - { slug: radio-id, title: Radio ID, type: term }
+      - { slug: tsbk, title: TSBK, type: term }
+      - { slug: csbk, title: CSBK, type: term }
+      - { slug: rest-channel, title: Rest channel, type: term }
 
   - id: protocols
     label: Protocols & standards
@@ -171,6 +190,10 @@ categories:
       - { slug: ax25, title: AX.25, type: protocol }
       - { slug: dsc, title: Digital Selective Calling (DSC), type: protocol }
       - { slug: mdc1200, title: MDC-1200, type: protocol }
+      - { slug: mode-s, title: Mode S, type: protocol }
+      - { slug: provoice, title: ProVoice, type: protocol }
+      - { slug: capacity-plus, title: Capacity Plus, type: protocol }
+      - { slug: lora, title: LoRa, type: protocol }
 
   - id: voice-coding
     label: Voice coding
@@ -197,6 +220,9 @@ categories:
       - { slug: bias-tee, title: Bias tee, type: hardware }
       - { slug: soapysdr, title: SoapySDR, type: technology }
       - { slug: rtl-tcp, title: rtl_tcp, type: technology }
+      - { slug: zadig, title: Zadig, type: hardware }
+      - { slug: saw-filter, title: SAW filter, type: hardware }
+      - { slug: coaxial-cable, title: Coaxial cable, type: hardware }
 
   - id: people
     label: People
@@ -212,6 +238,8 @@ categories:
       - { slug: andrew-viterbi, title: Andrew Viterbi, type: person }
       - { slug: richard-hamming, title: Richard Hamming, type: person }
       - { slug: reginald-fessenden, title: Reginald Fessenden, type: person }
+      - { slug: john-costas, title: John P. Costas, type: person }
+      - { slug: fred-gardner, title: Floyd M. Gardner, type: person }
 
   - id: organizations
     label: Organizations & standards bodies
@@ -225,3 +253,7 @@ categories:
       - { slug: icao, title: ICAO, type: organization }
       - { slug: dvsi, title: Digital Voice Systems (DVSI), type: organization }
       - { slug: m17-project, title: M17 Project, type: organization }
+      - { slug: radioreference, title: RadioReference, type: organization }
+      - { slug: ofcom, title: Ofcom, type: organization }
+      - { slug: rtca, title: RTCA, type: organization }
+      - { slug: eurocae, title: EUROCAE, type: organization }

--- a/docs/reference/automatic-frequency-control.md
+++ b/docs/reference/automatic-frequency-control.md
@@ -1,0 +1,37 @@
+---
+slug: automatic-frequency-control
+title: Automatic frequency control (AFC)
+entry_type: term
+category: sdr-dsp
+description: Automatic frequency control (AFC) continuously measures and corrects a small carrier-frequency offset so a demodulator stays centred on the signal despite oscillator drift.
+keywords: AFC, automatic frequency control, carrier offset, frequency tracking, PPM, drift
+aka: [AFC, "automatic frequency control"]
+autolink: true
+see_also: [ppm-frequency-correction, costas-loop, demodulation, constellation-diagram]
+related_lessons:
+  - { title: "Tuning for a clean lock", url: /learn/tuning-with-scopes/ }
+external:
+  - { title: "Automatic frequency control (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_frequency_control }
+---
+
+**Automatic frequency control** (**AFC**) continuously measures a residual
+carrier-frequency offset and nudges the receiver to cancel it, keeping the demodulator
+centred on the signal as oscillators drift. Where [PPM correction](/reference/ppm-frequency-correction/)
+fixes a static error, AFC **tracks** a changing one.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A signal drifting off centre over time being pulled back to the centre frequency by automatic frequency control." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="20" x2="40" y2="100" stroke="currentColor" stroke-opacity="0.4"/><line x1="40" y1="100" x2="430" y2="100" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="40" y1="55" x2="430" y2="55" stroke="currentColor" stroke-dasharray="4 3" stroke-opacity="0.5"/><text x="44" y="50" font-size="8" fill="currentColor">centre</text>
+  <path d="M50 80 C 130 80 150 30 220 40 C 290 50 300 56 420 55" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="240" y="115" text-anchor="middle" font-size="8.5" fill="currentColor">AFC pulls the offset back toward centre</text>
+</svg>
+<figcaption>AFC continuously corrects carrier-frequency offset, keeping the demodulator locked as the signal drifts.</figcaption>
+</figure>
+
+## Overview
+
+AFC often works alongside a [Costas loop](/reference/costas-loop/) (for phase) and
+appears in GopherTrunk's receiver telemetry as a carrier-error reading; a steadily
+**rotating [constellation](/reference/constellation-diagram/)** is the symptom AFC is
+there to remove.

--- a/docs/reference/baseband.md
+++ b/docs/reference/baseband.md
@@ -1,0 +1,39 @@
+---
+slug: baseband
+title: Baseband
+entry_type: term
+category: sdr-dsp
+description: Baseband is a signal centred at (or near) zero frequency, after a receiver has mixed the carrier away. SDRs deliver IQ samples at baseband for software to process.
+keywords: baseband, zero-IF, complex baseband, IQ, downconversion, DC
+aka: [baseband, "complex baseband"]
+autolink: true
+see_also: [iq-data, intermediate-frequency, local-oscillator, dc-offset]
+related_lessons:
+  - { title: "IQ data & complex signals", url: /learn/iq-data/ }
+external:
+  - { title: "Baseband (Wikipedia)", url: https://en.wikipedia.org/wiki/Baseband }
+---
+
+**Baseband** is a signal centred at (or near) **zero frequency**, after the carrier has
+been mixed away. An SDR delivers **complex baseband** [IQ samples](/reference/iq-data/) —
+the channel shifted down to 0 Hz — which is the natural form for software to filter and
+demodulate.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A signal at a high carrier frequency shifted down to sit centred on zero hertz at baseband." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="85" x2="430" y2="85" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="120" y1="85" x2="120" y2="30" stroke="currentColor" stroke-dasharray="3 3" stroke-opacity="0.5"/><text x="120" y="100" text-anchor="middle" font-size="8" fill="currentColor">0 Hz</text>
+  <path d="M340 85 L350 50 L360 85 Z" fill="none" stroke="currentColor"/><text x="350" y="42" text-anchor="middle" font-size="8" fill="currentColor">carrier</text>
+  <path d="M110 85 L120 45 L130 85 Z" fill="currentColor" fill-opacity="0.25" stroke="currentColor"/>
+  <path d="M340 60 q-110 -25 -215 -12" fill="none" stroke="currentColor" stroke-dasharray="4 3" marker-end="url(#bbar)"/>
+  <text x="240" y="108" text-anchor="middle" font-size="8.5" fill="currentColor">mixed down to baseband (0 Hz)</text>
+  <defs><marker id="bbar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Baseband is the channel shifted down to 0 Hz; SDRs output complex (IQ) baseband samples.</figcaption>
+</figure>
+
+## Overview
+
+Working at complex baseband lets software represent both positive and negative
+frequencies around the centre (thanks to [IQ](/reference/iq-data/)), so the whole
+captured band is available for [filtering](/reference/digital-filter/) and demodulation.

--- a/docs/reference/bptc.md
+++ b/docs/reference/bptc.md
@@ -1,0 +1,38 @@
+---
+slug: bptc
+title: BPTC
+entry_type: algorithm
+category: algorithms
+description: BPTC (block product turbo code) is the (196,96) forward-error-correction scheme that protects DMR data and control bursts using interleaved row and column parity.
+keywords: BPTC, block product turbo code, BPTC(196,96), DMR FEC, product code, interleaving
+aka: ["BPTC", "BPTC(196,96)", "block product turbo code"]
+autolink: true
+see_also: [forward-error-correction, hamming-code, interleaving, dmr, csbk]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+---
+
+**BPTC** (**block product turbo code**), specifically **BPTC(196,96)**, is the
+[forward-error-correction](/reference/forward-error-correction/) scheme that protects
+[DMR](/reference/dmr/) data and control bursts. It arranges bits in a grid and applies
+parity across **both rows and columns**, so the two passes can correct errors the other
+misses.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 170" role="img" aria-label="A grid of data bits with parity computed across each row and down each column." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1" fill="none"><rect x="40" y="20" width="160" height="100"/>
+    <line x1="80" y1="20" x2="80" y2="120"/><line x1="120" y1="20" x2="120" y2="120"/><line x1="160" y1="20" x2="160" y2="120"/>
+    <line x1="40" y1="45" x2="200" y2="45"/><line x1="40" y1="70" x2="200" y2="70"/><line x1="40" y1="95" x2="200" y2="95"/></g>
+  <rect x="200" y="20" width="40" height="100" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1"/><text x="220" y="135" text-anchor="middle" font-size="8" fill="currentColor">row parity</text>
+  <rect x="40" y="120" width="160" height="28" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1"/><text x="120" y="138" text-anchor="middle" font-size="8" fill="currentColor">column parity</text>
+</svg>
+<figcaption>BPTC computes parity across both rows and columns of a bit grid, with interleaving to spread bursts.</figcaption>
+</figure>
+
+## Overview
+
+The "product" structure plus [interleaving](/reference/interleaving/) makes BPTC robust
+against the burst errors typical of a fading mobile channel — important for the
+[CSBK](/reference/csbk/) control messages that keep a trunked DMR system coordinated.

--- a/docs/reference/capacity-plus.md
+++ b/docs/reference/capacity-plus.md
@@ -1,0 +1,40 @@
+---
+slug: capacity-plus
+title: Capacity Plus
+entry_type: protocol
+category: protocols
+description: Capacity Plus is Motorola's proprietary single-site DMR trunking mode that pools channels and rotates the control signalling, extending conventional DMR with trunked capacity.
+keywords: Capacity Plus, Cap Plus, Motorola DMR trunking, MOTOTRBO, rest channel, single-site trunking
+aka: [Capacity Plus, "Cap Plus", "Capacity Max"]
+autolink: true
+see_also: [dmr, dmr-tier-3, rest-channel, trunked-radio, csbk]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+---
+
+**Capacity Plus** is Motorola's proprietary **DMR trunking** mode (part of the MOTOTRBO
+family) that pools several channels and **rotates the control signalling** among them
+(see [rest channel](/reference/rest-channel/)), giving conventional [DMR](/reference/dmr/)
+trunked capacity without a separate dedicated control channel. (Capacity Max is the
+larger multi-site successor.)
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A pool of DMR channels with control rotating among them, several carrying two TDMA voice slots." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1" font-size="8" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="40" width="90" height="40" fill="currentColor" fill-opacity="0.2"/><line x1="85" y1="40" x2="85" y2="80"/><text x="85" y="95">rest/control</text>
+    <rect x="150" y="40" width="90" height="40" fill="none"/><line x1="195" y1="40" x2="195" y2="80"/><text x="195" y="95">voice</text>
+    <rect x="260" y="40" width="90" height="40" fill="none"/><line x1="305" y1="40" x2="305" y2="80"/><text x="305" y="95">voice</text>
+    <rect x="370" y="40" width="70" height="40" fill="none"/><line x1="405" y1="40" x2="405" y2="80"/><text x="405" y="95">voice</text>
+  </g>
+  <text x="230" y="22" text-anchor="middle" font-size="8.5" fill="currentColor">pooled two-slot DMR channels; control rotates</text>
+</svg>
+<figcaption>Capacity Plus pools two-slot DMR channels and moves control among them rather than dedicating one.</figcaption>
+</figure>
+
+## Overview
+
+Following Capacity Plus means tracking the rotating control as it hops, then decoding the
+granted [timeslot](/reference/tdma/) — GopherTrunk's DMR support is vendor-aware of these
+Motorola grant formats.

--- a/docs/reference/channelizer.md
+++ b/docs/reference/channelizer.md
@@ -1,0 +1,43 @@
+---
+slug: channelizer
+title: Channelizer
+entry_type: algorithm
+category: sdr-dsp
+description: A channelizer splits one wideband IQ capture into many narrow channels in parallel — how GopherTrunk follows a control channel and several voice channels from a single SDR.
+keywords: channelizer, channelization, polyphase, wideband, multi-channel, DDC, parallel decode
+aka: [channelizer, channelization]
+autolink: true
+see_also: [digital-down-converter, decimation, digital-filter, software-defined-radio, control-channel]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Filter bank (Wikipedia)", url: https://en.wikipedia.org/wiki/Filter_bank }
+---
+
+A **channelizer** splits a single wideband [IQ](/reference/iq-data/) capture into **many
+narrow channels at once**. Each output is one channel, shifted to
+[baseband](/reference/baseband/), [filtered](/reference/digital-filter/), and
+[decimated](/reference/decimation/) — so one SDR can feed many decoders in parallel.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A wide input band fanning out into several separate narrow channel outputs." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="50" width="90" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="65" y="69" text-anchor="middle" font-size="9" fill="currentColor">wide IQ</text>
+  <rect x="180" y="44" width="90" height="42" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="225" y="69" text-anchor="middle" font-size="9" fill="currentColor">channelizer</text>
+  <line x1="110" y1="65" x2="179" y2="65" stroke="currentColor" marker-end="url(#char)"/>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <rect x="340" y="22" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="390" y="37">control ch</text>
+    <rect x="340" y="54" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="390" y="69">voice ch 1</text>
+    <rect x="340" y="86" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="390" y="101">voice ch 2</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1"><line x1="270" y1="60" x2="339" y2="33" marker-end="url(#char)"/><line x1="270" y1="65" x2="339" y2="65" marker-end="url(#char)"/><line x1="270" y1="70" x2="339" y2="97" marker-end="url(#char)"/></g>
+  <defs><marker id="char" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A channelizer fans one wide capture into many narrow channels, enabling simultaneous decodes.</figcaption>
+</figure>
+
+## Overview
+
+Efficient channelizers use a *polyphase filter bank* to extract evenly-spaced channels
+at once. In a trunking context this is what lets GopherTrunk watch the
+[control channel](/reference/control-channel/) while simultaneously following the
+[voice channels](/reference/voice-channel/) it assigns.

--- a/docs/reference/coaxial-cable.md
+++ b/docs/reference/coaxial-cable.md
@@ -1,0 +1,37 @@
+---
+slug: coaxial-cable
+title: Coaxial cable
+entry_type: hardware
+category: hardware
+description: Coaxial cable carries RF between antenna and receiver with a centre conductor inside a shield. Every metre and connector adds loss — more at higher frequencies — so short, quality runs matter.
+keywords: coaxial cable, coax, feedline, RG-58, RG-6, LMR-400, cable loss, shield, impedance
+aka: [coax, "coaxial cable", feedline]
+autolink: true
+see_also: [attenuation, path-loss, antenna, standing-wave-ratio, low-noise-amplifier]
+related_lessons:
+  - { title: "Antennas 101", url: /learn/antennas/ }
+external:
+  - { title: "Coaxial cable (Wikipedia)", url: https://en.wikipedia.org/wiki/Coaxial_cable }
+---
+
+**Coaxial cable** ("coax") carries RF between the antenna and receiver. A centre
+conductor runs inside a tubular **shield**, separated by a dielectric, which keeps the
+signal contained and the impedance constant (commonly 50 Ω). Every metre and every
+connector adds [loss](/reference/attenuation/) — and the loss grows with frequency.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 320 130" role="img" aria-label="A cutaway of coaxial cable showing the centre conductor, dielectric, shield, and outer jacket as concentric layers." xmlns="http://www.w3.org/2000/svg">
+  <ellipse cx="160" cy="65" rx="120" ry="48" fill="none" stroke="currentColor" stroke-width="1.4"/>
+  <ellipse cx="160" cy="65" rx="92" ry="36" fill="none" stroke="currentColor" stroke-opacity="0.6"/>
+  <ellipse cx="160" cy="65" rx="58" ry="22" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-opacity="0.6"/>
+  <circle cx="160" cy="65" r="6" fill="currentColor"/>
+  <g font-size="8" fill="currentColor"><text x="160" y="58" text-anchor="middle">core</text><text x="160" y="95" text-anchor="middle">dielectric</text><text x="160" y="118" text-anchor="middle">shield + jacket</text></g>
+</svg>
+<figcaption>Coax carries RF on a centre conductor inside a shield; keep runs short and quality high to limit loss.</figcaption>
+</figure>
+
+## Overview
+
+A long or low-grade cable can quietly undo a good antenna, so operators keep feedline
+short or mount a [low-noise amplifier](/reference/low-noise-amplifier/) at the antenna. A
+poor match also raises [SWR](/reference/standing-wave-ratio/).

--- a/docs/reference/csbk.md
+++ b/docs/reference/csbk.md
@@ -1,0 +1,34 @@
+---
+slug: csbk
+title: CSBK
+entry_type: term
+category: trunked-radio
+description: A CSBK (control signalling block) is the single-block control message in DMR, carrying call setup, channel grants, and system data on a Tier III control channel.
+keywords: CSBK, control signalling block, DMR control channel, Tier III, channel grant, signalling
+aka: [CSBK, "control signalling block", "control signaling block"]
+autolink: true
+see_also: [control-channel, channel-grant, dmr-tier-3, dmr, tsbk]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+---
+
+A **CSBK** (**control signalling block**) is the single-block control message of
+[DMR](/reference/dmr/). On a [Tier III](/reference/dmr-tier-3/) control channel, CSBKs
+carry call requests, [channel grants](/reference/channel-grant/), and system data — the
+DMR counterpart of P25's [TSBK](/reference/tsbk/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A DMR control channel carrying CSBK blocks, one of which grants a traffic channel and slot." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="30" width="400" height="24" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="230" y="46" text-anchor="middle" font-size="8.5" fill="currentColor">DMR Tier III control channel</text>
+  <g stroke="currentColor" stroke-width="1.1"><rect x="40" y="66" width="80" height="26" fill="none"/><rect x="130" y="66" width="90" height="26" fill="currentColor" fill-opacity="0.22"/><rect x="230" y="66" width="80" height="26" fill="none"/><rect x="320" y="66" width="80" height="26" fill="none"/></g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="80" y="83">CSBK</text><text x="175" y="80">CSBK</text><text x="175" y="90" font-size="7">(grant)</text><text x="270" y="83">CSBK</text><text x="360" y="83">CSBK</text></g>
+</svg>
+<figcaption>DMR Tier III coordinates the system with CSBKs; a grant CSBK assigns a traffic channel and timeslot.</figcaption>
+</figure>
+
+## Overview
+
+CSBKs are protected by [BPTC](/reference/bptc/) coding. Following them is how a decoder
+tracks trunked DMR, just as TSBKs are followed on P25.

--- a/docs/reference/dc-offset.md
+++ b/docs/reference/dc-offset.md
@@ -1,0 +1,37 @@
+---
+slug: dc-offset
+title: DC offset (DC spike)
+entry_type: term
+category: sdr-dsp
+description: A DC offset is a constant component in an SDR's IQ stream that appears as a spike at the centre (0 Hz) of the spectrum — an artefact of zero-IF receivers, not a real signal.
+keywords: DC offset, DC spike, center spike, zero-IF, IQ imbalance, LO leakage
+aka: [DC offset, DC spike, "center spike"]
+autolink: true
+see_also: [baseband, iq-data, local-oscillator, fft-and-waterfall]
+related_lessons:
+  - { title: "The FFT & reading a waterfall", url: /learn/fft-and-waterfall/ }
+external:
+  - { title: "DC bias (Wikipedia)", url: https://en.wikipedia.org/wiki/DC_bias }
+---
+
+A **DC offset** is a constant (zero-frequency) component in the [IQ](/reference/iq-data/)
+stream that shows up as a **spike in the exact centre** of the spectrum and waterfall.
+It is an artefact of zero-IF/[baseband](/reference/baseband/) receivers — local-oscillator
+leakage and converter bias — **not** a real signal on the air.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A spectrum with a sharp narrow spike exactly at the centre frequency, the DC spike, distinct from real signals elsewhere." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="95" x2="430" y2="95" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M30 88 L80 90 L130 86 L180 89 L230 88 L280 90 L330 87 L380 89 L430 88" fill="none" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.5"/>
+  <line x1="230" y1="95" x2="230" y2="35" stroke="currentColor" stroke-width="2.2"/><text x="230" y="28" text-anchor="middle" font-size="8.5" fill="currentColor">DC spike (0 Hz)</text>
+  <path d="M150 95 L160 60 L170 95 Z" fill="currentColor" fill-opacity="0.25" stroke="currentColor"/><text x="160" y="52" text-anchor="middle" font-size="8" fill="currentColor">real signal</text>
+</svg>
+<figcaption>The DC spike sits exactly at the tuned centre; it's an artefact to ignore or notch, not a station.</figcaption>
+</figure>
+
+## Overview
+
+Operators avoid it by tuning slightly off-centre so the channel of interest doesn't sit
+under the spike, or by enabling a DC-blocking [filter](/reference/iir-filter/). It is a
+common source of "phantom carrier" confusion for newcomers reading a
+[waterfall](/reference/fast-fourier-transform/).

--- a/docs/reference/dibit.md
+++ b/docs/reference/dibit.md
@@ -1,0 +1,34 @@
+---
+slug: dibit
+title: Dibit
+entry_type: term
+category: modulation
+description: A dibit is a pair of bits carried by a single symbol in four-level modulations such as C4FM and 4FSK — the unit each P25 or DMR symbol represents.
+keywords: dibit, two bits per symbol, 4FSK, C4FM, P25 symbol, DMR symbol
+aka: [dibit]
+autolink: true
+see_also: [symbol-rate, c4fm, frequency-shift-keying, constellation-diagram]
+related_lessons:
+  - { title: "Symbols, baud & bitrate", url: /learn/symbols-and-baud/ }
+external:
+  - { title: "Dibit (Wikipedia)", url: https://en.wikipedia.org/wiki/Dibit }
+---
+
+A **dibit** is a **pair of bits** represented by one transmitted symbol. In the
+four-level modulations used by [P25](/reference/p25-phase-1/) ([C4FM](/reference/c4fm/))
+and [DMR](/reference/dmr/) ([4FSK](/reference/frequency-shift-keying/)), each of the four
+symbol states maps to one of the four dibits `00`, `01`, `10`, `11`.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 130" role="img" aria-label="Four symbol levels each labelled with the two-bit dibit it represents." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-opacity="0.35"><line x1="120" y1="30" x2="340" y2="30"/><line x1="120" y1="60" x2="340" y2="60"/><line x1="120" y1="90" x2="340" y2="90"/><line x1="120" y1="120" x2="340" y2="120"/></g>
+  <g font-size="10" fill="currentColor" text-anchor="end" font-family="monospace"><text x="110" y="33">+3 → 01</text><text x="110" y="63">+1 → 00</text><text x="110" y="93">-1 → 10</text><text x="110" y="123">-3 → 11</text></g>
+</svg>
+<figcaption>Each of the four C4FM/4FSK levels carries one dibit, so the bit rate is twice the symbol rate.</figcaption>
+</figure>
+
+## Overview
+
+Because each symbol carries two bits, a four-level signal's **bit rate is twice its
+[symbol rate](/reference/symbol-rate/)** — which is why P25 Phase 1's 4800-baud C4FM
+runs at 9600 bits per second.

--- a/docs/reference/dtmf.md
+++ b/docs/reference/dtmf.md
@@ -1,0 +1,42 @@
+---
+slug: dtmf
+title: DTMF
+entry_type: term
+category: algorithms
+description: DTMF (dual-tone multi-frequency) signalling encodes each keypad digit as the sum of two simultaneous tones — one from a low group and one from a high group.
+keywords: DTMF, dual-tone multi-frequency, touch-tone, Goertzel, signalling tones
+aka: [DTMF, touch-tone, "dual-tone multi-frequency"]
+autolink: true
+see_also: [fast-fourier-transform, mdc1200]
+related_lessons:
+  - { title: "Anatomy of a signal", url: /learn/signal-anatomy/ }
+external:
+  - { title: "DTMF (Wikipedia)", url: https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling }
+---
+
+**DTMF** (**dual-tone multi-frequency**, "touch-tone") encodes each key as the **sum of
+two tones** — one from a low-frequency group (rows) and one from a high-frequency group
+(columns). Detecting which two tones are present identifies the digit. It appears as
+in-band signalling on some radio systems.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 300 200" role="img" aria-label="A telephone keypad grid with a low-frequency tone per row and a high-frequency tone per column." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <text x="40" y="55">697</text><text x="40" y="90">770</text><text x="40" y="125">852</text><text x="40" y="160">941</text>
+    <text x="90" y="30">1209</text><text x="140" y="30">1336</text><text x="190" y="30">1477</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1" fill="none">
+    <rect x="70" y="40" width="40" height="28"/><rect x="120" y="40" width="40" height="28"/><rect x="170" y="40" width="40" height="28"/>
+    <rect x="70" y="75" width="40" height="28"/><rect x="120" y="75" width="40" height="28"/><rect x="170" y="75" width="40" height="28"/>
+    <rect x="70" y="110" width="40" height="28"/><rect x="120" y="110" width="40" height="28"/><rect x="170" y="110" width="40" height="28"/>
+    <rect x="70" y="145" width="40" height="28"/><rect x="120" y="145" width="40" height="28"/><rect x="170" y="145" width="40" height="28"/></g>
+  <g font-size="11" fill="currentColor" text-anchor="middle"><text x="90" y="59">1</text><text x="140" y="59">2</text><text x="190" y="59">3</text><text x="90" y="94">4</text><text x="140" y="94">5</text><text x="190" y="94">6</text><text x="90" y="129">7</text><text x="140" y="129">8</text><text x="190" y="129">9</text><text x="90" y="164">*</text><text x="140" y="164">0</text><text x="190" y="164">#</text></g>
+</svg>
+<figcaption>Each DTMF key sounds one row tone plus one column tone; a detector identifies the pair.</figcaption>
+</figure>
+
+## Overview
+
+DTMF tones are detected with narrow band-pass filters or the **Goertzel algorithm** (an
+efficient single-frequency [DFT](/reference/fast-fourier-transform/)). GopherTrunk
+synthesises DTMF among other call-progress tones in its audio path.

--- a/docs/reference/eurocae.md
+++ b/docs/reference/eurocae.md
@@ -1,0 +1,39 @@
+---
+slug: eurocae
+title: EUROCAE
+entry_type: organization
+category: organizations
+description: EUROCAE is the European standards body for aviation electronics; its ED-102 series mirrors RTCA's DO-260 ADS-B requirements for use in Europe.
+keywords: EUROCAE, ED-102, ADS-B standards, Europe, aviation, avionics
+aka: [EUROCAE]
+autolink: true
+see_also: [ads-b, mode-s, rtca, icao]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "EUROCAE (Wikipedia)", url: https://en.wikipedia.org/wiki/EUROCAE }
+---
+
+**EUROCAE** (the European Organisation for Civil Aviation Equipment) is the European
+standards body for **aviation electronics**. Its **ED-102** series mirrors
+[RTCA](/reference/rtca/)'s DO-260 [ADS-B](/reference/ads-b/) requirements for use in
+Europe, under the umbrella of [ICAO](/reference/icao/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="EUROCAE publishing the ED-102 standard, the European counterpart to RTCA's DO-260 for ADS-B." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="110" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="75" y="61">EUROCAE</text>
+    <rect x="175" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="230" y="61">ED-102</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">ADS-B (Europe)</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="130" y1="58" x2="174" y2="58" marker-end="url(#or_euc)"/><line x1="285" y1="58" x2="329" y2="58" marker-end="url(#or_euc)"/></g>
+  </g>
+  <defs><marker id="or_euc" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>EUROCAE's ED-102 is the European counterpart to RTCA's DO-260 for ADS-B.</figcaption>
+</figure>
+
+
+## Overview
+
+ED-102A and DO-260B are effectively harmonised, so an ADS-B decoder built to one works
+with the other; documentation often cites both.

--- a/docs/reference/fir-filter.md
+++ b/docs/reference/fir-filter.md
@@ -1,0 +1,40 @@
+---
+slug: fir-filter
+title: FIR filter
+entry_type: algorithm
+category: sdr-dsp
+description: A finite impulse response (FIR) filter computes each output as a weighted sum of recent input samples. It is the workhorse digital filter in SDR — stable and exactly linear-phase.
+keywords: FIR filter, finite impulse response, tapped delay line, linear phase, digital filter, convolution
+aka: [FIR, "finite impulse response filter"]
+autolink: true
+see_also: [digital-filter, iir-filter, decimation, matched-filter, root-raised-cosine-filter]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Finite impulse response (Wikipedia)", url: https://en.wikipedia.org/wiki/Finite_impulse_response }
+---
+
+A **FIR** (**finite impulse response**) filter produces each output sample as a
+**weighted sum of the most recent input samples** — a tapped delay line multiplied by a
+set of coefficients (taps). It is the most common [digital filter](/reference/digital-filter/)
+in SDR because it is always stable and can have exactly linear phase.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A tapped delay line of samples, each multiplied by a coefficient and summed to form the output." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2" fill="none"><rect x="40" y="30" width="40" height="26"/><rect x="100" y="30" width="40" height="26"/><rect x="160" y="30" width="40" height="26"/><rect x="220" y="30" width="40" height="26"/></g>
+  <g font-size="9" fill="currentColor" text-anchor="middle"><text x="60" y="48">z⁻¹</text><text x="120" y="48">z⁻¹</text><text x="180" y="48">z⁻¹</text><text x="240" y="48">z⁻¹</text></g>
+  <g stroke="currentColor" stroke-width="1"><line x1="60" y1="56" x2="60" y2="85"/><line x1="120" y1="56" x2="120" y2="85"/><line x1="180" y1="56" x2="180" y2="85"/><line x1="240" y1="56" x2="240" y2="85"/></g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="60" y="98">×a₀</text><text x="120" y="98">×a₁</text><text x="180" y="98">×a₂</text><text x="240" y="98">×a₃</text></g>
+  <circle cx="300" cy="92" r="12" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="300" y="96" text-anchor="middle" font-size="11" fill="currentColor">Σ</text>
+  <g stroke="currentColor" stroke-width="1"><line x1="60" y1="100" x2="289" y2="92"/><line x1="120" y1="100" x2="289" y2="92"/><line x1="180" y1="100" x2="289" y2="92"/><line x1="240" y1="100" x2="289" y2="92"/></g>
+  <line x1="312" y1="92" x2="360" y2="92" stroke="currentColor" marker-end="url(#firar)"/><text x="385" y="96" font-size="9" fill="currentColor">out</text>
+  <defs><marker id="firar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A FIR filter delays the input, scales each tap by a coefficient, and sums them — a direct convolution.</figcaption>
+</figure>
+
+## Overview
+
+FIR filters are used for channel selection, [pulse shaping](/reference/pulse-shaping/),
+and as the anti-alias filter before [decimation](/reference/decimation/). Their
+coefficients directly define the [frequency response](/reference/digital-filter/).

--- a/docs/reference/fred-gardner.md
+++ b/docs/reference/fred-gardner.md
@@ -1,0 +1,34 @@
+---
+slug: fred-gardner
+title: Floyd M. Gardner
+entry_type: person
+category: people
+description: Floyd M. Gardner was an engineer and author whose work on phase-locked loops and the Gardner timing-error detector shaped modern digital symbol-timing recovery.
+keywords: Floyd Gardner, Gardner timing recovery, phaselock techniques, symbol timing, PLL
+aka: ["Floyd Gardner", "Floyd M. Gardner", "Fred Gardner"]
+autolink: true
+see_also: [gardner-timing-recovery, clock-recovery, mueller-muller-timing-recovery]
+related_lessons:
+  - { title: "Clock recovery & symbol timing", url: /learn/clock-recovery/ }
+external:
+  - { title: "Floyd M. Gardner (Wikipedia)", url: https://en.wikipedia.org/wiki/Floyd_M._Gardner }
+---
+
+**Floyd M. Gardner** was an engineer and author whose work on phase-locked loops — and
+the **[Gardner timing-error detector](/reference/gardner-timing-recovery/)** — underpins
+modern digital **symbol-timing recovery**. His book *Phaselock Techniques* is a standard
+reference.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 120" role="img" aria-label="A symbol waveform sampled twice per symbol at the midpoint and peak, the basis of the Gardner detector." xmlns="http://www.w3.org/2000/svg">
+  <path d="M30 85 C 90 85 90 35 150 35 C 210 35 210 85 270 85 C 330 85 330 35 390 35" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <g fill="currentColor"><circle cx="90" cy="60" r="3"/><circle cx="150" cy="35" r="3"/><circle cx="210" cy="60" r="3"/><circle cx="270" cy="85" r="3"/></g>
+  <text x="220" y="110" text-anchor="middle" font-size="8.5" fill="currentColor">two samples per symbol (midpoint + peak) estimate timing</text>
+</svg>
+<figcaption>Gardner's detector uses a midpoint and a peak sample per symbol to drive timing recovery.</figcaption>
+</figure>
+
+## Contribution
+
+The Gardner detector is prized because it works without carrier phase lock, making it a
+common choice in SDR demodulators (it features in several GopherTrunk decoders).

--- a/docs/reference/gfsk.md
+++ b/docs/reference/gfsk.md
@@ -1,0 +1,41 @@
+---
+slug: gfsk
+title: GFSK
+entry_type: technology
+category: modulation
+description: GFSK (Gaussian frequency-shift keying) is FSK whose symbol transitions are smoothed by a Gaussian filter, narrowing the spectrum. It is used by AIS, Bluetooth, and many low-power radios.
+keywords: GFSK, Gaussian frequency-shift keying, AIS modulation, pulse shaping, narrowband FSK
+aka: [GFSK, Gaussian FSK]
+autolink: true
+see_also: [frequency-shift-keying, gmsk, pulse-shaping, ais]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "Frequency-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-shift_keying#Gaussian_frequency-shift_keying }
+---
+
+**GFSK** (**Gaussian frequency-shift keying**) is [frequency-shift keying](/reference/frequency-shift-keying/)
+in which the data is passed through a **Gaussian filter** before it shifts the carrier,
+rounding off the otherwise abrupt frequency steps. This smoothing narrows the
+transmitted spectrum, so GFSK fits more signals into less bandwidth.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A sharp two-level FSK transition compared with a smoothly rounded Gaussian-filtered transition." xmlns="http://www.w3.org/2000/svg">
+  <path d="M30 80 H100 V40 H170 V80 H240" fill="none" stroke="currentColor" stroke-width="1.3" stroke-opacity="0.5"/>
+  <text x="135" y="104" text-anchor="middle" font-size="8.5" fill="currentColor">plain FSK (sharp)</text>
+  <path d="M260 80 C 300 80 300 40 330 40 C 360 40 360 80 400 80 C 415 80 420 78 430 78" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="350" y="104" text-anchor="middle" font-size="8.5" fill="currentColor">GFSK (rounded)</text>
+</svg>
+<figcaption>A Gaussian filter rounds the frequency transitions, narrowing the spectrum at a small cost in detectability.</figcaption>
+</figure>
+
+## Overview
+
+GFSK is closely related to [GMSK](/reference/gmsk/) (a special case with a particular
+modulation index). It is widely used where spectral efficiency matters at low cost —
+[AIS](/reference/ais/) marine transponders, Bluetooth, and many ISM-band radios.
+
+## Relevance
+
+For SDR decoding, GFSK is handled like other FSK with a matched filter tuned to the
+Gaussian pulse shape, followed by [symbol-timing recovery](/reference/clock-recovery/).

--- a/docs/reference/iir-filter.md
+++ b/docs/reference/iir-filter.md
@@ -1,0 +1,41 @@
+---
+slug: iir-filter
+title: IIR filter
+entry_type: algorithm
+category: sdr-dsp
+description: An infinite impulse response (IIR) filter feeds back past outputs, achieving a sharp response with few coefficients — efficient but without the exact linear phase of a FIR filter.
+keywords: IIR filter, infinite impulse response, recursive filter, feedback, biquad, digital filter
+aka: [IIR, "infinite impulse response filter"]
+autolink: true
+see_also: [fir-filter, digital-filter, automatic-gain-control]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Infinite impulse response (Wikipedia)", url: https://en.wikipedia.org/wiki/Infinite_impulse_response }
+---
+
+An **IIR** (**infinite impulse response**) filter computes each output from both recent
+**inputs and past outputs** — it has **feedback**. That recursion achieves a sharp
+frequency response with far fewer coefficients than a [FIR filter](/reference/fir-filter/),
+at the cost of nonlinear phase and a need to watch stability.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A filter block with a feedback path from output back to input, characteristic of an IIR filter." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="50" x2="70" y2="50" stroke="currentColor"/><text x="30" y="42" font-size="9" fill="currentColor">in</text>
+  <circle cx="85" cy="50" r="12" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="85" y="54" text-anchor="middle" font-size="11" fill="currentColor">Σ</text>
+  <rect x="130" y="36" width="80" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="170" y="54" text-anchor="middle" font-size="9" fill="currentColor">delays</text>
+  <line x1="97" y1="50" x2="129" y2="50" stroke="currentColor" marker-end="url(#iirar)"/>
+  <line x1="210" y1="50" x2="300" y2="50" stroke="currentColor" marker-end="url(#iirar)"/><text x="320" y="54" font-size="9" fill="currentColor">out</text>
+  <path d="M260 50 V 95 H 85 V 63" fill="none" stroke="currentColor" stroke-dasharray="4 3" marker-end="url(#iirar)"/>
+  <text x="170" y="110" text-anchor="middle" font-size="8.5" fill="currentColor">feedback path</text>
+  <defs><marker id="iirar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An IIR filter feeds past outputs back into the input, giving a sharp response from very few terms.</figcaption>
+</figure>
+
+## Overview
+
+IIR designs (often built from cascaded *biquad* sections) suit narrowband tasks like
+DC blocking and the loop filters in [AGC](/reference/automatic-gain-control/) and
+[timing recovery](/reference/clock-recovery/), where efficiency matters more than phase
+linearity.

--- a/docs/reference/intermediate-frequency.md
+++ b/docs/reference/intermediate-frequency.md
@@ -1,0 +1,39 @@
+---
+slug: intermediate-frequency
+title: Intermediate frequency (IF)
+entry_type: term
+category: sdr-dsp
+description: The intermediate frequency (IF) is the fixed lower frequency a superheterodyne receiver mixes the incoming signal down to, where filtering and digitising are easier.
+keywords: intermediate frequency, IF, superheterodyne, mixing, low-IF, zero-IF, downconversion
+aka: [IF, "intermediate frequency"]
+autolink: true
+see_also: [superheterodyne-receiver, local-oscillator, baseband, analog-to-digital-converter]
+related_lessons:
+  - { title: "How an SDR receiver works", url: /learn/sdr-receiver/ }
+external:
+  - { title: "Intermediate frequency (Wikipedia)", url: https://en.wikipedia.org/wiki/Intermediate_frequency }
+---
+
+The **intermediate frequency** (**IF**) is the fixed, lower frequency that a
+[superheterodyne receiver](/reference/superheterodyne-receiver/) shifts the wanted
+signal down to before filtering and digitising. Mixing the variable input frequency to a
+**constant IF** lets the receiver use one well-designed filter regardless of the tuned
+channel.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A high radio frequency mixed with a local oscillator to produce a fixed lower intermediate frequency." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="80" x2="430" y2="80" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="360" y1="80" x2="360" y2="40" stroke="currentColor" stroke-width="2"/><text x="360" y="32" text-anchor="middle" font-size="8" fill="currentColor">RF</text>
+  <line x1="110" y1="80" x2="110" y2="50" stroke="currentColor" stroke-width="2"/><text x="110" y="42" text-anchor="middle" font-size="8" fill="currentColor">IF (fixed)</text>
+  <path d="M360 78 q-40 -30 -120 -20 q-80 10 -130 20" fill="none" stroke="currentColor" stroke-dasharray="4 3" marker-end="url(#ifar)"/>
+  <text x="240" y="104" text-anchor="middle" font-size="8.5" fill="currentColor">mixer + local oscillator shift RF → IF</text>
+  <defs><marker id="ifar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Mixing the tuned signal to a constant intermediate frequency lets one filter handle any channel.</figcaption>
+</figure>
+
+## Overview
+
+Many SDRs use a **low-IF** or **zero-IF** ([baseband](/reference/baseband/)) architecture,
+where the IF is at or near 0 Hz — convenient for the [ADC](/reference/analog-to-digital-converter/)
+but introducing a [DC offset](/reference/dc-offset/) artefact to manage.

--- a/docs/reference/john-costas.md
+++ b/docs/reference/john-costas.md
@@ -1,0 +1,38 @@
+---
+slug: john-costas
+title: John P. Costas
+entry_type: person
+category: people
+description: John P. Costas was an American engineer who invented the Costas loop, a carrier-recovery technique essential to demodulating suppressed-carrier and phase-shift-keyed signals.
+keywords: John Costas, Costas loop, carrier recovery, PSK, SSB, engineer
+aka: ["John Costas", "John P. Costas"]
+autolink: true
+see_also: [costas-loop, phase-shift-keying, single-sideband, demodulation]
+related_lessons:
+  - { title: "Clock recovery & symbol timing", url: /learn/clock-recovery/ }
+external:
+  - { title: "John P. Costas (Wikipedia)", url: https://en.wikipedia.org/wiki/John_P._Costas_(engineer) }
+---
+
+**John P. Costas** was an American engineer best known for the **[Costas loop](/reference/costas-loop/)**,
+a phase-locked carrier-recovery circuit he devised in the 1950s. It made coherent
+reception of suppressed-carrier signals (such as [SSB](/reference/single-sideband/) and
+later [PSK](/reference/phase-shift-keying/)) practical.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A feedback loop: phase detector, loop filter, controlled oscillator feeding back — the Costas loop." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <rect x="50" y="35" width="70" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="85" y="52">phase det</text>
+    <rect x="160" y="35" width="70" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="195" y="52">loop filter</text>
+    <rect x="270" y="35" width="80" height="28" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="310" y="52">oscillator</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="120" y1="49" x2="159" y2="49" marker-end="url(#jcar)"/><line x1="230" y1="49" x2="269" y2="49" marker-end="url(#jcar)"/><path d="M310 63 V 90 H 85 V 64" fill="none" marker-end="url(#jcar)"/></g>
+  </g>
+  <defs><marker id="jcar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Costas's carrier-recovery loop feeds a phase-error estimate back to a controlled oscillator.</figcaption>
+</figure>
+
+## Contribution
+
+The Costas loop remains a standard building block in digital receivers, including the
+carrier recovery used when demodulating phase-modulated digital-voice systems.

--- a/docs/reference/lora.md
+++ b/docs/reference/lora.md
@@ -1,0 +1,37 @@
+---
+slug: lora
+title: LoRa
+entry_type: protocol
+category: protocols
+description: LoRa is a low-power, long-range modulation that encodes data as chirps — frequency sweeps across the channel — giving excellent sensitivity for IoT telemetry in ISM bands.
+keywords: LoRa, chirp spread spectrum, CSS, LoRaWAN, IoT, long range, ISM band, dechirp
+aka: [LoRa, "chirp spread spectrum"]
+autolink: true
+see_also: [frequency-shift-keying, bandwidth, signal-to-noise-ratio]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "LoRa (Wikipedia)", url: https://en.wikipedia.org/wiki/LoRa }
+---
+
+**LoRa** is a low-power, long-range modulation that encodes data as **chirps** —
+frequency sweeps that ramp across the channel. Chirp spread spectrum gives LoRa
+excellent sensitivity (it decodes well below the [noise floor](/reference/noise-floor/)),
+making it popular for low-rate IoT telemetry in ISM bands.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A spectrogram showing repeated rising frequency sweeps (chirps), the signature of LoRa." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="380" height="80" fill="none" stroke="currentColor" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-width="1.8" fill="none"><path d="M50 95 L110 25"/><path d="M120 95 L180 25"/><path d="M190 95 L250 25"/><path d="M260 95 L320 25"/><path d="M330 95 L390 25"/></g>
+  <text x="30" y="60" font-size="8" fill="currentColor" transform="rotate(-90 30 60)">freq</text>
+  <text x="230" y="114" text-anchor="middle" font-size="8.5" fill="currentColor">time → · each ramp is one chirp symbol</text>
+</svg>
+<figcaption>LoRa encodes symbols as rising frequency chirps; the diagonal sweeps are its waterfall signature.</figcaption>
+</figure>
+
+## Overview
+
+A receiver "de-chirps" by multiplying with a reference sweep, collapsing each chirp to a
+tone whose frequency encodes the symbol. LoRa is unrelated to the trunked-voice systems
+GopherTrunk targets, but is a common sight on the [waterfall](/reference/fast-fourier-transform/)
+in the 433/868/915 MHz ISM bands.

--- a/docs/reference/mode-s.md
+++ b/docs/reference/mode-s.md
@@ -1,0 +1,38 @@
+---
+slug: mode-s
+title: Mode S
+entry_type: protocol
+category: protocols
+description: Mode S is the selective-addressing aviation transponder protocol on 1090 MHz that underlies ADS-B, carrying a 24-bit aircraft address and CRC-protected data in 56- or 112-bit frames.
+keywords: Mode S, Mode-S, 1090 MHz, transponder, ICAO 24-bit address, squitter, ADS-B, CRC-24
+aka: [Mode S, Mode-S]
+autolink: true
+see_also: [ads-b, compact-position-reporting, cyclic-redundancy-check, icao]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "Secondary surveillance radar — Mode S (Wikipedia)", url: https://en.wikipedia.org/wiki/Secondary_surveillance_radar#Mode_S }
+  - { title: "GopherTrunk ADS-B decoder", url: /adsb.html }
+---
+
+**Mode S** (mode select) is the selective-addressing aviation transponder protocol on
+**1090 MHz** that carries each aircraft's unique **24-bit ICAO address** and forms the
+foundation of [ADS-B](/reference/ads-b/). Messages are 56- or 112-bit frames protected
+by a [CRC-24](/reference/cyclic-redundancy-check/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A Mode S frame: a short pulse preamble followed by a data block of address and payload ending in a CRC." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.2"><rect x="30" y="45" width="14" height="26" fill="currentColor" fill-opacity="0.4"/><rect x="50" y="45" width="14" height="26" fill="currentColor" fill-opacity="0.4"/><rect x="74" y="45" width="14" height="26" fill="currentColor" fill-opacity="0.4"/></g>
+  <text x="58" y="86" text-anchor="middle" font-size="8" fill="currentColor">preamble</text>
+  <rect x="110" y="45" width="120" height="26" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="170" y="62" text-anchor="middle" font-size="8.5" fill="currentColor">ICAO addr + data</text>
+  <rect x="230" y="45" width="180" height="26" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="320" y="62" text-anchor="middle" font-size="8.5" fill="currentColor">payload</text>
+  <text x="230" y="98" text-anchor="middle" font-size="8" fill="currentColor">56- or 112-bit frame · CRC-24 · 1090 MHz PPM</text>
+</svg>
+<figcaption>A Mode S frame: pulse preamble, then a CRC-protected data block keyed by the aircraft's 24-bit address.</figcaption>
+</figure>
+
+## Overview
+
+ADS-B is carried in *extended squitter* (DF17/18) Mode S frames whose payload includes
+identity, position, and velocity. GopherTrunk decodes these (via a BEAST upstream or
+native demod) into tracked aircraft — see the [ADS-B](/adsb.html) page.

--- a/docs/reference/nrzi.md
+++ b/docs/reference/nrzi.md
@@ -1,0 +1,36 @@
+---
+slug: nrzi
+title: NRZI
+entry_type: term
+category: modulation
+description: NRZI (non-return-to-zero inverted) is a line code where a bit is represented by the presence or absence of a transition rather than by a fixed level — used in AX.25/APRS and AIS.
+keywords: NRZI, non-return-to-zero inverted, line code, AX.25, APRS, AIS, bit stuffing
+aka: [NRZI, "non-return-to-zero inverted"]
+autolink: true
+see_also: [ax25, aprs, ais, frequency-shift-keying, clock-recovery]
+related_lessons:
+  - { title: "The demodulation pipeline", url: /learn/demodulation-pipeline/ }
+external:
+  - { title: "Non-return-to-zero (Wikipedia)", url: https://en.wikipedia.org/wiki/Non-return-to-zero#NRZI }
+---
+
+**NRZI** (**non-return-to-zero inverted**) is a line code in which each bit is conveyed
+by **whether the signal level changes**, not by the level itself: conventionally a `0`
+causes a transition and a `1` causes none (or vice-versa). It is used by
+[AX.25](/reference/ax25/)/[APRS](/reference/aprs/) and [AIS](/reference/ais/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A bit pattern above a NRZI waveform that changes level on each zero and holds level on each one." xmlns="http://www.w3.org/2000/svg">
+  <g font-family="monospace" font-size="11" fill="currentColor" text-anchor="middle"><text x="60" y="30">0</text><text x="110" y="30">1</text><text x="160" y="30">1</text><text x="210" y="30">0</text><text x="260" y="30">0</text><text x="310" y="30">1</text></g>
+  <path d="M35 80 V50 H85 V80 H135 V80 H185 V50 H235 V80 H285 V50 H335 V50 H385" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="230" y="108" text-anchor="middle" font-size="8.5" fill="currentColor">transition = 0 · no transition = 1</text>
+</svg>
+<figcaption>NRZI encodes bits as the presence or absence of a level transition, which guarantees frequent edges for timing.</figcaption>
+</figure>
+
+## Overview
+
+Because NRZI ties bits to transitions, combining it with **bit stuffing** (as
+[HDLC](/reference/ax25/) does) guarantees regular edges, which keeps the receiver's
+[clock recovery](/reference/clock-recovery/) locked even through long runs of identical
+data bits.

--- a/docs/reference/numerically-controlled-oscillator.md
+++ b/docs/reference/numerically-controlled-oscillator.md
@@ -1,0 +1,41 @@
+---
+slug: numerically-controlled-oscillator
+title: Numerically controlled oscillator (NCO)
+entry_type: term
+category: sdr-dsp
+description: A numerically controlled oscillator (NCO) generates a digital sine/cosine of programmable frequency using a phase accumulator — the tunable mixer at the heart of an SDR's digital down-converter.
+keywords: NCO, numerically controlled oscillator, phase accumulator, DDS, digital mixing, frequency synthesis
+aka: [NCO, "numerically controlled oscillator", DDS]
+autolink: true
+see_also: [digital-down-converter, local-oscillator, decimation, iq-data]
+related_lessons:
+  - { title: "Filtering & decimation", url: /learn/filtering-decimation/ }
+external:
+  - { title: "Numerically controlled oscillator (Wikipedia)", url: https://en.wikipedia.org/wiki/Numerically-controlled_oscillator }
+---
+
+A **numerically controlled oscillator** (**NCO**) generates a digital sine and cosine
+of any programmable frequency from a **phase accumulator** — a counter that adds a fixed
+step each sample and looks up the corresponding sine value. It is the software
+equivalent of a [local oscillator](/reference/local-oscillator/) and the tunable mixer
+inside a [digital down-converter](/reference/digital-down-converter/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A phase accumulator adding a step each sample, feeding a sine lookup that outputs a digital tone." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="44" width="120" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="90" y="58">phase accumulator</text><text x="90" y="70" font-size="7.5">+ step each sample</text>
+    <rect x="190" y="44" width="90" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="235" y="64">sine LUT</text>
+    <line x1="150" y1="60" x2="189" y2="60" stroke="currentColor" marker-end="url(#ncoar)"/>
+    <line x1="280" y1="60" x2="320" y2="60" stroke="currentColor" marker-end="url(#ncoar)"/>
+  </g>
+  <path d="M325 60 q8 -16 16 0 t16 0 t16 0 t16 0 t16 0 t16 0 t8 0" fill="none" stroke="currentColor" stroke-width="1.4"/>
+  <defs><marker id="ncoar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An NCO steps a phase accumulator each sample and looks up the sine — a precisely tunable digital oscillator.</figcaption>
+</figure>
+
+## Overview
+
+Changing the accumulator's step instantly retunes the NCO, which is how an SDR
+**digitally tunes** to a channel: multiply the [IQ](/reference/iq-data/) stream by the
+NCO's output to shift that channel to [baseband](/reference/baseband/) before filtering.

--- a/docs/reference/ofcom.md
+++ b/docs/reference/ofcom.md
@@ -1,0 +1,41 @@
+---
+slug: ofcom
+title: Ofcom
+entry_type: organization
+category: organizations
+description: Ofcom is the United Kingdom's communications regulator, allocating and licensing radio spectrum — the UK counterpart to the FCC.
+keywords: Ofcom, UK regulator, spectrum, licensing, United Kingdom, communications
+aka: [Ofcom]
+autolink: true
+see_also: [fcc, itu, frequency-bands]
+related_lessons:
+  - { title: "Frequency, bands & the spectrum", url: /learn/frequency-and-spectrum/ }
+  - { title: "Legal & ethical monitoring", url: /learn/legal-ethical/ }
+external:
+  - { title: "Ofcom (Wikipedia)", url: https://en.wikipedia.org/wiki/Ofcom }
+---
+
+**Ofcom** (the Office of Communications) is the **United Kingdom's communications
+regulator**. It allocates and licenses radio spectrum and sets the rules for its use —
+the UK counterpart to the United States' [FCC](/reference/fcc/), working within the
+global framework set by the [ITU](/reference/itu/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="The ITU framework within which Ofcom regulates UK spectrum and licenses users." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="110" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="75" y="61">ITU (global)</text>
+    <rect x="175" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="230" y="61">Ofcom (UK)</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">licensed users</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="130" y1="58" x2="174" y2="58" marker-end="url(#or_ofc)"/><line x1="285" y1="58" x2="329" y2="58" marker-end="url(#or_ofc)"/></g>
+  </g>
+  <defs><marker id="or_ofc" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Ofcom regulates UK spectrum within the ITU's international framework.</figcaption>
+</figure>
+
+
+## Overview
+
+Whether and what you may legally receive depends on national rules; in the UK those are
+Ofcom's. See the [legal &amp; ethical monitoring](/learn/legal-ethical/) lesson, and always
+check the regulator for your own jurisdiction.

--- a/docs/reference/pi-4-dqpsk.md
+++ b/docs/reference/pi-4-dqpsk.md
@@ -1,0 +1,44 @@
+---
+slug: pi-4-dqpsk
+title: π/4-DQPSK
+entry_type: technology
+category: modulation
+description: π/4-DQPSK (π/4-shifted differential quadrature phase-shift keying) is a phase modulation that rotates the constellation by 45° each symbol, used by TETRA and other digital systems.
+keywords: pi/4-DQPSK, differential QPSK, TETRA modulation, phase-shift keying, 8-point constellation
+aka: ["pi/4-DQPSK", "π/4 DQPSK", differential QPSK]
+autolink: true
+see_also: [phase-shift-keying, cqpsk, constellation-diagram, tetra]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "π/4-QPSK (Wikipedia)", url: https://en.wikipedia.org/wiki/Phase-shift_keying#%CF%80/4%E2%80%93QPSK }
+---
+
+**π/4-DQPSK** (π/4-shifted differential quadrature [phase-shift keying](/reference/phase-shift-keying/))
+is a four-symbol phase modulation in which the constellation is **rotated by 45° (π/4)
+every symbol** and information is carried in the *change* of phase rather than its
+absolute value. It is the air-interface modulation of [TETRA](/reference/tetra/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 240 240" role="img" aria-label="An eight-point constellation formed by two QPSK sets offset by 45 degrees, as used by pi/4-DQPSK." xmlns="http://www.w3.org/2000/svg">
+  <line x1="20" y1="120" x2="220" y2="120" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="120" y1="20" x2="120" y2="220" stroke="currentColor" stroke-opacity="0.4"/>
+  <g fill="currentColor"><circle cx="190" cy="120" r="4"/><circle cx="120" cy="50" r="4"/><circle cx="50" cy="120" r="4"/><circle cx="120" cy="190" r="4"/></g>
+  <g fill="currentColor" fill-opacity="0.55"><circle cx="170" cy="70" r="4"/><circle cx="70" cy="70" r="4"/><circle cx="70" cy="170" r="4"/><circle cx="170" cy="170" r="4"/></g>
+  <text x="212" y="134" font-size="10" fill="currentColor">I</text><text x="106" y="30" font-size="10" fill="currentColor">Q</text>
+</svg>
+<figcaption>π/4-DQPSK alternates between two QPSK constellations offset by 45°, so symbols never pass through the origin.</figcaption>
+</figure>
+
+## Overview
+
+By alternating between two QPSK constellations offset by 45°, π/4-DQPSK guarantees a
+phase transition at every symbol (helping [clock recovery](/reference/clock-recovery/))
+while avoiding transitions through the origin, which keeps the signal's amplitude
+envelope more constant and easier to amplify efficiently.
+
+## Relevance
+
+Differential encoding means the receiver only needs to measure phase *changes*, so it
+tolerates a constant carrier-phase offset without an absolute phase reference. This
+robustness is why TETRA and several other professional systems adopted it.

--- a/docs/reference/provoice.md
+++ b/docs/reference/provoice.md
@@ -1,0 +1,36 @@
+---
+slug: provoice
+title: ProVoice
+entry_type: protocol
+category: protocols
+description: ProVoice is the digital-voice option for EDACS trunked systems, using an AMBE-family vocoder over the otherwise analog-trunking EDACS air interface.
+keywords: ProVoice, EDACS digital voice, M/A-COM, AMBE, digital trunking
+aka: [ProVoice]
+autolink: true
+see_also: [edacs, ambe, vocoder, trunked-radio]
+related_lessons:
+  - { title: "The digital protocol landscape", url: /learn/protocol-landscape/ }
+external:
+  - { title: "Enhanced Digital Access Communications System (Wikipedia)", url: https://en.wikipedia.org/wiki/Enhanced_Digital_Access_Communications_System }
+---
+
+**ProVoice** is the **digital-voice option for [EDACS](/reference/edacs/)** trunked
+systems (GE/Ericsson, later M/A-COM). It replaces EDACS's analog FM voice with a digital
+[AMBE](/reference/ambe/)-family [vocoder](/reference/vocoder/) while keeping the EDACS
+control-channel signalling.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="An EDACS control channel assigning a voice channel that carries digital ProVoice AMBE frames instead of analog FM." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="24" width="400" height="22" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="230" y="39" text-anchor="middle" font-size="8.5" fill="currentColor">EDACS control channel</text>
+  <g stroke="currentColor" stroke-width="1.1" fill="none"><rect x="120" y="64" width="60" height="26"/><rect x="180" y="64" width="60" height="26"/><rect x="240" y="64" width="60" height="26"/><rect x="300" y="64" width="60" height="26"/></g>
+  <text x="240" y="105" text-anchor="middle" font-size="8" fill="currentColor">ProVoice = digital AMBE frames (vs analog FM)</text>
+  <line x1="230" y1="46" x2="240" y2="62" stroke="currentColor" stroke-dasharray="3 3"/>
+</svg>
+<figcaption>ProVoice carries digital AMBE voice over EDACS, in place of the system's analog FM voice channels.</figcaption>
+</figure>
+
+## Overview
+
+Because ProVoice uses a proprietary vocoder, decoding it has historically required
+licensed components; the EDACS trunking layer itself is followed the same way regardless
+of whether the voice is analog or ProVoice.

--- a/docs/reference/pulse-shaping.md
+++ b/docs/reference/pulse-shaping.md
@@ -1,0 +1,40 @@
+---
+slug: pulse-shaping
+title: Pulse shaping
+entry_type: term
+category: modulation
+description: Pulse shaping filters each transmitted symbol so the signal occupies less bandwidth and avoids inter-symbol interference — commonly with a root-raised-cosine filter.
+keywords: pulse shaping, root-raised-cosine, inter-symbol interference, spectral splatter, Nyquist filter
+aka: ["pulse shaping"]
+autolink: true
+see_also: [root-raised-cosine-filter, bandwidth, symbol-rate, matched-filter]
+related_lessons:
+  - { title: "Digital modulation & constellations", url: /learn/digital-modulation/ }
+external:
+  - { title: "Pulse shaping (Wikipedia)", url: https://en.wikipedia.org/wiki/Pulse_shaping }
+---
+
+**Pulse shaping** is filtering each transmitted symbol's pulse so the signal occupies
+**less bandwidth** and successive symbols don't smear into one another
+(inter-symbol interference). Sharp rectangular pulses spray energy into adjacent
+channels; a shaped pulse keeps it contained.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A rectangular pulse with a wide spectrum versus a shaped pulse with a narrow spectrum." xmlns="http://www.w3.org/2000/svg">
+  <path d="M30 90 V50 H80 V90" fill="none" stroke="currentColor" stroke-width="1.3" stroke-opacity="0.5"/>
+  <text x="55" y="106" text-anchor="middle" font-size="8" fill="currentColor">rectangular</text>
+  <path d="M150 90 Q 185 90 195 55 Q 205 35 215 55 Q 225 90 260 90" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <text x="205" y="106" text-anchor="middle" font-size="8" fill="currentColor">shaped</text>
+  <line x1="300" y1="90" x2="440" y2="90" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M300 88 L350 88 L360 78 L370 88 L420 88" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <path d="M300 88 C 340 88 340 50 360 30 C 380 50 380 88 420 88" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity="0.5" stroke-dasharray="3 2"/>
+  <text x="360" y="106" text-anchor="middle" font-size="8" fill="currentColor">narrow vs wide spectrum</text>
+</svg>
+<figcaption>Shaping each symbol pulse (often with a root-raised-cosine filter) contains the signal's spectrum.</figcaption>
+</figure>
+
+## Overview
+
+The most common choice is the [root-raised-cosine filter](/reference/root-raised-cosine-filter/),
+split between transmitter and receiver so that together they form a Nyquist filter with
+zero inter-symbol interference at the sampling instants.

--- a/docs/reference/radioreference.md
+++ b/docs/reference/radioreference.md
@@ -1,0 +1,41 @@
+---
+slug: radioreference
+title: RadioReference
+entry_type: organization
+category: organizations
+description: RadioReference is the largest community database of radio systems, frequencies, talkgroups, and trunked-system parameters — the usual first stop for finding what to monitor.
+keywords: RadioReference, frequency database, trunked systems, talkgroups, scanner database, RR
+aka: [RadioReference, RR]
+autolink: true
+see_also: [trunked-radio, control-channel, talkgroup, project-25]
+related_lessons:
+  - { title: "Finding & identifying systems", url: /learn/finding-systems/ }
+external:
+  - { title: "RadioReference.com", url: https://www.radioreference.com/ }
+---
+
+**RadioReference** is the largest community-maintained **database of radio systems** —
+frequencies, [trunked-system](/reference/trunked-radio/) types,
+[control channels](/reference/control-channel/), and [talkgroups](/reference/talkgroup/),
+catalogued by location. It is the usual first stop when deciding what to monitor.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="RadioReference cataloguing systems that an operator looks up to configure a scanner." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="110" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="75" y="61">RadioReference</text>
+    <rect x="175" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="230" y="61">system + TG data</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">your scanner config</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="130" y1="58" x2="174" y2="58" marker-end="url(#or_rr)"/><line x1="285" y1="58" x2="329" y2="58" marker-end="url(#or_rr)"/></g>
+  </g>
+  <defs><marker id="or_rr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Operators look up local systems on RadioReference and import the details into their scanner.</figcaption>
+</figure>
+
+
+## Overview
+
+For most populated areas, the local systems are already documented on RadioReference, so
+you can look up a system's control-channel frequency and talkgroup list rather than
+discovering them from scratch. GopherTrunk can [import](/import.html) these details
+directly.

--- a/docs/reference/resampler.md
+++ b/docs/reference/resampler.md
@@ -1,0 +1,38 @@
+---
+slug: resampler
+title: Resampler
+entry_type: algorithm
+category: sdr-dsp
+description: A resampler converts a stream from one sample rate to another — essential when an SDR's native rate doesn't match the rate a decoder needs.
+keywords: resampler, resampling, sample-rate conversion, interpolation, decimation, fractional resampling
+aka: [resampler, resampling]
+autolink: true
+see_also: [sample-rate, decimation, digital-filter, nyquist-theorem]
+related_lessons:
+  - { title: "Sample rate, bandwidth & Nyquist", url: /learn/sample-rate-nyquist/ }
+external:
+  - { title: "Sample-rate conversion (Wikipedia)", url: https://en.wikipedia.org/wiki/Sample-rate_conversion }
+---
+
+A **resampler** converts a sample stream from one [sample rate](/reference/sample-rate/)
+to another. SDRs rarely produce exactly the rate a decoder wants (a P25 channel needs a
+multiple of 4800 baud, say), so a resampler bridges the two — by a whole-number ratio or
+a fractional one.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="An input stream of samples at one spacing converted to an output stream at a different spacing." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor"><circle cx="30" cy="40" r="3"/><circle cx="58" cy="40" r="3"/><circle cx="86" cy="40" r="3"/><circle cx="114" cy="40" r="3"/><circle cx="142" cy="40" r="3"/><circle cx="170" cy="40" r="3"/></g>
+  <text x="100" y="26" font-size="8.5" fill="currentColor">input rate</text>
+  <line x1="200" y1="55" x2="240" y2="55" stroke="currentColor" marker-end="url(#rsar)"/><text x="220" y="48" text-anchor="middle" font-size="8" fill="currentColor">resample</text>
+  <g fill="currentColor"><circle cx="280" cy="80" r="3"/><circle cx="320" cy="80" r="3"/><circle cx="360" cy="80" r="3"/><circle cx="400" cy="80" r="3"/></g>
+  <text x="350" y="100" font-size="8.5" fill="currentColor">output rate</text>
+  <defs><marker id="rsar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A resampler changes the sample rate (here reducing it) while preserving the underlying signal.</figcaption>
+</figure>
+
+## Overview
+
+Resampling combines interpolation, filtering, and [decimation](/reference/decimation/);
+done carelessly it causes [aliasing](/reference/aliasing/), so a resampler always
+includes an anti-alias [filter](/reference/digital-filter/).

--- a/docs/reference/rest-channel.md
+++ b/docs/reference/rest-channel.md
@@ -1,0 +1,41 @@
+---
+slug: rest-channel
+title: Rest channel
+entry_type: term
+category: trunked-radio
+description: In some trunked systems the control channel rotates among the pool — the channel currently carrying control signalling is the "rest channel", and it changes as calls are assigned.
+keywords: rest channel, distributed control channel, DMR Capacity Plus, rotating control channel, trunking
+aka: ["rest channel"]
+autolink: true
+see_also: [control-channel, channel-grant, trunked-radio, capacity-plus, dmr]
+related_lessons:
+  - { title: "Finding & identifying systems", url: /learn/finding-systems/ }
+external:
+  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+---
+
+A **rest channel** is the channel currently carrying control signalling in trunked
+systems that **rotate the control function around the pool** rather than dedicate one
+frequency to it. When a call is assigned to the current rest channel, control moves to
+another idle channel — the new rest channel.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A pool of channels where one is marked as the rest channel carrying control; an arrow shows the rest role moving to another channel when a call starts." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.1" font-size="8" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="40" width="80" height="32" fill="currentColor" fill-opacity="0.22"/><text x="80" y="56">ch 1</text><text x="80" y="66" font-size="7">rest (control)</text>
+    <rect x="140" y="40" width="80" height="32" fill="none"/><text x="180" y="60">ch 2</text>
+    <rect x="240" y="40" width="80" height="32" fill="none"/><text x="280" y="60">ch 3</text>
+    <rect x="340" y="40" width="80" height="32" fill="none"/><text x="380" y="60">ch 4</text>
+  </g>
+  <path d="M80 74 q60 30 120 0" fill="none" stroke="currentColor" stroke-dasharray="3 3" marker-end="url(#rcar)"/>
+  <text x="150" y="108" text-anchor="middle" font-size="8" fill="currentColor">control moves when this channel takes a call</text>
+  <defs><marker id="rcar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>With a rotating control channel, the "rest channel" is wherever control currently lives, and it moves as calls are assigned.</figcaption>
+</figure>
+
+## Overview
+
+Rotating control (used by Motorola [Capacity Plus](/reference/capacity-plus/) and some
+DMR systems) complicates monitoring: a scanner must follow the rest channel as it hops,
+rather than camping on one fixed [control channel](/reference/control-channel/).

--- a/docs/reference/rtca.md
+++ b/docs/reference/rtca.md
@@ -1,0 +1,39 @@
+---
+slug: rtca
+title: RTCA
+entry_type: organization
+category: organizations
+description: RTCA is a US standards body for aviation electronics; its DO-260 series defines the ADS-B performance requirements that transponders must meet.
+keywords: RTCA, DO-260, ADS-B standards, aviation, MOPS, avionics
+aka: [RTCA]
+autolink: true
+see_also: [ads-b, mode-s, icao, eurocae]
+related_lessons:
+  - { title: "Other signals you'll meet", url: /learn/other-signals/ }
+external:
+  - { title: "RTCA (Wikipedia)", url: https://en.wikipedia.org/wiki/RTCA }
+---
+
+**RTCA** is a United States standards organization for **aviation electronics**. Its
+**DO-260** series of Minimum Operational Performance Standards (MOPS) defines the
+[ADS-B](/reference/ads-b/) requirements that aircraft transponders must meet, alongside
+the international standards from [ICAO](/reference/icao/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 100" role="img" aria-label="RTCA publishing the DO-260 standard that defines ADS-B transponder behaviour." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="110" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="75" y="61">RTCA</text>
+    <rect x="175" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="230" y="61">DO-260 (MOPS)</text>
+    <rect x="330" y="42" width="110" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="385" y="61">ADS-B transponders</text>
+    <g stroke="currentColor" stroke-width="1.1"><line x1="130" y1="58" x2="174" y2="58" marker-end="url(#or_rtc)"/><line x1="285" y1="58" x2="329" y2="58" marker-end="url(#or_rtc)"/></g>
+  </g>
+  <defs><marker id="or_rtc" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>RTCA's DO-260 standards define how ADS-B transponders must perform.</figcaption>
+</figure>
+
+
+## Overview
+
+RTCA's DO-260B is the ADS-B specification most often cited in decoder documentation; its
+European counterpart is [EUROCAE](/reference/eurocae/)'s ED-102A.

--- a/docs/reference/saw-filter.md
+++ b/docs/reference/saw-filter.md
@@ -1,0 +1,37 @@
+---
+slug: saw-filter
+title: SAW filter
+entry_type: hardware
+category: hardware
+description: A SAW (surface acoustic wave) filter is a compact, sharp band-pass filter often placed in an SDR front end — for example to pass only the 1090 MHz ADS-B band and reject strong out-of-band signals.
+keywords: SAW filter, surface acoustic wave, band-pass, front-end filter, 1090 MHz, ADS-B, preselector
+aka: [SAW filter, "surface acoustic wave filter"]
+autolink: true
+see_also: [low-noise-amplifier, ads-b, bandwidth, attenuation]
+related_lessons:
+  - { title: "Antennas 101", url: /learn/antennas/ }
+external:
+  - { title: "Surface acoustic wave (Wikipedia)", url: https://en.wikipedia.org/wiki/Surface_acoustic_wave }
+---
+
+A **SAW** (**surface acoustic wave**) filter is a compact, sharp **band-pass** filter
+built on a piezoelectric substrate. In an SDR front end it acts as a preselector —
+passing only the wanted band and strongly rejecting out-of-band signals that would
+otherwise overload the receiver.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A sharp band-pass response curve passing a narrow band and rejecting everything outside it." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="95" x2="430" y2="95" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="40" y1="20" x2="40" y2="95" stroke="currentColor" stroke-opacity="0.4"/>
+  <path d="M40 88 L200 88 C 215 88 215 30 235 30 L 245 30 C 265 30 265 88 280 88 L 430 88" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.8"/>
+  <text x="240" y="24" text-anchor="middle" font-size="9" fill="currentColor">passband (e.g. 1090 MHz)</text>
+  <text x="110" y="80" font-size="8" fill="currentColor">rejected</text><text x="360" y="80" font-size="8" fill="currentColor">rejected</text>
+</svg>
+<figcaption>A SAW filter passes one narrow band with steep skirts, protecting the receiver from strong out-of-band signals.</figcaption>
+</figure>
+
+## Overview
+
+ADS-B receive chains commonly add a 1090 MHz SAW filter (often with a
+[low-noise amplifier](/reference/low-noise-amplifier/)) so nearby cellular and broadcast
+transmitters don't desensitise the [front end](/reference/superheterodyne-receiver/).

--- a/docs/reference/tsbk.md
+++ b/docs/reference/tsbk.md
@@ -1,0 +1,37 @@
+---
+slug: tsbk
+title: TSBK
+entry_type: term
+category: trunked-radio
+description: A TSBK (trunking signalling block) is the unit of control-channel signalling in P25 — the message that announces channel grants, registrations, and system parameters.
+keywords: TSBK, trunking signalling block, P25 control channel, channel grant, single block, signalling
+aka: [TSBK, "trunking signalling block", "trunking signaling block"]
+autolink: true
+see_also: [control-channel, channel-grant, project-25, p25-phase-1, csbk]
+related_lessons:
+  - { title: "What is trunked radio?", url: /learn/what-is-trunking/ }
+external:
+  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+---
+
+A **TSBK** (**trunking signalling block**) is the unit of control-channel signalling in
+[P25](/reference/project-25/). Each TSBK is a short, error-protected message on the
+[control channel](/reference/control-channel/) carrying one piece of system business — a
+[channel grant](/reference/channel-grant/), a registration, an affiliation, or a system
+parameter.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A control channel carrying a stream of TSBK blocks, one of which is a channel grant." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="30" width="400" height="24" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="230" y="46" text-anchor="middle" font-size="8.5" fill="currentColor">P25 control channel</text>
+  <g stroke="currentColor" stroke-width="1.1"><rect x="40" y="66" width="80" height="26" fill="none"/><rect x="130" y="66" width="80" height="26" fill="currentColor" fill-opacity="0.22"/><rect x="220" y="66" width="80" height="26" fill="none"/><rect x="310" y="66" width="80" height="26" fill="none"/></g>
+  <g font-size="8" fill="currentColor" text-anchor="middle"><text x="80" y="83">TSBK</text><text x="170" y="80">TSBK</text><text x="170" y="90" font-size="7">(grant)</text><text x="260" y="83">TSBK</text><text x="350" y="83">TSBK</text></g>
+</svg>
+<figcaption>The P25 control channel is a stream of TSBKs; one announces a grant pointing radios to a voice channel.</figcaption>
+</figure>
+
+## Overview
+
+Decoding TSBKs is exactly how a scanner follows a P25 system: read the grant TSBKs and
+retune to the assigned [voice channel](/reference/voice-channel/) in step with the radios.
+P25 Phase 2 uses *MAC PDU* messages for the same role. DMR's equivalent is the
+[CSBK](/reference/csbk/).

--- a/docs/reference/zadig.md
+++ b/docs/reference/zadig.md
@@ -1,0 +1,37 @@
+---
+slug: zadig
+title: Zadig
+entry_type: hardware
+category: hardware
+description: Zadig is a Windows utility that installs the generic WinUSB driver onto an SDR dongle, replacing the default TV-tuner driver so SDR software can access the device.
+keywords: Zadig, WinUSB, RTL-SDR driver, Windows, libusb, DVB-T driver, USB driver
+aka: [Zadig, WinUSB]
+autolink: true
+see_also: [rtl-sdr, rtl2832u, rtl-tcp, soapysdr]
+related_lessons:
+  - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/sdr-hardware/ }
+external:
+  - { title: "Zadig", url: https://zadig.akeo.ie/ }
+---
+
+**Zadig** is a small Windows utility that installs the generic **WinUSB** driver onto an
+SDR dongle. Out of the box, Windows binds an [RTL-SDR](/reference/rtl-sdr/) to its
+TV-tuner (DVB-T) driver; Zadig replaces that with WinUSB so SDR software can talk to the
+device directly.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A dongle's default TV-tuner driver being replaced by the WinUSB driver via Zadig." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="44" width="90" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3"/><text x="75" y="63" text-anchor="middle" font-size="8.5" fill="currentColor">DVB-T driver</text>
+  <line x1="125" y1="59" x2="185" y2="59" stroke="currentColor" marker-end="url(#zar)"/><text x="155" y="51" text-anchor="middle" font-size="8" fill="currentColor">Zadig</text>
+  <rect x="195" y="44" width="90" height="30" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="240" y="63" text-anchor="middle" font-size="8.5" fill="currentColor">WinUSB</text>
+  <line x1="290" y1="59" x2="350" y2="59" stroke="currentColor" marker-end="url(#zar)"/>
+  <rect x="360" y="44" width="80" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="400" y="63" text-anchor="middle" font-size="8.5" fill="currentColor">SDR app</text>
+  <defs><marker id="zar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Zadig swaps the dongle's default Windows driver for WinUSB so SDR software can access it.</figcaption>
+</figure>
+
+## Overview
+
+GopherTrunk's Windows installer bundles Zadig to automate this step. On Linux and macOS
+the equivalent access is handled by libusb/IOKit without a separate tool.


### PR DESCRIPTION
## Summary

Follow-up to the RF & SDR knowledge base (#700). Reviews the **original content audit's term universe** against the reference encyclopedia and fills the gaps — creating **32 new reference articles** for terms the docs discuss but that never got their own page. Every new page includes a hand-authored, theme-aware inline **SVG** where a diagram helps (all of them, here).

### New articles by category
- **Modulation (5):** π/4-DQPSK, GFSK, NRZI, dibit, pulse shaping
- **SDR & DSP (9):** NCO, FIR filter, IIR filter, intermediate frequency, baseband, channelizer, resampler, AFC, DC offset
- **Algorithms (2):** BPTC, DTMF
- **Trunked radio (3):** TSBK, CSBK, rest channel
- **Protocols (4):** Mode S, ProVoice, Capacity Plus, LoRa
- **Hardware (3):** Zadig, SAW filter, coaxial cable
- **Organizations (4):** RadioReference, Ofcom, RTCA, EUROCAE
- **People (2):** John P. Costas, Floyd M. Gardner

### Wiring
- Registered all 32 in `docs/_data/reference.yml`, so they appear in the hub category grid and A–Z index, and the distinctive ones join the site-wide autolink map (`reference-terms.json`). `llms.txt` picks them up automatically.
- Each follows the established reference template (definition-first lead, infobox where useful, `see_also` / `related_lessons` / external `sameAs`, `DefinedTerm`/`Person` JSON-LD).

## Verification
Local Jekyll build is clean. The 32 new SVGs all parse as well-formed XML, sampled JSON-LD blocks are valid, GA is present on every new page, and the internal-link checker reports **zero broken links** (caught and fixed one bad `/reference/fft-and-waterfall/` link → `/reference/fast-fourier-transform/`).

## Notes
- Docs/content only, under `docs/reference/` + the data file. No code touched.
- A few highly granular audit items (individual tuner part numbers, minor vocoder sub-steps, single-letter abbreviations) were intentionally left out as not meriting standalone encyclopedia pages.

https://claude.ai/code/session_01FBZ8YkcJnbYzP5LuVMnpbs

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBZ8YkcJnbYzP5LuVMnpbs)_