### PR TITLE
P25: decode standard broadcasts under vendor MFID; faster topology; DMR AnncChanFreq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,13 +49,23 @@ for tagged releases.
   rounded the tuned frequency to 3 decimals (showing a 6.25 kHz-raster channel
   like 160.5875 MHz as "160.588"); it now prints 4 decimals, matching the rest
   of the UI. Display-only — the SDR was always tuned to the exact frequency.
-- **P25 identity / band-plan / neighbor accuracy under noise.** Status-broadcast
-  accumulation was last-write-wins, so a single corrupt-but-CRC-passing TSBK
-  could set a wrong WACN / System ID or inject a phantom band-plan slot
-  (e.g. a stray VHF base on a UHF site). Identity is now resolved by majority
-  vote across observations, and band-plan slots and neighbors must be seen at
-  least twice before they surface — while live grant resolution still accepts a
-  first sighting, so voice channels are unaffected.
+- **P25 identity accuracy under noise.** Status-broadcast accumulation was
+  last-write-wins, so a single corrupt-but-CRC-passing TSBK could set a wrong
+  WACN / System ID. Identity (WACN/SysID/RFSS/Site) is now resolved by majority
+  vote across observations, so a repeated correct value out-votes a one-shot
+  wrong one. Neighbors and band-plan slots surface on the first sighting
+  (de-duplicated) to match OP25's latency.
+- **P25 Motorola identity/neighbors not decoding.** On some Motorola trunks the
+  band-plan and network/site/secondary broadcast opcodes (IDEN, RFSS, Network
+  Status, Adjacent Site) arrive under the vendor MFID (0x90); they were routed
+  to vendor dispatch and dropped, so WACN / System ID / neighbors stayed empty
+  even though the control channel locked. These always-standard opcodes are now
+  decoded regardless of MFID (an INFO line flags when one is seen under a vendor
+  MFID), matching OP25/boatbod.
+- **DMR Tier III Announce Channel-Frequency** (C_BCAST anncd_type 5) is now
+  recognised and its raw payload surfaced once at INFO, so its (site-specific)
+  layout can be validated off-air; neighbor/voice frequencies continue to
+  resolve through the configured band-plan resolver / LCN learner.
 
 ## [v0.4.6] — 2026-06-18
 

--- a/internal/radio/dmr/tier3/control.go
+++ b/internal/radio/dmr/tier3/control.go
@@ -60,6 +60,11 @@ type ControlChannel struct {
 	locked           bool
 	last             LockState
 
+	// chanFreqLogged guards the one-shot INFO census of an Announce
+	// Channel-Frequency (C_BCAST anncd_type 5) raw payload — see
+	// handleBroadcast. Single-threaded with the IQ pump.
+	chanFreqLogged bool
+
 	// topo accumulates the system topology (identity + adjacent sites) for the
 	// hunt/discovery layer; read via Topology().
 	topo topologyModel
@@ -222,6 +227,20 @@ func (c *ControlChannel) handleBroadcast(cc uint8, b BroadcastAnnouncement) {
 		c.topo.applySiteParams(gs.RFSSID, gs.SiteID)
 	case AnncAdjacentSite:
 		c.topo.applyAdjacent(ParseAdjacentSite(b.Payload))
+	case AnncChanFreq:
+		// Announce Channel-Frequency (anncd_type 5) is the LCN ↔ frequency
+		// relationship. ETSI TS 102 361-4 leaves the exact octet layout to be
+		// validated against a real off-air burst (the way Gen_Site_Params and
+		// CallTimer_Parms were), and DMR Tier III otherwise carries only a
+		// 12-bit LCN — not absolute Hz — so neighbour/voice frequencies are
+		// resolved through the band-plan Resolver (LinearBandPlan / the dmrlcn
+		// learner). Surface the raw payload once so the layout can be reversed
+		// from this site; do not guess a frequency the engine would retune to.
+		if !c.chanFreqLogged {
+			c.chanFreqLogged = true
+			c.log.Info("dmr/tier3: announce channel-frequency (raw, layout unvalidated)",
+				"system", c.systemName, "cc", cc, "payload", b.Payload)
+		}
 	}
 }
 

--- a/internal/radio/p25/phase1/bandplan_snapshot_test.go
+++ b/internal/radio/p25/phase1/bandplan_snapshot_test.go
@@ -8,11 +8,8 @@ func TestBandPlanSnapshot(t *testing.T) {
 		t.Fatalf("empty band plan should snapshot to nothing")
 	}
 	// Apply out of ID order; Snapshot must return ascending channel-ID order.
