### PR TITLE
fix(p25): decode LRA byte in status broadcasts so WACN/SysID/RFSS/Site/neighbors are correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,22 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+- **P25 discovery now decodes WACN / System ID / RFSS / Site / neighbors
+  correctly.** The Phase 1 Network-, RFSS-, and Adjacent-Site Status
+  Broadcast TSBK parsers were dropping the leading LRA byte, so every
+  field read one byte early — WACN and System ID came out wrong, RFSS/Site
+  read as 0, and advertised neighbors showed garbled IDs with no resolvable
+  frequency. The parsers now follow the TIA-102.AABF layout (matching the
+  repo's independent Phase 2 decoders), which also corrects the `rfss_id` /
+  `site_id` labels on `grant` events and `KindSiteUpdate`.
+
 ### Added
+- **Voice-channel frequencies in the Hunt discovery view.** The discovery
+  model now records the band-plan-resolved voice/traffic frequency of every
+  grant, surfaced both per-talkgroup (a Frequencies column) and per-site (a
+  Voice channels column) in the Hunt panel, and in the `system` JSON as
+  `talkgroups[].frequencies` and `sites[].voice_channels`.
 - **P25 site identity in grant events and a `/api/v1/sites` endpoint**
   (#698). Every `grant` event now carries `rfss_id` / `site_id`,
   decoded from the camped site's RFSS Status Broadcast, so downstream

--- a/internal/hunt/accumulate.go
+++ b/internal/hunt/accumulate.go
@@ -124,11 +124,25 @@ func Accumulate(dst *DiscoveredSystem, obs Observation) {
 	}
 
 	// Talkgroups: every grant's destination group is an observed talkgroup.
+	// A grant also names the voice/traffic channel it was granted on — record
+	// its frequency on both the talkgroup and the camped site. The decoder
+	// usually resolves FrequencyHz at grant time (the band plan was already
+	// primed); fall back to the accumulated band plan for grants whose channel
+	// ID only resolved on a later capture.
 	for _, g := range obs.Result.Grants {
 		if g.GroupID == 0 {
 			continue
 		}
-		dst.addTalkgroup(g.GroupID, g.Encrypted, at)
+		freqHz := g.FrequencyHz
+		if freqHz == 0 {
+			if hz, ok := dst.bandPlanFreq(g.ChannelID, g.ChannelNum); ok {
+				freqHz = hz
+			}
+		}
+		dst.addTalkgroup(g.GroupID, g.Encrypted, freqHz, at)
+		if freqHz != 0 {
+			dst.addVoiceChannel(rfss, site, freqHz)
+		}
 	}
 }
 

--- a/internal/hunt/system.go
+++ b/internal/hunt/system.go
@@ -72,6 +72,10 @@ type DiscoveredSite struct {
 	ControlChannels []DiscoveredChannel `json:"control_channels"`
 	Secondary       []uint32            `json:"secondary,omitempty"`
 	Neighbors       []NeighborRef       `json:"neighbors,omitempty"`
+	// VoiceChannels are the distinct voice/traffic-channel frequencies (Hz)
+	// seen granted on this site, resolved from each grant's (ChannelID,
+	// ChannelNumber) against the band plan. Empty until a grant resolves.
+	VoiceChannels []uint32 `json:"voice_channels,omitempty"`
 }
 
 // DiscoveredChannel is one observed frequency on a site.
@@ -90,6 +94,10 @@ type DiscoveredTalkgroup struct {
 	Encrypted bool      `json:"encrypted,omitempty"`
 	Count     int       `json:"count"`
 	FirstSeen time.Time `json:"first_seen"`
+	// Frequencies are the distinct voice-channel frequencies (Hz) observed
+	// carrying this talkgroup, resolved from each grant against the band
+	// plan. Empty until a grant for this talkgroup resolves a frequency.
+	Frequencies []uint32 `json:"frequencies,omitempty"`
 }
 
 // NeighborRef is an adjacent site advertised by the control channel.
@@ -163,24 +171,43 @@ func (s *DiscoveredSystem) addControlChannel(rfss, siteID uint8, hz uint32, conf
 	})
 }
 
