### PR TITLE
web: group repeated identical events (grants/registration/affiliation) to cut the firehose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Group duplicate events in the Events & CC Activity panels.** A "Group
+  duplicates" toggle (on by default) collapses repeated events with identical
+  content — the same grant / registration / affiliation re-sent every few
+  seconds — into one row with an ×N count and the latest timestamp, so the
+  panels stop spamming. Toggle off for the raw per-event stream.
 - **Motorola opcodes 0x05 / 0x09 (MFID 0x90) named and captured.** Cross-checked
   against SDRtrunk / OP25: 0x05 is `MOTOROLA_OSP_TRAFFIC_CHANNEL_ID`, 0x09 is
   `MOTOROLA_OSP_SYSTEM_LOADING` — neither carries neighbour / secondary-CC data,

--- a/web/src/lib/groupEvents.test.ts
+++ b/web/src/lib/groupEvents.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import type { EventDTO } from "../api/types";
+import { groupEvents, contentKey } from "./groupEvents";
+
+const grant = (tg: number, ts: string): EventDTO => ({
+  kind: "grant",
+  timestamp: ts,
+  payload: { system: "S", group_id: tg, frequency_hz: 451_000_000 },
+});
+
+describe("groupEvents", () => {
+  it("collapses identical events into one entry with a count and latest timestamp", () => {
+    const events = [
+      grant(100, "2026-06-19T05:00:00Z"),
+      grant(100, "2026-06-19T05:00:02Z"),
+      grant(100, "2026-06-19T05:00:05Z"),
+    ];
+    const groups = groupEvents(events);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].count).toBe(3);
+    expect(groups[0].firstTimestamp).toBe("2026-06-19T05:00:00Z");
+    expect(groups[0].lastTimestamp).toBe("2026-06-19T05:00:05Z");
+    // representative is the most recent occurrence
+    expect(groups[0].event.timestamp).toBe("2026-06-19T05:00:05Z");
+  });
+
+  it("keeps events with different payloads separate", () => {
+    const groups = groupEvents([
+      grant(100, "2026-06-19T05:00:00Z"),
+      grant(200, "2026-06-19T05:00:01Z"),
+      grant(100, "2026-06-19T05:00:02Z"),
+    ]);
+    expect(groups).toHaveLength(2);
+    const tg100 = groups.find((g) => (g.event.payload as { group_id: number }).group_id === 100)!;
+    expect(tg100.count).toBe(2);
+  });
+
+  it("orders groups by last occurrence (most-recently-active last)", () => {
+    // tg200 fires last, so it should sort after tg100 even though tg100 appeared first.
+    const groups = groupEvents([
+      grant(100, "2026-06-19T05:00:00Z"),
+      grant(200, "2026-06-19T05:00:01Z"),
+      grant(100, "2026-06-19T05:00:02Z"),
+      grant(200, "2026-06-19T05:00:09Z"),
+    ]);
+    expect(groups.map((g) => (g.event.payload as { group_id: number }).group_id)).toEqual([100, 200]);
+  });
+
+  it("groups regardless of payload key order (stable stringify)", () => {
+    const a: EventDTO = { kind: "registration", timestamp: "t1", payload: { src: 1, system: "S" } };
+    const b: EventDTO = { kind: "registration", timestamp: "t2", payload: { system: "S", src: 1 } };
+    expect(contentKey(a)).toBe(contentKey(b));
+    expect(groupEvents([a, b])).toHaveLength(1);
+  });
+});

