### PR TITLE
docs(blog): add 14-part "Build in the Open" GitHub + Claude Code series

### DIFF
--- a/build-in-the-open-prompt.md
+++ b/build-in-the-open-prompt.md
@@ -1,0 +1,94 @@
+# Prompt: Write the "Build in the Open" blog series
+
+Write a 14-part blog series titled **"Build in the Open: GitHub + Claude Code
+from Idea to Release"** for the GopherTrunk Jekyll blog. It teaches how to set
+up a GitHub repo and use Claude Code to build software, idea → release.
+
+## Ground rules
+- Teach a **generic, transferable strategy** that works for any language/stack.
+  In every post, explain the principle generically FIRST, then add a "How
+  GopherTrunk does it" subsection using real artifacts from this repo as one
+  worked example.
+- Reuse the existing publishing pipeline — do not invent a new one. Posts go in
+  `docs/_posts/`, future-dated; the daily cron in `.github/workflows/pages.yml`
+  drips them out one per day (`future:false` in `docs/_config.yml`).
+
+## Files to create
+- 14 posts: `docs/_posts/2026-06-DD-build-in-the-open-NN-slug.md` dated
+  consecutively **2026-06-18 → 2026-07-01** (NN = 01–14). Or write undated and
+  run `scripts/schedule-series.py --apply 2026-06-18 docs/_posts/*build-in-the-open*.md`.
+- Series landing page `docs/blog/series/build-in-the-open.md`, modeled on
+  `docs/blog/series/sdr-internals.md` (layout: page, nav_group: Blog,
+  permalink `/blog/series/build-in-the-open/`, Liquid loop filtering
+  `series == "Build in the Open"` sorted by `series_part`, linking the
+  **tutorials** category).
+
+## Post URLs
+Posts resolve to `/blog/tutorials/<slug>/` (permalink `/blog/:categories/:title/`
+in `docs/_config.yml`). Use that pattern for all internal series-navigation links.
+
+## Front matter (every post)
+title (keyword-front-loaded "Build in the Open, Part N: …"), description
+(≤155 chars, answer-first, keyword-rich), keywords, category: tutorials, tags,
+author: Matt Cheramie, image: /assets/gophertrunk-logo.png,
+series: "Build in the Open", series_part: N. Do NOT set `hide_ctas`.
+
+## Body structure (serve skimmer, overviewer, deep-diver — inverted pyramid)
+1. **TL;DR** blockquote + **Key takeaways** bullets at the very top (important
+   info + one-sentence answer first — what AI search lifts).
+2. Italic one-line series blurb + `## In this post` bullet map.
+3. Full sections: generic technique, then "How GopherTrunk does it" worked
+   example with real commands/code/file paths. Question-style headings.
+4. `## FAQ` — 3–5 real "How do I / When should I / What is" Q&As, concise
+   self-contained answers (SEO + answer-engine).
+5. `## Series navigation` — Part N of 14, prev/next + back-to-Part-1 via
+   `relative_url`.
+The standard 3 site CTAs (Try / Support / Join) inject automatically via the
+layout — just don't suppress them and keep posts multi-section.
+
+## The 14 posts
+1. Picking what to build: how pros decide (validate demand, scope an MVP).
+2. Choosing your language, platforms & tech stack.
+3. Brainstorming features with Claude + writing the README as a roadmap
+   (incl. CLAUDE.md).
+4. Git & GitHub fundamentals via the web interface.
+5. Branching & the three ways to merge to main (many small commits→1 PR; 3–5
+   large commits→1 PR; one squashed commit→1 PR) and when to use each.
+6. Planning & tracking work + inviting contributors (Issues, labels, milestones,
+   project boards, CONTRIBUTING/CoC/CODEOWNERS, collaborator roles).
+7. GitHub Actions: which workflows to create and why.
+8. Testing: how to build and write tests (pyramid, table-driven, fixtures/golden,
+   fakes vs mocks, race, coverage, CI gate, writing tests with Claude Code).
+9. Documentation done right: what lives where (Diátaxis).
+10. Websites, support pages & GitHub Pages (custom domain, Jekyll, drip-release).
+11. Releases: cadence, pre-release vs release, SemVer & changelogs.
+12. Optimizing & securing your repository (About/topics/badges; branch protection,
+    secret scanning, Dependabot/SCA, SECURITY.md, signed/checksummed releases).
+13. Advanced Git & GitHub features (rebase/cherry-pick/bisect/reflog/worktrees;
+    Discussions, wikis, code search, Codespaces, Packages/GHCR, Environments).
+14. The CLI workflow & Claude Code as your daily driver (gh CLI; Claude Code CLI
+    + web sessions, CLAUDE.md, slash commands, hooks).
+
+## GopherTrunk reference facts to cite
+Pure-Go `CGO_ENABLED=0` single static ~10MB binary, cross-compiles Linux/macOS/
+Windows; Go toolchain pinned 1.25.11; README "What is this?" + Status snapshot
+as a living roadmap; branch naming `claude/issue-NNN-desc`, Conventional Commits,
+squash-on-merge; 5 workflows (ci.yml with 6 jobs incl. govulncheck + license
+audit + multi-OS USB; release.yml; installer.yml PR-only with paths-ignore +
+cancel-in-progress; pages.yml daily cron; cleanup-branches.yml); `make test`
+(-race), `make integration` + `//go:build integration`, per-protocol
+`make integration-cc-<proto>`, golden IQ in `samples/`, env-gated real-hardware
+tests; `docs/` ~50 md + 180-entry encyclopedia + 30-lesson learning path;
+gophertrunk.org via Jekyll + CNAME, landing page synthesized from README, SEO
+plugins, FUNDING.yml (Sponsors + Ko-fi); SemVer v0.4.5, Keep-a-Changelog +
+`## [Unreleased]`, tag `vX.Y.Z` → release.yml, `make release-dry-run`, ldflags
+version injection, SHA256SUMS, prerelease before v1.0.0; rulesets
+main-branch-protection.json + release-tags-protection.json; SECURITY.md threat
+model + private advisories + bearer-token/constant-time crypto.
+
+## Finish
+Verify locally (Jekyll build with future dates visible: all 14 render, series
+page lists all 14 in order, tutorials category + RSS include them), confirm
+unique series_part 1–14, run the schedule-series.py dry run to confirm dates
+06-18→07-01, then commit on `claude/github-claude-blog-series-lb1apw` with
+`docs(blog): add 14-part "Build in the Open" GitHub + Claude Code series` and push.

--- a/docs/_posts/2026-06-18-build-in-the-open-01-picking-what-to-build.md
+++ b/docs/_posts/2026-06-18-build-in-the-open-01-picking-what-to-build.md
@@ -1,0 +1,173 @@
+---
+title: "Build in the Open, Part 1: Picking What to Build — How Pros Decide"
+description: How experienced developers choose what software to build — validating demand, scoping a first version, and avoiding the build-trap, with GopherTrunk as a worked example.
+keywords: what to build, choosing a software project, MVP scope, validate an idea, side project ideas, open source project, claude code, github
+category: tutorials
+tags: [github, claude-code, product, planning, getting-started]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 1
+---
+
+> **TL;DR:** Don't start with code — start with a problem you understand well
+> enough to be annoyed by. Pick something narrow enough to ship a first useful
+> version in weeks, validate that at least a few other people share the pain,
+> and write the idea down as a one-sentence problem statement before you open an
+> editor. The best first project is one *you* will actually use.
+
+**Key takeaways**
+
+- Build to scratch a real itch — your own, ideally — not to chase a market you
+  can't see.
+- Validate demand cheaply (search, forums, existing tools) *before* committing.
+- Scope ruthlessly to a "walking skeleton": the smallest end-to-end slice that
+  does one real thing.
+- Write a problem statement and success criteria first; let those drive every
+  later decision.
+
+*This is Part 1 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **How professionals decide what to build** — and why "a cool idea" is the
+  wrong starting point.
+- **Validating demand** without writing a line of code.
+- **Scoping a first version** down to something you can actually finish.
+- **Writing it down**: the problem statement and success criteria that anchor
+  the whole project.
+- **How GopherTrunk got picked**, as a concrete example you can copy.
+
+## Start with a problem, not a product
+
+The most common way side projects die is that they begin as a *solution*
+looking for a problem. Someone learns a shiny framework, decides to "build an
+app with it," and three weekends later abandons a half-built thing nobody —
+including the author — needed.
+
+Experienced builders invert that. They start from a **problem they personally
+feel**: a task that's tedious, a tool that's missing, a workflow that's broken.
+This is the classic "scratch your own itch" rule, and it works because it solves
+the hardest problem in software up front — *motivation and judgment*. When you
+are the user, you don't need a focus group to tell you whether a feature is
+good. You already know.
+
+A useful litmus test: **can you state the problem in one sentence, without
+mentioning your solution?** "I want to build a React dashboard" is a solution.
+"I can't see all my home-lab services' health in one place" is a problem. Lead
+with the second kind.
+
+## Validate that the problem is real (and shared)
+
+Scratching your own itch gets you a user of one. Before you sink months in, do a
+few hours of cheap validation to confirm other people feel the same pain — that
+turns a throwaway script into a project worth maintaining.
+
+You don't need surveys or a landing page. You need to read:
+
+- **Search the obvious terms.** If nobody is asking about it anywhere, either
+  you've found a gap or the need isn't real. Figure out which.
+- **Find where the niche hangs out** — a subreddit, a Discord, a forum, a tag on
+  Stack Overflow — and read what people complain about.
+- **Inventory the existing tools.** If alternatives exist, that's *good*: it
+  proves demand. Your job is then to be meaningfully different (faster, simpler,
+  free, cross-platform, open source), not first.
+- **Look for "I wish X could…" comments.** Unmet wishes next to an existing tool
+  are the richest seam of project ideas there is.
+
+This is also the perfect place to use Claude Code as a research partner: ask it
+to summarize the landscape, list existing tools and their trade-offs, and
+surface the recurring complaints. You'll cover in an afternoon what used to take
+a week — we'll go deep on research-with-Claude in
+[Part 3]({{ '/blog/tutorials/build-in-the-open-03-brainstorm-with-claude-readme-roadmap/' | relative_url }}).
+
+## Scope to a walking skeleton
+
+Once the problem is real, the failure mode shifts from "wrong idea" to "too big
+to finish." The fix is to scope your first version to a **walking skeleton**:
+the thinnest possible slice that runs end-to-end and does *one* genuinely useful
+thing.
+
+A good way to find that slice is **MoSCoW**: sort every feature you can imagine
+into *Must / Should / Could / Won't*. Your first milestone is **only the
+Musts** — and you should be ruthless about what counts. Everything else is a
+roadmap, not a v1.
+
+The walking skeleton matters because it forces every layer of the system to
+exist, even if each is minimal. That flushes out the hard integration problems
+early, when they're cheap to fix, instead of after you've polished a feature
+nobody can reach yet.
+
+## Write it down before you write code
+
+Two short artifacts will save you from months of drift. Write them *before* the
+first commit:
+
+1. **A problem statement.** One or two sentences: who has the problem, what the
+   problem is, and why existing options fall short.
+2. **Success criteria.** How you'll know the first version worked — concrete and
+   checkable, e.g. "decodes one real signal end-to-end on my hardware."
+
+These become the seed of your README (Part 3) and the yardstick for every "should
+I build this?" decision later. When a tempting feature shows up, you hold it
+against the problem statement. If it doesn't serve that, it waits.
+
+## How GopherTrunk got picked
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) is a digital-trunking
+radio scanner — software that decodes and records voice calls from
+software-defined radio (SDR) hardware. Here's how it maps onto everything above:
+
+- **A real, personal itch.** Existing scanner software worked, but installing it
+  meant wrestling with C libraries (`librtlsdr`, `libusb`) and platform-specific
+  build pain. The problem statement was essentially: *"There's no SDR trunking
+  scanner that installs as a single, dependency-free binary on any OS."*
+- **Validated against existing tools.** The space already had mature
+  competitors — proof the demand was real. GopherTrunk didn't need to be first;
+  it needed to be **different**, and its difference was concrete: *pure Go,
+  `CGO_ENABLED=0`, one ~10 MB static binary* that cross-compiles to Linux,
+  macOS, and Windows with `go build`.
+- **A walking skeleton, not the whole radio.** The project supports 11+
+  protocols today (P25, DMR, NXDN, TETRA…), but the first useful slice was
+  narrow: get **one** protocol's control channel to "light up" end-to-end —
+  hardware → DSP → decode → event. Everything else was a roadmap item.
+- **Written down as a living roadmap.** That scope lives in the README's "What
+  is this?" and "Status snapshot" sections to this day, listing what's done and
+  what's still a gap — exactly the problem-statement-plus-success-criteria idea,
+  grown up.
+
+You don't need to be building a radio for this to transfer. Swap "SDR scanner"
+for "budgeting CLI," "team status dashboard," or "static-site generator" — the
+moves are identical: real itch, cheap validation, ruthless scope, write it down.
+
+## FAQ
+
+**How do I know if my idea is too small?**
+It probably isn't. Beginners almost always over-scope, not under-scope. If you
+can describe the whole first version in a paragraph and build it in a few weeks,
+that's a feature, not a bug — ship it and learn from real use.
+
+**What if a tool that does this already exists?**
+That's a positive signal: it means the problem is real and someone proved people
+will use a solution. Compete on a clear, specific difference — simpler, faster,
+free, open source, cross-platform — rather than trying to do everything the
+incumbent does.
+
+**Should I use Claude Code this early, before there's any code?**
+Yes. The idea and validation stage is one of the highest-leverage places to use
+it: market scans, competitor summaries, brainstorming feature lists, and
+pressure-testing your problem statement. Code comes later.
+
+**Do I need to pick the programming language now?**
+Not yet — but soon. Once the problem and scope are clear, your constraints
+(platforms, performance, distribution) will point at a language. That's
+[Part 2]({{ '/blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/' | relative_url }}).
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: Choosing Your Language, Platforms & Tech Stack]({{ '/blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/' | relative_url }})

