### PR TITLE
ci(pages): rebuild docs daily and drip series on consecutive days

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,15 +16,16 @@ on:
       - "README.md"
       - ".github/workflows/pages.yml"
   schedule:
-    # Weekday rebuild so future-dated posts publish one per weekday. A series
-    # can be committed all at once with `future: false` (docs/_config.yml) and
-    # consecutive weekday dates; each run reveals the posts that have come due.
-    # 13:00 UTC = 08:00 America/Chicago (CDT) — safely past local midnight, so a
-    # post dated "today" is already in the past at build time. GitHub cron is
-    # UTC and best-effort (may be delayed under load, which is fine for a daily
-    # drip). Note: GitHub disables scheduled workflows after 60 days with no
-    # repo commits — not a concern for an active repo.
-    - cron: "0 13 * * 1-5"
+    # Daily rebuild so future-dated posts publish on their date. A series can be
+    # committed all at once with `future: false` (docs/_config.yml) and
+    # consecutive dates; each run reveals the posts that have come due. Runs
+    # every day including weekends. 16:00 UTC = 11:00 America/Chicago (CDT) —
+    # well past local midnight, so a post dated "today" is already in the past at
+    # build time. GitHub cron is UTC (does not follow DST) and best-effort (may
+    # be delayed under load, which is fine for a daily drip). Note: GitHub
+    # disables scheduled workflows after 60 days with no repo commits — not a
+    # concern for an active repo.
+    - cron: "0 16 * * *"
   workflow_dispatch:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,18 +187,16 @@ request-by-request diffing.
 Blog posts live in `docs/_posts/` and are dated by filename
 (`YYYY-MM-DD-slug.md`). To release a multi-part series gradually
 instead of all at once, commit the whole series in one PR but date
-the posts on **consecutive future weekdays**. Jekyll's `future:
+the posts on **consecutive future days**. Jekyll's `future:
 false` (set in [`docs/_config.yml`](docs/_config.yml)) keeps a
 future-dated post out of the built site — absent from the page list,
 `feed.xml`, and `sitemap.xml` — until a build runs on or after its
-date. A weekday `schedule:` cron in
+date. A daily `schedule:` cron in
 [`.github/workflows/pages.yml`](.github/workflows/pages.yml) rebuilds
-the site every weekday morning, so each post goes live on its date,
-one per weekday. Nothing else to do — no draft branches, no daily
-commits.
+the site every day, so each post goes live on its date, one per day.
+Nothing else to do — no draft branches, no daily commits.
 
-Assign the weekday dates with the helper rather than counting by
-hand (it skips Sat/Sun for you):
+Assign the dates with the helper rather than counting by hand:
 
 ```sh
 # preview, then re-run with --apply once it looks right

--- a/scripts/schedule-series.py
+++ b/scripts/schedule-series.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
-"""Re-date a blog post series onto consecutive weekdays.
+"""Re-date a blog post series onto consecutive days.
 
 GopherTrunk's docs site (docs/) dates posts by filename
 (`YYYY-MM-DD-slug.md`) and hides future-dated posts until a build runs on or
-after their date (`future: false` in docs/_config.yml). A weekday cron in
-.github/workflows/pages.yml then rebuilds the site each weekday, so a series
-committed all at once drips out one post per weekday.
+after their date (`future: false` in docs/_config.yml). A daily cron in
+.github/workflows/pages.yml then rebuilds the site every day, so a series
+committed all at once drips out one post per day, including weekends.
 
-This helper assigns those weekday dates for you. Give it a start date and the
-posts in reading order; it rewrites each filename's `YYYY-MM-DD-` prefix to the
-next weekday (skipping Sat/Sun). It prints a dry-run table by default; pass
---apply to perform the renames with `git mv`.
+This helper assigns those dates for you. Give it a start date and the posts in
+reading order; it rewrites each filename's `YYYY-MM-DD-` prefix to consecutive
+calendar days. It prints a dry-run table by default; pass --apply to perform the
+renames with `git mv`.
 
 Examples:
-    # Preview: schedule a series starting Mon 2026-07-06, in part order
+    # Preview: schedule a series starting 2026-07-06, in part order
     scripts/schedule-series.py 2026-07-06 docs/_posts/*sdr-internals*.md
 
     # Apply the renames (uses `git mv` so history follows)
@@ -36,26 +36,14 @@ import sys
 DATE_PREFIX = re.compile(r"^(\d{4})-(\d{2})-(\d{2})-(.+)$")
 
 
-def next_weekday(day: dt.date) -> dt.date:
-    """Return `day` if it's a weekday, else the following Monday."""
-    while day.weekday() >= 5:  # 5 = Sat, 6 = Sun
-        day += dt.timedelta(days=1)
-    return day
-
-
-def weekday_dates(start: dt.date, count: int) -> list[dt.date]:
-    """`count` consecutive weekdays starting at/after `start`."""
-    dates: list[dt.date] = []
-    day = next_weekday(start)
-    for _ in range(count):
-        dates.append(day)
-        day = next_weekday(day + dt.timedelta(days=1))
-    return dates
+def consecutive_dates(start: dt.date, count: int) -> list[dt.date]:
+    """`count` consecutive calendar days starting at `start`."""
+    return [start + dt.timedelta(days=i) for i in range(count)]
 
 
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
-        description="Re-date a post series onto consecutive weekdays.",
+        description="Re-date a post series onto consecutive calendar days.",
     )
     parser.add_argument("start", help="first publish date, YYYY-MM-DD")
     parser.add_argument("files", nargs="+", help="post files in reading order")
@@ -71,7 +59,7 @@ def main(argv: list[str]) -> int:
     except ValueError:
         parser.error(f"start date {args.start!r} is not valid YYYY-MM-DD")
 
-    dates = weekday_dates(start, len(args.files))
+    dates = consecutive_dates(start, len(args.files))
 
     renames: list[tuple[str, str]] = []
     for path, date in zip(args.files, dates):


### PR DESCRIPTION
## Why

Follow-up to #706, which set up the drip-release system on a **weekday-only**
cadence (`0 13 * * 1-5`, 08:00 Central) with a helper that skipped weekends.
Two adjustments on top of that merged work:

1. Publish **every day**, not just weekdays.
2. Move the rebuild to **11:00 Central**.

This keeps the whole system internally consistent — daily cron ↔ helper dates
posts on consecutive calendar days ↔ docs describe a one-post-per-day drip.

## What

- **`.github/workflows/pages.yml`** — change the `schedule:` cron from
  `0 13 * * 1-5` to `0 16 * * *` (every day at 11:00 Central / 16:00 UTC).
- **`scripts/schedule-series.py`** — replace the weekday-skipping logic
  (`next_weekday`/`weekday_dates`) with `consecutive_dates`, so a series is
  dated on consecutive calendar days **including weekends**. Docstring and
  examples updated to match.
- **`CONTRIBUTING.md`** — "Publishing a blog series" now describes a daily
  rebuild / consecutive-days cadence instead of weekdays.

## Verification

- `pages.yml` YAML parses; triggers intact (`push`, `schedule`,
  `workflow_dispatch`); cron is `0 16 * * *`.
- `scripts/schedule-series.py` compiles; dry-run with a **Friday** start now
  produces Fri → **Sat → Sun** → Mon (no skipping), confirming weekends are
  included.
- Scheduled workflows run from the default branch, so the new cadence takes
  effect once this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9eHTLJFyNDrppSVKvTeyY)_