--- a/web/src/lib/groupEvents.ts
+++ b/web/src/lib/groupEvents.ts
@@ -1,0 +1,60 @@
+import type { EventDTO } from "../api/types";
+
+// GroupedEvent collapses repeated events with identical content into one entry
+// that carries an occurrence count and the first/last timestamps it was seen.
+export interface GroupedEvent {
+  // Representative occurrence — the most recent one; its timestamp equals
+  // lastTimestamp, so existing newest-first views keep working unchanged.
+  event: EventDTO;
+  count: number;
+  firstTimestamp: string;
+  lastTimestamp: string;
+}
+
+// stableStringify produces a deterministic JSON string (object keys sorted
+// recursively) so two payloads with identical content but different key order
+// still collapse into the same group.
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+// contentKey identifies an event by kind + payload content (ignoring its
+// timestamp), so the spammy repeats — grants, registrations, affiliations re-
+// emitted with identical fields — share one key. Event kinds contain no spaces,
+// so a space cleanly separates the kind from the serialized payload.
+export function contentKey(ev: EventDTO): string {
+  return `${ev.kind} ${stableStringify(ev.payload ?? null)}`;
+}
+
+// groupEvents collapses events with identical kind + payload into a single
+// entry carrying an occurrence count and the first/last timestamps. Input is
+// assumed chronological (oldest→newest, as the store ring holds it); the output
+// preserves that order keyed on each group's LAST occurrence, so a caller that
+// reverse()s for a newest-first view shows the most-recently-active group on
+// top (a still-firing grant stays live rather than sinking).
+export function groupEvents(events: EventDTO[]): GroupedEvent[] {
+  const byKey = new Map<string, GroupedEvent>();
+  for (const ev of events) {
+    const key = contentKey(ev);
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.event = ev; // most-recent representative
+      existing.lastTimestamp = ev.timestamp;
+      byKey.delete(key); // re-insert to move to the most-recent position
+      byKey.set(key, existing);
+    } else {
+      byKey.set(key, {
+        event: ev,
+        count: 1,
+        firstTimestamp: ev.timestamp,
+        lastTimestamp: ev.timestamp,
+      });
+    }
+  }
+  return Array.from(byKey.values());
+}

--- a/web/src/panels/CCActivity.test.tsx
+++ b/web/src/panels/CCActivity.test.tsx
@@ -89,6 +89,20 @@ describe("CCActivity panel", () => {
     expect(row!.textContent).toMatch(/EMERG/);
   });
 
