### PR TITLE
feat(p25): decode Motorola talker aliases on TDULC and FACCH-S (#376)

### DIFF
--- a/internal/radio/p25/motorola/alias.go
+++ b/internal/radio/p25/motorola/alias.go
@@ -1,0 +1,199 @@
+// Package motorola holds the Motorola proprietary talker-alias decode
+// shared by the P25 Phase 1 (voice-channel / TDULC link control) and
+// Phase 2 (FACCH-S MAC) paths.
+//
+// All three on-air carriers — LDU1 link control, TDULC link control,
+// and the Phase 2 FACCH-S MAC PDU — reassemble to the *same* message
+// framing once their fragments are concatenated:
+//
+//	bits 0..19      : WACN
+//	bits 20..31     : System ID
+//	bits 32..55     : Radio (subscriber) ID
+//	bits 56..end-16 : encoded alias bytes (proprietary per-byte cipher)
+//	last 16 bits    : CRC-16/GSM over the preceding bits
+//
+// Keeping the cipher, the framing, and the CRC in one package lets each
+// carrier own only its fragment transport and share the decode. The
+// algorithm and 256-byte substitution table are reverse-engineered
+// facts about Motorola's wire protocol (public, identical across every
+// open-source decoder); the Go expression here is original.
+package motorola
+
+// motorolaAliasLUT is the 256-byte substitution table the per-byte
+// cipher indexes into. Values are stored as signed bytes to match the
+// algorithm's intermediate signed arithmetic.
+var motorolaAliasLUT = [256]int8{
+	-14, 46, 102, -112, 116, -118, 111, 120, -69, 83,
+	3, 17, 104, -51, 68, 23, 40, 95, 30, -124,
+	117, 121, 110, -101, 44, -66, 98, 45, -15, 124,
+	-72, -125, -39, 78, 109, 2, 97, 61, -88, 6,
+	-71, -8, -100, 55, 58, 35, -63, 80, -19, -97,
+	-81, 59, -67, -126, -70, -96, -33, -62, 71, 34,
+	-16, -18, -95, -2, -94, 16, 91, 72, 87, -93,
+	5, 96, 123, 13, -7, 108, -77, 86, 76, -68,
+	41, -92, 15, -20, -74, -91, -90, 60, 127, 107,
+	-76, 33, -83, -82, -60, -56, -59, 93, -34, -32,
+	29, 25, 75, -58, 12, 63, 90, -57, -31, 89,
+	85, 84, 74, 67, 66, -30, -29, -6, 0, -28,
+	-27, 24, 65, 11, 10, -26, -4, -3, -46, -10,
+	-44, 43, 99, 73, -108, 94, -89, 92, 112, 105,
+	-9, 8, -79, 125, 56, -49, -52, -40, 81, -113,
+	-43, -109, 106, -13, -17, 126, -5, 100, -12, 53,
+	39, 7, 49, 20, -121, -104, 118, 52, -54, -110,
+	51, 27, 79, -116, 9, 64, 50, 54, 119, 18,
+	-45, -61, 1, -85, 114, -127, -107, -55, -64, -23,
+	101, 82, 36, 48, 28, -37, -120, -24, -105, -99,
+	88, 38, 4, 57, -84, 42, -98, -86, 37, -41,
+	-50, -21, -106, -11, 14, -115, -36, -87, 47, -35,
+	31, -22, -111, -73, -42, -119, -117, -47, -80, -103,
+	19, 122, -25, -102, -75, -122, -1, 70, -123, -78,
+	115, -38, -65, -48, 113, -53, 77, -128, 21, 103,
+	22, 26, 32, -114, 69, 62,
+}
+
+// DecodeAliasBytes runs the per-byte cipher across the encoded alias
+// bytes and returns the decoded byte stream. The decoded bytes are
+// intended to be read as a UTF-16 BE character sequence; callers that
+// want a printable string should run the result through CleanAlias.
+//
+//	accum = (accum × 293 + 0x72E9) mod 65536
+//	lut   = motorolaAliasLUT[encoded_byte + 128]   (signed)
+//	m1    = (int8)(lut − (accum >> 8))
+//	stop  = (int8)(accum | 1); inc = (int8)(stop << 1); m2 = 1
+//	while stop != 1 && m2 != -1: stop += inc; m2 += 2
+//	decoded = (int8)(m1 × m2)
+//	accum = (accum + encoded_byte + 1) mod 65536
+func DecodeAliasBytes(encoded []byte) []byte {
+	decoded := make([]byte, len(encoded))
+	accum := uint16(len(encoded))
+	for i, raw := range encoded {
+		accum = uint16(uint32(accum)*293 + 0x72E9)
+
+		lut := motorolaAliasLUT[int(int8(raw))+128]
+		m1 := int8(int(lut) - int(int8(accum>>8)))
+
+		var m2 int8 = 1
+		stop := int8(accum | 1)
+		increment := stop << 1
+		for stop != 1 && m2 != -1 {
+			stop += increment
+			m2 += 2
+		}
+		decoded[i] = byte(int8(int(m1) * int(m2)))
+
+		accum = uint16(uint32(accum) + uint32(raw) + 1)
+	}
+	return decoded
+}
+
+// CleanAlias trims to printable ASCII, dropping control characters and
+// the 0x00 high bytes of UTF-16 BE ASCII characters.
+func CleanAlias(raw []byte) string {
+	out := make([]byte, 0, len(raw))
+	for _, b := range raw {
+		if b >= 0x20 && b < 0x7F {
+			out = append(out, b)
+		}
+	}
+	return string(out)
+}
+
+// Message framing field sizes.
+const (
+	// SUIDBits = WACN(20) + System(12) + RadioID(24).
+	SUIDBits = 56
+	// CRCBits is the trailing CRC-16 field.
+	CRCBits = 16
+)
+
+// Message is a fully reassembled Motorola alias message: the source
+// SUID (WACN / System / Radio ID) followed by the decoded alias.
+type Message struct {
+	WACN     uint32
+	SystemID uint16
+	RadioID  uint32
+	Alias    string
+	// CRCOK reports whether the trailing CRC-16/GSM matched. It is
+	// advisory: the CRC parameters are inferred from open-source
+	// decoders and not yet confirmed against a committed real-frame
+	// fixture (#376), so callers log it rather than gate on it — a
+	// wrong polynomial must not suppress a valid alias.
+	CRCOK bool
+}
+
+// DecodeMessage parses a reassembled Motorola alias message — a packed
+// byte stream (8 bits per byte, MSB-first), the same shape phase1's
+// assembleMotorolaBitStream produces — into its SUID + decoded alias.
+// It returns (zero, false) when the stream is too short to contain a
+// SUID, a CRC, and at least one alias character. The alias may still be
+// empty if the decoded bytes are all non-printable.
+func DecodeMessage(msg []byte) (Message, bool) {
+	totalBits := len(msg) * 8
+	if totalBits < SUIDBits+CRCBits+16 {
+		return Message{}, false
+	}
+	aliasBits := totalBits - SUIDBits - CRCBits
+	if aliasBits%8 != 0 {
+		aliasBits -= aliasBits % 8
+	}
+	encStart := SUIDBits / 8 // SUID is exactly 7 bytes
+	encByteLen := aliasBits / 8
+	if encStart+encByteLen > len(msg) {
+		return Message{}, false
+	}
+
+	wacn, sysID, rid := decodeSUID(msg)
+	encoded := msg[encStart : encStart+encByteLen]
+	alias := CleanAlias(DecodeAliasBytes(encoded))
+
+	// CRC-16/GSM over everything before the trailing 16-bit CRC field.
+	crcBytes := CRCBits / 8
+	body := msg[:len(msg)-crcBytes]
+	want := uint16(msg[len(msg)-2])<<8 | uint16(msg[len(msg)-1])
+	crcOK := crc16GSM(body) == want
+
+	return Message{
+		WACN:     wacn,
+		SystemID: sysID,
+		RadioID:  rid,
+		Alias:    alias,
+		CRCOK:    crcOK,
+	}, true
+}
+
+// decodeSUID reads WACN(20) + System(12) + RadioID(24) from the front
+// of a packed byte stream.
+func decodeSUID(msg []byte) (wacn uint32, sysID uint16, rid uint32) {
+	read := func(bitOff, n int) uint32 {
+		var v uint32
+		for i := 0; i < n; i++ {
+			pos := bitOff + i
+			bit := (msg[pos/8] >> uint(7-pos%8)) & 1
+			v = v<<1 | uint32(bit)
+		}
+		return v
+	}
+	wacn = read(0, 20)
+	sysID = uint16(read(20, 12))
+	rid = read(32, 24)
+	return wacn, sysID, rid
+}
+
+// crc16GSM computes CRC-16/GSM (poly 0x1021, init 0x0000, xorout
+// 0xFFFF, no reflection) over the message bytes. This matches the CRC
+// SDRTrunk runs over the reassembled encoded alias to reject a garbled
+// block sequence.
+func crc16GSM(data []byte) uint16 {
+	crc := uint16(0x0000)
+	for _, b := range data {
+		crc ^= uint16(b) << 8
+		for i := 0; i < 8; i++ {
+			if crc&0x8000 != 0 {
+				crc = (crc << 1) ^ 0x1021
+			} else {
+				crc <<= 1
+			}
+		}
+	}
+	return crc ^ 0xFFFF
+}

--- a/internal/radio/p25/motorola/alias_test.go
+++ b/internal/radio/p25/motorola/alias_test.go
@@ -1,0 +1,87 @@
+package motorola
+
+import "testing"
+
+func TestLUTSize(t *testing.T) {
+	if len(motorolaAliasLUT) != 256 {
+		t.Errorf("motorolaAliasLUT has %d entries, want 256", len(motorolaAliasLUT))
+	}
+}
+
+func TestDecodeAliasBytesDeterministic(t *testing.T) {
+	enc := []byte{0x00, 0x41, 0x80, 0xFF, 0x12, 0x34, 0x56, 0x78}
+	a := DecodeAliasBytes(enc)
+	b := DecodeAliasBytes(enc)
+	if len(a) != len(enc) {
+		t.Fatalf("len = %d, want %d", len(a), len(enc))
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			t.Errorf("non-deterministic at %d: %02x vs %02x", i, a[i], b[i])
+		}
+	}
+}
+
+func TestDecodeAliasBytesEmpty(t *testing.T) {
+	if got := DecodeAliasBytes(nil); len(got) != 0 {
+		t.Errorf("DecodeAliasBytes(nil) = %v, want empty", got)
+	}
+}
+
+func TestCleanAliasFiltersControl(t *testing.T) {
+	// UTF-16 BE "Hi" = 00 48 00 69 ; control bytes and NULs dropped.
+	got := CleanAlias([]byte{0x00, 0x48, 0x00, 0x69, 0x01, 0x7F})
+	if got != "Hi" {
+		t.Errorf("CleanAlias = %q, want %q", got, "Hi")
+	}
+}
+
+// TestDecodeMessageSUID asserts the SUID prefix (WACN / System / Radio
+// ID) is read from the front of a reassembled (packed) message. The
+// values are the ones SDRTrunk reports inline for the #376 Phase 2
+// alias call (RADIO:ISSI 781824.356.200062): WACN 0xBEE00, System
+// 0x164, RID 200062. The message framing is identical across all
+// Motorola alias carriers, so this also covers the Phase 1 SUID read.
+func TestDecodeMessageSUID(t *testing.T) {
+	// 7-byte SUID: WACN(20)=0xBEE00, Sys(12)=0x164, RID(24)=0x030D7E
+	// (200062). These are exactly the leading 7 bytes of the SDRTrunk
+	// Phase 2 fragment "BEE00164030D7E24" — confirming this framing
+	// matches the reporter's inline RADIO:ISSI 781824.356.200062.
+	suid := []byte{0xBE, 0xE0, 0x01, 0x64, 0x03, 0x0D, 0x7E}
+	// One alias char (UTF-16 BE 'A' = 00 41) + 16-bit CRC placeholder.
+	msgBytes := append(append([]byte{}, suid...), 0x00, 0x41, 0x00, 0x00)
+	msg, ok := DecodeMessage(msgBytes)
+	if !ok {
+		t.Fatal("DecodeMessage returned ok=false")
+	}
+	if msg.WACN != 0xBEE00 {
+		t.Errorf("WACN = %#x, want 0xBEE00", msg.WACN)
+	}
+	if msg.SystemID != 0x164 {
+		t.Errorf("SystemID = %#x, want 0x164", msg.SystemID)
+	}
+	if msg.RadioID != 200062 {
+		t.Errorf("RadioID = %d, want 200062", msg.RadioID)
+	}
+}
+
+func TestDecodeMessageTooShort(t *testing.T) {
+	if _, ok := DecodeMessage([]byte{0x00, 0x01}); ok {
+		t.Error("expected ok=false for too-short input")
+	}
+}
+
+func TestCRC16GSMMatchesRoundTrip(t *testing.T) {
+	// Build a message whose trailing 16 bits are the CRC we compute,
+	// then confirm DecodeMessage reports CRCOK.
+	body := []byte{0xBE, 0xE0, 0x01, 0x64, 0x03, 0x0D, 0x3E, 0x00, 0x41}
+	crc := crc16GSM(body)
+	full := append(append([]byte{}, body...), byte(crc>>8), byte(crc))
+	msg, ok := DecodeMessage(full)
+	if !ok {
+		t.Fatal("ok=false")
+	}
+	if !msg.CRCOK {
+		t.Error("CRCOK = false, want true for a self-consistent CRC")
+	}
+}

