### PR TITLE
Fix Systems detail modal crash on null scanner systems list

### DIFF
--- a/web/src/panels/Systems.test.tsx
+++ b/web/src/panels/Systems.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 
 vi.mock("../api/client", () => ({
   api: { systems: vi.fn(), scanner: vi.fn() },
@@ -77,5 +77,33 @@ describe("Systems panel", () => {
     const row = screen.getByText("Metro P25").closest("tr")!;
     // Band plan cell shows the em dash placeholder.
     expect(row.textContent).toContain("—");
+  });
+
+  it("opens the detail modal when the scanner has a null systems list", async () => {
+    // The daemon marshals an empty hunt list as JSON `null` (Go nil
+    // slice), so `scanner.systems` can be null at runtime even though
+    // the type says it's an array. The detail modal must not crash
+    // calling `.find` on it.
+    vi.mocked(api.scanner).mockResolvedValue({
+      scan_mode: "all",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      systems: null as any,
+      conventional: { enabled: false, channels: [] },
+      tg_scan_count: 0,
+      tg_total: 0,
+    });
+    vi.mocked(api.systems).mockResolvedValue([
+      { name: "Main_Site_1", protocol: "p25", control_channels: [765_000_000] },
+    ]);
+
+    render(<Systems />);
+    await waitFor(() => expect(api.scanner).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText("Main_Site_1"));
+
+    // Modal renders the live-identity section instead of throwing.
+    expect(
+      await screen.findByText(/Network identity \(decoded live\)/i),
+    ).toBeInTheDocument();
   });
 });

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -203,7 +203,7 @@ export function Systems() {
             }
           />
           {(() => {
-            const hunt = scanner?.systems.find((h) => h.name === selected.name);
+            const hunt = scanner?.systems?.find((h) => h.name === selected.name);
             const hint = identityEmptyHint(hunt);
             return (
               <div>


### PR DESCRIPTION
Clicking a system in the Systems tab crashed with "Cannot read
properties of null (reading 'find')" whenever the scanner reported
no active control-channel hunt statuses.

The daemon builds ScannerStatus.Systems with append, so an empty
hunt list stays a nil slice and is marshaled as JSON `null`. The
detail modal's optional chain `scanner?.systems.find(...)` only
guarded `scanner` being null, not `scanner.systems`, so `.find` was
called on null.

Guard the systems list too (`scanner?.systems?.find`) and add a
regression test that opens the modal with a null systems list.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Kbigm98u22EdeQ6csqn6Rj