-	// Each slot is applied corroborationMin (2) times so it clears the
-	// corroboration gate Snapshot enforces.
+	// A single sighting surfaces (first-sighting policy — matches OP25).
 	bp.Apply(IdentifierUpdate{ChannelID: 3, BaseHz: 853_000_000, SpacingHz: 12_500})
-	bp.Apply(IdentifierUpdate{ChannelID: 3, BaseHz: 853_000_000, SpacingHz: 12_500})
-	bp.Apply(IdentifierUpdate{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500, AccessTDMA: true})
 	bp.Apply(IdentifierUpdate{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500, AccessTDMA: true})
 
 	got := bp.Snapshot()
@@ -24,15 +21,5 @@ func TestBandPlanSnapshot(t *testing.T) {
 	}
 	if got[0].BaseHz != 851_000_000 || !got[0].AccessTDMA {
 		t.Errorf("slot 1 = %+v, want base 851M TDMA", got[0])
-	}
-
-	// A slot seen only once must not surface (one-shot CRC false positive).
-	bp.Apply(IdentifierUpdate{ChannelID: 5, BaseHz: 136_000_000, SpacingHz: 6_250})
-	if got := bp.Snapshot(); len(got) != 2 {
-		t.Errorf("one-shot slot leaked into snapshot: len = %d, want 2", len(got))
-	}
-	// ...but it still resolves a live grant via Frequency (not corroboration-gated).
-	if _, err := bp.Frequency(5, 10); err != nil {
-		t.Errorf("Frequency on a once-seen slot should resolve: %v", err)
 	}
 }

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -959,10 +959,20 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 	atomic.AddInt64(&c.stats.TSBKDecoded, 1)
 	// Manufacturer-specific TSBKs are decoded in the vendor's opcode
 	// namespace (Motorola patch/regroup, Harris regroup, talker alias)
