### PR TITLE
docs: post-release v0.4.6 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
-### Fixed
-- **P25 discovery now decodes WACN / System ID / RFSS / Site / neighbors
-  correctly.** The Phase 1 Network-, RFSS-, and Adjacent-Site Status
-  Broadcast TSBK parsers were dropping the leading LRA byte, so every
-  field read one byte early — WACN and System ID came out wrong, RFSS/Site
-  read as 0, and advertised neighbors showed garbled IDs with no resolvable
-  frequency. The parsers now follow the TIA-102.AABF layout (matching the
-  repo's independent Phase 2 decoders), which also corrects the `rfss_id` /
-  `site_id` labels on `grant` events and `KindSiteUpdate`.
+## [v0.4.6] — 2026-06-18
+
+This release focuses on **P25 site and identity decoding**. Encrypted calls
+are now configurable — a new `trunking.encrypted_calls.mode` stops a few long
+encrypted calls from exhausting the voice-tuner pool and starving clear
+traffic (#711). Every `grant` event carries the decoded RFSS/site, exposed
+alongside a new `GET /api/v1/sites` endpoint (#698), the web Systems panel's
+WACN / System ID / RFSS / Site fields finally populate from the live site
+tracker instead of sitting on "Awaiting status broadcasts" (#673), and a
+Phase 1 status-broadcast parsing bug that had every WACN / System ID / RFSS /
+Site / neighbor reading one byte early is fixed (#716). Motorola **talker
+aliases** now decode off the Phase 1 TDULC terminator and Phase 2 FACCH-S, not
+just LDU1 (#376), and the Hunt discovery view surfaces the voice/traffic
+frequencies behind each grant. On the docs side: two new deep-dive blog series
+("Build in the Open" and "RF Front End") and a full Git & GitHub learning path.
 
 ### Added
 - **Configurable handling of encrypted calls** (#711). A new
@@ -47,6 +53,42 @@ for tagged releases.
   — each with the control-channel frequency it was heard on — merged
   with optional human-readable names configured per system under
   `trunking.systems[].sites` (`rfss` / `site` / `name`).
+- **P25 Motorola talker aliases on TDULC and FACCH-S** (#376). Real
+  Motorola talker aliases ride two carriers the decoder previously skipped
+  past — the Phase 1 TDULC terminator and the Phase 2 FACCH-S — not just
+  LDU1 link control, so aliases never surfaced on many systems. All three
+  carriers now share one decode primitive (a new `internal/radio/p25/motorola`
+  package handling the cipher + WACN|System|RID|alias|CRC-16 framing), and
+  completed aliases publish the existing `KindTalkerAlias` event, bound onto
+  the RID and surfaced at `/api/v1/rids`.
+- **P25 System Information panel populates from the live site tracker**
+  (#673). The web Systems detail panel showed WACN / System ID / RFSS / Site
+  stuck on "Awaiting status broadcasts" because `GET /api/v1/systems` built
+  its DTOs solely from static config. The endpoints now overlay the always-on
+  site tracker's decoded over-the-air identity (WACN/System ID system-wide,
+  RFSS/Site from the most recently heard site), falling back to config values
+  when nothing has been decoded yet.
+- **"Build in the Open" blog series.** A 14-part tutorial series taking a
+  project from idea to public release with GitHub and Claude Code, using
+  GopherTrunk as the worked example, drip-released one post per weekday.
+- **"RF Front End" blog series.** A 14-part deep dive into GopherTrunk's
+  pure-Go RF source layer (RTL-SDR, Airspy, HackRF): the Device contract, the
+  driver registry, the no-libusb USB transport across Linux/macOS/Windows,
+  per-radio register bring-up, and IQ conversion.
+- **Git & GitHub learning path.** The single "Learn RF & SDR" curriculum
+  becomes a multi-path "Learn" section, adding a complete 29-lesson Git &
+  GitHub path alongside the existing RF & SDR one. Old RF lesson URLs keep
+  working via redirects.
+
+### Fixed
+- **P25 discovery now decodes WACN / System ID / RFSS / Site / neighbors
+  correctly** (#716). The Phase 1 Network-, RFSS-, and Adjacent-Site Status
+  Broadcast TSBK parsers were dropping the leading LRA byte, so every
+  field read one byte early — WACN and System ID came out wrong, RFSS/Site
+  read as 0, and advertised neighbors showed garbled IDs with no resolvable
+  frequency. The parsers now follow the TIA-102.AABF layout (matching the
+  repo's independent Phase 2 decoders), which also corrects the `rfss_id` /
+  `site_id` labels on `grant` events and `KindSiteUpdate`.
 
 ## [v0.4.5] — 2026-06-17
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.4.5
+VERSION=v0.4.6
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.4.5" -%}
+  {%- assign ver = "v0.4.6" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.4.6.md
+++ b/docs/announcements/v0.4.6.md
@@ -1,0 +1,53 @@
+# GopherTrunk v0.4.6 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.4.6 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.6
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.4.6 — configurable handling of encrypted calls so they stop starving the voice-tuner pool, P25 site identity on every grant + a /api/v1/sites endpoint, the Systems panel now shows live WACN/SysID/RFSS/Site, Motorola talker aliases decoded off TDULC + FACCH-S, and a status-broadcast byte-offset fix
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.4.6 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.4.5:**
+
+* **Configurable handling of encrypted calls** (#711) — a new `trunking.encrypted_calls.mode` chooses how the engine spends scarce voice SDRs on encrypted calls: `follow` (default, unchanged), `metadata` (follow briefly to grab talker alias / source RID / encryption sync, then release after ~1.5 s), or `ignore` (never tie up a tuner). Calls whose KeyID matches a configured key are exempt and always followed. Runtime-mutable via the API, the TUI, and SIGHUP — no restart. Stops a few long encrypted calls from exhausting the tuner pool and dropping clear traffic.
+* **P25 site identity on every grant + `/api/v1/sites`** (#698) — `grant` events now carry `rfss_id` / `site_id` decoded from the RFSS Status Broadcast, so dashboards/exporters can label calls by site instead of an opaque channel_id. A new `GET /api/v1/sites` lists discovered sites with the control-channel frequency each was heard on, merged with optional human-readable names from config.
+* **Systems panel populates from the live site tracker** (#673) — the web Systems detail panel no longer sits on "Awaiting status broadcasts"; WACN / System ID / RFSS / Site now reflect the decoded over-the-air identity.
+* **Motorola talker aliases on TDULC + FACCH-S** (#376) — aliases ride the Phase 1 TDULC terminator and Phase 2 FACCH-S, not just LDU1, so they finally surface on many systems (bound onto the RID at `/api/v1/rids`).
+* **Status-broadcast byte-offset fix** (#716) — the Phase 1 status-broadcast parsers were dropping the leading LRA byte, so WACN / System ID / RFSS / Site / neighbors all read one byte early; now corrected to the TIA-102.AABF layout.
+* Plus voice/traffic frequencies in the Hunt discovery view, two new blog series ("Build in the Open" and "RF Front End"), and a full Git & GitHub learning path.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.6
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.4.6 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.4.5:**
+- **Configurable encrypted-call handling** (#711) — `trunking.encrypted_calls.mode`: `follow` / `metadata` / `ignore`, so long encrypted calls stop starving the voice-tuner pool. Runtime-mutable; configured keys stay exempt.
+- **P25 site identity on every grant + `/api/v1/sites`** (#698) — grants carry `rfss_id` / `site_id`; new endpoint lists discovered sites with their CC frequency.
+- **Systems panel shows live WACN/SysID/RFSS/Site** (#673) — populated from the always-on site tracker instead of static config.
+- **Motorola talker aliases on TDULC + FACCH-S** (#376) — decoded off two more carriers, not just LDU1.
+- **Status-broadcast byte-offset fix** (#716) — WACN/SysID/RFSS/Site/neighbors no longer read one byte early.
+- Plus Hunt voice-channel frequencies, two new blog series, and a Git & GitHub learning path.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.6>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow tagged v0.4.6, so sync the docs to match:

- CHANGELOG: promote [Unreleased] to [v0.4.6] (2026-06-18) and backfill the
  user-visible changes that shipped without a changelog entry — Motorola
  talker aliases decoded off the Phase 1 TDULC terminator and Phase 2
  FACCH-S, not just LDU1 (#376); the web Systems panel now populating
  WACN/System ID/RFSS/Site from the live site tracker (#673); and the
  docs-site additions (the "Build in the Open" and "RF Front End" blog
  series and the new Git & GitHub learning path). The pre-existing
  [Unreleased] entries (configurable encrypted-call handling #711, P25
  site identity + /api/v1/sites #698, Hunt voice-channel frequencies, and
  the status-broadcast LRA-byte fix #716) are reorganized under the
  versioned heading with a fresh empty [Unreleased] block above.
- README: bump the Linux quick-install VERSION to v0.4.6.
- latest-version.html: bump the GitHub Pages fallback tag to v0.4.6.
- announcements: add the v0.4.6 social blurb drafts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017dbH5nmjhckJY6XXZLibH3