### PR TITLE
feat: expose P25 site identity in grant events and via /api/v1/sites (#698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **P25 site identity in grant events and a `/api/v1/sites` endpoint**
+  (#698). Every `grant` event now carries `rfss_id` / `site_id`,
+  decoded from the camped site's RFSS Status Broadcast, so downstream
+  tooling (Prometheus exporters, dashboards) can label calls by site
+  instead of an opaque `channel_id`. A new `GET /api/v1/sites`
+  endpoint lists the sites GT has discovered from the control channel
+  — each with the control-channel frequency it was heard on — merged
+  with optional human-readable names configured per system under
+  `trunking.systems[].sites` (`rfss` / `site` / `name`).
+
 ## [v0.4.4] — 2026-06-16
 
 This release is the **RF & SDR learning hub** — a structured, vendor-neutral

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -341,6 +341,7 @@ type Daemon struct {
 	engine       *trunking.Engine
 	voicePool    *trunking.VoicePool
 	affiliations *trunking.AffiliationTracker
+	siteTracker  *trunking.SiteTracker
 	recorder     *voice.Recorder
 	broadcast    *broadcast.Manager
 	composer     *composer.Composer
@@ -694,10 +695,15 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			log.Warn("daemon: dmr Tier III system has no dmr_band_plan; voice grants will be dropped (no-bandplan)",
 				"system", sys.Name)
 		}
+		var sites []trunking.ConfiguredSite
+		for _, sc := range sys.Sites {
+			sites = append(sites, trunking.ConfiguredSite{RFSS: sc.RFSS, Site: sc.Site, Name: sc.Name})
+		}
 		s := trunking.System{
 			Name:                    sys.Name,
 			Protocol:                proto,
 			ControlChannels:         sys.ControlChannels,
+			Sites:                   sites,
 			P25BandPlan:             p25BandPlan,
 			DMRBandPlan:             dmrBandPlan,
 			DMRInterleavedVoice:     resolveDMRInterleavedVoice(proto, sys.DMRInterleavedVoice),
@@ -1061,6 +1067,17 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			return nil, fmt.Errorf("daemon: affiliation tracker: %w", err)
 		}
 		d.affiliations = at
+	}
+
+	// Site tracker — always on. Subscribes to the bus and accumulates
+	// the P25 sites discovered from the control channel, surfaced at
+	// GET /api/v1/sites.
+	{
+		st, err := trunking.NewSiteTracker(trunking.SiteTrackerOptions{Bus: d.bus})
+		if err != nil {
+			return nil, fmt.Errorf("daemon: site tracker: %w", err)
+		}
+		d.siteTracker = st
 	}
 
 	// Tone-out detector — optional. Built before the composer so it can
@@ -2009,6 +2026,9 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		if d.affiliations != nil {
 			opts.Affiliations = affiliationProvider{d.affiliations}
 		}
+		if d.siteTracker != nil {
+			opts.Sites = sitesProvider{d.siteTracker}
+		}
 		if d.metrics != nil {
 			opts.MetricsHandler = d.metrics.Handler()
 		}
@@ -2265,6 +2285,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	if d.affiliations != nil {
 		d.spawn(runCtx, "affiliations", false, func(ctx context.Context) error {
 			return d.affiliations.Run(ctx)
+		})
+	}
+	if d.siteTracker != nil {
+		d.spawn(runCtx, "sites", false, func(ctx context.Context) error {
+			return d.siteTracker.Run(ctx)
 		})
 	}
 	if d.retention != nil {
@@ -2932,6 +2957,9 @@ func (d *Daemon) Close() {
 		if d.affiliations != nil {
 			_ = d.affiliations.Close()
 		}
+		if d.siteTracker != nil {
+			_ = d.siteTracker.Close()
+		}
 		if d.metrics != nil {
 			_ = d.metrics.Close()
 		}
@@ -3551,6 +3579,12 @@ func (b broadcastStatus) BroadcastStats() any { return b.mgr.Stats() }
 type affiliationProvider struct{ t *trunking.AffiliationTracker }
 
 func (a affiliationProvider) Affiliations() []trunking.UnitActivity { return a.t.Snapshot() }
+
+// sitesProvider adapts the SiteTracker into the api.SitesProvider
+// interface.
+type sitesProvider struct{ t *trunking.SiteTracker }
+
+func (s sitesProvider) Sites() []trunking.SiteInfo { return s.t.Snapshot() }
 
 // wrapBasebandRecorders replaces the Device of every pool entry whose
 // serial appears in baseband.record with a RecordingDevice, teeing its

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -629,6 +629,20 @@ trunking:
       # to let the affiliation tracker surface RIDs live without any
       # operator-configured aliases.
       # rid_alias_file: "../config/rids-p25.csv"
+      # Optional human-readable names for the P25 sites of this system,
+      # keyed by their RFSS and Site IDs (issue #698). GT discovers a
+      # site's RFSS/Site from the control channel; these names are pure
+      # presentation metadata merged into GET /api/v1/sites so a site
+      # reads as a place rather than a pair of integers. Grants on the
+      # SSE stream also carry rfss_id/site_id so consumers can label
+      # metrics by site. Omit to surface discovered sites without names.
+      # sites:
+      #   - rfss: 1
+      #     site: 1
+      #     name: "Mt Anakie"
+      #   - rfss: 2
+      #     site: 9
+      #     name: "Murradoc Hill"
 
     # DMR Tier III trunked system. A T3 voice-grant CSBK references its
     # traffic channel by a 12-bit Logical Channel Number (LCN), never an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,13 @@ constructed only when its config section is present:
   table of unit→talkgroup activity built from `KindGrant`,
   `KindAffiliation` and `KindUnitRegistration` events, served at
   `GET /api/v1/affiliations`.
+- **`trunking.SiteTracker`** — an in-memory table of the P25 sites
+  discovered from the control channel, built from `KindSiteUpdate`
+  events (published on each RFSS Status Broadcast) and served at
+  `GET /api/v1/sites`. Operator-supplied site names from
+  `trunking.systems[].sites` in the config are merged onto the
+  discovered rows, and every `grant` event also carries `rfss_id` /
+  `site_id` so downstream tooling can label calls by site (issue #698).
 - **`log.MessageLog`** — a rotating, human-readable text log of
   every trunking event, enabled via `log.message_log`.
 

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+)
+
+// handleListSites serves GET /api/v1/sites: the union of P25 sites GT
+// has discovered from the control channel and the sites named in the
+// system config, keyed by (system, RFSS, site). Discovered rows carry
+// control_channel_hz (and WACN / SystemID); configured names are merged
+// onto matching rows, and configured sites GT has not yet heard are
+// listed with control_channel_hz omitted so a site's name always shows
+// (issue #698).
+func (s *Server) handleListSites(w http.ResponseWriter, _ *http.Request) {
+	type key struct {
+		system string
+		rfss   uint8
+		site   uint8
+	}
+	byKey := make(map[key]*SiteDTO)
+
+	// Discovered sites first — these carry the live control-channel
+	// frequency and network identity.
+	if s.sites != nil {
+		for _, si := range s.sites.Sites() {
+			k := key{si.System, si.RFSSID, si.SiteID}
+			byKey[k] = &SiteDTO{
+				System:           si.System,
+				RFSSID:           si.RFSSID,
+				SiteID:           si.SiteID,
+				ControlChannelHz: si.ControlChannelHz,
+				WACN:             si.WACN,
+				SystemID:         si.SystemID,
+			}
+		}
+	}
+
+	// Merge operator-supplied names; append configured-but-unseen sites.
+	for _, sys := range s.systems {
+		for _, cs := range sys.Sites {
+			k := key{sys.Name, cs.RFSS, cs.Site}
+			if dto, ok := byKey[k]; ok {
+				dto.Name = cs.Name
+				continue
+			}
+			byKey[k] = &SiteDTO{
+				System: sys.Name,
+				RFSSID: cs.RFSS,
+				SiteID: cs.Site,
+				Name:   cs.Name,
+			}
+		}
+	}
+
+	out := make([]SiteDTO, 0, len(byKey))
+	for _, dto := range byKey {
+		out = append(out, *dto)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].System != out[j].System {
+			return out[i].System < out[j].System
+		}
+		if out[i].RFSSID != out[j].RFSSID {
+			return out[i].RFSSID < out[j].RFSSID
+		}
+		return out[i].SiteID < out[j].SiteID
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"sites": out})
+}

--- a/internal/api/handlers_sites_test.go
+++ b/internal/api/handlers_sites_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeSites is a stand-in SitesProvider for the handler test.
+type fakeSites struct{ sites []trunking.SiteInfo }
+
+func (f fakeSites) Sites() []trunking.SiteInfo { return f.sites }
+
+func TestListSitesUnionAndNameMerge(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	// One discovered site (rfss 1 / site 1) that is also named in config,
+	// and one configured-but-unseen site (rfss 2 / site 9).
+	discovered := fakeSites{sites: []trunking.SiteInfo{
+		{System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 420012500, WACN: 0xBEE00, SystemID: 0x123},
+	}}
+	systems := []trunking.System{{
+		Name: "MMR",
+		Sites: []trunking.ConfiguredSite{
+			{RFSS: 1, Site: 1, Name: "Mt Anakie"},
+			{RFSS: 2, Site: 9, Name: "Murradoc Hill"},
+		},
+	}}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: systems, Sites: discovered})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/sites")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Sites []SiteDTO `json:"sites"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Sites) != 2 {
+		t.Fatalf("got %d sites, want 2 (union): %+v", len(body.Sites), body.Sites)
+	}
+
+	// Sorted by (system, rfss, site): (1,1) then (2,9).
+	first := body.Sites[0]
+	if first.RFSSID != 1 || first.SiteID != 1 {
+		t.Fatalf("first site = %+v, want rfss 1 / site 1", first)
+	}
+	if first.Name != "Mt Anakie" {
+		t.Errorf("discovered site name not merged: %q", first.Name)
+	}
+	if first.ControlChannelHz != 420012500 {
+		t.Errorf("discovered control_channel_hz = %d, want 420012500", first.ControlChannelHz)
+	}
+
+	second := body.Sites[1]
+	if second.RFSSID != 2 || second.SiteID != 9 || second.Name != "Murradoc Hill" {
+		t.Fatalf("configured-only site wrong: %+v", second)
+	}
+	if second.ControlChannelHz != 0 {
+		t.Errorf("unseen site should have no control_channel_hz, got %d", second.ControlChannelHz)
+	}
+}
+
+// TestListSitesNoProvider confirms the route degrades gracefully when no
+// site tracker is wired (empty list, not a 500).
+func TestListSitesNoProvider(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/sites")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Sites []SiteDTO `json:"sites"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Sites) != 0 {
+		t.Fatalf("want empty sites, got %+v", body.Sites)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -273,6 +273,7 @@ type Server struct {
 	history      HistoryQuery
 	locations    LocationQuery
 	affiliations AffiliationProvider
+	sites        SitesProvider
 	metrics      http.Handler
 	log          *slog.Logger
 	version      string
@@ -433,6 +434,13 @@ type AffiliationProvider interface {
 	Affiliations() []trunking.UnitActivity
 }
 
+// SitesProvider is the read side of the site tracker, supplying the
+// P25 sites discovered from the control channel for GET /api/v1/sites
+// (issue #698).
+type SitesProvider interface {
+	Sites() []trunking.SiteInfo
+}
+
 // HistoryFilter mirrors storage.HistoryFilter for the api layer's
 // purposes (passed through to whatever HistoryQuery implementation the
 // daemon wires up).
@@ -490,6 +498,9 @@ type ServerOptions struct {
 	// Affiliations is optional. When non-nil the server exposes
 	// GET /api/v1/affiliations (the unit-activity table).
 	Affiliations AffiliationProvider
+	// Sites is optional. When non-nil the server exposes
+	// GET /api/v1/sites (the discovered-P25-site table, issue #698).
+	Sites SitesProvider
 	// MetricsHandler is optional. When non-nil it is mounted at
 	// GET /metrics; the daemon passes internal/metrics.Metrics.Handler()
 	// here. Decoupling via http.Handler keeps the api package free of a
@@ -788,6 +799,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		history:        opts.History,
 		locations:      opts.Locations,
 		affiliations:   opts.Affiliations,
+		sites:          opts.Sites,
 		metrics:        opts.MetricsHandler,
 		log:            log,
 		version:        opts.Version,
@@ -936,6 +948,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/calls/history", s.handleCallHistory)
 	mux.HandleFunc("GET /api/v1/locations", s.handleLocations)
 	mux.HandleFunc("GET /api/v1/affiliations", s.handleAffiliations)
+	mux.HandleFunc("GET /api/v1/sites", s.handleListSites)
 	mux.HandleFunc("GET /api/v1/rids", s.handleListRIDs)
 	mux.HandleFunc("GET /api/v1/rids/{id}", s.handleGetRID)
 	mux.HandleFunc("GET /api/v1/rids/{id}/history", s.handleRIDHistory)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -302,6 +302,12 @@ type GrantDTO struct {
 	FrequencyHz   uint32 `json:"frequency_hz"`
 	ChannelID     uint8  `json:"channel_id,omitempty"`
 	ChannelNumber uint16 `json:"channel_number,omitempty"`
+	// RFSSID / SiteID name the P25 site whose control channel granted
+	// the call, so consumers can label metrics by site instead of the
+	// opaque channel_id (issue #698). Zero (and omitted) on non-P25
+	// grants and until the site's RFSS Status TSBK has been decoded.
+	RFSSID uint8 `json:"rfss_id,omitempty"`
+	SiteID uint8 `json:"site_id,omitempty"`
 	// Timeslot is the 1-based TDMA slot (0 = n/a, 1 = TS1, 2 = TS2).
 	// Non-zero only for slotted protocols (DMR Tier III); identifies
 	// which of a carrier's two calls this is.
@@ -324,11 +330,27 @@ func grantToDTO(g trunking.Grant) GrantDTO {
 		GroupID: g.GroupID, SourceID: g.SourceID,
 		FrequencyHz: g.FrequencyHz,
 		ChannelID:   g.ChannelID, ChannelNumber: g.ChannelNum,
+		RFSSID: g.RFSSID, SiteID: g.SiteID,
 		Timeslot:  g.Timeslot,
 		Encrypted: g.Encrypted, Emergency: g.Emergency,
 		DataCall:    g.DataCall,
 		AlgorithmID: g.AlgorithmID, KeyID: g.KeyID,
 	}
+}
+
+// SiteDTO is one row of GET /api/v1/sites: a P25 site GT has either
+// discovered from the control channel, named in the system config, or
+// both (issue #698). Name is empty when the operator has not labelled
+// the site; ControlChannelHz is zero for a configured site GT has not
+// yet heard over the air.
+type SiteDTO struct {
+	System           string `json:"system"`
+	RFSSID           uint8  `json:"rfss_id"`
+	SiteID           uint8  `json:"site_id"`
+	ControlChannelHz uint32 `json:"control_channel_hz,omitempty"`
+	Name             string `json:"name"`
+	WACN             uint32 `json:"wacn,omitempty"`
+	SystemID         uint16 `json:"system_id,omitempty"`
 }
 
 // CallEncryptionDTO mirrors trunking.CallEncryption for SSE / REST

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -999,6 +999,16 @@ type TrunkingConfig struct {
 	VoiceCallGrouping string `yaml:"voice_call_grouping"`
 }
 
+// SiteConfig names one P25 site by its RFSS and Site IDs. It is pure
+// presentation metadata: GT discovers a site's identity from the
+// control channel and merges the Name into GET /api/v1/sites so the
+// site reads as a place rather than a pair of integers (issue #698).
+type SiteConfig struct {
+	RFSS uint8  `yaml:"rfss"`
+	Site uint8  `yaml:"site"`
+	Name string `yaml:"name"`
+}
+
 type SystemConfig struct {
 	Name            string   `yaml:"name"`
 	Protocol        string   `yaml:"protocol"`
@@ -1013,6 +1023,15 @@ type SystemConfig struct {
 	// catalogue blank for this system (live observations still
 	// surface via the affiliation tracker).
 	RIDAliasFile string `yaml:"rid_alias_file"`
+
+	// Sites is the optional catalogue of human-readable names for the
+	// P25 sites of this system, keyed by their RFSS and Site IDs
+	// (issue #698). GT discovers a site's RFSS/Site from the control
+	// channel; these names are pure presentation metadata merged into
+	// GET /api/v1/sites so a discovered site reads as e.g.
+	// "Mt Anakie" instead of "rfss 1 / site 1". Ignored for non-P25
+	// protocols. Leave empty to surface discovered sites without names.
+	Sites []SiteConfig `yaml:"sites"`
 
 	// TETRAColourCode is the 30-bit extended colour code the TETRA
 	// scrambler uses to seed its LFSR (ETSI EN 300 392-2 §8.2.5).
@@ -1874,6 +1893,18 @@ func validateSystem(i int, s SystemConfig) error {
 		if len(b) > 32 {
 			return fmt.Errorf("trunking.systems[%d].encryption_keys[%d]: key is %d bytes, must be 1..32", i, k, len(b))
 		}
+	}
+	type rfssSite struct{ rfss, site uint8 }
+	seenSites := make(map[rfssSite]int, len(s.Sites))
+	for k, st := range s.Sites {
+		if strings.TrimSpace(st.Name) == "" {
+			return fmt.Errorf("trunking.systems[%d].sites[%d]: name required", i, k)
+		}
+		key := rfssSite{st.RFSS, st.Site}
+		if prev, dup := seenSites[key]; dup {
+			return fmt.Errorf("trunking.systems[%d].sites[%d]: duplicate rfss %d / site %d (also at sites[%d])", i, k, st.RFSS, st.Site, prev)
+		}
+		seenSites[key] = k
 	}
 	return nil
 }

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -185,6 +185,11 @@ var fieldMetas = map[string]FieldMeta{
 	"EncryptionKeyConfig.Algorithm": {Help: "Decryption algorithm. Today only DMR RC4 (Enhanced Privacy).", Options: opts("rc4", "rc4 (DMR Enhanced Privacy)")},
 	"EncryptionKeyConfig.Key":       {Help: "Raw key, hex-encoded. Spaces and a 0x prefix are tolerated."},
 
+	"SystemConfig.Sites": {Label: "Sites", Help: "Optional human-readable names for the P25 sites of this system, keyed by RFSS/Site. Presentation metadata only — surfaced via GET /api/v1/sites. P25 only."},
+	"SiteConfig.RFSS":    {Label: "RFSS ID", Help: "RF Sub-System ID of the site (from the control channel's RFSS Status Broadcast)."},
+	"SiteConfig.Site":    {Label: "Site ID", Help: "Site ID within the RFSS (from the control channel's RFSS Status Broadcast)."},
+	"SiteConfig.Name":    {Label: "Name", Help: "Human-readable site name shown in GET /api/v1/sites, e.g. \"Mt Anakie\"."},
+
 	// ---- API & Web ---------------------------------------------------------
 	"APIConfig.HTTPAddr":            {Label: "HTTP address", Help: "TCP listen address for REST/SSE/WebSocket, e.g. 127.0.0.1:8080. Empty disables it."},
 	"APIConfig.GRPCAddr":            {Label: "gRPC address", Help: "TCP listen address for the gRPC server. Empty disables it."},

--- a/internal/configbuilder/webschema_test.go
+++ b/internal/configbuilder/webschema_test.go
@@ -32,6 +32,14 @@ var webRoundTripAllow = map[string][]string{
 	"LoRaChannelConfig":    {"CenterHz", "Bandwidth", "Oversample", "SubChannels", "LoRaWANKeys"},
 	"LoRaSubChannelConfig": {"OffsetHz", "SpreadingFactor", "SyncWord"},
 	"LoRaWANKeyConfig":     {"DevAddr", "NwkSKey", "AppSKey"},
+
+	// Per-system P25 site name catalogue (issue #698). Optional
+	// presentation metadata surfaced via GET /api/v1/sites; it round-trips
+	// through the SystemConfig index signature and the whole Sites array
+	// (each a SiteConfig) is preserved as unknown JSON. Editable in the TUI
+	// and raw YAML; a bespoke web editor is a follow-up.
+	"SystemConfig": {"Sites"},
+	"SiteConfig":   {"RFSS", "Site", "Name"},
 }
 
 // TestConfigSchemaCoveredByWebBuilder fails when a config.Config field has no

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -129,6 +129,14 @@ const (
 	// source ID + encrypted state at grant time do not need this
 	// event — the values are already on the Grant.
 	KindCallSourceUpdate Kind = "call.source"
+	// KindSiteUpdate fires when the P25 control-channel decoder parses
+	// an RFSS Status Broadcast (TSBK 0x3A), naming the site it is
+	// camped on and the control-channel frequency it was heard on.
+	// Payload is a trunking.SiteUpdate. The SiteTracker subscribes and
+	// accumulates the discovered sites behind GET /api/v1/sites so
+	// downstream tooling can map a grant's RFSS/Site to a human
+	// site name (issue #698).
+	KindSiteUpdate Kind = "site.update"
 	// KindBookmarkCreated / KindBookmarkUpdated / KindBookmarkDeleted
 	// fire whenever the bookmarks store mutates. Payload is a
 	// storage.Bookmark (or {ID} for deletes). Surfaced over SSE / WS

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1030,6 +1030,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		c.netModel.ApplyNetworkStatus(ParseNetworkStatusBroadcast(t.Payload))
 	case OpRFSSStatusBroadcast:
 		c.netModel.ApplyRFSSStatus(ParseRFSSStatusBroadcast(t.Payload))
+		c.publishSiteUpdate()
 	case OpSecondaryControlChannel:
 		c.netModel.ApplySecondaryControlChannel(ParseSecondaryControlChannelBroadcast(t.Payload))
 	case OpAdjacentSiteStatusBroadcast:
@@ -1236,10 +1237,13 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 	// the Phase 2 MAC dispatch path PR #409 added was dead code on
 	// MMR-class systems.
 	protocol := "p25"
+	// Snapshot the site topology once: the camped site's RFSS/Site is
+	// stamped onto every grant (issue #698) and the WACN/SystemID feeds
+	// the Phase 2 PN44 seed below.
+	net := c.netModel.Snapshot()
 	var p2dec trunking.P25Phase2Decode
 	if c.bandPlan.IsTDMA(g.channelID) {
 		protocol = "p25-phase2"
-		net := c.netModel.Snapshot()
 		seed := framing.PN44SeedFromIdentity(net.WACN, net.SystemID, nac&0x0FFF)
 		p2dec = trunking.P25Phase2Decode{
 			Trellis:    c.p25Phase2Trellis,
@@ -1259,6 +1263,8 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 			FrequencyHz:        freq,
 			ChannelID:          g.channelID,
 			ChannelNum:         g.channelNumber,
+			RFSSID:             net.RFSS,
+			SiteID:             net.Site,
 			Encrypted:          so.Encrypted(),
 			Emergency:          so.Emergency(),
 			DataCall:           g.dataCall,
@@ -1275,6 +1281,32 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 	// ALGID/KID are unavailable at grant time on Phase 1 (the LDU2
 	// Encryption Sync carries them); the engine backfills via
 	// KindCallEncryption once the voice frame lands.
+}
+
+// publishSiteUpdate emits a KindSiteUpdate naming the site this control
+// channel is camped on, joining the decoded RFSS/Site identity to the
+// frequency the decoder is tuned to. The SiteTracker accumulates these
+// into the GET /api/v1/sites table (issue #698). Called from
+// dispatchTSBK after every RFSS Status Broadcast — cheap, and lets
+// control_channel_hz stay accurate as the decoder hops control
+// channels. Skipped until the site has actually been identified.
+func (c *ControlChannel) publishSiteUpdate() {
+	net := c.netModel.Snapshot()
+	if net.RFSS == 0 && net.Site == 0 {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindSiteUpdate,
+		Payload: trunking.SiteUpdate{
+			System:           c.systemName,
+			RFSSID:           net.RFSS,
+			SiteID:           net.Site,
+			ControlChannelHz: c.freqHz,
+			WACN:             net.WACN,
+			SystemID:         net.SystemID,
+			At:               c.now(),
+		},
+	})
 }
 
 // drainPendingGrants re-publishes every voice grant that arrived for

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -2,8 +2,10 @@ package phase1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 func TestNetworkModelAccumulates(t *testing.T) {
@@ -66,5 +68,56 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 	}
 	if len(cfg.Neighbors) != 1 || cfg.Neighbors[0].Site != 8 {
 		t.Errorf("neighbours = %v, want one site-8 entry", cfg.Neighbors)
+	}
+}
+
+// TestControlChannelPublishesSiteUpdate drives an RFSS Status Broadcast
+// through the control channel and checks a KindSiteUpdate naming the
+// camped site (with the tuned control-channel frequency) is published
+// on the bus (issue #698).
+func TestControlChannelPublishesSiteUpdate(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	const ccHz = 420012500
+	cc := New(Options{Bus: bus, SystemName: "MMR", FrequencyHz: ccHz})
+
+	// NSB first so WACN/SystemID are populated, then RFSS to name the site.
+	nsb := TSBK{Opcode: OpNetworkStatusBroadcast, Payload: [8]byte{0xAB, 0xCD, 0xE1, 0x23}}
+	rfss := TSBK{Opcode: OpRFSSStatusBroadcast, Payload: [8]byte{9, 0, 4, 7}}
+	base := 0
+	for _, tsbk := range []TSBK{nsb, rfss} {
+		cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk), base)
+		base += 1 << 20
+	}
+
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindSiteUpdate {
+				continue
+			}
+			u, ok := ev.Payload.(trunking.SiteUpdate)
+			if !ok {
+				t.Fatalf("KindSiteUpdate payload is %T, want trunking.SiteUpdate", ev.Payload)
+			}
+			if u.System != "MMR" || u.RFSSID != 4 || u.SiteID != 7 {
+				t.Fatalf("site update identity wrong: %+v", u)
+			}
+			if u.ControlChannelHz != ccHz {
+				t.Fatalf("control_channel_hz = %d, want %d", u.ControlChannelHz, ccHz)
+			}
+			// WACN comes from the NSB; the RFSS Status Broadcast then sets
+			// SystemID from its own field (p1/p2 → 4 for this payload).
+			if u.WACN != 0xABCDE || u.SystemID != 4 {
+				t.Fatalf("site update network ids wrong: %+v", u)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no KindSiteUpdate published within deadline")
+		}
 	}
 }

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -21,6 +21,15 @@ type Grant struct {
 	FrequencyHz uint32 // voice channel frequency
 	ChannelID   uint8  // raw channel ID (P25 band-plan ID, DMR LCN high)
 	ChannelNum  uint16 // raw channel number within the ID
+	// RFSSID and SiteID identify the P25 site whose control channel
+	// granted the call, decoded from the site's RFSS Status Broadcast
+	// (TSBK 0x3A) and accumulated in the control channel's NetworkModel.
+	// They let downstream consumers (Prometheus exporters, dashboards)
+	// label a grant by site instead of resolving the opaque ChannelID
+	// against a manual lookup table (issue #698). Both stay zero on
+	// non-P25 grants and until the first RFSS Status TSBK has landed.
+	RFSSID uint8
+	SiteID uint8
 	// Timeslot identifies the TDMA logical channel a call occupies on
 	// its carrier, 1-based: 0 = not applicable / unknown (P25 Phase 1,
 	// NXDN, analog — frequency alone identifies the call), 1 = TS1,
@@ -269,4 +278,22 @@ type CallSourceUpdate struct {
 	SourceID     uint32
 	Encrypted    bool
 	At           time.Time
+}
+
+// SiteUpdate is the payload of an events.KindSiteUpdate event. The P25
+// control-channel decoder publishes one each time it parses an RFSS
+// Status Broadcast (TSBK 0x3A), naming the site it is currently camped
+// on and the control-channel frequency it heard it on. The SiteTracker
+// accumulates these into the queryable table behind GET /api/v1/sites
+// (issue #698). ControlChannelHz comes from the decoder's tuned
+// frequency — grants carry only the voice ChannelID, not the control
+// channel — so a SiteUpdate is the only place the two are joined.
+type SiteUpdate struct {
+	System           string
+	RFSSID           uint8
+	SiteID           uint8
+	ControlChannelHz uint32
+	WACN             uint32
+	SystemID         uint16
+	At               time.Time
 }

--- a/internal/trunking/site.go
+++ b/internal/trunking/site.go
@@ -149,6 +149,15 @@ type DMRBandPlanTableEntry struct {
 	FreqHz uint32
 }
 
+// ConfiguredSite is an operator-supplied name for a P25 site, keyed by
+// its RFSS and Site IDs. It carries no decoding role — GET /api/v1/sites
+// merges the Name onto the matching discovered site (issue #698).
+type ConfiguredSite struct {
+	RFSS uint8
+	Site uint8
+	Name string
+}
+
 // System describes one trunked radio system the engine should track.
 type System struct {
 	Name            string
@@ -158,6 +167,13 @@ type System struct {
 	SystemID        uint16   // 12-bit system identifier (P25 SYSID)
 	RFSS            uint8    // RF SubSystem ID (P25)
 	Site            uint8    // Site ID
+
+	// Sites is the operator's optional catalogue of human-readable site
+	// names, keyed by (RFSS, Site), surfaced through GET /api/v1/sites
+	// so a discovered P25 site can carry a name instead of an opaque
+	// ID (issue #698). The decoder does not consult these — they are
+	// pure presentation metadata merged into the sites listing.
+	Sites []ConfiguredSite
 
 	// TETRAColourCode is the low 30 bits of the extended colour code
 	// the TETRA scrambler uses to seed its LFSR per ETSI EN 300 392-2

--- a/internal/trunking/site_tracker.go
+++ b/internal/trunking/site_tracker.go
@@ -1,0 +1,169 @@
+package trunking
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// SiteInfo records one P25 site the control-channel decoder has
+// identified over the air. It is the row type of the SiteTracker's
+// snapshot — the data behind GET /api/v1/sites (issue #698). Name is
+// not set here; the API layer merges operator-supplied names from the
+// system config onto matching rows.
+type SiteInfo struct {
+	System           string    `json:"system"`
+	RFSSID           uint8     `json:"rfss_id"`
+	SiteID           uint8     `json:"site_id"`
+	ControlChannelHz uint32    `json:"control_channel_hz,omitempty"`
+	WACN             uint32    `json:"wacn,omitempty"`
+	SystemID         uint16    `json:"system_id,omitempty"`
+	FirstSeen        time.Time `json:"first_seen"`
+	LastSeen         time.Time `json:"last_seen"`
+}
+
+// SiteTracker maintains a live table of the P25 sites GT has decoded
+// from the control channel. It subscribes to the events bus and folds
+// in every events.KindSiteUpdate (published when the decoder parses an
+// RFSS Status Broadcast), keyed by (system, RFSS, site). Unlike the
+// camped-site snapshot in p25/phase1.NetworkModel — which only knows
+// the current site — the tracker accumulates every site seen as the
+// decoder hops control channels, so a multi-site system surfaces all
+// of its sites over time. Entries never expire: a system's site roster
+// is small and stable, and operators want the full list even for sites
+// that have gone quiet.
+type SiteTracker struct {
+	bus *events.Bus
+	now func() time.Time
+
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+
+	mu    sync.Mutex
+	sites map[siteKey]*SiteInfo
+}
+
+// siteKey identifies a site within the tracker table.
+type siteKey struct {
+	system string
+	rfss   uint8
+	site   uint8
+}
+
+// SiteTrackerOptions configure a tracker.
+type SiteTrackerOptions struct {
+	Bus *events.Bus
+	// Now is injectable for tests; defaults to time.Now.
+	Now func() time.Time
+}
+
+// NewSiteTracker validates opts and returns a tracker that has already
+// subscribed to the bus.
+func NewSiteTracker(opts SiteTrackerOptions) (*SiteTracker, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("trunking: SiteTracker requires an events.Bus")
+	}
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	t := &SiteTracker{
+		bus:     opts.Bus,
+		now:     opts.Now,
+		runDone: make(chan struct{}),
+		sites:   make(map[siteKey]*SiteInfo),
+	}
+	t.sub = opts.Bus.Subscribe()
+	return t, nil
+}
+
+// Run drains site-update events until ctx cancels or the bus closes.
+func (t *SiteTracker) Run(ctx context.Context) error {
+	defer close(t.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-t.sub.C:
+			if !ok {
+				return nil
+			}
+			if ev.Kind == events.KindSiteUpdate {
+				if u, ok := ev.Payload.(SiteUpdate); ok {
+					t.observe(u)
+				}
+			}
+		}
+	}
+}
+
+// observe records (or refreshes) a discovered site.
+func (t *SiteTracker) observe(u SiteUpdate) {
+	key := siteKey{system: u.System, rfss: u.RFSSID, site: u.SiteID}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	s := t.sites[key]
+	if s == nil {
+		s = &SiteInfo{
+			System:    u.System,
+			RFSSID:    u.RFSSID,
+			SiteID:    u.SiteID,
+			FirstSeen: t.now(),
+		}
+		t.sites[key] = s
+	}
+	if u.ControlChannelHz != 0 {
+		s.ControlChannelHz = u.ControlChannelHz
+	}
+	if u.WACN != 0 {
+		s.WACN = u.WACN
+	}
+	if u.SystemID != 0 {
+		s.SystemID = u.SystemID
+	}
+	s.LastSeen = t.now()
+}
+
+// Snapshot returns every tracked site, ordered by system then RFSS/Site
+// so the listing is stable across calls.
+func (t *SiteTracker) Snapshot() []SiteInfo {
+	t.mu.Lock()
+	out := make([]SiteInfo, 0, len(t.sites))
+	for _, s := range t.sites {
+		out = append(out, *s)
+	}
+	t.mu.Unlock()
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].System != out[j].System {
+			return out[i].System < out[j].System
+		}
+		if out[i].RFSSID != out[j].RFSSID {
+			return out[i].RFSSID < out[j].RFSSID
+		}
+		return out[i].SiteID < out[j].SiteID
+	})
+	return out
+}
+
+// Len returns the number of tracked sites.
+func (t *SiteTracker) Len() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.sites)
+}
+
+// Close releases the bus subscription and waits for Run to drain.
+func (t *SiteTracker) Close() error {
+	t.closeOnce.Do(func() {
+		t.sub.Close()
+		select {
+		case <-t.runDone:
+		case <-time.After(time.Second):
+		}
+	})
+	return nil
+}