-	// — see tsbk_vendor.go.
-	if t.IsVendorMFID() {
+	// — see tsbk_vendor.go. The band-plan and network/site/secondary
+	// broadcast opcodes (IDEN, RFSS/NSB/adjacent/secondary) live in the
+	// standard TIA namespace on every vendor's control channel — Motorola
+	// and Harris never redefine them — so they are decoded via the standard
+	// switch even when the MFID marks the block vendor-specific. Some
+	// Motorola sites emit exactly these under MFID 0x90, which is why their
+	// WACN/SysID/neighbours otherwise never surfaced (matches OP25/boatbod).
+	if t.IsVendorMFID() && !isStandardBroadcastOpcode(t.Opcode) {
 		c.dispatchVendorTSBK(t, nac)
 		return
+	}
+	if t.IsVendorMFID() && c.diagFirst(diagVendorBroadcast|uint32(t.Opcode)) {
+		c.log.Info("p25: standard broadcast opcode under vendor MFID",
+			"system", c.systemName, "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
 	}
 	switch t.Opcode {
 	case OpIdentifierUpdate:
@@ -1129,9 +1139,27 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 // categories so an unhandled-opcode key and an alias-source key never
 // collide. See ControlChannel.diagSeen.
 const (
-	diagUnhandledTSBK uint32 = 1 << 24
-	diagAliasSrc      uint32 = 2 << 24
+	diagUnhandledTSBK   uint32 = 1 << 24
+	diagAliasSrc        uint32 = 2 << 24
+	diagVendorBroadcast uint32 = 3 << 24
 )
+
+// isStandardBroadcastOpcode reports whether op is one of the band-plan or
+// network/site/secondary broadcast opcodes that are always standard TIA
+// messages regardless of MFID — so they are decoded via the standard dispatch
+// even when a vendor MFID marks the block manufacturer-specific. Grant opcodes
+// are deliberately excluded: opcode 0x00 under MFID 0x90 is a Motorola patch,
+// not a group voice grant, so it must stay on the vendor path.
+func isStandardBroadcastOpcode(op Opcode) bool {
+	switch op {
+	case OpIdentifierUpdate, OpIdentifierUpdateVUHF, OpIdentifierUpdateTDMA,
+		OpSecondaryControlChannel, OpRFSSStatusBroadcast,
+		OpNetworkStatusBroadcast, OpAdjacentSiteStatusBroadcast:
+		return true
+	default:
+		return false
+	}
+}
 
 // maxUnhandledSamples caps how many raw payloads are logged per distinct
 // (MFID,opcode) so a busy CC stays bounded; 8 is enough to catch a full

--- a/internal/radio/p25/phase1/identifier.go
+++ b/internal/radio/p25/phase1/identifier.go
@@ -353,20 +353,17 @@ var ErrUnknownChannelID = errors.New("p25/phase1: no IdentifierUpdate for channe
 // the control channel reads/writes from a single goroutine so that's
 // the natural usage shape.
 type BandPlan struct {
-	slots  [16]IdentifierUpdate
-	known  [16]bool
-	counts [16]int // sightings per channel ID (for Snapshot corroboration)
+	slots [16]IdentifierUpdate
+	known [16]bool
 }
 
-// Apply records (or replaces) the band-plan slot for u.ChannelID and counts
-// the sighting.
+// Apply records (or replaces) the band-plan slot for u.ChannelID.
 func (b *BandPlan) Apply(u IdentifierUpdate) {
 	if int(u.ChannelID) >= len(b.slots) {
 		return
 	}
 	b.slots[u.ChannelID] = u
 	b.known[u.ChannelID] = true
-	b.counts[u.ChannelID]++
 }
 
 // Frequency returns the downlink frequency in Hz for the given
@@ -407,18 +404,14 @@ func (b *BandPlan) IsTDMA(channelID uint8) bool {
 	return b.slots[channelID].AccessTDMA
 }
 
-// Snapshot returns the IdentifierUpdate entries for every channel ID seen at
-// least corroborationMin times, in ascending channel-ID order. Used by the
-// signal-lab / hunt layers to surface the band plan a control channel
-// advertised so a discovered system can be documented and exported. The
-// corroboration gate keeps a one-shot CRC false positive from injecting a
-// phantom slot (e.g. a stray VHF base on a UHF site); live grant resolution
-// (Frequency/Known) is deliberately not gated, so a once-seen slot still
-// resolves an in-progress voice grant.
+// Snapshot returns the IdentifierUpdate entries for every known channel ID,
+// in ascending channel-ID order. Used by the signal-lab / hunt layers to
+// surface the band plan a control channel advertised so a discovered system
+// can be documented and exported.
 func (b *BandPlan) Snapshot() []IdentifierUpdate {
 	var out []IdentifierUpdate
 	for id := 0; id < len(b.slots); id++ {
-		if b.known[id] && b.counts[id] >= corroborationMin {
+		if b.known[id] {
 			out = append(out, b.slots[id])
 		}
 	}

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -23,14 +23,9 @@ import (
 // identity or inject a phantom band-plan slot / neighbour. Identity
 // scalars (WACN/SysID/RFSS/Site/LRA) are resolved by majority vote — a
 // lone observation is still surfaced, but a repeated correct value
-// out-votes a one-shot wrong one. Neighbours must be seen at least
-// corroborationMin times before Snapshot surfaces them.
-
-// corroborationMin is how many independent sightings a neighbour (and, in
-// BandPlan.Snapshot, a band-plan slot) needs before it is trusted. Two is
-// enough to reject a one-shot CRC false positive while a real, repeating
-// broadcast clears the bar within a second or two of dwell.
-const corroborationMin = 2
+// out-votes a one-shot wrong one. Neighbours and band-plan slots surface on
+// the first sighting (de-duplicated), to match OP25's latency — the identity
+// majority-vote already absorbs the one-shot-corruption case that matters.
 
 // Channel is a (band-plan ID, channel number) pair.
 type Channel struct {
@@ -79,9 +74,8 @@ type NetworkModel struct {
 	// secondary CC is low-risk and not part of the corroboration scope).
 	secondary []Channel
 
-	// Neighbours — sighting count + latest channel info per (RFSS, Site).
-	neighborVotes map[neighborKey]int
-	neighborData  map[neighborKey]NeighborSite
+	// Neighbours — latest channel info per (RFSS, Site), de-duplicated.
+	neighborData map[neighborKey]NeighborSite
 }
 
 // ensure lazily initialises the vote maps so the zero value is usable.
@@ -92,7 +86,6 @@ func (m *NetworkModel) ensure() {
 		m.rfssVotes = map[uint8]int{}
 		m.siteVotes = map[uint8]int{}
 		m.lraVotes = map[uint8]int{}
-		m.neighborVotes = map[neighborKey]int{}
 		m.neighborData = map[neighborKey]NeighborSite{}
 	}
 }
@@ -144,19 +137,18 @@ func (m *NetworkModel) ApplySecondaryControlChannel(s SecondaryControlChannelBro
 }
 
 // ApplyAdjacentSite folds an Adjacent Site Status Broadcast (0x3C) in,
-// counting sightings per (RFSS, Site) and keeping the latest channel info.
+// de-duplicating by (RFSS, Site) and keeping the latest channel info.
 func (m *NetworkModel) ApplyAdjacentSite(a AdjacentSiteStatusBroadcast) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.ensure()
 	key := neighborKey{RFSS: a.RFSS, Site: a.Site}
-	m.neighborVotes[key]++
 	m.neighborData[key] = NeighborSite{RFSS: a.RFSS, Site: a.Site, ChannelID: a.ChannelID, ChannelNumber: a.ChannelNumber}
 }
 
-// Snapshot returns a deep copy of the accumulated topology. Identity
-// fields are the most-observed value; neighbours appear only once seen at
-// least corroborationMin times, sorted by (RFSS, Site) for stable output.
+// Snapshot returns a deep copy of the accumulated topology. Identity fields
+// are the most-observed value; neighbours are every de-duplicated adjacent
+// site seen, sorted by (RFSS, Site) for stable output.
 func (m *NetworkModel) Snapshot() NetworkConfig {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -168,10 +160,8 @@ func (m *NetworkModel) Snapshot() NetworkConfig {
 		LRA:       majority(m.lraVotes),
 		Secondary: append([]Channel(nil), m.secondary...),
 	}
-	for key, c := range m.neighborVotes {
-		if c >= corroborationMin {
-			out.Neighbors = append(out.Neighbors, m.neighborData[key])
-		}
+	for _, n := range m.neighborData {
+		out.Neighbors = append(out.Neighbors, n)
 	}
 	sort.Slice(out.Neighbors, func(i, j int) bool {
 		if out.Neighbors[i].RFSS != out.Neighbors[j].RFSS {

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -14,10 +14,7 @@ func TestNetworkModelAccumulates(t *testing.T) {
 	m.ApplyRFSSStatus(RFSSStatusBroadcast{SystemID: 0x123, RFSS: 4, Site: 7, LRA: 9})
 	m.ApplySecondaryControlChannel(SecondaryControlChannelBroadcast{
 		ChannelAID: 1, ChannelANumber: 100, ChannelBID: 1, ChannelBNumber: 200})
-	// Neighbours need corroborationMin (2) sightings before Snapshot surfaces
-	// them, so each site is broadcast twice.
 	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})
-	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 9, ChannelID: 1, ChannelNumber: 301})
 	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 9, ChannelID: 1, ChannelNumber: 301})
 	// Re-broadcast of site 8 must update in place, not duplicate.
 	m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 305})
@@ -60,10 +57,8 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 	adj := TSBK{Opcode: OpAdjacentSiteStatusBroadcast,
 		Payload: AssembleAdjacentSiteStatusBroadcast(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})}
 
-	// The adjacent-site broadcast is sent twice so it clears the
-	// corroborationMin (2) gate and Snapshot surfaces the neighbour.
 	base := 0
-	for _, tsbk := range []TSBK{nsb, rfss, adj, adj} {
+	for _, tsbk := range []TSBK{nsb, rfss, adj} {
 		cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk), base)
 		base += 1 << 20
 	}
@@ -74,6 +69,37 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 	}
 	if len(cfg.Neighbors) != 1 || cfg.Neighbors[0].Site != 8 {
 		t.Errorf("neighbours = %v, want one site-8 entry", cfg.Neighbors)
+	}
+}
+
+// TestControlChannelDecodesBroadcastUnderVendorMFID drives the network/site
+// broadcasts with the Motorola vendor MFID (0x90) — the form a real VHF site
+// was seen emitting — and checks the standard broadcast opcodes are still
+// decoded (WACN/SysID/RFSS/Site/neighbour surface) rather than dropped as
+// unhandled vendor TSBKs, while a genuine Motorola vendor opcode (a patch)
+// stays on the vendor path.
+func TestControlChannelDecodesBroadcastUnderVendorMFID(t *testing.T) {
+	cc := New(Options{Bus: events.NewBus(8), SystemName: "MotoVHF"})
+
+	nsb := TSBK{Opcode: OpNetworkStatusBroadcast, MFID: MFIDMotorola,
+		Payload: [8]byte{0x00, 0xAB, 0xCD, 0xE1, 0x23}}
+	rfss := TSBK{Opcode: OpRFSSStatusBroadcast, MFID: MFIDMotorola,
+		Payload: [8]byte{9, 0x01, 0x23, 4, 7}}
+	adj := TSBK{Opcode: OpAdjacentSiteStatusBroadcast, MFID: MFIDMotorola,
+		Payload: AssembleAdjacentSiteStatusBroadcast(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})}
+
+	base := 0
+	for _, tsbk := range []TSBK{nsb, rfss, adj} {
+		cc.Process(buildLockedStreamWithTSBK(10, 0x2C2, DUIDTrunkingSignaling, tsbk), base)
+		base += 1 << 20
+	}
+
+	cfg := cc.NetworkSnapshot()
+	if cfg.WACN != 0xABCDE || cfg.SystemID != 0x123 || cfg.RFSS != 4 || cfg.Site != 7 {
+		t.Errorf("vendor-MFID broadcasts not decoded: %+v", cfg)
+	}
+	if len(cfg.Neighbors) != 1 || cfg.Neighbors[0].Site != 8 {
+		t.Errorf("neighbour from vendor-MFID adjacent broadcast missing: %v", cfg.Neighbors)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #727 from field testing a **Motorola VHF P25 site** (CC 172.225 MHz, NAC 0x2C2): the control channel locked and the band plan populated, but WACN/System ID/neighbors stayed empty — while OP25/boatbod surfaces them in ~15–20 s.

### P25: decode standard broadcasts regardless of MFID (the main fix)
`dispatchTSBK` routed **every** vendor-MFID block to the vendor path, which has no case for the band-plan / network-status / RFSS / adjacent-site / secondary-CC opcodes. Some Motorola sites tag exactly these standard opcodes with MFID `0x90`, so they were dropped and identity/neighbors never surfaced. These opcodes (`0x33/0x34/0x39/0x3A/0x3B/0x3C/0x3D`) are always-standard TIA messages, so they're now decoded via the standard switch even under a vendor MFID (grant opcodes still stay vendor-side — `0x00`/MFID `0x90` is a Motorola patch, not a group grant). A one-shot **INFO** line (`p25: standard broadcast opcode under vendor MFID`) flags it so the cause is confirmable from the field log. Matches OP25/boatbod.

### P25: surface neighbors & band-plan on first sighting
Keeps the identity **majority-vote** from #727 (the wrong-WACN fix), but drops the ≥2-sighting floor so neighbors and band-plan slots appear on first sighting again, matching OP25's latency. The "136 MHz phantom" slot that motivated the floor turned out to be a **real multiband band plan** (IDEN id 4 @ 160.5875 resolves the 172.225 CC), so the floor only added latency / hid data.

### DMR Tier III: recognise Announce Channel-Frequency (C_BCAST anncd_type 5)
Now recognised and its raw payload surfaced **once at INFO** so the (site-specific) octet layout can be validated against a real off-air burst — the same way the repo validated its other C_BCAST sub-types. No guessed frequency parser is shipped: Tier III otherwise carries only a 12-bit LCN (not absolute Hz, per `docs/hardware.md`), so neighbor/voice frequencies keep resolving through the band-plan resolver / LCN learner.

## Not included (deliberately)
- **TETRA lock** (468.475/468.775): a documented sync-burst demod-margin gap (`samples/tetra/README.md`) needing ≥30 s, ≥72 kHz captures. The #727 streaming monitor already gives TETRA the long dwell it needs when the protocol is forced; closing the actual lock is a capture-gated follow-up — no speculative DSP committed.
- DMR "0 talkgroups" is expected (TGs come only from live grants, not a static broadcast).

## Files
`internal/radio/p25/phase1/{control,network,identifier}.go`, `internal/radio/dmr/tier3/control.go`, tests, CHANGELOG.

## Testing
`go build ./...`, full `go test ./...`, and `gofmt -l .` all clean. New test drives NSB/RFSS/adjacent under MFID 0x90 and asserts WACN/SysID/neighbor surface; band-plan/neighbor first-sighting and identity majority-vote tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q

---
_Generated by [Claude Code](https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q)_