### PR TITLE
P25 discovery: streaming long-dwell CC monitor, identity corroboration, UTUAR decode, freq precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,17 @@ for tagged releases.
   buffering the whole dwell, so a P25 site can be watched for minutes without
   recording gigabytes of IQ. It stops early once identity, neighbors, and the
   band plan stop changing (converge-and-stop), capped at the requested time.
+- **P25 Unit-to-Unit Answer Request decoding** (opcode 0x05). The private-call
+  answer-request handshake is now decoded — in both the standard and Motorola
+  (MFID 0x90) forms — and published as a new `unit.request` bus event carrying
+  the calling/called radio IDs, surfaced on the web CC-activity panel and the
+  message log instead of being logged as an unhandled vendor TSBK.
 
 ### Fixed
+- **Hunt progress frequency precision.** The identifying-phase progress line
+  rounded the tuned frequency to 3 decimals (showing a 6.25 kHz-raster channel
+  like 160.5875 MHz as "160.588"); it now prints 4 decimals, matching the rest
+  of the UI. Display-only — the SDR was always tuned to the exact frequency.
 - **P25 identity / band-plan / neighbor accuracy under noise.** Status-broadcast
   accumulation was last-write-wins, so a single corrupt-but-CRC-passing TSBK
   could set a wrong WACN / System ID or inject a phantom band-plan slot

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -97,6 +97,8 @@ func eventToDTO(ev events.Event) EventDTO {
 		dto.Payload = affiliationToDTO(p)
 	case trunking.UnitRegistration:
 		dto.Payload = unitRegistrationToDTO(p)
+	case trunking.UnitToUnitRequest:
+		dto.Payload = unitToUnitRequestToDTO(p)
 	case trunking.Patch:
 		dto.Payload = patchToDTO(p)
 	case events.DMRGrantObserved:

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -420,6 +420,24 @@ func unitRegistrationToDTO(u trunking.UnitRegistration) UnitRegistrationDTO {
 	}
 }
 