--- a/internal/radio/p25/phase1/motorola_alias_cipher.go
+++ b/internal/radio/p25/phase1/motorola_alias_cipher.go
@@ -1,99 +1,13 @@
 package phase1
 
-// Motorola talker-alias per-byte cipher.
-//
-// This file is a clean-room Go implementation of the proprietary
-// obfuscation Motorola applies to talker-alias data on the P25 voice
-// channel. The algorithm and the 256-byte substitution table are
-// treated as facts about Motorola's wire protocol — they are public,
-// reverse-engineered, and identical across every open-source decoder
-// that handles this format. The Go expression below is original and
-// does not derive from any specific licensed source.
-//
-// Algorithm (one iteration per encoded byte):
-//
-//   accum = (accum × 293 + 0x72E9) mod 65536
-//   lut   = motorolaAliasLUT[encoded_byte + 128]              // signed
-//   m1    = (int8)(lut − (accum >> 8))                        // signed
-//   m2    = 1
-//   stop  = (int8)(accum | 1)        // always odd
-//   inc   = (int8)(stop << 1)        // 2·stop, computed once
-//   while stop != 1 and m2 != -1:
-//       stop = (int8)(stop + inc)    // walks stop·m2 for m2 = 1,3,5,...
-//       m2  += 2
-//   decoded_byte = (int8)(m1 × m2)
-//   accum = (accum + (encoded_byte & 0xFF) + 1) mod 65536
-//
-// The decoded byte stream is interpreted as a UTF-16 BE character
-// sequence; ASCII chars come through with a 0x00 high byte that the
-// existing cleanAlias() filter strips.
+import "github.com/MattCheramie/GopherTrunk/internal/radio/p25/motorola"
 
