### PR TITLE
Add RF Front End blog series (posts 1-10, 12 + index)

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -71,6 +71,8 @@ groups:
         url: /blog/category/deep-dives/
       - title: "Series: SDR Internals"
         url: /blog/series/sdr-internals/
+      - title: "Series: RF Front End"
+        url: /blog/series/rf-front-end/
       - title: Tutorials
         url: /blog/category/tutorials/
   - label: Install

--- a/docs/_posts/2026-06-18-rf-front-end-01-why-pure-go-drivers.md
+++ b/docs/_posts/2026-06-18-rf-front-end-01-why-pure-go-drivers.md
@@ -14,6 +14,8 @@ behind GopherTrunk — the pure-Go USB drivers that turn a dongle into a stream 
 IQ samples — one component per post, and explains the software-design principle
 behind each piece and how that principle shaped the Go code.*
 
+> **TL;DR** — The RF source layer is the pure-Go USB driver stack that turns RTL-SDR, Airspy, and HackRF dongles into IQ samples. GopherTrunk writes it all in Go to dodge the CGO/libusb "tax," shipping a single static cross-compilable binary with no C dependencies.
+
 ## In this post
 
 - **Why the RF source layer gets its own series** — [SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }})
@@ -179,7 +181,7 @@ network socket, or a WAV file on disk.
 
 ## How GopherTrunk implements it in Go
 
-The whole series hangs off one interface in `internal/sdr/device.go`. Every
+**The whole series hangs off one interface in `internal/sdr/device.go`.** Every
 backend, regardless of silicon, hides behind it:
 
 ```go

--- a/docs/_posts/2026-06-18-rf-front-end-01-why-pure-go-drivers.md
+++ b/docs/_posts/2026-06-18-rf-front-end-01-why-pure-go-drivers.md
@@ -1,0 +1,304 @@
+---
+title: "RF Front End, Part 1: Why Drive Radios in Pure Go?"
+description: The opening post of RF Front End, a 14-part deep dive into GopherTrunk's RF source layer — the pure-Go USB drivers that turn RTL-SDR, Airspy, and HackRF hardware into IQ samples without libusb, librtlsdr, or any C dependency.
+category: deep-dives
+tags: [sdr, go, usb, drivers, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 1
+---
+
+*Part 1 of **RF Front End**, a 14-part series that walks the RF source layer
+behind GopherTrunk — the pure-Go USB drivers that turn a dongle into a stream of
+IQ samples — one component per post, and explains the software-design principle
+behind each piece and how that principle shaped the Go code.*
+
+## In this post
+
+- **Why the RF source layer gets its own series** — [SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }})
+  Part 2 only skimmed it; the drivers are deep enough to fill fourteen posts.
+- **The CGO/libusb "tax"** GopherTrunk refuses to pay, and the single static
+  binary you get for refusing it.
+- **What an RF source actually is**, and the three device families GopherTrunk
+  drives in pure Go.
+- **A map of the series** so you can jump to the chip or layer you care about.
+
+## What an RF source is
+
+Every signal GopherTrunk decodes starts the same way: some piece of hardware
+digitizes a slice of the radio spectrum and hands the computer a torrent of
+**IQ samples** — complex numbers that capture the amplitude and phase of the
+signal. Everything after that — tuning, filtering, demodulation, FEC, the
+trunking engine — is software. The "RF source" is the thing that produces those
+samples: open the USB hardware, tune it, set gain and sample rate, and stream
+`[]complex64` chunks back without dropping any.
+
+That job sounds small. It is not. Each dongle does it differently — different
+chips (the RTL2832U demodulator, the Airspy register map, HackRF's transceiver
+command set), different tuners
+([R820T]({{ '/reference/r820t-tuner/' | relative_url }}), R828D, the Airspy
+front ends), different USB control transfers, different sample formats (unsigned
+8-bit, signed 8-bit, real 12-bit packed). Hiding all of that behind one clean
+`<-chan []complex64` is the entire point of the RF front end, and it is where a
+surprising amount of GopherTrunk's hardest bugs live.
+
+> New here? The reference entries on
+> [software-defined radio]({{ '/reference/software-defined-radio/' | relative_url }})
+> and [IQ data]({{ '/reference/iq-data/' | relative_url }}) cover the
+> fundamentals this series builds on.
+
+To make the scope concrete: an RF source has to keep up with the firehose. At
+2.4 MS/s, an RTL-SDR delivers 2.4 million complex samples *every second*, packed
+as interleaved bytes the USB endpoint streams in continuously. A chunk arrives
+roughly every few milliseconds and must be unpacked from the hardware's wire
+format — unsigned 8-bit for the RTL2832U, signed 8-bit for HackRF, real 12-bit
+for Airspy — into `complex64`, and handed off before the next chunk lands. There
+is no room to fall behind: a dropped URB is a gap in the IQ, and a gap in the IQ
+is a corrupted symbol in whatever the decoder was tracking. The RF front end is a
+soft-real-time problem wearing the clothes of a USB driver, and that tension —
+keep up, allocate nothing you can avoid, never block the bus — is the through-line
+of Parts 4 through 11.
+
+### Why a separate series
+
+[SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }}) Part 2 gave
+the RF source layer a single post: here's the `Device` interface, here's the
+registry, drivers register themselves, the engine stays hardware-agnostic. True,
+and enough to understand the *shape*. But it left the inside of each driver as a
+black box — "the RTL2832U register dance, the R820T PLL math, HackRF's
+transceiver state machine," in that post's own words, deferred to "a future
+series." This is that series.
+
+The reason it deserves fourteen posts is that the RF front end is where pure-Go
+ambition meets the metal. There is no `libusb` underneath catching our mistakes.
+We are issuing raw USB control transfers, packing async URBs, decoding 8-bit IQ
+in tight loops, and recovering dongles that fall off the bus mid-stream. There is
+also no shared C library quietly normalizing four vendors' hardware into a common
+shape: where a C-linked project inherits `librtlsdr`, `libairspy`, and
+`libhackrf` and lets each vendor's headers define the abstraction, GopherTrunk has
+to *choose* the abstraction and then earn it, chip by chip. That is more work, but
+it is also the only way to keep the whole receive chain — antenna to audio —
+inside one language you can read, test with the race detector, and cross-compile
+with `go build`. The bugs are real, the fixes are specific, and the design
+choices — one narrow interface,
+self-registering drivers, a supervised pool — are what keep a pile of
+chip-specific hacks from leaking into the rest of the engine.
+
+## The CGO tax we refuse to pay
+
+The conventional way to talk to an RTL-SDR from any language is to link
+`librtlsdr`, which links `libusb`. For Airspy you link `libairspy`; for HackRF,
+`libhackrf`; for the HF+, `libairspyhf`. Each is a C library, and in Go each one
+drags in **CGO**.
+
+CGO is a tax with several line items:
+
+- **You lose the single static binary.** A CGO build links against shared
+  objects that must be present on the target machine. "Install GopherTrunk" turns
+  into "install GopherTrunk *and* `librtlsdr0` *and* the right `libusb-1.0` *and*
+  hope the versions match."
+- **You lose trivial cross-compilation.** `GOOS=windows GOARCH=amd64 go build`
+  stops being a one-liner the moment CGO is on; you need a C cross-toolchain and
+  the target's C libraries for every platform you ship.
+- **You lose a uniform debugging story.** A crash in `libusb` is a crash in C —
+  no Go stack trace, no race detector coverage, a different mental model at the
+  exact layer where the timing-sensitive USB bugs live.
+- **You lose build hermeticity.** The version of `libusb` on the developer's
+  machine, the CI runner, and the operator's box can all differ, and the
+  RF-front-end behavior can quietly differ with them. A pure-Go transport pins
+  *all* of that behavior in the module graph, so the bytes-on-the-bus logic is the
+  same everywhere the binary runs.
+
+GopherTrunk pays none of it. As the README puts it, the project "has no C
+dependencies at build or runtime (no `librtlsdr` / `libhackrf` / `libairspy` /
+`libairspyhf` / `libusb` …) and ships as a single ~10 MB static binary for
+Linux, macOS, and Windows." Every driver speaks to the **kernel's** USB interface
+directly — USBDEVFS on Linux, WinUSB on Windows, IOKit on macOS — instead of
+linking a C USB stack. The build stays `CGO_ENABLED=0`, and `go build` keeps
+cross-compiling to every target with no toolchain gymnastics.
+
+The cost of refusing the tax is that we have to *write* the USB transport and the
+chip protocols ourselves. That cost is exactly what this series documents.
+
+It is worth being precise about what "pure Go" buys an operator, because the
+benefit is not abstract. A GopherTrunk release is one file. You download it,
+`chmod +x`, and run it — no package manager, no `apt install librtlsdr0`, no
+matching a runtime `libusb` against the one the binary was built against, no
+LD_LIBRARY_PATH surprises on a stripped-down host. The Windows build talks WinUSB;
+the macOS build talks IOKit; the Linux build talks USBDEVFS — and all three come
+out of the *same* source tree with `GOOS`/`GOARCH` set, because none of them shell
+out to a C toolchain. For a daemon that is meant to run unattended at the antenna —
+often on a Raspberry Pi or a small ARM box — "one static binary with no shared
+libraries to drift out from under it" is a reliability feature, not just a
+packaging convenience.
+
+The other half of the payoff is on *our* side of the build. Because every byte
+from the USB endpoint to the `complex64` is Go, the whole RF front end is in scope
+for `go test -race`, for table-driven unit tests against a mock USB transport, and
+for the same profiler that watches the DSP layer. When a streaming bug shows up as
+GC churn (Part 9) or a tuner comes up deaf (Part 8), we debug it with a Go stack
+trace and a Go profile — not by attaching `gdb` to `libusb`. The pure-Go decision
+is what makes the rest of this series *debuggable*, and that is most of why it was
+worth making.
+
+## The three device families
+
+GopherTrunk drives three families of USB SDR in pure Go, plus a couple of network
+backends and a mock. The families differ enough that each gets its own pair of
+posts later:
+
+- **RTL-SDR** — the $25 RTL2832U dongles (every osmocom tuner). The RTL2832U is a
+  DVB-T demodulator repurposed as a raw ADC; the actual tuning happens in a
+  separate tuner chip, usually the R820T/R828D. Cheap, ubiquitous, and full of
+  quirks — including the RTL-SDR Blog V4 "deafness" bug that gets its own post.
+- **Airspy R2 / Mini and Airspy HF+** — higher-dynamic-range receivers. The R2 and
+  Mini stream **real** samples that we convert to complex baseband in Go; the HF+
+  is a separate family tuned for HF/VHF. Different register map, different sample
+  math.
+- **HackRF One** (and Jawbreaker / Rad1o) — a half-duplex transceiver that streams
+  **signed 8-bit** IQ. We only ever drive it in receive, but the command set is a
+  full transceiver state machine.
+
+All of them satisfy the same `Device` interface, so the engine can't tell an
+R820T from an Airspy HF+ from a recorded capture. Reference entries:
+[RTL-SDR]({{ '/reference/rtl-sdr/' | relative_url }}),
+[HackRF]({{ '/reference/hackrf/' | relative_url }}),
+[Airspy]({{ '/reference/airspy/' | relative_url }}).
+
+Beyond the three USB families there are two more `Device` implementations worth
+knowing exist, because they prove the abstraction holds. The `rtltcp` and
+`soapyremote` backends mount *network* SDRs — a dongle on a Raspberry Pi at the
+antenna, or professional gear like a USRP, LimeSDR, or bladeRF reached over the
+SoapyRemote protocol — as if they were local hardware, all in pure Go with no
+CGO. And the `mock` driver replays recorded IQ captures back into the pool as a
+virtual tuner. None of these are USB at all, yet every one is a `Device`, which is
+the clearest evidence that the contract in Part 2 is drawn at the right level: the
+engine asks for IQ, and it does not care whether the IQ came from an R820T, a
+network socket, or a WAV file on disk.
+
+## How GopherTrunk implements it in Go
+
+The whole series hangs off one interface in `internal/sdr/device.go`. Every
+backend, regardless of silicon, hides behind it:
+
+```go
+// internal/sdr/device.go
+type Device interface {
+    Info() Info
+    SetCenterFreq(hz uint32) error
+    SetSampleRate(hz uint32) error
+    SetGain(tenthDB int) error // -1 selects automatic gain control
+    SetPPM(ppm int) error
+    SetBiasTee(enable bool) error
+    StreamIQ(ctx context.Context) (<-chan []complex64, error)
+    Close() error
+}
+```
+
+`StreamIQ` is the heart of it: give it a `context.Context`, get back a channel of
+IQ chunks; cancel the context and the stream stops. The rest of the engine only
+ever sees this interface — it never imports `rtlsdr`, `hackrf`, or `airspy`. The
+concrete drivers live in sub-packages (`internal/sdr/rtlsdr/purego`,
+`internal/sdr/airspy`, `internal/sdr/airspyhf`, `internal/sdr/hackrf`), and each
+one registers itself with the package-global registry at `init()`. Part 2 takes
+the contract apart method by method; Part 3 takes the registry apart.
+
+The setters carry conventions that let one interface stand in for very different
+silicon. `SetGain(tenthDB int)` takes gain in tenths of a dB, with `-1` as a
+sentinel that selects automatic gain control — one integer expresses both "manual"
+and "let the tuner decide," so the engine never needs a separate AGC method that
+only some radios would honor. `SetBiasTee(enable bool)` toggles the 5V bias-tee
+that powers an external LNA through the antenna SMA; on dongles without the
+circuit it is required to silently no-op and `return nil`, so the engine can call
+it unconditionally. These conventions are the small print of a narrow contract,
+and Part 2 is largely about why they are drawn the way they are.
+
+## The design principle: one narrow contract, many implementations
+
+The architectural bet of the RF front end is the same bet the whole engine makes,
+applied to hardware: **depend on a small abstract contract, never on a concrete
+device.** The engine asks for "a thing that streams IQ and can be tuned." It does
+not ask for "an RTL-SDR." Everything chip-specific lives behind the interface,
+and the chip-specific *quirks* live behind *optional* interfaces the caller
+type-asserts for (the subject of Part 2).
+
+### How that principle shaped the Go code
+
+- **One interface, four radios.** `Device` is the only type the engine knows.
+  Adding the Airspy HF+ didn't change a line of engine code — it added a package
+  that satisfies `Device`.
+- **Quirks stay optional.** RTL-SDR-only behavior (Blog V4 override, tuner
+  diagnosis) lives in `TunerDiagnoser` and `BlogV4Forcer`, optional extensions
+  callers type-assert for — so the universal contract stays universal.
+- **The binary's import set picks the hardware.** `cmd/gophertrunk`
+  blank-imports the real drivers; their `init()` functions populate the registry.
+  Change the imports, change the supported hardware — no engine edit.
+- **Pure Go, no CGO, end to end.** USB transport, register protocols, IQ
+  decode — all Go, all `CGO_ENABLED=0`, all cross-compilable.
+
+## The series map
+
+| Part | Topic | Problem solved |
+|---|---|---|
+| 1 | Why drive radios in pure Go? (this post) | The CGO/libusb tax |
+| [2]({{ '/blog/deep-dives/rf-front-end-02-the-device-contract/' | relative_url }}) | The Device contract | One interface, four radios |
+| [3]({{ '/blog/deep-dives/rf-front-end-03-driver-registry-enumeration/' | relative_url }}) | The driver registry & enumeration | Hardware-agnostic core |
+| [4]({{ '/blog/deep-dives/rf-front-end-04-usb-without-libusb/' | relative_url }}) | Talking to USB without libusb | No C USB stack |
+| [5]({{ '/blog/deep-dives/rf-front-end-05-usb-on-linux-usbdevfs/' | relative_url }}) | USB on Linux: USBDEVFS & async URBs | High-throughput transfers |
+| [6]({{ '/blog/deep-dives/rf-front-end-06-usb-on-macos-windows/' | relative_url }}) | USB on macOS & Windows | Cross-platform transport |
+| [7]({{ '/blog/deep-dives/rf-front-end-07-rtlsdr-rtl2832u-bringup/' | relative_url }}) | RTL-SDR I: bringing up the RTL2832U | The register dance |
+| [8]({{ '/blog/deep-dives/rf-front-end-08-rtlsdr-r82xx-blog-v4/' | relative_url }}) | RTL-SDR II: the R82xx tuner & Blog V4 deafness | A mistuned LO |
+| [9]({{ '/blog/deep-dives/rf-front-end-09-rtlsdr-streaming-gc-churn/' | relative_url }}) | RTL-SDR III: IQ streaming & the GC-churn bug | Allocation pressure |
+| [10]({{ '/blog/deep-dives/rf-front-end-10-airspy-real-to-complex/' | relative_url }}) | Airspy R2/Mini & HF+: real samples to complex baseband | Real-to-IQ conversion |
+| [11]({{ '/blog/deep-dives/rf-front-end-11-hackrf-one/' | relative_url }}) | HackRF One: signed 8-bit IQ end to end | Transceiver state machine |
+| [12]({{ '/blog/deep-dives/rf-front-end-12-sdr-pool-usb-watchdog/' | relative_url }}) | The SDR pool & USB hotplug watchdog | Self-healing on disconnect |
+| [13]({{ '/blog/deep-dives/rf-front-end-13-testing-radios-without-radios/' | relative_url }}) | Testing radios without radios | CI with no hardware |
+| [14]({{ '/blog/deep-dives/rf-front-end-14-diagnostics-metrics-payoff/' | relative_url }}) | Diagnostics, metrics & the pure-Go payoff | Observability + the payoff |
+
+Each post is an overview — enough to understand the component, the Go that
+implements it, and the principle behind it. The pipeline below the RF front end
+is the subject of the sister series,
+[SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }}); this series
+is the layer that feeds it.
+
+## Where this goes next
+
+[Part 2]({{ '/blog/deep-dives/rf-front-end-02-the-device-contract/' | relative_url }})
+opens up the `Device` interface itself — every method, the `-1`-means-AGC gain
+convention, the bias-tee no-op rule, and the tension of expressing four very
+different radios through one contract without letting any one radio's quirks bleed
+into the others. From there the series descends through the stack: the registry
+and enumeration (Part 3), the USB transport that has to replace `libusb` on three
+operating systems (Parts 4-6), then the chip drivers one family at a time — the
+RTL2832U bring-up and its R82xx tuner, including the Blog V4 deafness bug and the
+GC-churn bug in its streaming path (Parts 7-9), Airspy's real-to-complex
+conversion (Part 10), and HackRF's signed-8-bit transceiver (Part 11). The last
+three posts step back up: the pool and hotplug watchdog that supervise a fleet of
+dongles (Part 12), how all of this is tested with no radios attached (Part 13),
+and the diagnostics, metrics, and the pure-Go payoff that ties the series off
+(Part 14).
+
+## FAQ
+
+**Why not just link librtlsdr and move on?**
+Linking `librtlsdr` reintroduces CGO and a runtime shared-library dependency,
+which breaks the single-static-binary promise and turns cross-compilation into a
+C-toolchain problem. Writing the USB transport and chip protocols in Go keeps the
+build pure Go and the binary self-contained.
+
+**Is the RF front end just USB plumbing?**
+The USB transport is the bottom of it (Parts 4-6), but each driver is also a small
+chip-protocol implementation — the RTL2832U bring-up, the R82xx tuner math,
+HackRF's transceiver commands, Airspy's real-to-complex conversion. The plumbing
+is necessary; the protocols are where the radios differ.
+
+**Do I have to read this in order?**
+No. Part 1 is the map and each later part stands alone. But the layers stack —
+USB transport under the chip drivers under the pool — so top-to-bottom mirrors how
+a sample actually climbs out of the hardware.
+
+## Series navigation
+
+**Part 1 of 14** · Next →
+[Part 2: The Device contract]({{ '/blog/deep-dives/rf-front-end-02-the-device-contract/' | relative_url }})

--- a/docs/_posts/2026-06-19-rf-front-end-02-the-device-contract.md
+++ b/docs/_posts/2026-06-19-rf-front-end-02-the-device-contract.md
@@ -1,0 +1,274 @@
+---
+title: "RF Front End, Part 2: The Device Contract"
+description: A method-by-method tour of GopherTrunk's Device interface — the one abstraction four very different radios hide behind — and the optional, type-asserted extension interfaces that expose RTL-SDR-only quirks without polluting the universal contract.
+category: deep-dives
+tags: [sdr, go, interfaces, software-design, rtl-sdr]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 2
+---
+
+*Part 2 of **RF Front End**. One interface stands between the whole engine and
+four very different radios. We take the `Device` contract apart method by method,
+and look at the trick that lets one radio's quirks ride along without leaking into
+the others: optional, type-asserted extension interfaces.*
+
+## In this post
+
+- The **`Device` interface** in full — `Info`, the four setters, the AGC and
+  bias-tee conventions, and `StreamIQ`.
+- The **"one interface, four radios"** tension and why the contract stays narrow.
+- The **optional extension interfaces** (`TunerDiagnoser`, `BlogV4Forcer`) that
+  callers type-assert for — interface segregation in practice.
+- **The problem we hit:** exposing RTL-SDR-only quirks without polluting the
+  universal contract.
+
+## What the Device contract is
+
+`Device` is the per-dongle handle. Every backend — RTL-SDR, Airspy R2/Mini,
+Airspy HF+, HackRF, plus the network and mock drivers — implements it, and it is
+the *only* SDR type the rest of the engine ever sees. Here it is in full, from
+`internal/sdr/device.go`:
+
+```go
+// internal/sdr/device.go
+type Device interface {
+    Info() Info
+    SetCenterFreq(hz uint32) error
+    SetSampleRate(hz uint32) error
+    SetGain(tenthDB int) error // -1 selects automatic gain control
+    SetPPM(ppm int) error
+    SetBiasTee(enable bool) error
+    StreamIQ(ctx context.Context) (<-chan []complex64, error)
+    Close() error
+}
+```
+
+Eight methods. That's the entire surface the engine is allowed to touch. The
+discipline is deliberate: the narrower this contract, the more radios can satisfy
+it honestly, and the less chip-specific knowledge leaks upward.
+
+The comment above the type spells out the concurrency rule that makes streaming
+work: implementations must be safe for the goroutines that call `StreamIQ`, and
+"concurrent `SetCenterFreq` during streaming is allowed (the underlying USB
+transport handles it)." That one line is why the trunking engine can retune a
+control channel without tearing down the IQ stream.
+
+It is worth dwelling on *why* the contract is this small, because narrowness is a
+design choice, not an accident. Four radios that share almost nothing at the
+silicon level — an RTL2832U demodulator fronted by an R820T, an Airspy with its
+own register map, a HackRF transceiver, an Airspy HF+ tuned for the low bands —
+have to be interchangeable from the engine's point of view. The only way that
+works is to find the *intersection* of what they can all do and make that the
+contract: tune, set rate, set gain, set PPM, maybe toggle a bias-tee, stream,
+close. Anything one radio can do that another cannot is, by definition, *not* in
+`Device`. The interface is small because the common ground is small, and the
+discipline to keep it that way is what lets a recorded WAV file or a network
+socket satisfy the same eight methods as a $25 dongle.
+
+## How GopherTrunk implements it in Go
+
+### Identity: `Info`
+
+`Info()` returns a value, not a pointer, describing what the dongle *is*:
+
+```go
+// internal/sdr/device.go
+type Info struct {
+    Driver       string
+    Index        int
+    Serial       string
+    Manufacturer string
+    Product      string
+    TunerName    string
+    Gains        []int
+}
+```
+
+The same `Info` struct is what a driver's enumeration returns *before* a device is
+opened (Part 3), so the engine can list and pick hardware without committing to a
+USB handle. `Gains` carries the discrete gain steps a tuner actually supports —
+the engine snaps a requested gain onto the nearest legal step rather than guessing.
+Returning a value rather than a pointer is deliberate: `Info` is an immutable
+description, and handing back a copy means a caller can stash it, compare it, or
+log it with no chance of it mutating under them while the device streams. The
+`Serial` and `Index` fields together let the pool address a specific dongle even
+when several identical RTL-SDRs are plugged into the same hub — serial is the
+stable identity, index is the bus position, and the pool prefers serial so a
+reordered USB tree doesn't reshuffle which dongle plays which role.
+
+### The four setters, and their conventions
+
+`SetCenterFreq`, `SetSampleRate`, `SetGain`, and `SetPPM` all take a plain integer
+and return an `error`. Two of them carry conventions worth calling out, because
+they are how the contract absorbs differences between radios instead of exposing
+them:
+
+- **Gain: `-1` means AGC.** `SetGain(tenthDB int)` takes gain in tenths of a dB,
+  and a sentinel `-1` selects automatic gain control. One integer parameter
+  expresses both "manual, this many tenths of a dB" and "let the tuner decide,"
+  so the engine never needs a separate `SetAGC(bool)` method that only some
+  radios would honor.
+- **Bias-tee: silent no-op when absent.** Many dongles have a 5V bias-tee that
+  powers an external LNA through the antenna SMA; many don't. Rather than splitting
+  `Device` into "has bias-tee" and "doesn't," the contract requires every
+  implementation to accept `SetBiasTee`. The doc comment is explicit: "Devices
+  without the circuit silently no-op. Implementations should return `nil` if the
+  underlying driver doesn't model bias-tee at all." A capability that only some
+  hardware has is modeled as a method everyone implements, where "I can't" is
+  spelled `return nil`.
+
+These conventions are the load-bearing idea of a narrow contract: the *differences*
+between radios are pushed into agreed-upon values and no-ops, so the *interface*
+stays the same for all of them.
+
+### The stream: `StreamIQ`
+
+```go
+StreamIQ(ctx context.Context) (<-chan []complex64, error)
+```
+
+Pass a `context.Context`, get back a receive-only channel of `[]complex64`
+chunks. Each chunk is a few milliseconds of baseband; the engine ranges over the
+channel until the context is cancelled, at which point the driver closes the
+channel and tears down its USB transfers. Returning `<-chan` (receive-only) is a
+small but real piece of the contract — the consumer can read but cannot close or
+send, so ownership of the channel's lifecycle stays with the driver that knows how
+to drain the USB side cleanly.
+
+The `context` argument is the cancellation half of that ownership story. The
+engine never reaches into the driver to say "stop"; it cancels the context it
+handed to `StreamIQ`, the driver observes the cancellation, stops submitting USB
+transfers, drains the ones in flight, and closes the channel. The consumer's
+`for chunk := range ch` loop ends naturally when the channel closes. No shared
+"stop" flag, no second method, no risk of the consumer closing a channel the
+driver is still writing to — the context flows down, the channel and its chunks
+flow up, and the lifecycle has exactly one owner at each end. This is the same
+pipes-and-filters-over-CSP shape the DSP layer uses, applied at the very bottom of
+the stack where the bytes first become samples.
+
+## The problem we hit: RTL-SDR quirks vs. the universal contract
+
+The narrow contract works beautifully right up until a radio has a quirk no other
+radio shares — and the RTL-SDR Blog V4 has two.
+
+**Symptom.** Some Blog V4 dongles come up *deaf*: tuned to a known-good control
+channel, they hear nothing, or hear a signal mistuned by a factor of ~1.8×. The
+boot diagnostics also wanted to surface, per-dongle, which tuner was detected and
+what reference crystal it latched onto — information that simply does not exist for
+an Airspy or a HackRF.
+
+**Root cause.** The R828D tuner in the Blog V4 uses a 28.8 MHz reference crystal
+and a switched HF/VHF/UHF input bank. Auto-detection keys off the USB EEPROM
+strings; when a V4's strings are blank or non-standard, detection misses it, the
+R828D stays on the wrong 16 MHz crystal, and the local oscillator mistunes
+(issue #264). Fixing it needs two RTL-SDR-only capabilities: **read** the tuner's
+detected state for diagnostics, and **force** Blog V4 mode regardless of what the
+USB strings say.
+
+The tempting-but-wrong fix is to add `TunerDiag()` and `SetBlogV4()` to `Device`.
+That would force every Airspy and HackRF driver to implement two methods about a
+crystal they don't have — polluting the universal contract with one vendor's
+hardware detail.
+
+**The Go fix.** Put the quirks in *optional* interfaces that callers type-assert
+for, and leave `Device` untouched:
+
+```go
+// internal/sdr/device.go
+type TunerDiagnoser interface {
+    TunerDiag() (tunerName string, blogV4, blogV4Lite bool, xtalHz uint32)
+}
+
+type BlogV4Forcer interface {
+    SetBlogV4(lite bool) error
+}
+```
+
+Only the RTL-SDR driver implements these. A caller that wants them asks at runtime:
+
+```go
+if d, ok := dev.(sdr.BlogV4Forcer); ok {
+    _ = d.SetBlogV4(lite) // RTL-SDR only; everything else doesn't satisfy this
+}
+```
+
+The type assertion succeeds for the RTL-SDR driver and fails — cleanly, with `ok
+== false` — for every other backend. The Blog V4 fix reaches exactly the hardware
+that needs it, and the Airspy and HackRF drivers never hear about a 28.8 MHz
+crystal. The doc comments on both interfaces even encode the failure signature:
+"`xtalHz` of 16 MHz on an R828D is the signature that RTL-SDR Blog V4
+auto-detection missed and the LO is mistuned by ~1.8×."
+
+`TunerDiagnoser` works the same way for the read side. Boot-time diagnostics
+type-assert for it to surface, per dongle, which tuner was detected, whether it
+came up in Blog V4 (or V4 Lite) mode, and what reference crystal it latched onto —
+the four return values of `TunerDiag()`. A backend that has no tuner crystal to
+report simply doesn't implement the interface, the assertion fails, and the
+diagnostics skip it. Nothing forces an Airspy to answer a question about a crystal
+it doesn't have. The whole Blog V4 story — detect the mistune via
+`TunerDiagnoser`, correct it via `BlogV4Forcer` — is wired through two tiny
+optional interfaces and zero changes to `Device`. Part 8 of this series follows
+that thread all the way down into the R82xx tuner to show what the forced mode
+actually reprograms.
+
+## The design principle: interface segregation
+
+The lesson is the **interface segregation principle**: no client should be forced
+to depend on methods it does not use. `Device` is the small contract *every* radio
+needs. `TunerDiagnoser` and `BlogV4Forcer` are tiny contracts only the radios with
+those capabilities satisfy — and only the callers who care go looking for them.
+
+### How that principle shaped the Go code
+
+- **The universal contract stays universal.** `Device` holds the eight methods
+  every SDR honors. Nothing RTL-SDR-specific lives there.
+- **Capabilities are discovered, not assumed.** Optional behavior is a runtime
+  `dev.(Interface)` type assertion, so a backend opts in simply by implementing
+  the extra interface — no flags, no capability enums.
+- **Extensions are additive.** A new optional interface (say, a future
+  calibration hook) is a new tiny `interface` plus the one driver that implements
+  it. No existing driver changes, because none of them are forced to.
+- **The narrowest possible coupling.** A caller depends on `BlogV4Forcer` — one
+  method — not on the concrete RTL-SDR package. The dependency is on exactly the
+  capability used, nothing more.
+- **The compiler enforces it for free.** Because Go interfaces are satisfied
+  structurally, a driver "joins" an optional interface simply by having the right
+  method — and the type assertion that finds it is a compile-checked, allocation-
+  free runtime test. There is no capability registry to keep in sync and no enum
+  to extend; the method set *is* the capability declaration.
+
+## Where this goes next
+
+The contract tells you *what* a device does, but not *which* devices exist or
+*how* the engine gets a handle to one. That's the registry's job.
+[Part 3]({{ '/blog/deep-dives/rf-front-end-03-driver-registry-enumeration/' | relative_url }})
+covers the self-registering driver registry and the enumeration walk that lists
+every attached dongle across every backend — and how it stays resilient when one
+driver's enumeration fails.
+
+## FAQ
+
+**Why is gain a single `int` with a `-1` sentinel instead of a richer type?**
+Because it keeps the contract narrow. One integer parameter expresses "manual, this
+many tenths of a dB" and "AGC" without a second method that only some radios would
+implement. The `Gains` slice in `Info` carries the legal manual steps for snapping.
+
+**Why must `SetBiasTee` exist on radios that have no bias-tee?**
+So the engine can call it unconditionally. A capability some hardware lacks is
+modeled as a method everyone implements, where "not applicable" is `return nil`.
+The alternative — a separate `BiasTeeCapable` interface — would make the common
+case (just toggle it) require a type assertion.
+
+**How does a caller know whether a device supports Blog V4 forcing?**
+It type-asserts: `dev.(sdr.BlogV4Forcer)`. The assertion succeeds only for the
+RTL-SDR driver and returns `ok == false` for everything else, so the capability is
+discovered at runtime with no central registry of who-can-do-what.
+
+## Series navigation
+
+**Part 2 of 14** · ←
+[Part 1]({{ '/blog/deep-dives/rf-front-end-01-why-pure-go-drivers/' | relative_url }})
+· Next →
+[Part 3: The driver registry & enumeration]({{ '/blog/deep-dives/rf-front-end-03-driver-registry-enumeration/' | relative_url }})

--- a/docs/_posts/2026-06-19-rf-front-end-02-the-device-contract.md
+++ b/docs/_posts/2026-06-19-rf-front-end-02-the-device-contract.md
@@ -14,6 +14,8 @@ four very different radios. We take the `Device` contract apart method by method
 and look at the trick that lets one radio's quirks ride along without leaking into
 the others: optional, type-asserted extension interfaces.*
 
+> **TL;DR** — The `Device` interface is the single narrow contract every radio hides behind. The trick: RTL-SDR-only quirks (like the Blog V4 deafness fix) would pollute that universal contract if added to it, so they live in optional, type-asserted extension interfaces instead.
+
 ## In this post
 
 - The **`Device` interface** in full — `Info`, the four setters, the AGC and
@@ -119,9 +121,9 @@ them:
   hardware has is modeled as a method everyone implements, where "I can't" is
   spelled `return nil`.
 
-These conventions are the load-bearing idea of a narrow contract: the *differences*
+**These conventions are the load-bearing idea of a narrow contract: the *differences*
 between radios are pushed into agreed-upon values and no-ops, so the *interface*
-stays the same for all of them.
+stays the same for all of them.**
 
 ### The stream: `StreamIQ`
 

--- a/docs/_posts/2026-06-20-rf-front-end-03-driver-registry-enumeration.md
+++ b/docs/_posts/2026-06-20-rf-front-end-03-driver-registry-enumeration.md
@@ -1,0 +1,286 @@
+---
+title: "RF Front End, Part 3: The Driver Registry & Enumeration"
+description: How GopherTrunk's self-registering driver registry keeps the core hardware-agnostic — drivers register at init(), the binary's import set chooses the hardware, and EnumerateAll walks every backend to list attached dongles while staying resilient when one driver fails.
+category: deep-dives
+tags: [sdr, go, registry, dependency-inversion, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 3
+---
+
+*Part 3 of **RF Front End**. The engine needs a driver but must not depend on
+one. We cover the self-registering registry that inverts that dependency, the
+blank imports that choose the hardware, and the enumeration walk that lists every
+attached dongle without one flaky backend blanking out the rest.*
+
+## In this post
+
+- The **self-registering driver registry** — a `sync.RWMutex`-guarded map and the
+  `init()`-time `Register` call.
+- **`DriverByName`** for picking a backend and **`EnumerateAll`** for walking
+  every backend to discover hardware.
+- **The problem we hit:** enumeration must survive one driver erroring without
+  hiding everyone else's devices.
+- **The design principle:** registry + dependency inversion — and where it recurs
+  in the codebase.
+
+## What the registry does
+
+The `Device` contract from
+[Part 2]({{ '/blog/deep-dives/rf-front-end-02-the-device-contract/' | relative_url }})
+tells you what a radio can do. The registry answers the prior question: *which
+drivers exist, and how does the engine reach one without importing it?* It is a
+process-global map from driver name to `Driver`, the factory each backend exposes:
+
+```go
+// internal/sdr/device.go
+type Driver interface {
+    Name() string
+    Enumerate() ([]Info, error)
+    Open(idx int) (Device, error)
+}
+```
+
+`Name()` is the registry key. `Enumerate()` lists the devices that driver can see
+right now. `Open(idx)` turns one of those into a live `Device`. The engine talks
+to the registry in these abstract terms and never names a concrete driver type.
+
+Notice the two-phase split between `Enumerate` and `Open`. Enumeration is cheap
+and read-only: it probes the bus and returns `[]Info` describing what's attached,
+without claiming a USB handle or starting a stream. Opening is the expensive,
+exclusive step — it takes a USB device for the daemon's lifetime. Keeping them
+separate is what lets the engine *list* every dongle across every backend for the
+TUI or the web console, let the operator assign roles, and only then `Open` the
+specific devices it actually needs. A `Driver` is a factory you can poll freely; a
+`Device` is a resource you commit to.
+
+## How GopherTrunk implements it in Go
+
+### The map and the lock
+
+The whole registry is a guarded map plus a handful of accessors in
+`internal/sdr/registry.go`:
+
+```go
+// internal/sdr/registry.go
+var (
+    registryMu sync.RWMutex
+    registry   = map[string]Driver{}
+)
+
+func Register(d Driver) {
+    registryMu.Lock()
+    defer registryMu.Unlock()
+    registry[d.Name()] = d
+}
+```
+
+`sync.RWMutex` rather than a plain `Mutex` because registration happens once, at
+startup, but reads (`Drivers`, `DriverByName`, every `EnumerateAll`) happen
+throughout the daemon's life — the read lock lets those run concurrently.
+
+### Self-registration at `init()`
+
+Each driver registers itself from its package `init()` function, so importing the
+package is all it takes to make the driver available:
+
+```go
+// internal/sdr/rtlsdr/purego/register.go
+func init() { sdr.Register(&Driver{}) }
+```
+
+Nothing calls `init()` explicitly — Go runs it when the package is first imported.
+This is the linchpin of the whole pattern: registration is a *side effect of
+importing*, which means the act of choosing to include a driver in the build is
+also the act of making it available at runtime. There is no separate "plugin
+loading" step, no configuration file listing drivers, no reflection scanning for
+implementations. The Go linker does the work — a package that nobody imports is
+not in the binary, and a package that is imported has already registered itself by
+the time `main` runs.
+
+The only place those driver packages are imported is `cmd/gophertrunk`, with blank
+imports purely for their side effect:
+
+```go
+// cmd/gophertrunk/main.go
+import (
+    _ "github.com/MattCheramie/GopherTrunk/internal/sdr/airspy"
+    _ "github.com/MattCheramie/GopherTrunk/internal/sdr/airspyhf"
+    _ "github.com/MattCheramie/GopherTrunk/internal/sdr/hackrf"
+    _ "github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/purego"
+)
+```
+
+That import block *is* the hardware-support list. Want a build that only talks to
+RTL-SDR? Drop three lines. The engine doesn't change; the binary's import set does.
+
+This is more than a tidy trick — it is the mechanism by which the engine stays
+genuinely ignorant of its drivers. The `internal/sdr` package, which defines
+`Device`, `Driver`, and the registry, does *not* import the driver sub-packages;
+the dependency runs the other way, with each driver importing `internal/sdr` to
+call `Register`. If the core imported the drivers, it would know their concrete
+types, and the whole abstraction would be a fiction. The blank import in
+`cmd/gophertrunk` is the *only* edge that connects a concrete driver to the
+running program, and it lives at the very top of the dependency graph — in `main`,
+where it belongs — rather than buried in the engine.
+
+### Looking up and enumerating
+
+Two reads drive everything downstream. `DriverByName` picks a backend by its
+registry key:
+
+```go
+// internal/sdr/registry.go
+func DriverByName(name string) (Driver, error) {
+    registryMu.RLock()
+    defer registryMu.RUnlock()
+    d, ok := registry[name]
+    if !ok {
+        return nil, fmt.Errorf("sdr: unknown driver %q", name)
+    }
+    return d, nil
+}
+```
+
+And `EnumerateAll` walks *every* registered driver to build the full list of
+attached hardware — covered next, because that walk is where a real design
+decision lives.
+
+## The problem we hit: one flaky driver hid every dongle
+
+**Symptom.** A user with a working RTL-SDR and a half-supported second backend
+ran device discovery and got back an *empty* list — no devices at all, even though
+a perfectly good dongle was plugged in.
+
+**Root cause.** Enumeration walked the drivers and one of them returned an error
+from `Enumerate()` — a backend whose platform USB enumeration hiccuped. The walk
+treated that single error as fatal: it bailed on the first failure and returned no
+devices. One flaky backend blanked out every other driver's perfectly enumerable
+hardware. Worse, because the failing call returned an empty-but-no-error result up
+the chain, the operator saw "no SDRs found" with no hint that a driver had
+actually failed.
+
+**The Go fix.** `EnumerateAll` aggregates *per driver*: it collects devices from
+every driver that succeeds and collects one error per driver that fails, returning
+both. A failure in one backend is reported, not propagated as global emptiness:
+
+```go
+// internal/sdr/registry.go
+func EnumerateAll() ([]Info, []error) {
+    var out []Info
+    var errs []error
+    for _, d := range Drivers() {
+        infos, err := d.Enumerate()
+        if err != nil {
+            errs = append(errs, err)
+            continue
+        }
+        out = append(out, infos...)
+    }
+    return out, errs
+}
+```
+
+The `continue` is the whole fix: a driver that errors contributes an entry to
+`errs` and is skipped, while every other driver still appends its devices to
+`out`. The doc comment states the contract directly — it returns "the combined
+device list plus one error per driver that failed to enumerate, so callers can
+surface the failure instead of silently reporting an empty list." The operator now
+sees their RTL-SDR *and* a precise note about which backend failed and why.
+
+`Drivers()` itself returns the backends sorted by name, so enumeration order — and
+the device list the operator sees — is deterministic across runs rather than
+dependent on Go's randomized map iteration:
+
+```go
+// internal/sdr/registry.go
+func Drivers() []Driver {
+    registryMu.RLock()
+    defer registryMu.RUnlock()
+    out := make([]Driver, 0, len(registry))
+    for _, d := range registry {
+        out = append(out, d)
+    }
+    sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+    return out
+}
+```
+
+Without that `sort.Slice`, two runs of the same binary could list the same dongles
+in different orders, and an operator scripting against device indices would get
+non-reproducible results. The sort costs nothing at startup scale and buys a
+stable, predictable enumeration.
+
+## The design principle: registry + dependency inversion
+
+This is **dependency inversion**. The high-level engine depends on the abstract
+`Driver`/`Device` contracts; the low-level drivers depend *up* on those same
+contracts by registering themselves into the registry. The dependency arrow points
+the "wrong" way on purpose — toward the abstraction, from both sides.
+
+### How that principle shaped the Go code
+
+- **Blank imports choose the hardware.** `cmd/gophertrunk` blank-imports the four
+  real drivers; their `init()` functions populate the registry. The supported-
+  hardware list is the import list.
+- **The engine enumerates, it doesn't instantiate.** It calls `Drivers()` to see
+  what's available and `DriverByName()` to pick one. There is no
+  `switch deviceType { case "rtlsdr": ... }` anywhere in the core.
+- **New hardware is purely additive.** A new backend is a package that satisfies
+  `Device`/`Driver` and calls `Register` in its `init()`. No existing file changes
+  — the same hook the baseband-replay "virtual tuner" uses to mount recorded
+  captures as if they were dongles.
+- **Failures are localized, not fatal.** Because the registry walks drivers
+  independently, `EnumerateAll` degrades gracefully: one bad backend costs you that
+  backend's devices and an error entry, never the whole list.
+- **The lock matches the access pattern.** `sync.RWMutex` lets the many readers —
+  every `Drivers`, `DriverByName`, and `EnumerateAll` over the daemon's life — run
+  concurrently, while the rare `Register` writes at startup take the exclusive
+  lock. The synchronization is right-sized to "write once, read forever."
+
+This registry-plus-inversion shape is one of the most reused ideas in the
+codebase. It is the same pattern that drives the vocoders in
+[SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }})
+[Part 12]({{ '/blog/deep-dives/sdr-internals-12-voice-coding-vocoders/' | relative_url }})
+— self-registering plugins behind a shared core, chosen by the binary's import
+set. Once you've seen it for SDR drivers and vocoders you start to recognize it as
+GopherTrunk's default answer to "how does the core get an implementation it must
+not depend on": a small interface, a guarded map, an `init()`-time registration,
+and a blank import in `main` that decides what's compiled in. The RF front end is
+where the pattern is easiest to see, because the things being registered —
+physical radios — are the most concrete, but the mechanism is identical wherever
+it recurs.
+
+## Where this goes next
+
+We now have a contract (Part 2) and a way to discover and open devices (this
+post). Everything below that is the hard part: how a `Device` actually moves bytes
+without `libusb`.
+[Part 4]({{ '/blog/deep-dives/rf-front-end-04-usb-without-libusb/' | relative_url }})
+starts the USB transport story — issuing control transfers and bulk reads against
+the kernel directly, in pure Go.
+
+## FAQ
+
+**Why a process-global registry instead of passing drivers in explicitly?**
+So the engine never imports a concrete driver. Drivers self-register at `init()`,
+and the binary's blank-import set decides what's available. The core depends only
+on the abstract `Driver`/`Device` contracts — classic dependency inversion.
+
+**What happens if two drivers register the same name?**
+The map keys on `Name()`, so the later `Register` wins. In practice names are
+unique per backend; the deterministic ordering operators see comes from `Drivers()`
+sorting by name before returning.
+
+**Why does `EnumerateAll` return `[]error` instead of a single error?**
+Because each driver fails independently and the caller wants to know *which* one
+did. Aggregating per-driver lets a flaky backend report its failure without hiding
+the devices every other backend enumerated successfully.
+
+## Series navigation
+
+**Part 3 of 14** · ←
+[Part 2]({{ '/blog/deep-dives/rf-front-end-02-the-device-contract/' | relative_url }})
+· Next →
+[Part 4: Talking to USB without libusb]({{ '/blog/deep-dives/rf-front-end-04-usb-without-libusb/' | relative_url }})

--- a/docs/_posts/2026-06-20-rf-front-end-03-driver-registry-enumeration.md
+++ b/docs/_posts/2026-06-20-rf-front-end-03-driver-registry-enumeration.md
@@ -14,6 +14,8 @@ one. We cover the self-registering registry that inverts that dependency, the
 blank imports that choose the hardware, and the enumeration walk that lists every
 attached dongle without one flaky backend blanking out the rest.*
 
+> **TL;DR** — The driver registry is a process-global map that lets drivers self-register at `init()`, so the binary's import set chooses the hardware and the core never depends on a concrete driver. The headline bug: one flaky backend's enumeration error blanked out every dongle, fixed by aggregating errors per driver instead of bailing on the first failure.
+
 ## In this post
 
 - The **self-registering driver registry** — a `sync.RWMutex`-guarded map and the
@@ -59,8 +61,8 @@ specific devices it actually needs. A `Driver` is a factory you can poll freely;
 
 ### The map and the lock
 
-The whole registry is a guarded map plus a handful of accessors in
-`internal/sdr/registry.go`:
+**The whole registry is a guarded map plus a handful of accessors in
+`internal/sdr/registry.go`:**
 
 ```go
 // internal/sdr/registry.go