+// UnitToUnitRequestDTO mirrors trunking.UnitToUnitRequest.
+type UnitToUnitRequestDTO struct {
+	System         string `json:"system"`
+	Protocol       string `json:"protocol"`
+	SourceID       uint32 `json:"source_id"`
+	TargetID       uint32 `json:"target_id"`
+	ServiceOptions uint8  `json:"service_options,omitempty"`
+}
+
+func unitToUnitRequestToDTO(u trunking.UnitToUnitRequest) UnitToUnitRequestDTO {
+	return UnitToUnitRequestDTO{
+		System: u.System, Protocol: u.Protocol,
+		SourceID:       u.SourceID,
+		TargetID:       u.TargetID,
+		ServiceOptions: u.ServiceOptions,
+	}
+}
+
 // PatchDTO mirrors trunking.Patch for SSE / REST consumers. Add=true is
 // a patch becoming active; Add=false is a cancel.
 type PatchDTO struct {

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -77,8 +77,16 @@ const (
 	// identifies the source unit, the WACN + System ID it's
 	// registering on, and the response code. Useful as a "which
 	// radios are on which site" feed.
-	KindAffiliation      Kind = "affiliation"
-	KindUnitRegistration Kind = "registration"
+	//
+	// KindUnitToUnitRequest fires when the system asks a radio whether it
+	// will answer a private (unit-to-unit) call. P25 control-channel
+	// publishes one per Unit-to-Unit Answer Request TSBK (opcode 0x05); the
+	// payload identifies the calling (source) and called (target) units. No
+	// channel is granted yet — it's the call-setup handshake. Useful as a
+	// "who is calling whom" feed alongside affiliations.
+	KindAffiliation       Kind = "affiliation"
+	KindUnitRegistration  Kind = "registration"
+	KindUnitToUnitRequest Kind = "unit.request"
 	// KindAudioState fires when an operator changes the live-audio
 	// cockpit — volume, mute, or recording-gate. The payload is the
 	// new state (the same shape as GET /api/v1/audio). Subscribers

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -206,7 +206,7 @@ func RunLiveHunt(ctx context.Context, opts LiveHuntOptions) (*DiscoveredSystem, 
 		progress(LiveHuntProgress{
 			Phase: PhaseIdentifying, CenterHz: cand.FreqHz,
 			CandidateN: i + 1, Candidates: len(candidates),
-			Detail: fmt.Sprintf("%.3f MHz", float64(cand.FreqHz)/1e6),
+			Detail: fmt.Sprintf("%.4f MHz", float64(cand.FreqHz)/1e6),
 		})
 
 		params := decodeParams{

--- a/internal/log/messagelog.go
+++ b/internal/log/messagelog.go
@@ -196,6 +196,11 @@ func formatEvent(ev events.Event) string {
 			body = fmt.Sprintf("%-12s system=%s proto=%s src=%d wacn=%d sysid=%d resp=%s",
 				"REGISTRATION", r.System, r.Protocol, r.SourceID, r.WACN, r.SystemID, r.Response)
 		}
+	case events.KindUnitToUnitRequest:
+		if u, ok := ev.Payload.(trunking.UnitToUnitRequest); ok {
+			body = fmt.Sprintf("%-12s system=%s proto=%s src=%d target=%d",
+				"U2U-REQUEST", u.System, u.Protocol, u.SourceID, u.TargetID)
+		}
 	case events.KindPatch:
 		body = fmt.Sprintf("%-12s %+v", "PATCH", ev.Payload)
 	case events.KindTalkerAlias:

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1013,6 +1013,8 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			groupID: g.TargetID, sourceID: g.SourceID,
 			channelID: g.ChannelID, channelNumber: g.ChannelNumber,
 		}, nac)
+	case OpUnitToUnitAnswerRequest:
+		c.publishUnitToUnitRequest(ParseUnitToUnitAnswerRequest(t.Payload), nac)
 	case OpTelephoneInterconnectGrant:
 		g := ParseTelephoneInterconnectGrant(t.Payload)
 		c.publishVoiceGrant(voiceGrant{
@@ -1106,6 +1108,14 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 		if alias, src, done := c.aliasAsm.Add(f); done {
 			c.publishTalkerAlias(src, alias)
 		}
+		return
+	}
+	// Unit-to-Unit Answer Request (opcode 0x05) is a standard call-setup
+	// message that some Motorola sites emit under the vendor MFID. The
+	// target/source layout is the standard one, so decode it here too rather
+	// than logging it as an unhandled vendor opcode.
+	if t.Opcode == OpUnitToUnitAnswerRequest {
+		c.publishUnitToUnitRequest(ParseUnitToUnitAnswerRequest(t.Payload), nac)
 		return
 	}
 	// Unrecognised vendor opcode: census + raw-payload sample so a field
@@ -1381,6 +1391,27 @@ func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse, nac
 		"system", c.systemName, "nac", nac,
 		"src", u.SourceID, "wacn", u.WACN, "sysid", u.SystemID,
 		"rsp", u.Response)
+}
+
+// publishUnitToUnitRequest publishes a trunking.UnitToUnitRequest on the bus
+// when the site issues a Unit-to-Unit Answer Request (opcode 0x05). No
+// band-plan resolution is needed — the answer request carries no channel, only
+// the calling/called radio IDs.
+func (c *ControlChannel) publishUnitToUnitRequest(u UnitToUnitAnswerRequest, nac uint16) {
+	c.bus.Publish(events.Event{
+		Kind: events.KindUnitToUnitRequest,
+		Payload: trunking.UnitToUnitRequest{
+			System:         c.systemName,
+			Protocol:       "p25",
+			SourceID:       u.SourceID,
+			TargetID:       u.TargetID,
+			ServiceOptions: uint8(u.ServiceOptions),
+			At:             c.now(),
+		},
+	})
+	c.log.Debug("p25: unit-to-unit answer request",
+		"system", c.systemName, "nac", nac,
+		"src", u.SourceID, "target", u.TargetID)
 }
 
 // MarkLost publishes a CCLost event for the current frequency and resets

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -77,6 +77,51 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 	}
 }
 
+// TestControlChannelPublishesUnitToUnitRequest drives a Unit-to-Unit Answer
+// Request (opcode 0x05) through the control channel — once with the standard
+// MFID and once with the Motorola vendor MFID (0x90), the form a real site was
+// seen emitting — and checks a KindUnitToUnitRequest naming the calling and
+// called units is published on the bus in both cases.
+func TestControlChannelPublishesUnitToUnitRequest(t *testing.T) {
+	for _, mfid := range []uint8{MFIDStandard, MFIDMotorola} {
+		bus := events.NewBus(16)
+		sub := bus.Subscribe()
+		cc := New(Options{Bus: bus, SystemName: "U2U"})
+
+		utuar := TSBK{
+			Opcode: OpUnitToUnitAnswerRequest,
+			MFID:   mfid,
+			Payload: AssembleUnitToUnitAnswerRequest(UnitToUnitAnswerRequest{
+				ServiceOptions: 0x00, TargetID: 0x1234AB, SourceID: 0x00CDEF}),
+		}
+		cc.Process(buildLockedStreamWithTSBK(10, 0x705, DUIDTrunkingSignaling, utuar), 0)
+
+		deadline := time.After(3 * time.Second)
+		got := false
+		for !got {
+			select {
+			case ev := <-sub.C:
+				if ev.Kind != events.KindUnitToUnitRequest {
+					continue
+				}
+				u, ok := ev.Payload.(trunking.UnitToUnitRequest)
+				if !ok {
+					t.Fatalf("mfid=%#x payload is %T, want trunking.UnitToUnitRequest", mfid, ev.Payload)
+				}
+				if u.SourceID != 0x00CDEF || u.TargetID != 0x1234AB {
+					t.Fatalf("mfid=%#x src/target = %d/%d, want %d/%d",
+						mfid, u.SourceID, u.TargetID, 0x00CDEF, 0x1234AB)
+				}
+				got = true
+			case <-deadline:
+				t.Fatalf("mfid=%#x: no KindUnitToUnitRequest published within deadline", mfid)
+			}
+		}
+		sub.Close()
+		bus.Close()
+	}
+}
+
 // TestControlChannelPublishesSiteUpdate drives an RFSS Status Broadcast
 // through the control channel and checks a KindSiteUpdate naming the
 // camped site (with the tuned control-channel frequency) is published

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -195,6 +195,39 @@ func AssembleUnitToUnitVoiceChannelGrant(g UnitToUnitVoiceChannelGrant) [8]byte 
 	return p
 }
 