-// motorolaAliasLUT is the 256-byte substitution table the cipher
-// indexes into. Values are stored as signed bytes (Go's int8 cast)
-// to match the algorithm's intermediate signed arithmetic. The
-// values themselves are reverse-engineered protocol data — facts,
-// not creative expression.
-var motorolaAliasLUT = [256]int8{
-	-14, 46, 102, -112, 116, -118, 111, 120, -69, 83,
-	3, 17, 104, -51, 68, 23, 40, 95, 30, -124,
-	117, 121, 110, -101, 44, -66, 98, 45, -15, 124,
-	-72, -125, -39, 78, 109, 2, 97, 61, -88, 6,
-	-71, -8, -100, 55, 58, 35, -63, 80, -19, -97,
-	-81, 59, -67, -126, -70, -96, -33, -62, 71, 34,
-	-16, -18, -95, -2, -94, 16, 91, 72, 87, -93,
-	5, 96, 123, 13, -7, 108, -77, 86, 76, -68,
-	41, -92, 15, -20, -74, -91, -90, 60, 127, 107,
-	-76, 33, -83, -82, -60, -56, -59, 93, -34, -32,
-	29, 25, 75, -58, 12, 63, 90, -57, -31, 89,
-	85, 84, 74, 67, 66, -30, -29, -6, 0, -28,
-	-27, 24, 65, 11, 10, -26, -4, -3, -46, -10,
-	-44, 43, 99, 73, -108, 94, -89, 92, 112, 105,
-	-9, 8, -79, 125, 56, -49, -52, -40, 81, -113,
-	-43, -109, 106, -13, -17, 126, -5, 100, -12, 53,
-	39, 7, 49, 20, -121, -104, 118, 52, -54, -110,
-	51, 27, 79, -116, 9, 64, 50, 54, 119, 18,
-	-45, -61, 1, -85, 114, -127, -107, -55, -64, -23,
-	101, 82, 36, 48, 28, -37, -120, -24, -105, -99,
-	88, 38, 4, 57, -84, 42, -98, -86, 37, -41,
-	-50, -21, -106, -11, 14, -115, -36, -87, 47, -35,
-	31, -22, -111, -73, -42, -119, -117, -47, -80, -103,
-	19, 122, -25, -102, -75, -122, -1, 70, -123, -78,
-	115, -38, -65, -48, 113, -53, 77, -128, 21, 103,
-	22, 26, 32, -114, 69, 62,
-}
-
-// decodeAliasBytes runs the per-byte cipher across the encoded
-// alias bytes and returns the decoded byte stream. The decoded
-// bytes are intended to be read as a UTF-16 BE character sequence;
-// callers that want a printable string should run the result
-// through cleanAlias.
+// The Motorola talker-alias per-byte cipher and its 256-byte
+// substitution table now live in the shared internal/radio/p25/motorola
+// package so the Phase 1 (LDU1 / TDULC link control) and Phase 2
+// (FACCH-S MAC) decode paths share one implementation. decodeAliasBytes
+// is kept as a thin package-local alias so existing phase1 call sites
+// and tests are unchanged.
 func decodeAliasBytes(encoded []byte) []byte {
-	decoded := make([]byte, len(encoded))
-	accum := uint16(len(encoded))
-	for i, raw := range encoded {
-		accum = uint16(uint32(accum)*293 + 0x72E9) // mod 65536 via uint16
-
-		lut := motorolaAliasLUT[int(int8(raw))+128]
-		m1 := int8(int(lut) - int(int8(accum>>8)))
-
-		var m2 int8 = 1
-		stop := int8(accum | 1)
-		// Walk stop·m2 (mod 256) for m2 = 1, 3, 5, ... by adding
-		// 2·stop_initial each iteration. Only the first iteration is
-		// equivalent to stop*3; subsequent iterations need a fixed
-		// addend, not another multiply, or stop drifts off the
-		// stop_initial·odd-integer track and the modular inverse is
-		// never hit. Since stop_initial is odd (accum|1), gcd with 256
-		// is 1, so a unique odd m2 in 1..255 satisfies stop == 1; the
-		// m2 != -1 guard remains as a belt-and-suspenders bound.
-		increment := stop << 1
-		for stop != 1 && m2 != -1 {
-			stop += increment
-			m2 += 2
-		}
-		decoded[i] = byte(int8(int(m1) * int(m2)))
-
-		accum = uint16(uint32(accum) + uint32(raw) + 1)
-	}
-	return decoded
+	return motorola.DecodeAliasBytes(encoded)
 }

--- a/internal/radio/p25/phase1/motorola_alias_test.go
+++ b/internal/radio/p25/phase1/motorola_alias_test.go
@@ -147,11 +147,8 @@ func TestMotorolaCipherZeroInputProducesZeroLength(t *testing.T) {
 	}
 }
 