-// addTalkgroup records (or bumps the activity count of) a talkgroup.
-func (s *DiscoveredSystem) addTalkgroup(dec uint32, encrypted bool, at time.Time) {
+// addTalkgroup records (or bumps the activity count of) a talkgroup. A
+// non-zero freqHz is merged into the talkgroup's observed voice-channel
+// frequencies, de-duplicated.
+func (s *DiscoveredSystem) addTalkgroup(dec uint32, encrypted bool, freqHz uint32, at time.Time) {
 	for i := range s.Talkgroups {
 		if s.Talkgroups[i].Dec == dec {
 			s.Talkgroups[i].Count++
 			if encrypted {
 				s.Talkgroups[i].Encrypted = true
 			}
+			if freqHz != 0 {
+				s.Talkgroups[i].Frequencies = appendUniqueFreq(s.Talkgroups[i].Frequencies, freqHz)
+			}
 			return
 		}
 	}
-	s.Talkgroups = append(s.Talkgroups, DiscoveredTalkgroup{
+	tg := DiscoveredTalkgroup{
 		Dec:       dec,
 		Hex:       fmt.Sprintf("%x", dec),
 		Encrypted: encrypted,
 		Count:     1,
 		FirstSeen: at,
-	})
+	}
+	if freqHz != 0 {
+		tg.Frequencies = []uint32{freqHz}
+	}
+	s.Talkgroups = append(s.Talkgroups, tg)
+}
+
+// addVoiceChannel records a voice/traffic-channel frequency observed on
+// (rfss, siteID), de-duplicating by frequency.
+func (s *DiscoveredSystem) addVoiceChannel(rfss, siteID uint8, hz uint32) {
+	if hz == 0 {
+		return
+	}
+	site := s.site(rfss, siteID)
+	site.VoiceChannels = appendUniqueFreq(site.VoiceChannels, hz)
 }
 
 // addNeighbor records an adjacent site on (rfss, siteID), de-duplicating by
@@ -231,8 +258,14 @@ func (s *DiscoveredSystem) sortAll() {
 			}
 			return nb[a].Site < nb[b].Site
 		})
+		vc := s.Sites[i].VoiceChannels
+		sort.Slice(vc, func(a, b int) bool { return vc[a] < vc[b] })
 	}
 	sort.Slice(s.Talkgroups, func(i, j int) bool { return s.Talkgroups[i].Dec < s.Talkgroups[j].Dec })
+	for i := range s.Talkgroups {
+		fr := s.Talkgroups[i].Frequencies
+		sort.Slice(fr, func(a, b int) bool { return fr[a] < fr[b] })
+	}
 	sort.Slice(s.BandPlan, func(i, j int) bool { return s.BandPlan[i].ChannelID < s.BandPlan[j].ChannelID })
 	// Resolve neighbour control-channel frequencies now that the band plan is
 	// fully accumulated (it may be incomplete on any single observation).

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -50,6 +50,9 @@ func (m *NetworkModel) ApplyNetworkStatus(n NetworkStatusBroadcast) {
 	defer m.mu.Unlock()
 	m.cfg.WACN = n.WACN
 	m.cfg.SystemID = n.SystemID
+	if n.LRA != 0 {
+		m.cfg.LRA = n.LRA
+	}
 }
 
 // ApplyRFSSStatus folds an RFSS Status Broadcast (0x3A) in.

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -46,13 +46,14 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 	defer bus.Close()
 	cc := New(Options{Bus: bus, SystemName: "S"})
 
-	// NSB payload: WACN 0xABCDE (p0<<12|p1<<4|p2>>4), SystemID 0x123
-	// ((p2&0x0F)<<8|p3) — see ParseNetworkStatusBroadcast.
+	// NSB payload: LRA p0, WACN 0xABCDE (p1<<12|p2<<4|p3>>4), SystemID
+	// 0x123 ((p3&0x0F)<<8|p4) — see ParseNetworkStatusBroadcast.
 	nsb := TSBK{Opcode: OpNetworkStatusBroadcast,
-		Payload: [8]byte{0xAB, 0xCD, 0xE1, 0x23}}
-	// RFSS payload: LRA p0, RFSS p2, Site p3 — see ParseRFSSStatusBroadcast.
+		Payload: [8]byte{0x00, 0xAB, 0xCD, 0xE1, 0x23}}
+	// RFSS payload: LRA p0, SystemID p1-2, RFSS p3, Site p4 —
+	// see ParseRFSSStatusBroadcast.
 	rfss := TSBK{Opcode: OpRFSSStatusBroadcast,
-		Payload: [8]byte{9, 0, 4, 7}}
+		Payload: [8]byte{9, 0x01, 0x23, 4, 7}}
 	adj := TSBK{Opcode: OpAdjacentSiteStatusBroadcast,
 		Payload: AssembleAdjacentSiteStatusBroadcast(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})}
 