+// UnitToUnitAnswerRequest (opcode 0x05) — the infrastructure asking a unit
+// whether it will answer a private (unit-to-unit) call another unit is
+// setting up. It carries no channel (no traffic is granted yet), only the two
+// radio IDs. Working-model payload layout (TIA-102.AABF):
+//
+//	byte 0   : service options
+//	bytes 1-3: target unit ID (24 bits) — the called unit being asked to answer
+//	bytes 4-6: source unit ID (24 bits) — the calling unit
+//	byte 7   : reserved
+type UnitToUnitAnswerRequest struct {
+	ServiceOptions ServiceOptions
+	TargetID       uint32
+	SourceID       uint32
+}
+
+// ParseUnitToUnitAnswerRequest decodes payload bytes for opcode 0x05.
+func ParseUnitToUnitAnswerRequest(p [8]byte) UnitToUnitAnswerRequest {
+	return UnitToUnitAnswerRequest{
+		ServiceOptions: ServiceOptions(p[0]),
+		TargetID:       uint32(p[1])<<16 | uint32(p[2])<<8 | uint32(p[3]),
+		SourceID:       uint32(p[4])<<16 | uint32(p[5])<<8 | uint32(p[6]),
+	}
+}
+
+// AssembleUnitToUnitAnswerRequest is the inverse; used by tests.
+func AssembleUnitToUnitAnswerRequest(u UnitToUnitAnswerRequest) [8]byte {
+	var p [8]byte
+	p[0] = byte(u.ServiceOptions)
+	p[1], p[2], p[3] = byte(u.TargetID>>16), byte(u.TargetID>>8), byte(u.TargetID)
+	p[4], p[5], p[6] = byte(u.SourceID>>16), byte(u.SourceID>>8), byte(u.SourceID)
+	return p
+}
+
 // TelephoneInterconnectGrant (opcode 0x08) — a grant for a call bridged
 // to the public telephone network. Working-model payload layout:
 //

--- a/internal/radio/p25/phase1/opcodes_grants_test.go
+++ b/internal/radio/p25/phase1/opcodes_grants_test.go
@@ -34,6 +34,13 @@ func TestParseUnitToUnitVoiceChannelGrant(t *testing.T) {
 	}
 }
 
