### PR TITLE
fix(sdr): serialize StreamIQ re-open behind async teardown (#686)

### DIFF
--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -257,8 +257,13 @@ type Device struct {
 	mu        sync.Mutex
 	closed    bool
 	streaming bool
-	rates     []uint32     // supported sample rates, Hz, descending order
-	cnv       *iqConverter // real-to-IQ converter, fresh per stream
+	// streamDone is closed when the current stream's teardown goroutine
+	// finishes (after `streaming` is cleared). A new StreamIQ waits on it
+	// so a fast retune can't race the previous stream's async cleanup
+	// (#686). Non-nil whenever streaming is true.
+	streamDone chan struct{}
+	rates      []uint32     // supported sample rates, Hz, descending order
+	cnv        *iqConverter // real-to-IQ converter, fresh per stream
 }
 
 // Info implements sdr.Device.
@@ -452,15 +457,31 @@ func (d *Device) SetBiasTee(enable bool) error {
 // delivering one complex64 chunk per URB.
 func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	d.mu.Lock()
-	if d.closed {
+	for {
+		if d.closed {
+			d.mu.Unlock()
+			return nil, usb.ErrClosed
+		}
+		if !d.streaming {
+			break
+		}
+		// A previous stream is still tearing down (its ctx was cancelled
+		// by a retune). Wait it out instead of failing fast with
+		// "stream already active" (#686). The hardware is single-stream
+		// and the prior teardown completes promptly; the wait is bounded
+		// by this call's ctx so shutdown can't hang here.
+		done := d.streamDone
 		d.mu.Unlock()
-		return nil, usb.ErrClosed
-	}
-	if d.streaming {
-		d.mu.Unlock()
-		return nil, errors.New("airspy: stream already active")
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		d.mu.Lock()
 	}
 	d.streaming = true
+	done := make(chan struct{})
+	d.streamDone = done
 	d.mu.Unlock()
 
 	// Fresh real-to-IQ converter per stream so filter memory never carries
@@ -472,6 +493,7 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		d.mu.Lock()
 		d.streaming = false
 		d.mu.Unlock()
+		close(done)
 		return nil, fmt.Errorf("airspy: receiver on: %w", err)
 	}
 
@@ -499,11 +521,13 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		d.mu.Lock()
 		d.streaming = false
 		d.mu.Unlock()
+		close(done)
 		return nil, fmt.Errorf("airspy: start bulk-in: %w", err)
 	}
 
 	go func() {
 		defer close(out)
+		defer close(done)
 		select {
 		case <-ctx.Done():
 		case <-streamDead:

--- a/internal/sdr/airspy/airspy_test.go
+++ b/internal/sdr/airspy/airspy_test.go
@@ -434,3 +434,44 @@ func TestStreamIQFlipsReceiverAndStops(t *testing.T) {
 		t.Fatalf("transport: %v", mt.Err)
 	}
 }
+
+// TestStreamIQReopenAfterCancelWaitsForTeardown is the regression for #686.
+// In scanner mode a fast retune cancels the stream ctx and immediately
+// re-opens. The previous stream's teardown clears `streaming` in a detached
+// goroutine, so StreamIQ must wait that teardown out rather than fail with
+// "airspy: stream already active". Here we cancel and re-open without
+// draining the first channel; the second call must block until cleanup
+// completes and then succeed.
+func TestStreamIQReopenAfterCancelWaitsForTeardown(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqReceiverMode, WValue: receiverModeOn},
+		{BRequest: reqReceiverMode, WValue: receiverModeOff},
+		{BRequest: reqReceiverMode, WValue: receiverModeOn},
+		{BRequest: reqReceiverMode, WValue: receiverModeOff},
+	}
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	if _, err := dev.StreamIQ(ctx1); err != nil {
+		t.Fatalf("first StreamIQ: %v", err)
+	}
+	cancel1()
+
+	// The bounded ctx makes a buggy wait loop fail loudly instead of hanging.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	ch, err := dev.StreamIQ(ctx2)
+	if err != nil {
+		t.Fatalf("reopen after cancel: %v", err)
+	}
+	cancel2()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := <-ch; !ok {
+			break
+		}
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}

--- a/internal/sdr/airspyhf/airspyhf.go
+++ b/internal/sdr/airspyhf/airspyhf.go
@@ -23,7 +23,6 @@ package airspyhf
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -213,7 +212,12 @@ type Device struct {
 	mu        sync.Mutex
 	closed    bool
 	streaming bool
-	rates     []uint32 // supported sample rates, Hz
+	// streamDone is closed when the current stream's teardown goroutine
+	// finishes (after `streaming` is cleared). A new StreamIQ waits on it
+	// so a fast retune can't race the previous stream's async cleanup
+	// (#686). Non-nil whenever streaming is true.
+	streamDone chan struct{}
+	rates      []uint32 // supported sample rates, Hz
 }
 
 // Info implements sdr.Device.
