### PR TITLE
ci(pages): drip-release blog series one post per weekday

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,6 +15,16 @@ on:
       - "docs/**"
       - "README.md"
       - ".github/workflows/pages.yml"
+  schedule:
+    # Weekday rebuild so future-dated posts publish one per weekday. A series
+    # can be committed all at once with `future: false` (docs/_config.yml) and
+    # consecutive weekday dates; each run reveals the posts that have come due.
+    # 13:00 UTC = 08:00 America/Chicago (CDT) — safely past local midnight, so a
+    # post dated "today" is already in the past at build time. GitHub cron is
+    # UTC and best-effort (may be delayed under load, which is fine for a daily
+    # drip). Note: GitHub disables scheduled workflows after 60 days with no
+    # repo commits — not a concern for an active repo.
+    - cron: "0 13 * * 1-5"
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,34 @@ request-by-request diffing.
    is fine on feature branches; the maintainer squashes on merge
    to keep `main` history clean).
 
+## Publishing a blog series
+
+Blog posts live in `docs/_posts/` and are dated by filename
+(`YYYY-MM-DD-slug.md`). To release a multi-part series gradually
+instead of all at once, commit the whole series in one PR but date
+the posts on **consecutive future weekdays**. Jekyll's `future:
+false` (set in [`docs/_config.yml`](docs/_config.yml)) keeps a
+future-dated post out of the built site — absent from the page list,
+`feed.xml`, and `sitemap.xml` — until a build runs on or after its
+date. A weekday `schedule:` cron in
+[`.github/workflows/pages.yml`](.github/workflows/pages.yml) rebuilds
+the site every weekday morning, so each post goes live on its date,
+one per weekday. Nothing else to do — no draft branches, no daily
+commits.
+
+Assign the weekday dates with the helper rather than counting by
+hand (it skips Sat/Sun for you):
+
+```sh
+# preview, then re-run with --apply once it looks right
+scripts/schedule-series.py 2026-07-06 docs/_posts/*my-series*.md
+```
+
+Pass the files in reading order (the default shell glob sorts
+lexically, which matches zero-padded part numbers like `-01-`,
+`-02-`). Reorder or re-time a series any time by editing the
+filename dates and pushing.
+
 ## Cutting a release
 
 Releases are produced by [`.github/workflows/release.yml`](.github/workflows/release.yml),

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,16 @@ description: Pure-Go digital-trunking RTL-SDR scanner engine. P25, DMR, TETRA, N
 url: https://gophertrunk.org
 lang: en
 markdown: kramdown
+
+# Blog scheduling. A post whose date is in the future is excluded from the
+# build until a build runs on or after that date. Paired with the weekday
+# `schedule:` cron in .github/workflows/pages.yml, this drips a series that is
+# committed all at once out one post per weekday. `future: false` is Jekyll's
+# default — stated explicitly so the mechanism is self-documenting and immune to
+# any builder default change. `timezone` makes a date-only post (midnight) flip
+# at local midnight instead of UTC, so "dated 2026-07-01 → live July 1" holds.
+future: false
+timezone: America/Chicago
 logo: /assets/gophertrunk-logo.png
 
 # jekyll-seo-tag picks these up automatically. `image` becomes the

--- a/scripts/schedule-series.py
+++ b/scripts/schedule-series.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Re-date a blog post series onto consecutive weekdays.
+
+GopherTrunk's docs site (docs/) dates posts by filename
+(`YYYY-MM-DD-slug.md`) and hides future-dated posts until a build runs on or
+after their date (`future: false` in docs/_config.yml). A weekday cron in
+.github/workflows/pages.yml then rebuilds the site each weekday, so a series
+committed all at once drips out one post per weekday.
+
+This helper assigns those weekday dates for you. Give it a start date and the
+posts in reading order; it rewrites each filename's `YYYY-MM-DD-` prefix to the
+next weekday (skipping Sat/Sun). It prints a dry-run table by default; pass
+--apply to perform the renames with `git mv`.
+
+Examples:
+    # Preview: schedule a series starting Mon 2026-07-06, in part order
+    scripts/schedule-series.py 2026-07-06 docs/_posts/*sdr-internals*.md
+
+    # Apply the renames (uses `git mv` so history follows)
+    scripts/schedule-series.py --apply 2026-07-06 docs/_posts/*sdr-internals*.md
+
+Files are processed in the order given on the command line, so glob/sort them
+into reading order first (the default shell glob sorts lexically, which matches
+zero-padded part numbers like -01-, -02-, ...).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import re
+import subprocess
+import sys
+
+DATE_PREFIX = re.compile(r"^(\d{4})-(\d{2})-(\d{2})-(.+)$")
+
+
+def next_weekday(day: dt.date) -> dt.date:
+    """Return `day` if it's a weekday, else the following Monday."""
+    while day.weekday() >= 5:  # 5 = Sat, 6 = Sun
+        day += dt.timedelta(days=1)
+    return day
+
+
+def weekday_dates(start: dt.date, count: int) -> list[dt.date]:
+    """`count` consecutive weekdays starting at/after `start`."""
+    dates: list[dt.date] = []
+    day = next_weekday(start)
+    for _ in range(count):
+        dates.append(day)
+        day = next_weekday(day + dt.timedelta(days=1))
+    return dates
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Re-date a post series onto consecutive weekdays.",
+    )
+    parser.add_argument("start", help="first publish date, YYYY-MM-DD")
+    parser.add_argument("files", nargs="+", help="post files in reading order")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="perform the renames (default is a dry run)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        start = dt.date.fromisoformat(args.start)
+    except ValueError:
+        parser.error(f"start date {args.start!r} is not valid YYYY-MM-DD")
+
+    dates = weekday_dates(start, len(args.files))
+
+    renames: list[tuple[str, str]] = []
+    for path, date in zip(args.files, dates):
+        directory, name = os.path.split(path)
+        m = DATE_PREFIX.match(name)
+        slug = m.group(4) if m else name  # tolerate files without a date prefix
+        new_name = f"{date.isoformat()}-{slug}"
+        renames.append((path, os.path.join(directory, new_name)))
+
+    width = max((len(os.path.basename(src)) for src, _ in renames), default=0)
+    print(f"{'date':<10}  {'weekday':<9}  {'file':<{width}}  ->  new name")
+    for (src, dst), date in zip(renames, dates):
+        print(
+            f"{date.isoformat():<10}  {date.strftime('%A'):<9}  "
+            f"{os.path.basename(src):<{width}}  ->  {os.path.basename(dst)}"
+        )
+
+    if not args.apply:
+        print("\n(dry run — re-run with --apply to perform the renames)")
+        return 0
+
+    for src, dst in renames:
+        if src == dst:
+            continue
+        if os.path.exists(dst):
+            print(f"error: target already exists: {dst}", file=sys.stderr)
+            return 1
+        try:
+            subprocess.run(["git", "mv", src, dst], check=True)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            # Fall back to a plain rename if git isn't available / file untracked.
+            os.rename(src, dst)
+    print("\nDone. Review with `git status` and commit when ready.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Why

The 14-part "SDR Internals" series went live all at once because every post is
dated on/before today and Jekyll's `future` flag defaults to `false`. The Pages
site rebuilds **only on push to `main`** (`.github/workflows/pages.yml` has no
scheduled trigger), so future-dating a post would hide it forever — nothing
would ever rebuild to reveal it on its day.

This adds a small system so a **future** series can be committed all at once but
release **one post per weekday**, with no queue, drafts branch, or
repo-writing bot. The already-published posts are intentionally left untouched.

## What

- **`docs/_config.yml`** — set `future: false` (explicit) + `timezone:
  America/Chicago`. A future-dated post is excluded from the build (page list,
  `feed.xml`, `sitemap.xml`) until a build runs on/after its date.
- **`.github/workflows/pages.yml`** — add a weekday `schedule:` cron
  (`0 13 * * 1-5`, 08:00 Central) so the site rebuilds every weekday morning and
  reveals each now-due post. `push` and `workflow_dispatch` triggers unchanged.
- **`scripts/schedule-series.py`** — helper that re-dates a series onto
  consecutive weekdays (skips Sat/Sun); dry-run by default, `--apply` uses
  `git mv`.
- **`CONTRIBUTING.md`** — new "Publishing a blog series" section documenting the
  flow.

## Authoring flow (next series)

```sh
scripts/schedule-series.py 2026-07-06 docs/_posts/*my-series*.md          # preview
scripts/schedule-series.py --apply 2026-07-06 docs/_posts/*my-series*.md  # apply
```

Commit + merge; posts then go live one per weekday automatically.

## Notes / verification

- The cron only takes effect once `pages.yml` is on `main` (scheduled workflows
  run from the default branch).
- Verified directly: YAML parses, triggers intact (`push`, `schedule`,
  `workflow_dispatch`), cron expression, `future: false` + `timezone`, and the
  helper's weekend-skipping (Fri start → Mon). A local Jekyll build wasn't
  possible (no Gemfile; the site builds only in CI via
  `actions/jekyll-build-pages`), so the future-date gate is verified by config
  and documented Jekyll semantics — the first scheduled run on `main` is the
  live proof.
- Timezone/publish-time default to `America/Chicago` / 08:00 Central; both are
  one-line changes if a different zone or time is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9eHTLJFyNDrppSVKvTeyY)_