--- a/docs/_posts/2026-06-19-build-in-the-open-02-choosing-language-platforms-stack.md
+++ b/docs/_posts/2026-06-19-build-in-the-open-02-choosing-language-platforms-stack.md
@@ -1,0 +1,210 @@
+---
+title: "Build in the Open, Part 2: Choosing Your Language, Platforms & Tech Stack"
+description: How to choose a programming language and tech stack — let your constraints (platforms, performance, distribution, team skills) decide, with GopherTrunk as a worked example.
+keywords: choosing a programming language, tech stack, picking a language, single binary, cross-compile, boring technology, distribution, claude code, github
+category: tutorials
+tags: [github, claude-code, architecture, planning, getting-started]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 2
+---
+
+> **TL;DR:** Don't pick a language because it's trendy — pick the one whose
+> strengths line up with your *constraints*. Write down where your software has
+> to run, how fast it has to be, how you'll ship it, and what you already know.
+> Those four answers usually point at one or two obvious choices. Favor boring,
+> proven tech, and treat **distribution** — how a stranger installs your thing —
+> as a first-class design decision, not an afterthought.
+
+**Key takeaways**
+
+- Constraints pick the language, not taste: target platforms, performance,
+  distribution, ecosystem, and the skills you already have.
+- "Boring" (mature, well-documented, widely used) beats "exciting" for anything
+  you intend to maintain.
+- Distribution is a feature. A single static binary beats a tool that needs a
+  runtime and three system libraries to install.
+- Pick your datastore and frontend the same way — by constraint — and pin your
+  toolchain versions so builds are reproducible and patched.
+
+*This is Part 2 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **Why constraints, not preferences, should pick your language** — the five
+  questions that do most of the deciding.
+- **Why "boring" technology usually wins** for projects you plan to keep.
+- **Treating distribution as a feature** — single binary vs. runtime
+  dependencies.
+- **Picking a frontend and a datastore** by the same constraint-first logic.
+- **How GopherTrunk chose its stack**, as a concrete example you can adapt.
+
+## Let your constraints pick the language
+
+In [Part 1]({{ '/blog/tutorials/build-in-the-open-01-picking-what-to-build/' | relative_url }})
+you wrote a problem statement and scoped a first version. That work pays off
+now, because a clear problem turns "what language should I use?" from a religious
+debate into a checklist. Ask five questions and write down the answers:
+
+1. **Where does it have to run?** A web service, a CLI on a teammate's laptop, a
+   phone, a Raspberry Pi, all of the above? Cross-platform reach narrows the
+   field fast.
+2. **How fast does it have to be?** Most software is I/O-bound and "fast enough"
+   in almost anything. A few projects genuinely need tight latency or raw
+   throughput — be honest about which you are.
+3. **How will people install it?** This is the one beginners forget, and it
+   matters more than almost anything else. We'll come back to it.
+4. **What does the ecosystem give you for free?** A mature library for your hard
+   problem (parsing, crypto, ML, DSP) can save months. Check what exists *before*
+   you commit.
+5. **What do you (or your team) already know?** Shipping in a language you know
+   beats stalling in one you're learning — unless learning it is the point.
+
+Notice that "which language is best" isn't on the list. There's no best
+language, only a best *fit* for a specific set of constraints. The same problem
+can have different right answers for a solo hobbyist and a ten-person team.
+
+## Why boring technology usually wins
+
+Once a few candidates survive the constraint checklist, prefer the **boring**
+one. "Boring" here is a compliment: it means mature, widely deployed, thoroughly
+documented, and supported by a deep bench of libraries and answered questions.
+
+Boring tech wins because the costs of software show up *after* the fun part.
+You'll spend far more time debugging, upgrading, and onboarding than you spent
+writing the first version. A popular, stable language means that when you hit a
+weird error at 11pm, someone has already hit it, asked about it, and posted the
+answer. A bleeding-edge stack means *you're* the one writing that post.
+
+Keep your "innovation budget" for the part of the project that's actually
+novel — your domain logic — and spend boring, proven choices everywhere else.
+
+## Distribution is a feature, not an afterthought
+
+Here's the constraint that quietly decides the most: **how does a stranger get
+your software running?** Every step between "found it" and "it works" loses
+users. Compare two ends of the spectrum:
+
+- **A single self-contained binary.** Download one file, run it. No interpreter
+  to install, no package manager, no "works on my machine" version skew. This is
+  the gold standard for CLI tools and self-hosted services.
+- **A runtime plus dependencies.** "Install Python 3.11, then `pip install`
+  these twelve packages, then make sure `libfoo-dev` is present, then…" Every
+  one of those is a place where a new user gives up.
+
+If your project is something people self-host or run locally, distribution
+should shape your language choice directly. Languages that compile to a single
+static binary — Go, Rust, sometimes C/C++ or Zig — make "download and run" real.
+Interpreted languages can get close with bundlers, but it's extra work you're
+choosing to take on. Decide this *up front*, because retrofitting easy
+distribution onto a stack that fights it is painful.
+
+## Picking a frontend and a datastore
+
+The same constraint-first logic applies to the rest of the stack.
+
+**Frontend.** If your tool needs a UI, ask what *kind*. A terminal UI (TUI) is
+perfect for developer tools and keeps everything in one binary. A browser-based
+console reaches non-technical users on any device with no install. A native
+desktop or mobile app buys you OS integration at the cost of platform-specific
+builds. For a web console, the boring-and-proven default today is a component
+framework (React, Vue, Svelte) with a fast build tool and a typed language —
+because type safety catches whole classes of bugs before they ship.
+
+**Datastore.** Don't reach for a heavyweight database server because "real apps
+have one." For a single-node tool or a self-hosted service, an embedded database
+that lives in one file — SQLite being the canonical choice — means *zero* setup
+for your users and keeps the single-binary dream alive. Scale to a client-server
+database (Postgres, MySQL) only when concurrency, multi-host access, or data
+size actually demands it.
+
+## Pin your toolchain
+
+One more habit that separates hobby projects from maintainable ones: **pin the
+version of your compiler/runtime and dependencies.** "Latest" is a moving target
+that makes builds non-reproducible and silently pulls in — or misses — security
+patches. Pin to a specific version, document why, and bump it deliberately when
+a fix or feature you need lands. Your future self and your CI both thank you.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) is a digital-trunking
+SDR scanner, and every stack decision traces straight back to a constraint.
+
+- **Language: pure Go, with `CGO_ENABLED=0`.** The problem statement from Part 1
+  was essentially "there's no SDR scanner that installs as a single,
+  dependency-free binary on any OS." Go delivers exactly that. By building with
+  CGO disabled, the project has **no C dependencies at build or runtime** — no
+  `librtlsdr`, `libhackrf`, `libusb`, `libasound2`, or `libmp3lame` — the very
+  libraries that make competing tools painful to install. The result ships as a
+  single **~10 MB static binary** that cross-compiles to Linux, macOS, and
+  Windows (including Apple Silicon) with `go build`. Distribution drove the
+  language, exactly as it should.
+
+- **Datastore: SQLite via `modernc.org/sqlite`.** GopherTrunk logs calls, pager
+  messages, vessels, and more — it needs a database. But the usual Go SQLite
+  driver requires CGO, which would have blown up the no-C-dependencies
+  constraint. The fix is `modernc.org/sqlite`, a **pure-Go** SQLite that needs no
+  CGO. One embedded file, zero setup for users, single binary preserved. You can
+  see it pinned in [`go.mod`](https://github.com/MattCheramie/GopherTrunk/blob/main/go.mod)
+  alongside the rest of the dependencies.
+
+- **Frontend: React 18 + Vite + TypeScript + Tailwind.** The web operator console
+  needs to reach non-technical users in any browser, so it's a standard, boring,
+  proven stack: React 18 for components, Vite for a fast build, TypeScript for
+  type safety, Tailwind for styling. It compiles to a **prebuilt static bundle
+  shipped alongside the daemon** — so there's no Node.js at runtime, and the
+  single-binary distribution story still holds. (There's also a Bubbletea TUI
+  cockpit for terminal users — same "one binary, no install" philosophy.)
+
+- **Toolchain pinned to Go 1.25.11.** [`go.mod`](https://github.com/MattCheramie/GopherTrunk/blob/main/go.mod)
+  contains a `toolchain go1.25.11` directive with a comment explaining exactly
+  why: it closes a list of stdlib CVEs that `govulncheck` flagged against earlier
+  1.25.x releases (an `html/template` XSS, `crypto/tls` issues, `crypto/x509`
+  chain-building bugs, and more). CI's `setup-go` is pinned to the same version
+  so the toolchain download doesn't repeat on every step. That's pinning done
+  right — specific version, documented reason, security-driven.
+
+Swap the domain and the moves are identical. A Python data tool might pick
+Postgres because it genuinely needs concurrent writers; a game might pick a
+native stack for GPU access; a docs site might pick a static-site generator for
+zero-runtime hosting. The discipline is the same: name your constraints, then
+let them choose.
+
+## FAQ
+
+**How do I choose a programming language for a new project?**
+List your hard constraints first — target platforms, performance needs, how
+you'll distribute it, what libraries you need, and what you already know — then
+pick the language whose strengths match. For anything you'll maintain, prefer a
+mature, widely-used language over a trendy one.
+
+**When should I use a single static binary instead of a runtime?**
+Whenever real people other than you will install your software — especially CLI
+tools and self-hosted services. A single binary removes the most common reason
+new users bounce: a broken or fiddly install. Choose a language that compiles to
+one (Go, Rust) if distribution matters.
+
+**What is a "boring" tech stack, and why is it good?**
+Boring means mature, stable, widely adopted, and well-documented. It's good
+because most of a project's cost is maintenance, debugging, and onboarding — all
+of which are far cheaper when the answer to your problem is already on the
+internet. Save novelty for your actual domain logic.
+
+**Do I need a database server like Postgres for my project?**
+Usually not at first. For a single-node tool or self-hosted service, an embedded
+database like SQLite needs zero setup and keeps your install a single file. Move
+to a client-server database only when concurrency, multi-host access, or scale
+genuinely require it.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1: Picking What to Build]({{ '/blog/tutorials/build-in-the-open-01-picking-what-to-build/' | relative_url }})
+· Next →
+[Part 3: Brainstorming Features with Claude & Writing the README as Your Roadmap]({{ '/blog/tutorials/build-in-the-open-03-brainstorm-with-claude-readme-roadmap/' | relative_url }})

--- a/docs/_posts/2026-06-20-build-in-the-open-03-brainstorm-with-claude-readme-roadmap.md
+++ b/docs/_posts/2026-06-20-build-in-the-open-03-brainstorm-with-claude-readme-roadmap.md
@@ -1,0 +1,212 @@
+---
+title: "Build in the Open, Part 3: Brainstorming Features with Claude & Writing the README as Your Roadmap"
+description: How to research a domain and brainstorm features with Claude Code, then write a README that doubles as a living roadmap — plus what CLAUDE.md is for.
+keywords: brainstorm features, claude code, readme as roadmap, project planning, CLAUDE.md, competitive research, prioritize features, github, living roadmap
+category: tutorials
+tags: [github, claude-code, planning, documentation, getting-started]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 3
+---
+
+> **TL;DR:** Use Claude Code as a research and brainstorming partner — ask it to
+> map the domain, list existing tools and their gaps, and propose features — then
+> *you* prioritize the list ruthlessly. Capture the result in a README that
+> doubles as a living roadmap: a clear "what is this?", a status snapshot of
+> what's done versus what's still a gap, and links to deeper planning docs. Add a
+> `CLAUDE.md` so Claude knows your project's standing rules every session.
+
+**Key takeaways**
+
+- Claude Code is at its best early: domain research, competitive scans, and
+  feature brainstorms in an afternoon instead of a week.
+- Brainstorming is divergent; *prioritizing* is convergent — that judgment call
+  stays yours. Sort into Must/Should/Could/Won't.
+- A great README answers "what is this, why should I care, how do I run it, and
+  what's the state of it" — fast.
+- A README-as-roadmap includes a status snapshot (done vs. gaps) so the
+  project's reality is always visible.
+- `CLAUDE.md` is your project's standing instructions to Claude — write it once,
+  benefit every session.
+
+*This is Part 3 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **How to brainstorm features with Claude Code** — prompts for domain research
+  and competitive scans.
+- **Turning a brainstorm into a prioritized list** you can actually build.
+- **What a great README contains** — and the order to put it in.
+- **The README as a living roadmap** — done vs. gaps, always current.
+- **What `CLAUDE.md` is** and why every project should have one.
+- **How GopherTrunk does it**, as a concrete example you can copy.
+
+## Brainstorming features with Claude Code
+
+In [Part 1]({{ '/blog/tutorials/build-in-the-open-01-picking-what-to-build/' | relative_url }})
+you validated a problem; in
+[Part 2]({{ '/blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/' | relative_url }})
+you chose a stack. Now you need to know *what to build*, in what order. This is
+one of the highest-leverage places to use Claude Code, because the work is mostly
+reading and synthesis — exactly what it's fast at.
+
+Treat it like a research assistant, not an oracle. Good prompts are specific and
+ask for structure:
+
+- **Map the domain.** *"I'm building a self-hosted X for Y users. Explain the
+  landscape: the main concepts, the hard problems, and the terms I should know."*
+- **Scan the competition.** *"List the existing tools that solve this, with each
+  one's strengths, weaknesses, and what users complain about. Where are the
+  gaps?"*
+- **Brainstorm features.** *"Given that problem and those competitors, propose a
+  feature list. Group features as table-stakes, differentiators, and
+  nice-to-haves."*
+- **Pressure-test scope.** *"For a first useful version I can ship in a few
+  weeks, which of these are truly essential and which can wait?"*
+
+Two habits make this trustworthy. First, **ask for sources or reasoning**, not
+just conclusions, so you can sanity-check. Second, remember Claude is generating
+candidates — the *judgment* about what's actually worth building is yours.
+
+## From brainstorm to a prioritized list
+
+A brainstorm gives you breadth; a project needs a spine. Converge the long list
+into something buildable using the same **MoSCoW** lens from Part 1:
+
+- **Must** — without these the thing doesn't solve the problem at all. This is
+  your first milestone, and only this.
+- **Should** — important but not launch-blocking. The near-term roadmap.
+- **Could** — nice if they're cheap; otherwise later.
+- **Won't (yet)** — explicitly out of scope. Writing these down is as valuable as
+  the Musts, because it stops scope creep and answers "why didn't you build X?"
+  before anyone asks.
+
+The output isn't a Gantt chart — it's a short, honest list of what's in, what's
+next, and what's deliberately not happening. That list is the raw material for
+your README.
+
+## What a great README contains
+
+The README is the front door. Most visitors decide in seconds whether to keep
+going, so lead with the answer. A strong README, roughly in order:
+
+1. **What is this?** One or two sentences a newcomer understands — the problem it
+   solves and who it's for. No jargon dump.
+2. **Why does it exist / what's different?** The one-line reason to pick this
+   over alternatives.
+3. **Quick start.** The shortest path from "found it" to "it's running" — copy-
+   pasteable commands.
+4. **Features.** What it actually does, in plain language.
+5. **Status.** How finished it is — what works, what's coming. (More on this
+   next.)
+6. **Build, contribute, license, links.** The logistics, near the bottom where
+   people who need them will look.
+
+Write for the person who has *never seen your project*, not for yourself.
+
+## The README as a living roadmap
+
+Here's the move that keeps a README honest: include a **status snapshot** — a
+short section listing what's done and what's still a gap. This turns the README
+from a static brochure into a *living roadmap*. It does three jobs at once:
+
+- **Sets expectations.** Visitors immediately know whether the feature they need
+  works today or is aspirational.
+- **Builds trust.** Naming your gaps openly reads as confidence, not weakness.
+- **Doubles as your plan.** The gap list *is* your near-term backlog.
+
+Keep the README's snapshot short and link out to deeper planning documents — a
+`roadmap.md` for near-term plans, a `status.md` for detailed per-feature state,
+and a `CHANGELOG.md` for what's already shipped. The README summarizes; those
+docs carry the detail. Update the snapshot whenever reality changes, and it stays
+trustworthy.
+
+## What CLAUDE.md is
+
+A `CLAUDE.md` file in your repo root is your project's **standing instructions to
+Claude Code** — it's read automatically at the start of a session and gives
+Claude the context a new contributor would need: how to build and test, coding
+conventions, architectural rules, what *not* to touch, and where things live.
+
+Think of it as onboarding docs that an AI actually reads every time. Instead of
+re-explaining "we use Conventional Commits" or "always run the linter before
+committing" in each session, you write it once in `CLAUDE.md`. Good entries are
+concrete and imperative: *"Run `make test` before committing,"* *"Never edit
+generated files in `proto/`,"* *"Match the existing table-driven test style."*
+You can generate a first draft with the `/init` command and then refine it as the
+project's conventions solidify.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk)'s
+[README](https://github.com/MattCheramie/GopherTrunk/blob/main/README.md) is a
+textbook README-as-roadmap.
+
+- **"What is this?" up top.** The README opens with a `## What is this?` section
+  that explains, in plain language, that GopherTrunk is a software-defined-radio
+  scanner that follows trunked-radio voice calls and decodes them to audio — what
+  hardware it runs on, and its defining difference (no C dependencies, single
+  ~10 MB static binary). A newcomer gets the whole pitch in one paragraph.
+
+- **A real status snapshot.** Further down, a `## Status snapshot` section states
+  plainly what runs end-to-end today, then a **"Remaining gaps:"** list naming
+  exactly what *isn't* finished — for example, which digital-voice composer chains
+  don't yet decode to PCM, and which subsystems still need on-air validation.
+  That honesty is the living-roadmap principle in action.
+
+- **Links out to deeper planning docs.** The snapshot ends by pointing to the
+  detailed planning trio: long-form per-protocol state in
+  [`docs/status.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/status.md),
+  near-term plans in
+  [`docs/roadmap.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/docs/roadmap.md),
+  and shipped work in
+  [`CHANGELOG.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/CHANGELOG.md).
+  README summarizes; those carry the detail.
+
+- **The README is literally the website.** This is the payoff. GopherTrunk's
+  GitHub Pages site at gophertrunk.org doesn't maintain a separate landing page —
+  the `pages.yml` workflow **synthesizes the landing page from `README.md` at
+  build time**, rewriting asset and cross-link paths so they resolve on the site.
+  Because the README *is* the homepage, keeping it accurate isn't busywork; it's
+  the one source of truth for the front door of both the repo and the site.
+
+Whatever you're building, the pattern transfers: research with Claude, prioritize
+yourself, and write a README whose status snapshot keeps it honest as the project
+grows.
+
+## FAQ
+
+**How do I use Claude Code to brainstorm features?**
+Give it your problem statement and ask for structured output: a domain map, a
+competitive scan of existing tools and their gaps, and a feature list grouped
+into table-stakes, differentiators, and nice-to-haves. Then *you* prioritize —
+Claude generates candidates, but the call on what's worth building is yours.
+
+**When should I write the README — before or after the code?**
+Start it early, even before much code exists. A README draft forces you to state
+what the project is and what its first version includes, and that clarity guides
+the build. Then keep it current — especially the status snapshot — as you ship.
+
+**What is CLAUDE.md and do I need one?**
+`CLAUDE.md` is a file in your repo that Claude Code reads automatically each
+session — your project's standing instructions: how to build and test,
+conventions, and what not to touch. You don't strictly need one, but it makes
+every session more accurate and saves you re-explaining the same rules. Run
+`/init` to generate a starting draft.
+
+**What should a README status snapshot include?**
+A short list of what works end-to-end today and an explicit list of remaining
+gaps, plus links to deeper planning docs (roadmap, status, changelog). Keep it
+brief in the README and update it when reality changes so it stays trustworthy.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2: Choosing Your Language, Platforms & Tech Stack]({{ '/blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/' | relative_url }})
+· Next →
+[Part 4: Git & GitHub Fundamentals (Using the Web Interface)]({{ '/blog/tutorials/build-in-the-open-04-git-github-fundamentals-web-interface/' | relative_url }})

--- a/docs/_posts/2026-06-21-build-in-the-open-04-git-github-fundamentals-web-interface.md
+++ b/docs/_posts/2026-06-21-build-in-the-open-04-git-github-fundamentals-web-interface.md
@@ -1,0 +1,214 @@
+---
+title: "Build in the Open, Part 4: Git & GitHub Fundamentals (Using the Web Interface)"
+description: A beginner's Git mental model — commits, branches, remotes, the staging area — and how to create a repo, edit files, and open your first pull request entirely in the GitHub web UI.
+keywords: git for beginners, github web interface, what is a commit, git branches, what is a remote, gitignore, first pull request, create a github repo, github
+category: tutorials
+tags: [github, git, getting-started, version-control, claude-code]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 4
+---
+
+> **TL;DR:** Git is a time machine for your files: a **commit** is a labeled
+> snapshot, a **branch** is a movable line of snapshots you can experiment on
+> safely, and a **remote** (like GitHub) is a shared copy everyone syncs to. You
+> can do all the basics — create a repo, add a README/.gitignore/license, edit
+> and commit files, make a branch, and open a pull request — entirely in the
+> GitHub website, no command line required. Learn the mental model first; the
+> buttons make sense after that.
+
+**Key takeaways**
+
+- A commit is a snapshot with a message; Git tracks *changes over time*, not
+  just the latest files.
+- Branches let you work without touching the stable version; `main` stays good
+  while you experiment.
+- A remote is the shared copy (GitHub). You "push" to share and "pull" to catch
+  up.
+- The whole beginner loop — edit, commit, branch, pull request — works in the
+  browser.
+- A `.gitignore` keeps build output and secrets *out* of your repo.
+
+*This is Part 4 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **What Git actually tracks** — commits, the staging area, and why snapshots
+  beat "final_v2_FINAL.zip".
+- **Why branches exist** and how they keep `main` safe.
+- **What a remote is** and how GitHub fits in.
+- **The web-based loop**: create a repo, edit, commit, branch, open a PR — all in
+  the browser.
+- **.gitignore essentials** — what to keep out.
+- **How GopherTrunk does it**, as a concrete example.
+
+## What Git actually tracks
+
+Forget the commands for a minute. Git is a system that records the **history of
+your files as a series of snapshots**. Each snapshot is a **commit**: the exact
+state of every tracked file at that moment, plus a short message describing what
+changed and why ("Add login form", "Fix off-by-one in parser").
+
+This is the core idea that makes Git worth learning: you're not saving *files*,
+you're saving *the story of how they changed*. You can look at any past commit,
+compare two of them, or undo back to one — without ever resorting to a folder
+full of `report-final-v3-actually-final.docx`.
+
+One subtlety beginners hit: between "I changed a file" and "it's in a commit"
+there's a middle step called the **staging area**. You *stage* the specific
+changes you want to include, then *commit* them together. It lets you commit one
+logical change at a time even if you edited several files. (In the GitHub web UI
+this is mostly hidden — committing in the browser stages and commits in one
+action — but it's worth knowing the term exists.)
+
+## Why branches exist
+
+A **branch** is a movable pointer to a line of commits. Every repo has a default
+branch, almost always called `main`, which holds the version you consider good.
+
+Branches matter because they let you work on something risky or unfinished
+**without putting `main` at risk**. You create a branch off `main`, make commits
+on it, and `main` stays exactly as it was. If the experiment works, you merge it
+back; if it doesn't, you throw the branch away and nothing of value is lost. This
+is why teams (and Claude Code) work on feature branches: `main` stays
+releasable while work happens to the side.
+
+The mental picture: `main` is the trunk of a tree; a branch grows off it, gets
+its own commits, and eventually either grafts back in (merge) or gets pruned.
+
+## What a remote is
+
+So far everything could live on your laptop. A **remote** is a copy of the repo
+hosted somewhere shared — GitHub being the most common. The remote is how you
+back up your work, collaborate, and publish.
+
+Two verbs connect you to it:
+
+- **Push** — send your local commits up to the remote so others (and your other
+  machines) can see them.
+- **Pull** — bring the remote's new commits down to your copy so you're up to
+  date.
+
+When you work entirely in the GitHub website, *the remote is the only copy you're
+touching* — every edit and commit happens directly on GitHub, so there's no
+separate push/pull step. That's exactly why the web interface is such a friendly
+on-ramp: you get commits, branches, and pull requests without yet installing Git
+or learning the command line.
+
+## The whole loop in the GitHub web interface
+
+Here's the complete beginner workflow, no terminal required.
+
+**1. Create the repository.** On GitHub, click **New repository**, give it a
+name, choose public or private, and — importantly — check the boxes to **add a
+README**, a **.gitignore** (pick the template for your language), and a
+**license**. Those three files give you a real starting commit instead of an
+empty repo.
+
+**2. Edit a file in the browser.** Open any file and click the pencil
+(**Edit**) icon. GitHub gives you a text editor right in the page. Make your
+change.
+
+**3. Commit it.** Scroll down to the **Commit changes** box. Write a short,
+descriptive message, choose "commit directly to `main`" *or* "create a new
+branch for this commit," and click commit. That's a real commit, recorded in
+history.
+
+**4. Create a branch.** Use the branch dropdown (top-left of the file list, says
+`main`), type a new branch name, and press enter. You're now working off to the
+side. Make your edits and commits here; `main` is untouched.
+
+**5. Open your first pull request (PR).** A **pull request** proposes merging your
+branch's changes into `main`. After committing to a branch, GitHub shows a
+**Compare & pull request** prompt — click it, write a title and a short
+description of *why* the change matters, and click **Create pull request**. Now
+your change is visible, reviewable, and (once approved) mergeable. PRs are the
+heart of collaborating on GitHub, and we'll dig into merge strategies in
+[Part 5]({{ '/blog/tutorials/build-in-the-open-05-three-ways-to-merge-to-main/' | relative_url }}).
+
+That's the entire loop: **edit → commit → branch → pull request**, all from a
+web browser.
+
+## .gitignore essentials
+
+Not everything belongs in a repo. A **`.gitignore`** file lists patterns Git
+should *not* track. Two categories matter most:
+
+- **Generated output** — compiled binaries, build folders, dependency caches.
+  These are produced from your source, so committing them just bloats the repo
+  and causes pointless conflicts. Examples: `node_modules/`, `dist/`, a compiled
+  binary, `*.test`.
+- **Secrets and local junk** — `.env` files with credentials, editor settings
+  (`.idea/`, `.vscode/`), OS cruft (`.DS_Store`). Secrets *especially* must never
+  be committed; once pushed, treat them as compromised.
+
+The GitHub "new repository" flow offers a language-appropriate `.gitignore`
+template, which is a great starting point you then tweak as your project grows.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) follows these exact
+fundamentals at scale.
+
+- **`main` plus feature branches.** The stable, releasable version lives on
+  `main`; all work happens on short-lived feature branches that merge back via
+  pull requests. `main` always stays in a shippable state.
+
+- **A clear branch-naming convention.** Branches follow a
+  `<topic>/<short-description>` shape — and for AI-assisted work the project uses
+  `claude/issue-NNN-desc` (for example, a branch tied to issue 698). A consistent
+  naming scheme makes it obvious at a glance what a branch is for and which issue
+  it addresses. The
+  [CONTRIBUTING guide](https://github.com/MattCheramie/GopherTrunk/blob/main/CONTRIBUTING.md)
+  spells the convention out.
+
+- **A `.gitignore` tuned for its stack.** GopherTrunk's
+  [`.gitignore`](https://github.com/MattCheramie/GopherTrunk/blob/main/.gitignore)
+  keeps Go build output out of the repo — `/bin/`, `/dist/`, stray `gophertrunk`
+  binaries, `*.test`, `*.out`, `*.prof` — alongside local secrets (`.env`,
+  `.env.*`), editor folders (`.idea/`, `.vscode/`), OS files (`.DS_Store`), and
+  the Jekyll docs-site build output (`docs/_site/`, `.jekyll-cache/`). The web
+  console has its own `web/.gitignore` ignoring `node_modules/` and the built
+  `dist/`. Generated and secret stuff stays out; source stays in.
+
+You don't need a project this size to use the same moves. Create a repo with a
+README, license, and `.gitignore`; keep `main` stable; do your work on a named
+branch; and open a PR — all from the browser if you like. The command line can
+come later.
+
+## FAQ
+
+**What is the difference between Git and GitHub?**
+Git is the version-control tool that records your file history as commits.
+GitHub is a website that hosts Git repositories — a *remote* — adding
+collaboration features like pull requests, issues, and code review on top. You
+can use Git without GitHub, but GitHub needs Git underneath.
+
+**Do I need to install Git or use the command line to start?**
+No. You can create a repository, edit and commit files, make branches, and open
+pull requests entirely in the GitHub website. The web interface is a friendly
+on-ramp; the command line is worth learning later but isn't required to begin.
+
+**What is a pull request and why use one?**
+A pull request proposes merging the commits on one branch into another (usually
+into `main`). It makes your change visible and reviewable before it lands, which
+is how teams collaborate safely and keep `main` stable. You create one from the
+branch dropdown's "Compare & pull request" prompt.
+
+**What should go in a .gitignore file?**
+Anything that's generated or secret: compiled binaries and build folders
+(`dist/`, `node_modules/`, `*.test`), dependency caches, credential files
+(`.env`), editor configs (`.idea/`, `.vscode/`), and OS cruft (`.DS_Store`).
+Committed source stays in; everything reproducible or sensitive stays out.
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3: Brainstorming Features with Claude & Writing the README as Your Roadmap]({{ '/blog/tutorials/build-in-the-open-03-brainstorm-with-claude-readme-roadmap/' | relative_url }})
+· Next →
+[Part 5: Branching & the Three Ways to Merge to Main]({{ '/blog/tutorials/build-in-the-open-05-three-ways-to-merge-to-main/' | relative_url }})

--- a/docs/_posts/2026-06-22-build-in-the-open-05-three-ways-to-merge-to-main.md
+++ b/docs/_posts/2026-06-22-build-in-the-open-05-three-ways-to-merge-to-main.md
@@ -1,0 +1,226 @@
+---
+title: "Build in the Open, Part 5: Branching & the Three Ways to Merge to Main"
+description: How to use Git branches and pick the right GitHub merge strategy — merge commit, squash & merge, or rebase & merge — with a clear "use this when" for each.
+keywords: git branching, merge to main, squash and merge, rebase and merge, merge commit, pull request, draft pr, required status checks, github, claude code
+category: tutorials
+tags: [github, git, branching, pull-requests, workflow]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 5
+---
+
+> **TL;DR:** A branch is a cheap, isolated copy of your work; a pull request is
+> how it gets back into `main`. GitHub gives you three merge buttons — **Create
+> a merge commit**, **Squash and merge**, and **Rebase and merge** — and they
+> match three real ways of shaping work: many small commits, a few large logical
+> commits, or one clean squashed commit per feature. Pick one default for the
+> repo, and let the *shape of the work* pick the exception.
+
+**Key takeaways**
+
+- Always branch off `main`; never commit straight to it. The branch is your
+  scratchpad, the PR is your gate.
+- **Squash and merge** keeps `main` linear and readable — one feature, one
+  commit. It's the safest default for most projects.
+- **Rebase and merge** preserves a curated set of logical commits without a
+  merge bubble — use it when each commit is a reviewable step.
+- **Create a merge commit** keeps the full branch history and records *when*
+  things merged — use it for long-lived or release branches.
+- Required status checks and review turn the merge button from a hope into a
+  guarantee.
+
+*This is Part 5 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **What a branch actually is** — and why you always make one.
+- **The pull request** as the gate: review, status checks, draft PRs.
+- **The three ways to merge to main**, mapped to GitHub's three merge buttons,
+  with a "use this when" for each.
+- **How to choose a default** for your repo and when to break it.
+- **How GopherTrunk does it** — squash-on-merge, Conventional Commits, and a
+  "one logical change per PR" rule.
+
+## What is a branch, and why always make one?
+
+A **branch** is a movable pointer to a line of commits. When you branch off
+`main`, you get an isolated copy of the project's history that you can commit to
+freely without touching the shared, "known-good" `main` branch. If the
+experiment works, you merge it back; if it doesn't, you delete the branch and
+nothing is lost.
+
+The rule experienced teams follow is simple: **`main` is always releasable, so
+nobody commits to it directly.** All work happens on a branch, and the only way
+in is a pull request. That single discipline buys you code review, automated
+testing, and a clean audit trail — for free.
+
+A good branch is *one thing*: one bug fix, one feature, one refactor. A branch
+named `fix-timezone-parsing` should not also quietly reformat three unrelated
+files. Keeping branches narrow is what makes the merge decision below easy.
+
+## The pull request is the gate
+
+A **pull request (PR)** proposes merging your branch into `main`. It's where
+three safety mechanisms live:
+
+- **Review.** A second pair of eyes (or, on a solo project, your own
+  cooled-off self the next morning) reads the diff and approves or requests
+  changes.
+- **Required status checks.** GitHub can *block* the merge button until your
+  CI — build, tests, linters — reports success. We cover building those checks
+  in [Part 7]({{ '/blog/tutorials/build-in-the-open-07-github-actions-which-workflows/' | relative_url }}).
+- **Draft PRs.** Open a PR as a **draft** when the work isn't done but you want
+  CI to run and reviewers to peek early. You can't merge a draft until you mark
+  it "Ready for review" — a built-in guardrail against merging half-finished
+  work.
+
+Crucially, the *shape* of the commits inside your branch and the *merge button*
+you press are two different decisions. The next sections connect them.
+
+## The three ways to merge to main
+
+There are three honest ways to land a branch, defined by how many commits you
+want to appear on `main`. GitHub exposes each as a merge-button option.
+
+### 1. Many small commits → one PR
+
+You committed often while exploring — "wip", "try other approach", "fix typo",
+"actually fix it". That's a perfectly good way to *work*; it's a terrible way to
+leave `main` looking. You have two choices at merge time:
+
+- **Squash and merge** collapses all of it into a single commit on `main`. The
+  messy journey stays on the branch (and in the closed PR), `main` stays clean.
+- **Create a merge commit** keeps every commit *and* adds a merge commit that
+  records the join. Honest, but it makes `main` noisy.
+
+**Use this when:** the work was exploratory or incremental and the individual
+commits aren't worth preserving. Reach for **squash and merge** here — it's the
+most common real-world case.
+
+### 2. Three to five large logical commits → one PR
+
+Sometimes a feature genuinely has a few distinct, reviewable steps: "add the
+parser", "wire it into the pipeline", "add the config flag". Each commit
+compiles, passes tests, and tells a story. You curated this history on purpose —
+often with an interactive rebase to tidy it before opening the PR.
+
+**Use this when:** each commit is a meaningful, self-contained step a future
+reader (or `git bisect`) would want to land on individually. Reach for **rebase
+and merge** to replay those commits onto `main` with no merge bubble, or a
+careful **merge commit** if you also want to record the integration point.
+
+### 3. One squashed / "special" commit → one PR
+
+The cleanest possible `main`: **one feature equals one commit.** Every entry in
+`git log main` is a complete, shippable unit you could revert in one move. This
+is what most polished open-source projects present, regardless of how messy the
+branch was underneath.
+
+**Use this when:** you want a linear, scannable `main` history and you don't need
+intermediate commits preserved. Reach for **squash and merge** and write the
+squash commit message carefully — it's the *one* line that survives.
+
+### Mapping it to GitHub's three buttons
+
+| Merge button | What lands on `main` | Best for |
+| --- | --- | --- |
+| **Create a merge commit** | All branch commits + a merge commit | Long-lived / release branches; preserving exact history |
+| **Squash and merge** | One new commit | Exploratory work; "one feature, one commit"; linear history |
+| **Rebase and merge** | Each branch commit, replayed, no merge commit | A small curated set of logical commits |
+
+You set which options are even *allowed* in **Settings → General → Pull
+Requests**. Many teams disable the ones they don't want so nobody picks the
+wrong one by accident.
+
+## How do I choose a default — and when do I break it?
+
+Pick **one** default merge method for the whole repo and use it 95% of the time.
+For most projects, that default should be **squash and merge**, because:
+
+- It makes `main` a clean list of features and fixes, not a transcript of
+  someone's afternoon.
+- It makes reverting trivial — one commit, one `git revert`.
+- It pairs naturally with **Conventional Commits** (e.g. `feat:`, `fix:`,
+  `docs:`), where the single squash message becomes the changelog entry.
+
+Break the default only when the work's shape demands it: a carefully sequenced
+refactor that benefits from rebase-and-merge, or a release/integration branch
+where a merge commit's record of "what merged when" is the whole point.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) keeps `main` linear
+with **squash-on-merge** as the standing rule. Its
+[`CONTRIBUTING.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/CONTRIBUTING.md)
+spells out both the branch discipline and the merge policy:
+
+- **One logical change per PR.** The guide's rule of thumb: *"if you can't
+  summarise the change in one sentence in the imperative mood, the change is
+  doing more than one thing and should be split."* Bug fixes ship as one commit
+  with a regression test; refactors are a separate PR, never bundled with a
+  behaviour change.
+- **Messy branches are fine; `main` is not.** Contributors are told force-push is
+  fine on feature branches because *"the maintainer squashes on merge to keep
+  `main` history clean."* That's case 1 above, applied as policy.
+- **Conventional Commits.** Look at the real history and the pattern is obvious —
+  `feat: expose P25 site identity in grant events and via /api/v1/sites (#698)`,
+  `fix(sdr): serialize StreamIQ re-open behind async teardown (#686)`,
+  `ci(pages): run docs rebuild daily at 11:00 Central`. Each squashed commit is a
+  typed, scoped, one-line summary that doubles as a changelog line.
+- **The merge button is gated, not free.** GopherTrunk's branch-protection
+  ruleset (`.github/rulesets/main-branch-protection.json`) requires the
+  `build-test`, `usb-windows`, and `usb-macos` status checks to pass and requires
+  review threads resolved before the merge button unlocks — and it allows all
+  three merge methods (`"allowed_merge_methods": ["merge", "squash", "rebase"]`)
+  so the maintainer can pick per-PR while defaulting to squash.
+- **A test plan rides along.** Every PR fills in the template at
+  [`.github/pull_request_template.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/.github/pull_request_template.md),
+  whose **Test plan** checklist asks for `make vet test` green locally,
+  `make integration` if the daemon changed, added/updated tests, and a hardware
+  smoke test if SDR/USB/vocoder code changed. The shape of the work is reviewed
+  *before* anyone reaches for the merge button.
+
+You're not building a radio, but the moves port directly: branch per change,
+keep each PR to one logical thing, gate the merge with CI and review, and squash
+unless the work's structure earns an exception.
+
+## FAQ
+
+**Should I squash, rebase, or merge-commit by default?**
+Default to **squash and merge** for a clean, linear `main` where one feature is
+one commit. Use **rebase and merge** when a few curated commits each deserve to
+survive, and a **merge commit** for long-lived or release branches where the
+record of when things merged matters.
+
+**What's the difference between rebase-and-merge and a merge commit?**
+Rebase-and-merge replays your branch's commits directly onto `main` with no extra
+commit, giving a straight line. A merge commit keeps your commits *and* adds a
+new commit recording the join, which preserves the exact branch topology but
+makes the history non-linear.
+
+**What is a draft pull request and when should I open one?**
+A draft PR runs your CI and lets reviewers see the work, but its merge button is
+disabled until you mark it "Ready for review." Open one when you want early
+feedback or to confirm checks pass before the work is finished.
+
+**Can I commit directly to main?**
+You can, but you shouldn't. Branch-protection rules (Part 12) can forbid it
+outright. Routing every change through a branch and PR gives you review,
+automated testing, and an easy path to revert.
+
+**How many commits should one PR have?**
+As many as the work honestly needs — but the PR should still represent **one
+logical change**. If your commits span two unrelated concerns, that's two PRs,
+not one.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4: Git & GitHub Fundamentals (the Web Interface)]({{ '/blog/tutorials/build-in-the-open-04-git-github-fundamentals-web-interface/' | relative_url }})
+· Next →
+[Part 6: Planning & Tracking Work — and Inviting Contributors]({{ '/blog/tutorials/build-in-the-open-06-issues-planning-inviting-contributors/' | relative_url }})

--- a/docs/_posts/2026-06-23-build-in-the-open-06-issues-planning-inviting-contributors.md
+++ b/docs/_posts/2026-06-23-build-in-the-open-06-issues-planning-inviting-contributors.md
@@ -1,0 +1,219 @@
+---
+title: "Build in the Open, Part 6: Planning & Tracking Work — and Inviting Contributors"
+description: How to plan work with GitHub Issues, labels, milestones, and Projects, link issues to PRs, and onboard contributors with CONTRIBUTING, templates, and roles.
+keywords: github issues, labels, milestones, github projects, closes issue, good first issue, contributing.md, code of conduct, codeowners, inviting contributors, claude code
+category: tutorials
+tags: [github, issues, planning, contributors, open-source]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 6
+---
+
+> **TL;DR:** Track work where the code lives. GitHub **Issues** capture *what*
+> needs doing, **labels** sort them, **milestones** group them toward a release,
+> and a **Project board** shows them moving from "todo" to "done." Link each PR
+> to its issue with `Closes #N` so merging auto-closes the work. To invite
+> contributors, make the path obvious: a `CONTRIBUTING.md`, a code of conduct,
+> issue/PR templates, and a few `good first issue` tickets do most of the work.
+
+**Key takeaways**
+
+- A good issue states the problem, the expected behaviour, and how you'll know
+  it's fixed — not just "X is broken."
+- Labels are a taxonomy (type + area + priority); keep it small enough to
+  actually use.
+- Milestones answer "what's in the next release?"; Projects answer "what's
+  moving right now?"
+- `Closes #N` in a PR body auto-closes the issue on merge — the single most
+  useful issue-to-PR link.
+- The contributor funnel is real: lower every step from "I want to help" to
+  "my PR merged."
+
+*This is Part 6 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **Writing good issues** that someone (including future you) can act on.
+- **Labels, milestones, and Projects** — what each is for and when to reach for
+  it.
+- **Linking issues to PRs** so merging closes the loop automatically.
+- **Inviting contributors**: the docs and signals that lower the barrier.
+- **Collaborator roles** and how much access to hand out.
+- **How GopherTrunk does it** — issue-referencing commits, branch naming, and
+  the scope rules that keep contributions reviewable.
+
+## What makes a good issue?
+
+An issue is a unit of trackable work. The difference between a useful issue and
+noise is structure. A good bug report has:
+
+1. **What happened** — the observed behaviour, with steps to reproduce.
+2. **What you expected** — so the gap is unambiguous.
+3. **Context** — version, OS, config, logs.
+4. **Acceptance criteria** — how everyone will know it's fixed.
+
+A good *feature* issue leads with the problem, not the solution: "operators
+can't tell which site a call came from" is more useful than "add a site-ID
+field," because it leaves room for the right design. **Issue templates** (in
+`.github/ISSUE_TEMPLATE/`) bake this structure in so reporters fill the right
+fields without being told.
+
+## Labels, milestones, and Projects — what's each for?
+
+These three tools overlap in newcomers' minds. They're distinct.
+
+### Labels: a small taxonomy
+
+Labels classify issues. The trap is making too many. A taxonomy that stays
+usable usually has three axes:
+
+- **Type:** `bug`, `enhancement`, `docs`, `question`.
+- **Area:** the subsystem — `area/ui`, `area/parser`, `area/ci`.
+- **Signal:** `good first issue`, `help wanted`, `priority/high`.
+
+`good first issue` deserves special mention: it's the label new contributors
+filter on, and GitHub surfaces it in its "contribute" UI. Curate a handful of
+genuinely small, well-described tickets under it.
+
+### Milestones vs. Projects
+
+- A **milestone** is a bucket of issues/PRs tied to a target — usually a
+  release like `v0.5.0`. It answers *"what ships next?"* and shows a progress
+  bar.
+- A **Project** (the boards under the repo's Projects tab) is a live view of
+  work — columns like *Todo / In progress / In review / Done* that cards move
+  across. It answers *"what's happening right now?"*
+
+Use milestones for *scope*, Projects for *flow*. A small project can run on
+issues + milestones alone and add a board only when several things are in flight
+at once.
+
+## How do I link an issue to a pull request?
+
+The magic words go in the PR description (or a commit message):
+
+- `Closes #42`, `Fixes #42`, `Resolves #42` — GitHub **auto-closes** issue #42
+  when the PR merges into the default branch.
+- `Refs #42` or a bare `#42` — creates a link *without* auto-closing, for
+  "related to" references.
+
+This is the highest-leverage habit on this whole list: it ties the *why* (the
+issue) to the *what* (the PR) permanently, and it keeps your issue tracker
+honest by closing work as it lands instead of leaving stale tickets.
+
+## How do I invite contributors?
+
+People help projects where helping is *easy*. Think of it as a funnel — every
+friction point loses people — and reduce friction at each step:
+
+- **They find the repo.** A clear README and topics (Part 12) get them in the
+  door.
+- **They want to help.** A `CONTRIBUTING.md` tells them how to set up, build,
+  test, and submit — so they don't have to ask.
+- **They pick something.** `good first issue` and `help wanted` labels give them
+  a safe entry point.
+- **They behave well together.** A `CODE_OF_CONDUCT.md` sets expectations and
+  makes the space welcoming.
+- **They submit.** Issue and PR templates make their first contribution land in
+  the right shape.
+- **The right people review.** A `CODEOWNERS` file auto-requests review from the
+  maintainers of the touched code.
+
+You don't need all of these on day one. A `CONTRIBUTING.md` and a couple of
+good-first-issues are the highest-value starting pair.
+
+## How much access should I give collaborators?
+
+GitHub's repository roles are tiered, and the rule is **least privilege**:
+
+- **Read** — can clone and open issues/PRs (the default for fork-based
+  contributors; they don't need more).
+- **Triage** — can manage issues and PRs without write access to code.
+- **Write** — can push branches and merge PRs. Hand this out once someone has a
+  track record.
+- **Maintain / Admin** — settings, secrets, protected branches. Keep this
+  circle tiny.
+
+Outside contributors fork the repo and open PRs from their fork — they never
+need write access for that. Branch protection (Part 12) means even collaborators
+with Write can't bypass review and CI.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) wires planning
+straight into its commit and branch conventions:
+
+- **Commits reference their issue.** The history is full of issue-linked
+  squash commits — `feat: expose P25 site identity in grant events and via
+  /api/v1/sites (#698)`, `fix(sdr): serialize StreamIQ re-open behind async
+  teardown (#686)`, `storage: persist mid-call backfilled RID + encryption on
+  call end (#696)`. The `(#NNN)` suffix ties every change on `main` back to the
+  tracked work that motivated it.
+- **Branch names embed the issue number.** Work lands on branches like
+  `claude/issue-698-features-…` and `claude/issue-686-fix-…`, so the branch, the
+  PR, and the issue all share one identifier from the first commit to the merge.
+- **CONTRIBUTING.md sets the scope contract.** Its "How changes are scoped"
+  section is the planning rulebook:
+  [`CONTRIBUTING.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/CONTRIBUTING.md)
+  requires **one logical change per PR**, says **bug fixes ship with a
+  regression test** that fails without the fix and passes with it, and keeps
+  **refactors in a separate PR, never bundled with a behaviour change.** New
+  features that span more than one package are designed in an issue or plan
+  *first*, then landed as incremental PRs that each close one tier.
+- **The PR template carries a 5-point test plan.** Every PR fills in
+  [`.github/pull_request_template.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/.github/pull_request_template.md):
+  `make vet test` green locally, `make integration` if the daemon changed,
+  tests added/updated, a real-hardware smoke test if SDR/USB/vocoder code
+  changed, plus a `## [Unreleased]` CHANGELOG bullet and a **Linked issues**
+  line (`Closes #NNN`). The template *is* the funnel — a contributor who fills
+  it in produces a reviewable PR by default.
+- **Hardware contributions have an opt-in path.** Because not every contributor
+  owns an SDR, CONTRIBUTING.md documents env-var-gated real-hardware tests
+  (e.g. the Airspy suite skips unless `GOPHERTRUNK_AIRSPY_REAL=1`, with
+  companion vars like `GOPHERTRUNK_AIRSPY_REAL_CENTER_HZ` and
+  `GOPHERTRUNK_AIRSPY_REAL_RATE_HZ`). The default test run stays green for
+  everyone; hardware validation is available to those who can run it.
+
+The lesson transfers to any project: track work in issues, link every PR back to
+one, write down how to contribute, and keep each contribution small enough to
+review.
+
+## FAQ
+
+**What's the difference between a milestone and a project board?**
+A milestone groups issues toward a target (usually a release) and shows a
+progress bar — it answers "what ships next?" A Project board shows work moving
+through columns like Todo → In progress → Done — it answers "what's happening
+right now?"
+
+**How do I make a PR close an issue automatically?**
+Put a closing keyword and the issue number in the PR description: `Closes #42`,
+`Fixes #42`, or `Resolves #42`. When the PR merges into the default branch,
+GitHub closes the issue for you. Use `Refs #42` to link without closing.
+
+**What is a "good first issue" and why does it matter?**
+It's a label for small, well-described tasks suitable for newcomers. GitHub
+surfaces these in its contribute UI, so curating a few genuinely beginner-sized
+tickets is one of the cheapest ways to attract first-time contributors.
+
+**Do contributors need write access to my repo?**
+No. Outside contributors fork the repo and open PRs from their fork — that needs
+only the default Read access. Grant Write only to trusted regulars, and keep
+Admin to a tiny circle.
+
+**What's the minimum to make a repo contributor-friendly?**
+A clear `README`, a `CONTRIBUTING.md` that explains setup/build/test/submit, and
+a couple of `good first issue` tickets. Add a code of conduct, templates, and
+CODEOWNERS as the project grows.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5: Branching & the Three Ways to Merge to Main]({{ '/blog/tutorials/build-in-the-open-05-three-ways-to-merge-to-main/' | relative_url }})
+· Next →
+[Part 7: GitHub Actions — Which Workflows to Create and Why]({{ '/blog/tutorials/build-in-the-open-07-github-actions-which-workflows/' | relative_url }})

--- a/docs/_posts/2026-06-24-build-in-the-open-07-github-actions-which-workflows.md
+++ b/docs/_posts/2026-06-24-build-in-the-open-07-github-actions-which-workflows.md
@@ -1,0 +1,244 @@
+---
+title: "Build in the Open, Part 7: GitHub Actions — Which Workflows to Create and Why"
+description: Which GitHub Actions workflows most projects need — CI, security scanning, release automation, docs build, scheduled jobs — and how to gate merges with them.
+keywords: github actions, ci cd, workflows, continuous integration, required status checks, concurrency, cancel-in-progress, release automation, govulncheck, claude code
+category: tutorials
+tags: [github, github-actions, ci-cd, automation, devops]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 7
+---
+
+> **TL;DR:** CI/CD is just "run my checks automatically." Most projects want a
+> handful of workflows: **CI** on every PR and push (build, test, lint, vet),
+> **security scanning**, **release automation** triggered by version tags, a
+> **docs/site build**, **PR-only or expensive checks**, and **scheduled
+> housekeeping** like stale-branch cleanup. Wire the important checks in as
+> *required status checks* so a red build can't merge, and use
+> `concurrency: cancel-in-progress` so new commits cancel stale runs.
+
+**Key takeaways**
+
+- Start with one CI workflow that builds, tests, vets, and checks formatting on
+  every PR — that's 80% of the value.
+- Make the checks you trust **required status checks** so the merge button stays
+  locked until they're green.
+- Trigger releases off **version tags** (`v*.*.*`), not branches, so publishing
+  is deliberate.
+- Use `paths-ignore` to skip irrelevant runs and `cancel-in-progress` to kill
+  superseded ones — both save runner minutes.
+- Scheduled (`cron`) jobs handle the chores no human should remember: stale
+  branches, nightly rebuilds, dependency audits.
+
+*This is Part 7 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **What CI/CD actually is**, in plain terms.
+- **The workflows most projects should have** — and why each exists.
+- **Required status checks** — turning a workflow into a merge gate.
+- **Concurrency and `cancel-in-progress`** — not wasting runner minutes.
+- **How GopherTrunk does it** — a tour of its five real workflows.
+
+## What is CI/CD, really?
+
+**Continuous Integration (CI)** means every change is automatically built and
+tested the moment it's proposed, so problems surface in minutes instead of at
+release time. **Continuous Delivery/Deployment (CD)** extends that to
+automatically packaging and shipping the result.
+
+On GitHub, both are **workflows** — YAML files in `.github/workflows/` that
+define *jobs* (groups of *steps*) and the *events* that trigger them
+(`on: pull_request`, `on: push`, `on: schedule`, a version tag, a manual
+`workflow_dispatch`). The mental model: *an event happens → a workflow runs →
+jobs report success or failure.*
+
+## Which workflows should most projects have?
+
+You don't need everything on day one, but here's the menu and why each item
+earns its place.
+
+### (a) CI on every PR and push
+
+The non-negotiable one. On every pull request (and every push to `main`), it
+should at least:
+
+- **build** the project,
+- **run the tests**,
+- **lint/format-check** (e.g. `gofmt`, `eslint`, `black --check`),
+- **vet/static-analyze** for obvious mistakes.
+
+This is the workflow you'll make a *required status check* so nothing red merges.
+
+### (b) Security scanning
+
+Automated checks for known-vulnerable dependencies (SCA), leaked secrets, and
+license problems. These catch a class of issue humans reliably miss, and they're
+cheap to run on every PR.
+
+### (c) Release automation on tags
+
+When you push a version tag (`v1.2.0`), a workflow builds your artifacts for each
+platform, generates checksums and release notes, and uploads them to a GitHub
+Release. Tagging — not pushing to a branch — is the trigger, which keeps
+publishing a deliberate act. (Full release mechanics are
+[Part 11]({{ '/blog/tutorials/build-in-the-open-11-releases-prerelease-semver-changelogs/' | relative_url }}).)
+
+### (d) Docs / site build
+
+If you publish a site (GitHub Pages, a docs portal), a workflow builds and
+deploys it when the docs change. We cover Pages in
+[Part 10]({{ '/blog/tutorials/build-in-the-open-10-websites-support-pages-github-pages/' | relative_url }}).
+
+### (e) PR-only or expensive checks
+
+Some checks are too slow or platform-specific to run everywhere. Scope them to
+pull requests (and skip them when only docs change) so they protect merges
+without slowing every push.
+
+### (f) Scheduled jobs
+
+A `cron` schedule runs a workflow on a timer — nightly dependency audits, a
+daily site rebuild, a weekly report. Great for anything that should happen
+"regularly" without a human triggering it.
+
+### (g) Housekeeping
+
+Automation for chores: deleting merged branches, closing stale issues, labeling.
+Often `workflow_dispatch` (manual, on demand) with a dry-run option so you can
+preview before it acts.
+
+## How do I make a check block merges?
+
+A workflow that runs but doesn't block anything is just advice. To make it a
+gate, mark its jobs as **required status checks** in your branch-protection
+settings (Part 12). Once a job is required, GitHub disables the merge button
+until that job reports success for the PR's head commit.
+
+One gotcha worth knowing now: a workflow *skipped* by `paths-ignore` does **not**
+report success — so if a check is required, skipping it can leave a PR stuck as
+"blocked." Either don't `paths-ignore` a required workflow, or make the required
+check one that always runs.
+
+## What is concurrency and cancel-in-progress?
+
+When you push three commits in quick succession, you don't want three full CI
+runs racing — the first two are obsolete. A `concurrency` group with
+`cancel-in-progress: true` cancels any in-flight run in the same group when a new
+one starts, so only the latest commit's run survives. It's the single easiest way
+to cut wasted runner minutes on active PRs. (For deploys, you usually set
+`cancel-in-progress: false` so you never kill a half-finished publish.)
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) runs **five**
+workflows in
+[`.github/workflows/`](https://github.com/MattCheramie/GopherTrunk/tree/main/.github/workflows),
+one for each need above.
+
+### `ci.yml` — the merge gate
+
+Triggered on every `pull_request` and on `push` to `main`, with several jobs:
+
+- **`build-test`** (Ubuntu): `go vet ./...`, a `gofmt` check that fails on any
+  unformatted file, `go build ./...`, `go test -race -count=1 ./...`, then
+  `make integration`.
+- **`usb-windows`** and **`usb-macos`**: build/vet/test the pure-Go USB
+  transport (`internal/sdr/rtlsdr/usb/...`) under `CGO_ENABLED=0` on
+  *native* Windows and macOS runners — because that code has platform-specific
+  backends (WinUSB, IOKit) that must compile everywhere.
+- **`dvsi`**: builds and tests the patent-encumbered DVSI vocoder backend behind
+  `-tags dvsi` using a mock transport, so the wire protocol is covered without
+  the real chip.
+- **`integration`**: runs `make test-integration` across the whole module so a
+  future `//go:build integration` test in a new package can't silently skip CI.
+- **`vulncheck`**: installs and runs `govulncheck ./...` — a failing CVE scan
+  **blocks merge**.
+- **`licenses`**: regenerates the dependency-license inventory with
+  `go-licenses` (`make licenses`) and diffs it against the committed copy
+  (currently `continue-on-error: true` while upstream has Go 1.25 false
+  positives).
+
+The ruleset at `.github/rulesets/main-branch-protection.json` makes
+**`build-test`, `usb-windows`, and `usb-macos`** required, so a red build on any
+of the three locks the merge button. Notably, `ci.yml` deliberately does *not*
+use `paths-ignore` — a comment in the file explains that skipping a *required*
+check would leave even docs-only PRs stuck as `mergeable_state=blocked`.
+
+### `release.yml` — release automation on tags
+
+Triggered by pushing a `v*.*.*` tag (or manually via `workflow_dispatch`). Three
+platform jobs build with `CGO_ENABLED=0` — `windows` (installer + portable ZIPs,
+amd64 and arm64), `linux` (amd64/arm64 tarballs), and `macos` (Intel/Apple
+Silicon) — and a final `release` job flattens the artifacts, writes
+`SHA256SUMS`, marks any `v0.x` tag as a pre-release, and publishes the GitHub
+Release. Version metadata is injected at build time via `-ldflags`.
+
+### `installer.yml` — a PR-only, expensive check
+
+"Windows installer (PR)" builds the full Inno Setup installer on every pull
+request, so a break in the Windows packaging surfaces *before* a release tag.
+It's the textbook expensive/PR-only workflow: it `paths-ignore`s `**/*.md`,
+`docs/**`, `LICENSE`, and `config.example.yaml` (a docs change can't break the
+installer), and it sets `concurrency` with `cancel-in-progress: true` so a quick
+rebase doesn't burn idle `windows-latest` minutes. It's *not* a required check,
+precisely because it can be skipped on docs PRs.
+
+### `pages.yml` — scheduled docs build + blog drip
+
+Builds `docs/` as a Jekyll site and deploys to GitHub Pages. It triggers on
+pushes that touch `docs/**` or `README.md`, **and on a daily `cron` at
+`0 16 * * *` (11:00 America/Chicago)**. That schedule is what powers this very
+blog series: posts are committed future-dated, Jekyll's `future: false` hides
+them, and each daily run reveals the posts that have come due — one per day, no
+draft branches. Its `concurrency` uses `cancel-in-progress: false` so a deploy is
+never interrupted.
+
+### `cleanup-branches.yml` — housekeeping
+
+A manual (`workflow_dispatch`) job that lists feature branches whose PRs have
+merged and deletes them, with a `dry_run` input (default `true`) so you preview
+the plan in the run summary before anything is removed. It skips protected,
+open-PR, and no-PR branches — exactly the careful, opt-in housekeeping pattern.
+
+Swap Go for your stack and the shape is identical: one CI gate, one security
+pass, tag-driven releases, a site build, a PR-only heavy check, and a scheduled
+chore.
+
+## FAQ
+
+**What's the minimum CI workflow a project needs?**
+One workflow, triggered on `pull_request`, that builds the project, runs the
+tests, and checks formatting/linting. Make it a required status check and you've
+captured most of CI's value.
+
+**How do I stop a workflow from blocking merges when it doesn't apply?**
+Be careful: a workflow skipped via `paths-ignore` does *not* report success, so
+if it's a *required* check the PR stays blocked. Either don't make path-filtered
+workflows required, or keep required checks on a job that always runs.
+
+**What does `concurrency: cancel-in-progress` do?**
+It cancels any in-flight run in the same concurrency group when a newer run
+starts, so rapid pushes don't pile up redundant runs. Use `true` for CI/PR
+checks; use `false` for deploys you don't want interrupted.
+
+**How should releases be triggered — on push or on tag?**
+On a version tag (e.g. `on: push: tags: ["v*.*.*"]`). Tagging is a deliberate
+act, which keeps you from publishing a release on every commit to `main`.
+
+**What runs a workflow on a schedule?**
+An `on: schedule` trigger with a `cron` expression (in UTC). GitHub's scheduler
+is best-effort and may be delayed under load, which is fine for daily chores like
+a docs rebuild or a dependency audit.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6: Planning & Tracking Work — and Inviting Contributors]({{ '/blog/tutorials/build-in-the-open-06-issues-planning-inviting-contributors/' | relative_url }})
+· Next →
+[Part 8: Testing — How to Build and Write Tests]({{ '/blog/tutorials/build-in-the-open-08-testing-how-to-write-tests/' | relative_url }})

--- a/docs/_posts/2026-06-25-build-in-the-open-08-testing-how-to-write-tests.md
+++ b/docs/_posts/2026-06-25-build-in-the-open-08-testing-how-to-write-tests.md
@@ -1,0 +1,233 @@
+---
+title: "Build in the Open, Part 8: Testing — How to Build and Write Tests"
+description: How to test software well — the testing pyramid, table-driven tests, golden files, race detection, coverage limits, and writing tests with Claude Code.
+keywords: how to write tests, testing pyramid, table-driven tests, golden files, race detector, test coverage, integration tests, claude code, github
+category: tutorials
+tags: [github, claude-code, testing, ci, go, quality]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 8
+---
+
+> **TL;DR:** Tests exist to let you change code without fear. Build them in
+> layers — lots of fast unit tests, fewer integration tests, a handful of
+> end-to-end tests — and make the fast layer the gate your CI enforces on every
+> pull request. Write tests as data (table-driven cases), pin tricky outputs
+> with golden files, turn the race detector on, and treat coverage as a
+> spotlight, not a score. Claude Code is excellent at the tedious parts:
+> generating table cases, hunting edge cases, and writing the regression test
+> that locks a bug shut.
+
+**Key takeaways**
+
+- The point of a test is *confidence to change things*, not a green checkmark.
+- Use the testing pyramid: many unit tests, fewer integration, few end-to-end.
+- Make tests data, not code — table-driven cases scale better than copy-paste.
+- Gate merges on the fast tests (Part 7's CI); keep slow/hardware tests opt-in.
+- Coverage tells you what *ran*, not what's *correct* — use it to find gaps.
+
+*This is Part 8 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **Why test at all** — and what's actually worth testing.
+- **The testing pyramid** — unit, integration, end-to-end, and the right mix.
+- **How to write good tests** — table-driven cases, fixtures, golden files,
+  fakes vs. mocks, the race detector, and coverage.
+- **Opt-in and hardware-gated tests** — for things CI can't run.
+- **Tests as the CI gate** — connecting this to Part 7's workflows.
+- **Writing tests with Claude Code** — where the leverage really is.
+- **How GopherTrunk does it**, as a concrete example you can copy.
+
+## Why test at all?
+
+The honest answer isn't "to catch bugs" — it's **to let you change code without
+being afraid of it**. A codebase with good tests is one you can refactor,
+upgrade, and hand to a stranger, because the tests will shout the moment
+something breaks. A codebase without them is one you tiptoe around.
+
+That reframing also tells you *what* to test. You don't test getters and
+one-line wrappers; you test the things that would hurt to get wrong:
+
+- **Logic with branches** — anything with `if`/`switch`, math, parsing, or state.
+- **Boundaries** — empty input, the maximum, off-by-one, the malformed packet.
+- **Bugs you've already hit** — every fixed bug deserves a test so it stays fixed.
+- **Contracts** — the promises your public functions and APIs make to callers.
+
+Skip the trivial. A test that can only fail if the language itself is broken is
+just maintenance cost.
+
+## What is the testing pyramid?
+
+The testing pyramid is a rule of thumb for the *mix* of tests, from cheap and
+plentiful at the bottom to expensive and rare at the top:
+
+1. **Unit tests** (the wide base): one function or type in isolation,
+   milliseconds each, no network or disk. You write thousands of these and run
+   them constantly.
+2. **Integration tests** (the middle): several components wired together — a
+   handler plus its database, a pipeline end-to-end — with real-ish parts but no
+   real outside world. Slower, fewer.
+3. **End-to-end tests** (the tip): the whole system as a user hits it. Slowest,
+   flakiest, and you keep only a handful that cover the critical paths.
+
+Most pain in real projects comes from an *inverted* pyramid — a few brittle
+end-to-end tests and no unit tests underneath. Push the bulk of your coverage
+down to the fast layer, where a failure points straight at the broken function.
+
+## How do you write a good test?
+
+A few techniques transfer to any language and test runner.
+
+### Make tests data: table-driven cases
+
+Instead of copy-pasting a test five times with different inputs, define a list
+of cases — input, expected output, a name — and loop over them. Adding a case
+becomes one line, and the failure message tells you exactly which row broke.
+Every mature test suite leans on this.
+
+### Pin tricky outputs with golden files
+
+When the expected output is large or fiddly (rendered HTML, a decoded frame, a
+formatted report), store a known-good copy as a *golden file* and assert the
+test output matches it. A flag like `-update` regenerates the goldens after an
+intentional change. You review the diff in code review like any other change.
+
+### Fakes vs. mocks
+
+Both stand in for real dependencies, but they're not the same:
+
+- A **fake** is a working lightweight implementation — an in-memory database, a
+  scripted data source. It behaves; you assert on results.
+- A **mock** records calls and lets you assert *that* something was called, with
+  what arguments. Useful, but over-mocking produces tests that pass while the
+  real system is broken. Prefer fakes when you can.
+
+### Turn on the race detector
+
+If your language has concurrency, it has a race detector or equivalent (Go's
+`-race`, ThreadSanitizer, etc.). Run your tests under it. Data races are the
+bugs that pass a thousand times and corrupt data on the thousand-and-first;
+the detector catches them deterministically.
+
+### Use coverage as a spotlight, not a score
+
+Coverage tells you which lines *executed* during the tests — not whether the
+assertions were meaningful. Chasing 100% rewards writing tests for trivial code
+and punishes nothing. Use coverage to *find untested branches* you care about,
+then decide if they're worth a test. The number is a map, not the territory.
+
+## Opt-in and hardware-gated tests
+
+Some tests can't run in CI: they need a GPU, a USB device, a paid API key, a
+specific OS. Don't delete them — **gate** them. Make the test skip by default
+unless an environment variable or build flag opts it in. The test lives in the
+repo, documents the expected behaviour, and runs on the one machine that can,
+while CI stays green and fast.
+
+## Tests as the CI gate
+
+This is where Part 7 pays off. Once you have a fast, reliable test command, you
+wire it into a CI workflow that runs on every pull request, and you mark it a
+**required status check** so a PR can't merge until it's green. That single rule
+turns "we have tests" into "broken code can't reach `main`." The fast layer
+(unit + the cheap integration tests) is the gate; the slow and hardware tests
+stay opt-in and run out of band.
+
+## Writing tests with Claude Code
+
+Tests are some of the highest-leverage work to hand to Claude Code, because the
+work is structured and the right answer is checkable:
+
+- **Generate table cases.** Give it a function and ask for a table-driven test
+  covering the obvious paths — it'll scaffold the cases and the loop in seconds.
+- **Hunt edge cases.** "What inputs would break this?" surfaces the empty
+  string, the negative number, the overflow, the nil you forgot.
+- **Write the regression test for a bug.** Describe the bug (or paste the stack
+  trace), and ask for a test that fails *before* the fix and passes *after*. Land
+  that test in the same PR as the fix — exactly the discipline good projects use.
+
+Always read what it produces. Claude is great at breadth; you supply the
+judgment about which cases actually matter and whether the assertions are real.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) is a pure-Go SDR
+trunking scanner, and its testing maps the pyramid onto a `Makefile` you can read
+top to bottom:
+
+- **The fast unit layer is `make test`.** It runs
+  `go test -race -count=1 ./...` — every package, under the race detector, with
+  caching disabled — and finishes in **under 30 seconds**. This is the command
+  contributors run constantly and the one CI gates on.
+- **Integration tests are build-tagged so they don't slow the unit run.**
+  `make integration` runs the tests behind `//go:build integration`, booting the
+  wired daemon end-to-end (no real SDR) and asserting the engine, recorder, call
+  log, metrics, and API all agree on a synthetic call. The build tag keeps them
+  out of the default `make test` path.
+- **Per-protocol "lights up" checks.** There's a focused integration target per
+  trunked protocol — `make integration-cc-nxdn`, `make integration-cc-dmr`,
+  `make integration-cc-tetra`, `make integration-cc-p25p2`, and so on — each of
+  which synthesizes IQ for that protocol's control channel and asserts the real
+  pipeline recovers the lock. That's an end-to-end critical path, isolated per
+  protocol so a failure points right at the broken decoder.
+- **Table-driven tests and `t.Parallel()` are house rules.** `CONTRIBUTING.md`
+  spells it out: tests are "parallel where it's safe (`t.Parallel()`),
+  table-driven for any function with more than two interesting inputs,
+  `t.Helper()` on helper functions so failure locations surface correctly."
+- **Golden IQ captures live under `samples/`.** Known-good signal captures act
+  as fixtures the decoders run against — golden files for radio.
+- **Real-hardware tests are env-gated.** `make test-airspy-real` sets
+  `GOPHERTRUNK_AIRSPY_REAL=1`; the package skips entirely unless that variable is
+  set, so the test ships in the repo but "never runs in CI," exactly as
+  `CONTRIBUTING.md` says. Overrides like `GOPHERTRUNK_AIRSPY_REAL_BIAS_TEE=1`
+  toggle extra checks. CI runs `make test`, `make integration`, and
+  `make test-dvsi` on every PR — a green CI is required before merge.
+
+You don't need a radio for any of this to transfer. Swap "decode a control
+channel" for "render an invoice" or "parse a config file": fast unit tests as
+the gate, tagged integration tests for the wiring, golden files for fiddly
+output, and opt-in tests for whatever CI can't reach.
+
+## FAQ
+
+**How many tests is enough?**
+Enough that you'd trust a stranger to refactor your code and find out from a
+failing test, not from production. That usually means solid unit coverage of
+your branching logic plus a few integration tests over the critical paths — not
+a coverage percentage you chase for its own sake.
+
+**Should I write tests before or after the code?**
+Either works; the discipline that matters is that tests exist and run in CI.
+Test-first (TDD) helps when the design is unclear; test-after is fine when it
+isn't. For bug fixes, always write the failing test first — it proves the bug is
+real and that your fix actually fixes it.
+
+**What's the difference between a fake and a mock?**
+A fake is a real (if simplified) working implementation you assert results
+against — an in-memory store, a scripted source. A mock records calls so you can
+assert that something was invoked. Fakes tend to produce more durable tests;
+heavy mocking can make tests pass while the system is broken.
+
+**How do I test something that needs hardware or a paid API?**
+Gate it. Make the test skip unless an environment variable or build tag opts it
+in, the way GopherTrunk gates its Airspy tests behind
+`GOPHERTRUNK_AIRSPY_REAL=1`. The test stays in the repo and runs where it can,
+while CI stays fast and green.
+
+**Can Claude Code write my tests for me?**
+It can write most of the scaffolding — table cases, edge cases, regression tests
+for a described bug — very well, and very fast. You still review the result and
+decide which cases matter. Treat it as a fast pair, not an oracle.
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7]({{ '/blog/tutorials/build-in-the-open-07-github-actions-which-workflows/' | relative_url }})
+· Next →
+[Part 9: Documentation Done Right]({{ '/blog/tutorials/build-in-the-open-09-documentation-done-right/' | relative_url }})

