### PR TITLE
web(events): freeze the stream while inspecting an event

### DIFF
--- a/web/src/panels/Events.test.tsx
+++ b/web/src/panels/Events.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { useShared } from "../store/shared";
+import type { EventDTO } from "../api/types";
+import { Events } from "./Events";
+
+function setStore(events: EventDTO[]) {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    connected: true,
+    wsStatus: "open",
+    mutations: null,
+    lastError: null,
+    events,
+    eventCap: 1000,
+    activeCalls: [],
+    devices: [],
+    systems: [],
+    talkgroups: [],
+    health: null,
+    audio: null,
+    scanner: null,
+  });
+}
+
+const evA: EventDTO = { kind: "grant", timestamp: "2026-06-19T05:00:00Z", payload: { tg: 1340 } };
+const evB: EventDTO = { kind: "registration", timestamp: "2026-06-19T05:00:01Z", payload: { src: 42 } };
+
+describe("Events panel", () => {
+  beforeEach(() => setStore([evA, evB]));
+
+  it("freezes the live stream while an event is expanded for inspection", async () => {
+    const user = userEvent.setup();
+    render(<Events />);
+
+    // Live by default — the hint invites inspection.
+    expect(screen.getByText(/Click an event to inspect/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+
+    // Expand an event by clicking its row.
+    await user.click(screen.getByText("registration"));
+
+    // Now frozen for inspection: Resume shows and the freeze hint explains why.
+    expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument();
+    expect(screen.getByText(/Frozen while you inspect/)).toBeInTheDocument();
+
+    // New events arriving must NOT push into the frozen view.
+    setStore([evA, evB, { kind: "patch", timestamp: "2026-06-19T05:00:02Z", payload: {} }]);
+    expect(screen.queryByText("patch")).not.toBeInTheDocument();
+
+    // Collapsing the event resumes the live stream.
+    await user.click(screen.getByText("registration"));
+    expect(screen.getByRole("button", { name: "Pause" })).toBeInTheDocument();
+  });
+
+  it("keeps a manual pause when an expanded event is collapsed", async () => {
+    const user = userEvent.setup();
+    render(<Events />);
+
+    await user.click(screen.getByRole("button", { name: "Pause" }));
+    await user.click(screen.getByText("grant")); // expand while already paused
+    await user.click(screen.getByText("grant")); // collapse
+
+    // Manual pause is preserved (not auto-resumed on collapse).
+    expect(screen.getByRole("button", { name: "Resume" })).toBeInTheDocument();
+  });
+});

--- a/web/src/panels/Events.tsx
+++ b/web/src/panels/Events.tsx
@@ -14,6 +14,9 @@ export function Events() {
   const [paused, setPaused] = useState(false);
   const [snapshot, setSnapshot] = useState<EventDTO[] | null>(null);
   const [expanded, setExpanded] = useState<string | null>(null);
+  // autoFrozen records that the freeze was triggered by expanding a row (so we
+  // resume on collapse), as opposed to a manual Pause the operator wants kept.
+  const [autoFrozen, setAutoFrozen] = useState(false);
 
   // When paused, freeze the table at the snapshot the user paused on;
   // when running, mirror the live store ring.
@@ -67,13 +70,34 @@ export function Events() {
     [],
   );
 
+  function freeze() {
+    setSnapshot(events.slice());
+    setPaused(true);
+  }
+  function resume() {
+    setPaused(false);
+    setSnapshot(null);
+  }
   function togglePause() {
-    if (paused) {
-      setPaused(false);
-      setSnapshot(null);
-    } else {
-      setSnapshot(events.slice());
-      setPaused(true);
+    setAutoFrozen(false); // a manual toggle owns the pause state from here on
+    if (paused) resume();
+    else freeze();
+  }
+
+  // Expanding a row to inspect it auto-freezes the live stream so the row
+  // doesn't scroll away as new events prepend (the whole point of "looking at
+  // an event"); collapsing it resumes — unless the operator had paused manually.
+  function handleRowClick(_r: EventDTO, key: string) {
+    const collapsing = expanded === key;
+    setExpanded(collapsing ? null : key);
+    if (collapsing) {
+      if (autoFrozen) {
+        resume();
+        setAutoFrozen(false);
+      }
+    } else if (!paused) {
+      freeze();
+      setAutoFrozen(true);
     }
   }
 
@@ -117,13 +141,19 @@ export function Events() {
         </button>
       </div>
 
+      <p className="text-xs text-muted">
+        {paused
+          ? autoFrozen
+            ? "Frozen while you inspect — collapse the event (or Resume) to go live."
+            : "Paused — display frozen; the stream keeps running underneath."
+          : "Click an event to inspect its payload — the stream freezes so it stays put."}
+      </p>
+
       <DataTable
         rows={ordered}
         columns={columns}
         rowKey={(r, i) => `${r.timestamp}-${r.kind}-${i}`}
-        onRowClick={(_r, key) =>
-          setExpanded((prev) => (prev === key ? null : key))
-        }
+        onRowClick={handleRowClick}
         renderExpansion={(r) => (
           <pre className="whitespace-pre-wrap break-words font-mono text-xs text-fg/80">
             {JSON.stringify(r, null, 2)}


### PR DESCRIPTION
## Summary

Fixes the recurring "looking at an event is basically impossible because of scrolling" report. The previous fix (#730) targeted the **CC Activity** pause; the actual surface for *inspecting* an event is the **Events** panel, where clicking a row expands its JSON payload.

### Root cause
The Events panel streams live and renders newest-first, so it **prepends new events at the top**. The moment you click a row to read its payload, fresh events push it down and the view scrolls away — and because the row key included the array index, every incoming event also shifted the keys and dropped the expansion. Pausing first worked, but the natural action (click to inspect) fought the live stream.

### Fix
Expanding an event now **auto-freezes the live stream** (snapshots the rows) so the event stays put while you read it; collapsing it resumes. A **manual Pause is preserved** — collapsing only auto-resumes a freeze that the expand triggered. Added a one-line hint ("Click an event to inspect — the stream freezes so it stays put" / "Frozen while you inspect…") and a regression test.

## Files
- `web/src/panels/Events.tsx` — freeze-on-expand, resume-on-collapse, hint copy.
- `web/src/panels/Events.test.tsx` — new: asserts a new event can't push into the frozen view while a row is expanded, and that a manual pause survives a collapse.

## Testing
`npm run build` (tsc + vite) clean; full `vitest` — 35 files / 213 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q

---
_Generated by [Claude Code](https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q)_