### PR TITLE
P25: TIA opcode designations, guard vendor UU_ANS_REQ, CC Activity pause + Systems identity UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Changed
+- **P25 TSBK opcodes now log with their TIA-102.AABC-D designations**
+  (`UU_ANS_REQ`, `NET_STS_BCST`, `GRP_V_CH_GRANT`, …) instead of the
+  OP25-derived names. The Go identifiers stay descriptive; `Opcode.String()`
+  and a new [`docs/specs/p25-tsbk-opcodes.md`](docs/specs/p25-tsbk-opcodes.md)
+  carry the canonical mnemonics (mirrors the NXDN package convention).
+
+### Fixed
+- **UU_ANS_REQ (opcode 0x05) is no longer mis-decoded under a vendor MFID.**
+  A Motorola (MFID 0x90) 0x05 decoded with the standard Target/Source layout
+  produced garbage radio IDs (`src=0`, `target=0x3C0000`); it is now left
+  unhandled (vendor namespace), while the standard-MFID UU_ANS_REQ still
+  publishes a `unit.request` event.
+- **CC Activity "pause" now actually freezes the table.** Previously it
+  re-sliced the live rows, so the list kept churning and an event was
+  impossible to read or click; it now snapshots the rows on pause.
+- **Systems detail no longer mislabels missing network identity as "Scanner
+  offline".** WACN/System ID/RFSS/Site are decoded live from status broadcasts
+  whenever the control channel is received, so an empty cell now reads
+  "Awaiting status broadcasts" (or "Hunting control channel" during a hunt).
+
 ### Added
 - **Site identity on registration & affiliation events** (#698). The
   `unit_registration` and `affiliation` events now carry `rfss_id` / `site_id`

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -51,6 +51,14 @@ but were not located at the time of this commit:
   + Phase 1 air interface. Currently the `internal/radio/p25/`
   implementations cite TIA-102 sections in code comments but
   no PDF is in-tree.
+- **TIA-102.AABC-D** — Project 25 FDMA Common Air Interface,
+  *Trunking Control Channel Messages* (TSBK opcodes / formats).
+  The authoritative source for the P25 Phase 1 TSBK opcode table.
+  TIA standards are sold by TIA and are **not** redistributable,
+  so the PDF is not committed; the opcode designations are
+  transcribed (not copied) into
+  [`p25-tsbk-opcodes.md`](p25-tsbk-opcodes.md) for cross-checking
+  the decoder.
 - **ETSI TS 102 361-2** — DMR Tier III air interface.
 
 Pulls welcome.

--- a/docs/specs/p25-tsbk-opcodes.md
+++ b/docs/specs/p25-tsbk-opcodes.md
@@ -1,0 +1,77 @@
+# P25 Phase 1 TSBK opcodes (OSP) — TIA designations
+
+Reference table for the P25 Phase 1 (FDMA) Trunking Signalling Block (TSBK)
+**Outbound Signalling Packet (OSP)** opcodes the control-channel decoder in
+[`internal/radio/p25/phase1`](../../internal/radio/p25/phase1/) recognises.
+
+The Go constant identifiers in [`opcodes.go`](../../internal/radio/p25/phase1/opcodes.go)
+stay descriptive/CamelCase (idiomatic Go), while `Opcode.String()` and the
+trailing comment on each constant carry the canonical **TIA designation** — so
+debug logs read in spec terms (`opcode=NET_STS_BCST`, `opcode=UU_ANS_REQ`)
+rather than the OP25-derived names they used to. This mirrors the convention
+already used in [`internal/radio/nxdn`](../../internal/radio/nxdn/) for NXDN
+message names.
+
+**Source:** TIA-102.AABC-D, *Project 25 — FDMA Common Air Interface — Trunking
+Control Channel Messages*, Table 7-1 (TSBK opcodes). The standard is published
+by TIA and is **not** redistributable, so — per this directory's policy — it is
+cited, not committed. See also the Aeroflex/Cobham application note
+*Understanding Advanced P25 Control Channel Functions* for worked message
+walk-throughs (e.g. UU_V_REQ → UU_ANS_REQ → UU_ANS_RSP call setup).
+
+## OSP opcode table
+
+| Hex | TIA designation | Meaning | Dispatched |
+| --- | --- | --- | --- |
+| 0x00 | `GRP_V_CH_GRANT` | Group Voice Channel Grant | ✅ grant |
+| 0x02 | `GRP_V_CH_GRANT_UPDT` | Group Voice Channel Grant Update | ✅ grant |
+| 0x03 | `GRP_V_CH_GRANT_UPDT_EXP` | Group Voice Channel Grant Update — Explicit | ✅ grant |
+| 0x04 | `UU_V_CH_GRANT` | Unit-to-Unit Voice Channel Grant | ✅ grant |
+| 0x05 | `UU_ANS_REQ` | Unit-to-Unit Answer Request | ✅ (standard MFID only) |
+| 0x06 | `UU_V_CH_GRANT_UPDT` | Unit-to-Unit Voice Channel Grant Update | — |
+| 0x08 | `TELE_INT_CH_GRANT` | Telephone Interconnect Voice Channel Grant | ✅ grant |
+| 0x0A | `TELE_INT_ANS_REQ` | Telephone Interconnect Answer Request | — |
+| 0x14 | `SNDCP_DAT_CH_GRANT` | SNDCP Data Channel Grant | ✅ grant |
+| 0x18 | `STS_UPDT` | Status Update | — |
+| 0x1A | `STS_Q` | Status Query | — |
+| 0x1C | `MSG_UPDT` | Message Update | — |
+| 0x1D | `RAD_MON_CMD` | Radio Unit Monitor Command | — |
+| 0x1F | `CALL_ALRT` | Call Alert | — |
+| 0x20 | `ACK_RSP_FNE` | Acknowledge Response — FNE | — |
+| 0x21 | `QUE_RSP` | Queued Response | — |
+| 0x24 | `EXT_FNCT_CMD` | Extended Function Command | — |
+| 0x27 | `DENY_RSP` | Deny Response | — |
+| 0x28 | `GRP_AFF_RSP` | Group Affiliation Response | ✅ affiliation |
+| 0x2A | `GRP_AFF_Q` | Group Affiliation Query | — |
+| 0x2B | `LOC_REG_RSP` | Location Registration Response | — |
+| 0x2C | `U_REG_RSP` | Unit Registration Response | ✅ registration |
+| 0x2D | `U_REG_CMD` | Unit Registration Command | — |
+| 0x2F | `U_DE_REG_ACK` | Unit De-Registration Acknowledge | — |
+| 0x33 | `IDEN_UP_TDMA` | Identifier Update for TDMA | ✅ band plan |
+| 0x34 | `IDEN_UP_VU` | Identifier Update — VHF/UHF | ✅ band plan |
+| 0x35 | `PROT_PARM_UPDT` | Protection Parameter Update | — |
+| 0x39 | `SCCB_EXP` | Secondary Control Channel Broadcast — Explicit | ✅ topology |
+| 0x3A | `RFSS_STS_BCST` | RFSS Status Broadcast | ✅ topology |
+| 0x3B | `NET_STS_BCST` | Network Status Broadcast (WACN + System ID) | ✅ topology |
+| 0x3C | `ADJ_STS_BCST` | Adjacent Site Status Broadcast (neighbours) | ✅ topology |
+| 0x3D | `IDEN_UP` | Identifier Update (700/800/900 MHz) | ✅ band plan |
+| 0x3F | `PROT_PARM_BCST` | Protection Parameter Broadcast | — |
+
+"Dispatched" marks opcodes the control channel acts on (`dispatchTSBK` in
+[`control.go`](../../internal/radio/p25/phase1/control.go)); the rest are
+decoded enough to log at debug and otherwise ignored. The
+standard-broadcast/band-plan opcodes (`0x33/0x34/0x39/0x3A/0x3B/0x3C/0x3D`) are
+dispatched **regardless of MFID**, because they live in the standard TIA
+namespace on every vendor's control channel.
+
+## UU_ANS_REQ (0x05) note
+
+`UU_ANS_REQ` is an OSP the FNE sends to a called unit during unit-to-unit call
+setup; it carries Service Options, a 24-bit **Target Address** (called unit) and
+a 24-bit **Source Address** (calling unit) — no channel is granted yet. The
+decoder parses it (`ParseUnitToUnitAnswerRequest`) and publishes a
+`unit.request` bus event **only under the standard MFID**. Under a vendor MFID
+(e.g. Motorola 0x90) opcode 0x05 is in the manufacturer's namespace, not the
+standard one: a field decode of a Motorola 0x05 with the standard layout
+produced garbage IDs (`src=0`, `target=0x3C0000`), so vendor 0x05 is left
+unhandled until its real layout is reversed.

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1120,17 +1120,14 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 		}
 		return
 	}
