### PR TITLE
p25: name Motorola 0x05/0x09 from SDRtrunk/OP25, capture raw (no speculative decode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **Raw-payload capture for the undecoded Motorola opcodes 0x05 / 0x09**
+  (MFID 0x90). These are emitted continuously on real systems and are suspected
+  to carry roaming / secondary-control-channel data, but their layout is
+  unverified — so they are logged at INFO (up to 64 samples each, grep
+  `motorola candidate opcode`) for offline correlation and decode/publish
+  nothing into the system map. See
+  [`docs/specs/p25-motorola-opcodes.md`](docs/specs/p25-motorola-opcodes.md).
+
 ### Changed
 - **P25 TSBK opcodes now log with their TIA-102.AABC-D designations**
   (`UU_ANS_REQ`, `NET_STS_BCST`, `GRP_V_CH_GRANT`, …) instead of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
-- **Raw-payload capture for the undecoded Motorola opcodes 0x05 / 0x09**
-  (MFID 0x90). These are emitted continuously on real systems and are suspected
-  to carry roaming / secondary-control-channel data, but their layout is
-  unverified — so they are logged at INFO (up to 64 samples each, grep
-  `motorola candidate opcode`) for offline correlation and decode/publish
-  nothing into the system map. See
+- **Motorola opcodes 0x05 / 0x09 (MFID 0x90) named and captured.** Cross-checked
+  against SDRtrunk / OP25: 0x05 is `MOTOROLA_OSP_TRAFFIC_CHANNEL_ID`, 0x09 is
+  `MOTOROLA_OSP_SYSTEM_LOADING` — neither carries neighbour / secondary-CC data,
+  and neither reference decoder field-decodes them. So they are named and their
+  raw payload is logged at INFO (up to 64 samples each, grep `motorola opcode`)
+  while decoding/publishing nothing into the system map. See
   [`docs/specs/p25-motorola-opcodes.md`](docs/specs/p25-motorola-opcodes.md).
 
 ### Changed

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -58,7 +58,10 @@ but were not located at the time of this commit:
   so the PDF is not committed; the opcode designations are
   transcribed (not copied) into
   [`p25-tsbk-opcodes.md`](p25-tsbk-opcodes.md) for cross-checking
-  the decoder.
+  the decoder. Motorola-proprietary (MFID 0x90) opcodes — which are
+  not in any standard — are tracked separately, with their
+  reverse-engineering status, in
+  [`p25-motorola-opcodes.md`](p25-motorola-opcodes.md).
 - **ETSI TS 102 361-2** — DMR Tier III air interface.
 
 Pulls welcome.

--- a/docs/specs/p25-motorola-opcodes.md
+++ b/docs/specs/p25-motorola-opcodes.md
@@ -1,16 +1,14 @@
-# Motorola proprietary P25 TSBK opcodes (MFID 0x90) — reverse-engineering status
+# Motorola proprietary P25 TSBK opcodes (MFID 0x90)
 
-Tracking doc for Motorola-specific (MFID `0x90`) Phase 1 TSBK opcodes observed
-on real systems but **not yet decoded**. Most P25 systems run Motorola gear, so
-these are worth reversing — but only from a *confirmed* layout. This file
-records the leads so the work isn't lost and isn't re-guessed.
+Status of Motorola-specific (MFID `0x90`) Phase 1 TSBK opcodes seen on real
+systems. Most P25 systems run Motorola gear, so these come up constantly.
 
 > ⚠️ **Nothing here is wired into the system map.** Opcodes `0x05` and `0x09`
-> (MFID 0x90) are captured raw by `logVendorProbe`
-> ([`control.go`](../../internal/radio/p25/phase1/control.go)) for offline
-> analysis and decode/publish **nothing**. A guessed bit layout would inject
-> phantom neighbours / frequencies — the exact bad-data class the corroboration
-> and identity work removed — so real decoding waits on verification.
+> (MFID 0x90) are named and their raw payload is captured by `logVendorProbe`
+> ([`control.go`](../../internal/radio/p25/phase1/control.go)) for the record;
+> no fields are decoded and nothing is published. A guessed bit layout would
+> inject phantom data — the bad-data class the corroboration/identity work
+> removed.
 
 ## Already decoded (MFID 0x90)
 
@@ -19,64 +17,51 @@ group-regroup add (0x00) / delete (0x01), patch-group channel grant (0x02) /
 update (0x03), and talker-alias fragments (0x15). Note also that the **standard**
 band-plan and network/site/secondary broadcasts (`0x33/0x34/0x39/0x3A/0x3B/0x3C/0x3D`)
 are decoded even under a vendor MFID (PR #728) — so on a Motorola site,
-neighbours should come from the standard `ADJ_STS_BCST` (0x3C) first. If they're
-empty, capture the `0x3C` debug lines before assuming the data only lives in a
-proprietary opcode.
+neighbours come from the standard `ADJ_STS_BCST` (0x3C), **not** from a
+proprietary opcode. If neighbours are empty, capture the `0x3C` debug lines.
 
-## Candidate opcodes (observed, undecoded)
+## Opcodes 0x05 and 0x09 — named, not field-decoded
 
-### Opcode 0x09 (MFID 0x90)
-- **Observed payload:** `0c80000000000000` (`lb=true`), repeated continuously.
-- **Hypothesis (community, unverified):** a "scan marker" radios hunt for when
-  picking up a control channel.
-- **Assessment:** the payload is `0x0C80` followed by all zeros — a near-constant
-  beacon with **no embedded site/frequency/neighbour fields**. Even the
-  community parser only pulls two bytes (`0x0C`, `0x80`) and yields no map data.
-  So this opcode, as observed, does **not** carry neighbour or secondary-CC
-  information. Likely a periodic status/keepalive flag, not a topology message.
+A community snippet (Discord, 2026-06) claimed `0x05` is a "roam beacon" and
+`0x09` a "scan marker" carrying neighbour / secondary-CC data, and supplied a Go
+parser. That was **wrong** — cross-checked against the two reference decoders:
 
-### Opcode 0x05 (MFID 0x90)
-- **Observed:** logged on the same Motorola site; raw payload bytes not yet
-  captured in a shared sample.
-- **Hypotheses (unverified):** community snippet proposes a "roam beacon"
-  (sub-type / sys-id fragment / neighbour site / channel IDEN + number /
-  preference class / RSSI threshold); separately it's the *standard* opcode
-  number for `UU_ANS_REQ`.
-- **Assessment:** decoding this 0x05 with the **standard** UU_ANS_REQ layout
-  produced garbage in the field (`src=0`, `target=0x3C0000`) — which is why
-  PR #730 stopped decoding vendor-MFID 0x05. The "roam beacon" layout is a
-  different, equally-unverified guess. No real `0x05` payload bytes have been
-  correlated against known neighbours yet.
+| Opcode | What it actually is (SDRtrunk) | OP25 (boatbod) | Field-decoded anywhere? |
+| --- | --- | --- | --- |
+| `0x05` | `MOTOROLA_OSP_TRAFFIC_CHANNEL_ID` ("Motorola Traffic Channel") | not handled | **No** — SDRtrunk's `MotorolaTrafficChannel` is a hex-only stub |
+| `0x09` | `MOTOROLA_OSP_SYSTEM_LOADING` ("Motorola System Loading") | not handled | **No** — SDRtrunk's `ChannelLoading` is an explicit "unknown / under reverse-engineering" placeholder |
 
-## Why these are not implemented
+Findings:
 
-The community-provided Go parser (Discord, 2026-06) is **not** sourced from a
-spec or a reference decoder and shows hallmarks of AI fabrication: invented
-terminology ("RoamBeacon", "ScanMarker", "MarkerMagic", "injection marker
-0x0C80"), no checkable citation, and a 0x09 parser that extracts no usable data.
-Implementing it would re-introduce phantom map entries. P25 standard opcode
-designations come from TIA-102.AABC-D; **vendor** opcodes are not in any
-standard, so the only trustworthy sources are a reference decoder or
-ground-truth correlation.
+- **Neither is a neighbour or secondary-CC message.** 0x05 concerns a traffic
+  channel; 0x09 is system/site loading telemetry. They are not the fix for
+  missing neighbours (that's the standard `0x3C`).
+- **No authoritative field layout exists.** OP25 ignores both; SDRtrunk
+  categorises them by opcode but does **not** extract fields (both classes are
+  stubs / RE placeholders). There is nothing trustworthy to "implement from".
+- The community `0x09` parser pulled only `0x0C 0x80` from `0c80000000000000`
+  (rest zeros) — i.e. no usable data — and the `0x05` "roam beacon" layout was a
+  fresh guess (decoding 0x05 with the standard UU_ANS_REQ layout already gave
+  garbage: `src=0`, `target=0x3C0000`).
 
-## Verification plan
+So this repo mirrors the reference decoders: **name** the two opcodes
+(`MOTOROLA_OSP_TRAFFIC_CHANNEL_ID` / `MOTOROLA_OSP_SYSTEM_LOADING`) and **capture**
+their raw payload (`logVendorProbe`, up to 64 samples/opcode at INFO — grep
+`motorola opcode`), but field-decode nothing.
 
-To decode either opcode for real, gather **one** of:
+## If they're ever worth field-decoding
 
-1. **A reference decode** — what OP25 (boatbod, `trunking.py`) and/or SDRTrunk
-   (`MotorolaTalkgroupOpcode` / MFID-90 handlers) actually do with MFID 0x90
-   opcodes `0x05` / `0x09`. Mirror that layout (with the working-model
-   disclaimer + symmetric `Assemble`/`Parse` + round-trip test the existing
-   vendor opcodes use). If neither decodes them, they are genuinely
-   undocumented and a guess is unjustified.
-2. **Ground-truth correlation** — ~10–20 real raw payloads (now captured by
-   `logVendorProbe`, up to 64 per opcode at INFO: grep
-   `motorola candidate opcode`) **paired** with the site's true neighbour list /
-   secondary-CC frequencies from a known-good decoder. Correlate the varying
-   payload fields against the known values to reverse the bit layout, then prove
-   it with an `Assemble`/`Parse` round-trip test before wiring it into
-   `NetworkModel`.
+They would need genuine reverse-engineering, since no reference decoder has done
+it: collect a correlation set of raw payloads (already captured by
+`logVendorProbe`) against known site state and reverse the layout, then prove it
+with an `Assemble`/`Parse` round-trip test before wiring anything into
+`NetworkModel`. Given 0x05/0x09 carry no topology data, this is low priority.
 
-Once a layout is confirmed, the dispatch in `dispatchVendorTSBK` swaps
-`logVendorProbe` for a real parser + `ApplyAdjacentSite` /
-`ApplySecondaryControlChannel` call.
+## Sources
+
+- SDRtrunk — `module/decode/p25/phase1/message/tsbk/Opcode.java` (opcode →
+  `MOTOROLA_OSP_TRAFFIC_CHANNEL_ID` = 5, `MOTOROLA_OSP_SYSTEM_LOADING` = 9) and
+  the `.../motorola/osp/` message classes (`MotorolaTrafficChannel`,
+  `ChannelLoading` — both stubs). <https://github.com/DSheirer/sdrtrunk>
+- OP25 (boatbod) — `op25/gr-op25_repeater/apps/trunking.py` (Motorola handling
+  covers only opcodes 0x00–0x03). <https://github.com/boatbod/op25>

--- a/docs/specs/p25-motorola-opcodes.md
+++ b/docs/specs/p25-motorola-opcodes.md
@@ -1,0 +1,82 @@
+# Motorola proprietary P25 TSBK opcodes (MFID 0x90) — reverse-engineering status
+
+Tracking doc for Motorola-specific (MFID `0x90`) Phase 1 TSBK opcodes observed
+on real systems but **not yet decoded**. Most P25 systems run Motorola gear, so
+these are worth reversing — but only from a *confirmed* layout. This file
+records the leads so the work isn't lost and isn't re-guessed.
+
+> ⚠️ **Nothing here is wired into the system map.** Opcodes `0x05` and `0x09`
+> (MFID 0x90) are captured raw by `logVendorProbe`
+> ([`control.go`](../../internal/radio/p25/phase1/control.go)) for offline
+> analysis and decode/publish **nothing**. A guessed bit layout would inject
+> phantom neighbours / frequencies — the exact bad-data class the corroboration
+> and identity work removed — so real decoding waits on verification.
+
+## Already decoded (MFID 0x90)
+
+See [`tsbk_vendor.go`](../../internal/radio/p25/phase1/tsbk_vendor.go): patch /
+group-regroup add (0x00) / delete (0x01), patch-group channel grant (0x02) /
+update (0x03), and talker-alias fragments (0x15). Note also that the **standard**
+band-plan and network/site/secondary broadcasts (`0x33/0x34/0x39/0x3A/0x3B/0x3C/0x3D`)
+are decoded even under a vendor MFID (PR #728) — so on a Motorola site,
+neighbours should come from the standard `ADJ_STS_BCST` (0x3C) first. If they're
+empty, capture the `0x3C` debug lines before assuming the data only lives in a
+proprietary opcode.
+
+## Candidate opcodes (observed, undecoded)
+
+### Opcode 0x09 (MFID 0x90)
+- **Observed payload:** `0c80000000000000` (`lb=true`), repeated continuously.
+- **Hypothesis (community, unverified):** a "scan marker" radios hunt for when
+  picking up a control channel.
+- **Assessment:** the payload is `0x0C80` followed by all zeros — a near-constant
+  beacon with **no embedded site/frequency/neighbour fields**. Even the
+  community parser only pulls two bytes (`0x0C`, `0x80`) and yields no map data.
+  So this opcode, as observed, does **not** carry neighbour or secondary-CC
+  information. Likely a periodic status/keepalive flag, not a topology message.
+
+### Opcode 0x05 (MFID 0x90)
+- **Observed:** logged on the same Motorola site; raw payload bytes not yet
+  captured in a shared sample.
+- **Hypotheses (unverified):** community snippet proposes a "roam beacon"
+  (sub-type / sys-id fragment / neighbour site / channel IDEN + number /
+  preference class / RSSI threshold); separately it's the *standard* opcode
+  number for `UU_ANS_REQ`.
+- **Assessment:** decoding this 0x05 with the **standard** UU_ANS_REQ layout
+  produced garbage in the field (`src=0`, `target=0x3C0000`) — which is why
+  PR #730 stopped decoding vendor-MFID 0x05. The "roam beacon" layout is a
+  different, equally-unverified guess. No real `0x05` payload bytes have been
+  correlated against known neighbours yet.
+
+## Why these are not implemented
+
+The community-provided Go parser (Discord, 2026-06) is **not** sourced from a
+spec or a reference decoder and shows hallmarks of AI fabrication: invented
+terminology ("RoamBeacon", "ScanMarker", "MarkerMagic", "injection marker
+0x0C80"), no checkable citation, and a 0x09 parser that extracts no usable data.
+Implementing it would re-introduce phantom map entries. P25 standard opcode
+designations come from TIA-102.AABC-D; **vendor** opcodes are not in any
+standard, so the only trustworthy sources are a reference decoder or
+ground-truth correlation.
+
+## Verification plan
+
+To decode either opcode for real, gather **one** of:
+
+1. **A reference decode** — what OP25 (boatbod, `trunking.py`) and/or SDRTrunk
+   (`MotorolaTalkgroupOpcode` / MFID-90 handlers) actually do with MFID 0x90
+   opcodes `0x05` / `0x09`. Mirror that layout (with the working-model
+   disclaimer + symmetric `Assemble`/`Parse` + round-trip test the existing
+   vendor opcodes use). If neither decodes them, they are genuinely
+   undocumented and a guess is unjustified.
+2. **Ground-truth correlation** — ~10–20 real raw payloads (now captured by
+   `logVendorProbe`, up to 64 per opcode at INFO: grep
+   `motorola candidate opcode`) **paired** with the site's true neighbour list /
+   secondary-CC frequencies from a known-good decoder. Correlate the varying
+   payload fields against the known values to reverse the bit layout, then prove
+   it with an `Assemble`/`Parse` round-trip test before wiring it into
+   `NetworkModel`.
+
+Once a layout is confirmed, the dispatch in `dispatchVendorTSBK` swaps
+`logVendorProbe` for a real parser + `ApplyAdjacentSite` /
+`ApplySecondaryControlChannel` call.

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1120,14 +1120,22 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 		}
 		return
 	}
+	// Motorola (MFID 0x90) opcodes 0x05 and 0x09 are emitted continuously on
+	// real systems and are *suspected* — but NOT confirmed — to carry roaming /
+	// secondary-control-channel information (see docs/specs/p25-motorola-opcodes.md).
+	// Capture a larger raw-payload sample for offline correlation, but
+	// deliberately decode and publish NOTHING into the system map: a guessed
+	// field layout would inject phantom neighbours/frequencies (a Motorola 0x05
+	// decoded with the standard UU_ANS_REQ layout already produced garbage IDs —
+	// src=0, target=0x3C0000). Wiring real fields in waits on a layout confirmed
+	// against a reference decoder or ground-truth captures.
+	if t.MFID == MFIDMotorola && (t.Opcode == 0x05 || t.Opcode == 0x09) {
+		c.logVendorProbe(t, nac)
+		return
+	}
 	// Unrecognised vendor opcode: census + raw-payload sample so a field
 	// test can name and reverse any alias-bearing transport we don't yet
-	// decode, while the per-frame detail stays at Debug. Note: opcode 0x05
-	// here is NOT decoded as the standard UU_ANS_REQ — under a vendor MFID
-	// the opcode is in the manufacturer's namespace, and a field decode of a
-	// Motorola 0x05 with the standard target/source layout produced garbage
-	// IDs (src=0, target=0x3C0000), so it stays unhandled until its real
-	// vendor layout is reversed.
+	// decode, while the per-frame detail stays at Debug.
 	c.logUnhandledTSBK(t, nac)
 	c.log.Debug("p25: vendor tsbk", "mfid", t.MFID, "opcode", t.Opcode, "nac", nac)
 }
@@ -1139,6 +1147,7 @@ const (
 	diagUnhandledTSBK   uint32 = 1 << 24
 	diagAliasSrc        uint32 = 2 << 24
 	diagVendorBroadcast uint32 = 3 << 24
+	diagVendorProbe     uint32 = 4 << 24
 )
 
 // isStandardBroadcastOpcode reports whether op is one of the band-plan or
@@ -1191,6 +1200,30 @@ func (c *ControlChannel) logUnhandledTSBK(t TSBK, nac uint16) {
 		c.log.Info("p25: unhandled tsbk payload",
 			"mfid", t.MFID, "opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
 			"lb", t.LB, "payload", fmt.Sprintf("%x", t.Payload[:]), "nac", nac)
+	}
+}
+
+// maxVendorProbeSamples bounds how many raw payloads logVendorProbe dumps per
+// distinct (MFID,opcode). Larger than maxUnhandledSamples because these are
+// deliberate reverse-engineering targets — a correlation set of a few dozen
+// frames (paired with the site's known neighbours / secondary CCs from a
+// reference decoder) is what reverses the field layout.
+const maxVendorProbeSamples = 64
+
+// logVendorProbe records a candidate-but-undecoded vendor TSBK for offline
+// analysis: it dumps the full raw payload at Info (up to maxVendorProbeSamples
+// per opcode) and does nothing else — no parse, no event, no map mutation — so
+// an unconfirmed layout cannot leak phantom data into the system map. See
+// docs/specs/p25-motorola-opcodes.md for the reverse-engineering status.
+func (c *ControlChannel) logVendorProbe(t TSBK, nac uint16) {
+	key := diagVendorProbe | uint32(t.MFID)<<8 | uint32(t.Opcode)
+	n := c.diagSeen[key]
+	c.diagSeen[key] = n + 1
+	if n < maxVendorProbeSamples {
+		c.log.Info("p25: motorola candidate opcode (undecoded — collecting for analysis)",
+			"mfid", t.MFID, "opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
+			"lb", t.LB, "payload", fmt.Sprintf("%x", t.Payload[:]),
+			"nac", nac, "sample", n+1, "max", maxVendorProbeSamples)
 	}
 }
 

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1120,16 +1120,16 @@ func (c *ControlChannel) dispatchVendorTSBK(t TSBK, nac uint16) {
 		}
 		return
 	}
-	// Motorola (MFID 0x90) opcodes 0x05 and 0x09 are emitted continuously on
-	// real systems and are *suspected* — but NOT confirmed — to carry roaming /
-	// secondary-control-channel information (see docs/specs/p25-motorola-opcodes.md).
-	// Capture a larger raw-payload sample for offline correlation, but
-	// deliberately decode and publish NOTHING into the system map: a guessed
-	// field layout would inject phantom neighbours/frequencies (a Motorola 0x05
-	// decoded with the standard UU_ANS_REQ layout already produced garbage IDs —
-	// src=0, target=0x3C0000). Wiring real fields in waits on a layout confirmed
-	// against a reference decoder or ground-truth captures.
-	if t.MFID == MFIDMotorola && (t.Opcode == 0x05 || t.Opcode == 0x09) {
+	// Motorola (MFID 0x90) Traffic Channel ID (0x05) and System Loading (0x09)
+	// are emitted continuously on real systems. SDRtrunk names them but does not
+	// field-decode them (its MotorolaTrafficChannel / ChannelLoading classes are
+	// hex-only stubs) and OP25 ignores them; neither carries neighbour or
+	// secondary-CC data. So we name and capture the raw payload for the record
+	// but decode/publish NOTHING into the system map — a guessed layout would
+	// inject phantom data (a Motorola 0x05 decoded with the standard UU_ANS_REQ
+	// layout already produced garbage: src=0, target=0x3C0000). See
+	// docs/specs/p25-motorola-opcodes.md.
+	if t.MFID == MFIDMotorola && (t.Opcode == OpMotorolaTrafficChannelID || t.Opcode == OpMotorolaSystemLoading) {
 		c.logVendorProbe(t, nac)
 		return
 	}
@@ -1220,10 +1220,24 @@ func (c *ControlChannel) logVendorProbe(t TSBK, nac uint16) {
 	n := c.diagSeen[key]
 	c.diagSeen[key] = n + 1
 	if n < maxVendorProbeSamples {
-		c.log.Info("p25: motorola candidate opcode (undecoded — collecting for analysis)",
+		c.log.Info("p25: motorola opcode (named, not field-decoded — collecting for analysis)",
 			"mfid", t.MFID, "opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
+			"name", motorolaProbeLabel(t.Opcode),
 			"lb", t.LB, "payload", fmt.Sprintf("%x", t.Payload[:]),
 			"nac", nac, "sample", n+1, "max", maxVendorProbeSamples)
+	}
+}
+
+// motorolaProbeLabel maps the probed Motorola opcodes to SDRtrunk's names so
+// the diagnostic log reads in known terms rather than a bare opcode number.
+func motorolaProbeLabel(op Opcode) string {
+	switch op {
+	case OpMotorolaTrafficChannelID:
+		return "MOTOROLA_OSP_TRAFFIC_CHANNEL_ID"
+	case OpMotorolaSystemLoading:
+		return "MOTOROLA_OSP_SYSTEM_LOADING"
+	default:
+		return "MOTOROLA_OSP_UNKNOWN"
 	}
 }
 

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -175,6 +175,46 @@ func TestControlChannelIgnoresVendorUnitToUnitRequest(t *testing.T) {
 	}
 }
 
+// TestMotorolaProbeOpcodesAreMapSafe drives the suspected-but-undecoded
+// Motorola opcodes 0x05 and 0x09 (MFID 0x90) through the control channel and
+// checks they inject NOTHING into the system map — no bus event and no
+// neighbour / secondary-CC in the topology snapshot. They are captured for
+// offline analysis only (logVendorProbe) until their layout is confirmed; this
+// guards against anyone wiring a guessed layout into the map.
+func TestMotorolaProbeOpcodesAreMapSafe(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	cc := New(Options{Bus: bus, SystemName: "Moto"})
+
+	for _, op := range []Opcode{0x05, 0x09} {
+		tsbk := TSBK{Opcode: op, MFID: MFIDMotorola,
+			Payload: [8]byte{0x0C, 0x80, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}}
+		cc.Process(buildLockedStreamWithTSBK(10, 0x2C2, DUIDTrunkingSignaling, tsbk), 0)
+	}
+
+	// No grant/patch/unit-request/etc. should be published from these.
+	deadline := time.After(300 * time.Millisecond)
+	for {
+		select {
+		case ev := <-sub.C:
+			switch ev.Kind {
+			case events.KindCCLocked, events.KindSiteUpdate, events.KindDecodeError:
+				// lock/site/decode bookkeeping is fine; only map-data events are forbidden
+			default:
+				t.Fatalf("Motorola probe opcode published a map event: %s", ev.Kind)
+			}
+		case <-deadline:
+			cfg := cc.NetworkSnapshot()
+			if len(cfg.Neighbors) != 0 || len(cfg.Secondary) != 0 {
+				t.Fatalf("probe opcodes leaked into topology: %+v", cfg)
+			}
+			return
+		}
+	}
+}
+
 // TestControlChannelPublishesSiteUpdate drives an RFSS Status Broadcast
 // through the control channel and checks a KindSiteUpdate naming the
 // camped site (with the tuned control-channel frequency) is published

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -175,12 +175,13 @@ func TestControlChannelIgnoresVendorUnitToUnitRequest(t *testing.T) {
 	}
 }
 
-// TestMotorolaProbeOpcodesAreMapSafe drives the suspected-but-undecoded
-// Motorola opcodes 0x05 and 0x09 (MFID 0x90) through the control channel and
-// checks they inject NOTHING into the system map — no bus event and no
-// neighbour / secondary-CC in the topology snapshot. They are captured for
-// offline analysis only (logVendorProbe) until their layout is confirmed; this
-// guards against anyone wiring a guessed layout into the map.
+// TestMotorolaProbeOpcodesAreMapSafe drives the named-but-not-field-decoded
+// Motorola opcodes Traffic Channel ID (0x05) and System Loading (0x09), MFID
+// 0x90, through the control channel and checks they inject NOTHING into the
+// system map — no bus event and no neighbour / secondary-CC in the topology
+// snapshot. Neither reference decoder (SDRtrunk / OP25) field-decodes them, so
+// they are captured for the record only (logVendorProbe); this guards against
+// anyone wiring a guessed layout into the map.
 func TestMotorolaProbeOpcodesAreMapSafe(t *testing.T) {
 	bus := events.NewBus(16)
 	defer bus.Close()
@@ -188,7 +189,7 @@ func TestMotorolaProbeOpcodesAreMapSafe(t *testing.T) {
 	defer sub.Close()
 	cc := New(Options{Bus: bus, SystemName: "Moto"})
 
-	for _, op := range []Opcode{0x05, 0x09} {
+	for _, op := range []Opcode{OpMotorolaTrafficChannelID, OpMotorolaSystemLoading} {
 		tsbk := TSBK{Opcode: op, MFID: MFIDMotorola,
 			Payload: [8]byte{0x0C, 0x80, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC}}
 		cc.Process(buildLockedStreamWithTSBK(10, 0x2C2, DUIDTrunkingSignaling, tsbk), 0)

--- a/internal/radio/p25/phase1/tsbk_vendor.go
+++ b/internal/radio/p25/phase1/tsbk_vendor.go
@@ -42,6 +42,16 @@ const (
 	// OpVendorTalkerAlias carries one fragment of a radio's display
 	// name; emitted under either vendor MFID.
 	OpVendorTalkerAlias Opcode = 0x15
+	// OpMotorolaTrafficChannelID (MOTOROLA_OSP_TRAFFIC_CHANNEL_ID) and
+	// OpMotorolaSystemLoading (MOTOROLA_OSP_SYSTEM_LOADING) are emitted
+	// continuously by Motorola sites. The names are SDRtrunk's; neither it nor
+	// OP25 field-decodes them — SDRtrunk's MotorolaTrafficChannel /
+	// ChannelLoading classes are hex-only stubs, OP25 ignores them — and
+	// neither carries neighbour or secondary-CC data. We name them so the probe
+	// log is meaningful and capture the raw payload, but field-decode nothing
+	// (no trustworthy layout exists). See docs/specs/p25-motorola-opcodes.md.
+	OpMotorolaTrafficChannelID Opcode = 0x05
+	OpMotorolaSystemLoading    Opcode = 0x09
 )
 
 // IsVendorMFID reports whether the TSBK's MFID is a recognised


### PR DESCRIPTION
## Summary

A Discord contact sent a Go parser for two "missing" Motorola opcodes (0x05 "RoamBeacon", 0x09 "ScanMarker"), claiming they carry the neighbours we can't decode. **I did not merge that parser** — and after pulling what the reference decoders actually do, it's confirmed wrong.

### What 0x05 / 0x09 actually are (cross-checked)
| Opcode | SDRtrunk | OP25 (boatbod) | Field-decoded? |
| --- | --- | --- | --- |
| `0x05` | `MOTOROLA_OSP_TRAFFIC_CHANNEL_ID` ("Motorola Traffic Channel") | not handled | **No** — `MotorolaTrafficChannel` is a hex-only stub |
| `0x09` | `MOTOROLA_OSP_SYSTEM_LOADING` ("Motorola System Loading") | not handled | **No** — `ChannelLoading` is an explicit "unknown / under RE" placeholder |

- **Neither carries neighbour or secondary-CC data** — so they are not the missing-neighbours fix (that's the standard `ADJ_STS_BCST` 0x3C, which #728 already decodes under a vendor MFID).
- **No authoritative field layout exists**: OP25 ignores both; SDRtrunk only categorises them by opcode and field-decodes neither. There's nothing trustworthy to "implement from."
- The community parser was fabricated: invented terminology, a `0x09` parser pulling no usable data from `0c80…000`, and a `0x05` layout that's a fresh guess (the standard UU_ANS_REQ layout already gave garbage `src=0`/`target=0x3C0000`, which is why #730 stopped decoding vendor 0x05).

### What this PR does (mirrors the reference decoders)
- **Names** the two opcodes — `OpMotorolaTrafficChannelID` (0x05) / `OpMotorolaSystemLoading` (0x09) — so the diagnostic log reads in SDRtrunk's terms.
- **Captures** their raw payload via `logVendorProbe` (up to 64 samples/opcode at INFO, grep `motorola opcode`) and **field-decodes / publishes nothing** into the system map.
- **Regression test** asserts both inject no bus event and no neighbour/secondary into the topology snapshot.
- **`docs/specs/p25-motorola-opcodes.md`** records the authoritative findings + sources (SDRtrunk `Opcode.java` + `.../motorola/osp/` stubs; OP25 `trunking.py` covers only 0x00–0x03).

## Files
`internal/radio/p25/phase1/{tsbk_vendor.go, control.go, network_test.go}`, `docs/specs/{p25-motorola-opcodes.md, README.md}`, CHANGELOG.

## Testing
`gofmt -l .`, `go build ./...`, `go test ./internal/radio/p25/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q