@@ -329,21 +333,38 @@ func (d *Device) SetBiasTee(enable bool) error {
 // delivering one complex64 chunk per URB.
 func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	d.mu.Lock()
-	if d.closed {
+	for {
+		if d.closed {
+			d.mu.Unlock()
+			return nil, usb.ErrClosed
+		}
+		if !d.streaming {
+			break
+		}
+		// A previous stream is still tearing down (its ctx was cancelled
+		// by a retune). Wait it out instead of failing fast with
+		// "stream already active" (#686). The hardware is single-stream
+		// and the prior teardown completes promptly; the wait is bounded
+		// by this call's ctx so shutdown can't hang here.
+		done := d.streamDone
 		d.mu.Unlock()
-		return nil, usb.ErrClosed
-	}
-	if d.streaming {
-		d.mu.Unlock()
-		return nil, errors.New("airspyhf: stream already active")
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		d.mu.Lock()
 	}
 	d.streaming = true
+	done := make(chan struct{})
+	d.streamDone = done
 	d.mu.Unlock()
 
 	if err := d.setReceiver(receiverModeOn); err != nil {
 		d.mu.Lock()
 		d.streaming = false
 		d.mu.Unlock()
+		close(done)
 		return nil, fmt.Errorf("airspyhf: receiver on: %w", err)
 	}
 
@@ -371,11 +392,13 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		d.mu.Lock()
 		d.streaming = false
 		d.mu.Unlock()
+		close(done)
 		return nil, fmt.Errorf("airspyhf: start bulk-in: %w", err)
 	}
 
 	go func() {
 		defer close(out)
+		defer close(done)
 		select {
 		case <-ctx.Done():
 		case <-streamDead:

--- a/internal/sdr/airspyhf/airspyhf_test.go
+++ b/internal/sdr/airspyhf/airspyhf_test.go
@@ -254,6 +254,47 @@ func TestStreamIQFlipsReceiverAndStops(t *testing.T) {
 	}
 }
 
+// TestStreamIQReopenAfterCancelWaitsForTeardown is the regression for #686.
+// A fast retune cancels the stream ctx and immediately re-opens. The
+// previous stream's teardown clears `streaming` in a detached goroutine,
+// so StreamIQ must wait that teardown out rather than fail with
+// "airspyhf: stream already active". We cancel and re-open without draining
+// the first channel; the second call must block until cleanup completes
+// and then succeed.
+func TestStreamIQReopenAfterCancelWaitsForTeardown(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqReceiverMode, WValue: receiverModeOn},
+		{BRequest: reqReceiverMode, WValue: receiverModeOff},
+		{BRequest: reqReceiverMode, WValue: receiverModeOn},
+		{BRequest: reqReceiverMode, WValue: receiverModeOff},
+	}
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	if _, err := dev.StreamIQ(ctx1); err != nil {
+		t.Fatalf("first StreamIQ: %v", err)
+	}
+	cancel1()
+
+	// The bounded ctx makes a buggy wait loop fail loudly instead of hanging.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	ch, err := dev.StreamIQ(ctx2)
+	if err != nil {
+		t.Fatalf("reopen after cancel: %v", err)
+	}
+	cancel2()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := <-ch; !ok {
+			break
+		}
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}
+
 func TestCleanVersionStringStripsPadding(t *testing.T) {
 	got := cleanVersionString([]byte("R3.0.7\x00garbage"))
 	if got != "R3.0.7" {

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -18,7 +18,6 @@ package hackrf
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -285,6 +284,11 @@ type Device struct {
 	mu         sync.Mutex
 	closed     bool
 	streaming  bool
+	// streamDone is closed when the current stream's teardown goroutine
+	// finishes (after `streaming` is cleared). A new StreamIQ waits on it
+	// so a fast retune can't race the previous stream's async cleanup
+	// (#686). Non-nil whenever streaming is true.
+	streamDone chan struct{}
 	sampleRate uint32
 }
 
@@ -426,26 +430,42 @@ func (d *Device) SetBiasTee(enable bool) error {
 // the device to off-mode.
 func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	d.mu.Lock()
-	if d.closed {
+	for {
+		if d.closed {
+			d.mu.Unlock()
+			return nil, usb.ErrClosed
+		}
+		if !d.streaming {
+			break
+		}
+		// A previous stream is still tearing down (its ctx was cancelled
+		// by a retune). Wait it out instead of failing fast with
+		// "stream already active" (#686). The hardware is single-stream
+		// and the prior teardown completes promptly; the wait is bounded
+		// by this call's ctx so shutdown can't hang here.
+		done := d.streamDone
 		d.mu.Unlock()
-		return nil, usb.ErrClosed
-	}
-	if d.streaming {
-		d.mu.Unlock()
-		return nil, errors.New("hackrf: stream already active")
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		d.mu.Lock()
 	}
 	d.streaming = true
+	done := make(chan struct{})
+	d.streamDone = done
 	d.mu.Unlock()
 
 	if err := d.setMode(transceiverModeReceive); err != nil {
 		d.mu.Lock()
 		d.streaming = false
 		d.mu.Unlock()
+		close(done)
 		return nil, fmt.Errorf("hackrf: set receive mode: %w", err)
 	}
 
 	out := make(chan []complex64, 8)
-	stopped := make(chan struct{})
 
 	onPacket := func(buf []byte) {
 		samples := decodeInt8IQ(buf)
@@ -470,12 +490,13 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		d.mu.Lock()
 		d.streaming = false
 		d.mu.Unlock()
+		close(done)
 		return nil, fmt.Errorf("hackrf: start bulk-in: %w", err)
 	}
 
 	go func() {
 		defer close(out)
-		defer close(stopped)
+		defer close(done)
 		select {
 		case <-ctx.Done():
 		case <-streamDead:

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -281,9 +281,9 @@ type Device struct {
 	t    usb.Transport
 	info sdr.Info
 
-	mu         sync.Mutex
-	closed     bool
-	streaming  bool
+	mu        sync.Mutex
+	closed    bool
+	streaming bool
 	// streamDone is closed when the current stream's teardown goroutine
 	// finishes (after `streaming` is cleared). A new StreamIQ waits on it
 	// so a fast retune can't race the previous stream's async cleanup

--- a/internal/sdr/hackrf/hackrf_test.go
+++ b/internal/sdr/hackrf/hackrf_test.go
@@ -377,3 +377,44 @@ func TestStreamIQFlipsModeAndStopsOnCancel(t *testing.T) {
 		t.Fatalf("transport error: %v", mt.Err)
 	}
 }
+
+// TestStreamIQReopenAfterCancelWaitsForTeardown is the regression for #686.
+// A fast retune cancels the stream ctx and immediately re-opens. The
+// previous stream's teardown clears `streaming` in a detached goroutine,
+// so StreamIQ must wait that teardown out rather than fail with
+// "hackrf: stream already active". We cancel and re-open without draining
+// the first channel; the second call must block until cleanup completes
+// and then succeed.
+func TestStreamIQReopenAfterCancelWaitsForTeardown(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqSetTransceiverMode, WValue: transceiverModeReceive},
+		{BRequest: reqSetTransceiverMode, WValue: transceiverModeOff},
+		{BRequest: reqSetTransceiverMode, WValue: transceiverModeReceive},
+		{BRequest: reqSetTransceiverMode, WValue: transceiverModeOff},
+	}
+
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	if _, err := dev.StreamIQ(ctx1); err != nil {
+		t.Fatalf("first StreamIQ: %v", err)
+	}
+	cancel1()
+
+	// The bounded ctx makes a buggy wait loop fail loudly instead of hanging.
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel2()
+	ch, err := dev.StreamIQ(ctx2)
+	if err != nil {
+		t.Fatalf("reopen after cancel: %v", err)
+	}
+	cancel2()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := <-ch; !ok {
+			break
+		}
+	}
+	if mt.Err != nil {
+		t.Fatalf("transport error: %v", mt.Err)
+	}
+}


### PR DESCRIPTION
In scanner mode a fast retune cancels the IQ stream's context and
immediately re-opens it. The USB drivers tear a stream down in a
detached goroutine that only clears `streaming` after StopBulkIn and
the receiver-off control transfer complete, so the next StreamIQ call
often observed `streaming == true` and failed with
"stream already active", logged repeatedly as "conv: StreamIQ failed".

Replace the fail-fast guard with a ctx-bounded wait: StreamIQ now waits
on a per-stream `streamDone` channel for any in-flight teardown to
finish before starting the next stream. The hardware is single-stream
and consumers cancel the old context before re-opening, so the prior
teardown always completes promptly; the wait honors the caller's
context so shutdown can't hang.

Applied identically to airspy, hackrf, and airspyhf (same teardown
pattern). Adds a regression test per driver that cancels and re-opens
without draining the first channel.