### PR TITLE
radioreference: treat feed-provider/admin accounts as premium (#723)

### DIFF
--- a/internal/radioreference/verify.go
+++ b/internal/radioreference/verify.go
@@ -56,11 +56,17 @@ func (c *Client) VerifyCredentials(ctx context.Context) (Account, error) {
 // subscriptionActive reports whether an RR expiry timestamp is in the future.
 // RR returns dates like "2025-12-31 00:00:00" or "2025-12-31" (and some
 // accounts a UNIX-seconds value); unparseable or empty values are treated as
-// "not premium".
+// "not premium". Feed Provider and Admin accounts keep premium for as long as
+// their feed is active, so RR reports their expiry as the sentinel strings
+// "Never - Feed Provider" / "Never - Admin" rather than a date — those count
+// as active.
 func subscriptionActive(expires string) bool {
 	expires = strings.TrimSpace(expires)
 	if expires == "" {
 		return false
+	}
+	if strings.HasPrefix(strings.ToLower(expires), "never") {
+		return true
 	}
 	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02T15:04:05", "2006-01-02", time.RFC3339} {
 		if t, err := time.Parse(layout, expires); err == nil {

--- a/internal/radioreference/verify_test.go
+++ b/internal/radioreference/verify_test.go
@@ -59,6 +59,26 @@ func TestVerifyCredentials_Expired(t *testing.T) {
 	}
 }
 
+func TestVerifyCredentials_FeedProvider(t *testing.T) {
+	// Feed Provider / Admin accounts have no expiry date — RR reports the
+	// subscription as the sentinel "Never - Feed Provider" / "Never - Admin".
+	for _, sentinel := range []string{"Never - Feed Provider", "Never - Admin"} {
+		t.Run(sentinel, func(t *testing.T) {
+			c := verifyClient(t, soapEnvelope(`<username>carol</username><subExpireDate>`+sentinel+`</subExpireDate>`))
+			acct, err := c.VerifyCredentials(context.Background())
+			if err != nil {
+				t.Fatalf("VerifyCredentials: %v", err)
+			}
+			if !acct.Premium {
+				t.Errorf("expected Premium=true for %q, got %+v", sentinel, acct)
+			}
+			if acct.Username != "carol" {
+				t.Errorf("Username = %q, want carol", acct.Username)
+			}
+		})
+	}
+}
+
 func TestVerifyCredentials_Fault(t *testing.T) {
 	fault := `<?xml version="1.0"?><SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">` +
 		`<SOAP-ENV:Body><SOAP-ENV:Fault><faultstring>Invalid username or password</faultstring></SOAP-ENV:Fault>` +


### PR DESCRIPTION
RR's getUserData returns subExpireDate as the sentinel strings
"Never - Feed Provider" / "Never - Admin" for accounts that hold
premium for as long as their feed is active. subscriptionActive only
parsed dates/UNIX timestamps, so these non-date values fell through to
false and the verify flow reported "no active premium subscription"
despite a valid premium account. Treat a "Never..." expiry as active.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TT7XPG6Rq8WpCuFeoBQTm4