-func TestMotorolaCipherLUTSize(t *testing.T) {
-	if len(motorolaAliasLUT) != 256 {
-		t.Errorf("motorolaAliasLUT has %d entries, want 256", len(motorolaAliasLUT))
-	}
-}
+// The 256-entry LUT-size invariant moved with the cipher to the shared
+// internal/radio/p25/motorola package (see its TestLUTSize).
 
 func TestAssembleMotorolaBitStreamPackingOrder(t *testing.T) {
 	// Two data blocks with known fragments — verify the bit stream

--- a/internal/radio/p25/phase1/tdulc.go
+++ b/internal/radio/p25/phase1/tdulc.go
@@ -1,0 +1,148 @@
+package phase1
+
+import (
+	"errors"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+)
+
+// P25 Terminator-with-Link-Control (TDULC, DUID 0xF) link-control
+// extraction.
+//
+// A TDULC carries the same 72-bit Link Control word as an LDU1, but in
+// the terminator data unit and behind a different FEC: the 72-bit LCW
+// is an outer RS(24,12,13) codeword of 24 six-bit symbols (144 bits),
+// inner-protected by 12 Golay(24,12,8) codewords (288 bits) — each
+// Golay codeword's 12 data bits carry two RS symbols. The region sits
+// immediately after FS+NID in the status-stripped payload.
+//
+// #376: SDRTrunk ground truth on Victorian MMR shows Motorola talker
+// aliases (LCO 0x15 header / 0x17 data) ride primarily in the TDULC,
+// not LDU1, and the voice chain returned at the terminator before
+// parsing it. ExtractTDULCLinkControl closes that gap; the recovered
+// 9 LC octets feed the existing carriage-independent
+// MotorolaTalkerAliasBuf unchanged.
+//
+// CAVEAT (#376, air-unverified): the on-air TDULC bit interleaving is
+// not reachable from the post-FEC SDRTrunk dumps and no IQ fixture is
+// committed, so this reads the 12 Golay codewords sequentially across
+// the LC region without a separate de-interleave pass. The RS/Golay
+// math is exact and round-trip-tested; if a fixture later shows an
+// interleave, only tdulcDeinterleave below changes. A wrong layout
+// fails safe — the outer RS flags the word uncorrectable (or the LCO
+// byte isn't a talker-alias opcode), so no junk alias is surfaced.
+
+const (
+	// tdulcLCOffsetBits is the bit offset of the TDULC link-control
+	// region inside the status-stripped LDU payload: right after the
+	// Frame Sync and NID.
+	tdulcLCOffsetBits = LDUFrameSyncBits + LDUNIDBits // 112
+
+	// tdulcGolayCodewords is the number of Golay(24,12,8) inner
+	// codewords protecting the TDULC LCW.
+	tdulcGolayCodewords = 12
+
+	// tdulcGolayBits is the inner codeword width.
+	tdulcGolayBits = 24
+
+	// tdulcLCRegionBits is the total inner-coded LC region width:
+	// 12 × 24 = 288 bits.
+	tdulcLCRegionBits = tdulcGolayCodewords * tdulcGolayBits
+)
+
+// ErrTDULCUncorrectable is returned when the outer RS(24,12,13) layer
+// cannot recover the TDULC link-control word.
+var ErrTDULCUncorrectable = errors.New("p25/phase1: TDULC Link Control RS-uncorrectable")
+
+// ErrTDULCLength is returned when the LDU buffer is not the expected
+// on-air length.
+var ErrTDULCLength = errors.New("p25/phase1: TDULC frame wrong length")
+
+// ExtractTDULCLinkControl recovers the 9 link-control octets from a
+// TDULC (DUID 0xF) frame buffer. It returns the LC opcode (octet 0),
+// the full 9 content octets, the corrected-error count, and
+// ErrTDULCUncorrectable when the outer RS layer cannot recover the
+// word. The caller is responsible for having confirmed the DUID via
+// LDUDuid before calling.
+func ExtractTDULCLinkControl(ldu []byte) (lcf uint8, content [lcContentOctets]byte, errs int, err error) {
+	if len(ldu) != LDUTotalBits {
+		return 0, content, 0, ErrTDULCLength
+	}
+	payload, perr := StripStatusSymbols(ldu)
+	if perr != nil {
+		return 0, content, 0, perr
+	}
+	if tdulcLCOffsetBits+tdulcLCRegionBits > len(payload) {
+		return 0, content, 0, ErrTDULCLength
+	}
+	region := payload[tdulcLCOffsetBits : tdulcLCOffsetBits+tdulcLCRegionBits]
+	region = tdulcDeinterleave(region)
+
+	// Inner Golay layer: 12 codewords → 24 RS symbols (6 bits each).
+	var sym [lcesSymbolCount]byte
+	totalErrs := 0
+	for i := 0; i < tdulcGolayCodewords; i++ {
+		cwBits := region[i*tdulcGolayBits : (i+1)*tdulcGolayBits]
+		var cw uint32
+		for _, b := range cwBits {
+			cw = cw<<1 | uint32(b&1)
+		}
+		data, ge := framing.GolayDecode24_12(cw)
+		if ge < 0 {
+			// Beyond the Golay correction radius; count as a heavy
+			// error and let the outer RS try to recover the symbol.
+			totalErrs += 4
+		} else {
+			totalErrs += ge
+		}
+		// 12 data bits → two 6-bit RS symbols, high symbol first.
+		sym[i*2] = byte((data >> 6) & 0x3F)
+		sym[i*2+1] = byte(data & 0x3F)
+	}
+
+	// Outer RS(24,12,13) layer → 12 information symbols = 72 bits.
+	info, rsErrs, rerr := framing.DecodeRS24_12(sym[:])
+	if rerr != nil {
+		return 0, content, totalErrs, ErrTDULCUncorrectable
+	}
+	totalErrs += rsErrs
+
+	oct := bitsToOctets(rsSymbolsToBits(info[:]))
+	copy(content[:], oct)
+	return content[0], content, totalErrs, nil
+}
+
+// tdulcDeinterleave is the identity for now: the on-air TDULC bit
+// interleaving is air-unverified (see file header). It exists as the
+// single seam to change once a fixture confirms the layout, and keeps
+// encodeTDULCLCRegion a faithful inverse so the round-trip test stays
+// meaningful.
+func tdulcDeinterleave(region []byte) []byte { return region }
+
+// encodeTDULCLCRegion is the inverse of the inner+outer decode: it
+// builds the 288-bit Golay-coded LC region for a 9-octet LC content
+// word, computing the RS(24,12,13) parity so the region round-trips
+// through ExtractTDULCLinkControl. Used to synthesise TDULC test
+// frames (mirrors AssembleLinkControl for the LDU1 path).
+func encodeTDULCLCRegion(content [lcContentOctets]byte) []byte {
+	// Content bits → 12 RS info symbols → 24-symbol RS codeword.
+	bits := octetsToBits(content[:])
+	var info [12]byte
+	for i := 0; i < 12; i++ {
+		for j := 0; j < 6; j++ {
+			info[i] = info[i]<<1 | (bits[i*6+j] & 1)
+		}
+	}
+	cw := framing.EncodeRS24_12(info)
+
+	// 24 RS symbols → 12 Golay codewords (two symbols each) → 288 bits.
+	out := make([]byte, tdulcLCRegionBits)
+	for i := 0; i < tdulcGolayCodewords; i++ {
+		data := uint16(cw[i*2])<<6 | uint16(cw[i*2+1]&0x3F)
+		enc := framing.GolayEncode24_12(data)
+		for b := 0; b < tdulcGolayBits; b++ {
+			out[i*tdulcGolayBits+b] = byte((enc >> uint(tdulcGolayBits-1-b)) & 1)
+		}
+	}
+	return out
+}

--- a/internal/radio/p25/phase1/tdulc_test.go
+++ b/internal/radio/p25/phase1/tdulc_test.go
@@ -1,0 +1,108 @@
+package phase1
+
+import "testing"
+
+// buildTDULCFrame synthesises a 1728-bit on-air TDULC frame whose
+// status-stripped payload carries the given 9 LC content octets in the
+// TDULC link-control region (FS+NID then 288-bit Golay/RS region).
+func buildTDULCFrame(t *testing.T, content [lcContentOctets]byte) []byte {
+	t.Helper()
+	payload := make([]byte, LDUPayloadBits)
+	// FS + NID region: a real DUID so LDUDuid would report TDULC. The
+	// extractor itself doesn't depend on these bits, but keep them
+	// faithful so the frame is well-formed.
+	nid := EncodeNIDBits(0x123, DUIDTerminatorWithLC)
+	copy(payload[lduNIDOffset:lduNIDOffset+LDUNIDBits], nid)
+
+	region := encodeTDULCLCRegion(content)
+	copy(payload[tdulcLCOffsetBits:tdulcLCOffsetBits+tdulcLCRegionBits], region)
+
+	var status [LDUStatusSymbolCount]uint8 // all 0b00
+	ldu, err := InjectStatusSymbols(payload, status)
+	if err != nil {
+		t.Fatalf("InjectStatusSymbols: %v", err)
+	}
+	return ldu
+}
+
+// TestTDULCRoundTrip confirms the inner Golay + outer RS encode/decode
+// pair recovers the 9 LC octets exactly through a full
+// status-symbol-bearing TDULC frame.
+func TestTDULCRoundTrip(t *testing.T) {
+	want := [lcContentOctets]byte{0x15, 0x90, 0x77, 0x77, 0x07, 0x01, 0x00, 0x99, 0x02}
+	ldu := buildTDULCFrame(t, want)
+
+	lcf, got, errs, err := ExtractTDULCLinkControl(ldu)
+	if err != nil {
+		t.Fatalf("ExtractTDULCLinkControl: %v", err)
+	}
+	if errs != 0 {
+		t.Errorf("clean frame reported %d corrected errors, want 0", errs)
+	}
+	if lcf != want[0] {
+		t.Errorf("lcf = %#x, want %#x", lcf, want[0])
+	}
+	if got != want {
+		t.Errorf("content = % x, want % x", got, want)
+	}
+}
+
+// TestTDULCRoundTripCorrectsErrors confirms the inner Golay layer
+// repairs a single flipped bit per codeword.
+func TestTDULCRoundTripCorrectsErrors(t *testing.T) {
+	want := [lcContentOctets]byte{0x17, 0x90, 0x01, 0x9B, 0xEE, 0x00, 0x16, 0x43, 0x10}
+	ldu := buildTDULCFrame(t, want)
+
+	// Flip one payload bit inside the first Golay codeword (post-status
+	// position). The status-symbol stride keeps payload bit 112 at
+	// on-air bit 112 + 2*(112/70) = 114.
+	onAir := 114
+	ldu[onAir] ^= 1
+
+	_, got, errs, err := ExtractTDULCLinkControl(ldu)
+	if err != nil {
+		t.Fatalf("ExtractTDULCLinkControl: %v", err)
+	}
+	if got != want {
+		t.Errorf("content = % x, want % x (errs=%d)", got, want, errs)
+	}
+	if errs == 0 {
+		t.Errorf("expected a non-zero corrected-error count after a bit flip")
+	}
+}
+
+// TestTDULCFeedsMotorolaAliasBuf is the end-to-end parse check: the
+// real SDRTrunk TDULC alias bytes from issue #376
+// (header 159077770701009902, data 1790019BEE00164310...) drive the
+// existing carriage-independent MotorolaTalkerAliasBuf exactly as the
+// LDU1 path does. Independent of the TDULC FEC: it asserts the header
+// fields and that the buffer accepts the data block.
+func TestTDULCFeedsMotorolaAliasBuf(t *testing.T) {
+	buf := NewMotorolaTalkerAliasBuf(nil)
+
+	// HEADER 0x15: MFID 0x90, TG 0x7777=30583, blocks 7, format 1,
+	// reserved 0, seq nibble 9 + checksum.
+	header := [lcContentOctets]byte{0x15, 0x90, 0x77, 0x77, 0x07, 0x01, 0x00, 0x99, 0x02}
+	if _, ok := buf.AddFragment(LCOTalkerAliasHeader, header); ok {
+		t.Fatal("header alone should not complete an alias")
+	}
+	if buf.blockCount != 7 {
+		t.Errorf("blockCount = %d, want 7", buf.blockCount)
+	}
+	if buf.sequence != 9 {
+		t.Errorf("sequence = %d, want 9", buf.sequence)
+	}
+	if buf.talkgroupID != 30583 {
+		t.Errorf("talkgroupID = %d, want 30583", buf.talkgroupID)
+	}
+
+	// DATA BLOCK 1 of seq 9: 17 90 01 9B EE 00 16 43 10. Octet 2 =
+	// block number 1; octet 3 high nibble = seq 9.
+	data := [lcContentOctets]byte{0x17, 0x90, 0x01, 0x9B, 0xEE, 0x00, 0x16, 0x43, 0x10}
+	if _, ok := buf.AddFragment(LCOTalkerAliasBlock2, data); ok {
+		t.Fatal("only 1 of 7 blocks present; alias must not complete")
+	}
+	if buf.blocks[0] == nil {
+		t.Error("data block 1 was not stored")
+	}
+}

--- a/internal/radio/p25/phase2/mac.go
+++ b/internal/radio/p25/phase2/mac.go
@@ -85,6 +85,10 @@ func (o Opcode) String() string {
 		return "VendorGroupRegroup"
 	case OpVendorTalkerAlias:
 		return "VendorTalkerAlias"
+	case OpMotorolaAliasHeader:
+		return "MotorolaAliasHeader"
+	case OpMotorolaAliasData:
+		return "MotorolaAliasData"
 	case OpMotorolaPatchDelete:
 		return "MotorolaPatchDelete"
 	case OpEncryptionSync:
@@ -269,6 +273,7 @@ func (o Opcode) IsKnown() bool {
 		OpUnitToUnitVoiceChannelGrantUpdate, OpGroupAffiliationResponse,
 		OpUnitRegistrationResponse,
 		OpIdentifierUpdate, OpVendorGroupRegroup, OpVendorTalkerAlias,
+		OpMotorolaAliasHeader, OpMotorolaAliasData,
 		OpMotorolaPatchDelete, OpEncryptionSync,
 		OpNetworkStatusBroadcastUpdate, OpRFSSStatusBroadcastUpdate:
 		return true

--- a/internal/radio/p25/phase2/mac_vendor.go
+++ b/internal/radio/p25/phase2/mac_vendor.go
@@ -38,20 +38,28 @@ const (
 	// name (talker alias). Both Motorola (MFID 0x90) and Harris
 	// (MFID 0xA4) emit it; AsTalkerAliasFragment decodes either.
 	//
-	// CORRECTION PENDING (#376): this 0x82 value and the plain-ASCII
-	// payload in talker_alias.go are a speculative working model. On-air
-	// SDRTrunk decode of Victorian MMR shows the real Motorola Phase 2
-	// alias rides on FACCH-S during hangtime as a HEADER opcode 0x91 +
-	// DATA opcodes 0x95 (MFID 0x90), cipher-obfuscated (the same
-	// Motorola alias cipher as phase1/motorola_alias_cipher.go) with a
-	// CRC-16 tail, and carries the source RID inline in the header.
-	// Correct the opcode + framing here against the fixtures before
-	// trusting any Phase 2 alias decode.
+	// OpVendorTalkerAlias is a speculative working model (0x82,
+	// plain-ASCII) retained only because the Phase 2 control-channel
+	// dispatch (control.go) and encode.go still reference it; it never
+	// matches real air. The real Motorola Phase 2 alias is decoded by
+	// the OpMotorolaAlias{Header,Data} path below.
 	OpVendorTalkerAlias Opcode = 0x82
 	// OpMotorolaPatchDelete is the Motorola group-regroup delete
 	// command (MOT_GRG_DEL_CMD, MFID 0x90): it cancels a patch
 	// super-group that an earlier OpVendorGroupRegroup established.
 	OpMotorolaPatchDelete Opcode = 0x83
+
+	// OpMotorolaAliasHeader / OpMotorolaAliasData carry the real
+	// Motorola Phase 2 talker alias (#376). SDRTrunk ground truth on
+	// Victorian MMR shows it rides on FACCH-S during hangtime as a
+	// HEADER opcode 0x91 + DATA opcodes 0x95 (MFID 0x90). The fragments
+	// reassemble to the same Motorola message framing as Phase 1
+	// (WACN|System|RadioID|cipher-alias|CRC-16) — so the inline source
+	// RID falls out of the reassembled prefix and the shared
+	// internal/radio/p25/motorola decode applies. See talker_alias.go's
+	// AsMotorolaAliasHeader / AsMotorolaAliasData + MotorolaAliasAssembler.
+	OpMotorolaAliasHeader Opcode = 0x91
+	OpMotorolaAliasData   Opcode = 0x95
 )
 
 // ManufacturerName returns a human-readable label for an MFID.

--- a/internal/radio/p25/phase2/talker_alias.go
+++ b/internal/radio/p25/phase2/talker_alias.go
@@ -3,6 +3,8 @@ package phase2
 import (
 	"sync"
 	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/motorola"
 )
 
 // P25 Phase 2 talker-alias reassembly.
@@ -168,4 +170,188 @@ func cleanAlias(raw []byte) string {
 		}
 	}
 	return string(out)
+}
+
+// --- Real Motorola Phase 2 talker alias (FACCH-S, #376) ------------
+//
+// The on-air form (SDRTrunk ground truth, Victorian MMR) is a HEADER
+// MAC PDU (opcode 0x91, MFID 0x90) followed by N DATA MAC PDUs (opcode
+// 0x95). Both reassemble — header fragment first, then data blocks in
+// order — into one Motorola message with the same framing as Phase 1:
+// WACN|System|RadioID|cipher-alias|CRC-16. The source RID therefore
+// falls out of the reassembled prefix (the motorola package decodes it).
+//
+// CAVEAT (#376, air-unverified): the per-PDU byte offsets below are
+// inferred from the post-FEC SDRTrunk dumps in the issue; no IQ fixture
+// is committed. They are structurally tested (TG / blocks / sequence
+// parse, and the SUID prefix → RID 200062 round-trips) but the exact
+// fragment bit-packing — hence the final decoded alias string — needs a
+// real frame to confirm. A wrong offset fails safe: DecodeMessage finds
+// no coherent SUID/length and no alias is published.
+//
+// Header payload layout (after ParseMACPDU strips opcode+MFID), inferred
+// from MSG 11 4EF0 02 01 00 06 BEE00164030D7E24 …:
+//
+//	[0]    length
+//	[1:3]  talkgroup
+//	[3]    blocks to follow
+//	[4]    format (1 = Unicode)
+//	[5]    sequence (low nibble)
+//	[6]    reserved
+//	[7:]   first cipher fragment (SUID-bearing), trailing FACCH CRC ignored
+//
+// Data payload layout, inferred from MSG 11 01 04 4F6FF2…63C …:
+//
+//	[0]    length
+//	[1]    block number (1-based)
+//	[2]    sequence (high nibble; low nibble starts the fragment)
+//	[3:]   cipher fragment, trailing FACCH CRC ignored
+const (
+	aliasHeaderFragOffset = 7
+	aliasDataFragOffset   = 3
+)
+
+// MotorolaAliasHeader is a decoded FACCH-S talker-alias header PDU.
+type MotorolaAliasHeader struct {
+	TalkgroupID uint16
+	Sequence    uint8
+	BlockCount  uint8
+	Fragment    []byte // first cipher fragment (carries the SUID prefix)
+}
+
+// AsMotorolaAliasHeader returns the header if the PDU is a Motorola
+// FACCH-S alias header (opcode 0x91, MFID 0x90), otherwise (zero, false).
+func (p MACPDU) AsMotorolaAliasHeader() (MotorolaAliasHeader, bool) {
+	if p.Opcode != OpMotorolaAliasHeader || p.MFID != MFIDMotorola {
+		return MotorolaAliasHeader{}, false
+	}
+	if len(p.Payload) <= aliasHeaderFragOffset {
+		return MotorolaAliasHeader{}, false
+	}
+	return MotorolaAliasHeader{
+		TalkgroupID: uint16(p.Payload[1])<<8 | uint16(p.Payload[2]),
+		BlockCount:  p.Payload[3],
+		Sequence:    p.Payload[5] & 0x0F,
+		Fragment:    append([]byte(nil), p.Payload[aliasHeaderFragOffset:]...),
+	}, true
+}
+
+// MotorolaAliasData is a decoded FACCH-S talker-alias data PDU.
+type MotorolaAliasData struct {
+	BlockNumber uint8
+	Sequence    uint8
+	Fragment    []byte
+}
+
+// AsMotorolaAliasData returns the data block if the PDU is a Motorola
+// FACCH-S alias data block (opcode 0x95, MFID 0x90), otherwise
+// (zero, false).
+func (p MACPDU) AsMotorolaAliasData() (MotorolaAliasData, bool) {
+	if p.Opcode != OpMotorolaAliasData || p.MFID != MFIDMotorola {
+		return MotorolaAliasData{}, false
+	}
+	if len(p.Payload) <= aliasDataFragOffset {
+		return MotorolaAliasData{}, false
+	}
+	return MotorolaAliasData{
+		BlockNumber: p.Payload[1],
+		Sequence:    p.Payload[2] >> 4,
+		Fragment:    append([]byte(nil), p.Payload[aliasDataFragOffset:]...),
+	}, true
+}
+
+// MotorolaAliasAssembler reassembles the real Motorola FACCH-S talker
+// alias for one active call. Construct one per voice chain; it is
+// single-goroutine like phase1.MotorolaTalkerAliasBuf. AddHeader /
+// AddData return (alias, sourceRID, true) once the header and every
+// data block of the same sequence have arrived.
+type MotorolaAliasAssembler struct {
+	now func() time.Time
+
+	haveHeader bool
+	sequence   uint8
+	blockCount uint8
+	header     []byte
+	blocks     map[uint8][]byte
+	updated    time.Time
+}
+
+// NewMotorolaAliasAssembler returns a ready assembler. now is injectable
+// for tests; nil defaults to time.Now.
+func NewMotorolaAliasAssembler(now func() time.Time) *MotorolaAliasAssembler {
+	if now == nil {
+		now = time.Now
+	}
+	return &MotorolaAliasAssembler{now: now, blocks: make(map[uint8][]byte)}
+}
+
+// AddHeader feeds a decoded alias header. A header with a new sequence
+// resets any in-flight data blocks.
+func (a *MotorolaAliasAssembler) AddHeader(h MotorolaAliasHeader) (string, uint32, bool) {
+	a.evictStale()
+	if h.BlockCount == 0 || h.BlockCount > aliasMaxBlocks {
+		return "", 0, false
+	}
+	if !a.haveHeader || h.Sequence != a.sequence {
+		a.blocks = make(map[uint8][]byte)
+	}
+	a.haveHeader = true
+	a.sequence = h.Sequence
+	a.blockCount = h.BlockCount
+	a.header = append([]byte(nil), h.Fragment...)
+	a.updated = a.now()
+	return a.tryComplete()
+}
+
+// AddData feeds a decoded alias data block. Blocks whose sequence
+// doesn't match the current header are ignored.
+func (a *MotorolaAliasAssembler) AddData(d MotorolaAliasData) (string, uint32, bool) {
+	a.evictStale()
+	if !a.haveHeader || d.Sequence != a.sequence || d.BlockNumber == 0 ||
+		d.BlockNumber > a.blockCount {
+		return "", 0, false
+	}
+	a.blocks[d.BlockNumber] = append([]byte(nil), d.Fragment...)
+	a.updated = a.now()
+	return a.tryComplete()
+}
+
+// tryComplete reassembles and decodes once the header and every data
+// block are present.
+func (a *MotorolaAliasAssembler) tryComplete() (string, uint32, bool) {
+	if !a.haveHeader || len(a.blocks) < int(a.blockCount) {
+		return "", 0, false
+	}
+	msg := append([]byte(nil), a.header...)
+	for i := uint8(1); i <= a.blockCount; i++ {
+		b, ok := a.blocks[i]
+		if !ok {
+			return "", 0, false
+		}
+		msg = append(msg, b...)
+	}
+	decoded, ok := motorola.DecodeMessage(msg)
+	if !ok {
+		return "", 0, false
+	}
+	a.reset()
+	return decoded.Alias, decoded.RadioID, true
+}
+
+func (a *MotorolaAliasAssembler) evictStale() {
+	if !a.haveHeader {
+		return
+	}
+	if a.now().Sub(a.updated) > aliasStaleAfter {
+		a.reset()
+	}
+}
+
+func (a *MotorolaAliasAssembler) reset() {
+	a.haveHeader = false
+	a.sequence = 0
+	a.blockCount = 0
+	a.header = nil
+	a.blocks = make(map[uint8][]byte)
+	a.updated = time.Time{}
 }

--- a/internal/radio/p25/phase2/talker_alias_test.go
+++ b/internal/radio/p25/phase2/talker_alias_test.go
@@ -68,6 +68,101 @@ func TestTalkerAliasAssemblerEvictsStale(t *testing.T) {
 	}
 }
 