+  it("collapses repeated identical grants into one row with a count (grouped by default)", () => {
+    const grant = (ts: string) => ({
+      kind: "grant",
+      timestamp: ts,
+      payload: { system: "Metro P25", protocol: "p25", group_id: 1234, frequency_hz: 851_012_500 },
+    });
+    setEvents([grant("2026-05-26T12:00:00Z"), grant("2026-05-26T12:00:03Z"), grant("2026-05-26T12:00:07Z")]);
+    renderPanel();
+    const rows = screen.getAllByText("Metro P25").map((el) => el.closest("tr"));
+    // Three identical grants collapse to a single row carrying ×3.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.textContent).toMatch(/×3/);
+  });
+
   it("renders affiliation events with response code", () => {
     setEvents([
       {

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useShared } from "../store/shared";
+import { groupEvents } from "../lib/groupEvents";
 import type { EventDTO, TalkgroupDTO } from "../api/types";
 
 // CC Activity panel — a focused view of the trunked control-channel
@@ -42,6 +43,8 @@ interface Row {
   // the surrounding text.
   details: React.ReactNode;
   raw: unknown;
+  // count > 1 when "group duplicates" collapsed N identical events into this row.
+  count?: number;
 }
 
 // ridLink renders an inline link to the per-RID detail page, styled
@@ -65,12 +68,20 @@ export function CCActivity() {
   const [paused, setPaused] = useState(false);
   const [systemFilter, setSystemFilter] = useState("");
   const [kindFilter, setKindFilter] = useState<string>("");
+  // Collapse repeated identical events (e.g. the same grant re-sent every few
+  // seconds) into one row with an ×N count and the latest timestamp, to cut the
+  // firehose. On by default; toggle off for a raw per-event view.
+  const [grouped, setGrouped] = useState(true);
 
   const rows = useMemo<Row[]>(() => {
     const tgByID = new Map<number, TalkgroupDTO>();
     for (const tg of talkgroups) tgByID.set(tg.id, tg);
     const list: Row[] = [];
-    for (const ev of events) {
+    const source = grouped
+      ? groupEvents(events)
+      : events.map((e) => ({ event: e, count: 1 }));
+    for (const g of source) {
+      const ev = g.event;
       const label = CC_KINDS[ev.kind];
       if (!label) continue;
       const row = renderRow(ev, label, tgByID);
@@ -79,11 +90,11 @@ export function CCActivity() {
         continue;
       }
       if (kindFilter && ev.kind !== kindFilter) continue;
-      list.push(row);
+      list.push(g.count > 1 ? { ...row, count: g.count } : row);
     }
-    // Newest first.
+    // Newest (most-recently-active) first.
     return list.reverse();
-  }, [events, talkgroups, systemFilter, kindFilter]);
+  }, [events, talkgroups, systemFilter, kindFilter, grouped]);
 
   // Pause must actually freeze the table so an operator can read/click a row
   // without it churning under them: snapshot rows at the moment of pausing and
@@ -119,6 +130,15 @@ export function CCActivity() {
             value={systemFilter}
             onChange={(e) => setSystemFilter(e.target.value)}
           />
+          <button
+            type="button"
+            className="px-2 py-1 rounded border border-border text-xs"
+            onClick={() => setGrouped(!grouped)}
+            aria-pressed={grouped}
+            title="Collapse repeated identical events into one row with a count"
+          >
+            {grouped ? "▦ grouped" : "≡ all"}
+          </button>
           <button
             type="button"
             className="px-2 py-1 rounded border border-border text-xs"
@@ -160,7 +180,17 @@ export function CCActivity() {
                   <td className="px-3 py-1 font-mono text-muted">
                     {formatTime(r.ts)}
                   </td>
-                  <td className="px-3 py-1">{r.label}</td>
+                  <td className="px-3 py-1">
+                    {r.label}
+                    {r.count && r.count > 1 ? (
+                      <span
+                        className="ml-1 px-1 rounded bg-surface text-muted text-[10px] font-mono"
+                        title={`${r.count} identical events collapsed`}
+                      >
+                        ×{r.count}
+                      </span>
+                    ) : null}
+                  </td>
                   <td className="px-3 py-1 font-mono text-accent">{r.system || "—"}</td>
                   <td className="px-3 py-1">{r.details}</td>
                 </tr>

--- a/web/src/panels/Events.tsx
+++ b/web/src/panels/Events.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { Column, DataTable } from "../components/DataTable";
 import type { EventDTO } from "../api/types";
 import { useShared } from "../store/shared";
+import { contentKey, groupEvents, type GroupedEvent } from "../lib/groupEvents";
 
 // Events renders the live ring buffer the WebSocket stream populates
 // into the shared store. No polling — the stream pushes everything;
@@ -17,6 +18,9 @@ export function Events() {
   // autoFrozen records that the freeze was triggered by expanding a row (so we
   // resume on collapse), as opposed to a manual Pause the operator wants kept.
   const [autoFrozen, setAutoFrozen] = useState(false);
+  // Collapse repeated identical events (same kind + payload) into one row with
+  // an ×N count and the latest timestamp, to cut the firehose. On by default.
+  const [grouped, setGrouped] = useState(true);
 
   // When paused, freeze the table at the snapshot the user paused on;
   // when running, mirror the live store ring.
@@ -33,36 +37,54 @@ export function Events() {
     );
   }, [visible, filter]);
 
-  // Newest events first — reverse so the latest is at the top, the
-  // mobile-friendly read order.
-  const ordered = useMemo(() => filtered.slice().reverse(), [filtered]);
+  // Group identical events (when enabled), then newest (most-recently-active)
+  // first — reverse so the latest is at the top, the mobile-friendly read order.
+  const ordered = useMemo<GroupedEvent[]>(() => {
+    const groups = grouped
+      ? groupEvents(filtered)
+      : filtered.map((e) => ({
+          event: e,
+          count: 1,
+          firstTimestamp: e.timestamp,
+          lastTimestamp: e.timestamp,
+        }));
+    return groups.slice().reverse();
+  }, [filtered, grouped]);
 
-  const columns: Column<EventDTO>[] = useMemo(
+  const columns: Column<GroupedEvent>[] = useMemo(
     () => [
       {
         key: "ts",
         header: "Time",
-        render: (r) => (
+        render: (g) => (
           <span className="font-mono text-xs text-muted whitespace-nowrap">
-            {r.timestamp.replace("T", " ").replace(/\..*$/, "")}
+            {g.event.timestamp.replace("T", " ").replace(/\..*$/, "")}
+            {g.count > 1 ? (
+              <span
+                className="ml-1 px-1 rounded bg-surface text-fg/70 text-[10px]"
+                title={`${g.count} identical events (since ${g.firstTimestamp})`}
+              >
+                ×{g.count}
+              </span>
+            ) : null}
           </span>
         ),
-        sort: (a, b) => a.timestamp.localeCompare(b.timestamp),
+        sort: (a, b) => a.event.timestamp.localeCompare(b.event.timestamp),
       },
       {
         key: "kind",
         header: "Kind",
-        render: (r) => (
-          <span className="font-mono text-accent">{r.kind}</span>
+        render: (g) => (
+          <span className="font-mono text-accent">{g.event.kind}</span>
         ),
-        sort: (a, b) => a.kind.localeCompare(b.kind),
+        sort: (a, b) => a.event.kind.localeCompare(b.event.kind),
       },
       {
         key: "preview",
         header: "Payload",
-        render: (r) => (
+        render: (g) => (
           <span className="text-xs font-mono text-muted truncate inline-block max-w-[28ch] sm:max-w-[60ch]">
-            {previewPayload(r.payload)}
+            {previewPayload(g.event.payload)}
           </span>
         ),
       },
@@ -87,7 +109,7 @@ export function Events() {
   // Expanding a row to inspect it auto-freezes the live stream so the row
   // doesn't scroll away as new events prepend (the whole point of "looking at
   // an event"); collapsing it resumes — unless the operator had paused manually.
-  function handleRowClick(_r: EventDTO, key: string) {
+  function handleRowClick(_g: GroupedEvent, key: string) {
     const collapsing = expanded === key;
     setExpanded(collapsing ? null : key);
     if (collapsing) {
@@ -133,6 +155,14 @@ export function Events() {
           aria-label="Filter events"
         />
         <button
+          className={grouped ? "btn-primary" : "btn-ghost"}
+          onClick={() => setGrouped(!grouped)}
+          aria-pressed={grouped}
+          title="Collapse repeated identical events into one row with a count"
+        >
+          {grouped ? "Grouped" : "All"}
+        </button>
+        <button
           className={paused ? "btn-primary" : "btn-ghost"}
           onClick={togglePause}
           aria-pressed={paused}
@@ -152,11 +182,14 @@ export function Events() {
       <DataTable
         rows={ordered}
         columns={columns}
-        rowKey={(r, i) => `${r.timestamp}-${r.kind}-${i}`}
+        rowKey={(g, i) => `${contentKey(g.event)}-${i}`}
         onRowClick={handleRowClick}
-        renderExpansion={(r) => (
+        renderExpansion={(g) => (
           <pre className="whitespace-pre-wrap break-words font-mono text-xs text-fg/80">
-            {JSON.stringify(r, null, 2)}
+            {g.count > 1
+              ? `// seen ${g.count}× — first ${g.firstTimestamp}, last ${g.lastTimestamp}\n`
+              : ""}
+            {JSON.stringify(g.event, null, 2)}
           </pre>
         )}
         expandedKey={expanded}


### PR DESCRIPTION
## Summary

The Events and CC Activity panels spam identical rows when a system re-sends the same **grant** (and **registration** / **affiliation**) every few seconds. This adds a **"Group duplicates"** toggle (on by default) that collapses events with identical content into one row.

### Behavior
- Events with the same **kind + payload** (timestamp ignored) collapse into a single row showing an **×N count** and the **latest timestamp**.
- A still-firing group bumps to the top (keyed on its last occurrence), so an active grant stays visible instead of scrolling away.
- Toggle **off** ("All") for the raw per-event view.
- In the Events panel, expanding a grouped row shows `// seen N× — first … last …` above the payload JSON.

### Implementation
- New shared `web/src/lib/groupEvents.ts` — `groupEvents()` + `contentKey()` with deterministic (key-sorted) payload stringify so identical payloads with different key order still group.
- `CCActivity.tsx` — group the row source, `×N` badge, "grouped/all" toggle (default on).
- `Events.tsx` — render `GroupedEvent` rows in the DataTable (ungrouped = groups of 1), `×N` badge, "Grouped/All" toggle (default on). Freeze-on-inspect (#731) still works.
- Tests: `groupEvents` unit tests + a CC Activity test asserting 3 identical grants collapse to one ×3 row.

## Testing
`npm run build` (tsc + vite) clean; full `vitest` — 36 files / 218 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q

---
_Generated by [Claude Code](https://claude.ai/code/session_019Yuza2zJxbvepigspYRK1q)_