-	// Unit-to-Unit Answer Request (opcode 0x05) is a standard call-setup
-	// message that some Motorola sites emit under the vendor MFID. The
-	// target/source layout is the standard one, so decode it here too rather
-	// than logging it as an unhandled vendor opcode.
-	if t.Opcode == OpUnitToUnitAnswerRequest {
-		c.publishUnitToUnitRequest(ParseUnitToUnitAnswerRequest(t.Payload), nac)
-		return
-	}
 	// Unrecognised vendor opcode: census + raw-payload sample so a field
 	// test can name and reverse any alias-bearing transport we don't yet
-	// decode, while the per-frame detail stays at Debug.
+	// decode, while the per-frame detail stays at Debug. Note: opcode 0x05
+	// here is NOT decoded as the standard UU_ANS_REQ — under a vendor MFID
+	// the opcode is in the manufacturer's namespace, and a field decode of a
+	// Motorola 0x05 with the standard target/source layout produced garbage
+	// IDs (src=0, target=0x3C0000), so it stays unhandled until its real
+	// vendor layout is reversed.
 	c.logUnhandledTSBK(t, nac)
 	c.log.Debug("p25: vendor tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
 }

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -103,48 +103,75 @@ func TestControlChannelDecodesBroadcastUnderVendorMFID(t *testing.T) {
 	}
 }
 