--- a/docs/_posts/2026-06-26-build-in-the-open-09-documentation-done-right.md
+++ b/docs/_posts/2026-06-26-build-in-the-open-09-documentation-done-right.md
@@ -1,0 +1,188 @@
+---
+title: "Build in the Open, Part 9: Documentation Done Right — What Lives Where"
+description: How to organize project documentation — README, CONTRIBUTING, SECURITY, CHANGELOG, in-repo docs — using the Diátaxis framework so docs are findable and don't rot.
+keywords: project documentation, README, CONTRIBUTING, Diátaxis, docs framework, technical writing, changelog, code of conduct, open source docs, claude code, github
+category: tutorials
+tags: [github, claude-code, documentation, writing, open-source]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 9
+---
+
+> **TL;DR:** Documentation isn't one thing — it's several kinds with different
+> jobs and different homes. The README is your front door; standard files like
+> CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, CHANGELOG, and LICENSE each answer one
+> recurring question; everything deeper lives in an in-repo `/docs` folder. Use
+> the **Diátaxis** framework — tutorials, how-to guides, reference, explanation —
+> to decide what kind of doc you're writing and where it belongs. Keep docs next
+> to the code so they version and rot together, and write each piece for one
+> specific reader.
+
+**Key takeaways**
+
+- Docs come in types; put each type where readers expect to find it.
+- The README is the front door — what, why, and a fast path to "it works."
+- Diátaxis splits docs into tutorials, how-to, reference, and explanation.
+- Keep docs in the repo, next to the code, so they version with it and rot less.
+- Every doc has one reader and one job — write to that, not to everyone at once.
+
+*This is Part 9 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **The standard files** every repo should have — and who each is for.
+- **What goes in the README** versus everywhere else.
+- **The Diátaxis framework** for organizing the deeper `/docs`.
+- **Why docs belong next to the code**, and how to keep them from rotting.
+- **How GopherTrunk does it**, as a concrete example you can copy.
+
+## The standard files and who they're for
+
+A handful of files have become conventions because each answers a question
+someone will inevitably ask. GitHub even surfaces several of them in its UI:
+
+- **README** — *"What is this and how do I start?"* The front door. Everyone
+  reads it first.
+- **CONTRIBUTING** — *"How do I help?"* Build, test, branch, and PR conventions
+  for would-be contributors.
+- **SECURITY** — *"I found a vulnerability, now what?"* The private disclosure
+  process, so bugs don't get reported publicly.
+- **CODE_OF_CONDUCT** — *"What behaviour is expected here?"* The community
+  ground rules.
+- **CHANGELOG** — *"What changed between versions?"* For users deciding whether
+  to upgrade (more on this in Part 11).
+- **LICENSE** — *"What am I allowed to do with this?"* The legal terms. Without
+  it, the default is "no rights granted."
+
+You don't need all of them on day one, but knowing the slot each fills means you
+never have to wonder *where* a given piece of information should go.
+
+## What belongs in the README?
+
+The README is the highest-traffic page you will ever write, so it earns the most
+care. It should answer, fast and in order:
+
+1. **What is this?** One or two sentences, no jargon.
+2. **Why does it exist / why would I use it?** The problem it solves.
+3. **How do I get to "it works"?** Install or run, in the fewest steps possible.
+4. **Where do I go next?** Links out to the deeper docs — *not* the docs
+   themselves.
+
+The README's job is to get someone oriented and then *hand them off*. The
+moment it tries to be the complete manual, it becomes too long to be the front
+door. Link out to `/docs` for everything past "hello world."
+
+## The Diátaxis framework: four kinds of docs
+
+Past the README, documentation gets disorganized because people mix four
+fundamentally different things into one page. **Diátaxis** is a widely used
+framework that names them and keeps them apart:
+
+- **Tutorials** — *learning-oriented.* A guided lesson for a newcomer: "build
+  your first X." The reader is a student; success is that they finish and feel
+  capable.
+- **How-to guides** — *task-oriented.* Steps to accomplish a specific goal the
+  reader already has: "how to configure TLS." The reader knows what they want.
+- **Reference** — *information-oriented.* Dry, complete, accurate descriptions:
+  every flag, every field, every endpoint. The reader is looking something up.
+- **Explanation** — *understanding-oriented.* The why and the how-it-works:
+  architecture, design decisions, background. The reader wants the mental model.
+
+The power of Diátaxis is diagnostic: when a doc feels muddled, it's usually
+trying to be two of these at once. A tutorial bloated with reference detail
+loses the beginner; a reference padded with tutorial hand-holding annoys the
+expert. Split them, and each gets clearer.
+
+## Keep docs next to the code
+
+Wherever it's reasonable, keep documentation **in the repository**, in a `/docs`
+folder, versioned alongside the code:
+
+- **It versions with the code.** A doc change rides in the same commit and PR as
+  the behaviour change, so the docs for v2 describe v2.
+- **It's reviewable.** Doc changes go through the same review as code changes —
+  reviewers can flag a stale instruction the way they'd flag a bug.
+- **It rots less.** Docs in a separate wiki or external site drift, because
+  nobody updates them when they change the code. Docs in the diff are right
+  there, demanding to be updated.
+
+The discipline that keeps docs alive is a simple rule in your CONTRIBUTING file:
+*if your change alters user-visible behaviour, update the docs in the same PR.*
+That turns documentation from a someday chore into part of "done."
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) treats docs as a
+first-class part of the repo, and the layout maps cleanly onto everything above:
+
+- **The README is the front door — and literally so.** Its
+  [Pages landing page]({{ '/' | relative_url }}) is *synthesized from the README
+  at build time* (see Part 10), so the front door and the homepage never drift
+  apart. The README links out to the deeper docs rather than absorbing them.
+- **The standard files are all present.** `CONTRIBUTING.md` documents the build,
+  test, branch, and PR conventions (including the table of `make` targets and the
+  opt-in hardware-test env vars); `SECURITY.md` carries the threat model and
+  private-disclosure process; `CHANGELOG.md` follows Keep a Changelog with an
+  `## [Unreleased]` section; `LICENSE` sets the terms.
+- **The `docs/` folder is large and structured** — around **50 markdown files**.
+  It's clearly organized along Diátaxis lines:
+  - **Tutorials / learning:** a **30-lesson learning path** under `docs/learn/`
+    (from `what-is-sdr.md` through `clock-recovery.md`, `digital-voice.md`, and a
+    `glossary.md`) — the learning-oriented tier.
+  - **Reference:** a **~180-entry reference encyclopedia** under
+    `docs/reference/` — the information-oriented tier you look things up in.
+  - **How-to guides:** install guides per platform (`install-linux.md`,
+    `install-macos.md`, `install-windows.md`), getting-started pages, and
+    operational guides (`guide-basics.md`, `guide-intermediate.md`,
+    `guide-advanced.md`, `hardening.md`).
+  - **Explanation:** `architecture.md` for the design, plus living-status docs
+    `status.md` and `roadmap.md` for where the project is and where it's going.
+- **Everything is reachable from the README**, which links out to install, the
+  guides, the learning path, the reference, and the status/roadmap docs — the
+  front door pointing at every room in the house.
+
+You don't need 50 files to apply this. Even a five-file project benefits from a
+README that hands off, the standard community files, and a `/docs` folder where
+each page knows whether it's a tutorial, a how-to, reference, or explanation.
+
+## FAQ
+
+**What's the minimum documentation a project needs?**
+A README that says what the project is and how to run it, and a LICENSE so people
+know what they're allowed to do. Add CONTRIBUTING and SECURITY the moment you
+invite outside contributors, and a CHANGELOG when you start cutting releases.
+
+**What is the Diátaxis framework?**
+A way to organize documentation into four distinct types — tutorials (learning),
+how-to guides (tasks), reference (lookup), and explanation (understanding) — each
+written for a different reader need. Its main value is spotting when one doc is
+trying to do two of those jobs and should be split.
+
+**Should documentation live in the repo or on a separate site?**
+Keep the source in the repo, next to the code, so docs version and get reviewed
+alongside changes. You can still *publish* them to a website (Part 10 covers
+that) — but the source of truth belongs in the diff, where it's least likely to
+rot.
+
+**How do I keep docs from going stale?**
+Make updating them part of "done." A line in CONTRIBUTING — "update the docs in
+the same PR as any user-visible change" — plus reviewers who enforce it does more
+than any tooling. Docs that travel with the code stay closer to the truth.
+
+**Where does the README stop and `/docs` begin?**
+The README orients and hands off: what, why, get-it-running, and links onward.
+Anything past the first successful run — full configuration, guides, reference,
+architecture — belongs in `/docs`, so the front door stays short enough to be a
+front door.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8]({{ '/blog/tutorials/build-in-the-open-08-testing-how-to-write-tests/' | relative_url }})
+· Next →
+[Part 10: Websites, Support Pages & GitHub Pages]({{ '/blog/tutorials/build-in-the-open-10-websites-support-pages-github-pages/' | relative_url }})