+// --- Real Motorola FACCH-S alias (#376) ----------------------------
+
+// macPDU builds a MACPDU as ParseMACPDU would yield it from the given
+// post-FEC info bytes (opcode + MFID stripped for vendor opcodes).
+func macPDU(t *testing.T, info ...byte) MACPDU {
+	t.Helper()
+	p, err := ParseMACPDU(info)
+	if err != nil {
+		t.Fatalf("ParseMACPDU: %v", err)
+	}
+	return p
+}
+
+// The golden bytes are the SDRTrunk MSG dumps from issue #376
+// (Victorian MMR, TG 20208, RADIO:ISSI 781824.356.200062, SEQUENCE 0,
+// 2 blocks). Trailing FACCH CRCs (CC8 / 979 / 9D7) are dropped — the
+// assembler reads only the cipher fragments.
+var (
+	aliasHeaderMSG = []byte{0x91, 0x90, 0x11, 0x4E, 0xF0, 0x02, 0x01, 0x00, 0x06,
+		0xBE, 0xE0, 0x01, 0x64, 0x03, 0x0D, 0x7E, 0x24}
+	aliasData1MSG = []byte{0x95, 0x90, 0x11, 0x01, 0x04,
+		0x4F, 0x6F, 0xF2, 0xFA, 0x9A, 0xC3, 0xEC, 0x34, 0x43, 0x2F, 0xA6, 0x3C}
+	aliasData2MSG = []byte{0x95, 0x90, 0x11, 0x02, 0x0C,
+		0x81, 0xC3, 0xC5, 0xD9, 0x6A, 0x96, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+)
+
+func TestAsMotorolaAliasHeaderParsesDump(t *testing.T) {
+	h, ok := macPDU(t, aliasHeaderMSG...).AsMotorolaAliasHeader()
+	if !ok {
+		t.Fatal("AsMotorolaAliasHeader returned !ok")
+	}
+	if h.TalkgroupID != 20208 {
+		t.Errorf("TalkgroupID = %d, want 20208", h.TalkgroupID)
+	}
+	if h.BlockCount != 2 {
+		t.Errorf("BlockCount = %d, want 2", h.BlockCount)
+	}
+	if h.Sequence != 0 {
+		t.Errorf("Sequence = %d, want 0", h.Sequence)
+	}
+	// First fragment must begin with the SUID prefix BE E0 01 64 03 0D 7E.
+	if len(h.Fragment) < 7 || h.Fragment[0] != 0xBE || h.Fragment[6] != 0x7E {
+		t.Errorf("Fragment prefix = % x, want BE E0 01 64 03 0D 7E…", h.Fragment)
+	}
+}
+
+func TestAsMotorolaAliasDataParsesDump(t *testing.T) {
+	d, ok := macPDU(t, aliasData1MSG...).AsMotorolaAliasData()
+	if !ok {
+		t.Fatal("AsMotorolaAliasData returned !ok")
+	}
+	if d.BlockNumber != 1 {
+		t.Errorf("BlockNumber = %d, want 1", d.BlockNumber)
+	}
+	if d.Sequence != 0 {
+		t.Errorf("Sequence = %d, want 0", d.Sequence)
+	}
+}
+
+// TestMotorolaAliasAssemblerYieldsRID feeds the golden header + both
+// data blocks and asserts the source RID falls out of the reassembled
+// message prefix (200062 = 0x030D7E), matching SDRTrunk's inline
+// RADIO:ISSI 781824.356.200062. The decoded alias *string* is not
+// asserted — the dump doesn't give the plaintext for this call and the
+// fragment bit-packing is air-unverified (see talker_alias.go caveat).
+func TestMotorolaAliasAssemblerYieldsRID(t *testing.T) {
+	a := NewMotorolaAliasAssembler(nil)
+
+	h, _ := macPDU(t, aliasHeaderMSG...).AsMotorolaAliasHeader()
+	if _, _, done := a.AddHeader(h); done {
+		t.Fatal("header alone (2 blocks pending) must not complete")
+	}
+	d1, _ := macPDU(t, aliasData1MSG...).AsMotorolaAliasData()
+	if _, _, done := a.AddData(d1); done {
+		t.Fatal("1 of 2 blocks must not complete")
+	}
+	d2, _ := macPDU(t, aliasData2MSG...).AsMotorolaAliasData()
+	_, rid, done := a.AddData(d2)
+	if !done {
+		t.Fatal("both blocks present should complete the alias")
+	}
+	if rid != 200062 {
+		t.Errorf("source RID = %d, want 200062", rid)
+	}
+}
+
+func TestMotorolaAliasAssemblerWrongOpcodeRejected(t *testing.T) {
+	// A 0x95 PDU before any header must not complete or panic.
+	d, _ := macPDU(t, aliasData1MSG...).AsMotorolaAliasData()
+	a := NewMotorolaAliasAssembler(nil)
+	if _, _, done := a.AddData(d); done {
+		t.Error("data before header must not complete")
+	}
+}
+
 func TestControlChannelPublishesTalkerAlias(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -122,6 +122,28 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	// so the voice channel's own LCO-0 LCs are how we tag a decoded
 	// alias with the right radio.
 	var lastSourceID uint32
+	// publishMotorolaAlias surfaces a completed voice-channel talker
+	// alias on the bus (the affiliation tracker binds it onto the RID).
+	// Shared by the LDU1 link-control path and the TDULC terminator
+	// path — Motorola systems carry these 0x15/0x17 LCs on either
+	// (#376), so both feed the same buffer and publish identically.
+	publishMotorolaAlias := func(alias string) {
+		if lastSourceID == 0 {
+			return
+		}
+		c.log.Info("composer: p25p1 motorola talker alias",
+			"system", system, "serial", serial, "src", lastSourceID, "alias", alias)
+		c.bus.Publish(events.Event{
+			Kind: events.KindTalkerAlias,
+			Payload: trunking.TalkerAlias{
+				System:   system,
+				Protocol: "p25-phase1",
+				SourceID: lastSourceID,
+				Alias:    alias,
+				At:       time.Now(),
+			},
+		})
+	}
 	// frames counts LDUs delivered by the receiver — i.e. real voice
 	// activity. The touch ticker (below) only refreshes the engine's
 	// LastHeardAt when this counter has advanced since the previous
@@ -159,6 +181,29 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 			// rolls the recording to a fresh file for the next over; it
 			// is not voice, so don't write or count it.
 			if derr == nil && (duid == phase1.DUIDTerminator || duid == phase1.DUIDTerminatorWithLC) {
+				// A TDULC terminator still carries link control, and on
+				// Motorola systems the talker alias (LCO 0x15 header /
+				// 0x17 data) rides here rather than in LDU1 (#376). Pull
+				// its LC before ending the call so the alias isn't lost
+				// on the terminator.
+				if duid == phase1.DUIDTerminatorWithLC {
+					if lcf, content, _, terr := phase1.ExtractTDULCLinkControl(ldu); terr == nil {
+						switch {
+						case phase1.IsTalkerAliasLCO(lcf):
+							if alias, ok := aliasBuf.AddFragment(lcf, content); ok {
+								publishMotorolaAlias(alias)
+							}
+						case lcf == phase1.LCOGroupVoiceChannelUser:
+							// A terminator LCO-0 can carry the source ID;
+							// keep lastSourceID current so a just-completed
+							// alias tags the right radio.
+							src := uint32(content[6])<<16 | uint32(content[7])<<8 | uint32(content[8])
+							if src != 0 {
+								lastSourceID = src
+							}
+						}
+					}
+				}
 				bt.onTransmissionEnd()
 				return
 			}
@@ -247,19 +292,8 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 				lcf := content[0]
 				switch {
 				case phase1.IsTalkerAliasLCO(lcf):
-					if alias, ok := aliasBuf.AddFragment(lcf, content); ok && lastSourceID != 0 {
-						c.log.Info("composer: p25p1 motorola talker alias",
-							"system", system, "serial", serial, "src", lastSourceID, "alias", alias)
-						c.bus.Publish(events.Event{
-							Kind: events.KindTalkerAlias,
-							Payload: trunking.TalkerAlias{
-								System:   system,
-								Protocol: "p25-phase1",
-								SourceID: lastSourceID,
-								Alias:    alias,
-								At:       time.Now(),
-							},
-						})
+					if alias, ok := aliasBuf.AddFragment(lcf, content); ok {
+						publishMotorolaAlias(alias)
 					}
 				default:
 					if lc, _, lerr := phase1.ParseLinkControl(blocks); lerr == nil {

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -109,6 +109,11 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 	rs, _ := c.sink.(rawFrameSink)
 	sfDec := p25p2.NewSuperframeDecoder()
 	aliasAsm := p25p2.NewTalkerAliasAssembler(nil)
+	// motorolaAliasAsm reassembles the real Motorola FACCH-S talker
+	// alias (header opcode 0x91 + data 0x95) that MMR-style systems emit
+	// during hangtime (#376). Distinct from aliasAsm above, which serves
+	// the speculative 0x82 working model still referenced by the CC path.
+	motorolaAliasAsm := p25p2.NewMotorolaAliasAssembler(nil)
 	// macSeen rate-limits the diagnostic per-PDU log to one line per
 	// opcode (+ MFID for vendor opcodes) per call — enough to confirm
 	// which transports MMR-style systems actually emit, without
@@ -188,6 +193,22 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 					if f, ok := pdu.AsTalkerAliasFragment(); ok {
 						alias, src, complete := aliasAsm.Add(f)
 						if complete {
+							c.publishP25Phase2TalkerAlias(system, src, alias)
+						}
+						continue
+					}
+					// Real Motorola FACCH-S alias: header (0x91) seeds the
+					// per-call reassembler, data blocks (0x95) complete it,
+					// and the source RID falls out of the decoded message
+					// prefix (#376).
+					if h, ok := pdu.AsMotorolaAliasHeader(); ok {
+						if alias, src, complete := motorolaAliasAsm.AddHeader(h); complete {
+							c.publishP25Phase2TalkerAlias(system, src, alias)
+						}
+						continue
+					}
+					if d, ok := pdu.AsMotorolaAliasData(); ok {
+						if alias, src, complete := motorolaAliasAsm.AddData(d); complete {
 							c.publishP25Phase2TalkerAlias(system, src, alias)
 						}
 						continue


### PR DESCRIPTION
Real Motorola P25 talker aliases never surfaced because the decoder
only scanned LDU1 link control. Field reports (SDRTrunk ground truth on
Victorian MMR) show the alias rides two other carriers, both now decoded:

- Phase 1 TDULC: the same LCO 0x15 header / 0x17 data blocks the repo
  already parses, but in the terminator (DUID 0xF) — which the voice
  chain returned past before reading its link control. New
  phase1.ExtractTDULCLinkControl recovers the 9 LC octets (Golay(24,12,8)
  inner + RS(24,12,13) outer) and feeds the existing, carriage-
  independent MotorolaTalkerAliasBuf.

- Phase 2 FACCH-S: header MAC opcode 0x91 + data opcodes 0x95 (MFID
  0x90), decoded via new AsMotorolaAliasHeader / AsMotorolaAliasData +
  MotorolaAliasAssembler. The fragments reassemble to the same Motorola
  message framing as Phase 1, so the inline source RID falls out of the
  decoded prefix.

All three carriers (LDU1, TDULC, FACCH-S) now share one decode primitive:
new internal/radio/p25/motorola package (cipher + WACN|System|RID|alias|
CRC-16 framing), with phase1 delegating to it. Completed aliases publish
the existing KindTalkerAlias event, which the affiliation tracker already
binds onto the RID and surfaces at /api/v1/rids.

The speculative Phase 2 0x82 model is retained (still referenced by the
CC path) but superseded by the 0x91/0x95 path.

CAVEAT: no IQ fixtures are committed (the issue's Dropbox link is
network-blocked here), so the TDULC codeword interleave and the Phase 2
per-PDU byte offsets are inferred from the post-FEC SDRTrunk dumps. They
are unit-tested for FEC round-trip and structure (TG/blocks/sequence
parse; SUID prefix BEE00164030D7E -> RID 200062), but the final decoded
alias string needs a real frame to confirm. Wrong offsets fail safe —
the RS layer / DecodeMessage reject incoherent input, so no junk alias is
surfaced. The p25p2 mac pdu / p25p1 motorola talker alias diagnostics are
left in to confirm against the reporter's next field run.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LTNDzMKu4grx5HLHFFQjMw