-// TestControlChannelPublishesUnitToUnitRequest drives a Unit-to-Unit Answer
-// Request (opcode 0x05) through the control channel — once with the standard
-// MFID and once with the Motorola vendor MFID (0x90), the form a real site was
-// seen emitting — and checks a KindUnitToUnitRequest naming the calling and
-// called units is published on the bus in both cases.
+// TestControlChannelPublishesUnitToUnitRequest drives a standard-MFID
+// Unit-to-Unit Answer Request (UU_ANS_REQ, opcode 0x05) through the control
+// channel and checks a KindUnitToUnitRequest naming the calling/called units
+// is published on the bus.
 func TestControlChannelPublishesUnitToUnitRequest(t *testing.T) {
-	for _, mfid := range []uint8{MFIDStandard, MFIDMotorola} {
-		bus := events.NewBus(16)
-		sub := bus.Subscribe()
-		cc := New(Options{Bus: bus, SystemName: "U2U"})
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	cc := New(Options{Bus: bus, SystemName: "U2U"})
 
-		utuar := TSBK{
-			Opcode: OpUnitToUnitAnswerRequest,
-			MFID:   mfid,
-			Payload: AssembleUnitToUnitAnswerRequest(UnitToUnitAnswerRequest{
-				ServiceOptions: 0x00, TargetID: 0x1234AB, SourceID: 0x00CDEF}),
-		}
-		cc.Process(buildLockedStreamWithTSBK(10, 0x705, DUIDTrunkingSignaling, utuar), 0)
+	utuar := TSBK{
+		Opcode: OpUnitToUnitAnswerRequest,
+		MFID:   MFIDStandard,
+		Payload: AssembleUnitToUnitAnswerRequest(UnitToUnitAnswerRequest{
+			ServiceOptions: 0x00, TargetID: 0x1234AB, SourceID: 0x00CDEF}),
+	}
+	cc.Process(buildLockedStreamWithTSBK(10, 0x705, DUIDTrunkingSignaling, utuar), 0)
 
-		deadline := time.After(3 * time.Second)
-		got := false
-		for !got {
-			select {
-			case ev := <-sub.C:
-				if ev.Kind != events.KindUnitToUnitRequest {
-					continue
-				}
-				u, ok := ev.Payload.(trunking.UnitToUnitRequest)
-				if !ok {
-					t.Fatalf("mfid=%#x payload is %T, want trunking.UnitToUnitRequest", mfid, ev.Payload)
-				}
-				if u.SourceID != 0x00CDEF || u.TargetID != 0x1234AB {
-					t.Fatalf("mfid=%#x src/target = %d/%d, want %d/%d",
-						mfid, u.SourceID, u.TargetID, 0x00CDEF, 0x1234AB)
-				}
-				got = true
-			case <-deadline:
-				t.Fatalf("mfid=%#x: no KindUnitToUnitRequest published within deadline", mfid)
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindUnitToUnitRequest {
+				continue
 			}
+			u, ok := ev.Payload.(trunking.UnitToUnitRequest)
+			if !ok {
+				t.Fatalf("payload is %T, want trunking.UnitToUnitRequest", ev.Payload)
+			}
+			if u.SourceID != 0x00CDEF || u.TargetID != 0x1234AB {
+				t.Fatalf("src/target = %d/%d, want %d/%d", u.SourceID, u.TargetID, 0x00CDEF, 0x1234AB)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no KindUnitToUnitRequest published within deadline")
 		}
-		sub.Close()
-		bus.Close()
+	}
+}
+
+// TestControlChannelIgnoresVendorUnitToUnitRequest checks that opcode 0x05 under
+// a Motorola MFID is NOT decoded as the standard UU_ANS_REQ — under a vendor
+// MFID the opcode is in the manufacturer's namespace, and decoding a Motorola
+// 0x05 with the standard layout produced garbage IDs in the field.
+func TestControlChannelIgnoresVendorUnitToUnitRequest(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	cc := New(Options{Bus: bus, SystemName: "U2U"})
+
+	utuar := TSBK{
+		Opcode: OpUnitToUnitAnswerRequest,
+		MFID:   MFIDMotorola,
+		Payload: AssembleUnitToUnitAnswerRequest(UnitToUnitAnswerRequest{
+			ServiceOptions: 0x00, TargetID: 0x1234AB, SourceID: 0x00CDEF}),
+	}
+	cc.Process(buildLockedStreamWithTSBK(10, 0x705, DUIDTrunkingSignaling, utuar), 0)
+
+	deadline := time.After(500 * time.Millisecond)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindUnitToUnitRequest {
+				t.Fatal("vendor-MFID 0x05 must not publish a UU_ANS_REQ event")
+			}
+		case <-deadline:
+			return // no UU_ANS_REQ event — correct
+		}
 	}
 }
 

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -8,77 +8,123 @@ import (
 // Opcode is the 6-bit TSBK opcode field per TIA-102.AABF Table 7.
 type Opcode uint8
 
-// TSBK opcodes follow the OP25 mapping (which is the de-facto reference
-// implementation of TIA-102.AABF). Vendor-specific extensions live behind
-// MFID != 0x00.
+// TSBK Outbound Signalling Packet (OSP) opcodes per TIA-102.AABC-D
+// (Project 25 FDMA Common Air Interface), Table 7-1. The Go identifiers stay
+// descriptive/CamelCase (idiomatic, and what the rest of the package uses),
+// while String() and the trailing comment carry the canonical TIA mnemonic —
+// the same convention internal/radio/nxdn uses for its spec message names, so
+// logs read in spec terms. Vendor-specific extensions live behind MFID != 0x00
+// (see tsbk_vendor.go). See docs/specs/p25-tsbk-opcodes.md for the full table.
 const (
-	OpGroupVoiceChannelGrant       Opcode = 0x00
-	OpGroupVoiceChannelUpdate      Opcode = 0x02
-	OpGroupVoiceChannelUpdateExpl  Opcode = 0x03
-	OpUnitToUnitVoiceChannelGrant  Opcode = 0x04
-	OpUnitToUnitAnswerRequest      Opcode = 0x05
-	OpUnitToUnitVoiceChannelUpdate Opcode = 0x06
-	OpTelephoneInterconnectGrant   Opcode = 0x08
-	OpTelephoneAnswerRequest       Opcode = 0x0A
-	OpSNDCPDataChannelGrant        Opcode = 0x14
-	OpStatusUpdate                 Opcode = 0x18
-	OpStatusQuery                  Opcode = 0x1A
-	OpMessageUpdate                Opcode = 0x1C
-	OpRadioUnitMonitor             Opcode = 0x1D
-	OpCallAlert                    Opcode = 0x1F
-	OpAcknowledgeResponse          Opcode = 0x20
-	OpQueuedResponse               Opcode = 0x21
-	OpExtendedFunctionCommand      Opcode = 0x24
-	OpDenyResponse                 Opcode = 0x27
-	OpGroupAffiliationResponse     Opcode = 0x28
-	OpGroupAffiliationQuery        Opcode = 0x2A
-	OpLocationRegistrationResponse Opcode = 0x2B
-	OpUnitRegistrationResponse     Opcode = 0x2C
-	OpUnitRegistrationCommand      Opcode = 0x2D
-	OpDeregistrationAck            Opcode = 0x2F
-	OpIdentifierUpdateTDMA         Opcode = 0x33
-	OpIdentifierUpdateVUHF         Opcode = 0x34
-	OpProtectionParamUpdate        Opcode = 0x35
-	OpSecondaryControlChannel      Opcode = 0x39
-	OpRFSSStatusBroadcast          Opcode = 0x3A
-	OpNetworkStatusBroadcast       Opcode = 0x3B
-	OpAdjacentSiteStatusBroadcast  Opcode = 0x3C
-	OpIdentifierUpdate             Opcode = 0x3D
-	OpProtectionParamBroadcast     Opcode = 0x3F
+	OpGroupVoiceChannelGrant       Opcode = 0x00 // GRP_V_CH_GRANT
+	OpGroupVoiceChannelUpdate      Opcode = 0x02 // GRP_V_CH_GRANT_UPDT
+	OpGroupVoiceChannelUpdateExpl  Opcode = 0x03 // GRP_V_CH_GRANT_UPDT_EXP
+	OpUnitToUnitVoiceChannelGrant  Opcode = 0x04 // UU_V_CH_GRANT
+	OpUnitToUnitAnswerRequest      Opcode = 0x05 // UU_ANS_REQ
+	OpUnitToUnitVoiceChannelUpdate Opcode = 0x06 // UU_V_CH_GRANT_UPDT
+	OpTelephoneInterconnectGrant   Opcode = 0x08 // TELE_INT_CH_GRANT
+	OpTelephoneAnswerRequest       Opcode = 0x0A // TELE_INT_ANS_REQ
+	OpSNDCPDataChannelGrant        Opcode = 0x14 // SNDCP_DAT_CH_GRANT
+	OpStatusUpdate                 Opcode = 0x18 // STS_UPDT
+	OpStatusQuery                  Opcode = 0x1A // STS_Q
+	OpMessageUpdate                Opcode = 0x1C // MSG_UPDT
+	OpRadioUnitMonitor             Opcode = 0x1D // RAD_MON_CMD
+	OpCallAlert                    Opcode = 0x1F // CALL_ALRT
+	OpAcknowledgeResponse          Opcode = 0x20 // ACK_RSP_FNE
+	OpQueuedResponse               Opcode = 0x21 // QUE_RSP
+	OpExtendedFunctionCommand      Opcode = 0x24 // EXT_FNCT_CMD
+	OpDenyResponse                 Opcode = 0x27 // DENY_RSP
+	OpGroupAffiliationResponse     Opcode = 0x28 // GRP_AFF_RSP
+	OpGroupAffiliationQuery        Opcode = 0x2A // GRP_AFF_Q
+	OpLocationRegistrationResponse Opcode = 0x2B // LOC_REG_RSP
+	OpUnitRegistrationResponse     Opcode = 0x2C // U_REG_RSP
+	OpUnitRegistrationCommand      Opcode = 0x2D // U_REG_CMD
+	OpDeregistrationAck            Opcode = 0x2F // U_DE_REG_ACK
+	OpIdentifierUpdateTDMA         Opcode = 0x33 // IDEN_UP_TDMA
+	OpIdentifierUpdateVUHF         Opcode = 0x34 // IDEN_UP_VU
+	OpProtectionParamUpdate        Opcode = 0x35 // PROT_PARM_UPDT
+	OpSecondaryControlChannel      Opcode = 0x39 // SCCB_EXP
+	OpRFSSStatusBroadcast          Opcode = 0x3A // RFSS_STS_BCST
+	OpNetworkStatusBroadcast       Opcode = 0x3B // NET_STS_BCST
+	OpAdjacentSiteStatusBroadcast  Opcode = 0x3C // ADJ_STS_BCST
+	OpIdentifierUpdate             Opcode = 0x3D // IDEN_UP
+	OpProtectionParamBroadcast     Opcode = 0x3F // PROT_PARM_BCST
 )
 
+// String returns the canonical TIA-102.AABC-D OSP mnemonic for the opcode
+// (e.g. "UU_ANS_REQ"), falling back to "OSP(0xNN)" for opcodes the decoder
+// does not name. Unknown vendor opcodes are reported by the caller with their
+// MFID, since the mnemonic is only meaningful in the standard namespace.
 func (o Opcode) String() string {
 	switch o {
 	case OpGroupVoiceChannelGrant:
-		return "GroupVoiceChannelGrant"
+		return "GRP_V_CH_GRANT"
 	case OpGroupVoiceChannelUpdate:
-		return "GroupVoiceChannelUpdate"
+		return "GRP_V_CH_GRANT_UPDT"
 	case OpGroupVoiceChannelUpdateExpl:
-		return "GroupVoiceChannelUpdateExplicit"
+		return "GRP_V_CH_GRANT_UPDT_EXP"
 	case OpUnitToUnitVoiceChannelGrant:
-		return "UnitToUnitVoiceChannelGrant"
+		return "UU_V_CH_GRANT"
 	case OpUnitToUnitAnswerRequest:
-		return "UnitToUnitAnswerRequest"
-	case OpAdjacentSiteStatusBroadcast:
-		return "AdjacentSiteStatusBroadcast"
-	case OpRFSSStatusBroadcast:
-		return "RFSSStatusBroadcast"
-	case OpNetworkStatusBroadcast:
-		return "NetworkStatusBroadcast"
-	case OpSecondaryControlChannel:
-		return "SecondaryControlChannelBroadcast"
-	case OpIdentifierUpdate:
-		return "IdentifierUpdate"
-	case OpIdentifierUpdateVUHF:
-		return "IdentifierUpdateVUHF"
-	case OpIdentifierUpdateTDMA:
-		return "IdentifierUpdateTDMA"
+		return "UU_ANS_REQ"
+	case OpUnitToUnitVoiceChannelUpdate:
+		return "UU_V_CH_GRANT_UPDT"
+	case OpTelephoneInterconnectGrant:
+		return "TELE_INT_CH_GRANT"
+	case OpTelephoneAnswerRequest:
+		return "TELE_INT_ANS_REQ"
+	case OpSNDCPDataChannelGrant:
+		return "SNDCP_DAT_CH_GRANT"
+	case OpStatusUpdate:
+		return "STS_UPDT"
+	case OpStatusQuery:
+		return "STS_Q"
+	case OpMessageUpdate:
+		return "MSG_UPDT"
+	case OpRadioUnitMonitor:
+		return "RAD_MON_CMD"
+	case OpCallAlert:
+		return "CALL_ALRT"
+	case OpAcknowledgeResponse:
+		return "ACK_RSP_FNE"
+	case OpQueuedResponse:
+		return "QUE_RSP"
+	case OpExtendedFunctionCommand:
+		return "EXT_FNCT_CMD"
+	case OpDenyResponse:
+		return "DENY_RSP"
 	case OpGroupAffiliationResponse:
-		return "GroupAffiliationResponse"
+		return "GRP_AFF_RSP"
+	case OpGroupAffiliationQuery:
+		return "GRP_AFF_Q"
+	case OpLocationRegistrationResponse:
+		return "LOC_REG_RSP"
 	case OpUnitRegistrationResponse:
-		return "UnitRegistrationResponse"
+		return "U_REG_RSP"
+	case OpUnitRegistrationCommand:
+		return "U_REG_CMD"
+	case OpDeregistrationAck:
+		return "U_DE_REG_ACK"
+	case OpIdentifierUpdateTDMA:
+		return "IDEN_UP_TDMA"
+	case OpIdentifierUpdateVUHF:
+		return "IDEN_UP_VU"
+	case OpProtectionParamUpdate:
+		return "PROT_PARM_UPDT"
+	case OpSecondaryControlChannel:
+		return "SCCB_EXP"
+	case OpRFSSStatusBroadcast:
+		return "RFSS_STS_BCST"
+	case OpNetworkStatusBroadcast:
+		return "NET_STS_BCST"
+	case OpAdjacentSiteStatusBroadcast:
+		return "ADJ_STS_BCST"
+	case OpIdentifierUpdate:
+		return "IDEN_UP"
+	case OpProtectionParamBroadcast:
+		return "PROT_PARM_BCST"
 	default:
-		return fmt.Sprintf("Opcode(%02X)", uint8(o))
+		return fmt.Sprintf("OSP(0x%02X)", uint8(o))
 	}
 }
 

--- a/internal/radio/p25/phase1/tsbk_test.go
+++ b/internal/radio/p25/phase1/tsbk_test.go
@@ -230,10 +230,11 @@ func TestParseAdjacentSiteStatusBroadcast(t *testing.T) {
 
 func TestOpcodeString(t *testing.T) {
 	cases := map[Opcode]string{
-		OpGroupVoiceChannelGrant: "GroupVoiceChannelGrant",
-		OpRFSSStatusBroadcast:    "RFSSStatusBroadcast",
-		OpNetworkStatusBroadcast: "NetworkStatusBroadcast",
-		Opcode(0x42):             "Opcode(42)",
+		OpGroupVoiceChannelGrant:  "GRP_V_CH_GRANT",
+		OpUnitToUnitAnswerRequest: "UU_ANS_REQ",
+		OpRFSSStatusBroadcast:     "RFSS_STS_BCST",
+		OpNetworkStatusBroadcast:  "NET_STS_BCST",
+		Opcode(0x42):              "OSP(0x42)",
 	}
 	for op, want := range cases {
 		if got := op.String(); got != want {

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useShared } from "../store/shared";
 import type { EventDTO, TalkgroupDTO } from "../api/types";
@@ -85,6 +85,18 @@ export function CCActivity() {
     return list.reverse();
   }, [events, talkgroups, systemFilter, kindFilter]);
 
+  // Pause must actually freeze the table so an operator can read/click a row
+  // without it churning under them: snapshot rows at the moment of pausing and
+  // render that snapshot until resumed. (Previously `paused` re-sliced the live
+  // rows, so it never froze anything.)
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+  const [frozen, setFrozen] = useState<Row[] | null>(null);
+  useEffect(() => {
+    setFrozen(paused ? rowsRef.current : null);
+  }, [paused]);
+  const displayRows = frozen ?? rows;
+
   return (
     <div className="space-y-3">
       <header className="flex flex-wrap items-center justify-between gap-3">
@@ -119,7 +131,7 @@ export function CCActivity() {
       </header>
 
       <div className="text-xs text-muted">
-        {rows.length} matching event{rows.length === 1 ? "" : "s"}
+        {displayRows.length} matching event{displayRows.length === 1 ? "" : "s"}
         {paused && " (paused — display frozen, the daemon is still receiving)"}
       </div>
 
@@ -134,7 +146,7 @@ export function CCActivity() {
             </tr>
           </thead>
           <tbody>
-            {rows.length === 0 ? (
+            {displayRows.length === 0 ? (
               <tr>
                 <td colSpan={4} className="px-3 py-4 text-center text-muted">
                   Nothing here yet — control-channel activity will appear
@@ -143,7 +155,7 @@ export function CCActivity() {
                 </td>
               </tr>
             ) : (
-              (paused ? rows.slice(0, rows.length) : rows).slice(0, 500).map((r, i) => (
+              displayRows.slice(0, 500).map((r, i) => (
                 <tr key={i} className="border-t border-border/60">
                   <td className="px-3 py-1 font-mono text-muted">
                     {formatTime(r.ts)}

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -44,19 +44,17 @@ function latestLearned(
   return null;
 }
 
-// Network identity (WACN/System ID/RFSS/Site) is populated from
-// decoded P25 TSBKs 0x3A/0x3B, not config. Translate the live hunt
-// state into operator-facing copy so an empty cell explains itself.
+// Network identity (WACN/System ID/RFSS/Site) is decoded live from P25 status
+// broadcasts (RFSS_STS_BCST 0x3A / NET_STS_BCST 0x3B), not config — the daemon
+// overlays it onto the system as those TSBKs arrive. An empty cell therefore
+// means "not decoded yet", not "scanner offline": the engine decodes identity
+// whenever the control channel is being received, independent of the CC-hunt
+// supervisor state (which is what `hunt` reflects, and is absent for a system
+// the always-on trunking engine is decoding). Only call out an active hunt;
+// otherwise say we're waiting on the (infrequent) status broadcasts.
 function identityEmptyHint(hunt: SystemHuntStatusDTO | undefined): string {
-  if (!hunt) return "Scanner offline";
-  switch (hunt.state) {
-    case "locked":
-      return "Awaiting status broadcasts";
-    case "hunting":
-      return "Hunting control channel";
-    default:
-      return hunt.state ? `System not locked (${hunt.state})` : "System not locked";
-  }
+  if (hunt?.state === "hunting") return "Hunting control channel";
+  return "Awaiting status broadcasts";
 }
 
 export function Systems() {


### PR DESCRIPTION
## Summary

From the latest field session (PR #728 merged). Five items, one PR.

### P25 opcodes now use TIA-102.AABC-D designations
`opcodes.go` previously followed the OP25 mapping. `Opcode.String()` now returns the canonical TIA mnemonics so logs read `opcode=UU_ANS_REQ`, `opcode=NET_STS_BCST`, `opcode=GRP_V_CH_GRANT`, etc. The Go identifiers stay descriptive/CamelCase (idiomatic; `go vet`/staticcheck-safe), with the TIA designation on a trailing comment — the same pattern `internal/radio/nxdn` already uses for its message names. A new **`docs/specs/p25-tsbk-opcodes.md`** carries the full OSP opcode table.

### UU_ANS_REQ (0x05) no longer mis-decoded under a vendor MFID
A field decode of the Motorola (MFID 0x90) 0x05 with the standard Target/Source layout produced garbage IDs (`src=0`, `target=0x3C0000`). Under a vendor MFID the opcode is in the manufacturer's namespace, so it's now left unhandled; the **standard-MFID** UU_ANS_REQ still parses (Service Options + 24-bit Target + Source, per the spec) and publishes a `unit.request` event. (Reverts the over-eager vendor-path decode added in #728.)

### UI: CC Activity "pause" actually freezes now
The pause button re-sliced the live `rows` (which re-memoize on every event), so it never froze — the list kept churning and an event was impossible to read or click. Now it snapshots rows on pause and renders the snapshot until resumed.

### UI: Systems detail no longer says "Scanner offline"
WACN/System ID/RFSS/Site are decoded live from status broadcasts (`RFSS_STS_BCST`/`NET_STS_BCST`) whenever the CC is received — independent of the CC-hunt supervisor state the old hint keyed on. An empty cell now reads "Awaiting status broadcasts" (or "Hunting control channel" during a hunt) instead of the misleading "Scanner offline".

### Reference documents
You asked to add the uploaded TIA-102.AABC-D standard + Aeroflex app note "for future reference." Those are **copyrighted and not redistributable** — and `docs/specs/README.md` already documents that policy (TIA-102 is explicitly listed as *not* in-tree). So instead of committing the PDFs, I transcribed the relevant opcode table into `docs/specs/p25-tsbk-opcodes.md` and cited both documents as sources. This keeps the repo's MIT-compatible licensing intact.

## Not addressed (needs a live daemon to verify)
The deeper "Systems panel shows live WACN for a hunt-only system" wiring is backend (hunt decodes into its own bus, not the daemon `SiteTracker` overlay). After #728 the always-on engine should decode the broadcasts and populate it; this PR fixes the misleading copy. Tell me if it's still blank with the engine running and I'll wire the hunt→SiteTracker path.

## Testing
`gofmt -l .`, `go build ./...`, full `go test ./...` clean (opcode-String + UU_ANS_REQ standard/vendor tests updated). Web `npm run build` + `vitest` (CC Activity + Systems panels, 15 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q

---
_Generated by [Claude Code](https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q)_