--- a/docs/_posts/2026-06-27-build-in-the-open-10-websites-support-pages-github-pages.md
+++ b/docs/_posts/2026-06-27-build-in-the-open-10-websites-support-pages-github-pages.md
@@ -1,0 +1,188 @@
+---
+title: "Build in the Open, Part 10: Websites, Support Pages & GitHub Pages"
+description: How to give a project a free website — enabling GitHub Pages, a Jekyll static site, a custom domain via CNAME, support and sponsor pages, and a drip-released blog.
+keywords: github pages, custom domain, jekyll, static site generator, project website, landing page, github sponsors, funding.yml, blog, claude code
+category: tutorials
+tags: [github, claude-code, github-pages, jekyll, website, seo]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 10
+---
+
+> **TL;DR:** Your project can have a real website for free. Turn on GitHub Pages,
+> point it at a static-site generator like Jekyll, and you get a fast, secure,
+> CDN-backed site built straight from your repo. Add a custom domain with a
+> one-line `CNAME` file, build a landing page that sells the project, add
+> support and sponsor pages so people can get help and chip in, and run a blog —
+> including scheduled, drip-released posts. The whole thing lives in the same
+> repo as your code and deploys on every push.
+
+**Key takeaways**
+
+- GitHub Pages hosts a static website from your repo, free, with HTTPS and a CDN.
+- A static-site generator (Jekyll) turns Markdown into a real site — no servers.
+- A custom domain is a one-line `CNAME` file plus a DNS record.
+- Support and sponsor pages let users get help and fund the work.
+- Future-dated posts plus a daily build = a blog that drip-releases itself.
+
+*This is Part 10 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **What GitHub Pages is** and why it's the easy default.
+- **Static-site generators** — what Jekyll buys you over hand-written HTML.
+- **Custom domains** with a `CNAME` file.
+- **Landing, support, and sponsor pages** — the pages a project actually needs.
+- **Running a blog** — including scheduled, drip-released posts.
+- **How GopherTrunk does it**, as a concrete example you can copy.
+
+## What is GitHub Pages?
+
+GitHub Pages is free static-site hosting built into GitHub. You enable it in
+**Settings → Pages**, choose a source (a branch, a `/docs` folder, or — better —
+GitHub Actions), and GitHub serves the result over HTTPS from a CDN at
+`username.github.io/repo`. Because the site is *static* — plain HTML, CSS, and
+JavaScript — there's nothing to run, nothing to patch, and nothing to pay for.
+
+"Static" sounds limiting but rarely is. Docs, landing pages, blogs, and
+marketing sites are all static by nature, and a static site is the fastest and
+most secure thing you can ship.
+
+## Why use a static-site generator?
+
+Writing raw HTML for every page gets old fast. A **static-site generator** lets
+you write content in Markdown, share layouts and navigation across pages, and
+build the whole site with one command. **Jekyll** is the generator GitHub Pages
+supports natively — Pages can build a Jekyll site for you with no extra setup.
+
+What a generator buys you:
+
+- **Markdown instead of HTML.** Write content; the generator wraps it in your
+  layout.
+- **Shared layouts and includes.** Change the header once, every page updates.
+- **Plugins.** SEO tags, sitemaps, and RSS feeds for free.
+- **A blog engine.** Drop a file in a posts folder and it becomes a post.
+
+Other generators (Hugo, Eleventy, Astro, MkDocs) work on Pages too, usually via
+a GitHub Actions build. Jekyll is just the path of least resistance.
+
+## Custom domains with a CNAME
+
+A `username.github.io` URL works, but a real project wants a real domain. Pages
+makes this a two-step affair:
+
+1. Add a file named **`CNAME`** to your site source containing just your domain,
+   e.g. `example.org`.
+2. At your DNS provider, point the domain at GitHub Pages (a `CNAME` record to
+   `username.github.io`, or `A`/`AAAA` records to GitHub's IPs for an apex
+   domain).
+
+GitHub then provisions a free TLS certificate, and your site serves over HTTPS
+on your own domain. One file, one DNS record, done.
+
+## The pages a project actually needs
+
+Beyond the docs, a few pages do real work:
+
+- **A landing page.** The pitch: what the project is, who it's for, and a
+  prominent path to download or get started. This is where you convert a curious
+  visitor into a user.
+- **A support / community page.** Where to ask questions and report problems —
+  links to issues, a Discord or forum, a FAQ. Reduces the "how do I get help?"
+  friction to zero.
+- **A sponsor / funding page.** If you want support for the work, make it easy.
+  GitHub reads a `.github/FUNDING.yml` file and renders a **Sponsor** button on
+  your repo automatically; you can list GitHub Sponsors, Ko-fi, Patreon, and
+  more.
+- **A blog.** For release notes, tutorials, and build-in-the-open posts like this
+  one — which doubles as SEO and a reason for people to come back.
+
+## Running a blog (and drip-releasing posts)
+
+A static blog is just dated files in a posts folder. The clever part is
+*scheduling*. Most generators, Jekyll included, will **exclude a post dated in
+the future** from the build. Pair that with a **daily scheduled rebuild** and you
+get a powerful pattern:
+
+1. Write a whole series at once, dating the posts on consecutive future days.
+2. Commit them all in one pull request.
+3. A daily build job rebuilds the site; each day, the posts that have "come due"
+   appear automatically.
+
+No draft branches, no daily commits, no manual publishing — the calendar does
+the releasing for you. (This very series is published exactly that way.)
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk)'s entire website —
+[gophertrunk.org](https://gophertrunk.org) — is a Jekyll site on GitHub Pages,
+built from the repo's `docs/` folder. The pieces line up with everything above:
+
+- **Custom domain via `CNAME`.** `docs/CNAME` contains exactly one line —
+  `gophertrunk.org` — and that's what serves the site on its own domain over
+  HTTPS.
+- **The landing page is synthesized from the README at build time.** The Pages
+  workflow (`.github/workflows/pages.yml`) has a "Synthesize landing page from
+  README.md" step that transforms `README.md` into `docs/index.md` during the
+  build — rewriting asset paths and cross-links and stripping the duplicate hero.
+  The homepage and the README can never drift apart, because there's only one
+  source (the doc-organization payoff from Part 9).
+- **SEO comes from plugins.** `docs/_config.yml` enables `jekyll-seo-tag`
+  (titles, meta descriptions, Open Graph/Twitter cards), `jekyll-sitemap`
+  (`sitemap.xml`), and `jekyll-feed` (an Atom feed at `/feed.xml`) — so search
+  engines and readers get structured metadata for free.
+- **Support and sponsor links are real files.** There's a `docs/support.md`
+  page, and `.github/FUNDING.yml` lists **GitHub Sponsors** (`github: MattCheramie`)
+  and **Ko-fi** (`ko_fi: Mrcheramie`), which GitHub turns into the repo's Sponsor
+  button.
+- **The blog drip-releases itself.** `docs/_config.yml` sets `future: false` (a
+  future-dated post stays out of the build until its date), and
+  `pages.yml` runs a daily `cron: "0 16 * * *"` rebuild. A whole series is
+  committed at once on consecutive future dates and goes live one post per day —
+  with a `scripts/schedule-series.py` helper to assign the dates. That's the
+  mechanism publishing the post you're reading now.
+
+You don't need a radio project to copy this. Any repo can flip on Pages, drop a
+`CNAME`, point Jekyll at a `/docs` folder, add a `FUNDING.yml`, and schedule a
+blog — all for the price of a push.
+
+## FAQ
+
+**Is GitHub Pages really free?**
+Yes, for public repositories, including HTTPS and CDN delivery, within generous
+soft bandwidth and size limits. For a project site, docs, or blog you will almost
+certainly never hit them.
+
+**Do I have to use Jekyll?**
+No. Jekyll is the generator Pages builds natively with zero config, but you can
+deploy any static site — Hugo, Eleventy, Astro, plain HTML — by building it in a
+GitHub Actions workflow and publishing the output. Jekyll is just the lowest-
+friction option.
+
+**How do I add a custom domain to GitHub Pages?**
+Add a `CNAME` file containing your domain to the site source, then create a DNS
+record at your registrar pointing the domain at GitHub Pages. GitHub provisions
+a free TLS certificate automatically once DNS resolves.
+
+**How do I schedule blog posts to publish on a future date?**
+Date the post in the future and configure your generator to exclude future-dated
+content (`future: false` in Jekyll), then run a daily scheduled build. Each
+build reveals the posts whose date has arrived — so you can write a series now and
+have it release one post per day.
+
+**How do I add a Sponsor button to my repo?**
+Add a `.github/FUNDING.yml` listing your funding platforms (GitHub Sponsors,
+Ko-fi, Patreon, etc.). GitHub reads it and shows a Sponsor button on the repo
+automatically — no other setup required.
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9]({{ '/blog/tutorials/build-in-the-open-09-documentation-done-right/' | relative_url }})
+· Next →
+[Part 11: Releases — Pre-release, SemVer & Changelogs]({{ '/blog/tutorials/build-in-the-open-11-releases-prerelease-semver-changelogs/' | relative_url }})

