### PR TITLE
Populate P25 System Information panel from live site tracker (#673)

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -7,6 +7,7 @@ import (
 
 	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // HealthDTO is the body shape returned by GET /api/v1/health. The
@@ -110,9 +111,15 @@ func (s *Server) handleDiagBanner(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleListSystems(w http.ResponseWriter, _ *http.Request) {
+	var live []trunking.SiteInfo
+	if s.sites != nil {
+		live = s.sites.Sites()
+	}
 	out := make([]SystemDTO, 0, len(s.systems))
 	for _, sys := range s.systems {
-		out = append(out, systemToDTO(sys))
+		dto := systemToDTO(sys)
+		overlayLiveIdentity(&dto, live)
+		out = append(out, dto)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"systems": out})
 }
@@ -121,11 +128,46 @@ func (s *Server) handleGetSystem(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	for _, sys := range s.systems {
 		if sys.Name == name {
-			writeJSON(w, http.StatusOK, systemToDTO(sys))
+			dto := systemToDTO(sys)
+			if s.sites != nil {
+				overlayLiveIdentity(&dto, s.sites.Sites())
+			}
+			writeJSON(w, http.StatusOK, dto)
 			return
 		}
 	}
 	s.writeError(w, http.StatusNotFound, "system not found")
+}
+
+// overlayLiveIdentity fills WACN/SystemID/RFSS/Site on dto from the live
+// SiteTracker snapshot (the same data behind GET /api/v1/sites) for the
+// matching system. Network identity (WACN/SYSID/RFSS/Site) is decoded from
+// P25 status-broadcast TSBKs over the air, not configured, so the static
+// config copy in s.systems leaves these zero — this is what populates the
+// web "System Information" panel (issue #673). WACN and SystemID are
+// system-wide; RFSS/Site reflect the most-recently-heard site (the currently
+// camped one). Live non-zero values win; config values survive when nothing
+// has been decoded yet.
+func overlayLiveIdentity(dto *SystemDTO, sites []trunking.SiteInfo) {
+	var rfssAt, wacnAt, sysAt time.Time
+	for _, si := range sites {
+		if si.System != dto.Name {
+			continue
+		}
+		if si.LastSeen.After(rfssAt) {
+			rfssAt = si.LastSeen
+			dto.RFSS = si.RFSSID
+			dto.Site = si.SiteID
+		}
+		if si.WACN != 0 && si.LastSeen.After(wacnAt) {
+			wacnAt = si.LastSeen
+			dto.WACN = si.WACN
+		}
+		if si.SystemID != 0 && si.LastSeen.After(sysAt) {
+			sysAt = si.LastSeen
+			dto.SystemID = si.SystemID
+		}
+	}
 }
 
 func (s *Server) handleListTalkgroups(w http.ResponseWriter, _ *http.Request) {

--- a/internal/api/handlers_systems_test.go
+++ b/internal/api/handlers_systems_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestListSystemsOverlaysLiveIdentity verifies GET /api/v1/systems fills the
+// WACN/SystemID/RFSS/Site network-identity fields from the live SiteTracker
+// snapshot rather than the (empty) static config copy — the fix for the
+// "System Information panel stuck on Awaiting status broadcasts" bug (#673).
+func TestListSystemsOverlaysLiveIdentity(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	// Config carries no decoded identity (operators don't set it); the
+	// SiteTracker has heard one site over the air.
+	systems := []trunking.System{{Name: "MMR", Protocol: trunking.ProtocolP25}}
+	discovered := fakeSites{sites: []trunking.SiteInfo{
+		{System: "MMR", RFSSID: 1, SiteID: 4, WACN: 0xBEE00, SystemID: 0x123, LastSeen: time.Unix(100, 0)},
+	}}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: systems, Sites: discovered})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/systems")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Systems []SystemDTO `json:"systems"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Systems) != 1 {
+		t.Fatalf("got %d systems, want 1", len(body.Systems))
+	}
+	got := body.Systems[0]
+	if got.WACN != 0xBEE00 {
+		t.Errorf("WACN = %#x, want 0xBEE00", got.WACN)
+	}
+	if got.SystemID != 0x123 {
+		t.Errorf("SystemID = %#x, want 0x123", got.SystemID)
+	}
+	if got.RFSS != 1 {
+		t.Errorf("RFSS = %d, want 1", got.RFSS)
+	}
+	if got.Site != 4 {
+		t.Errorf("Site = %d, want 4", got.Site)
+	}
+}
+
+// TestListSystemsUsesMostRecentSite checks that for a multi-site system the
+// RFSS/Site shown reflect the most-recently-heard site (the currently camped
+// one), while WACN/SystemID — system-wide values — come from the latest
+// non-zero observation.
+func TestListSystemsUsesMostRecentSite(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	systems := []trunking.System{{Name: "MMR", Protocol: trunking.ProtocolP25}}
+	discovered := fakeSites{sites: []trunking.SiteInfo{
+		{System: "MMR", RFSSID: 1, SiteID: 4, WACN: 0xBEE00, SystemID: 0x123, LastSeen: time.Unix(100, 0)},
+		{System: "MMR", RFSSID: 1, SiteID: 9, LastSeen: time.Unix(200, 0)}, // newer, no identity bytes decoded yet
+	}}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: systems, Sites: discovered})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/systems")
+	defer resp.Body.Close()
+	var body struct {
+		Systems []SystemDTO `json:"systems"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := body.Systems[0]
+	if got.Site != 9 {
+		t.Errorf("Site = %d, want 9 (most recently heard)", got.Site)
+	}
+	// WACN/SystemID held from the earlier row that actually carried them.
+	if got.WACN != 0xBEE00 || got.SystemID != 0x123 {
+		t.Errorf("WACN/SystemID = %#x/%#x, want 0xBEE00/0x123", got.WACN, got.SystemID)
+	}
+}


### PR DESCRIPTION
The web Systems detail panel showed WACN/System ID/RFSS/Site stuck on
"Awaiting status broadcasts" because GET /api/v1/systems built its DTOs
solely from the static config copy of each system, which never carries
the over-the-air network identity. The decoded values were already
accumulated by the always-on SiteTracker (behind GET /api/v1/sites) but
the systems endpoint never consulted it.

Overlay the live SiteTracker snapshot onto each system DTO in
handleListSystems and handleGetSystem: WACN/SystemID (system-wide) take
the latest non-zero observation, RFSS/Site reflect the most recently
heard site. Config values survive when nothing has been decoded yet.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UZn3yzgGznY2oWu9AhHHyF