@@ -85,8 +86,8 @@ func TestControlChannelPublishesSiteUpdate(t *testing.T) {
 	cc := New(Options{Bus: bus, SystemName: "MMR", FrequencyHz: ccHz})
 
 	// NSB first so WACN/SystemID are populated, then RFSS to name the site.
-	nsb := TSBK{Opcode: OpNetworkStatusBroadcast, Payload: [8]byte{0xAB, 0xCD, 0xE1, 0x23}}
-	rfss := TSBK{Opcode: OpRFSSStatusBroadcast, Payload: [8]byte{9, 0, 4, 7}}
+	nsb := TSBK{Opcode: OpNetworkStatusBroadcast, Payload: [8]byte{0x00, 0xAB, 0xCD, 0xE1, 0x23}}
+	rfss := TSBK{Opcode: OpRFSSStatusBroadcast, Payload: [8]byte{9, 0x01, 0x23, 4, 7}}
 	base := 0
 	for _, tsbk := range []TSBK{nsb, rfss} {
 		cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk), base)
@@ -110,9 +111,9 @@ func TestControlChannelPublishesSiteUpdate(t *testing.T) {
 			if u.ControlChannelHz != ccHz {
 				t.Fatalf("control_channel_hz = %d, want %d", u.ControlChannelHz, ccHz)
 			}
-			// WACN comes from the NSB; the RFSS Status Broadcast then sets
-			// SystemID from its own field (p1/p2 → 4 for this payload).
-			if u.WACN != 0xABCDE || u.SystemID != 4 {
+			// WACN comes from the NSB; both the NSB and the RFSS Status
+			// Broadcast carry SystemID 0x123 for these payloads.
+			if u.WACN != 0xABCDE || u.SystemID != 0x123 {
 				t.Fatalf("site update network ids wrong: %+v", u)
 			}
 			return

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -316,16 +316,17 @@ func ParseUnitRegistrationResponse(p [8]byte) UnitRegistrationResponse {
 	}
 }
 
-// NetworkStatusBroadcast (opcode 0x3B explicit / 0x3C is Adjacent in some
-// vendor variants — TIA-102.AABF is unfortunately revised over time;
-// callers should look at MFID + opcode together to disambiguate). This
-// parser handles the standard explicit-form payload:
+// NetworkStatusBroadcast (opcode 0x3B) carries the system's network
+// identity. Payload layout per TIA-102.AABF — identical to the Phase 2
+// Network Status Broadcast (see phase2/mac.go AsNetworkStatusBroadcast):
 //
-//	bytes 0-2:  WACN ID (20 bits in upper 20 of 24)
-//	bytes 2-3:  System ID (12 bits)
-//	bytes 4-5:  channel
-//	bytes 6-7:  system service class
+//	byte 0:     LRA (Location Registration Area)
+//	bytes 1-3:  WACN ID (20 bits in the upper 20 of bytes 1-3)
+//	bytes 3-4:  System ID (low nibble of byte 3 + byte 4)
+//	bytes 5-6:  channel (4-bit ID + 12-bit number)
+//	byte 7:     system service class
 type NetworkStatusBroadcast struct {
+	LRA           uint8
 	WACN          uint32 // 20-bit
 	SystemID      uint16 // 12-bit
 	ChannelID     uint8
@@ -334,26 +335,29 @@ type NetworkStatusBroadcast struct {
 }
 
 func ParseNetworkStatusBroadcast(p [8]byte) NetworkStatusBroadcast {
-	wacn := uint32(p[0])<<12 | uint32(p[1])<<4 | uint32(p[2]>>4)
-	sysid := uint16(p[2]&0x0F)<<8 | uint16(p[3])
-	chanField := binary.BigEndian.Uint16(p[4:6])
+	wacn := uint32(p[1])<<12 | uint32(p[2])<<4 | uint32(p[3])>>4
+	sysid := uint16(p[3]&0x0F)<<8 | uint16(p[4])
+	chanField := binary.BigEndian.Uint16(p[5:7])
 	return NetworkStatusBroadcast{
+		LRA:           p[0],
 		WACN:          wacn,
 		SystemID:      sysid,
 		ChannelID:     uint8(chanField >> 12),
 		ChannelNumber: chanField & 0x0FFF,
-		ServiceClass:  binary.BigEndian.Uint16(p[6:8]),
+		ServiceClass:  uint16(p[7]),
 	}
 }
 
-// RFSSStatusBroadcast (opcode 0x3A in standard form). Payload:
+// RFSSStatusBroadcast (opcode 0x3A) names the site the receiver is
+// camped on. Payload layout per TIA-102.AABF — identical to the Phase 2
+// RFSS Status Broadcast (see phase2/mac_standard.go AsRFSSStatusBroadcast):
 //
 //	byte 0:     LRA (Location Registration Area)
-//	byte 1:     System ID high nibble + RFSS ID
-//	byte 2:     RFSS ID continued / Site ID
-//	byte 3:     Site ID continued
-//	bytes 4-5:  channel
-//	bytes 6-7:  system service class
+//	bytes 1-2:  System ID (12 bits, low nibble of byte 1 + byte 2)
+//	byte 3:     RFSS ID
+//	byte 4:     Site ID
+//	bytes 5-6:  channel (4-bit ID + 12-bit number)
+//	byte 7:     system service class
 type RFSSStatusBroadcast struct {
 	LRA           uint8
 	SystemID      uint16 // 12-bit
@@ -403,16 +407,20 @@ func AssembleSecondaryControlChannelBroadcast(s SecondaryControlChannelBroadcast
 }
 
 // AdjacentSiteStatusBroadcast (opcode 0x3C) announces a neighbouring
-// site a radio may roam to. Working-model payload layout:
+// site a radio may roam to. Payload layout per TIA-102.AABF — it shares
+// the RFSS Status Broadcast field layout, except byte 1's high nibble
+// carries the CFVA (conventional/failsoft/valid/active) flags rather
+// than reserved bits, and it still names the neighbour's System ID:
 //
 //	byte 0    : LRA (Location Registration Area)
-//	byte 1    : RFSS ID
-//	byte 2    : Site ID
-//	bytes 3-4 : the neighbour's control channel
-//	bytes 5-6 : system service class
-//	byte 7    : reserved
+//	bytes 1-2 : System ID (12 bits, low nibble of byte 1 + byte 2)
+//	byte 3    : RFSS ID
+//	byte 4    : Site ID
+//	bytes 5-6 : the neighbour's control channel (4-bit ID + 12-bit number)
+//	byte 7    : system service class
 type AdjacentSiteStatusBroadcast struct {
 	LRA           uint8
+	SystemID      uint16 // 12-bit
 	RFSS, Site    uint8
 	ChannelID     uint8
 	ChannelNumber uint16
@@ -420,11 +428,12 @@ type AdjacentSiteStatusBroadcast struct {
 
 // ParseAdjacentSiteStatusBroadcast decodes payload for opcode 0x3C.
 func ParseAdjacentSiteStatusBroadcast(p [8]byte) AdjacentSiteStatusBroadcast {
-	ch := binary.BigEndian.Uint16(p[3:5])
+	ch := binary.BigEndian.Uint16(p[5:7])
 	return AdjacentSiteStatusBroadcast{
 		LRA:           p[0],
-		RFSS:          p[1],
-		Site:          p[2],
+		SystemID:      uint16(p[1]&0x0F)<<8 | uint16(p[2]),
+		RFSS:          p[3],
+		Site:          p[4],
 		ChannelID:     uint8(ch >> 12),
 		ChannelNumber: ch & 0x0FFF,
 	}
@@ -433,20 +442,24 @@ func ParseAdjacentSiteStatusBroadcast(p [8]byte) AdjacentSiteStatusBroadcast {
 // AssembleAdjacentSiteStatusBroadcast is the inverse; for tests.
 func AssembleAdjacentSiteStatusBroadcast(a AdjacentSiteStatusBroadcast) [8]byte {
 	var p [8]byte
-	p[0], p[1], p[2] = a.LRA, a.RFSS, a.Site
-	binary.BigEndian.PutUint16(p[3:5], uint16(a.ChannelID&0x0F)<<12|a.ChannelNumber&0x0FFF)
+	p[0] = a.LRA
+	p[1] = uint8(a.SystemID>>8) & 0x0F
+	p[2] = uint8(a.SystemID)
+	p[3] = a.RFSS
+	p[4] = a.Site
+	binary.BigEndian.PutUint16(p[5:7], uint16(a.ChannelID&0x0F)<<12|a.ChannelNumber&0x0FFF)
 	return p
 }
 
 func ParseRFSSStatusBroadcast(p [8]byte) RFSSStatusBroadcast {
-	chanField := binary.BigEndian.Uint16(p[4:6])
+	chanField := binary.BigEndian.Uint16(p[5:7])
 	return RFSSStatusBroadcast{
 		LRA:           p[0],
 		SystemID:      uint16(p[1]&0x0F)<<8 | uint16(p[2]),
-		RFSS:          p[2], // some variants split high/low nibble; documented per-implementation
-		Site:          p[3],
+		RFSS:          p[3],
+		Site:          p[4],
 		ChannelID:     uint8(chanField >> 12),
 		ChannelNumber: chanField & 0x0FFF,
-		ServiceClass:  binary.BigEndian.Uint16(p[6:8]),
+		ServiceClass:  uint16(p[7]),
 	}
 }

--- a/internal/radio/p25/phase1/tsbk_test.go
+++ b/internal/radio/p25/phase1/tsbk_test.go
@@ -2,7 +2,48 @@ package phase1
 
 import (
 	"testing"
+
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 )
+
+// TestStatusBroadcastLayoutMatchesPhase2 feeds the same argument bytes to
+// the Phase 1 status-broadcast parsers and the independent Phase 2
+// decoders (phase2/mac.go, phase2/mac_standard.go) and asserts they agree
+// on WACN / System ID / RFSS / Site. The two share the TIA-102.AABF
+// layout; this guards against the two implementations drifting apart again
+// (the Phase 1 side previously omitted the leading LRA byte).
+func TestStatusBroadcastLayoutMatchesPhase2(t *testing.T) {
+	// Network Status Broadcast: LRA 0x07, WACN 0xABCDE, SystemID 0x123,
+	// channel 4.010. Phase 2 carries a 12-bit Color Code where Phase 1
+	// carries the service class, so compare only the shared identity fields.
+	nsb := [8]byte{0x07, 0xAB, 0xCD, 0xE1, 0x23, 0x40, 0x10, 0x42}
+	p1n := ParseNetworkStatusBroadcast(nsb)
+	p2n, ok := p25phase2.MACPDU{
+		Opcode:  p25phase2.OpNetworkStatusBroadcastUpdate,
+		Payload: append(nsb[:], 0x00), // Phase 2 NSB-Update is one byte longer
+	}.AsNetworkStatusBroadcast()
+	if !ok {
+		t.Fatal("phase2 AsNetworkStatusBroadcast returned !ok")
+	}
+	if p1n.LRA != p2n.LRA || p1n.WACN != p2n.WACN || p1n.SystemID != p2n.SystemID {
+		t.Errorf("NSB phase1=%+v disagrees with phase2 LRA/WACN/SystemID %d/%05X/%03X",
+			p1n, p2n.LRA, p2n.WACN, p2n.SystemID)
+	}
+
+	// RFSS Status Broadcast: LRA 0x09, SystemID 0x123, RFSS 4, Site 7.
+	rfss := [8]byte{0x09, 0x01, 0x23, 0x04, 0x07, 0x40, 0x10, 0x42}
+	p1r := ParseRFSSStatusBroadcast(rfss)
+	p2r, ok := p25phase2.MACPDU{
+		Opcode:  p25phase2.OpRFSSStatusBroadcastUpdate,
+		Payload: rfss[:],
+	}.AsRFSSStatusBroadcast()
+	if !ok {
+		t.Fatal("phase2 AsRFSSStatusBroadcast returned !ok")
+	}
+	if p1r.LRA != p2r.LRA || p1r.SystemID != p2r.SystemID || p1r.RFSS != p2r.RFSS || p1r.Site != p2r.Site {
+		t.Errorf("RFSS phase1=%+v disagrees with phase2 %+v", p1r, p2r)
+	}
+}
 
 func TestTSBKAssembleParseRoundTrip(t *testing.T) {
 	in := TSBK{
@@ -117,9 +158,15 @@ func TestParseUnitRegistrationResponse(t *testing.T) {
 }
 
 func TestParseNetworkStatusBroadcast(t *testing.T) {
-	// WACN = 0xABCDE (20-bit), SystemID = 0x123 (12-bit).
-	p := [8]byte{0xAB, 0xCD, 0xE1, 0x23, 0x40, 0x10, 0x00, 0x42}
+	// LRA = 0x07, WACN = 0xABCDE (20-bit), SystemID = 0x123 (12-bit),
+	// channel = 4.010, service class = 0x42. Layout per TIA-102.AABF:
+	// byte 0 LRA, bytes 1-3 WACN, bytes 3-4 SystemID, bytes 5-6 channel,
+	// byte 7 service class — matching phase2/mac.go AsNetworkStatusBroadcast.
+	p := [8]byte{0x07, 0xAB, 0xCD, 0xE1, 0x23, 0x40, 0x10, 0x42}
 	n := ParseNetworkStatusBroadcast(p)
+	if n.LRA != 0x07 {
+		t.Errorf("LRA = %02X, want 07", n.LRA)
+	}
 	if n.WACN != 0xABCDE {
 		t.Errorf("WACN = %05X, want ABCDE", n.WACN)
 	}
@@ -128,6 +175,56 @@ func TestParseNetworkStatusBroadcast(t *testing.T) {
 	}
 	if n.ChannelID != 0x4 || n.ChannelNumber != 0x010 {
 		t.Errorf("Channel = %X.%03X", n.ChannelID, n.ChannelNumber)
+	}
+	if n.ServiceClass != 0x42 {
+		t.Errorf("ServiceClass = %02X, want 42", n.ServiceClass)
+	}
+}
+
+// TestParseRFSSStatusBroadcast pins the corrected byte layout (LRA, then
+// 12-bit SystemID, then RFSS at byte 3 and Site at byte 4) against the
+// independent Phase 2 decoder in phase2/mac_standard.go.
+func TestParseRFSSStatusBroadcast(t *testing.T) {
+	// LRA = 0x09, SystemID = 0x123, RFSS = 4, Site = 7, channel = 4.010.
+	p := [8]byte{0x09, 0x01, 0x23, 0x04, 0x07, 0x40, 0x10, 0x42}
+	r := ParseRFSSStatusBroadcast(p)
+	if r.LRA != 0x09 {
+		t.Errorf("LRA = %02X, want 09", r.LRA)
+	}
+	if r.SystemID != 0x123 {
+		t.Errorf("SystemID = %03X, want 123", r.SystemID)
+	}
+	if r.RFSS != 4 || r.Site != 7 {
+		t.Errorf("RFSS/Site = %d/%d, want 4/7", r.RFSS, r.Site)
+	}
+	if r.ChannelID != 0x4 || r.ChannelNumber != 0x010 {
+		t.Errorf("Channel = %X.%03X, want 4.010", r.ChannelID, r.ChannelNumber)
+	}
+}
+
+// TestParseAdjacentSiteStatusBroadcast checks the corrected neighbour
+// layout via an Assemble/Parse round-trip plus the real on-air Mt Anakie
+// frame already pinned for CRC in TestTSBKAcceptsMtAnakieOnAirVector.
+func TestParseAdjacentSiteStatusBroadcast(t *testing.T) {
+	in := AdjacentSiteStatusBroadcast{
+		LRA: 0x0A, SystemID: 0x164, RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300,
+	}
+	out := ParseAdjacentSiteStatusBroadcast(AssembleAdjacentSiteStatusBroadcast(in))
+	if out != in {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+
+	// Mt Anakie on-air ADJ_STS_BCST payload (the 8 argument bytes of the
+	// 0x3C frame in TestTSBKAcceptsMtAnakieOnAirVector). LRA 0, SystemID
+	// 0x164, RFSS 4, Site 0x2E, channel 0xF.065.
+	p := [8]byte{0x00, 0x31, 0x64, 0x04, 0x2E, 0xF0, 0x65, 0x70}
+	a := ParseAdjacentSiteStatusBroadcast(p)
+	if a.SystemID != 0x164 || a.RFSS != 4 || a.Site != 0x2E {
+		t.Errorf("on-air ADJ = SystemID %03X RFSS %d Site %02X, want 164/4/2E",
+			a.SystemID, a.RFSS, a.Site)
+	}
+	if a.ChannelID != 0xF || a.ChannelNumber != 0x065 {
+		t.Errorf("on-air ADJ channel = %X.%03X, want F.065", a.ChannelID, a.ChannelNumber)
 	}
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -200,6 +200,8 @@ export interface DiscoveredTalkgroup {
   hex: string;
   encrypted?: boolean;
   count: number;
+  // Distinct voice-channel frequencies (Hz) observed carrying this talkgroup.
+  frequencies?: number[];
 }
 
 // BandPlanEntry mirrors hunt.BandPlanEntry — one P25 IDEN_UP band-plan slot:
@@ -221,6 +223,8 @@ export interface DiscoveredSite {
   control_channels?: { frequency_hz: number; is_control?: boolean; confidence?: number }[];
   secondary?: number[];
   neighbors?: NeighborRef[];
+  // Distinct voice/traffic-channel frequencies (Hz) granted on this site.
+  voice_channels?: number[];
 }
 
 // HuntRRReport mirrors api.HuntRRReport — the RadioReference cross-reference of

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -358,6 +358,7 @@ export function Hunt() {
                 <th>Hex</th>
                 <th>Encrypted</th>
                 <th>Activity</th>
+                <th>Frequencies</th>
               </tr>
             </thead>
             <tbody>
@@ -367,6 +368,11 @@ export function Hunt() {
                   <td>{tg.hex}</td>
                   <td>{tg.encrypted ? "🔒" : "—"}</td>
                   <td>{tg.count}</td>
+                  <td>
+                    {tg.frequencies && tg.frequencies.length > 0
+                      ? tg.frequencies.map((h) => (h / 1e6).toFixed(4)).join(", ")
+                      : "—"}
+                  </td>
                 </tr>
               ))}
             </tbody>
@@ -384,6 +390,7 @@ export function Hunt() {
                 <th>RFSS</th>
                 <th>Control channels</th>
                 <th>Neighbors</th>
+                <th>Voice channels</th>
               </tr>
             </thead>
             <tbody>
@@ -408,6 +415,11 @@ export function Hunt() {
                               : id;
                           })
                           .join(", ")
+                      : "—"}
+                  </td>
+                  <td>
+                    {site.voice_channels && site.voice_channels.length > 0
+                      ? site.voice_channels.map((h) => (h / 1e6).toFixed(4)).join(", ")
                       : "—"}
                   </td>
                 </tr>


### PR DESCRIPTION
The Phase 1 Network-, RFSS-, and Adjacent-Site Status Broadcast TSBK
parsers omitted the leading LRA (Location Registration Area) byte that
every P25 OSP status broadcast carries (TIA-102.AABF), so every field was
read one byte too early: WACN and System ID came out wrong, RFSS/Site read
as 0, and advertised neighbors showed garbled IDs with channels parsed
from the wrong bytes (so no frequency could be resolved). NAC was correct
because it comes from the NID, a separate path.

Realign all three parsers to the standard layout (LRA, then WACN/SystemID,
then RFSS/Site at bytes 3/4, channel at bytes 5-6), matching this repo's
independent Phase 2 decoders (phase2/mac.go, phase2/mac_standard.go). This
also corrects the rfss_id/site_id labels on grant events and KindSiteUpdate.

Add a cross-decoder test asserting the Phase 1 and Phase 2 parsers agree on
the same bytes, plus direct decode tests (including the on-air Mt Anakie
ADJ frame), so the two layouts can't drift apart again.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JeGwyVHfh7znV8kne7kg7N