+func TestParseUnitToUnitAnswerRequest(t *testing.T) {
+	in := UnitToUnitAnswerRequest{ServiceOptions: 0x05, TargetID: 0x1234AB, SourceID: 0x00CDEF}
+	if got := ParseUnitToUnitAnswerRequest(AssembleUnitToUnitAnswerRequest(in)); got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+}
+
 func TestParseTelephoneInterconnectGrant(t *testing.T) {
 	in := TelephoneInterconnectGrant{ServiceOptions: 0x80, ChannelID: 1, ChannelNumber: 0x05, CallTimer: 600, TargetID: 0x00ABCD}
 	if got := ParseTelephoneInterconnectGrant(AssembleTelephoneInterconnectGrant(in)); got != in {

--- a/internal/trunking/affiliation.go
+++ b/internal/trunking/affiliation.go
@@ -82,6 +82,20 @@ type UnitRegistration struct {
 	At       time.Time
 }
 
+// UnitToUnitRequest is published on the events bus when the system asks a
+// radio whether it will answer a private (unit-to-unit) call. Emitted by P25
+// control-channel decoders on opcode 0x05 (Unit-to-Unit Answer Request). No
+// channel is granted yet — it's the call-setup handshake — so only the two
+// radio IDs (and the service options) are carried.
+type UnitToUnitRequest struct {
+	System         string // System name, matches trunking.System.Name
+	Protocol       string // "p25"
+	SourceID       uint32 // calling unit
+	TargetID       uint32 // called unit being asked to answer
+	ServiceOptions uint8  // P25 service-options octet (priority / encryption flags)
+	At             time.Time
+}
+
 // TalkerAlias is published on the events bus when a radio's display
 // name (the "talker alias") has been fully reassembled from the
 // multi-fragment vendor MAC PDUs that carry it. Emitted by the P25

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -21,6 +21,7 @@ const CC_KINDS: Record<string, string> = {
   "call.end": "Call end",
   "affiliation": "Affiliation",
   "registration": "Registration",
+  "unit.request": "Unit→Unit",
   "patch": "Patch",
   "talker.alias": "Talker alias",
   "cc.locked": "CC locked",
@@ -219,6 +220,19 @@ function renderRow(
           {"radio "}
           {radio ? ridLink(radio) : "?"}
           {suffix}
+        </>
+      );
+      return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };
+    }
+    case "unit.request": {
+      const system = str(payload.system);
+      const src = num(payload.source_id ?? payload.source);
+      const target = num(payload.target_id ?? payload.target);
+      const details = (
+        <>
+          {src ? ridLink(src) : "?"}
+          {" → "}
+          {target ? ridLink(target) : "?"}
         </>
       );
       return { ts: ev.timestamp, kind: ev.kind, label, system, details, raw: ev.payload };


### PR DESCRIPTION
## Summary

Improves P25 trunk discovery accuracy and adds a way to monitor a control channel for minutes without recording gigabytes of IQ. Driven by field reports against a known UHF site (NAC `2C1`): wrong WACN/System ID, phantom band-plan slots, empty neighbors, an unhandled `UnitToUnitAnswerRequest`, and a frequency-display rounding glitch.

Two commits:

### 1. Streaming long-dwell CC monitor + identity corroboration
- **Streaming monitor (opt-in).** New `monitor_seconds` (web Hunt "Monitor" field / `-monitor-seconds` CLI flag) feeds the live SDR straight into the existing decoder with **bounded memory** instead of buffering the whole dwell, so a site can be watched for minutes. **Converge-and-stop**: ends early once identity, neighbors, and the band plan settle, capped at the requested time. New `siglab.RunReaderMonitor` (stream-time tick hook) + `internal/hunt/monitor.go`.
- **Corroboration.** Status-broadcast accumulation was last-write-wins, so a single corrupt-but-CRC-passing TSBK (the multi-alignment NID/TSBK search inflates that exposure) could set a wrong WACN/System ID or inject a phantom band-plan slot (e.g. a stray VHF base on a UHF site). Identity is now resolved by **majority vote**; band-plan slots and neighbors require **≥2 sightings** before they surface. Live grant resolution (`BandPlan.Frequency`/`Known`) still accepts a first sighting, so voice channels are unaffected.

### 2. UnitToUnitAnswerRequest decode + hunt frequency precision
- **UTUAR (opcode 0x05).** Previously ignored — and, under the Motorola MFID `0x90` the site emits, logged as an unhandled "vendor tsbk" with a mislabeled standard name. Now decoded in **both** the standard and Motorola paths into 24-bit Target/Source radio IDs and published as a new `unit.request` bus event → SSE DTO, web CC-activity panel (`src → target`), and message log.
- **Frequency display.** The hunt identifying-phase progress line rounded a 6.25 kHz-raster channel like `160.5875` to `160.588` (`%.3f` → `%.4f`). Display-only; the SDR was always tuned to the exact Hz.

## Files
- Decoder: `internal/radio/p25/phase1/{network,identifier,opcodes,control}.go`
- Streaming: `internal/siglab/engine.go`, `internal/hunt/{monitor,livehunt}.go`
- Events/API/web: `internal/events/bus.go`, `internal/trunking/affiliation.go`, `internal/api/{types,sse}.go`, `internal/log/messagelog.go`, `web/src/panels/{Hunt,CCActivity}.tsx`, `web/src/api/types.ts`
- Wiring: `cmd/gophertrunk/{hunt,hunt_live,hunt_cockpit}.go`

## Testing
- `go build ./...` clean; full `go test ./...` green (new unit tests: corroboration majority/threshold, streaming monitor + converge-and-stop, `RunReaderMonitor` tick/early-stop, UTUAR round-trip + control-channel event for both MFIDs).
- Web `npm run build` + `vitest` (Hunt + CCActivity panels) pass.

## Notes / non-goals
- The band plan still lists channel IDs 2/3/4 (440 / 136 / 160.5875 MHz) — post-fix these decode repeatedly with clean trellis `metric=0`, i.e. the site genuinely broadcasts them, so the parser is left unchanged.
- We lack a reference decode of the exact UTUAR payload; the parser follows the documented TIA/SDRTrunk layout (ServiceOptions, Target, Source). If field RIDs look wrong, the byte offsets are the thing to re-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q

---
_Generated by [Claude Code](https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q)_