### PR TITLE
docs: post-release v0.4.5 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,80 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.4.5] — 2026-06-17
+
+This release pairs two operator-facing fixes with a large docs-site
+expansion. The Hunt panel's control-channel parser, previously locked to
+P25, now covers **every trunked protocol with a standalone control
+channel** — P25, DMR Tier III, NXDN, dPMR, EDACS, Motorola, MPT 1327,
+TETRA, and YSF — via a protocol selector, and its listen window becomes a
+free-form seconds field instead of a fixed dropdown (#707). On the decode
+side, a fast scanner retune could race the USB stream teardown and fail the
+next capture with `stream already active` / `conv: StreamIQ failed`; the
+re-open now waits on the in-flight teardown across all drivers (#686). And
+call history finally keeps the **mid-call backfilled radio ID and
+encryption** on P25 Phase 2 grants, which start with a placeholder RID and
+only surface identity on the traffic channel (#696). Alongside the code,
+the docs site gains the **GopherTrunk Reference** encyclopedia (≈180
+cross-linked entries with hand-authored SVG diagrams) and a 14-part **SDR
+Internals** deep-dive blog series.
+
+### Added
+
+- **GopherTrunk Reference encyclopedia (#700, #701).** A new data-driven
+  `/reference/` encyclopedia (≈180 entries) spanning RF fundamentals,
+  modulation, voice coding, SDR & DSP, algorithms, antennas & propagation,
+  hardware, trunked radio, protocols, people, and organizations. Entries
+  follow a uniform profile, most carry a hand-authored theme-aware inline
+  SVG structure/concept diagram, and the set is wired into the glossary and
+  `llms.txt` so it is discoverable to both readers and AI search.
+- **"SDR Internals" blog series (#705).** A 14-part deep-dive series — from
+  "what is software-defined radio" through the driver registry, the
+  streaming pool & concurrency, DSP foundations, tuning/channelization,
+  demodulation, symbol timing, equalization/FFT, framing/FEC, and the
+  protocol-decoder state machines — with a series landing page and nav
+  entry.
+- **Download / support / community CTAs across the docs site (#697,
+  #702).** Non-home pages and the reference layouts now carry consistent
+  call-to-action links, with tightened per-page meta descriptions.
+
+### Changed
+
+- **Hunt control-channel parser now covers all trunked protocols (#707).**
+  The "Parse a control channel" Hunt panel was hardcoded to `p25` over an
+  already protocol-agnostic API; it now exposes a protocol selector for
+  every trunked protocol with a dedicated standalone control channel (P25,
+  DMR Tier III, NXDN, dPMR, EDACS, Motorola, MPT 1327, TETRA, YSF) and
+  forwards the choice to the hunt start. The fixed 5/10/15/20 s "Listen
+  for" dropdown becomes a free-form numeric seconds input (min 1, default
+  15) with a hint about the ~19 MB/s IQ cost. No backend change.
+
+### Fixed
+
+- **Scanner retune no longer races the IQ stream teardown (#686).** In
+  scanner mode a fast retune cancels the IQ stream's context and
+  immediately re-opens it, but the USB drivers tear a stream down in a
+  detached goroutine that clears `streaming` only after `StopBulkIn` and
+  the receiver-off control transfer complete — so the next `StreamIQ` often
+  saw `streaming == true` and failed with "stream already active" (logged
+  repeatedly as "conv: StreamIQ failed"). The fail-fast guard is replaced
+  with a context-bounded wait on a per-stream `streamDone` channel, applied
+  identically to rtlsdr, airspy, hackrf, and airspyhf, with a per-driver
+  regression test that cancels and re-opens without draining the first
+  stream.
+- **Call history keeps the mid-call RID + encryption on call end (#696).**
+  `recordEnd` previously wrote only `ended_at` / `duration` / `reason`,
+  discarding the call's final identity. On P25 Phase 2 compressed grants the
+  source RID starts at 0 and is backfilled mid-call on the traffic channel,
+  and `ALGID`/`KID` likewise surface mid-call (Phase 1 LDU2, Phase 2
+  EncryptionSync) — so `call_log` rows kept the grant-time placeholders
+  (`source_id=0`, `algorithm_id=0`) and RIDs never appeared in history on
+  exactly those Phase 2 systems. The end UPDATE now also persists
+  `source_id` / `encrypted` / `algorithm_id` / `key_id` from the end grant
+  with never-downgrade semantics (`COALESCE(NULLIF(?, 0), col)`, and an
+  encryption flag that only upgrades). (`recordings.skip_encrypted` is
+  unrelated — it only gates WAV/raw file writing.)
+
 ## [v0.4.4] — 2026-06-16
 
 This release is the **RF & SDR learning hub** — a structured, vendor-neutral

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.4.4
+VERSION=v0.4.5
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.4.4" -%}
+  {%- assign ver = "v0.4.5" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.4.5.md
+++ b/docs/announcements/v0.4.5.md
@@ -1,0 +1,51 @@
+# GopherTrunk v0.4.5 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.4.5 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.5
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.4.5 — the Hunt control-channel parser now covers every trunked protocol (P25/DMR/NXDN/EDACS/Motorola/MPT1327/TETRA/YSF), Phase 2 call history keeps the backfilled RID + encryption, a scanner-retune stream race is fixed, plus a ~180-entry RF/SDR Reference encyclopedia and a 14-part "SDR Internals" series
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.4.5 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.4.4:**
+
+* **Control-channel parser for every trunked protocol** (#707) — the Hunt tab's "Parse a control channel" panel was locked to P25; it now has a protocol selector covering every trunked protocol with a dedicated standalone control channel (P25, DMR Tier III, NXDN, dPMR, EDACS, Motorola, MPT 1327, TETRA, YSF), and the fixed 5/10/15/20 s dropdown becomes a free-form seconds field.
+* **Phase 2 call history keeps the backfilled RID + encryption** (#696) — on P25 Phase 2 compressed grants the source radio ID starts at 0 and is backfilled mid-call on the traffic channel (ALGID/KID surface mid-call too), but call history kept the grant-time placeholders, so RIDs never showed up on exactly those systems. Call end now persists the final source_id / encrypted / algorithm_id / key_id with never-downgrade semantics.
+* **Scanner-retune stream race fixed** (#686) — a fast retune cancels the IQ stream and immediately re-opens it, but the USB teardown runs in a detached goroutine, so the next StreamIQ often failed with "stream already active" (logged as "conv: StreamIQ failed"). Re-open now waits on the in-flight teardown across rtlsdr, airspy, hackrf, and airspyhf.
+* **GopherTrunk Reference encyclopedia** (#700, #701) — a new ~180-entry [/reference/](https://gophertrunk.org/reference/) covering RF fundamentals, modulation, voice coding, SDR & DSP, algorithms, antennas & propagation, hardware, trunked radio, protocols, people, and organizations, most with hand-authored theme-aware SVG diagrams and wired into the glossary + llms.txt.
+* **"SDR Internals" deep-dive series** (#705) — a 14-part blog series from "what is SDR" through the driver registry, streaming pool, DSP foundations, tuning, demodulation, symbol timing, FEC, and protocol-decoder state machines.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.5
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.4.5 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.4.4:**
+- **Control-channel parser for every trunked protocol** (#707) — the Hunt "Parse a control channel" panel adds a protocol selector (P25, DMR Tier III, NXDN, dPMR, EDACS, Motorola, MPT 1327, TETRA, YSF) and a free-form listen-seconds field instead of the fixed dropdown.
+- **Phase 2 call history keeps the backfilled RID + encryption** (#696) — Phase 2 grants start with src=0 and backfill identity mid-call; call end now persists the real source_id / encrypted / algorithm_id / key_id (never-downgrade) so RIDs finally appear in history.
+- **Scanner-retune stream race fixed** (#686) — fast retunes no longer hit "stream already active"; re-open waits on the in-flight async teardown across rtlsdr / airspy / hackrf / airspyhf.
+- **RF/SDR Reference encyclopedia** (#700, #701) — ~180 cross-linked [/reference/](https://gophertrunk.org/reference/) entries with hand-authored SVG diagrams, wired into the glossary and llms.txt.
+- **"SDR Internals" series** (#705) — a 14-part deep dive from "what is SDR" to protocol-decoder state machines.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.5>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow tagged v0.4.5, so sync the docs to match:

- CHANGELOG: promote [Unreleased] to [v0.4.5] (2026-06-17) and backfill the
  user-visible changes that shipped without a changelog entry — the Hunt
  control-channel parser generalized from P25-only to every trunked protocol
  with a standalone control channel plus a free-form listen window (#707); the
  scanner-retune StreamIQ re-open race fixed across rtlsdr/airspy/hackrf/airspyhf
  (#686); Phase 2 call history now persisting the mid-call backfilled RID +
  encryption on call end (#696); and the docs-site additions — the ~180-entry
  GopherTrunk Reference encyclopedia (#700, #701), the 14-part "SDR Internals"
  blog series (#705), and site-wide download/support/community CTAs (#697, #702).
- README: bump the Linux quick-install VERSION to v0.4.5.
- latest-version.html: bump the GitHub Pages fallback tag to v0.4.5.
- announcements: add the v0.4.5 social blurb drafts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ALs8yWJwYM8uCkeaLAQREw