### PR TITLE
feat(sdr): autotune — per-dongle carrier-error tracking + digital correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Autotune — per-dongle carrier-error correction** (opt-in, `sdr.autotune`).
+  Ported in concept from trunk-recorder's autotune. Each SDR's crystal error
+  shifts the received carrier off-centre; with autotune on, the daemon watches
+  the locked P25 Phase 1 receiver's residual carrier offset (control channel
+  and voice calls), keeps a running average of the last 20 measurements per
+  device serial, and shifts the channel's digital down-converter by that
+  average so the demod's AFC starts near lock at the next acquisition. It never
+  rewrites the dongle's hardware ppm — it logs a suggested value (with a
+  >3.5 PPM "verify your ppm" warning) you can bake into the device block by
+  hand. Off by default and zero-cost when disabled; safe to leave on for
+  TCXO-equipped units (the correction stays near zero).
 - **Site identity on registration & affiliation events** (#698). The
   `unit_registration` and `affiliation` events now carry `rfss_id` / `site_id`
   (alongside `grant`), plus a `nac` field on all three. Registration and

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/api"
 	"github.com/MattCheramie/GopherTrunk/internal/api/rigctld"
+	"github.com/MattCheramie/GopherTrunk/internal/autotune"
 	"github.com/MattCheramie/GopherTrunk/internal/broadcast"
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	gtdiag "github.com/MattCheramie/GopherTrunk/internal/diag"
@@ -382,8 +383,13 @@ type Daemon struct {
 	// the control tuner (issue #402); kept so the USB-reacquire path can
 	// re-wrap the fresh tuner handle and preserve the offset. Zero disables.
 	controlLOOffsetHz float64
-	convScan          *conventional.Scanner
-	widebandT2        []*widebandt2.Engine
+	// autotune is the per-dongle carrier-error registry shared by the CC
+	// decoder and the voice composer (sdr.autotune). Nil-safe: when the
+	// knob is off, Get returns nil and both paths keep their pre-autotune
+	// behaviour. See internal/autotune.
+	autotune   *autotune.Registry
+	convScan   *conventional.Scanner
+	widebandT2 []*widebandt2.Engine
 	// dmrLearners holds one DMR LCN autoconfig learner per wideband DMR
 	// Tier III control channel whose system ships without a dmr_band_plan.
 	// Each watches grants + RF onsets to learn the LCN→frequency plan and
@@ -630,6 +636,10 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		bus:       events.NewBus(64),
 		ready:     make(chan struct{}),
 		iqPrimary: make(map[string]bool),
+		autotune:  autotune.NewRegistry(cfg.SDR.Autotune, log),
+	}
+	if cfg.SDR.Autotune {
+		log.Info("autotune: enabled — tracking per-dongle carrier error and applying digital correction (P25 Phase 1 control + voice)")
 	}
 	if cfgPath != "" {
 		w, err := config.NewWriter(cfgPath)
@@ -1222,6 +1232,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			Devices:       &poolDevices{pool: d.pool, rateHz: cfg.SDR.SampleRate, virtualMap: d.virtualVoiceMap()},
 			Sink:          sink,
 			Engine:        d.engine,
+			Autotune:      d.autotune,
 			Log:           log,
 			IQSampleRate:  cfg.SDR.SampleRate,
 			PCMSampleRate: cfg.Recordings.SampleRate,
@@ -1388,6 +1399,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					IQCorrect:    iqCorrect,
 					Conjugate:    iqInvert,
 					LOOffsetHz:   loOffsetHz,
+					Autotune:     d.autotune.Get(controlEntry.Info.Serial),
 				}
 				d.controlSerial = controlEntry.Info.Serial
 				// The CC decoder owns StreamIQ on this dongle's broker,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -187,6 +187,13 @@ sdr:
   # IQ-death recovery (ccdecoder retry loop, voice Bind reacquire) is
   # unaffected by this knob. See docs/hardware.md.
   watchdog_interval_ms: 30000
+  # autotune: track each dongle's carrier-frequency error on locked P25
+  # Phase-1 control + voice channels, keep a running average (per device
+  # serial), and shift the digital down-converter so the demod's AFC starts
+  # near lock. Never touches the hardware ppm — it just logs a suggested
+  # ppm/error value you can paste into the device block. Off by default;
+  # safe to leave on (the correction stays near zero on a good crystal).
+  autotune: false
   devices:
     - serial: "00000001"   # match `gophertrunk sdr list`; first-found wins when blank
       role: control        # control | voice | auto

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -1,0 +1,175 @@
+// Package autotune tracks the per-dongle carrier-frequency error of an SDR
+// source and turns it into a digital tuning correction, ported in concept from
+// trunk-recorder's AutotuneManager (trunk-recorder/autotune.cc).
+//
+// Every RTL-SDR crystal is a little off, which shifts the received carrier off
+// centre. A demodulator's AFC / carrier-recovery loop measures that residual
+// offset in Hz once it locks (GopherTrunk reads it from
+// internal/radio/p25/phase1/receiver.Receiver.AFCOffsetHz). This package keeps
+// a running average of the last MaxHistory measurements and exposes it as an
+// offset the caller applies digitally — by shifting the channel's down-
+// converter target — so the next recorder/decoder hands its loop a starting
+// frequency that is already close to lock. It never rewrites the dongle's
+// hardware PPM; it only reports a suggested config value the operator can bake
+// in by hand.
+//
+// A Manager is per physical dongle (keyed by serial in a Registry): a control
+// SDR and a voice SDR have independent crystal errors and independent
+// corrections.
+package autotune
+
+import (
+	"fmt"
+	"log/slog"
+	"math"
+	"sync"
+)
+
+const (
+	// MaxHistory is how many recent error measurements feed the running
+	// average. Matches trunk-recorder's MAX_HISTORY.
+	MaxHistory = 20
+	// PPMThreshold is the correction magnitude (in PPM, relative to the
+	// channel centre frequency) above which the source is flagged as
+	// mis-configured. Matches trunk-recorder's PPM_THRESHOLD.
+	PPMThreshold = 3.5
+	// SuggestedErrorRounding rounds the suggested config value to the
+	// nearest N Hz. Matches trunk-recorder's SUGGESTED_ERROR_ROUNDING.
+	SuggestedErrorRounding = 10
+)
+
+// Manager accumulates carrier-error measurements for one SDR source and serves
+// the running-average correction. It is safe for concurrent use: the control
+// decoder and the voice composer both call into the same Manager.
+type Manager struct {
+	log    *slog.Logger
+	serial string
+
+	mu      sync.Mutex
+	history []int // most-recent-first; capped at MaxHistory
+	avg     int   // cached running average, in Hz
+}
+
+// NewManager returns a Manager labelled with the dongle serial for logging. A
+// nil logger is tolerated (logging becomes a no-op).
+func NewManager(serial string, log *slog.Logger) *Manager {
+	if log == nil {
+		log = slog.New(slog.NewTextHandler(discard{}, nil))
+	}
+	return &Manager{log: log, serial: serial}
+}
+
+// AddErrorMeasurement folds one observation into the running average. observedHz
+// is the loop's freshly-measured residual offset; currentOffsetHz is the
+// autotune offset that was already applied while that residual was observed, so
+// total = observed + applied is the source's true error. centerFreqHz is the
+// channel centre the measurement was taken at, used only for the PPM sanity
+// warning. Port of AutotuneManager::add_error_measurement.
+func (m *Manager) AddErrorMeasurement(observedHz, currentOffsetHz int, centerFreqHz uint32) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	total := observedHz + currentOffsetHz
+	// Prepend, then trim the oldest past MaxHistory (deque push_front /
+	// pop_back).
+	m.history = append([]int{total}, m.history...)
+	if len(m.history) > MaxHistory {
+		m.history = m.history[:MaxHistory]
+	}
+
+	sum := 0
+	for _, e := range m.history {
+		sum += e
+	}
+	m.avg = sum / len(m.history)
+
+	m.log.Debug("autotune: measurement", "serial", m.serial,
+		"observed_hz", observedHz, "applied_hz", currentOffsetHz,
+		"total_hz", total, "avg_hz", m.avg, "samples", len(m.history))
+
+	if centerFreqHz != 0 {
+		ppm := float64(m.avg) / (float64(centerFreqHz) / 1e6)
+		if math.Abs(ppm) > PPMThreshold {
+			m.log.Warn("autotune: correction exceeds PPM threshold; verify configured ppm",
+				"serial", m.serial, "avg_hz", m.avg, "ppm", ppm,
+				"threshold_ppm", PPMThreshold, "center_mhz", float64(centerFreqHz)/1e6)
+		}
+	}
+}
+
+// AverageError returns the cached running-average correction in Hz. Callers
+// apply it digitally as targetHz - AverageError(). Port of get_average_error.
+func (m *Manager) AverageError() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.avg
+}
+
+// StatusString renders the live correction and a suggested config value, given
+// the channel centre frequency and the operator's currently-configured error in
+// Hz (derive from the dongle's configured ppm: round(ppm * centerHz/1e6)). Port
+// of AutotuneManager::get_status_string, adapted to GopherTrunk's ppm config: it
+// also reports the suggested value as a ppm so it can be pasted into the device
+// block.
+func (m *Manager) StatusString(centerFreqHz uint32, initialErrorHz int) string {
+	correction := m.AverageError()
+	total := initialErrorHz - correction
+	suggested := int(math.Round(float64(total)/SuggestedErrorRounding) * SuggestedErrorRounding)
+
+	if centerFreqHz == 0 {
+		return fmt.Sprintf("AutoTune: %+d Hz, suggested error: %+d Hz", correction, suggested)
+	}
+	suggestedPPM := float64(suggested) / (float64(centerFreqHz) / 1e6)
+	return fmt.Sprintf("AutoTune: %+d Hz, suggested error: %+d Hz (ppm %+.1f)",
+		correction, suggested, suggestedPPM)
+}
+
+// Reset clears the measurement history. Port of AutotuneManager::reset. The
+// cached average is intentionally left in place so an in-flight correction is
+// not yanked to zero mid-call (matches trunk-recorder, which only clears the
+// deque).
+func (m *Manager) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.history = nil
+}
+
+// Registry hands out per-serial Managers. When disabled, Get returns nil so
+// every call site collapses to the pre-autotune behaviour at zero cost.
+type Registry struct {
+	enabled bool
+	log     *slog.Logger
+
+	mu  sync.Mutex
+	mgr map[string]*Manager
+}
+
+// NewRegistry builds a Registry. When enabled is false, Get always returns nil.
+func NewRegistry(enabled bool, log *slog.Logger) *Registry {
+	return &Registry{enabled: enabled, log: log, mgr: map[string]*Manager{}}
+}
+
+// Enabled reports whether autotune is on.
+func (r *Registry) Enabled() bool { return r != nil && r.enabled }
+
+// Get returns the shared Manager for a dongle serial, creating it on first use.
+// Returns nil when the Registry is nil or disabled, so callers can write
+// `if m := reg.Get(serial); m != nil { ... }`.
+func (r *Registry) Get(serial string) *Manager {
+	if !r.Enabled() {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	m, ok := r.mgr[serial]
+	if !ok {
+		m = NewManager(serial, r.log)
+		r.mgr[serial] = m
+	}
+	return m
+}
+
+// discard is an io.Writer that drops everything, used to build a no-op logger.
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/autotune/autotune_test.go
+++ b/internal/autotune/autotune_test.go
@@ -1,0 +1,124 @@
+package autotune
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestAverageAndAccumulation(t *testing.T) {
+	m := NewManager("test", nil)
+
+	// observed + currentOffset is the stored total.
+	m.AddErrorMeasurement(100, 0, 851_000_000) // total 100
+	if got := m.AverageError(); got != 100 {
+		t.Fatalf("avg after one: got %d want 100", got)
+	}
+	m.AddErrorMeasurement(200, 0, 851_000_000) // totals {200,100} -> 150
+	if got := m.AverageError(); got != 150 {
+		t.Fatalf("avg after two: got %d want 150", got)
+	}
+	// A measurement taken while +150 was already applied: true error 350.
+	m.AddErrorMeasurement(200, 150, 851_000_000) // totals {350,200,100} -> 216
+	if got := m.AverageError(); got != 216 {
+		t.Fatalf("avg with applied offset: got %d want 216", got)
+	}
+}
+
+func TestHistoryCappedAtMax(t *testing.T) {
+	m := NewManager("test", nil)
+	// Push MaxHistory zeros, then MaxHistory more of 1000. The oldest zeros
+	// must be evicted, leaving the average at 1000.
+	for i := 0; i < MaxHistory; i++ {
+		m.AddErrorMeasurement(0, 0, 0)
+	}
+	for i := 0; i < MaxHistory; i++ {
+		m.AddErrorMeasurement(1000, 0, 0)
+	}
+	if got := m.AverageError(); got != 1000 {
+		t.Fatalf("avg should have evicted all zeros: got %d want 1000", got)
+	}
+	if len(m.history) != MaxHistory {
+		t.Fatalf("history len: got %d want %d", len(m.history), MaxHistory)
+	}
+}
+
+func TestReset(t *testing.T) {
+	m := NewManager("test", nil)
+	m.AddErrorMeasurement(500, 0, 0)
+	m.Reset()
+	if len(m.history) != 0 {
+		t.Fatalf("history not cleared: %v", m.history)
+	}
+	// Next measurement starts a fresh average, not blended with the old one.
+	m.AddErrorMeasurement(20, 0, 0)
+	if got := m.AverageError(); got != 20 {
+		t.Fatalf("avg after reset: got %d want 20", got)
+	}
+}
+
+func TestStatusStringSuggestedRounding(t *testing.T) {
+	m := NewManager("test", nil)
+	m.AddErrorMeasurement(123, 0, 851_000_000) // avg 123
+
+	// initial error 0, total = 0 - 123 = -123, rounded to nearest 10 -> -120.
+	s := m.StatusString(851_000_000, 0)
+	if !strings.Contains(s, "AutoTune: +123 Hz") {
+		t.Errorf("status missing correction: %q", s)
+	}
+	if !strings.Contains(s, "suggested error: -120 Hz") {
+		t.Errorf("status suggested value wrong: %q", s)
+	}
+	if !strings.Contains(s, "ppm") {
+		t.Errorf("status missing ppm hint: %q", s)
+	}
+}
+
+func TestPPMThresholdWarning(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	m := NewManager("dongleA", log)
+
+	// 3.5 PPM at 100 MHz is 350 Hz. 1000 Hz is ~10 PPM -> must warn.
+	m.AddErrorMeasurement(1000, 0, 100_000_000)
+	if !strings.Contains(buf.String(), "exceeds PPM threshold") {
+		t.Fatalf("expected PPM warning, got: %q", buf.String())
+	}
+
+	// A small error well under threshold must not warn.
+	buf.Reset()
+	m2 := NewManager("dongleB", log)
+	m2.AddErrorMeasurement(50, 0, 100_000_000) // 0.5 PPM
+	if strings.Contains(buf.String(), "exceeds PPM threshold") {
+		t.Fatalf("unexpected PPM warning: %q", buf.String())
+	}
+}
+
+func TestRegistryDisabledReturnsNil(t *testing.T) {
+	r := NewRegistry(false, nil)
+	if r.Enabled() {
+		t.Fatal("registry should be disabled")
+	}
+	if r.Get("abc") != nil {
+		t.Fatal("disabled registry must return nil manager")
+	}
+	// nil registry is also safe.
+	var nilReg *Registry
+	if nilReg.Enabled() || nilReg.Get("x") != nil {
+		t.Fatal("nil registry must be safe and return nil")
+	}
+}
+
+func TestRegistrySharesPerSerial(t *testing.T) {
+	r := NewRegistry(true, nil)
+	a1 := r.Get("serial-A")
+	a2 := r.Get("serial-A")
+	b := r.Get("serial-B")
+	if a1 == nil || a1 != a2 {
+		t.Fatal("same serial must return the same Manager")
+	}
+	if b == a1 {
+		t.Fatal("different serials must return different Managers")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -666,8 +666,18 @@ type SDRConfig struct {
 	// lowering it — e.g. to 1_024_000 — roughly halves per-chunk decode
 	// work. Running fewer simultaneous dongles on a weak CPU has the same
 	// effect.
-	SampleRate uint32         `yaml:"sample_rate"`
-	Devices    []DeviceConfig `yaml:"devices"`
+	SampleRate uint32 `yaml:"sample_rate"`
+	// Autotune enables per-dongle carrier-error tracking and digital
+	// frequency correction (ported from trunk-recorder's autotune). When
+	// on, the daemon watches each source's locked carrier offset (P25
+	// Phase-1 control + voice), keeps a running average per device serial,
+	// and shifts the channel's digital down-converter so the demodulator's
+	// AFC starts close to lock. It never rewrites the dongle's hardware
+	// ppm — it only logs a suggested ppm/error value you can bake into the
+	// device block by hand. Off by default; harmless to leave on for
+	// TCXO-equipped units (the correction simply stays near zero).
+	Autotune bool           `yaml:"autotune"`
+	Devices  []DeviceConfig `yaml:"devices"`
 	// RTLTCP lists remote rtl_tcp endpoints (host:port + optional
 	// per-endpoint metadata) to mount as virtual tuners. Each entry
 	// becomes a pool device alongside any locally-attached USB

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -87,6 +87,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SDRConfig.RTLTCP":             {Label: "rtl_tcp sources", Help: "Remote rtl_tcp endpoints mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
 	"SDRConfig.SoapyRemote":        {Label: "SoapyRemote sources", Help: "Remote SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, RTL) mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
 	"SDRConfig.WatchdogIntervalMs": {Help: "USB-disconnect watchdog poll interval (ms). 0 = default 30 s; negative disables it."},
+	"SDRConfig.Autotune":           {Label: "Autotune", Help: "Track each dongle's carrier-frequency error on locked P25 Phase 1 control + voice and apply a digital correction so the demod's AFC starts near lock. Never rewrites hardware ppm — logs a suggested value. Off by default; safe to leave on."},
 
 	"DeviceConfig.Serial":        {Help: "USB serial that selects this dongle. Run `gophertrunk sdr list` to see attached serials."},
 	"DeviceConfig.Role":          {Help: "Pool role hint. control/voice pin a P25-trunking dongle; wideband fans several channels off one stick; auto lets the pool decide.", Options: opts("", "(auto)", "control", "control", "voice", "voice", "auto", "auto", "wideband", "wideband")},

--- a/internal/configbuilder/webschema_test.go
+++ b/internal/configbuilder/webschema_test.go
@@ -21,9 +21,10 @@ import (
 // Adding a field to a config struct WITHOUT giving it a typed entry in types.ts
 // (a bespoke web editor) must be a deliberate choice recorded here.
 var webRoundTripAllow = map[string][]string{
-	// Rarely-tuned SDR watchdog interval; the web SDR section doesn't render
-	// it (round-trips via the SDRConfig index signature). Editable in the TUI.
-	"SDRConfig": {"WatchdogIntervalMs"},
+	// Rarely-tuned SDR watchdog interval + the autotune enable flag; the web
+	// SDR section doesn't render a bespoke editor for either (they round-trip
+	// via the SDRConfig index signature). Editable in the TUI and raw YAML.
+	"SDRConfig": {"WatchdogIntervalMs", "Autotune"},
 
 	// The LoRa section round-trips through the web Config Builder's generic
 	// index-signature editor; a bespoke typed editor in types.ts is a

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -52,6 +52,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/autotune"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -217,6 +218,13 @@ type Options struct {
 	// behaviour — used when the path is disabled or at pass-through rates
 	// where there is no room to offset.
 	LOOffsetHz float64
+	// Autotune, when non-nil, is the per-dongle carrier-error tracker for
+	// the control SDR (sdr.autotune enabled). The decoder samples the
+	// locked C4FM receiver's AFCOffsetHz once per second, folds it into the
+	// running average, and shifts the digital down-converter by that
+	// average at each (re)acquisition so the demod's AFC starts near lock.
+	// Nil disables autotune at zero cost. See internal/autotune.
+	Autotune *autotune.Manager
 }
 
 // Decoder is the long-lived component that converts the control
@@ -231,7 +239,18 @@ type Decoder struct {
 	// channel sits at +loOffsetHz in the delivered baseband and the DDC is
 	// built with this offset to mix it back to 0 Hz. Zero disables it.
 	loOffsetHz float64
-	systems    map[string]trunking.System
+	// autotune, when non-nil, tracks the control dongle's carrier error
+	// (Options.Autotune). autotuneApplied records the Hz correction folded
+	// into the DDC offset at the last (re)build, so the next measurement
+	// reports observed + applied as the source's true error (guarded by
+	// mu). locked mirrors the CC lock state from the bus so the pump only
+	// samples AFC on a real lock; lastATSampleAt throttles sampling to
+	// roughly once per second (owned by the pump goroutine).
+	autotune        *autotune.Manager
+	autotuneApplied int
+	locked          atomic.Bool
+	lastATSampleAt  time.Time
+	systems         map[string]trunking.System
 
 	// ddc decimates the raw SDR IQ stream to pipelineRateHz before
 	// the active pipeline sees a chunk; ddcTarget records the
@@ -240,8 +259,14 @@ type Decoder struct {
 	// ddcTargetForProtocol). pipelineRateHz is what the per-protocol
 	// factories receive as PipelineOptions.SampleRateHz. All three
 	// are owned by handleProgress / pump under mu.
-	ddc            *Downconverter
-	ddcTarget      float64
+	ddc       *Downconverter
+	ddcTarget float64
+	// ddcOffsetHz is the frequency offset the current DDC was built with
+	// (loOffsetHz + the autotune correction). Part of the rebuild key so a
+	// changed autotune average re-tunes the down-converter at the next
+	// acquisition; without autotune it stays equal to loOffsetHz and the
+	// build is byte-exact with before.
+	ddcOffsetHz    float64
 	pipelineRateHz float64
 
 	// sub is the bus subscription the Decoder uses to learn about
@@ -372,6 +397,7 @@ func New(opts Options) (*Decoder, error) {
 		sub:          opts.Bus.Subscribe(),
 		metrics:      opts.Metrics,
 		fec:          opts.FEC,
+		autotune:     opts.Autotune,
 	}
 	empty := ""
 	d.activeSystem.Store(&empty)
@@ -431,7 +457,18 @@ func (d *Decoder) Run(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			if ev.Kind != events.KindHuntProgress {
+			switch ev.Kind {
+			case events.KindCCLocked:
+				// Gate autotune sampling on a real lock — the AFC estimate
+				// only means anything once the FSW is correlating. Payload
+				// shape is per-protocol, so we only read the lock edge.
+				d.locked.Store(true)
+				continue
+			case events.KindCCLost:
+				d.locked.Store(false)
+				continue
+			case events.KindHuntProgress:
+			default:
 				continue
 			}
 			p, ok := ev.Payload.(trunking.HuntProgress)
@@ -637,16 +674,34 @@ func (d *Decoder) clearActiveLocked() {
 // retunes within the same rate reuse the existing filter. Caller
 // holds d.mu.
 func (d *Decoder) ensureDownconverterLocked(targetHz float64) {
-	if d.ddc != nil && d.ddcTarget == targetHz {
+	// The DDC mixes the channel sitting at +loOffsetHz in the delivered
+	// baseband down to 0 Hz. A dongle crystal error δ leaves the wanted
+	// carrier at loOffsetHz+δ instead, so the receiver's AFC has to drag it
+	// in from δ away. Autotune estimates δ as a running average and folds it
+	// into the mix offset here, so each fresh acquisition starts with the
+	// carrier already near DC. The correction only changes between
+	// acquisitions (the average is sampled while locked but applied at the
+	// next build), so a stable lock never sees its DDC rebuilt out from
+	// under it.
+	offset := d.loOffsetHz
+	applied := 0
+	if d.autotune != nil {
+		applied = d.autotune.AverageError()
+		offset += float64(applied)
+	}
+	if d.ddc != nil && d.ddcTarget == targetHz && d.ddcOffsetHz == offset {
 		return
 	}
-	d.ddc = NewDownconverterWithOffset(d.sampleRateHz, targetHz, d.loOffsetHz)
+	d.ddc = NewDownconverterWithOffset(d.sampleRateHz, targetHz, offset)
 	d.ddcTarget = targetHz
+	d.ddcOffsetHz = offset
+	d.autotuneApplied = applied
 	d.pipelineRateHz = d.ddc.outRateHz
 	d.log.Info("ccdecoder: digital down-converter configured",
 		"sdr_rate_hz", d.sampleRateHz,
 		"pipeline_rate_hz", d.pipelineRateHz,
-		"lo_offset_hz", d.loOffsetHz)
+		"lo_offset_hz", d.loOffsetHz,
+		"autotune_hz", applied)
 }
 
 // pump down-converts a raw IQ chunk and forwards it to the active
@@ -676,6 +731,41 @@ func (d *Decoder) pump(iq []complex64) {
 	}
 	d.ddcOut = d.ddc.Process(d.ddcOut, iq)
 	d.active.Process(d.ddcOut)
+	d.sampleAutotuneLocked()
+}
+
+// afcReporter is the optional capability a pipeline exposes when its
+// receiver tracks a carrier-frequency offset in Hz (today: P25 Phase 1
+// C4FM). Autotune reads it to fold the residual offset into the running
+// average. Pipelines without an AFC stage simply don't implement it.
+type afcReporter interface {
+	AFCOffsetHz() float64
+}
+
+// sampleAutotuneLocked folds the active receiver's residual carrier offset
+// into the running average about once a second while the CC is locked, then
+// logs the suggested correction. The new average takes effect at the next
+// acquisition (ensureDownconverterLocked), not mid-lock, so a stable lock is
+// never disturbed. Caller holds d.mu.
+func (d *Decoder) sampleAutotuneLocked() {
+	if d.autotune == nil || !d.locked.Load() {
+		return
+	}
+	rep, ok := d.active.(afcReporter)
+	if !ok {
+		return
+	}
+	now := time.Now()
+	if !d.lastATSampleAt.IsZero() && now.Sub(d.lastATSampleAt) < time.Second {
+		return
+	}
+	d.lastATSampleAt = now
+
+	observed := int(math.Round(rep.AFCOffsetHz()))
+	d.autotune.AddErrorMeasurement(observed, d.autotuneApplied, d.activeFreqHz)
+	d.log.Info("ccdecoder: "+d.autotune.StatusString(d.activeFreqHz, 0),
+		"system", d.activeAt, "freq_hz", d.activeFreqHz,
+		"observed_hz", observed, "applied_hz", d.autotuneApplied)
 }
 
 // observeIQPower folds one raw IQ chunk into the per-second power / DC /

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/autotune"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -1550,6 +1551,106 @@ func TestDecoderLocksP25Phase1WithLOOffset(t *testing.T) {
 			t.Fatalf("locked with LOOffsetHz=0 on an off-channel signal — the negative control is invalid (the channel should be unrecoverable without the DDC offset)")
 		}
 	})
+}
+
+// TestDecoderAutotuneMeasuresAndCorrectsOffset proves the autotune feedback
+// loop end-to-end on the live decode path: a P25 control channel synthesized
+// with a known carrier-frequency error δ is recovered by the receiver, and the
+// decoder's autotune tracker folds the receiver's residual AFC estimate into
+// its running average with the SIGN that lets ensureDownconverterLocked cancel
+// the error at the next acquisition (mix offset = loOffsetHz + average). If the
+// receiver reported the offset with the opposite sign, the average would have
+// the wrong sign and this test would catch it.
+func TestDecoderAutotuneMeasuresAndCorrectsOffset(t *testing.T) {
+	const (
+		nac          = 0x293
+		controlFreq  = 851_000_000
+		sdrRateHz    = 2_048_000.0
+		narrowRateHz = 48_000.0
+		deviationHz  = 1800.0
+		frameRepeats = 40
+		carrierErrHz = 600.0 // the dongle's crystal error
+	)
+
+	// Centred control channel, then shifted UP to +carrierErrHz to emulate a
+	// crystal error that leaves the wanted carrier carrierErrHz above DC in the
+	// delivered baseband. NewNCO(-f).Mix multiplies by exp(+j2π·f·n/Fs), i.e.
+	// shifts the centred channel up to +f — the same construction the LO-offset
+	// test uses.
+	dibits := buildP25CCDibits(nac, frameRepeats)
+	narrow := demod.ModulateP25C4FM(dibits, narrowRateHz, deviationHz)
+	centred := dsp.NewResampler(128, 3, 8, 8.0).Process(nil, narrow)
+	offChannel := dsp.NewNCO(-carrierErrHz, sdrRateHz).Mix(nil, centred)
+
+	bus := events.NewBus(256)
+	defer bus.Close()
+	mgr := autotune.NewManager("test-dongle", nil)
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{},
+		Systems: []trunking.System{{
+			Name: "ATSys", Protocol: trunking.ProtocolP25,
+			ControlChannels: []uint32{controlFreq},
+		}},
+		SampleRateHz: sdrRateHz,
+		Autotune:     mgr,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer d.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	d.handleProgress(trunking.HuntProgress{System: "ATSys", AttemptedFreqHz: controlFreq})
+	if d.active == nil {
+		t.Fatalf("handleProgress did not install a pipeline")
+	}
+	// With no measurements yet the DDC must be built with zero correction —
+	// byte-identical to the non-autotune path.
+	if d.autotuneApplied != 0 {
+		t.Fatalf("autotuneApplied = %d before any measurement, want 0", d.autotuneApplied)
+	}
+
+	const chunk = 8_192
+	locked := false
+	for off := 0; off < len(offChannel); off += chunk {
+		end := off + chunk
+		if end > len(offChannel) {
+			end = len(offChannel)
+		}
+		d.pump(offChannel[off:end])
+		if !locked {
+			for drained := false; !drained; {
+				select {
+				case ev := <-sub.C:
+					if ev.Kind == events.KindCCLocked {
+						// Simulate the Run loop's lock bookkeeping so
+						// sampleAutotuneLocked starts folding measurements.
+						d.locked.Store(true)
+						locked = true
+					}
+				default:
+					drained = true
+				}
+			}
+		}
+	}
+	if !locked {
+		t.Fatalf("control channel never locked with a %.0f Hz carrier error", carrierErrHz)
+	}
+
+	avg := mgr.AverageError()
+	if avg == 0 {
+		t.Fatalf("autotune recorded no measurement after lock")
+	}
+	// The measured average must approximate the true carrier error and carry
+	// the sign the DDC correction expects: ensureDownconverterLocked mixes by
+	// (loOffsetHz + avg), and the carrier sits at +carrierErrHz, so avg must be
+	// ≈ +carrierErrHz for the next acquisition to pull it to DC.
+	const tol = 200.0 // Hz — CoarseAFC estimate + symbol-rate rounding slack
+	if diff := float64(avg) - carrierErrHz; diff < -tol || diff > tol {
+		t.Fatalf("autotune average = %d Hz, want %.0f ± %.0f Hz (wrong sign means the DDC correction would worsen the error)", avg, carrierErrHz, tol)
+	}
 }
 
 // TestClearActiveClearsIQPowerSeries: when the decoder swaps pipelines

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -358,6 +358,12 @@ func (p *p25Phase1Pipeline) Process(iq []complex64) { p.rx.Process(iq) }
 func (p *p25Phase1Pipeline) Reset()                 { p.rx.Reset() }
 func (p *p25Phase1Pipeline) Close() error           { return nil }
 
+// AFCOffsetHz reports the receiver's current estimate of the true carrier
+// offset in Hz, so the decoder's autotune tracker can fold it into the
+// per-dongle running average. 0 on the CQPSK path (no AFC stage). Satisfies
+// the unexported afcReporter capability the decoder type-asserts for.
+func (p *p25Phase1Pipeline) AFCOffsetHz() float64 { return p.rx.AFCOffsetHz() }
+
 // newP25Phase2Pipeline wires internal/radio/p25/phase2/receiver into
 // p25phase2.ControlChannel.Process. The receiver's DibitSink forwards
 // H-DQPSK dibits into the state machine (20-dibit outbound sync

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -29,6 +29,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/autotune"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/equalizer"
@@ -171,6 +172,13 @@ type Options struct {
 	// default; the existing AudioLPF + naive decimation produces
 	// equivalent audio when the two rates are integer multiples.
 	AudioResampler AudioResamplerConfig
+	// Autotune, when non-nil, is the shared per-dongle carrier-error
+	// registry (sdr.autotune). The P25 Phase 1 voice chain pre-rotates its
+	// IQ by the voice dongle's running-average correction so the receiver's
+	// AFC starts near lock, and folds the residual offset back into the
+	// average at end-of-call. Nil disables autotune on the voice path at
+	// zero cost. See internal/autotune.
+	Autotune *autotune.Registry
 }
 
 // DeEmphasisConfig holds runtime knobs for the post-FM-demod
@@ -232,6 +240,7 @@ type Composer struct {
 	lpfCfg     AudioLPFConfig
 	agcCfg     AudioAGCConfig
 	resampCfg  AudioResamplerConfig
+	autotune   *autotune.Registry
 
 	sub       *events.Subscription
 	runDone   chan struct{}
@@ -321,6 +330,7 @@ func New(opts Options) (*Composer, error) {
 		lpfCfg:     opts.AudioLPF,
 		agcCfg:     opts.AudioAGC,
 		resampCfg:  opts.AudioResampler,
+		autotune:   opts.Autotune,
 		chains:     make(map[string]*chain),
 		runDone:    make(chan struct{}),
 	}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
@@ -74,6 +75,25 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	symbolHz := iqHz / float64(decim)
 
 	mode := c.resolveP25Phase1DemodMode(serial, demodMode)
+
+	// Autotune: pre-rotate the voice IQ by this dongle's running-average
+	// carrier-error correction so the receiver's AFC starts near lock, then
+	// fold the residual back into the average at end-of-call. atManager is
+	// nil when sdr.autotune is off (or on the CQPSK path the average stays
+	// 0), in which case atNCO stays nil and the loop below is byte-exact
+	// with the pre-autotune behaviour. The correction is captured once at
+	// call start; the +offset convention matches the control decoder's DDC.
+	atManager := c.autotune.Get(serial)
+	var (
+		atNCO     *dsp.NCO
+		atApplied int
+	)
+	if atManager != nil {
+		atApplied = atManager.AverageError()
+		if atApplied != 0 {
+			atNCO = dsp.NewNCO(float64(atApplied), symbolHz)
+		}
+	}
 
 	// Surface the resolved demod mode + sample rates once per call so an
 	// operator can confirm from logs that voice grants are running the
@@ -338,6 +358,26 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 		},
 	})
 
+	// At end-of-call fold this call's residual carrier offset into the
+	// dongle's running average — but only if the receiver actually locked
+	// and decoded voice (frames > 0), so noise on a never-locked call can't
+	// poison the average. The residual (AFCOffsetHz) plus what we already
+	// applied (atApplied) is the dongle's true error; the next call on this
+	// serial picks up the updated correction. centerFreq is 0 here (the
+	// chain isn't handed the grant frequency), so the PPM sanity warning is
+	// the control decoder's job; the average + suggested value still log.
+	if atManager != nil {
+		defer func() {
+			if frames.Load() == 0 {
+				return
+			}
+			observed := int(math.Round(rx.AFCOffsetHz()))
+			atManager.AddErrorMeasurement(observed, atApplied, 0)
+			c.log.Info("composer: p25p1 "+atManager.StatusString(0, 0),
+				"serial", serial, "observed_hz", observed, "applied_hz", atApplied)
+		}()
+	}
+
 	touchTicker := time.NewTicker(c.touchEvery)
 	defer touchTicker.Stop()
 	// logDecodeQuality emits a rolling decode-quality summary. Gated to
@@ -377,6 +417,11 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 			samples := iq
 			if decim > 1 {
 				samples = decimateComplex(lpf.Process(nil, iq), decim)
+			}
+			if atNCO != nil {
+				// Shift the estimated carrier (at +atApplied Hz) down to DC.
+				// In-place is safe (NCO.Mix supports dst aliasing src).
+				samples = atNCO.Mix(samples, samples)
 			}
 			rx.Process(samples)
 		}


### PR DESCRIPTION
Port trunk-recorder's AutotuneManager concept to GopherTrunk. Each SDR
crystal is a little off, shifting the received carrier off-centre; the new
internal/autotune package tracks the locked P25 Phase 1 receiver's residual
carrier offset (control channel + voice calls), keeps a running average of
the last 20 measurements per device serial, and feeds that average back as a
digital tuning correction so the demodulator's AFC starts near lock at the
next acquisition.

- internal/autotune: Manager (deque-of-20 average, PPM>3.5 warning, suggested
  config value rounded to 10 Hz) + per-serial Registry. Faithful to
  autotune.cc/.h; never rewrites hardware ppm.
- ccdecoder: samples Receiver.AFCOffsetHz() once/sec while CC-locked, folds it
  into the average, and adds it to the down-converter mix offset at each
  (re)acquisition. New AFCOffsetHz() on the P25 P1 pipeline. Sign validated by
  a synthesized-offset integration test (+600 Hz error -> +597 Hz measured).
- voice composer: P25 P1 chain pre-rotates IQ by the dongle's average so the
  voice AFC starts near lock, and folds the residual back at end-of-call.
- config: sdr.autotune flag (off by default; zero-cost when disabled), wired
  through the daemon to both the CC decoder and the composer; fieldmeta + web
  round-trip registration; config.example.yaml + CHANGELOG.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MgYDFouAfEhAMf73c1MaCs