### PR TITLE
Add "Intro to Software Dev" learning path

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -75,6 +75,14 @@ defaults:
       learn_path: git
       nav_group: Learn
       permalink: /learn/git/:basename/
+  - scope:
+      path: "learn/intro-software-dev"
+      type: pages
+    values:
+      layout: lesson
+      learn_path: intro-software-dev
+      nav_group: Learn
+      permalink: /learn/intro-software-dev/:basename/
   # Encyclopedia articles under /reference/ get the reference layout and nav
   # group automatically. The hub (reference/index.md) overrides to reference-hub.
   - scope:

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -496,3 +496,303 @@ paths:
       minutes: 10
       level: beginner
       status: full
+
+  - id: intro-software-dev
+    label: "Intro to Software Dev"
+    title: "Intro to Software Development — from punch cards to your own solo stack"
+    tagline: "How software is built — the history, the languages, the principles and patterns, and how to choose your tools and ship your own software solo."
+    start_slug: what-is-software
+    workload: "PT8H"
+    intro: >
+      A guided path from "what even is software?" to shipping your own program.
+      Start with the story of how computing got here — the hardware, the
+      languages, and the people — then build a working model of how modern
+      languages differ and what they're good (and bad) at. Learn the principles
+      and patterns that separate code that lasts from code that rots, the
+      systems teams use to ship, how to choose the right language for a job, and
+      finally how to assemble your own solo development stack, workflow, and
+      distribution strategy. Examples lean on real-time and radio software — the
+      kind of streaming, signal-crunching code behind GopherTrunk.
+    modules:
+      - id: history
+        label: "Module 1 — A Brief History of Software"
+        blurb: "Where software came from: the hardware, the first languages, the pioneers, and the cheap compute that put a radio receiver inside a program."
+        lessons:
+          - slug: what-is-software
+            title: What is software?
+            summary: Hardware vs. software, the stored-program idea, and what "code" really is — the one idea everything else builds on.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: computing-hardware-story
+            title: From looms to microprocessors
+            summary: The hardware story — Babbage and Lovelace, ENIAC, the transistor, and the microchip that put a computer on every desk.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: birth-of-languages
+            title: From machine code to high-level languages
+            summary: Why we stopped writing 1s and 0s — assembly, FORTRAN, COBOL, LISP, and C, and what each one made possible.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: the-pioneers
+            title: The people who built programming
+            summary: Lovelace, Turing, Hopper, Ritchie, Kay, and the engineers whose ideas you still use every day.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: internet-to-edge
+            title: PCs, the internet & the age of cheap compute
+            summary: From mainframes to the cloud and the edge — and how falling compute costs made software-defined radio possible.
+            minutes: 9
+            level: beginner
+            status: full
+
+      - id: languages
+        label: "Module 2 — Modern Programming Languages"
+        blurb: "The families languages fall into, how they run, and the capabilities, trade-offs, and security properties that set them apart."
+        lessons:
+          - slug: language-families
+            title: Paradigms & language families
+            summary: Imperative, object-oriented, functional, and declarative — the big families and how a language can belong to several.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: compiled-vs-interpreted
+            title: Compiled, interpreted & JIT
+            summary: How source code becomes something a computer runs — and why the answer shapes speed, portability, and tooling.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: type-systems
+            title: Type systems & safety
+            summary: Static vs. dynamic, strong vs. weak — what types catch, what they cost, and why it matters for reliable code.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: memory-management
+            title: Memory — manual, GC & ownership
+            summary: Stacks, heaps, garbage collection, and Rust-style ownership — and why memory model is the deepest language difference.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: concurrency-models
+            title: Concurrency & parallelism
+            summary: Threads, async, goroutines, and actors — doing many things at once, the way streaming radio data demands.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: language-security
+            title: Language-level security
+            summary: Memory safety, undefined behaviour, and the software supply chain — how your language choice changes your attack surface.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: principles
+        label: "Module 3 — Software Development Principles"
+        blurb: "The timeless, language-agnostic ideas that make code readable, changeable, and robust instead of a tangle nobody dares touch."
+        lessons:
+          - slug: clean-code
+            title: Writing readable code
+            summary: Naming, small functions, and comments that earn their place — code is read far more often than it's written.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: dry-kiss-yagni
+            title: DRY, KISS, YAGNI & separation of concerns
+            summary: The four maxims that fight complexity — repeat yourself less, keep it simple, and don't build what you don't need yet.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: solid
+            title: SOLID & object-oriented design
+            summary: The five principles that keep object-oriented code flexible — explained with plain examples, not jargon.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: abstraction-coupling
+            title: Abstraction, coupling & cohesion
+            summary: Good fences make good modules — hiding detail behind interfaces so parts of a program can change independently.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: robustness-and-errors
+            title: Errors, edge cases & defensive programming
+            summary: Handling failure on purpose — because real-world inputs, like a noisy radio channel, never behave.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: patterns
+        label: "Module 4 — Software Design Patterns"
+        blurb: "Named, reusable solutions to problems that come up again and again — including the streaming and plugin shapes signal software lives on."
+        lessons:
+          - slug: what-are-patterns
+            title: What is a design pattern?
+            summary: Where patterns came from, how to read one, and the anti-patterns that signal trouble.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: creational-patterns
+            title: "Creational patterns: factory, builder, singleton"
+            summary: Patterns for making objects — flexibly, step by step, or exactly once.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: structural-patterns
+            title: "Structural patterns: adapter, facade, decorator"
+            summary: Patterns for composing objects — wrapping, simplifying, and extending without rewriting.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: behavioral-patterns
+            title: "Behavioral patterns: observer, strategy, state"
+            summary: Patterns for how objects talk and decide — swapping algorithms and reacting to change.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: concurrency-and-pipelines
+            title: Concurrency & streaming patterns
+            summary: Pipelines, producer/consumer, and pub-sub — the patterns a real-time DSP chain is built from.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: architectural-patterns
+            title: "Architecture patterns: layered, event-driven & plugins"
+            summary: The big-picture shapes — including the plugin architecture that lets a scanner add a new decoder without a rewrite.
+            minutes: 10
+            level: advanced
+            status: full
+
+      - id: process
+        label: "Module 5 — Development Systems & Strategies"
+        blurb: "How software actually gets built and kept alive: life cycles, version control, testing, automation, and fighting technical debt."
+        lessons:
+          - slug: sdlc-and-methodologies
+            title: The software life cycle — Waterfall to Agile
+            summary: The stages every project moves through, and the methodologies — Waterfall, Agile, Scrum, Kanban — teams use to manage them.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: version-control-collab
+            title: Version control & collaboration
+            summary: Why every project lives in version control, how teams work together without stepping on each other, and where to go deeper.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: testing
+            title: Testing — unit, integration & beyond
+            summary: The kinds of tests, what each is for, and why signal-processing code needs them most of all.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: build-and-ci-cd
+            title: Build systems, CI/CD & automation
+            summary: Turning source into a shippable artifact automatically — and catching problems the moment they're introduced.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: docs-and-maintenance
+            title: Documentation, tech debt & maintenance
+            summary: The unglamorous work that decides whether software survives — writing it down and paying down debt.
+            minutes: 8
+            level: intermediate
+            status: full
+
+      - id: choosing-a-language
+        label: "Module 6 — Choosing the Right Language"
+        blurb: "A full toolkit for the question every project starts with: which language? Driven by requirements, trade-offs, and the domain you're in."
+        lessons:
+          - slug: why-language-choice-matters
+            title: Why language choice matters (and when it doesn't)
+            summary: What the language decision actually buys you, what it locks in, and the cases where it barely matters.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: from-requirements
+            title: Start with requirements
+            summary: Turning needs — performance, safety, ecosystem, team, timeline — into the criteria that pick a language for you.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: performance-vs-productivity
+            title: The performance ↔ productivity trade-off
+            summary: Fast to run vs. fast to write — the central tension, and how to find the right point on the curve for your project.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: language-tour
+            title: A tour of today's major languages
+            summary: C, C++, Rust, Go, Python, JavaScript/TypeScript, Java, and friends — strengths, drawbacks, and sweet spots.
+            minutes: 12
+            level: intermediate
+            status: full
+          - slug: language-for-the-domain
+            title: Matching language to domain
+            summary: Web, systems, data, mobile, embedded, and DSP/RF — the languages each field reaches for, and why.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: decision-framework
+            title: A practical decision framework
+            summary: A repeatable way to choose, worked through real cases — including why a pure-Go engine fits a software-defined-radio scanner.
+            minutes: 10
+            level: advanced
+            status: full
+
+      - id: solo-stack
+        label: "Module 7 — Build Your Solo Developer Stack"
+        blurb: "Putting it all together as a team of one: pick your stack, set up your workflow, and ship and distribute software you build alone."
+        lessons:
+          - slug: solo-developer-mindset
+            title: The solo developer — wearing every hat
+            summary: What changes when you're designer, coder, tester, and release manager at once, and how to use your speed without drowning.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: choosing-your-stack
+            title: Choosing your stack
+            summary: Picking a language, frameworks, and tools you can be productive and happy in for the long haul — solo edition.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: dev-environment-workflow
+            title: Your environment & daily workflow
+            summary: Editor, terminal, version control, and the loop you'll run a hundred times a day — set up once, benefit forever.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: scoping-a-project
+            title: From idea to project
+            summary: Scoping a v1 you can actually finish, structuring the repo, and resisting the urge to build everything at once.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: quality-when-solo
+            title: Keeping quality high alone
+            summary: Tests, linters, and CI as the teammate you don't have — guardrails that review your work when no one else can.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: packaging-and-distribution
+            title: Packaging & distributing your software
+            summary: Cross-platform binaries, releases, and versioning — how a solo project like GopherTrunk reaches users on every OS.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: shipping-and-maintaining
+            title: Shipping v1 & maintaining solo
+            summary: Cutting the first release, gathering feedback, and sustaining a project — and yourself — over the long run.
+            minutes: 9
+            level: intermediate
+            status: full
+
+    glossary:
+      slug: glossary
+      title: Glossary of software development terms
+      summary: Plain-language definitions for every term in the learning path, cross-linked to the lessons.
+      minutes: 12
+      level: beginner
+      status: full

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -2,8 +2,8 @@
 layout: learn-index
 title: Learn
 lede: Free, structured learning paths that take you from complete beginner to confident practitioner — one short, self-contained lesson at a time.
-description: Free, structured GopherTrunk learning paths — radio & SDR fundamentals and a complete Git & GitHub course — taking you from beginner to expert one short lesson at a time.
-keywords: GopherTrunk learn, SDR tutorial, learn git, github tutorial, radio fundamentals, free courses
+description: Free, structured GopherTrunk learning paths — radio & SDR fundamentals, a complete Git & GitHub course, and an intro to software development — taking you from beginner to expert one short lesson at a time.
+keywords: GopherTrunk learn, SDR tutorial, learn git, github tutorial, radio fundamentals, learn software development, programming for beginners, free courses
 permalink: /learn/
 ---
 

--- a/docs/learn/intro-software-dev/abstraction-coupling.md
+++ b/docs/learn/intro-software-dev/abstraction-coupling.md
@@ -1,0 +1,119 @@
+---
+slug: abstraction-coupling
+title: Abstraction, coupling & cohesion
+description: Hiding detail behind interfaces, measuring how modules depend on each other, and why loose coupling plus high cohesion is the goal of good design.
+keywords: abstraction, coupling, cohesion, loose coupling, high cohesion, information hiding, encapsulation, leaky abstraction, interface design, software modularity
+level: intermediate
+status: full
+faq:
+  - q: "What's the difference between coupling and cohesion?"
+    a: "Coupling measures how much one module depends on another — how entangled they are. Cohesion measures how focused a single module is — how well its parts belong together. The goal is loose coupling (modules barely depend on each other's internals) and high cohesion (each module does one well-defined job)."
+  - q: "What is a leaky abstraction?"
+    a: "An abstraction is leaky when its hidden details bleed through and the caller has to know about them anyway. A \"simple\" file interface that mysteriously fails on network paths is leaking the underlying network's behavior. Leaks aren't always avoidable, but they undermine the point of hiding detail."
+  - q: "How are abstraction and encapsulation related?"
+    a: "Abstraction is about exposing a simple *what* — a clean interface — while hiding the complex *how*. Encapsulation (information hiding) is the mechanism that enforces it: keeping internal state and helpers private so callers can't reach in and depend on them. Abstraction is the goal; encapsulation is how you protect it."
+---
+# Abstraction, coupling & cohesion
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Abstraction** — hide the *how* behind a clean *what*. **Coupling & cohesion** — aim for loose coupling and high cohesion. **Information hiding** — keep internals private so callers can't depend on them.
+</div>
+
+The [SOLID principles](/learn/intro-software-dev/solid/) all rest on a few deeper ideas. This lesson names them directly: **abstraction** (hiding detail behind an interface), **coupling** (how much modules depend on each other), and **cohesion** (how focused a module is). Get these right and your code stays flexible — parts can be understood, tested, and changed in isolation. Get them wrong and you end up with a brittle web where every change ripples everywhere. These aren't abstract niceties; they're the difference between a codebase you can evolve and one you're afraid to touch.
+
+## Abstraction: a clean *what* over a messy *how*
+
+Abstraction means **exposing a simple interface that describes what something does, while hiding how it does it.** When you call `sort()`, you don't know or care whether it's quicksort or mergesort — you depend on the promise ("returns sorted output"), not the mechanism. That contract is the abstraction; everything behind it is free to change.
+
+Good abstractions shrink the amount you have to hold in your head. Instead of reasoning about a thousand lines of filter math, you reason about a single operation with a clear name and a clear contract. Consider a DSP block in a radio pipeline:
+
+```go
+// The abstraction: a clean contract.
+type Stage interface {
+    Process(samples []complex128) []complex128
+}
+
+// A concrete stage hides a lattice of filter coefficients, gain
+// staging, and buffering behind one method.
+type BandpassFilter struct {
+    coeffs []float64   // hidden internals — callers never see these
+    state  []complex128
+}
+func (f *BandpassFilter) Process(samples []complex128) []complex128 {
+    // ... filtering math the caller doesn't need to understand ...
+}
+```
+
+Any pipeline can chain stages — `Process(samples) -> samples` — without knowing a single thing about each stage's internals. Swap the bandpass filter for a notch filter and the pipeline code doesn't change. That's the power of a well-drawn `what`.
+
+## Information hiding and encapsulation
+
+Abstraction only holds if the internals stay genuinely hidden. **Information hiding** is the discipline of keeping a module's internal state and helper logic private, exposing only the interface. **Encapsulation** is the language mechanism that enforces it — private fields, unexported names, access modifiers.
+
+Why it matters: anything you expose, someone will depend on. The moment callers reach into `filter.coeffs` directly, those coefficients become part of your public contract, and you can no longer change them freely without breaking callers. By keeping them private, you reserve the right to change *how* the filter works without anyone noticing — because all they ever touched was `Process`.
+
+The rule of thumb: **expose as little as possible.** A small public surface is a small set of promises you have to keep. In Go, this is the capitalization convention — `Process` is public, `coeffs` is private — and it's not cosmetic; it's the contract boundary.
+
+## Coupling: how much modules depend on each other
+
+**Coupling** measures how entangled two modules are. Tightly coupled modules know each other's internals, so a change in one forces a change in the other. Loosely coupled modules interact only through narrow, stable interfaces, so each can change behind its contract without disturbing its neighbors.
+
+A rough spectrum from worse to better:
+
+- **Tight (content coupling)** — one module reaches into another's internal state directly.
+- **Shared global state** — modules communicate through global variables, creating invisible dependencies.
+- **Data coupling** — modules pass exactly the data they need through a clean interface. This is the goal.
+
+The aim is **loose coupling**: minimize what each module needs to know about any other. Loose coupling is what makes code testable (you can substitute a fake for a dependency), reusable (a module isn't welded to its original neighbors), and safe to change (effects stay local). The [Dependency Inversion Principle](/learn/intro-software-dev/solid/) is precisely a technique for loosening coupling — depend on an interface, not a concrete type.
+
+## Cohesion: how focused a module is
+
+**Cohesion** is the flip side. Where coupling is *between* modules, cohesion is *within* one: how well do its parts belong together? A highly cohesive module does one well-defined job, and everything in it serves that job. A low-cohesion module is a grab-bag — a `Utils` class that validates emails, parses dates, and resizes images has no coherent reason to exist as a unit.
+
+The target is **high cohesion**: each module focused on a single responsibility (you'll recognize this as SRP from the SOLID lesson). High cohesion makes a module easy to name, easy to understand, and easy to change for one reason at a time.
+
+The two ideas combine into the central slogan of modular design:
+
+> **Aim for loose coupling and high cohesion.**
+
+| | Loose coupling | High cohesion |
+|---|---|---|
+| **Scope** | Between modules | Within a module |
+| **Means** | Few, narrow dependencies | One focused responsibility |
+| **Payoff** | Local changes, easy testing | Clear purpose, simple to reason about |
+
+When both hold, your modules behave like well-designed components: self-contained, with clear connectors. When coupling is tight or cohesion is low, you get the dreaded "big ball of mud" where nothing can move without everything moving.
+
+## Leaky abstractions
+
+Abstractions are powerful, but they're never perfect — and pretending otherwise causes bugs. A **leaky abstraction** is one whose hidden details surface anyway, forcing the caller to know what the abstraction claimed to hide. Joel Spolsky's "Law of Leaky Abstractions" puts it bluntly: all non-trivial abstractions leak to some degree.
+
+Examples:
+
+- A network file path behind a "looks like a local file" interface — fast until the network hiccups and the abstraction stalls or fails in ways a real local file never would.
+- An ORM that lets you ignore SQL — until a query is slow and you must understand the SQL it generates.
+- A radio `Stage` whose `Process` silently assumes a specific sample rate — callers feeding a different rate get garbage, because an assumption leaked through the clean signature.
+
+You can't eliminate leaks, but you can manage them: document the assumptions and edge behavior, make failure modes explicit (return an error rather than misbehave silently), and keep the abstraction honest about what it promises. An abstraction that hides *less* but never lies is often better than one that hides everything and occasionally deceives.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — loose coupling between modules and high cohesion within them is the central goal of modular design." markdown="0">
+  <p class="knowledge-check__q">Quick check: what combination of coupling and cohesion are you aiming for?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Tight coupling and low cohesion</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Loose coupling and high cohesion</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Tight coupling and high cohesion</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Abstraction** — expose a simple *what* (a contract) and hide the messy *how* behind it.
+- **Information hiding** — keep internals private; anything you expose becomes a promise you must keep.
+- **Coupling** — minimize how much modules depend on each other; loose coupling keeps changes local.
+- **Cohesion** — keep each module focused on one job; high cohesion makes purpose clear.
+- **The goal** — loose coupling plus high cohesion, the backbone of modular, changeable design.
+- **Leaky abstractions** — no abstraction is perfect; document assumptions and surface failures honestly.
+
+Next up: what happens when the world doesn't cooperate — [errors, edge cases and defensive programming](/learn/intro-software-dev/robustness-and-errors/).

--- a/docs/learn/intro-software-dev/architectural-patterns.md
+++ b/docs/learn/intro-software-dev/architectural-patterns.md
@@ -1,0 +1,108 @@
+---
+slug: architectural-patterns
+title: "Architecture patterns: layered, event-driven & plugins"
+description: Architecture patterns shape whole systems. Learn layered, client-server, event-driven, MVC, and plugin (microkernel) architecture — and monolith vs microservices.
+keywords: architecture patterns, layered architecture, client server, event-driven, microkernel, plugin architecture, MVC, monolith, microservices, software architecture
+level: advanced
+status: full
+faq:
+  - q: "What is the difference between a design pattern and an architecture pattern?"
+    a: "A **design pattern** solves a local problem inside a program — how a few classes are created, composed, or coordinated. An **architecture pattern** describes the shape of a *whole system* — how its major parts are divided and how they communicate. Layered, event-driven, and plugin architectures are about overall structure; Factory or Observer are about pieces within it."
+  - q: "What is a plugin (microkernel) architecture?"
+    a: "A **plugin** or **microkernel** architecture has a small, stable core that provides the essential framework, plus separate plugin modules that add features through a defined extension interface. The core knows nothing about specific plugins. A scanner engine uses this so a new protocol decoder can be added as a plugin without modifying the core — a direct application of the open/closed principle."
+  - q: "Should I choose a monolith or microservices?"
+    a: "A **monolith** is one deployable unit — simpler to build, test, and run, and the right default for most projects. **Microservices** split the system into independently deployable services, which helps large teams scale and deploy parts separately but adds network, operational, and data-consistency complexity. Start with a well-structured monolith; move to services only when real scaling or team pressures justify the overhead."
+---
+# Architecture patterns: layered, event-driven & plugins
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Layered** — stack UI, logic, and data so each layer depends only on the one below. **Event-driven** — components communicate through events rather than direct calls, for loose coupling. **Plugin (microkernel)** — a small core plus pluggable modules, so new features (like a protocol decoder) drop in without touching the core.
+</div>
+
+The patterns so far operated *inside* a program — how classes are made, composed, coordinated, and streamed. **Architecture patterns** zoom all the way out: they describe the shape of a *whole system* — its major parts and how they communicate. Choosing an architecture is one of the earliest and most consequential decisions in a project, because it sets the boundaries everything else lives within. This lesson surveys the big shapes — layered, client-server, event-driven, plugin/microkernel, and MVC — and the monolith-versus-microservices question. Several map cleanly onto how a scanner engine like GopherTrunk is built; you can see the real thing on the [architecture](/architecture.html) page.
+
+## Layered architecture
+
+A **layered** (or *n-tier*) architecture organizes the system into horizontal layers, each with a clear responsibility, where each layer depends only on the layer directly beneath it. The classic three:
+
+| Layer | Responsibility | Example |
+|-------|----------------|---------|
+| **Presentation (UI)** | Display information and take user input | The web dashboard, the CLI |
+| **Logic (business)** | The rules and processing | Trunk-following logic, talkgroup filtering |
+| **Data** | Storage and retrieval | The call database, config files |
+
+The rule that makes it work is *directional dependency*: the UI calls the logic, the logic calls the data, and nothing calls upward. Because each layer talks only to its neighbour through a defined interface, you can replace one (swap a web UI for a CLI, swap one database for another) without disturbing the rest. This is the system-scale version of the [abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/) ideas: clear boundaries, dependencies pointing one way. The cost is that a request often passes through every layer, which adds some ceremony for trivial operations — but the structure keeps a growing codebase comprehensible.
+
+## Client-server
+
+In a **client-server** architecture, work is split between **clients** that request services and a **server** that provides them, communicating over a network. The server centralizes shared resources and logic; many clients connect to it. The web is the giant example: browsers (clients) request pages from web servers.
+
+A networked scanner fits naturally. A headless engine runs on a machine near the antenna, doing the capture and decoding; browser clients connect from anywhere to view live calls and change settings. Centralizing the heavy work on the server means clients can be thin and numerous. The trade-offs are the usual networked ones: you must handle latency, connection loss, authentication, and the server becoming a bottleneck or single point of failure. Client-server often combines with the layered style — the server itself is internally layered.
+
+## Event-driven architecture
+
+An **event-driven** architecture has components communicate by producing and reacting to **events** rather than calling each other directly. A component announces that something happened ("call decoded," "signal lost"); other components that care react. An event bus or broker typically routes events between producers and consumers.
+
+This is the Observer and publish/subscribe idea (from the [behavioral patterns](/learn/intro-software-dev/behavioral-patterns/) and [concurrency](/learn/intro-software-dev/concurrency-and-pipelines/) lessons) promoted to a whole-system principle. Its great strength is **loose coupling**: an event producer does not know or care which components consume its events, so you can add new reactions — a new logger, a notifier, an analytics module — without modifying the producer. That makes the system easy to extend and naturally suited to asynchronous, real-time work like a stream of decoded calls. The cost is that flow of control is harder to follow: there is no single call stack to trace, so debugging "who reacted to what, in what order" takes more effort and good tooling.
+
+## Plugin (microkernel) architecture
+
+A **plugin** architecture — also called **microkernel** — separates a minimal **core** from a set of **plugin** modules that extend it through a defined interface. The core provides only the essential, stable framework and knows *nothing* about any specific plugin. Plugins register themselves and add features.
+
+This is the pattern that matters most for a scanner engine. The core handles the universal machinery — capturing samples, managing channels, routing decoded output — and each **protocol decoder is a plugin** conforming to a common decoder interface:
+
+```text
+interface ProtocolPlugin {
+  name() -> string
+  canHandle(signal) -> bool
+  decode(samples) -> calls
+}
+
+// the core discovers and registers plugins, knowing only the interface:
+core.register(P25Plugin())
+core.register(DmrPlugin())
+core.register(NxdnPlugin())
+```
+
+Adding support for a new protocol means writing one new plugin and registering it — **the core is never modified**. That is the [open/closed principle](/learn/intro-software-dev/solid/) at the architectural scale: the system is open to extension (new plugins) but closed to modification (the core stays put). It also keeps responsibilities cleanly separated and lets third parties extend the system without access to its internals. Notice how the smaller patterns reappear here: a [factory](/learn/intro-software-dev/creational-patterns/) chooses which plugin to instantiate, and an [adapter](/learn/intro-software-dev/structural-patterns/) can wrap a quirky decoder to fit the plugin interface. Architecture is patterns composed at the largest scale.
+
+## Model-View-Controller
+
+**Model-View-Controller (MVC)** is a pattern for structuring the parts of a system that have a user interface, by splitting responsibilities three ways:
+
+- **Model** — the data and the rules that govern it (the calls, talkgroups, system state).
+- **View** — how that data is presented to the user (the dashboard, the waterfall display).
+- **Controller** — handles user input and mediates between view and model.
+
+Separating these means the same model can drive different views (a web view and a CLI view), and you can change how something looks without touching the logic. MVC and its relatives (MVVM, MVP) are the standard organizing principle inside the presentation layer of countless applications, and they pair naturally with event-driven communication — the model publishes a change, and the views, as observers, update.
+
+## Monolith versus microservices
+
+A final, much-debated axis is *how many deployable pieces* the system is.
+
+- A **monolith** is a single deployable application — all the layers and modules ship and run together. It is simpler to develop, test, debug, and deploy, and it is the right default for most projects, including a well-structured scanner engine.
+- **Microservices** split the system into many small, independently deployable services that communicate over the network. This lets large teams develop and deploy parts separately and scale hot components independently — but it adds substantial complexity: network calls, distributed data, partial failures, deployment orchestration, and harder debugging.
+
+The honest guidance is to **start with a clean monolith** and adopt microservices only when concrete pressures — team size, independent scaling, separate release cadences — outweigh the operational overhead. A monolith built with clear layers and plugin boundaries can be split later if it must; a premature mesh of services is far harder to undo. Choosing among all of these is exactly the kind of trade-off the [decision framework](/learn/intro-software-dev/decision-framework/) lesson exists to weigh, and you can see one real set of choices on GopherTrunk's [architecture](/architecture.html) page.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a plugin/microkernel core stays unchanged while new decoders are added as plugins through a defined interface." markdown="0">
+  <p class="knowledge-check__q">Quick check: Which architecture lets a scanner add a new protocol decoder without modifying its core?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Client-server architecture</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Plugin (microkernel) architecture</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Layered architecture</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Architecture patterns shape whole systems** — they define the major parts and how they communicate, unlike design patterns that work inside a program.
+- **Layered** — UI, logic, and data layers each depend only on the one below, so any layer can be replaced behind its interface.
+- **Client-server** — clients request, a server provides; centralizes shared work (a headless engine serving browser clients) at the cost of network concerns.
+- **Event-driven** — components react to events instead of calling each other, giving loose coupling and easy extension at the cost of harder-to-trace control flow.
+- **Plugin (microkernel)** — a small stable core plus pluggable modules; new protocol decoders drop in without touching the core (open/closed at scale).
+- **MVC and monolith vs microservices** — MVC separates model, view, and controller in UI code; prefer a clean monolith and adopt microservices only when real scaling or team pressures justify the overhead.
+
+Next up: Module 5 zooms out to the whole development process — how teams plan, build, and ship software. See [The software development lifecycle](/learn/intro-software-dev/sdlc-and-methodologies/).

--- a/docs/learn/intro-software-dev/behavioral-patterns.md
+++ b/docs/learn/intro-software-dev/behavioral-patterns.md
@@ -1,0 +1,139 @@
+---
+slug: behavioral-patterns
+title: "Behavioral patterns: observer, strategy, state"
+description: Behavioral patterns govern how objects interact. Learn Observer for publish/subscribe events, Strategy for swappable algorithms, and State for behavior that changes with state.
+keywords: behavioral patterns, observer pattern, strategy pattern, state pattern, publish subscribe, event, swappable algorithm, state machine, design patterns
+level: intermediate
+status: full
+faq:
+  - q: "What are behavioral patterns about?"
+    a: "Behavioral patterns describe how objects *interact and divide responsibility* at runtime — the patterns of communication between objects. Rather than how objects are built (creational) or composed (structural), they focus on flow of control and notifications: who tells whom about a change, which algorithm runs, and how behavior shifts as conditions change."
+  - q: "When should I use Strategy instead of an if/else?"
+    a: "Use **Strategy** when you have several interchangeable algorithms for the same job and want to choose among them at runtime, add new ones easily, or test them in isolation. A small fixed `if`/`else` is fine for two stable choices. Strategy pays off when the set of algorithms grows, varies by configuration, or you want each one as a self-contained, swappable object."
+  - q: "How is the State pattern different from a big switch statement?"
+    a: "A switch on a status field scatters the per-state logic across every method that checks it. The **State** pattern puts each state's behavior in its own object and lets the current state object decide what happens and when to transition. Behavior changes by swapping the state object, so adding a new state means adding one class instead of editing every switch."
+---
+# Behavioral patterns: observer, strategy, state
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Observer** — objects subscribe to events and get notified when something changes, without the source knowing who is listening. **Strategy** — wrap interchangeable algorithms so you can swap them at runtime. **State** — let an object change its behavior by changing which state object is active.
+</div>
+
+Creational patterns make objects; structural patterns arrange them. **Behavioral patterns** handle the third question: once the objects exist and are connected, *how do they talk to each other and divide up the work?* These patterns are about communication and responsibility — who notifies whom, which algorithm runs, and how an object's behavior shifts as its situation changes. Three are essential: **Observer** for event notifications, **Strategy** for swappable algorithms, and **State** for behavior that depends on state. A trunking scanner uses all three, so the examples will stay close to home.
+
+## What behavioral patterns are for
+
+The hard part of a running program is rarely a single object — it is the *interactions*. When a call is decoded, the UI, the logger, and the recorder all need to know. When the user picks a demodulation mode, the right algorithm has to run. When a trunking follower moves from idle to active, its whole behavior changes. You *could* handle each with ad-hoc code, but that tends to scatter logic and tighten coupling. Behavioral patterns give these interactions a clean, named shape, mostly by keeping the parties from depending too directly on each other — another application of low [coupling](/learn/intro-software-dev/abstraction-coupling/).
+
+## Observer
+
+The **Observer** pattern defines a one-to-many dependency so that when one object (the *subject*) changes state, all its dependents (the *observers*) are notified automatically. It is the engine behind publish/subscribe, event listeners, and most UI frameworks.
+
+The crucial property is decoupling: the subject does not know who is listening or what they will do. It just publishes events; anyone interested subscribes. In a scanner, the decode engine publishes a "new call decoded" event, and several unrelated parts react:
+
+```text
+class CallFeed {                 // the subject
+  observers = []
+  subscribe(o)   { observers.add(o) }
+  publish(call)  { for o in observers: o.onCall(call) }
+}
+
+// independent observers, each does its own thing:
+ui.subscribe       -> onCall(c): displayRow(c)
+logger.subscribe   -> onCall(c): writeLine(c)
+recorder.subscribe -> onCall(c): startRecording(c)
+
+decodeEngine.feed.publish(newCall)   // everyone reacts
+```
+
+Add a new reaction — say, a webhook notifier — by writing one observer and subscribing it. The decode engine never changes. Remove one by unsubscribing. The trade-off to watch: with many observers and frequent events, notification order and cascading updates can get hard to reason about, and you must remember to unsubscribe to avoid leaks. But for "many things care when X happens," Observer is the standard answer.
+
+There is a design choice inside Observer worth naming: **push** versus **pull**. In a *push* model the subject hands the observers the changed data directly (`onCall(call)` above), which is convenient when every observer needs the same payload. In a *pull* model the subject just signals "something changed" and each observer asks back for the details it wants. Push is simpler and common; pull is handy when different observers need different slices of the state and you do not want to over-share. The same pattern reappears across the stack at a larger scale — it is the foundation of event-driven architectures, which the [architectural patterns](/learn/intro-software-dev/architectural-patterns/) lesson returns to.
+
+## Strategy
+
+The **Strategy** pattern defines a family of interchangeable algorithms, encapsulates each one as an object behind a common interface, and makes them swappable at runtime. The client picks a strategy and uses it without knowing the algorithm's internals.
+
+Radio work is full of interchangeable algorithms. Demodulation is the obvious one: FM, AM, and SSB are different math for the same job — turn baseband samples into audio. Rather than a giant switch buried in the pipeline, make each a strategy:
+
+```text
+interface Demodulator { demod(samples) -> audio }
+
+class FmDemod  implements Demodulator { demod(s) { ...FM math... } }
+class AmDemod  implements Demodulator { demod(s) { ...AM math... } }
+class SsbDemod implements Demodulator { demod(s) { ...SSB math... } }
+
+class Receiver {
+  demod: Demodulator           // the current strategy
+  setMode(d) { demod = d }     // swap at runtime
+  process(s) { return demod.demod(s) }
+}
+
+rx.setMode(FmDemod())          // user flips a mode switch
+```
+
+The receiver holds a `Demodulator` and delegates to it. Switching modes is swapping the strategy object — no branching logic inside `process`. The same shape fits choosing a *filtering* strategy, a squelch algorithm, or a sort order in a totally different program. Strategy is the open/closed principle from [SOLID](/learn/intro-software-dev/solid/) made concrete: add a new algorithm by adding a class, never by editing the chooser.
+
+Strategy and the structural Decorator can look similar, but the intent differs: Strategy *replaces* the algorithm for a step; Decorator *wraps* to add behavior around an existing one.
+
+## State
+
+The **State** pattern lets an object alter its behavior when its internal state changes — the object appears to change its class. You give each state its own object, move the state-specific behavior into those objects, and let the current state decide what to do and when to transition to another state.
+
+A trunking *follower* is a textbook example. As it tracks a control channel, it moves through distinct modes, and what it does with an incoming message depends entirely on which mode it is in:
+
+| State | Behavior | Transitions to |
+|-------|----------|----------------|
+| **Idle** | Listen to the control channel only | Affiliated, when a system is identified |
+| **Affiliated** | Watch for grants on talkgroups of interest | Active, when a grant arrives |
+| **Active** | Tune the voice channel and decode the call | Affiliated, when the call ends |
+
+Without the pattern, every method becomes a tangle of `if state == ...` checks, and the same status variable is interpreted in a dozen places. With the State pattern, each mode is an object that knows its own behavior and its own exits:
+
+```text
+interface FollowerState { onMessage(ctx, msg) }
+
+class Idle implements FollowerState {
+  onMessage(ctx, msg) {
+    if msg.identifiesSystem: ctx.setState(Affiliated())
+  }
+}
+class Affiliated implements FollowerState {
+  onMessage(ctx, msg) {
+    if msg.isGrant && interested(msg): ctx.setState(Active(msg.channel))
+  }
+}
+class Active implements FollowerState {
+  onMessage(ctx, msg) {
+    if msg.isCallEnd: ctx.setState(Affiliated())
+    else: decodeVoice(msg)
+  }
+}
+
+// the follower just delegates to its current state:
+class Follower { state; onMessage(m) { state.onMessage(this, m) } }
+```
+
+Now behavior changes by swapping `state`, and adding a new mode (say, a *Hold* state) means adding one class, not editing every method. This is the **state machine** idea — a finite set of states with defined transitions — expressed as objects. The trade-off is more small classes, but for anything with genuinely distinct modes and rules about moving between them, that structure is far clearer than scattered conditionals.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Strategy encapsulates interchangeable algorithms so you can swap them at runtime." markdown="0">
+  <p class="knowledge-check__q">Quick check: You want to let the user switch between FM, AM, and SSB demodulation at runtime. Which pattern fits?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Observer</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Strategy</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Singleton</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Behavioral patterns govern interaction** — how objects communicate and divide responsibility at runtime, mostly by keeping the parties loosely coupled.
+- **Observer** — a subject notifies many observers when it changes, without knowing who is listening; the basis of publish/subscribe and UI events.
+- **Strategy** — interchangeable algorithms behind one interface, swappable at runtime; pick a demodulator or filter without branching logic.
+- **State** — each state is an object owning its behavior and transitions; a trunking follower moves through idle / affiliated / active by swapping the state object.
+- **State machine** — the State pattern is the object-oriented expression of a finite state machine, far clearer than scattered status checks.
+- **Open/closed in action** — Observer, Strategy, and State all let you add reactions, algorithms, or states by adding classes, not editing existing code.
+
+Next up: scaling these ideas to real-time data — concurrency and streaming patterns, where pipelines, producers and consumers, and backpressure dominate signal software. See [Concurrency & streaming patterns](/learn/intro-software-dev/concurrency-and-pipelines/).

--- a/docs/learn/intro-software-dev/birth-of-languages.md
+++ b/docs/learn/intro-software-dev/birth-of-languages.md
@@ -1,0 +1,120 @@
+---
+slug: birth-of-languages
+title: From machine code to high-level languages
+description: How programming climbed from raw machine code through assembly to high-level languages like FORTRAN, COBOL, LISP, and C — and what a compiler actually does.
+keywords: machine code, assembly language, high-level languages, FORTRAN, COBOL, LISP, ALGOL, C programming language, compiler, abstraction in programming
+level: beginner
+status: full
+faq:
+  - q: "What is the difference between machine code and a high-level language?"
+    a: "**Machine code** is the raw numbers a processor executes directly — fast for the chip, nearly unreadable for humans. A **high-level language** lets you write something close to English or math, like `total = price * quantity`, which a tool then translates down to machine code. High-level languages trade a little control for an enormous gain in readability and productivity."
+  - q: "What does a compiler do?"
+    a: "A **compiler** is a program that translates source code written in a high-level language into machine code the processor can run. It reads your whole program, checks it, and produces an executable. This is the key idea that makes high-level languages practical — you write for humans, and the compiler handles the translation to the machine."
+  - q: "Why is C still used for radio and DSP code?"
+    a: "**C** (1972) gives you direct, predictable control over memory and hardware while still being far more readable than assembly. Digital signal processing needs to move large streams of samples quickly with tight, well-understood performance, and C delivers that. Decades of mature radio and DSP libraries are written in C, so it remains the backbone of low-level signal code."
+---
+# From machine code to high-level languages
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Abstraction climbs** — programming rose from raw machine code to assembly to human-friendly high-level languages. **Compilers translate** — they turn readable source code into machine code so you write for humans, not the chip. **Languages have purposes** — FORTRAN for numbers, COBOL for business, LISP for AI, C for systems.
+</div>
+
+A computer only understands one thing: numbers that mean "do this operation." Yet nobody writes serious software in those numbers anymore. This lesson is the story of how programming climbed away from the raw machine — a ladder of **abstraction**, where each rung let people say more while typing less. By the end you'll know what machine code, assembly, and high-level languages are, what a compiler does, and why a handful of languages from the 1950s and 70s still shape the code behind today's radios. This builds directly on [the hardware story](/learn/intro-software-dev/computing-hardware-story/) — now we make that hardware usable.
+
+## The bottom rung: machine code
+
+At the very bottom is **machine code** — the numeric instructions the processor reads and executes directly. Every chip family has its own set of these instructions, encoded as raw numbers. Written out, a program in machine code is just a wall of values like:
+
+```text
+10110000 01100001
+```
+
+That happens to mean "put the number 97 into a register" on one kind of processor. It is fast for the chip and almost impossible for a human to read, write, or debug. Early programmers really did work at this level, toggling switches or punching cards — slow, error-prone, and unforgiving.
+
+## Assembly: names instead of numbers
+
+The first step up was **assembly language**. Instead of writing the number for "add," you write a short mnemonic like `ADD`; instead of a raw memory address, you write a name. A small program called an **assembler** translates those mnemonics back into the exact machine-code numbers.
+
+```text
+MOV  AL, 97   ; put 97 into register AL
+ADD  AL, 1    ; add 1, AL now holds 98
+```
+
+Assembly is a thin, human-readable skin over machine code — one assembly line usually maps to one machine instruction. It made programming far more bearable, but it's still tied to one specific processor, and you still think in terms of registers and addresses rather than the actual problem you're solving.
+
+## Why abstraction was needed
+
+Assembly solved readability but not the deeper problem: you were still thinking like the machine, not like the problem. Writing a payroll calculation or a physics simulation meant translating your idea into thousands of tiny register operations by hand, and a program written for one processor wouldn't run on another.
+
+The goal of **abstraction** is to let you express *what you want* without spelling out every machine step. Compare:
+
+```text
+; assembly: load, add, store, by hand
+LOAD  R1, price
+LOAD  R2, qty
+MUL   R3, R1, R2
+STORE R3, total
+```
+
+```text
+high-level: one readable line
+total = price * qty
+```
+
+Both end up as the same machine code. But the second is shorter, clearer, harder to get wrong, and — crucially — *portable*: the same line can be translated for many different processors. That trade is the heart of high-level languages: give up a little fine control to gain enormous productivity and portability.
+
+## Compilers: the translators
+
+What turns that readable line into machine code is a **compiler** — a program whose job is translation. It reads your entire source file, checks it for errors, and produces an executable file of machine code the processor can run directly.
+
+This is a profound idea, and it's only possible because of the stored-program design from lesson one: a compiler is just software that reads other software as data and writes new software out. Programs writing programs. (Some languages translate-and-run line by line instead of compiling ahead of time — that distinction gets its own treatment in [compiled vs interpreted](/learn/intro-software-dev/compiled-vs-interpreted/).)
+
+The first compilers were a hard sell — many programmers doubted a machine could generate code as good as a human's hand-tuned assembly. They were proven wrong, and the productivity gain was so large there was no going back.
+
+## The first great languages
+
+Once compilers worked, languages bloomed — each shaped by the problem its creators cared about. A few from the early era still echo through computing today:
+
+| Language | Year | Built for | Why it mattered |
+|----------|------|-----------|-----------------|
+| **FORTRAN** | 1957 | Scientific & numeric computing | First widely used high-level language; made fast math practical |
+| **LISP** | 1958 | Symbolic / AI computing | Pioneered functional ideas; foundational to AI research |
+| **COBOL** | 1959 | Business data processing | English-like syntax; still runs banks and governments |
+| **ALGOL** | late 1950s | Algorithms & language design | Introduced block structure that shaped nearly every later language |
+| **C** | 1972 | Systems programming | Close to the metal yet portable; still the backbone of low-level code |
+
+**FORTRAN** (FORmula TRANslation) was built so scientists and engineers could write formulas almost as they'd write them on paper. That focus on fast numerical computation is directly relevant to signal work — the math behind filtering and demodulating a radio signal is exactly the kind of number-crunching FORTRAN was designed to make easy, and its descendants still dominate scientific computing.
+
+**COBOL**, shaped by the work of **Grace Hopper** and a committee, used deliberately English-like syntax so business processes would be readable by non-specialists. Astonishingly, huge amounts of banking and government software still run on COBOL today.
+
+**LISP** took a different path entirely — treating code and data as the same kind of list, and pioneering the **functional** style of programming. It became the language of early artificial intelligence research and seeded ideas that mainstream languages only adopted decades later.
+
+**ALGOL** is the quiet influencer. Few people used it directly, but its **block structure** — grouping statements with clear nesting — became the template for almost every language that followed, from C to Python.
+
+## C: the language radio code still speaks
+
+If one language deserves special attention here, it's **C** (1972), created by **Dennis Ritchie** at Bell Labs alongside the Unix operating system. C hits a rare sweet spot: it's high-level enough to be readable and portable, yet low-level enough to give you direct, predictable control over memory and hardware. You can write fast, tight code without dropping all the way to assembly.
+
+That combination made C the default language for operating systems, embedded devices, and — importantly for us — **digital signal processing**. Crunching a continuous stream of radio samples in real time demands exactly what C offers: speed, tight memory control, and predictable performance. A great deal of the SDR and DSP code running underneath GopherTrunk and its peers is written in C or its close relative C++, and decades of mature, battle-tested signal libraries exist in C. When you tune a software radio, somewhere underneath, C is doing the heavy math. The pioneers behind C and these other languages get their own profiles in [the next lesson](/learn/intro-software-dev/the-pioneers/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a compiler translates high-level source code into the machine code the processor runs." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the job of a compiler?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To run the computer's hardware directly without any software</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">To translate high-level source code into machine code the processor can run</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To turn machine code back into the original English description</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Machine code** — the raw numeric instructions a chip executes; fast for the processor, brutal for humans.
+- **Assembly** — readable mnemonics that map one-to-one onto machine code, but still tied to one processor.
+- **Abstraction** — high-level languages let you express *what* you want, gaining readability and portability for a little lost control.
+- **Compilers** — programs that translate source code into machine code, making high-level languages practical.
+- **The first greats** — FORTRAN for science, COBOL for business, LISP for AI, ALGOL for design influence.
+- **C** — close to the metal yet portable, and still the backbone of the DSP and radio code under tools like GopherTrunk.
+
+Next up: behind every one of these breakthroughs was a person. We meet the people who built programming — from Ada Lovelace to Margaret Hamilton — in [The people who built programming](/learn/intro-software-dev/the-pioneers/).

--- a/docs/learn/intro-software-dev/build-and-ci-cd.md
+++ b/docs/learn/intro-software-dev/build-and-ci-cd.md
@@ -1,0 +1,105 @@
+---
+slug: build-and-ci-cd
+title: Build systems, CI/CD & automation
+description: How source becomes a running program — build systems, dependency management and lockfiles, continuous integration and delivery, pipelines, artifacts, reproducible builds and cross-compilation.
+keywords: build systems, CI/CD, continuous integration, continuous delivery, dependency management, lockfiles, pipelines, build artifacts, reproducible builds, cross-compilation
+level: intermediate
+status: full
+faq:
+  - q: "What's the difference between continuous delivery and continuous deployment?"
+    a: "Both keep your software always in a releasable state by automating the pipeline up to production. The difference is the final step: continuous delivery produces a deployable build but a human decides when to push it live, while continuous deployment goes all the way automatically — every change that passes the pipeline ships to production with no manual gate. Deployment is delivery with the last button pressed for you."
+  - q: "Why do lockfiles matter?"
+    a: "A lockfile records the exact versions (and often checksums) of every dependency your project resolved to, including indirect ones. Without it, two people — or your CI server — might install slightly different versions and get different behavior, the classic \"works on my machine\" problem. The lockfile makes dependency resolution reproducible, so everyone builds against identical inputs."
+  - q: "What is cross-compilation?"
+    a: "Cross-compilation is building a binary for a platform other than the one you're compiling on — for example, producing a Windows and an ARM Linux executable from your x86 Mac or Linux machine. Languages like Go make this remarkably easy, letting one toolchain emit binaries for many operating systems and architectures, which is how a single project ships installers for everyone without needing one machine per target."
+---
+# Build systems, CI/CD & automation
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Build systems** — turn source into a runnable program and manage dependencies reproducibly. **CI/CD** — build and test on every push, then automate the path to release. **Reproducible & cross-platform** — pin inputs, produce identical artifacts, and emit binaries for many OSes from one toolchain.
+</div>
+
+Source code isn't a program — it's instructions for *producing* one. The machinery that compiles, links, tests, packages, and ships your code is some of the highest-leverage automation in software. Done well, a developer pushes a commit and, minutes later, a tested, reproducible artifact exists, ready to deploy. This lesson walks from the build itself through dependency management to **CI/CD** — the pipelines that build and test automatically on every change and carry it toward release — and ends on reproducible builds and cross-compilation.
+
+## Build systems
+
+A **build** transforms your source into something runnable. The exact steps depend on the language, but the idea is universal.
+
+- **Compilers** translate source into machine code or bytecode. A C compiler turns `.c` files into object files, then a **linker** stitches them into an executable.
+- **Make** and its descendants are classic build orchestrators: a `Makefile` declares targets and their dependencies, and `make` rebuilds only what changed. The principle — describe outputs in terms of inputs, rebuild only the stale parts — underlies nearly every build tool since.
+- **Language build tools** wrap this up per ecosystem: `go build` compiles a Go program, `cargo build` does it for Rust, `npm`/`yarn` build and bundle JavaScript projects, Maven and Gradle handle Java. Each knows its language's conventions so you rarely hand-write build steps.
+
+The common thread: a build is a *function* from source (plus dependencies) to an artifact. The more deterministic that function, the more you can trust and automate it.
+
+## Dependency management and lockfiles
+
+Almost no project is self-contained — you stand on libraries written by others. A **dependency manager** (Go modules, Cargo, npm, pip, and so on) records what your project needs and fetches it. But there's a subtlety: a requirement like "version 1.x" can resolve to different exact versions over time, and that's a recipe for "works on my machine."
+
+The fix is a **lockfile** (`go.sum`, `Cargo.lock`, `package-lock.json`, `poetry.lock`). It pins the *exact* version — often with a checksum — of every dependency, including the indirect ones pulled in transitively. Commit the lockfile, and everyone (and every CI run) installs byte-for-byte the same dependency tree. That's the foundation of reproducibility: without pinned inputs, you can't have a reproducible output.
+
+| Language | Build tool | Lockfile |
+| --- | --- | --- |
+| Go | `go build` / modules | `go.sum` |
+| Rust | Cargo | `Cargo.lock` |
+| JavaScript | npm / yarn | `package-lock.json` / `yarn.lock` |
+| Python | pip / Poetry | `requirements.txt` / `poetry.lock` |
+
+## Continuous Integration
+
+**Continuous Integration (CI)** is the practice of automatically building and testing your code on *every push* (and every pull request). A CI server watches the repository; when a change lands, it checks out the code, installs the pinned dependencies, builds it, and runs the [test suite](/learn/intro-software-dev/testing/). If anything fails, the team learns within minutes — while the change is fresh and small — rather than discovering a week-old breakage tangled with ten other changes.
+
+The name comes from *integrating* everyone's work frequently into the shared main line, instead of letting branches drift for weeks and merging in one painful "big bang." Frequent integration plus automated checks keeps `main` continuously in a known-good state. CI is the automated enforcement of "don't break the build," and it's what makes the pull-request workflow from the [version control lesson](/learn/intro-software-dev/version-control-collab/) trustworthy: reviewers see a green check confirming the change builds and passes tests before they even read it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — CI automatically builds and runs the tests on every push, catching breakage within minutes." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does Continuous Integration do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Lets each developer keep their branch unmerged for months</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Automatically builds and runs the tests on every push</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Manually deploys code to production once a quarter</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Continuous Delivery and Deployment
+
+CI gets you a tested build. **Continuous Delivery (CD)** extends the automation so that build is always in a *releasable* state — packaged, staged, and ready to ship at the press of a button, with a human choosing *when*. **Continuous Deployment** removes even that button: every change that passes the full pipeline is shipped to production automatically, no manual gate. The distinction is just where the human stands:
+
+- **Continuous Delivery** — always ready to release; a person clicks "go."
+- **Continuous Deployment** — passing the pipeline *is* the release.
+
+Which you want depends on risk tolerance and how good your tests are. A high-stakes system might keep a human gate; a web app with strong test coverage and easy rollback might deploy dozens of times a day.
+
+## Pipelines and artifacts
+
+The whole automated sequence is a **pipeline** — a series of stages that a change flows through, each gating the next: lint → build → test → package → deploy. If any stage fails, the pipeline stops and the change doesn't advance. Pipelines are typically defined in code (a YAML file in the repo) so the process itself is versioned and reviewable.
+
+The output of a successful build is an **artifact** — a compiled binary, a container image, a packaged installer. Artifacts are stored and versioned so you can deploy a known build, and roll back to a previous one if something goes wrong. The pipeline produces artifacts once and promotes the *same* artifact through environments, rather than rebuilding at each stage and risking inconsistency.
+
+On GitHub, the common tool for all of this is **[GitHub Actions](/learn/git/github-actions/)**, which runs your pipeline on every push and can build artifacts and publish releases. For a project like GopherTrunk, a single Actions workflow might build the decoder, run the [golden-file tests](/learn/intro-software-dev/testing/) against captured signals, and — only if everything's green — publish release binaries.
+
+## Reproducible builds and cross-compilation
+
+Two qualities elevate a build from "it ran" to "I trust it."
+
+**Reproducible builds** mean that the same source plus the same pinned dependencies always produces a bit-for-bit identical artifact, regardless of who builds it or when. This is powerful: it lets others independently verify that a published binary really came from the claimed source (a security property), and it eliminates a whole class of "the build machine was different" mysteries. Lockfiles, pinned tool versions, and controlled build environments are what make it possible.
+
+**Cross-compilation** is producing binaries for platforms *other than* the one you're building on — a Windows `.exe` and an ARM Linux binary emitted from your x86 development machine. Go is famous for making this trivial: set `GOOS` and `GOARCH` and `go build` produces a binary for that target.
+
+```bash
+GOOS=windows GOARCH=amd64 go build -o gophertrunk.exe   # Windows from Linux
+GOOS=darwin  GOARCH=arm64 go build -o gophertrunk-mac    # Apple Silicon
+```
+
+One toolchain, many targets. A CI pipeline can fan out across a build matrix and emit binaries for every supported OS and architecture in a single run — which is exactly how a project ships installers for Windows, macOS, and Linux without needing a separate machine for each. That hand-off, from "we have binaries for everyone" to "users can actually install it," is the subject of [packaging & distribution](/learn/intro-software-dev/packaging-and-distribution/).
+
+## Recap
+
+- **Build systems** — compilers, Make, and language tools (`go build`, Cargo, npm) turn source plus dependencies into a runnable artifact.
+- **Lockfiles** — pin exact dependency versions so every build uses identical inputs; the basis of reproducibility.
+- **CI** — automatically builds and tests on every push, catching breakage in minutes and keeping `main` known-good.
+- **CD** — Continuous Delivery keeps a build always releasable; Continuous Deployment ships it automatically; the difference is the human gate.
+- **Pipelines & artifacts** — staged, versioned-in-code automation that produces stored, deployable, rollback-able artifacts.
+- **Reproducible & cross-compiled** — identical outputs from identical inputs, and one toolchain emitting binaries for many platforms.
+
+Next up: the work that outlasts the build — [documentation, tech debt & maintenance](/learn/intro-software-dev/docs-and-maintenance/).

--- a/docs/learn/intro-software-dev/choosing-your-stack.md
+++ b/docs/learn/intro-software-dev/choosing-your-stack.md
@@ -1,0 +1,168 @@
+---
+slug: choosing-your-stack
+title: Choosing your stack
+description: How a solo developer picks a primary language, a small set of dependable libraries and tools, and favours boring, maintainable tech with easy distribution.
+keywords: choosing a stack, solo developer stack, boring technology, single binary, fewer dependencies, maintainable tech, Go distribution, technology choice
+level: intermediate
+status: full
+faq:
+  - q: "How should a solo developer choose a programming language?"
+    a: "Pick the language you are **most productive in** and can maintain alone for years — usually one you already know well, with a large standard library, good documentation, and a healthy ecosystem. Novelty is a tax you pay every day you work alone. A language that compiles to a **single binary**, like Go, removes a whole category of distribution and ops headaches when you have no operations team."
+  - q: "What is \"boring technology\" and why does it matter?"
+    a: "**Boring technology** is mature, widely used, well-documented tooling whose failure modes are understood and searchable. As a solo dev your scarcest resource is attention, and boring tech spends almost none of it — answers already exist on the internet, the edges are mapped, and you are not the one debugging a brand-new framework at midnight. Save your novelty budget for the part that is actually your idea."
+  - q: "Should I minimise dependencies?"
+    a: "Mostly yes. Every dependency is something you must understand, update, and trust to keep working. **Fewer moving parts** means less that can break while you are not looking. Pull in a library when it solves a genuinely hard problem (cryptography, parsing, DSP), but resist adding one to save ten lines of code you could own outright."
+---
+# Choosing your stack
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Productive primary language** — pick what you can maintain alone for years. **Boring tech** — mature and well-documented beats new and exciting. **Minimise moving parts** — fewer dependencies, easy single-binary distribution.
+</div>
+
+Module 6 gave you a framework for choosing a language on its technical merits. As a
+solo developer you apply that framework through one extra lens: **what can one person
+realistically maintain?** A team can afford a sprawling stack because it has people
+to babysit each part. You cannot. Your stack has to be small enough to hold in one
+head, boring enough to never surprise you, and easy enough to ship that distribution
+is not its own second project. This lesson is about making those choices on purpose,
+using the [decision framework](/learn/intro-software-dev/decision-framework/) you
+already have — just weighted heavily toward maintainability.
+
+## Pick one primary language you are productive in
+
+Your primary language is the single most consequential choice in your stack, because
+you will spend more time in it than anywhere else. The instinct to learn something
+shiny for the project is usually a mistake. Optimise for **throughput over years**,
+not excitement over a weekend:
+
+- **Fluency.** A language you already know well lets you spend your attention on the
+  *problem*, not on remembering syntax. As a beginner-to-intermediate solo dev, this
+  alone outweighs most theoretical advantages of a "better" language.
+- **A large standard library.** The more the language ships with — HTTP, JSON, file
+  handling, testing — the fewer third-party dependencies you must manage.
+- **Strong documentation and a healthy community.** When you hit a wall at midnight,
+  the answer needs to already exist somewhere searchable.
+- **Good tooling out of the box.** A built-in formatter, test runner and build tool
+  mean you configure less and ship more.
+
+You can absolutely have a second language for a specific job — a shell script here,
+some SQL there — but resist running your project across several languages of equal
+weight. Each one is a separate set of tools, idioms, and gotchas to keep current.
+
+## Favour boring technology
+
+There is a famous idea among small teams: spend your **innovation tokens** wisely.
+You only get a few; every genuinely novel, unproven piece of your stack costs one,
+because you will be the one mapping its sharp edges in production. Everything else
+should be **boring** — mature, popular, and thoroughly documented.
+
+Boring is not an insult. Boring means:
+
+- The failure modes are **known and searchable**, so you are debugging a solved
+  problem, not pioneering.
+- The library is **still maintained** and will not be abandoned next year, leaving you
+  holding it.
+- The hiring-yourself problem is solved — *you* can come back in a year and still
+  understand it.
+
+Spend your one or two innovation tokens on the part of the project that is genuinely
+your idea — the clever algorithm, the unusual feature. Make everything around it
+deliberately dull.
+
+## Keep the moving parts to a minimum
+
+Every component in your stack — a database, a message queue, a build tool, a
+dependency — is a thing that can break, needs updating, and must be understood. Alone,
+the cost of each one is fully yours. So the default answer to "should I add this?" is
+**no, unless it earns its place.**
+
+A useful test before adding anything:
+
+- Does it solve a problem that is genuinely **hard to do myself** (cryptography,
+  parsing, signal processing)? If yes, take the dependency — do not roll your own
+  crypto.
+- Or am I adding it to save a few lines I could just **write and own**? If so, skip it.
+
+| Choice | Heavier (more to maintain) | Lighter (solo-friendly) |
+| --- | --- | --- |
+| Data storage | Separate database server | A local file or embedded DB |
+| Many small libraries | Dozens of dependencies | A handful you actually understand |
+| Deployment | Orchestrated services | One process you run |
+
+Fewer parts is not just less work — it is fewer 3am surprises. The most maintainable
+system is the one with the least in it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — boring, mature technology has known, searchable failure modes, so a solo dev spends almost no attention on it." markdown="0">
+  <p class="knowledge-check__q">Quick check: why do solo developers favour "boring" technology?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because new technology is always slower than old technology</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because mature, well-documented tools have known failure modes and cost almost no attention to run</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because employers only ever ask about old technologies</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Distribution should be part of the choice
+
+Here is a factor teams rarely weigh but solo devs must: **how hard is it to get your
+program onto a stranger's machine?** With no operations team, anything that requires
+the user to install a runtime, set up dependencies, or configure an environment is
+support burden you will personally absorb — every email, every "it doesn't work on my
+laptop."
+
+This is where a language that compiles to a **single static binary** is a quiet
+superpower. **Go** is the standard example: `go build` produces one self-contained
+executable with no runtime to install, and you can **cross-compile** it for Linux,
+macOS and Windows from your own machine. The user downloads one file and runs it. No
+"install Python 3.11 first," no dependency hell, no version conflicts.
+
+Compare the two distribution stories:
+
+```text
+Interpreted stack:  user installs runtime → installs deps → hopes versions match → runs
+Single binary:      user downloads one file → runs
+```
+
+For a tool aimed at non-technical users — exactly the case for radio software a
+scanner hobbyist downloads from the [downloads](/downloads.html) page — that
+difference is enormous. The fewer steps between "I want this" and "it's running," the
+fewer people give up. We unpack the full distribution strategy in
+[packaging and distributing your software](/learn/intro-software-dev/packaging-and-distribution/);
+for now, just let "how will I ship it?" be a real input to your stack choice, not an
+afterthought.
+
+## A worked stack for a small radio tool
+
+Suppose you are building a modest software-defined-radio utility — capture some
+samples, decode a signal, log the result. A maintainable solo stack might be:
+
+- **Language:** Go — you are fluent, the standard library covers most of it, and the
+  single-binary output makes shipping to hobbyists trivial.
+- **Dependencies:** one well-maintained library for talking to the SDR device, and the
+  standard library for everything else. That is the whole list.
+- **Storage:** a plain log file or a small embedded database — no separate server to
+  run.
+- **Tooling:** the language's built-in formatter, linter and test runner; Git for
+  version control.
+
+Notice what is *not* there: no microservices, no exotic framework, no database to
+administer. Every piece is something one person can hold in their head and maintain
+for years. That restraint is the whole point. If you want to see how these choices
+play out in a real radio codebase, the GopherTrunk
+[architecture](/architecture.html) page is a good companion read.
+
+## Recap
+
+- **One productive primary language** — fluency, a big standard library, and good
+  docs beat novelty when you work alone.
+- **Boring technology** — mature, searchable, maintained tools cost almost no
+  attention; spend your innovation tokens on your actual idea.
+- **Minimise moving parts** — every dependency and service is yours to maintain, so
+  add them only when they earn it.
+- **Distribution is a stack choice** — favour tech (like Go's single binary) that gets
+  your program running in one step.
+- **Hold it in one head** — the best solo stack is the smallest one that does the job.
+
+Next up: turning that stack into a fast, comfortable place to work in
+[your environment and daily workflow](/learn/intro-software-dev/dev-environment-workflow/).

--- a/docs/learn/intro-software-dev/clean-code.md
+++ b/docs/learn/intro-software-dev/clean-code.md
@@ -1,0 +1,139 @@
+---
+slug: clean-code
+title: Writing readable code
+description: Code is read far more than it is written. Learn naming, small functions, why-not-what comments, consistent style, and the real cost of cleverness.
+keywords: clean code, readable code, code readability, good naming, intention-revealing names, small functions, code comments, code style, maintainable code
+level: beginner
+status: full
+faq:
+  - q: "Why does readability matter more than writing code quickly?"
+    a: "Because code is read far more often than it is written. A line you type once may be read dozens of times during reviews, debugging, and future changes. Optimizing for the reader saves vastly more time over a project's life than the few seconds saved by terse code."
+  - q: "Should I add comments to all my code?"
+    a: "No. Aim for code that explains itself through good names and structure, and reserve comments for the *why* — intent, trade-offs, and non-obvious constraints. Comments that merely restate what the code already says tend to drift out of date and add noise."
+  - q: "Is clever, compact code a sign of skill?"
+    a: "Rarely. The harder skill is making complex logic look simple and obvious. Cleverness that the next reader (often you, months later) has to decode is a liability. Prefer the boring, clear version unless a measured performance need forces otherwise."
+---
+# Writing readable code
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Read over write** — code is read far more than it's written, so optimize for the reader. **Names carry meaning** — intention-revealing names beat clever abbreviations. **Comments explain why** — the code already shows the *what*.
+</div>
+
+Most beginners assume the hard part of programming is getting a program to run. It isn't. The hard part is keeping it understandable once it works — by your teammates, by future maintainers, and by *you* six months from now when you've forgotten every assumption you made. A program is written once but read many times: during review, during debugging, every time someone extends it. That asymmetry is the single most important fact about writing code, and clean code is simply the discipline of optimizing for the reader instead of the writer.
+
+This lesson covers the everyday habits that make code readable: naming things well, keeping functions small and focused, commenting intent rather than mechanics, formatting consistently, and resisting the temptation to be clever. None of these require talent — just attention.
+
+## Code is read far more than it is written
+
+When you write a line of code, you do it once. That line then gets read again and again: by a reviewer approving your change, by a colleague hunting a bug nearby, by a future contributor adding a feature, and by you, long after you've lost the context. Studies and experience both point the same way — developers spend far more time reading code than writing it.
+
+The practical conclusion: **a few seconds saved while typing is never worth minutes lost while reading.** Terse, dense, "efficient-to-type" code is a false economy. Clear code that takes slightly longer to write pays for itself many times over. Every clean-code habit below flows from this one principle.
+
+## Good names are intention-revealing
+
+Naming is the highest-leverage readability skill. A good name tells the reader *what something is* and *why it exists* without forcing them to read the surrounding code. A bad name forces a detour into the implementation just to understand a single line.
+
+The rules are simple:
+
+- **Reveal intent.** A name should answer why this exists and how it's used.
+- **Avoid cryptic abbreviations.** `sr` could be sample rate, success rate, or string. `sampleRateHz` cannot be misread.
+- **Encode units and meaning** when it prevents bugs: `timeoutMs`, `frequencyHz`, `bufferSizeBytes`.
+- **Be consistent.** Pick one word per concept — don't mix `fetch`, `get`, and `retrieve` for the same idea.
+- **Avoid noise words** like `data`, `info`, `manager`, `temp` that add length without meaning.
+
+Here is the difference in a signal-processing context:
+
+```go
+// Before: what is sr? what is n? what does this loop do?
+func proc(b []float64, sr int, n int) []float64 {
+    out := make([]float64, 0)
+    for i := 0; i < len(b); i += n {
+        out = append(out, b[i])
+    }
+    return out
+}
+
+// After: the signature alone tells the story.
+func downsample(samples []float64, sampleRateHz int, decimationFactor int) []float64 {
+    decimated := make([]float64, 0)
+    for i := 0; i < len(samples); i += decimationFactor {
+        decimated = append(decimated, samples[i])
+    }
+    return decimated
+}
+```
+
+The logic is identical; the second version is readable at a glance. `sampleRateHz` beats `sr` every time — and notice that once the names are good, the function barely needs a comment at all.
+
+## Small, focused functions
+
+A function should do one thing and do it at one level of abstraction. When a function tries to validate input, transform data, and write a result all at once, the reader has to hold all three concerns in their head simultaneously. Splitting it lets each part be named, understood, and tested on its own.
+
+Signs a function is doing too much:
+
+- You'd struggle to name it without using "and."
+- It has many parameters or deeply nested conditionals.
+- You have to scroll to see all of it.
+- Sections are separated by blank lines and a comment — those are usually functions waiting to be extracted.
+
+Small functions also turn comments into names. Instead of `// now normalize the gain`, you call `normalizeGain(samples)`. The name documents the step, and the documentation can never go stale because it *is* the code.
+
+There's no magic line count, but a useful instinct: if a function no longer fits comfortably on your screen, it's probably hiding a smaller function inside it.
+
+## Comments explain *why*, not *what*
+
+Good code already says *what* it does — that's what the names and structure are for. Comments earn their place when they explain things the code *can't*: the reason behind a choice, a non-obvious constraint, a workaround for an external bug, or a trade-off you deliberately made.
+
+```go
+// Bad — restates the obvious, will rot when the code changes.
+i++ // increment i
+
+// Good — explains a why the code cannot show.
+// The receiver hardware emits a spurious DC spike at bin 0; skip it
+// so the FFT peak detector doesn't lock onto a non-signal.
+spectrum[0] = 0
+```
+
+The danger of *what*-comments is that they drift. Code changes; the comment beside it often doesn't, and now it actively lies to the reader. A wrong comment is worse than no comment. So the rule is: if a comment just narrates the next line, delete it and improve the name instead. Save comments for intent, gotchas, and links to the reasoning.
+
+## Consistent formatting and style
+
+Consistency lets readers stop noticing the layout and start seeing the logic. When indentation, brace placement, naming case, and import ordering are uniform across a codebase, differences become meaningful — a difference signals a *real* difference, not just a stylistic whim.
+
+The good news is you rarely have to think about this manually. Modern languages ship formatters and linters that enforce a single style automatically:
+
+- **Go** has `gofmt` — one canonical format, no debate.
+- Many ecosystems use tools like Prettier, Black, or `rustfmt`.
+- Linters (`golangci-lint`, ESLint, and friends) catch suspicious patterns beyond formatting.
+
+Adopt the tools, run them on save or in CI, and spend your attention on substance instead of spacing. A consistent style is also a courtesy: it makes diffs small and reviews focused on behavior rather than cosmetics.
+
+## The cost of cleverness
+
+There is a seductive pull toward clever code — a one-liner that chains five operations, a bitwise trick, an obscure language feature that saves three lines. It feels like craftsmanship. Usually it's a trap.
+
+> "Everyone knows that debugging is twice as hard as writing a program in the first place. So if you're as clever as you can be when you write it, how will you ever debug it?" — Brian Kernighan
+
+Clever code shifts cost from the writer (who understood it in the moment) to every future reader (who has to reverse-engineer it). The genuinely hard skill is making complicated logic *look* simple — choosing the boring, explicit version that anyone can follow. Reserve cleverness for the rare spot where profiling proves you need it, and when you do, wrap it in a clear name and a *why*-comment explaining the trade-off.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — code is read far more often than written, so the reader's time is what you're optimizing." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is the core reason clean code matters?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It makes programs run faster at runtime</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Code is read far more often than it is written</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Compilers reject code that isn't well formatted</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Read over write** — code is read far more than written, so optimize every choice for the future reader.
+- **Names reveal intent** — `sampleRateHz` beats `sr`; avoid cryptic abbreviations and noise words.
+- **Functions stay small** — one job, one level of abstraction; extract steps into well-named helpers.
+- **Comments explain why** — let names show the *what*; reserve comments for intent and gotchas.
+- **Style is consistent** — lean on formatters and linters so attention goes to logic, not layout.
+- **Cleverness has a cost** — the boring, clear version usually wins; clever code is hard to debug.
+
+Next up: with readable code as the foundation, we turn to the design heuristics that keep it lean — [DRY, KISS, YAGNI and separation of concerns](/learn/intro-software-dev/dry-kiss-yagni/).

--- a/docs/learn/intro-software-dev/compiled-vs-interpreted.md
+++ b/docs/learn/intro-software-dev/compiled-vs-interpreted.md
@@ -1,0 +1,178 @@
+---
+slug: compiled-vs-interpreted
+title: Compiled, interpreted & JIT
+description: How source code becomes something a machine runs — ahead-of-time compilation, interpreters and bytecode VMs, and just-in-time compilation, with their real trade-offs.
+keywords: compiled language, interpreted language, JIT compilation, bytecode, virtual machine, ahead of time compilation, language performance, static binary
+level: beginner
+status: full
+faq:
+  - q: "What is the difference between a compiled and an interpreted language?"
+    a: "A **compiled** language is translated to machine code ahead of time (C, Rust, Go), producing a binary the CPU runs directly. An **interpreted** language is read and executed at run time by another program, the interpreter (classic Python, Ruby). The line is fuzzy — many \"interpreted\" languages compile to bytecode first."
+  - q: "What does JIT compilation do?"
+    a: "**Just-in-time (JIT)** compilation translates code to machine code *while the program runs*, often optimising the hot paths it observes. The JVM, JavaScript's V8 and .NET use it to combine portability with near-native speed, at the cost of slower startup and higher memory use."
+  - q: "Why do compiled languages suit real-time radio?"
+    a: "Real-time DSP needs **predictable, low-latency performance** with no surprise pauses. Ahead-of-time compiled languages like C, Rust and Go produce native code with no interpreter overhead and tighter control over timing, so samples are processed before the next buffer arrives."
+---
+# Compiled, interpreted & JIT
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Compiled** — translated to machine code before you ship it. **Interpreted** — executed by another program at run time. **JIT** — compiles hot paths on the fly for portability *and* speed.
+</div>
+
+A CPU only understands **machine code** — raw numeric instructions for that exact
+processor. The source code you write is for humans. The bridge between the two is
+where languages differ most, and the choice shapes how fast your program runs,
+how quickly it starts, how easily it ships to other machines, and how portable it
+is. There are three broad strategies — **ahead-of-time compilation**,
+**interpretation**, and **just-in-time compilation** — and most real systems blur
+the lines between them.
+
+## Ahead-of-time compilation
+
+A **compiler** translates your entire source program into machine code *before*
+it ever runs, producing an executable binary. This is **ahead-of-time (AOT)**
+compilation, used by **C, C++, Rust and Go**.
+
+```text
+source.go  ──►  compiler  ──►  native binary  ──►  CPU runs it directly
+            (once, on your machine)        (every time, no translation)
+```
+
+The payoff:
+
+- **Speed** — the CPU runs native instructions with no translation layer in the
+  way; compilers also optimise aggressively (inlining, vectorising, eliminating
+  dead code).
+- **Predictable performance** — what you compiled is what runs, every time.
+- **No runtime dependency on a toolchain** — the user does not need a compiler or
+  interpreter installed.
+
+The costs are a **compile step** between editing and running (slower iteration on
+huge codebases) and **platform-specific binaries** — a binary built for x86-64
+Linux will not run on an ARM Mac without recompiling.
+
+## Interpreters and bytecode VMs
+
+An **interpreter** reads your source and executes it directly, statement by
+statement, every time the program runs. **Python and Ruby** are the canonical
+examples. In practice most modern "interpreted" languages do a half-step first:
+they compile source to **bytecode** — a compact, portable instruction set for a
+**virtual machine (VM)** — and the VM interprets that bytecode. CPython compiles
+`.py` files to `.pyc` bytecode and runs it on the Python VM.
+
+The trade-offs invert the compiled story:
+
+- **Slower execution** — the VM adds overhead interpreting each operation.
+- **Fast iteration and flexibility** — no separate build step; you can change code
+  and re-run instantly, and the language can do dynamic things at run time.
+- **Portability** — the *same* bytecode runs anywhere the VM is installed; you ship
+  source or bytecode, not a per-platform binary. But the user must have the
+  interpreter installed.
+
+## Just-in-time compilation
+
+**Just-in-time (JIT)** compilation is the hybrid that tries to get both speed and
+portability. The program ships as bytecode, but as it runs the **JIT compiler**
+translates frequently-executed ("hot") sections into native machine code on the
+fly — and can optimise based on what it actually observes happening.
+
+- The **JVM** (Java, Kotlin, Scala) compiles bytecode to native code via its HotSpot
+  JIT.
+- **V8** powers JavaScript in Chrome and Node.js with aggressive JIT optimisation.
+- **.NET** JIT-compiles its intermediate language (IL).
+
+The result is often near-native steady-state speed. The costs are **slower
+startup** (the JIT has to warm up before hot paths are optimised) and **higher
+memory use** (it holds both bytecode and generated native code). This is why a
+long-running server loves a JIT but a short command-line tool may not — it exits
+before warm-up pays off.
+
+| Approach | Examples | Speed | Startup | Distribution |
+|----------|----------|-------|---------|--------------|
+| AOT compiled | C, Rust, Go | fastest, predictable | instant | per-platform binary |
+| Interpreted / bytecode VM | Python, Ruby | slowest | fast | source + interpreter |
+| JIT | JVM, V8, .NET | near-native after warm-up | slow warm-up | bytecode + VM |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a JIT compiles hot paths to native code while the program runs, trading slower startup for higher steady-state speed." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a just-in-time (JIT) compiler do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Translates all source to a native binary before shipping</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Compiles frequently-run code to native machine code while the program is running</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Interprets source line by line without ever producing machine code</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## The trade-off, summarised
+
+No approach is "best" — each optimises different things:
+
+- **Raw, predictable speed:** AOT compiled wins. The work is done up front and never
+  repeated.
+- **Developer iteration speed and dynamism:** interpreters win. Edit, run, repeat.
+- **Long-running throughput with portability:** JIT wins, once warmed up.
+- **Startup latency:** AOT is instant; JIT is worst.
+- **Distribution simplicity:** AOT can ship a single self-contained file; interpreted
+  and JIT generally require a runtime on the target machine.
+
+## The line is blurrier than it looks
+
+It is tempting to file each language under one heading, but the boundaries are
+soft, and modern toolchains deliberately blur them:
+
+- **CPython compiles before it interprets.** The "interpreted" label hides a real
+  compile step to bytecode; the interpreter runs the bytecode, not your source
+  text directly.
+- **Java is compiled *and* JIT-compiled.** Source compiles ahead of time to
+  bytecode, which the JVM then JIT-compiles to native code as it runs — two
+  translation stages.
+- **Many compiled languages ship an interpreter too.** Rust and Go have fast
+  build-and-run modes for quick iteration; some C++ environments offer interpreters
+  for experimentation.
+- **AOT for traditionally-JIT languages.** GraalVM can compile Java ahead of time
+  to a native image for instant startup, trading away some peak throughput.
+
+The useful mental model is therefore not "which box is this language in" but
+"where does translation to machine code happen — before run time, during it, or
+never (the interpreter does it on the fly)?" That question, plus how much the
+runtime optimises, predicts the speed, startup and distribution characteristics
+better than any single label. When you read that a language is "fast" or "slow",
+ask *which* of these stages it is doing and *when*.
+
+## Why this matters for GopherTrunk
+
+Two concerns from radio software make the choice concrete.
+
+First, **real-time DSP** demands predictable, low-latency performance. A
+software-defined radio produces samples continuously, and each buffer must be
+filtered and demodulated before the next one arrives. An interpreter's per-operation
+overhead, or a JIT pausing to recompile, can blow the timing budget and **drop
+samples**. Ahead-of-time compiled languages — C, Rust, Go — give native speed and
+tighter timing control, which is why DSP cores are almost always compiled. (The
+related worry of garbage-collection pauses is covered in
+[memory management](/learn/intro-software-dev/memory-management/).)
+
+Second, **distribution**. Because Go compiles ahead of time and can produce a
+**single statically-linked binary** with no external runtime, you can build one
+file and hand it to a user on Linux, macOS or Windows — no interpreter, no
+dependency hunt. That is a real advantage for shipping a tool like GopherTrunk to
+people who just want to run it, a theme we pick up in
+[packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/).
+
+## Recap
+
+- **A CPU only runs machine code** — the strategy for getting there is what separates
+  languages.
+- **AOT compiled** (C, Rust, Go) — fast, predictable, instant startup; ships as a
+  per-platform binary.
+- **Interpreted / bytecode VM** (Python, Ruby) — slower but flexible with fast
+  iteration; needs the interpreter installed.
+- **JIT** (JVM, V8, .NET) — bytecode plus on-the-fly native compilation; near-native
+  speed after a slow warm-up.
+- **Real-time radio wants compiled** — predictable timing avoids dropped samples.
+- **One static Go binary is easy to ship** — no runtime to install on the target
+  machine.
+
+Next up: how languages catch mistakes before they ever run — [type systems and
+safety](/learn/intro-software-dev/type-systems/).

--- a/docs/learn/intro-software-dev/computing-hardware-story.md
+++ b/docs/learn/intro-software-dev/computing-hardware-story.md
@@ -1,0 +1,91 @@
+---
+slug: computing-hardware-story
+title: From looms to microprocessors
+description: The hardware lineage behind computing — punch-card looms, Babbage's engine, vacuum tubes, the transistor, integrated circuits, Moore's Law, and the chip.
+keywords: history of computing hardware, Jacquard loom, Babbage Analytical Engine, Ada Lovelace, ENIAC, transistor 1947, integrated circuit, Moore's Law, Intel 4004, microprocessor
+level: beginner
+status: full
+faq:
+  - q: "Who invented the transistor and when?"
+    a: "The transistor was invented at **Bell Labs in 1947** by John Bardeen, Walter Brattain, and William Shockley. It replaced bulky, hot, fragile vacuum tubes with a small, reliable solid-state switch, and it's the single device that made cheap, dense computing possible. Every modern chip is built from billions of transistors."
+  - q: "What was the first commercial microprocessor?"
+    a: "The **Intel 4004**, released in 1971, is widely considered the first commercial microprocessor — a complete central processing unit on a single chip. It was modest by today's standards, but it proved you could put a whole CPU on one piece of silicon, which set the path toward personal computers and the cheap embedded chips inside today's devices."
+  - q: "What is Moore's Law?"
+    a: "**Moore's Law** is the observation, made by Intel co-founder Gordon Moore in 1965, that the number of transistors on a chip roughly doubles every couple of years. It isn't a law of physics — it's an industry trend — but for decades it drove steadily cheaper, faster computing, which is exactly why a powerful radio-processing CPU now costs almost nothing."
+---
+# From looms to microprocessors
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Punch cards predate computers** — programmable looms and tabulators showed machines could follow encoded instructions. **The transistor changed everything** — the 1947 solid-state switch made cheap, dense electronics possible. **Moore's Law** — decades of doubling transistor counts turned room-sized machines into thirty-dollar dongles.
+</div>
+
+Software is instructions, but instructions need a machine to run on. This lesson traces that machine's lineage — from a weaving loom in 1804 to the chip in the device on your desk. It's a story of one idea (encode a task, let a machine carry it out) riding successive waves of better, smaller, cheaper hardware. The payoff at the end is concrete: it's why a cheap USB stick can now do the radio work that once filled an equipment rack. If you haven't yet, the previous lesson on [what software is](/learn/intro-software-dev/what-is-software/) sets up the hardware/software split this builds on.
+
+## Punch cards before computers
+
+The deep ancestor of the program isn't electronic at all — it's a loom. In 1804 **Joseph-Marie Jacquard** demonstrated a loom controlled by **punch cards**: holes punched in stiff cards told the loom which threads to raise on each pass, letting it weave intricate patterns automatically. Swap the cards, weave a different pattern. That's a *program* — a removable set of instructions changing what a machine produces — a century and a half before the first computer.
+
+That punch-card idea proved astonishingly durable. It reappeared in computing repeatedly, and well into the twentieth century "writing a program" literally meant punching holes in cards.
+
+## Babbage's engines and the first algorithm
+
+In the 1830s, English mathematician **Charles Babbage** designed the **Analytical Engine** — a mechanical, general-purpose computer driven by punch cards, with separate units for processing ("the mill") and storage ("the store"). It was never fully built in his lifetime, but on paper it had the bones of a modern computer: it could be programmed to carry out arbitrary calculations.
+
+Working with Babbage, **Ada Lovelace** wrote notes on the engine that included an algorithm for computing Bernoulli numbers — widely regarded as the first published computer program. She also grasped something Babbage barely emphasized: that such a machine could manipulate *any* symbols, not just numbers — music or logic, in principle — anticipating general-purpose computing by a century. We profile her further in [the pioneers](/learn/intro-software-dev/the-pioneers/).
+
+## Tabulators and the rise of data processing
+
+The next leap was commercial. For the 1890 US Census, **Herman Hollerith** built electric **tabulating machines** that read data from punch cards, dramatically speeding up what had been a years-long manual count. His company eventually merged into what became **IBM**. For the first half of the twentieth century, "data processing" largely meant rooms full of punch-card tabulators — programmable in a limited way, and enormously profitable.
+
+## Vacuum tubes: the first electronic computers
+
+The machines so far were mechanical or electromechanical — gears, relays, moving parts. The first fully *electronic* computers replaced moving switches with **vacuum tubes**, which switch electric current with no mechanical motion and so run far faster.
+
+The famous example is **ENIAC** (completed in 1945), built at the University of Pennsylvania. It contained roughly 18,000 vacuum tubes, filled a large room, and consumed enormous power. It was a thousand times faster than the relay machines before it — and a maintenance nightmare, since tubes burned out constantly. Vacuum tubes proved electronic computing worked, but they were hot, bulky, fragile, and power-hungry. Something had to replace them.
+
+## The transistor and the integrated circuit
+
+That replacement arrived in **1947** at **Bell Labs**, where Bardeen, Brattain, and Shockley invented the **transistor** — a tiny solid-state switch with no vacuum, no filament, and no moving parts. It does the same job as a tube but is smaller, cooler, more reliable, and far cheaper. The transistor is arguably the most important invention of the century, and everything that follows is a consequence of it.
+
+The next step was packing many transistors together. In the late 1950s, Jack Kilby (Texas Instruments) and Robert Noyce (Fairchild) independently developed the **integrated circuit (IC)** — multiple transistors and their connections fabricated together on a single piece of silicon. Instead of wiring components by hand, you could *print* an entire circuit at once. That made it possible to keep cramming in more and more transistors:
+
+- **Vacuum tube** — one switch, the size of a small light bulb.
+- **Discrete transistor** — one switch, the size of a pea.
+- **Integrated circuit** — many switches on one chip.
+- **Modern chip** — billions of switches on a fingernail-sized die.
+
+## Moore's Law and the microprocessor
+
+In 1965, Intel co-founder **Gordon Moore** observed that the number of transistors on a chip was doubling roughly every couple of years, and predicted it would continue. That trend — **Moore's Law** — held for decades and became the metronome of the whole industry. It isn't a physical law; it's a self-reinforcing industry expectation. But its effect was real: computing got exponentially cheaper and faster, year after year.
+
+That trend made the **microprocessor** possible — an entire CPU on one chip. The **Intel 4004** (1971) is generally credited as the first commercial example. Within a few years, microprocessors powered the first **personal computers**, putting a machine that once filled a room onto a desk, and then into a pocket.
+
+## Why a $30 dongle can replace a rack
+
+Here's where this lineage pays off for radio. Doing software-defined radio means two things have to be cheap and fast: an **analog-to-digital converter (ADC)** that turns the incoming signal into a stream of numbers, and a **CPU** fast enough to crunch those numbers in real time using **digital signal processing (DSP)**.
+
+For most of the twentieth century, neither was cheap. High-speed ADCs and processors fast enough to demodulate a signal in software cost a fortune, so radios stayed hardware: physical mixers, filters, and detectors, each soldered for one job.
+
+Moore's Law dissolved that barrier. Fast ADCs became commodity parts, and ordinary CPUs grew powerful enough to do real-time DSP. The result is the modern SDR: a tiny board that digitizes the airwaves, handed off to software running on a regular laptop. A receiver that once meant a rack of specialized gear is now a **thirty-dollar USB dongle plus free software** — a direct dividend of the entire chain from Jacquard's cards to today's silicon. GopherTrunk exists because that hardware finally got cheap enough.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the 1947 transistor replaced the vacuum tube with a small, cheap, reliable solid-state switch." markdown="0">
+  <p class="knowledge-check__q">Quick check: Which invention replaced the hot, fragile vacuum tube and made cheap, dense computing possible?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The punch card</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The transistor (Bell Labs, 1947)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The vacuum-tube amplifier</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Punch cards came first** — Jacquard's loom (1804) showed a machine following removable, encoded instructions: a program before computers.
+- **Babbage and Lovelace** — the Analytical Engine sketched a general-purpose computer, and Ada Lovelace wrote the first algorithm for it.
+- **Tabulators** — Hollerith's punch-card machines industrialized data processing and seeded IBM.
+- **Tubes then transistors** — ENIAC proved electronic computing; the 1947 transistor made it small, cheap, and reliable.
+- **ICs and Moore's Law** — integrated circuits packed transistors together, and decades of doubling drove exponential cost and speed gains.
+- **The dividend** — cheap fast ADCs and CPUs are why a thirty-dollar SDR dongle now does what once needed a rack.
+
+Next up: with the machine in place, how did we learn to talk to it? We trace the climb from raw machine code through assembly to high-level languages in [From machine code to high-level languages](/learn/intro-software-dev/birth-of-languages/).

--- a/docs/learn/intro-software-dev/concurrency-and-pipelines.md
+++ b/docs/learn/intro-software-dev/concurrency-and-pipelines.md
@@ -1,0 +1,104 @@
+---
+slug: concurrency-and-pipelines
+title: "Concurrency & streaming patterns"
+description: Pipelines, producer/consumer with bounded buffers, and pub/sub fan-out are the patterns behind real-time signal software. Learn backpressure, queues, and why this shape dominates DSP.
+keywords: pipeline pattern, dataflow, producer consumer, bounded buffer, backpressure, publish subscribe, fan-out, actor model, channels, concurrency, DSP pipeline
+level: advanced
+status: full
+faq:
+  - q: "What is backpressure?"
+    a: "**Backpressure** is the mechanism by which a slow consumer signals a fast producer to slow down. With a bounded buffer between them, once the buffer fills the producer blocks (or drops data) until the consumer catches up. Without backpressure, a fast SDR feeding a slow decoder would grow an unbounded queue until memory runs out — so backpressure is what keeps a real-time pipeline stable."
+  - q: "Why do pipelines dominate real-time signal software?"
+    a: "Digital signal processing is naturally a sequence of stages — capture, filter, decimate, demodulate, decode — where each stage transforms a stream and hands it on. The pipeline pattern maps directly onto that, lets each stage run concurrently on its own core, and uses bounded queues between stages to balance speed. It matches both the math and the hardware, which is why it is the default shape."
+  - q: "What is the difference between producer/consumer and publish/subscribe?"
+    a: "In **producer/consumer**, items flow through a shared queue and each item is handled by *one* consumer — work is divided up. In **publish/subscribe (fan-out)**, each event is delivered to *every* subscriber — the same data is broadcast to many independent handlers. One splits a workload; the other distributes copies of events."
+---
+# Concurrency & streaming patterns
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Pipeline** — stages connected by queues, each transforming a stream and passing it on, exactly like a DSP chain. **Producer/consumer with bounded buffers** — backpressure stops a fast source from overrunning a slow sink. **Pub/sub fan-out** — one event delivered to many independent subscribers.
+</div>
+
+The GoF patterns so far described single-threaded object designs. Real-time signal software has a different dominant problem: a relentless stream of data arriving faster than any one step can fully process, which must flow through several stages *at once*. A software radio captures millions of samples per second and must filter, demodulate, and decode them continuously, without falling behind. The patterns that solve this are about **concurrency and dataflow** — pipelines, producers and consumers, fan-out, and the idea of backpressure. This lesson builds on [concurrency models](/learn/intro-software-dev/concurrency-models/) and maps directly onto the [demodulation pipeline](/learn/rf-sdr/demodulation-pipeline/) from the [RF & SDR path](/learn/rf-sdr/).
+
+## The pipeline (dataflow) pattern
+
+A **pipeline** decomposes processing into a series of **stages**, each of which takes a stream of items, transforms them, and passes the result to the next stage. The stages are connected by **queues** (often called channels). Each stage runs concurrently, so while stage 3 works on item 10, stage 1 is already pulling in item 12.
+
+This is not a metaphor for DSP — it *is* DSP. A receive chain is literally a pipeline:
+
+```text
+capture  →[queue]→  filter/decimate  →[queue]→  demodulate  →[queue]→  decode
+ (SDR)                (lower the rate)            (to audio)            (to data)
+```
+
+Each arrow is a queue; each box is a stage running on its own thread or task. Why this shape wins:
+
+- **Concurrency for free.** Stages run in parallel on different cores, so total throughput is set by the *slowest* stage, not the sum of all of them.
+- **Separation of concerns.** Each stage does one job and knows nothing about its neighbours except the data format on the queue — very low coupling.
+- **Composability.** Insert, remove, or swap a stage (add a new filter, change the demodulator) by rewiring queues, not rewriting the whole flow.
+
+A stage is, in effect, both a consumer of its input queue and a producer for its output queue — which brings us to the core relationship.
+
+## Producer/consumer and bounded buffers
+
+The fundamental two-party version is **producer/consumer**: one part (the producer) generates items and puts them on a queue; another part (the consumer) takes items off and processes them. The queue between them decouples their timing — the producer does not have to wait for the consumer to finish each item, and vice versa.
+
+The critical design choice is making that queue a **bounded buffer** — a queue with a fixed maximum size. This is the single most important decision in a streaming system, because it is what creates **backpressure**:
+
+> **Backpressure** is the feedback that makes a fast producer slow down to match a slow consumer. When the bounded buffer fills, the producer blocks until space frees up — automatically pacing the whole pipeline to its slowest stage.
+
+Consider an SDR producing samples far faster than a CPU-bound P25 decoder can consume them. With an **unbounded** queue, the producer never waits, so the backlog grows without limit until the program exhausts memory and crashes — latency climbing the whole time. With a **bounded** buffer:
+
+```text
+buffer = BoundedQueue(capacity = 1024)
+
+producer:  loop { samples = sdr.read(); buffer.put(samples) }  // blocks when full
+consumer:  loop { samples = buffer.get(); decode(samples) }    // blocks when empty
+```
+
+When the decoder lags, the buffer fills, `put` blocks, and the producer is forced to wait — the system self-regulates. The bound also forces an honest design conversation: if the producer *cannot* be slowed (a real radio will not stop emitting samples for you), you must choose a strategy when the buffer is full — **block**, **drop oldest/newest**, or **expand capacity** — and for real-time radio the answer is often to drop samples deliberately rather than fall behind forever. Either way, the bound makes the decision explicit instead of letting an unbounded queue hide a slow crash.
+
+## Channels and how stages communicate
+
+The queues between stages are usually implemented as **channels**: thread-safe conduits you send to and receive from, with the locking and signalling handled for you. Channels are the backbone of the message-passing style of concurrency (covered in [concurrency models](/learn/intro-software-dev/concurrency-models/)), and many languages provide them directly — Go's `chan`, for instance, is a bounded or unbounded channel built into the language.
+
+The reason streaming systems favour channels over shared mutable memory is that **sharing data by communicating** sidesteps most concurrency bugs. If a sample buffer is only ever owned by one stage at a time and handed off through a channel, two threads never touch it simultaneously, so there is no data race to guard with locks. The queue *is* the synchronization. This is why "don't communicate by sharing memory; share memory by communicating" became a guiding slogan for pipeline-heavy software.
+
+## Fan-out, fan-in, and publish/subscribe
+
+Straight-line pipelines are the start; real systems branch.
+
+- **Fan-out** — one stage's output is split across *several* consumers running in parallel, so a CPU-heavy step (like decoding) can be scaled across multiple workers pulling from the same queue. Each item still goes to exactly *one* worker; this is producer/consumer with many consumers, used to parallelize a bottleneck.
+- **Fan-in** — multiple producers' outputs are merged into a single queue for a downstream stage (for example, several tuned channels feeding one logger).
+- **Publish/subscribe** — distinct from fan-out: here each event is delivered to *every* subscriber, not just one. This is the concurrent cousin of the Observer pattern. When a call is decoded, the same event is broadcast to the UI, the recorder, and a webhook — each gets its own copy and reacts independently.
+
+The difference matters: **fan-out divides a workload** (one item, one worker), while **pub/sub broadcasts events** (one event, all subscribers). Both are everyday tools in a signal pipeline — fan-out to keep up with the sample rate, pub/sub to notify everything that cares about a decoded result.
+
+## The actor idea
+
+A complementary model is the **actor**. An actor is an independent unit that owns its private state and communicates *only* by sending and receiving messages through its own mailbox (a queue). It never shares memory; it just processes one message at a time and may send messages to other actors.
+
+Actors fit signal software well because each stage — a tuner, a decoder, a channel follower — can be an actor with its own state and inbox, wired together by message passing. Since an actor handles one message at a time, its internal state needs no locks, and the system scales by adding more actors. Whether you call them stages, goroutines, or actors, the underlying recipe is the same and is why this shape dominates real-time signal software: **independent units, connected by bounded queues, paced by backpressure.** It matches the math (a chain of transforms), the hardware (many cores), and the timing reality (data never stops arriving).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a bounded buffer creates backpressure, forcing the fast producer to wait for the slow consumer." markdown="0">
+  <p class="knowledge-check__q">Quick check: A fast SDR feeds a slow decoder through a bounded queue. What happens when the queue fills?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The queue grows without limit until memory runs out</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The producer blocks (backpressure) until the consumer frees space</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The consumer automatically speeds up to match the producer</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Pipeline** — processing as concurrent stages connected by queues; this *is* the shape of a DSP chain (capture → filter → demodulate → decode).
+- **Producer/consumer** — a queue decouples a producer's timing from a consumer's; the foundational two-party streaming relationship.
+- **Bounded buffers and backpressure** — a fixed-size queue forces a fast producer to wait for a slow consumer, keeping the system stable instead of growing an unbounded backlog.
+- **Channels** — thread-safe queues that let stages share data by communicating, avoiding data races without manual locks.
+- **Fan-out vs pub/sub** — fan-out divides one workload across many workers (one item, one worker); pub/sub broadcasts each event to all subscribers.
+- **Actors** — independent message-driven units with private state; another expression of the same "units connected by queues" recipe that dominates real-time signal software.
+
+Next up: zooming out from individual processes to whole-system shapes — layered, client-server, event-driven, and plugin architectures. See [Architecture patterns](/learn/intro-software-dev/architectural-patterns/).

--- a/docs/learn/intro-software-dev/concurrency-models.md
+++ b/docs/learn/intro-software-dev/concurrency-models.md
@@ -1,0 +1,193 @@
+---
+slug: concurrency-models
+title: Concurrency & parallelism
+description: Concurrency vs parallelism, OS threads and locks, async/await event loops, Go's goroutines and channels, the actor model, and how data races happen.
+keywords: concurrency, parallelism, threads, async await, goroutines, channels, CSP, actor model, data race
+level: intermediate
+status: full
+faq:
+  - q: "What is the difference between concurrency and parallelism?"
+    a: "**Concurrency** is *dealing with* many tasks at once — structuring a program so tasks can make progress independently, even on a single core by interleaving. **Parallelism** is *doing* many things at literally the same instant, which requires multiple cores. Concurrency is about structure; parallelism is about execution."
+  - q: "What is a data race?"
+    a: "A **data race** happens when two threads access the same memory at the same time and at least one is writing, with no synchronisation. The result is unpredictable — corrupted values or crashes that appear randomly. Locks, channels and the actor model are different strategies for avoiding them."
+  - q: "How are goroutines different from OS threads?"
+    a: "**Goroutines** are lightweight tasks managed by Go's runtime, not the operating system. They start with tiny stacks and the runtime multiplexes many of them onto a few OS threads, so you can run hundreds of thousands cheaply. They communicate over **channels** rather than sharing memory directly."
+---
+# Concurrency & parallelism
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Concurrency vs parallelism** — structuring tasks vs running them simultaneously. **Models** — threads+locks, async/await, channels, actors. **Data races** — the bug every model tries to prevent.
+</div>
+
+Modern programs rarely do one thing at a time. They wait on a network, read from a
+device, and crunch numbers — ideally without each task blocking the others, and
+ideally using all the CPU cores you paid for. The trouble is that doing several
+things at once is where some of the nastiest, hardest-to-reproduce bugs live.
+Languages offer different **concurrency models** to make this tractable, and
+choosing one is a major part of a language's character. We start by untangling two
+words that get used interchangeably but are not the same.
+
+## Concurrency vs parallelism
+
+- **Concurrency** is about *structure*: organising a program so that multiple tasks
+  can be in progress and make independent progress. Even on a single CPU core, a
+  concurrent program can interleave tasks — work on task A, pause it while it waits
+  for I/O, switch to task B. It is about *dealing with* many things at once.
+- **Parallelism** is about *execution*: literally running multiple computations at
+  the same instant, which requires multiple cores. It is about *doing* many things
+  at once.
+
+The two are related but independent. You can have concurrency without parallelism
+(one core juggling tasks), and the goal of a good concurrency model is to make it
+easy to express tasks that the runtime can *also* run in parallel when cores are
+available. As Rob Pike put it: concurrency is a way to structure things; if it
+works, parallelism may be a free bonus.
+
+## Threads and locks
+
+The oldest model is **OS threads**: the operating system gives your process
+multiple threads of execution that share the same memory and can run on different
+cores. It is powerful and parallel by nature, but sharing memory is exactly where
+the danger lies.
+
+When two threads touch the same data and at least one writes, you have a
+**data race**, and the result is undefined — a value half-updated, a counter that
+loses increments, a crash that appears once a week. The traditional fix is a
+**lock** (mutex): only one thread may hold the lock and touch the shared data at a
+time.
+
+```text
+thread A:  lock → read/modify shared counter → unlock
+thread B:  ........ wait for lock ........ → lock → ... → unlock
+```
+
+Locks work but introduce their own hazards: **deadlock** (two threads each waiting
+on a lock the other holds), forgotten locks, and performance loss from contention.
+"Shared memory plus locks" is correct in principle and treacherous in practice,
+which motivated every model that follows.
+
+## Async/await event loops
+
+For workloads dominated by **waiting** — network requests, disk reads — you often
+do not need parallelism at all; you need to not block while waiting.
+**Async/await** runs many tasks concurrently on a single thread using an **event
+loop**. When a task hits an `await` on something slow, it yields control back to
+the loop, which runs other ready tasks; when the slow thing completes, the task
+resumes.
+
+```python
+async def fetch(url):
+    data = await http_get(url)   # yields to the loop while waiting
+    return parse(data)
+```
+
+JavaScript (Node.js), Python (`asyncio`), C# and Rust all offer this. It is
+excellent for **I/O-bound** work — thousands of concurrent connections on one
+thread — but does little for **CPU-bound** work, since a long computation still
+hogs the single thread and blocks everything else.
+
+## Goroutines and channels (CSP)
+
+**Go** popularised a model based on **Communicating Sequential Processes (CSP)**.
+Instead of sharing memory and guarding it with locks, you run lightweight
+**goroutines** and have them **communicate over channels**. The slogan: *"Do not
+communicate by sharing memory; share memory by communicating."*
+
+- A **goroutine** is a tiny task the Go runtime schedules onto OS threads; they cost
+  almost nothing, so you can have hundreds of thousands.
+- A **channel** is a typed pipe; one goroutine sends values, another receives. The
+  channel handles synchronisation, so there is no explicit lock and no data race on
+  the data that flows through it.
+
+```go
+samples := make(chan float64)      // a typed channel
+go produce(samples)                // one goroutine sends
+go consume(samples)                // another receives
+```
+
+This makes concurrent *pipelines* natural to express, which is why Go is so common
+in networked and streaming systems.
+
+## The actor model
+
+The **actor model** (made famous by **Erlang**, and used by Elixir and Akka) goes
+further: the unit of concurrency is an **actor** — an isolated process with its own
+private state that **shares nothing**. Actors communicate only by sending each
+other **messages**, processed one at a time from a mailbox.
+
+Because no state is shared, **data races are structurally impossible**, and
+because actors are isolated, one can crash and be restarted without taking down
+the others. Erlang built telecom systems with famous uptime on exactly this "let
+it crash and supervise" philosophy. The trade-off is message-passing overhead and
+a different way of thinking about program structure.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — concurrency is structuring tasks to progress independently; parallelism is running them at the same instant on multiple cores." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the difference between concurrency and parallelism?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">They mean the same thing — both require multiple CPU cores</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Concurrency is structuring tasks to progress independently; parallelism is running them simultaneously on multiple cores</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Concurrency needs multiple cores; parallelism works on one core</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Choosing a model, and the costs you can't escape
+
+No concurrency model is universally best; each suits a different workload, and the
+right question is what your program spends its time doing.
+
+- **I/O-bound** work — waiting on networks, disks, devices — favours async/await or
+  lightweight tasks like goroutines. You have many things waiting and few things
+  computing, so cheap concurrency matters more than raw parallelism.
+- **CPU-bound** work — heavy number-crunching like DSP — favours real parallelism
+  across threads or cores, because the bottleneck is computation, not waiting.
+- **Fault-tolerant, long-running systems** favour the actor model, where isolation
+  lets parts crash and restart independently.
+
+Whatever you choose, some costs are inherent. Splitting work across tasks adds
+**coordination overhead** — passing messages, acquiring locks, scheduling. Beyond
+a point, adding more parallelism yields diminishing returns because the sequential
+and coordination portions dominate (this is **Amdahl's law** in spirit: a program's
+speed-up is capped by the fraction that cannot be parallelised). And concurrency
+bugs — races, deadlocks, subtle ordering issues — are among the hardest to
+reproduce and fix, because they depend on timing that changes from run to run. The
+appeal of channels and actors is precisely that they make whole categories of these
+bugs impossible by design, trading a little overhead for a lot of certainty.
+
+## A streaming radio pipeline
+
+Concurrency is not academic for radio software — it is the whole architecture. A
+live capture from a software-defined radio naturally splits into stages that must
+run *at the same time*, each feeding the next:
+
+- a **capture thread** pulling raw [IQ samples](/learn/rf-sdr/iq-data/) off the
+  device as fast as they arrive, never blocking;
+- a **DSP thread** filtering and demodulating those samples;
+- a **decode thread** turning the demodulated signal into packets, audio or text.
+
+These form a **pipeline**, and channels (or queues) are the perfect glue: the
+capture stage sends buffers down a channel, the DSP stage receives, processes, and
+sends results onward to the decode stage. Each stage runs concurrently, the
+runtime can spread them across cores in parallel, and the channels handle
+hand-off without a single shared-memory data race. If one stage falls behind, a
+bounded channel provides natural back-pressure. We build out this exact pattern in
+[concurrency and pipelines](/learn/intro-software-dev/concurrency-and-pipelines/).
+
+## Recap
+
+- **Concurrency vs parallelism** — concurrency structures independent tasks;
+  parallelism runs them at the same instant on multiple cores.
+- **Threads and locks** — powerful and parallel, but shared memory invites data
+  races and deadlocks.
+- **Async/await** — single-threaded event loops excel at I/O-bound work, not
+  CPU-bound work.
+- **Goroutines and channels** — Go's CSP model communicates instead of sharing
+  memory, making pipelines natural.
+- **Actor model** — isolated, share-nothing actors pass messages, so data races are
+  impossible by construction.
+- **Data races are the enemy** — every model is, at heart, a strategy for avoiding
+  unsynchronised shared writes.
+
+Next up: how a language's design shapes its attack surface — [language-level
+security](/learn/intro-software-dev/language-security/).

--- a/docs/learn/intro-software-dev/creational-patterns.md
+++ b/docs/learn/intro-software-dev/creational-patterns.md
@@ -1,0 +1,135 @@
+---
+slug: creational-patterns
+title: "Creational patterns: factory, builder, singleton"
+description: Creational patterns control how objects get made. Learn Factory and Factory Method, Builder for complex assembly, and why Singleton is often an anti-pattern.
+keywords: creational patterns, factory pattern, factory method, builder pattern, singleton, object creation, abstract factory, design patterns
+level: intermediate
+status: full
+faq:
+  - q: "What problem do creational patterns solve?"
+    a: "They handle *how objects are created* so the rest of your code does not have to hard-code which concrete class to instantiate or how to assemble it. By isolating creation, you can swap implementations, build complex objects step by step, or control how many instances exist — all without rewriting the callers that use the result."
+  - q: "What is the difference between a Factory and a Builder?"
+    a: "A **Factory** decides *which* object to create and returns it ready to use, hiding the concrete class from the caller. A **Builder** assembles *one complex* object step by step, letting you set many optional parts before producing the finished result. Use a factory when the choice of type varies; use a builder when construction has many parameters or stages."
+  - q: "Why is Singleton considered an anti-pattern?"
+    a: "A **Singleton** guarantees one shared instance with a global access point, but that global state hides dependencies, makes code hard to test (you cannot easily substitute a fake), and creates tight coupling to the single instance. It is sometimes justified for genuinely unique resources, but passing a shared object explicitly is usually cleaner than reaching for a global singleton."
+---
+# Creational patterns: factory, builder, singleton
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Factory** — create objects without naming the concrete class, so callers stay decoupled from implementations. **Builder** — assemble a complex object step by step instead of a giant constructor. **Singleton** — one shared instance, useful occasionally but often an anti-pattern because of global state.
+</div>
+
+Every program has to create objects somewhere. The naive way is to write `new ConcreteThing(...)` wherever you need one. That works until the exact type needs to vary, or the constructor grows a dozen parameters, or you need to control how many instances exist. **Creational patterns** are the Gang of Four's answers to those situations: they put a layer between "I need an object" and "here is exactly how it gets built." This lesson covers the three most common — Factory, Builder, and Singleton — using a software-defined radio receiver as the running example. The pseudocode is deliberately tiny; the point is the shape, not the syntax.
+
+## The problem creational patterns solve
+
+When code says `new FskDecoder()` directly, two things are now baked in: the *decision* of which decoder to use, and the *details* of how to construct it. That tight binding becomes painful when:
+
+- The concrete type should depend on runtime input (which protocol did we detect?).
+- Construction is complicated (set the sample rate, the gain, the filter, the squelch, then start).
+- You want exactly one of something shared across the program.
+
+Creational patterns isolate that creation logic so the rest of the code depends on an **interface** or an abstract step, not a specific class. This is the open/closed principle from [SOLID](/learn/intro-software-dev/solid/) in action: you can add a new decoder without editing the callers that ask for one. It is also a direct way to reduce [coupling](/learn/intro-software-dev/abstraction-coupling/).
+
+## Factory and Factory Method
+
+A **Factory** is code whose job is to create and return objects, hiding the concrete class behind a common interface. The caller asks for "a decoder for this protocol" and receives something it can use, without knowing — or caring — which class it actually got.
+
+Imagine a scanner that supports several digital protocols. Without a factory, every place that needs a decoder has a tangle of `if`/`else` choosing the class. With a factory, that decision lives in exactly one place:
+
+```text
+interface Decoder { decode(samples) }
+
+function NewDecoder(protocol) -> Decoder {
+  switch protocol {
+    case "P25":   return new P25Decoder()
+    case "DMR":   return new DmrDecoder()
+    case "NXDN":  return new NxdnDecoder()
+    default:      throw "unknown protocol"
+  }
+}
+
+// caller never names a concrete class:
+dec = NewDecoder(detectedProtocol)
+dec.decode(samples)
+```
+
+The caller depends only on the `Decoder` interface. Adding a new protocol means writing one new class and adding one line to `NewDecoder` — no other code changes.
+
+**Factory Method** is the more formal GoF variant. Instead of a standalone function, the creation step is a *method* that subclasses override. A base `ReceiverPipeline` class might declare `createDecoder()` as the step subclasses fill in: a `TrunkedPipeline` overrides it to return a trunking decoder, an `AnalogPipeline` returns an FM decoder. The base class controls the overall flow; subclasses control which object gets created. The intent is the same — defer the choice of concrete class — just expressed through inheritance rather than a function.
+
+There is also **Abstract Factory**, which creates whole *families* of related objects (a matching decoder, filter, and display for a given mode), but Factory Method covers the everyday case.
+
+It is worth being precise about *why* this helps, because "hide the constructor" sounds trivial. The real win is that the decision about which class to build is captured in one named place that the whole system shares. When a bug appears in protocol selection, you fix it once in `NewDecoder` rather than hunting through every call site that built a decoder by hand. When you want to log every decoder creation, or pool and reuse decoders instead of allocating fresh ones, the factory is the single hook where that policy lives. Centralizing creation turns a scattered, repeated decision into one maintainable seam — which is the recurring theme of every creational pattern.
+
+## Builder
+
+A **Builder** separates the construction of a complex object from its representation, so the same step-by-step process can produce different configurations. Reach for it when an object has many parts or many optional settings and a single constructor would be an unreadable wall of arguments.
+
+Configuring a receiver is a perfect example. There are many knobs — frequency, sample rate, gain mode, filter bandwidth, squelch — and most have sensible defaults. A telescoping constructor (`Receiver(freq, rate, gain, bw, squelch, agc, ...)`) is error-prone; nobody remembers the order. A builder reads cleanly:
+
+```text
+rx = ReceiverBuilder()
+       .tuneTo(854_000_000)
+       .sampleRate(2_400_000)
+       .gain("auto")
+       .filterBandwidth(12_500)
+       .squelch(-60)
+       .build()
+```
+
+Each call sets one part and returns the builder, so they chain. Only `build()` produces the finished, validated `Receiver`. Benefits:
+
+- **Readable** — each setting is named, so the call site documents itself.
+- **Flexible** — set only what you need; defaults fill the rest.
+- **Safe** — `build()` can validate the combination before handing back a half-configured object.
+
+Use a Builder when *construction is complex*; use a Factory when *the type to construct varies*. They compose nicely — a factory can use a builder internally.
+
+## Singleton — and why it is often an anti-pattern
+
+A **Singleton** ensures a class has exactly one instance and provides a global point of access to it. The classic shape:
+
+```text
+class HardwareBus {
+  static instance = null
+  static get() {
+    if (instance == null) instance = new HardwareBus()
+    return instance
+  }
+}
+// anywhere in the program:
+HardwareBus.get().send(command)
+```
+
+The appeal is obvious: some things really are unique — a single physical USB radio, one connection to a piece of hardware — and a singleton makes that one instance reachable from anywhere.
+
+But that "reachable from anywhere" is exactly the trap. A singleton is **global mutable state** wearing a class costume, and global state causes recurring problems:
+
+- **Hidden dependencies.** A function that calls `HardwareBus.get()` depends on it, but nothing in its signature says so. You only discover the dependency by reading the body.
+- **Hard to test.** You cannot easily swap in a fake hardware bus for a unit test, because the code reaches out to the global directly instead of receiving it as a parameter.
+- **Tight coupling.** Every caller is welded to the one concrete instance, which is the opposite of what the other creational patterns work so hard to achieve.
+
+The usual better option is **dependency injection**: create the one instance at the top of your program (the "composition root") and *pass it in* to whatever needs it. You still have one instance, but the dependency is explicit and you can substitute a test double. So treat Singleton as a pattern you should be able to recognize and justify, not a default. When you find yourself reaching for it for convenience rather than a genuine "there can only be one" constraint, that is usually the [decision framework](/learn/intro-software-dev/decision-framework/) telling you to pass the object explicitly instead.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a factory returns an object through a common interface so the caller never names the concrete class." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the main job of a Factory?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Guarantee there is only one instance of a class in the whole program</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Create and return an object without the caller naming the concrete class</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Assemble one complex object step by step from many optional parts</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Creational patterns isolate object creation** — so callers depend on interfaces and abstract steps, not concrete classes or constructors.
+- **Factory / Factory Method** — choose and return the right concrete type behind a common interface; add new types without touching callers (open/closed).
+- **Builder** — assemble a complex object step by step with named, chainable steps; ideal when there are many parts or optional settings.
+- **Factory vs Builder** — factory varies *which* type; builder controls *how* one complex object is built. They compose.
+- **Singleton** — one shared instance with global access; occasionally justified, but usually an anti-pattern because of hidden dependencies and poor testability.
+- **Prefer injection** — pass a shared instance in explicitly rather than reaching for a global singleton.
+
+Next up: structural patterns — Adapter, Facade, and Decorator — which deal with how objects are *composed* into larger structures. See [Structural patterns](/learn/intro-software-dev/structural-patterns/).

--- a/docs/learn/intro-software-dev/decision-framework.md
+++ b/docs/learn/intro-software-dev/decision-framework.md
@@ -1,0 +1,180 @@
+---
+slug: decision-framework
+title: A practical decision framework
+description: A repeatable five-step method for choosing a language — eliminate on hard constraints, weight soft criteria, score a short list, prototype the risky part, then commit — with worked examples.
+keywords: choosing a programming language, decision framework, language selection, hard constraints, weighted criteria, prototype, SDR scanner, Go, worked examples
+level: advanced
+status: full
+faq:
+  - q: "How do I actually decide between two close languages?"
+    a: "Stop debating on paper and prototype the riskiest part in each. Build the one piece you're least sure about — the hot DSP loop, the concurrency model, the deployment story — and measure. A half-day spike usually settles an argument that a week of discussion won't, because it tests reality instead of opinion."
+  - q: "Why is Go a good fit for an SDR scanner engine, but not a slam dunk?"
+    a: "Go fits the *plumbing* — easy concurrency for capture and decode pipelines, fast-enough garbage-collected performance, and a single static binary anyone can download and run. The caveat is the hot DSP loop: C, C++ or Rust give more raw throughput and tighter timing. Go is strong overall, but you weigh that throughput trade-off honestly."
+  - q: "Should I always pick the highest-scoring language from the framework?"
+    a: "Treat the score as a guide, not a verdict. It organises the trade-offs and exposes your assumptions, but a small score gap can be overturned by team familiarity, a critical library or a deployment requirement. Use it to narrow to a short list and force a prototype, then commit with judgement."
+---
+# A practical decision framework
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Eliminate, then weigh, then prototype** — hard constraints cut the field, soft criteria rank the rest, a spike tests reality. **Score to think, not to obey** — the number organises trade-offs, judgement decides. **Then commit** — a chosen-and-shipped language beats a perfect one still being debated.
+</div>
+
+You've now got the pieces — what the choice decides, how to read requirements, the
+core trade-off, the languages and the domains. This lesson assembles them into a
+method you can actually run, the same way each time. It's deliberately simple: five
+steps that move from facts (which languages are even possible?) to judgement (which
+should we commit to?). We then run it on three concrete examples, including
+GopherTrunk's own situation.
+
+## The five steps
+
+1. **List the hard constraints, and eliminate.** These are pass/fail requirements — a
+   real-time latency budget, a target platform, a memory ceiling, a licence. Anything
+   that fails one is out. This is the cheapest, highest-leverage step: it often cuts
+   the field from a dozen to three.
+2. **Weight the soft criteria.** For what survives, list what *matters and by how much* —
+   team familiarity, ecosystem, raw performance, deployment ease, hiring, maintainability.
+   Assign weights honestly *before* you score, so you can't fudge them to favour a
+   pre-chosen winner.
+3. **Score a short list.** Rate each surviving language against each weighted criterion.
+   The numbers won't be precise, and that's fine — the point is to make the trade-offs
+   explicit and visible, not to compute a winner to three decimal places.
+4. **Prototype the risky part.** Don't decide on paper. Build the single thing you're
+   *least* sure about in your top one or two candidates — the hot loop, the concurrency
+   model, the build-and-ship step — and measure. A half-day spike beats a week of
+   argument.
+5. **Decide and commit.** Pick, write down *why* (so future-you remembers the
+   reasoning), and stop relitigating. Indecision is itself a cost.
+
+```text
+constraints → eliminate → weight → score short list → prototype risky part → commit
+   (facts)                                                              (judgement)
+```
+
+## Worked example 1: an internal CRUD web app
+
+A small team needs an internal tool — forms, a database, some reports, a few hundred
+users.
+
+- **Hard constraints:** runs on the company's Linux servers; finished in six weeks.
+  These eliminate almost nothing — every mainstream language qualifies.
+- **Weights:** team familiarity (high), ecosystem (medium), performance (low — it's
+  I/O-bound and small).
+- **Score:** the team already knows **Python** and uses Django elsewhere. Go and Java
+  would work fine but offer no advantage that matters here.
+- **Prototype:** unnecessary — no part is risky.
+- **Decide:** Python. The lesson: when nothing's at the extremes, **familiarity and
+  ecosystem win**, exactly as the first lesson promised.
+
+## Worked example 2: firmware for a sensor
+
+A battery-powered microcontroller must read a sensor and report over radio, with
+kilobytes of RAM.
+
+- **Hard constraints:** runs on a tiny MCU; minimal memory; predictable timing; no
+  garbage collector pauses. These eliminate Python, JavaScript, Java, Go — anything
+  that needs a heavy runtime or GC.
+- **Weights:** footprint (critical), timing predictability (critical), safety (high),
+  team experience (medium).
+- **Score:** **C** (ubiquitous on MCUs, total control, but unsafe) vs **Rust**
+  (same control, memory-safe, steeper ramp and thinner embedded ecosystem).
+- **Prototype:** flash a minimal sensor-read loop in both; check binary size, timing
+  and toolchain pain.
+- **Decide:** C if the team's deep in it and the ecosystem's there; Rust if safety is
+  paramount and they can absorb the curve. The lesson: **hard constraints did most of
+  the work** — by step one the field was down to two.
+
+## Worked example 3: GopherTrunk's SDR scanner engine
+
+Now the real one. The task: an engine that captures samples from an SDR device,
+runs trunk-tracking and decode pipelines across many channels at once, and ships to
+non-technical users who just want to download and run it on Linux, macOS or Windows.
+See [GopherTrunk's architecture](/architecture.html) and
+[hardware support](/hardware.html) for the full picture.
+
+- **Hard constraints:** real-time-ish stream handling without dropping samples;
+  cross-platform; **easy for non-technical users to install and run**. That last one
+  matters more than it looks.
+- **Weights:** concurrency (high — many channels and clients), deployment simplicity
+  (high — users aren't developers), raw DSP throughput (medium), team familiarity
+  (medium), safety (medium).
+- **Score the short list:**
+
+| Criterion | Go | C++ | Rust | Python |
+|---|---|---|---|---|
+| Concurrency for capture/decode pipelines | strong | manual, error-prone | strong but harder | GIL hampers CPU threads |
+| Deployment to non-technical users | one static binary | per-platform build/link pain | single binary, harder build | needs runtime + deps |
+| Raw DSP throughput (hot loop) | good, not the fastest | fastest | fastest, safe | slow unless delegated |
+| Learning curve / iteration speed | gentle, fast compiles | steep, slow builds | steep | gentle |
+| Memory safety | GC, safe-ish | unsafe by default | safe, no GC | safe |
+
+**Why Go is a strong fit here.** The engine is mostly *concurrent coordination* —
+pulling a sample stream, fanning it to many decoders, juggling channels and network
+clients. Go's goroutines and channels express that cleanly. It's garbage-collected
+but **fast enough** for this coordination work, compiles in seconds, and — the
+clincher for GopherTrunk's audience — **cross-compiles to a single static binary** so
+a non-technical user downloads one file and runs it on Linux, macOS or Windows, no
+runtime, no dependency hunt. That deployment story is a genuine product advantage
+when your users aren't programmers.
+
+**Where Go costs you, honestly.** For the *tightest DSP inner loops*, **C, C++ and
+Rust deliver more raw throughput and tighter timing control** — no GC pauses, full
+control over memory layout and vectorisation. If a particular demodulator becomes the
+bottleneck, Go's garbage collector and somewhat lower numeric ceiling are real
+trade-offs. The mitigations are the mixed-language patterns from the previous lesson:
+keep Go for the concurrent plumbing and, where a hot loop demands it, drop to C via
+cgo or a native library for that piece. This is a *trade-off*, not a free win — Go is
+chosen here because the balance of concurrency, deployment and "good enough" speed
+fits *this* product, not because it beats C on raw DSP. A different SDR project with a
+brutal single-channel throughput requirement might well land on C++ or Rust instead.
+
+- **Prototype:** build the capture-to-decode pipeline for a couple of channels in Go,
+  measure whether it keeps up with the sample rate on target hardware, and confirm the
+  cross-compiled binary runs cleanly on all three OSes.
+- **Decide:** Go for the engine, with the door open to native code for any proven hot
+  loop — and write down that reasoning.
+
+The packaging side of "one downloadable binary" is its own topic — see
+[packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the first step is eliminating languages that fail a hard, pass/fail constraint; it cheaply cuts the field before any scoring." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the first and highest-leverage step of the framework?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Score every popular language against weighted criteria</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Eliminate any language that fails a hard, pass/fail constraint</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Pick whichever language the team likes most and move on</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Using the framework well
+
+A few habits keep it honest:
+
+- **Set weights before scoring.** Otherwise you'll quietly tune them to justify a
+  decision you already made.
+- **Treat the score as a thinking aid, not a verdict.** A narrow gap can be overturned
+  by a critical library, the team's skills or a deployment need.
+- **Always prototype the risk.** The framework's real power is forcing you to test the
+  scary part for real instead of arguing about it.
+- **Commit and record why.** Future maintainers — including you — will thank you for a
+  paragraph explaining the choice. And remember the first lesson: switching later is
+  costly, so commit deliberately, then build.
+
+## Recap
+
+- **Five steps** — eliminate on hard constraints, weight soft criteria, score a short
+  list, prototype the risky part, decide and commit.
+- **Hard constraints do the heavy lifting** — they cheaply cut the field before any
+  scoring.
+- **Score to think, not to obey** — the number organises trade-offs; judgement,
+  ecosystem and team can override a close call.
+- **Prototype the risk** — a short spike settles arguments that paper debate won't.
+- **GopherTrunk's engine fits Go** — easy concurrency, fast-enough GC'd performance and
+  a single cross-platform binary for non-technical users — while C/C++/Rust still win
+  raw DSP throughput, an honest trade-off, not a free lunch.
+
+Next up: putting a chosen language to work as a one-person team — the
+[solo developer mindset](/learn/intro-software-dev/solo-developer-mindset/) that opens
+Module 7.

--- a/docs/learn/intro-software-dev/dev-environment-workflow.md
+++ b/docs/learn/intro-software-dev/dev-environment-workflow.md
@@ -1,0 +1,174 @@
+---
+slug: dev-environment-workflow
+title: Your environment & daily workflow
+description: Set up an editor, terminal, Git, dotfiles, format-on-save and a tight edit-build-test loop, plus reproducible environments for fast, comfortable solo development.
+keywords: development environment, daily workflow, edit build test loop, dotfiles, formatters linters, devcontainer, version managers, Git workflow
+level: intermediate
+status: full
+faq:
+  - q: "What is the edit-build-test loop?"
+    a: "The **edit-build-test loop** is the core cycle of programming — change some code, build or run it, and check the result. The speed of this loop, often called **inner loop** time, is one of the biggest factors in how productive and happy you are. Solo developers should obsess over keeping it fast, because they run it thousands of times a week with no one else to share the wait."
+  - q: "Why bother with dotfiles?"
+    a: "**Dotfiles** are the small config files (for your shell, editor, Git and tools) that capture how your environment is set up. Keeping them in a Git repository means a new machine can be made to feel like home in minutes, your settings are backed up and versioned, and you never lose that one perfect config you spent an evening tuning."
+  - q: "What makes an environment \"reproducible\"?"
+    a: "A **reproducible environment** is one anyone — including future you — can recreate exactly, with the same language version and tools, rather than relying on whatever happens to be installed. **Version managers** pin language versions per project, and **containers or devcontainers** package the whole toolchain, so \"works on my machine\" stops being a problem even when the only machine is yours."
+---
+# Your environment & daily workflow
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Comfortable tools** — editor, terminal and Git you know cold. **Tight loop** — a fast edit-build-test cycle you run all day. **Reproducible** — dotfiles and containers so any machine, including future you, can rebuild it.
+</div>
+
+Your stack decides *what* you build with; your environment decides *how it feels* to
+do it. Solo, you run the same small loop — change code, run it, check it — thousands
+of times a week, with no one to share the waiting or the friction. So the payoff for
+tuning your environment is enormous and entirely yours. This lesson sets up a
+workplace that is fast, comfortable and reproducible: an editor you know cold, a
+terminal that fits your hand, version control you trust, automatic formatting, and a
+build-test loop tight enough that you stay in flow. None of it is fancy; all of it
+compounds.
+
+## Editor, terminal, and version control
+
+Three tools form the floor of any setup. You do not need the *best* ones — you need
+ones you know deeply:
+
+- **Editor or IDE.** Whether it is a full IDE or a lean editor, learn its keybindings,
+  its search, its jump-to-definition. Fluency here means your hands keep up with your
+  thoughts. A good language server giving you autocomplete and inline errors as you
+  type is worth far more than any theme.
+- **Terminal.** You will live here — running builds, tests, Git and your program.
+  Learn a handful of shell basics and let the terminal become an extension of the
+  editor rather than a scary other place.
+- **Version control with Git.** This is non-negotiable, even alone. Git is your undo
+  button across the whole project, your record of *why* a change was made, and your
+  safety net for trying risky ideas on a branch. If Git still feels like magic
+  incantations, work through the dedicated [Git & GitHub path](/learn/git/) — it pays
+  for itself within a week.
+
+Commit small and often, with messages that explain *why*, not just *what*. Future you
+is the new hire reading them, and you will not remember the context.
+
+## Capture your setup in dotfiles
+
+Once your environment feels right, **save it.** Your shell config, editor settings,
+Git config and tool preferences are all just text files — your **dotfiles** — and
+they belong in a Git repository of their own. The benefits are quietly huge:
+
+- A **new machine** becomes home in minutes, not an afternoon of half-remembered
+  tweaks.
+- Your settings are **backed up and versioned**, so the perfect config you tuned one
+  evening is never lost to a dead laptop.
+- You can **see and undo** changes to your environment the same way you do for code.
+
+You do not have to do this on day one, but the moment you find yourself re-configuring
+the same thing on a second machine, start a dotfiles repo. It is the cheapest
+insurance in software.
+
+## Let tools do the boring checks
+
+A solo developer has no one to nitpick style in review, so hand that job to machines
+and forget about it. Two tools earn their place immediately:
+
+- **A formatter** rewrites your code to a consistent style automatically. Run it
+  **on save**. You stop thinking about indentation and spacing entirely, and you never
+  again argue with yourself about it. Many languages ship one (Go has `gofmt`; others
+  have equivalents).
+- **A linter** flags likely bugs and bad smells — unused variables, suspicious
+  comparisons, ignored errors. Run it on save or on every build so problems surface
+  the instant you create them, not days later.
+
+```text
+on save:  format the file  →  run the linter  →  show errors inline
+```
+
+Wiring these into your editor means quality checks happen *for free*, thousands of
+times a day, with zero willpower required. This is the first installment of the
+"automation as your missing teammate" idea we develop in
+[keeping quality high alone](/learn/intro-software-dev/quality-when-solo/).
+
+## Keep the loop tight
+
+The **edit-build-test loop** is the heartbeat of your day: change something, build or
+run it, see the result. The shorter that cycle, the more you stay in flow and the
+faster you learn whether an idea works. A loop that takes 30 seconds versus 2 seconds
+is the difference between deep focus and constantly losing your train of thought.
+
+Things that keep the loop fast:
+
+- **Incremental builds** — only rebuild what changed, not the whole project.
+- **Run the smallest unit** — execute the single test or function you are working on,
+  not the entire suite, while iterating.
+- **Watch mode** — tools that rerun automatically on save remove the manual step
+  entirely.
+- **Fast feedback inline** — errors appearing in the editor beat reading a wall of
+  terminal output.
+
+Treat a slow inner loop as a bug worth fixing. Every second you shave gets multiplied
+by the thousands of times you run it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a fast edit-build-test loop keeps you in flow and gives near-instant feedback, which you run thousands of times a week." markdown="0">
+  <p class="knowledge-check__q">Quick check: why do solo developers obsess over a fast edit-build-test loop?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because faster builds make the final program run faster too</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because they run the loop thousands of times a week, so its speed compounds into focus and productivity</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because slow loops use more electricity</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Make the environment reproducible
+
+The classic disaster is "it works on my machine" — and when you are the only machine,
+the disaster is a dead laptop or a fresh install wiping out a setup you can no longer
+recreate. **Reproducible environments** solve this by capturing not just your code but
+the tools that build it:
+
+- **Version managers** pin the exact language version per project, so upgrading the
+  language globally never silently breaks an old project.
+- **Containers and devcontainers** package the whole toolchain — language, libraries,
+  system tools — into a definition file you commit alongside the code. Anyone, on any
+  machine, gets the identical environment from one command.
+
+The payoff is that future you, on a new computer a year from now, can clone the repo
+and be productive in minutes instead of rebuilding a fragile setup from memory. It is
+the same bus-factor insurance as dotfiles, applied to the project itself.
+
+## A concrete daily loop
+
+Here is what a focused solo session can actually look like, tying it all together:
+
+1. Open the project; the editor's language server lights up with autocomplete and
+   inline errors.
+2. Create a **branch** for today's task so the main branch stays shippable.
+3. Write a small change; on save, the **formatter** tidies it and the **linter**
+   flags an unused import you fix immediately.
+4. Run just the **one test** for the function you are changing — under a second —
+   watch it go red, make it green.
+5. Run the program against real input. For a radio tool that might mean feeding it a
+   captured sample file and watching it decode; the tight loop lets you tweak the
+   parser and re-run in seconds.
+6. **Commit** with a message explaining *why*, then move to the next small step.
+7. When the task is done and tests pass, merge the branch back.
+
+That is the rhythm: tiny changes, instant feedback, frequent commits, a clean main
+branch. Repeat it and real software accumulates almost without you noticing.
+
+## Recap
+
+- **Know your core tools cold** — editor, terminal and Git fluency lets your hands
+  keep up with your thinking.
+- **Use Git even alone** — it is your undo, your history, and your safety net for
+  risky ideas.
+- **Save your setup in dotfiles** — version your environment so a new machine becomes
+  home in minutes.
+- **Automate formatting and linting** — run them on save so quality checks cost no
+  willpower.
+- **Keep the loop tight** — a fast edit-build-test cycle compounds into focus and
+  productivity.
+- **Make it reproducible** — version managers and containers mean future you can
+  rebuild the whole environment from the repo.
+
+Next up: turning a vague idea into a project you can actually finish in
+[from idea to project](/learn/intro-software-dev/scoping-a-project/).

--- a/docs/learn/intro-software-dev/docs-and-maintenance.md
+++ b/docs/learn/intro-software-dev/docs-and-maintenance.md
@@ -1,0 +1,92 @@
+---
+slug: docs-and-maintenance
+title: Documentation, tech debt & maintenance
+description: The kinds of documentation, writing for future readers, technical debt and how to pay it down, refactoring, deprecation, bus factor, and why most of a program's life is maintenance.
+keywords: software documentation, README, API docs, technical debt, refactoring, deprecation, software maintenance, bus factor, writing for maintainers, architecture docs
+level: intermediate
+status: full
+faq:
+  - q: "Isn't taking on technical debt always a bad idea?"
+    a: "No — deliberate, well-understood debt can be a smart trade. Shipping a quick-but-imperfect solution to hit a deadline or validate an idea is reasonable, as long as you know you're borrowing and plan to repay. The dangerous kind is accidental or ignored debt that compounds silently until the codebase grinds to a halt. Like financial debt, it's a tool when managed and a trap when forgotten."
+  - q: "What is the bus factor?"
+    a: "The bus factor is the number of people who'd have to be hit by a bus (or just leave) before a project is in serious trouble because nobody else understands it. A bus factor of one means a single person holds critical knowledge in their head alone. Documentation, code review, and shared ownership raise the bus factor, making the project resilient to any one person leaving."
+  - q: "How is refactoring different from rewriting?"
+    a: "Refactoring changes a program's internal structure without changing its external behavior — you improve the code while it keeps doing exactly what it did, ideally with tests proving so. A rewrite throws the existing code out and builds anew, which is far riskier because you lose all the accumulated bug fixes and edge-case handling. Most of the time, steady refactoring beats a dramatic rewrite."
+---
+# Documentation, tech debt & maintenance
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Maintenance is the main act** — most of a program's life is spent being maintained, not first written. **Docs serve future readers** — including you, six months from now. **Tech debt is a tool** — deliberate and repaid, it's fine; ignored, it compounds until the code seizes.
+</div>
+
+There's a myth that software is "done" when it first ships. In reality, that's the starting line. Most of a program's life — and most of the total effort spent on it — happens *after* the initial version: fixing bugs, adapting to new requirements, keeping dependencies current, and helping the next person understand it. This final lesson of the module is about that long tail: the documentation that makes code survivable, the technical debt that accumulates as you go, and the maintenance reality that defines a project's real cost.
+
+## The kinds of documentation
+
+"Documentation" isn't one thing. Different readers need different documents, and good projects layer several:
+
+- **READMEs** — the front door. What is this, what problem does it solve, how do I install and run it, where do I go next. The first thing anyone sees; often the only thing they read.
+- **API / reference docs** — the precise contract of every public function, type, and endpoint: what it takes, what it returns, what it guarantees. Frequently generated from comments in the code so they stay close to the source.
+- **Architecture docs** — the big picture: how the major components fit together and *why* the design is the way it is. These capture the reasoning future maintainers can't reverse-engineer from code alone.
+- **Tutorials and reference material** — task-oriented guides that walk a newcomer from zero to working, distinct from dry reference. *This very site is an example* — a structured learning path is documentation in the tutorial-and-reference tradition, designed to take a reader from punch cards to shipping their own software.
+
+A useful frame (the "Diátaxis" idea) is that tutorials, how-to guides, reference, and explanation each serve a different need, and mixing them muddies all four. You don't need every kind for every project, but knowing which kind you're writing keeps it focused.
+
+## Writing for future readers
+
+The single most important audience for documentation is the **future reader** — most often *you*, months from now, with every assumption forgotten. Code shows *what* it does; it rarely captures *why* a decision was made, what alternatives were rejected, or what constraint forced an ugly workaround. That "why" is exactly what evaporates from memory and exactly what a maintainer most needs.
+
+This connects directly to writing [readable code](/learn/intro-software-dev/clean-code/): clear names and structure are the first layer of documentation, and prose fills the gaps that code can't express. The test of good documentation isn't how thorough it looks — it's whether someone unfamiliar can get unstuck without finding you and asking. Write down the non-obvious, keep it near the code so it doesn't rot, and delete docs that have gone stale rather than letting them mislead.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — comments and docs are most valuable for the 'why' that code can't express on its own." markdown="0">
+  <p class="knowledge-check__q">Quick check: what should documentation most focus on capturing?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A line-by-line restatement of what every line of code does</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The 'why' — intent, trade-offs, and constraints the code can't show</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing — good code never needs any documentation</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Technical debt
+
+**Technical debt** is the implied future cost of choosing a quick or easy solution now instead of a better one that would take longer. The metaphor, coined by Ward Cunningham, is deliberate: like financial debt, you get something now (speed) and pay interest later (every future change in that area is slower and riskier).
+
+Crucially, debt isn't automatically bad. **Deliberate, strategic debt** is a legitimate tool — ship a rough version to hit a deadline or validate whether an idea even works, *knowing* you've borrowed and intending to repay. The trouble is the other kinds:
+
+- **Reckless debt** — cutting corners with no awareness, leaving a mess by accident.
+- **Ignored debt** — debt you took on knowingly but never circle back to pay down.
+
+Untended debt **compounds.** Each shortcut makes the next change a little harder, until a once-nimble codebase becomes one where every small task is a slog and developers fear touching anything. The skill is treating debt like a loan: take it on consciously, track it, and *pay it down* — usually by refactoring — before the interest swallows your velocity.
+
+## Refactoring and deprecation
+
+**Refactoring** is improving the internal structure of code *without changing what it does externally.* You rename for clarity, extract a tangled function into smaller ones, remove duplication — and the program behaves identically throughout. This is how you pay down debt safely, and it's exactly where [your test suite](/learn/intro-software-dev/testing/) earns its keep: tests give you the confidence to restructure aggressively, because they'll scream if behavior changes. Refactoring without tests is just hoping. Note the contrast with a *rewrite*, which discards the code entirely and forfeits years of accumulated bug fixes and edge-case handling — almost always riskier than steady, test-backed refactoring.
+
+**Deprecation** is how you retire something gracefully. When an API or feature needs to go but people depend on it, you don't yank it overnight — you mark it deprecated, document the replacement, give users time and warnings to migrate, and only then remove it. Good deprecation respects the people building on your work and is part of the maturity of any long-lived project or library.
+
+## Maintenance is most of the life
+
+Step back and the dominant fact of software is this: **the initial build is a small fraction of the total.** A program that lives for years spends those years being maintained — adapting to new operating systems, patching security holes, fixing bugs found in the wild, adding features, and tracking dependency changes. Studies of software cost have long put maintenance at well over half — often the large majority — of total lifetime effort.
+
+This reframes everything in the module. The point of [readable code](/learn/intro-software-dev/clean-code/), tests, version control, and CI isn't bureaucracy — it's that they make the *long, dominant maintenance phase* survivable. Code optimized only for getting written fast becomes a liability the moment someone has to change it, which is approximately always.
+
+Take GopherTrunk as a concrete case. Radio protocols evolve, new signal types appear, operating systems shift under your feet, and dependencies need updating. A decoder written without docs or golden-file tests might work the day it ships and become unmaintainable a year later, when the original author has forgotten the protocol's quirks and no test pins down correct behavior. Invest in maintainability and that same decoder stays changeable for as long as people need it.
+
+## Bus factor
+
+A blunt but useful measure of project health is the **bus factor**: how many people would have to be hit by a bus (or simply leave) before the project is in serious trouble because the knowledge left with them. A bus factor of **one** — a single person holding critical understanding in their head alone — is a fragile project, one resignation away from a crisis.
+
+Almost everything in this module raises the bus factor. Documentation externalizes knowledge from heads into shared, durable form. [Code review](/learn/intro-software-dev/version-control-collab/) spreads understanding across the team as a side effect. Version control records the *why* behind changes. Tests encode expected behavior so it isn't tribal lore. Raising the bus factor is what turns a clever individual's project into a resilient, lasting one — and it's the quiet through-line of every practice in this module.
+
+## Recap
+
+- **Documentation has kinds** — READMEs, API/reference, architecture docs, and tutorials/reference (like this site); each serves a different reader.
+- **Write for future readers** — capture the *why* code can't express; the test is whether someone can get unstuck without asking you.
+- **Tech debt is a tool** — deliberate, tracked, repaid debt is fine; reckless or ignored debt compounds until the code seizes up.
+- **Refactor with tests** — improve structure without changing behavior; far safer than a rewrite, and tests make it fearless.
+- **Deprecate gracefully** — retire features with warnings, a migration path, and time, respecting those who depend on you.
+- **Maintenance dominates** — most of a program's life and cost is maintenance, which is why every practice in this module exists; raising the bus factor keeps the project alive.
+
+Next up: with the systems behind shipping understood, the next module asks a sharper question — [why language choice matters](/learn/intro-software-dev/why-language-choice-matters/) when you start a project of your own.

--- a/docs/learn/intro-software-dev/dry-kiss-yagni.md
+++ b/docs/learn/intro-software-dev/dry-kiss-yagni.md
@@ -1,0 +1,118 @@
+---
+slug: dry-kiss-yagni
+title: DRY, KISS, YAGNI & separation of concerns
+description: Four heuristics that keep code lean — DRY, KISS, YAGNI and separation of concerns — plus when duplication is fine and abstraction is the wrong call.
+keywords: DRY principle, KISS principle, YAGNI, separation of concerns, don't repeat yourself, premature abstraction, wrong abstraction, over-engineering, software design heuristics
+level: beginner
+status: full
+faq:
+  - q: "Does DRY mean I should never duplicate any code?"
+    a: "No. DRY is about not duplicating *knowledge* — a single rule or fact that lives in one place. Two pieces of code that happen to look alike today but represent different ideas can safely stay separate. Forcing them together creates the \"wrong abstraction,\" which is harder to undo than duplication."
+  - q: "How is KISS different from YAGNI?"
+    a: "KISS says keep the solution to a real problem as simple as possible. YAGNI says don't build solutions to problems you don't yet have. KISS is about *how* you solve today's problem; YAGNI is about *whether* you should solve a speculative future one at all."
+  - q: "What is separation of concerns in plain terms?"
+    a: "It means each part of a program should deal with one concern — one area of responsibility — and not tangle itself with unrelated ones. For example, keep code that reads radio samples separate from code that decodes them and code that displays results, so each can change independently."
+---
+# DRY, KISS, YAGNI & separation of concerns
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**DRY** — every piece of knowledge has one home, but don't over-abstract. **KISS & YAGNI** — solve today's problem simply, skip tomorrow's imaginary one. **Separation of concerns** — one part, one responsibility.
+</div>
+
+Once your code is readable, the next question is structural: how do you keep a growing program from collapsing under its own weight? Over decades, the industry distilled a handful of heuristics that answer this — short slogans that pack hard-won judgement. The four in this lesson, **DRY, KISS, YAGNI, and separation of concerns**, work together to keep code lean and changeable. But heuristics are guidelines, not laws. Misapplied, each can do real damage, and the most interesting part of this lesson is knowing when *not* to follow them.
+
+## DRY — Don't Repeat Yourself
+
+DRY says that **every piece of knowledge should have a single, authoritative representation** in your system. If a business rule, a constant, or a calculation appears in five places, a change means finding and editing all five — and missing one is a bug.
+
+The classic example is a magic number scattered around:
+
+```go
+// Repeated knowledge — change one and you must change them all.
+buffer := make([]float64, 48000)        // sample rate
+window := 48000 / 100                   // 10 ms window
+if elapsedSamples > 48000*5 { ... }     // 5-second timeout
+
+// DRY — the sample rate has one home.
+const sampleRateHz = 48000
+buffer := make([]float64, sampleRateHz)
+window := sampleRateHz / 100
+if elapsedSamples > sampleRateHz*5 { ... }
+```
+
+Now "the sample rate is 48 kHz" is stated once. DRY applies far beyond constants: a validation rule, an API endpoint format, a data schema — anything that encodes a fact your system relies on.
+
+The crucial nuance: **DRY is about knowledge, not about characters.** Two snippets that look identical but represent *different* facts are not a DRY violation, and merging them is a mistake.
+
+## The wrong-abstraction trap
+
+The most common way DRY backfires is premature deduplication. You see two functions that look 90% alike, so you extract a shared helper with a flag or two to cover the differences. It feels clean. Then the two callers start evolving in different directions, you add another flag, then a conditional, then a special case — and soon the "shared" abstraction is a tangle that serves no one well.
+
+Sandi Metz put it sharply: **"duplication is far cheaper than the wrong abstraction."** Duplicated code is easy to understand and easy to delete. A wrong abstraction has tendrils everywhere and is painful to unwind.
+
+A safer rule of thumb than "never repeat":
+
+- Don't abstract on the *first* duplication. Copy it.
+- Wait until you see the pattern a third time and understand which parts truly vary.
+- If an abstraction starts sprouting boolean flags and special cases, that's a signal it's wrong — consider inlining it back into separate copies.
+
+Duplication is a smell worth watching, but it is a *cheaper* problem than over-abstraction.
+
+## KISS — Keep It Simple
+
+KISS reminds you that **the simplest design that solves the actual problem is almost always the best one.** Complexity is not a sign of sophistication; it's a cost you pay forever in comprehension, bugs, and onboarding.
+
+Simplicity shows up as: fewer moving parts, fewer layers of indirection, fewer configuration options, and straightforward control flow. When you reach for a design pattern, a generic framework, or a configurable abstraction, ask whether the plain version would do. Often a function and a slice beat a class hierarchy and a plugin registry.
+
+KISS doesn't mean "no abstractions" — some problems are genuinely complex and need structure. It means: match the complexity of the solution to the complexity of the problem, and not a notch more.
+
+## YAGNI — You Aren't Gonna Need It
+
+YAGNI targets a specific, seductive failure: building for an imagined future. "We might want to support multiple databases someday, so let me add an abstraction layer now." "Someday we'll have plugins, so let me build a registry." Most of those somedays never arrive, and the speculative machinery sits there as dead weight — extra code to read, test, and maintain, often guessing the future wrong.
+
+The principle: **implement things when you actually need them, not when you merely foresee needing them.** This is hard because anticipating needs *feels* responsible. But YAGNI argues that the cost of adding a feature later (when you understand the real requirement) is almost always lower than the cost of carrying unused, speculative code now — and of getting the guess wrong.
+
+YAGNI and KISS reinforce each other: skipping speculative features (YAGNI) keeps today's design simple (KISS). Together they're the antidote to over-engineering.
+
+A quick contrast:
+
+| Principle | Question it answers | Failure it prevents |
+|-----------|--------------------|--------------------|
+| DRY | Does this knowledge live in one place? | Inconsistent edits, drift |
+| KISS | Is this the simplest solution to the real problem? | Needless complexity |
+| YAGNI | Am I building for a need I actually have? | Speculative over-engineering |
+
+## Separation of concerns
+
+Separation of concerns (SoC) is the structural backbone behind the slogans: **each part of a program should be responsible for one concern and minimally entangled with others.** A "concern" is a distinct area of responsibility — input, business logic, storage, presentation.
+
+Consider a small radio pipeline in GopherTrunk. One natural separation:
+
+- **Acquisition** — pull raw IQ samples from the SDR hardware.
+- **Decoding** — turn samples into demodulated frames.
+- **Presentation** — show decoded messages in the UI.
+
+If these are tangled into one function, changing the display forces you to understand sample acquisition, and swapping the hardware risks breaking the decoder. Kept separate, each can change, be tested, and be reasoned about on its own. You could replace the SDR with a file-based source without touching a line of decode logic.
+
+Separation of concerns is *why* DRY, KISS, and YAGNI pay off: clean seams between responsibilities are what make code simple to keep simple, easy to deduplicate correctly, and cheap to extend later. It's also the conceptual bridge to the next lesson — [SOLID](/learn/intro-software-dev/solid/) is, in large part, a rigorous take on separating concerns in object-oriented designs.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — DRY is about deduplicating knowledge; identical-looking code for different ideas should stay separate." markdown="0">
+  <p class="knowledge-check__q">Quick check: two functions look almost identical but encode different business rules. What does DRY advise?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Always merge them into one shared helper with flags</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Leave them separate — they represent different knowledge</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Delete one of them since they're nearly the same</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **DRY** — give each piece of *knowledge* one authoritative home; deduplicate facts, not coincidentally similar text.
+- **Wrong abstraction** — duplication is cheaper than the wrong abstraction; wait for the pattern to prove itself before extracting.
+- **KISS** — match solution complexity to the real problem; the simplest design that works usually wins.
+- **YAGNI** — build for needs you have, not ones you imagine; speculative code is mostly dead weight.
+- **Separation of concerns** — give each part one responsibility and clean seams, so it can change independently.
+
+Next up: a deeper, object-oriented framework for one-job design — the [SOLID principles](/learn/intro-software-dev/solid/).

--- a/docs/learn/intro-software-dev/from-requirements.md
+++ b/docs/learn/intro-software-dev/from-requirements.md
@@ -1,0 +1,151 @@
+---
+slug: from-requirements
+title: Start with requirements
+description: Drive a language choice from real requirements — performance, safety, real-time limits, platform, ecosystem, team and timeline — by turning fuzzy needs into concrete, testable criteria.
+keywords: software requirements, language selection criteria, performance targets, real-time constraints, deployment targets, ecosystem, team skills, non-functional requirements
+level: intermediate
+status: full
+faq:
+  - q: "Why start a language choice from requirements rather than preferences?"
+    a: "Because requirements are the only thing that can actually eliminate options. A real-time latency budget, a target platform, or a licensing constraint rules languages in or out on facts, not taste. Starting from preference tends to rationalise a choice you already made for fashion or familiarity."
+  - q: "What is the difference between a functional and a non-functional requirement?"
+    a: "A **functional** requirement is what the software must *do* (\"decode P25 trunked audio\"). A **non-functional** requirement is *how well* it must do it — speed, latency, reliability, resource limits, portability. Non-functional requirements are usually what drive a language choice, because they touch the performance ceiling and platform."
+  - q: "How do I turn a vague need into a usable criterion?"
+    a: "Attach a number or a hard fact. \"Fast\" becomes \"process a 2.4 MS/s stream with under 50 ms latency.\" \"Runs everywhere\" becomes \"ships as one binary for Linux, macOS and Windows on x86-64 and ARM.\" Concrete criteria can be tested against a candidate; vague ones can't."
+---
+# Start with requirements
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Requirements drive the choice** — performance, safety, real-time, platform, ecosystem, team and timeline, not fashion. **Make them concrete** — turn "fast" into a number. **Hard constraints eliminate** — some needs rule whole languages out instantly.
+</div>
+
+The previous lesson argued there is no "best" language, only the best fit for a
+job. But "fit" is empty until you know what you're fitting *to*. That's the
+requirements. The discipline here is simple to state and easy to skip: write down
+what the software actually has to do and how well, *then* see which languages
+clear the bar. Done well, this turns an argument about taste into a short list you
+can defend.
+
+## The requirements that move the needle
+
+Not every requirement affects language choice. Many — the colour of a button, the
+exact wording of an error — are language-agnostic. These are the categories that
+genuinely steer the decision:
+
+- **Performance targets.** Throughput and latency. "Handle 10k requests/sec" or
+  "filter each sample buffer in under 5 ms." High enough targets push you toward
+  compiled languages.
+- **Correctness and safety needs.** How costly is a bug? Avionics, medical and
+  financial code value languages that catch errors early — strong static types,
+  memory safety. A throwaway script does not.
+- **Real-time constraints.** A *deadline per operation*, not just average speed.
+  Audio, control loops and radio DSP must finish each cycle on time, every time —
+  this distrusts unpredictable pauses.
+- **Platform and deployment targets.** Where does it run? A microcontroller, a phone,
+  a browser, a Raspberry Pi, a user's laptop? The target can eliminate languages that
+  don't run there at all.
+- **Ecosystem and libraries.** Does a mature library already solve the hard part?
+  Reaching for Python's NumPy or GNU Radio can outweigh a language's raw speed.
+- **Team skills.** What can your people build well *now*, and what can they learn in
+  the time you have?
+- **Timeline.** A two-week prototype and a ten-year platform reward very different
+  trade-offs between speed-to-write and long-term rigour.
+- **Licensing and legal.** Some libraries, runtimes or compilers carry licences (GPL,
+  commercial) that conflict with how you intend to ship. Check before you commit.
+
+## Functional vs non-functional
+
+A useful split: **functional** requirements are what the system does;
+**non-functional** requirements are how well it does it.
+
+| | Functional | Non-functional |
+|---|---|---|
+| Question | What must it *do*? | How *well*? |
+| Examples | "Decode trunked audio", "export CSV" | latency, throughput, memory, portability, safety |
+| Effect on language | usually neutral | often decisive |
+
+Most languages can be made to *do* almost anything. It's the non-functional column —
+the latency budget, the memory ceiling, the deployment story — that pushes you
+toward or away from a language. So weight those heavily when choosing.
+
+## Turning fuzzy needs into concrete criteria
+
+"It needs to be fast and run everywhere" is not a requirement; it's a wish. The job
+is to attach numbers and hard facts so a candidate language can be *tested* against
+it.
+
+| Fuzzy wish | Concrete criterion |
+|---|---|
+| "Fast" | "Process a 2.4 MS/s I/Q stream with end-to-end latency under 50 ms" |
+| "Runs everywhere" | "Ship one self-contained binary for Linux, macOS and Windows, x86-64 and ARM" |
+| "Reliable" | "No crashes over a 72-hour soak test; recover from a dropped USB device" |
+| "Easy for users" | "Non-technical user downloads one file and double-clicks — no runtime install" |
+| "Handles lots of users" | "Sustain 5,000 concurrent connections on a 2-core VM" |
+
+Concrete criteria do two things: they let you *eliminate* options on facts, and they
+become the acceptance tests you prototype against later (see
+[the decision framework](/learn/intro-software-dev/decision-framework/)).
+
+## How a hard constraint eliminates options
+
+Some requirements are pass/fail. They don't *favour* a language — they *forbid*
+others. These are the most valuable requirements you can find, because they shrink
+the field fast.
+
+Consider: **"must process a live sample stream in real time on a Raspberry Pi."**
+Walk through what that single sentence rules out:
+
+- **Real time** distrusts long, unpredictable garbage-collection pauses, so a
+  heavily GC'd, JIT-warming runtime is a worry for the tightest inner loop.
+- **Live stream, on a Pi** means a CPU and memory budget — a slow interpreted inner
+  loop may simply not keep up, dropping samples.
+- The combination steers the *DSP core* toward C, C++, Rust or carefully-written Go,
+  and away from pure CPython in the hot path.
+
+Notice it doesn't ban Python from the project — only from the inner loop. You might
+still prototype in Python and push the heavy lifting into native code. Hard
+constraints scope *which part* of the system each language can own. The related
+timing reasoning lives in
+[compiled vs interpreted](/learn/intro-software-dev/compiled-vs-interpreted/) and
+[memory management](/learn/intro-software-dev/memory-management/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a concrete criterion attaches a number or hard fact so candidate languages can be tested against it." markdown="0">
+  <p class="knowledge-check__q">Quick check: which of these is a *concrete*, testable requirement?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">"The app should feel snappy and modern"</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">"Process a 2.4 MS/s stream with under 50 ms end-to-end latency"</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">"Use whichever language is most popular right now"</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Watch for fashion in disguise
+
+Even disciplined teams smuggle preferences into "requirements." Guard against it:
+
+- **"We need it to scale"** — to *what* number, by when? Often the honest answer is a
+  few hundred users, which almost anything handles.
+- **"It must be enterprise-grade"** — define the actual reliability and support needs;
+  the phrase alone justifies nothing.
+- **"X is the modern way"** — modern for whom? Momentum is a real signal for hiring
+  and ecosystem, but it is not a functional requirement.
+
+When a requirement can't be tested or counted, treat it as a *preference* and weight
+it as such in the next lessons — honestly, not disguised as a hard constraint.
+
+## Recap
+
+- **Requirements come before language** — you can't judge fit without knowing what
+  you're fitting to.
+- **Some categories actually move the needle** — performance, safety, real-time,
+  platform, ecosystem, team, timeline and licensing.
+- **Non-functional requirements usually decide it** — most languages can *do* the
+  job; how *well* is what separates them.
+- **Make fuzzy needs concrete** — attach a number or hard fact so candidates can be
+  tested.
+- **Hard constraints eliminate** — one sentence like "real-time stream on a Pi" can
+  rule whole languages out of the hot path.
+
+Next up: the single biggest trade-off behind every language choice —
+[performance versus productivity](/learn/intro-software-dev/performance-vs-productivity/).

--- a/docs/learn/intro-software-dev/glossary.md
+++ b/docs/learn/intro-software-dev/glossary.md
@@ -1,0 +1,425 @@
+---
+slug: glossary
+title: Glossary of software development terms
+description: Plain-language definitions for every key software development term in the Intro to Software Development learning path, cross-linked to the lessons that explain them.
+keywords: software development glossary, programming terms, programming glossary, software engineering definitions
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of software development terms
+
+This is a plain-language reference for the key terms used across the Intro to Software Development path. Definitions are short on purpose; each links to the lesson that explains the idea in full. Terms are grouped by theme and roughly ordered from foundational to advanced within each group, following the shape of the path itself.
+
+## History and hardware
+
+**Hardware** — The physical parts of a computer you can touch: chips, memory, drives, screens. Software is the instructions that run on it. See [What is software?](/learn/intro-software-dev/what-is-software/)
+
+**Software** — Instructions that tell hardware what to do. Unlike hardware, it can be changed without rebuilding the machine. See [What is software?](/learn/intro-software-dev/what-is-software/)
+
+**Stored-program computer** — A design where a program is held in the same memory as the data it works on, so the machine can be reprogrammed instead of rewired. This idea underpins essentially every modern computer. See [What is software?](/learn/intro-software-dev/what-is-software/)
+
+**Firmware** — Low-level software baked into a device that controls its hardware directly, sitting between pure hardware and ordinary programs. See [What is software?](/learn/intro-software-dev/what-is-software/)
+
+**Operating system (OS)** — The software that manages a computer's hardware and resources and gives other programs a consistent way to run. See [What is software?](/learn/intro-software-dev/what-is-software/)
+
+**Vacuum tube** — An early electronic switch used in the first electronic computers; large, hot, and unreliable compared with what replaced it. See [The story of computing hardware](/learn/intro-software-dev/computing-hardware-story/)
+
+**Punch card** — A stiff card with holes punched in it, used to feed programs and data into early computers. See [The story of computing hardware](/learn/intro-software-dev/computing-hardware-story/)
+
+**ENIAC** — One of the first general-purpose electronic computers (1940s), built from thousands of vacuum tubes. See [The story of computing hardware](/learn/intro-software-dev/computing-hardware-story/)
+
+**Transistor** — A tiny electronic switch that replaced the vacuum tube, making computers far smaller, faster, and more reliable. See [The story of computing hardware](/learn/intro-software-dev/computing-hardware-story/)
+
+**Integrated circuit** — Many transistors fabricated together on a single chip, the building block of modern electronics. See [The story of computing hardware](/learn/intro-software-dev/computing-hardware-story/)
+
+**Microprocessor** — A complete processing unit on a single chip; the "brain" that runs a computer's instructions. See [The story of computing hardware](/learn/intro-software-dev/computing-hardware-story/)
+
+**Moore's Law** — The observation that the number of transistors on a chip roughly doubles every couple of years, driving decades of rapid improvement in computing. See [The story of computing hardware](/learn/intro-software-dev/computing-hardware-story/)
+
+**Mainframe** — A large, powerful central computer shared by many users, common in early business and institutional computing. See [From the internet to the edge](/learn/intro-software-dev/internet-to-edge/)
+
+**Client-server** — A model where client programs request services from a central server that holds shared data or logic. See [From the internet to the edge](/learn/intro-software-dev/internet-to-edge/)
+
+**Cloud** — Computing power and storage provided over the internet on demand, instead of from machines you own and run yourself. See [From the internet to the edge](/learn/intro-software-dev/internet-to-edge/)
+
+**Edge computing** — Running computation close to where data is produced (devices, sensors, local servers) rather than in a distant data centre, to reduce latency. See [From the internet to the edge](/learn/intro-software-dev/internet-to-edge/)
+
+**Open source** — Software whose source code is published so anyone can read, use, and contribute to it, usually under a licence that permits this. See [From the internet to the edge](/learn/intro-software-dev/internet-to-edge/)
+
+## Languages and paradigms
+
+**Machine code** — The raw numeric instructions a processor executes directly. Everything else eventually becomes machine code. See [The birth of languages](/learn/intro-software-dev/birth-of-languages/)
+
+**Assembly** — A human-readable shorthand for machine code, with one line roughly per processor instruction. See [The birth of languages](/learn/intro-software-dev/birth-of-languages/)
+
+**High-level language** — A language written in terms closer to human ideas than to the hardware, then translated down to machine code. See [The birth of languages](/learn/intro-software-dev/birth-of-languages/)
+
+**Compiler** — A program that translates source code into another form, typically machine code or bytecode, before it runs. See [The birth of languages](/learn/intro-software-dev/birth-of-languages/)
+
+**Paradigm** — A broad style of organising programs and thinking about problems, such as object-oriented or functional. See [Language families](/learn/intro-software-dev/language-families/)
+
+**Imperative** — A style where you write step-by-step instructions that change the program's state. See [Language families](/learn/intro-software-dev/language-families/)
+
+**Procedural** — An imperative style organised around procedures or functions that you call to do work. See [Language families](/learn/intro-software-dev/language-families/)
+
+**Object-oriented** — A style that bundles data and the behaviour that acts on it into objects. See [Language families](/learn/intro-software-dev/language-families/)
+
+**Functional** — A style that builds programs from functions and favours immutable data and avoiding side effects. See [Language families](/learn/intro-software-dev/language-families/)
+
+**Declarative** — A style where you describe *what* you want rather than the steps to compute it, as in a database query. See [Language families](/learn/intro-software-dev/language-families/)
+
+**Multi-paradigm** — A language that supports more than one paradigm, letting you mix styles as it suits the problem. See [Language families](/learn/intro-software-dev/language-families/)
+
+## How code runs
+
+**Compiled language** — A language whose programs are translated to machine code ahead of time, then run directly by the processor. See [Compiled vs interpreted](/learn/intro-software-dev/compiled-vs-interpreted/)
+
+**Interpreted language** — A language whose programs are read and executed on the fly by an interpreter, with no separate build step. See [Compiled vs interpreted](/learn/intro-software-dev/compiled-vs-interpreted/)
+
+**Bytecode** — A compact, portable intermediate form between source code and machine code, run by a virtual machine. See [Compiled vs interpreted](/learn/intro-software-dev/compiled-vs-interpreted/)
+
+**Virtual machine** — A software layer that executes bytecode, letting the same program run on different hardware. See [Compiled vs interpreted](/learn/intro-software-dev/compiled-vs-interpreted/)
+
+**JIT (just-in-time compilation)** — Compiling code to machine code while the program runs, combining the portability of bytecode with much of the speed of compiled code. See [Compiled vs interpreted](/learn/intro-software-dev/compiled-vs-interpreted/)
+
+**Ahead-of-time (AOT) compilation** — Compiling a program fully before it runs, so no compilation happens at run time. See [Compiled vs interpreted](/learn/intro-software-dev/compiled-vs-interpreted/)
+
+**Managed language** — A language that runs on a runtime which handles services like memory management and safety for you, rather than leaving them to the programmer. See [A tour of the languages](/learn/intro-software-dev/language-tour/)
+
+## Types and memory
+
+**Static typing** — Types are checked before the program runs, catching many mistakes at compile time. See [Type systems](/learn/intro-software-dev/type-systems/)
+
+**Dynamic typing** — Types are checked while the program runs, giving flexibility at the cost of later error detection. See [Type systems](/learn/intro-software-dev/type-systems/)
+
+**Strong vs weak typing** — How strictly a language stops you from mixing incompatible types; strong typing resists silent conversions, weak typing allows more of them. See [Type systems](/learn/intro-software-dev/type-systems/)
+
+**Type inference** — When the language works out a value's type for you, so you do not have to write it explicitly. See [Type systems](/learn/intro-software-dev/type-systems/)
+
+**Type safety** — The guarantee that operations only run on compatible types, preventing whole classes of bugs. See [Type systems](/learn/intro-software-dev/type-systems/)
+
+**Gradual typing** — Mixing static and dynamic typing in one program, adding type checks where they help and leaving them out elsewhere. See [Type systems](/learn/intro-software-dev/type-systems/)
+
+**Stack** — A region of memory used for short-lived data like function calls and local variables, managed automatically in last-in first-out order. See [Memory management](/learn/intro-software-dev/memory-management/)
+
+**Heap** — A region of memory for data whose size or lifetime is not known in advance, allocated and freed more flexibly than the stack. See [Memory management](/learn/intro-software-dev/memory-management/)
+
+**Pointer** — A value that holds the memory address of something else, letting code refer to data indirectly. See [Memory management](/learn/intro-software-dev/memory-management/)
+
+**Manual memory management** — When the programmer explicitly allocates and frees memory, with full control but more room for error. See [Memory management](/learn/intro-software-dev/memory-management/)
+
+**Garbage collection** — Automatic reclaiming of memory the program no longer uses, so the programmer does not free it by hand. See [Memory management](/learn/intro-software-dev/memory-management/)
+
+**Memory leak** — Memory that is allocated but never released, slowly consuming resources until the program slows or crashes. See [Memory management](/learn/intro-software-dev/memory-management/)
+
+**Ownership** — A model where each piece of data has a clear owner responsible for its lifetime, used to manage memory safely without a garbage collector. See [Memory management](/learn/intro-software-dev/memory-management/)
+
+**Borrow checker** — A compiler feature (notably in Rust) that enforces ownership and borrowing rules to prevent memory errors before the program runs. See [Memory management](/learn/intro-software-dev/memory-management/)
+
+## Concurrency
+
+**Concurrency** — Structuring a program so several tasks make progress in overlapping time periods, whether or not they truly run at the same instant. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+**Parallelism** — Actually running multiple tasks at the same time, typically on multiple processor cores. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+**Thread** — An independent path of execution within a program; multiple threads can run concurrently and share memory. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+**Async/await** — Language syntax for writing concurrent code that waits for slow operations without blocking, in a style that reads like ordinary sequential code. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+**Goroutine** — A lightweight, cheap unit of concurrent execution in Go, many of which can run at once. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+**Channel** — A typed conduit for passing values safely between concurrent tasks, coordinating them by communication rather than shared memory. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+**Actor model** — A concurrency approach where independent actors hold private state and interact only by sending messages. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+**Race condition** — A bug where the result depends on the unpredictable timing of concurrent tasks accessing shared data. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+**Deadlock** — A standstill where tasks each wait for a resource another holds, so none can ever proceed. See [Concurrency models](/learn/intro-software-dev/concurrency-models/)
+
+## Security
+
+**Memory safety** — A property that prevents bugs like accessing memory you should not, which are a major source of security vulnerabilities. See [Language security](/learn/intro-software-dev/language-security/)
+
+**Undefined behaviour** — Code whose result the language does not define, which may work by luck but can fail unpredictably or open security holes. See [Language security](/learn/intro-software-dev/language-security/)
+
+**Buffer overflow** — Writing past the end of a block of memory, corrupting nearby data and a classic route to security exploits. See [Language security](/learn/intro-software-dev/language-security/)
+
+**Dependency** — External code your program relies on, pulled in so you do not have to write it yourself. See [Language security](/learn/intro-software-dev/language-security/)
+
+**Supply chain** — The full set of tools, libraries, and dependencies that go into building your software, each of which can introduce risk. See [Language security](/learn/intro-software-dev/language-security/)
+
+**CVE (Common Vulnerabilities and Exposures)** — A publicly catalogued, uniquely identified security flaw in a piece of software. See [Language security](/learn/intro-software-dev/language-security/)
+
+**Sandboxing** — Running code in a restricted environment so it cannot harm the rest of the system even if it misbehaves. See [Language security](/learn/intro-software-dev/language-security/)
+
+## Principles of good code
+
+**Readability** — How easily a human can understand code; the primary thing clean code optimises for, since code is read far more than written. See [Writing readable code](/learn/intro-software-dev/clean-code/)
+
+**Naming** — Choosing clear, intention-revealing names for variables, functions, and types so code explains itself. See [Writing readable code](/learn/intro-software-dev/clean-code/)
+
+**Code smell** — A surface sign that something may be wrong with the design, hinting at a deeper problem worth a closer look. See [Writing readable code](/learn/intro-software-dev/clean-code/)
+
+**DRY (Don't Repeat Yourself)** — Avoid duplicating knowledge; keep each piece of logic in one place so changes happen once. See [DRY, KISS, and YAGNI](/learn/intro-software-dev/dry-kiss-yagni/)
+
+**KISS (Keep It Simple, Stupid)** — Prefer the simplest solution that works; complexity should be earned, not added by default. See [DRY, KISS, and YAGNI](/learn/intro-software-dev/dry-kiss-yagni/)
+
+**YAGNI (You Aren't Gonna Need It)** — Don't build features or flexibility on speculation; add them when a real need appears. See [DRY, KISS, and YAGNI](/learn/intro-software-dev/dry-kiss-yagni/)
+
+**Separation of concerns** — Splitting a system so each part handles one distinct responsibility, keeping concerns from tangling together. See [DRY, KISS, and YAGNI](/learn/intro-software-dev/dry-kiss-yagni/)
+
+**SOLID** — A set of five object-oriented design principles that together encourage flexible, maintainable code. See [SOLID](/learn/intro-software-dev/solid/)
+
+**Single responsibility** — The idea that a unit of code should have one reason to change, that is, one clear job. See [SOLID](/learn/intro-software-dev/solid/)
+
+**Open/closed** — Code should be open to extension but closed to modification, so you add behaviour without rewriting what works. See [SOLID](/learn/intro-software-dev/solid/)
+
+**Liskov substitution** — A subtype should be usable anywhere its base type is expected, without breaking the program. See [SOLID](/learn/intro-software-dev/solid/)
+
+**Interface segregation** — Prefer several small, focused interfaces over one large one, so users depend only on what they need. See [SOLID](/learn/intro-software-dev/solid/)
+
+**Dependency inversion** — Depend on abstractions rather than concrete details, so high-level code is not tied to low-level specifics. See [SOLID](/learn/intro-software-dev/solid/)
+
+**Dependency injection** — Supplying a component's dependencies from outside rather than having it create them, making code easier to test and swap. See [SOLID](/learn/intro-software-dev/solid/)
+
+**Abstraction** — Hiding details behind a simpler interface so you can use something without knowing how it works inside. See [Abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/)
+
+**Encapsulation** — Bundling data with the code that uses it and hiding the internals, so outside code interacts only through a defined surface. See [Abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/)
+
+**Interface** — The agreed surface through which one piece of code talks to another, independent of the implementation behind it. See [Abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/)
+
+**Coupling** — How dependent two parts of a system are on each other; loose coupling makes change safer and easier. See [Abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/)
+
+**Cohesion** — How well the parts of a single unit belong together; high cohesion means a component does one thing well. See [Abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/)
+
+**Leaky abstraction** — An abstraction that forces you to understand the details it was meant to hide. See [Abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/)
+
+## Robustness and errors
+
+**Error handling** — How a program detects, reports, and recovers from things going wrong. See [Robustness and errors](/learn/intro-software-dev/robustness-and-errors/)
+
+**Exception** — A signal that an error occurred, which interrupts normal flow so it can be caught and handled elsewhere. See [Robustness and errors](/learn/intro-software-dev/robustness-and-errors/)
+
+**Edge case** — An unusual or extreme input or situation at the boundary of what code expects, where bugs often hide. See [Robustness and errors](/learn/intro-software-dev/robustness-and-errors/)
+
+**Defensive programming** — Writing code that anticipates bad input and misuse, checking assumptions rather than trusting them. See [Robustness and errors](/learn/intro-software-dev/robustness-and-errors/)
+
+**Fail fast** — Detecting problems and stopping immediately, rather than continuing in a broken state that is harder to diagnose. See [Robustness and errors](/learn/intro-software-dev/robustness-and-errors/)
+
+**Graceful degradation** — Continuing to provide reduced but useful service when part of a system fails, instead of collapsing entirely. See [Robustness and errors](/learn/intro-software-dev/robustness-and-errors/)
+
+**Idempotency** — A property where doing an operation more than once has the same effect as doing it once, which makes retries safe. See [Robustness and errors](/learn/intro-software-dev/robustness-and-errors/)
+
+## Design patterns
+
+**Design pattern** — A reusable, named solution to a problem that recurs in software design. See [What are design patterns?](/learn/intro-software-dev/what-are-patterns/)
+
+**Anti-pattern** — A common response to a problem that looks helpful but causes more harm than good. See [What are design patterns?](/learn/intro-software-dev/what-are-patterns/)
+
+**Gang of Four** — The four authors of the influential 1994 book that catalogued the classic object-oriented design patterns. See [What are design patterns?](/learn/intro-software-dev/what-are-patterns/)
+
+**Boilerplate** — Repetitive setup code you must write that carries little unique meaning of its own. See [What are design patterns?](/learn/intro-software-dev/what-are-patterns/)
+
+**Factory** — A creational pattern that creates objects through a dedicated method, hiding which concrete type is built. See [Creational patterns](/learn/intro-software-dev/creational-patterns/)
+
+**Builder** — A creational pattern that constructs a complex object step by step, separating how it is built from what it becomes. See [Creational patterns](/learn/intro-software-dev/creational-patterns/)
+
+**Singleton** — A creational pattern that ensures a class has only one instance and provides a single point of access to it. See [Creational patterns](/learn/intro-software-dev/creational-patterns/)
+
+**Adapter** — A structural pattern that wraps one interface so it looks like another, letting incompatible parts work together. See [Structural patterns](/learn/intro-software-dev/structural-patterns/)
+
+**Facade** — A structural pattern that puts a simple front over a complex subsystem, giving callers an easier way in. See [Structural patterns](/learn/intro-software-dev/structural-patterns/)
+
+**Decorator** — A structural pattern that adds behaviour to an object by wrapping it, without changing the original. See [Structural patterns](/learn/intro-software-dev/structural-patterns/)
+
+**Observer** — A behavioural pattern where objects subscribe to another object and are notified automatically when it changes. See [Behavioural patterns](/learn/intro-software-dev/behavioral-patterns/)
+
+**Strategy** — A behavioural pattern that lets you swap interchangeable algorithms behind a common interface at run time. See [Behavioural patterns](/learn/intro-software-dev/behavioral-patterns/)
+
+**State pattern** — A behavioural pattern where an object changes its behaviour as its internal state changes, as if changing class. See [Behavioural patterns](/learn/intro-software-dev/behavioral-patterns/)
+
+**Publish/subscribe** — A messaging pattern where publishers send events without knowing who, if anyone, is listening, and subscribers receive the events they care about. See [Behavioural patterns](/learn/intro-software-dev/behavioral-patterns/)
+
+## Concurrency and architecture patterns
+
+**Pipeline** — A design where data flows through a series of stages, each doing one step of the processing. See [Concurrency and pipelines](/learn/intro-software-dev/concurrency-and-pipelines/)
+
+**Producer/consumer** — A pattern where producers create work items and consumers process them, usually buffered by a queue between them. See [Concurrency and pipelines](/learn/intro-software-dev/concurrency-and-pipelines/)
+
+**Backpressure** — A mechanism that lets a slow consumer signal a fast producer to slow down, preventing work from piling up uncontrollably. See [Concurrency and pipelines](/learn/intro-software-dev/concurrency-and-pipelines/)
+
+**Message queue** — A buffer that holds messages between parts of a system so senders and receivers do not have to act at the same moment. See [Concurrency and pipelines](/learn/intro-software-dev/concurrency-and-pipelines/)
+
+**Layered architecture** — Organising a system into stacked layers (such as presentation, logic, data) where each layer talks mainly to the one below. See [Architectural patterns](/learn/intro-software-dev/architectural-patterns/)
+
+**Event-driven** — An architecture where components react to events as they happen rather than being called in a fixed sequence. See [Architectural patterns](/learn/intro-software-dev/architectural-patterns/)
+
+**Plugin architecture** — A design where a core program can be extended by add-on modules without changing the core itself. See [Architectural patterns](/learn/intro-software-dev/architectural-patterns/)
+
+**MVC (Model-View-Controller)** — A pattern that separates data (model), presentation (view), and input handling (controller) so each can change independently. See [Architectural patterns](/learn/intro-software-dev/architectural-patterns/)
+
+**Monolith** — An application built and deployed as a single unit, with all its parts in one codebase. See [Architectural patterns](/learn/intro-software-dev/architectural-patterns/)
+
+**Microservices** — An architecture that splits an application into small, independently deployable services that communicate over a network. See [Architectural patterns](/learn/intro-software-dev/architectural-patterns/)
+
+## Process, methodology and delivery
+
+**SDLC (software development life cycle)** — The overall sequence of stages a project moves through, from idea and requirements to delivery and maintenance. See [The SDLC and methodologies](/learn/intro-software-dev/sdlc-and-methodologies/)
+
+**Waterfall** — A sequential approach where each phase is completed before the next begins, with little going back. See [The SDLC and methodologies](/learn/intro-software-dev/sdlc-and-methodologies/)
+
+**Agile** — A flexible approach that delivers software in small increments and adapts to change instead of following a fixed plan. See [The SDLC and methodologies](/learn/intro-software-dev/sdlc-and-methodologies/)
+
+**Scrum** — A popular Agile framework that organises work into fixed-length sprints with defined roles and ceremonies. See [The SDLC and methodologies](/learn/intro-software-dev/sdlc-and-methodologies/)
+
+**Kanban** — An Agile method that visualises work on a board and limits how much is in progress at once to keep flow steady. See [The SDLC and methodologies](/learn/intro-software-dev/sdlc-and-methodologies/)
+
+**Sprint** — A short, fixed time box (often one to four weeks) in which a Scrum team completes a planned chunk of work. See [The SDLC and methodologies](/learn/intro-software-dev/sdlc-and-methodologies/)
+
+**MVP (minimum viable product)** — The smallest version of a product that delivers real value and can be learned from. See [The SDLC and methodologies](/learn/intro-software-dev/sdlc-and-methodologies/)
+
+**Version control** — A system that records changes to code over time, letting you review history, recover old states, and collaborate safely. See [Version control and collaboration](/learn/intro-software-dev/version-control-collab/)
+
+**Repository** — The store of a project's files together with their full change history under version control. See [Version control and collaboration](/learn/intro-software-dev/version-control-collab/)
+
+**Commit** — A saved snapshot of changes in version control, with a message describing what changed and why. See [Version control and collaboration](/learn/intro-software-dev/version-control-collab/)
+
+**Branch** — A separate line of development where you can work without affecting the main version until you are ready. See [Version control and collaboration](/learn/intro-software-dev/version-control-collab/)
+
+**Merge** — Combining the changes from one branch into another. See [Version control and collaboration](/learn/intro-software-dev/version-control-collab/)
+
+**Pull request** — A proposal to merge your changes, opened so others can review and discuss them first. See [Version control and collaboration](/learn/intro-software-dev/version-control-collab/)
+
+**Code review** — Having another developer read proposed changes to catch problems and share knowledge before they merge. See [Version control and collaboration](/learn/intro-software-dev/version-control-collab/)
+
+## Testing
+
+**Unit test** — An automated test that checks one small piece of code in isolation. See [Testing](/learn/intro-software-dev/testing/)
+
+**Integration test** — A test that checks that several parts work correctly together. See [Testing](/learn/intro-software-dev/testing/)
+
+**End-to-end test** — A test that exercises the whole system the way a real user would, from start to finish. See [Testing](/learn/intro-software-dev/testing/)
+
+**Regression test** — A test that guards against a previously fixed bug coming back. See [Testing](/learn/intro-software-dev/testing/)
+
+**TDD (test-driven development)** — A practice of writing a failing test first, then writing just enough code to make it pass. See [Testing](/learn/intro-software-dev/testing/)
+
+**Mock** — A stand-in for a real dependency in a test, used to isolate the code under test and control its surroundings. See [Testing](/learn/intro-software-dev/testing/)
+
+**Code coverage** — A measure of how much of your code your tests actually exercise. See [Testing](/learn/intro-software-dev/testing/)
+
+**Golden file** — A saved reference output that a test compares against to catch unintended changes. See [Testing](/learn/intro-software-dev/testing/)
+
+## Build and delivery
+
+**Build system** — Tooling that turns source code into a runnable program, handling compilation and assembly steps. See [Builds and CI/CD](/learn/intro-software-dev/build-and-ci-cd/)
+
+**Dependency management** — Declaring, fetching, and tracking the external libraries a project relies on, including their versions. See [Builds and CI/CD](/learn/intro-software-dev/build-and-ci-cd/)
+
+**Continuous integration (CI)** — Automatically building and testing every change as it is merged, so problems surface early. See [Builds and CI/CD](/learn/intro-software-dev/build-and-ci-cd/)
+
+**Continuous delivery (CD)** — Automating the steps to release software so a tested change can be shipped quickly and reliably. See [Builds and CI/CD](/learn/intro-software-dev/build-and-ci-cd/)
+
+**Artifact** — A built output of the process, such as a binary or package, that can be stored and deployed. See [Builds and CI/CD](/learn/intro-software-dev/build-and-ci-cd/)
+
+**Cross-compilation** — Building a program on one type of machine to run on a different type, such as compiling on a laptop for a small device. See [Builds and CI/CD](/learn/intro-software-dev/build-and-ci-cd/)
+
+## Documentation and maintenance
+
+**Documentation** — Written explanation of how software works and how to use it, for users and future maintainers. See [Documentation and maintenance](/learn/intro-software-dev/docs-and-maintenance/)
+
+**Refactoring** — Improving the internal structure of code without changing what it does, to keep it clean as it grows. See [Documentation and maintenance](/learn/intro-software-dev/docs-and-maintenance/)
+
+**Technical debt** — The future cost of taking shortcuts now; like financial debt, it accrues interest until you pay it down. See [Documentation and maintenance](/learn/intro-software-dev/docs-and-maintenance/)
+
+**Deprecation** — Marking a feature as outdated and discouraged, signalling it will be removed so users can move off it. See [Documentation and maintenance](/learn/intro-software-dev/docs-and-maintenance/)
+
+**Bus factor** — The number of people who would have to be lost before a project stalls; a bus factor of one is a warning sign. See [Documentation and maintenance](/learn/intro-software-dev/docs-and-maintenance/)
+
+## Choosing a language
+
+**Lock-in** — Becoming so tied to a particular technology that moving away from it is costly or impractical. See [Why language choice matters](/learn/intro-software-dev/why-language-choice-matters/)
+
+**Switching cost** — The effort, time, and risk involved in moving from one technology to another. See [Why language choice matters](/learn/intro-software-dev/why-language-choice-matters/)
+
+**Ecosystem** — The libraries, tools, and community around a language that make it more or less productive in practice. See [Why language choice matters](/learn/intro-software-dev/why-language-choice-matters/)
+
+**Requirements** — What a system must actually do and the conditions it must meet, gathered before deciding how to build it. See [Starting from requirements](/learn/intro-software-dev/from-requirements/)
+
+**Constraint** — A fixed limit the solution must respect, such as a deadline, budget, platform, or performance target. See [Starting from requirements](/learn/intro-software-dev/from-requirements/)
+
+**Real-time** — A requirement that a system respond within strict, guaranteed time limits, where being late is itself a failure. See [Starting from requirements](/learn/intro-software-dev/from-requirements/)
+
+**Performance** — How fast and efficiently a program runs with the resources it has. See [Performance vs productivity](/learn/intro-software-dev/performance-vs-productivity/)
+
+**Productivity** — How quickly and easily developers can build and change software, often traded off against raw performance. See [Performance vs productivity](/learn/intro-software-dev/performance-vs-productivity/)
+
+**Premature optimization** — Tuning for speed before you know it matters, adding complexity that often is not needed. See [Performance vs productivity](/learn/intro-software-dev/performance-vs-productivity/)
+
+**Native library** — Precompiled code, often written in a lower-level language, that a program calls for speed or to reach system features. See [Performance vs productivity](/learn/intro-software-dev/performance-vs-productivity/)
+
+**Domain** — The particular problem area or field a piece of software serves, which shapes what tools fit best. See [Choosing a language for the domain](/learn/intro-software-dev/language-for-the-domain/)
+
+**Systems programming** — Writing low-level software like operating systems, drivers, and runtimes, where control and performance matter most. See [Choosing a language for the domain](/learn/intro-software-dev/language-for-the-domain/)
+
+**Embedded** — Software that runs on small, resource-limited devices dedicated to a specific job rather than general computing. See [Choosing a language for the domain](/learn/intro-software-dev/language-for-the-domain/)
+
+**Scripting** — Writing short, often interpreted programs to automate tasks or glue other tools together. See [Choosing a language for the domain](/learn/intro-software-dev/language-for-the-domain/)
+
+**Decision framework** — A structured way to weigh options against your needs so a choice is reasoned rather than arbitrary. See [A decision framework](/learn/intro-software-dev/decision-framework/)
+
+**Prototype** — A quick, throwaway or rough build made to test an idea or reduce uncertainty before committing to it. See [A decision framework](/learn/intro-software-dev/decision-framework/)
+
+**Trade-off** — A choice where gaining one quality means giving up another, such as speed versus simplicity. See [A decision framework](/learn/intro-software-dev/decision-framework/)
+
+## Going solo and shipping
+
+**Solo developer** — Someone who builds and maintains software largely on their own, wearing every role at once. See [The solo developer mindset](/learn/intro-software-dev/solo-developer-mindset/)
+
+**Tech stack** — The combined set of languages, frameworks, and tools chosen to build a project. See [Choosing your stack](/learn/intro-software-dev/choosing-your-stack/)
+
+**Framework** — A reusable foundation that provides structure and calls your code, shaping how an application is built. See [Choosing your stack](/learn/intro-software-dev/choosing-your-stack/)
+
+**Library** — A collection of reusable code you call from your own program to avoid reinventing common functionality. See [Choosing your stack](/learn/intro-software-dev/choosing-your-stack/)
+
+**IDE (integrated development environment)** — An editor bundled with tools like building, debugging, and code navigation in one place. See [The development environment workflow](/learn/intro-software-dev/dev-environment-workflow/)
+
+**Linter** — A tool that scans code for likely mistakes and style problems without running it. See [The development environment workflow](/learn/intro-software-dev/dev-environment-workflow/)
+
+**Formatter** — A tool that automatically rewrites code into a consistent style, ending arguments over layout. See [The development environment workflow](/learn/intro-software-dev/dev-environment-workflow/)
+
+**Dotfiles** — Personal configuration files for your tools and shell, often kept in version control to reproduce your setup. See [The development environment workflow](/learn/intro-software-dev/dev-environment-workflow/)
+
+**Devcontainer** — A defined, containerised development environment so everyone (including future you) works with the same setup. See [The development environment workflow](/learn/intro-software-dev/dev-environment-workflow/)
+
+**Build-test loop** — The fast cycle of changing code, building it, and running tests that drives day-to-day development. See [The development environment workflow](/learn/intro-software-dev/dev-environment-workflow/)
+
+**Scope creep** — The gradual, unplanned growth of what a project is meant to do, which threatens deadlines and focus. See [Scoping a project](/learn/intro-software-dev/scoping-a-project/)
+
+**Milestone** — A meaningful checkpoint in a project marking that a defined chunk of work is complete. See [Scoping a project](/learn/intro-software-dev/scoping-a-project/)
+
+**Specification** — A clear written statement of what is to be built and how it should behave. See [Scoping a project](/learn/intro-software-dev/scoping-a-project/)
+
+**Pre-commit hook** — An automated check that runs before a commit is recorded, blocking obvious problems early. See [Quality when you are solo](/learn/intro-software-dev/quality-when-solo/)
+
+**Guardrail** — An automated check or constraint that keeps you from making certain mistakes, even when no one is reviewing. See [Quality when you are solo](/learn/intro-software-dev/quality-when-solo/)
+
+## Packaging and distribution
+
+**Binary** — A compiled, runnable file produced from source code, ready to execute on a target machine. See [Packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/)
+
+**Semantic versioning** — A version-numbering scheme (major.minor.patch) that signals the nature of each change to users. See [Packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/)
+
+**Release** — A specific, packaged version of software made available for people to use. See [Packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/)
+
+**Package manager** — A tool that installs, updates, and manages software and its dependencies for you. See [Packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/)
+
+**Code signing** — Cryptographically marking software so users can verify who produced it and that it has not been tampered with. See [Packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/)
+
+**Checksum** — A short value computed from a file that lets you verify the file downloaded intact and unaltered. See [Packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/)
+
+**Release notes** — A summary of what changed in a release, telling users what is new, fixed, or removed. See [Shipping and maintaining](/learn/intro-software-dev/shipping-and-maintaining/)
+
+**Maintenance** — The ongoing work of keeping released software working: fixing bugs, updating dependencies, and adapting to change. See [Shipping and maintaining](/learn/intro-software-dev/shipping-and-maintaining/)

--- a/docs/learn/intro-software-dev/index.md
+++ b/docs/learn/intro-software-dev/index.md
@@ -1,0 +1,31 @@
+---
+layout: learn-hub
+learn_path: intro-software-dev
+permalink: /learn/intro-software-dev/
+title: Intro to Software Development — from punch cards to your own solo stack
+description: A free, structured learning path covering software development from the ground up — its history, modern programming languages and their trade-offs, design principles and patterns, how teams ship, how to choose the right language, and how to build and distribute your own software solo.
+keywords: learn software development, programming for beginners, history of programming, programming languages compared, software design patterns, SOLID principles, choosing a programming language, solo developer, software distribution
+---
+
+"Software development" sounds like a single skill, but it's really a stack of
+them — a bit of history, a working model of how languages differ, a handful of
+durable principles and patterns, the systems teams use to ship, and the judgement
+to pick the right tool for a job. This path builds that stack one short lesson at
+a time, starting from absolute zero and ending with you shipping your own program.
+
+**Who this is for.** Complete newcomers are welcome — no prior coding required.
+If you already write code, use the module list to jump to the parts you're missing:
+language internals, design patterns, choosing a language, or going solo. Every
+lesson is self-contained and cross-linked, so you can read straight through or
+hop around.
+
+**How the path works.** Seven modules move from *story* to *practice*. We open
+with how computing got here — the hardware, the languages, and the people. Then
+we dig into what actually separates modern languages, the principles and patterns
+that keep code alive, and the systems teams use to ship. Module 6 is a complete
+toolkit for choosing the right language for a project, and Module 7 walks you
+through assembling your own solo development stack, workflow, and distribution
+strategy. Examples lean gently on real-time and radio software — the streaming,
+signal-crunching kind of code behind **GopherTrunk** — so abstract ideas stay
+concrete. Mark lessons complete as you go; your progress is saved in your
+browser. New here? **[Start with lesson 1: What is software?](what-is-software/)**

--- a/docs/learn/intro-software-dev/internet-to-edge.md
+++ b/docs/learn/intro-software-dev/internet-to-edge.md
@@ -1,0 +1,97 @@
+---
+slug: internet-to-edge
+title: PCs, the internet & the age of cheap compute
+description: From mainframes to minicomputers, PCs, the web, cloud, mobile, and edge — how cheap, abundant compute and open source made software-defined radio practical.
+keywords: history of computing, mainframe, minicomputer, personal computer, client server, the web, cloud computing, edge computing, open source, software-defined radio
+level: beginner
+status: full
+faq:
+  - q: "What is the difference between cloud and edge computing?"
+    a: "**Cloud computing** runs your software in large, remote data centers you rent over the internet, scaling up on demand. **Edge computing** pushes work back out to small devices near where the data is — sensors, phones, an SDR plugged into a laptop. They're complementary: the edge handles real-time, local work, and the cloud handles heavy storage and large-scale processing."
+  - q: "How did cheap computing make software-defined radio possible?"
+    a: "Software radio needs an ordinary computer fast enough to process a stream of radio samples in real time. Decades of falling chip prices put that much power in any laptop, while cheap analog-to-digital hardware digitizes the signal. Add free, open-source DSP libraries and a thirty-dollar dongle, and a setup that once needed specialized lab gear now runs on a personal machine."
+  - q: "Why does open source matter for software development?"
+    a: "**Open source** means software whose code is published for anyone to read, use, and improve. It lets developers build on shared, peer-reviewed foundations instead of reinventing everything, which dramatically speeds up progress. Whole fields — including software-defined radio — exist as practical hobbies today largely because their core libraries are free and open."
+---
+# PCs, the internet & the age of cheap compute
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Compute spread outward** — from shared mainframes to personal PCs to phones to tiny edge devices. **The network changed everything** — client/server, the web, and the cloud connected those machines. **Cheap compute plus open source** — made software-defined radio a laptop hobby instead of lab work.
+</div>
+
+In the last lesson we met the people who built programming in labs and on mainframes. This final lesson of the module follows what happened when computing left the lab — getting smaller, cheaper, and more connected until it reached everyone, everywhere. That same arc is the reason you can do real radio work on a personal laptop today, so it's a fitting bridge from history into the practical modules ahead. It builds on [the pioneers](/learn/intro-software-dev/the-pioneers/) and the whole hardware story before it.
+
+## Mainframes: computing as a shared resource
+
+The first commercial computers were **mainframes** — room-sized, hugely expensive machines that an entire organization shared. A company or university might own one, and everyone's jobs queued up to run on it. You didn't sit at a computer; you submitted work to *the* computer and waited.
+
+This shaped early software culture: computing time was precious and rationed, programs were submitted on punch cards or terminals, and access was a privilege. The mainframe model — many users, one powerful central machine — is worth remembering, because computing keeps swinging between centralized and personal, and we'll see that pendulum return.
+
+## Minicomputers: smaller, closer, cheaper
+
+By the 1960s and 70s, the **minicomputer** shrank that model. Still not personal, but small and cheap enough that a single department or lab could own one outright rather than sharing a corporate mainframe. Machines like Digital Equipment Corporation's PDP series put real computing within reach of researchers and engineers — and, not coincidentally, it was on this class of machine that Unix and C were born. Minicomputers were the proving ground where the falling cost of hardware first started to democratize who could compute.
+
+## The personal computer
+
+The microprocessor — a whole CPU on one chip, from [the hardware lesson](/learn/intro-software-dev/computing-hardware-story/) — made the next leap possible: the **personal computer**. Through the late 1970s and 1980s, machines small and affordable enough for one person arrived on desks at home and at work. Computing stopped being something you shared and became something you *owned*.
+
+This was a genuine inversion of the mainframe model. Instead of many people queuing for one big machine, each person had their own. An entire software industry sprang up to fill those machines with applications, and for the first time ordinary people — not just trained operators — wrote and ran their own programs.
+
+## Networks: client/server and the web
+
+Personal machines were powerful, but isolated. The next era connected them.
+
+- **Client/server.** Networks let a personal machine (the **client**) request services from a more powerful shared machine (the **server**) — files, databases, email. This recombined the personal and the central: your own computer in front of you, talking to shared resources over a network.
+- **The web.** In 1989, **Tim Berners-Lee** proposed the **World Wide Web** — a system of linked documents accessed over the internet through a browser. It turned the internet from a specialist tool into something anyone could use, and unleashed an explosion of connected software.
+
+The web mattered enormously for software because it made *distribution* trivial. You no longer shipped programs on disks; you served them over the network, instantly, worldwide. That shift sets up everything in the later [packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/) lesson.
+
+## Cloud, mobile, and the edge
+
+The last three waves came quickly and overlap today:
+
+| Era | What it is | The shift |
+|-----|-----------|-----------|
+| **Cloud** | Renting computing in vast remote data centers, on demand | Back to centralized — but infinitely scalable and pay-as-you-go |
+| **Mobile** | Powerful computers in everyone's pocket | A capable computer with every person, all the time |
+| **Edge / embedded** | Small, cheap chips doing real work near the data source | Compute pushed back out to the physical world |
+
+Notice the pendulum: the **cloud** swung back toward the centralized, shared model of the mainframe — only now the "mainframe" is a global data center you rent by the minute. **Mobile** put a capable computer in every pocket. And **edge computing** pushed processing back out to tiny, cheap chips embedded in sensors, appliances, cars — and radios. After decades of swinging between central and personal, today we have *all of it at once*: data centers, laptops, phones, and a flood of small embedded devices, all networked together.
+
+## Open source: software as a shared commons
+
+One force runs through all of this: **open source**. Open-source software publishes its code for anyone to read, use, and improve, usually for free. Instead of every team rebuilding the same foundations in secret, the community shares peer-reviewed building blocks that everyone can stand on.
+
+The impact is hard to overstate. **Linux** (open source) runs most of the world's servers and underlies Android. Countless libraries that developers rely on every day are open source. Progress compounds because you start from everyone else's best work rather than from scratch. Open source turned software into a shared commons, and that commons is exactly what makes the next point possible.
+
+## How cheap compute made the radio software
+
+Pull the threads together and you arrive back at GopherTrunk's world. Three trends converged:
+
+1. **Cheap, abundant compute.** Decades of Moore's Law mean any ordinary laptop has the raw power to process a stream of radio samples in real time — something that once required specialized digital signal processing hardware.
+2. **Cheap digitizing hardware.** Inexpensive analog-to-digital devices — like a thirty-dollar USB dongle — turn the airwaves into the stream of numbers that software then works on.
+3. **Open-source DSP libraries.** Free, community-built signal-processing software does the heavy mathematical lifting, so you don't have to write filters and demodulators from scratch.
+
+Put those together and **software-defined radio** stops being a lab discipline and becomes a laptop hobby. The receiver that once meant a rack of dedicated equipment is now mostly *software*, running on the same personal computer you use for everything else, built on open libraries anyone can download. It is the exact endpoint of this whole module: cheap compute, networks, and open source democratized not just computing in general, but radio specifically. If you want to chase that thread further, the [RF & SDR path](/learn/rf-sdr/) picks it up from the radio side.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — cloud is centralized rented data centers; edge pushes compute out to small devices near the data." markdown="0">
+  <p class="knowledge-check__q">Quick check: What best describes the difference between cloud and edge computing?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Cloud runs on your phone; edge runs in remote data centers</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Cloud is centralized rented data centers; edge pushes compute out to small devices near the data</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">They are two names for the exact same thing</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Mainframes** — computing began as a costly central resource everyone shared and queued for.
+- **Minicomputers and PCs** — falling hardware costs moved computing first to departments, then to individual desks.
+- **Networks** — client/server and the web connected those personal machines and made software distribution instant and worldwide.
+- **Cloud, mobile, edge** — the pendulum swung back to centralized data centers while also putting compute in every pocket and tiny device.
+- **Open source** — a shared, peer-reviewed software commons let progress compound instead of restarting from scratch.
+- **The payoff** — cheap compute plus cheap digitizers plus open DSP libraries turned software-defined radio into something you run on a laptop.
+
+Next up: this module told the story; the next one digs into the tools. We start by mapping how programming languages group into families with shared traits in [Language families](/learn/intro-software-dev/language-families/).

--- a/docs/learn/intro-software-dev/language-families.md
+++ b/docs/learn/intro-software-dev/language-families.md
@@ -1,0 +1,200 @@
+---
+slug: language-families
+title: Paradigms & language families
+description: Imperative, object-oriented, functional and declarative paradigms explained — why most real languages mix them, and how dataflow thinking maps onto signal pipelines.
+keywords: programming paradigms, imperative programming, object-oriented programming, functional programming, declarative programming, multi-paradigm languages, pure functions, mutable state
+level: beginner
+status: full
+faq:
+  - q: "What is a programming paradigm?"
+    a: "A **paradigm** is a style of organising code and reasoning about computation — for example *imperative* (step-by-step instructions), *object-oriented* (bundles of state and behaviour), *functional* (composing pure transformations), or *declarative* (describe the result, let the system find the steps)."
+  - q: "Are most modern languages object-oriented or functional?"
+    a: "Most are **multi-paradigm**. Python, Rust, JavaScript and even Go let you write procedural, object-style and functional code in the same file. The paradigm is a way *you* choose to think, more than a rule the language forces."
+  - q: "Why does functional style suit signal processing?"
+    a: "Signal processing is mostly **data flowing through transformations** — filter, mix, decimate, demodulate. That is exactly what functional composition models: pure functions chained into a pipeline, each output feeding the next, with no hidden shared state to corrupt the stream."
+---
+# Paradigms & language families
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Paradigms** — styles for organising code, not rival tribes. **Multi-paradigm** — real languages blend several at once. **Pure vs mutable** — controlling state is the deep dividing line.
+</div>
+
+When people argue about programming languages, they are usually arguing about
+**paradigms** — the underlying styles for structuring code and reasoning about
+what a program *does*. A paradigm is not a feature you switch on; it is a mental
+model. Understanding the handful of major paradigms gives you a map: you can look
+at any unfamiliar language and recognise the shapes inside it, instead of
+memorising a thousand unrelated rules. This lesson lays out that map, then shows
+why almost every language you will actually use mixes paradigms freely.
+
+## Imperative and procedural
+
+The **imperative** paradigm is the oldest and most direct: you tell the computer
+*how* to do something as an ordered sequence of statements that change state.
+Assign a value, loop, increment a counter, branch on a condition. It mirrors how
+the hardware really works, which is why it feels natural and why early languages
+were imperative.
+
+**Procedural** programming is imperative code organised into reusable
+*procedures* (functions). Instead of one long script, you factor work into named
+routines that call each other. C is the classic procedural language.
+
+```c
+int sum_to(int n) {
+    int total = 0;
+    for (int i = 1; i <= n; i++) {
+        total += i;      // mutate state step by step
+    }
+    return total;
+}
+```
+
+The defining trait here is **mutable state**: variables change over time, and the
+order of statements matters. That power is also the risk — bugs often come from
+state changing when or where you did not expect.
+
+## Object-oriented
+
+**Object-oriented programming (OOP)** bundles state and the behaviour that acts
+on it into **objects**. An object has *fields* (data) and *methods* (functions
+that operate on that data). The big ideas are:
+
+- **Encapsulation** — hide internal data behind a clean interface.
+- **Inheritance** — derive specialised types from general ones.
+- **Polymorphism** — treat different types uniformly through a shared interface.
+
+OOP shines when a problem decomposes naturally into "things" with identity and
+lifecycle — a `User`, a `Connection`, a `Receiver` tuned to a frequency. Java,
+C#, Ruby and Python all support it strongly. Critics note that overusing
+inheritance creates rigid, tangled hierarchies, which is why modern OOP leans on
+**composition** ("has-a") over deep inheritance ("is-a").
+
+## Functional
+
+**Functional programming (FP)** treats computation as the evaluation of
+functions, ideally **pure** ones. A pure function:
+
+- always returns the same output for the same input, and
+- has **no side effects** — it does not mutate shared state, write files, or
+  print.
+
+Pure functions are easy to test, reason about, and run in parallel, because they
+cannot interfere with each other. FP favours **immutable data**, **higher-order
+functions** (functions that take or return functions), and composing small
+transformations into pipelines. Haskell is purely functional; Elixir, Clojure and
+Scala lean functional; and most mainstream languages now offer `map`, `filter`
+and `reduce`.
+
+```python
+# Pure pipeline: each step transforms, nothing is mutated
+samples = [0.1, -0.4, 0.9, -0.2]
+scaled  = map(lambda x: x * 2, samples)
+loud    = filter(lambda x: abs(x) > 1.0, scaled)
+```
+
+The contrast with imperative code is the **mutable state vs pure functions**
+axis. Imperative code says "change this variable, then that one." Functional code
+says "produce a new value from old values." Most subtle bugs live in shared
+mutable state, so reducing it is a recurring theme across modern language design.
+
+## Declarative (including logic and SQL)
+
+**Declarative** programming flips the question from *how* to *what*: you describe
+the result you want and let the system figure out the steps. FP is one declarative
+family, but the term covers more:
+
+- **SQL** — you declare *what* rows you want; the database engine plans *how* to
+  fetch them. `SELECT name FROM stations WHERE freq > 144000000` never tells the
+  engine which index to scan.
+- **Logic programming** (Prolog) — you state facts and rules, then pose queries;
+  the engine searches for solutions that satisfy them.
+- **Markup and config** (HTML, CSS, Terraform) — you declare a desired structure
+  or end-state, not a procedure.
+
+Declarative code is often shorter and harder to get subtly wrong, at the cost of
+giving up fine control over execution.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a pure function has no side effects and always returns the same output for the same input." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes a function "pure" in functional programming?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It is written in a functional-only language like Haskell</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It has no side effects and gives the same output for the same input</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It runs faster than an equivalent loop</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Real languages are multi-paradigm
+
+Here is the practical punchline: **the paradigms above are not separate
+languages**. Almost every language you will meet is **multi-paradigm**, and the
+"paradigm" is a style *you* choose for a given piece of code.
+
+| Language | Procedural | OOP | Functional | Declarative-ish |
+|----------|:---------:|:---:|:----------:|:---------------:|
+| Python   | yes | yes | yes (map/comprehensions) | partial |
+| Rust     | yes | traits/structs | strong (iterators, closures) | macros |
+| Go       | yes | structs + interfaces | limited | no |
+| JavaScript | yes | prototypes/classes | strong | JSX/templating |
+
+**Python** lets you write a quick procedural script, define classes, or chain
+functional comprehensions. **Rust** combines struct-and-trait OOP-style code with
+genuinely functional iterators and a strong emphasis on immutability by default.
+**Go** is mostly procedural with lightweight interfaces and deliberately omits
+much functional machinery, favouring simplicity. Knowing the paradigms lets you
+read each language for what it offers rather than forcing it into one box.
+
+## Choosing a paradigm for the job
+
+Because most languages let you mix styles, the practical skill is matching a
+paradigm to a problem rather than picking a "favourite". A few rules of thumb:
+
+- **Reach for imperative/procedural** when you are close to the hardware or in a
+  tight performance loop — the step-by-step model maps directly onto what the CPU
+  does, and you want exact control over each operation.
+- **Reach for object-oriented** when the domain is full of long-lived "things" with
+  identity and lifecycle — a connection, a session, a tuned receiver — and you want
+  to hide their internals behind clean interfaces.
+- **Reach for functional** when you are transforming data and want each step to be
+  independently testable, easy to reason about, and safe to run in parallel. Pure
+  functions shine wherever shared mutable state would otherwise cause subtle bugs.
+- **Reach for declarative** when *what* you want is clearer than *how* to get it —
+  querying data (SQL), describing infrastructure, or expressing rules.
+
+The mark of an experienced developer is comfort moving between these within one
+codebase: a procedural inner loop, wrapped in an object that owns a resource,
+assembled from functional transformations, configured declaratively. None of these
+is wrong; each is a tool, and the paradigms are the labels on the toolbox.
+
+## Why this matters for signal pipelines
+
+In radio software like **GopherTrunk**, raw samples arrive as a continuous stream
+of [IQ data](/learn/rf-sdr/iq-data/) and pass through stage after stage: a
+band-pass filter, a frequency shift, decimation, demodulation, decoding. That is
+**dataflow** — a perfect fit for **functional thinking**. Each stage is naturally
+a pure transformation: samples in, samples out, no hidden state to corrupt the
+buffer. Modelling a DSP chain as composed pure functions makes each stage
+independently testable and safe to parallelise across cores, a theme we revisit in
+[concurrency models](/learn/intro-software-dev/concurrency-models/). You will
+still use imperative loops for the tight inner number-crunching and objects to
+represent a tuned receiver — which is exactly the multi-paradigm reality.
+
+## Recap
+
+- **Paradigms are styles, not languages** — imperative, OOP, functional and
+  declarative are ways to organise and reason about code.
+- **Imperative/procedural** — step-by-step instructions over mutable state; closest
+  to the hardware.
+- **Object-oriented** — bundle state and behaviour into objects; prefer composition
+  over deep inheritance.
+- **Functional** — compose pure, side-effect-free transformations; immutable data
+  by default.
+- **Declarative** — describe *what* you want (SQL, logic, config) and let the system
+  find *how*.
+- **Most languages are multi-paradigm** — Python, Rust and Go let you mix styles;
+  dataflow pipelines map cleanly onto functional composition.
+
+Next up: how the same source code becomes something the machine can run — the
+difference between [compiled, interpreted and JIT
+execution](/learn/intro-software-dev/compiled-vs-interpreted/).

--- a/docs/learn/intro-software-dev/language-for-the-domain.md
+++ b/docs/learn/intro-software-dev/language-for-the-domain.md
@@ -1,0 +1,152 @@
+---
+slug: language-for-the-domain
+title: Matching language to domain
+description: Which languages each field reaches for and why — web, mobile, systems, data science, embedded, scripting and DSP/RF/SDR — with honest notes on the heavy overlaps.
+keywords: language by domain, web development languages, mobile development, systems programming, data science languages, embedded programming, DSP languages, SDR, GNU Radio
+level: intermediate
+status: full
+faq:
+  - q: "Why does each domain tend to converge on a few languages?"
+    a: "Mostly gravity, not law. Once a field's best libraries, tooling, tutorials and hiring pool cluster around a language, new projects pick it because everything they need is already there. Python won data science this way; JavaScript owns the browser because it's the only language that runs there natively."
+  - q: "Can I use my favourite language outside its usual domain?"
+    a: "Often yes, with caveats. You can write a web backend in almost anything and DSP in many languages. But you'll fight a thinner ecosystem, fewer examples and a smaller hiring pool. The convention exists because the support is there — going against it is a cost you should choose deliberately, not by accident."
+  - q: "What languages are used for software-defined radio?"
+    a: "A common split: C and C++ for the performance-critical DSP, Python for prototyping and orchestration (often via NumPy or GNU Radio), and Go for concurrent stream-handling engines that capture and route samples. Rust is a growing option where memory safety plus speed both matter. The heavy inner loop and the glue code don't have to be the same language."
+---
+# Matching language to domain
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Domains converge on a few languages** — because libraries, tooling and hiring cluster there. **The convention is gravity, not law** — you can break it, at a cost. **Many systems mix languages** — a fast core with a productive shell, especially in DSP and RF.
+</div>
+
+Languages don't get chosen in a vacuum — they get chosen inside a *field*, and each
+field has gravitated toward a handful of go-to languages. That convergence isn't
+arbitrary: it's where the best libraries, the most examples and the deepest hiring
+pool already are. This lesson maps the major domains to the languages they reach for
+and, more usefully, *why*. It's honest about the overlaps too — most of these
+boundaries are fuzzy, and many real systems blend several languages.
+
+## Why domains cluster
+
+Before the map, the mechanism. A domain converges on a language for compounding,
+self-reinforcing reasons:
+
+- **Libraries** solve the domain's hard problems there first.
+- **Tooling** (debuggers, profilers, frameworks) matures around it.
+- **Examples and answers** accumulate, so newcomers learn faster.
+- **Hiring** gets easier, so teams keep picking it.
+
+Each reason makes the next stronger. That's why "use what the domain uses" is a
+sensible default — and why going against it should be a deliberate choice, not a
+reflex.
+
+## The domain map
+
+| Domain | Usual languages | Why |
+|---|---|---|
+| **Web front-end** | JavaScript / TypeScript | the only language browsers run natively; TS adds safety |
+| **Web back-end** | Go, Python, Node, Java, Ruby, C# | broad field — almost any language works; pick by team/ecosystem |
+| **Mobile** | Swift (iOS), Kotlin (Android) | each is the platform-native, first-class language |
+| **Systems / OS** | C, C++, Rust | direct hardware/memory control; Rust adds safety |
+| **Data science / ML** | Python, R, Julia | unmatched numeric ecosystem (NumPy, pandas, PyTorch); R for stats |
+| **Embedded** | C, C++, Rust, MicroPython | tiny footprint, hardware control; MicroPython for prototyping |
+| **Scripting / automation** | Python, shell (Bash) | quick to write, glue tools together |
+| **DSP / RF / SDR** | C / C++ (heavy DSP), Python (prototyping), Go (stream engines) | per-sample deadlines need speed; Python for fast iteration |
+
+### Web
+
+The front-end is the one place with no real choice: browsers run **JavaScript** (and
+its typed superset **TypeScript**), so that's that. The back-end is the opposite —
+wide open. **Go, Python, Node, Java, Ruby and C#** all serve web back-ends well, and
+here the decision really is mostly team familiarity, ecosystem and the deployment
+story rather than language merit.
+
+### Mobile and systems
+
+**Mobile** rewards the platform-native language: **Swift** for Apple, **Kotlin** for
+Android, because the tooling, APIs and performance are first-class there.
+**Systems and OS** work — kernels, drivers, runtimes — demands low-level control, so
+it's **C** and **C++**, with **Rust** increasingly chosen for new components that want
+that control *plus* memory safety.
+
+### Data, embedded and scripting
+
+**Data science and ML** belong to **Python**, almost entirely because of its
+ecosystem — NumPy, pandas, scikit-learn, PyTorch — with **R** strong for statistics
+and **Julia** an up-and-comer for high-performance numerics. **Embedded** work runs
+close to the metal in **C**, **C++** and increasingly **Rust**, with **MicroPython**
+handy for prototyping on capable microcontrollers. **Scripting and automation** —
+gluing tools together, one-off tasks — is **Python** and **shell** territory, chosen
+for sheer speed of writing.
+
+## DSP, RF and SDR: a mixed-language world
+
+Signal processing and software-defined radio are where this path's examples live, and
+they're a textbook case of *mixing* languages by role rather than picking one. The
+defining constraint is a **per-sample deadline**: a radio produces a relentless I/Q
+stream, and each buffer must be filtered and demodulated before the next arrives or
+samples drop. That single fact splits the work:
+
+- **C / C++ for the heavy DSP.** The filters, FFTs and demodulators in the hot inner
+  loop run where every cycle counts. Decades of optimised DSP code, and the rawest
+  throughput, live here. Much of GNU Radio's signal-processing blocks are C++.
+- **Python for prototyping and orchestration.** You explore an algorithm interactively
+  with **NumPy**/**SciPy**, or wire up a **GNU Radio** flowgraph, getting ideas working
+  fast — then push the proven hot path down into native code. **MATLAB** plays a
+  similar prototyping role in industry.
+- **Go for concurrent stream-handling engines.** The *plumbing* around the DSP — capturing
+  samples from a device, fanning them out to decoders, juggling many channels and
+  network clients at once — is concurrency-heavy coordination, and Go's goroutines and
+  channels fit it cleanly. It compiles to one static binary, which matters for shipping
+  to users.
+- **Rust** is a growing option where you want the inner-loop speed of C/C++ *and*
+  memory safety, at the cost of a steeper ramp.
+
+The honest takeaway: the heavy math and the glue **don't have to be the same
+language**, and in practice they usually aren't. GopherTrunk sits here — see the
+[RF & SDR path](/learn/rf-sdr/) for the signal side and
+[GopherTrunk's architecture](/architecture.html) for how the pieces fit. We work a
+full SDR example in the [decision framework](/learn/intro-software-dev/decision-framework/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — DSP/SDR commonly mixes languages by role: C/C++ for the hot inner loop, Python for prototyping, Go for concurrent stream plumbing." markdown="0">
+  <p class="knowledge-check__q">Quick check: in a typical SDR system, which split is most common?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Everything written in a single language for purity</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">C/C++ for heavy DSP, Python to prototype, Go for concurrent stream handling</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Pure Python for the per-sample inner loop on constrained hardware</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## The overlaps are real
+
+Don't read the map as a set of walls. The boundaries leak constantly:
+
+- **Web back-ends** can be written in nearly anything — the table lists six options and
+  there are more.
+- **Go** does data work, **Python** runs production web back-ends, **Rust** writes web
+  services and **C++** does machine learning under the hood of the Python libraries.
+- The right question isn't "what is *the* language for X?" but "what does X usually use,
+  what are the reasons, and do my requirements match those reasons?" Sometimes they
+  don't, and a non-conventional choice is correct — just made with eyes open.
+
+The convention tells you where the support is. Your requirements tell you whether to
+follow it. Reconciling those two is exactly what a decision framework is for.
+
+## Recap
+
+- **Domains cluster on a few languages** because libraries, tooling, examples and
+  hiring compound there.
+- **The map** — web front-end is JS/TS; back-end is wide open; mobile is Swift/Kotlin;
+  systems is C/C++/Rust; data science is Python/R/Julia; embedded is C/C++/Rust;
+  scripting is Python/shell.
+- **DSP/RF/SDR mixes languages by role** — C/C++ for heavy DSP, Python for prototyping,
+  Go for concurrent stream engines, Rust where safety plus speed matter.
+- **Overlaps are everywhere** — most boundaries leak, and many systems blend several
+  languages.
+- **Convention is a default, not a law** — follow it unless your requirements give you
+  a deliberate reason not to.
+
+Next up: turning all of this into a repeatable method you can actually run —
+[a practical decision framework](/learn/intro-software-dev/decision-framework/).

--- a/docs/learn/intro-software-dev/language-security.md
+++ b/docs/learn/intro-software-dev/language-security.md
@@ -1,0 +1,195 @@
+---
+slug: language-security
+title: Language-level security
+description: Why most severe CVEs trace to memory bugs in C/C++, what undefined behaviour and bounds checking mean, sandboxing, and how the software supply chain shapes attack surface.
+keywords: memory safety, software security, undefined behaviour, bounds checking, buffer overflow, software supply chain, typosquatting, SBOM
+level: intermediate
+status: full
+faq:
+  - q: "Why are memory-safe languages considered more secure?"
+    a: "A large share of severe security vulnerabilities come from **memory bugs** — buffer overflows, use-after-free — in memory-unsafe languages like C and C++. Memory-safe languages (Rust, Go, Java, Python) prevent these by construction, so choosing one removes an entire category of exploitable bugs from your code."
+  - q: "What is the software supply chain risk?"
+    a: "Modern programs depend on many third-party packages, each of which can introduce vulnerabilities or be malicious. **Supply-chain attacks** include typosquatting (a fake package with a near-identical name), compromised maintainers, and hidden malware. Lockfiles and SBOMs help you know and pin exactly what you depend on."
+  - q: "What is undefined behaviour?"
+    a: "**Undefined behaviour** is code whose result the language specification does not define — like reading past an array's end in C. The compiler may do anything: crash, return garbage, or silently keep going in an exploitable state. It is a major source of both bugs and security holes in low-level languages."
+---
+# Language-level security
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Memory safety** — removes the bug class behind most severe CVEs. **Undefined behaviour** — low-level code that can do *anything*. **Supply chain** — your dependencies are part of your attack surface.
+</div>
+
+Security is not only a matter of careful coding — it is partly decided the moment
+you pick a language. The language's design determines which mistakes are even
+*possible*, how much of your safety rests on every programmer being perfect, and
+how large your **attack surface** is. This lesson looks at security from that
+angle: memory safety, undefined behaviour, the protections languages do (or do
+not) give you, and the increasingly important question of the code you did not
+write yourself — your dependencies.
+
+## Memory safety and the CVE record
+
+The single biggest language-level security lever is **memory safety**. A
+*memory-unsafe* language — chiefly **C and C++** — lets a program read or write
+memory it should not: past the end of a buffer, after it has been freed, through a
+dangling pointer. These are not just bugs; they are **exploitable**. An attacker
+who can overflow a buffer can often overwrite adjacent data or inject code.
+
+The evidence is stark and consistent. Studies from Microsoft and Google have both
+reported that around **70% of their severe security vulnerabilities** stem from
+memory-safety bugs in C/C++ code. This finding is so well-established that the US
+NSA and CISA have publicly urged industry to move toward **memory-safe
+languages**.
+
+A **memory-safe language** — Rust, Go, Java, C#, Python, JavaScript — makes those
+bugs impossible (or catches them at compile time, in Rust's case). The mechanism
+varies: garbage collection, runtime bounds checks, or ownership (see
+[memory management](/learn/intro-software-dev/memory-management/)). The
+consequence is the same: choosing a memory-safe language *deletes the most common
+category of severe vulnerability from your program* before you write a line.
+
+## Undefined behaviour and bounds checking
+
+Two related concepts explain *why* unsafe languages are so risky.
+
+**Undefined behaviour (UB)** is code whose outcome the language specification
+deliberately does not define. In C, reading past an array's end, signed integer
+overflow, or using a freed pointer are all UB. The compiler is free to assume UB
+never happens and optimise accordingly — so the program may crash, return garbage,
+or, worst of all, *keep running in a corrupted, attacker-controllable state*. UB is
+why C bugs are so unpredictable.
+
+**Bounds checking** is the main defence. Before accessing element *i* of an array,
+a bounds-checked language verifies *i* is in range and fails safely (an exception
+or panic) if not.
+
+```python
+data = [1, 2, 3]
+data[7]   # Python: IndexError — safe, predictable failure
+```
+
+```c
+int data[3];
+data[7];   // C: undefined behaviour — reads whatever is there, no check
+```
+
+Memory-safe languages bounds-check by default. The tiny per-access cost buys you a
+predictable crash instead of a silent, exploitable overflow — almost always the
+right trade outside the hottest inner loops.
+
+## Sandboxing and isolation
+
+Beyond the language core, **sandboxing** limits what running code can do even if it
+is buggy or hostile. The idea is *least privilege*: give code only the capabilities
+it needs.
+
+- **WebAssembly** runs untrusted code in a tightly confined sandbox with no ambient
+  access to the host system.
+- **Browsers** isolate each tab and script in a restricted environment.
+- **Containers and OS sandboxes** (seccomp, capabilities) restrict syscalls and file
+  access.
+
+Sandboxing is defence in depth: it does not fix the bug, but it shrinks the *blast
+radius* when one is exploited. Combining a memory-safe language with a sandbox
+gives you two independent layers of protection.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — industry studies (Microsoft, Google) consistently attribute roughly 70% of severe CVEs to memory-safety bugs in C/C++." markdown="0">
+  <p class="knowledge-check__q">Quick check: where do the majority of severe security vulnerabilities tend to come from?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Weak passwords chosen by end users</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Memory-safety bugs in memory-unsafe languages like C and C++</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Programs written in interpreted languages</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## The software supply chain
+
+Most of the code in a modern program is not yours — it is **dependencies**: open-source
+libraries pulled in through a package manager, each with its own dependencies, often
+hundreds deep. Every one of those is part of your **attack surface**, and attackers
+have noticed. **Supply-chain attacks** are now a leading threat:
+
+- **Typosquatting** — a malicious package with a name one keystroke from a popular
+  one (`reqeusts` instead of `requests`), hoping you mistype it.
+- **Compromised maintainers** — an attacker takes over a legitimate package and ships
+  malware in an update to its existing users.
+- **Dependency confusion** — tricking a build into pulling a public package instead of
+  an intended internal one.
+
+Several practices reduce the risk:
+
+- **Lockfiles** (`package-lock.json`, `Cargo.lock`, `go.sum`) pin the *exact* version
+  and cryptographic hash of every dependency, so builds are reproducible and a
+  swapped package is detected.
+- **SBOMs** (Software Bill of Materials) — a machine-readable inventory of everything
+  in your build, so when a vulnerability is announced you can instantly tell whether
+  you are affected.
+- **Minimal dependencies and vetting** — fewer, well-audited packages mean less
+  surface to attack.
+
+Language ecosystems differ here. Go's standard library is large enough that many
+programs need few external dependencies; the npm ecosystem favours many tiny
+packages, widening the surface. This is a real factor when
+[choosing a language for a domain](/learn/intro-software-dev/language-for-the-domain/).
+
+## Security is more than the language
+
+Choosing a memory-safe language and pinning your dependencies are powerful, but
+they are not the whole story — they remove *categories* of bugs, not all bugs. A
+few classes of vulnerability are largely language-independent and still demand
+care:
+
+- **Injection** — SQL injection, command injection and cross-site scripting all
+  come from mixing untrusted data into a command or query. The fix is the same in
+  every language: never build commands by string concatenation; use parameterised
+  queries and proper escaping.
+- **Logic and authorisation flaws** — granting access you should not, trusting a
+  client-supplied value, leaking secrets in logs. No type system catches a missing
+  permission check.
+- **Cryptographic mistakes** — rolling your own crypto, using weak algorithms, or
+  mishandling keys. Use vetted libraries, never invent your own.
+- **Misconfiguration** — exposed debug endpoints, default credentials, overly broad
+  permissions.
+
+The right mental model is **defence in depth**: a memory-safe language removes the
+most common severe category, bounds checking and sandboxing add layers, careful
+input handling closes the injection class, and good operational hygiene covers the
+rest. Language choice raises the floor of your security; it does not let you stop
+thinking. Treat untrusted input as hostile, keep dependencies few and pinned, and
+assume any one layer can fail.
+
+## Why this matters when parsing the air
+
+Bring it back to radio. A tool like **GopherTrunk** spends much of its time
+**parsing untrusted input**: demodulated frames pulled out of the air, from
+transmitters you do not control, possibly malformed, possibly crafted. Parsing
+attacker-influenced byte streams is *exactly* the scenario where a memory-safety
+bug becomes a remote exploit — a malformed frame that overruns a fixed buffer in C
+is a textbook attack vector.
+
+Writing that frame-parsing code in a **memory-safe language** means a malformed
+packet produces a safe error — a bounds-check panic, a rejected frame — instead of
+a corrupted, attacker-controlled process. You cannot control what arrives over the
+air, but you *can* control whether your parser turns a bad frame into a crash or a
+compromise. Choosing memory safety for the code that touches untrusted radio data
+is one of the highest-leverage security decisions you will make.
+
+## Recap
+
+- **Memory safety is the biggest lever** — roughly 70% of severe CVEs trace to memory
+  bugs in C/C++; safe languages delete that bug class.
+- **Undefined behaviour** — unspecified outcomes (like out-of-bounds reads) that
+  compilers may turn into silent, exploitable corruption.
+- **Bounds checking** — memory-safe languages fail predictably instead of reading
+  past an array.
+- **Sandboxing** — least-privilege isolation (WebAssembly, browsers, containers)
+  limits the blast radius of any bug.
+- **Supply chain** — dependencies are attack surface; typosquatting and compromised
+  maintainers are real, mitigated by lockfiles and SBOMs.
+- **Memory safety protects untrusted-input parsers** — like code reading demodulated
+  frames off the air.
+
+Next up: Module 3 turns from language internals to craft, starting with what makes
+code readable and maintainable — [clean code](/learn/intro-software-dev/clean-code/).

--- a/docs/learn/intro-software-dev/language-tour.md
+++ b/docs/learn/intro-software-dev/language-tour.md
@@ -1,0 +1,164 @@
+---
+slug: language-tour
+title: A tour of today's major languages
+description: A fair, even-handed survey of the major programming languages — C, C++, Rust, Go, Python, JavaScript/TypeScript, Java/C# and more — with honest strengths, drawbacks and typical uses.
+keywords: programming languages compared, C, C++, Rust, Go, Python, JavaScript, TypeScript, Java, C#, Swift, Kotlin, language comparison table
+level: intermediate
+status: full
+faq:
+  - q: "Which programming language should a beginner learn first?"
+    a: "There's no single answer, but Python is a common first language because it's readable and forgiving, and JavaScript is hard to avoid if you want to build for the web. The skills transfer: once you understand variables, loops, functions and types in one language, picking up the next is far easier."
+  - q: "Is Rust replacing C and C++?"
+    a: "Not replacing, but increasingly competing for new systems work. Rust offers memory safety without a garbage collector, which addresses a major source of C and C++ bugs. But C and C++ have decades of existing code, tooling and trained engineers, and a steep Rust learning curve slows adoption. Expect coexistence, not replacement."
+  - q: "What is the difference between Java and C#?"
+    a: "They're close cousins — both statically typed, garbage-collected, JIT-compiled managed languages with large ecosystems aimed at big applications. Java runs on the JVM and dominates enterprise and Android backends; C# runs on .NET and is strong in Windows, game development (Unity) and enterprise. The choice is often ecosystem and platform, not language merit."
+---
+# A tour of today's major languages
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Every language is a trade-off** — strengths come bundled with real drawbacks. **The big split is control vs convenience** — systems languages vs managed/dynamic ones. **Pick by fit, not fandom** — match the tool to the job, team and platform.
+</div>
+
+There are hundreds of programming languages, but you'll choose between a couple
+dozen, and realistically a handful for any given project. This is a fair survey of
+the major ones — what each is genuinely good at, what it genuinely costs you, and
+where it tends to be used. No fanboyism: every language here is loved and cursed by
+the people who use it daily, and every one has real drawbacks, including the ones
+this site is built in. Use the table at the end as a cheat sheet, and the
+[language families](/learn/intro-software-dev/language-families/) lesson for the
+deeper "why they differ."
+
+## The systems languages: control and speed
+
+These compile to native code and give you direct control over memory and hardware.
+You pay for that control with complexity or risk.
+
+**C** — the bedrock. Almost every operating system, language runtime and embedded
+device has C at its core. It's small, fast, portable and *everywhere*. The cost is
+**safety**: manual memory management means buffer overflows, use-after-free and
+dangling pointers — whole categories of security bugs that C does nothing to stop.
+It's still the default for OS kernels, drivers and tight embedded work.
+
+**C++** — C plus enormous power: objects, templates, generics, RAII, a huge standard
+library. It can be as fast as C while offering far higher-level abstractions, which
+is why it dominates game engines, high-performance trading, browsers and serious DSP.
+The drawback is **complexity** — C++ is vast, with decades of accumulated features
+and sharp edges; it inherits C's memory-safety risks unless you're disciplined, and
+it's genuinely hard to master.
+
+**Rust** — the modern answer to "fast *and* safe." Rust's borrow checker enforces
+memory safety at **compile time** with no garbage collector, eliminating data races
+and use-after-free *without* a runtime cost. Performance rivals C and C++. The price
+is a **steep learning curve** — the borrow checker is famously hard at first — and a
+younger (though fast-growing) ecosystem. Increasingly chosen for new systems work,
+CLIs, WebAssembly and safety-critical components.
+
+**Go** — built at Google for simplicity at scale. Go is compiled and fast, with
+**first-class concurrency** (goroutines and channels), **very fast compiles**, and a
+killer deployment story: a **single static binary** you can drop on any machine.
+It's deliberately small and easy to learn. The trade-offs are real: a **garbage
+collector** (so brief pauses, and less control than C/Rust), **less raw throughput**
+than C/C++/Rust in the tightest numeric loops, and a minimalist design some find
+limiting — generics only arrived in 2022, and error handling is verbose. Excellent
+for network services, CLIs, infrastructure and concurrent stream processing.
+
+## The productivity languages: speed of writing
+
+These trade run-time speed for how fast a human can write and change code.
+
+**Python** — prized for readability and a vast ecosystem. It's a joy to write and
+the default for **data science, machine learning, scientific computing, scripting
+and automation**, largely thanks to libraries like NumPy, pandas and PyTorch. The
+costs: it's **slow** in pure-Python loops, and the **GIL** (global interpreter lock)
+limits true multithreaded CPU parallelism in the standard interpreter. You work
+around both by delegating heavy work to native libraries (see
+[performance vs productivity](/learn/intro-software-dev/performance-vs-productivity/)).
+
+**JavaScript** — the language of the web, and the *only* one that runs natively in
+every browser. With Node.js it runs servers too, so you can use one language across
+the whole stack. The ecosystem (npm) is enormous. The drawbacks are decades of
+quirky design decisions and famously loose dynamic typing that lets subtle bugs
+through. **TypeScript** — JavaScript with a static type layer — addresses the typing
+problem and has become the default for serious front-end and Node work; it compiles
+away to plain JavaScript. See [type systems](/learn/intro-software-dev/type-systems/).
+
+## The managed enterprise languages
+
+**Java** — statically typed, garbage-collected, JIT-compiled on the JVM. Its
+strengths are a **massive, mature ecosystem**, strong tooling, real cross-platform
+portability ("write once, run anywhere") and battle-tested reliability at scale. It
+runs enormous enterprise systems and Android backends. Critics find it **verbose**
+and ceremony-heavy, with slower startup and higher memory use than native code,
+though modern Java has modernised considerably.
+
+**C#** — Microsoft's JVM-equivalent on .NET. Very similar trade-offs to Java —
+managed, typed, big ecosystem — with arguably more modern language features. It's
+the backbone of Windows enterprise software and, via **Unity**, much of the game
+industry. Historically Windows-centric, though .NET is now genuinely cross-platform.
+
+## Specialist and mobile languages
+
+A few you'll meet in specific domains:
+
+- **Swift** — Apple's modern, safe language for iOS and macOS apps. Clean and fast,
+  but its centre of gravity is Apple's platforms.
+- **Kotlin** — a more concise, safer language on the JVM; Google's preferred language
+  for Android, and usable anywhere Java is.
+- **Julia** — designed for high-performance numerical and scientific computing, aiming
+  to be as fast as C while as easy as Python. Smaller ecosystem.
+- **R** — a statistics-and-data specialist, beloved by statisticians and researchers;
+  excellent for analysis and plotting, less suited to general programming.
+- **MATLAB** — a commercial powerhouse for engineering, signal processing and control
+  systems; superb for DSP prototyping, but proprietary and licensed.
+
+## The comparison at a glance
+
+| Language | Strengths | Drawbacks | Typical use |
+|---|---|---|---|
+| **C** | tiny, fast, ubiquitous, portable | memory-unsafe, low-level, manual | OS, drivers, embedded |
+| **C++** | fast + powerful abstractions | complex, sharp edges, unsafe by default | engines, DSP, browsers |
+| **Rust** | memory-safe *and* fast, no GC | steep learning curve, younger ecosystem | systems, CLIs, WASM |
+| **Go** | simple, great concurrency, fast compiles, single binary | GC pauses, less raw speed than C/Rust, minimalist | services, CLIs, infra, stream engines |
+| **Python** | readable, huge data/ML ecosystem | slow loops, GIL limits CPU threads | data science, ML, scripting |
+| **JS / TS** | runs in every browser, full-stack, huge npm; TS adds types | JS quirks, loose typing (TS mitigates) | web front-end, Node backends |
+| **Java** | mature, portable, scalable, strong tooling | verbose, heavier startup/memory | enterprise, Android backends |
+| **C#** | modern, big ecosystem, Unity | historically Windows-leaning | enterprise, games |
+| **Swift / Kotlin** | safe, modern mobile languages | tied to Apple / JVM-Android | iOS / Android apps |
+| **Julia / R / MATLAB** | strong numeric/DSP/stats | niche, smaller (or licensed) ecosystems | science, signal processing |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Rust enforces memory safety at compile time with its borrow checker and no garbage collector, at the cost of a steep learning curve." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is Rust's defining strength?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's the easiest language to learn for total beginners</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Memory safety without a garbage collector, enforced at compile time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It runs natively inside every web browser</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Reading the table fairly
+
+Two cautions before you use this as a scorecard. First, **drawbacks are contextual** —
+Go's garbage collector is a non-issue for a web service and a real consideration for a
+hard real-time DSP loop; Python's speed is irrelevant for a script and decisive for an
+inner loop. A "con" only counts if it touches *your* requirements. Second, **ecosystem
+and team often outweigh raw language merit** — the "best" language with no libraries and
+no one to write it loses to a good-enough one with both. The next lesson turns this
+survey into something more actionable: which languages each *domain* actually reaches
+for, and why.
+
+## Recap
+
+- **Systems languages** (C, C++, Rust, Go) — control and speed; C is unsafe, C++ is
+  complex, Rust is safe-but-steep, Go is simple-but-GC'd.
+- **Productivity languages** (Python, JS/TS) — fast to write; Python is slow with a
+  GIL, JS is quirky, TypeScript adds the types JS lacks.
+- **Managed enterprise** (Java, C#) — portable, scalable, big ecosystems; verbose and
+  heavier than native code.
+- **Specialists** — Swift/Kotlin for mobile, Julia/R/MATLAB for numeric and DSP work.
+- **Judge in context** — every drawback is conditional, and ecosystem plus team
+  frequently outweigh raw language differences.
+
+Next up: which of these each field actually picks, and the reasons behind it —
+[matching language to domain](/learn/intro-software-dev/language-for-the-domain/).

--- a/docs/learn/intro-software-dev/memory-management.md
+++ b/docs/learn/intro-software-dev/memory-management.md
@@ -1,0 +1,199 @@
+---
+slug: memory-management
+title: Memory — manual, GC & ownership
+description: Stack vs heap, manual malloc/free and its dangers, garbage collection and its pauses, and Rust's ownership model — three approaches to managing memory safely.
+keywords: memory management, stack and heap, garbage collection, manual memory, malloc free, Rust ownership, borrow checker, use after free
+level: intermediate
+status: full
+faq:
+  - q: "What is the difference between the stack and the heap?"
+    a: "The **stack** holds local variables and function call frames; it is fast and freed automatically when a function returns. The **heap** is a larger pool for data whose size or lifetime is not known at compile time; it must be allocated and eventually released, and managing that is where the hard problems live."
+  - q: "What is garbage collection and what is its downside?"
+    a: "**Garbage collection (GC)** automatically frees memory no longer reachable by the program, removing whole categories of bugs. Its downside is the **GC pause** — the runtime periodically does collection work, which can briefly stop or slow the program at unpredictable times."
+  - q: "How does Rust manage memory without a garbage collector?"
+    a: "Rust uses **ownership** and a compile-time **borrow checker**. Each value has one owner; when the owner goes out of scope the memory is freed automatically. The compiler enforces rules about borrowing references, guaranteeing memory safety with no runtime GC and no manual free."
+---
+# Memory — manual, GC & ownership
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Manual** — total control, but leaks and use-after-free bugs. **Garbage collection** — automatic and safe, but unpredictable pauses. **Ownership** — Rust's compile-time safety with no GC.
+</div>
+
+Every running program needs **memory** to hold its data, and that memory has to be
+handed out when the program needs it and reclaimed when it is done. How a language
+handles that reclamation is one of its defining characteristics — it shapes the
+language's safety, its speed, and whether it is suitable for hard real-time work.
+There are three broad strategies — **manual management**, **garbage collection**,
+and **ownership** — but first we need the distinction that underlies all of them:
+the stack versus the heap.
+
+## Stack vs heap
+
+A program's memory is split into two regions that behave very differently.
+
+The **stack** is fast, ordered storage for local variables and the bookkeeping of
+function calls. When a function is called, a *frame* is pushed; when it returns,
+the frame is popped and its locals vanish automatically. Allocation is essentially
+free — just move a pointer. The catch: the size of everything on the stack must be
+known at compile time, and it lives only as long as its function.
+
+The **heap** is a large, flexible pool for data whose size or lifetime is not
+known up front — a buffer sized by user input, an object that must outlive the
+function that created it, a growing list. Heap memory must be explicitly
+*allocated* and eventually *released*. **All the hard memory problems live on the
+heap**, because something has to decide when each piece is no longer needed.
+
+```text
+stack:  fast, auto-freed, fixed-size, function-scoped
+heap:   flexible, manually/automatically managed, the source of memory bugs
+```
+
+## Manual management and its dangers
+
+In **C and C++** you manage the heap yourself. You call `malloc` (or `new`) to
+allocate and `free` (or `delete`) to release, and it is entirely your
+responsibility to get it right.
+
+```c
+char *buf = malloc(1024);   // ask for memory
+// ... use buf ...
+free(buf);                  // you must release it — exactly once
+```
+
+This gives **maximum control and speed** — no runtime overhead, deterministic
+timing — and it is why C and C++ dominate operating systems, embedded work and
+high-performance DSP. But it is dangerous. The classic failure modes:
+
+- **Memory leak** — you allocate but never `free`; the program's memory use grows
+  until it slows or crashes.
+- **Use-after-free** — you `free` memory then keep using the pointer; behaviour is
+  undefined and often exploitable.
+- **Double free** — you `free` the same block twice, corrupting the allocator.
+- **Buffer overflow** — you write past the end of an allocation, clobbering adjacent
+  memory; a leading cause of security vulnerabilities (more in
+  [language-level security](/learn/intro-software-dev/language-security/)).
+
+These bugs are notoriously hard to find because the symptom often appears far from
+the cause.
+
+## Garbage collection
+
+The first big answer is to take the job away from the programmer. A **garbage
+collector (GC)** is part of the language runtime that automatically finds memory no
+longer reachable by the program and frees it. **Java, Go, Python, C# and
+JavaScript** are all garbage-collected.
+
+The benefit is enormous: **whole classes of bugs simply disappear**. No leaks from
+forgotten frees, no use-after-free, no double frees. You allocate and forget; the
+GC cleans up. This is a big part of why these languages are so productive.
+
+The cost is the **GC pause**. Periodically the collector must do work — scanning
+for reachable objects, reclaiming the rest — and depending on the algorithm this
+can briefly **stop the program** ("stop-the-world") or steal CPU at unpredictable
+moments. Modern collectors (Go's concurrent GC, Java's ZGC and G1) have shrunk
+these pauses dramatically, often to well under a millisecond, but the pauses are
+**non-deterministic**: you cannot be certain exactly when one will happen.
+
+## Ownership: a third way
+
+**Rust** takes a different path entirely — **memory safety without a garbage
+collector and without manual `free`**, enforced at compile time. The mechanism is
+**ownership** plus a **borrow checker**:
+
+- Every value has exactly one **owner** (a variable).
+- When the owner goes out of scope, the value is freed automatically — predictably,
+  at a known point, with no runtime collector.
+- You can **borrow** references to a value, but the compiler enforces rules: many
+  shared (read-only) borrows, or exactly one mutable borrow, never both at once.
+
+```rust
+fn main() {
+    let buf = vec![0u8; 1024]; // buf owns the heap allocation
+    process(&buf);             // borrow it, read-only
+}                              // buf goes out of scope here → freed automatically
+```
+
+The **borrow checker** rejects use-after-free, double-free, and data races *at
+compile time*. There is no GC pause because there is no GC — frees happen at
+deterministic points the compiler inserts. The trade-off is a steeper learning
+curve: you must satisfy the borrow checker, which can feel like fighting the
+compiler until the rules click. The payoff is C-like performance with
+memory safety guaranteed.
+
+| Approach | Languages | Safety | Runtime cost | Predictability |
+|----------|-----------|--------|--------------|----------------|
+| Manual | C, C++ | unsafe (your job) | none | fully deterministic |
+| Garbage collection | Java, Go, Python | safe | GC pauses | non-deterministic |
+| Ownership | Rust | safe (compile-time) | none | deterministic |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Rust frees memory at compile-time-determined scope exits via ownership, so there's no garbage collector and no GC pause." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does Rust achieve memory safety without garbage-collection pauses?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It runs a faster garbage collector in the background</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Compile-time ownership rules free memory at known scope exits — no GC at all</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It keeps everything on the stack and never uses the heap</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Reference counting and RAII
+
+Between fully manual and fully garbage-collected sits a family of techniques worth
+knowing, because you will meet them constantly.
+
+**Reference counting** tracks how many references point at a heap object. Each new
+reference bumps a counter; each one dropped decrements it; when it hits zero, the
+object is freed immediately and deterministically. Python uses reference counting
+as its primary mechanism (with a backup cycle collector), and C++'s
+`shared_ptr` and Rust's `Rc`/`Arc` offer it on demand. It is simple and gives
+prompt cleanup, but it has two costs: the bookkeeping overhead on every reference
+change, and an inability to free **reference cycles** (two objects pointing at each
+other keep each other alive), which is why Python needs a separate cycle collector.
+
+**RAII** — *Resource Acquisition Is Initialisation* — is the C++ and Rust idiom of
+tying a resource's lifetime to an object's scope. You acquire the resource in a
+constructor and release it in a destructor, which the language runs automatically
+when the object goes out of scope. RAII handles not just memory but files, locks
+and sockets — anything that must be released — with the same deterministic,
+scope-based rule that underpins Rust's ownership model. It is a big reason
+deterministic languages can be safe *and* free of a garbage collector: cleanup is
+guaranteed by the structure of the code, not by a periodic sweep.
+
+## Why GC pauses matter for real-time radio
+
+Here is where these abstractions bite in practice. A software-defined radio
+delivers a relentless stream of [IQ samples](/learn/rf-sdr/iq-data/) — at 2.4
+million samples per second, a new buffer arrives roughly every few milliseconds,
+and the program must consume each one before the next arrives or the hardware's
+buffer overflows and **samples are dropped**. Dropped samples mean corrupted
+audio, missed packets, decode failures.
+
+Now suppose a garbage-collected runtime decides to pause for a collection just as a
+buffer needs processing. Even a sub-millisecond pause, at the wrong moment and
+multiplied across a long capture, can cause overruns. This is the core reason hard
+real-time DSP gravitates toward **manual** (C/C++) or **ownership-based** (Rust)
+languages, where memory reclamation is **deterministic** and you control exactly
+when it happens. Go is GC'd but is often used in radio tooling for the control and
+orchestration layers — where occasional sub-millisecond pauses are harmless —
+while the tightest sample-crunching stays in C or Rust. Picking the right tool per
+layer is exactly the judgement in
+[choosing a language for the domain](/learn/intro-software-dev/language-for-the-domain/).
+
+## Recap
+
+- **Stack vs heap** — the stack is fast and auto-freed; the heap is flexible and the
+  source of memory bugs.
+- **Manual management** (C/C++) — total control and speed, but risks leaks,
+  use-after-free, double-frees and buffer overflows.
+- **Garbage collection** (Java, Go, Python) — automatic and safe, eliminating whole
+  bug classes, at the cost of unpredictable pauses.
+- **Ownership** (Rust) — compile-time borrow checking gives memory safety with no GC
+  and deterministic frees.
+- **Determinism is the key axis for real-time** — manual and ownership models give
+  predictable timing; GC does not.
+- **GC pauses can drop radio samples** — which is why tight DSP avoids garbage
+  collection.
+
+Next up: doing many things at once without tripping over yourself — [concurrency
+and parallelism](/learn/intro-software-dev/concurrency-models/).

--- a/docs/learn/intro-software-dev/packaging-and-distribution.md
+++ b/docs/learn/intro-software-dev/packaging-and-distribution.md
@@ -1,0 +1,185 @@
+---
+slug: packaging-and-distribution
+title: Packaging & distributing your software
+description: Turn your program into something others can install — single binaries vs interpreters, cross-compilation, semantic versioning, release channels, signing and docs.
+keywords: software distribution, packaging, single binary, cross-compilation, semantic versioning, GitHub Releases, package managers, code signing, auto-update
+level: advanced
+status: full
+faq:
+  - q: "What is the easiest way to distribute software as a solo developer?"
+    a: "Ship **prebuilt single binaries** through **GitHub Releases**. You cross-compile one self-contained executable per operating system, attach them to a tagged release, and the user downloads the file for their platform and runs it — no runtime to install, no dependencies to resolve. It costs you almost nothing per release (CI can build them) and removes the most common reason non-technical users give up."
+  - q: "What is semantic versioning?"
+    a: "**Semantic versioning** (semver) is the MAJOR.MINOR.PATCH numbering scheme. You bump **PATCH** for backward-compatible bug fixes, **MINOR** for backward-compatible new features, and **MAJOR** when you make a breaking change. It tells users at a glance whether an upgrade is safe, which builds trust and reduces support questions about what changed."
+  - q: "Why do checksums and code signing matter?"
+    a: "Both let users trust that the file they downloaded is really yours and was not tampered with. A **checksum** lets them verify the download is intact and unmodified; **code signing** attaches a verified identity so the operating system does not warn them off (or block them) when they run it. For software a stranger installs, this trust is the difference between \"just works\" and scary security warnings."
+---
+# Packaging & distributing your software
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Binaries beat dependencies** — a single file the user just runs. **Cross-compile and version** — build for every OS, number releases with semver. **Channels and trust** — GitHub Releases, package managers, checksums and signing.
+</div>
+
+A working program on your machine helps exactly one person: you. Distribution is the
+step that turns it into something a stranger can install and run — and for a solo
+developer it is often the part that decides whether anyone ever uses what you built.
+This is the distribution-strategy lesson of the path. We cover how to package your
+program so others can install it, how to build it for every operating system, how to
+version and publish releases, the channels you can ship through, and the trust signals
+that stop the user's machine from treating your software as a threat. The closer you
+get the user's experience to "download one thing and run it," the more of them will
+actually use your work.
+
+## Binaries vs interpreters: what does the user need?
+
+The first question is what the user must have on their machine *before* your program
+will run. There are two broad answers, and they create very different experiences:
+
+- **Compiled single binary.** The build process produces one self-contained
+  executable with everything baked in. The user downloads it and runs it — nothing
+  else to install. Languages like **Go** and **Rust** make this the default, and it is
+  the gentlest possible install story.
+- **Interpreter plus dependencies.** The program is source code that needs a runtime
+  (Python, Node, a JVM) plus a set of libraries installed at the right versions. This
+  is fine for other developers, but for a non-technical user it means installing the
+  runtime, resolving dependencies, and matching versions — every step a chance to fail
+  and an email to you.
+
+```text
+Single binary:        download file → run                       (1 step)
+Interpreter + deps:   install runtime → install deps → run      (3+ steps, version-sensitive)
+```
+
+You can soften the interpreter story — bundlers and containers package the runtime
+with the code — but if you have the choice and your audience is non-technical, the
+single binary wins decisively. This is exactly why the
+[choosing your stack](/learn/intro-software-dev/choosing-your-stack/) lesson treated
+easy distribution as a language-selection factor, not an afterthought.
+
+## Cross-compilation: one machine, every platform
+
+Your users are on Linux, macOS and Windows; you develop on one of them. **Cross-
+compilation** lets you produce executables for *all* of those targets from your single
+development machine, without owning three computers.
+
+Go's tooling is the poster child — you set a target OS and architecture and `go build`
+emits a binary for it:
+
+```text
+build for linux/amd64   → myapp
+build for darwin/arm64  → myapp        (Apple Silicon Macs)
+build for windows/amd64 → myapp.exe
+```
+
+In practice you let **CI do this on every release** (see
+[build, test and CI/CD](/learn/intro-software-dev/build-and-ci-cd/)): one tagged
+commit triggers a job that compiles every platform variant and attaches them to the
+release automatically. You never build them by hand. The result is that a user on any
+common system finds a file that just runs on their machine, and you did nothing manual
+to produce it.
+
+## Versioning and release artifacts
+
+When you publish a build, two things make it usable and trustworthy: a clear version
+number and well-formed artifacts.
+
+**Semantic versioning** (semver) numbers releases as `MAJOR.MINOR.PATCH`:
+
+| Bump | When | Example |
+| --- | --- | --- |
+| PATCH | Backward-compatible bug fix | 1.4.2 → 1.4.3 |
+| MINOR | Backward-compatible new feature | 1.4.3 → 1.5.0 |
+| MAJOR | Breaking change | 1.5.0 → 2.0.0 |
+
+A user reading `1.5.0 → 1.5.1` knows it is a safe update; `1.x → 2.0` warns them to
+read the notes. That single convention prevents a lot of confusion and support
+questions.
+
+A **release** then bundles, for that version:
+
+- the **binaries** for each OS/architecture,
+- **checksums** so users can verify the downloads are intact,
+- **release notes** describing what changed,
+- and the **source** (automatic on most platforms).
+
+Tag the commit with the version, and the release is a permanent, referenceable
+snapshot anyone can come back to.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — in semver you bump MAJOR for a breaking, backward-incompatible change." markdown="0">
+  <p class="knowledge-check__q">Quick check: in semantic versioning, when do you increase the MAJOR number?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Every time you publish any new release at all</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">When you make a breaking, backward-incompatible change</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only when you fix a small bug</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Channels, trust, and updates
+
+How do people find and install your release? You have several **distribution
+channels**, and you can use more than one:
+
+- **GitHub Releases** — the simplest and most solo-friendly: attach your binaries to a
+  tagged release and link to it. Free, permanent, and where developers already look.
+- **Package managers** — meet users where they live: **Homebrew** on macOS, **apt** on
+  Linux, **winget** on Windows. More setup, but installs and updates become one
+  command for the user.
+- **Containers** — publish a container image for users who run that way (often
+  developers and servers).
+- **App stores** — the most polished install for consumer apps, but with review
+  processes, fees, and overhead that are often too heavy for a solo project.
+
+Two trust signals matter for software a stranger runs:
+
+- **Checksums** prove the download is intact and unmodified.
+- **Code signing** attaches a verified identity, so macOS and Windows do not warn the
+  user away from (or outright block) an "unknown developer." It costs money and setup,
+  but for non-technical audiences it removes a scary barrier.
+
+Finally, consider **auto-update** so users do not get stranded on an old, buggy
+version — even just a startup check that says "a newer release is available" goes a
+long way. And whatever channel you choose, **install instructions and documentation**
+are part of distribution: a clear "download this, run that" beats the most elegant
+binary nobody can figure out how to start.
+
+## How a solo SDR project ships: the GopherTrunk pattern
+
+Bring it together with a concrete case. **GopherTrunk** is radio software aimed partly
+at scanner hobbyists — people who want to listen, not to compile code. A heavyweight
+distribution story would lose most of them at step one. So the strategy is exactly the
+solo-friendly one this lesson describes:
+
+- Written in a language that **cross-compiles to a single binary**, so there is no
+  runtime for the user to install.
+- **CI builds prebuilt binaries for every operating system** on each tagged release —
+  Linux, macOS and Windows — with no manual building.
+- Those binaries are published as versioned **releases**, and the
+  [downloads](/downloads.html) page simply points the user to the right file for their
+  system.
+- Supporting docs — including a [hardware](/hardware.html) page on which radios and
+  dongles work — close the gap between "downloaded it" and "it's running."
+
+The payoff: a non-technical hobbyist visits the downloads page, grabs one file for
+their OS, plugs in a supported dongle, and is scanning — no toolchain, no dependency
+hunt, no terminal required. That is what good distribution buys you. The hard
+engineering inside is real, but the *install* is one step, and that is what turns a
+personal project into something a community can actually use.
+
+## Recap
+
+- **Single binaries beat interpreters** — one self-contained file the user just runs
+  removes the most common reason people give up.
+- **Cross-compile in CI** — build for Linux, macOS and Windows from one machine, on
+  every release, with no manual effort.
+- **Version with semver** — MAJOR.MINOR.PATCH tells users at a glance whether an
+  upgrade is safe.
+- **Ship through the right channels** — GitHub Releases is the solo default; package
+  managers and containers reach more users.
+- **Build trust** — checksums and code signing stop tampering fears and scary OS
+  warnings.
+- **Distribution includes docs** — clear install instructions and auto-update keep
+  users from getting stuck or stranded.
+
+Next up: cutting your first real release and keeping the project healthy over time in
+[shipping v1 and maintaining solo](/learn/intro-software-dev/shipping-and-maintaining/).

--- a/docs/learn/intro-software-dev/performance-vs-productivity.md
+++ b/docs/learn/intro-software-dev/performance-vs-productivity.md
@@ -1,0 +1,160 @@
+---
+slug: performance-vs-productivity
+title: The performance ↔ productivity trade-off
+description: The central tension in language choice — languages fast to run versus fast to write, why productivity often wins, and the cases like real-time radio where it can't.
+keywords: performance vs productivity, fast languages, developer productivity, premature optimization, make it work make it right make it fast, native libraries, real-time, GIL
+level: intermediate
+status: full
+faq:
+  - q: "Are compiled languages always the right choice for performance?"
+    a: "Only when performance is actually the binding constraint. For most software the bottleneck is the network, the database or developer time — not the language's raw speed. Compiled languages shine when you have a genuine CPU-bound, latency-sensitive or resource-constrained problem, like real-time DSP on limited hardware."
+  - q: "If Python is slow, why is it so popular for data science and ML?"
+    a: "Because the slow part is delegated. Libraries like NumPy, pandas and PyTorch are thin Python interfaces over highly optimised C, C++, Fortran and GPU code. You write productive Python, but the heavy number-crunching runs in fast native code — so you get most of the productivity and most of the speed."
+  - q: "What does \"premature optimization\" actually mean?"
+    a: "Optimising code for speed before you know it matters — guessing at bottlenecks instead of measuring them. It wastes effort and complicates code that was fine as it was. The discipline is to make it work, make it right, then make it fast only where profiling proves it's needed."
+---
+# The performance ↔ productivity trade-off
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Fast to run vs fast to write** — the core tension behind every language choice. **Productivity usually wins** — developer time costs more than hardware, until it doesn't. **Real-time and embedded are the exception** — you can't add servers to a Raspberry Pi.
+</div>
+
+If you had to compress language choice to one axis, this would be it. Some languages
+are fast to *run* — they squeeze the most out of the hardware. Others are fast to
+*write* — they let a developer get a working thing done quickly. You rarely get the
+maximum of both, and most of choosing a language is deciding which one your problem
+actually rewards. This lesson lays out the trade-off and, just as importantly, where
+it doesn't apply.
+
+## The two kinds of "fast"
+
+When people say a language is "fast," they usually mean one of two different things:
+
+- **Fast to run** — low CPU and memory cost, predictable timing. **C, C++, Rust and
+  Go** sit here. They compile ahead of time to native code, give you control over
+  memory, and run with little overhead.
+- **Fast to write** — fewer lines, less ceremony, quick iteration, easy to read.
+  **Python, JavaScript and Ruby** live here. Dynamic typing, garbage collection and
+  rich standard libraries let you express a lot with a little, at some run-time cost.
+
+```text
+fast to RUN                                          fast to WRITE
+ C  C++  Rust   ────   Go   ────   Java  C#   ────   JS  ────  Python  Ruby
+ (control, speed)      (a strong middle)              (productivity, speed of dev)
+```
+
+This is a spectrum, not two boxes. **Go** is the interesting middle: compiled and
+genuinely fast, yet simple and quick to write — bought partly by accepting garbage
+collection and, historically, fewer features (it lacked generics until 2022). **Java
+and C#** also occupy a managed middle, with big ecosystems and JIT-driven speed.
+There's no free lunch — every position pays for what it gains.
+
+## Productivity often beats raw speed — because of economics
+
+Here's the uncomfortable truth for performance purists: for most software,
+**developer time is the scarce resource, not CPU cycles.**
+
+- **Hardware is cheap and elastic.** If a web service is slow, you can often add a
+  bigger server or another instance for a few dollars a month — far less than the
+  cost of a developer-month spent shaving milliseconds.
+- **Most programs aren't CPU-bound.** They wait on the network, the disk or the
+  database. Making the language faster does nothing for time spent waiting.
+- **Slow software that ships beats fast software that doesn't.** A product that
+  reaches users in a productive language wins over a faster one that's still being
+  hand-optimised six months later.
+
+So the default bias for ordinary software is toward productivity — and that's a
+*rational* default, not laziness. You reach for raw speed when measurement, not
+intuition, says you need it.
+
+## "Make it work, make it right, make it fast"
+
+This old maxim (Kent Beck) is the practical discipline behind the trade-off, and the
+order matters:
+
+1. **Make it work** — get something correct and running, in whatever is quickest.
+2. **Make it right** — clean it up, structure it, make it maintainable and tested.
+3. **Make it fast** — *only now*, and only where you've measured a real bottleneck.
+
+The trap it guards against is **premature optimization** — twisting code for speed
+before you know speed is even a problem. Premature optimization wastes effort,
+complicates code, and usually targets the wrong place anyway, because intuition about
+bottlenecks is notoriously bad. **Profile first; optimise the proven hot path; leave
+the rest readable.**
+
+## Productivity languages call into fast native code
+
+The trade-off has a clever escape hatch that resolves much of the tension: a
+productive language can **delegate the slow part to a fast one.**
+
+- **NumPy, pandas, SciPy** give Python array math implemented in C and Fortran. Your
+  loop-heavy number-crunching runs at native speed while you write ordinary Python.
+- **PyTorch and TensorFlow** push tensor math onto optimised C++ and GPU kernels.
+- **GNU Radio** drives C++ DSP blocks from a Python flowgraph.
+
+The pattern is a thin, productive layer over a fast core. This is *why* "Python is
+slow" coexists with "Python dominates data science" — the slow interpreter never
+touches the hot loop. When you can structure your problem this way, you often get
+most of the productivity *and* most of the speed. The catch: it only works when the
+expensive work can be handed off in big chunks. Fine-grained, per-sample logic that
+can't be vectorised away gets no benefit, and pays full interpreter tax.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — libraries like NumPy run the heavy math in compiled C/Fortran, so Python stays productive while the hot loop runs at native speed." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does Python achieve good performance for data science despite being slow itself?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The Python interpreter was rewritten to match C speed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Heavy work is delegated to fast native libraries like NumPy and PyTorch</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Python skips type checking, which makes loops as fast as C</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## When you *can't* just add servers
+
+The "hardware is cheap, optimise later" logic has hard limits, and missing them is a
+classic mistake. Some problems can't be solved by throwing more machines at them:
+
+- **Real-time deadlines.** A control loop or audio pipeline must finish each cycle on
+  time. A second server doesn't help a single thread that misses its deadline; you
+  need the work to *be* fast, with predictable timing and no surprise pauses.
+- **Embedded and constrained hardware.** A microcontroller or a Raspberry Pi has the
+  CPU and RAM it has. You cannot scale out — you must fit the budget you're given.
+- **Radio and DSP.** Software-defined radio produces a relentless sample stream;
+  each buffer must be filtered and demodulated before the next arrives or samples
+  **drop**. That's a per-buffer deadline on finite hardware — exactly where raw
+  speed and predictability stop being optional. Python is excellent for *prototyping*
+  DSP, but the production inner loop usually lives in C, C++, Rust or carefully
+  written Go.
+
+In these domains the trade-off flips: productivity is still nice, but performance is
+a **hard constraint**, and you choose a language that can meet it. GopherTrunk lives
+in this world — see the [RF & SDR path](/learn/rf-sdr/) for where the deadlines come
+from. The point is not "compiled good, interpreted bad"; it's *know which side of
+the line your problem is on* before you let economics pick for you.
+
+## A balanced default
+
+Put together, a sane default policy looks like this:
+
+- **Bias to productivity** for ordinary, I/O-bound, scalable software — and measure
+  before optimising.
+- **Bias to performance** when you have a real, proven CPU-bound or real-time
+  constraint on hardware you can't simply grow.
+- **Mix both** when you can: a productive shell around a fast core.
+
+## Recap
+
+- **Two kinds of fast** — fast to run (C, C++, Rust, Go) and fast to write (Python,
+  JS, Ruby); Go and the managed languages sit in between.
+- **Productivity is the usual default** — developer time costs more than hardware,
+  and most software isn't CPU-bound.
+- **Make it work, make it right, make it fast** — optimise last, only where profiling
+  proves it matters, to avoid premature optimization.
+- **Productive languages delegate** — NumPy and friends run the heavy work in native
+  code, recovering much of the speed.
+- **Real-time and embedded flip the rule** — when you can't add servers, performance
+  becomes a hard constraint, as it is in radio DSP.
+
+Next up: a fair, even-handed survey of the major languages you'll actually choose
+between — [a tour of today's major languages](/learn/intro-software-dev/language-tour/).

--- a/docs/learn/intro-software-dev/quality-when-solo.md
+++ b/docs/learn/intro-software-dev/quality-when-solo.md
@@ -1,0 +1,156 @@
+---
+slug: quality-when-solo
+title: Keeping quality high alone
+description: Use tests, linters, type checks and CI as the teammate you don't have — automated guardrails plus pre-commit hooks and self code review, kept realistically light.
+keywords: solo quality, automated tests, continuous integration, pre-commit hooks, self code review, linters, type checks, guardrails, sustainable process
+level: intermediate
+status: full
+faq:
+  - q: "How does a solo developer review code with no one else?"
+    a: "Two ways. First, you make **machines** do the mechanical review — tests, linters, type checks and CI catch the bugs and slips a human reviewer would. Second, you create distance from yourself: open a **pull request to your own project** and read it as a critic, and **sleep on** big changes so you see them with fresh, less attached eyes the next day. Distance is what a second reviewer really provides, and you can manufacture some of it deliberately."
+  - q: "Is CI worth it for a one-person project?"
+    a: "Usually yes, and it is cheap to set up. **Continuous integration** runs your tests and checks automatically on every push, so you find out within minutes if something broke — even on a machine that is not yours, catching \"works on my machine\" problems. It is the closest thing a solo dev has to a tireless teammate who checks every change without ever getting bored or distracted."
+  - q: "How much process does a solo project actually need?"
+    a: "Enough to catch real mistakes, and no more. A formatter, a linter, tests on the important parts, and CI cover most of the value. You do not need heavy ceremony, sign-off gates, or 100% test coverage. The goal is guardrails that protect you cheaply, not bureaucracy that slows you down — process should feel like a safety net, not a tax."
+---
+# Keeping quality high alone
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Automation is your reviewer** — tests, linters, type checks and CI catch what no human can. **Manufacture distance** — PRs to yourself and sleeping on changes. **Just enough process** — guardrails, not bureaucracy.
+</div>
+
+On a team, quality is partly someone else's job — a reviewer who spots your mistake, a
+QA engineer who finds the crash, a CI server someone else maintained. Alone, all of
+that is gone, and the temptation is to skip it and just "be careful." But you cannot
+be careful at midnight on the hundredth change, and you have no second pair of eyes to
+catch you when you slip. The solo answer is not heroic discipline — it is **building
+guardrails that do the reviewing for you**, automatically, every time, forever. This
+lesson is about assembling that automated teammate, plus a couple of human tricks to
+review your own work, while keeping the whole thing realistically light.
+
+## Automation is the teammate you don't have
+
+Think of each automated check as a colleague who reviews every single change without
+ever getting tired, bored or distracted. Four of them carry most of the weight:
+
+- **Tests** — code that checks your code, proving the important behaviour still works
+  after every change. They are how you refactor without fear and the closest thing to
+  a QA engineer you have. The [testing lesson](/learn/intro-software-dev/testing/)
+  goes deep on writing them well.
+- **Linters** — flag likely bugs and risky patterns the moment you write them: unused
+  values, ignored errors, suspicious comparisons.
+- **Type checks** — in a typed language (or with optional typing added on), the
+  compiler or checker catches whole categories of mistakes — wrong shapes, null
+  surprises — before the program even runs.
+- **Continuous integration (CI)** — runs all of the above automatically on every push,
+  on a clean machine that is not yours, so nothing slips through and "works on my
+  machine" gets caught.
+
+The shift in mindset is this: you do not have to *remember* to check things or *be
+sharp enough* to catch them. You set the guardrails up once, and from then on the
+machine reviews every change for free. That is how a solo dev keeps quality high
+without superhuman vigilance.
+
+## Catch problems before they land: pre-commit hooks
+
+A **pre-commit hook** runs checks automatically the instant you try to commit, and
+refuses the commit if they fail. It is the earliest possible guardrail — problems are
+stopped before they ever enter your history.
+
+A sensible solo hook does the cheap, fast things:
+
+```text
+on git commit:
+  format the code   →  if it changed anything, fix it
+  run the linter    →  block on errors
+  run quick tests   →  block on failures
+```
+
+Keep hooks **fast** — a hook that takes 30 seconds trains you to bypass it, which
+defeats the purpose. Put the slow, thorough stuff (the full test suite,
+cross-platform builds) in CI, where it can take its time after the push. Fast checks
+locally, thorough checks remotely: that split keeps both your loop tight and your main
+branch trustworthy.
+
+## Manufacture the distance a reviewer gives you
+
+The deepest value of a code reviewer is not their cleverness — it is their
+**distance**. They did not just write the code, so they see it fresh, without the
+author's blind spots and emotional attachment. You can deliberately recreate some of
+that distance:
+
+- **Pull requests to yourself.** Even alone, push your change to a branch and open a
+  PR against your own main. Then read the diff *as a reviewer*, not as the author —
+  the side-by-side view and the act of switching roles surfaces things you glide past
+  in your editor. CI runs on the PR too, so you get the checks before you merge. (The
+  [version control & collaboration lesson](/learn/intro-software-dev/version-control-collab/)
+  covers the PR mechanics.)
+- **Sleep on big changes.** The code that looked obviously correct at 2am often looks
+  obviously wrong at 9am. For anything significant, let it sit overnight and reread it
+  with fresh eyes before merging. Tomorrow-you is the second reviewer.
+- **Rubber-duck it.** Explain the tricky change out loud, as if to someone else.
+  Articulating it forces the gaps into the open.
+
+None of these fully replace a real second person — but together they recover a
+meaningful slice of what review provides, at zero cost.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — automated checks act as a tireless reviewer, catching bugs and slips on every change without a second person." markdown="0">
+  <p class="knowledge-check__q">Quick check: how do tests, linters and CI help a solo developer most?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">They make the program run faster for end users</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">They act as a tireless automated reviewer, catching mistakes on every change with no second person</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">They remove the need to ever test the program by hand or think about design</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Keep it realistic — guardrails, not bureaucracy
+
+It is easy to over-correct and bury a tiny project under team-sized process. Resist.
+The goal is a safety net that protects you cheaply, not ceremony that slows you to a
+crawl. A right-sized solo setup is roughly:
+
+- **Formatter and linter** on save and on commit — near-zero cost, constant payoff.
+- **Tests on the parts that matter** — the core logic, the tricky algorithm, the bits
+  that would be embarrassing or dangerous to get wrong. You do **not** need to test
+  every trivial getter, and you do not need 100% coverage.
+- **CI on every push** — set up once, runs forever.
+- **Self-review and sleeping on it** for anything non-trivial.
+
+| Worth it for a solo dev | Probably overkill |
+| --- | --- |
+| Format + lint automatically | Mandatory multi-stage sign-off |
+| Test the core and the risky bits | Chasing 100% coverage |
+| CI runs tests on every push | Heavy release-approval ceremony |
+| Self-PR + sleep on big changes | A formal QA team process |
+
+Match the process to the stakes. A weekend utility needs less than software people pay
+for or rely on for safety. The skill is dialing in *just enough* — enough to sleep
+well, not so much that you stop shipping.
+
+## A radio-tool example
+
+Imagine your single-frequency logger from the previous lesson. The guardrails that
+keep it solid are modest but real: a **test** that feeds it a known captured sample and
+asserts it detects the signal at the right moment; a **linter** that nags you about the
+error you forgot to handle when the radio device disconnects; and **CI** that builds
+and tests it on Linux, macOS and Windows on every push — catching the path bug that
+only shows up on Windows, which you would never have found on your own machine. That is
+three small investments standing in for an entire QA team, and they let you change the
+decoder with confidence instead of crossing your fingers.
+
+## Recap
+
+- **Automation is your reviewer** — tests, linters, type checks and CI catch on every
+  change what a human reviewer would, tirelessly.
+- **Pre-commit hooks** — stop problems before they enter your history; keep them fast.
+- **Fast local, thorough remote** — quick checks on commit, the heavy suite in CI.
+- **Manufacture distance** — PRs to yourself and sleeping on big changes recover much
+  of what a second reviewer provides.
+- **Right-size the process** — guardrails that protect you cheaply, not bureaucracy;
+  skip 100% coverage and sign-off gates.
+- **Match process to stakes** — a hobby tool needs less than software people rely on.
+
+Next up: turning your solid v1 into something other people can install in
+[packaging and distributing your software](/learn/intro-software-dev/packaging-and-distribution/).

--- a/docs/learn/intro-software-dev/robustness-and-errors.md
+++ b/docs/learn/intro-software-dev/robustness-and-errors.md
@@ -1,0 +1,123 @@
+---
+slug: robustness-and-errors
+title: Errors, edge cases & defensive programming
+description: Errors are normal, not exceptional. Learn error-handling styles, boundary validation, fail-fast vs fail-soft, idempotency and graceful degradation.
+keywords: error handling, defensive programming, edge cases, fail fast, graceful degradation, input validation, idempotency, Go error handling, exceptions, Result type, robustness
+level: intermediate
+status: full
+faq:
+  - q: "Are errors really \"normal\" rather than exceptional?"
+    a: "Yes. Networks drop packets, files go missing, users type garbage, and radio signals arrive full of noise. These are everyday occurrences, not rare anomalies. Robust code treats error paths as a first-class part of the design, not an afterthought bolted on at the end."
+  - q: "What is the difference between failing fast and failing soft?"
+    a: "Failing fast means stopping immediately when something is wrong — surfacing the error loudly so it can't propagate silently. Failing soft (graceful degradation) means continuing with reduced functionality. You fail fast on programmer errors and broken invariants, and fail soft on expected, recoverable conditions like a noisy input."
+  - q: "What does idempotent mean and why does it matter?"
+    a: "An idempotent operation produces the same result whether it runs once or many times. It matters because failures often trigger retries; if \"process this frame\" or \"create this record\" is idempotent, a retry after a timeout can't cause duplicate work or corruption."
+---
+# Errors, edge cases & defensive programming
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Errors are normal** — design for them, don't bolt them on. **Validate at boundaries** — distrust input from the outside world. **Fail fast or soft deliberately** — crash on bugs, degrade gracefully on expected trouble.
+</div>
+
+A program that only works when everything goes right barely works at all. Real systems run in a hostile world: networks drop, disks fill, users mistype, and — for software like GopherTrunk — radio signals arrive smeared with noise and dropped samples. The defining trait of professional code isn't that it handles the happy path; it's that it handles everything *else* with composure. This lesson is about robustness: treating errors as normal, validating what you can't trust, and choosing deliberately how to respond when things go wrong.
+
+## Errors are normal, not exceptional
+
+The biggest mindset shift is to stop thinking of errors as rare anomalies. A file not existing, a connection timing out, a malformed message — these are routine. If error handling feels like an annoying afterthought, your design is fighting reality.
+
+Robust code treats the error path as a **first-class part of the design**, considered alongside the success path from the start. The question for every operation that touches the outside world is not "what if this fails?" but "*when* this fails, what should happen?" Asking it early leads to clear, deliberate handling; asking it never leads to crashes and silent corruption.
+
+## Styles of error handling
+
+Languages take different approaches to representing and propagating errors. Knowing the trade-offs helps you write robust code in any of them.
+
+- **Exceptions** (Java, Python, C#) — errors are thrown and unwind the stack until something catches them. Convenient, but easy to ignore: an uncaught exception can crash the program, and it's not obvious from a function's signature what it might throw.
+- **Explicit error returns** (Go) — functions return an error value alongside their result, and the caller must decide what to do. Verbose, but the error path is impossible to overlook because it's right there in the code.
+- **Result / Option types** (Rust's `Result`, many functional languages) — errors are part of the return type, and the compiler forces you to handle both the success and failure cases before you can use the value.
+
+```go
+// Go makes the error path explicit and unavoidable.
+frame, err := decoder.Decode(raw)
+if err != nil {
+    return fmt.Errorf("decoding frame: %w", err)  // wrap with context, propagate
+}
+// only reach here on success
+use(frame)
+```
+
+There's no universally "best" style, but the modern lean is toward **explicit** handling (returns or Result types) over invisible exceptions, precisely because errors are normal and should be visible. Whatever the style, the anti-pattern is the same: swallowing an error silently — an empty `catch {}` or ignoring a returned error — which turns a recoverable problem into a mysterious one later.
+
+## Validate inputs at the boundaries
+
+A robust system distrusts data crossing into it from the outside: user input, network payloads, file contents, hardware feeds. **Validate at the boundary** — the moment data enters your system — so that the interior code can assume it's working with well-formed values.
+
+This concentrates messy, defensive checks at the edges and keeps the core clean. Inside the boundary, you've already established invariants (the frame length is valid, the field is non-negative), so deep internal code doesn't need to re-check everything. Pushing validation to the edges is both safer and tidier than scattering paranoid checks everywhere.
+
+A related idea is **fail fast**: when an input violates an invariant, reject it immediately and loudly rather than letting a bad value slip deeper, where it'll cause a confusing failure far from the cause. The closer an error is reported to its origin, the easier it is to diagnose.
+
+## Defensive programming — without paranoia
+
+Defensive programming means writing code that anticipates misuse and bad data. Done well, it makes systems resilient. Done blindly, it bloats code with redundant checks and hides real bugs.
+
+Useful defensive habits:
+
+- **Check assumptions at boundaries**, then trust them internally.
+- **Use assertions or guard clauses** to catch programmer errors early during development.
+- **Handle the edge cases**: empty inputs, zero, negative numbers, maximum values, off-by-one limits, concurrent access. Most bugs live at the edges, not the middle.
+- **Make illegal states unrepresentable** where the type system allows — a value that can't be constructed wrong can't be wrong.
+
+The balance: defend against the things that *can* genuinely happen (external input, hardware faults, concurrency), but don't wrap every internal call in needless checks. Excessive defensiveness can mask bugs — a swallowed error that "shouldn't happen" hides the fact that it did.
+
+## Fail fast vs fail soft
+
+Two opposite responses to trouble, each right in its place:
+
+| | Fail fast | Fail soft (graceful degradation) |
+|---|---|---|
+| **Behavior** | Stop immediately, surface the error | Continue with reduced functionality |
+| **Best for** | Programmer bugs, broken invariants | Expected, recoverable conditions |
+| **Example** | Corrupt internal state → crash loudly | One noisy frame → drop it, keep decoding |
+
+The art is matching the response to the cause. A violated internal invariant means your *program* is wrong — fail fast, crash loudly, fix the bug. A noisy radio frame means the *world* is messy — fail soft, skip it, carry on. Confusing the two is a classic mistake: crashing on every bit of expected noise makes a system useless, while soldiering on with corrupt internal state makes it dangerous.
+
+**Graceful degradation** is the broader principle behind fail-soft: when part of a system can't function, the rest keeps working at reduced capability rather than collapsing entirely. A streaming decoder that hits an undecodable frame should drop it and keep processing the stream, not halt.
+
+## Idempotency and retries
+
+Because failures trigger retries — a timeout, a dropped connection, a restarted process — operations that might run more than once should be **idempotent**: running them twice has the same effect as running them once. Setting a value to `x` is idempotent; appending `x` to a list is not. When an operation is idempotent, a retry after an ambiguous failure is safe; when it isn't, retries risk duplicates and corruption. Designing for idempotency is what makes retry logic trustworthy in any system that can fail partway through.
+
+## Putting it together: a resilient radio decoder
+
+These ideas converge sharply in a real-time radio decoder, the kind at the heart of GopherTrunk. Signals from the air are *never* clean: there's background noise, fading, interference, dropped samples when the hardware can't keep up, and frames that arrive truncated or corrupted. The decoder must absorb all of this **without crashing**.
+
+A robust design applies everything from this lesson:
+
+- **Errors are normal** — a malformed frame is expected input, handled on the main path, not an exceptional event.
+- **Validate at the boundary** — check frame length, sync words, and checksums the moment bytes arrive; reject the bad ones cleanly.
+- **Fail soft** — drop an undecodable frame and keep processing the stream; one bad frame must not kill the pipeline.
+- **Graceful degradation** — under heavy noise, output fewer valid messages rather than collapsing.
+- **Fail fast on bugs** — if an *internal* invariant breaks (a buffer index is impossible), that's a programmer error worth surfacing loudly.
+
+This robustness is exactly what makes streaming pipelines viable — see how the stages connect in [concurrency and pipelines](/learn/intro-software-dev/concurrency-and-pipelines/) — and it's only trustworthy if you prove it under bad inputs, which is the job of [testing](/learn/intro-software-dev/testing/). A decoder that survives noise, drops, and malformed frames in tests is one you can trust on the air.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a noisy or malformed frame is expected, so fail soft: drop it and keep decoding the stream." markdown="0">
+  <p class="knowledge-check__q">Quick check: a radio decoder receives a malformed frame from a noisy signal. What's the robust response?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Crash the program so the error can't be missed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Drop the bad frame and keep processing the stream</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Silently retry decoding the same frame forever</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Errors are normal** — design the error path as a first-class concern, not an afterthought.
+- **Know the styles** — exceptions, explicit returns, and Result types; the modern lean is toward explicit, visible handling.
+- **Validate at boundaries** — distrust external input at the edge so internal code can trust its invariants.
+- **Fail fast vs fail soft** — crash loudly on programmer bugs, degrade gracefully on expected, recoverable trouble.
+- **Idempotency** — make retry-able operations safe to run more than once.
+- **Resilience in practice** — a radio decoder must tolerate noise, drops, and malformed frames without crashing.
+
+Next up: Module 4 begins by asking what design patterns even are — [what are patterns](/learn/intro-software-dev/what-are-patterns/).

--- a/docs/learn/intro-software-dev/scoping-a-project.md
+++ b/docs/learn/intro-software-dev/scoping-a-project.md
@@ -1,0 +1,170 @@
+---
+slug: scoping-a-project
+title: From idea to project
+description: Turn a vague idea into a v1 you can finish — MVP thinking, ruthless scope-cutting, a short spec, a sensible repo, and milestones, with a worked SDR example.
+keywords: project scoping, MVP, minimum viable product, cutting scope, writing a spec, README first, milestones, scope creep, solo project
+level: intermediate
+status: full
+faq:
+  - q: "What is an MVP?"
+    a: "An **MVP**, or minimum viable product, is the smallest version of your idea that actually delivers value to a user. It is not a half-built mess — it is a complete, useful thing with a deliberately narrow scope. The point is to finish and ship something real quickly, learn from it, and expand from there rather than spending months on features no one has asked for yet."
+  - q: "How do I stop scope from creeping?"
+    a: "Write down what v1 **is and is not** before you start, and treat that list as a contract. When a tempting new idea appears, do not build it — add it to a \"later\" list. Most scope creep comes from saying yes in the moment. A written, deliberately small scope gives you something concrete to say no against, which is the only reliable defence when you are alone."
+  - q: "Should I write a spec before coding?"
+    a: "A short one, yes. A page or two — often just a README written first — that says what the thing does, who it is for, and what v1 includes, forces you to think before you type and gives you a target to aim at. It does not need to be formal or long. The act of writing it usually reveals that half your planned features are not actually needed for v1."
+---
+# From idea to project
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Define a finishable v1** — the smallest version that is genuinely useful. **Cut ruthlessly** — write down what v1 is *not*. **Spec first** — a short README and milestones beat diving straight into code.
+</div>
+
+The graveyard of solo projects is full of brilliant ideas that were never finished —
+not because the developer lacked skill, but because they never defined a version 1
+small enough to reach. Working alone, your scarcest resource is *finishing energy*,
+and the surest way to run out of it is to aim at the whole grand vision at once. This
+lesson is about the opposite discipline: shrinking an idea down to something you can
+actually ship, writing just enough of a plan to aim at it, and ruthlessly defending
+that boundary against your own enthusiasm. Get this right and the rest of the module —
+quality, packaging, shipping — has something real to act on.
+
+## Define a v1 you can actually finish
+
+Every idea has a grand version: all the features, all the polish, all the
+platforms. **That is not your first goal.** Your first goal is a **v1** — the smallest
+version that is genuinely useful to one real person (even if that person is you). This
+is **MVP thinking**: a minimum *viable* product is complete and useful, just narrow.
+
+The test for whether something belongs in v1 is brutal and clarifying:
+
+- *Without this, is the program still useful to someone?* If yes, it is not v1 — it is
+  later.
+- *Is this the one core thing the program is fundamentally for?* If yes, it is v1.
+
+Almost everything fails the first test. That is the point. A v1 you can finish in
+weeks and put in front of users teaches you more than a v3 you imagine for months and
+never ship. **Shipping something small is progress; planning something huge is not.**
+
+## Cut scope ruthlessly — and write down what you cut
+
+The single most valuable artefact in early scoping is not a list of features to
+build. It is a list of features you are **deliberately not building yet.** Writing
+"v1 does NOT include X, Y, Z" turns vague restraint into a concrete decision you can
+point at later.
+
+This matters because of two classic, opposite traps:
+
+- **The infinite-polish trap.** Endlessly refining what you have — another setting,
+  another edge case — because finishing and shipping feels scarier than tinkering.
+  Polish is a stalling tactic in disguise.
+- **The rewrite-everything trap.** Convincing yourself the whole thing must be torn
+  down and rebuilt "properly" before it is good enough to ship. It almost never must.
+  Ship the imperfect thing, then improve it in place.
+
+Both traps are forms of avoiding the finish line. A written, intentionally small scope
+is your defence against both, because it tells you, in your own earlier words, when
+you are done.
+
+## Write the README first
+
+Before you write code, write the **README** — the document that explains what the
+thing is. Writing it *first* (sometimes called "readme-driven development") is a
+forcing function: you cannot describe a product you have not actually thought through.
+
+A first README needs only:
+
+- **What it does**, in one or two sentences a stranger would understand.
+- **Who it is for** and the problem it solves for them.
+- **What v1 includes** — and a short "not yet" list of what it does not.
+- A rough idea of **how someone will run it.**
+
+```text
+# Tinylog
+A tiny command-line tool to log activity on one radio frequency to a CSV file.
+
+v1: tune one frequency, detect activity, append timestamped rows.
+Not yet: scanning multiple frequencies, audio recording, a GUI.
+```
+
+Half the time, writing this reveals that several of your "essential" features are
+nowhere near essential. That realization, before you have written a line of code, is
+worth an hour of typing many times over.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an MVP is the smallest complete, useful version, built to ship and learn from quickly rather than to be impressive." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is the goal of defining an MVP for your v1?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To include every feature you can think of so users are never disappointed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">To ship the smallest genuinely useful version quickly, then learn and expand from real use</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To spend as long as possible perfecting it before anyone sees it</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Structure the repo and set milestones
+
+A little structure up front keeps a small project from turning into a single
+1,000-line file you are afraid to touch. You do not need elaborate architecture — just
+sensible separation:
+
+- A clear **entry point** (where the program starts).
+- Logic grouped into a few **modules or packages** by responsibility, not crammed
+  together.
+- Tests living **alongside the code** they cover.
+- The **README**, a license, and config at the top level where people expect them.
+
+Then break the road to v1 into a few **milestones** — concrete, checkable steps, each
+of which leaves the program in a working state:
+
+1. It runs and prints something.
+2. It does the core thing once, by hand.
+3. It does the core thing reliably, with tests.
+4. It is packaged so someone else can run it.
+
+Milestones turn "build the whole thing" — which is paralysing — into "finish the next
+small thing," which is doable. Each one is a little win that keeps momentum alive,
+which for a solo dev is half the battle.
+
+## Worked example: scoping a radio logger
+
+Suppose you want to build "a software-defined-radio scanner" — monitor a whole band,
+record audio, identify systems, the works. That is a wonderful v3 and a terrible v1.
+Apply the discipline above and shrink it hard:
+
+- **The grand vision:** a multi-frequency scanner with audio recording, a database of
+  systems, a live waterfall display, and trunk-tracking.
+- **The honest v1:** *a single-frequency activity logger.* Tune to **one** frequency,
+  detect when there is activity, and append a timestamped row to a file. That is it.
+
+Look at what that v1 deliberately does **not** include: no scanning across
+frequencies, no audio capture, no display, no database. Each of those is a real
+feature for later — and each would have stretched v1 from weeks into never. The single
+frequency logger is finishable, genuinely useful (people want activity logs), and it
+forces you to solve the actual hard part — talking to the radio and detecting a signal
+on captured [IQ samples](/learn/rf-sdr/iq-data/) — without the distraction of ten
+other features.
+
+Once that logger works, ships, and you have used it, *then* you expand: a second
+frequency, then a list, and you are on the road to a real scanner — built incrementally
+on a foundation that already works, rather than imagined whole and never reached. If
+you want to go deep on the radio side of such a project, the
+[RF & SDR path](/learn/rf-sdr/) is the companion to this one. This incremental, ship-then-grow
+path is exactly how a project like GopherTrunk gets from a single useful feature to a
+full toolkit.
+
+## Recap
+
+- **Aim at a finishable v1** — the smallest version that is genuinely useful, not the
+  grand vision.
+- **MVP thinking** — small and complete beats large and unfinished; ship to learn.
+- **Cut ruthlessly and write it down** — a "v1 does not include…" list is your defence
+  against scope creep.
+- **Avoid both traps** — infinite polish and total rewrites are both ways of dodging the
+  finish line.
+- **README first** — writing what it is before coding reveals which features are
+  actually essential.
+- **Milestones over mountains** — break the path into small, working steps that each
+  leave the program runnable.
+
+Next up: keeping that v1 solid without a team to review it in
+[keeping quality high alone](/learn/intro-software-dev/quality-when-solo/).

--- a/docs/learn/intro-software-dev/sdlc-and-methodologies.md
+++ b/docs/learn/intro-software-dev/sdlc-and-methodologies.md
@@ -1,0 +1,104 @@
+---
+slug: sdlc-and-methodologies
+title: The software life cycle — Waterfall to Agile
+description: The stages of the software development life cycle, plus Waterfall, Agile values, Scrum and Kanban — and an honest take on when process helps and when it's overhead.
+keywords: software development life cycle, SDLC, Waterfall, Agile, Scrum, Kanban, sprints, software methodologies, iterative development, WIP limits
+level: beginner
+status: full
+faq:
+  - q: "Is Agile always better than Waterfall?"
+    a: "No. Agile shines when requirements are uncertain and feedback is valuable — most product software. Waterfall (or something close to it) still fits work where requirements are fixed and verification is expensive or regulated, such as aerospace, medical devices, or a firmware load that physically ships once. The honest answer is to match the process weight to the project's uncertainty and cost of change."
+  - q: "What's the difference between Scrum and Kanban?"
+    a: "Scrum organizes work into fixed-length sprints with defined roles and ceremonies (planning, standup, review, retrospective) and commits to a batch of work per sprint. Kanban has no sprints — it visualizes a continuous flow of tasks on a board and limits work in progress so the team finishes things before starting new ones. Scrum is cadence-driven; Kanban is flow-driven."
+  - q: "Do solo developers need a methodology at all?"
+    a: "Not a formal one. The value of heavyweight process is mostly coordinating many people. Solo, you still benefit from the underlying ideas — work in small iterations, keep something working, write down decisions — but you can drop the ceremonies. Use just enough structure to avoid losing track, and no more."
+---
+# The software life cycle — Waterfall to Agile
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The SDLC** — every project moves through requirements, design, build, test, deploy, maintain. **Waterfall vs Agile** — sequential up-front planning versus iterative feedback. **Process is a dial** — match its weight to the project's uncertainty, not a checklist to obey.
+</div>
+
+Writing code is only one slice of building software. Around it sits a whole life cycle — figuring out what to build, designing how, verifying it works, shipping it, and keeping it alive for years. *How* a team moves through that cycle is its **methodology**, and the industry has swung between two poles: plan everything first (Waterfall), or plan a little and learn fast (Agile). This lesson lays out the stages every project passes through, then the methodologies built on top, and stays honest about when heavier process earns its keep and when it's just overhead.
+
+## The stages of the software development life cycle
+
+Whatever the methodology, software passes through the same logical phases. They might be one big sequence or repeated in tight loops, but the activities are constant:
+
+- **Requirements** — figuring out what problem you're solving and what "done" means. The most expensive mistakes are made here: building the wrong thing well.
+- **Design** — deciding the architecture, data structures, interfaces, and technologies. How will the pieces fit together?
+- **Implementation** — actually writing the code. This is what beginners picture as "software development," but it's often a minority of the total effort.
+- **Testing** — verifying the software does what it should and breaks gracefully when it shouldn't. (A whole [testing lesson](/learn/intro-software-dev/testing/) is coming.)
+- **Deployment** — getting the software into users' hands: a release, a package, a server rollout.
+- **Maintenance** — fixing bugs, adapting to change, and extending the software over its life. For most software this is the *longest and largest* phase by far.
+
+The crucial insight is that the **cost of fixing a mistake rises the later you catch it.** A misunderstood requirement is cheap to fix on a whiteboard, painful to fix after the architecture is built around it, and brutal to fix once it's shipped to thousands of users. Every methodology is really a different bet on how to manage that rising cost.
+
+## Waterfall — one direction, plan first
+
+The **Waterfall** model treats those stages as a strict sequence: finish requirements, then finish design, then implement, then test, then deploy. Each phase "flows" into the next like water down steps, and you don't go back up. It was the dominant model for decades, borrowed from manufacturing and construction where you genuinely can't pour a foundation after framing the walls.
+
+**Where it works:** when requirements are well understood and stable, when the cost of change after release is enormous, or when regulation demands extensive up-front documentation and sign-off. A firmware image burned into a million devices, or avionics software, benefits from heavy front-loaded rigor — you get one shot.
+
+**Where it fails:** most software isn't like that. Requirements are *discovered*, not handed down complete; users don't know what they want until they see something. Waterfall's failure mode is spending months building precisely the wrong thing, because the first time anyone tests against reality is near the end, when changing course is most expensive. The plan looks tidy; the world doesn't cooperate.
+
+## Agile — iterate and respond
+
+The **Agile** movement (codified in the 2001 Agile Manifesto) was a reaction to exactly that failure. Rather than one long sequence, Agile runs the whole life cycle in short, repeated loops, delivering small slices of working software and adjusting based on feedback. Its core values are worth knowing in their original spirit:
+
+- **Working software** over comprehensive documentation — a running slice you can demo beats a thick spec.
+- **Individuals and interactions** over rigid processes and tools.
+- **Customer collaboration** over contract negotiation.
+- **Responding to change** over following a plan — because the plan *will* be wrong, and that's fine.
+
+Agile doesn't mean "no planning" or "no documentation." It means planning continuously in small increments and treating change as expected rather than as failure. The bet is that frequent feedback catches misunderstandings early — while they're still cheap to fix.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Agile prioritizes adapting over rigidly following a plan, because requirements are discovered over time." markdown="0">
+  <p class="knowledge-check__q">Quick check: which best captures a core Agile value?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Finish a complete specification before any code is written</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Deliver working software in small increments and respond to change</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Avoid talking to customers until the product is finished</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Scrum and Kanban — two ways to do Agile
+
+Agile is a set of values, not a recipe. Two concrete frameworks dominate practice.
+
+**Scrum** organizes work into fixed-length iterations called **sprints**, usually one to four weeks. The team commits to a chunk of work per sprint and aims to finish a potentially shippable increment by the end. It defines a few roles and ceremonies:
+
+| Element | What it is |
+| --- | --- |
+| Product Owner | Owns and prioritizes the backlog — decides *what* matters next |
+| Scrum Master | Facilitates the process, removes blockers |
+| Development team | Builds the increment |
+| Sprint planning | Picks what to do this sprint |
+| Daily standup | Short sync: progress, plans, blockers |
+| Sprint review | Demo the increment to stakeholders |
+| Retrospective | Reflect on the *process* and improve it |
+
+**Kanban** drops sprints entirely. Work is visualized as cards moving across a board (To Do → In Progress → Done), and the team sets **WIP (work-in-progress) limits** — a cap on how many items can be in each column at once. When a column is full, you can't start new work; you must finish or unblock something first. This pulls the team toward *flow* and exposes bottlenecks: if cards pile up in "In Review," that's where the team is starved. Kanban suits continuous streams of work — support, operations, or maintenance — where a fixed sprint commitment feels artificial.
+
+Many teams blend the two ("Scrumban") or invent their own variant. The frameworks are tools, not religions.
+
+## How much process is enough?
+
+Here's the honest part. Process exists mostly to **coordinate people and manage risk.** Its value scales with team size, the cost of failure, and the number of stakeholders who must stay aligned. A regulated team of forty shipping medical software needs real ceremony; a two-person side project drowning in standups and burndown charts is paying overhead for coordination it doesn't need.
+
+Consider a small team building a decoder for a new radio protocol in GopherTrunk. The requirements are genuinely fuzzy — nobody fully knows the protocol until they've captured and stared at real signals. Waterfall would be a disaster: you can't spec what you haven't reverse-engineered. A lightweight iterative loop fits perfectly — decode a little, compare against captured samples, learn, repeat. The methodology should *serve* the discovery, not fight it.
+
+The skill isn't picking the "best" methodology — it's reading the situation. High uncertainty and cheap iteration favor Agile. Fixed requirements and expensive change favor more up-front rigor. Most real teams land somewhere in between and tune as they go. Process is a dial, not a switch.
+
+## Recap
+
+- **The SDLC** — requirements, design, implementation, testing, deployment, maintenance; the same stages underlie every methodology.
+- **Cost of change rises late** — fixing a mistake gets more expensive the further downstream you catch it, which every methodology tries to manage.
+- **Waterfall** — sequential and plan-first; great for stable, high-stakes, regulated work, dangerous when requirements are uncertain.
+- **Agile** — iterative loops delivering working software and responding to change; bets that fast feedback catches mistakes early.
+- **Scrum vs Kanban** — Scrum is cadence-driven (sprints, roles, ceremonies); Kanban is flow-driven (a board with WIP limits).
+- **Process is a dial** — match its weight to team size, uncertainty, and the cost of failure; ceremony for its own sake is overhead.
+
+Next up: the system every project relies on to track history and let people work together — [version control & collaboration](/learn/intro-software-dev/version-control-collab/).

--- a/docs/learn/intro-software-dev/shipping-and-maintaining.md
+++ b/docs/learn/intro-software-dev/shipping-and-maintaining.md
@@ -1,0 +1,168 @@
+---
+slug: shipping-and-maintaining
+title: Shipping v1 & maintaining solo
+description: Cut your first release with done over perfect, write release notes, gather and triage feedback, maintain sustainably, handle burnout and scope creep, and play the long game.
+keywords: shipping software, release notes, gathering feedback, triage, sustainable maintenance, burnout, scope creep, saying no, open source community
+level: intermediate
+status: full
+faq:
+  - q: "When is my software ready to ship?"
+    a: "When the v1 you scoped works and is genuinely useful — not when it is perfect, because it never will be. **Done is better than perfect.** Shipping an imperfect-but-useful v1 and improving it from real feedback beats polishing forever in private. The first release is a starting line, not a final exam; you can and will fix things after it is out."
+  - q: "How do I handle feedback and bug reports as a solo maintainer?"
+    a: "Give people one clear place to report (issues or discussions), then **triage** rather than react — sort what comes in by impact, fix the things that matter, and politely decline or defer the rest. You cannot do everything, and trying to is how solo projects burn out. A short, honest \"not right now, but noted\" is a complete and acceptable answer."
+  - q: "How do solo maintainers avoid burning out long-term?"
+    a: "By treating maintenance as a marathon, not a sprint — keeping scope bounded, automating the repetitive work, saying no to requests outside the project's purpose, and giving themselves permission to step back. Burnout comes from unbounded obligation, so the cure is bounded commitment: do what is sustainable, decline the rest, and protect your own energy as the project's most important resource."
+---
+# Shipping v1 & maintaining solo
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Done over perfect** — ship the useful v1 and improve from real feedback. **Triage, don't drown** — one place for feedback, sort by impact, say no often. **Play the long game** — sustainable pace beats heroic bursts.
+</div>
+
+Everything in this module has been building toward one act: putting your software in
+front of real people. This final lesson is about crossing that line — cutting the
+first release without waiting for a perfection that never arrives — and then doing the
+quieter, longer work of keeping the project alive without it consuming you. Shipping is
+exhilarating and a little terrifying; maintaining is where most solo projects either
+find their footing or quietly fade. We will cover both: how to release, how to listen,
+how to triage, and how to keep going for the long haul. And then, since this is the
+end of the path, we will send you off to build something real.
+
+## Cut the first release: done over perfect
+
+The hardest part of v1 is not the code — it is *letting go*. There is always one more
+thing to fix, one more case to handle, one more polish to apply. At some point you have
+to decide the v1 you scoped is good enough and **ship it.**
+
+Repeat the mantra: **done is better than perfect.** Not because quality does not
+matter, but because:
+
+- A useful tool in people's hands teaches you more in a week than another month of
+  private polishing ever will.
+- The "imperfections" you are obsessing over are often not the ones users actually
+  care about — you cannot know which is which until it ships.
+- A release you can improve beats a masterpiece you never finish.
+
+So when the v1 from your [scope](/learn/intro-software-dev/scoping-a-project/) works,
+passes its [guardrails](/learn/intro-software-dev/quality-when-solo/), and is
+[packaged](/learn/intro-software-dev/packaging-and-distribution/) so others can run it —
+tag it, publish it, and announce it. The first release is a starting line, not a final
+exam.
+
+## Write release notes people can read
+
+Every release deserves **release notes** — a short, human-readable summary of what
+changed. They are not a chore; they are how users decide whether to upgrade and how
+they trust that the project is alive and cared for.
+
+Good notes are brief and grouped:
+
+```text
+## v1.1.0
+Added
+- Log to CSV as well as plain text
+Fixed
+- Crash when the radio device disconnects mid-capture
+Changed
+- Faster signal detection on quiet frequencies
+```
+
+Write them for a user, not a compiler — "fixed the crash when your dongle unplugs," not
+a raw commit list. Paired with the [semantic version](/learn/intro-software-dev/packaging-and-distribution/)
+number, good notes turn every release into a small, trustworthy moment of
+communication with the people who use your work.
+
+## Gather and triage feedback
+
+Once people use your software, they will tell you things — bugs, requests, confusion,
+occasionally praise. Channel that into **one clear place**: GitHub **issues** for bugs
+and **discussions** for questions and ideas. A single front door beats feedback
+scattered across email, chat and your own memory.
+
+Then **triage** rather than react. You cannot do everything, so sort what arrives:
+
+- **Real bugs that hurt users** — fix these first.
+- **Good ideas that fit the project** — note them, schedule the worthwhile ones.
+- **Out-of-scope requests** — politely decline or defer; "not right now, but noted" is
+  a complete answer.
+- **Duplicates and noise** — close kindly, point to the existing thread.
+
+Triage is the skill that keeps feedback from becoming an avalanche. The goal is not to
+satisfy every request — it is to keep the project's purpose intact while genuinely
+listening.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — done over perfect means shipping a genuinely useful v1 and improving it from real feedback, rather than polishing forever." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does "done is better than perfect" mean for your first release?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Quality does not matter, so ship anything that compiles</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Ship a genuinely useful v1 now and improve it from real feedback, rather than polishing forever in private</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Never release until every possible feature and edge case is finished</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Maintain sustainably and protect your energy
+
+A project does not end at v1 — that is when maintenance begins, and maintenance is a
+**marathon, not a sprint.** Your most precious resource is not time or skill; it is your
+own sustained energy, and the whole art is spending it carefully:
+
+- **Bound your scope.** **Scope creep** — saying yes to feature after feature until the
+  project sprawls beyond what one person can carry — is the quiet killer. Hold the line
+  on what the project is *for*.
+- **Learn to say no.** Most requests are reasonable in isolation and unsustainable in
+  aggregate. A polite, honest "this isn't where I'm taking the project" protects both
+  you and the project's coherence. Saying no is a maintenance skill, not rudeness.
+- **Automate the repetitive.** Let CI build and test releases; let bots handle the
+  mechanical. Every chore you automate is energy saved for the work only you can do.
+- **Permit yourself to step back.** It is fine to slow down, take a break, or say a
+  project is in low-maintenance mode. Burnout comes from *unbounded obligation*; the
+  cure is **bounded commitment.** A maintainer who paces themselves outlasts one who
+  sprints and quits.
+
+This is the discipline the whole module has pointed at: give yourself the structure —
+and the limits — a healthy team would. The limits are not a weakness. They are what let
+you still be here, and still enjoying it, a year from now.
+
+## Build a small community and play the long game
+
+You do not have to stay solo forever in spirit, even if you write all the code. A
+little community makes the long game far easier and far more rewarding:
+
+- **Be welcoming.** A friendly reply to a first-time bug reporter costs a minute and
+  earns goodwill that compounds.
+- **Write things down.** Good docs and clear issues let users help each other and turn
+  some of them into contributors who lighten your load.
+- **Celebrate use.** People building things with your software is the whole point —
+  notice it, thank them, and let it refuel you.
+
+Over time, a useful, well-maintained tool with a kind maintainer attracts exactly the
+help that eases the bus-factor-of-one problem we opened the module with. That is the
+long game: not a heroic launch, but a sustainable rhythm of small releases, honest
+communication, and steady care — the same pattern that lets a one-person radio project
+like GopherTrunk keep serving hobbyists from the [downloads](/downloads.html) page
+release after release.
+
+## Recap
+
+- **Done over perfect** — ship the useful v1 and improve from real feedback instead of
+  polishing forever.
+- **Release notes** — short, human, grouped, paired with a semver number, so users
+  trust and understand each update.
+- **One door, then triage** — funnel feedback to issues and discussions, then sort by
+  impact rather than reacting to everything.
+- **Maintain sustainably** — bound your scope, automate the repetitive, and protect
+  your energy as the project's key resource.
+- **Say no on purpose** — declining out-of-scope work keeps both you and the project
+  healthy.
+- **Play the long game** — a welcoming maintainer and steady small releases beat a
+  heroic burst that burns out.
+
+You have reached the end of the path. You started at "what is software?" and arrived
+here with a stack you can maintain, a workflow that keeps you fast, a way to keep
+quality high alone, and a strategy to package, ship and sustain real software. That is
+a complete solo developer toolkit — congratulations on finishing. Keep the
+[glossary](/learn/intro-software-dev/glossary/) handy for any term you want to revisit,
+and then do the only thing that turns all of this into skill: go build something real,
+scope it small, and ship it.

--- a/docs/learn/intro-software-dev/solid.md
+++ b/docs/learn/intro-software-dev/solid.md
@@ -1,0 +1,142 @@
+---
+slug: solid
+title: SOLID & object-oriented design
+description: The five SOLID principles explained plainly with tiny examples — single responsibility, open/closed, Liskov, interface segregation, dependency inversion.
+keywords: SOLID principles, object-oriented design, single responsibility principle, open closed principle, Liskov substitution, interface segregation, dependency inversion, OOP design
+level: intermediate
+status: full
+faq:
+  - q: "Do SOLID principles only apply to object-oriented languages?"
+    a: "The classic formulations are OO-flavored — they talk about classes and interfaces. But the underlying ideas (one job per unit, depend on abstractions, don't force fat interfaces on callers) translate to any paradigm, including functional and procedural code. The vocabulary changes; the goal of changeable, decoupled code does not."
+  - q: "What does \"depend on abstractions, not concretions\" actually mean?"
+    a: "It means your high-level code should talk to an interface (a contract describing *what* it needs) rather than to a specific implementation (a concrete *how*). That way you can swap implementations — a real radio decoder, a test stub, a file replay — without changing the code that uses them."
+  - q: "Is it bad to violate a SOLID principle?"
+    a: "Not necessarily. SOLID is a set of heuristics, not laws. Applied dogmatically they cause as much over-engineering as they prevent. Use them to diagnose pain — code that's hard to change or test — rather than as a checklist to satisfy for its own sake."
+---
+# SOLID & object-oriented design
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**SRP & OCP** — one reason to change; open to extension, closed to modification. **LSP & ISP** — subtypes must honor the contract; keep interfaces small. **DIP** — depend on abstractions, not concrete details.
+</div>
+
+SOLID is a set of five design principles, popularized by Robert C. Martin, that aim at one outcome: code that's **easy to change without breaking**. They're framed in object-oriented terms — classes, interfaces, inheritance — but the spirit generalizes. Each principle is really a refinement of ideas from the [previous lesson](/learn/intro-software-dev/dry-kiss-yagni/): give each unit one job, and depend on contracts rather than concrete details. We'll take them one at a time with a tiny example each, then tie them together with a radio-decoder design that foreshadows [architectural patterns](/learn/intro-software-dev/architectural-patterns/).
+
+A caution up front: SOLID is a toolbox of heuristics, not a law to satisfy. Reach for these when code resists change or testing — not to score points.
+
+## S — Single Responsibility Principle
+
+A unit of code should have **one reason to change** — it should answer to a single concern or stakeholder. When a class mixes responsibilities, a change to one drags in the others and risks breaking them.
+
+```go
+// Violates SRP: parsing, business logic, and persistence in one place.
+type FrameHandler struct{}
+func (h FrameHandler) Handle(raw []byte) {
+    frame := parse(raw)      // parsing concern
+    validate(frame)          // domain rule concern
+    saveToDisk(frame)        // storage concern
+}
+```
+
+Split into a parser, a validator, and a store, and each can change for its own reason — a new disk format doesn't touch parsing logic. SRP is separation of concerns applied at the level of a single class or module.
+
+## O — Open/Closed Principle
+
+Software should be **open for extension but closed for modification.** You should be able to add new behavior without editing existing, tested code — because editing working code risks breaking it.
+
+The usual mechanism is an abstraction with multiple implementations:
+
+```go
+type Demodulator interface {
+    Demod(samples []float64) []byte
+}
+
+// Adding FM support means writing a new type, not editing the old ones.
+type AMDemod struct{}
+type FMDemod struct{}
+```
+
+Code that consumes a `Demodulator` never changes when you add a new one. Contrast that with a giant `switch mode { case "AM": ...; case "FM": ... }` that you must reopen and re-test for every new mode. OCP is what lets a system grow at its edges instead of churning its core.
+
+## L — Liskov Substitution Principle
+
+Named after Barbara Liskov, this one is about inheritance done honestly: **a subtype must be usable anywhere its base type is expected, without surprising the caller.** If code works with a base type, swapping in a derived type shouldn't change correctness.
+
+The classic violation is the rectangle/square trap: a `Square` that inherits from `Rectangle` but overrides `setWidth` to also change the height breaks any code that assumed width and height move independently. The subtype technically *is* a rectangle but doesn't *behave* like one, so substitution fails.
+
+The practical takeaway: a subtype must honor the **contract** of its parent — its expectations, guarantees, and invariants — not just its method signatures. If a subclass throws where the parent didn't, or tightens what inputs it accepts, it's an LSP violation waiting to bite a caller.
+
+## I — Interface Segregation Principle
+
+**Clients shouldn't be forced to depend on methods they don't use.** A fat interface with a dozen methods couples every implementer to all of them, even when they only care about two.
+
+```go
+// Fat — a read-only file source is forced to implement Write and Tune.
+type Radio interface {
+    Read() []float64
+    Write([]float64)
+    Tune(freqHz int)
+    SetGain(db int)
+}
+
+// Segregated — small interfaces clients can compose as needed.
+type SampleSource interface { Read() []float64 }
+type Tunable      interface { Tune(freqHz int) }
+```
+
+Now a file-based replay source implements just `SampleSource`. Small, role-focused interfaces keep implementations honest and make dependencies explicit. Go's standard library leans hard on this — `io.Reader` and `io.Writer` are single-method interfaces precisely so anything can satisfy them.
+
+## D — Dependency Inversion Principle
+
+**High-level code should depend on abstractions, not on concrete low-level details** — and the abstraction shouldn't depend on the details either. In practice: your important logic talks to an interface, and the concrete implementation is supplied from outside (often called dependency injection).
+
+```go
+// High-level pipeline depends on the SampleSource interface, not a specific radio.
+func Run(src SampleSource, d Demodulator) {
+    for {
+        d.Demod(src.Read())
+    }
+}
+```
+
+`Run` doesn't know or care whether `src` is a real SDR, a network stream, or a file replaying captured samples — which, not coincidentally, is exactly what makes it [testable](/learn/intro-software-dev/testing/): the test passes in a fake source. DIP is the principle that turns rigid, hard-to-test code into flexible, swappable components.
+
+## Tying it together: a pluggable decoder
+
+Watch how the principles combine into one design. Suppose GopherTrunk must decode several radio protocols and gain more over time. Define a contract:
+
+```go
+type Decoder interface {
+    Name() string
+    Decode(frame []byte) (Message, error)
+}
+```
+
+- **SRP** — each decoder handles exactly one protocol.
+- **OCP** — adding a protocol means writing a new `Decoder`, not editing existing ones.
+- **LSP** — every decoder honors the same contract, so the pipeline treats them uniformly.
+- **ISP** — the interface is tiny; decoders aren't forced to implement unrelated methods.
+- **DIP** — the pipeline depends on `Decoder`, not on any concrete protocol.
+
+The payoff: new radio protocols **slot in without touching existing code**, and you can register decoders dynamically — the seed of a plugin architecture we'll explore in [architectural patterns](/learn/intro-software-dev/architectural-patterns/) and [what are patterns](/learn/intro-software-dev/what-are-patterns/). The same idea drives the [RF & SDR path](/learn/rf-sdr/), where many modulation schemes share one processing skeleton.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — DIP means high-level logic depends on an interface, so implementations can be swapped freely." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the Dependency Inversion Principle ask you to do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Make every class inherit from a common base class</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Depend on abstractions (interfaces), not concrete implementations</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Invert the order in which dependencies are installed</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **SRP** — one reason to change; don't mix unrelated responsibilities in one unit.
+- **OCP** — add behavior by extension, not by editing tested code; abstractions over big switches.
+- **LSP** — subtypes must honor the parent's contract so substitution never surprises callers.
+- **ISP** — keep interfaces small and role-focused; don't force clients to depend on unused methods.
+- **DIP** — high-level logic depends on abstractions; inject concrete implementations from outside.
+- **SOLID is OO-flavored but general** — the deeper ideas (one job, depend on contracts) apply to any paradigm.
+
+Next up: the concepts that underpin all of SOLID — [abstraction, coupling and cohesion](/learn/intro-software-dev/abstraction-coupling/).

--- a/docs/learn/intro-software-dev/solo-developer-mindset.md
+++ b/docs/learn/intro-software-dev/solo-developer-mindset.md
@@ -1,0 +1,154 @@
+---
+slug: solo-developer-mindset
+title: The solo developer — wearing every hat
+description: What changes when you are the whole team — product, design, code, test, release and support — plus the advantages, the traps, and the self-discipline to ship.
+keywords: solo developer, indie developer, wearing every hat, bus factor, burnout, self-discipline, full context, software ownership
+level: beginner
+status: full
+faq:
+  - q: "What does it mean to be a solo developer?"
+    a: "A **solo developer** owns every role on a project at once — product manager deciding what to build, designer shaping how it feels, programmer writing it, tester checking it, release engineer shipping it, and support answering users. There is no one to hand work to, so the same person carries the idea from first sketch to last bug report."
+  - q: "What is the biggest risk of working alone?"
+    a: "The honest answer is **you** — there is no second set of eyes to catch your mistakes, no one to tell you a feature is over-engineered, and no one to share the load when you burn out. The single biggest structural risk is a **bus factor of one** — if you stop, everything stops — which is why solo devs lean hard on automation and good notes."
+  - q: "How do solo developers avoid burning out?"
+    a: "By giving themselves the **structure a team would impose** — a defined scope, a stopping point, automated checks instead of heroics, and permission to say no. Burnout among solo devs usually comes from unbounded scope and no recovery time, not from the coding itself. Sustainable pace beats sprints you cannot repeat."
+---
+# The solo developer — wearing every hat
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Every hat** — alone you are product, design, code, test, release and support. **Speed vs safety** — no coordination cost, but no review and a bus factor of one. **Self-imposed structure** — give yourself the discipline a team would force on you.
+</div>
+
+Most of this path has quietly assumed a team — code reviewers, a CI server someone
+else set up, a designer who handed you mockups. This final module strips that away.
+Here you are the whole company: the only person who decides what to build, builds
+it, checks it works, ships it, and answers the email when it breaks. That is both
+the most freeing and the most dangerous way to make software, and by the end of
+this module you will have three concrete things to tame it — a **stack** you can
+maintain alone, a **workflow** that keeps you fast, and a **distribution strategy**
+that gets your program into other people's hands. This first lesson is about the
+mindset that makes the rest possible.
+
+## You are now the entire org chart
+
+On a team, a software product is split across specialists. Solo, all of those roles
+collapse into one person who switches between them many times a day:
+
+- **Product manager** — deciding what is worth building and, more importantly, what
+  is not.
+- **Designer** — shaping how the thing looks, reads and feels to use.
+- **Programmer** — actually writing and structuring the code.
+- **Tester / QA** — proving it works and finding where it breaks.
+- **Release engineer** — packaging, versioning and publishing a build people can run.
+- **Support & community** — fielding bug reports, questions and feature requests.
+
+The skill of the solo developer is not being world-class at all six — nobody is. It
+is **noticing which hat you are wearing** and not letting the fun ones crowd out the
+boring ones. The trap is spending every hour as Programmer (the part most of us
+enjoy) while Tester, Release Engineer and Support quietly go unstaffed. A program
+that is 95% coded and never released helps no one.
+
+## The real advantages of going solo
+
+Working alone is not a consolation prize. It has genuine, hard-to-replicate
+strengths that big teams spend a fortune trying to recreate:
+
+- **Speed.** There is no coordination cost — no standups, no sign-off, no waiting on
+  another team's queue. You can have an idea at breakfast and ship it by dinner.
+- **Full context.** The entire system fits in one head. You wrote every line, so you
+  know exactly why a decision was made and what will break if you change it. Teams
+  lose this constantly; you have it for free.
+- **Coherence.** A single author tends to produce a more consistent product — one
+  voice, one set of conventions, one taste running through the whole thing.
+- **No politics.** You answer to the users and to yourself. Priorities do not get
+  hijacked by someone else's roadmap.
+
+These advantages are why a single motivated person can build something genuinely
+useful — a focused utility, a niche tool, a hobby project that thousands come to
+rely on. Many beloved open-source projects started as one person scratching an itch.
+
+## The traps that come with it
+
+The same forces that make solo work fast also make it fragile. The four big ones:
+
+- **No review.** Nobody catches the off-by-one, the leaked secret, the design that
+  made sense at 2am and not at 9am. The team's safety net is gone, so you have to
+  rebuild it out of tools (we get to that in
+  [keeping quality high alone](/learn/intro-software-dev/quality-when-solo/)).
+- **Tunnel vision.** With no second opinion you can chase the wrong feature for weeks,
+  convinced it matters, because there is no one to ask "does anyone actually want
+  this?"
+- **Burnout.** Unbounded scope plus "if I don't do it, no one will" is a recipe for
+  exhaustion. Solo projects die far more often from the maintainer running out of
+  energy than from a technical failure.
+- **Bus factor of one.** If you get sick, distracted, or simply move on, the project
+  stops dead. There is no redundancy. Good documentation and automation are partly an
+  insurance policy against your own absence.
+
+Naming these traps is half the defence. None of them are reasons not to build solo —
+they are reasons to build solo *deliberately*.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a bus factor of one means the whole project depends on a single person, so if they stop, everything stops." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a "bus factor of one" describe?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A project that can only run on one computer at a time</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A project that depends entirely on one person, so if they stop, it stops</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A bug that only one user has ever reported</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Be the structure you no longer have
+
+A good team is, in large part, a machine for imposing helpful constraints: code
+review forces a second look, a sprint forces a stopping point, a definition of done
+forces you to actually finish. Alone, those constraints vanish unless you
+deliberately recreate them. That is the central discipline of solo development —
+**giving yourself the structure a team would have given you.**
+
+In practice that looks like:
+
+- **A defined scope and a stopping point** — a written idea of what "version 1" is,
+  so you know when you are done rather than polishing forever. We build this in
+  [from idea to project](/learn/intro-software-dev/scoping-a-project/).
+- **Automated guardrails** — tests, linters and CI that review your work when no
+  human can, so quality does not depend on you being sharp at midnight.
+- **Notes to your future self** — a README, comments, and commit messages, because in
+  six months *you* are the new contributor with no context.
+- **A small ritual** — a tight, repeatable daily loop (covered next) so progress does
+  not depend on motivation alone.
+
+This is not bureaucracy. It is the minimum scaffolding that lets a single person
+ship reliable software without burning out — just enough process, and no more.
+
+## A solo example: one person, one radio tool
+
+Consider a project like **GopherTrunk** itself — radio software a hobbyist downloads
+and runs. Even imagined as a one-person effort, every hat is in play: someone
+decided which radios to support (product), designed how scanning feels (design),
+wrote the signal handling (code), confirmed it decodes real transmissions (test),
+built installers for each operating system (release), and answered "why won't my
+dongle work?" on the forum (support). The reason a non-technical scanner enthusiast
+can just visit the [downloads](/downloads.html) page and run the program is that one
+disciplined developer wore all of those hats in turn — and crucially, did not skip
+the unglamorous ones. That is the whole game, and the rest of this module shows you
+how to play it.
+
+## Recap
+
+- **You are the whole team** — product, design, code, test, release and support all
+  land on one person who switches hats all day.
+- **Real advantages** — speed, full context, coherence and no politics make a single
+  motivated person genuinely powerful.
+- **Real traps** — no review, tunnel vision, burnout and a bus factor of one are the
+  fragilities to defend against.
+- **Self-imposed structure** — alone, you must deliberately recreate the constraints a
+  team would have forced on you.
+- **Don't skip the boring hats** — testing, releasing and supporting are where most
+  solo projects quietly fail.
+- **The module's promise** — by the end you will have a stack, a workflow, and a way
+  to ship real software.
+
+Next up: turning Module 6's theory into a concrete, maintainable toolkit in
+[choosing your stack](/learn/intro-software-dev/choosing-your-stack/).

--- a/docs/learn/intro-software-dev/structural-patterns.md
+++ b/docs/learn/intro-software-dev/structural-patterns.md
@@ -1,0 +1,139 @@
+---
+slug: structural-patterns
+title: "Structural patterns: adapter, facade, decorator"
+description: Structural patterns compose objects into larger structures. Learn Adapter for incompatible interfaces, Facade for hiding complexity, and Decorator for wrapping behavior.
+keywords: structural patterns, adapter pattern, facade pattern, decorator pattern, wrapper, interface, composition, design patterns
+level: intermediate
+status: full
+faq:
+  - q: "What do structural patterns do?"
+    a: "Structural patterns describe how to *compose* classes and objects into larger structures while keeping them flexible. Instead of changing what objects do, they arrange how objects fit together — making mismatched interfaces work (Adapter), hiding a complex subsystem behind a simple front (Facade), or wrapping an object to add behavior (Decorator)."
+  - q: "What is the difference between Adapter and Facade?"
+    a: "An **Adapter** converts one existing interface into another the client expects, usually wrapping a single object so it fits where it otherwise would not. A **Facade** provides a brand-new, simpler interface in front of a whole subsystem of many parts. Adapter is about *compatibility*; Facade is about *simplicity*."
+  - q: "How is Decorator different from just editing the class?"
+    a: "A **Decorator** wraps an object and adds behavior from the outside, sharing the same interface, so you can stack features (logging, gain, buffering) in any combination at runtime without modifying the original class. Editing the class changes it for everyone and cannot be combined or removed per use — decoration keeps the core untouched and the additions optional."
+---
+# Structural patterns: adapter, facade, decorator
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Adapter** — wrap an object so an incompatible interface fits where the client expects. **Facade** — put a simple front over a complex subsystem so callers see one easy entry point. **Decorator** — wrap an object to add behavior while keeping the same interface, so features stack.
+</div>
+
+The creational patterns answered *how objects get made*. **Structural patterns** answer the next question: *how do objects fit together into larger structures?* They are mostly about composition and wrapping — taking objects that already exist and arranging them so the whole is flexible and the parts stay loosely coupled. Three structural patterns come up constantly: **Adapter** makes mismatched things work together, **Facade** hides complexity behind a simple front, and **Decorator** adds behavior by wrapping. As before, the examples lean on a software radio, where you routinely connect hardware drivers, hide DSP chains, and stack processing stages.
+
+## What structural patterns are for
+
+Real systems are assembled from parts written at different times by different people: a third-party hardware driver, your own DSP code, a UI toolkit. Getting those parts to cooperate without welding them tightly together is a recurring design problem. Structural patterns are templates for that assembly. They share a family resemblance — most of them involve one object **wrapping** another — but each solves a distinct problem:
+
+- **Adapter** — the interfaces do not match, and you need them to.
+- **Facade** — the subsystem is complex, and you want a simple way in.
+- **Decorator** — the object is fine, but you want to add behavior around it.
+
+All three lean on the same principle: program to an **interface**, and keep dependencies pointing at that interface rather than at concrete classes. That keeps [coupling](/learn/intro-software-dev/abstraction-coupling/) low.
+
+## Adapter
+
+An **Adapter** converts the interface of one class into another interface that the client expects, letting classes work together that otherwise could not because of incompatible interfaces. It is the universal travel plug of software.
+
+The classic SDR example is hardware. An RTL-SDR dongle, an Airspy, and a HackRF each ship with their own driver, and the function names and data formats differ: one offers `read_samples()`, another `rxStream()`, another a callback. Your decode pipeline should not care which radio is plugged in. So you define one interface your code talks to, and write a thin adapter per device that translates:
+
+```text
+interface SampleSource { read() -> samples }
+
+class RtlSdrAdapter implements SampleSource {
+  rtl  // the vendor driver object
+  read() {
+    raw = rtl.read_samples()      // vendor's call
+    return toComplex(raw)         // translate to our format
+  }
+}
+
+class HackRfAdapter implements SampleSource {
+  hrf
+  read() { return hrf.rxStream().asComplex() }
+}
+
+// pipeline depends only on SampleSource:
+process(source: SampleSource) { loop { handle(source.read()) } }
+```
+
+Now the pipeline works with any device, present or future. Supporting a new radio means writing one new adapter — the pipeline never changes. The adapter absorbs the differences so the rest of the system sees a single, clean interface.
+
+There are two flavours worth knowing. An **object adapter** holds a reference to the wrapped object (composition) and delegates to it — that is what the example above does, and it is the more flexible choice because one adapter can wrap any object that offers the vendor calls. A **class adapter** instead inherits from both interfaces, which ties it to one concrete class at compile time. In modern code, the object adapter is almost always preferred, because composition keeps the coupling loose and lets you wrap objects you do not control. Either way, the adapter's whole value is that it is the *only* place in the codebase that knows the vendor's quirks: a units mismatch, a different sample format, an awkward callback model — all of it is quarantined behind the clean interface so it cannot leak into the rest of the system.
+
+## Facade
+
+A **Facade** provides a unified, simplified interface to a set of interfaces in a subsystem, making the subsystem easier to use. Where an adapter wraps *one* object to fix compatibility, a facade fronts a *whole* collection of objects to fix complexity.
+
+Decoding a signal involves many steps: tune, set gain, decimate, filter, demodulate, recover the clock, decode symbols. Each is its own component with its own settings — a genuine pipeline (the next lesson and the [demodulation pipeline](/learn/rf-sdr/demodulation-pipeline/) lesson cover that chain in depth). Most callers do not want to orchestrate all of that. A facade collapses it to one call:
+
+```text
+class RadioFacade {
+  tuneAndDecode(freq, mode) -> stream {
+    src   = openDevice()
+    tuned = tuner.tune(src, freq)
+    base  = decimator.run(filter.run(tuned))
+    sym   = demod(mode).run(base)
+    return decoder(mode).run(clockRecover(sym))
+  }
+}
+
+// the UI just says:
+calls = radio.tuneAndDecode(854_000_000, "P25")
+```
+
+The complexity still exists — the facade does not delete the DSP chain — it just hides it behind one friendly entry point. Two payoffs: callers are simpler, and they are *decoupled* from the subsystem's internals. If you re-order the DSP stages or swap a filter, only the facade changes; every caller keeps working. A facade does not forbid access to the inner parts for the rare caller who needs them — it just offers an easy default path for the common case.
+
+Facades also help when a subsystem is *legacy or messy*. You may not be able to clean up a tangled set of components right away, but you can put a sane facade in front of them, point all new code at the facade, and refactor the mess behind it later without breaking those callers. In that role the facade becomes a stable seam — a boundary you can hold steady while everything behind it changes. This is the same boundary-drawing instinct that runs through the whole [SOLID](/learn/intro-software-dev/solid/) lesson: decide where one part ends and another begins, then let dependencies cross only through a narrow, deliberate interface.
+
+## Decorator
+
+A **Decorator** attaches additional responsibilities to an object dynamically by wrapping it, providing a flexible alternative to subclassing for extending behavior. The decorator implements the *same interface* as the thing it wraps, so from the outside it looks identical — but it does something extra before or after delegating to the inner object.
+
+Suppose you have a `SampleSource` (perhaps via the adapter above) and you want optional extra stages: a logging tap that counts samples, and a gain stage that scales them. You could bake these into the source, but then every source needs them and you cannot turn them off. Instead, wrap:
+
+```text
+class GainStage implements SampleSource {
+  inner: SampleSource
+  factor
+  read() { return scale(inner.read(), factor) }   // add behavior, then delegate
+}
+
+class LoggingStage implements SampleSource {
+  inner: SampleSource
+  read() {
+    s = inner.read()
+    metrics.count(s.length)
+    return s
+  }
+}
+
+// stack them however you like, at runtime:
+src = LoggingStage(GainStage(RtlSdrAdapter(rtl), 1.5))
+```
+
+Because every layer is a `SampleSource`, they nest in any order and any combination. You can add logging without gain, gain without logging, or both — decided at runtime, not compile time. This is the open/closed principle from [SOLID](/learn/intro-software-dev/solid/) again: you extend behavior by adding wrappers, never by editing the core class. It also avoids a subclass explosion — without decorators you would need `LoggedSource`, `GainSource`, `LoggedGainSource`, and so on for every combination.
+
+A subtle but important point: Decorator looks structurally like Adapter (both wrap an object), but the *intent* differs. Adapter changes an interface to make things fit; Decorator keeps the interface the same and adds behavior. Same shape, different purpose — which is exactly why knowing the pattern *names* matters when you discuss a design.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a facade puts one simple interface in front of a whole complex subsystem." markdown="0">
+  <p class="knowledge-check__q">Quick check: Which structural pattern hides a whole complex subsystem behind one simple entry point?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Adapter</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Facade</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Decorator</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Structural patterns compose objects** — they arrange how parts fit together, mostly through wrapping, keeping the whole flexible and loosely coupled.
+- **Adapter** — converts one object's interface into the one a client expects; wrap each SDR driver so the pipeline sees a single `SampleSource`.
+- **Facade** — a simple front over a complex subsystem; one `tuneAndDecode()` call hides the whole DSP chain and decouples callers from it.
+- **Decorator** — wraps an object with the same interface to add behavior (gain, logging) that stacks in any order at runtime, instead of subclassing.
+- **Adapter vs Decorator** — same wrapping shape, different intent: Adapter changes the interface, Decorator preserves it and adds behavior.
+- **Common thread** — program to interfaces so wrappers and fronts can be swapped without touching the code that uses them.
+
+Next up: behavioral patterns — Observer, Strategy, and State — which govern how objects *interact and share responsibility* at runtime. See [Behavioral patterns](/learn/intro-software-dev/behavioral-patterns/).

--- a/docs/learn/intro-software-dev/testing.md
+++ b/docs/learn/intro-software-dev/testing.md
@@ -1,0 +1,109 @@
+---
+slug: testing
+title: Testing — unit, integration & beyond
+description: The test pyramid explained — unit, integration and end-to-end tests, plus TDD, regression tests, mocking, code coverage and its limits, and golden-file testing for signal code.
+keywords: software testing, test pyramid, unit tests, integration tests, end-to-end tests, test-driven development, regression tests, mocking, code coverage, golden files
+level: intermediate
+status: full
+faq:
+  - q: "What's the difference between unit, integration, and end-to-end tests?"
+    a: "A unit test checks one small piece (a function or class) in isolation. An integration test checks that several pieces work together correctly — say, a parser feeding a decoder. An end-to-end test exercises the whole system the way a user would, from input to output. Unit tests are fast and numerous; end-to-end tests are slow and few, which is why the test pyramid favors many unit tests at the base."
+  - q: "Does 100% code coverage mean my code is bug-free?"
+    a: "No. Coverage only measures which lines ran during tests, not whether your assertions actually checked the right things. You can execute every line and still assert nothing meaningful, miss edge cases, or have wrong expected values. Coverage is a useful signal for finding untested code, but it's a floor, not a guarantee of correctness."
+  - q: "What is a golden file and when would I use one?"
+    a: "A golden file is a known-good reference output saved alongside your tests. The test runs your code against a fixed input and compares the result byte-for-byte (or value-for-value) against the golden file. It's ideal when output is large or complex and hard to eyeball — like the decoded result of a captured radio signal — because it pins down exactly what \"correct\" means and flags any regression instantly."
+---
+# Testing — unit, integration & beyond
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The test pyramid** — many fast unit tests, fewer integration tests, a handful of end-to-end. **Tests pin down "correct"** — golden files and regression tests catch breakage you'd never spot by eye. **Coverage is a floor, not a guarantee** — running a line isn't the same as checking it.
+</div>
+
+Testing is how you turn "I think it works" into "I know it works, and I'll know the moment it stops." It's not a phase you tack on at the end — good teams write tests alongside the code, and a [CI pipeline](/learn/intro-software-dev/build-and-ci-cd/) runs them automatically on every change. This lesson covers the kinds of tests and how they fit together, a few essential techniques, and the limits of the metric everyone loves to quote: code coverage. The motivating example throughout is signal-processing code, where bugs are nearly impossible to catch by reading.
+
+## The test pyramid
+
+Not all tests are equal, and a healthy test suite balances three layers — usually drawn as a pyramid, wide at the bottom and narrow at the top.
+
+- **Unit tests** (the base) check a single small piece — one function or class — in isolation. They're fast, focused, and numerous; a good suite has thousands. When one fails, it points straight at the broken unit.
+- **Integration tests** (the middle) check that several pieces work *together* — a parser handing frames to a decoder, code talking to a database. Fewer of these, and slower, because they exercise real seams between components.
+- **End-to-end (E2E) tests** (the tip) drive the whole system the way a user would, from input all the way to final output. They give the most confidence that the product actually works, but they're slow, brittle, and expensive to maintain — so you keep them few.
+
+```
+        /\        E2E         (few, slow, high confidence)
+       /  \
+      /----\      Integration (some, medium)
+     /      \
+    /--------\    Unit        (many, fast, focused)
+```
+
+The pyramid shape is the guidance: lean on lots of fast unit tests at the base, fewer integration tests in the middle, and only a thin layer of E2E at the top. An "inverted pyramid" — mostly slow E2E tests — is a classic anti-pattern: the suite becomes slow and flaky, and a single failure tells you little about *where* the problem is.
+
+## Test-driven development, briefly
+
+**Test-driven development (TDD)** flips the usual order: you write a failing test *first*, then write just enough code to make it pass, then refactor. The rhythm is "red, green, refactor." Writing the test first forces you to clarify what the code should do before you build it, and it guarantees the test actually fails when the behavior is missing (a test that passes before you write the code is testing nothing). TDD isn't mandatory and isn't always the right fit, but the discipline of specifying behavior up front is valuable even when you don't follow it strictly.
+
+## Regression tests and why they matter
+
+A **regression** is when something that used to work breaks. A **regression test** is one you add specifically to lock in a fixed bug so it can never silently return. The workflow is simple and powerful: a bug is reported, you write a test that reproduces it (and fails), you fix the code until the test passes, and now that test guards the behavior forever. Over time your regression tests accumulate into a record of every mistake you've made — and a wall preventing you from making them twice.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the pyramid favors many fast, focused unit tests at the base and only a few slow end-to-end tests at the top." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the test pyramid recommend?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Mostly slow end-to-end tests, with very few unit tests</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Many fast unit tests at the base, fewer integration, a handful of end-to-end</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">An equal number of every kind of test, regardless of speed</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Mocking, fakes, and isolation
+
+To test a unit *in isolation*, you often need to stand in for its dependencies — you don't want a unit test hitting a real network, a real database, or a real radio. **Test doubles** fill that gap:
+
+- A **fake** is a lightweight working implementation — for example, a sample source that replays a file instead of reading a live SDR.
+- A **mock** records how it was called and lets you assert that your code interacted with it correctly (it called `send()` once, with these arguments).
+- A **stub** simply returns canned responses.
+
+This is exactly where the [dependency inversion](/learn/intro-software-dev/solid/) idea pays off: if your code depends on an interface rather than a concrete radio, a test can pass in a fake source and run deterministically, with no hardware in the loop. Good seams make code testable; testable code tends to be well-designed code.
+
+## The motivating case: testing a signal decoder
+
+Here's where testing stops being abstract. Signal-processing and DSP code is **notoriously hard to debug by eye.** A demodulator emits streams of numbers; a decoder turns noisy samples into bits and then into messages. If a sign is flipped, a filter coefficient is off, or the timing recovery drifts, the output is *subtly* wrong — not a crash, just garbage that looks plausible. You cannot reliably stare at a buffer of floats and know whether it's right.
+
+The answer is **golden-file testing.** You capture a real signal once — a recording of an actual over-the-air transmission whose correct decoded content you've verified — and save both the raw capture and the expected decoded output (the "golden" reference) in your test suite. The test then runs the decoder against the captured samples and compares its output against the golden file:
+
+```go
+func TestDecodeP25(t *testing.T) {
+    samples := loadCapture("testdata/p25_voice.iq")   // known input
+    got := Decode(samples)
+    want := loadGolden("testdata/p25_voice.expected") // verified correct output
+    if !bytes.Equal(got, want) {
+        t.Fatalf("decoded output drifted from golden reference")
+    }
+}
+```
+
+This is how you *trust* a decoder. The moment a refactor, a dependency bump, or a "harmless" tweak changes the output by a single byte, the test goes red and tells you instantly. For a project like GopherTrunk, a library of golden sample captures — one per protocol, per edge case — is the difference between confident change and praying nothing broke. It's the testing technique that makes signal code maintainable at all. The [RF & SDR path](/learn/rf-sdr/) goes deeper into the signal side.
+
+## Code coverage and its limits
+
+**Code coverage** measures the percentage of your code that runs during the test suite — which lines, branches, or functions were exercised. It's genuinely useful for *finding untested code*: a module sitting at 0% coverage is a red flag, and watching coverage tells you where to aim next.
+
+But coverage is widely misread. It measures whether a line *ran*, not whether your test *checked* anything meaningful about it. You can hit 100% coverage with tests that assert nothing, miss every edge case, or compare against wrong expected values. High coverage with weak assertions is false confidence. Treat coverage as a **floor** — a signal for gaps — never as a target to chase or a proof of correctness. A smaller suite of sharp, well-asserted tests beats a sprawling one written to game a number.
+
+## Tests run automatically
+
+The final piece: tests only protect you if they run, every time. That's the job of **continuous integration** — on every push, the CI server builds the code and runs the whole suite, so a regression is caught within minutes of being introduced rather than weeks later in production. Tests plus CI is the combination that lets a team move fast *without* breaking things. We cover that machinery next, and how tests interact with graceful failure is the subject of [robustness & error handling](/learn/intro-software-dev/robustness-and-errors/).
+
+## Recap
+
+- **The test pyramid** — many fast unit tests at the base, fewer integration tests, a thin layer of slow end-to-end tests on top.
+- **TDD** — write the failing test first, then the code; it clarifies intent and guarantees the test really tests something.
+- **Regression tests** — lock in every fixed bug so it can never silently come back.
+- **Mocks and fakes** — stand in for real dependencies so units can be tested in isolation, deterministically.
+- **Golden files** — pin down "correct" for output you can't eyeball; the key to trusting signal/DSP decoders against known captures.
+- **Coverage is a floor** — it shows what ran, not what was checked; never mistake a high number for correctness.
+
+Next up: how code gets compiled, tested, and shipped automatically — [build systems, CI/CD & automation](/learn/intro-software-dev/build-and-ci-cd/).

--- a/docs/learn/intro-software-dev/the-pioneers.md
+++ b/docs/learn/intro-software-dev/the-pioneers.md
@@ -1,0 +1,76 @@
+---
+slug: the-pioneers
+title: The people who built programming
+description: Short profiles of the people who built programming — Lovelace, Turing, Hopper, von Neumann, Ritchie & Thompson, Kay, and Hamilton — and what each contributed.
+keywords: Ada Lovelace, Alan Turing, Grace Hopper, John von Neumann, Dennis Ritchie, Ken Thompson, Alan Kay, Margaret Hamilton, history of programming, computing pioneers
+level: beginner
+status: full
+faq:
+  - q: "Who wrote the first computer program?"
+    a: "**Ada Lovelace** is widely credited with the first published algorithm intended for a machine — her notes on Babbage's Analytical Engine in the 1840s included a method for computing Bernoulli numbers. She also saw, ahead of her time, that such a machine could manipulate any symbols, not just numbers, anticipating general-purpose computing."
+  - q: "Why is Grace Hopper associated with \"debugging\"?"
+    a: "**Grace Hopper's** team famously logged a real moth stuck in a relay of the Harvard Mark II, taping it into the logbook as the \"first actual case of bug being found.\" The term predates her, but the story made it iconic. Her far bigger contribution was pioneering the **compiler** and helping create **COBOL**, proving machines could translate human-readable code."
+  - q: "What did Margaret Hamilton contribute?"
+    a: "**Margaret Hamilton** led the team that wrote the onboard flight software for NASA's Apollo missions, and she championed treating software as a rigorous engineering discipline — she's often credited with popularizing the term **\"software engineering.\"** Her work on error handling and priority scheduling helped the Apollo 11 landing recover from an overload at a critical moment."
+---
+# The people who built programming
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Ideas have authors** — the abstractions we take for granted were each invented by someone. **Theory and practice** — Turing and von Neumann gave the field its foundations; Hopper, Ritchie, and Hamilton made it usable. **A broad cast** — programming was built by mathematicians, engineers, and visionaries across more than a century.
+</div>
+
+The previous lessons followed ideas — the stored program, the transistor, the compiler. This one follows people. Every abstraction you rely on was, at some point, an unproven idea in one person's head. Knowing who they were and what they actually did turns the history from a list of dates into a human story, and it gives you a map of *why* things are the way they are. These are tight profiles, not biographies — just enough to place each pioneer and their lasting contribution. They build on the hardware and language stories from [the previous lesson](/learn/intro-software-dev/birth-of-languages/).
+
+## Ada Lovelace — the first algorithm
+
+**Ada Lovelace** (1815–1852), an English mathematician, worked with Charles Babbage on his proposed Analytical Engine. In her published notes from the 1840s she included a step-by-step method for the machine to compute Bernoulli numbers — widely regarded as the first algorithm written for a computer. More striking still was her insight that the engine could operate on *any* symbols that could be encoded, not just numbers — it might, she mused, even compose music. That leap — seeing a calculating machine as a general symbol-manipulator — anticipated the idea of general-purpose computing by roughly a century.
+
+## Alan Turing — what computing even means
+
+**Alan Turing** (1912–1954), a British mathematician, gave the field its theoretical bedrock. In 1936 he described an abstract device — now called a **Turing machine** — a simple model that reads and writes symbols on a tape according to rules. With it he defined precisely what it means for a problem to be **computable**, and proved that some problems can never be solved by any machine, no matter how powerful. He also showed that a single "universal" machine could simulate any other — the theoretical seed of the general-purpose computer. During World War II he was central to breaking German ciphers at Bletchley Park, work with profound real-world impact.
+
+## Grace Hopper — compilers, COBOL, and the "bug"
+
+**Grace Hopper** (1906–1992), a US Navy rear admiral and mathematician, fought the prevailing belief that programs had to be written in machine-level code. She built one of the first **compilers**, proving a machine could translate readable instructions into executable code, and she was a driving force behind **COBOL**, the English-like business language that still runs banks today. She's also tied to the word **"debugging"**: her team taped a real moth — found jamming a relay in the Harvard Mark II — into their logbook as the "first actual case of bug being found." She spent decades insisting computing should be accessible to ordinary people, not just specialists.
+
+## John von Neumann — the stored-program architecture
+
+**John von Neumann** (1903–1957), a Hungarian-American polymath, lent his name to the design that nearly every computer still follows. His 1945 report describing the **stored-program** computer — instructions and data sharing one memory — became the blueprint for the **von Neumann architecture** we met in lesson one. Whether you store a program or wire it in is *the* dividing line between a fixed machine and a general-purpose computer, and his clear articulation of it shaped the entire industry. He contributed across mathematics, physics, and economics too, but in computing this single idea is foundational.
+
+## Dennis Ritchie & Ken Thompson — C and Unix
+
+At Bell Labs around 1970, **Ken Thompson** and **Dennis Ritchie** built two things that still underpin modern computing. Thompson created the first version of the **Unix** operating system; Ritchie created the **C** programming language and, with Thompson, rebuilt Unix in C — proving an operating system could be written in a portable high-level language rather than assembly. The combination spread everywhere. Today **Linux** (a Unix-like system), the internet's servers, Android phones, and most embedded devices descend from that work. And as the last lesson noted, the DSP and radio code under tools like GopherTrunk is still largely written in Ritchie's C. Few pairs of people have left a wider footprint.
+
+## Alan Kay — objects and personal computing
+
+**Alan Kay** (born 1940) helped invent the way we think about and use computers. At Xerox PARC in the 1970s he led work on **Smalltalk** and helped popularize **object-oriented programming (OOP)** — organizing software around self-contained "objects" that bundle data with the operations on it, a style that came to dominate large-scale software. Kay also championed the vision of a personal, portable computer for everyone (his "Dynabook" concept) and contributed to the graphical, windowed interface that PARC pioneered and the rest of the industry later adopted. Much of how software is *structured* today traces back to his ideas.
+
+## Margaret Hamilton — software engineering as a discipline
+
+**Margaret Hamilton** (born 1936) led the team at MIT that wrote the onboard flight software for NASA's **Apollo** missions. She insisted software be built with the rigor of an engineering discipline — she's often credited with popularizing the term **"software engineering"** itself, at a time when programming was treated as an afterthought to hardware. Her emphasis on robust error handling proved its worth during the Apollo 11 landing: when the guidance computer was overloaded with tasks, her software's priority scheduling shed the less critical work and kept the landing on track. She made the case, decades early, that software's reliability is a matter of disciplined engineering, not luck.
+
+## What this cast has in common
+
+Look across these seven and a pattern emerges. Some were **theorists** (Turing, von Neumann) who defined what was possible; others were **builders** (Hopper, Ritchie, Thompson, Hamilton) who made it practical; and some were **visionaries** (Lovelace, Kay) who saw further than their hardware could reach. Progress needed all three. The abstractions you'll lean on for the rest of this path — compilers, operating systems, objects, reliable software — each began as one of these people's stubborn convictions.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Margaret Hamilton led the Apollo flight software and helped establish 'software engineering' as a discipline." markdown="0">
+  <p class="knowledge-check__q">Quick check: Who led the Apollo onboard flight software team and helped popularize the term "software engineering"?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Grace Hopper</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Margaret Hamilton</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Ada Lovelace</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Ada Lovelace** — wrote the first algorithm and foresaw general-purpose, symbol-manipulating machines.
+- **Alan Turing** — defined computability with the Turing machine and the idea of a universal computer.
+- **Grace Hopper** — pioneered the compiler, drove COBOL, and made the "bug" famous.
+- **John von Neumann** — articulated the stored-program architecture nearly every computer still uses.
+- **Ritchie & Thompson** — created C and Unix, the ancestors of Linux, the web's servers, and most embedded code.
+- **Alan Kay & Margaret Hamilton** — gave us object-oriented programming and personal computing, and software engineering as a rigorous discipline.
+
+Next up: from these foundations, computing escaped the lab and reached everyone. We trace mainframes to PCs to the internet to cheap edge devices — and how that flood of compute made software radio practical — in [PCs, the internet & the age of cheap compute](/learn/intro-software-dev/internet-to-edge/).

--- a/docs/learn/intro-software-dev/type-systems.md
+++ b/docs/learn/intro-software-dev/type-systems.md
@@ -1,0 +1,221 @@
+---
+slug: type-systems
+title: Type systems & safety
+description: Static vs dynamic, strong vs weak typing, type inference and gradual typing — what type checking catches before run time, what it costs, and where it earns its keep.
+keywords: type system, static typing, dynamic typing, strong typing, type inference, gradual typing, TypeScript, type safety
+level: intermediate
+status: full
+faq:
+  - q: "What is the difference between static and dynamic typing?"
+    a: "With **static typing** (Rust, Go, Java) types are checked at compile time, before the program runs, so whole classes of bugs are caught early. With **dynamic typing** (Python, Ruby, JavaScript) types are checked at run time, which is more flexible but lets type errors slip through until that line actually executes."
+  - q: "Is strong typing the same as static typing?"
+    a: "No. **Static vs dynamic** is *when* types are checked; **strong vs weak** is *how strictly* the language enforces them. Python is dynamically typed but strongly typed — it refuses to add a string to an integer. JavaScript is dynamic and weaker — it silently coerces types."
+  - q: "What is gradual typing?"
+    a: "**Gradual typing** lets you add optional type annotations to a dynamically-typed language and check them with a separate tool. TypeScript adds types to JavaScript; Python type hints checked by mypy do the same for Python. You get many compile-time guarantees without giving up the language's flexibility."
+---
+# Type systems & safety
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Static vs dynamic** — *when* types are checked. **Strong vs weak** — *how strictly* they're enforced. **Gradual typing** — add type safety to a dynamic language incrementally.
+</div>
+
+Every value in a program has a **type** — integer, string, list, a `Receiver`
+object. A **type system** is the set of rules a language uses to track those types
+and decide which operations are allowed. Type systems are one of the deepest
+dividing lines between languages, and the debates around them are really debates
+about a trade-off: how much **safety** you want guaranteed up front versus how
+much **flexibility and brevity** you are willing to trade for it. This lesson
+gives you the vocabulary to reason about that trade-off instead of arguing by
+reflex.
+
+## Static vs dynamic typing
+
+The first axis is *when* the language checks types.
+
+**Static typing** checks types at **compile time**, before the program runs. The
+compiler knows the type of every variable and rejects code that misuses them. C,
+C++, Rust, Go, Java and C# are statically typed.
+
+**Dynamic typing** checks types at **run time**, as each operation executes. A
+variable can hold a string now and a number later; the language only complains
+when an actual operation is invalid. Python, Ruby and JavaScript are dynamically
+typed.
+
+```python
+# Dynamic (Python): this is fine until the line runs
+def gain(x):
+    return x * 2      # works for numbers... or strings, surprisingly
+gain("oops")          # returns "oopsoops" — no error, maybe not what you meant
+```
+
+```go
+// Static (Go): the compiler rejects the mismatch before you can run it
+func gain(x float64) float64 { return x * 2 }
+gain("oops") // compile error: cannot use "oops" as float64
+```
+
+The static-typing payoff is that **whole classes of bugs are caught at compile
+time** — passing the wrong type, calling a method that does not exist, returning
+the wrong shape of data. The dynamic-typing payoff is **flexibility and less
+ceremony**: quick scripts, duck typing, and code that adapts at run time.
+
+## Strong vs weak typing
+
+A separate axis — often confused with the first — is *how strictly* the language
+enforces types once it knows them.
+
+**Strong typing** refuses to silently mix incompatible types. **Weak typing**
+performs implicit conversions ("coercion") to make operations work, sometimes
+surprisingly.
+
+- **Python** is *dynamically* but *strongly* typed: `"3" + 5` raises an error
+  rather than guessing.
+- **JavaScript** is *dynamically* and *weakly* typed: `"3" + 5` yields `"35"`
+  (it coerces the number to a string), and `"3" * 5` yields `15`.
+
+So the two axes are independent. You can have static+strong (Rust), dynamic+strong
+(Python), dynamic+weak (JavaScript), and static-but-looser (C, which lets you cast
+fairly freely). "Strong" and "static" both push toward safety, but they are not
+the same property.
+
+| | Static | Dynamic |
+|---|---|---|
+| **Strong** | Rust, Go, Java | Python, Ruby |
+| **Weak(er)** | C, C++ | JavaScript, PHP |
+
+## Type inference
+
+A common objection to static typing is the **ceremony** — writing the type of
+everything. **Type inference** removes most of it: the compiler *deduces* types
+from context, so you get static checking with dynamic-looking brevity.
+
+```rust
+let count = 0;              // Rust infers i32
+let names = vec!["a", "b"]; // infers Vec<&str>
+```
+
+Rust, Go (`:=`), Swift, Kotlin and modern C++ (`auto`) all infer types heavily.
+You annotate at the boundaries — function signatures, public APIs — and let the
+compiler fill in the rest. This is a big reason modern statically-typed languages
+feel far less verbose than 1990s Java.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — static is about *when* types are checked (compile time); strong is about *how strictly* they're enforced. They're independent axes." markdown="0">
+  <p class="knowledge-check__q">Quick check: Python rejects <code>"3" + 5</code> at run time. What does that make it?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Statically and weakly typed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Dynamically and strongly typed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Statically and strongly typed</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## What checking catches — and what it costs
+
+A good type system pays for itself by catching mistakes for free, every time you
+compile:
+
+- **Wrong-type arguments** — you cannot pass a string where a count is expected.
+- **Null/None misuse** — languages like Rust and Kotlin make "no value" a distinct,
+  checked type so you cannot forget to handle it.
+- **Refactoring safety** — rename a field and the compiler lists every site that
+  must change.
+- **Self-documenting APIs** — the signature tells you what goes in and what comes
+  out.
+
+But it is not free:
+
+- **Ceremony** — even with inference, you write more annotations than in a dynamic
+  language.
+- **Rigidity** — some genuinely dynamic patterns become awkward to express, and you
+  occasionally fight the type checker to express something it cannot model.
+- **Slower prototyping** — you must make the types line up before you can run
+  anything.
+
+The right answer depends on the project's size and lifetime. A throwaway script
+barely benefits; a large, long-lived, multi-author system benefits enormously,
+which is why such systems tend toward static typing over time. The
+[decision framework](/learn/intro-software-dev/decision-framework/) covers how to
+weigh this for a real project.
+
+## Gradual typing
+
+You do not have to choose all-or-nothing. **Gradual typing** lets you add
+*optional* type annotations to a dynamic language and check them with a separate
+tool, so untyped and typed code coexist.
+
+- **TypeScript** adds a static type layer over JavaScript; you opt in file by file,
+  and a type checker catches errors before the code ships, even though it still
+  runs as plain JavaScript.
+- **Python type hints** (`def gain(x: float) -> float:`) are checked by tools like
+  **mypy** or **pyright**, while the interpreter ignores them at run time.
+
+Gradual typing has become the default for large dynamic codebases: keep the
+flexibility for quick work, add guarantees where the code is critical or shared.
+
+## Generics and richer type systems
+
+The conversation does not stop at "static or dynamic". Statically-typed languages
+also differ in how *expressive* their type systems are — how much of a program's
+meaning you can encode in types so the compiler enforces it for you.
+
+- **Generics (parametric polymorphism)** let you write code once that works for many
+  types while staying fully type-checked — a `List<T>` is a list of *some specific*
+  type, not a list of "anything". Java, C#, Rust, Swift and (since 1.18) Go all
+  have generics.
+- **Sum types / enums with data** (Rust's `enum`, Swift's `enum`, Haskell's
+  algebraic data types) let you say "a value is exactly one of these cases", and the
+  compiler forces you to handle every case — invaluable for modelling protocol
+  messages or parser states.
+- **Option/Result types** replace `null` and exception-based error handling with
+  values the type system makes you unwrap, so "I forgot to handle the error case"
+  becomes a compile error.
+
+The general principle is **"make illegal states unrepresentable"**: design your
+types so that a value that should not exist cannot even be constructed. The more a
+type system lets you express, the more bugs become compile errors instead of run
+time surprises — at the cost of more upfront design thinking. This is why the
+expressiveness of a language's type system, not just whether it has one, is part of
+the [decision framework](/learn/intro-software-dev/decision-framework/) for serious
+projects.
+
+## A units bug a type system can prevent
+
+In radio software you constantly juggle quantities that are *just numbers* to the
+computer but mean very different things: a frequency in hertz, a **sample rate**
+in samples-per-second, a gain in dB, a count of samples. A plain `float` lets you
+accidentally pass a sample rate where a frequency belongs, and nothing complains —
+the bug surfaces later as garbled audio.
+
+A strong, static type system lets you wrap each quantity in its own type:
+
+```rust
+struct Hertz(f64);
+struct SampleRate(f64);
+
+fn tune(freq: Hertz) { /* ... */ }
+
+let sr = SampleRate(2_048_000.0);
+tune(sr); // compile error: expected Hertz, found SampleRate
+```
+
+Now the mistake is impossible to compile, not merely unlikely. This is the
+type system catching a **whole class of unit-confusion bugs** — exactly the kind
+that are maddening to debug at run time when all you see is noise where signal
+should be.
+
+## Recap
+
+- **Static vs dynamic** — whether types are checked at compile time or run time.
+- **Strong vs weak** — how strictly the language enforces types; independent of the
+  static/dynamic axis.
+- **Type inference** — gives static safety without spelling out every type.
+- **Checking catches bugs early** — wrong types, null misuse, broken refactors — but
+  costs ceremony and some rigidity.
+- **Gradual typing** — TypeScript and Python hints add optional, checkable types to
+  dynamic languages.
+- **Types encode meaning** — wrapping hertz and sample-rate in distinct types makes
+  unit-confusion bugs un-compilable.
+
+Next up: how programs get and release the memory they use — [manual management,
+garbage collection and ownership](/learn/intro-software-dev/memory-management/).

--- a/docs/learn/intro-software-dev/version-control-collab.md
+++ b/docs/learn/intro-software-dev/version-control-collab.md
@@ -1,0 +1,101 @@
+---
+slug: version-control-collab
+title: Version control & collaboration
+description: Why every project lives in version control — history, branching, safety — plus centralized vs distributed VCS, Git, and how teams collaborate with pull requests and review.
+keywords: version control, Git, distributed version control, centralized version control, branching, pull requests, code review, collaboration, commit history, merge requests
+level: beginner
+status: full
+faq:
+  - q: "Why use version control for a project that's just me?"
+    a: "Even solo, version control gives you a complete, undoable history of every change, the freedom to experiment on a branch without fear, and a safety net when something breaks — you can see exactly what changed and roll back. It also makes future collaboration or open-sourcing effortless because the history already exists. The cost is near zero; the upside is large."
+  - q: "What's the difference between centralized and distributed version control?"
+    a: "In a centralized system (like older Subversion) there is one central server holding the history, and you check files out from it. In a distributed system like Git, every clone is a full copy of the entire history, so you can commit, branch, and view history offline. Distributed systems are more resilient and enable flexible collaboration flows, which is a big reason Git won."
+  - q: "Are pull requests a Git feature?"
+    a: "Not exactly. Git itself handles commits, branches, and merging. Pull requests (or merge requests) are a feature of hosting platforms like GitHub and GitLab built on top of Git — they wrap a proposed merge with discussion, code review, and automated checks. Git provides the plumbing; the platform provides the collaboration workflow."
+---
+# Version control & collaboration
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Version control is non-negotiable** — every serious project keeps a full, undoable history. **Git won** — distributed, fast, and the de facto standard. **Collaboration flows** — branches, pull requests, and code review let many people work without chaos.
+</div>
+
+If there's one tool every software project uses, it's **version control.** It records the complete history of your code — who changed what, when, and why — lets people work in parallel without overwriting each other, and gives you a safety net to undo mistakes. It's so foundational that "the project lives in version control" is just assumed. This lesson explains *why* that's true and sketches how teams collaborate on top of it. It's an intro: the [Git & GitHub path](/learn/git/) covers the mechanics in depth, and we'll point you there for the details.
+
+## Why every project lives in version control
+
+Imagine writing software with no version control: files named `decoder_final_v2_REALLY_final.go`, no record of why a line changed, and a teammate emailing you a zip that silently clobbers your afternoon's work. That's the world version control abolishes. A **version control system (VCS)** gives you four things that are hard to live without:
+
+- **History** — a timestamped, attributed log of every change, so you can answer "what changed and why?" and trace a bug to the commit that introduced it.
+- **Branching** — the ability to develop a feature or experiment in isolation, on a separate line, without destabilizing the working version.
+- **Collaboration** — many people editing the same project at once, with the system merging their work and flagging genuine conflicts.
+- **Safety** — every committed state is recoverable. Delete the wrong thing? Roll back. Break the build? Bisect the history to find the culprit.
+
+These benefits aren't just for teams. Even working solo, a VCS turns "I broke something an hour ago and don't know what" into a two-command investigation. The cost of adopting it is almost nothing; the cost of skipping it compounds with every change.
+
+## Centralized vs distributed
+
+There are two broad architectures for a VCS, and the difference shaped the modern tooling.
+
+**Centralized** systems (such as the older Subversion, or CVS before it) keep the single source of truth on a central server. You check out files, make changes, and commit back to the server. There's exactly one repository, and you generally need to be connected to it to do meaningful work. Simple to reason about, but the server is a single point of failure and offline work is limited.
+
+**Distributed** systems (Git, Mercurial) give *every* clone a complete copy of the entire history. When you clone a repo, you get all the commits, all the branches, the whole timeline. You can commit, branch, view history, and diff entirely offline; you only need the network to share with others. This makes the system resilient — every clone is effectively a backup — and unlocks flexible workflows where people sync peer-to-peer or through one or more shared remotes.
+
+| | Centralized | Distributed |
+| --- | --- | --- |
+| History location | One central server | Every clone has the full history |
+| Offline work | Limited | Full commit/branch/log offline |
+| Single point of failure | The server | None — every clone is a backup |
+| Examples | Subversion, CVS | Git, Mercurial |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — in a distributed VCS like Git, every clone holds the complete history, so you can work and commit offline." markdown="0">
+  <p class="knowledge-check__q">Quick check: what defines a distributed version control system?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">All history lives only on a central server you must stay connected to</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Every clone holds a complete copy of the project's history</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It can only ever have one branch at a time</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Git — the de facto standard
+
+In practice, "version control" today almost always means **Git.** Created by Linus Torvalds in 2005 to manage Linux kernel development, Git is distributed, extremely fast, and ruthlessly good at branching and merging — which made experimentation cheap and collaboration scalable. It became the overwhelming default, and the hosting platforms built around it (GitHub, GitLab, Bitbucket) turned it into the backbone of modern collaboration and open source.
+
+A few core concepts you'll meet everywhere:
+
+- A **commit** is a snapshot of your project at a point in time, with a message explaining the change.
+- A **branch** is a movable pointer to a line of development — cheap to create, so you make one per feature or fix.
+- **Merging** combines the work from one branch into another, and Git only bothers you when two changes genuinely conflict.
+- A **remote** is a shared copy (often on GitHub) that the team pushes to and pulls from.
+
+We won't reteach Git here — the dedicated path does that properly. Start with [what version control is](/learn/git/what-is-version-control/) for the foundations and [branches](/learn/git/branches/) for the model that makes parallel work possible.
+
+## How teams collaborate
+
+Version control enables collaboration, but teams add a *workflow* on top to keep it orderly. The common shape, often called a feature-branch or pull-request workflow, looks like this:
+
+1. **Branch** off the main line to work on a feature or fix in isolation, so the shared `main` branch always stays in a working state.
+2. **Commit** your changes to that branch as you go, in small, well-described steps.
+3. **Open a pull request** (PR) — or "merge request" on GitLab — proposing that your branch be merged into `main`.
+4. **Review** — teammates read the change, leave comments, and request fixes. Automated checks (build and tests) usually run here too.
+5. **Merge** once approved and green, folding the work into `main`.
+
+The pull request is where collaboration becomes a conversation rather than a file dump. **Code review** — a second pair of eyes before code lands — catches bugs, spreads knowledge across the team, and keeps quality consistent. It's one of the highest-value habits in software, and it's nearly free.
+
+This shows up directly in a project like GopherTrunk: a contributor adding support for a new radio protocol opens a branch, builds the decoder, and submits a PR. Reviewers can see *exactly* what changed, run the automated tests against sample captures, and discuss the approach — all without anyone risking the stability of `main`. For the full mechanics, see [pull requests](/learn/git/pull-requests/) in the Git path.
+
+## Where to go deeper
+
+This lesson is deliberately a tour, not a manual. Branching strategies, resolving merge conflicts, rebasing, and the day-to-day commands all live in the dedicated [Git & GitHub path](/learn/git/). If you take one action from this lesson, make it this: put your next project in Git from commit one. The habit pays for itself almost immediately, and it's the substrate that the rest of this module — [testing](/learn/intro-software-dev/testing/) and [build & CI/CD](/learn/intro-software-dev/build-and-ci-cd/) — builds on.
+
+## Recap
+
+- **Version control is foundational** — it gives you history, branching, collaboration, and safety; every serious project uses it.
+- **Solo or team, it pays off** — even alone, an undoable history and fearless experimentation are worth the near-zero cost.
+- **Centralized vs distributed** — centralized keeps history on one server; distributed (Git) gives every clone the full history and offline power.
+- **Git is the standard** — distributed, fast, great at branching; the platforms around it power modern collaboration and open source.
+- **Collaboration flows** — branch, commit, open a pull request, review, merge; code review is a high-value, low-cost habit.
+- **Go deeper in the Git path** — this lesson is an intro; the [Git & GitHub path](/learn/git/) covers the mechanics properly.
+
+Next up: how to know your code actually works — [testing: unit, integration & beyond](/learn/intro-software-dev/testing/).

--- a/docs/learn/intro-software-dev/what-are-patterns.md
+++ b/docs/learn/intro-software-dev/what-are-patterns.md
@@ -1,0 +1,95 @@
+---
+slug: what-are-patterns
+title: What is a design pattern?
+description: A design pattern is a named, reusable solution to a recurring design problem. Learn the GoF categories, how patterns become shared vocabulary, and anti-patterns.
+keywords: design pattern, gang of four, GoF, creational structural behavioral, software design, anti-pattern, god object, golden hammer, Christopher Alexander
+level: beginner
+status: full
+faq:
+  - q: "What exactly is a design pattern?"
+    a: "A **design pattern** is a named, reusable description of a solution to a problem that comes up again and again in software design. It is not finished code you paste in — it is a template for how to arrange classes, objects, and responsibilities so the design stays flexible. The pattern gives you a vocabulary word (\"use a factory here\") that captures a whole approach in one term."
+  - q: "Where did design patterns come from?"
+    a: "The idea was borrowed from architecture. **Christopher Alexander** wrote about patterns in building design in the 1970s. In 1994 four authors — the \"Gang of Four\" — published *Design Patterns*, cataloguing 23 reusable solutions for object-oriented software. That book made patterns a standard part of how developers talk about design."
+  - q: "Can you use too many design patterns?"
+    a: "Yes. Patterns solve specific problems, and forcing one where it is not needed adds indirection and complexity for no benefit — the \"golden hammer\" anti-pattern. A pattern earns its place when it removes a real pain (a hard-to-change design, duplicated logic, tight coupling). If the simple version already works, the simple version usually wins."
+---
+# What is a design pattern?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Pattern** — a named, reusable solution to a recurring design problem. **Vocabulary, not code** — patterns are templates and shared language, not copy-paste snippets. **Three GoF families** — creational, structural, and behavioral patterns cover how objects are made, composed, and made to cooperate.
+</div>
+
+You have written enough code by now to notice something: the same shapes keep reappearing. You need an object but you do not want the caller to know which exact class it is. You need to add behavior to something without rewriting it. You need one part of a program to react when another part changes. These problems show up in a scanner's decoder engine, a web server, and a video game alike. Over decades, the community noticed these recurring problems and wrote down the proven solutions. Those write-ups are **design patterns**. This lesson explains what a pattern is, where the idea came from, the three classic families, and the failure modes — including overusing patterns themselves.
+
+## A pattern is a named, reusable solution
+
+A **design pattern** is a description of a solution to a problem that recurs in software design, captured in a way you can reuse across many situations. Each pattern has four rough parts:
+
+- **A name** — so you can refer to the whole idea in one or two words.
+- **A problem** — the situation where the pattern applies.
+- **A solution** — the general arrangement of classes and objects, not a specific implementation.
+- **Consequences** — the trade-offs you accept by using it.
+
+The key word is *general*. A pattern is not a library function or a code template you paste into your editor. It is closer to a recipe written at the level of "make a roux, then add liquid" rather than "use exactly 30 grams of this brand of flour." You still have to implement it in your own language, for your own types, in your own codebase. Two correct uses of the same pattern can look quite different in source code while sharing the same underlying structure.
+
+This is why patterns survive language changes. The Factory idea works in Java, Go, Python, and Rust even though the syntax differs wildly. You are reusing the *design*, not the bytes.
+
+## Patterns are vocabulary, not copy-paste code
+
+The most underrated benefit of patterns is communication. When a teammate says "let's put a **facade** over the DSP chain so the UI only sees one call," everyone who knows the term instantly understands a whole design decision: a simple front hiding a complex subsystem, where to draw the boundary, and roughly what the interface looks like. That single word replaces a paragraph of explanation.
+
+> A shared pattern vocabulary lets a team discuss design at a higher altitude — talking about responsibilities and relationships instead of lines of code.
+
+This connects directly to ideas earlier in the path. Patterns are tools for managing [abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/) — most of them exist to keep parts of a system from depending too tightly on each other. And many of them are concrete ways to honour the principles in [SOLID](/learn/intro-software-dev/solid/), especially the open/closed principle: design so you can extend behavior without editing existing code.
+
+Because patterns are vocabulary, learning them is partly learning to *recognize* them in code you read. Much existing software already uses these structures, sometimes without naming them. Once you have the names, you start seeing factories and observers everywhere — in frameworks, standard libraries, and the GopherTrunk codebase.
+
+## Where the idea came from
+
+Patterns did not start in software. The architect **Christopher Alexander** introduced the concept in the late 1970s, in books like *A Pattern Language*, to describe recurring good solutions in building and town design — a window seat, a courtyard that catches light, the right width for a walkable street. Each was a named solution to a human problem, reusable across many buildings.
+
+Software people borrowed the idea. In 1994, four authors — Erich Gamma, Richard Helm, Ralph Johnson, and John Vlissides, collectively nicknamed the **"Gang of Four" (GoF)** — published *Design Patterns: Elements of Reusable Object-Oriented Software*. It catalogued **23 patterns** for object-oriented design and gave each a name, a problem, a solution, and consequences. That book is the reason "design pattern" is now a standard phrase, and its 23 patterns are still the canonical core. Later work added concurrency patterns, enterprise patterns, and architectural patterns, but the GoF catalogue is where most people start.
+
+## The three GoF categories
+
+The Gang of Four sorted their 23 patterns into three families by *what kind of problem* each solves. You will spend the next three lessons on these in detail; here is the map.
+
+| Category | The problem it addresses | Examples |
+|----------|--------------------------|----------|
+| **Creational** | How objects get *created*, without hard-coding the exact class | Factory Method, Builder, Singleton, Abstract Factory, Prototype |
+| **Structural** | How objects are *composed* into larger structures | Adapter, Facade, Decorator, Proxy, Composite, Bridge |
+| **Behavioral** | How objects *interact* and share responsibility | Observer, Strategy, State, Command, Iterator, Template Method |
+
+A quick way to remember it: **creational** is about *making* things, **structural** is about *arranging* things, and **behavioral** is about *coordinating* things. A real radio decoder uses all three at once — a factory chooses which protocol decoder to build, an adapter wraps the hardware driver, and an observer notifies the UI when a call is decoded.
+
+## Anti-patterns: the shapes to avoid
+
+Patterns describe good recurring solutions. **Anti-patterns** are the opposite: recurring *bad* solutions that look tempting but cause pain. Naming them is just as useful, because it lets a team say "that's a god object" and agree to fix it. A few classics:
+
+- **God object** — one class that knows and does everything. It accumulates responsibilities until nothing can change without touching it. The cure is splitting responsibilities (high cohesion, low coupling).
+- **Spaghetti code** — control flow so tangled, with no clear structure, that you cannot follow it. Usually the result of growth without design.
+- **Golden hammer** — "when all you have is a hammer, everything looks like a nail." Reaching for the same favourite tool or pattern for every problem, whether it fits or not.
+
+The golden hammer is the one that bites pattern enthusiasts directly: once you learn the catalogue, there is a strong urge to use it. But every pattern adds indirection. A factory you do not need is just a confusing extra layer between the caller and the object. Patterns are medicine for specific diseases — applying them to a healthy design only adds side effects. The skill is not memorizing all 23; it is judging *when a real problem calls for one*, which is exactly the kind of judgement the [decision framework](/learn/intro-software-dev/decision-framework/) lesson trains.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a pattern is a reusable design template and a shared name, not finished source code." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is a design pattern, most precisely?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A code snippet you copy and paste into your project unchanged</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A named, reusable template for solving a recurring design problem</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A rule that every program must follow to compile</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A pattern is a named, reusable solution** — a general template (name, problem, solution, consequences) for a recurring design problem, not finished code.
+- **Vocabulary first** — patterns let a team discuss design at a higher level; "use a facade here" carries a whole decision in one word.
+- **Origins** — Christopher Alexander brought patterns from architecture; the Gang of Four's 1994 book catalogued 23 for object-oriented software.
+- **Three GoF families** — creational (making objects), structural (arranging objects), behavioral (coordinating objects).
+- **Anti-patterns** — god object, spaghetti code, and the golden hammer are recurring *bad* solutions worth naming so you can avoid them.
+- **Patterns can be overused** — every pattern adds indirection; use one only when a real design problem calls for it.
+
+Next up: the creational patterns — Factory, Builder, and Singleton — and how they decide *how objects get made*. See [Creational patterns](/learn/intro-software-dev/creational-patterns/).

--- a/docs/learn/intro-software-dev/what-is-software.md
+++ b/docs/learn/intro-software-dev/what-is-software.md
@@ -1,0 +1,112 @@
+---
+slug: what-is-software
+title: What is software?
+description: Software is instructions and data living in memory. Learn the hardware/software split, the stored-program idea, and how software stacks in layers.
+keywords: what is software, hardware vs software, stored program, von Neumann architecture, instructions and data, firmware, operating system, software-defined radio
+level: beginner
+status: full
+faq:
+  - q: "What is the difference between hardware and software?"
+    a: "**Hardware** is the physical machine — chips, wires, memory, screens — the parts you can touch. **Software** is the set of instructions that tells that hardware what to do. The same hardware can run completely different software, which is exactly why one laptop can be a word processor one minute and a radio receiver the next."
+  - q: "What does \"stored-program\" mean?"
+    a: "It means a computer keeps both its instructions (the program) and the data those instructions work on in the same memory. Because instructions are just numbers in memory, a program can be loaded, replaced, or even modified like any other data. This idea, often credited to the **von Neumann** design, is why we can install new apps without rewiring anything."
+  - q: "Is software-defined radio really \"just software\"?"
+    a: "Mostly. A small amount of hardware turns radio waves into a stream of numbers, and from there the demodulating, filtering, and decoding is done by software. Functions that used to need dedicated circuits — mixers, filters, detectors — become math running on a regular CPU, which is why a cheap dongle plus a laptop can do what once filled a rack."
+---
+# What is software?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Hardware vs software** — hardware is the physical machine; software is the instructions that drive it. **Stored-program idea** — instructions and data both live in memory as numbers. **Layers** — firmware, operating system, and applications stack on top of each other to make a machine usable.
+</div>
+
+This is lesson 1 of the path. Before we talk about languages, history, or design, it's worth being precise about the thing this whole field is built on: software. We use the word loosely — "the software crashed," "update your software" — but underneath it is one of the most elegant ideas of the twentieth century. By the end of this lesson you'll understand what a program actually *is*, why a single machine can do thousands of unrelated jobs, and why modern radios are increasingly made of code rather than copper.
+
+## Hardware you can touch, software you can't
+
+Start with the obvious split. **Hardware** is everything physical: the processor, the memory chips, the storage drive, the keyboard, the antenna plugged into the back. If you drop it and it breaks, it was hardware.
+
+**Software** is the set of instructions that tells hardware what to do. It has no mass and no shape. You can copy it infinitely at almost no cost, send it around the world in seconds, and run the exact same software on millions of different machines.
+
+The crucial relationship between them is this: *the hardware is general, the software is specific*. A processor doesn't "know" how to be a spreadsheet or a video game or a radio. It only knows how to do a small set of very simple operations — add two numbers, compare two numbers, move a number from here to there, jump to a different instruction. Software is what arranges millions of those tiny operations into something useful.
+
+That generality is the whole magic trick. The same laptop can be a calculator, a music studio, and — with the right software and a small USB device — a wideband radio scanner. Nothing about the hardware changed. Only the instructions did.
+
+## What is a program, really?
+
+A **program** is an ordered list of instructions for the machine to carry out. The raw form those instructions take is **machine code** — numbers that the processor reads directly. Each number means something specific to that particular kind of chip: "load this value," "add," "store the result," "if zero, jump."
+
+People almost never write those numbers by hand anymore (we'll see why in [From machine code to high-level languages](/learn/intro-software-dev/birth-of-languages/)). But it's important to know that, at the very bottom, that's all a running program is — a sequence of numeric instructions being fetched and executed, one after another, billions of times per second.
+
+Here's a deliberately tiny example of what an instruction stream looks like in human-readable assembly form, where each line maps to one machine operation:
+
+```text
+LOAD  R1, 5      ; put the number 5 in register R1
+LOAD  R2, 3      ; put the number 3 in register R2
+ADD   R3, R1, R2 ; R3 = R1 + R2  (now R3 holds 8)
+STORE R3, total  ; write R3 into the memory slot named "total"
+```
+
+Real programs are these same primitive steps stacked into the millions. The art of software is composing simplicity into complexity.
+
+## The stored-program idea
+
+Early computing machines were often wired for a single task. To make them do something else, you physically rewired them or fed in a new arrangement of switches and cables — a process that could take days.
+
+The breakthrough was the **stored-program** concept, associated with the design John von Neumann described in 1945 (building on ideas already circulating among the ENIAC team). The insight is deceptively simple:
+
+> Store the program in the computer's memory, in the same place and the same form as the data.
+
+Because an instruction is just a number, and data is just numbers, there's no fundamental difference between them. The machine pulls instructions out of memory the same way it pulls out data. This is the **von Neumann architecture**, and almost every computer you've ever used follows it.
+
+The consequences are enormous:
+
+- **You can change software instantly.** Loading a new program is just writing new numbers into memory — no rewiring.
+- **Programs can manipulate other programs.** Compilers, operating systems, and updaters all work because code is just data that other code can read and write.
+- **One machine, endless purposes.** The same physical computer runs anything you load into it.
+
+Instructions and data sharing one memory is why your computer can download a brand-new application this afternoon and run it without any physical change. The machine didn't learn a new skill — you just handed it a new list of numbers to follow.
+
+## Software comes in layers
+
+You rarely deal with raw machine code because software is built in **layers**, each one hiding the messiness of the layer below it. From the metal upward:
+
+| Layer | What it is | Example |
+|-------|-----------|---------|
+| **Firmware** | Tiny software baked into a hardware device, telling it how to behave at the lowest level | The code inside an SSD, a Wi-Fi chip, or an SDR dongle |
+| **Operating system** | Manages the hardware and shares it among programs | Linux, Windows, macOS, Android |
+| **Libraries / runtime** | Reusable building blocks programs lean on | A DSP filtering library, a graphics toolkit |
+| **Applications** | The programs you actually open and use | A browser, a game, GopherTrunk |
+
+Each layer trusts the one beneath it and serves the one above it. When you click "play" in an app, that request travels down through libraries, the operating system, firmware, and finally the hardware — and the result travels back up. You see a single smooth action; underneath, every layer did its job.
+
+This layering is also how a complete beginner can build something real. You don't have to understand transistors to write an app, because dozens of layers of other people's software stand between your code and the silicon.
+
+## When the hardware moves into the software
+
+Here's the idea this whole site circles back to. For most of radio's history, a receiver was *hardware*: physical tuners, mixers, and filters made of coils and capacitors, each soldered for one job. Want a different band or mode? Different hardware.
+
+**Software-defined radio (SDR)** flips that. A minimal piece of hardware grabs the radio signal and turns it into a stream of numbers (we'll meet the [radio waves](/learn/rf-sdr/radio-waves/) themselves in the RF path). Everything after that — tuning, filtering, demodulating, decoding — becomes *software*: math running on an ordinary CPU. The filter that used to be a physical coil is now a few lines of code processing those numbers.
+
+SDR is the purest expression of the lesson here: *if you can describe a job as instructions operating on data, you can move it out of hardware and into software*. That's why a thirty-dollar USB dongle plus a laptop can now scan, decode, and analyze signals that once demanded a rack of specialized equipment. The radio became software. GopherTrunk lives in exactly this world.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — in a stored-program computer, instructions and data both live in memory as numbers." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the core idea of the stored-program (von Neumann) architecture?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Software must be permanently wired into the hardware</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A program's instructions and its data both live in the same memory, as numbers</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Each program needs its own dedicated processor</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Hardware vs software** — hardware is the physical, general-purpose machine; software is the specific instructions that drive it.
+- **A program is instructions** — at bottom, a running program is a stream of simple numeric operations the processor executes one after another.
+- **Stored-program idea** — instructions and data share one memory as numbers, so software can be loaded, replaced, and even written by other software.
+- **One machine, many jobs** — that shared memory is why a single computer can run any program you give it without physical change.
+- **Layers** — firmware, operating system, libraries, and applications stack up, each hiding the complexity below.
+- **SDR** — software-defined radio shows the endpoint of "move it into software": the receiver becomes math on a CPU.
+
+Next up: how the physical machine got here — from Jacquard looms and Babbage's engines through the transistor, the microprocessor, and the cheap chips that made SDR possible. See [From looms to microprocessors](/learn/intro-software-dev/computing-hardware-story/).

--- a/docs/learn/intro-software-dev/why-language-choice-matters.md
+++ b/docs/learn/intro-software-dev/why-language-choice-matters.md
@@ -1,0 +1,136 @@
+---
+slug: why-language-choice-matters
+title: Why language choice matters (and when it doesn't)
+description: What picking a programming language actually decides — ecosystem, team, performance ceiling, deployment, maintenance — and the cases where any mainstream language will do.
+keywords: choosing a programming language, language selection, ecosystem, switching cost, lock-in, best programming language, team familiarity, technology decision
+level: beginner
+status: full
+faq:
+  - q: "Is there a single best programming language?"
+    a: "No. \"Best\" only means anything relative to a goal, a team and a set of constraints. A language that is ideal for real-time DSP may be a poor fit for a quick data-cleaning script. The useful question is \"best **for this job, with this team, on this deadline**\" — not \"best\" in the abstract."
+  - q: "Does the language I choose really matter for a typical web app?"
+    a: "Often less than people think. For many CRUD-style applications — forms, a database, some pages — any mainstream language (Python, JavaScript, Go, Java, C#, Ruby) can do the job well. There the deciding factors are usually the team's familiarity, the ecosystem and hiring, not raw language differences."
+  - q: "How expensive is it to switch languages later?"
+    a: "Expensive and rarely clean. Rewrites are slow, risky and easy to underestimate; you also accumulate lock-in through libraries, hiring and accumulated know-how. That switching cost is exactly why the initial choice is worth a little deliberate thought — not endless agonising, but more than a coin flip."
+---
+# Why language choice matters (and when it doesn't)
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**It sets defaults** — ecosystem, hiring, performance ceiling and deployment all flow from the language. **It often doesn't decide much** — for many apps, any mainstream language works and team familiarity wins. **There is no "best" language** — only best-for-this-job.
+</div>
+
+Choosing a programming language feels momentous, and online it is treated like a
+loyalty test. The truth is more boring and more useful: the choice matters a great
+deal for *some* decisions and barely at all for others. This module is a complete
+toolkit for telling the two apart and picking deliberately. Before we get to
+frameworks, requirements and trade-offs, it helps to be clear-eyed about what a
+language choice actually buys you — and what it doesn't.
+
+## What the choice actually decides
+
+Picking a language is rarely about syntax. It quietly settles several things that
+are hard to change later:
+
+- **The ecosystem.** You inherit a language's libraries, frameworks, tooling and
+  community. Python's data-science stack, JavaScript's web tooling and Go's
+  networking libraries are reasons to pick those languages on their own — the
+  language is the price of admission to the ecosystem.
+- **Hiring and the team.** You can only build with people who know — or can learn —
+  the language. A niche language can mean a smaller hiring pool and a steeper
+  on-ramp for new contributors.
+- **The performance ceiling.** A language sets an upper bound on how fast and how
+  lean your software *can* be. You can write slow C, but you cannot make CPython
+  match hand-tuned C in a tight loop. For most software this ceiling is irrelevant;
+  for real-time or embedded work it is decisive.
+- **The deployment story.** How you ship matters. A single static binary you can
+  hand to a user is a very different experience from "install this runtime, then
+  these dependencies, then…". We return to this in
+  [packaging and distribution](/learn/intro-software-dev/packaging-and-distribution/).
+- **Long-term maintenance.** Code is read far more than it is written. The language
+  shapes how readable, refactorable and safe your codebase stays over years.
+
+## What it often doesn't decide
+
+Here is the part the internet leaves out: for a huge swathe of software, the
+language barely matters.
+
+- **Most CRUD apps work in anything.** If your program shows forms, reads and writes
+  a database, and serves some pages, then Python, JavaScript/Node, Go, Java, C# and
+  Ruby will all do the job competently. The bottleneck is usually the network and the
+  database, not the language.
+- **Team familiarity usually beats theoretical fit.** A team that is fluent in one
+  language will out-ship a team fumbling through a "better" one they don't know. A
+  mediocre fit you know well often beats a perfect fit you don't.
+- **Architecture and clarity matter more than language.** A well-structured Python
+  service is more maintainable than a tangled Rust one. The principles in this path —
+  [SOLID](/learn/intro-software-dev/solid/), clean code, sensible boundaries — travel
+  across every language.
+
+The honest rule of thumb: the language choice matters most at the **extremes** —
+extreme performance needs, extreme safety needs, an unusual platform — and least in
+the comfortable middle where most software lives.
+
+## Switching cost and lock-in
+
+If the choice didn't stick, none of this would matter. But it does stick.
+
+- **Rewrites are expensive and risky.** Porting a working system to another language
+  means re-implementing, re-testing and re-debugging behaviour you already had —
+  usually with no new features to show for it. Famous rewrites have sunk products.
+- **Lock-in compounds.** Over time you accumulate libraries, internal tools, hiring,
+  documentation and muscle memory in one language. Each adds gravity that resists a
+  switch.
+- **You can hedge — partly.** Clean module boundaries and avoiding language-specific
+  cleverness make a future migration less painful, but they never make it free.
+
+This switching cost is precisely *why* the first choice deserves thought. Not weeks
+of agonising — but more than fashion.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — for typical CRUD-style apps, several mainstream languages work fine and team familiarity usually decides it." markdown="0">
+  <p class="knowledge-check__q">Quick check: for a standard CRUD web app with a small experienced team, what usually matters most?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Picking the theoretically fastest language at any cost</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The team's existing familiarity and the ecosystem fit</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Choosing whichever language is trending this year</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## The myth of the "best" language
+
+Every language has passionate advocates, and most of their claims are *locally*
+true. C really is fast. Python really is productive. Rust really is safe. The error
+is treating any one of these as a universal verdict.
+
+- **"Best" is always relative.** Best at what? On what hardware? For whom? A language
+  that wins for a high-throughput DSP core may lose badly for a five-line automation
+  script.
+- **Trade-offs are the whole story.** Speed trades against productivity; safety trades
+  against learning curve; flexibility trades against predictability. No language
+  escapes the triangle — it just picks a corner. We unpack the biggest of these in
+  [the performance ↔ productivity trade-off](/learn/intro-software-dev/performance-vs-productivity/).
+- **Fashion is not a requirement.** "Everyone's using it" tells you about hiring and
+  ecosystem momentum — useful signals — but it is not the same as fit for *your*
+  problem.
+
+The goal of this module is to replace "which language is best?" with a better
+question: **given my actual requirements, my team and my constraints, which
+languages clear the bar — and which clears it best?** That always starts with the
+requirements, which is exactly where we go next.
+
+## Recap
+
+- **Language choice sets durable defaults** — ecosystem, hiring, performance ceiling,
+  deployment and maintainability all follow from it.
+- **For many apps it barely matters** — most mainstream languages handle CRUD work,
+  and team familiarity usually wins.
+- **It matters most at the extremes** — unusual performance, safety or platform needs
+  are where the choice becomes decisive.
+- **Switching is costly** — rewrites and lock-in are real, which is why a little
+  upfront thought pays off.
+- **There is no "best" language** — only the best fit for a specific job, team and
+  set of constraints.
+
+Next up: how to drive the decision from real requirements instead of fashion —
+[start with requirements](/learn/intro-software-dev/from-requirements/).


### PR DESCRIPTION
Add a third structured learning path under /learn/ covering software
development from the ground up, matching the existing RF & SDR and Git &
GitHub paths in format and the shared data-driven Jekyll system.

The path spans 7 modules / 40 lessons plus a glossary:
  1. A Brief History of Software (hardware, languages, the pioneers)
  2. Modern Programming Languages (families, how code runs, types,
     memory, concurrency, language-level security)
  3. Software Development Principles (clean code, DRY/KISS/YAGNI, SOLID,
     coupling/cohesion, robustness)
  4. Software Design Patterns (creational, structural, behavioral,
     concurrency/streaming, architectural)
  5. Development Systems & Strategies (SDLC, version control, testing,
     CI/CD, docs & maintenance)
  6. Choosing the Right Language (a dedicated, requirements-driven module
     with a language tour, domain mapping, and a decision framework)
  7. Build Your Solo Developer Stack (stack, workflow, scoping, quality,
     packaging & distribution, shipping & maintaining)

Examples carry a subtle RF/SDR slant (streaming sample pipelines,
real-time DSP constraints, plugin decoders, cross-platform binary
distribution) to keep abstract ideas concrete.

Changes:
- docs/_data/learn.yml: new intro-software-dev path entry (drives the
  chooser, hub, lesson nav, and llms.txt automatically)
- docs/_config.yml: defaults scope for the new lesson path
- docs/learn/index.md: chooser SEO description mentions the third path
- docs/learn/intro-software-dev/: hub, 40 lessons, and glossary

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011wNBTcHJU4DRUY3tej4kc7