--- a/internal/trunking/site_tracker_test.go
+++ b/internal/trunking/site_tracker_test.go
@@ -1,0 +1,82 @@
+package trunking
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+func TestSiteTrackerObservesSiteUpdates(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	tr, err := NewSiteTracker(SiteTrackerOptions{Bus: bus})
+	if err != nil {
+		t.Fatalf("NewSiteTracker: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go tr.Run(ctx)
+	t.Cleanup(func() { cancel(); tr.Close() })
+
+	bus.Publish(events.Event{
+		Kind: events.KindSiteUpdate,
+		Payload: SiteUpdate{
+			System: "MMR", RFSSID: 1, SiteID: 1,
+			ControlChannelHz: 420012500, WACN: 0xBEE00, SystemID: 0x123,
+		},
+	})
+
+	waitFor(t, func() bool { return tr.Len() == 1 })
+	snap := tr.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("snapshot has %d sites, want 1", len(snap))
+	}
+	s := snap[0]
+	if s.System != "MMR" || s.RFSSID != 1 || s.SiteID != 1 {
+		t.Fatalf("site identity wrong: %+v", s)
+	}
+	if s.ControlChannelHz != 420012500 || s.WACN != 0xBEE00 || s.SystemID != 0x123 {
+		t.Fatalf("site network fields wrong: %+v", s)
+	}
+}
+
+func TestSiteTrackerDedupesAndUpdates(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	tr, _ := NewSiteTracker(SiteTrackerOptions{Bus: bus})
+	ctx, cancel := context.WithCancel(context.Background())
+	go tr.Run(ctx)
+	t.Cleanup(func() { cancel(); tr.Close() })
+
+	// Two distinct sites plus a refresh of the first on a different CC.
+	bus.Publish(events.Event{Kind: events.KindSiteUpdate, Payload: SiteUpdate{System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 420012500}})
+	bus.Publish(events.Event{Kind: events.KindSiteUpdate, Payload: SiteUpdate{System: "MMR", RFSSID: 2, SiteID: 9, ControlChannelHz: 423012500}})
+	bus.Publish(events.Event{Kind: events.KindSiteUpdate, Payload: SiteUpdate{System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 420112500}})
+
+	waitFor(t, func() bool { return tr.Len() == 2 })
+	snap := tr.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("want 2 sites, got %d: %+v", len(snap), snap)
+	}
+	// Snapshot is sorted by (system, rfss, site); the (1,1) site is first
+	// and must reflect the most-recent control-channel frequency.
+	if snap[0].RFSSID != 1 || snap[0].SiteID != 1 || snap[0].ControlChannelHz != 420112500 {
+		t.Fatalf("first site not the refreshed (1,1): %+v", snap[0])
+	}
+	if snap[1].RFSSID != 2 || snap[1].SiteID != 9 {
+		t.Fatalf("second site wrong: %+v", snap[1])
+	}
+}


### PR DESCRIPTION
Surface the RFSS/Site identity GT already decodes on the P25 control
channel so downstream tooling can label calls and metrics by site
instead of an opaque channel_id.

- Grant events now carry rfss_id/site_id, stamped in publishVoiceGrant
  from the camped site's NetworkModel snapshot; mirrored into GrantDTO.
- New KindSiteUpdate event, published on each RFSS Status Broadcast,
  joins the decoded RFSS/Site to the tuned control-channel frequency.
- New trunking.SiteTracker accumulates discovered sites (mirrors the
  AffiliationTracker pattern), exposed via a SitesProvider to the API.
- New GET /api/v1/sites returns the union of discovered and configured
  sites, merging operator-supplied names from trunking.systems[].sites
  (rfss/site/name) onto matching rows.
- Config, daemon wiring, docs, CHANGELOG, and config.example.yaml.
- Tests for the tracker, the control-channel event, and the endpoint.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KYKLf1vgEcPbS3XC87vvZh