### PR TITLE
feat(p25): stamp rfss_id/site_id/nac on registration & affiliation events (#698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Site identity on registration & affiliation events** (#698). The
+  `unit_registration` and `affiliation` events now carry `rfss_id` / `site_id`
+  (alongside `grant`), plus a `nac` field on all three. Registration and
+  affiliation are handled by the radio's actual serving site, so they give a
+  genuine RID→site location fix that grant-site — announced on every site of a
+  wide-area call — cannot. Phase 2 (TDMA) control channels now also discover
+  their sites into `GET /api/v1/sites`.
 - **Streaming long-dwell control-channel monitor for Hunt** (opt-in). A new
   `monitor_seconds` (web Hunt "Monitor" field / `-monitor-seconds` CLI flag)
   decodes a locked control channel from the live SDR in real time instead of

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,8 +116,12 @@ constructed only when its config section is present:
   events (published on each RFSS Status Broadcast) and served at
   `GET /api/v1/sites`. Operator-supplied site names from
   `trunking.systems[].sites` in the config are merged onto the
-  discovered rows, and every `grant` event also carries `rfss_id` /
-  `site_id` so downstream tooling can label calls by site (issue #698).
+  discovered rows. The `grant`, `unit_registration` and `affiliation`
+  events also carry `rfss_id` / `site_id` / `nac` so downstream tooling
+  can label calls by site — registration and affiliation are handled by
+  the radio's actual serving site, giving a genuine RID→site location
+  fix where grant-site (announced on every site of a wide-area call)
+  cannot (issue #698).
 - **`log.MessageLog`** — a rotating, human-readable text log of
   every trunking event, enabled via `log.message_log`.
 

--- a/internal/api/sse_test.go
+++ b/internal/api/sse_test.go
@@ -34,6 +34,33 @@ func TestEventToDTOAffiliationJSON(t *testing.T) {
 	}
 }
 
+// TestEventToDTOAffiliationSiteJSON pins the wire shape once the serving
+// site is known: rfss_id / site_id / nac appear (issue #698 addendum).
+func TestEventToDTOAffiliationSiteJSON(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindAffiliation,
+		Payload: trunking.Affiliation{
+			System:   "MMR",
+			Protocol: "p25",
+			SourceID: 0xABCDEF,
+			GroupID:  0x1234,
+			Response: trunking.AffiliationAccepted,
+			RFSSID:   1,
+			SiteID:   9,
+			NAC:      0x293,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(body)
+	want := `{"system":"MMR","protocol":"p25","source_id":11259375,"group_id":4660,"response":"accepted","rfss_id":1,"site_id":9,"nac":659}`
+	if got != want {
+		t.Errorf("affiliation+site JSON =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
 // TestEventToDTOUnitRegistrationJSON pins the wire shape of the
 // registration event for the same reason.
 func TestEventToDTOUnitRegistrationJSON(t *testing.T) {
@@ -56,6 +83,34 @@ func TestEventToDTOUnitRegistrationJSON(t *testing.T) {
 	want := `{"system":"MMR","protocol":"p25","source_id":1122867,"wacn":781832,"system_id":1332,"response":"accepted"}`
 	if got != want {
 		t.Errorf("registration JSON =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// TestEventToDTOUnitRegistrationSiteJSON pins the registration wire shape
+// once the serving site is known (issue #698 addendum).
+func TestEventToDTOUnitRegistrationSiteJSON(t *testing.T) {
+	dto := eventToDTO(events.Event{
+		Kind: events.KindUnitRegistration,
+		Payload: trunking.UnitRegistration{
+			System:   "MMR",
+			Protocol: "p25",
+			SourceID: 0x112233,
+			WACN:     0xBEE08,
+			SystemID: 0x534,
+			Response: trunking.RegistrationAccepted,
+			RFSSID:   2,
+			SiteID:   9,
+			NAC:      0x293,
+		},
+	})
+	body, err := json.Marshal(dto.Payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(body)
+	want := `{"system":"MMR","protocol":"p25","source_id":1122867,"wacn":781832,"system_id":1332,"response":"accepted","rfss_id":2,"site_id":9,"nac":659}`
+	if got != want {
+		t.Errorf("registration+site JSON =\n  %s\nwant\n  %s", got, want)
 	}
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -309,6 +309,10 @@ type GrantDTO struct {
 	// grants and until the site's RFSS Status TSBK has been decoded.
 	RFSSID uint8 `json:"rfss_id,omitempty"`
 	SiteID uint8 `json:"site_id,omitempty"`
+	// NAC is the control channel's Network Access Code (Phase 2: the
+	// NSB Color Code). Coarse — not unique per site — so consumers
+	// label by (rfss_id, site_id). Zero/omitted on non-P25 grants.
+	NAC uint16 `json:"nac,omitempty"`
 	// Timeslot is the 1-based TDMA slot (0 = n/a, 1 = TS1, 2 = TS2).
 	// Non-zero only for slotted protocols (DMR Tier III); identifies
 	// which of a carrier's two calls this is.
@@ -332,6 +336,7 @@ func grantToDTO(g trunking.Grant) GrantDTO {
 		FrequencyHz: g.FrequencyHz,
 		ChannelID:   g.ChannelID, ChannelNumber: g.ChannelNum,
 		RFSSID: g.RFSSID, SiteID: g.SiteID,
+		NAC:       g.NAC,
 		Timeslot:  g.Timeslot,
 		Encrypted: g.Encrypted, Emergency: g.Emergency,
 		DataCall:    g.DataCall,
@@ -388,6 +393,13 @@ type AffiliationDTO struct {
 	GroupID           uint32 `json:"group_id"`
 	AnnouncementGroup uint32 `json:"announcement_group,omitempty"`
 	Response          string `json:"response"`
+	// RFSSID / SiteID name the radio's serving site (a genuine
+	// RID→site fix, unlike grant-site) and NAC is the coarse control
+	// channel access code (issue #698). Zero/omitted on non-P25
+	// affiliations and until the site's status broadcast has decoded.
+	RFSSID uint8  `json:"rfss_id,omitempty"`
+	SiteID uint8  `json:"site_id,omitempty"`
+	NAC    uint16 `json:"nac,omitempty"`
 }
 
 func affiliationToDTO(a trunking.Affiliation) AffiliationDTO {
@@ -397,6 +409,9 @@ func affiliationToDTO(a trunking.Affiliation) AffiliationDTO {
 		GroupID:           a.GroupID,
 		AnnouncementGroup: a.AnnouncementGroup,
 		Response:          a.Response.String(),
+		RFSSID:            a.RFSSID,
+		SiteID:            a.SiteID,
+		NAC:               a.NAC,
 	}
 }
 
@@ -408,6 +423,13 @@ type UnitRegistrationDTO struct {
 	WACN     uint32 `json:"wacn"`
 	SystemID uint16 `json:"system_id"`
 	Response string `json:"response"`
+	// RFSSID / SiteID name the radio's serving site (a genuine
+	// RID→site fix) and NAC is the coarse control channel access code
+	// (issue #698). Zero/omitted on non-P25 registrations and until the
+	// site's status broadcast has decoded.
+	RFSSID uint8  `json:"rfss_id,omitempty"`
+	SiteID uint8  `json:"site_id,omitempty"`
+	NAC    uint16 `json:"nac,omitempty"`
 }
 
 func unitRegistrationToDTO(u trunking.UnitRegistration) UnitRegistrationDTO {
@@ -417,6 +439,9 @@ func unitRegistrationToDTO(u trunking.UnitRegistration) UnitRegistrationDTO {
 		WACN:     u.WACN,
 		SystemID: u.SystemID,
 		Response: u.Response.String(),
+		RFSSID:   u.RFSSID,
+		SiteID:   u.SiteID,
+		NAC:      u.NAC,
 	}
 }
 

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1265,6 +1265,7 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 			ChannelNum:         g.channelNumber,
 			RFSSID:             net.RFSS,
 			SiteID:             net.Site,
+			NAC:                nac,
 			Encrypted:          so.Encrypted(),
 			Emergency:          so.Emergency(),
 			DataCall:           g.dataCall,
@@ -1344,6 +1345,7 @@ func (c *ControlChannel) publishGroupGrant(g GroupVoiceChannelGrant, nac uint16)
 // band-plan resolution is needed — affiliations don't carry channel
 // info.
 func (c *ControlChannel) publishAffiliation(g GroupAffiliationResponse, nac uint16) {
+	net := c.netModel.Snapshot()
 	c.bus.Publish(events.Event{
 		Kind: events.KindAffiliation,
 		Payload: trunking.Affiliation{
@@ -1353,6 +1355,9 @@ func (c *ControlChannel) publishAffiliation(g GroupAffiliationResponse, nac uint
 			GroupID:           uint32(g.GroupAddress),
 			AnnouncementGroup: uint32(g.AnnouncementGroup),
 			Response:          trunking.AffiliationResponse(g.Response),
+			RFSSID:            net.RFSS,
+			SiteID:            net.Site,
+			NAC:               nac,
 			At:                c.now(),
 		},
 	})
@@ -1365,6 +1370,7 @@ func (c *ControlChannel) publishAffiliation(g GroupAffiliationResponse, nac uint
 // publishUnitRegistration publishes a trunking.UnitRegistration on the
 // bus when the site issues a Unit Registration Response (opcode 0x2C).
 func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse, nac uint16) {
+	net := c.netModel.Snapshot()
 	c.bus.Publish(events.Event{
 		Kind: events.KindUnitRegistration,
 		Payload: trunking.UnitRegistration{
@@ -1374,6 +1380,9 @@ func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse, nac
 			WACN:     u.WACN,
 			SystemID: u.SystemID,
 			Response: trunking.RegistrationResponse(u.Response),
+			RFSSID:   net.RFSS,
+			SiteID:   net.Site,
+			NAC:      nac,
 			At:       c.now(),
 		},
 	})

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -561,6 +561,12 @@ func TestControlChannelPublishesAffiliation(t *testing.T) {
 	sub := bus.Subscribe()
 	defer sub.Close()
 
+	// Feed an RFSS Status Broadcast first (LRA=9, SystemID=0x123,
+	// RFSS=1, Site=1) so the affiliation event stamps the serving site
+	// (issue #698).
+	rfssTSBK := TSBK{LB: true, Opcode: OpRFSSStatusBroadcast, Payload: [8]byte{0x09, 0x01, 0x23, 0x01, 0x01, 0x00, 0x00, 0x00}}
+	rfssStream := buildLockedStreamWithTSBK(10, 0x111, DUIDTrunkingSignaling, rfssTSBK)
+
 	// Response = denied (2), AnnGroup = 0xAABB, Group = 0x1234,
 	// TargetID = 0xABCDEF.
 	payload := [8]byte{0x02, 0xAA, 0xBB, 0x12, 0x34, 0xAB, 0xCD, 0xEF}
@@ -573,6 +579,7 @@ func TestControlChannelPublishesAffiliation(t *testing.T) {
 		FrequencyHz: 851_000_000,
 		Now:         func() time.Time { return time.Unix(1_700_000_001, 0).UTC() },
 	})
+	cc.Process(rfssStream, 0)
 	cc.Process(stream, 0)
 
 	var got *trunking.Affiliation
@@ -603,6 +610,12 @@ func TestControlChannelPublishesAffiliation(t *testing.T) {
 	if got.Response != trunking.AffiliationDenied {
 		t.Errorf("Response = %v, want denied", got.Response)
 	}
+	if got.RFSSID != 1 || got.SiteID != 1 {
+		t.Errorf("site = RFSS %d / Site %d, want 1/1", got.RFSSID, got.SiteID)
+	}
+	if got.NAC != 0x111 {
+		t.Errorf("NAC = %03X, want 111", got.NAC)
+	}
 	if got.At.Unix() != 1_700_000_001 {
 		t.Errorf("At = %v, want injected Now", got.At)
 	}
@@ -613,6 +626,11 @@ func TestControlChannelPublishesUnitRegistration(t *testing.T) {
 	defer bus.Close()
 	sub := bus.Subscribe()
 	defer sub.Close()
+
+	// Feed an RFSS Status Broadcast first (RFSS=2, Site=9) so the
+	// registration event stamps the serving site (issue #698).
+	rfssTSBK := TSBK{LB: true, Opcode: OpRFSSStatusBroadcast, Payload: [8]byte{0x09, 0x01, 0x23, 0x02, 0x09, 0x00, 0x00, 0x00}}
+	rfssStream := buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, rfssTSBK)
 
 	// Response = accepted (0), WACN = 0xBEE08, SystemID = 0x534,
 	// SourceID = 0x112233.
@@ -626,6 +644,7 @@ func TestControlChannelPublishesUnitRegistration(t *testing.T) {
 		FrequencyHz: 851_000_000,
 		Now:         func() time.Time { return time.Unix(1_700_000_002, 0).UTC() },
 	})
+	cc.Process(rfssStream, 0)
 	cc.Process(stream, 0)
 
 	var got *trunking.UnitRegistration
@@ -655,6 +674,12 @@ func TestControlChannelPublishesUnitRegistration(t *testing.T) {
 	}
 	if got.Response != trunking.RegistrationAccepted {
 		t.Errorf("Response = %v, want accepted", got.Response)
+	}
+	if got.RFSSID != 2 || got.SiteID != 9 {
+		t.Errorf("site = RFSS %d / Site %d, want 2/9", got.RFSSID, got.SiteID)
+	}
+	if got.NAC != 0x222 {
+		t.Errorf("NAC = %03X, want 222", got.NAC)
 	}
 	if got.At.Unix() != 1_700_000_002 {
 		t.Errorf("At = %v, want injected Now", got.At)

--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -65,6 +65,19 @@ type ControlChannel struct {
 	// they use. Guarded by mu.
 	lastEncSync EncryptionSync
 	hasEncSync  bool
+	// Camped-site identity accumulated from the control channel's
+	// status broadcasts: siteRFSS / siteSite come from the RFSS Status
+	// Broadcast (opcode 0xFA), netWACN / netSysID / nac from the
+	// Network Status Broadcast (the Color Code equals the Phase 1 NAC
+	// per spec). Stamped onto grant / affiliation / registration events
+	// so consumers can label them by serving site (issue #698). The
+	// Phase 2 MAC has no NetworkModel — a simple last-seen cache (like
+	// bandPlan / lastEncSync above) is sufficient. Guarded by mu.
+	siteRFSS uint8
+	siteSite uint8
+	netWACN  uint32
+	netSysID uint16
+	nac      uint16
 }
 
 // TrellisMode selects how the Process adapter interprets the MAC
@@ -453,6 +466,21 @@ func (c *ControlChannel) Ingest(p MACPDU) {
 	}
 	if nsb, ok := p.AsNetworkStatusBroadcast(); ok {
 		c.installSeedFromNSB(nsb)
+		// Capture the network identity so site / grant / affiliation /
+		// registration events can carry WACN + System ID + NAC. The
+		// Color Code equals the Phase 1 NAC per TIA-102.BBAB.
+		c.mu.Lock()
+		c.netWACN = nsb.WACN
+		c.netSysID = nsb.SystemID
+		c.nac = nsb.ColorCode
+		c.mu.Unlock()
+	}
+	if r, ok := p.AsRFSSStatusBroadcast(); ok {
+		c.mu.Lock()
+		c.siteRFSS = r.RFSS
+		c.siteSite = r.Site
+		c.mu.Unlock()
+		c.publishSiteUpdate()
 	}
 	if u, ok := p.AsIdentifierUpdate(); ok {
 		c.mu.Lock()
@@ -561,6 +589,47 @@ type LockState struct {
 func (s LockState) LockedFrequencyHz() uint32 { return s.FrequencyHz }
 func (s LockState) LockedNAC() uint16         { return 0 }
 
+// siteIdentity returns the camped site's RFSS / Site / NAC accumulated
+// from the control channel's status broadcasts, for stamping onto grant
+// / affiliation / registration events (issue #698). RFSS and Site stay
+// zero until an RFSS Status Broadcast has been decoded; NAC stays zero
+// until a Network Status Broadcast lands.
+func (c *ControlChannel) siteIdentity() (rfss, site uint8, nac uint16) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.siteRFSS, c.siteSite, c.nac
+}
+
+// publishSiteUpdate emits a KindSiteUpdate naming the site this Phase 2
+// control channel is camped on, joining the decoded RFSS/Site identity
+// to the tuned frequency. The SiteTracker accumulates these into GET
+// /api/v1/sites (issue #698), so Phase 2 (TDMA) control channels now
+// surface their sites the same way Phase 1 does. Skipped until the site
+// has actually been identified.
+func (c *ControlChannel) publishSiteUpdate() {
+	if c.bus == nil {
+		return
+	}
+	c.mu.Lock()
+	rfss, site, wacn, sysid := c.siteRFSS, c.siteSite, c.netWACN, c.netSysID
+	c.mu.Unlock()
+	if rfss == 0 && site == 0 {
+		return
+	}
+	c.bus.Publish(events.Event{
+		Kind: events.KindSiteUpdate,
+		Payload: trunking.SiteUpdate{
+			System:           c.systemName,
+			RFSSID:           rfss,
+			SiteID:           site,
+			ControlChannelHz: c.freqHz,
+			WACN:             wacn,
+			SystemID:         sysid,
+			At:               c.now(),
+		},
+	})
+}
+
 func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, groupID uint32) {
 	if c.bus == nil {
 		return
@@ -600,6 +669,7 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 		Seed:       c.scramblerSeed,
 	}
 	c.mu.Unlock()
+	rfss, site, nac := c.siteIdentity()
 	c.bus.Publish(events.Event{
 		Kind: events.KindGrant,
 		Payload: trunking.Grant{
@@ -610,6 +680,9 @@ func (c *ControlChannel) publishGrant(g GroupVoiceChannelGrant, op Opcode, group
 			FrequencyHz:     freq,
 			ChannelID:       g.ChannelID,
 			ChannelNum:      g.ChannelNumber,
+			RFSSID:          rfss,
+			SiteID:          site,
+			NAC:             nac,
 			Encrypted:       so.Encrypted(),
 			Emergency:       so.Emergency(),
 			AlgorithmID:     algID,
@@ -662,6 +735,7 @@ func (c *ControlChannel) publishAffiliation(g GroupAffiliationResponse) {
 	if c.bus == nil {
 		return
 	}
+	rfss, site, nac := c.siteIdentity()
 	c.bus.Publish(events.Event{
 		Kind: events.KindAffiliation,
 		Payload: trunking.Affiliation{
@@ -671,6 +745,9 @@ func (c *ControlChannel) publishAffiliation(g GroupAffiliationResponse) {
 			GroupID:           uint32(g.GroupAddress),
 			AnnouncementGroup: uint32(g.AnnouncementGroup),
 			Response:          trunking.AffiliationResponse(g.Response),
+			RFSSID:            rfss,
+			SiteID:            site,
+			NAC:               nac,
 			At:                c.now(),
 		},
 	})
@@ -682,6 +759,7 @@ func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse) {
 	if c.bus == nil {
 		return
 	}
+	rfss, site, nac := c.siteIdentity()
 	c.bus.Publish(events.Event{
 		Kind: events.KindUnitRegistration,
 		Payload: trunking.UnitRegistration{
@@ -691,6 +769,9 @@ func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse) {
 			WACN:     u.WACN,
 			SystemID: u.SystemID,
 			Response: trunking.RegistrationResponse(u.Response),
+			RFSSID:   rfss,
+			SiteID:   site,
+			NAC:      nac,
 			At:       c.now(),
 		},
 	})

--- a/internal/radio/p25/phase2/mac_coverage_test.go
+++ b/internal/radio/p25/phase2/mac_coverage_test.go
@@ -107,6 +107,80 @@ func TestControlChannelEmitsAffiliationAndRegistration(t *testing.T) {
 	}
 }
 
+// TestControlChannelStampsSiteIdentity confirms that once the Phase 2
+// control channel has decoded a Network Status Broadcast (WACN / System
+// ID / Color Code) and an RFSS Status Broadcast (RFSS / Site), it (a)
+// publishes a KindSiteUpdate so the site surfaces in GET /api/v1/sites,
+// and (b) stamps rfss_id / site_id / nac onto the grant, affiliation,
+// and registration events (issue #698 addendum).
+func TestControlChannelStampsSiteIdentity(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+
+	// NSB: LRA=0x07, WACN=0xABCDE, SystemID=0x123, ColorCode(=NAC)=0x293.
+	cc.Ingest(MACPDU{Opcode: OpNetworkStatusBroadcastUpdate,
+		Payload: []byte{0x07, 0xAB, 0xCD, 0xE1, 0x23, 0x29, 0x30, 0x00, 0x00}})
+	// RFSS Status: RFSS=5, Site=9.
+	cc.Ingest(MACPDU{Opcode: OpRFSSStatusBroadcastUpdate,
+		Payload: []byte{0x07, 0x01, 0x23, 0x05, 0x09, 0x00, 0x00}})
+
+	cc.Ingest(grantPDU(0x1234, 0x00ABCD, 0x1, 0x002))
+	cc.Ingest(EncodeGroupAffiliationResponse(GroupAffiliationResponse{
+		Response: 0, GroupAddress: 0x1234, TargetID: 0x00ABCD,
+	}))
+	cc.Ingest(EncodeUnitRegistrationResponse(UnitRegistrationResponse{
+		Response: 0, WACN: 0xABCDE, SystemID: 0x123, SourceID: 0x00BEEF,
+	}))
+
+	var sawSite, sawGrant, sawAff, sawReg bool
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindSiteUpdate:
+				s := ev.Payload.(trunking.SiteUpdate)
+				if s.RFSSID == 5 && s.SiteID == 9 && s.WACN == 0xABCDE &&
+					s.SystemID == 0x123 && s.ControlChannelHz == 851_000_000 {
+					sawSite = true
+				}
+			case events.KindGrant:
+				g := ev.Payload.(trunking.Grant)
+				if g.RFSSID == 5 && g.SiteID == 9 && g.NAC == 0x293 {
+					sawGrant = true
+				}
+			case events.KindAffiliation:
+				a := ev.Payload.(trunking.Affiliation)
+				if a.RFSSID == 5 && a.SiteID == 9 && a.NAC == 0x293 {
+					sawAff = true
+				}
+			case events.KindUnitRegistration:
+				r := ev.Payload.(trunking.UnitRegistration)
+				if r.RFSSID == 5 && r.SiteID == 9 && r.NAC == 0x293 {
+					sawReg = true
+				}
+			}
+		default:
+			if !sawSite {
+				t.Error("no KindSiteUpdate event carrying the decoded site")
+			}
+			if !sawGrant {
+				t.Error("grant did not carry rfss_id/site_id/nac")
+			}
+			if !sawAff {
+				t.Error("affiliation did not carry rfss_id/site_id/nac")
+			}
+			if !sawReg {
+				t.Error("registration did not carry rfss_id/site_id/nac")
+			}
+			return
+		}
+	}
+}
+
 func TestControlChannelPatchDelete(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/trunking/affiliation.go
+++ b/internal/trunking/affiliation.go
@@ -39,7 +39,20 @@ type Affiliation struct {
 	GroupID           uint32              // talkgroup the unit is joining
 	AnnouncementGroup uint32              // optional announcement-group association (0 if unused)
 	Response          AffiliationResponse // accepted / failed / denied / refused
-	At                time.Time
+	// RFSSID and SiteID identify the P25 site that handled this
+	// affiliation, decoded from the control channel's RFSS Status
+	// Broadcast. Unlike a grant (announced on every site participating
+	// in a wide-area call), an affiliation is handled by the radio's
+	// actual serving site — so these are a genuine RID→site location
+	// fix for mobility tracking (issue #698). NAC is the control
+	// channel's Network Access Code (Phase 2: the NSB Color Code); it
+	// is not unique per site, so consumers must key on (RFSSID, SiteID).
+	// All three stay zero on non-P25 affiliations and until the site's
+	// RFSS Status / Network Status broadcast has been decoded.
+	RFSSID uint8
+	SiteID uint8
+	NAC    uint16
+	At     time.Time
 }
 
 // RegistrationResponse encodes the P25 Unit Registration Response value
@@ -79,7 +92,17 @@ type UnitRegistration struct {
 	WACN     uint32               // 20-bit Wide Area Communications Network ID
 	SystemID uint16               // 12-bit system identifier
 	Response RegistrationResponse // accepted / failed / denied / refused
-	At       time.Time
+	// RFSSID and SiteID identify the P25 site that handled this
+	// registration — the radio's actual serving site, so a genuine
+	// RID→site location fix for mobility tracking (issue #698). NAC is
+	// the control channel's Network Access Code (Phase 2: the NSB Color
+	// Code); not unique per site, so consumers must key on (RFSSID,
+	// SiteID). All three stay zero on non-P25 registrations and until
+	// the site's RFSS Status / Network Status broadcast has decoded.
+	RFSSID uint8
+	SiteID uint8
+	NAC    uint16
+	At     time.Time
 }
 
 // TalkerAlias is published on the events bus when a radio's display

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -30,6 +30,12 @@ type Grant struct {
 	// non-P25 grants and until the first RFSS Status TSBK has landed.
 	RFSSID uint8
 	SiteID uint8
+	// NAC is the control channel's Network Access Code (Phase 2: the
+	// Network Status Broadcast Color Code, equal to the Phase 1 NAC per
+	// spec). It is a coarse sanity-check field — not unique per site —
+	// so site labelling must key on (RFSSID, SiteID) (issue #698). Zero
+	// on non-P25 grants.
+	NAC uint16
 	// Timeslot identifies the TDMA logical channel a call occupies on
 	// its carrier, 1-based: 0 = not applicable / unknown (P25 Phase 1,
 	// NXDN, analog — frequency alone identifies the call), 1 = TS1,


### PR DESCRIPTION
The site stamped on a grant is "the site whose control channel announced
the grant" — on a multi-site system a wide-area talkgroup is granted on
every participating site at once, so grant-site can't answer "where is
this radio". Unit registration and group affiliation are handled by the
radio's actual serving site, so they're a genuine RID->site location fix
for mobility tracking.

- Add RFSSID/SiteID/NAC to trunking.Affiliation and trunking.UnitRegistration,
  and NAC to trunking.Grant; surface them on the SSE/REST DTOs (omitempty,
  so existing wire pins stay valid when zero).
- Phase 1: stamp from the control channel's NetworkModel snapshot + the
  decoded NAC, mirroring the grant path.
- Phase 2: the TDMA control channel had no NetworkModel — add a lightweight
  camped-site cache fed by the RFSS Status Broadcast (RFSS/Site) and Network
  Status Broadcast (WACN/SystemID, and ColorCode as the NAC equivalent),
  stamp grant/affiliation/registration, and publish KindSiteUpdate so Phase 2
  sites now surface in GET /api/v1/sites too.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015CSgJqjCVGsCZVnCBCpXpu