### PR TITLE
feat(p25): streaming long-dwell CC monitor + identity corroboration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **Streaming long-dwell control-channel monitor for Hunt** (opt-in). A new
+  `monitor_seconds` (web Hunt "Monitor" field / `-monitor-seconds` CLI flag)
+  decodes a locked control channel from the live SDR in real time instead of
+  buffering the whole dwell, so a P25 site can be watched for minutes without
+  recording gigabytes of IQ. It stops early once identity, neighbors, and the
+  band plan stop changing (converge-and-stop), capped at the requested time.
+
+### Fixed
+- **P25 identity / band-plan / neighbor accuracy under noise.** Status-broadcast
+  accumulation was last-write-wins, so a single corrupt-but-CRC-passing TSBK
+  could set a wrong WACN / System ID or inject a phantom band-plan slot
+  (e.g. a stray VHF base on a UHF site). Identity is now resolved by majority
+  vote across observations, and band-plan slots and neighbors must be seen at
+  least twice before they surface — while live grant resolution still accepts a
+  first sighting, so voice channels are unaffected.
+
 ## [v0.4.6] — 2026-06-18
 
 This release focuses on **P25 site and identity decoding**. Encrypted calls

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -57,6 +57,7 @@ func runHunt(args []string) {
 	autoGainSet := fs.String("auto-gain-set", "", "live: comma-separated gains in dB for -auto-gain (default: a conservative spread; use a device-appropriate set for RTL/Airspy)")
 	surveyAudio := fs.String("survey-audio", "", "survey: write a WAV clip per active analog FM carrier into this directory")
 	maxDwellSeconds := fs.Float64("max-dwell-seconds", 0, "survey: extend per-candidate dwell up to this many seconds, listening until carrier activity (0 = fixed -dwell-seconds)")
+	monitorSeconds := fs.Float64("monitor-seconds", 0, "live: stream each locked control channel in real time for up to this many seconds (converge-and-stop), instead of buffering the dwell — lets you monitor a CC for minutes without recording gigabytes (0 = off)")
 	identifyMinConf := fs.Float64("identify-min-confidence", 0, "survey: skip the trunking identify for a digital carrier below this classifier confidence (0 = always identify)")
 	classSNRGate := fs.Float64("class-snr-gate", 0, "survey classifier: min SNR (dB) to classify a carrier (0 = default 3)")
 	classDigitalProm := fs.Float64("class-digital-prominence", 0, "survey classifier: min baud-line prominence for a digital call (0 = default 15)")
@@ -205,6 +206,7 @@ FLAGS:`)
 			outDir:           *out,
 			surveyAudioDir:   *surveyAudio,
 			maxDwellSeconds:  *maxDwellSeconds,
+			monitorSeconds:   *monitorSeconds,
 			identifyMinConf:  *identifyMinConf,
 			classSNRGate:     *classSNRGate,
 			classDigitalProm: *classDigitalProm,

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -112,6 +112,7 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 		AutoGain:        req.AutoGain,
 		AutoGainSet:     gainSet,
 		MaxDwellSeconds: req.MaxDwellSeconds,
+		MonitorSeconds:  req.MonitorSeconds,
 		Serial:          req.Serial,
 		FFTSize:         req.FFTSize,
 		DwellSeconds:    req.DwellSeconds,

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -30,6 +30,7 @@ type huntLiveParams struct {
 	outDir           string // explicit -out dir, for the gain-recommendation sidecar
 	surveyAudioDir   string
 	maxDwellSeconds  float64
+	monitorSeconds   float64
 	identifyMinConf  float64
 	classSNRGate     float64
 	classDigitalProm float64
@@ -146,6 +147,7 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 		PeakOpts:              hunt.PeakOptions{ThresholdDb: float32(p.peakThresholdDb), MinSpacingHz: p.minSpacingHz},
 		DwellSeconds:          p.dwellSeconds,
 		MaxDwellSeconds:       p.maxDwellSeconds,
+		MonitorSeconds:        p.monitorSeconds,
 		MinConfidence:         p.minConfidence,
 		AutoTune:              p.autoTune,
 		Name:                  p.name,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -55,6 +55,7 @@ type HuntStartRequest struct {
 	AutoGain        bool      `json:"auto_gain,omitempty"`      // post-run: sweep gains on locked CCs, recommend the best
 	AutoGainSet     string    `json:"auto_gain_set,omitempty"`  // optional comma-separated gain ladder in dB (e.g. "0,8.7,16.6")
 	MaxDwellSeconds float64   `json:"max_dwell_seconds,omitempty"`
+	MonitorSeconds  float64   `json:"monitor_seconds,omitempty"` // >0: stream a locked CC in real time for up to this long (converge-and-stop), instead of buffering the dwell
 	Protocol        string    `json:"protocol,omitempty"`
 	DwellSeconds    float64   `json:"dwell_seconds,omitempty"`
 	SweepDwellMs    int       `json:"sweep_dwell_ms,omitempty"`

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -106,8 +106,15 @@ type LiveHuntOptions struct {
 	// capture (in DwellSeconds chunks) until carrier activity is seen or this
 	// ceiling is reached — useful for bursty paging. 0 ⇒ a single fixed dwell.
 	MaxDwellSeconds float64
-	MinConfidence   float64
-	AutoTune        bool
+	// MonitorSeconds, when > 0, switches each candidate from the buffered
+	// fixed-dwell capture to a streaming long-dwell control-channel monitor:
+	// live IQ is decoded in real time (bounded memory, no multi-GB capture) for
+	// up to this many seconds, stopping early once identity + neighbors + band
+	// plan settle. The short DwellSeconds prefix is still captured first to
+	// identify the protocol. Opt-in: 0 ⇒ today's buffered behavior.
+	MonitorSeconds float64
+	MinConfidence  float64
+	AutoTune       bool
 
 	// SurveyAudioDir, when set, makes a survey write a WAV clip per active
 	// analog-FM carrier into this directory.
@@ -202,6 +209,25 @@ func RunLiveHunt(ctx context.Context, opts LiveHuntOptions) (*DiscoveredSystem, 
 			Detail: fmt.Sprintf("%.3f MHz", float64(cand.FreqHz)/1e6),
 		})
 
+		params := decodeParams{
+			Protocol:      opts.Protocol,
+			Format:        siglab.FormatF32,
+			SampleRateHz:  float64(rate),
+			FrequencyHz:   cand.FreqHz,
+			AutoTune:      opts.AutoTune,
+			MinConfidence: opts.MinConfidence,
+			Log:           log,
+		}
+
+		// Streaming long-dwell monitor: decode the live source in real time
+		// instead of buffering the whole dwell (the only way to watch a CC for
+		// minutes without recording gigabytes of IQ).
+		if opts.MonitorSeconds > 0 {
+			rep := monitorCandidate(ctx, sys, opts.Source, cand.FreqHz, nSamples, opts.MonitorSeconds, params)
+			reports = append(reports, rep)
+			continue
+		}
+
 		if err := opts.Source.Tune(cand.FreqHz); err != nil {
 			reports = append(reports, CaptureReport{
 				Path:  fmt.Sprintf("%.4f MHz", float64(cand.FreqHz)/1e6),
@@ -219,15 +245,7 @@ func RunLiveHunt(ctx context.Context, opts LiveHuntOptions) (*DiscoveredSystem, 
 		// shared identify→decode→accumulate body over a seekable reader.
 		buf := siglab.EncodeCapture(iq, siglab.FormatF32)
 		rep := decodeAndAccumulate(sys, bytes.NewReader(buf),
-			fmt.Sprintf("%.4f MHz", float64(cand.FreqHz)/1e6), decodeParams{
-				Protocol:      opts.Protocol,
-				Format:        siglab.FormatF32,
-				SampleRateHz:  float64(rate),
-				FrequencyHz:   cand.FreqHz,
-				AutoTune:      opts.AutoTune,
-				MinConfidence: opts.MinConfidence,
-				Log:           log,
-			})
+			fmt.Sprintf("%.4f MHz", float64(cand.FreqHz)/1e6), params)
 		reports = append(reports, rep)
 	}
 

--- a/internal/hunt/monitor.go
+++ b/internal/hunt/monitor.go
@@ -1,0 +1,216 @@
+package hunt
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Streaming long-dwell control-channel monitor.
+//
+// The buffered per-candidate path (RunLiveHunt's default) captures the entire
+// dwell into memory before decoding — fine for a 3 s grab, but a 5–10 min CC
+// monitor would buffer gigabytes of IQ. monitorCandidate instead streams live
+// IQ straight into the siglab decoder (bounded memory) and stops early once
+// the accumulated topology (identity + neighbors + band plan) settles, capped
+// at MonitorSeconds. It is the streaming sibling of decodeAndAccumulate.
+
+const (
+	// monitorTick is how often the converge-and-stop check runs (stream time).
+	monitorTick = 2 * time.Second
+	// monitorStability is how long the topology must stop changing before the
+	// dwell is considered settled.
+	monitorStability = 30 * time.Second
+	// monitorMinDwell is the minimum dwell before convergence can trigger, so a
+	// site's slower-cycling broadcasts (adjacent sites, full band plan) get a
+	// chance to arrive before we declare the picture complete.
+	monitorMinDwell = 20 * time.Second
+)
+
+// streamReader adapts an IQSource into an io.Reader of encoded samples for the
+// siglab decoder. Each Read pulls a chunk from the source and serves it in the
+// requested sample format, buffering the remainder between calls. It returns
+// io.EOF when ctx is done (the dwell cap) or the source ends, so the decoder
+// assembles and returns the topology accumulated so far.
+type streamReader struct {
+	ctx    context.Context
+	src    IQSource
+	chunk  int
+	format siglab.SampleFormat
+	buf    []byte
+	done   bool
+}
+
+func (s *streamReader) Read(p []byte) (int, error) {
+	for len(s.buf) == 0 {
+		if s.done {
+			return 0, io.EOF
+		}
+		if s.ctx.Err() != nil {
+			s.done = true
+			return 0, io.EOF
+		}
+		iq, err := s.src.Capture(s.ctx, s.chunk)
+		if err != nil || len(iq) == 0 {
+			// ctx cancellation, deadline, or end-of-stream — end the dwell
+			// gracefully; the decoder still returns what it accumulated.
+			s.done = true
+			return 0, io.EOF
+		}
+		s.buf = siglab.EncodeCapture(iq, s.format)
+	}
+	n := copy(p, s.buf)
+	s.buf = s.buf[n:]
+	return n, nil
+}
+
+// monitorCandidate tunes the source at one control-channel frequency, captures
+// a short prefix to identify the protocol (unless one is forced), then streams
+// the live source into the decoder for up to monitorSeconds, folding the
+// accumulated system into sys. It mirrors decodeAndAccumulate's identify gate
+// and accumulation, but decodes a continuing stream instead of a fixed buffer.
+func monitorCandidate(ctx context.Context, sys *DiscoveredSystem, src IQSource, freqHz uint32, prefixSamples int, monitorSeconds float64, p decodeParams) CaptureReport {
+	log := p.Log
+	if log == nil {
+		log = slog.New(slog.DiscardHandler)
+	}
+	source := fmt.Sprintf("%.4f MHz", float64(freqHz)/1e6)
+	rep := CaptureReport{Path: source}
+
+	if err := src.Tune(freqHz); err != nil {
+		rep.Error = fmt.Sprintf("tune: %v", err)
+		return rep
+	}
+
+	// Short prefix for identify + carrier offset (same gate as the buffered path).
+	prefixIQ, err := captureN(ctx, src, prefixSamples)
+	if err != nil {
+		rep.Error = fmt.Sprintf("prefix capture: %v", err)
+		return rep
+	}
+	prefixBytes := siglab.EncodeCapture(prefixIQ, p.Format)
+
+	proto := p.Protocol
+	conf := 1.0
+	tuneHz := 0.0
+	if proto == trunking.ProtocolUnknown {
+		minConf := p.MinConfidence
+		if minConf <= 0 {
+			minConf = 0.40
+		}
+		idr, err := siglab.IdentifyReader(bytes.NewReader(prefixBytes), source, siglab.IdentifyConfig{
+			SampleRateHz: p.SampleRateHz,
+			Format:       p.Format,
+			AutoTune:     p.AutoTune,
+			Conjugate:    p.Conjugate,
+			IQCorrect:    p.IQCorrect,
+			MaxSamples:   p.IdentifyMaxSamples,
+			Log:          log,
+		})
+		if err != nil {
+			rep.Error = fmt.Sprintf("identify: %v", err)
+			return rep
+		}
+		conf = idr.Confidence
+		if idr.Inconclusive || idr.Confidence < minConf {
+			rep.Protocol = idr.Winner
+			rep.Confidence = idr.Confidence
+			rep.Skipped = true
+			rep.SkipReason = fmt.Sprintf("no trunked control channel above confidence %.2f (best: %s @ %.2f)",
+				minConf, idr.Winner, idr.Confidence)
+			return rep
+		}
+		wp, err := idr.WinnerProtocol()
+		if err != nil {
+			rep.Error = fmt.Sprintf("winner protocol: %v", err)
+			return rep
+		}
+		proto = wp
+		tuneHz = idr.TuneHz
+	}
+	rep.Protocol = proto.String()
+	rep.Confidence = conf
+
+	// Stream the prefix followed by the continuing live source. The dwell is
+	// capped by monitorSeconds; convergence may stop it sooner.
+	dwellCtx, cancel := context.WithTimeout(ctx, time.Duration(monitorSeconds*float64(time.Second)))
+	defer cancel()
+	live := &streamReader{ctx: dwellCtx, src: src, chunk: prefixSamples, format: p.Format}
+	r := io.MultiReader(bytes.NewReader(prefixBytes), live)
+
+	cfg := siglab.Config{
+		Protocol:     proto,
+		FrequencyHz:  freqHz,
+		SampleRateHz: p.SampleRateHz,
+		Format:       p.Format,
+		AutoTune:     false,
+		TuneHz:       tuneHz,
+		Conjugate:    p.Conjugate,
+		IQCorrect:    p.IQCorrect,
+		// CollectIQDiag engages the P25 Phase 1 deep path that snapshots the
+		// system topology (WACN/SYSID/RFSS/Site + neighbors + band plan); the
+		// generic pipeline would only yield a NAC. Matches decodeAndAccumulate.
+		CollectIQDiag: true,
+		Log:           log,
+	}
+
+	res, err := siglab.RunReaderMonitor(r, source, cfg, monitorTick, convergeAndStop())
+	if err != nil {
+		rep.Error = fmt.Sprintf("monitor decode: %v", err)
+		return rep
+	}
+
+	before := len(sys.Talkgroups)
+	Accumulate(sys, Observation{
+		Protocol:       proto.String(),
+		Confidence:     conf,
+		Result:         res,
+		FallbackFreqHz: freqHz,
+		At:             time.Now(),
+	})
+	rep.Locked = res.Locked
+	if res.Lock != nil {
+		rep.ControlHz = res.Lock.FrequencyHz
+	}
+	if res.Signal != nil {
+		rep.ErrorRate = res.Signal.DecodeErrorRate
+	}
+	rep.Talkgroups = len(sys.Talkgroups) - before
+	return rep
+}
+
+// convergeAndStop returns a monitor tick callback that stops the dwell once
+// identity is present and the topology (neighbors / secondary CCs / band-plan
+// slots) has stopped growing for monitorStability, after a monitorMinDwell
+// floor. The returned closure carries the per-run change-tracking state.
+func convergeAndStop() func(*siglab.TopologySnapshot, float64) bool {
+	var (
+		lastChangeSec        float64
+		prevN, prevS, prevBP int
+		haveID               bool
+		seenChange           bool
+	)
+	stability := monitorStability.Seconds()
+	minDwell := monitorMinDwell.Seconds()
+	return func(topo *siglab.TopologySnapshot, sec float64) bool {
+		if topo == nil {
+			return false
+		}
+		n, s, bp := len(topo.Neighbors), len(topo.Secondary), len(topo.BandPlan)
+		id := topo.WACN != 0 && topo.SystemID != 0
+		if !seenChange || n != prevN || s != prevS || bp != prevBP || id != haveID {
+			prevN, prevS, prevBP, haveID, seenChange = n, s, bp, id, true
+			lastChangeSec = sec
+		}
+		if !id || sec < minDwell {
+			return false
+		}
+		return sec-lastChangeSec >= stability
+	}
+}

--- a/internal/hunt/monitor_test.go
+++ b/internal/hunt/monitor_test.go
@@ -1,0 +1,96 @@
+package hunt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestRunLiveHunt_Monitor drives the streaming long-dwell monitor path
+// (MonitorSeconds > 0) over a synthesized P25 control-channel buffer served
+// cyclically by a FileIQSource. It proves the live stream is decoded in real
+// time (no whole-dwell buffer) and still maps the system the same way the
+// buffered path does, while the dwell cap bounds the run.
+func TestRunLiveHunt_Monitor(t *testing.T) {
+	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{
+		Protocol: trunking.ProtocolP25,
+		Format:   siglab.FormatF32,
+	})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	rate := uint32(meta.SampleRateHz)
+	src := NewFileIQSource(iq, rate)
+
+	const candHz = 851_000_000
+	sys, reports, err := RunLiveHunt(context.Background(), LiveHuntOptions{
+		Source:     src,
+		Candidates: []uint32{candHz},
+		// Short identify prefix; the monitor then streams the cyclic buffer.
+		DwellSeconds: float64(len(iq)) / float64(rate),
+		// Cap the dwell so the test stops promptly even if identity never
+		// corroborates (converge-and-stop may end it sooner).
+		MonitorSeconds: 2,
+		MinConfidence:  0.3,
+		Name:           "Monitor Test",
+	})
+	if err != nil {
+		t.Fatalf("RunLiveHunt (monitor): %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("len(reports) = %d, want 1", len(reports))
+	}
+	r := reports[0]
+	if r.Error != "" {
+		t.Fatalf("candidate errored: %s", r.Error)
+	}
+	if r.Skipped {
+		t.Fatalf("candidate skipped: %s", r.SkipReason)
+	}
+	if r.Protocol != "p25" {
+		t.Errorf("protocol = %q, want p25", r.Protocol)
+	}
+	if !r.Locked {
+		t.Errorf("expected a lock on the synthesized P25 control channel")
+	}
+	if len(sys.Sites) != 1 {
+		t.Fatalf("len(Sites) = %d, want 1", len(sys.Sites))
+	}
+	foundCC := false
+	for _, ch := range sys.Sites[0].ControlChannels {
+		if ch.FrequencyHz == candHz {
+			foundCC = true
+		}
+	}
+	if !foundCC {
+		t.Errorf("control channel %d not recorded; site = %+v", candHz, sys.Sites[0])
+	}
+}
+
+// TestConvergeAndStop checks the converge-and-stop policy: it holds until
+// identity is present, waits out the minimum dwell, then stops once the
+// topology stops changing for the stability window.
+func TestConvergeAndStop(t *testing.T) {
+	stop := convergeAndStop()
+	withID := &siglab.TopologySnapshot{WACN: 0xBEE08, SystemID: 0x534}
+
+	// No identity yet ⇒ never converges, however long the dwell.
+	if stop(&siglab.TopologySnapshot{}, 1000) {
+		t.Fatal("converged with no identity")
+	}
+	// Identity present but inside the minimum-dwell floor ⇒ keep going.
+	if stop(withID, monitorMinDwell.Seconds()-1) {
+		t.Fatal("converged before the minimum dwell")
+	}
+	// Identity present, past the floor, but not yet stable for the window.
+	base := monitorMinDwell.Seconds() + 1
+	if stop(withID, base) {
+		t.Fatal("converged before the stability window elapsed")
+	}
+	// Stable for the whole window ⇒ converge.
+	if !stop(withID, base+monitorStability.Seconds()) {
+		t.Fatal("did not converge after a stable stability window")
+	}
+}

--- a/internal/radio/p25/phase1/bandplan_snapshot_test.go
+++ b/internal/radio/p25/phase1/bandplan_snapshot_test.go
@@ -8,7 +8,11 @@ func TestBandPlanSnapshot(t *testing.T) {
 		t.Fatalf("empty band plan should snapshot to nothing")
 	}
 	// Apply out of ID order; Snapshot must return ascending channel-ID order.
+	// Each slot is applied corroborationMin (2) times so it clears the
+	// corroboration gate Snapshot enforces.
 	bp.Apply(IdentifierUpdate{ChannelID: 3, BaseHz: 853_000_000, SpacingHz: 12_500})
+	bp.Apply(IdentifierUpdate{ChannelID: 3, BaseHz: 853_000_000, SpacingHz: 12_500})
+	bp.Apply(IdentifierUpdate{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500, AccessTDMA: true})
 	bp.Apply(IdentifierUpdate{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500, AccessTDMA: true})
 
 	got := bp.Snapshot()
@@ -20,5 +24,15 @@ func TestBandPlanSnapshot(t *testing.T) {
 	}
 	if got[0].BaseHz != 851_000_000 || !got[0].AccessTDMA {
 		t.Errorf("slot 1 = %+v, want base 851M TDMA", got[0])
+	}
+
+	// A slot seen only once must not surface (one-shot CRC false positive).
+	bp.Apply(IdentifierUpdate{ChannelID: 5, BaseHz: 136_000_000, SpacingHz: 6_250})
+	if got := bp.Snapshot(); len(got) != 2 {
+		t.Errorf("one-shot slot leaked into snapshot: len = %d, want 2", len(got))
+	}
+	// ...but it still resolves a live grant via Frequency (not corroboration-gated).
+	if _, err := bp.Frequency(5, 10); err != nil {
+		t.Errorf("Frequency on a once-seen slot should resolve: %v", err)
 	}
 }

--- a/internal/radio/p25/phase1/identifier.go
+++ b/internal/radio/p25/phase1/identifier.go
@@ -353,17 +353,20 @@ var ErrUnknownChannelID = errors.New("p25/phase1: no IdentifierUpdate for channe
 // the control channel reads/writes from a single goroutine so that's
 // the natural usage shape.
 type BandPlan struct {
-	slots [16]IdentifierUpdate
-	known [16]bool
+	slots  [16]IdentifierUpdate
+	known  [16]bool
+	counts [16]int // sightings per channel ID (for Snapshot corroboration)
 }
 
-// Apply records (or replaces) the band-plan slot for u.ChannelID.
+// Apply records (or replaces) the band-plan slot for u.ChannelID and counts
+// the sighting.
 func (b *BandPlan) Apply(u IdentifierUpdate) {
 	if int(u.ChannelID) >= len(b.slots) {
 		return
 	}
 	b.slots[u.ChannelID] = u
 	b.known[u.ChannelID] = true
+	b.counts[u.ChannelID]++
 }
 
 // Frequency returns the downlink frequency in Hz for the given
@@ -404,14 +407,18 @@ func (b *BandPlan) IsTDMA(channelID uint8) bool {
 	return b.slots[channelID].AccessTDMA
 }
 
-// Snapshot returns the IdentifierUpdate entries for every known channel ID,
-// in ascending channel-ID order. Used by the signal-lab / hunt layers to
-// surface the band plan a control channel advertised so a discovered system
-// can be documented and exported.
+// Snapshot returns the IdentifierUpdate entries for every channel ID seen at
+// least corroborationMin times, in ascending channel-ID order. Used by the
+// signal-lab / hunt layers to surface the band plan a control channel
+// advertised so a discovered system can be documented and exported. The
+// corroboration gate keeps a one-shot CRC false positive from injecting a
+// phantom slot (e.g. a stray VHF base on a UHF site); live grant resolution
+// (Frequency/Known) is deliberately not gated, so a once-seen slot still
+// resolves an in-progress voice grant.
 func (b *BandPlan) Snapshot() []IdentifierUpdate {
 	var out []IdentifierUpdate
 	for id := 0; id < len(b.slots); id++ {
-		if b.known[id] {
+		if b.known[id] && b.counts[id] >= corroborationMin {
 			out = append(out, b.slots[id])
 		}
 	}

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -1,6 +1,9 @@
 package phase1
 
-import "sync"
+import (
+	"sort"
+	"sync"
+)
 
 // P25 trunked-system topology model.
 //
@@ -11,6 +14,23 @@ import "sync"
 // queryable NetworkConfig, the rough equivalent of SDRtrunk's P25
 // network-configuration monitor. It is fed from the control channel's
 // dispatchTSBK and snapshot-read by the daemon / API.
+//
+// Accumulation is corroborated rather than last-write-wins: every TSBK
+// that survives the trellis + CRC gate still occasionally carries a
+// corrupt-but-CRC-passing payload (the control channel evaluates a grid
+// of NID/TSBK alignment hypotheses per frame, which multiplies that
+// exposure), and a single such frame must not poison the reported
+// identity or inject a phantom band-plan slot / neighbour. Identity
+// scalars (WACN/SysID/RFSS/Site/LRA) are resolved by majority vote — a
+// lone observation is still surfaced, but a repeated correct value
+// out-votes a one-shot wrong one. Neighbours must be seen at least
+// corroborationMin times before Snapshot surfaces them.
+
+// corroborationMin is how many independent sightings a neighbour (and, in
+// BandPlan.Snapshot, a band-plan slot) needs before it is trusted. Two is
+// enough to reject a one-shot CRC false positive while a real, repeating
+// broadcast clears the bar within a second or two of dwell.
+const corroborationMin = 2
 
 // Channel is a (band-plan ID, channel number) pair.
 type Channel struct {
@@ -37,21 +57,61 @@ type NetworkConfig struct {
 	Neighbors []NeighborSite
 }
 
+// neighborKey identifies a neighbour by (RFSS, Site).
+type neighborKey struct {
+	RFSS uint8
+	Site uint8
+}
+
 // NetworkModel is the thread-safe accumulator behind NetworkConfig.
 // The zero value is ready to use.
 type NetworkModel struct {
-	mu  sync.Mutex
-	cfg NetworkConfig
+	mu sync.Mutex
+
+	// Identity vote tallies — Snapshot reports the most-observed value.
+	wacnVotes  map[uint32]int
+	sysidVotes map[uint16]int
+	rfssVotes  map[uint8]int
+	siteVotes  map[uint8]int
+	lraVotes   map[uint8]int
+
+	// Secondary control channels — de-duplicated on first sight (a
+	// secondary CC is low-risk and not part of the corroboration scope).
+	secondary []Channel
+
+	// Neighbours — sighting count + latest channel info per (RFSS, Site).
+	neighborVotes map[neighborKey]int
+	neighborData  map[neighborKey]NeighborSite
+}
+
+// ensure lazily initialises the vote maps so the zero value is usable.
+func (m *NetworkModel) ensure() {
+	if m.wacnVotes == nil {
+		m.wacnVotes = map[uint32]int{}
+		m.sysidVotes = map[uint16]int{}
+		m.rfssVotes = map[uint8]int{}
+		m.siteVotes = map[uint8]int{}
+		m.lraVotes = map[uint8]int{}
+		m.neighborVotes = map[neighborKey]int{}
+		m.neighborData = map[neighborKey]NeighborSite{}
+	}
 }
 
 // ApplyNetworkStatus folds a Network Status Broadcast (0x3B) in.
 func (m *NetworkModel) ApplyNetworkStatus(n NetworkStatusBroadcast) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.cfg.WACN = n.WACN
-	m.cfg.SystemID = n.SystemID
+	m.ensure()
+	// WACN/SysID are meaningless at zero (absent), so a zero never gets a
+	// vote — it cannot out-rank a real value seen the same number of times.
+	if n.WACN != 0 {
+		m.wacnVotes[n.WACN]++
+	}
+	if n.SystemID != 0 {
+		m.sysidVotes[n.SystemID]++
+	}
 	if n.LRA != 0 {
-		m.cfg.LRA = n.LRA
+		m.lraVotes[n.LRA]++
 	}
 }
 
@@ -59,10 +119,17 @@ func (m *NetworkModel) ApplyNetworkStatus(n NetworkStatusBroadcast) {
 func (m *NetworkModel) ApplyRFSSStatus(r RFSSStatusBroadcast) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.cfg.SystemID = r.SystemID
-	m.cfg.RFSS = r.RFSS
-	m.cfg.Site = r.Site
-	m.cfg.LRA = r.LRA
+	m.ensure()
+	if r.SystemID != 0 {
+		m.sysidVotes[r.SystemID]++
+	}
+	// RFSS and Site of zero are valid (RFSS 0 is a real, common value), so
+	// they are always counted.
+	m.rfssVotes[r.RFSS]++
+	m.siteVotes[r.Site]++
+	if r.LRA != 0 {
+		m.lraVotes[r.LRA]++
+	}
 }
 
 // ApplySecondaryControlChannel folds a Secondary Control Channel
@@ -70,35 +137,63 @@ func (m *NetworkModel) ApplyRFSSStatus(r RFSSStatusBroadcast) {
 func (m *NetworkModel) ApplySecondaryControlChannel(s SecondaryControlChannelBroadcast) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.cfg.Secondary = upsertChannel(m.cfg.Secondary, Channel{s.ChannelAID, s.ChannelANumber})
+	m.secondary = upsertChannel(m.secondary, Channel{s.ChannelAID, s.ChannelANumber})
 	if s.ChannelBID != 0 || s.ChannelBNumber != 0 {
-		m.cfg.Secondary = upsertChannel(m.cfg.Secondary, Channel{s.ChannelBID, s.ChannelBNumber})
+		m.secondary = upsertChannel(m.secondary, Channel{s.ChannelBID, s.ChannelBNumber})
 	}
 }
 
 // ApplyAdjacentSite folds an Adjacent Site Status Broadcast (0x3C) in,
-// de-duplicating by (RFSS, Site).
+// counting sightings per (RFSS, Site) and keeping the latest channel info.
 func (m *NetworkModel) ApplyAdjacentSite(a AdjacentSiteStatusBroadcast) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	ns := NeighborSite{RFSS: a.RFSS, Site: a.Site, ChannelID: a.ChannelID, ChannelNumber: a.ChannelNumber}
-	for i, e := range m.cfg.Neighbors {
-		if e.RFSS == ns.RFSS && e.Site == ns.Site {
-			m.cfg.Neighbors[i] = ns
-			return
-		}
-	}
-	m.cfg.Neighbors = append(m.cfg.Neighbors, ns)
+	m.ensure()
+	key := neighborKey{RFSS: a.RFSS, Site: a.Site}
+	m.neighborVotes[key]++
+	m.neighborData[key] = NeighborSite{RFSS: a.RFSS, Site: a.Site, ChannelID: a.ChannelID, ChannelNumber: a.ChannelNumber}
 }
 
-// Snapshot returns a deep copy of the accumulated topology.
+// Snapshot returns a deep copy of the accumulated topology. Identity
+// fields are the most-observed value; neighbours appear only once seen at
+// least corroborationMin times, sorted by (RFSS, Site) for stable output.
 func (m *NetworkModel) Snapshot() NetworkConfig {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := m.cfg
-	out.Secondary = append([]Channel(nil), m.cfg.Secondary...)
-	out.Neighbors = append([]NeighborSite(nil), m.cfg.Neighbors...)
+	out := NetworkConfig{
+		WACN:      majority(m.wacnVotes),
+		SystemID:  majority(m.sysidVotes),
+		RFSS:      majority(m.rfssVotes),
+		Site:      majority(m.siteVotes),
+		LRA:       majority(m.lraVotes),
+		Secondary: append([]Channel(nil), m.secondary...),
+	}
+	for key, c := range m.neighborVotes {
+		if c >= corroborationMin {
+			out.Neighbors = append(out.Neighbors, m.neighborData[key])
+		}
+	}
+	sort.Slice(out.Neighbors, func(i, j int) bool {
+		if out.Neighbors[i].RFSS != out.Neighbors[j].RFSS {
+			return out.Neighbors[i].RFSS < out.Neighbors[j].RFSS
+		}
+		return out.Neighbors[i].Site < out.Neighbors[j].Site
+	})
 	return out
+}
+
+// majority returns the most-observed key in a vote tally, or the zero
+// value when the tally is empty. Ties are resolved by the larger key so
+// the result is deterministic regardless of map iteration order.
+func majority[K ~uint8 | ~uint16 | ~uint32](votes map[K]int) K {
+	var best K
+	bestCount := 0
+	for k, c := range votes {
+		if c > bestCount || (c == bestCount && k > best) {
+			best, bestCount = k, c
+		}
+	}
+	return best
 }
 
 // upsertChannel appends ch to chans if not already present.

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -14,7 +14,10 @@ func TestNetworkModelAccumulates(t *testing.T) {
 	m.ApplyRFSSStatus(RFSSStatusBroadcast{SystemID: 0x123, RFSS: 4, Site: 7, LRA: 9})
 	m.ApplySecondaryControlChannel(SecondaryControlChannelBroadcast{
 		ChannelAID: 1, ChannelANumber: 100, ChannelBID: 1, ChannelBNumber: 200})
+	// Neighbours need corroborationMin (2) sightings before Snapshot surfaces
+	// them, so each site is broadcast twice.
 	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})
+	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 9, ChannelID: 1, ChannelNumber: 301})
 	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 9, ChannelID: 1, ChannelNumber: 301})
 	// Re-broadcast of site 8 must update in place, not duplicate.
 	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 305})
@@ -57,8 +60,10 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 	adj := TSBK{Opcode: OpAdjacentSiteStatusBroadcast,
 		Payload: AssembleAdjacentSiteStatusBroadcast(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})}
 
+	// The adjacent-site broadcast is sent twice so it clears the
+	// corroborationMin (2) gate and Snapshot surfaces the neighbour.
 	base := 0
-	for _, tsbk := range []TSBK{nsb, rfss, adj} {
+	for _, tsbk := range []TSBK{nsb, rfss, adj, adj} {
 		cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk), base)
 		base += 1 << 20
 	}

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -86,7 +86,50 @@ func RunReaderStream(r io.Reader, source string, cfg Config, onEvent func(EventR
 		tuneHz = est
 	}
 
-	return runReader(r, source, decode, bytesPerSample, tuneHz, cfg, onEvent)
+	return runReader(r, source, decode, bytesPerSample, tuneHz, cfg, onEvent, nil)
+}
+
+// monitorHook drives converge-and-stop dwell on a streaming source. Every
+// Interval of stream time the read loop calls OnTick with the current
+// accumulated topology and the elapsed stream seconds; returning true ends the
+// run early (the Result assembled so far is returned as usual).
+type monitorHook struct {
+	Interval time.Duration
+	OnTick   func(topo *TopologySnapshot, streamSec float64) (stop bool)
+}
+
+// tickSec is the interval in seconds; nil-safe so the read loop can call it
+// unconditionally before checking whether monitoring is active.
+func (m *monitorHook) tickSec() float64 {
+	if m == nil || m.Interval <= 0 {
+		return 0
+	}
+	return m.Interval.Seconds()
+}
+
+// RunReaderMonitor decodes a (typically live, effectively unbounded) stream,
+// invoking onTick every tick of stream time with the current accumulated
+// topology so the caller can converge-and-stop a long control-channel dwell.
+// It is the streaming sibling of RunReader: memory stays bounded (chunked
+// reads, nothing is buffered whole), and the run ends when onTick returns
+// true, the reader hits EOF, or a read errors. The carrier must already be
+// tuned via cfg.TuneHz — auto-tune (which needs to seek) is not supported.
+func RunReaderMonitor(r io.Reader, source string, cfg Config, tick time.Duration, onTick func(*TopologySnapshot, float64) bool) (*Result, error) {
+	if cfg.SampleRateHz <= 0 {
+		return nil, fmt.Errorf("siglab: sample rate must be > 0")
+	}
+	if !ccdecoder.HasFactory(cfg.Protocol) {
+		return nil, fmt.Errorf("siglab: no pipeline registered for protocol %s", cfg.Protocol)
+	}
+	if cfg.AutoTune {
+		return nil, fmt.Errorf("siglab: RunReaderMonitor does not support auto-tune (tune via cfg.TuneHz)")
+	}
+	if tick <= 0 {
+		tick = time.Second
+	}
+	decode, bytesPerSample := cfg.Format.Decoder()
+	mon := &monitorHook{Interval: tick, OnTick: onTick}
+	return runReader(r, source, decode, bytesPerSample, cfg.TuneHz, cfg, nil, mon)
 }
 
 // RunReaderAutoTuneMulti decodes cfg.Protocol against each detected carrier
@@ -126,7 +169,7 @@ func RunReaderAutoTuneMulti(r io.ReadSeeker, source string, cfg Config, maxCandi
 			return nil, fmt.Errorf("siglab: auto-tune rewind: %w", err)
 		}
 		runCfg.TuneHz = off
-		res, err := runReader(r, source, decode, bytesPerSample, off, runCfg, nil)
+		res, err := runReader(r, source, decode, bytesPerSample, off, runCfg, nil, nil)
 		if err != nil {
 			continue
 		}
@@ -179,7 +222,7 @@ func ccYield(r *Result) int64 {
 // pipeline chain (so a replay lock implies an on-air lock), drains the bus
 // into a Result, and runs the optional analyzer. Split out so a future
 // in-memory source (synthesized IQ) can share it.
-func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample int, tuneHz float64, cfg Config, onEvent func(EventRecord)) (*Result, error) {
+func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample int, tuneHz float64, cfg Config, onEvent func(EventRecord), mon *monitorHook) (*Result, error) {
 	logger := cfg.logger()
 
 	// Mirror the production ccdecoder DDC: decimate to the per-protocol
@@ -279,6 +322,11 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 	var states []ReceiverState
 	captureState := bundle.stateAt != nil && cfg.CollectReceiverState
 
+	// Converge-and-stop monitoring (streaming long-dwell): fire the tick on
+	// stream time so the caller sees the same cadence however fast replay runs.
+	monitoring := mon != nil && mon.OnTick != nil && bundle.topology != nil
+	nextMonitorAt := mon.tickSec()
+
 	chunk := cfg.chunkSamples()
 	buf := make([]byte, chunk*bytesPerSample)
 	samples := make([]complex64, chunk)
@@ -322,6 +370,17 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 				if t := float64(totalSamples) / cfg.SampleRateHz; t >= nextStateLogAt {
 					states = append(states, bundle.stateAt(t))
 					nextStateLogAt = t + stateLogIntervalSec
+				}
+			}
+
+			// Converge-and-stop: hand the caller the live topology on the tick
+			// cadence; a true return ends the dwell early.
+			if monitoring {
+				if t := float64(totalSamples) / cfg.SampleRateHz; t >= nextMonitorAt {
+					nextMonitorAt = t + mon.tickSec()
+					if mon.OnTick(bundle.topology(), t) {
+						break
+					}
 				}
 			}
 		}

--- a/internal/siglab/monitor_test.go
+++ b/internal/siglab/monitor_test.go
@@ -1,0 +1,77 @@
+package siglab
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestRunReaderMonitor_TickAndStop checks the streaming monitor entry point:
+// the tick callback fires on the stream-time cadence with the live topology,
+// and returning true ends the run early.
+func TestRunReaderMonitor_TickAndStop(t *testing.T) {
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	data := EncodeCapture(iq, FormatF32)
+	cfg := Config{
+		Protocol:     trunking.ProtocolP25,
+		SystemName:   "monitor-test",
+		SampleRateHz: meta.SampleRateHz,
+		Format:       FormatF32,
+		// Deep path required for topology() to be wired (the tick reads it).
+		CollectIQDiag: true,
+	}
+
+	// Tick fires; returning false lets the run read to EOF.
+	ticks := 0
+	res, err := RunReaderMonitor(bytes.NewReader(data), "monitor", cfg, 50*time.Millisecond,
+		func(topo *TopologySnapshot, sec float64) bool {
+			ticks++
+			return false
+		})
+	if err != nil {
+		t.Fatalf("RunReaderMonitor: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if ticks == 0 {
+		t.Error("expected at least one monitor tick over the capture")
+	}
+
+	// Returning true on the first tick must stop the run early without error.
+	stopped := 0
+	res2, err := RunReaderMonitor(bytes.NewReader(data), "monitor", cfg, 50*time.Millisecond,
+		func(topo *TopologySnapshot, sec float64) bool {
+			stopped++
+			return true
+		})
+	if err != nil {
+		t.Fatalf("RunReaderMonitor (early stop): %v", err)
+	}
+	if res2 == nil {
+		t.Fatal("nil result on early stop")
+	}
+	if stopped != 1 {
+		t.Errorf("early-stop callback fired %d times, want 1", stopped)
+	}
+}
+
+// TestRunReaderMonitor_RejectsAutoTune documents that the streaming monitor
+// requires a pre-resolved carrier (cfg.TuneHz), since it cannot seek to
+// re-estimate one mid-stream.
+func TestRunReaderMonitor_RejectsAutoTune(t *testing.T) {
+	cfg := Config{
+		Protocol:     trunking.ProtocolP25,
+		SampleRateHz: 48_000,
+		Format:       FormatF32,
+		AutoTune:     true,
+	}
+	if _, err := RunReaderMonitor(bytes.NewReader(nil), "x", cfg, time.Second, func(*TopologySnapshot, float64) bool { return false }); err == nil {
+		t.Fatal("expected an error when AutoTune is set")
+	}
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -314,6 +314,7 @@ export interface HuntStartRequest {
   auto_gain?: boolean;
   auto_gain_set?: string;
   max_dwell_seconds?: number;
+  monitor_seconds?: number;
   protocol?: string;
   dwell_seconds?: number;
   name?: string;

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -110,6 +110,7 @@ export function Hunt() {
   const [ccFreq, setCCFreq] = useState(""); // single control-channel freq, MHz
   const [ccProto, setCCProto] = useState("p25"); // trunked protocol to decode
   const [ccDwell, setCCDwell] = useState(15); // listen seconds (see parseCC)
+  const [ccMonitorMin, setCCMonitorMin] = useState(0); // streaming long-dwell minutes; 0 = off
 
   useEffect(() => {
     let cancel = false;
@@ -185,6 +186,7 @@ export function Hunt() {
         no_sweep: true,
         protocol: ccProto,
         dwell_seconds: ccDwell,
+        monitor_seconds: ccMonitorMin > 0 ? ccMonitorMin * 60 : undefined,
       });
     } catch (e: unknown) {
       setError(e instanceof Error ? `parse CC failed: ${e.message}` : "parse CC failed");
@@ -227,7 +229,8 @@ export function Hunt() {
           it. The band plan, talkgroups and system identity below fill in as the
           CC is read — longer listening (or re-running) discovers more talkgroups
           and neighbor sites. Each second buffers ~19 MB of IQ, so prefer
-          re-running over very long dwells.
+          re-running over very long dwells — or set <em>Monitor</em> below to
+          stream the CC in real time (bounded memory) for minutes at a time.
         </p>
         <label>
           Protocol
@@ -256,6 +259,20 @@ export function Hunt() {
             value={ccDwell}
             onChange={(e) => setCCDwell(Number(e.target.value))}
           />
+        </label>
+        <label>
+          Monitor (minutes, 0 = off)
+          <input
+            type="number"
+            min={0}
+            step={1}
+            value={ccMonitorMin}
+            onChange={(e) => setCCMonitorMin(Number(e.target.value))}
+          />
+          <span className="hint">
+            Streams the control channel and stops early once identity, neighbors
+            and band plan settle (capped at this many minutes).
+          </span>
         </label>
         <div className="hunt-buttons">
           <button onClick={parseCC} disabled={!canMutate || running}>


### PR DESCRIPTION
Discovery against a known UHF P25 site reported a wrong WACN/System ID, a
band plan with phantom slots (stray 136/160 MHz bases on a 450 MHz site),
neighbors that never filled, and no practical way to watch a control channel
for 5-10 minutes (hunt buffers the whole dwell to memory before parsing).

Accuracy: status-broadcast accumulation was last-write-wins, so a single
corrupt-but-CRC-passing TSBK (the multi-alignment NID/TSBK search inflates
that exposure) could poison identity or inject a phantom band-plan slot.
Identity (WACN/SysID/RFSS/Site/LRA) is now resolved by majority vote, and
band-plan slots and neighbors must be corroborated (>=2 sightings) before
Snapshot surfaces them. Live grant resolution (BandPlan.Frequency/Known) still
accepts a first sighting, so voice-channel resolution is unchanged.

Monitoring: add an opt-in streaming monitor that feeds the live SDR straight
into the siglab decoder (bounded memory, no whole-dwell buffer) for up to
monitor_seconds, stopping early once identity/neighbors/band-plan settle
(converge-and-stop). Exposed as monitor_seconds (API), -monitor-seconds (CLI),
and a "Monitor" field on the web Hunt panel's parse-CC controls.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q