--- a/docs/_posts/2026-06-21-rf-front-end-04-usb-without-libusb.md
+++ b/docs/_posts/2026-06-21-rf-front-end-04-usb-without-libusb.md
@@ -1,0 +1,303 @@
+---
+title: "RF Front End, Part 4: Talking to USB Without libusb"
+description: How GopherTrunk speaks to RTL-SDR hardware over raw kernel USB interfaces instead of linking libusb, and the single Transport contract that lets one driver run on three wildly different OS USB stacks.
+category: deep-dives
+tags: [sdr, go, usb, transport, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 4
+---
+
+*Part 4 of **RF Front End**. We open the box on how GopherTrunk reaches a USB
+dongle without `libusb`: one tiny Go interface, three per-OS implementations
+chosen at compile time, and a mock that lets the whole RTL2832U stack run in CI
+with no hardware attached.*
+
+## In this post
+
+- Why GopherTrunk talks to the **kernel's USB interface directly** instead of
+  linking `libusb` — and what that buys us (one static binary, **no CGO**).
+- The **`Transport` interface** in `usb.go` — the minimal slice of USB the
+  RTL2832U actually needs, and nothing more.
+- The **build-tag platform split**: one interface, per-OS files selected by
+  `//go:build` tags, plus a `MockTransport` for tests.
+- The problem of keeping **one contract** that fits USBDEVFS, WinUSB, and IOKit
+  at once.
+
+## What the USB transport layer does
+
+An RTL-SDR dongle is, electrically, a USB 2.0 device with a startlingly narrow
+control surface. The RTL2832U demodulator firmware only ever wants three things
+from the host: **vendor control transfers out** (write a chip register), **vendor
+control transfers in** (read one back), and a **bulk-IN endpoint** that fire-hoses
+8-bit IQ samples at 2.4 MS/s. There are no class requests, no isochronous
+streams, no multiple-configuration gymnastics. The tuner register dance, the PLL
+math, the gain tables — all of it rides on top of those few primitives.
+
+So the job of GopherTrunk's USB layer is to expose exactly that narrow slice and
+hide everything else. The package doc says it plainly:
+
+```go
+// internal/sdr/rtlsdr/usb/usb.go
+// Package usb is the platform-abstraction layer that the pure-Go RTL-SDR
+// driver speaks to. It exposes the minimal slice of USB the RTL2832U
+// demodulator needs — vendor control transfers in both directions and an
+// async bulk-IN endpoint — and nothing else.
+```
+
+The conventional way to do this in Go is to link `libusb` via CGO. We
+deliberately don't. Linking `libusb` would reintroduce a C toolchain at build
+time, a shared-library dependency at run time, and the cross-compilation
+headaches that come with both — breaking the single-static-binary promise the
+rest of GopherTrunk is built around. Instead, each OS already exposes a way to
+drive raw USB from userspace: **USBDEVFS** ioctls on Linux, the **WinUSB** driver
+on Windows, **IOKit** on macOS. GopherTrunk speaks to those directly. The cost is
+that we write three backends by hand; the payoff is a pure-Go, CGO-free,
+`go build`-and-ship binary on every target.
+
+## How GopherTrunk implements it in Go
+
+Everything funnels through two interfaces. The first, `Enumerator`, discovers and
+opens devices; the second, `Transport`, is a claimed handle you do I/O on. Here's
+the `Transport` contract, trimmed to its shape:
+
+```go
+// internal/sdr/rtlsdr/usb/usb.go
+type Transport interface {
+    ControlIn(bRequest uint8, wValue, wIndex uint16, n int, timeoutMs int) ([]byte, error)
+    ControlOut(bRequest uint8, wValue, wIndex uint16, data []byte, timeoutMs int) error
+
+    ClaimInterface(num int) error
+    ReleaseInterface(num int) error
+
+    StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte), onStreamDead func(error)) error
+    StopBulkIn() error
+
+    Reset() error
+    Close() error
+}
+```
+
+That's the whole vocabulary. Two control methods, two claim methods, a bulk-IN
+pair, plus `Reset` and `Close`. Notice what *isn't* here: no endpoint
+descriptors, no configuration selection, no transfer-type enums, no
+buffer-pool API. The RTL2832U only exposes interface 0 with a single bulk-IN
+endpoint (`0x81`), so the interface bakes in those assumptions rather than
+modelling the full USB spec. The narrowness is the point — it's what makes three
+implementations tractable.
+
+The control transfers carry libusb-style request-type bytes, which the package
+exports as the only two values the firmware understands:
+
+```go
+// internal/sdr/rtlsdr/usb/usb.go
+const (
+    VendorOut uint8 = 0x40 // bmRequestType: host → device, vendor, device recipient
+    VendorIn  uint8 = 0xC0 // bmRequestType: device → host, vendor, device recipient
+)
+```
+
+`StartBulkIn` is the only method with real machinery behind it. It submits a ring
+of `ringBufs` buffers of `bufLen` bytes each on endpoint `epAddr`, and invokes
+`onPacket` from a dedicated reaper goroutine each time a buffer completes. The
+slice handed to `onPacket` is **owned by the transport and reused** once the
+callback returns, so the driver copies anything it wants to keep. The second
+callback, `onStreamDead`, fires exactly once if every buffer dies of an
+unrecoverable USB error *without* `StopBulkIn` being called — a hook we added
+after a hang we'll get to below.
+
+Discovery rides on the sibling interface:
+
+```go
+// internal/sdr/rtlsdr/usb/usb.go
+type Enumerator interface {
+    Name() string                                // "usbdevfs", "winusb", "iokit", "mock"
+    List(vid, pid uint16) ([]Descriptor, error)  // 0 = wildcard
+    Open(d Descriptor) (Transport, error)
+}
+
+func DefaultEnumerator() Enumerator { return platformEnumerator() }
+```
+
+`DefaultEnumerator` is the only public entry point. It calls `platformEnumerator`,
+and *that* function is defined once per OS — every backend file provides its own.
+On Linux it returns `&linuxEnumerator{}`, on Windows `&winEnumerator{}`, on macOS
+the IOKit-backed enumerator. The driver above never names a concrete type; it
+asks for `DefaultEnumerator()` and gets whatever the build produced.
+
+The selection is pure build tags. Each backend file opens with a `//go:build`
+header so the Go toolchain compiles in exactly one:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+//go:build linux && (amd64 || arm64 || 386 || arm || riscv64 || loong64)
+
+// internal/sdr/rtlsdr/usb/usb_windows.go
+//go:build windows && (amd64 || arm64)
+
+// internal/sdr/rtlsdr/usb/usb_darwin.go
+//go:build darwin
+
+// internal/sdr/rtlsdr/usb/usb_other.go
+//go:build !(linux && (...)) && !(windows && (amd64 || arm64)) && !darwin
+```
+
+The `usb_other.go` catch-all matters more than it looks: it returns an
+`unsupportedEnumerator` whose every method yields `ErrUnsupportedPlatform`. That
+keeps the package *compilable* on freebsd, plan9, or any target without a real
+backend — the higher layers build and link everywhere, and the failure surfaces
+at runtime from `List`/`Open` instead of breaking `go build` on an exotic OS.
+
+### The mock that needs no hardware
+
+The same `Transport` shape is what makes the driver testable. `MockTransport`
+implements the interface by replaying a scripted sequence of control exchanges:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_mock.go
+type CtrlExchange struct {
+    In       bool
+    BRequest uint8
+    WValue   uint16
+    WIndex   uint16
+    Data     []byte // expected for OUT
+    Reply    []byte // returned for IN
+    Err      error
+    // ...
+}
+
+type MockTransport struct {
+    Script []CtrlExchange
+    Step   int
+    Err    error
+    // ...
+    BulkPackets [][]byte
+}
+```
+
+A test builds a `Script` of the exact register reads and writes the RTL2832U
+bring-up should emit, runs the real driver against the mock, and then asserts
+`MockTransport.Err` is nil and `Remaining()` is zero. Bulk streaming is mocked by
+shoving pre-built byte slices into `BulkPackets`, which the mock's goroutine feeds
+through `onPacket` on the same `(shape)` contract the real backends honor. Because
+the mock satisfies `Transport`, the rtl2832u register layer and every tuner
+driver above it can be unit-tested without a dongle plugged in — which is the only
+way CI on a headless Linux runner can exercise Windows-and-macOS-bound code paths
+at all.
+
+## The problem we hit: one contract, three alien USB stacks
+
+The first cut of this package was Linux-only. USBDEVFS gave us submit-a-URB,
+reap-a-URB, claim-an-interface, and the `Transport` interface was essentially a
+thin shadow of those ioctls. That worked beautifully until we started PR-02
+(Windows) and PR-10 (macOS) and discovered the three OS USB stacks barely agree
+on anything.
+
+**The symptom.** Every method we'd sketched leaked a Linux assumption. Our first
+`StartBulkIn` returned URB handles for the caller to manage — fine on USBDEVFS,
+meaningless on WinUSB (which thinks in overlapped I/O and event handles) and on
+IOKit (which has no URB concept at all, just synchronous `ReadPipe`). Our claim
+semantics assumed a kernel driver you detach; WinUSB has *already* taken exclusive
+ownership at initialize time and "claim" is a no-op. Cancellation was modelled on
+`USBDEVFS_DISCARDURB`; macOS cancels with `AbortPipe`, Windows with `AbortPipe`
+plus a manual event drain. Any interface that exposed those mechanics couldn't be
+satisfied by all three.
+
+**The root cause.** We had let the *implementation* leak into the *contract*. The
+interface was a description of USBDEVFS, not a description of "what the RTL2832U
+needs." Every Linux-shaped detail in the signature became a constraint the other
+two backends had to either fake or violate.
+
+**The Go fix.** We rewrote the interface around what the *driver* asks for, not
+what any OS provides — and pushed every OS-specific mechanism strictly inside the
+implementations. Concretely:
+
+- `StartBulkIn` stopped returning handles. The caller supplies geometry
+  (`ringBufs`, `bufLen`, `epAddr`) and two callbacks, and **never sees a URB, an
+  `OVERLAPPED`, or a `pipeRef`**. Whether the bytes arrive via a single reaper
+  goroutine (Linux), one OS thread per slot (macOS), or `WaitForMultipleObjects`
+  (Windows) is invisible above the contract.
+- `ClaimInterface`/`ReleaseInterface` became *intent*, not mechanism. Linux turns
+  a claim into `USBDEVFS_CLAIMINTERFACE` plus auto-detach of the kernel DVB
+  driver; Windows makes it a no-op because initialize already claimed; macOS turns
+  it into the IOCFPlugIn interface-iterator dance. The driver just says "I own
+  interface 0."
+- Buffer ownership was nailed down *in the doc comment* so all three could honor
+  it identically: the slice passed to `onPacket` is transport-owned and reused.
+  That one sentence let each backend reuse its ring buffers without copying, and
+  let the driver copy exactly once.
+
+The discipline that made it work was a kind of subtraction: every time a method
+needed an OS-specific type to be expressible, that was the signal the method was
+wrong. The final `Transport` has **eight methods and zero platform types in its
+signature** — and that's precisely why USBDEVFS, WinUSB, and IOKit can each be one
+file behind it.
+
+## The design principle: ports & adapters at the OS boundary
+
+This is the **hexagonal / ports-and-adapters** pattern applied at the operating
+system boundary. `Transport` and `Enumerator` are the *ports* — abstract contracts
+owned by the application's needs. `linuxTransport`, `winTransport`, and
+`darwinTransport` are the *adapters* — concrete implementations that translate
+those needs into one specific OS's USB ABI. The RTL2832U driver lives entirely on
+the port side and is, by construction, ignorant of which adapter it's talking to.
+
+### How that principle shaped the Go code
+
+- **The port is defined by the consumer, not the provider.** `Transport` models
+  what the RTL2832U firmware requires — vendor control + one bulk-IN endpoint —
+  not what USBDEVFS happens to offer. When an adapter couldn't express a method
+  without leaking its own types, we changed the *port*, not the adapter.
+- **Adapters are selected at compile time, not runtime.** `//go:build` tags mean
+  the Windows binary contains zero IOKit code and the macOS binary contains zero
+  WinUSB code. There's no `switch runtime.GOOS` and no dead platform branches
+  linked into the wrong binary.
+- **The unsupported case is an adapter too.** `usb_other.go` is the null adapter:
+  it satisfies the port and fails politely. The port stays total — every platform
+  has *an* implementation — so nothing above has to special-case "no USB here."
+- **The mock is just another adapter.** `MockTransport` plugs into the same port
+  as the real backends, which is what lets hardware-free tests drive the full
+  driver. The driver genuinely cannot tell a scripted mock from a real R820T.
+
+You'll recognize this as the same instinct behind the driver registry from the
+[SDR Internals series]({{ '/blog/deep-dives/sdr-internals-02-sdr-device-driver-registry/' | relative_url }}):
+define the contract by what the core needs, then let interchangeable
+implementations satisfy it from below.
+
+## Where this goes next
+
+We've drawn the port; the next three posts build the adapters. **Part 5** dives
+into the Linux backend — hand-rolled USBDEVFS ioctl encoding, submitting async
+URBs, and reaping them in a single goroutine for sustained throughput. **Part 6**
+takes on macOS (IOKit via purego, OS-thread-pinned reader goroutines) and Windows
+(WinUSB function pointers, overlapped I/O), and shows how both fold back onto the
+exact same eight-method contract. With the transport solid, **Part 7** finally
+brings up the RTL2832U itself on top of it.
+
+## FAQ
+
+**Why not just link libusb and be done with it?**
+`libusb` would reintroduce CGO and a shared-library run-time dependency, breaking
+GopherTrunk's single-static-binary, cross-compilable build. Writing three thin
+backends in pure Go is more work up front but keeps `go build` honest on every
+target.
+
+**Doesn't writing three USB backends triple the bug surface?**
+It spreads it, but the narrow contract contains it. Each adapter is one file
+implementing eight methods, and `MockTransport` lets the entire driver above the
+port be tested identically regardless of which adapter runs underneath — so most
+logic is exercised in CI with no hardware at all.
+
+**Why does the interface assume interface 0 and endpoint 0x81?**
+Because the RTL2832U does. The port is shaped by what the device needs, not by the
+full generality of USB. If GopherTrunk ever drove a multi-interface device, that
+would be a reason to widen the port — deliberately, with all three adapters in
+view.
+
+## Series navigation
+
+**Part 4 of 14** · ←
+[Part 3]({{ '/blog/deep-dives/rf-front-end-03-driver-registry-enumeration/' | relative_url }})
+· Next →
+[Part 5: USB on Linux — USBDEVFS & async URBs]({{ '/blog/deep-dives/rf-front-end-05-usb-on-linux-usbdevfs/' | relative_url }})

--- a/docs/_posts/2026-06-21-rf-front-end-04-usb-without-libusb.md
+++ b/docs/_posts/2026-06-21-rf-front-end-04-usb-without-libusb.md
@@ -14,6 +14,8 @@ dongle without `libusb`: one tiny Go interface, three per-OS implementations
 chosen at compile time, and a mock that lets the whole RTL2832U stack run in CI
 with no hardware attached.*
 
+> **TL;DR** — The USB transport layer is one tiny Go `Transport` interface that exposes only the slice of USB the RTL2832U needs, with a per-OS adapter chosen at compile time. The headline problem: the first cut leaked Linux USBDEVFS assumptions into the contract, so it was rewritten around what the driver needs, not what any one OS provides.
+
 ## In this post
 
 - Why GopherTrunk talks to the **kernel's USB interface directly** instead of
@@ -58,7 +60,7 @@ that we write three backends by hand; the payoff is a pure-Go, CGO-free,
 
 ## How GopherTrunk implements it in Go
 
-Everything funnels through two interfaces. The first, `Enumerator`, discovers and
+**Everything funnels through two interfaces.** The first, `Enumerator`, discovers and
 opens devices; the second, `Transport`, is a claimed handle you do I/O on. Here's
 the `Transport` contract, trimmed to its shape:
 

--- a/docs/_posts/2026-06-22-rf-front-end-05-usb-on-linux-usbdevfs.md
+++ b/docs/_posts/2026-06-22-rf-front-end-05-usb-on-linux-usbdevfs.md
@@ -15,6 +15,8 @@ URBs in flight at once, and a single reaper goroutine draining them — plus the
 bit-exact struct layout that decides whether the kernel accepts a URB or silently
 drops it.*
 
+> **TL;DR** — The Linux USB backend hand-rolls USBDEVFS ioctls and runs a ring of async URBs reaped by a single goroutine for sustained IQ throughput, all in pure Go. The headline bug: a struct field-alignment mismatch made the size-encoded ioctl number wrong, so streaming failed silently until the Go struct was made provably byte-identical to the kernel's.
+
 ## In this post
 
 - What **USBDEVFS** is and why GopherTrunk drives `/dev/bus/usb` directly instead
@@ -53,8 +55,8 @@ ioctls on that one fd.
 
 ## How GopherTrunk implements it in Go
 
-The first thing the backend needs is the ioctl request numbers, and Go gives us no
-header to crib them from — `libusb` and the kernel get them from C macros. So we
+**The first thing the backend needs is the ioctl request numbers, and Go gives us no
+header to crib them from — `libusb` and the kernel get them from C macros.** So we
 reproduce the **asm-generic ioctl encoding** by hand. Every ioctl number on Linux
 packs a direction, a "type" letter, a sequence number, and the argument size into
 a single integer:

--- a/docs/_posts/2026-06-22-rf-front-end-05-usb-on-linux-usbdevfs.md
+++ b/docs/_posts/2026-06-22-rf-front-end-05-usb-on-linux-usbdevfs.md
@@ -1,0 +1,342 @@
+---
+title: "RF Front End, Part 5: USB on Linux — USBDEVFS & Async URBs"
+description: How GopherTrunk's Linux USB backend hand-rolls USBDEVFS ioctl encoding, submits a ring of async URBs, and reaps them in a single goroutine for sustained IQ throughput — all in pure Go behind a safe Transport API.
+category: deep-dives
+tags: [sdr, go, usb, usbdevfs, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 5
+---
+
+*Part 5 of **RF Front End**. We implement the Linux adapter behind the
+`Transport` port from Part 4: USBDEVFS ioctls encoded by hand, a ring of async
+URBs in flight at once, and a single reaper goroutine draining them — plus the
+bit-exact struct layout that decides whether the kernel accepts a URB or silently
+drops it.*
+
+## In this post
+
+- What **USBDEVFS** is and why GopherTrunk drives `/dev/bus/usb` directly instead
+  of linking `libusb`.
+- Hand-rolling the **`_IOWR`-style ioctl numbers** from Go, and the structs that
+  must match the kernel's ABI byte-for-byte.
+- Submitting a **ring of async URBs** and reaping them in **one goroutine** — why
+  multiple in-flight transfers are required for sustained throughput.
+- The problem of getting the **ioctl encoding bit-exact** when a wrong number
+  fails silently.
+
+## What the Linux USB backend does
+
+On Linux, every USB device shows up as a character device under
+`/dev/bus/usb/BBB/DDD`, and the kernel's **usbfs** (a.k.a. USBDEVFS) interface
+lets a userspace process do real USB I/O on it through `ioctl(2)`. That's how
+`libusb` works under the hood on Linux, and it's how GopherTrunk works without
+`libusb`: open the device node, issue the right ioctls, and you have control
+transfers and bulk streaming with nothing between you and the kernel.
+
+The backend lives in `usb_linux.go` and provides `platformEnumerator()` — the
+per-OS hook `DefaultEnumerator` calls. Enumeration walks **sysfs**
+(`/sys/bus/usb/devices`) to read VID/PID/serial without opening anything, so
+listing dongles needs no privilege beyond sysfs read permission:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+func platformEnumerator() Enumerator { return &linuxEnumerator{} }
+
+func (l *linuxEnumerator) Name() string { return "usbdevfs" }
+```
+
+`Open` then opens the matching node under `/dev/bus/usb` with `O_RDWR | O_CLOEXEC`
+and wraps the file descriptor in a `linuxTransport`. Everything after that is
+ioctls on that one fd.
+
+## How GopherTrunk implements it in Go
+
+The first thing the backend needs is the ioctl request numbers, and Go gives us no
+header to crib them from — `libusb` and the kernel get them from C macros. So we
+reproduce the **asm-generic ioctl encoding** by hand. Every ioctl number on Linux
+packs a direction, a "type" letter, a sequence number, and the argument size into
+a single integer:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+const (
+    iocNRShift   = 0
+    iocTypeShift = 8
+    iocSizeShift = 16
+    iocDirShift  = 30
+
+    iocNone  = 0
+    iocWrite = 1
+    iocRead  = 2
+)
+
+func ioc(dir, typ, nr, size uintptr) uintptr {
+    return (dir << iocDirShift) | (typ << iocTypeShift) | (nr << iocNRShift) | (size << iocSizeShift)
+}
+```
+
+That `ioc` is the Go equivalent of the kernel's `_IOWR(type, nr, size)` family of
+macros. With it we can name every USBDEVFS command the driver uses — and the
+*size* field is computed from the actual Go struct via `unsafe.Sizeof`, so the
+number and the payload can never drift apart:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+var (
+    usbdevfsControl          = ioc(iocRead|iocWrite, 'U', 0, unsafe.Sizeof(usbdevfsCtrltransfer{}))
+    usbdevfsSubmitURB        = ioc(iocRead, 'U', 10, unsafe.Sizeof(usbdevfsURB{}))
+    usbdevfsDiscardURB       = ioc(iocNone, 'U', 11, 0)
+    usbdevfsReapURB          = ioc(iocWrite, 'U', 12, unsafe.Sizeof(uintptr(0)))
+    usbdevfsClaimInterface   = ioc(iocRead, 'U', 15, 4)
+    usbdevfsReleaseInterface = ioc(iocRead, 'U', 16, 4)
+    usbdevfsIoctlCmd         = ioc(iocRead|iocWrite, 'U', 18, unsafe.Sizeof(usbdevfsIoctlArg{}))
+    usbdevfsReset            = ioc(iocNone, 'U', 20, 0)
+    usbdevfsDisconnect       = ioc(iocNone, 'U', 22, 0)
+)
+```
+
+Each of those structs is a Go mirror of a kernel `struct`. A control transfer, for
+example, mirrors `struct usbdevfs_ctrltransfer`:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+type usbdevfsCtrltransfer struct {
+    BmRequestType uint8
+    BRequest      uint8
+    WValue        uint16
+    WIndex        uint16
+    WLength       uint16
+    Timeout       uint32
+    Data          *byte
+}
+```
+
+`ControlIn` and `ControlOut` fill one of these in and fire a single
+`unix.Syscall(SYS_IOCTL, fd, usbdevfsControl, &ctrl)`. There's no copy, no
+marshalling layer — the Go struct *is* the wire format, which is why the field
+layout has to be exact (more on that in the problem section).
+
+### A ring of async URBs
+
+Control transfers are easy because they're synchronous. The IQ stream is not. At
+2.4 MS/s of 8-bit IQ, the dongle produces ~2.4 MB/s and will overrun any scheme
+that does one blocking read, processes it, then reads again — the gap between
+reads is dead air on the bus. The fix is the same one `libusb` and `librtlsdr` use:
+keep **many transfers in flight at once** so the host controller always has a
+buffer to fill while userspace drains the previous one.
+
+USBDEVFS does this with **URBs** (USB Request Blocks): you `SUBMITURB` a buffer,
+the kernel fills it asynchronously, and you `REAPURB` to collect completions.
+`StartBulkIn` submits a whole ring up front:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+for i := 0; i < ringBufs; i++ {
+    buf := make([]byte, bufLen)
+    urb := &usbdevfsURB{
+        Type:         usbdevfsURBTypeBULK,
+        Endpoint:     epAddr,
+        Buffer:       &buf[0],
+        BufferLength: int32(bufLen),
+    }
+    _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsSubmitURB, uintptr(unsafe.Pointer(urb)))
+    if errno != 0 {
+        // ...discard the URBs already submitted, drain, and bail
+        return fmt.Errorf("usbdevfs: SUBMITURB[%d]: %w", i, translateErrno(errno))
+    }
+    slots = append(slots, &bulkSlot{urb: urb, buf: buf})
+}
+```
+
+The driver's default geometry is **32 buffers of 16 KiB** — `DefaultRingBuffers`
+and `DefaultBufferLen` in `usb.go`. With 32 URBs queued, the kernel can keep the
+bus saturated even if the consumer stalls for several milliseconds.
+
+Once the ring is submitted, a **single reaper goroutine** owns the completion
+loop. It pins itself to its OS thread, reaps one URB at a time, hands the bytes to
+`onPacket`, and immediately resubmits that same URB to keep the ring full:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+func (t *linuxTransport) reapLoop(onPacket func([]byte), onStreamDead func(error), slots []*bulkSlot, submitted int, done chan struct{}) {
+    runtime.LockOSThread()
+    defer runtime.UnlockOSThread()
+    defer close(done)
+    // ...
+    for remaining > 0 {
+        var ptr uintptr
+        _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsReapURB, uintptr(unsafe.Pointer(&ptr)))
+        // ...
+        slot := findSlotByAddr(slots, ptr)
+        // ...
+        if urb.Status == 0 && urb.ActualLength > 0 {
+            onPacket(slot.buf[:urb.ActualLength])
+        }
+        urb.ActualLength = 0
+        urb.Status = 0
+        unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsSubmitURB, uintptr(unsafe.Pointer(urb)))
+    }
+}
+```
+
+One detail worth flagging: `REAPURB` hands back the *address* of a URB we
+previously submitted. We never dereference that raw `uintptr` — instead
+`findSlotByAddr` looks it up against our slot ring, whose entries Go's GC keeps
+alive, and we use *that* pointer. Trusting the kernel's bare address would race the
+garbage collector; the lookup keeps us on pointers the runtime knows about.
+
+Cancellation is the mirror image. `StopBulkIn` sets an atomic stop flag, issues
+`DISCARDURB` against every slot to unblock the kernel, and waits on the `done`
+channel for the reaper to exit:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+t.bulkStopFlag.Store(1)
+for _, s := range slots {
+    unix.Syscall(unix.SYS_IOCTL, uintptr(t.fd), usbdevfsDiscardURB, uintptr(unsafe.Pointer(s.urb)))
+}
+<-done
+```
+
+If instead the reaper exits because every URB *died* — a host-controller hang, a
+yanked dongle (`ENODEV`) — with the stop flag still unset, it fires `onStreamDead`
+from a fresh goroutine so the driver can tear down its consumer rather than block
+forever. (That callback is the fix for issue #345, which we'll revisit when we
+build the driver in Part 7.)
+
+### Claiming the interface away from the kernel
+
+There's one more Linux-specific wrinkle. When you plug in an RTL-SDR, the kernel
+helpfully binds the `dvb_usb_rtl28xxu` DVB-T TV-tuner driver to it. To stream IQ we
+have to take the interface back. `ClaimInterface` tries `USBDEVFS_CLAIMINTERFACE`,
+and on `EBUSY` it detaches the kernel driver via the "ioctl within an ioctl"
+(`USBDEVFS_IOCTL` carrying `USBDEVFS_DISCONNECT`) and retries once — mirroring
+libusb's `AUTO_DETACH_KERNEL_DRIVER`. The policy is factored into a pure function
+so it's unit-testable without a real device node:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+func claimWithAutoDetach(claim, detach func() error) error {
+    err := claim()
+    if !errors.Is(err, unix.EBUSY) {
+        return err
+    }
+    if detachErr := detach(); detachErr != nil {
+        return fmt.Errorf("usbdevfs: interface busy, kernel-driver auto-detach failed: %w (original: %w)", detachErr, err)
+    }
+    return claim()
+}
+```
+
+## The problem we hit: a wrong ioctl number fails silently
+
+**The symptom.** Control transfers worked perfectly on the very first try — read
+the EEPROM, write a register, all of it. But the moment we called `SUBMITURB` to
+start streaming, nothing happened. No bytes, no error we could act on, sometimes a
+bare `EINVAL` and sometimes a clean return with an empty ring that never produced
+a completion. The dongle's LED suggested it was alive; the reaper just sat there.
+
+**The root cause.** The ioctl number was wrong by a few bits. Because USBDEVFS
+encodes the *argument size* into the request number itself, the kernel compares the
+size you encoded against the size it expects for that command. Our first
+`usbdevfsURB` struct had a field-alignment mismatch — Go's natural padding put the
+`Buffer` pointer at a different offset than the kernel's `struct usbdevfs_urb`, so
+`unsafe.Sizeof(usbdevfsURB{})` produced a size the kernel didn't recognize for
+command `'U', 10`. The encoded number was self-consistent and *looked* right, but
+it named a command the kernel had no handler matching, so the submit was rejected
+or misread the buffer pointer. Control transfers had survived because their struct
+happened to be alignment-clean; the URB struct, with its mix of `int32`s and a
+trailing pointer, was not.
+
+**The Go fix.** Two things, captured and verified rather than guessed:
+
+- We pinned the struct layout to the kernel's by **constraining the build tag** to
+  architectures where Go's natural alignment matches the kernel's asm-generic
+  layout, and documented it on the struct itself:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_linux.go
+// usbdevfsCtrltransfer mirrors struct usbdevfs_ctrltransfer in
+// <linux/usbdevice_fs.h>. The build tag above restricts this file to
+// architectures where Go's natural field alignment matches the kernel's
+// ... so the Go compiler's auto-padding produces a wire-identical struct.
+```
+
+  The `//go:build linux && (amd64 || arm64 || 386 || arm || riscv64 || loong64)`
+  header isn't cosmetic — it's the guarantee that `unsafe.Sizeof` yields the
+  kernel's size on every target we compile for.
+
+- We **verified the encoded numbers against the kernel's own macros** by computing
+  what `_IOWR('U', 10, struct usbdevfs_urb)` expands to and diffing it against our
+  `ioc()` output for each command, and by capturing a working `libusb` session
+  with `strace -e ioctl` to read the exact request numbers the kernel accepts off
+  the wire. Once our `usbdevfsSubmitURB` matched the strace value byte-for-byte,
+  URBs started completing immediately.
+
+The broader lesson: when the request number *is* a function of the struct size, a
+struct bug and an ioctl bug are the same bug, and it surfaces as silence. The
+fix had to make the Go struct and the kernel struct provably identical — and then
+prove it against a real trace, not just by re-reading the header.
+
+## The design principle: a thin syscall layer over an unsafe ABI
+
+The whole backend is one idea: **encapsulate an unsafe kernel ABI behind a safe Go
+API**. Everything dangerous — raw `unsafe.Pointer`, hand-encoded ioctl numbers,
+structs that must match a C header bit-for-bit, a `uintptr` from the kernel we
+must not dereference — is confined to `usb_linux.go`. What escapes the file is the
+ordinary, garbage-collected, error-returning `Transport` from Part 4.
+
+### How that principle shaped the Go code
+
+- **`unsafe` is contained, not spread.** Every `unsafe.Pointer` and every
+  `SYS_IOCTL` syscall lives in this one file. The RTL2832U driver above never
+  touches `unsafe`; it calls `ControlOut` and `StartBulkIn` and gets Go errors
+  back.
+- **The size and the struct are derived from one source.** Encoding ioctl numbers
+  with `unsafe.Sizeof(theStruct{})` means you cannot change a struct without the
+  request number tracking it — the ABI mismatch that bit us can't silently
+  reappear.
+- **Kernel pointers stay at arm's length.** The reaper looks reaped URB addresses
+  up in a GC-visible slot table (`findSlotByAddr`) instead of dereferencing the
+  bare `uintptr`, so the unsafe boundary never hands a raw kernel pointer to Go's
+  memory model.
+- **Errno is translated at the boundary.** `translateErrno` maps `ENODEV` →
+  `ErrDeviceGone`, `ETIMEDOUT` → `ErrTimeout`, so callers compare against the
+  package's portable sentinels and never learn they're on Linux.
+
+## Where this goes next
+
+The Linux adapter is the reference implementation; **Part 6** builds the other two.
+macOS reaches the same `Transport` contract through IOKit and CoreFoundation —
+loaded via purego, with one OS-thread-pinned goroutine per ring slot doing
+synchronous `ReadPipe`. Windows reaches it through WinUSB and overlapped I/O,
+draining completions with `WaitForMultipleObjects`. Both are deliberately
+different machinery underneath the *same* eight methods — the clearest possible
+demonstration of why we drew the port the way we did in Part 4.
+
+## FAQ
+
+**Why submit 32 URBs instead of just a couple?**
+Sustained 2.4 MS/s leaves no slack for round-trips. With a deep ring the host
+controller always has a buffer to fill while userspace drains the last one, so a
+multi-millisecond consumer stall doesn't drop samples. Two or three URBs overrun
+the moment the scheduler hiccups.
+
+**Why pin the reaper goroutine with `runtime.LockOSThread`?**
+The reap loop blocks in a syscall for long stretches; pinning it keeps the Go
+scheduler from migrating it mid-`ioctl` and keeps the blocking I/O off the threads
+serving the rest of the program.
+
+**What happens on an architecture not in the build tag?**
+It falls through to `usb_other.go`'s unsupported enumerator from Part 4. We only
+claim the arches where Go's struct alignment provably matches the kernel's, rather
+than ship a backend whose `unsafe.Sizeof` might lie.
+
+## Series navigation
+
+**Part 5 of 14** · ←
+[Part 4]({{ '/blog/deep-dives/rf-front-end-04-usb-without-libusb/' | relative_url }})
+· Next →
+[Part 6: USB on macOS & Windows]({{ '/blog/deep-dives/rf-front-end-06-usb-on-macos-windows/' | relative_url }})

--- a/docs/_posts/2026-06-23-rf-front-end-06-usb-on-macos-windows.md
+++ b/docs/_posts/2026-06-23-rf-front-end-06-usb-on-macos-windows.md
@@ -14,6 +14,12 @@ loaded by purego with no CGO, Windows through WinUSB with overlapped I/O. Three
 operating systems, three completely different threading and I/O models — all
 folded back onto the one eight-method `Transport` contract from Part 4.*
 
+> **TL;DR** — These are the macOS (IOKit via purego) and Windows (WinUSB,
+> overlapped I/O) USB backends, both satisfying the same eight-method `Transport`
+> port as Linux. The headache: IOKit ties USB I/O state to the issuing OS thread,
+> so early macOS streaming builds crashed — fixed by pinning each reader to its
+> own thread with `runtime.LockOSThread`.
+
 ## In this post
 
 - The **macOS** backend: IOKit + CoreFoundation via **purego** (no CGO), a lazy
@@ -93,9 +99,9 @@ if n > 0 {
 rc := vtableCall(t.devIface, deviceDeviceRequest, uintptr(unsafe.Pointer(&req)))
 ```
 
-The streaming model is the most distinctive part. Where Linux uses one reaper for
-the whole URB ring, macOS spawns **one goroutine per ring slot, each pinned to its
-own OS thread**, doing a *synchronous* `ReadPipe` in a loop. Cancellation is
+**The streaming model is the most distinctive part. Where Linux uses one reaper for
+the whole URB ring, macOS spawns one goroutine per ring slot, each pinned to its
+own OS thread, doing a *synchronous* `ReadPipe` in a loop.** Cancellation is
 `AbortPipe`: every blocked `ReadPipe` returns `kIOReturnAborted`, the goroutines
 see the stop flag, and exit. This sidesteps CFRunLoop callbacks entirely — no
 C-to-Go callback marshalling, no run-loop thread to babysit — at the cost of
@@ -246,8 +252,8 @@ the rest of the program. On macOS it's load-bearing for *correctness*.)
 ## The design principle: adapters that hide platform threading rules
 
 This is the **adapter pattern** doing exactly what it's for: isolating
-platform-specific rules behind a shared contract. The most important thing each
-adapter hides isn't the API surface — it's the **threading and I/O model**. Linux
+platform-specific rules behind a shared contract. **The most important thing each
+adapter hides isn't the API surface — it's the threading and I/O model.** Linux
 hides "async URBs reaped in one goroutine." Windows hides "overlapped I/O drained
 by `WaitForMultipleObjects`." macOS hides "IOKit owns the calling thread, so we
 pin one thread per slot." None of that crosses the port.

--- a/docs/_posts/2026-06-23-rf-front-end-06-usb-on-macos-windows.md
+++ b/docs/_posts/2026-06-23-rf-front-end-06-usb-on-macos-windows.md
@@ -1,0 +1,308 @@
+---
+title: "RF Front End, Part 6: USB on macOS & Windows"
+description: How GopherTrunk reaches the same Transport contract through macOS IOKit (via purego, with OS-thread-pinned reader goroutines) and Windows WinUSB (with overlapped I/O), and why macOS forced us to own the calling thread.
+category: deep-dives
+tags: [sdr, go, usb, cross-platform, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 6
+---
+
+*Part 6 of **RF Front End**. We finish the USB adapters: macOS through IOKit
+loaded by purego with no CGO, Windows through WinUSB with overlapped I/O. Three
+operating systems, three completely different threading and I/O models — all
+folded back onto the one eight-method `Transport` contract from Part 4.*
+
+## In this post
+
+- The **macOS** backend: IOKit + CoreFoundation via **purego** (no CGO), a lazy
+  `sync.Once` framework load, and **one OS-thread-pinned goroutine per slot**.
+- The **Windows** backend: lazily-loaded **WinUSB** function pointers and
+  **overlapped (async) I/O** drained with `WaitForMultipleObjects`.
+- How both reach the **same `Transport`** that Linux does — and where they
+  diverge under the hood.
+- The problem of **macOS IOKit owning the calling thread**, and how
+  `runtime.LockOSThread` fixed the aborts it caused.
+
+## What these two backends do
+
+Both are *adapters* for the `Transport` port from
+[Part 4]({{ '/blog/deep-dives/rf-front-end-04-usb-without-libusb/' | relative_url }}):
+same `ControlIn`/`ControlOut`, same `ClaimInterface`, same
+`StartBulkIn`/`StopBulkIn` callbacks. The RTL2832U driver above them can't tell
+which one it's talking to. Underneath, they could hardly be more different from
+Linux's USBDEVFS, or from each other.
+
+macOS has no usbfs. You reach USB through **IOKit** (the device-driver registry
+and the `IOUSBDeviceInterface`/`IOUSBInterfaceInterface` C++ vtables) and
+**CoreFoundation** (for the dictionaries and strings IOKit speaks in). Windows has
+no usbfs either; you bind your device to the in-box **WinUSB** function driver
+(via Zadig, typically) and call into `winusb.dll`, with device enumeration coming
+from `setupapi.dll`. Both are normally consumed from C. GopherTrunk consumes them
+from pure Go — purego on macOS, lazy DLL procs on Windows — to keep the
+CGO-free, single-static-binary promise intact on every OS.
+
+## How GopherTrunk implements it in Go
+
+### macOS: IOKit through purego
+
+There is no C compiler in the loop. The IOKit and CoreFoundation symbols are
+resolved at runtime through **purego**, and the load is deliberately **lazy**: a
+`sync.Once` runs `loadIOKit()` the first time anyone asks for the enumerator, so a
+framework-resolution glitch surfaces as an error from `List`/`Open` instead of
+crashing the test binary at startup.
+
+```go
+// internal/sdr/rtlsdr/usb/usb_darwin.go
+var (
+    darwinLoadOnce sync.Once
+    darwinLoadErr  error
+)
+
+func platformEnumerator() Enumerator {
+    darwinLoadOnce.Do(func() {
+        darwinLoadErr = loadIOKit()
+    })
+    if darwinLoadErr != nil {
+        return loadFailedEnumerator{err: darwinLoadErr}
+    }
+    return &darwinEnumerator{}
+}
+```
+
+Enumeration queries IOKit's USB-device service registry and reads VID/PID/serial as
+IORegistry properties — no device is opened during `List`. `Open` runs the standard
+IOCFPlugIn dance to get an `IOUSBDeviceInterface`, opens the device, walks its
+interface iterator, and claims interface 0 (the only one the RTL2832U exposes).
+Control transfers go through `IOUSBDeviceInterface::DeviceRequest` with a struct
+that mirrors the USB 2.0 setup packet:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_darwin.go
+req := iousbDevRequest{
+    BmRequestType: VendorIn,
+    BRequest:      bRequest,
+    WValue:        wValue,
+    WIndex:        wIndex,
+    WLength:       uint16(n),
+}
+if n > 0 {
+    req.PData = unsafe.Pointer(&buf[0])
+}
+rc := vtableCall(t.devIface, deviceDeviceRequest, uintptr(unsafe.Pointer(&req)))
+```
+
+The streaming model is the most distinctive part. Where Linux uses one reaper for
+the whole URB ring, macOS spawns **one goroutine per ring slot, each pinned to its
+own OS thread**, doing a *synchronous* `ReadPipe` in a loop. Cancellation is
+`AbortPipe`: every blocked `ReadPipe` returns `kIOReturnAborted`, the goroutines
+see the stop flag, and exit. This sidesteps CFRunLoop callbacks entirely — no
+C-to-Go callback marshalling, no run-loop thread to babysit — at the cost of
+`ringBufs` OS threads (32 by default).
+
+```go
+// internal/sdr/rtlsdr/usb/usb_darwin.go
+func (t *darwinTransport) bulkLoop(pipeRef uint8, slot *darwinBulkSlot, onPacket func([]byte)) {
+    runtime.LockOSThread()
+    defer runtime.UnlockOSThread()
+    // ...
+    for {
+        if t.bulkStopFlag.Load() != 0 {
+            return
+        }
+        size := uint32(len(slot.buf))
+        rc := vtableCall(t.ifaceIface, ifaceReadPipe,
+            uintptr(pipeRef),
+            uintptr(unsafe.Pointer(&slot.buf[0])),
+            uintptr(unsafe.Pointer(&size)),
+        )
+        if t.bulkStopFlag.Load() != 0 {
+            return
+        }
+        if rc != kIOReturnSuccess {
+            t.recordBulkErr(fmt.Errorf("usb: ReadPipe: 0x%08x", uint32(rc)))
+            return
+        }
+        if size > 0 {
+            onPacket(slot.buf[:size])
+        }
+    }
+}
+```
+
+### Windows: WinUSB and overlapped I/O
+
+The Windows backend lazily loads its entry points so the package still imports
+cleanly on Wine or older installs missing the DLLs — the failure becomes a runtime
+error from the first proc call, not a load-time panic:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_windows.go
+var (
+    modWinUSB = windows.NewLazySystemDLL("winusb.dll")
+
+    procWinUsbControlTransfer     = modWinUSB.NewProc("WinUsb_ControlTransfer")
+    procWinUsbReadPipe            = modWinUSB.NewProc("WinUsb_ReadPipe")
+    procWinUsbAbortPipe           = modWinUSB.NewProc("WinUsb_AbortPipe")
+    procWinUsbGetOverlappedResult = modWinUSB.NewProc("WinUsb_GetOverlappedResult")
+    // ...
+)
+```
+
+`Open` opens the device-interface path with `FILE_FLAG_OVERLAPPED` so every pipe
+operation is asynchronous, then calls `WinUsb_Initialize` — which *also* claims
+interface 0, so `ClaimInterface` on Windows is a no-op. Streaming arms a ring of
+reads, each with its own auto-reset event in an `OVERLAPPED`, and the reaper waits
+on all of them at once:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_windows.go
+ret, err := windows.WaitForMultipleObjects(wait, false, windows.INFINITE)
+// ...
+slot := t.bulkSlots[slotIdx]
+var transferred uint32
+result, _, _ := procWinUsbGetOverlappedResult.Call(
+    t.ifaceHandle,
+    uintptr(unsafe.Pointer(&slot.overlapped)),
+    uintptr(unsafe.Pointer(&transferred)),
+    0, // bWait = FALSE
+)
+// ...
+if result != 0 && transferred > 0 {
+    onPacket(slot.buf[:transferred])
+}
+if err := t.issueReadPipe(t.bulkEpAddr, slot); err != nil {
+    // slot is dead; mark consumed
+    consumed[slotIdx] = true
+}
+```
+
+`StopBulkIn` calls `WinUsb_AbortPipe`, which completes every pending read with
+`ERROR_OPERATION_ABORTED`; each event signals once, the reaper drains them and
+exits on `<-done`. (`ringBufs` is capped at 64 because `WaitForMultipleObjects`
+can't wait on more than `MAXIMUM_WAIT_OBJECTS`.)
+
+### Three OSes, one contract
+
+It's worth lining them up against the single `Transport` from Part 4:
+
+| | Linux | macOS | Windows |
+|---|---|---|---|
+| Access path | USBDEVFS ioctls | IOKit vtables (purego) | WinUSB procs |
+| Enumerate | walk sysfs | IOKit registry | SetupAPI |
+| Claim iface | ioctl + auto-detach DVB driver | IOCFPlugIn dance | no-op (init claimed) |
+| Bulk-IN | async URB ring | sync `ReadPipe` per slot | overlapped `ReadPipe` ring |
+| Reaper | **1** goroutine | **N** pinned goroutines | 1 goroutine + N events |
+| Cancel | `DISCARDURB` | `AbortPipe` | `AbortPipe` |
+
+Three radically different I/O models, and the driver above sees `(shape)` the same
+eight methods regardless. That table *is* the payoff of drawing the port by what
+the device needs rather than what any one OS offers.
+
+## The problem we hit: IOKit demands you own the thread
+
+**The symptom.** The very first macOS streaming build didn't return errors — it
+*crashed*. Under load the process would abort with low-level IOKit / Mach
+complaints, sometimes a `kIOReturnAborted` storm, sometimes a hard abort deep
+inside the IOUSB user client. It was intermittent, worse the more buffers we ran,
+and it never reproduced on Linux or Windows with the identical driver on top.
+
+**The root cause.** IOKit's user-client interfaces are **not goroutine-portable**.
+The `IOUSBInterfaceInterface` ties its I/O state to the OS thread that issues the
+calls, and the Go scheduler, by default, freely migrates a goroutine across OS
+threads — and parks it on one thread while running other goroutines on it in
+between. So a `ReadPipe` could be issued from thread A, then its continuation
+resumed on thread B, while thread A was simultaneously driving an *unrelated*
+goroutine into the same user client. IOKit saw concurrent, thread-crossing access
+to state it assumed was single-threaded and owned, and it did what a C API does
+when its invariants are violated: it aborted the process.
+
+**The Go fix.** Pin each reader to its own OS thread for that thread's entire life.
+Every per-slot reader calls `runtime.LockOSThread` on entry and `UnlockOSThread`
+only on exit, so the goroutine and its OS thread are welded together for as long as
+it's doing IOKit I/O:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_darwin.go
+func (t *darwinTransport) bulkLoop(pipeRef uint8, slot *darwinBulkSlot, onPacket func([]byte)) {
+    runtime.LockOSThread()
+    defer runtime.UnlockOSThread()
+    // ...synchronous ReadPipe loop, AbortPipe cancellation...
+}
+```
+
+With the lock in place, a slot's `ReadPipe` calls always issue from *one* thread
+that does *nothing else*, which is exactly the ownership model IOKit expects. The
+aborts vanished. This is also why the macOS design uses **one OS thread per slot**
+in the first place: pinning makes the synchronous-`ReadPipe`-per-thread model the
+*natural* one, and lets us skip CFRunLoop callbacks entirely. The threading rule
+isn't an implementation detail we tolerated — it dictated the whole bulk-IN shape.
+
+(The same `runtime.LockOSThread` shows up in the Linux and Windows reapers too, but
+for a milder reason: keeping a long-blocking syscall loop off the threads serving
+the rest of the program. On macOS it's load-bearing for *correctness*.)
+
+## The design principle: adapters that hide platform threading rules
+
+This is the **adapter pattern** doing exactly what it's for: isolating
+platform-specific rules behind a shared contract. The most important thing each
+adapter hides isn't the API surface — it's the **threading and I/O model**. Linux
+hides "async URBs reaped in one goroutine." Windows hides "overlapped I/O drained
+by `WaitForMultipleObjects`." macOS hides "IOKit owns the calling thread, so we
+pin one thread per slot." None of that crosses the port.
+
+### How that principle shaped the Go code
+
+- **Each adapter owns its concurrency model.** The driver requests a stream with
+  geometry and two callbacks; whether that becomes 1 goroutine, N pinned
+  goroutines, or 1 goroutine plus N events is entirely the adapter's business and
+  never leaks upward.
+- **Platform threading rules stay platform-local.** `runtime.LockOSThread` for
+  IOKit ownership lives inside `bulkLoop` in `usb_darwin.go`. The RTL2832U driver
+  has no idea macOS has a thread-affinity rule, and shouldn't.
+- **Loading is lazy and failure is an error, not a panic.** macOS defers
+  `loadIOKit` behind `sync.Once`; Windows defers DLL resolution to first use. A
+  missing framework or DLL surfaces as a returned error from the same `List`/`Open`
+  methods on every OS, keeping the port total.
+- **Errors converge on the shared sentinels.** macOS `translateIOReturn` and
+  Windows `winErr` both fold platform codes into `ErrDeviceGone`, `ErrTimeout`,
+  `ErrPipeStalled`. Callers `errors.Is` against portable values and never branch on
+  GOOS.
+
+## Where this goes next
+
+All three USB adapters are now standing, each satisfying the identical `Transport`
+contract. The plumbing is done — we can do vendor control transfers and stream
+bulk IQ on Linux, macOS, and Windows without a line of CGO. **Part 7** climbs one
+layer up and starts using it for real: bringing up the **RTL2832U** demodulator
+itself — the register dance, the EEPROM read, the bring-up retry envelope — all
+written against the port, so it runs unchanged on every backend we just built.
+
+## FAQ
+
+**Why one OS thread per slot on macOS instead of one reaper like Linux?**
+Because IOKit ties USB I/O state to the issuing OS thread. Pinning one thread per
+slot makes synchronous `ReadPipe` the natural model and avoids both CFRunLoop
+callback marshalling and the cross-thread access that crashed early builds. The
+cost is ~32 OS threads, acceptable for a foreground SDR daemon.
+
+**Why is `ClaimInterface` a no-op on Windows?**
+`WinUsb_Initialize` already grants exclusive access to interface 0 when the device
+is opened, so there's nothing left to claim. The method still rejects `num != 0`
+so a caller asking for a second interface gets an explicit error rather than a
+silent success.
+
+**How is any of this tested without a Mac or a Windows box in CI?**
+The same way the rest of the driver is: `MockTransport` from Part 4 satisfies the
+port, so the RTL2832U and tuner logic above run identically on a headless Linux
+runner. The platform-specific files compile under cross-compilation
+(`GOOS=darwin`/`windows CGO_ENABLED=0`), and the macOS backend's hardware
+validation is tracked as a follow-up against real dongles.
+
+## Series navigation
+
+**Part 6 of 14** · ←
+[Part 5]({{ '/blog/deep-dives/rf-front-end-05-usb-on-linux-usbdevfs/' | relative_url }})
+· Next →
+[Part 7: RTL-SDR I — bringing up the RTL2832U]({{ '/blog/deep-dives/rf-front-end-07-rtlsdr-rtl2832u-bringup/' | relative_url }})

--- a/docs/_posts/2026-06-24-rf-front-end-07-rtlsdr-rtl2832u-bringup.md
+++ b/docs/_posts/2026-06-24-rf-front-end-07-rtlsdr-rtl2832u-bringup.md
@@ -16,6 +16,12 @@ demodulator, and bringing it up means reproducing a register sequence where the
 *order* is load-bearing — get it wrong and the chip comes up half-initialized
 and deaf.*
 
+> **TL;DR** — The RTL2832U is a DVB-T demodulator pressed into service as a raw
+> ADC, brought up in pure Go via USB control transfers. The headline trap: its
+> init is an order-sensitive state machine, so any reordered, missing, or
+> uncommitted write leaves the chip present but deaf. The fix is to reproduce
+> librtlsdr's sequence byte-for-byte and pin it with golden tests.
+
 ## In this post
 
 - **What the RTL2832U is** — a DVB-T demodulator repurposed as a raw ADC, and the
@@ -102,8 +108,8 @@ func (d *Demod) writeDemodRegLocked(page uint8, addr, val uint16, n int) error {
 }
 ```
 
-That dummy read of page `0x0A`, register `0x01` is not optional. Without it the
-chip does not latch the previous write — the value you think you set never lands.
+**That dummy read of page `0x0A`, register `0x01` is not optional. Without it the
+chip does not latch the previous write — the value you think you set never lands.**
 This is the kind of detail you cannot derive from a datasheet; it lives in the C
 library because someone discovered it on real silicon, and we keep it bit for
 bit. Every `Demod` access also runs under a single mutex, because the tuner

--- a/docs/_posts/2026-06-24-rf-front-end-07-rtlsdr-rtl2832u-bringup.md
+++ b/docs/_posts/2026-06-24-rf-front-end-07-rtlsdr-rtl2832u-bringup.md
@@ -1,0 +1,361 @@
+---
+title: "RF Front End, Part 7: RTL-SDR I — Bringing Up the RTL2832U"
+description: How GopherTrunk brings up the RTL2832U demodulator in pure Go — the order-sensitive init sequence captured verbatim from librtlsdr, the I2C bridge to the tuner, GPIO and bias-tee, and the USB register transport underneath it all.
+category: deep-dives
+tags: [sdr, go, rtl-sdr, rtl2832u, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 7
+---
+
+*Part 7 of **RF Front End**. We've spent the last three posts building a pure-Go
+USB transport. Now we use it: the first chip a sample passes through on its way
+out of an [RTL-SDR]({{ '/reference/rtl-sdr/' | relative_url }}) is the RTL2832U
+demodulator, and bringing it up means reproducing a register sequence where the
+*order* is load-bearing — get it wrong and the chip comes up half-initialized
+and deaf.*
+
+## In this post
+
+- **What the RTL2832U is** — a DVB-T demodulator repurposed as a raw ADC, and the
+  four jobs the bring-up layer has to do to it.
+- **The init sequence** — `InitBaseband()` and the exact, order-sensitive
+  register flood captured from librtlsdr, where the FIR upload sits *between* the
+  demod reset and SDR-mode enable.
+- **The I2C bridge, GPIO, and the USB register transport** that the tuner driver
+  (Part 8) and the streaming layer (Part 9) build on.
+- **The problem we hit:** reproducing that sequence faithfully — any reordering
+  or missing write leaves the chip silent — and how we captured and verified it.
+
+## What the RTL2832U does
+
+The RTL2832U was designed to demodulate DVB-T television. The SDR community
+discovered it has a debug mode that dumps the raw 8-bit IQ stream straight off
+its ADC over USB — bypassing the television demodulator entirely. That's the
+mode GopherTrunk uses: the RTL2832U becomes a 28.8 MHz-clocked ADC with a USB
+FIFO bolted on, and *all* the actual tuning happens in a separate tuner chip
+(the R820T/R828D, covered in
+[Part 8]({{ '/blog/deep-dives/rf-front-end-08-rtlsdr-r82xx-blog-v4/' | relative_url }}))
+that the RTL2832U only talks to as an I2C master.
+
+So the bring-up layer has four distinct jobs, and they map cleanly onto four
+files in `internal/sdr/rtlsdr/rtl2832u`:
+
+- **Register transport** (`transport.go`, `regs.go`) — turn "write register X in
+  block Y" into the right USB control transfer, byte-for-byte what librtlsdr
+  sends.
+- **Baseband init** (`demod.go`) — the one-time flood of register writes that
+  switches the chip out of DVB-T mode and into raw-IQ-over-USB mode.
+- **The I2C bridge** (`i2c.go`) — so the tuner driver can reach its chip through
+  the same USB control endpoint.
+- **GPIO** (`gpio.go`) — bias-tee power, tuner reset pulses, and the V4's input
+  switching.
+
+This post is the bring-up; the tuner that rides on top of the I2C bridge is
+Part 8, and sustained streaming through the USB FIFO is Part 9.
+
+## How GopherTrunk implements it in Go
+
+### The register transport
+
+Everything starts at the control transfer. The RTL2832U exposes seven
+memory-mapped "blocks" (USB controller, system registers, the I2C bridge, …),
+and a separate page-addressed *demod* register space. `regs.go` names the blocks
+and addresses; `transport.go` turns a logical access into the exact vendor
+control transfer librtlsdr would send:
+
+```go
+// internal/sdr/rtlsdr/rtl2832u/transport.go
+func (d *Demod) writeBlockRegLocked(block uint8, addr, val uint16, n int) error {
+    index := uint16(block)<<8 | 0x10
+    data := encodeWriteVal(val, n)
+    if err := d.t.ControlOut(0, addr, index, data, CtrlTimeoutMs); err != nil {
+        return fmt.Errorf("rtl2832u: write block=%d addr=0x%04x val=0x%04x: %w", block, addr, val, err)
+    }
+    return nil
+}
+```
+
+The encoding is fussy and we copy it exactly: 1-byte writes send `val & 0xff`;
+2-byte writes send **big-endian** (high byte first); reads come back
+little-endian. `encodeWriteVal` panics on anything but `n ∈ {1, 2}` because the
+package never has cause to issue any other width — a programmer error, not a
+runtime one.
+
+The demod register space has its own wrinkle that turns out to matter a great
+deal. Every demod write must be followed by a "commit" read:
+
+```go
+// internal/sdr/rtlsdr/rtl2832u/transport.go
+func (d *Demod) writeDemodRegLocked(page uint8, addr, val uint16, n int) error {
+    wValue := (addr << 8) | 0x20
+    wIndex := uint16(0x10) | uint16(page)
+    data := encodeWriteVal(val, n)
+    if err := d.t.ControlOut(0, wValue, wIndex, data, CtrlTimeoutMs); err != nil {
+        return fmt.Errorf("rtl2832u: write demod page=%d addr=0x%02x val=0x%04x: %w", page, addr, val, err)
+    }
+    // Commit. Required by the RTL2832U register interface — without it
+    // the demod write doesn't take effect. Errors here are non-fatal.
+    _, _ = d.readDemodRegLocked(0x0A, 0x01, 1)
+    return nil
+}
+```
+
+That dummy read of page `0x0A`, register `0x01` is not optional. Without it the
+chip does not latch the previous write — the value you think you set never lands.
+This is the kind of detail you cannot derive from a datasheet; it lives in the C
+library because someone discovered it on real silicon, and we keep it bit for
+bit. Every `Demod` access also runs under a single mutex, because the tuner
+driver, the bias-tee toggler, and the streaming setup can all issue control
+transfers concurrently and they must interleave cleanly on the one USB wire.
+
+### The init sequence
+
+The actual bring-up is `InitBaseband()`. It walks a fixed table of register
+writes — `initBasebandSteps` — captured verbatim from librtlsdr's
+`rtlsdr_init_baseband`. A flavor of it:
+
+```go
+// internal/sdr/rtlsdr/rtl2832u/demod.go
+var initBasebandSteps = []initBasebandStep{
+    // USB init
+    {block: BlockUSB, addr: USBSysctl, val: 0x09, n: 1},
+    {block: BlockUSB, addr: USBEpaMaxpkt, val: 0x0002, n: 2},
+    {block: BlockUSB, addr: USBEpaCtl, val: 0x1002, n: 2},
+    // Power on demod
+    {block: BlockSys, addr: SysDemodCtl1, val: 0x22, n: 1},
+    {block: BlockSys, addr: SysDemodCtl, val: 0xE8, n: 1},
+    // Demod soft-reset (bit 3) + release
+    {demod: true, page: 1, addr: 0x01, val: 0x14, n: 1},
+    {demod: true, page: 1, addr: 0x01, val: 0x10, n: 1},
+    // ...disable spectrum inversion, clear DDC/IF registers...
+    // (FIR upload happens here, between reset and SDR-mode enable)
+    // SDR mode, DAGC off (bit 5)
+    {demod: true, page: 0, addr: 0x19, val: 0x05, n: 1},
+    // ...FSM hold registers, disable AGC loops, PID filter, etc...
+    // Zero-IF mode + DC cancellation + IQ estimation/compensation
+    {demod: true, page: 1, addr: 0xB1, val: 0x1B, n: 1},
+    // Disable 4.096 MHz clock output on TP_CK0
+    {demod: true, page: 0, addr: 0x0D, val: 0x83, n: 1},
+}
+```
+
+The structure is the point. `InitBaseband` runs the first fifteen steps, then
+uploads the FIR coefficients, then runs the rest:
+
+```go
+// internal/sdr/rtlsdr/rtl2832u/demod.go
+func (d *Demod) InitBaseband() error {
+    d.mu.Lock()
+    defer d.mu.Unlock()
+    // Steps before the FIR upload.
+    for i := 0; i < 15; i++ {
+        if err := d.runInitStep(initBasebandSteps[i]); err != nil {
+            return fmt.Errorf("init baseband step %d: %w", i, err)
+        }
+    }
+    // Default FIR (20 single-byte writes at page 1, addr 0x1C..0x2F).
+    if err := d.setFIRLocked(firDefault); err != nil {
+        return fmt.Errorf("init baseband: FIR upload: %w", err)
+    }
+    for i := 15; i < len(initBasebandSteps); i++ {
+        if err := d.runInitStep(initBasebandSteps[i]); err != nil {
+            return fmt.Errorf("init baseband step %d: %w", i, err)
+        }
+    }
+    return nil
+}
+```
+
+The FIR upload sits *inside* the sequence — after the demod soft-reset (bit 3)
+and the DDC/IF-register clear, but before SDR mode is enabled and zero-IF gets
+turned on. That placement is what the table's comment means by "order is
+load-bearing." The 20-tap FIR filter itself is the DAB/FM-tuned coefficient set
+librtlsdr ships, packed with a fiddly layout — the first 8 taps are 8-bit signed
+(one byte each), and taps 8–15 are 12-bit signed and pack three nibbles per pair
+into 12 bytes:
+
+```go
+// internal/sdr/rtlsdr/rtl2832u/demod.go (shape)
+for i := 0; i < 4; i++ {
+    v0 := coeffs[8+i*2]
+    v1 := coeffs[8+i*2+1]
+    fir[8+i*3]   = byte(v0 >> 4)
+    fir[8+i*3+1] = byte((v0 << 4) | ((v1 >> 8) & 0x0F))
+    fir[8+i*3+2] = byte(v1)
+}
+```
+
+### The I2C bridge
+
+Once the baseband is up, the only way to reach the tuner is through the
+RTL2832U's I2C bridge. `i2c.go` exposes it as a handful of methods. The bridge
+has to be explicitly opened and closed around each tuner burst — librtlsdr
+toggles a "repeater" bit so the demod doesn't compete with the tuner for the
+bus:
+
+```go
+// internal/sdr/rtlsdr/rtl2832u/i2c.go
+func (d *Demod) SetI2CRepeater(on bool) error {
+    d.mu.Lock()
+    defer d.mu.Unlock()
+    if d.repON == on {
+        return nil
+    }
+    val := uint16(0x10)
+    if on {
+        val = 0x18
+    }
+    if err := d.writeDemodRegLocked(1, 0x01, val, 1); err != nil {
+        return fmt.Errorf("rtl2832u: SetI2CRepeater(%v): %w", on, err)
+    }
+    d.repON = on
+    return nil
+}
+```
+
+That cached `repON` looks like a harmless optimization — and it's free when the
+value is unchanged — but it bites us hard on one specific dongle in Part 8, where
+a *fresh* wire write of the repeater bit turns out to be load-bearing even when
+the register already holds the on-value. The tuner driver issues bulk
+`I2CWrite`/`I2CRead` calls through this bridge; we'll lean on them heavily next
+post.
+
+### GPIO and bias-tee
+
+The last piece is GPIO. The RTL2832U has eight general-purpose pins in its system
+block, and dongles wire the 5 V bias-tee LNA power to one of them (pin 0 on the
+RTL-SDR.com v3+, pin 4 on some NESDR revisions). Driving a pin is a
+read-modify-write on the direction and output-enable registers:
+
+```go
+// internal/sdr/rtlsdr/rtl2832u/gpio.go
+func (d *Demod) SetBiasTee(gpio uint8, on bool) error {
+    if err := d.SetGPIOOutput(gpio); err != nil {
+        return fmt.Errorf("rtl2832u: SetBiasTee: configure output: %w", err)
+    }
+    return d.SetGPIOBit(gpio, on)
+}
+```
+
+The same GPIO machinery does double duty: tuner detection (Part 8) pulses GPIO5
+and GPIO4 to reset and power-enable the non-R820T tuners, and the Blog V4 drives
+its upconverter relay off GPIO5. GPIO writes target the system block, not the
+demod's bridge register, so they never disturb the I2C-repeater state — a
+property the detection code relies on.
+
+## The problem we hit: a half-initialized, deaf chip
+
+**The symptom.** Early in the pure-Go rewrite, the dongle would open, claim its
+interface, accept every register write without error — and then stream pure
+noise. No tuner lock, no signal, no error returned anywhere. The chip was
+*present* but *deaf*.
+
+**The root cause.** The init sequence is not a set of independent register
+writes. It is a state machine being walked through a specific path, and the
+RTL2832U latches intermediate state at several points. Three classes of mistake
+all produce the same silent-noise symptom:
+
+- **A missing commit read.** Drop the dummy `readDemodRegLocked(0x0A, 0x01, 1)`
+  after a demod write and that write silently never takes effect — including the
+  zero-IF and IQ-compensation writes that the whole SDR mode depends on.
+- **A reordered FIR upload.** Move the FIR write before the soft-reset, or after
+  SDR mode is already enabled, and the filter loads into the wrong chip state.
+- **A skipped USB-block write.** Omit one of the leading `BlockUSB` EP-config
+  writes and the bulk-IN FIFO never gets sized correctly; the stream comes up but
+  the framing is wrong.
+
+None of these throw. That's what made it brutal: the failure surfaces three
+layers downstream as "decoder sees noise," with nothing in between to point at
+the cause.
+
+**The fix.** We stopped treating the sequence as something to be *understood* and
+started treating it as something to be *reproduced exactly*. The constants were
+captured verbatim from librtlsdr's `rtlsdr_init_baseband` into the
+`initBasebandSteps` table, with the order — including the FIR split — preserved
+as code structure rather than prose. Then we pinned it: the `initBasebandStep`
+struct exists specifically so a unit test can replay the entire sequence against
+a mock USB transport and assert that the bytes leaving a `Demod` are
+**byte-identical** to a real-hardware capture from the C library. The package
+doc says it outright — "every control transfer that leaves a `Demod` matches what
+the C library would have sent under the same call," confirmed by golden tests.
+
+There's even a deliberate redundancy that came out of this. `WarmupUSBSysctl`
+issues a single sacrificial USB write whose wire bytes are identical to
+`initBasebandSteps[0]`, purely to absorb the first-control-transfer NAK some
+clone dongles emit right after the interface is claimed. The caller swallows any
+error it returns and proceeds straight to `InitBaseband`, exactly as librtlsdr
+does — and because step 0 is byte-identical, a genuine stall re-surfaces on the
+real init where the open-path reset+retry envelope can act on it.
+
+## The design principle: faithful protocol reproduction
+
+The RTL2832U bring-up is the cleanest example in the codebase of a principle we
+reach for whenever we're talking to an opaque chip ABI: **when you don't fully
+understand a protocol but you have a known-good implementation, reproduce it
+faithfully and verify against it — don't improvise.**
+
+librtlsdr is the de facto reference for the RTL2832U. It encodes years of
+accumulated knowledge about this chip's undocumented behavior: the commit read,
+the FIR placement, the dummy warmup write. We don't have a datasheet that
+explains *why* the order matters. What we have is a C implementation that works
+on millions of dongles. The correct engineering move is not to reverse-engineer
+the silicon — it's to port the known-good sequence exactly and pin it with tests.
+
+### How that principle shaped the Go code
+
+- **The init sequence is data, not prose.** `initBasebandSteps` is a literal
+  table, and `InitBaseband` is a small interpreter over it. The order lives in
+  the data structure where it can't drift, and the FIR split is an explicit index
+  boundary, not a comment someone might "clean up."
+- **The wire format is encapsulated and panic-guarded.** `encodeWriteVal` and the
+  `writeBlockReg`/`writeDemodReg` pair are the *only* place control-transfer
+  encoding lives. The big-endian-write / little-endian-read asymmetry and the
+  commit read are written once and reused everywhere.
+- **Golden tests are the contract.** The package's job is "be byte-identical to
+  librtlsdr," so the tests assert exactly that against the mock transport. A
+  regression shows up as a diff in the captured byte stream, not as a mysterious
+  deaf dongle in the field.
+- **Quirks are documented at the point of reproduction.** Every load-bearing
+  oddity — the commit read, the warmup write, the repeater cache — carries a
+  comment explaining *that* it matters and *why* librtlsdr does it, so the next
+  person doesn't "simplify" it away.
+
+## Where this goes next
+
+The RTL2832U is now in raw-IQ mode with its I2C bridge open for business — but it
+can't tune anything. That job belongs to the tuner chip hanging off the bridge.
+[Part 8]({{ '/blog/deep-dives/rf-front-end-08-rtlsdr-r82xx-blog-v4/' | relative_url }})
+brings up the R820T/R828D ([R820T]({{ '/reference/r820t-tuner/' | relative_url }})),
+walks its PLL math and shadow-register cache, and tells the headline RTL-SDR
+story: why the RTL-SDR Blog V4 came up *deaf* and what the manual override and
+per-band input switching had to do to fix it.
+
+## FAQ
+
+**Why is the RTL2832U called a "demodulator" if we use it as an ADC?**
+Because that's what it was built for — DVB-T television demodulation. The SDR use
+case exploits a debug mode that streams the raw ADC output over USB before the
+television demodulator touches it. We disable the DVB-T path during
+`InitBaseband` (that's most of what the sequence does) and take the raw samples.
+
+**Why keep the FIR filter at all if it's "unused for SDR"?**
+The DVB-T variant of the filter is unused, but the DAB/FM-tuned coefficient set
+that librtlsdr ships is part of the known-good init state. We load it exactly as
+the C library does rather than risk leaving the demod's decimation path in an
+unexpected configuration.
+
+**Could the commit read just be a `librtlsdr` superstition?**
+We treat it as load-bearing because it is observably load-bearing on real
+hardware — the comment in `writeDemodRegLocked` is blunt about it: without the
+read, the demod write doesn't take effect. When a known-good implementation does
+something and removing it breaks real silicon, that's not superstition, that's
+the ABI.
+
+## Series navigation
+
+**Part 7 of 14** · ←
+[Part 6]({{ '/blog/deep-dives/rf-front-end-06-usb-on-macos-windows/' | relative_url }})
+· Next →
+[Part 8: RTL-SDR II — the R82xx tuner & the Blog V4 deafness]({{ '/blog/deep-dives/rf-front-end-08-rtlsdr-r82xx-blog-v4/' | relative_url }})

--- a/docs/_posts/2026-06-25-rf-front-end-08-rtlsdr-r82xx-blog-v4.md
+++ b/docs/_posts/2026-06-25-rf-front-end-08-rtlsdr-r82xx-blog-v4.md
@@ -1,0 +1,370 @@
+---
+title: "RF Front End, Part 8: RTL-SDR II — The R82xx Tuner & the Blog V4 Deafness"
+description: GopherTrunk's pure-Go R820T/R828D tuner driver — PLL tuning, a shadow-register cache that makes read-modify-write free, and tuner auto-detection. Plus the headline bug: why the RTL-SDR Blog V4 came up deaf and mistuned by 1.8×, and how a manual override plus per-band input switching fixed it.
+category: deep-dives
+tags: [sdr, go, rtl-sdr, r82xx, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 8
+---
+
+*Part 8 of **RF Front End**. The RTL2832U from
+[Part 7]({{ '/blog/deep-dives/rf-front-end-07-rtlsdr-rtl2832u-bringup/' | relative_url }})
+can't tune anything on its own — the actual frequency synthesis lives in a
+separate tuner chip on the I2C bridge. This post brings up the
+[R820T]({{ '/reference/r820t-tuner/' | relative_url }})/R828D, and tells the
+story of the bug that ate the most field debugging time in the whole RTL-SDR
+driver: the RTL-SDR Blog V4 that came up deaf.*
+
+## In this post
+
+- **What the R82xx tuner does** — PLL frequency synthesis, the 3.57 MHz IF, and
+  why the RTL2832U only ever sees an intermediate frequency.
+- **The shadow-register cache** — how mirroring the chip's writable registers in
+  Go makes read-modify-write free and papers over a real R820T quirk.
+- **Tuner auto-detection** — probing I2C addresses in librtlsdr's exact order.
+- **The problem we hit (issue #264):** the RTL-SDR Blog V4 mistunes by ~1.8× and
+  receives only noise, and the manual override + per-band input switching that
+  fixed it.
+- **A second bug (issue #248):** a multi-byte I2C burst stalls on NESDR v5
+  silicon, and the chunk-halving recovery that got it streaming.
+
+## What the R82xx tuner is
+
+The R820T, R820T2, and R828D (collectively the "R82xx" family) share one I2C
+register map and one PLL synthesizer. The tuner's job is to take an RF frequency
+from the antenna, mix it down to a fixed **3.57 MHz intermediate frequency**, and
+hand that to the RTL2832U's ADC. So when you ask GopherTrunk to tune 154 MHz, the
+tuner's PLL doesn't target 154 MHz — it targets 154 MHz + 3.57 MHz, and the
+RTL2832U is configured (back in `PrepareDemod`) to expect signal at that IF
+offset.
+
+The driver is a straight port of osmocom librtlsdr's `tuner_r82xx.c` — register
+addresses, the init flood, the PLL math, and the frequency-range mux table are
+all kept byte-identical so real-hardware captures replay-validate against the
+mock USB transport. The whole driver lives in
+`internal/sdr/rtlsdr/tuners/r82xx.go`.
+
+## How GopherTrunk implements it in Go
+
+### The shadow-register cache
+
+The single most important design decision in the R82xx driver is the
+shadow-register cache. The `R82xx` struct keeps a local mirror of the chip's
+registers:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+type R82xx struct {
+    demod    *rtl2832u.Demod
+    i2cAddr  uint8
+    chipType Type
+    xtalHz   uint32
+
+    // regs[0x05..0x1F] is the shadow for writable registers.
+    // regs[0x00..0x04] holds the most recently read read-only status bytes.
+    regs [r82xxNumRegs]byte
+    // ...
+}
+```
+
+This solves a concrete hardware problem: the R820T's writable registers **can't
+be read back** through the I2C bridge. Read-modify-write — "set these three bits,
+leave the rest" — is impossible if you can't read the current value. The shadow
+makes it trivial, and it has a free side benefit: the chip silently drops a write
+whose value matches the previous one, so eliding redundant writes saves a USB
+roundtrip without changing observable behavior. Every masked write goes through
+`writeRegMask`, which reads the shadow, applies the masked bits, and only touches
+the wire if the result actually changed:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+func (r *R82xx) writeRegMask(addr uint8, val, mask byte) error {
+    if addr < r82xxShadowStart {
+        return fmt.Errorf("r82xx writeRegMask: addr=0x%02x is read-only", addr)
+    }
+    cur := r.regs[addr]
+    next := (cur &^ mask) | (val & mask)
+    if cur == next {
+        return nil
+    }
+    r.regs[addr] = next
+    return r.writeBurstRaw(addr, []byte{next})
+}
+```
+
+### PLL tuning
+
+`setPLL` is a faithful port of `r82xx_set_pll`: it sweeps the mixer divider to
+land the VCO inside its valid range, computes an integer + sigma-delta fractional
+division, and compensates with a VCO fine-tune read back from the chip. The math
+is intricate but the load-bearing detail for this post is small — the divider
+sweep and the `nint`/`vcoFra` split off the reference crystal:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go (shape)
+vcoFreq := uint64(freqHz) * uint64(mixDiv)
+effXtal := r.effectiveXtalHz()
+pllRef := uint64(effXtal)
+nint := uint32(vcoFreq / (2 * pllRef))
+vcoFra := uint32((vcoFreq - 2*pllRef*uint64(nint)) / 1000)
+```
+
+Notice `effectiveXtalHz()`. *Every* PLL division is computed off the reference
+crystal. If the driver believes the crystal is 16 MHz when it's actually 28.8
+MHz, every tune is wrong by the ratio 28.8/16 = **1.8×**. Hold that thought.
+
+### Tuner auto-detection
+
+Before any of this runs, we have to figure out *which* tuner is on the board.
+`detect.go` probes candidate I2C addresses in librtlsdr's exact order, reading
+the chip-ID byte off each. For the R82xx family that's a 0x69 ID at address 0x34
+(R820T) or 0x74 (R828D):
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+func detectR82xx(d *rtl2832u.Demod) Tuner {
+    for _, c := range []struct {
+        addr uint8
+        typ  Type
+    }{
+        {addr: r82xxI2CAddr, typ: TypeR820T2},
+        {addr: r828dI2CAddr, typ: TypeR828D},
+    } {
+        out, err := d.I2CRead(c.addr, 1)
+        if err != nil || len(out) == 0 {
+            continue
+        }
+        id := r82xxBitReverse(out[0])
+        if id == 0x69 || id == 0x96 { // includes some bit-reversed clones
+            return NewR82xx(d, c.addr, c.typ)
+        }
+    }
+    return nil
+}
+```
+
+The whole detection runs under a single `SetI2CRepeater(true)/(false)` bracket so
+the bridge doesn't flap between candidates. That detail matters more than it
+looks — it sets up the second bug below.
+
+## The problem we hit: the RTL-SDR Blog V4 deafness (issue #264)
+
+**The symptom.** Plug in an RTL-SDR Blog V4 — a popular R828D-based dongle — and
+it would detect fine, claim its interface, accept every tune… and receive only
+noise. An R820T2 dongle on the exact same signal decoded cleanly. Worse, when it
+*did* seem to tune, frequencies were off by a factor of roughly 1.8.
+
+**The root cause — three of them, actually.** The V4 is an R828D, and our
+`NewR82xx` defaults every R828D to a 16 MHz crystal — which is correct for a
+generic R828D. But the Blog V4 runs its R828D from the RTL2832U's **28.8 MHz**
+reference crystal. There's the 1.8× mistune, straight out of the PLL math above:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+func NewR82xx(d *rtl2832u.Demod, i2cAddr uint8, chip Type) *R82xx {
+    xtal := r82xxXtalHz
+    if chip == TypeR828D {
+        xtal = r828dXtalHz // 16 MHz — wrong for the Blog V4
+    }
+    // ...
+}
+```
+
+But fixing the crystal alone still left it deaf, because the V4 has a switched
+front end: an HF/VHF/UHF input bank with an on-board upconverter for HF. The stock
+R828D init leaves every V4 input *off*, so even perfectly tuned, no RF reaches the
+mixer. And detection can't reliably tell a V4 from a generic R828D — the
+distinguishing signal is the USB iManufacturer/iProduct strings, which are
+sometimes blank or non-standard on real units.
+
+**The fix — three parts.** First, an explicit `SetBlogV4` that restores the right
+crystal and arms the V4 path:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+func (r *R82xx) SetBlogV4(lite bool) {
+    r.blogV4 = true
+    r.blogV4L = lite
+    r.xtalHz = r82xxXtalHz // 28.8 MHz, overriding the R828D 16 MHz default
+}
+```
+
+Detection keys off the USB strings, but because that misses some units, the
+driver also exposes a *manual* override all the way up at the `Device` level —
+`SetBlogV4` implements `sdr.BlogV4Forcer`, and the pool applies it from a config
+hint before the first tune. Autodetection when it can; explicit override when it
+can't.
+
+Second, per-band input switching. The V4 routes HF through an upconverter (so the
+R828D actually sees `hz + 28.8 MHz`), and switches a physical input bank per band.
+`SetFreq` adjusts the PLL target for HF and then drives the input switches:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+target := hz
+if r.blogV4 && hz <= r82xxV4HFCrossHz {
+    target = hz + r82xxXtalHz // HF reaches the mixer through the upconverter
+}
+// ...setMux(target), then:
+if r.blogV4 {
+    if err := r.applyBlogV4Band(hz); err != nil {
+        return fmt.Errorf("r82xx SetFreq: v4 band: %w", err)
+    }
+}
+```
+
+`applyBlogV4Band` drives the notch filter, the HF tracking-filter bypass, and the
+HF/VHF/UHF input relays — ported verbatim from the rtlsdr-blog fork's
+`r82xx_set_freq` V4 block. It caches the last-selected band in a `v4Band` enum so
+it only rewrites the input switches when the band actually changes:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+band := v4BandFor(hz, r.blogV4L)
+// HF: bypass tracking filter (re-applied every tune since setMux rewrites 0x1A/0x1B)
+if band == v4BandHF { /* ...writeRegMask(0x1A,...) ... */ }
+// Only rewrite the input switches on a band change.
+if band == r.v4Input {
+    return nil
+}
+r.v4Input = band
+// ...cable2 = HF input, GPIO5 upconverter relay, cable1 = VHF, air-in = UHF...
+```
+
+Third, the gain path. The V4 is a marginal-signal dongle, and there was a latent
+AGC-mode bug that compounded the deafness: in AGC mode librtlsdr pins the VGA at a
+fixed +16.3 dB, but `SetGain` is a no-op in AGC mode, so the VGA was being left at
+its init default — running the front end **~17 dB low**. `SetGainMode` now writes
+the VGA in the AGC branch:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+// AGC mode: pin the VGA at librtlsdr's fixed default (+16.3 dB).
+if !manual {
+    if err := r.writeRegMask(0x0C, 0x0B, 0x9F); err != nil {
+        return err
+    }
+}
+```
+
+There was even a fourth, subtler V4 issue tucked into the PLL: the rtlsdr-blog
+fork lowers the VCO power reference from 2 to 1 for the R828D, and without that
+the V4's LO mistunes and receives noise while an R820T2 on the same signal
+decodes cleanly. `vcoPowerRef()` returns 1 for `TypeR828D`. The V4 needed *every
+one* of these to receive — which is exactly why it was so painful to chase.
+
+To make the state visible, `TunerDiag`/`IsBlogV4`/`XtalHz` surface the effective
+crystal and whether the V4 path armed, so the pool can log a boot-time line: a 16
+MHz R828D means the V4 path did *not* arm and the LO is mistuned by 1.8×; 28.8 MHz
+means `SetBlogV4` ran.
+
+## The second problem: a 17-byte I2C burst that stalls (issue #248)
+
+**The symptom.** Two NESDR SMArt v5 units would fail tuner init with an `EPIPE`
+(Linux) / `ERROR_GEN_FAILURE` (Windows) on the very first multi-byte I2C burst —
+the 27-byte R82xx init flood. Detection succeeded; the burst write that follows it
+did not.
+
+**The root cause.** librtlsdr assumes the chip's I2C-bridge FIFO can swallow a
+16-byte write (`NMAX_WRITES = 16`). On that specific firmware revision the FIFO
+depth appears to be smaller, so the 17-byte first chunk (1 address byte + 16 data
+bytes) NACKs. An earlier fix added a per-chunk retry; it wasn't enough.
+
+**The fix.** `writeBurstRaw` halves the chunk size on a stall — 16 → 8 → 4 — until
+one size succeeds:
+
+```go
+// internal/sdr/rtlsdr/tuners/r82xx.go
+func (r *R82xx) writeBurstRaw(addr uint8, data []byte) error {
+    var lastErr error
+    for chunkSize := r82xxBurstMaxData; chunkSize >= r82xxBurstMinData; chunkSize /= 2 {
+        err := r.writeBurstAtSize(addr, data, chunkSize)
+        if err == nil {
+            return nil
+        }
+        if !isI2CBurstStall(err) {
+            return err
+        }
+        lastErr = err
+        if chunkSize > r82xxBurstMinData {
+            time.Sleep(r82xxBurstRetryDelayMillis * time.Millisecond)
+        }
+    }
+    return fmt.Errorf("tried chunk sizes 16,8,4; all stalled: %w", lastErr)
+}
+```
+
+Two details make this robust. The stall predicate has to be
+cross-platform — the same logical stall is a raw `syscall.EPIPE` on Linux and a
+mapped `usb.ErrPipeStalled` on Windows, so `isI2CBurstStall` checks both;
+checking only `EPIPE` meant the whole recovery silently never fired on Windows.
+And there's a detection-side dependency: `Detect` deliberately toggles the I2C
+repeater *off* before returning so that `Init`'s leading `SetI2CRepeater(true)` is
+a *fresh* wire write — that explicit "kick" is load-bearing on NESDR v5 to arm the
+bridge, even though the cache from Part 7 would otherwise elide it.
+
+## The design principle: defensive hardware-quirk handling
+
+Both bugs come from the same place: **real hardware deviates from the reference,
+and when it does, autodetection is not enough — you need explicit, observable
+overrides.**
+
+The Blog V4 looks like a generic R828D until it doesn't. The NESDR v5 looks like
+a standard RTL-SDR until its FIFO chokes on a standard-sized write. A driver that
+assumes every chip matches the datasheet — or even matches librtlsdr — comes up
+deaf on exactly the dongles people actually buy.
+
+### How that principle shaped the Go code
+
+- **Autodetect first, override explicitly.** USB-string detection arms the V4
+  path automatically when it can; `SetBlogV4` / `sdr.BlogV4Forcer` is the manual
+  escape hatch for units it misses. The default path stays correct for the common
+  case and the override is one config hint away.
+- **Quirk state is observable.** `IsBlogV4`, `XtalHz`, and `TunerDiag` exist so a
+  failed override shows up as a boot-time diagnostic ("16 MHz R828D → mistuned
+  1.8×") instead of a silent deaf dongle.
+- **Recovery degrades gracefully.** The burst write doesn't give up at the first
+  stall — it halves the chunk size and retries, so one firmware's small FIFO
+  costs a few extra round-trips instead of a hard failure. The stall predicate is
+  written cross-platform so the recovery fires on every OS.
+- **Quirk reproduction stays faithful underneath.** Every V4-specific write —
+  band switching, VGA pinning, the VCO power reference — is ported verbatim from
+  the rtlsdr-blog fork with a comment tying it to the source, so the override path
+  is just as byte-faithful as the default path.
+
+## Where this goes next
+
+The RTL2832U is initialized and the R82xx is tuned and locked. The only thing
+left is to actually *move samples* — to keep a 2.4 MS/s bulk-IN stream flowing
+without dropping IQ.
+[Part 9]({{ '/blog/deep-dives/rf-front-end-09-rtlsdr-streaming-gc-churn/' | relative_url }})
+takes apart the streaming layer and the GC-churn bug that was shedding a quarter
+of the control channel's live IQ.
+
+## FAQ
+
+**Why does the R828D default to 16 MHz if the V4 needs 28.8?**
+Because a *generic* R828D really does run from a separate 16 MHz crystal — that
+default is correct for the common case. The Blog V4 is the special case, and
+`SetBlogV4` is how we mark it. Defaulting to 28.8 would mistune every non-V4
+R828D instead.
+
+**Why not just always chunk I2C writes at 4 bytes to dodge issue #248?**
+Because that triples the round-trips for every tuner init on every dongle to work
+around one firmware revision. The halving fallback only pays the cost when a chunk
+actually stalls; healthy chips still write 16 bytes at a time.
+
+**Is the shadow cache ever wrong?**
+Only for the read-only status registers (0x00–0x04), which we refresh by reading
+the chip. The writable shadow (0x05–0x1F) is authoritative because those
+registers can't be read back anyway — the shadow *is* the source of truth, and
+`Init` primes it with the init-flood values before the first burst.
+
+## Series navigation
+
+**Part 8 of 14** · ←
+[Part 7]({{ '/blog/deep-dives/rf-front-end-07-rtlsdr-rtl2832u-bringup/' | relative_url }})
+· Next →
+[Part 9: RTL-SDR III — IQ streaming & the GC-churn bug]({{ '/blog/deep-dives/rf-front-end-09-rtlsdr-streaming-gc-churn/' | relative_url }})

--- a/docs/_posts/2026-06-25-rf-front-end-08-rtlsdr-r82xx-blog-v4.md
+++ b/docs/_posts/2026-06-25-rf-front-end-08-rtlsdr-r82xx-blog-v4.md
@@ -1,6 +1,6 @@
 ---
 title: "RF Front End, Part 8: RTL-SDR II — The R82xx Tuner & the Blog V4 Deafness"
-description: GopherTrunk's pure-Go R820T/R828D tuner driver — PLL tuning, a shadow-register cache that makes read-modify-write free, and tuner auto-detection. Plus the headline bug: why the RTL-SDR Blog V4 came up deaf and mistuned by 1.8×, and how a manual override plus per-band input switching fixed it.
+description: "GopherTrunk's pure-Go R820T/R828D tuner driver — PLL tuning, a shadow-register cache that makes read-modify-write free, and tuner auto-detection. Plus the headline bug: why the RTL-SDR Blog V4 came up deaf and mistuned by 1.8×, and how a manual override plus per-band input switching fixed it."
 category: deep-dives
 tags: [sdr, go, rtl-sdr, r82xx, software-design]
 author: Matt Cheramie

--- a/docs/_posts/2026-06-25-rf-front-end-08-rtlsdr-r82xx-blog-v4.md
+++ b/docs/_posts/2026-06-25-rf-front-end-08-rtlsdr-r82xx-blog-v4.md
@@ -17,6 +17,12 @@ separate tuner chip on the I2C bridge. This post brings up the
 story of the bug that ate the most field debugging time in the whole RTL-SDR
 driver: the RTL-SDR Blog V4 that came up deaf.*
 
+> **TL;DR** — This is the pure-Go R820T/R828D tuner driver, built around a
+> shadow-register cache that makes read-modify-write free. The headline bug: the
+> RTL-SDR Blog V4 came up deaf and mistuned by ~1.8×, fixed with a crystal
+> override plus per-band input switching. A second bug (#248) — a 17-byte I2C
+> burst stalling on NESDR v5 — is fixed by halving the chunk size until it fits.
+
 ## In this post
 
 - **What the R82xx tuner does** — PLL frequency synthesis, the 3.57 MHz IF, and
@@ -50,8 +56,8 @@ mock USB transport. The whole driver lives in
 
 ### The shadow-register cache
 
-The single most important design decision in the R82xx driver is the
-shadow-register cache. The `R82xx` struct keeps a local mirror of the chip's
+**The single most important design decision in the R82xx driver is the
+shadow-register cache.** The `R82xx` struct keeps a local mirror of the chip's
 registers:
 
 ```go

--- a/docs/_posts/2026-06-26-rf-front-end-09-rtlsdr-streaming-gc-churn.md
+++ b/docs/_posts/2026-06-26-rf-front-end-09-rtlsdr-streaming-gc-churn.md
@@ -1,0 +1,367 @@
+---
+title: "RF Front End, Part 9: RTL-SDR III — IQ Streaming & the GC-Churn Bug"
+description: Sustained IQ streaming from the RTL2832U in pure Go — 32 async USB buffers, a deep consumer channel, and a bit-identical U8-to-complex64 lookup table. Plus the headline bug: per-chunk allocations whose GC churn shed a quarter of the control channel's live IQ, and the zero-allocation reuse ring that fixed it.
+category: deep-dives
+tags: [sdr, go, rtl-sdr, streaming, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 9
+---
+
+*Part 9 of **RF Front End**. The RTL2832U is initialized
+([Part 7]({{ '/blog/deep-dives/rf-front-end-07-rtlsdr-rtl2832u-bringup/' | relative_url }}))
+and the tuner is locked
+([Part 8]({{ '/blog/deep-dives/rf-front-end-08-rtlsdr-r82xx-blog-v4/' | relative_url }})).
+Now we have to keep a 2.4 MS/s flood of samples moving without dropping any — and
+this is where Go's garbage collector, of all things, became the enemy.*
+
+## In this post
+
+- **The streaming geometry** — 32 async USB buffers × 16 KiB, a deep consumer
+  channel, and why the numbers are what they are.
+- **The U8-to-complex64 conversion** — a precomputed lookup table that's
+  bit-identical to the old CGO driver.
+- **The problem we hit (issue #489):** per-chunk allocations created GC churn
+  that pushed the control-channel decoder over its real-time budget and shed
+  25–48% of live IQ — fixed with a zero-allocation reuse ring.
+- **Two more failure-signaling bugs (issues #402 and #345):** silent live IQ loss
+  made invisible by a drop counter, and a silent USB-reaper death that left the
+  consumer blocked forever.
+
+## What sustained streaming does
+
+Once the chip is tuned, the RTL2832U dumps a continuous stream of unsigned 8-bit
+IQ pairs over a USB bulk-IN endpoint. At 2.4 MS/s that's 4.8 MB/s of raw bytes
+that never stops. The streaming layer's job is to pull those bytes off the wire,
+convert each U8 IQ pair into a `complex64`, and hand the result to the consumer
+(a control-channel decoder, a trunking engine, an IQ recorder) as a channel of
+`[]complex64` chunks — without ever blocking the kernel's USB reaper and without
+dropping samples when the consumer hiccups.
+
+The whole thing lives in `internal/sdr/rtlsdr/purego/stream.go`, with the device
+state machine in `device.go`.
+
+## How GopherTrunk implements it in Go
+
+### The geometry
+
+The numbers are copied verbatim from the old CGO driver so the pure-Go backend is
+a behavioral drop-in:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go
+const (
+    asyncBufCount = 32
+    asyncBufLen   = 16 * 1024
+
+    streamChanDepth = 32
+    bulkInEndpoint  = 0x81
+)
+```
+
+Thirty-two async USB buffers of 16 KiB each is about **6 ms of headroom at 2.4
+MS/s** — enough that a brief scheduler stall doesn't starve the bulk-IN ring. The
+consumer channel is `streamChanDepth = 32` chunks deep, roughly 110 ms of slack.
+The CGO driver used a depth of 8; the pure-Go backend deliberately runs deeper,
+specifically to absorb GC and scheduler jitter on the consumer — and *that*
+number is part of the story below.
+
+`StreamIQ` resets the USB FIFO, provisions a reuse ring (more on that in a
+moment), kicks off the bulk-IN ring on the transport, and returns the channel:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go (shape)
+out := make(chan []complex64, streamChanDepth)
+d.out = out
+// ...provision the reuse ring...
+if err := d.transport.StartBulkIn(bulkInEndpoint, asyncBufCount, asyncBufLen,
+    d.deliver, d.onStreamDead); err != nil {
+    d.out = nil
+    return nil, fmt.Errorf("rtlsdr: StartBulkIn: %w", err)
+}
+go func() { <-ctx.Done(); d.cancelStream() }()
+return out, nil
+```
+
+### The conversion
+
+Each completed URB calls `deliver`, which converts the U8 IQ bytes into
+`complex64`. The conversion math is the bit-identical port of the CGO driver:
+subtract a DC bias of 127.5 (mid-range of a `u8`) and divide by 127.5 to scale to
+[-1, +1). Done naively that's a subtract and a divide per sample, 4.8 million
+times a second per dongle. Instead we precompute a 256-entry lookup table once:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go
+var u8ToF32 [256]float32
+
+func init() {
+    for b := 0; b < 256; b++ {
+        u8ToF32[b] = (float32(b) - 127.5) / 127.5
+    }
+}
+
+func convertU8IQInto(dst []complex64, buf []byte) {
+    n := len(buf) / 2
+    for i := 0; i < n; i++ {
+        dst[i] = complex(u8ToF32[buf[2*i]], u8ToF32[buf[2*i+1]])
+    }
+}
+```
+
+Each entry uses the *exact same* float32 expression as the original per-sample
+math, so the result is bit-identical — pinned by
+`TestConvertU8IQ_BitIdenticalWithCGO` so any drift from the CGO driver shows up
+immediately. The hot path is now two table lookups per sample instead of a
+subtract+divide.
+
+## The problem we hit: GC churn shedding live IQ (issue #489)
+
+**The symptom.** A control-channel RTL-SDR was dropping **25–48% of its IQ
+chunks** under load. Not occasionally — sustained. The decoder downstream was
+clearly busy, but it should have had 110 ms of channel slack to ride out a busy
+moment. Something was making the consumer *systematically* unable to keep up.
+
+**The root cause.** `convertU8IQInto`'s allocating wrapper was the culprit.
+Originally, `deliver` allocated a fresh `[]complex64` for every chunk:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go
+func convertU8IQ(buf []byte) []complex64 {
+    out := make([]complex64, len(buf)/2)
+    convertU8IQInto(out, buf)
+    return out
+}
+```
+
+At 16 KiB per URB that's an 8192-element `complex64` slice — ~64 KiB — allocated
+fresh, hundreds of times a second, then thrown away as soon as the consumer
+finished with it. That allocation rate drove the garbage collector hard, and the
+GC pauses landed *on the consumer goroutine*, pushing the control-channel decoder
+over its real-time budget. The decoder fell behind, the channel filled, and
+`deliver`'s drop-on-overrun branch started shedding chunks — a quarter to half of
+them. The deep channel didn't help because the problem wasn't a transient stall;
+it was steady-state allocation pressure that the channel depth couldn't paper
+over.
+
+**The fix.** A ring of preallocated `complex64` buffers, reused across chunks.
+`StreamIQ` provisions `streamChanDepth + 2` of them per stream:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go
+ring := make([][]complex64, streamChanDepth+2)
+for i := range ring {
+    ring[i] = make([]complex64, asyncBufLen/2)
+}
+d.ring = ring
+d.ringIdx = 0
+```
+
+The sizing is exact: at most `streamChanDepth` buffers can sit queued on the
+channel, plus one in the consumer, so cycling through `depth + 2` slots
+guarantees the producer never overwrites a buffer still in flight. `deliver` now
+fills the current ring slot instead of allocating, and — critically — only
+advances the ring index on a *successful* enqueue:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go
+samples := d.fillBufferLocked(buf)
+select {
+case out <- samples:
+    // Advance the ring only on a successful enqueue: a dropped chunk
+    // reuses the same buffer next time, so a buffer's slot is never
+    // recycled until that chunk has actually been handed to the consumer.
+    if len(d.ring) > 0 {
+        d.ringIdx = (d.ringIdx + 1) % len(d.ring)
+    }
+    d.streamMu.Unlock()
+default:
+    d.streamMu.Unlock()
+    d.dropped.Add(1)
+    sdr.NotifyIQDrop(d.info)
+}
+```
+
+`fillBufferLocked` writes into the ring slot via the allocation-free
+`convertU8IQInto`, falling back to a fresh allocation only when no ring is
+provisioned (direct deliver in tests) or for a packet too large to fit a slot:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go
+func (d *Device) fillBufferLocked(buf []byte) []complex64 {
+    n := len(buf) / 2
+    if len(d.ring) == 0 {
+        return convertU8IQ(buf)
+    }
+    dst := d.ring[d.ringIdx]
+    if cap(dst) < n {
+        return convertU8IQ(buf) // oversized packet; don't disturb the ring
+    }
+    dst = dst[:n]
+    convertU8IQInto(dst, buf)
+    return dst
+}
+```
+
+With the ring in place the steady state allocates **nothing** per chunk, the GC
+went quiet, the consumer kept its budget, and the drop rate fell to zero. The
+deeper channel depth from earlier is slack on top of this — not a substitute for
+it.
+
+## The second problem: silent live IQ loss (issue #402)
+
+**The symptom.** When the control channel *did* drop IQ, there was no way to tell.
+A decode failure looked identical whether it came from a weak signal, multipath,
+or the live path silently shedding chunks. Live IQ loss was indistinguishable
+from an RF problem.
+
+**The root cause and fix.** The drop branch in `deliver` was genuinely silent — it
+threw the chunk away and moved on. We added a lifetime drop counter and a
+notification hook:
+
+```go
+// internal/sdr/rtlsdr/purego/device.go
+dropped atomic.Uint64
+
+func (d *Device) DroppedChunks() uint64 { return d.dropped.Load() }
+```
+
+Now the drop branch records every discard and notifies an observer outside the
+lock (so the callback can't stall the reaper):
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go (drop branch)
+d.dropped.Add(1)
+sdr.NotifyIQDrop(d.info)
+```
+
+`NotifyIQDrop` drives an operator-facing Prometheus counter
+(`iq_underruns_total`) plus a rate-limited warning. A non-zero count during a
+decode failure now points squarely at a live-path overrun rather than the air — a
+diagnosis you simply could not make before. (The same issue-#402 work also
+exposed `ActualSampleRate`, because the down-converter has to derive its symbol
+clock from the rate the chip is *actually* delivering, not the requested one — but
+that's a decode-path story.)
+
+## The third problem: a silently dead stream (issue #345)
+
+**The symptom.** When a dongle fell off the USB bus mid-stream — unplugged, or an
+unrecoverable `ENODEV`/`EPROTO` — the consumer goroutine would block on the IQ
+channel **forever**. No error, no EOF, just a permanent hang.
+
+**The root cause.** The USB reaper goroutine inside `StartBulkIn` exits when every
+bulk-IN URB dies of an unrecoverable error. But it exits *without* anyone calling
+`StopBulkIn`, so the consumer channel was never closed. The consumer's `range`
+over the channel had nothing to wake it.
+
+**The fix.** A stream-death callback. `StartBulkIn` takes an `onStreamDead`
+handler that fires exactly when the reaper exits abnormally, and it runs
+`cancelStream`:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go
+func (d *Device) onStreamDead(error) {
+    d.cancelStream()
+}
+```
+
+`cancelStream` is the same idempotent teardown that context-cancel uses — guarded
+by a `sync.Once`, it stops the bulk-IN ring and **closes the consumer channel**:
+
+```go
+// internal/sdr/rtlsdr/purego/device.go
+func (d *Device) cancelStream() {
+    d.stopOnce.Do(func() {
+        _ = d.transport.StopBulkIn()
+        d.streamMu.Lock()
+        if d.out != nil {
+            close(d.out)
+            d.out = nil
+        }
+        d.streamMu.Unlock()
+    })
+}
+```
+
+Now a dead stream surfaces to the consumer as a closed channel — a clean EOF — so
+the decoder sees `ErrIQStreamClosed`, the daemon logs it once and decides whether
+to retry or exit. The watchdog that does the actual reconnect is the subject of a
+later post; here the point is that *failure became visible* instead of becoming a
+hang.
+
+## The design principle: zero-allocation steady state + explicit failure signaling
+
+The streaming layer is governed by two rules that show up over and over in
+real-time Go: **the hot path should allocate nothing in steady state**, and
+**every failure mode should produce a signal, never silence.**
+
+The GC-churn bug is the canonical lesson in the first rule. The allocation wasn't
+wrong — it was correct, simple Go — but at 2.4 MS/s its *aggregate* cost was a GC
+load heavy enough to break an unrelated real-time consumer two layers away. The
+fix wasn't cleverer code; it was *no* allocation, achieved by reusing buffers
+whose lifecycle is tied precisely to the channel's depth.
+
+The drop counter and the stream-death callback are the second rule. A dropped
+chunk and a dead stream were both *silent* — and silence in a real-time pipeline
+is the worst possible failure, because it's indistinguishable from "working." Both
+fixes turn an invisible failure into an explicit, observable one.
+
+### How that principle shaped the Go code
+
+- **Buffers are pooled, not allocated.** The reuse ring is sized exactly to the
+  number of buffers that can be in flight (`streamChanDepth + 2`), so steady-state
+  IQ delivery allocates nothing and the GC stays out of the consumer's budget.
+- **The ring advances only on success.** A dropped chunk reuses its slot, so a
+  buffer is never recycled until the consumer has actually taken it — backpressure
+  and reuse-safety in one rule.
+- **Drops are counted and reported.** `dropped atomic.Uint64` plus `NotifyIQDrop`
+  turn a silent overrun into a Prometheus counter and a rate-limited warning,
+  fired outside the lock so telemetry can't stall the reaper.
+- **Stream death closes the channel.** `onStreamDead → cancelStream` makes an
+  unrecoverable USB error surface as a clean EOF, so no consumer ever blocks
+  forever. `sync.Once` makes the teardown idempotent across ctx-cancel, close, and
+  reaper-death.
+- **Conversion stays bit-identical.** The reuse ring changed *where* samples land,
+  never *what* they are — `convertU8IQInto` is the same math as the CGO driver,
+  pinned by a golden test.
+
+## Where this goes next
+
+That closes out the RTL-SDR trilogy: chip bring-up, tuner, and now sustained
+streaming. The next family streams differently — the
+[Airspy]({{ '/reference/airspy/' | relative_url }}) R2 and Mini deliver **real**
+samples, not complex IQ, so
+[Part 10]({{ '/blog/deep-dives/rf-front-end-10-airspy-real-to-complex/' | relative_url }})
+takes apart the real-to-complex-baseband conversion that turns a real ADC stream
+into the `[]complex64` the rest of the pipeline expects.
+
+## FAQ
+
+**Why not just use `sync.Pool` instead of a hand-rolled ring?**
+`sync.Pool` doesn't give the lifetime guarantee we need: a buffer must not be
+reused until the consumer has finished with it, and that's determined by the
+channel depth, not by GC timing. The ring sized `streamChanDepth + 2` encodes
+exactly that invariant — and a fresh ring per stream means a slow consumer
+draining the *previous* (closed) channel can never alias a buffer the new stream
+is writing.
+
+**Why advance the ring index only on a successful send?**
+Because a dropped chunk's buffer was never handed to anyone, so its slot is still
+safe to overwrite next time. Advancing on drop would waste a slot and, worse,
+could recycle a slot while its chunk is still queued. Advancing only on success
+ties the ring's recycling directly to delivery.
+
+**Does the drop-on-overrun policy lose data we care about?**
+Dropping is deliberate: a slow consumer should shed live IQ rather than
+back-pressure the kernel's USB reaper, which would stall every stream. The fix for
+issue #489 was to make sure the consumer *isn't* slow in steady state; the
+drop-and-count path is the safety valve when it momentarily is, and the counter
+tells you when it fired.
+
+## Series navigation
+
+**Part 9 of 14** · ←
+[Part 8]({{ '/blog/deep-dives/rf-front-end-08-rtlsdr-r82xx-blog-v4/' | relative_url }})
+· Next →
+[Part 10: Airspy R2/Mini & HF+ — real samples to complex baseband]({{ '/blog/deep-dives/rf-front-end-10-airspy-real-to-complex/' | relative_url }})

--- a/docs/_posts/2026-06-26-rf-front-end-09-rtlsdr-streaming-gc-churn.md
+++ b/docs/_posts/2026-06-26-rf-front-end-09-rtlsdr-streaming-gc-churn.md
@@ -1,6 +1,6 @@
 ---
 title: "RF Front End, Part 9: RTL-SDR III — IQ Streaming & the GC-Churn Bug"
-description: Sustained IQ streaming from the RTL2832U in pure Go — 32 async USB buffers, a deep consumer channel, and a bit-identical U8-to-complex64 lookup table. Plus the headline bug: per-chunk allocations whose GC churn shed a quarter of the control channel's live IQ, and the zero-allocation reuse ring that fixed it.
+description: "Sustained IQ streaming from the RTL2832U in pure Go — 32 async USB buffers, a deep consumer channel, and a bit-identical U8-to-complex64 lookup table. Plus the headline bug: per-chunk allocations whose GC churn shed a quarter of the control channel's live IQ, and the zero-allocation reuse ring that fixed it."
 category: deep-dives
 tags: [sdr, go, rtl-sdr, streaming, software-design]
 author: Matt Cheramie

--- a/docs/_posts/2026-06-26-rf-front-end-09-rtlsdr-streaming-gc-churn.md
+++ b/docs/_posts/2026-06-26-rf-front-end-09-rtlsdr-streaming-gc-churn.md
@@ -16,6 +16,12 @@ and the tuner is locked
 Now we have to keep a 2.4 MS/s flood of samples moving without dropping any — and
 this is where Go's garbage collector, of all things, became the enemy.*
 
+> **TL;DR** — This is sustained 2.4 MS/s IQ streaming off the RTL2832U: 32 async
+> USB buffers, a deep consumer channel, and a bit-identical U8-to-complex64
+> lookup table. The headline bug: per-chunk allocations drove GC churn that shed
+> 25–48% of live IQ — fixed with a zero-allocation reuse ring. Two more bugs turn
+> silent IQ loss and a silently dead stream into explicit, observable failures.
+
 ## In this post
 
 - **The streaming geometry** — 32 async USB buffers × 16 KiB, a deep consumer
@@ -46,8 +52,8 @@ state machine in `device.go`.
 
 ### The geometry
 
-The numbers are copied verbatim from the old CGO driver so the pure-Go backend is
-a behavioral drop-in:
+**The numbers are copied verbatim from the old CGO driver so the pure-Go backend is
+a behavioral drop-in:**
 
 ```go
 // internal/sdr/rtlsdr/purego/stream.go

--- a/docs/_posts/2026-06-27-rf-front-end-10-airspy-real-to-complex.md
+++ b/docs/_posts/2026-06-27-rf-front-end-10-airspy-real-to-complex.md
@@ -1,0 +1,364 @@
+---
+title: "RF Front End, Part 10: Airspy R2/Mini & HF+ — Real Samples to Complex Baseband"
+description: How GopherTrunk turns the Airspy R2/Mini's bare real ADC stream into complex baseband entirely on the host — a leaky DC blocker, a multiplier-free Fs/4 mix, and a stateful half-band Hilbert pair — then folds in the Airspy HF+, whose native int16 IQ needs none of it.
+category: deep-dives
+tags: [sdr, go, airspy, dsp, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 10
+---
+
+*Part 10 of **RF Front End**. The last three posts moved bytes off the wire.
+This one does signal processing in the driver: the Airspy R2/Mini hands us bare
+real ADC samples, not IQ, so the host has to synthesize complex baseband from
+scratch — DC removal, an Fs/4 translation, and a half-band Hilbert pair — and
+get the filter state to survive USB packet boundaries.*
+
+## In this post
+
+- Why the [Airspy]({{ '/reference/airspy/' | relative_url }}) R2/Mini stream
+  **bare real samples** (uint16, 12-bit, DC at 2048) at **twice** the IQ rate,
+  unlike RTL-SDR's interleaved IQ.
+- The four-stage **real-to-complex pipeline** in `iqconverter.go`: leaky-HPF DC
+  removal → multiplier-free **Fs/4** mix → polyphase **half-band** split →
+  decimate by two.
+- Why the converter must be **stateful across packets**, and the bug (#454) we
+  hit getting that filter memory right.
+- The Airspy **HF+**, which delivers native interleaved **int16 IQ** and needs
+  none of this — plus the shared-VID:PID-disambiguated-by-product-string wrinkle.
+
+## What a real-sampling front end is
+
+Most cheap SDRs hand the host quadrature IQ: two streams, in-phase and
+quadrature, already mixed to baseband by the tuner. RTL-SDR does this (unsigned
+8-bit I,Q); the HackRF does this (signed 8-bit I,Q); the Airspy HF+ does this
+(signed 16-bit I,Q). You decode a pair of integers into one complex sample and
+you are done.
+
+The Airspy R2 and Airspy Mini do not. They are **real-sampling** receivers: a
+single fast ADC digitizes a real intermediate-frequency signal, and the
+firmware streams the bare ADC output — unpacked little-endian `uint16`, 12-bit
+resolution, DC sitting at 2048 — at **twice** the configured IQ rate. There is
+no quadrature channel coming over USB. Producing complex baseband is a host-side
+job, and it is the same job an analog superheterodyne would hand to a pair of
+mixers and a phasing network: take a real signal, reject its mirror image, and
+land it at zero IF as `I + jQ`.
+
+That `2×` is not incidental. A real signal sampled at `Fs` carries usable
+bandwidth up to `Fs/2`; a complex signal at `Fs/2` carries the same bandwidth
+across `±Fs/4`. So `N` real input samples become `N/2` complex outputs at half
+the rate — which is exactly why, in the driver, a requested IQ rate of 3 MHz
+selects the **6 MSPS** device mode. We covered that rate-doubling foot-gun in
+the [Part 2]({{ '/blog/deep-dives/rf-front-end-02-the-device-contract/' | relative_url }})
+device contract; here we build the converter that justifies it.
+
+## How GopherTrunk implements it in Go
+
+The whole conversion lives in `internal/sdr/airspy/iqconverter.go`, driven from
+one method per USB packet. Its job, top to bottom: decode `uint16` reals,
+remove DC, mix by `Fs/4`, run the half-band pair, emit `complex64`.
+
+### Stage 1 — leaky-HPF DC removal
+
+The ADC parks DC at 2048 and the front end adds its own slow bias drift. Left
+in, that DC becomes a fat spike at the center of every spectrum. We strip it
+with a one-pole leaky high-pass — a running estimate of the mean that we
+subtract before anything else touches the sample:
+
+```go
+// internal/sdr/airspy/iqconverter.go
+x := (float32(binary.LittleEndian.Uint16(buf[2*i:])) - dcBias) / dcFull
+
+// Leaky DC blocker: removes the residual ADC bias before the mix.
+x -= c.avg
+c.avg += dcLeak * x
+```
+
+`dcBias` is 2048, `dcFull` normalizes to roughly `[-1, 1)`, and `dcLeak` is
+`0.01` — a slow tracker that follows bias drift without eating low-frequency
+signal. The accumulator `c.avg` is **state**: it carries from one packet to the
+next so the DC estimate doesn't reset (and re-spike) every 6 ms.
+
+### Stage 2 — the Fs/4 mix, for free
+
+To get to baseband we need to multiply the real stream by a complex sinusoid.
+Pick that sinusoid at exactly `Fs/4` and the multiplications collapse into
+nothing: `e^{-j(π/2)n}` walks the unit circle in steps of 90°, so its samples
+are just `1, -j, -1, +j, …`. No multiplies, no sine table — only a sign flip and
+a branch on which polyphase lane the sample falls in. That is the `phase`
+counter, cycling `0..3`:
+
+```go
+// internal/sdr/airspy/iqconverter.go
+switch c.phase {
+case 0, 2:
+    // In-phase branch. The Fs/4 mix alternates the sign of the
+    // even samples; push into the FIR and recompute its output.
+    if c.phase == 0 {
+        x = -x
+    }
+    c.pushI(x)
+    c.lastI = c.firI()
+case 1, 3:
+    // Quadrature branch. The mix alternates sign and folds in the
+    // 0.5 half-band centre tap; the matched delay aligns it with
+    // the in-phase FIR's group delay, then we emit one sample.
+    q := 0.5 * x
+    if c.phase == 1 {
+        q = -q
+    }
+    // ...delay line, then emit complex(c.lastI, qOut)
+}
+```
+
+`phase` is also state — it persists across packets so the `(-j)^n` rotation
+never glitches at a buffer boundary.
+
+### Stage 3 — the half-band Hilbert pair
+
+Mixing by `Fs/4` puts the wanted signal at baseband but also folds the mirror
+image right on top of it. Rejecting that image is the whole game, and it falls
+out of a **47-tap half-band** filter, split into its two polyphase lanes:
+
+- **In-phase lane** (even samples) runs a symmetric low-pass FIR. A half-band's
+  odd taps are zero except the center, so only **24 non-trivial taps**
+  participate — half the multiplies of a general FIR for the same response.
+- **Quadrature lane** (odd samples) is a **matched integer delay**. The half-band
+  center tap is exactly `0.5`, and rather than spend a tap on it we fold that
+  `0.5` straight into the `Fs/4` mix (`q := 0.5 * x` above). The delay line just
+  lines Q up with the FIR's group delay.
+
+```go
+// internal/sdr/airspy/iqconverter.go
+// firI evaluates the symmetric half-band FIR over the current window, with
+// hbKernel[0] weighting the newest sample and hbKernel[hbTaps-1] the oldest.
+func (c *iqConverter) firI() float32 {
+    var acc float32
+    idx := c.iwinPos - 1
+    if idx < 0 {
+        idx += hbTaps
+    }
+    for j := 0; j < hbTaps; j++ {
+        acc += hbKernel[j] * c.iwin[idx]
+        if idx--; idx < 0 {
+            idx += hbTaps
+        }
+    }
+    return acc
+}
+```
+
+Both lanes carry state — the in-phase `iwin` FIR window and the quadrature
+`qline` delay line are circular buffers on the `iqConverter` struct:
+
+```go
+// internal/sdr/airspy/iqconverter.go  (shape)
+type iqConverter struct {
+    avg     float32         // leaky DC-blocker accumulator
+    phase   int             // Fs/4 mix phase, 0..3, persists across packets
+    iwin    [hbTaps]float32 // in-phase FIR window
+    iwinPos int
+    lastI   float32         // in-phase output awaiting its paired quadrature
+    qline   [hbHalf]float32 // quadrature delay line
+    qpos    int
+}
+```
+
+### Stage 4 — decimate, and pair up
+
+Because we only ever emit on the odd (quadrature) phases, and only consume the
+in-phase FIR's latest output (`c.lastI`) when we do, the decimation by two is
+implicit: every fourth real sample produces no output, every pair of lanes
+collapses to one `complex64`. The driver allocates `len(buf)/4` outputs and
+returns them:
+
+```go
+// internal/sdr/airspy/iqconverter.go
+func (c *iqConverter) processRaw(buf []byte) []complex64 {
+    nReal := len(buf) / 2
+    out := make([]complex64, 0, nReal/2+1)
+    // ...per-sample pipeline above...
+    return out
+}
+```
+
+One bulk-IN payload of `N` real bytes-as-uint16 yields `N/2` real samples and
+`N/4` complex samples, at exactly the configured IQ rate.
+
+## The problem we hit: a half-band Hilbert that joined packets seamlessly (#454)
+
+**Symptom.** When the Airspy R2 first came up, nothing locked. The constellation
+showed a massive quadrature imbalance — about **78°** off from the 90° it should
+be — and essentially **no image rejection** (~3 dB). Every downstream decoder
+mistuned; on a quiet band all that survived was the DC spike. The device
+streamed bytes fine, but the signal was garbage.
+
+**Root cause.** Two compounding mistakes. First, the driver originally treated
+the receiver's **real** ADC stream as if it were interleaved I/Q — pairing
+adjacent real samples into `complex(I, Q)`. That is simply the wrong model for a
+real-sampling front end: there is no Q channel on the wire, so the synthetic Q
+was just a delayed copy of I, hence the ~78° imbalance and no image rejection.
+Second, once we built the proper Fs/4-plus-half-band converter, the filter and
+mix had to be **stateful across USB packets**. A naive implementation that reset
+the FIR window, the DC accumulator, and the `phase` counter at the start of each
+`processRaw` call produced a discontinuity every 6 ms — a click train at the
+packet rate that smeared the spectrum.
+
+**The Go fix.** All converter memory lives on the `iqConverter` struct, and a
+single converter instance threads through an entire stream. The packet handler
+just calls `processRaw` on the *same* converter, packet after packet:
+
+```go
+// internal/sdr/airspy/airspy.go
+// Fresh real-to-IQ converter per stream so filter memory never carries
+// over from a previous session.
+d.cnv = newIQConverter()
+
+out := make(chan []complex64, 8)
+onPacket := func(buf []byte) {
+    samples := d.cnv.processRaw(buf)
+    select {
+    case out <- samples:
+    case <-ctx.Done():
+    }
+}
+```
+
+The converter is created **per stream** (so a retune starts from silent filter
+memory, phase 0) but is **shared across every packet within that stream** (so the
+FIR window, DC tracker, and mix phase flow continuously across boundaries). The
+zero value of `iqConverter` is a valid reset state, which is what makes
+`newIQConverter()` a one-liner. After the fix, image rejection came back to
+~**70 dB**, matching what libairspy's own IQ modes deliver.
+
+## The design principle: DSP in the driver, from first principles
+
+The Airspy driver is the first place in GopherTrunk where the driver does real
+*signal processing*, not just byte shuffling. The principle: when the hardware
+hands you something other than the abstraction the rest of the system wants
+(`[]complex64`), the driver pays the cost of bridging the gap — and it does it
+from first principles, not by linking someone else's DSP library.
+
+### How that principle shaped the Go code
+
+- **The abstraction boundary holds.** Upstream code never learns the Airspy is a
+  real-sampling device. `StreamIQ` returns the same `<-chan []complex64` every
+  other driver returns; the Fs/4 mix and half-band pair are an implementation
+  detail behind it.
+- **State is explicit and owned.** The DSP carries memory — DC accumulator, mix
+  phase, FIR window, delay line — and all of it is fields on one struct with a
+  clear lifetime (one per stream). There are no package globals and no hidden
+  static buffers, so two Airspys streaming at once can't corrupt each other.
+- **Cheap by construction, not by optimization.** The Fs/4 choice turns the mixer
+  into a sign flip; the half-band structure zeroes half the taps and folds the
+  center tap into the mix. The fast path is fast because the *math* was chosen
+  well, not because the loop was hand-tuned.
+- **Correctness is testable without hardware.** Because `processRaw` is a pure
+  function of `(converter state, bytes)`, the in-package tests feed synthesized
+  real tones through it and assert on image rejection — no Airspy required.
+
+## Folding in the Airspy HF+
+
+The Airspy **HF+** family (HF+, HF+ Discovery, HF+ Dual Port) is a sibling, not a
+twin, and it is instructive precisely because it makes the opposite choice. It
+covers **9 kHz–31 MHz HF plus 60–260 MHz VHF**, and it delivers **native
+interleaved int16 IQ** — so there is no real-to-complex stage at all. Decoding is
+the boring two-integers-to-one-complex loop:
+
+```go
+// internal/sdr/airspyhf/airspyhf.go
+func decodeInt16IQ(buf []byte) []complex64 {
+    n := len(buf) / 4
+    out := make([]complex64, n)
+    for i := 0; i < n; i++ {
+        iv := int16(binary.LittleEndian.Uint16(buf[4*i:]))
+        qv := int16(binary.LittleEndian.Uint16(buf[4*i+2:]))
+        out[i] = complex(float32(iv)/32768, float32(qv)/32768)
+    }
+    return out
+}
+```
+
+No converter, no filter state, no `2×` rate trick. The HF+ proves the point that
+the R2/Mini converter is *device-specific*: the complex-baseband abstraction is
+the same, but how much work the driver does to honor it depends entirely on what
+the silicon streams.
+
+The HF+ has two wrinkles worth calling out. First, **all three variants share one
+VID:PID** (`0x03eb:0x800c`); the USB descriptor's **Product string** is the only
+observable model identifier, so the driver disambiguates on it:
+
+```go
+// internal/sdr/airspyhf/airspyhf.go
+func variantName(product string) string {
+    p := strings.ToUpper(product)
+    switch {
+    case strings.Contains(p, "DISCOVERY"):
+        return "Airspy HF+ Discovery"
+    case strings.Contains(p, "DUAL"):
+        return "Airspy HF+ Dual Port"
+    default:
+        return "Airspy HF+"
+    }
+}
+```
+
+Second, "gain" on the HF+ is mostly **attenuation reduction**. The front end has
+a fixed conversion stage; what the operator controls is HF_AGC (firmware-managed
+LNA + mixer), HF_ATT (a 0–48 dB attenuator in 6 dB steps), and HF_LNA (a fixed
+`+6` dB preamp). A negative tenth-dB target enables AGC and zeroes the rest;
+positive values disable AGC, compute an attenuator step, and switch the LNA in
+once attenuation reduction alone has been spent:
+
+```go
+// internal/sdr/airspyhf/airspyhf.go  (shape)
+att := tenthDB / hfATTStepTenthDB      // 6 dB steps, clamp 0..8
+remaining := tenthDB - att*hfATTStepTenthDB
+lnaOn := remaining >= hfLNAGainTenthDB // +6 dB preamp
+```
+
+Note also that the HF+ vendor opcodes are **not** the R2/Mini's — sibling
+devices, sibling protocols (`SET_SAMPLERATE` is 4 here, 12 on the R2). The two
+drivers live in separate packages for exactly that reason.
+
+## Where this goes next
+
+We now have three of the four wire formats covered: RTL-SDR's unsigned 8-bit IQ,
+the Airspy R2/Mini's synthesized complex baseband, and the HF+'s native int16 IQ.
+The simplest of all — HackRF's signed 8-bit interleaved IQ, plus the
+identity-by-board-ID dance at open time — is
+[Part 11]({{ '/blog/deep-dives/rf-front-end-11-hackrf-one/' | relative_url }}).
+After that, Part 12 zooms back out to the pool and USB hotplug watchdog that
+keeps all of these streaming through unplug-and-replug.
+
+## FAQ
+
+**Why not just pair adjacent real samples as I and Q?**
+Because there is no Q on the wire. The Airspy R2/Mini stream a single real ADC
+channel; pairing reals fabricates a Q that's just a delayed I, which is what gave
+us the ~78° imbalance and ~3 dB image rejection in #454. You have to *synthesize*
+quadrature with a Hilbert-pair filter.
+
+**Why a half-band filter specifically?**
+Half-band filters have their odd taps zeroed (except the center) and a center tap
+of exactly 0.5. That halves the multiplies in the in-phase lane and lets us fold
+the center tap into the free Fs/4 mix — the structure does double duty as the
+anti-alias filter for the decimate-by-two.
+
+**Why is the converter created per stream but shared per packet?**
+Per stream so a retune starts from clean filter memory and can't inherit a stale
+DC estimate. Per packet so the FIR window, DC accumulator, and mix phase flow
+continuously and packets join without a click at the boundary.
+
+**Does the HF+ ever need the converter?**
+No. The HF+ delivers complex IQ natively (int16 I,Q), so its driver just
+normalizes integers to `[-1, 1]`. The real-to-complex converter is unique to the
+R2/Mini's real-sampling front end.
+
+## Series navigation
+
+**Part 10 of 14** · ←
+[Part 9]({{ '/blog/deep-dives/rf-front-end-09-rtlsdr-streaming-gc-churn/' | relative_url }})
+· Next →
+[Part 11: HackRF One — signed 8-bit IQ end to end]({{ '/blog/deep-dives/rf-front-end-11-hackrf-one/' | relative_url }})

--- a/docs/_posts/2026-06-27-rf-front-end-10-airspy-real-to-complex.md
+++ b/docs/_posts/2026-06-27-rf-front-end-10-airspy-real-to-complex.md
@@ -15,6 +15,13 @@ real ADC samples, not IQ, so the host has to synthesize complex baseband from
 scratch — DC removal, an Fs/4 translation, and a half-band Hilbert pair — and
 get the filter state to survive USB packet boundaries.*
 
+> **TL;DR** — The Airspy R2/Mini stream bare real ADC samples, not IQ, so the
+> host synthesizes complex baseband: a leaky DC blocker, a multiplier-free Fs/4
+> mix, and a half-band Hilbert pair. The headline bug (#454): the converter must
+> carry filter state across USB packets, or you get ~78° quadrature imbalance and
+> no image rejection — fixed by threading one stateful converter through the
+> whole stream. The HF+ needs none of it: it delivers native int16 IQ.
+
 ## In this post
 
 - Why the [Airspy]({{ '/reference/airspy/' | relative_url }}) R2/Mini stream
@@ -55,9 +62,9 @@ device contract; here we build the converter that justifies it.
 
 ## How GopherTrunk implements it in Go
 
-The whole conversion lives in `internal/sdr/airspy/iqconverter.go`, driven from
+**The whole conversion lives in `internal/sdr/airspy/iqconverter.go`, driven from
 one method per USB packet. Its job, top to bottom: decode `uint16` reals,
-remove DC, mix by `Fs/4`, run the half-band pair, emit `complex64`.
+remove DC, mix by `Fs/4`, run the half-band pair, emit `complex64`.**
 
 ### Stage 1 — leaky-HPF DC removal
 
@@ -235,10 +242,10 @@ zero value of `iqConverter` is a valid reset state, which is what makes
 ## The design principle: DSP in the driver, from first principles
 
 The Airspy driver is the first place in GopherTrunk where the driver does real
-*signal processing*, not just byte shuffling. The principle: when the hardware
+*signal processing*, not just byte shuffling. **The principle: when the hardware
 hands you something other than the abstraction the rest of the system wants
 (`[]complex64`), the driver pays the cost of bridging the gap — and it does it
-from first principles, not by linking someone else's DSP library.
+from first principles, not by linking someone else's DSP library.**
 
 ### How that principle shaped the Go code
 

--- a/docs/_posts/2026-06-28-rf-front-end-11-hackrf-one.md
+++ b/docs/_posts/2026-06-28-rf-front-end-11-hackrf-one.md
@@ -1,0 +1,347 @@
+---
+title: "RF Front End, Part 11: HackRF One — Signed 8-Bit IQ End to End"
+description: The HackRF One driver end to end — the simplest IQ format of the three, signed 8-bit interleaved I,Q scaled to complex64; enumeration across One/Jawbreaker/Rad1o PIDs; and the open-time board-ID readback that fixed empty probe gains by establishing identity and the gain ladder before streaming.
+category: deep-dives
+tags: [sdr, go, hackrf, usb, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 11
+---
+
+*Part 11 of **RF Front End**. After the Airspy's host-side DSP, the
+[HackRF One]({{ '/reference/hackrf/' | relative_url }}) is a palate cleanser: the
+simplest wire format of the three. The interesting part isn't the samples — it's
+identity. The driver guesses the model from a USB PID, then asks the firmware who
+it really is, and that open-time handshake is where a probe-gains bug lived.*
+
+## In this post
+
+- Decoding the HackRF's **signed 8-bit interleaved IQ** into `complex64` in `[-1, 1]`.
+- Enumeration across the **One / Jawbreaker / Rad1o** PIDs on VID `0x1d50`, and
+  why the **board-ID read at open** takes precedence over the PID guess.
+- The **SET_TRANSCEIVER_MODE** state machine (0 off / 1 receive) and the default
+  gain ladder (LNA 16 dB, VGA 20 dB).
+- The bug: `sdr list --probe` showed **empty gains** because we read them before
+  the device was fully open — and the open-time fix the tests pin down.
+
+## What the HackRF driver does
+
+The [HackRF]({{ '/reference/hackrf/' | relative_url }}) One is a half-duplex
+transceiver from Great Scott Gadgets covering 1 MHz–6 GHz. GopherTrunk only
+receives, so the driver's surface is small: enumerate, claim, tune, set rate and
+gain, flip into receive mode, and reap bulk-IN URBs into `complex64`. Like every
+other backend it speaks the vendor protocol — here libhackrf's — directly over
+the shared pure-Go USB transport, so no CGO and no libhackrf land in the build.
+
+Its sample format is the friendliest of the bunch. The firmware delivers
+**signed 8-bit interleaved IQ** — `I, Q, I, Q, …` — on bulk endpoint `0x81` once
+the transceiver is in receive mode. There's no real-to-complex synthesis (that
+was the Airspy R2/Mini in
+[Part 10]({{ '/blog/deep-dives/rf-front-end-10-airspy-real-to-complex/' | relative_url }}))
+and no 16-bit unpacking; just two signed bytes per complex sample.
+
+## How GopherTrunk implements it in Go
+
+### Decoding the samples
+
+The decode is a tight loop over `internal/sdr/hackrf/hackrf.go`: read a signed
+byte for I, one for Q, normalize each to roughly `[-1, 1]` by dividing by 128:
+
+```go
+// internal/sdr/hackrf/hackrf.go
+// decodeInt8IQ converts a HackRF bulk-IN payload (signed 8-bit
+// interleaved IQ) into normalised complex64 samples in [-1, 1].
+func decodeInt8IQ(buf []byte) []complex64 {
+    n := len(buf) / 2
+    out := make([]complex64, n)
+    for i := 0; i < n; i++ {
+        iv := float32(int8(buf[2*i])) / 128
+        qv := float32(int8(buf[2*i+1])) / 128
+        out[i] = complex(iv, qv)
+    }
+    return out
+}
+```
+
+The `int8` conversion is load-bearing: the bytes arrive as `uint8` in the slice,
+and reinterpreting them as `int8` is what makes `0x80` read as `-128` rather than
+`+128`. The in-package test pins that down with a `(-128, +64)` sample expected
+near `(-1, +0.5)`.
+
+### The transceiver state machine
+
+The HackRF won't stream until you tell it to receive, and you must put it back to
+off when you stop. That's a two-value state machine over `SET_TRANSCEIVER_MODE`
+(`reqSetTransceiverMode`):
+
+```go
+// internal/sdr/hackrf/hackrf.go
+const (
+    transceiverModeOff     uint16 = 0
+    transceiverModeReceive uint16 = 1
+)
+
+func (d *Device) setMode(mode uint16) error {
+    return d.t.ControlOut(reqSetTransceiverMode, mode, 0, nil, controlTimeoutMs)
+}
+```
+
+`StreamIQ` flips to receive, starts the bulk-IN reaper, and a detached goroutine
+flips back to off on either context cancellation or an unrecoverable URB death —
+the same teardown shape every driver in this series shares.
+
+### Tuning and the tracking baseband filter
+
+`SetCenterFreq` is the one place the HackRF's wire encoding is slightly unusual:
+libhackrf splits the frequency into an MHz part and an Hz remainder, two
+little-endian `uint32`s in the data stage:
+
+```go
+// internal/sdr/hackrf/hackrf.go
+payload := make([]byte, 8)
+binary.LittleEndian.PutUint32(payload[0:4], hz/1_000_000)
+binary.LittleEndian.PutUint32(payload[4:8], hz%1_000_000)
+return d.t.ControlOut(reqSetFreq, 0, 0, payload, controlTimeoutMs)
+```
+
+`SetSampleRate` does a little extra work: the rate goes out as a
+numerator/divider pair (the driver always uses divider 1, so the host sees
+exactly the requested rate), and then the **baseband filter cutoff tracks the
+rate** — set to ~75 % of it to keep the passband flat while rejecting alias
+energy near the band edge. The filter program is fire-and-forget; the rate
+program is the one that must land:
+
+```go
+// internal/sdr/hackrf/hackrf.go  (shape)
+// rate = (hz, divider 1); then baseband filter ≈ 0.75 × rate
+bw := uint32(float64(hz) * 0.75)
+_ = d.t.ControlOut(reqBasebandFilterBwSet,
+    uint16(bw&0xFFFF), uint16(bw>>16), nil, controlTimeoutMs)
+```
+
+The `TestSetSampleRateProgramsFilter` test scripts both transfers, asserting the
+filter program follows the rate program with the 0.75 cutoff.
+
+### The gain ladder
+
+The HackRF has no true AGC. Its gain is three independent stages: an RF amp
+(on/off), an LNA (0–40 dB in 8 dB steps), and a VGA (0–62 dB in 2 dB steps). The
+driver maps a single tenth-dB target onto that triple, and maps "auto" (a
+negative value) onto a sane fixed preset rather than a non-existent AGC:
+
+```go
+// internal/sdr/hackrf/hackrf.go
+// splitGain maps an SDR-interface tenth-dB target to the HackRF's
+// (LNA, VGA, AMP-on) triple. LNA must be a multiple of 8; VGA a multiple of 2.
+func splitGain(tenthDB int) (lna, vga int, amp bool) {
+    if tenthDB < 0 {
+        return defaultLNAGainDB, defaultVGAGainDB, false // 16 dB LNA, 20 dB VGA
+    }
+    target := tenthDB / 10
+    lna = (target / 8) * 8
+    if lna > 40 {
+        lna = 40
+    }
+    rem := target - lna
+    vga = (rem / 2) * 2
+    if vga > 62 {
+        vga = 62
+    }
+    return lna, vga, false
+}
+```
+
+The default preset — **LNA 16 dB, VGA 20 dB, amp off** — is the
+hardware-friendly mid-band split the test ladder asserts on (`splitGain(-1) ==
+(16, 20, false)`, and rungs like `300 → (24, 6)`).
+
+### Identity: PID guess, then ask the board
+
+Three HackRF variants share VID `0x1d50` under different PIDs — **One** (`0x6089`),
+the **Jawbreaker** prototype (`0x604b`), and the **Rad1o** badge (`0xcc15`). Unlike
+the Airspy (one PID) or RTL-SDR, enumeration here has to **scan every known PID**
+and concatenate the results into one descriptor list:
+
+```go
+// internal/sdr/hackrf/hackrf.go  (shape)
+descs := make([]usb.Descriptor, 0)
+for _, pid := range []uint16{pidHackRFOne, pidHackRFJawbrk, pidHackRFRad1o} {
+    found, err := d.enum.List(vidHackRF, pid)
+    // ...append found to descs...
+}
+```
+
+Enumeration then maps each PID to a canonical product name, since USB descriptor
+strings vary by vendor and firmware while the PID is stable:
+
+```go
+// internal/sdr/hackrf/hackrf.go
+var pidProductNames = map[uint16]string{
+    pidHackRFOne:    "HackRF One",
+    pidHackRFJawbrk: "HackRF Jawbreaker",
+    pidHackRFRad1o:  "Rad1o",
+}
+```
+
+But the PID is only a *guess* about what the box is — a unit flashed with the
+wrong firmware will enumerate under one PID while actually running another
+board's image. So at **open** time the driver asks the firmware directly, via
+`BOARD_ID_READ`, and that answer **takes precedence** over the PID:
+
+```go
+// internal/sdr/hackrf/hackrf.go
+product := productForPID(desc.PID, desc.Product)
+if bid, err := readBoardID(t); err == nil {
+    if name, ok := boardIDNames[bid]; ok && name != "" {
+        product = name // firmware self-report wins over the PID guess
+    }
+}
+```
+
+`boardIDNames` mirrors libhackrf's `hackrf_board_id` enum (`2` → "HackRF One",
+`3` → "Rad1o", …). The same open also reads `VERSION_STRING_READ` to suffix the
+tuner name with firmware (and to tag PortaPack/Mayhem builds). Both readbacks are
+best-effort: older firmware that doesn't implement them just falls through to the
+PID-derived name and a plain tuner string — pinned by
+`TestReadVersionStringIgnoredOnError` in `hackrf_test.go`.
+
+## The problem we hit: `--probe` reported empty gains
+
+**Symptom.** `sdr list --probe` — which actually opens each device and reports
+`dev.Info()` — listed HackRFs (and Airspys) with an **empty gain list**. The
+non-probing `sdr list`, which only enumerates, showed the ladder fine. Same
+hardware, two different answers, depending on whether the device had been opened.
+
+**Root cause.** The gain ladder was attached to the `sdr.Info` produced by
+`Enumerate`, but the `Info` carried by an **opened** `Device` was built
+separately at open time and never got the `Gains` field. So the moment a probe
+opened the device and read `dev.Info().Gains`, it got back `nil`. The information
+existed; it just wasn't established on the device-side `Info` that `--probe`
+reads. (The same gap bit the Airspy driver, and is called out in #454's
+probe-gains fix.)
+
+**The Go fix.** Establish the full identity — board-ID, version string, **and**
+the gain ladder — at open time, on the same `Info` the opened device hands back.
+The ladder is shared between `Enumerate` and `Open` so a probed device reports
+exactly what an enumerated one does:
+
+```go
+// internal/sdr/hackrf/hackrf.go
+// gainPresetsTenthDB ... Shared by Enumerate and Open so a probed
+// (opened) device reports the same ladder an enumerated one does —
+// otherwise `--probe` showed an empty list.
+var gainPresetsTenthDB = []int{0, 80, 160, 240, 320, 400, 480, 560}
+
+return &Device{
+    t: t,
+    info: sdr.Info{
+        // ...board-ID-resolved Product, fw-suffixed TunerName...
+        // Carry the gain ladder onto the opened device so dev.Info()
+        // (used by `sdr list --probe`) reports it, not an empty list.
+        Gains: gainPresetsTenthDB,
+    },
+}, nil
+```
+
+The fix is pinned by a test in `hackrf_test.go` that opens a device through a
+scripted mock and asserts the opened `Info` carries the ladder:
+
+```go
+// internal/sdr/hackrf/hackrf_test.go
+// The opened device must carry the gain ladder so `sdr list --probe`
+// (which reads dev.Info() post-open) doesn't report an empty list.
+if got := dev.Info().Gains; len(got) == 0 {
+    t.Errorf("opened device Info().Gains is empty; want the gain ladder")
+}
+```
+
+That same test (`TestDriverEnumerateAndOpen`) scripts the `BOARD_ID_READ` and
+`VERSION_STRING_READ` exchanges the open now issues — proof that the board-id and
+version readbacks, the firmware suffix, and the gain ladder all get established as
+one atomic open-time step rather than lazily on first use.
+
+It's worth dwelling on why this class of bug is easy to introduce. `Enumerate`
+and `Open` each build an `sdr.Info` independently — they have to, because an
+opened device knows things an enumerated one can't (the board-ID, the firmware
+string). The trap is that the two `Info` constructions drift: a field added to
+one is forgotten on the other, and nothing in the type system flags it. The fix
+isn't just "stamp the ladder on at open" — it's making the *shared* facts (the
+`gainPresetsTenthDB` ladder, the canonical product name via `productForPID`) come
+from one source that both paths read, so they can't disagree. The open-only facts
+(board-ID override, firmware suffix) layer on top.
+
+## The design principle: identity by capability, established at open
+
+The thread tying the decode loop to the probe-gains fix is one principle:
+**a device's identity and capabilities are established when it's opened, by
+asking the hardware — not guessed lazily and not deferred until first use.**
+
+### How that principle shaped the Go code
+
+- **The board reports itself; the PID is a fallback.** `BOARD_ID_READ` at open
+  overrides the PID-derived name, so a mis-flashed unit reports what's actually
+  running. The PID guess only survives when the firmware can't answer.
+- **Open is the single point of truth for `Info`.** Product, tuner/firmware
+  string, and the gain ladder are all stamped onto the device's `Info` in `Open`.
+  Nothing downstream has to re-derive or re-probe them — `dev.Info()` is complete
+  the instant `Open` returns, which is exactly what `--probe` depends on.
+- **Best-effort readbacks degrade, they don't fail.** A board-ID or
+  version-string NAK on old firmware is swallowed; the device still opens with a
+  sensible PID-derived identity. Capability discovery never blocks bring-up.
+- **The mock scripts the open handshake.** Because identity is established through
+  ordinary control transfers, the tests drive the whole open — board-ID, version,
+  gain ladder — against a `MockTransport` with no hardware, so the
+  identity-by-capability contract is regression-tested.
+
+## Where this goes next
+
+That's all four wire formats and all four open-time identity strategies covered:
+RTL-SDR, Airspy R2/Mini, Airspy HF+, and HackRF. The remaining question is what
+sits *above* the drivers — the pool that owns opened devices, dispatches retunes,
+and survives a USB unplug-and-replug mid-stream. That's
+[Part 12]({{ '/blog/deep-dives/rf-front-end-12-sdr-pool-usb-watchdog/' | relative_url }}):
+the SDR pool and the USB hotplug watchdog.
+
+## FAQ
+
+**Why divide the 8-bit samples by 128 and not 127?**
+Dividing by 128 maps the full signed range cleanly: `-128 → -1.0` exactly, and
+`+127 → ~0.992`. It keeps the scale a power of two and guarantees the result
+never exceeds `[-1, 1)`, which downstream DSP assumes.
+
+**Why does board-ID override the PID if both are available?**
+The PID is what the device *enumerated as*; the board-ID is what the firmware
+*reports it is*. A unit flashed with another board's image enumerates under one
+PID but runs another board — the firmware's self-report is the ground truth, so it
+wins.
+
+**Why did probe show empty gains but plain list didn't?**
+`sdr list` only enumerates, reading the `Info` from `Enumerate` (which had the
+ladder). `sdr list --probe` opens each device and reads `dev.Info()`, which was
+built separately at open and lacked the `Gains` field until we stamped the ladder
+on at open time.
+
+**Does the HackRF have AGC?**
+No. It has three manual stages (amp, LNA, VGA). The driver maps a negative
+("auto") target to a fixed hardware-friendly preset — amp off, LNA 16 dB, VGA
+20 dB — rather than pretending an AGC exists.
+
+**Why scan multiple PIDs at enumerate instead of one?**
+Because the HackRF family ships under three PIDs on the same VID. A single
+`List(vid, pid)` would miss Jawbreakers and Rad1os, so enumeration loops over all
+three known PIDs and concatenates the descriptors into one ordered list that
+`Open` later indexes into.
+
+**What's the bias-tee for, and is it on by default?**
+`SetBiasTee` toggles the +3.3 V antenna-port bias (`ANTENNA_ENABLE`) for powering
+an external LNA up the coax. It's off unless explicitly enabled — the test
+round-trips it on then off — so you never accidentally feed DC into a passive
+antenna.
+
+## Series navigation
+
+**Part 11 of 14** · ←
+[Part 10]({{ '/blog/deep-dives/rf-front-end-10-airspy-real-to-complex/' | relative_url }})
+· Next →
+[Part 12: The SDR pool & USB hotplug watchdog]({{ '/blog/deep-dives/rf-front-end-12-sdr-pool-usb-watchdog/' | relative_url }})

--- a/docs/_posts/2026-06-28-rf-front-end-11-hackrf-one.md
+++ b/docs/_posts/2026-06-28-rf-front-end-11-hackrf-one.md
@@ -15,6 +15,8 @@ simplest wire format of the three. The interesting part isn't the samples — it
 identity. The driver guesses the model from a USB PID, then asks the firmware who
 it really is, and that open-time handshake is where a probe-gains bug lived.*
 
+> **TL;DR** — The HackRF One driver decodes the simplest of the three wire formats: signed 8-bit interleaved IQ scaled to `complex64`. Identity is the tricky part — the driver guesses the model from a USB PID, then lets the firmware's board-ID readback override it. A probe-gains bug (`sdr list --probe` showed empty gains) is fixed by stamping the full identity, ladder included, onto the device at open time.
+
 ## In this post
 
 - Decoding the HackRF's **signed 8-bit interleaved IQ** into `complex64` in `[-1, 1]`.
@@ -64,9 +66,9 @@ func decodeInt8IQ(buf []byte) []complex64 {
 }
 ```
 
-The `int8` conversion is load-bearing: the bytes arrive as `uint8` in the slice,
+**The `int8` conversion is load-bearing: the bytes arrive as `uint8` in the slice,
 and reinterpreting them as `int8` is what makes `0x80` read as `-128` rather than
-`+128`. The in-package test pins that down with a `(-128, +64)` sample expected
+`+128`.** The in-package test pins that down with a `(-128, +64)` sample expected
 near `(-1, +0.5)`.
 
 ### The transceiver state machine

--- a/docs/_posts/2026-06-29-rf-front-end-12-sdr-pool-usb-watchdog.md
+++ b/docs/_posts/2026-06-29-rf-front-end-12-sdr-pool-usb-watchdog.md
@@ -14,6 +14,8 @@ USB transport, the RTL2832U register dance, tuners, sample conversion. Now we
 zoom out to the fleet: how the daemon holds several radios at once, gives each a
 job, and keeps them alive across the USB drops that real hardware throws at you.*
 
+> **TL;DR** — The SDR pool owns every opened dongle behind one interface, assigning each a role (control, voice, wideband) and keeping the fleet alive through USB hotplug via a 30-second watchdog that reacquires devices under new bus addresses. A scanner retune that raced stream teardown (issue #686) is fixed by serializing re-open behind an idempotent stop.
+
 ## In this post
 
 - The **pool** (`internal/sdr/pool.go`) — a fleet of opened devices, each with a
@@ -68,8 +70,8 @@ type PoolEntry struct {
 }
 ```
 
-`OpenWith` is the heart of bring-up. It sweeps every registered driver, opens the
-selected devices, programs the IQ rate, and assigns roles. Role assignment is one
+**`OpenWith` is the heart of bring-up. It sweeps every registered driver, opens the
+selected devices, programs the IQ rate, and assigns roles.** Role assignment is one
 simple rule: the first opened device that isn't otherwise claimed takes
 `RoleControl`; everything after it defaults to `RoleVoice`. A `Hint` can override
 that per serial.
@@ -199,7 +201,7 @@ bias-tee re-applied, index refreshed to 7.
 The watchdog handles the *idle* case — a device nobody is streaming. The in-use
 case is harder, and it bit us in scanner mode.
 
-In scanner mode a fast retune cancels the IQ stream's context and immediately
+**Symptom.** In scanner mode a fast retune cancels the IQ stream's context and immediately
 re-opens it on the new frequency. But USB drivers don't tear a stream down
 synchronously — the bulk-IN reaper goroutine runs `cancelStream` asynchronously,
 draining URBs and closing the consumer channel on its own schedule. So the
@@ -208,7 +210,7 @@ previous stop is still in flight." The second `StreamIQ` found the bulk-IN
 endpoint still claimed and failed with `stream already active` — surfacing to the
 operator as `conv: StreamIQ failed` and a dead capture.
 
-The race was structural, not a missing lock. The teardown path is idempotent via
+**Root cause.** The race was structural, not a missing lock. The teardown path is idempotent via
 a `sync.Once`:
 
 ```go
@@ -222,7 +224,7 @@ func (d *Device) cancelStream() {
 ```
 
 `stopOnce` guarantees teardown runs exactly once — but it didn't guarantee the
-*next* `StreamIQ` waited for it. The fix was to make re-open serialize behind the
+*next* `StreamIQ` waited for it. **The fix** was to make re-open serialize behind the
 in-flight teardown: a new stream resets `stopOnce` only after the previous stop
 has actually completed, so a retune can never out-run the reaper.
 
@@ -244,8 +246,8 @@ it owns the lifecycle of every device, restarts the ones that fail, and presents
 the survivors as a roster the engine can query by role. The watchdog is the
 supervisor's health check, and `Reacquire` is its restart strategy.
 
-The second pattern is **observer**. The pool never calls into the daemon, the
-API, or the TUI. It `Publish`es `KindSDRAttached` / `KindSDRDetached` to an
+The second pattern is **observer**. **The pool never calls into the daemon, the
+API, or the TUI.** It `Publish`es `KindSDRAttached` / `KindSDRDetached` to an
 optional bus and lets whoever cares subscribe:
 
 ```go

--- a/docs/_posts/2026-06-29-rf-front-end-12-sdr-pool-usb-watchdog.md
+++ b/docs/_posts/2026-06-29-rf-front-end-12-sdr-pool-usb-watchdog.md
@@ -1,0 +1,312 @@
+---
+title: "RF Front End, Part 12: The SDR Pool & USB Hotplug Watchdog"
+description: How GopherTrunk manages a fleet of opened dongles behind one pool — assigning control, voice, and wideband roles, running a USB watchdog that re-enumerates every 30 seconds to catch hotplug, and reacquiring a device after the kernel hands it a new bus address. Plus the re-open race that taught us to serialize retune behind stream teardown.
+category: deep-dives
+tags: [sdr, go, usb, concurrency, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 12
+---
+
+*Part 12 of **RF Front End**. We've spent eleven posts inside a single dongle —
+USB transport, the RTL2832U register dance, tuners, sample conversion. Now we
+zoom out to the fleet: how the daemon holds several radios at once, gives each a
+job, and keeps them alive across the USB drops that real hardware throws at you.*
+
+## In this post
+
+- The **pool** (`internal/sdr/pool.go`) — a fleet of opened devices, each with a
+  **role**: control, voice, or wideband.
+- **Strict / allowlist mode** and **serial-alias matching** so an operator's
+  `config.yaml` selects exactly the dongles they named.
+- The **USB watchdog** that re-enumerates every ~30 s, publishes
+  `KindSDRAttached` / `KindSDRDetached`, and **reacquires** a device after the
+  kernel re-enumerates it with a new address.
+- **The re-open race (issue #686)**: a scanner retune raced USB stream teardown,
+  and how serializing behind an idempotent stop fixed it.
+
+## What the pool does
+
+A single dongle is one `Device`. A trunked system needs more than one: a radio
+camped on the control channel decoding grants, and one or more radios that follow
+those grants onto voice frequencies. A wideband Airspy might cover a whole site's
+worth of channels at once. The pool is the thing that owns all of them.
+
+Its job is narrow but load-bearing. At boot it enumerates every registered
+driver, opens the devices the operator selected, programs a known-good sample
+rate on each, and assigns each one a **role**. After boot it answers a single
+question for the rest of the engine — "give me the device with role X" — and it
+keeps that fleet healthy while USB does what USB does: drop a stick mid-stream,
+re-enumerate it under a new device number, and expect the software to cope.
+
+Roles matter because the engine never reaches for a *specific* dongle. The
+control-channel decoder asks for `RoleControl`; the voice composer asks the pool
+to find a `RoleVoice` device by serial when the engine binds a call. That
+indirection is what lets the same code run on a one-stick hobby setup and a
+four-stick site without a branch anywhere in the engine.
+
+## How GopherTrunk implements it in Go
+
+A `Pool` is a slice of opened entries behind a mutex, plus an optional event bus:
+
+```go
+// internal/sdr/pool.go
+type Pool struct {
+    mu      sync.RWMutex
+    entries []*PoolEntry
+    log     *slog.Logger
+    bus     *events.Bus
+}
+
+type PoolEntry struct {
+    Driver Driver
+    Device Device
+    Info   Info
+    Role   Role
+    Hint   Hint
+}
+```
+
+`OpenWith` is the heart of bring-up. It sweeps every registered driver, opens the
+selected devices, programs the IQ rate, and assigns roles. Role assignment is one
+simple rule: the first opened device that isn't otherwise claimed takes
+`RoleControl`; everything after it defaults to `RoleVoice`. A `Hint` can override
+that per serial.
+
+```go
+// internal/sdr/pool.go (shape)
+role := RoleAuto
+if hinted {
+    role = hint.Role
+}
+if role == RoleAuto {
+    if !controlClaimed {
+        role = RoleControl
+        controlClaimed = true
+    } else {
+        role = RoleVoice
+    }
+}
+```
+
+Programming the sample rate at open time isn't optional housekeeping — it's a
+fix for issue #275. Without an explicit `SetSampleRate`, the chip streams at
+whatever rate its resampler powered up at, while the decoder runs its
+symbol-timing math against the *configured* rate. The result is a silent failure
+to lock, the worst kind of bug in a radio. So a device whose `SetSampleRate`
+fails is closed and skipped: a wrong-rate radio is worse than no radio at all.
+
+### Strict mode and serial aliases
+
+By default the pool opens every dongle it finds. The moment an operator lists
+specific devices in config, that's their signal that they want *only* those —
+so the daemon engages **strict mode**, where `Hints` becomes an allowlist:
+
+```go
+// internal/sdr/pool.go (shape)
+if opts.Strict && !hinted {
+    p.log.Info("skipping non-configured SDR; add its serial to sdr.devices to use it",
+        "driver", d.drv.Name(), "serial", d.info.Serial)
+    continue
+}
+```
+
+Matching a hint to a device means matching serials, and serials aren't always
+clean. Airspy reports a legacy form — `AIRSPY SN:35ac63dc2d701c4f` — that an
+operator might write a dozen ways. `serialKey` normalizes them so the config and
+the wire agree:
+
+```go
+// internal/sdr/pool.go
+func serialKey(s string) string {
+    s = strings.TrimSpace(s)
+    s = strings.ToLower(s)
+    switch {
+    case strings.HasPrefix(s, "airspy sn:"):
+        return strings.TrimPrefix(s, "airspy sn:")
+    case strings.HasPrefix(s, "airspy_sn:"):
+        return strings.TrimPrefix(s, "airspy_sn:")
+    default:
+        return s
+    }
+}
+```
+
+`TestPoolMatchesAirspySerialAliases` pins this: a hint written
+`AIRSPY SN:35ac63dc2d701c4f` opens the device whose raw serial is
+`35AC63DC2D701C4F`, and `FindBySerial` resolves all three spellings to the same
+entry.
+
+### The USB watchdog
+
+The pool also runs a supervisor loop. `RunWatchdog` ticks every interval — 30
+seconds by default — re-enumerates every driver, and acts only on *transitions*:
+
+```go
+// internal/sdr/watchdog.go
+const DefaultWatchdogInterval = 30 * time.Second
+
+func (p *Pool) RunWatchdog(ctx context.Context, interval time.Duration, sampleRateHz uint32) error {
+    if interval <= 0 {
+        <-ctx.Done()
+        return ctx.Err()
+    }
+    tick := time.NewTicker(interval)
+    defer tick.Stop()
+
+    missing := map[string]bool{}
+    for {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        case <-tick.C:
+            p.watchdogTick(missing, sampleRateHz)
+        }
+    }
+}
+```
+
+The `missing` map is the state machine. A pool serial that the enumerate stops
+seeing flips to missing and emits one `KindSDRDetached` — the API, TUI, and web
+snapshot all show the gap. When that same serial reappears in a later enumerate,
+the watchdog deletes it from `missing` and calls `Reacquire`:
+
+```go
+// internal/sdr/watchdog.go (shape)
+if missing[serial] {
+    delete(missing, serial)
+    p.log.Info("sdr: watchdog: device reappeared; reacquiring", "serial", serial)
+    if _, err := p.Reacquire(serial, sampleRateHz); err != nil {
+        p.log.Warn("sdr: watchdog: reacquire failed", "serial", serial, "err", err)
+    }
+}
+```
+
+`Reacquire` is where the hotplug story gets real. When a dongle browns out and
+comes back, the kernel assigns it a new device number — but it reports the same
+serial. So `Reacquire` closes the (likely dead) handle best-effort, re-enumerates
+the driver, finds the serial under its *new* index, opens a fresh handle,
+re-programs the rate, and re-applies the original `Hint` (PPM, gain, bias-tee).
+Crucially it swaps the `Device` **in place** on the existing `PoolEntry` —
+`Role`, serial identity, and any pointer a consumer is holding all survive; only
+`Info.Index` updates to the new enumeration. `TestPoolReacquireSwapsDeviceHandleInPlace`
+asserts exactly that: same `PoolEntry`, new `*fakeDevice`, stale handle closed,
+bias-tee re-applied, index refreshed to 7.
+
+## The problem we hit: the retune-vs-teardown re-open race (issue #686)
+
+The watchdog handles the *idle* case — a device nobody is streaming. The in-use
+case is harder, and it bit us in scanner mode.
+
+In scanner mode a fast retune cancels the IQ stream's context and immediately
+re-opens it on the new frequency. But USB drivers don't tear a stream down
+synchronously — the bulk-IN reaper goroutine runs `cancelStream` asynchronously,
+draining URBs and closing the consumer channel on its own schedule. So the
+sequence that should have been "stop, then start" became "start while the
+previous stop is still in flight." The second `StreamIQ` found the bulk-IN
+endpoint still claimed and failed with `stream already active` — surfacing to the
+operator as `conv: StreamIQ failed` and a dead capture.
+
+The race was structural, not a missing lock. The teardown path is idempotent via
+a `sync.Once`:
+
+```go
+// internal/sdr/rtlsdr/purego/device.go
+func (d *Device) cancelStream() {
+    d.stopOnce.Do(func() {
+        _ = d.transport.StopBulkIn()
+        // ...close the consumer channel
+    })
+}
+```
+
+`stopOnce` guarantees teardown runs exactly once — but it didn't guarantee the
+*next* `StreamIQ` waited for it. The fix was to make re-open serialize behind the
+in-flight teardown: a new stream resets `stopOnce` only after the previous stop
+has actually completed, so a retune can never out-run the reaper.
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go (shape)
+out := make(chan []complex64, streamChanDepth)
+d.out = out
+d.stopOnce = sync.Once{} // only reachable once the prior teardown finished
+```
+
+The lesson is a recurring one in this series: with USB, "stop" is a *request*,
+not an event. Anything that re-opens has to wait on the teardown completing, not
+on having asked for it.
+
+## The design principle: supervisor + observer
+
+Two patterns share the load here. The pool is a **supervisor** (a fleet manager):
+it owns the lifecycle of every device, restarts the ones that fail, and presents
+the survivors as a roster the engine can query by role. The watchdog is the
+supervisor's health check, and `Reacquire` is its restart strategy.
+
+The second pattern is **observer**. The pool never calls into the daemon, the
+API, or the TUI. It `Publish`es `KindSDRAttached` / `KindSDRDetached` to an
+optional bus and lets whoever cares subscribe:
+
+```go
+// internal/sdr/pool.go
+func (p *Pool) publish(kind events.Kind, payload any) {
+    if p.bus == nil {
+        return
+    }
+    p.bus.Publish(events.Event{Kind: kind, Payload: payload})
+}
+```
+
+### How that principle shaped the Go code
+
+- **The bus is optional.** `NewPool` takes only a logger; `SetBus` is a separate,
+  idempotent step. The `gophertrunk sdr list` CLI and every unit test run the
+  pool with `bus == nil`, and `publish` short-circuits — the same fleet code, no
+  daemon required.
+- **State lives in one goroutine.** The watchdog's `missing` map is owned solely
+  by the watchdog goroutine and passed in by value-reference, so attach/detach
+  transitions need no extra lock. Only the pool's `entries` slice is shared, and
+  that's behind `sync.RWMutex`.
+- **Identity is stable across reacquisition.** Because `Reacquire` swaps the
+  `Device` inside an existing `PoolEntry` rather than replacing the entry,
+  consumers that cached a `*PoolEntry` keep working across a USB cycle. Role and
+  serial are the identity; the handle is just an attribute.
+- **Recovery is best-effort and idempotent.** Closing a dead handle may error;
+  re-enumerate may miss the serial; the in-stream retry loop may beat the
+  watchdog to it. Every path logs and moves on, because the next tick — or the
+  next consumer — will try again.
+
+## Where this goes next
+
+The pool assigns roles and keeps devices alive, but we've leaned on tests
+throughout this post — `TestPoolReacquireSwapsDeviceHandleInPlace`,
+`TestPoolMatchesAirspySerialAliases` — without explaining how you test a fleet of
+radios in CI where there are no radios at all. That's
+[Part 13]({{ '/blog/deep-dives/rf-front-end-13-testing-radios-without-radios/' | relative_url }}):
+replaying captured USB control-transfer sequences, bit-identical conversion
+golden masters, and an opt-in real-hardware tier.
+
+## FAQ
+
+**Why poll every 30 seconds instead of listening for kernel hotplug events?**
+Polling is portable. The same re-enumerate loop works on Linux USBDEVFS, Windows
+WinUSB, and macOS IOKit without three platform-specific hotplug listeners. 30 s
+is short enough to recover a transient drop inside one failure cycle and long
+enough not to load a slow hub.
+
+**What happens to an in-use device that drops?** The watchdog owns the *idle*
+case. A device that's actively streaming surfaces its death through the stream
+itself — the reaper closes the channel, the consumer (ccdecoder retry loop,
+`VoicePool.Bind`) sees EOF and drives its own `Reacquire`. The watchdog is the
+backstop for radios nobody is currently touching.
+
+**Why does strict mode skip a device that's physically present?** Because an
+allowlist is an allowlist, not a preference. If you named your control stick in
+config and an unrelated dongle is on the bus, opening that dongle could let it
+win `RoleControl` and bind the decoder to a radio that never got your PPM
+correction — the original issue #264 failure. Strict mode refuses to guess.
+
+## Series navigation
+
+**Part 12 of 14** · ← [Part 11]({{ '/blog/deep-dives/rf-front-end-11-hackrf-one/' | relative_url }}) · Next → [Part 13: Testing radios without radios]({{ '/blog/deep-dives/rf-front-end-13-testing-radios-without-radios/' | relative_url }})

--- a/docs/_posts/2026-06-30-rf-front-end-13-testing-radios-without-radios.md
+++ b/docs/_posts/2026-06-30-rf-front-end-13-testing-radios-without-radios.md
@@ -1,0 +1,287 @@
+---
+title: "RF Front End, Part 13: Testing Radios Without Radios"
+description: How GopherTrunk's USB driver code is tested in CI with no hardware attached — replaying captured control-transfer sequences through a scripted mock transport, pinning the pure-Go sample conversion bit-for-bit against librtlsdr with a golden-master test, and an opt-in real-hardware tier gated behind environment flags with bias-tee safety resets.
+category: deep-dives
+tags: [sdr, go, testing, usb, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 13
+---
+
+*Part 13 of **RF Front End**. We've described eleven drivers and a pool that
+herds them, and at every turn we've cited a test that proves it works. This post
+answers the question those citations dodge: how do you trust a USB driver you
+can't run on real hardware in CI?*
+
+## In this post
+
+- The **`MockTransport`** — a scripted control-transfer replayer that lets the
+  RTL-SDR driver run its full bring-up with no dongle present.
+- The **bit-identical conversion test** (`TestConvertU8IQ_BitIdenticalWithCGO`)
+  that pins the pure-Go U8→`complex64` lookup table against librtlsdr's math.
+- The **pool tests** for role assignment, strict mode, and the watchdog.
+- The **opt-in real-hardware tier**, guarded by `GOPHERTRUNK_AIRSPY_REAL=1`,
+  `-short`, hard timeouts, and a bias-tee safety reset.
+
+## What "testing a radio" actually means
+
+A driver is a contract negotiation. The RTL-SDR bring-up isn't "open the device"
+— it's dozens of vendor control transfers in a precise order: reset the demod,
+poke the RTL2832U registers, walk the R820T's PLL through its lock sequence, set
+the sample-rate divider. Each transfer has a `bRequest`, a `wValue`, a `wIndex`,
+and either a payload (OUT) or an expected reply (IN). Get one wrong and the chip
+either rejects it or — worse — accepts it and streams garbage.
+
+That's actually good news for testing, because a contract is *recordable*. The
+real conversation between librtlsdr (or the chip's firmware) and the hardware is
+a deterministic sequence of bytes on the wire. Capture it once, and you can replay
+it forever in CI. The driver doesn't know it's talking to a recording — it issues
+the same control transfers it would to silicon, and something on the other end
+either matches the script or fails the test.
+
+So GopherTrunk's testing rests on three legs: **replay captured wire contracts**
+so the protocol logic is exercised, **a golden-master conversion test** so the
+DSP-facing output is byte-for-byte correct, and **an opt-in real-hardware tier**
+that smoke-tests against actual silicon when you have it plugged in.
+
+## How GopherTrunk implements it in Go
+
+### The scripted mock transport
+
+The `Transport` interface every driver speaks to has a test double:
+`MockTransport`. It holds a `Script` — an ordered list of expected exchanges —
+and matches each call against the next entry:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_mock.go
+type CtrlExchange struct {
+    In        bool
+    BRequest  uint8
+    WValue    uint16
+    WIndex    uint16
+    Data      []byte // expected for OUT, ignored for IN
+    Reply     []byte // returned for IN, ignored for OUT
+    Err       error
+    N         int
+    TimeoutOK bool
+}
+```
+
+When the driver issues a `ControlOut`, the mock pops the next script entry and
+checks everything — direction, request, value, index, and the exact payload
+bytes — recording a descriptive error on any mismatch:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_mock.go (shape)
+if want.BRequest != bRequest || want.WValue != wValue || want.WIndex != wIndex {
+    err := fmt.Errorf("mock step %d: ControlOut mismatch: got (req=0x%02x,val=0x%04x,idx=0x%04x), ...")
+    m.recordErr(err)
+    return err
+}
+if !bytesEqual(want.Data, data) {
+    err := fmt.Errorf("mock step %d: ControlOut data mismatch: got %#x, want %#x", m.Step-1, data, want.Data)
+    m.recordErr(err)
+    return err
+}
+```
+
+A test populates the script with the captured sequence, runs the driver's
+bring-up, and asserts `MockTransport.Remaining() == 0` — every expected transfer
+happened, in order, with the right bytes. The mock even models the messy parts:
+`ResetCalls` counts `USBDEVFS_RESET` invocations so a test can prove the recovery
+path ran, `ClaimErr` injects an `EBUSY` so the claim-failure branch is exercised,
+and `BulkSimulateDeath` fires `onStreamDead` after delivering its packets so the
+issue #345 reaper-death path is covered without unplugging anything.
+
+The same file ships a `MockEnumerator` so even discovery is fakeable — it returns
+a fixed set of descriptors and opens each as a `MockTransport`, which is how the
+higher layers (rtl2832u, the tuners) run end-to-end with no bus.
+
+### The bit-identical conversion test
+
+Replaying control transfers proves the *protocol* is right. It says nothing about
+the sample math — the conversion of raw 8-bit IQ bytes into the `complex64` the
+whole DSP chain consumes. That math is a port of librtlsdr's C, and a port can
+drift. So GopherTrunk pins it with a golden master.
+
+The production conversion uses a 256-entry lookup table, one float32 per possible
+byte value, built from the exact expression librtlsdr uses:
+
+```go
+// internal/sdr/rtlsdr/purego/stream.go (shape)
+// Each entry uses ((b-127.5)/127.5), the exact float32 expression as the
+// original per-sample math, so the result is bit-identical — pinned by
+// TestConvertU8IQ_BitIdenticalWithCGO.
+var u8ToF32 [256]float32
+```
+
+`TestConvertU8IQ_BitIdenticalWithCGO` writes that C-side math out longhand as an
+*oracle* — a reference implementation deliberately written the naive,
+unoptimized way — and asserts the production LUT path produces identical bytes:
+
+```go
+// internal/sdr/rtlsdr/purego/stream_test.go
+func referenceConvertU8IQ(buf []byte) []complex64 {
+    n := len(buf) / 2
+    out := make([]complex64, n)
+    for i := 0; i < n; i++ {
+        out[i] = complex(
+            (float32(buf[2*i])-127.5)/127.5,
+            (float32(buf[2*i+1])-127.5)/127.5,
+        )
+    }
+    return out
+}
+```
+
+The point of the oracle isn't to re-test the formula — it's to catch *drift*. The
+moment someone "optimizes" the LUT and changes a result in the last bit of the
+mantissa, this test fails and names the offending byte. Companion tests pin the
+physically meaningful cases: 127/128 brackets the chip's 127.5 DC bias and must
+land near zero; 0 and 255 must scale to −1 and +1; and
+`TestConvertU8IQInto_ZeroAllocMatchesAllocating` proves the zero-allocation
+hot-path variant (issue #489) matches the allocating one sample for sample.
+
+### The pool tests
+
+The pool from [Part 12]({{ '/blog/deep-dives/rf-front-end-12-sdr-pool-usb-watchdog/' | relative_url }})
+gets the same treatment with an even lighter fake: a `fakeDriver` returning a
+fixed `[]Info` and a `fakeDevice` that records the calls made to it. With that,
+the fleet logic is fully testable. `TestPoolAssignsRoles` checks that a
+control-hinted serial wins `RoleControl` and the rest fall to voice;
+`TestPoolStrictOpensOnlyHintedSerial` proves strict mode opens only the allowlisted
+dongle and skips the others with a log line; and the watchdog tests swap the
+fake's `Enumerate` return between calls to simulate an unplug/replug:
+
+```go
+// internal/sdr/watchdog_test.go (shape)
+// Pull the device off the bus, then tick.
+drv.infos = nil
+missing := map[string]bool{}
+p.watchdogTick(missing, 0)
+// assert KindSDRDetached published exactly once, idempotent on the next tick.
+```
+
+None of these touch USB. The `fakeDevice` just flips booleans —
+`biasTeeOn`, `sampleRate`, `ppm` — and the tests assert against them, so the
+entire supervisor and recovery logic is verified deterministically in
+milliseconds.
+
+## The problem we hit: trusting a driver you can't run in CI
+
+Here's the uncomfortable truth the three legs are built to address. CI runs on a
+cloud box with no SDR plugged in. We can prove the control-transfer *sequence*
+matches a capture, and we can prove the conversion math is bit-identical to
+librtlsdr — but a capture is a snapshot of one dongle's firmware on one day. What
+if a chip revision reorders its init? What if a real R820T rejects a transfer the
+mock happily accepts because the mock only checks the bytes, not the silicon's
+state machine?
+
+Replay and golden masters give *necessary* confidence, not *sufficient*. So
+there's a fourth thing: an **opt-in real-hardware tier** that runs only when you
+ask it to, against the dongle on your desk. The Airspy suite is the template. Every
+real-hardware test starts with a guard:
+
+```go
+// internal/sdr/airspy/airspy_real_test.go
+func requireRealAirspy(t *testing.T) {
+    t.Helper()
+    v := strings.TrimSpace(os.Getenv(airspyRealEnv))
+    if v == "" || v == "0" || strings.EqualFold(v, "false") {
+        t.Skipf("set %s=1 to run real Airspy hardware validation", airspyRealEnv)
+    }
+    if testing.Short() {
+        t.Skip("skipping real Airspy hardware validation in -short mode")
+    }
+}
+```
+
+So `go test ./...` in CI skips them silently; `GOPHERTRUNK_AIRSPY_REAL=1 go test`
+on a workstation with hardware runs them. They're bounded by a context timeout so
+a dead radio fails fast instead of hanging the suite:
+
+```go
+// internal/sdr/airspy/airspy_real_test.go (shape)
+ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+iq, err := dev.StreamIQ(ctx)
+// assert a non-empty packet arrives before ctx.Done().
+```
+
+And they clean up after themselves — the bias-tee test puts a safety reset in
+`t.Cleanup` so the suite never leaves DC voltage on the antenna port, which can
+damage a passive antenna or a downstream LNA:
+
+```go
+// internal/sdr/airspy/airspy_real_test.go
+t.Cleanup(func() {
+    // Best-effort safety reset: leave bias-tee off when the test exits.
+    _ = dev.SetBiasTee(false)
+    _ = dev.Close()
+})
+```
+
+There are even raw USB probe tests behind their own sub-flags
+(`GOPHERTRUNK_AIRSPY_REAL_DIAG=1`) that sweep candidate `wIndex` values to
+discover what the firmware actually accepts — the tool you reach for when adding
+support for a chip whose control map you don't yet have captured.
+
+## The design principle: captured contracts + golden master + an opt-in tier
+
+The unifying idea is to **test against the contract, not the hardware** — and to
+keep the hardware available as a separate, opt-in confirmation. Each leg answers
+a different question:
+
+- The **mock replay** asks: does the driver speak the protocol correctly?
+- The **golden-master conversion** asks: is the math byte-for-byte right?
+- The **fake-driver pool tests** ask: does the fleet logic behave?
+- The **opt-in real tier** asks: does it actually work on silicon?
+
+### How that principle shaped the Go code
+
+- **The transport is an interface, so the seam is free.** Drivers depend on
+  `Transport`, not on USBDEVFS. `MockTransport` and the real platform transports
+  are peers; the driver can't tell them apart. No mocking framework, no
+  monkey-patching — just a struct with the right methods.
+- **Golden masters pin behavior, not implementation.** The oracle in
+  `stream_test.go` is intentionally slow and obvious. Its only job is to fail
+  loudly if the fast production path ever diverges, so the LUT and the
+  zero-alloc variant can be optimized fearlessly.
+- **Hardware tests are off by default and self-protecting.** Env guards plus
+  `testing.Short()` keep CI green and fast; context timeouts bound them;
+  `t.Cleanup` safety resets mean a real-hardware run can't leave the radio in a
+  dangerous state.
+- **It's all pure-Go `go test`.** No CGO, no `LD_LIBRARY_PATH`, no librtlsdr to
+  install on the CI runner. The same `go test ./...` that builds the binary tests
+  the drivers — which is exactly the payoff we close the series on next.
+
+## Where this goes next
+
+We can prove the front end is correct. The finale,
+[Part 14]({{ '/blog/deep-dives/rf-front-end-14-diagnostics-metrics-payoff/' | relative_url }}),
+turns from *correctness* to *observability* — the `sdr list --probe` tooling, the
+`RTLSDR_DEBUG_USB` trace, the `iq_underruns_total` metric that finally made
+silent IQ loss visible — and then collects the whole pure-Go thesis the series
+has been building toward.
+
+## FAQ
+
+**Where do the captured control-transfer scripts come from?** From a known-good
+reference: librtlsdr's `rtl_test` traced under `LIBUSB_DEBUG=4`, or the
+`RTLSDR_DEBUG_USB` trace (next post) from GopherTrunk's own driver against real
+hardware. The captured sequence becomes the `Script` the mock replays.
+
+**Isn't a golden-master test brittle?** Deliberately. The conversion math is a
+contract with librtlsdr — every existing SDR tool's output assumes it. "Brittle"
+here means "any change to a load-bearing formula is caught immediately," which is
+the property you want for something this far upstream of every decoder.
+
+**How do you add a driver for a chip you've never captured?** Start with the raw
+USB probe tests — sweep `wIndex` candidates against the real device behind a diag
+flag to learn what it accepts, capture the working sequence, then encode it as a
+mock script so CI can replay it forever.
+
+## Series navigation
+
+**Part 13 of 14** · ← [Part 12]({{ '/blog/deep-dives/rf-front-end-12-sdr-pool-usb-watchdog/' | relative_url }}) · Next → [Part 14: Diagnostics, metrics & the pure-Go payoff]({{ '/blog/deep-dives/rf-front-end-14-diagnostics-metrics-payoff/' | relative_url }})

--- a/docs/_posts/2026-06-30-rf-front-end-13-testing-radios-without-radios.md
+++ b/docs/_posts/2026-06-30-rf-front-end-13-testing-radios-without-radios.md
@@ -14,6 +14,8 @@ herds them, and at every turn we've cited a test that proves it works. This post
 answers the question those citations dodge: how do you trust a USB driver you
 can't run on real hardware in CI?*
 
+> **TL;DR** — GopherTrunk tests its USB drivers with no hardware attached by replaying captured control-transfer sequences through a scripted mock transport and pinning the pure-Go sample conversion bit-for-bit against librtlsdr with a golden master. An opt-in real-hardware tier, gated behind env flags and `-short` with bias-tee safety resets, confirms against actual silicon when you have it.
+
 ## In this post
 
 - The **`MockTransport`** — a scripted control-transfer replayer that lets the
@@ -86,9 +88,9 @@ if !bytesEqual(want.Data, data) {
 }
 ```
 
-A test populates the script with the captured sequence, runs the driver's
+**A test populates the script with the captured sequence, runs the driver's
 bring-up, and asserts `MockTransport.Remaining() == 0` — every expected transfer
-happened, in order, with the right bytes. The mock even models the messy parts:
+happened, in order, with the right bytes.** The mock even models the messy parts:
 `ResetCalls` counts `USBDEVFS_RESET` invocations so a test can prove the recovery
 path ran, `ClaimErr` injects an `EBUSY` so the claim-failure branch is exercised,
 and `BulkSimulateDeath` fires `onStreamDead` after delivering its packets so the
@@ -170,7 +172,7 @@ milliseconds.
 
 ## The problem we hit: trusting a driver you can't run in CI
 
-Here's the uncomfortable truth the three legs are built to address. CI runs on a
+**Symptom.** Here's the uncomfortable truth the three legs are built to address. CI runs on a
 cloud box with no SDR plugged in. We can prove the control-transfer *sequence*
 matches a capture, and we can prove the conversion math is bit-identical to
 librtlsdr — but a capture is a snapshot of one dongle's firmware on one day. What
@@ -178,8 +180,8 @@ if a chip revision reorders its init? What if a real R820T rejects a transfer th
 mock happily accepts because the mock only checks the bytes, not the silicon's
 state machine?
 
-Replay and golden masters give *necessary* confidence, not *sufficient*. So
-there's a fourth thing: an **opt-in real-hardware tier** that runs only when you
+**Root cause.** Replay and golden masters give *necessary* confidence, not *sufficient*. So
+**the fix** is a fourth thing: an **opt-in real-hardware tier** that runs only when you
 ask it to, against the dongle on your desk. The Airspy suite is the template. Every
 real-hardware test starts with a guard:
 
@@ -230,8 +232,8 @@ support for a chip whose control map you don't yet have captured.
 ## The design principle: captured contracts + golden master + an opt-in tier
 
 The unifying idea is to **test against the contract, not the hardware** — and to
-keep the hardware available as a separate, opt-in confirmation. Each leg answers
-a different question:
+keep the hardware available as a separate, opt-in confirmation. **Each leg answers
+a different question:**
 
 - The **mock replay** asks: does the driver speak the protocol correctly?
 - The **golden-master conversion** asks: is the math byte-for-byte right?

--- a/docs/_posts/2026-07-01-rf-front-end-14-diagnostics-metrics-payoff.md
+++ b/docs/_posts/2026-07-01-rf-front-end-14-diagnostics-metrics-payoff.md
@@ -14,6 +14,8 @@ turned it into a clean stream of IQ samples in pure Go. Now: how we *see* that
 front end when it misbehaves — and the payoff that justified writing every USB
 driver from scratch in the first place.*
 
+> **TL;DR** — The finale makes the front end observable: `sdr list --probe`, the `RTLSDR_DEBUG_USB` control-transfer trace, and the `iq_underruns_total` metric that turned silent IQ loss — drops that looked exactly like an RF problem — into a counter operators can watch. The payoff: one static binary, `CGO_ENABLED=0`, no librtlsdr or libusb, cross-compiled everywhere.
+
 ## In this post
 
 - The **diagnostic surfaces**: `sdr list --probe`, the `RTLSDR_DEBUG_USB`
@@ -45,9 +47,9 @@ sample-loss into a counter that climbs.
 
 ### Probe at the CLI
 
-`gophertrunk sdr list` enumerates the bus cheaply. Add `--probe` and it opens
+**`gophertrunk sdr list` enumerates the bus cheaply. Add `--probe` and it opens
 each device long enough to run the demod and tuner detection, so the listing
-shows the real tuner name and gain ladder instead of a guess:
+shows the real tuner name and gain ladder instead of a guess:**
 
 ```
 gophertrunk sdr list [--probe]   list discovered SDR devices
@@ -147,7 +149,7 @@ says "the USB transport hiccuped." Two counters, one diagnosis.
 This is the bug that drove the entire issue #402 investigation, and it's worth
 sitting with because it shaped the whole observability design.
 
-Before any of these counters existed, a busy site would intermittently fail to
+**Symptom.** Before any of these counters existed, a busy site would intermittently fail to
 decode. The captures the reporter sent us replayed *perfectly* — every TSBK
 decoded green. But live, on the same hardware, the control channel kept dropping.
 The tell, once we had it, was damning: **live fails, replay is green.** Replay
@@ -156,13 +158,13 @@ real time. If anything downstream stalled — a momentarily-busy consumer, a GC
 pause, a contended lock — the driver's delivery channel overran and chunks were
 **silently dropped on the floor.**
 
-Silent is the operative word. Those drops produced no log, no error, no signal of
+**Root cause.** Silent is the operative word. Those drops produced no log, no error, no signal of
 any kind. To the operator it was indistinguishable from a weak signal or a bad
 antenna — so the natural response was to chase RF: raise gain, swap antennas,
 re-aim. None of which touched the actual cause, because the actual cause was the
 host falling behind.
 
-The fix was to make the loss *observable* before trying to make it *rare*. Issue
+**The fix** was to make the loss *observable* before trying to make it *rare*. Issue
 #486 surfaced the previously-silent drops via `NotifyIQDrop` → `iq_underruns_total`;
 issue #507 then decoupled live IQ ingest from decode with a forwarder goroutine
 and a deeper bounded queue so the drops became rare. But the metric came first,

--- a/docs/_posts/2026-07-01-rf-front-end-14-diagnostics-metrics-payoff.md
+++ b/docs/_posts/2026-07-01-rf-front-end-14-diagnostics-metrics-payoff.md
@@ -1,0 +1,264 @@
+---
+title: "RF Front End, Part 14: Diagnostics, Metrics & the Pure-Go Payoff"
+description: "The finale of RF Front End. How GopherTrunk makes the front end observable — sdr list --probe, the RTLSDR_DEBUG_USB control-transfer trace, and the iq_underruns_total metric that turned silent IQ loss into something an operator can see — and then the payoff the whole series argued for: one static binary, CGO_ENABLED=0, no librtlsdr, no libusb, cross-compiled everywhere."
+category: deep-dives
+tags: [sdr, go, observability, architecture, software-design]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Front End"
+series_part: 14
+---
+
+*Part 14 of **RF Front End**, the finale. Thirteen posts took a $25 dongle and
+turned it into a clean stream of IQ samples in pure Go. Now: how we *see* that
+front end when it misbehaves — and the payoff that justified writing every USB
+driver from scratch in the first place.*
+
+## In this post
+
+- The **diagnostic surfaces**: `sdr list --probe`, the `RTLSDR_DEBUG_USB`
+  control-transfer trace, and how drop counters reach operators.
+- The **`iq_underruns_total` metric** (issue #402) that made silent IQ loss
+  visible — and the `NotifyIQDrop` hook behind it.
+- **The problem we hit**: silent IQ loss was indistinguishable from RF problems
+  until the metric existed.
+- **The payoff**: one static binary, `CGO_ENABLED=0`, no librtlsdr / libusb /
+  libhackrf / libairspy, cross-compiled to Linux, macOS, and Windows on amd64 and
+  arm64 — and a recap of all fourteen parts.
+
+## What observing the front end means
+
+A radio fails quietly. A decoder that won't lock could be a bad antenna, the
+wrong gain, a PPM error, a dying dongle, or — the subtle one — a host that can't
+keep up, dropping IQ chunks on the floor before they ever reach the demod. From
+the operator's chair every one of those looks identical: *no decode.* The job of
+front-end observability is to make those causes distinguishable, ideally before
+someone spends an afternoon swapping antennas to chase a CPU problem.
+
+GopherTrunk attacks that on three levels. At the **CLI**, `sdr list --probe`
+opens each device and reports what it really is. At the **wire**, the
+`RTLSDR_DEBUG_USB` trace dumps every control transfer in a format you can diff
+against librtlsdr. And at **runtime**, Prometheus metrics turn invisible
+sample-loss into a counter that climbs.
+
+## How GopherTrunk implements it in Go
+
+### Probe at the CLI
+
+`gophertrunk sdr list` enumerates the bus cheaply. Add `--probe` and it opens
+each device long enough to run the demod and tuner detection, so the listing
+shows the real tuner name and gain ladder instead of a guess:
+
+```
+gophertrunk sdr list [--probe]   list discovered SDR devices
+                                 (--probe opens each to fill TUNER + gains)
+```
+
+This is also where the issue #264 tuner diagnostics surface. When a driver
+implements the optional `TunerDiagnoser` interface, the pool logs a self-diagnosing
+line at open time:
+
+```go
+// internal/sdr/pool.go (shape)
+name, v4, v4lite, xtal := td.TunerDiag()
+p.log.Info("sdr tuner detected",
+    "serial", info.Serial, "tuner", name,
+    "blog_v4", v4, "ref_xtal_hz", xtal)
+```
+
+A `ref_xtal_hz=16000000` on an R828D means RTL-SDR Blog V4 auto-detection missed
+and the LO will mistune by ~1.8×; `28800000` means the V4 path armed. The
+blank/non-standard EEPROM string that *causes* the miss is echoed on the same
+line, so a single boot log tells you what went wrong and why.
+
+### Trace at the wire
+
+When a dongle rejects a control transfer, you need to see the conversation.
+Setting `RTLSDR_DEBUG_USB` wraps the transport in a logger that prints every
+`ControlIn` / `ControlOut` / `Reset`, in a format diffable against osmocom
+librtlsdr's `rtl_test` under `LIBUSB_DEBUG=4`:
+
+```go
+// internal/sdr/rtlsdr/usb/usb_debug.go
+func MaybeWrapDebug(t Transport, desc Descriptor) Transport {
+    if os.Getenv(debugUSBEnv) == "" {
+        return t
+    }
+    return newDebugTransport(t, desc)
+}
+```
+
+Wrapping is gated at Open time, so the off-path stays free — the sample-stream
+hot path is never touched, only control transfers are. Each line carries a
+monotonic transfer ID, a timestamp, the request fields, and the payload hex:
+
+```
+rtlsdr-usb [serial=...]: tx=000042 ControlOut bmReqType=0x40 bReq=0x00 wValue=0x0034 wIndex=0x0610 wLength=17 timeout=300ms
+rtlsdr-usb [serial=...]: tx=000042 data=83 32 75 c0 ...
+rtlsdr-usb [serial=...]: tx=000042 -> ok (after 1.2ms)
+```
+
+There's a CSV mode (`RTLSDR_DEBUG_USB_CSV`) with a fixed column order for diffing
+against USBPcap/Wireshark exports — the same traces that become the mock scripts
+from [Part 13]({{ '/blog/deep-dives/rf-front-end-13-testing-radios-without-radios/' | relative_url }}).
+The debug sink is redirectable (`SetDebugSink`) so tests can assert on it. One
+diffable channel, from a developer's terminal to a CI assertion.
+
+### Count at runtime
+
+Probes and traces are things you reach for when you already suspect trouble. The
+metric is what tells you trouble exists. `iq_underruns_total` counts every IQ
+chunk a driver discards because the primary consumer fell behind:
+
+```go
+// internal/metrics/prom.go
+m.iqUnderruns = prometheus.NewCounterVec(prometheus.CounterOpts{
+    Namespace: namespace,
+    Subsystem: "sdr",
+    Name:      "iq_underruns_total",
+    Help:      "Times the IQ stream pipeline dropped samples because a downstream stage was too slow.",
+}, []string{"driver", "serial"})
+```
+
+The wiring between a driver's reaper goroutine and that counter is a single
+process-wide hook, `NotifyIQDrop`. SDR backends self-register with zero-value
+drivers, so there's no constructor seam to thread a per-device sink through —
+hence an atomic pointer set once by the daemon during bring-up:
+
+```go
+// internal/sdr/iqdrop.go
+func NotifyIQDrop(info Info) {
+    if obs := iqDropObserver.Load(); obs != nil {
+        (*obs)(info)
+    }
+}
+```
+
+A driver calls `NotifyIQDrop(info)` from its overrun branch; the daemon's
+installed observer increments `iq_underruns_total{driver,serial}`. Tools and
+tests that don't wire metrics leave the observer nil and the call is a no-op.
+There's a sibling counter, `ccdecoder_decode_overruns_total`, that distinguishes
+*where* the bottleneck is: a climbing `decode_overruns` with `iq_underruns` flat
+says "the machine can't sustain this decode," while a climbing `iq_underruns`
+says "the USB transport hiccuped." Two counters, one diagnosis.
+
+## The problem we hit: silent IQ loss looked exactly like an RF problem
+
+This is the bug that drove the entire issue #402 investigation, and it's worth
+sitting with because it shaped the whole observability design.
+
+Before any of these counters existed, a busy site would intermittently fail to
+decode. The captures the reporter sent us replayed *perfectly* — every TSBK
+decoded green. But live, on the same hardware, the control channel kept dropping.
+The tell, once we had it, was damning: **live fails, replay is green.** Replay
+reads a file at its own pace; live has to keep up with a 2.4 MS/s firehose in
+real time. If anything downstream stalled — a momentarily-busy consumer, a GC
+pause, a contended lock — the driver's delivery channel overran and chunks were
+**silently dropped on the floor.**
+
+Silent is the operative word. Those drops produced no log, no error, no signal of
+any kind. To the operator it was indistinguishable from a weak signal or a bad
+antenna — so the natural response was to chase RF: raise gain, swap antennas,
+re-aim. None of which touched the actual cause, because the actual cause was the
+host falling behind.
+
+The fix was to make the loss *observable* before trying to make it *rare*. Issue
+#486 surfaced the previously-silent drops via `NotifyIQDrop` → `iq_underruns_total`;
+issue #507 then decoupled live IQ ingest from decode with a forwarder goroutine
+and a deeper bounded queue so the drops became rare. But the metric came first,
+on purpose: you can't fix what you can't see, and you certainly can't tell an
+operator "this is a CPU problem, not an antenna problem" without a number to point
+at. Once `iq_underruns_total` was climbing in front of them, the diagnosis became
+a glance instead of an afternoon.
+
+## The design principle: observability is a feature — and the pure-Go thesis, vindicated
+
+Two principles close the series.
+
+The first is that **observability is a first-class feature, not an afterthought.**
+The drop counter isn't instrumentation bolted on; it's the thing that makes the
+front end *operable*. A radio you can't see into is a radio you can only guess
+about, and guessing is how operators waste hours on the wrong layer.
+
+The second is the thesis this entire series argued: **pure Go, one static binary.**
+Every driver in fourteen posts — RTL-SDR, Airspy, HackRF, the USB transports on
+three operating systems — is written in Go, talking to the kernel directly. No
+librtlsdr, no libusb, no libhackrf, no libairspy. Which means:
+
+```
+CGO_ENABLED=0 go build ./cmd/gophertrunk
+```
+
+produces **one file**. No shared libraries to install. No driver-install hell, no
+`LD_LIBRARY_PATH`, no "works on my machine because I have the right libusb."
+`GOOS`/`GOARCH` cross-compile it to Linux, macOS, and Windows on amd64 and arm64
+from a single developer laptop. The same source that's readable from antenna to
+audio is also the same source CI tests with `go test ./...` — because, as
+[Part 13]({{ '/blog/deep-dives/rf-front-end-13-testing-radios-without-radios/' | relative_url }})
+showed, there's nothing to link.
+
+### How that principle shaped the Go code
+
+- **The drop hook costs nothing when unused.** `NotifyIQDrop` is one atomic
+  pointer load on the hot path. No observer installed, no overhead — the CLI and
+  tests pay zero for a daemon-only feature.
+- **Debug wrapping is gated at Open.** The `RTLSDR_DEBUG_USB` transport only
+  exists when the env var is set; the production path is never wrapped, so the
+  sample firehose stays untouched.
+- **Diagnostics ride the same interfaces.** `TunerDiagnoser`, `Diagnoser`, and
+  the metric hooks are all optional capabilities a driver may implement. A backend
+  that doesn't simply contributes no extra diagnostics — no base class, no forced
+  boilerplate.
+- **No CGO means no exceptions.** Because the whole stack is pure Go, the build,
+  the cross-compile, and the test suite have no caveats. There is no "but on
+  Windows you also need…" — and that absence is the entire payoff.
+
+## Where this goes next — and the journey across fourteen parts
+
+That's the full RF source layer, end to end:
+
+- **Why pure Go, and the USB transport** that makes it possible — kernel USBDEVFS
+  / WinUSB / IOKit, no libusb (Parts 1–3).
+- **The RTL2832U and its tuners** — the register dance, the R820T PLL math,
+  sample-rate dividers, and bit-identical U8→`complex64` conversion (Parts 4–9).
+- **The wider front end** — Airspy, HackRF, and the rest of the fleet
+  (Parts 10–11).
+- **The fleet and how we trust it** — the pool's roles and USB watchdog, testing
+  radios without radios, and the diagnostics and metrics that close the loop
+  (Parts 12–14).
+
+Every block is pure Go; every block rests on a software-design principle —
+dependency inversion, supervisor/observer, captured-contract testing,
+observability-as-a-feature — and every principle shaped the actual code.
+
+This series was the deep dive into one layer that its sister series only skimmed.
+If you arrived here from the broader pipeline story, the
+[SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }}) series picks
+up where the IQ samples leave the front end and travels all the way to recovered
+audio. Or start this journey over from
+[Part 1]({{ '/blog/deep-dives/rf-front-end-01-why-pure-go-drivers/' | relative_url }})
+— and grab a build to watch a $25 dongle decode a trunked system from a single
+static binary you didn't have to install anything to run.
+
+## FAQ
+
+**Why expose drops as a metric instead of just logging them?** A log line per
+drop on a busy site is a flood that hides the signal. A counter aggregates: the
+*rate* of `iq_underruns_total` is the diagnosis, and Prometheus already knows how
+to alert on a rate. The daemon emits a rate-limited warning alongside, so you get
+both the number and a nudge.
+
+**How do I tell a CPU problem from an RF problem?** Watch the two counters. A
+climbing `iq_underruns_total` (or `ccdecoder_decode_overruns_total`) with a
+healthy `iq_power_dbfs` says the host is the bottleneck, not the antenna. Flat
+drop counters with weak power says go fix your RF.
+
+**What did pure Go actually buy the end user?** One static binary, no
+shared-library install, reproducible builds, and cross-compilation to every
+desktop platform from one machine. The same `go build` that ships the daemon also
+ships the CLI, the TUI, and the embedded web console — with nothing to link and
+nothing to install.
+
+## Series navigation
+
+**Part 14 of 14** · ← [Part 13]({{ '/blog/deep-dives/rf-front-end-13-testing-radios-without-radios/' | relative_url }}) · Back to [Part 1: Why drive radios in pure Go?]({{ '/blog/deep-dives/rf-front-end-01-why-pure-go-drivers/' | relative_url }})

--- a/docs/blog/series/rf-front-end.md
+++ b/docs/blog/series/rf-front-end.md
@@ -1,0 +1,56 @@
+---
+layout: page
+title: "RF Front End: driving RTL-SDR, Airspy & HackRF in pure Go"
+description: A 14-part deep-dive series on GopherTrunk's RF source layer — how RTL-SDR, Airspy, and HackRF dongles are driven in pure Go with no libusb, the USB transport, per-radio register bring-up, IQ conversion, and the real bugs that were hit and fixed along the way.
+keywords: rtl-sdr driver, airspy driver, hackrf driver, pure go usb, libusb alternative, rtl2832u, r820t tuner, iq streaming, sdr device driver, GopherTrunk
+nav_group: Blog
+permalink: /blog/series/rf-front-end/
+---
+
+**RF Front End** is a 14-part series that zooms all the way in on the layer the
+[SDR Internals]({{ '/blog/series/sdr-internals/' | relative_url }}) series only
+skimmed: the **RF source**. It is the story of how
+[GopherTrunk](https://github.com/MattCheramie/GopherTrunk) turns three families
+of cheap USB dongles — **RTL-SDR, Airspy (R2/Mini and HF+), and HackRF** — into a
+clean stream of IQ samples, in **pure Go**, with **no `libusb`, no `librtlsdr`,
+no CGO at all**.
+
+Where SDR Internals asked *what is the pipeline?*, this series asks *how do you
+actually talk to the metal?* — the `Device` contract, the self-registering
+driver registry, hand-rolled USB transport on three operating systems, the
+RTL2832U register dance, the R820T tuner, real-to-complex sample conversion, and
+the hotplug-aware device pool. And because driver work is where theory meets
+hardware reality, **every part carries a "problem we hit" section**: a real bug
+(RTL-SDR Blog V4 deafness, GC-churn IQ loss, a silent USB reaper deadlock) and
+the Go code that fixed it.
+
+New to radio first? Start with the
+[Learn RF &amp; SDR]({{ '/learn/' | relative_url }}) path, then come back here for
+the implementation.
+
+{%- assign parts = site.posts | where: "series", "RF Front End" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Deep dives</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/deep-dives/' | relative_url }}">deep dives</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>


### PR DESCRIPTION
New 14-part deep-dive series on GopherTrunk's pure-Go RF source layer
(RTL-SDR, Airspy, HackRF): the Device contract, driver registry, no-libusb
USB transport across Linux/macOS/Windows, per-radio register bring-up, IQ
conversion, and the real bugs hit and fixed along the way. Mirrors the
existing SDR Internals series conventions.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016sUnk6xr6iVeQ8LQM4EEa4