### PR TITLE
docs: post-release v0.4.7 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.4.7] — 2026-06-19
+
+This release sharpens **P25 discovery accuracy** and **identity corroboration**.
+Status-broadcast identity (WACN / System ID / RFSS / Site) is now resolved by
+majority vote instead of last-write-wins, so a single corrupt-but-CRC-passing
+TSBK can no longer poison the system map; the always-standard band-plan /
+network / site opcodes are decoded even when a Motorola trunk sends them under
+the vendor MFID (#728); registration and affiliation events carry `rfss_id` /
+`site_id` / `nac` for a genuine RID→site fix (#698); and a new opt-in
+streaming long-dwell control-channel monitor watches a site for minutes
+without recording gigabytes of IQ (#722). Encrypted-call handling moves to a
+per-system policy and `metadata` mode now releases the voice tuner the moment
+the talker alias completes (#711). New **autotune** tracks each dongle's
+carrier error and digitally corrects it (#729), the web console gains a
+group-duplicate-events toggle, a freeze-while-inspecting stream, and a fixed CC
+Activity pause, and a RadioReference fix recognises feed-provider / admin
+accounts as premium (#723). On the docs side: a new "Intro to Software Dev"
+learning path (#725).
+
 ### Added
 - **Group duplicate events in the Events & CC Activity panels.** A "Group
   duplicates" toggle (on by default) collapses repeated events with identical
@@ -20,29 +39,6 @@ for tagged releases.
   raw payload is logged at INFO (up to 64 samples each, grep `motorola opcode`)
   while decoding/publishing nothing into the system map. See
   [`docs/specs/p25-motorola-opcodes.md`](docs/specs/p25-motorola-opcodes.md).
-
-### Changed
-- **P25 TSBK opcodes now log with their TIA-102.AABC-D designations**
-  (`UU_ANS_REQ`, `NET_STS_BCST`, `GRP_V_CH_GRANT`, …) instead of the
-  OP25-derived names. The Go identifiers stay descriptive; `Opcode.String()`
-  and a new [`docs/specs/p25-tsbk-opcodes.md`](docs/specs/p25-tsbk-opcodes.md)
-  carry the canonical mnemonics (mirrors the NXDN package convention).
-
-### Fixed
-- **UU_ANS_REQ (opcode 0x05) is no longer mis-decoded under a vendor MFID.**
-  A Motorola (MFID 0x90) 0x05 decoded with the standard Target/Source layout
-  produced garbage radio IDs (`src=0`, `target=0x3C0000`); it is now left
-  unhandled (vendor namespace), while the standard-MFID UU_ANS_REQ still
-  publishes a `unit.request` event.
-- **CC Activity "pause" now actually freezes the table.** Previously it
-  re-sliced the live rows, so the list kept churning and an event was
-  impossible to read or click; it now snapshots the rows on pause.
-- **Systems detail no longer mislabels missing network identity as "Scanner
-  offline".** WACN/System ID/RFSS/Site are decoded live from status broadcasts
-  whenever the control channel is received, so an empty cell now reads
-  "Awaiting status broadcasts" (or "Hunting control channel" during a hunt).
-
-### Added
 - **Autotune — per-dongle carrier-error correction** (opt-in, `sdr.autotune`).
   Ported in concept from trunk-recorder's autotune. Each SDR's crystal error
   shifts the received carrier off-centre; with autotune on, the daemon watches
@@ -72,8 +68,21 @@ for tagged releases.
   (MFID 0x90) forms — and published as a new `unit.request` bus event carrying
   the calling/called radio IDs, surfaced on the web CC-activity panel and the
   message log instead of being logged as an unhandled vendor TSBK.
+- **"Intro to Software Dev" learning path** (#725). A third structured path
+  under `/learn/` — 7 modules / 40 lessons plus a glossary — covering software
+  development from a brief history through languages, principles, design
+  patterns, development systems, choosing a language, and building a solo
+  developer stack, with examples carrying a subtle RF/SDR slant. Joins the
+  existing RF & SDR and Git & GitHub paths in the shared data-driven Jekyll
+  system, so the chooser, hub, lesson nav, and `llms.txt` pick it up
+  automatically.
 
 ### Changed
+- **P25 TSBK opcodes now log with their TIA-102.AABC-D designations**
+  (`UU_ANS_REQ`, `NET_STS_BCST`, `GRP_V_CH_GRANT`, …) instead of the
+  OP25-derived names. The Go identifiers stay descriptive; `Opcode.String()`
+  and a new [`docs/specs/p25-tsbk-opcodes.md`](docs/specs/p25-tsbk-opcodes.md)
+  carry the canonical mnemonics (mirrors the NXDN package convention).
 - **Encrypted-call handling is now per-system** (#711). The `encrypted_calls`
   policy (`mode` + `metadata_follow_ms`) moved from the global
   `trunking.encrypted_calls` key to per-system `trunking.systems[].encrypted_calls`,
@@ -91,6 +100,26 @@ for tagged releases.
   bound rather than a fixed wall-clock hold.
 
 ### Fixed
+- **UU_ANS_REQ (opcode 0x05) is no longer mis-decoded under a vendor MFID.**
+  A Motorola (MFID 0x90) 0x05 decoded with the standard Target/Source layout
+  produced garbage radio IDs (`src=0`, `target=0x3C0000`); it is now left
+  unhandled (vendor namespace), while the standard-MFID UU_ANS_REQ still
+  publishes a `unit.request` event.
+- **CC Activity "pause" now actually freezes the table.** Previously it
+  re-sliced the live rows, so the list kept churning and an event was
+  impossible to read or click; it now snapshots the rows on pause.
+- **Events stream freezes while inspecting an event.** Opening an event for
+  inspection no longer lets the live stream churn underneath the selection, so
+  the row you clicked stays put until you dismiss it.
+- **Systems detail no longer mislabels missing network identity as "Scanner
+  offline".** WACN/System ID/RFSS/Site are decoded live from status broadcasts
+  whenever the control channel is received, so an empty cell now reads
+  "Awaiting status broadcasts" (or "Hunting control channel" during a hunt).
+- **Systems detail modal no longer crashes on a null systems list** (#721).
+  Clicking a system crashed with "Cannot read properties of null (reading
+  'find')" whenever the scanner reported no active control-channel hunt
+  statuses (the daemon marshals an empty hunt list as JSON `null`); the optional
+  chain now guards the systems list too (`scanner?.systems?.find`).
 - **Hunt progress frequency precision.** The identifying-phase progress line
   rounded the tuned frequency to 3 decimals (showing a 6.25 kHz-raster channel
   like 160.5875 MHz as "160.588"); it now prints 4 decimals, matching the rest
@@ -112,6 +141,12 @@ for tagged releases.
   recognised and its raw payload surfaced once at INFO, so its (site-specific)
   layout can be validated off-air; neighbor/voice frequencies continue to
   resolve through the configured band-plan resolver / LCN learner.
+- **RadioReference feed-provider / admin accounts now recognised as premium**
+  (#723). `getUserData` returns the sentinel strings `"Never - Feed Provider"` /
+  `"Never - Admin"` as the subscription expiry for accounts that hold premium
+  for as long as their feed is active; the parser only handled dates / UNIX
+  timestamps, so these fell through to "no active premium subscription". A
+  `"Never…"` expiry is now treated as active.
 
 ## [v0.4.6] — 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.4.6
+VERSION=v0.4.7
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.4.6" -%}
+  {%- assign ver = "v0.4.7" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.4.7.md
+++ b/docs/announcements/v0.4.7.md
@@ -1,0 +1,55 @@
+# GopherTrunk v0.4.7 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.4.7 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.7
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.4.7 — P25 discovery gets majority-vote identity (no more poisoning from one corrupt TSBK), standard opcodes decoded even under a Motorola vendor MFID, site identity on registration/affiliation events, a streaming long-dwell CC monitor, per-system encrypted-call handling, and new per-dongle autotune
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.4.7 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.4.6:**
+
+* **P25 identity is now majority-voted** — status-broadcast accumulation was last-write-wins, so one corrupt-but-CRC-passing TSBK could poison WACN / System ID. Identity is now resolved by majority vote across observations, and neighbors / band-plan slots surface on first sighting to match OP25's latency.
+* **Standard opcodes decoded under a Motorola vendor MFID** (#728) — on some Motorola trunks the band-plan / network / site opcodes (IDEN, RFSS, Network Status, Adjacent Site) arrive under MFID 0x90 and were being dropped, so WACN / System ID / neighbors stayed empty even with the CC locked. These always-standard opcodes now decode regardless of MFID.
+* **Site identity on registration & affiliation events** (#698) — `unit_registration` and `affiliation` events now carry `rfss_id` / `site_id` / `nac`, giving a genuine RID→serving-site fix that wide-area grant-site can't. Phase 2 control channels also discover sites into `/api/v1/sites`.
+* **Streaming long-dwell control-channel monitor** (#722, opt-in) — a new `monitor_seconds` decodes a locked CC from the live SDR in real time instead of buffering the whole dwell, so a P25 site can be watched for minutes without recording gigabytes of IQ. Converge-and-stop once identity/neighbors/band-plan settle.
+* **Per-system encrypted-call handling + alias short-circuit** (#711) — `encrypted_calls` (`follow` / `metadata` / `ignore`) moved to per-system config, and `metadata` mode now releases the voice tuner the instant the talker alias completes instead of holding for the full window. (Breaking: a global `trunking.encrypted_calls` block must move under the relevant `trunking.systems[]` entry.)
+* **Per-dongle autotune** (#729, opt-in `sdr.autotune`) — watches each SDR's residual carrier offset and shifts its digital down-converter so the demod's AFC starts near lock, never touching the hardware ppm (it logs a suggested value instead).
+* Plus a group-duplicate-events toggle and freeze-while-inspecting in the web console, a fixed CC Activity pause, the P25 Unit-to-Unit Answer Request decode, a RadioReference fix that recognises feed-provider / admin accounts as premium (#723), and a new "Intro to Software Dev" learning path (#725).
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.7
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.4.7 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.4.6:**
+- **Majority-voted P25 identity** — one corrupt-but-CRC-passing TSBK can no longer poison WACN / System ID; neighbors/band-plan surface on first sighting.
+- **Standard opcodes under a Motorola vendor MFID** (#728) — IDEN / RFSS / Network Status / Adjacent Site now decode even when sent under MFID 0x90.
+- **Site identity on registration & affiliation** (#698) — events carry `rfss_id` / `site_id` / `nac` for a real RID→serving-site fix; Phase 2 discovers sites too.
+- **Streaming long-dwell CC monitor** (#722) — watch a P25 site for minutes from the live SDR without recording gigabytes of IQ; converge-and-stop.
+- **Per-system encrypted-call handling + alias short-circuit** (#711) — `follow` / `metadata` / `ignore` per system; `metadata` frees the tuner the moment the alias completes. (Breaking: global block moves under `trunking.systems[]`.)
+- **Per-dongle autotune** (#729) — digitally corrects each SDR's carrier error so the demod starts near lock; never rewrites hardware ppm.
+- Plus group-duplicate-events + freeze-while-inspecting in the web UI, fixed CC Activity pause, P25 UU Answer Request decode, RadioReference feed-provider/admin → premium (#723), and an "Intro to Software Dev" learning path (#725).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.7>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow tagged v0.4.7, so sync the docs to match:

- CHANGELOG: promote [Unreleased] to [v0.4.7] (2026-06-19) with a release
  summary, consolidate the per-PR Added/Changed/Fixed blocks that had
  accumulated under one [Unreleased] heading into a single set, and backfill
  the user-visible changes that shipped without a changelog entry — the new
  "Intro to Software Dev" learning path (#725), the Systems detail modal
  crash on a null systems list (#721), and RadioReference feed-provider /
  admin accounts now recognised as premium (#723). A fresh empty
  [Unreleased] block sits above the versioned heading.
- README: bump the Linux quick-install VERSION to v0.4.7.
- latest-version.html: bump the GitHub Pages fallback tag to v0.4.7.
- announcements: add the v0.4.7 social blurb drafts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SURZnt7LZ1oMjiQo4dUmkB