--- a/docs/_posts/2026-06-28-build-in-the-open-11-releases-prerelease-semver-changelogs.md
+++ b/docs/_posts/2026-06-28-build-in-the-open-11-releases-prerelease-semver-changelogs.md
@@ -1,0 +1,244 @@
+---
+title: "Build in the Open, Part 11: Releases — Cadence, Pre-Release vs. Release, SemVer & Changelogs"
+description: How to ship software releases the right way — Semantic Versioning, pre-releases, git tags, Keep a Changelog notes, and automated, checksummed builds.
+keywords: semantic versioning, semver, software releases, pre-release, git tags, changelog, keep a changelog, release notes, github releases, claude code
+category: tutorials
+tags: [github, releases, semver, changelog, ci-cd, claude-code]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 11
+---
+
+> **TL;DR:** A release is just a *tagged, named, downloadable snapshot* of your
+> project plus notes that tell people what changed. Use Semantic Versioning
+> (`MAJOR.MINOR.PATCH`) so the number means something, release often instead of
+> hoarding changes, ship pre-releases (`alpha`/`beta`/`rc`, or any `0.x` while
+> you're still stabilizing) to set expectations, keep a human-readable changelog
+> in the [Keep a Changelog](https://keepachangelog.com/) format, and automate
+> the build so a single `git tag` produces signed, checksummed artifacts.
+
+**Key takeaways**
+
+- SemVer encodes a *promise*: bump MAJOR for breaking changes, MINOR for new
+  features, PATCH for fixes.
+- Anything below `1.0.0` is implicitly a pre-release — the public API may still
+  change. Ship a `0.x` or `-rc` build before you commit to `v1.0.0`.
+- Maintain a `CHANGELOG.md` with an `## [Unreleased]` section you fill in as you
+  go, so cutting a release is just renaming a heading.
+- Let a tag trigger the build. Publishing artifacts by hand is how you ship the
+  wrong binary at 2 a.m.
+- Always ship checksums (`SHA256SUMS`) so users can verify what they downloaded.
+
+*This is Part 11 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **What a release actually is** — and why "tag, notes, artifacts" is the whole
+  game.
+- **Semantic Versioning** — what each number promises, and how to bump it.
+- **Pre-releases** — alpha/beta/rc, the `0.x` convention, and why you want one
+  before `v1.0.0`.
+- **Release cadence** — why shipping small and often beats the big-bang release.
+- **Writing changelogs and release notes** people will actually read.
+- **Automating the build** so a tag produces checksummed artifacts.
+- **How GopherTrunk does it**, end to end, with real commands.
+
+## What is a release, really?
+
+Strip away the ceremony and a release is three things:
+
+1. **A tag** — an immutable git pointer (`v0.4.5`) to one exact commit.
+2. **A name and notes** — a human-readable summary of what changed.
+3. **Artifacts** — the built binaries, archives, or packages users download,
+   plus checksums so they can verify integrity.
+
+Everything else — version policy, changelogs, automation — exists to make those
+three things trustworthy and repeatable. If you get the tag right and the build
+is reproducible from it, you can always reconstruct exactly what a user is
+running.
+
+## Semantic Versioning: make the number mean something
+
+[Semantic Versioning](https://semver.org/) (SemVer) is a contract written into
+the version number `MAJOR.MINOR.PATCH`:
+
+- **MAJOR** (`1.x.x` → `2.0.0`): you broke backward compatibility. Users must
+  read the notes before upgrading.
+- **MINOR** (`1.2.x` → `1.3.0`): you added functionality, backward-compatibly.
+  Safe to upgrade.
+- **PATCH** (`1.2.3` → `1.2.4`): you fixed a bug, no API change. Always safe.
+
+The discipline is what makes this useful. If a "patch" quietly changes behavior,
+the number is lying and your users stop trusting it. When in doubt about whether
+something is a feature or a fix, ask: *could this surprise someone who upgrades
+without reading?* If yes, it's at least a MINOR.
+
+A subtle but important rule: **everything below `1.0.0` is a free-for-all.**
+SemVer §4 says the public API should not be considered stable until `1.0.0`. A
+`0.x` version is itself a signal — "I'm still figuring out the shape of this,
+expect change." That's not a cop-out; it's an honest label.
+
+## Pre-releases: alpha, beta, rc — and the 0.x convention
+
+A **pre-release** is a version you ship knowing it's not the final cut. SemVer
+gives you a suffix for this (`1.0.0-alpha`, `1.0.0-beta.2`, `1.0.0-rc.1`), and
+the convention is a rough confidence ladder:
+
+- **alpha** — feature-incomplete, expect bugs, for early testers.
+- **beta** — feature-complete, hunting for bugs.
+- **rc** (release candidate) — believed shippable; if nothing breaks, this
+  *becomes* the release.
+
+Two reasons to bother. First, it sets expectations honestly. Second — and this
+is the one people skip — **a pre-release exercises your release machinery on
+real infrastructure before it matters.** The first time you push a tag and watch
+the build run is exactly when you find out your version-injection is broken or
+your artifact paths are wrong. Far better to discover that on `v0.99.0` than on
+`v1.0.0`.
+
+## Release often, in small bites
+
+The instinct to batch up "enough" changes into a big release is a trap. Large
+releases are riskier (more surface area to regress), harder to write notes for,
+and slower to get feedback on. Shipping small and often means each release is
+easy to reason about, easy to roll back, and keeps users in the habit of
+upgrading. Your cadence doesn't have to be fixed — "whenever there's something
+worth shipping" is a perfectly good policy for a side project.
+
+## Write a changelog humans will read
+
+A `CHANGELOG.md` is the project's release diary. The
+[Keep a Changelog](https://keepachangelog.com/) format is the de-facto standard
+and it's dead simple:
+
+- Newest version at the top.
+- An `## [Unreleased]` section you append to *as you merge changes* — so the work
+  is already done when you cut a release.
+- Changes grouped under `### Added`, `### Changed`, `### Fixed`, `### Removed`,
+  `### Deprecated`, `### Security`.
+
+Write entries for *users*, not for git. "Fixed null pointer in handler" is a
+commit message; "Scanner no longer crashes when a talkgroup has no name" is a
+changelog entry. When you cut a release, you rename `[Unreleased]` to the new
+version with a date and open a fresh `[Unreleased]`. That's it.
+
+GitHub Releases can also auto-generate notes from merged PR titles, which is a
+great complement to a hand-written changelog: the changelog tells the *story*,
+the auto-notes give the *complete* list.
+
+## Automate the build off the tag
+
+Manual release builds are where mistakes live. The pattern that scales:
+
+1. You push a tag matching a pattern (e.g. `v*.*.*`).
+2. A CI workflow triggers on that tag, builds every target, injects the version
+   into the binary, computes checksums, and creates the GitHub Release with the
+   artifacts attached.
+
+Inject the version at build time rather than hard-coding it in source — that way
+the binary can report exactly which release and commit it came from. In Go this
+is `-ldflags "-X pkg.Version=..."`; other ecosystems have equivalents. And always
+publish a `SHA256SUMS` file so anyone can verify the download wasn't corrupted or
+tampered with.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) is on **SemVer
+`v0.4.5`** — squarely in the honest `0.x` "still stabilizing" range, with the
+public API and config schema free to evolve until `v1.0.0`. Here's the full
+release machinery, all real:
+
+**The changelog is the source of truth.** `CHANGELOG.md` opens by declaring it
+follows Keep a Changelog and Semantic Versioning, and the top of the file is
+always an `## [Unreleased]` section. Contributors add a line there as part of
+every PR — `CONTRIBUTING.md` literally lists "Add a line to `CHANGELOG.md` under
+`## [Unreleased]`" as step 3 of sending a pull request. Cutting `v0.4.5` was just
+promoting that section to a dated heading.
+
+**A tag triggers everything.** `.github/workflows/release.yml` is wired to
+`on: push: tags: ["v*.*.*"]` (plus a manual `workflow_dispatch` button). Pushing
+`vX.Y.Z` builds Windows, Linux, and macOS artifacts for both `amd64` and `arm64`
+in parallel, then a final `release` job flattens them and publishes the GitHub
+Release.
+
+**Version is injected at link time.** Each build computes the version, short
+commit SHA, and UTC build time and bakes them in via ldflags:
+
+```text
+-ldflags "-X github.com/MattCheramie/GopherTrunk/internal/version.Version=${VERSION} \
+          -X github.com/MattCheramie/GopherTrunk/internal/version.Commit=${COMMIT} \
+          -X github.com/MattCheramie/GopherTrunk/internal/version.BuildTime=${BUILD_TIME}"
+```
+
+So `gophertrunk version` always reports exactly which release and commit you're
+running.
+
+**Rehearse before you tag.** `CONTRIBUTING.md`'s "Cutting a release" section
+tells you to dry-run first:
+
+```sh
+make release-dry-run VERSION=v0.99.0
+```
+
+That builds `dist/dry-run/gophertrunk` with the same ldflags the real workflow
+uses, runs `./gophertrunk version` against it, and writes a `SHA256SUMS` file —
+so packaging or ldflags breakage surfaces *before* a tag is cut.
+
+**Pre-release before v1.0.0.** The repo's stated policy is that "the first
+production release should be a prerelease (e.g. `v0.99.0`)" so the full workflow
+runs end-to-end against live GitHub Actions before `v1.0.0` ships. And the
+release job encodes the SemVer pre-release rule in code: any `v0.x` tag *or* any
+tag with a hyphen suffix (`v1.0.0-rc.1`) is published with `prerelease: true`;
+only a clean `v1.0.0+` lands as the "latest" stable release.
+
+**Checksums and tag protection.** The final job runs `sha256sum * > SHA256SUMS`
+over every artifact, and every release ends with the line "All artifacts are
+SHA-256-checksummed in `SHA256SUMS`." Tags themselves are protected: the
+`.github/rulesets/release-tags-protection.json` ruleset matches `refs/tags/v*`
+and blocks both `deletion` and `update`, so a published release tag can never be
+silently moved to point at different code.
+
+You don't need a multi-OS matrix to copy this. The portable moves are: pick
+SemVer, keep an `[Unreleased]` changelog, trigger the build off a tag, inject the
+version, ship checksums, and rehearse with a pre-release.
+
+## FAQ
+
+**When should I release v1.0.0?**
+When you're willing to promise API stability — that you won't make breaking
+changes without bumping to `2.0.0`. If you're still reshaping the public
+interface, stay on `0.x`. There's no rush; plenty of widely-used software lives
+happily at `0.x` for years.
+
+**Do I need a changelog if GitHub auto-generates release notes?**
+They serve different purposes. Auto-generated notes list every merged PR — great
+for completeness. A hand-written `CHANGELOG.md` curates the *user-facing story*
+and groups changes by type. The best setup uses both, which is exactly what
+GopherTrunk does (`generate_release_notes: true` alongside `CHANGELOG.md`).
+
+**What's the difference between a tag and a release?**
+A tag is a git concept: an immutable pointer to a commit. A "release" is a
+GitHub feature layered on top — a tag plus a title, notes, and downloadable
+artifacts. You can have tags with no release, but not a release without a tag.
+
+**Why inject the version instead of writing it in a file?**
+A version file can drift from reality — someone forgets to bump it, or a local
+build reports the wrong number. Injecting `Version`/`Commit`/`BuildTime` at link
+time means the binary always tells the truth about exactly what produced it.
+
+**Should pre-releases show up as the "latest" download?**
+No. Mark them `prerelease: true` so users who just want the stable build aren't
+handed a release candidate. GopherTrunk's release job does this automatically for
+any `0.x` or hyphen-suffixed tag.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10: Websites, Support Pages & GitHub Pages]({{ '/blog/tutorials/build-in-the-open-10-websites-support-pages-github-pages/' | relative_url }})
+· Next →
+[Part 12: Optimizing & Securing Your Repository]({{ '/blog/tutorials/build-in-the-open-12-optimizing-securing-your-repository/' | relative_url }})

--- a/docs/_posts/2026-06-29-build-in-the-open-12-optimizing-securing-your-repository.md
+++ b/docs/_posts/2026-06-29-build-in-the-open-12-optimizing-securing-your-repository.md
@@ -1,0 +1,232 @@
+---
+title: "Build in the Open, Part 12: Optimizing & Securing Your Repository"
+description: How to make your GitHub repo discoverable and safe — About box, badges, branch protection, secret scanning, Dependabot, SECURITY.md, and least-privilege tokens.
+keywords: github repository security, branch protection, secret scanning, dependabot, sca, security.md, github badges, repository optimization, govulncheck, claude code
+category: tutorials
+tags: [github, security, repository, badges, dependabot, claude-code]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 12
+---
+
+> **TL;DR:** A good public repo does two jobs — it *sells itself* and it
+> *protects itself*. Optimize discoverability with a filled-in About box, topics,
+> a social-preview image, and honest status badges. Harden it with branch
+> protection / required checks, secret scanning + push protection, automated
+> dependency-CVE scanning (Dependabot / SCA), a `SECURITY.md` disclosure policy,
+> checksummed releases, and least-privilege `GITHUB_TOKEN` permissions in your
+> Actions. Most of this is free and takes an afternoon.
+
+**Key takeaways**
+
+- The About box, topics, and a social-preview image are the cheapest SEO and
+  first-impression wins you'll ever get.
+- Badges should be *honest signals* (CI passing, latest release, license), not
+  decoration.
+- Branch protection with required status checks stops broken code from reaching
+  `main`.
+- Turn on secret scanning + push protection so credentials can't be committed in
+  the first place.
+- Scan dependencies for known CVEs automatically; a `SECURITY.md` tells people
+  how to report what you missed.
+- Give Actions the *minimum* token permissions they need — default to
+  read-only.
+
+*This is Part 12 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **Optimizing for discovery** — the About box, topics, social preview, badges,
+  and a tidy repo.
+- **Securing the front door** — branch protection and required status checks.
+- **Stopping secrets at the source** — secret scanning and push protection.
+- **Watching your dependencies** — Dependabot, SCA, and CVE scanning.
+- **A disclosure policy** — what `SECURITY.md` should say.
+- **Least-privilege Actions** — locking down `GITHUB_TOKEN`.
+- **How GopherTrunk does it**, with its real rulesets and CI checks.
+
+## Half one: optimize for discovery
+
+A repo nobody can find or understand is a tree falling in an empty forest. These
+are low-effort, high-leverage fixes.
+
+### Fill in the About box
+
+The little gear next to "About" on your repo's homepage controls three things
+that GitHub search and Google both index:
+
+- **Description** — one sentence, what it *is* and what makes it different.
+- **Website** — your docs or landing page (the one you built in
+  [Part 10]({{ '/blog/tutorials/build-in-the-open-10-websites-support-pages-github-pages/' | relative_url }})).
+- **Topics** — tags like `golang`, `sdr`, `cli`. These power GitHub topic pages
+  and "explore" discovery. Add 5–10 relevant ones.
+
+### Add a social-preview image
+
+Settings → General → Social preview. Upload an image and every time your repo is
+shared on social media, Slack, or Discord it renders a rich card instead of a
+bare URL. This is a one-time upload that pays off forever.
+
+### Use badges as honest signals
+
+Badges at the top of your README communicate health at a glance: is CI passing,
+what's the latest release, what license, what language version. Keep them
+*truthful* — a green CI badge that's actually broken is worse than no badge.
+Good additions include a code-quality/report-card badge and a docs link.
+
+### Keep the repo tidy
+
+Discoverability is also legibility. A clear directory structure, the standard
+"repository health" files (README, LICENSE, CONTRIBUTING, CODE_OF_CONDUCT,
+SECURITY, issue/PR templates), and a `.gitignore` that keeps build junk out all
+make the repo feel maintained — which is itself a signal to potential users and
+contributors.
+
+## Half two: secure the repository
+
+Optimization gets people in the door. Security keeps the door from being kicked
+off its hinges.
+
+### Branch protection and required checks
+
+Protect `main` so nobody (including you on a bad day) can push broken code or
+force-push history away. The essentials:
+
+- Require changes to come through a pull request.
+- Require your CI status checks to pass before merge.
+- Block force-pushes (non-fast-forward) and branch deletion.
+
+On GitHub this is "branch protection rules" or the newer, JSON-defined
+**rulesets** — which have the advantage that you can commit them to the repo and
+review changes to your protection policy like any other code.
+
+### Secret scanning + push protection
+
+Secret scanning watches for committed credentials (API keys, tokens) and alerts
+you. **Push protection** goes further — it *blocks the push* before the secret
+ever lands in history. Turn both on (free for public repos). The best secret is
+the one that never gets committed; the second best is one you're told about
+within seconds.
+
+### Dependabot and dependency CVE scanning (SCA)
+
+Your code is only as secure as its dependencies. **Software Composition Analysis
+(SCA)** means scanning your dependency tree for known CVEs. Two complementary
+tools:
+
+- **Dependabot** — opens PRs to bump dependencies with known vulnerabilities,
+  and can keep all deps current on a schedule.
+- **A CVE scanner in CI** — fails the build if a vulnerable dependency is in the
+  graph, so you find out at PR time, not in production.
+
+### A SECURITY.md disclosure policy
+
+When someone finds a vulnerability, they need a *private* way to tell you.
+`SECURITY.md` documents that path. Good ones include: which versions are
+supported, how to report privately (GitHub's private security advisories are the
+standard), what's in and out of scope, and rough response timelines. This turns
+a scary surprise into a managed process.
+
+### Least-privilege Actions tokens
+
+Every workflow run gets a `GITHUB_TOKEN`. By default it can be broad. Set
+`permissions:` to the minimum each workflow needs — read-only for CI, `contents:
+write` only for the job that publishes releases. A leaked or exploited workflow
+with read-only scope can do far less damage than one with write-everything.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) treats both halves as
+first-class. Here's the real configuration.
+
+**Honest badges.** The README header carries six: a live CI status badge
+(`actions/workflows/ci.yml/badge.svg`), a release badge
+(`shields.io/github/v/release` with `include_prereleases&sort=semver` — so it
+honestly shows the `0.x` pre-release state), an Apache-2.0 license badge, a
+Go-version badge pulled from `go.mod`, a **Go Report Card** code-quality badge,
+and a docs badge linking to gophertrunk.org. Every one is a live signal, not a
+static image.
+
+**Protection as committed rulesets.** Branch and tag protection live in the repo
+as JSON, reviewable like code:
+
+- `.github/rulesets/main-branch-protection.json` targets the default branch and
+  requires pull requests, resolves review threads
+  (`required_review_thread_resolution: true`), blocks `deletion` and
+  `non_fast_forward`, and — crucially — requires three status checks to pass
+  before merge: `build-test`, `usb-windows`, and `usb-macos`.
+- `.github/rulesets/release-tags-protection.json` (from
+  [Part 11]({{ '/blog/tutorials/build-in-the-open-11-releases-prerelease-semver-changelogs/' | relative_url }}))
+  matches `refs/tags/v*` and blocks both `deletion` and `update`, so published
+  release tags are immutable.
+
+**CVE scanning is a required check.** The CI workflow has a dedicated `vulncheck`
+job that installs and runs `govulncheck ./...` — Go's official vulnerability
+scanner — enumerating known CVEs across the direct and transitive dependency
+graph. Because `build-test` and the USB jobs are required, a failing security
+scan keeps a PR from merging. There's also a `licenses` job that regenerates the
+third-party license inventory with `go-licenses`, backstopping the hand-curated
+table.
+
+**A real disclosure policy.** `SECURITY.md` is not boilerplate — it opens with a
+*threat model* (an operator running the daemon on a private network or single
+host they own), lists supported versions, and routes reports through **GitHub's
+private security advisory** workflow with explicit "do not open a public issue"
+guidance. It enumerates what's in scope (auth bypass, path traversal, SQL
+injection, DoS, memory-safety bugs) and out (operator misconfiguration,
+`auth.mode: disabled`), and publishes a severity-based response timeline
+(critical: ≤7 days initial, ≤30 days fix).
+
+**Crypto and secrets done right.** The API uses bearer-token auth with
+*constant-time comparison* (`crypto/subtle.ConstantTimeCompare`), so
+token-comparison side channels are out of scope by construction, per
+`SECURITY.md`. And the one real build secret — the RadioReference app key — is
+never committed; it's injected at build time via ldflags
+(`-X ...radioreference.DefaultAppKey=${RR_APP_KEY}`) from a GitHub Actions
+secret. The `release.yml` workflow also declares `permissions: contents: write`
+explicitly rather than inheriting broad defaults, and ships SHA-256 checksums
+with every release.
+
+The portable lesson: commit your protection rules, make a CVE scan a required
+check, write a real `SECURITY.md`, keep secrets out of source, and scope your
+tokens tight.
+
+## FAQ
+
+**Are these features free?**
+For public repositories, yes — branch protection, rulesets, secret scanning,
+push protection, and Dependabot are all free on GitHub. CVE scanners like
+`govulncheck` are free open-source tools you run in CI.
+
+**What's the difference between Dependabot and a CVE scanner like govulncheck?**
+Dependabot proactively opens PRs to *update* vulnerable or outdated
+dependencies. A scanner like `govulncheck` runs in CI and *fails the build* when
+a known-vulnerable dependency is present. They're complementary: one fixes,
+one gates.
+
+**Why use rulesets instead of classic branch protection?**
+Rulesets can be exported as JSON and committed to the repo, so changes to your
+protection policy are reviewable and versioned like any other code. GopherTrunk
+keeps both `main` and tag protection under `.github/rulesets/`.
+
+**What belongs in SECURITY.md?**
+Supported versions, a private reporting channel (GitHub advisories are
+standard), what's in and out of scope, and rough response timelines. A short
+threat model up front helps reporters know what you actually care about.
+
+**How do I keep secrets out of my repo?**
+Never commit them. Store them as GitHub Actions secrets and inject them at build
+or runtime, turn on push protection to block accidental commits, and prefer
+build-time injection (like GopherTrunk's ldflags app-key) over checked-in config.
+
+## Series navigation
+
+**Part 12 of 14** · ←
+[Part 11: Releases — SemVer & Changelogs]({{ '/blog/tutorials/build-in-the-open-11-releases-prerelease-semver-changelogs/' | relative_url }})
+· Next →
+[Part 13: Advanced Git & GitHub Features]({{ '/blog/tutorials/build-in-the-open-13-advanced-git-and-github-features/' | relative_url }})

--- a/docs/_posts/2026-06-30-build-in-the-open-13-advanced-git-and-github-features.md
+++ b/docs/_posts/2026-06-30-build-in-the-open-13-advanced-git-and-github-features.md
@@ -1,0 +1,205 @@
+---
+title: "Build in the Open, Part 13: Advanced Git & GitHub Features"
+description: Level up beyond commit and push — interactive rebase, cherry-pick, bisect, reflog, worktrees, conflict resolution, plus Discussions, Codespaces, GHCR, and Environments.
+keywords: git rebase, interactive rebase, git cherry-pick, git bisect, git reflog, git worktrees, merge conflicts, github discussions, codespaces, ghcr, claude code
+category: tutorials
+tags: [github, git, advanced, ghcr, codespaces, claude-code]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 13
+---
+
+> **TL;DR:** Once `commit`, `push`, and `merge` are muscle memory, a second tier
+> of Git tools makes you dramatically more effective: interactive rebase to clean
+> history, cherry-pick to move a single commit, stash to park work, bisect to
+> find the commit that broke something, reflog to recover "lost" work, and
+> worktrees to check out multiple branches at once. On the platform side, GitHub
+> offers far more than PRs — Discussions, code search, Codespaces, container/
+> package hosting (GHCR), deployment Environments, and a GraphQL API.
+
+**Key takeaways**
+
+- **Interactive rebase** (`git rebase -i`) reorders, squashes, and rewords
+  commits to tell a clean story.
+- **Bisect** binary-searches your history to pinpoint the commit that introduced
+  a bug — automatically.
+- **Reflog** is your undo button for almost anything; lost work is rarely
+  actually lost.
+- **Worktrees** let you have several branches checked out in parallel without
+  stashing or re-cloning.
+- GitHub is a platform, not just a Git host: Discussions, Codespaces, GHCR, and
+  Environments all build on the same repo.
+- Conflicts are routine, not a crisis — resolve them deliberately, test, then
+  commit.
+
+*This is Part 13 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real.*
+
+## In this post
+
+- **Git power tools** — rebase, cherry-pick, stash, bisect, reflog, worktrees,
+  tags.
+- **Resolving merge conflicts** with confidence instead of dread.
+- **Advanced GitHub features** — Discussions, code search, Codespaces, GHCR,
+  Environments, GraphQL.
+- **How GopherTrunk uses them** — conflict-resolution branches, a published
+  container image, and generated protobuf.
+
+## Half one: Git power tools
+
+These are the commands that separate "I can use Git" from "Git works for me."
+
+### Interactive rebase: curate your history
+
+`git rebase -i HEAD~5` opens an editor listing your last five commits. You can
+`pick`, `squash` (fold into the previous), `reword` (edit the message),
+`reorder`, or `drop` them. This is how you turn a messy "wip", "fix typo", "fix
+again" trail into a few clean, logical commits before opening a PR. Rebase
+*rewrites history*, so the rule is simple: rebase freely on your own
+not-yet-shared branches; never on shared branches others have based work on.
+
+### Cherry-pick: grab one commit
+
+`git cherry-pick <sha>` copies a single commit onto your current branch. Perfect
+for back-porting a fix to a release branch, or pulling one useful commit out of
+an abandoned branch without merging the rest.
+
+### Stash: park work mid-thought
+
+`git stash` shelves your uncommitted changes so you can switch context — fix an
+urgent bug, then `git stash pop` to bring your work back. A clean way to handle
+"I need to drop this for five minutes" without making a throwaway commit.
+
+### Bisect: find the commit that broke it
+
+`git bisect` is a hidden superpower. Tell it a known-good commit and a
+known-bad one, and it binary-searches between them, checking out a midpoint each
+time for you to test. You can even automate it: `git bisect run ./test.sh` lets
+the test suite find the culprit hands-free across hundreds of commits in a dozen
+steps.
+
+### Reflog: undo almost anything
+
+`git reflog` records *every* move of `HEAD` — including after a bad reset, a
+botched rebase, or a deleted branch. Find the SHA you were on and `git reset
+--hard <sha>` (or `git checkout`) to get back. Work you think you destroyed is
+usually sitting in the reflog for weeks.
+
+### Worktrees: multiple branches at once
+
+`git worktree add ../project-hotfix hotfix-branch` checks out another branch
+into a *separate directory* sharing the same repo. No stashing, no second clone
+— review a PR in one window while you keep building in another. Especially handy
+when a long build or test run shouldn't block other work.
+
+### Resolve conflicts deliberately
+
+A merge conflict just means two branches changed the same lines. It's routine.
+The calm workflow: open each conflicted file, find the `<<<<<<<` / `=======` /
+`>>>>>>>` markers, decide what the *correct* combined result is (not just "pick a
+side"), remove the markers, **run your tests**, then `git add` and commit. The
+fear comes from treating conflicts as rare emergencies; resolve a few
+deliberately and they become mundane.
+
+## Half two: advanced GitHub features
+
+The platform layered on top of Git is deep. The high-value pieces:
+
+- **Discussions** — a forum attached to your repo for Q&A, ideas, and
+  announcements, separate from the issue tracker (issues are for actionable work;
+  discussions are for conversation).
+- **Wikis** — long-form docs that live alongside the repo without cluttering it.
+- **Code search & navigation** — GitHub's indexed search and "go to definition"
+  make a large codebase browsable in the web UI.
+- **Codespaces** — a full, cloud-hosted dev environment spun up from your repo in
+  a browser; great for contributors who don't want to set up a local toolchain.
+- **GHCR / Packages** — GitHub Container Registry and package hosting, so you can
+  publish Docker images and language packages right next to your code.
+- **Environments + environment secrets** — named deploy targets (staging,
+  production) with their own protected secrets and approval gates.
+- **The GraphQL API** — query exactly the repo data you need in one request;
+  more powerful than the REST API for complex automation.
+- **Insights, saved replies, keyboard shortcuts** — the quality-of-life layer.
+  Press <kbd>?</kbd> on any GitHub page to see the shortcuts.
+
+You won't use all of these on day one, but knowing they exist means you reach for
+the right tool when the need shows up.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk)'s history and tooling
+show several of these in action.
+
+**Conflict-resolution branches in the open.** The git log makes the merge
+workflow visible — there's a real branch
+`claude/pr-674-merge-conflicts-bmivyc` whose merge commit
+(`1a56ec8 Merge pull request #708`) exists *specifically* to reconcile a
+long-running branch against an evolved `main`, including a
+`Merge remote-tracking branch 'origin/claude/issue-376-fix-q1l2cc'`. Conflicts
+aren't hidden; they're resolved on a dedicated branch and merged cleanly.
+
+**Squash-friendly, near-linear history.** As covered in
+[Part 5]({{ '/blog/tutorials/build-in-the-open-05-three-ways-to-merge-to-main/' | relative_url }}),
+the maintainer squashes on merge to keep `main` legible — `CONTRIBUTING.md` notes
+"force-push is fine on feature branches; the maintainer squashes on merge to keep
+`main` history clean." That discipline is exactly what makes a `git bisect` over
+`main` fast and meaningful: each commit is one logical, testable change.
+
+**A published container image.** GopherTrunk ships a Docker image to GitHub's
+container registry — `docker-compose.yml` pulls
+`image: ghcr.io/mattcheramie/gophertrunk:latest`, built from a multi-stage
+`Dockerfile` (`golang:1.25-bookworm` builder → `debian:bookworm-slim` runtime).
+That's GHCR/Packages doing real work: container hosting next to the code, no
+separate registry account.
+
+**Generated code regenerated reproducibly.** The gRPC API is defined in `.proto`
+files under `proto/`, and the generated Go lands in `internal/api/pb/v1` via a
+single `make proto` (which shells out to `protoc` with the Go and gRPC plugins).
+Keeping generation behind one command means the generated tree is reproducible
+and easy to review when it changes — the same legibility principle as squashed
+commits, applied to machine-generated code.
+
+The takeaway: you don't have to adopt everything at once. Learn rebase and reflog
+first (they'll save you weekly), keep history clean enough that bisect is useful,
+and reach for the platform features — GHCR, Codespaces, Discussions — when a
+concrete need appears.
+
+## FAQ
+
+**Is rebase dangerous?**
+Only if you rebase *shared* history. On your own feature branch that nobody else
+has pulled, rebase freely to clean things up. The rule: never rewrite commits
+others have already based work on. And if you do make a mistake, `git reflog`
+will get you back.
+
+**When should I use cherry-pick vs. merge?**
+Merge when you want a whole branch's changes. Cherry-pick when you want *one*
+specific commit — typically back-porting a single fix to a release branch
+without dragging along everything else on the source branch.
+
+**How is git bisect faster than reading the log?**
+It binary-searches. Across 1,000 commits it finds the culprit in about 10 test
+runs instead of checking each one. With `git bisect run <script>` it's fully
+automated — you walk away and it reports the exact commit.
+
+**What's the difference between GitHub Issues and Discussions?**
+Issues track *actionable work* — bugs and tasks that get closed when done.
+Discussions are for open-ended conversation — questions, ideas, announcements —
+that may never "close." Use both for what they're built for.
+
+**What is GHCR?**
+GitHub Container Registry — free container image hosting tied to your repo. You
+push Docker images to `ghcr.io/<owner>/<image>` and pull them anywhere, exactly
+how GopherTrunk's `docker-compose.yml` references
+`ghcr.io/mattcheramie/gophertrunk:latest`.
+
+## Series navigation
+
+**Part 13 of 14** · ←
+[Part 12: Optimizing & Securing Your Repository]({{ '/blog/tutorials/build-in-the-open-12-optimizing-securing-your-repository/' | relative_url }})
+· Next →
+[Part 14: The CLI Workflow & Claude Code as Your Daily Driver]({{ '/blog/tutorials/build-in-the-open-14-cli-workflow-claude-code-daily-driver/' | relative_url }})

--- a/docs/_posts/2026-07-01-build-in-the-open-14-cli-workflow-claude-code-daily-driver.md
+++ b/docs/_posts/2026-07-01-build-in-the-open-14-cli-workflow-claude-code-daily-driver.md
@@ -1,0 +1,215 @@
+---
+title: "Build in the Open, Part 14: The CLI Workflow & Claude Code as Your Daily Driver"
+description: Tie the whole idea-to-release journey into one repeatable loop using the gh CLI and Claude Code — CLAUDE.md, slash commands, hooks, MCP servers, and web sessions.
+keywords: gh cli, claude code, claude code cli, claude.md, slash commands, hooks, mcp servers, developer workflow, command line workflow, github automation
+category: tutorials
+tags: [github, cli, claude-code, workflow, gh, mcp]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Build in the Open"
+series_part: 14
+---
+
+> **TL;DR:** The fastest builders live close to the command line and treat an AI
+> agent as a full member of the workflow. The `gh` CLI puts issues, PRs,
+> releases, and CI runs a keystroke away without leaving your terminal. Claude
+> Code — in the CLI *or* on the web — turns plain-English intent into branches,
+> commits, and PRs, anchored by a `CLAUDE.md` memory file, sharpened with slash
+> commands and hooks, and extended with MCP servers. Stitch Parts 1–13 together
+> and you get one repeatable daily loop: idea → issue → branch → build with
+> Claude → PR → CI → merge → release.
+
+**Key takeaways**
+
+- The `gh` CLI lets you create issues, open PRs, watch CI runs, and cut releases
+  without touching the browser.
+- Claude Code reads `CLAUDE.md` as project memory, so it learns your conventions
+  once and applies them every session.
+- Slash commands package repeatable prompts; hooks automate checks; MCP servers
+  give the agent new tools.
+- Claude Code on the web matches the exact same repo setup — branches, PRs,
+  conventions — as the CLI.
+- The whole series collapses into one loop you can run every day on any project.
+
+*This is Part 14 of **Build in the Open**, a 14-part series on taking a software
+project from a blank idea to a public release using GitHub and Claude Code. Each
+post teaches a technique you can apply to any project in any language, then shows
+how the open-source [GopherTrunk](https://github.com/MattCheramie/GopherTrunk)
+scanner does it for real. This is the finale.*
+
+## In this post
+
+- **Why the CLI wins** — staying in one place beats tab-switching.
+- **The `gh` CLI** — issues, PRs, releases, and CI runs from the terminal.
+- **Claude Code as a daily driver** — CLI and web, and how they share a setup.
+- **`CLAUDE.md`, slash commands, hooks, and MCP** — making the agent yours.
+- **The daily loop** — Parts 1–13 as one repeatable cycle.
+- **How GopherTrunk does it**, and a send-off.
+
+## Why work from the command line?
+
+Every context switch costs focus. Bouncing between editor, browser tabs for
+issues and PRs, and a terminal for git fragments your attention. Pulling all of
+it into the command line — or into a single agent conversation — keeps you in
+flow. It's also scriptable and repeatable in a way clicking never is: a workflow
+you can type is a workflow you can automate.
+
+## The `gh` CLI: GitHub without the browser
+
+[`gh`](https://cli.github.com/) is GitHub's official command-line tool. It covers
+most of what you'd otherwise open a browser for:
+
+- **Issues:** `gh issue create`, `gh issue list`, `gh issue view 698`.
+- **Pull requests:** `gh pr create`, `gh pr view`, `gh pr checks`,
+  `gh pr merge --squash`.
+- **CI runs:** `gh run list`, `gh run watch`, `gh run view --log` to tail a
+  workflow without opening the Actions tab.
+- **Releases:** `gh release create v0.99.0 ...` to cut a release (or just push
+  the tag and let your release workflow from
+  [Part 11]({{ '/blog/tutorials/build-in-the-open-11-releases-prerelease-semver-changelogs/' | relative_url }})
+  do the rest).
+
+Authenticate once with `gh auth login` and the whole GitHub side of the workflow
+lives at your prompt.
+
+## Claude Code as your daily driver
+
+Claude Code is an AI agent that works *in* your project — reading files, running
+commands, editing code, and opening PRs. The shift is from "ask a chatbot,
+copy-paste answers" to "delegate a task and review the result." You describe
+intent ("add a `/api/v1/sites` endpoint and a regression test"), and the agent
+does the multi-step work: explore the code, make the change, run the tests, and
+prepare a commit.
+
+It comes in two forms that share the same setup:
+
+- **The CLI** — `claude` in your terminal, right next to `gh` and `git`.
+- **The web** — Claude Code on the web runs against the same repository, the
+  same branch conventions, the same `CLAUDE.md`. Start a task from your phone or
+  a browser, and it operates exactly as the CLI would.
+
+Because both read the same project configuration, the agent behaves
+consistently no matter where you launch it.
+
+### CLAUDE.md: project memory
+
+`CLAUDE.md` is a file in your repo that Claude Code reads automatically every
+session. It's where you encode the conventions you'd otherwise repeat constantly:
+how to run tests, your commit-message style, branch-naming rules, "don't touch
+the generated `pb/` directory by hand," and so on. Write it once and every future
+session — CLI or web — starts already knowing how your project works. We
+introduced it back in
+[Part 3]({{ '/blog/tutorials/build-in-the-open-03-brainstorm-with-claude-readme-roadmap/' | relative_url }});
+by now it's the agent's onboarding doc.
+
+### Slash commands, hooks, and MCP servers
+
+Three ways to bend Claude Code to your workflow:
+
+- **Slash commands** package a repeatable prompt behind a short name — e.g. a
+  `/code-review` command that runs your standard review pass. Stop re-typing the
+  same instructions.
+- **Hooks** run your own commands at lifecycle points — for example, auto-running
+  a formatter or test suite after the agent edits a file, so quality gates fire
+  without you asking.
+- **MCP servers** (Model Context Protocol) give the agent new tools — a GitHub
+  MCP server to manage issues and PRs, a database server to run queries, a Canva
+  server to make graphics. MCP is how you extend what the agent can *reach*.
+
+## The daily loop: Parts 1–13 as one cycle
+
+Everything in this series collapses into a single repeatable loop you can run on
+any project, in any language:
+
+1. **Decide what to build** ([Part 1]({{ '/blog/tutorials/build-in-the-open-01-picking-what-to-build/' | relative_url }})) and **pick the stack** (Part 2) — once per project.
+2. **Capture the idea** as an issue (Part 6), brainstormed and scoped with Claude (Part 3).
+3. **Branch** off `main` (Parts 4–5): `git switch -c claude/issue-NNN-desc`.
+4. **Build with Claude Code**, guided by `CLAUDE.md`, with tests (Part 8) and docs (Part 9) as you go.
+5. **Open a PR** with `gh pr create`; CI runs your required checks (Part 7).
+6. **Review, resolve conflicts** (Part 13), and **merge** with the right strategy (Part 5).
+7. **Release** when there's something worth shipping (Part 11), on a secured, optimized repo (Part 12), surfaced on your site (Part 10).
+
+Then back to step 2. That loop, run consistently, is how a blank idea becomes a
+released, maintained project.
+
+## How GopherTrunk does it
+
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) *is* this loop, made
+visible in its own history. The git log reads like a tour of the workflow:
+branches named `claude/issue-698-features-ytrap7` and
+`claude/release-workflow-docs-sync-bdhhjz`, each landing as a squashed
+`Merge pull request #NNN` — the exact `claude/...` branch-naming and PR-driven
+convention this series taught. Commit `72c7ef3 feat: expose P25 site identity in
+grant events and via /api/v1/sites (#698)` is a single logical change, tested and
+merged through a PR, then promoted into `CHANGELOG.md`'s `## [Unreleased]`
+section, ready for the next tag to ship it.
+
+Releases are tag-driven (`make release-dry-run` to rehearse, then push `vX.Y.Z`
+or use `gh release` / the Actions button), CI gates every PR with required checks
+including `govulncheck`, and the daily Pages cron drips this very blog series out
+one post at a time. The same project setup that the CLI uses is exactly what
+Claude Code on the web operates against — same branches, same conventions, same
+`CLAUDE.md`. The work that produced these 14 posts ran through that loop too.
+
+## The journey, end to end
+
+Look back at where we started: a blank idea and the advice to scratch your own
+itch. From there we chose a language and platforms, brainstormed features and
+wrote the README as a roadmap, learned Git and GitHub from the web UI, mastered
+branching and the three ways to merge, planned work and invited contributors,
+wired up CI with GitHub Actions, built a real test suite, documented the project
+properly, published a website, cut SemVer releases with changelogs, optimized and
+secured the repo, leveled up with advanced Git, and finally tied it all together
+at the command line with Claude Code.
+
+That's the whole arc — **idea to release** — and none of it required being an
+expert at the start. It required picking one real problem and turning the crank
+on the loop, one PR at a time.
+
+So: now go build something. Pick the itch that's been bugging you, write the
+one-sentence problem statement, open the repo, and start the loop. The tools are
+free, the workflow is proven, and the only missing ingredient is the thing only
+you can supply — the project worth building.
+
+Thanks for reading **Build in the Open**.
+
+## FAQ
+
+**Do I need the CLI, or is the web enough?**
+Either works, and they share the same setup. Many people use the CLI at their
+desk and Claude Code on the web for kicking off tasks from a phone or browser.
+Because both read your repo's `CLAUDE.md` and conventions, the experience is
+consistent.
+
+**What goes in CLAUDE.md?**
+Anything you'd otherwise repeat every session: how to run tests and lint, commit
+and branch conventions, files the agent should leave alone, and pointers to key
+docs. Treat it as the agent's onboarding guide.
+
+**What's the difference between a slash command and a hook?**
+A slash command is something *you* invoke to run a packaged prompt. A hook fires
+*automatically* at a lifecycle point (like after a file edit), without you asking
+— ideal for formatters and test gates.
+
+**What is an MCP server?**
+A Model Context Protocol server extends what Claude Code can reach — issues and
+PRs via a GitHub server, a database, design tools, and more. It's how you give
+the agent new capabilities beyond editing files and running shell commands.
+
+**Can I really run this whole loop on a non-Go project?**
+Yes — that's the point of the series. The principles (SemVer, CI gates,
+PR-driven branches, a `CLAUDE.md`, tag-triggered releases) are language-agnostic.
+GopherTrunk is just one worked example; swap Go for Python, JS, or Rust and the
+loop is identical.
+
+## Series navigation
+
+**Part 14 of 14** · ←
+[Part 13: Advanced Git & GitHub Features]({{ '/blog/tutorials/build-in-the-open-13-advanced-git-and-github-features/' | relative_url }})
+
+That's a wrap on **Build in the Open** — fourteen parts from a blank idea to a
+secured, released, documented project. Revisit
+[Part 1: Picking What to Build]({{ '/blog/tutorials/build-in-the-open-01-picking-what-to-build/' | relative_url }})
+to start a new project from scratch, or browse the whole journey on the
+[series index]({{ '/blog/series/build-in-the-open/' | relative_url }}). Now go
+build something.

--- a/docs/blog/series/build-in-the-open.md
+++ b/docs/blog/series/build-in-the-open.md
@@ -1,0 +1,47 @@
+---
+layout: page
+title: "Build in the Open: GitHub + Claude Code from idea to release"
+description: A 14-part tutorial series on taking a software project from a blank idea to a public release using GitHub and Claude Code — a generic, transferable workflow, with the open-source GopherTrunk scanner as the worked example.
+keywords: github tutorial, claude code, build software with ai, open source workflow, git branching, github actions, semantic versioning, github pages, repository security
+nav_group: Blog
+permalink: /blog/series/build-in-the-open/
+---
+
+**Build in the Open** is a 14-part series on taking a software project from a
+blank idea all the way to a public release — using **GitHub** and **Claude
+Code** — **one stage per post**. Each part teaches a technique you can apply to
+*any* project in *any* language, then shows how the open-source
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) scanner does it for
+real, so every lesson comes with a concrete worked example you can copy.
+
+New to the project? Grab a build from the
+[downloads page]({{ '/downloads.html' | relative_url }}) and follow along, or
+read the [GopherTrunk README](https://github.com/MattCheramie/GopherTrunk) to
+see the patterns in their natural habitat.
+
+{%- assign parts = site.posts | where: "series", "Build in the Open" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Tutorials</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/tutorials/' | relative_url }}">tutorials</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>


### PR DESCRIPTION
A tutorial series taking a project from idea to public release using GitHub
and Claude Code. Teaches a generic, transferable workflow with GopherTrunk as
the worked example. Each post serves three reader tiers (TL;DR/key takeaways,
scannable overview, full deep dive), includes an FAQ for AEO/SEO, and inherits
the standard site CTAs.

Posts are future-dated 2026-06-18 .. 2026-07-01 to drip-release daily via the
pages.yml cron. Adds the series landing page and a standalone handoff prompt
(build-in-the-open-prompt.md) to regenerate the series.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pye7ogH17UH8Wbx9ZVRLTw