### PR TITLE
docs: add Digital & Trunked Radio learning path

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -83,6 +83,14 @@ defaults:
       learn_path: intro-software-dev
       nav_group: Learn
       permalink: /learn/intro-software-dev/:basename/
+  - scope:
+      path: "learn/digital-trunking"
+      type: pages
+    values:
+      layout: lesson
+      learn_path: digital-trunking
+      nav_group: Learn
+      permalink: /learn/digital-trunking/:basename/
   # Encyclopedia articles under /reference/ get the reference layout and nav
   # group automatically. The hub (reference/index.md) overrides to reference-hub.
   - scope:

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -796,3 +796,245 @@ paths:
       minutes: 12
       level: beginner
       status: full
+
+  - id: digital-trunking
+    label: "Digital & Trunked Radio"
+    title: "Learn Digital & Trunked Radio — from analog roots to decoding every system"
+    tagline: "How land-mobile radio went digital and learned to share channels — the history, the end-to-end signal chain, and every trunking system GopherTrunk follows."
+    start_slug: why-radio-went-digital
+    workload: "PT7H"
+    intro: >
+      Public-safety and commercial radio quietly went through two revolutions:
+      trunking, which lets a whole fleet share a handful of frequencies, and the
+      jump from analog to digital voice. This path tells that story from the
+      start, then walks the digital signal end to end — vocoder, modulation,
+      framing, control channel — before taking each trunking system in turn:
+      P25, DMR, TETRA, NXDN, Motorola, EDACS, LTR, MPT-1327 and friends. You
+      finish able to recognise a system on the waterfall and follow it in
+      GopherTrunk. New to radio? Skim the RF & SDR path first; this one assumes
+      only the basics.
+    modules:
+      - id: history
+        label: "Module 1 — A Brief History of Trunked & Digital Radio"
+        blurb: "How we got here: from one-frequency-per-fleet, to shared trunked channels, to the digital standards that run public safety today."
+        lessons:
+          - slug: why-radio-went-digital
+            title: Why radio went digital
+            summary: The analog two-way era, the problems it ran into — congestion, privacy, capacity — and the pressures that pushed radio toward digital.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: birth-of-trunking
+            title: "The birth of trunking: sharing channels"
+            summary: How automatic channel-sharing replaced fixed frequencies, and why one control channel changed everything about scanning.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: analog-trunking-era
+            title: "The analog trunking era: SmartNet, EDACS, LTR & MPT-1327"
+            summary: The first big trunked systems were analog voice with digital control — the architectures that still shape digital trunking today.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: the-digital-leap
+            title: "The digital leap: P25, TETRA & DMR are born"
+            summary: How three regions answered the same question differently, giving us the digital trunking standards in use across the world.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: standards-and-bodies
+            title: "Standards & who sets them: APCO, ETSI, TIA & the DMRA"
+            summary: Why open standards matter for interoperability, who writes them, and how to read a spec number when you meet one.
+            minutes: 7
+            level: beginner
+            status: full
+
+      - id: digital-radio
+        label: "Module 2 — Digital Radio End-to-End"
+        blurb: "The complete digital chain: turning a voice into bits, putting bits on a carrier, protecting them from errors, and packing many calls onto one channel."
+        lessons:
+          - slug: analog-vs-digital-voice
+            title: Analog vs. digital voice
+            summary: What actually changes when voice goes digital — the trade of graceful static for a clean signal that drops off a cliff.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: voice-to-bits-vocoders
+            title: "From voice to bits: vocoders"
+            summary: How IMBE and AMBE+2 squeeze speech into a few kbps, why every digital system needs one, and what that means for decoding.
+            minutes: 9
+            level: advanced
+            status: full
+          - slug: digital-modulation-for-trunking
+            title: "Digital modulation for trunking: C4FM, π/4-DQPSK & CQPSK"
+            summary: The handful of modulations digital trunking actually uses, how to spot each on a constellation, and why P25 picked two of them.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: framing-fec-interleaving
+            title: "Framing, error correction & interleaving"
+            summary: Why raw bits are never sent bare — how frames, FEC, and interleaving let a decoder rebuild a message through fading and noise.
+            minutes: 9
+            level: advanced
+            status: full
+          - slug: tdma-vs-fdma
+            title: "TDMA vs. FDMA: fitting more calls on a channel"
+            summary: Time slots vs. separate frequencies — the capacity trick behind P25 Phase 2 and DMR, and how it changes what you decode.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: the-control-channel
+            title: "The control channel: the system's heartbeat"
+            summary: A frequency that carries only data — what it broadcasts, why it never stops, and why decoding it is the whole game.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: how-trunking-works
+        label: "Module 3 — How Trunking Works"
+        blurb: "The mechanics every trunked system shares: talkgroups, affiliation, the request-grant-release dance, multi-site coverage, and encryption."
+        lessons:
+          - slug: conventional-vs-trunked
+            title: Conventional vs. trunked radio
+            summary: Fixed frequencies vs. channels assigned on demand — the core difference, and why a trunked system can't be scanned the old way.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: talkgroups-ids-affiliation
+            title: "Talkgroups, radio IDs & affiliation"
+            summary: The virtual channels you actually follow, the unit IDs behind them, and how radios register with the system over the air.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: anatomy-of-a-call
+            title: "Anatomy of a trunked call: request, grant, release"
+            summary: One call from keyup to hang-time, step by step — the exact sequence a control-channel decoder watches unfold.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: control-channel-signaling
+            title: "Control-channel signaling: what the data says"
+            summary: Inside the message stream — grants, updates, registrations, and system parameters — and how a tracker turns it into a live map.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: trunking-flavors
+            title: "Trunking flavors: dedicated vs. distributed, message vs. transmission"
+            summary: The design choices that distinguish systems — where the control data lives and how long a channel stays assigned.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: sites-simulcast-roaming
+            title: "Sites, simulcast & roaming: multi-site systems"
+            summary: How a system covers a whole region with many sites, what simulcast is, and why both matter when you pick a control channel.
+            minutes: 9
+            level: advanced
+            status: full
+          - slug: encryption-and-authentication
+            title: Encryption & authentication
+            summary: Why some talkgroups go silent, how encryption is signaled, what GopherTrunk can and can't do, and how radios prove who they are.
+            minutes: 8
+            level: intermediate
+            status: full
+
+      - id: p25-dmr
+        label: "Module 4 — P25 & DMR: The Dominant Systems"
+        blurb: "The two digital trunking standards you'll meet most — examined in depth, from frame structure to the way GopherTrunk follows them."
+        lessons:
+          - slug: p25-phase-1
+            title: P25 Phase 1
+            summary: The North American public-safety standard — C4FM, 9600 bps, IMBE voice, and the control-channel messages that drive it.
+            minutes: 12
+            level: intermediate
+            status: full
+          - slug: p25-phase-2
+            title: "P25 Phase 2: TDMA"
+            summary: Doubling capacity with two-slot TDMA and the AMBE+2 vocoder — how Phase 2 differs from Phase 1 on the air and in the decoder.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: dmr-tier-2-3
+            title: "DMR: Tier II & Tier III"
+            summary: The ETSI two-slot TDMA standard — conventional repeaters vs. full Tier III trunking, and what GopherTrunk reads from each.
+            minutes: 11
+            level: intermediate
+            status: full
+
+      - id: other-systems
+        label: "Module 5 — Other Digital Systems You'll Meet"
+        blurb: "The rest of the landscape GopherTrunk decodes — from European TETRA to legacy LTR, and the amateur digital voice modes in between."
+        lessons:
+          - slug: tetra
+            title: TETRA
+            summary: Europe's public-safety standard — four-slot TDMA, π/4-DQPSK, and why it sounds and looks unlike anything in North America.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: nxdn
+            title: NXDN
+            summary: The narrow 4FSK system from Icom and Kenwood — NXDN48/96, its control channel, and where you'll run into it.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: motorola-smartnet
+            title: "Motorola SmartNet / SmartZone & Type II"
+            summary: The analog-trunking giant — Type II fleet/subfleet IDs, SmartZone multi-site, and why so much of it is still on the air.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: edacs-ltr-mpt1327
+            title: "EDACS, LTR & MPT-1327"
+            summary: Three legacy trunking families — sub-audible LTR, GE/Ericsson EDACS, and the British MPT-1327 standard — and how to recognise them.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: dpmr-dstar-ysf
+            title: "dPMR, D-STAR & System Fusion"
+            summary: The lighter digital modes — dPMR's NXDN cousin, plus the amateur-radio voice standards D-STAR and Yaesu System Fusion.
+            minutes: 7
+            level: beginner
+            status: full
+
+      - id: gophertrunk
+        label: "Module 6 — Decoding Digital Trunking with GopherTrunk"
+        blurb: "Everything applied: spot a system on the waterfall, find its control channel, follow every call, and fix it when the lock won't hold."
+        lessons:
+          - slug: identifying-the-system
+            title: Identifying what you're hearing
+            summary: Reading bandwidth, symbol rate, and the waterfall to tell P25 from DMR from NXDN — before you ever decode a bit.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: finding-the-control-channel
+            title: Finding the control channel
+            summary: Using Hunt, online databases, and the data burst's telltale signature to lock the one frequency that maps the whole system.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: following-a-system-end-to-end
+            title: Following a system end to end
+            summary: The full GopherTrunk path for a trunked call — control channel in, talkgroup grant, voice channel tuned, audio out.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: multisite-and-simulcast-in-practice
+            title: Multi-site & simulcast in practice
+            summary: Choosing the right site, surviving simulcast distortion, and what to do when the system spans more than you can hear.
+            minutes: 9
+            level: advanced
+            status: full
+          - slug: troubleshooting-a-decode
+            title: Troubleshooting a digital decode
+            summary: A checklist for the usual culprits — gain, PPM, the wrong control channel, encryption, simulcast — when a system won't decode.
+            minutes: 9
+            level: advanced
+            status: full
+
+    # Standalone reference, not part of the sequential path (no prev/next slot).
+    glossary:
+      slug: glossary
+      title: Glossary of digital & trunked radio terms
+      summary: Plain-language definitions for every term in the learning path, cross-linked to the lessons.
+      minutes: 12
+      level: beginner
+      status: full

--- a/docs/learn/digital-trunking/analog-trunking-era.md
+++ b/docs/learn/digital-trunking/analog-trunking-era.md
@@ -1,0 +1,148 @@
+---
+slug: analog-trunking-era
+title: "The analog trunking era: SmartNet, EDACS, LTR & MPT-1327"
+description: The first big trunked systems carried analog voice with digital control — Motorola Type I/II, EDACS, LTR, and MPT-1327 — and the concepts they invented that digital systems inherited.
+keywords: analog trunking, Motorola SmartNet, SmartZone, Motorola Type II, EDACS, LTR, Logic Trunked Radio, MPT-1327, message trunking, transmission trunking, distributed control
+level: intermediate
+status: full
+prereq:
+  - birth-of-trunking
+faq:
+  - q: What is the difference between analog and digital trunking?
+    a: Analog trunking carries the voice as ordinary FM but uses digital signalling to assign channels — the control is digital, the audio is analog. Digital trunking carries the voice itself as bits through a vocoder. Many ideas, like dedicated control channels and talkgroups, were invented in the analog era and carried straight into digital systems.
+  - q: What is the difference between message and transmission trunking?
+    a: In transmission trunking, a channel is assigned for a single transmission (one press of the key) and released the instant the user lets go. In message trunking, the channel is held through a short hang time so a back-and-forth conversation stays on one channel. Message trunking feels smoother; transmission trunking returns channels to the pool faster.
+  - q: What was LTR and why was it different?
+    a: LTR (Logic Trunked Radio) used distributed control with no single dedicated control channel. Each repeater carried sub-audible data alongside the voice, and the radios worked out channel assignments collectively. That made LTR cheap and simple for business systems, but it signals very differently from dedicated-control systems like SmartNet or EDACS.
+  - q: Are analog trunked systems still on the air?
+    a: Yes. Motorola Type II, EDACS, LTR, and MPT-1327 systems still operate in places, even as many agencies migrate to P25 and DMR. GopherTrunk decodes a range of these legacy systems, so understanding them is still useful for a scanner enthusiast.
+gophertrunk_links:
+  - title: Status
+    url: /status.html
+    note: which legacy trunking systems GopherTrunk decodes.
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch dedicated-control signalling on a legacy system.
+---
+
+# The analog trunking era: SmartNet, EDACS, LTR & MPT-1327
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The first big trunked systems carried **analog voice** but **digital control**. The major
+families were **Motorola Type I/II/IIi** (branded **SmartNet/SmartZone**), **GE/Ericsson
+EDACS**, **LTR** (Logic Trunked Radio — *distributed* control, sub-audible data, **no
+dedicated control channel**), and **MPT-1327** (the British/European standard). These
+architectures invented the vocabulary digital systems inherited: **dedicated vs
+distributed control**, and **message vs transmission trunking**. Many are **still on the
+air**, and **GopherTrunk decodes them**.
+</div>
+
+Trunking arrived years before digital voice. For a long while the state of the art was a
+clever hybrid — your voice still went out as ordinary FM, but a computer chose the channel
+and announced it as data. This lesson surveys those analog trunked systems, because the
+concepts they pioneered shape every digital standard that came after.
+
+## The hybrid idea: analog voice, digital control
+
+Picture the trunking machinery from the last lesson — a controller, a channel pool, a
+control channel handing out assignments — but the audio on each voice channel is plain
+[analog FM](/learn/rf-sdr/analog-modulation/). That's the whole analog trunking era in one
+sentence. The *organising* layer was digital and modern; the *voice* layer was the same
+FM that had been around for decades. This split is why a single system could enjoy
+trunking's spectrum efficiency without anyone needing a vocoder.
+
+These systems also settled two design questions that still matter:
+
+- **Dedicated vs distributed control.** A *dedicated*-control system reserves one channel
+  full-time as the control channel (SmartNet, EDACS). A *distributed*-control system has no
+  single control channel; the signalling rides along with the voice on each repeater (LTR).
+- **Message vs transmission trunking.** *Transmission* trunking releases a channel the
+  instant a user unkeys; *message* trunking holds it through a short hang time so a
+  conversation stays put. The trade-off is faster channel reuse versus smoother
+  back-and-forth.
+
+## The major families
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="Four labelled boxes representing Motorola, EDACS, LTR, and MPT-1327, with Motorola, EDACS, and MPT-1327 grouped as dedicated control and LTR set apart as distributed control." xmlns="http://www.w3.org/2000/svg">
+  <text x="260" y="18" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">Analog trunking families</text>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="40" width="110" height="46" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/>
+    <text x="75" y="60">Motorola</text>
+    <text x="75" y="74" font-size="8">Type I/II/IIi</text>
+    <rect x="145" y="40" width="110" height="46" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/>
+    <text x="200" y="60">EDACS</text>
+    <text x="200" y="74" font-size="8">GE / Ericsson</text>
+    <rect x="395" y="40" width="110" height="46" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/>
+    <text x="450" y="60">MPT-1327</text>
+    <text x="450" y="74" font-size="8">UK / Europe</text>
+    <rect x="270" y="40" width="110" height="46" rx="5" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/>
+    <text x="325" y="60">LTR</text>
+    <text x="325" y="74" font-size="8">distributed</text>
+  </g>
+  <text x="167" y="112" text-anchor="middle" font-size="9" fill="currentColor">dedicated control channel</text>
+  <text x="325" y="112" text-anchor="middle" font-size="9" fill="currentColor">no dedicated control</text>
+  <line x1="20" y1="98" x2="315" y2="98" stroke="currentColor" stroke-width="1" stroke-opacity="0.5"/>
+  <line x1="270" y1="92" x2="270" y2="130" stroke="currentColor" stroke-width="1" stroke-opacity="0.5" stroke-dasharray="3 3"/>
+</svg>
+<figcaption>Motorola, EDACS, and MPT-1327 use a dedicated control channel; LTR is the odd one out, distributing its signalling across every repeater.</figcaption>
+</figure>
+
+**Motorola Type I/II/IIi** is the most widespread legacy family, sold under the
+**SmartNet** and **SmartZone** brand names. Type I, Type II, and the hybrid Type IIi differ
+mainly in how they encode talkgroup and radio identity, and SmartZone added multi-site
+coverage. Type II in particular blanketed North American public safety and business for
+years.
+
+**EDACS** (Enhanced Digital Access Communications System) came from **GE**, later
+**Ericsson**. It used a dedicated control channel with very fast channel assignment and a
+distinctive signalling scheme, and was common in public-safety and utility deployments.
+
+**LTR (Logic Trunked Radio)** is the conceptual outlier. It has **no dedicated control
+channel**: each repeater carries **sub-audible data** beneath the voice, and the radios
+coordinate channel use collectively — *distributed* control. That made LTR inexpensive and
+simple, which is why it was popular for smaller business systems.
+
+**MPT-1327** is the British/European standard, an open specification widely deployed
+outside North America for business and government trunking. Like the Motorola and EDACS
+families, it uses a dedicated control channel.
+
+## How they compare
+
+| System | Origin | Control | Typical use |
+|--------|--------|---------|-------------|
+| Motorola Type I/II/IIi (SmartNet/SmartZone) | Motorola | Dedicated | US public safety & business |
+| EDACS | GE / Ericsson | Dedicated | Public safety, utilities |
+| LTR | E.F. Johnson | **Distributed** (sub-audible) | Small business systems |
+| MPT-1327 | UK / open standard | Dedicated | Business & government outside US |
+
+The shared thread is *analog voice, digital control*. Where they diverge — dedicated vs
+distributed control, and how they encode IDs — is exactly the kind of difference that
+decides how a monitor follows them.
+
+## What digital inherited
+
+When the digital standards arrived, they didn't reinvent trunking — they reused it.
+Dedicated control channels, talkgroups, affiliation, and the message/transmission trunking
+distinction all came straight out of this era. P25, DMR Tier III, and TETRA are, at the
+trunking layer, refinements of ideas that SmartNet and EDACS proved in the field. The big
+addition was digital *voice* — vocoders, error correction, and built-in encryption — on top
+of a trunking model that already worked.
+
+These systems haven't vanished. Many are **still on the air**, and **GopherTrunk decodes a
+range of them**, so they're not just history. The [Status reference](/status.html) tracks
+which it handles.
+
+## Recap
+
+- The first big trunked systems carried **analog voice** with **digital control**.
+- **Motorola Type I/II/IIi (SmartNet/SmartZone)** and **EDACS** used **dedicated** control channels.
+- **LTR** was different — **distributed** control with **sub-audible data** and no dedicated control channel.
+- **MPT-1327** was the open British/European standard, dedicated-control, used worldwide outside North America.
+- They invented **dedicated vs distributed control** and **message vs transmission trunking**, which digital systems inherited; many are **still on the air** and **GopherTrunk decodes them**.
+
+We dig into these per-system in [Motorola SmartNet](/learn/digital-trunking/motorola-smartnet/)
+and [EDACS, LTR & MPT-1327](/learn/digital-trunking/edacs-ltr-mpt1327/), and compare every
+flavour in [Trunking flavours](/learn/digital-trunking/trunking-flavors/). Next, we cross the
+line into digital voice in [The digital leap](/learn/digital-trunking/the-digital-leap/).

--- a/docs/learn/digital-trunking/analog-vs-digital-voice.md
+++ b/docs/learn/digital-trunking/analog-vs-digital-voice.md
@@ -1,0 +1,160 @@
+---
+slug: analog-vs-digital-voice
+title: Analog vs. digital voice
+description: Analog FM voice fades gracefully into noise; digital voice stays clean then falls off the digital cliff at the BER threshold. The trade-offs that drove radio to digital.
+keywords: analog vs digital voice, digital cliff, cliff effect, BER threshold, vocoder artifacts, graceful degradation, FM voice, digital trunking voice, robotic audio, underwater audio
+level: intermediate
+status: full
+prereq:
+  - the-digital-leap
+  - digital-modulation
+faq:
+  - q: What is the digital cliff?
+    a: The digital cliff is the abrupt way digital voice fails at the edge of coverage. As long as the signal stays above the bit-error-rate threshold the error correction can handle, audio is perfect. Drop below it and the audio doesn't fade gracefully like analog — it garbles and cuts out, as if walking off a cliff.
+  - q: Why does analog FM degrade gracefully but digital does not?
+    a: In analog FM the voice waveform rides the carrier directly, so as the signal weakens you simply hear more hiss but can still make out words. In digital, voice is a stream of bits protected by error correction. The decoder either recovers the bits or it doesn't, so quality stays flat then collapses once errors overwhelm the correction.
+  - q: Why does digital voice sometimes sound robotic or underwater?
+    a: Digital voice is reconstructed by a vocoder that models speech from a handful of parameters rather than reproducing the original sound. On clean signals it sounds crisp; on marginal signals or with unusual voices it can sound robotic, watery, or underwater because the model is guessing at detail it cannot fully capture.
+  - q: If digital fails so abruptly, why did everyone switch to it?
+    a: Digital buys capacity through trunking and narrow channels, privacy through encryption, and features like talkgroups and embedded radio IDs. It also keeps voice clean across most of the coverage area instead of fading into static. The hard failure edge is the price paid for those gains.
+gophertrunk_links:
+  - title: Voice calibration
+    url: /voice-calibration.html
+    note: tune GopherTrunk for the cleanest decoded audio.
+  - title: Vocoders
+    url: /vocoders.html
+    note: the codecs that turn the recovered bits back into speech.
+---
+
+# Analog vs. digital voice
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+In **analog FM**, the voice waveform rides the carrier directly, so the signal
+**degrades gracefully** — as it weakens you hear more hiss but can still copy words.
+In **digital**, voice becomes **bits plus error correction**, so audio stays clean
+and hiss-free right up to the **BER threshold**, then falls off the **digital cliff**
+and cuts out abruptly. Digital also adds **vocoder artifacts** — a robotic or
+"underwater" timbre — because speech is reconstructed from a model. Agencies accepted
+that hard edge in exchange for **capacity, privacy, and features**, which is exactly
+why the trunked systems GopherTrunk decodes are digital.
+</div>
+
+The [RF & SDR path covers this from the signal side](/learn/rf-sdr/digital-voice/);
+here we frame it for trunking. Before you can follow a P25 or DMR call, it helps to
+know *why* its audio behaves so differently from the analog scanner traffic you may
+already know — and why that behaviour shapes everything about monitoring a digital
+system.
+
+## How analog voice carries speech
+
+In an analog FM channel, the speech waveform **modulates the carrier directly**: as
+your voice rises and falls, the carrier's frequency shifts in step, and the receiver
+turns those shifts back into sound. There is no model in the middle — what comes out
+is a direct (if imperfect) copy of what went in.
+
+That directness is the source of analog's famous **graceful degradation**. As the
+signal weakens, noise simply adds on top of the recovered audio. First a little hiss,
+then more, then a lot — but a trained ear can pull words out of surprisingly deep
+static. The signal *fades*; it doesn't suddenly vanish. One conversation occupies one
+channel, and that channel is usable across a wide, soft-edged coverage area.
+
+## How digital voice carries speech
+
+Digital throws out the direct waveform. Speech is first squeezed by a
+**[vocoder](/learn/rf-sdr/vocoders/)** into a few kilobits per second of parameters,
+then wrapped in **[forward error correction](/learn/rf-sdr/demodulation-pipeline/)** and
+sent as [digital modulation](/learn/rf-sdr/digital-modulation/). The receiver
+demodulates the symbols back to bits, lets the error correction repair what it can,
+and feeds the recovered parameters to the vocoder to **reconstruct** audio.
+
+This indirection is what unlocks everything digital trunking is built on. Because the
+voice is now just data, the same channel can also carry talkgroup numbers, radio IDs,
+and signalling alongside it; the bits can be encrypted; and several calls can share a
+channel through time-slotting. But it also means the audio is only as good as the
+decoder's ability to recover bits — which leads straight to the cliff.
+
+## The digital cliff
+
+Error correction can fix a *limited* number of bit errors. As long as the channel's
+**bit error rate (BER)** stays under the threshold the FEC can repair, every bit is
+recovered and the audio is flawless — no hiss at all. Push the BER past that
+threshold and the FEC is overwhelmed: the recovered bits are wrong, the vocoder is
+fed garbage, and the audio breaks into burbles and then **cuts out**. There is almost
+no middle ground. This abrupt, all-or-nothing failure is the **digital cliff**.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 160" role="img" aria-label="A graph of audio quality versus signal strength. The analog curve declines as a smooth downward slope. The digital curve stays flat and high, then drops off a vertical cliff at the bit-error-rate threshold." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="125" x2="420" y2="125" stroke="currentColor" stroke-opacity="0.4"/>
+  <line x1="40" y1="20" x2="40" y2="125" stroke="currentColor" stroke-opacity="0.4"/>
+  <text x="230" y="148" text-anchor="middle" font-size="10" fill="currentColor">weaker  ←  signal strength  →  stronger</text>
+  <text x="20" y="75" font-size="10" fill="currentColor" transform="rotate(-90 20 75)">quality</text>
+  <path d="M60 123 C170 108 300 64 410 38" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="350" y="34" font-size="10" fill="currentColor">analog</text>
+  <path d="M160 123 L160 48 L410 48" fill="none" stroke="currentColor" stroke-width="2"/>
+  <text x="350" y="44" font-size="10" fill="currentColor">digital</text>
+  <line x1="160" y1="48" x2="160" y2="123" stroke="currentColor" stroke-width="2"/>
+  <text x="160" y="115" font-size="9" fill="currentColor" text-anchor="middle">BER cliff</text>
+</svg>
+<figcaption>Analog quality slides down a gradual slope; digital stays clear and hiss-free, then drops off a cliff once the bit error rate passes the threshold the error correction can repair.</figcaption>
+</figure>
+
+The practical upshot: a digital system is usually either **decoding well or not at
+all**. There is little of the "weak but workable" zone analog gives you. Improving
+[SNR](/learn/rf-sdr/decibels/) — a better antenna, placement, or
+[gain](/learn/rf-sdr/gain-and-agc/) — doesn't make a marginal decode *prettier*; it
+moves you back from the cliff edge so the decode succeeds at all.
+
+## Vocoder artifacts
+
+Even well above the cliff, digital voice has a distinctive sound. Because the
+vocoder **models** speech rather than reproducing the waveform, it can introduce a
+slightly **robotic** or **"underwater"** timbre, most noticeable on background noise,
+music, sirens, or voices the model handles poorly. In good conditions it is crisp and
+hiss-free — often *clearer* than analog — but it never sounds quite like an open
+microphone. Recognising this timbre is useful: it tells you you're listening to a
+reconstructed signal, and the next lesson explains exactly how that reconstruction
+works.
+
+## The trade-offs
+
+| Aspect | Analog FM | Digital |
+|--------|-----------|---------|
+| Failure at the edge | Gradual fade into hiss | Abrupt cliff at BER threshold |
+| Audio in good conditions | Slight hiss always present | Clean, hiss-free, slightly robotic |
+| Capacity | One call per channel | Trunking + time-slots pack many more |
+| Privacy | Anyone can listen | Optional strong encryption |
+| Extra data | None | Talkgroup, radio ID, status embedded |
+| Weak-signal copy | Often possible by ear | Usually all-or-nothing |
+
+Neither is strictly "better" — they fail differently. Agencies chose digital because
+the capacity, privacy, and feature gains outweighed the loss of graceful degradation,
+and because regulators were pushing toward narrower channels that digital handles
+well. For a monitor, the lesson is to stop expecting analog behaviour: with digital
+you chase a *clean lock*, not a *readable signal*.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — digital stays clean until the BER threshold, then falls off the cliff." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does digital voice behave as the signal weakens toward the edge of coverage?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It gradually fades into hiss like analog</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It stays clear, then garbles and cuts out abruptly</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It slowly gets quieter but stays intelligible</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Analog FM** carries the voice waveform directly and **degrades gracefully** into
+  hiss as the signal weakens.
+- **Digital voice** is bits plus error correction, so it stays clean then falls off
+  the **digital cliff** at the BER threshold.
+- The vocoder's modelling introduces a **robotic or "underwater"** timbre even on
+  strong signals.
+- Digital won on **capacity, privacy, and features**; the hard failure edge is the
+  price.
+- For monitoring, raise [SNR](/learn/rf-sdr/decibels/) to back off the cliff — a
+  marginal digital signal decodes well or not at all.
+
+Next, we open up that vocoder: [from voice to bits](voice-to-bits-vocoders/), where
+we meet IMBE, AMBE+2, and how a few kilobits become speech again.

--- a/docs/learn/digital-trunking/anatomy-of-a-call.md
+++ b/docs/learn/digital-trunking/anatomy-of-a-call.md
@@ -1,0 +1,143 @@
+---
+slug: anatomy-of-a-call
+title: "Anatomy of a trunked call: request, grant, release"
+description: One trunked call end to end — a radio requests a channel on the control channel, the system grants and announces a voice channel, affiliated radios retune, the call happens, and the channel is released after hang-time.
+keywords: trunked call, channel request, channel grant, grant update, voice channel, hang time, channel release, late entry, control channel, retune, P25 grant
+level: intermediate
+status: full
+prereq:
+  - talkgroups-ids-affiliation
+  - what-is-trunking
+faq:
+  - q: What happens when someone keys up on a trunked system?
+    a: Their radio sends a channel request on the control channel. The system finds a free voice channel and broadcasts a grant naming the talkgroup and the channel. Every radio affiliated to that talkgroup retunes to the voice channel, the conversation happens there, and when it ends the channel is released back to the pool after a short hang-time.
+  - q: What is hang-time?
+    a: Hang-time is a short window the system holds the voice channel open after a transmission ends, in case someone replies. It keeps a back-and-forth conversation on the same channel instead of re-requesting one for every over. When hang-time expires with no further traffic, the channel is released to the pool.
+  - q: What is late entry?
+    a: Late entry is joining a call already in progress. If a radio — or a monitor — affiliates or tunes in after the initial grant, it can still pick up the call because the control channel periodically repeats the grant as a grant update. That repeated announcement lets latecomers find the active voice channel.
+  - q: What is a grant update?
+    a: A grant update is a control-channel message that re-announces an in-progress call's talkgroup and voice channel. The system sends it periodically while a call is active so radios that missed or arrived after the first grant can still find and follow the call. It is how late entry and channel-following stay reliable.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch grant and release messages for live calls scroll past in real time.
+  - title: Radio IDs
+    url: /radio-ids.html
+    note: see which radio ID requested each call as it is granted.
+---
+
+# Anatomy of a trunked call: request, grant, release
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Every trunked call follows the same arc. A radio keys up and sends a **channel request**
+on the [control channel](/learn/digital-trunking/the-control-channel/). The system finds a free voice channel and
+broadcasts a **grant** — "talkgroup 101, go to channel 3" — which **affiliated** radios
+hear and **retune** to. The conversation happens on that voice channel, with periodic
+**grant updates** so latecomers can join (**late entry**). When traffic stops, the channel
+is held briefly for **hang-time**, then **released** back to the pool. Decoding the grants
+is exactly how a follower knows where every call goes.
+
+</div>
+
+You now know the [identities](talkgroups-ids-affiliation/) a trunked system tracks. This
+lesson stitches them together into a single call, from the moment a user presses the
+push-to-talk to the moment the channel returns to the pool.
+
+## The four phases
+
+A trunked call moves through four phases, all coordinated on the control channel:
+
+1. **Request.** A user keys up. Their radio sends a **channel request** on the
+   [control channel](/learn/digital-trunking/the-control-channel/), naming its talkgroup (and carrying its
+   [radio ID](talkgroups-ids-affiliation/)).
+2. **Grant.** The system computer finds a **free voice channel** and broadcasts a **grant**
+   on the control channel: "talkgroup 101 → channel 3." Every radio
+   [affiliated](talkgroups-ids-affiliation/) to talkgroup 101 hears that data message.
+3. **Conversation.** Those radios **retune** to channel 3 and the call happens there. While
+   it's active, the system periodically re-sends a **grant update** so radios that arrive
+   late can still find the channel.
+4. **Release.** When traffic stops, the system holds the channel for a short **hang-time**
+   in case of a reply. If none comes, the channel is **released** back to the pool for the
+   next call — possibly a completely different talkgroup.
+
+The voice channel is never owned by a talkgroup; it's borrowed for the call and handed
+back. The next call from the same group may land somewhere else entirely.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 560 180" role="img" aria-label="A horizontal timeline of a trunked call with four labelled stages: request, grant, conversation on a voice channel, and release after hang-time." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="100" x2="530" y2="100" stroke="currentColor" stroke-opacity="0.4" stroke-width="1.5"/>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <circle cx="80" cy="100" r="6" fill="currentColor"/>
+    <text x="80" y="80" font-weight="600">Request</text>
+    <text x="80" y="128" font-size="8">radio keys up (CC)</text>
+    <circle cx="200" cy="100" r="6" fill="currentColor"/>
+    <text x="200" y="80" font-weight="600">Grant</text>
+    <text x="200" y="128" font-size="8">"TG 101 → ch 3"</text>
+    <rect x="280" y="86" width="160" height="28" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/>
+    <text x="360" y="104" font-size="9">conversation on ch 3</text>
+    <text x="360" y="74" font-size="8">grant updates repeat →</text>
+    <circle cx="490" cy="100" r="6" fill="currentColor"/>
+    <text x="490" y="80" font-weight="600">Release</text>
+    <text x="490" y="128" font-size="8">after hang-time</text>
+  </g>
+  <text x="280" y="160" text-anchor="middle" font-size="11" fill="currentColor">The voice channel is borrowed for the call, then returned to the pool.</text>
+</svg>
+<figcaption>One call end to end: request on the control channel, grant of a voice channel, the conversation (with repeated grant updates for late entry), then release after hang-time.</figcaption>
+</figure>
+
+## Watching it on the control channel
+
+Because every phase is announced as data, a follower sees the whole call as a sequence of
+control-channel messages — this is the stream GopherTrunk reads:
+
+| Time | Control-channel message | What a follower does |
+|------|-------------------------|----------------------|
+| 0.0 s | Radio 1147 requests TG 101 | Note the request |
+| 0.1 s | Grant: TG 101 → channel 3 | Tune a receiver to ch 3, record |
+| 0.1–6.0 s | Grant update: TG 101 still on ch 3 | Keep following; late joiners can enter |
+| 6.0 s | (traffic stops) | Hold ch 3 through hang-time |
+| 7.5 s | TG 101 released; ch 3 freed | Return ch 3 to the pool, ready for next |
+
+The first **grant** is the cue to point a receiver at the voice channel. The **grant
+updates** are insurance: if a radio (or the follower) was busy at 0.1 s, it can still latch
+onto the call at 3 s and not miss the rest. When the **release** arrives, the follower frees
+the channel and is immediately ready for the next grant.
+
+## Hang-time and late entry
+
+Two details make trunking feel seamless.
+
+**Hang-time** is the short pause the system keeps a channel open after a transmission ends.
+Conversations are a back-and-forth, and re-requesting a channel for every single over would
+add latency and churn. Holding the channel briefly lets the reply land on the *same*
+channel, so a normal exchange stays put until the talking actually stops.
+
+**Late entry** is joining a call already underway. Thanks to the repeated **grant
+updates**, a radio that powers on or switches talkgroups mid-call — or a monitor that tunes
+in late — can discover the active voice channel and pick up the conversation in progress.
+Without grant updates, you'd only ever hear calls you happened to catch at the instant of
+the first grant.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — grant updates re-announce an active call so late joiners can find the voice channel." markdown="0">
+  <p class="knowledge-check__q">Quick check: what lets a radio join a trunked call that's already in progress?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The initial channel request</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Periodic grant updates on the control channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Parking on the voice frequency</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A call has four phases: **request**, **grant**, **conversation**, **release**.
+- The **request** rides the control channel; the **grant** names the talkgroup and voice
+  channel.
+- Affiliated radios **retune** to the granted channel; **grant updates** repeat during the
+  call.
+- **Late entry** lets radios join a call in progress thanks to those updates.
+- After traffic stops, **hang-time** holds the channel briefly, then it's **released**.
+
+Next, we open up the control channel itself and read [what the data
+says](control-channel-signaling/) — the full vocabulary of trunking messages.

--- a/docs/learn/digital-trunking/birth-of-trunking.md
+++ b/docs/learn/digital-trunking/birth-of-trunking.md
@@ -1,0 +1,148 @@
+---
+slug: birth-of-trunking
+title: "The birth of trunking: sharing channels"
+description: How trunked radio was born — a central controller assigns a free channel per call and reclaims it, packing many groups onto a few frequencies, and why this breaks old-style scanning.
+keywords: birth of trunking, trunked radio history, control channel, channel sharing, conventional radio, Motorola trunking, GE trunking, channel assignment, trunking explained, scanner
+level: beginner
+status: full
+prereq:
+  - why-radio-went-digital
+faq:
+  - q: What is trunking in radio?
+    a: Trunking is automatic channel sharing. Instead of each group owning a permanent frequency, a central controller keeps a small pool of channels and hands out a free one for the duration of each call, then reclaims it. Because real conversations are short and bursty, a few shared channels can serve far more groups than fixed assignments ever could.
+  - q: How is trunking different from conventional radio?
+    a: In conventional radio every group has a fixed frequency it always uses, so you scan by listening to that frequency. In trunked radio the frequency for a given call is chosen on the fly by a controller, so there is no permanent home channel. You have to read the control channel to know where each conversation went.
+  - q: Why does trunking break old-style scanning?
+    a: An old scanner assumes a group lives on one frequency, so it parks there and listens. On a trunked system the same group lands on a different voice channel almost every call, while other groups reuse the channel it just vacated. Parked on one frequency you hear a meaningless jumble. You have to follow the control channel instead.
+  - q: When did trunking appear?
+    a: Trunked land-mobile systems emerged in the 1970s and 1980s as spectrum filled up, with Motorola and GE among the pioneers. The earliest systems carried analog voice but used digital signalling to assign channels, the same core idea that every modern digital trunked system still uses.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch the controller hand out channels in real time.
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: find the control channel that runs a trunked system.
+---
+
+# The birth of trunking: sharing channels
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Conventional** radio gives each group its own permanent frequency — wasteful, because
+most channels sit **idle** most of the time. **Trunking** fixes that with a **central
+controller** that assigns a **free channel per call** and **reclaims** it when the call
+ends. A dedicated **control channel** coordinates the dance, telling each radio where to
+go. Trunking emerged in the **1970s–80s** with **Motorola** and **GE** among the pioneers.
+Because the frequency for a call is chosen on the fly, trunking **breaks old-style
+scanning** — you must follow the control channel, not a fixed frequency.
+</div>
+
+The last lesson listed *more users per slice of spectrum* as a digital promise. Trunking
+is the single biggest idea that delivers it — and, crucially, it predates digital voice.
+It's a way of *organising* channels that's so effective every modern digital standard
+builds on it.
+
+## The waste in conventional radio
+
+Start with how radio worked before trunking: **conventional**. Each group — Dispatch,
+Fire Ground, Public Works — owns a permanent frequency. It's simple and dependable. It's
+also enormously wasteful, because radio traffic is **bursty**. A dispatcher might transmit
+for ten seconds, then nothing for two minutes. All that time, the group's dedicated
+frequency sits silent, *reserved* and unusable by anyone else, while a neighbouring busy
+channel has users waiting in line. Multiply that across forty groups in a county and you
+have most of your spectrum idle most of the time, yet still "full" because every channel
+is assigned to someone.
+
+## The trunking idea: a controller and a pool
+
+Trunking pools the channels and shares them on demand. A **central controller** — a
+computer at the system's heart — keeps a small set of frequencies and a rule: when a radio
+wants to talk, find a **free channel**, assign it for *just that call*, and **reclaim** it
+the instant the call ends, back into the pool for whoever needs it next.
+
+The classic analogy is a **bank**. The old conventional way is one teller per customer,
+each with their own roped-off line — most tellers idle while one line backs up. Trunking is
+the modern way: one queue feeds *all* the tellers, and you're routed to whichever opens up.
+Far fewer tellers serve far more customers with almost no waiting, because nobody is locked
+to a specific window. Channels are the tellers; calls are the customers.
+
+## The control channel makes it work
+
+The coordination has to happen somewhere, and that somewhere is the **control channel** —
+one frequency dedicated to carrying *data*, never voice. It runs constantly, and it's the
+hinge the whole system turns on:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 200" role="img" aria-label="A central controller connected to a control channel at top and a pool of voice channels below; the controller assigns a free voice channel to a call and reclaims it afterward." xmlns="http://www.w3.org/2000/svg">
+  <rect x="200" y="14" width="140" height="34" rx="6" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.5"/>
+  <text x="270" y="35" text-anchor="middle" font-size="12" fill="currentColor" font-weight="600">Central controller</text>
+  <rect x="40" y="74" width="460" height="30" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.3"/>
+  <text x="270" y="93" text-anchor="middle" font-size="11" fill="currentColor">Control channel — data: “Group A, take channel 2”</text>
+  <line x1="270" y1="48" x2="270" y2="74" stroke="currentColor" stroke-width="1.4"/>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="138" width="100" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+    <text x="90" y="159">Voice 1 (free)</text>
+    <rect x="155" y="138" width="100" height="34" rx="5" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+    <text x="205" y="155">Voice 2</text>
+    <text x="205" y="167" font-size="8">Group A active</text>
+    <rect x="270" y="138" width="100" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+    <text x="320" y="159">Voice 3 (free)</text>
+    <rect x="385" y="138" width="100" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+    <text x="435" y="159">Voice 4 (free)</text>
+  </g>
+  <line x1="205" y1="104" x2="205" y2="136" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/>
+  <text x="270" y="192" text-anchor="middle" font-size="10" fill="currentColor">Assigned for one call, then released back to the pool.</text>
+</svg>
+<figcaption>A central controller listens for requests, assigns a free voice channel via the control channel, and reclaims it when the call ends.</figcaption>
+</figure>
+
+A radio keys up and sends a request on the control channel. The controller finds a free
+voice channel and broadcasts the assignment — "Group A, take channel 2." Every radio in
+Group A hears that data message and retunes to channel 2 to listen. When the call ends, the
+channel goes back in the pool. The next call from Group A might land somewhere else
+entirely. The control-channel data rides on the same kinds of
+[digital modulation](/learn/rf-sdr/digital-modulation/) you met in the RF path.
+
+## A short history
+
+Trunking grew up as spectrum pressure became acute in the **1970s and 1980s**. **Motorola**
+and **GE** were among the pioneers building commercial trunked systems, and the early ones
+carried **analog voice** with **digital control** — the voice was old-fashioned FM, but the
+channel assignments were already computer-managed data. That hybrid era is the subject of
+the next lesson; for now, the point is that the organising idea — controller, pool,
+per-call assignment — arrived well before digital voice and outlasted it.
+
+## Why this breaks old-style scanning
+
+Here's the consequence that matters for monitoring. An old scanner assumes a group lives on
+*one* frequency, so it parks there and waits. On a trunked system that assumption is false:
+the same group hops to a different voice channel nearly every call, while other groups reuse
+the channel it just left. Park on one frequency and you hear fragments of unrelated
+conversations — a jumble. To follow a trunked system you have to read the **control
+channel** and let *it* tell you where each call went. That's exactly why
+[GopherTrunk's RF-path primer](/learn/rf-sdr/what-is-trunking/) is short — it introduces the
+idea — while *this* path goes much deeper into the signalling and the systems built on it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — the controller assigns a free channel per call and takes it back afterward." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a trunking controller do with a voice channel when a call ends?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Keeps it permanently assigned to that group</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Releases it back into the shared pool</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Shuts the channel off until the next day</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Conventional** radio wastes spectrum: each group's permanent frequency sits idle most of the time.
+- **Trunking** pools channels and a **central controller** assigns a **free one per call**, then reclaims it.
+- A dedicated **control channel** carries the data that coordinates every assignment.
+- Trunking emerged in the **1970s–80s**, with **Motorola** and **GE** among the pioneers, first carrying analog voice with digital control.
+- Because frequencies change call to call, trunking **breaks old-style scanning** — you follow the control channel.
+
+We've talked about why trunking matters at the level of one group; for the deeper
+contrast, see [Conventional vs trunked](/learn/digital-trunking/conventional-vs-trunked/).
+Next, we'll meet the first big real-world trunked systems in
+[The analog trunking era](/learn/digital-trunking/analog-trunking-era/).

--- a/docs/learn/digital-trunking/control-channel-signaling.md
+++ b/docs/learn/digital-trunking/control-channel-signaling.md
@@ -1,0 +1,153 @@
+---
+slug: control-channel-signaling
+title: "Control-channel signaling: what the data says"
+description: The message types on a trunked control channel — voice grants and updates, registration and affiliation, system status, neighbor-site broadcasts, and the identifier updates that map channel numbers to real frequencies.
+keywords: control channel signaling, TSBK, CSBK, channel grant, grant update, affiliation, identifier update, IDEN, adjacent site, network status, channel map, P25, DMR
+level: advanced
+status: full
+prereq:
+  - anatomy-of-a-call
+  - what-is-trunking
+faq:
+  - q: What kinds of messages are on a trunking control channel?
+    a: A control channel carries channel grants and grant updates for calls, registration and affiliation messages from radios, system service and status broadcasts, adjacent-site (neighbor) announcements, identifier or frequency-band updates that map channel numbers to real frequencies, and network status. Together these let a decoder build a complete live picture of the system.
+  - q: How does a channel number become an actual frequency?
+    a: Grants reference a channel number, not a frequency. Identifier or frequency-band update messages provide the formula — a base frequency, channel spacing, and other parameters — that converts a channel number into a real transmit frequency. A trunk-tracker must collect these before it can tune to a granted voice channel.
+  - q: What are TSBK and CSBK?
+    a: TSBK (Trunking Signaling Block) is the message unit P25 uses to carry control-channel signaling on its dedicated control channel. CSBK (Control Signaling Block) is the equivalent in DMR. Both are short, structured data blocks whose type field says whether they carry a grant, an affiliation, a status broadcast, and so on.
+  - q: Why does a trunk-tracker need neighbor-site messages?
+    a: Adjacent-site broadcasts list the control-channel frequencies of neighboring sites in a multi-site system. A tracker uses them to know where a radio might roam and which other control channels exist, which is useful both for following roaming users and for finding a stronger site to monitor.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: see decoded control-channel messages by type as GopherTrunk reads them.
+---
+
+# Control-channel signaling: what the data says
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+The control channel is a constant stream of short, typed data messages. **Grants** and
+**grant updates** announce calls and their voice channels; **registration/affiliation**
+messages track which radios and talkgroups are active; **system status** and **network
+status** describe the system; **adjacent-site** broadcasts list neighbor control channels;
+and crucially, **identifier/frequency-band updates** carry the formula that turns a
+**channel number** into a real **frequency**. In P25 these ride in **TSBKs**; in DMR, in
+**CSBKs**. A trunk-tracker assembles all of this into a **live channel map**.
+
+</div>
+
+You've watched a [single call](anatomy-of-a-call/) flow through the control channel. Now we
+catalogue the *full vocabulary* — the message types that, taken together, let a decoder
+reconstruct the entire system. This is the most data-dense part of trunking, and it's where
+a "trunk-tracker" earns its name.
+
+## The carrier: TSBK and CSBK
+
+Control-channel messages aren't free-form; each is a short, structured **block** with a
+**type** field. Two concrete carriers dominate the digital world:
+
+- **P25** packs its signaling into **TSBKs** — *Trunking Signaling Blocks*. Each TSBK is a
+  fixed-size block whose opcode says what kind of message it is.
+- **DMR** Tier III uses **CSBKs** — *Control Signaling Blocks* — the analogous unit on the
+  DMR control channel.
+
+The idea is the same in both: a stream of small, typed packets. A decoder reads the type,
+then parses the fields that type defines. Everything below is just *which types matter* and
+*what they tell you*.
+
+## The message families
+
+| Message family | What it carries | Why a tracker needs it |
+|----------------|-----------------|------------------------|
+| Group voice channel grant | Talkgroup + assigned voice channel + source radio ID | The cue to tune a receiver to a new call |
+| Grant update | Re-announcement of an active call's channel | Late entry; staying locked to ongoing calls |
+| Unit/group registration & affiliation | A radio registering or declaring its talkgroup | Live roster of active radios and groups |
+| System service / status | System capabilities and operating parameters | Confirms identity and features of the system |
+| Adjacent (neighbor) site broadcast | Control-channel frequencies of nearby sites | Following roaming; finding a stronger site |
+| Identifier / frequency-band update | Base frequency, spacing — the channel-number formula | Converting channel numbers into real frequencies |
+| Network status | Network/system identifiers (e.g. system ID, WACN) | Pinning down exactly which system this is |
+
+Each family answers a different question. The grants say *where calls are happening*. The
+registration and affiliation messages say *who is on the system*. The status and network
+messages say *what system this is*. The neighbor broadcasts say *what's around it*. And the
+identifier updates — easy to overlook — are what make the grants *usable at all*.
+
+## From channel number to frequency
+
+Here's the subtlety that trips up newcomers: a **grant doesn't contain a frequency**. It
+says "go to channel 3," where *channel 3* is an abstract number. To turn that number into a
+real frequency you tune, the decoder needs the **identifier / frequency-band update**
+messages (P25 calls these IDEN updates). These carry a **base frequency**, a **channel
+spacing**, and related parameters — effectively a formula:
+
+> frequency = base + (channel number × spacing) ± offset
+
+Until a tracker has collected the relevant identifier update, a grant for "channel 3" is
+meaningless — there's no way to know *which* frequency channel 3 is. This is why a freshly
+locked control channel sometimes takes a moment before calls become followable: the tracker
+is waiting to hear the identifier updates that complete its map.
+
+## Assembling the live channel map
+
+Put the families together and a trunk-tracker maintains a continuously updated model of the
+whole system:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 560 210" role="img" aria-label="A diagram showing control-channel message types flowing into a trunk-tracker, which combines identifier updates and grants to produce a live channel map of talkgroups, frequencies, and active calls." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="30" width="150" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="95" y="45">Grants & updates</text>
+    <rect x="20" y="62" width="150" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="95" y="77">Affiliation/registration</text>
+    <rect x="20" y="94" width="150" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="95" y="109">Identifier updates</text>
+    <rect x="20" y="126" width="150" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="95" y="141">Neighbor & status</text>
+  </g>
+  <rect x="220" y="60" width="120" height="60" rx="6" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.5"/>
+  <text x="280" y="86" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">Trunk-</text>
+  <text x="280" y="100" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">tracker</text>
+  <g stroke="currentColor" stroke-width="1.2">
+    <line x1="170" y1="41" x2="220" y2="72"/><line x1="170" y1="73" x2="220" y2="82"/>
+    <line x1="170" y1="105" x2="220" y2="98"/><line x1="170" y1="137" x2="220" y2="108"/>
+  </g>
+  <rect x="390" y="40" width="150" height="100" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="465" y="60" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">Live channel map</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="465" y="82">channel № → frequency</text>
+    <text x="465" y="98">talkgroups active now</text>
+    <text x="465" y="114">radios affiliated</text>
+    <text x="465" y="130">neighbor sites</text>
+  </g>
+  <line x1="340" y1="90" x2="390" y2="90" stroke="currentColor" stroke-width="1.5" marker-end="url(#cm)"/>
+  <defs><marker id="cm" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A trunk-tracker fuses the message families — especially identifier updates with grants — into a live channel map: which numbers map to which frequencies, which talkgroups and radios are active, and what neighbor sites exist.</figcaption>
+</figure>
+
+This map is what GopherTrunk's **[CC Activity](/cc-activity.html)** panel exposes: the raw,
+typed messages decoded in real time. Watching them is the clearest way to understand a
+system — and to spot, for example, that you've locked a control channel but haven't yet
+seen the identifier update you need.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — identifier/frequency-band updates carry the formula that maps channel numbers to frequencies." markdown="0">
+  <p class="knowledge-check__q">Quick check: a grant says "go to channel 3." Which message tells you what frequency channel 3 is?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The affiliation message</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The identifier / frequency-band update</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The neighbor-site broadcast</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Control-channel signaling is a stream of short, **typed blocks** — **TSBK** (P25),
+  **CSBK** (DMR).
+- **Grants** and **grant updates** announce calls; **affiliation/registration** track
+  active radios.
+- **System/network status** identify the system; **adjacent-site** broadcasts list neighbor
+  control channels.
+- **Identifier/frequency-band updates** carry the formula that turns **channel numbers**
+  into **frequencies**.
+- A trunk-tracker fuses these into a **live channel map** — exactly what CC Activity shows.
+
+Next, we step back and compare the [trunking flavors](trunking-flavors/) — dedicated vs.
+distributed control, and message vs. transmission trunking.

--- a/docs/learn/digital-trunking/conventional-vs-trunked.md
+++ b/docs/learn/digital-trunking/conventional-vs-trunked.md
@@ -1,0 +1,130 @@
+---
+slug: conventional-vs-trunked
+title: "Conventional vs. trunked radio"
+description: Conventional radio puts each group on a fixed frequency you can just listen to; trunked radio assigns channels on demand from a controller — why the old park-on-a-frequency scan fails.
+keywords: conventional radio, trunked radio, fixed frequency, control channel, P25 conventional, digital conventional, scanning, repeater, talkgroup, channel assignment
+level: beginner
+status: full
+prereq:
+  - what-is-trunking
+faq:
+  - q: What is the difference between conventional and trunked radio?
+    a: In conventional radio, each group has its own fixed frequency it always uses, so you tune to that frequency to listen. In trunked radio, a small pool of frequencies is shared and a controller assigns a free one to each call on demand. Conventional is simple to scan; trunked requires you to decode the control channel to follow conversations as they hop.
+  - q: Can conventional radio be digital?
+    a: Yes. Conventional only describes how channels are assigned — fixed, not pooled. The voice on a conventional channel can be analog FM or digital, including P25 conventional, DMR Tier II, or NXDN conventional. A digital conventional channel still lives on one frequency; it just carries a digital voice signal instead of analog.
+  - q: Why can't I scan a trunked system the old way?
+    a: Because a trunked call can land on any frequency in the pool, and a different call lands there a moment later. Parking a scanner on one frequency hears fragments of unrelated conversations. To follow a group you have to read the control channel, which announces which voice channel each call uses.
+  - q: Is a repeater the same as trunking?
+    a: No. A repeater simply rebroadcasts a single conventional channel to extend range; it is still one fixed frequency. Trunking adds a controller that manages a pool of channels across many repeaters and assigns them per call. A trunked site is built from several repeaters working together under one control channel.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch the control-channel traffic that a trunked system needs and a conventional one does not.
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: tell whether a frequency is a plain conventional channel or a trunked control channel.
+---
+
+# Conventional vs. trunked radio
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Conventional** radio gives each group its own **fixed frequency** — you tune to it and
+listen, which is why a classic scanner works. **Trunked** radio pools a few frequencies
+and a **controller** assigns a free one to each call on demand, so the frequency a group
+uses *changes call to call*. Conventional can itself be **digital** (P25 conventional,
+DMR Tier II) — "conventional" describes the *channel plan*, not the voice. You **cannot**
+park a scanner on a trunked system: you must decode its **control channel** to follow
+who's talking.
+
+</div>
+
+Before diving into how trunking works in detail, it's worth nailing the one distinction
+everything else hangs on: how a system decides *which frequency* a conversation uses. Get
+this straight and the rest of the path falls into place.
+
+## Conventional: one group, one frequency
+
+In a **conventional** system, each user group is assigned a **fixed frequency** it always
+uses. Police dispatch is on one channel, fire ground on another, public works on a third,
+and they never move. To listen, you do the obvious thing — tune your receiver to that
+frequency and wait for traffic. A scanner just steps through a list of these frequencies,
+stopping whenever one is active.
+
+Conventional channels are often *repeated*: a repeater on a hilltop rebroadcasts the
+channel to extend range. That's still conventional — it's one fixed frequency, just heard
+further. Simplicity is the whole appeal. The cost is **spectrum**: every group needs its
+own channel whether it's busy or idle, which wastes airwaves when most channels sit silent
+most of the time.
+
+## Conventional doesn't mean analog
+
+A common trap is to assume "conventional" means old analog FM. It doesn't.
+**Conventional** describes only the *channel plan* — fixed frequencies, no pooling. The
+**voice** riding on a conventional channel can be:
+
+- **Analog FM** — the classic narrowband voice scanners have always heard, or
+- **Digital** — **P25 conventional**, **DMR Tier II**, **NXDN conventional**, and others.
+
+A P25 conventional channel is still one frequency you can tune to; it just carries a
+[digital voice](/learn/rf-sdr/digital-voice/) signal that needs a
+[vocoder](voice-to-bits-vocoders/) to turn back into audio. So "is it digital?" and "is it
+trunked?" are two **independent** questions. A system can be analog-conventional,
+digital-conventional, analog-trunked, or digital-trunked.
+
+## Trunked: a shared pool, assigned on demand
+
+In a **trunked** system there is no fixed home frequency. A small pool of channels is
+shared across many groups, and a **controller** hands out a free channel for the duration
+of each call, then reclaims it. Coordination rides on a dedicated
+[control channel](/learn/digital-trunking/the-control-channel/) — one frequency that carries *data*, announcing where
+each call goes. Members of a group hear each other through their
+[talkgroup](talkgroups-ids-affiliation/), regardless of which voice channel the system
+picked.
+
+This is far more spectrum-efficient: ten shared channels can serve forty groups, because
+real conversations are short and bursty. But it means the **frequency a group uses is not
+stable** — the next call from the same talkgroup might be on a completely different
+channel.
+
+## Why the old scan fails on trunking
+
+This is the crux. On a conventional system, "park on the frequency" works because the
+frequency *is* the group. On a trunked system, parking on a voice frequency hears whatever
+call happened to be assigned there — a fragment of one conversation, then silence, then a
+fragment of an unrelated one. There is no way to follow a single group that way.
+
+To follow a trunked group you have to read the **control channel** and let it tell you
+which voice channel each call uses, retuning in step. That is exactly the job
+[GopherTrunk](/learn/digital-trunking/the-control-channel/) does, and it's why so much of this path is about the
+control channel rather than the voice channels.
+
+| | Conventional | Trunked |
+|---|---|---|
+| Channel assignment | Fixed — each group has its own frequency | On demand — controller assigns from a pool |
+| Where you listen | Tune to the group's frequency | Decode the control channel, follow its grants |
+| Voice can be | Analog FM **or** digital | Analog **or** digital |
+| Old scanner works? | Yes — park on the frequency | No — calls hop across the pool |
+| Spectrum efficiency | Low — idle channels still reserved | High — channels shared across groups |
+| Coordination | None needed | Dedicated control channel carries data |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — conventional describes the channel plan, so it can carry digital voice too." markdown="0">
+  <p class="knowledge-check__q">Quick check: can a conventional system carry digital voice?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Yes — e.g. P25 conventional on a fixed frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">No — conventional always means analog FM</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only if it has a control channel</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Conventional** = each group on a **fixed frequency** you can tune to and listen.
+- **Trunked** = a **shared pool** with a **controller** assigning channels per call.
+- "Conventional" describes the *channel plan*, not the voice — it can be **digital**.
+- A classic scanner works on conventional but **fails** on trunked, where calls hop.
+- To follow a trunked group you decode the **control channel**, not a voice frequency.
+
+Next, we look at the identities a trunked system tracks — [talkgroups, radio IDs and
+affiliation](talkgroups-ids-affiliation/) — the virtual channels you actually follow.

--- a/docs/learn/digital-trunking/digital-modulation-for-trunking.md
+++ b/docs/learn/digital-trunking/digital-modulation-for-trunking.md
@@ -1,0 +1,168 @@
+---
+slug: digital-modulation-for-trunking
+title: "Digital modulation for trunking: C4FM, π/4-DQPSK & CQPSK"
+description: The handful of modulations digital trunking uses — C4FM and CQPSK for P25, π/4-DQPSK for TETRA, 4FSK for DMR and NXDN — and how each looks on a constellation and eye diagram.
+keywords: C4FM, CQPSK, LSM, pi/4-DQPSK, 4FSK, P25 modulation, DMR modulation, NXDN modulation, TETRA modulation, constellation, eye diagram, simulcast modulation
+level: intermediate
+status: full
+prereq:
+  - digital-modulation
+  - symbols-and-baud
+faq:
+  - q: What modulation does P25 Phase 1 use?
+    a: P25 Phase 1 uses C4FM, a four-level frequency-shift keying. It runs at 4800 symbols per second, and because four levels carry two bits each, that yields 9600 bits per second. The same signal can also be produced with CQPSK, a linear-modulation cousin that fits the same constellation.
+  - q: Why does P25 specify both C4FM and CQPSK?
+    a: They produce a compatible on-air signal but suit different transmitters. C4FM uses a constant-envelope FM-style path that works with cheap, efficient nonlinear amplifiers in handhelds. CQPSK (also called LSM) is a linear modulation that simulcast transmitters need so multiple sites can overlap cleanly, so infrastructure often uses it.
+  - q: What is the difference between 4FSK and π/4-DQPSK?
+    a: 4FSK shifts the carrier among four frequencies, one per symbol, and is used by DMR and NXDN as well as P25 Phase 1's C4FM. π/4-DQPSK is a phase-shift modulation used by TETRA that rotates the carrier phase in quarter-pi steps, encoding bits in the change of phase rather than its absolute value.
+  - q: How can I see these modulations in GopherTrunk?
+    a: The Constellation panel plots each received symbol in the IQ plane, so you can see the four points of C4FM or the ring of π/4-DQPSK, and the Eye diagram shows the symbol levels against time. Tight clusters and a wide-open eye mean a clean lock; smearing means errors are near.
+gophertrunk_links:
+  - title: Constellation
+    url: /constellation.html
+    note: see the live symbol constellation of the system you're decoding.
+  - title: Eye diagram
+    url: /eye-diagram.html
+    note: judge timing and noise margin on the recovered symbols.
+---
+
+# Digital modulation for trunking: C4FM, π/4-DQPSK & CQPSK
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Digital trunking uses only a **handful of modulations**. **C4FM** is four-level FSK —
+P25 Phase 1 runs it at **4800 symbols/s × 2 bits = 9600 bps**. **CQPSK** (also called
+**LSM**) is a *linear* cousin that produces a compatible constellation and is used by
+**simulcast** transmitters. **π/4-DQPSK** is the phase-shift modulation of **TETRA**,
+and plain **4FSK** carries **DMR** and **NXDN**. Each has a recognisable
+**constellation** and **eye diagram**, which GopherTrunk plots live so you can judge a
+lock at a glance. Understanding these shapes is how you tell systems apart and tune a
+clean signal.
+
+</div>
+
+You met the [three families of digital modulation](/learn/rf-sdr/digital-modulation/)
+already — FSK, PSK, QAM — and the relationship between
+[symbols and baud](/learn/rf-sdr/symbols-and-baud/). This lesson narrows that to the
+*specific* modulations digital trunked systems actually use, because once you can name
+the shape on the scope, you're halfway to identifying the system.
+
+## C4FM — the P25 Phase 1 workhorse
+
+**C4FM** (Continuous 4-level FM) is a **four-level FSK**: the carrier sits at one of
+four small frequency deviations per symbol. Four levels means each symbol carries
+**two bits** (a *dibit*). P25 Phase 1 runs C4FM at **4800 symbols per second**, so:
+
+> 4800 symbols/s × 2 bits/symbol = **9600 bits per second**
+
+The four deviations map to fixed dibits, the same scheme DMR's 4FSK uses:
+
+| Deviation | Symbol level | Dibit |
+|-----------|--------------|-------|
+| +1800 Hz | +3 | 01 |
+| +600 Hz | +1 | 00 |
+| −600 Hz | −1 | 10 |
+| −1800 Hz | −3 | 11 |
+
+C4FM's appeal is that it is **constant-envelope** — the amplitude never changes, only
+the frequency — so it works with the cheap, efficient *nonlinear* amplifiers in
+handheld radios without distorting. On a [symbol scope](/learn/rf-sdr/digital-modulation/)
+you see four stacked levels; on a constellation you see four points.
+
+## CQPSK / LSM — the linear twin for simulcast
+
+Here is the clever part of P25: it also defines **CQPSK** (Compatible QPSK), often
+called **LSM** (Linear Simulcast Modulation). CQPSK is a *linear* modulation — it
+shifts **phase**, not frequency — yet it is engineered to produce a signal that a
+C4FM receiver can decode and that lands on the **same constellation**. A radio doesn't
+care which one transmitted it.
+
+Why bother with two ways to make the same signal? Because of **simulcast**: large
+systems broadcast the same channel from many transmitters at once over an overlapping
+area. For those overlapping signals to combine cleanly rather than smear, the
+transmitters need the tighter control that a **linear** modulation gives. C4FM's
+nonlinear path is fine for a single handheld but not for phase-precise simulcast, so
+infrastructure transmitters often use **CQPSK/LSM** while the constellation a receiver
+sees stays the same. (This is exactly why simulcast distortion is its own decoding
+challenge, covered later in the path.)
+
+## π/4-DQPSK and 4FSK — the rest of the field
+
+Two more shapes round out digital trunking:
+
+- **π/4-DQPSK** — used by **TETRA**. This is a *differential* phase-shift keying that
+  rotates the carrier phase in steps of a quarter of pi, encoding bits in the **change**
+  of phase between symbols rather than its absolute value. On a constellation it traces
+  an eight-point ring; differential coding makes it forgiving of phase ambiguity.
+- **4FSK** — the same four-level FSK family as C4FM, used by **DMR** and **NXDN**.
+  DMR and P25 Phase 1 share the underlying 4FSK idea, which is why their constellations
+  and eye diagrams look so alike even though the systems differ in every other respect.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 500 200" role="img" aria-label="Two constellations side by side. The left shows four points in a vertical column labelled C4FM and 4FSK. The right shows eight points arranged in a ring labelled pi over four DQPSK." xmlns="http://www.w3.org/2000/svg">
+  <!-- 4FSK / C4FM -->
+  <g>
+    <line x1="30" y1="100" x2="200" y2="100" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="115" y1="20" x2="115" y2="180" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor">
+      <circle cx="115" cy="40" r="4"/><text x="135" y="44" font-size="9">+3</text>
+      <circle cx="115" cy="80" r="4"/><text x="135" y="84" font-size="9">+1</text>
+      <circle cx="115" cy="120" r="4"/><text x="135" y="124" font-size="9">−1</text>
+      <circle cx="115" cy="160" r="4"/><text x="135" y="164" font-size="9">−3</text>
+    </g>
+    <text x="115" y="196" text-anchor="middle" font-size="11" fill="currentColor">C4FM / 4FSK — 4 levels</text>
+  </g>
+  <!-- pi/4 DQPSK -->
+  <g>
+    <line x1="290" y1="100" x2="460" y2="100" stroke="currentColor" stroke-opacity="0.3"/>
+    <line x1="375" y1="20" x2="375" y2="180" stroke="currentColor" stroke-opacity="0.3"/>
+    <g fill="currentColor">
+      <circle cx="375" cy="48" r="4"/><circle cx="412" cy="63" r="4"/><circle cx="427" cy="100" r="4"/><circle cx="412" cy="137" r="4"/>
+      <circle cx="375" cy="152" r="4"/><circle cx="338" cy="137" r="4"/><circle cx="323" cy="100" r="4"/><circle cx="338" cy="63" r="4"/>
+    </g>
+    <text x="375" y="196" text-anchor="middle" font-size="11" fill="currentColor">π/4-DQPSK — 8-point ring</text>
+  </g>
+</svg>
+<figcaption>C4FM and 4FSK stack four symbol levels (a vertical column on a symbol scope, four points on a constellation); π/4-DQPSK rotates phase around an eight-point ring. CQPSK is engineered to land on the same four-point pattern as C4FM.</figcaption>
+</figure>
+
+## Reading them on the scopes
+
+Every one of these modulations is just a pattern of symbols, and GopherTrunk draws
+those symbols live. On the **[Constellation panel](/constellation.html)** you'll see
+the four points of C4FM/4FSK or the ring of π/4-DQPSK; tight, well-separated clusters
+mean a clean signal, while smearing toward the centre signals low
+[SNR](/learn/rf-sdr/decibels/), mistuning, or a clock problem. The
+**[Eye diagram](/eye-diagram.html)** shows the same symbols against time — for the
+four-level modes you'll see **three stacked eyes**, and the wider they open, the more
+margin the decoder has.
+
+These views are how you both **identify** a system and **tune** it: a P25 simulcast
+signal that won't lock often shows a recognisable distortion on the constellation, and
+the only way to spot that is to look. Later lessons on
+[tuning with scopes](/learn/rf-sdr/tuning-with-scopes/) lean directly on what you've
+just learned to read.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — 4 levels carry 2 bits each, so 4800 × 2 = 9600 bps." markdown="0">
+  <p class="knowledge-check__q">Quick check: P25 Phase 1 C4FM runs at 4800 symbols/s. What is its bit rate?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">4800 bps</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">9600 bps</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">19200 bps</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **C4FM** is four-level FSK; P25 Phase 1 runs it at **4800 symbols/s = 9600 bps**.
+- **CQPSK / LSM** is a linear cousin that lands on the same constellation and is used
+  by **simulcast** transmitters that need phase precision.
+- **π/4-DQPSK** carries **TETRA**; plain **4FSK** carries **DMR** and **NXDN**.
+- Each has a recognisable **constellation** and **eye diagram** that GopherTrunk plots
+  live.
+- Reading those shapes is how you **identify** a system and **tune** a clean lock.
+
+Next, we look inside the bitstream itself: [framing, error correction and
+interleaving](framing-fec-interleaving/) — the structure that lets digital survive
+fading.

--- a/docs/learn/digital-trunking/dmr-tier-2-3.md
+++ b/docs/learn/digital-trunking/dmr-tier-2-3.md
@@ -1,0 +1,183 @@
+---
+slug: dmr-tier-2-3
+title: "DMR: Tier II & Tier III"
+description: DMR explained in depth — ETSI TS 102 361, two-slot TDMA in 12.5 kHz, 4FSK and AMBE+2, the three tiers, color codes, CSBK signaling, and the proprietary Capacity/Connect variants.
+keywords: DMR, ETSI TS 102 361, Tier II, Tier III, two-slot TDMA, 4FSK, AMBE+2, color code, CSBK, Capacity Plus, Connect Plus, Capacity Max, Hytera XPT, DMR trunking
+level: intermediate
+status: full
+prereq:
+  - tdma-vs-fdma
+  - control-channel-signaling
+faq:
+  - q: What is DMR?
+    a: DMR (Digital Mobile Radio) is an open ETSI standard, TS 102 361, widely used in business, utility and amateur radio. It fits two-slot TDMA into a 12.5 kHz channel — about 6.25 kHz equivalent per call — using 4FSK at 4800 symbols per second and the AMBE+2 vocoder. Its low cost made it the dominant digital standard outside public safety.
+  - q: What are the three DMR tiers?
+    a: Tier I is license-free, low-power simplex for personal and light commercial use. Tier II is conventional licensed operation with two-slot TDMA repeaters — the most common business DMR. Tier III is trunked DMR, with a dedicated control channel and CSBK signaling that assigns calls across a channel pool.
+  - q: What is a DMR color code?
+    a: A color code is a value carried in DMR bursts that works like a NAC or CTCSS tone — radios ignore traffic whose color code does not match. It lets neighboring repeaters share a frequency without interfering. GopherTrunk reads the color code to confirm it is decoding the right repeater.
+  - q: How do proprietary DMR trunking systems differ from Tier III?
+    a: Vendors built their own trunked schemes on the DMR physical layer — Motorola Capacity Plus, Connect Plus and Capacity Max, and Hytera XPT — before or alongside open Tier III. They use vendor-specific control signaling rather than standard Tier III CSBKs, so a decoder needs system-specific support to follow them, while conventional Tier II DMR is well covered by the open standard.
+gophertrunk_links:
+  - title: DMR encryption
+    url: /dmr-encryption.html
+    note: configure known keys for DMR systems with RC4 Enhanced Privacy.
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch CSBK signaling on a Tier III control channel.
+  - title: Vocoders
+    url: /vocoders.html
+    note: see how GopherTrunk renders DMR's AMBE+2 voice frames.
+---
+
+# DMR: Tier II & Tier III
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**DMR** (Digital Mobile Radio) is the open **ETSI TS 102 361** standard that dominates
+business, utility and amateur digital radio. It packs **two-slot TDMA** into a **12.5 kHz**
+channel — **≈6.25 kHz equivalent** per call — using **4FSK at 4800 symbols/s (9600 bps)**
+and the **AMBE+2** vocoder. It comes in **three tiers**: **Tier I** (license-free
+simplex), **Tier II** (conventional two-slot repeaters), and **Tier III** (trunked, with a
+dedicated control channel and **CSBK** signaling). A **color code** keeps repeaters apart
+like a NAC. Vendors also built proprietary trunked variants — **Capacity Plus, Connect
+Plus, Capacity Max, Hytera XPT** — that differ from open Tier III.
+</div>
+
+Where [P25](p25-phase-1/) rules North-American public safety, **DMR** rules almost
+everything else digital: taxis, warehouses, utilities, security, and a vast amateur
+network. Its appeal is simple — it is an open standard with cheap radios that doubles
+capacity on existing 12.5 kHz channels. This lesson unpacks how it works and the tiers
+you will meet.
+
+## The physical layer: two slots in 12.5 kHz
+
+DMR uses **4FSK** — the same four-level FSK family as P25's
+[C4FM](digital-modulation-for-trunking/) — running at **4800 symbols/s**, which (two bits
+per symbol) gives **9600 bps**. The clever part is **two-slot TDMA**: a single 12.5 kHz
+channel is split in *time* into two alternating slots, so it carries **two simultaneous
+calls**. That is the same **6.25 kHz equivalent** efficiency idea as P25 Phase 2, but DMR
+built it in from the start across the whole standard. Voice rides in the **AMBE+2**
+[vocoder](/learn/rf-sdr/vocoders/) — specifically the 3600×2450 variant, distinct from the
+3600×2400 variant P25 Phase 2 and NXDN use.
+
+A **color code** (0–15) is carried in the bursts and works like a P25 NAC or an analog
+CTCSS tone: a radio ignores traffic whose color code does not match, so neighbouring
+repeaters can reuse a frequency without interfering. GopherTrunk reads it to confirm it is
+locked to the intended repeater.
+
+## The three tiers
+
+DMR is defined as three tiers, escalating in capability:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 200" role="img" aria-label="Three stacked tiers of DMR. Tier I license-free simplex at the bottom, Tier II conventional two-slot repeater in the middle, Tier III trunked with a control channel at the top." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="11" fill="currentColor">
+    <rect x="60" y="140" width="420" height="44" rx="5" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.4"/>
+    <text x="270" y="158" text-anchor="middle" font-weight="600">Tier I — license-free, low-power simplex</text>
+    <text x="270" y="174" text-anchor="middle" font-size="9">no repeater, no infrastructure</text>
+    <rect x="60" y="86" width="420" height="44" rx="5" fill="currentColor" fill-opacity="0.16" stroke="currentColor" stroke-width="1.4"/>
+    <text x="270" y="104" text-anchor="middle" font-weight="600">Tier II — conventional licensed, two-slot repeater</text>
+    <text x="270" y="120" text-anchor="middle" font-size="9">fixed channel, 2 calls per frequency, color code</text>
+    <rect x="60" y="32" width="420" height="44" rx="5" fill="currentColor" fill-opacity="0.26" stroke="currentColor" stroke-width="1.6"/>
+    <text x="270" y="50" text-anchor="middle" font-weight="600">Tier III — trunked, dedicated control channel</text>
+    <text x="270" y="66" text-anchor="middle" font-size="9">CSBK signaling assigns calls across a channel pool</text>
+  </g>
+</svg>
+<figcaption>The three DMR tiers escalate from license-free simplex (Tier I) through conventional two-slot repeaters (Tier II) to fully trunked operation with a control channel (Tier III).</figcaption>
+</figure>
+
+- **Tier I** — **license-free**, low-power **simplex** (radio to radio, no repeater). Think
+  consumer and very light commercial use. There is no infrastructure to follow.
+- **Tier II** — **conventional, licensed** operation through **two-slot repeaters**. Each
+  repeater sits on a fixed pair of frequencies and carries two slots. This is the
+  workhorse of commercial DMR and amateur DMR repeaters. There is *no* control channel —
+  you monitor it much like a conventional channel, decoding whichever slot is active.
+- **Tier III** — **trunked** DMR. A **dedicated control channel** carries **CSBK**
+  (Control Signaling Block) messages that grant calls across a pool of channels, exactly
+  the trunking pattern you know from P25 but with DMR's signaling vocabulary.
+
+## Conventional Tier II vs. trunked Tier III
+
+The practical difference is whether there is a control channel to follow.
+
+| | DMR Tier II | DMR Tier III |
+|---|-------------|--------------|
+| Operation | Conventional | Trunked |
+| Control channel | None | Dedicated, CSBK signaling |
+| Channel assignment | Fixed per repeater | Assigned per call from a pool |
+| Signaling | Embedded link control | CSBK grants on control channel |
+| How you monitor | Watch the repeater's two slots | Decode control channel, follow grants |
+| GopherTrunk grant | `dmr-tier2` | `dmr-tier3` |
+
+For **Tier II**, GopherTrunk treats the repeater like a conventional digital channel:
+lock the carrier, read the embedded link control to learn the talkgroup and source ID per
+slot, and decode AMBE+2 for whichever slot is transmitting. For **Tier III**, it does the
+full trunking dance — lock the **control channel**, read **CSBKs** on the
+**[CC Activity](/cc-activity.html)** panel, and follow each grant to the assigned voice
+channel and slot, exactly as it does for [P25](p25-phase-1/) but with DMR framing.
+
+## CSBKs: DMR's trunking signaling
+
+The **CSBK** is to Tier III what the TSBK is to P25: a fixed-size control message. On a
+Tier III control channel a continuous stream of CSBKs announces channel grants,
+registrations, and system parameters. The grant CSBKs tell a follower which physical
+channel and **time slot** a talkgroup's call was assigned. Because DMR is two-slot, a
+Tier III grant — like P25 Phase 2 — references a *slot* as well as a frequency, so the
+decoder must tune the channel and then lock the correct slot.
+
+## The proprietary variants
+
+Here is the wrinkle that makes DMR trunking messy in the field: several major **trunked
+DMR systems are not open Tier III** at all. Vendors built their own trunking on top of the
+DMR physical layer — often before Tier III was finalized — using **vendor-specific control
+signaling** rather than standard CSBK grants:
+
+- **Motorola Capacity Plus** — single-site (and Multi-Site) trunking that spreads calls
+  across a repeater's slots without a separate dedicated control channel in the
+  Tier III sense.
+- **Motorola Connect Plus** — multi-site trunking using a dedicated control channel, but
+  with Motorola's own signaling, not open CSBKs.
+- **Motorola Capacity Max** — Motorola's later, larger multi-site trunked architecture.
+- **Hytera XPT** — Hytera's distributed trunking scheme.
+
+All sit on the same 4FSK + AMBE+2 physical layer, so they *look* like DMR on a scope, but
+their control signaling differs from the open standard. A decoder therefore needs
+**system-specific support** to follow each one; the open Tier III CSBK logic does not
+automatically apply. Conventional Tier II, by contrast, is well covered by the open
+standard and the most reliably decoded.
+
+## Encryption on DMR
+
+Many commercial DMR systems protect voice with **RC4/ARC4 "Enhanced Privacy."**
+GopherTrunk supports **known-key** decode: an operator supplies a key they are authorized
+to hold, declared per system with a `key_id`, `algorithm: rc4`, and the hex key. It reads
+the encrypted flag from the link control before voice starts, and for unencrypted calls
+decodes AMBE+2 end to end. The full configuration and current pipeline status — including
+which descramble step is still pending — are in [DMR encryption](/dmr-encryption.html).
+GopherTrunk performs **no key recovery**; only monitor systems you are legally permitted
+to monitor.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — Tier III is the trunked tier, with a dedicated control channel and CSBK signaling." markdown="0">
+  <p class="knowledge-check__q">Quick check: which DMR tier is trunked, with a dedicated control channel?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Tier I</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Tier II</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Tier III</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **DMR** is the open **ETSI TS 102 361** standard: **two-slot TDMA in 12.5 kHz, 4FSK at
+  9600 bps, AMBE+2** voice, with a **color code** that keeps repeaters apart.
+- **Tier I** is license-free simplex; **Tier II** is conventional two-slot repeaters;
+  **Tier III** is trunked with a control channel and **CSBK** signaling.
+- GopherTrunk reads embedded link control on **Tier II** and follows **CSBK grants** on
+  **Tier III**, including the per-call **slot**.
+- Proprietary **Capacity Plus / Connect Plus / Capacity Max / Hytera XPT** share DMR's
+  physical layer but use vendor signaling, needing system-specific support.
+- DMR **RC4 Enhanced Privacy** is supported in a known-key model only.
+
+That closes the P25 and DMR module. The next module opens with another major trunked
+family rooted in Europe: [TETRA](tetra/).

--- a/docs/learn/digital-trunking/dpmr-dstar-ysf.md
+++ b/docs/learn/digital-trunking/dpmr-dstar-ysf.md
@@ -1,0 +1,138 @@
+---
+slug: dpmr-dstar-ysf
+title: "dPMR, D-STAR & System Fusion"
+description: dPMR, D-STAR, and Yaesu System Fusion explained — the lighter digital modes you meet on the air, mostly not trunked, with narrowband 4FSK, GMSK, and C4FM voice.
+keywords: dPMR, D-STAR, System Fusion, C4FM, GMSK, 4FSK FDMA, 6.25 kHz, amateur radio digital, AMS, DV voice, M17, narrowband digital voice
+level: beginner
+status: full
+prereq:
+  - nxdn
+  - voice-to-bits-vocoders
+faq:
+  - q: What is dPMR?
+    a: dPMR (digital Private Mobile Radio) is an ETSI narrowband standard using 6.25 kHz FDMA with 4FSK modulation. It is very close to NXDN in footprint and is used mostly for conventional, light commercial radio. It is not usually a trunked system, but you'll meet it on business and utility channels.
+  - q: What is D-STAR?
+    a: D-STAR is a digital amateur-radio mode developed with Icom. It uses GMSK modulation at 4800 bps carrying a single voice stream (DV) plus slow data. It is a ham mode rather than a trunked public-safety system, popular for repeaters and internet-linked networks.
+  - q: What is Yaesu System Fusion?
+    a: System Fusion is Yaesu's amateur digital mode, built on C4FM 4FSK. Its Automatic Mode Select (AMS) feature lets a repeater handle both digital and analog signals automatically, so a Fusion repeater can pass either. Like D-STAR, it is an amateur mode, not a trunked system.
+  - q: Are these modes trunked?
+    a: Mostly no. dPMR, D-STAR, and System Fusion are predominantly conventional — fixed channels and repeaters rather than control-channel trunking. You'll still meet them on the air, and GopherTrunk can decode their voice even though there's usually no control channel to follow.
+gophertrunk_links:
+  - title: M17
+    url: /m17.html
+    note: GopherTrunk's support for the open M17 digital voice mode.
+  - title: Vocoders
+    url: /vocoders.html
+    note: how GopherTrunk decodes the voice these modes carry.
+---
+
+# dPMR, D-STAR & System Fusion
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A round-up of the **lighter digital modes** you'll meet that are mostly **not trunked**.
+**dPMR** is an **ETSI 6.25 kHz 4FSK FDMA** standard, close to NXDN, used for light
+commercial radio. **D-STAR** is an **amateur** mode (Icom) using **GMSK at 4800 bps** with a
+single **DV** voice stream plus slow data. **Yaesu System Fusion** is amateur **C4FM** that
+can **mix digital and analog** via **AMS**. These are mostly **conventional**, but you'll
+still hear them — and **GopherTrunk can decode their voice**. The open **[M17](/m17.html)**
+mode rounds out the picture.
+
+</div>
+
+The systems earlier in this module were full trunked networks. These last few are different:
+they're mostly **conventional** digital modes — fixed channels and repeaters — that you'll
+nonetheless run across on the air. None usually has a [control channel](the-control-channel/)
+to follow, but each carries digital voice GopherTrunk can decode.
+
+## dPMR — NXDN's close cousin
+
+**dPMR** (digital Private Mobile Radio) is an **ETSI** standard that uses **6.25 kHz FDMA**
+with **4FSK** modulation. If that sounds almost identical to [NXDN](nxdn/), it is — the two
+share the same narrowband 4FSK footprint and are easy to confuse on the
+[waterfall](/learn/rf-sdr/fft-and-waterfall/). They're separate standards, but their on-air
+fingerprints are nearly the same width and shape.
+
+dPMR is used mostly for **conventional, light commercial** radio — small business fleets and
+similar — rather than big trunked networks. Treat it as the European sibling of NXDN that you
+identify the same way: very narrow, 4FSK, confirmed by the decoder.
+
+## D-STAR — the amateur GMSK mode
+
+**D-STAR** (Digital Smart Technologies for Amateur Radio) is a **ham-radio** mode developed
+with **Icom**. Its traits:
+
+- **GMSK** modulation — Gaussian Minimum Shift Keying — at **4800 bps**. This is a different
+  scheme from the 4FSK of NXDN/dPMR and the C4FM of Fusion.
+- A **single voice stream** (called **DV**, digital voice) plus a **slow data** channel
+  riding alongside for things like callsigns and short messages.
+- Strong support for **internet-linked** repeater networks, which made it popular for
+  long-distance amateur contacts.
+
+It is an amateur mode, so you won't find public-safety trunking here — just ham operators on
+repeaters and simplex.
+
+## Yaesu System Fusion — C4FM that mixes modes
+
+**Yaesu System Fusion** is Yaesu's amateur digital mode, built on **C4FM** — the same
+four-level FSK family you met in [digital modulation for
+trunking](digital-modulation-for-trunking/). Its standout feature is **AMS**, *Automatic Mode
+Select*: a Fusion repeater can **automatically handle both digital and analog** signals,
+switching as needed. That lets a single repeater serve digital Fusion users and traditional
+analog FM users without anyone choosing a mode by hand — a pragmatic bridge for clubs moving
+to digital gradually.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 160" role="img" aria-label="Three light digital modes side by side: dPMR using 4FSK FDMA, D-STAR using GMSK, and System Fusion using C4FM with automatic analog and digital handling." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <text x="90" y="20" text-anchor="middle" font-weight="600">dPMR</text>
+    <rect x="30" y="32" width="120" height="60" rx="6" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="1.2"/>
+    <text x="90" y="56" text-anchor="middle" font-size="9">4FSK FDMA</text>
+    <text x="90" y="72" text-anchor="middle" font-size="9">6.25 kHz</text>
+    <text x="90" y="88" text-anchor="middle" font-size="8">light commercial</text>
+    <text x="260" y="20" text-anchor="middle" font-weight="600">D-STAR</text>
+    <rect x="200" y="32" width="120" height="60" rx="6" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="1.2"/>
+    <text x="260" y="56" text-anchor="middle" font-size="9">GMSK 4800 bps</text>
+    <text x="260" y="72" text-anchor="middle" font-size="9">DV + slow data</text>
+    <text x="260" y="88" text-anchor="middle" font-size="8">amateur</text>
+    <text x="430" y="20" text-anchor="middle" font-weight="600">System Fusion</text>
+    <rect x="370" y="32" width="120" height="60" rx="6" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="1.2"/>
+    <text x="430" y="56" text-anchor="middle" font-size="9">C4FM</text>
+    <text x="430" y="72" text-anchor="middle" font-size="9">AMS: digital + analog</text>
+    <text x="430" y="88" text-anchor="middle" font-size="8">amateur</text>
+    <text x="260" y="125" text-anchor="middle" font-size="9">All mostly conventional — no control channel to follow.</text>
+  </g>
+</svg>
+<figcaption>Three lighter digital modes: dPMR (narrowband 4FSK), D-STAR (GMSK), and System Fusion (C4FM with automatic analog/digital handling) — mostly conventional, not trunked.</figcaption>
+</figure>
+
+## Not trunked, but still on the air
+
+The common thread is that none of these is normally a **trunked** system. There's usually no
+control channel granting voice channels — they're [conventional](conventional-vs-trunked/)
+modes on fixed frequencies and repeaters. You meet them not by hunting a control channel but
+by tuning the channel directly. The good news is that **GopherTrunk can decode the voice**
+they carry once you're on the right frequency, even though there's no trunking to track.
+
+One more worth knowing: **[M17](/m17.html)** is a fully **open**, community-developed digital
+voice mode — free of the patent-encumbered [vocoders](/learn/rf-sdr/vocoders/) the others rely
+on. GopherTrunk supports it, and it's a refreshing contrast to the proprietary codecs
+elsewhere in this path.
+
+## Recap
+
+- **dPMR** is an **ETSI 6.25 kHz 4FSK FDMA** standard, nearly a twin of NXDN, for light
+  commercial use.
+- **D-STAR** is an **amateur** mode using **GMSK at 4800 bps** with a single **DV** voice
+  stream plus slow data.
+- **Yaesu System Fusion** is amateur **C4FM**, and its **AMS** feature mixes digital and
+  analog on one repeater.
+- These are mostly **conventional** — no control channel — but **GopherTrunk decodes their
+  voice**.
+- The open **M17** mode is a patent-free alternative worth knowing.
+
+That wraps the survey of other digital systems. The next module gets hands-on, starting with
+[identifying the system](identifying-the-system/) you're actually looking at.
+
+You can also revisit the broader catalogue of non-trunked transmissions in [other
+signals](/learn/rf-sdr/other-signals/).

--- a/docs/learn/digital-trunking/edacs-ltr-mpt1327.md
+++ b/docs/learn/digital-trunking/edacs-ltr-mpt1327.md
@@ -1,0 +1,148 @@
+---
+slug: edacs-ltr-mpt1327
+title: "EDACS, LTR & MPT-1327"
+description: EDACS, LTR, and MPT-1327 explained — three legacy trunking families with a fast EDACS control channel, LTR's distributed sub-audible data, and MPT-1327's global reach.
+keywords: EDACS, LTR, MPT-1327, Logic Trunked Radio, AFS, agency fleet subfleet, ProVoice, LTR-Net, Passport, distributed control, legacy trunking, 9600 bps control channel
+level: intermediate
+status: full
+prereq:
+  - trunking-flavors
+  - analog-trunking-era
+faq:
+  - q: What is EDACS?
+    a: EDACS (Enhanced Digital Access Communications System) is a trunking family from GE, later Ericsson and Harris. It uses a fast dedicated 9600 bps control channel and an AFS — Agency/Fleet/Subfleet — talkgroup numbering scheme. Voice is usually analog FM, though a digital variant called ProVoice exists.
+  - q: How is LTR different from other trunking systems?
+    a: LTR (Logic Trunked Radio) has no dedicated control channel. Instead, low-speed sub-audible data is carried on every repeater alongside the voice, so the trunking control is distributed across all the channels rather than centralised on one. Variants include LTR-Net and Passport.
+  - q: What is MPT-1327?
+    a: MPT-1327 is a British signaling standard for analog trunking, widely used internationally outside North America. It uses a 1200 bps control channel and analog FM voice. It was one of the most common trunking standards in Europe, Africa, Australia, and elsewhere for commercial and government fleets.
+  - q: Are these systems still in use?
+    a: Yes, though they're legacy and shrinking as operators migrate to P25 and DMR. EDACS, LTR, and MPT-1327 systems still run in various regions, and a scanner enthusiast still meets them. Recognising each by its control-channel behaviour is a useful skill.
+gophertrunk_links:
+  - title: Status
+    url: /status.html
+    note: which legacy trunking protocols GopherTrunk decodes.
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch the control-channel data these systems use to coordinate calls.
+---
+
+# EDACS, LTR & MPT-1327
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Three legacy trunking families you'll still meet. **EDACS** (GE/Ericsson/Harris) uses a
+**fast dedicated 9600 bps control channel** and **AFS — Agency/Fleet/Subfleet** numbering,
+with a digital **ProVoice** voice option. **LTR** (Logic Trunked Radio) is unusual:
+**no dedicated control channel** — low-speed **sub-audible data rides on every repeater**,
+so control is **distributed**, with variants **LTR-Net** and **Passport**. **MPT-1327** is
+the **British/European** standard with a **1200 bps control channel**, used widely
+**internationally**. All three are mostly **analog FM voice** with digital signaling.
+
+</div>
+
+Beyond Motorola's [SmartNet](motorola-smartnet/), three other legacy families filled the
+analog-trunking world. Each solved the [trunking](conventional-vs-trunked/) problem
+differently, and each has a recognisable fingerprint on the air.
+
+## EDACS
+
+**EDACS** — Enhanced Digital Access Communications System — came from **General Electric**,
+passing through **Ericsson** and then **Harris** as the product line changed hands. Its
+hallmarks:
+
+- A **fast, dedicated control channel** running at **9600 bps** — quicker than SmartNet's
+  3600 bps or MPT's 1200 bps, which made EDACS feel snappy in assigning channels.
+- **AFS** talkgroup numbering — **Agency / Fleet / Subfleet** — a three-level hierarchy that
+  organises [talkgroups](talkgroups-ids-affiliation/) by agency, then fleet within it, then
+  subfleet, rather than a flat number.
+- Voice is usually **analog FM**, but a **digital variant, ProVoice**, exists for systems
+  that wanted digital audio over the EDACS infrastructure.
+
+EDACS was a serious public-safety and utility contender in its day and you'll still find
+systems running.
+
+## LTR
+
+**LTR** — Logic Trunked Radio — takes a genuinely different approach to everything else in
+this path. There is **no dedicated control channel at all**.
+
+Instead, **low-speed sub-audible data** is carried on **every repeater**, riding along below
+the voice on each channel. The trunking logic is **distributed** across all the channels
+rather than centralised on one control frequency: each repeater announces its own status,
+and radios use that scattered data to find and follow calls. This makes LTR systems cheaper
+and simpler to build — there's no separate control channel to dedicate — but it means the
+"control" information is spread out rather than sitting in one place.
+
+Common variants you'll meet:
+
+- **LTR-Net** — a networked, multi-site evolution of basic LTR.
+- **Passport** — another LTR variant with its own roaming and numbering features.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 170" role="img" aria-label="A comparison: a centralised system with one dedicated control channel feeding voice channels, versus LTR where each repeater carries its own sub-audible control data." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <text x="135" y="18" text-anchor="middle" font-weight="600">Dedicated control (EDACS, MPT)</text>
+    <rect x="40" y="30" width="190" height="22" rx="4" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <text x="135" y="45" text-anchor="middle" font-size="9">one control channel</text>
+    <rect x="40" y="70" width="58" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="1"/><text x="69" y="84" text-anchor="middle" font-size="8">voice</text>
+    <rect x="106" y="70" width="58" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="1"/><text x="135" y="84" text-anchor="middle" font-size="8">voice</text>
+    <rect x="172" y="70" width="58" height="20" rx="3" fill="none" stroke="currentColor" stroke-width="1"/><text x="201" y="84" text-anchor="middle" font-size="8">voice</text>
+    <line x1="135" y1="52" x2="135" y2="68" stroke="currentColor" stroke-width="1" stroke-dasharray="3 2"/>
+    <text x="405" y="18" text-anchor="middle" font-weight="600">Distributed (LTR)</text>
+    <rect x="310" y="70" width="58" height="34" rx="3" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1"/><text x="339" y="86" text-anchor="middle" font-size="8">voice</text><text x="339" y="98" text-anchor="middle" font-size="7">+ sub-audible</text>
+    <rect x="376" y="70" width="58" height="34" rx="3" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1"/><text x="405" y="86" text-anchor="middle" font-size="8">voice</text><text x="405" y="98" text-anchor="middle" font-size="7">+ sub-audible</text>
+    <rect x="442" y="70" width="58" height="34" rx="3" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1"/><text x="471" y="86" text-anchor="middle" font-size="8">voice</text><text x="471" y="98" text-anchor="middle" font-size="7">+ sub-audible</text>
+    <text x="405" y="128" text-anchor="middle" font-size="9">every repeater carries its own control data</text>
+  </g>
+</svg>
+<figcaption>EDACS and MPT-1327 use one dedicated control channel; LTR distributes the control as sub-audible data on every repeater, with no separate control frequency.</figcaption>
+</figure>
+
+## MPT-1327
+
+**MPT-1327** is a **British signaling standard** (the "MPT" prefix comes from the UK Ministry
+of Posts and Telecommunications) that became the **dominant trunking standard outside North
+America**. It uses a **1200 bps control channel** and **analog FM** voice.
+
+For decades MPT-1327 was the go-to for commercial and government fleets across **Europe,
+Africa, Australia, Asia, and Latin America** — taxi companies, utilities, transport, and
+public services. Its international ubiquity is roughly the role SmartNet played in the US.
+You're most likely to meet it if you monitor outside North America.
+
+## Telling them apart
+
+| System | Control channel | Talkgroup numbering | Origin | Where common |
+|--------|-----------------|---------------------|--------|--------------|
+| **EDACS** | Dedicated, **9600 bps** (fast) | **AFS** (Agency/Fleet/Subfleet) | GE → Ericsson → Harris | US public safety, utilities |
+| **LTR** | **None** — distributed sub-audible on every repeater | Home repeater + ID | Specialised mobile radio | Business, light commercial |
+| **MPT-1327** | Dedicated, **1200 bps** | Prefix + ident | UK (MPT) | International, outside North America |
+
+The quickest fingerprints: EDACS has a *fast* dedicated control channel; **LTR has no
+dedicated control channel** to find at all (look for sub-audible data on the voice
+repeaters); and MPT-1327's slower 1200 bps control channel turns up mostly outside the US.
+As always, the surest identification is letting a decoder read the [control-channel
+signaling](control-channel-signaling/) once it's locked.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — LTR has no dedicated control channel; the data is distributed across every repeater." markdown="0">
+  <p class="knowledge-check__q">Quick check: which of these systems has no dedicated control channel?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">EDACS</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">MPT-1327</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">LTR</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **EDACS** (GE/Ericsson/Harris) uses a **fast 9600 bps dedicated control channel** and
+  **AFS** numbering, with a digital **ProVoice** option.
+- **LTR** has **no dedicated control channel** — control is **distributed** as sub-audible
+  data on every repeater; variants include **LTR-Net** and **Passport**.
+- **MPT-1327** is the **British/European** standard, **1200 bps** control channel, used
+  **widely internationally**.
+- All three carry mostly **analog FM voice** with digital signaling.
+- Tell them apart by control-channel behaviour — or let the decoder identify the signaling.
+
+Next, we lighten up with the smaller digital modes you'll meet on the bands: [dPMR, D-STAR
+& System Fusion](dpmr-dstar-ysf/).

--- a/docs/learn/digital-trunking/encryption-and-authentication.md
+++ b/docs/learn/digital-trunking/encryption-and-authentication.md
@@ -1,0 +1,149 @@
+---
+slug: encryption-and-authentication
+title: "Encryption & authentication"
+description: How trunked systems encrypt voice — DES-OFB, AES-256, ADP/RC4 and proprietary schemes — why encryption is signaled in the headers so a decoder can see it, and authentication, stun and kill commands.
+keywords: encryption, DES-OFB, AES-256, ADP, RC4, P25 encryption, ALGID, key ID, encryption flag, authentication, stun, kill, clear vs secure talkgroup, DMR encryption
+level: intermediate
+status: full
+prereq:
+  - control-channel-signaling
+  - encryption
+faq:
+  - q: What encryption do trunked systems use?
+    a: Common schemes include DES-OFB, AES-256, and ADP (a lighter RC4-based option), plus vendor-proprietary modes like Motorola DVP. AES-256 is the strong, standard choice for P25 public safety. Each is identified in the signaling by an algorithm ID, so a decoder can tell which one is in use even without the key.
+  - q: Can GopherTrunk decode encrypted calls?
+    a: No. Without the encryption key, the voice payload is unintelligible, and GopherTrunk does not attempt to break encryption. What it can do is read the headers and show that a call is encrypted, including which algorithm and key ID the call advertises, so you know why there's no audio.
+  - q: How does a decoder know a call is encrypted?
+    a: Encryption is signaled in the call's headers. A flag marks the call as encrypted, and fields like the algorithm ID (ALGID) and key ID name the scheme and key. Because these travel in the clear alongside the voice, a decoder can see and display the encryption status even though it cannot read the protected audio.
+  - q: What are stun and kill commands?
+    a: Stun and kill are system commands sent to a specific radio to disable it — stun temporarily, kill more permanently — typically when a radio is lost or stolen. They ride the control channel like other unit-addressed messages. They concern the radios on the system, not a monitor's ability to receive.
+gophertrunk_links:
+  - title: DMR encryption
+    url: /dmr-encryption.html
+    note: see how GopherTrunk surfaces DMR encryption status on a call.
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch for the encryption flags and key IDs in the signaling.
+---
+
+# Encryption & authentication
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Trunked systems protect voice with encryption — **AES-256** (the strong standard),
+**DES-OFB**, **ADP** (an RC4-based lighter option), and vendor-proprietary modes. Crucially,
+encryption is **signaled in the headers**: an **encryption flag** plus an **algorithm ID
+(ALGID)** and **key ID** ride in the clear, so a decoder can **see that a call is
+encrypted** — and which scheme — even though it **cannot decode the audio** without the
+key. Talkgroups can be **clear** or **secure**. Systems also support **authentication** and
+**stun/kill** commands. GopherTrunk shows an **encrypted indicator**; it does **not** break
+encryption.
+
+</div>
+
+Encryption is the wall a monitor inevitably meets. You did the [conceptual
+groundwork](/learn/rf-sdr/encryption/) in the RF & SDR path; here we make it concrete for
+trunking — *which* schemes appear, *how* the system tells you a call is protected, and what
+a decoder can and can't do about it.
+
+## What encrypts the voice
+
+Encryption sits on the **voice payload** — the [vocoder](voice-to-bits-vocoders/) bits —
+scrambling them so only a radio holding the matching key can recover audio. The schemes you
+meet on trunked systems include:
+
+| Scheme | Notes |
+|--------|-------|
+| AES-256 | The strong, standard choice for P25 public safety |
+| DES-OFB | Older block cipher in output-feedback mode; still in use |
+| ADP (RC4-based) | A lighter, lower-cost option; weaker than AES |
+| Proprietary (e.g. Motorola DVP family) | Vendor-specific modes, including legacy designs |
+
+The takeaway isn't the cryptographic detail — it's that **strong, modern encryption (AES)
+is effectively unbreakable to a monitor**, and even the lighter schemes require the key. A
+receiver without the key gets noise where the audio should be.
+
+## Encryption is signaled in the clear
+
+Here's the part that matters for decoding. The **encryption status travels in the call's
+headers**, *not* hidden inside the encrypted payload. A call carries:
+
+- an **encryption flag** marking it as protected,
+- an **algorithm ID** (P25 calls this **ALGID**) naming the scheme, and
+- a **key ID** indicating which key the call uses.
+
+These fields are in the clear so that *receiving radios* know how to handle the call — and
+that same visibility lets a **decoder see and display** the encryption status. So even
+though the audio is locked, a monitor can tell you *this call is encrypted, with this
+algorithm, under this key*. That's a genuinely useful thing to know: it distinguishes "I
+can't hear it because it's encrypted" from "I can't hear it because my lock is bad."
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 170" role="img" aria-label="A diagram of a call frame showing a clear header carrying an encryption flag, algorithm ID, and key ID, followed by an encrypted voice payload that the decoder cannot read." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="50" width="200" height="50" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+  <text x="140" y="42" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Header (in the clear)</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="140" y="70">ENC flag · ALGID · key ID</text>
+    <text x="140" y="88" font-size="8">decoder reads these</text>
+  </g>
+  <rect x="260" y="50" width="240" height="50" rx="5" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="380" y="42" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Voice payload (encrypted)</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="380" y="78">unreadable without the key</text>
+  </g>
+  <text x="270" y="135" text-anchor="middle" font-size="11" fill="currentColor">The decoder can SEE the call is encrypted; it cannot HEAR the audio.</text>
+</svg>
+<figcaption>The header travels in the clear with an encryption flag, algorithm ID, and key ID, so a decoder can report exactly that a call is encrypted — while the voice payload stays locked without the key.</figcaption>
+</figure>
+
+## Clear vs. secure talkgroups
+
+Encryption is usually applied per **talkgroup** (and can vary per call). A **clear**
+talkgroup carries unencrypted audio you can decode normally; a **secure** talkgroup is
+encrypted and yields no audio without the key. Many systems mix the two — some channels
+clear, some secure — and you'll often find that monitoring a system means hearing the clear
+talkgroups while the secure ones show only as *encrypted* in the log.
+
+## Authentication, stun, and kill
+
+Beyond scrambling voice, trunked systems manage the *radios themselves*. **Authentication**
+lets the system verify a radio's identity before granting it service, so a cloned or rogue
+radio can be rejected. And **stun**/**kill** commands — unit-addressed messages on the
+control channel — can disable a radio remotely, temporarily (stun) or more permanently
+(kill), typically when one is lost or stolen. These are operational features of the system;
+they don't affect whether *you* can receive, but they're part of the signaling vocabulary
+you may see.
+
+## What GopherTrunk can and can't do
+
+To be plain about it: GopherTrunk **shows an encrypted indicator** for protected calls,
+reading the flag and identifiers from the headers — see how DMR encryption status surfaces
+in **[DMR encryption](/dmr-encryption.html)**. It does **not** attempt to break encryption,
+because modern schemes like AES-256 are designed to resist exactly that. Encrypted audio
+stays encrypted; the honest, useful thing a decoder offers is *telling you so clearly*,
+rather than leaving you to wonder why a strong, well-locked signal produces no voice.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the encryption flag and IDs are in the clear, so a decoder can see (not hear) an encrypted call." markdown="0">
+  <p class="knowledge-check__q">Quick check: how can a decoder show that a call is encrypted without the key?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">By partially decrypting the audio</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The encryption flag and algorithm/key IDs travel in the clear in the header</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It can't — encryption is completely invisible</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Trunked voice is encrypted with **AES-256**, **DES-OFB**, **ADP (RC4)**, or proprietary
+  schemes.
+- Encryption is **signaled in the clear** — an **encryption flag**, **ALGID**, and **key
+  ID** in the header.
+- A decoder can therefore **see that a call is encrypted** without being able to **decode**
+  it.
+- Talkgroups can be **clear** or **secure**; systems also use **authentication** and
+  **stun/kill**.
+- GopherTrunk shows an **encrypted indicator** but does **not** break encryption.
+
+That completes how trunking works. The next module turns to the protocols themselves,
+starting with [P25 Phase 1](p25-phase-1/) — the workhorse of North-American public safety.

--- a/docs/learn/digital-trunking/finding-the-control-channel.md
+++ b/docs/learn/digital-trunking/finding-the-control-channel.md
@@ -1,0 +1,147 @@
+---
+slug: finding-the-control-channel
+title: Finding the control channel
+description: Locate the one frequency worth monitoring — use GopherTrunk's Hunt feature, online databases like RadioReference, and the telltale constant data burst, then add the system so GopherTrunk can follow it.
+keywords: control channel, find control channel, RadioReference, GopherTrunk hunt, control channel data burst, add trunked system, config.yaml, control channel frequency, hunt SDR
+level: intermediate
+status: full
+prereq:
+  - the-control-channel
+  - identifying-the-system
+faq:
+  - q: How do I find a trunked system's control channel?
+    a: Three ways, often combined. Look it up in a database like RadioReference, which lists known control-channel frequencies for documented systems. Recognise it on the air by its constant data burst — a control channel never goes quiet. Or let GopherTrunk's Hunt feature sweep a band, detect candidate carriers, identify the protocol, and report which one is the control channel.
+  - q: What does a control channel look like on the waterfall?
+    a: A control channel carries data continuously, so on the waterfall it shows as a carrier that is always active — a solid, unbroken trace rather than the on-and-off bursts of a voice channel. That constant activity is its single most reliable visual signature. Voice channels light up only when a call is granted; the control channel never stops.
+  - q: What is GopherTrunk's Hunt feature?
+    a: Hunt is GopherTrunk's tool for discovering systems you don't have frequencies for. It sweeps a band or processes IQ captures, detects carriers above the noise floor, runs each through the protocol identifier and decoder, and builds a map of the system — identity, control channel, and observed talkgroups — which it can export or merge straight into your config so you can start scanning.
+  - q: How do I add a system once I know its control channel?
+    a: Add the control-channel frequency and system type to GopherTrunk's configuration. If you discovered it with Hunt, the tool can commit the discovery into config.yaml directly. Either way, once the control channel and protocol are configured, GopherTrunk locks the control channel and begins following grants across the system.
+gophertrunk_links:
+  - title: Hunt (discover systems)
+    url: /hunt.html
+    note: sweep a band or process captures to find control channels you don't have.
+  - title: CC Activity
+    url: /cc-activity.html
+    note: confirm a control channel is locked by watching its chatter scroll live.
+---
+
+# Finding the control channel
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+To follow a trunked system you need exactly one frequency: its **[control
+channel](the-control-channel/)**. Find it three ways — look it up in a **database** like
+RadioReference, recognise its **constant data burst** on the
+[waterfall](/learn/rf-sdr/fft-and-waterfall/) (a control channel *never* goes quiet),
+or let GopherTrunk's **[Hunt](/hunt.html)** feature sweep a band, identify carriers, and
+report which one is the control channel. Then **add the control-channel frequency and
+system type** to your configuration — Hunt can even commit it for you — and GopherTrunk
+locks on and starts following grants.
+</div>
+
+You've learned to [identify](identifying-the-system/) what a system *is*. Now you need
+the one frequency to point GopherTrunk at. Everything else — voice channels,
+talkgroups, who's talking — flows from decoding the control channel, so finding it is
+the whole job.
+
+## Path 1 — look it up in a database
+
+For documented systems, someone has already done the work. **RadioReference.com** is
+the largest community database, listing system identities, sites, and — crucially —
+**control-channel frequencies** for tens of thousands of systems. Search by county or
+agency, note the listed control-channel (and alternate control-channel) frequencies and
+the system type, and you have everything you need to configure GopherTrunk.
+
+This is the easy path, and it's where you should start. The catch: **many systems are
+undocumented**. A new county system, a recently rebanded site, or a private network may
+not be in any database — which is where the other two paths come in.
+
+## Path 2 — recognise it on the air
+
+A control channel has one unmistakable signature: **it carries data continuously and
+never stops**. While voice channels light up only when a call is granted and fall silent
+between calls, the control channel transmits its [signalling](control-channel-signaling/)
+stream every moment the system is up.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 180" role="img" aria-label="A waterfall sketch showing one carrier that is solid and unbroken labelled control channel, and several other carriers that flicker on and off labelled voice channels." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <text x="20" y="20" font-weight="600">Waterfall — time runs downward</text>
+    <!-- control channel: solid column -->
+    <rect x="70" y="34" width="22" height="128" fill="currentColor" fill-opacity="0.5"/>
+    <text x="81" y="176" text-anchor="middle" font-size="9">control</text>
+    <!-- voice channels: broken columns -->
+    <g fill="currentColor" fill-opacity="0.5">
+      <rect x="180" y="40" width="22" height="34"/><rect x="180" y="120" width="22" height="28"/>
+      <rect x="290" y="60" width="22" height="50"/>
+      <rect x="400" y="34" width="22" height="20"/><rect x="400" y="90" width="22" height="44"/>
+    </g>
+    <text x="191" y="176" text-anchor="middle" font-size="9">voice 1</text>
+    <text x="301" y="176" text-anchor="middle" font-size="9">voice 2</text>
+    <text x="411" y="176" text-anchor="middle" font-size="9">voice 3</text>
+  </g>
+</svg>
+<figcaption>The control channel is the one carrier that's always lit. Voice channels flicker on only while a call is granted — so the unbroken column is your control channel.</figcaption>
+</figure>
+
+On the [waterfall](/learn/rf-sdr/fft-and-waterfall/) that constant activity stands out as
+a solid, unbroken column while the voice channels around it flicker. Tune to the
+suspect carrier, watch its [constellation](/constellation.html), and if it locks into a
+steady symbol stream that never pauses, you've almost certainly found the control
+channel. The [finding-systems](/learn/rf-sdr/finding-systems/) lesson covers the
+band-scanning side of this in more depth.
+
+## Path 3 — let GopherTrunk Hunt for it
+
+When you have no frequencies at all, GopherTrunk's **[Hunt](/hunt.html)** feature
+automates the search. Point it at a band (or feed it IQ captures of a suspected control
+channel) and it:
+
+1. **Sweeps** the band with an FFT and **detects carriers** above the noise floor.
+2. **Identifies** the protocol of each candidate across all of GopherTrunk's decoders.
+3. **Decodes** the control channel and **accumulates** what it sees — the system's
+   identity, the control-channel frequency, and every talkgroup observed in a grant.
+4. **Exports** a system map, and can **merge the discovery straight into your
+   config** so you can start scanning immediately.
+
+Because Hunt doesn't assume the control channel is the loudest carrier, it works even
+when the control channel sits off-centre and below a louder voice channel. This is the
+tool that closes the loop on undocumented systems — and it builds the same map a
+database lookup would have given you, straight from the air.
+
+## Adding the system so GopherTrunk can follow it
+
+Once you know the **control-channel frequency** and the **system type**, you add them to
+GopherTrunk's configuration. If you found the system with Hunt, the tool can commit the
+discovery into `config.yaml` for you; if you found it by hand, you enter the frequency
+and protocol yourself. Either way, GopherTrunk then **locks the control channel** and
+begins reading grants.
+
+Confirm it worked in the **[CC Activity](/cc-activity.html)** panel: within seconds of a
+good lock you should see affiliations, registrations, and voice grants scrolling past.
+If the panel stays empty, the control channel either isn't locked or you've got the wrong
+frequency — a problem we'll tackle in [troubleshooting](troubleshooting-a-decode/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the control channel transmits data constantly, so it's the carrier that never goes quiet." markdown="0">
+  <p class="knowledge-check__q">Quick check: on the waterfall, which carrier is most likely the control channel?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The one that lights up briefly every few seconds</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The one that's solid and never goes quiet</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The widest one on the band</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- You only need **one frequency** — the control channel — to follow a whole system.
+- A **database** like RadioReference lists control channels for documented systems.
+- On the air, the control channel is the carrier that **never goes quiet** — a solid
+  column on the [waterfall](/learn/rf-sdr/fft-and-waterfall/).
+- **[Hunt](/hunt.html)** sweeps, identifies, and maps undocumented systems automatically.
+- Add the **control-channel frequency and system type** to config, then confirm the lock
+  in **[CC Activity](/cc-activity.html)**.
+
+Next, we'll trace the whole pipeline — from a locked control channel to recorded audio —
+in [following a system end to end](following-a-system-end-to-end/).

--- a/docs/learn/digital-trunking/following-a-system-end-to-end.md
+++ b/docs/learn/digital-trunking/following-a-system-end-to-end.md
@@ -1,0 +1,153 @@
+---
+slug: following-a-system-end-to-end
+title: Following a system end to end
+description: Trace one trunked call through GopherTrunk — control channel decoded, talkgroup grant seen, voice channel tuned, vocoder run, audio out and recorded — the full pipeline that turns a lock into labelled audio.
+keywords: trunked call pipeline, control channel grant, voice channel follow, vocoder, GopherTrunk pipeline, talkgroup grant, multiple simultaneous calls, radio IDs, web console, architecture
+level: intermediate
+status: full
+prereq:
+  - finding-the-control-channel
+  - anatomy-of-a-call
+faq:
+  - q: What happens after GopherTrunk locks a control channel?
+    a: It reads the control channel's grants in real time. When it sees a talkgroup granted a voice channel, it tunes a receiver to that channel, demodulates and decodes it, runs the vocoder frames through a speech decoder to produce audio, and plays and records the result tagged with the talkgroup and radio ID. Then it's immediately ready for the next grant.
+  - q: Can GopherTrunk follow more than one call at once?
+    a: Yes. Because it decodes the control channel continuously, it knows every voice-channel grant as it happens and can task receivers to capture multiple simultaneous calls across the system. It mixes or queues them for playback and recording according to the priorities you set, so a busy system doesn't drop calls.
+  - q: How does GopherTrunk know which voice channel to tune?
+    a: The control channel announces it. Each grant names the talkgroup and the voice channel it's been assigned, so GopherTrunk reads the grant, looks up the frequency, and tunes a receiver there. Periodic grant updates let it catch calls already in progress, so late entry is handled too.
+  - q: Where can I watch this pipeline happen?
+    a: The web console shows each stage live — the CC Activity panel for control-channel grants, the Radio IDs panel for who's transmitting, and the active-call view for audio. The architecture page is the engineering view of the same flow. Watching these together is the fastest way to confirm the whole chain is healthy.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch grants arrive and calls start in real time.
+  - title: Radio IDs
+    url: /radio-ids.html
+    note: see which radio ID is transmitting on each call.
+  - title: Web console
+    url: /web.html
+    note: where every stage of the pipeline is visible live.
+---
+
+# Following a system end to end
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+With the [control channel locked](finding-the-control-channel/), GopherTrunk runs a
+continuous loop. It **decodes the control channel**, sees a **talkgroup grant**, **tunes
+a receiver** to the assigned **voice channel**, **demodulates and decodes** it, feeds the
+**[vocoder](/learn/rf-sdr/vocoders/)** frames to a speech decoder, and **plays and
+records** the audio tagged with the talkgroup and **[radio ID](/radio-ids.html)**.
+Because it keeps reading the control channel in parallel, it can **follow several calls
+at once**. Every stage is visible in the **[web console](/web.html)** — which makes
+watching the pipeline the fastest way to confirm it's healthy.
+</div>
+
+This is the trunking equivalent of [From antenna to
+audio](/learn/rf-sdr/antenna-to-audio/): the whole chain assembled, but with the
+trunking logic in the middle. We'll follow a single dispatch call from a grant on the
+control channel to a labelled recording on disk.
+
+## Stage 1 — the control channel is decoded continuously
+
+GopherTrunk is locked to the [control channel](the-control-channel/) and reading its
+[signalling](control-channel-signaling/) stream every moment. Affiliations,
+registrations, and — the part we care about — **channel grants** flow past. This
+decoding never pauses; it's the running map of the system, and you can watch it scroll
+in the **[CC Activity](/cc-activity.html)** panel.
+
+## Stage 2 — a grant is seen
+
+A user keys up. Their radio requests a channel, the system finds a free one, and the
+control channel broadcasts a **grant**: *"talkgroup 101 → voice channel 3."* GopherTrunk
+reads it, notes the talkgroup, the voice-channel frequency, and the transmitting
+**[radio ID](/radio-ids.html)**. This is the moment a call is born — the
+[anatomy-of-a-call](anatomy-of-a-call/) request-and-grant arc, seen from the decoder's
+side.
+
+## Stage 3 — the voice channel is tuned and decoded
+
+GopherTrunk tasks a receiver to tune to **voice channel 3** and runs the full receive
+chain on it — [filter, demodulate, recover symbols](/learn/rf-sdr/demodulation-pipeline/),
+decode. Because it's still reading the control channel in parallel, it can do this
+*and* catch the next grant elsewhere, capturing **multiple simultaneous calls** across
+the system. Periodic **grant updates** let it join calls already in progress (late
+entry), so nothing slips by.
+
+## Stage 4 — the vocoder reconstructs the voice
+
+The voice channel doesn't carry audio — it carries **[vocoder](/learn/rf-sdr/vocoders/)**
+frames, speech compressed to a few kilobits per second by a codec like **IMBE** (P25
+Phase 1) or **AMBE+2** (DMR, P25 Phase 2). GopherTrunk feeds those frames into a matching
+speech decoder, which **reconstructs an audible waveform**. This is the step that turns
+abstract bits back into a human voice.
+
+## Stage 5 — audio out and recording
+
+The reconstructed audio is played live in the console and written to a file **tagged
+with the talkgroup, radio ID, timestamp, and system**. From here GopherTrunk can stream
+it onward to services like Broadcastify or RdioScanner. The call that began as a grant
+on the control channel is now a labelled recording — and the engine is already following
+the next one.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 120" role="img" aria-label="The trunking pipeline as a row of boxes: control channel, grant seen, tune voice channel, demodulate and decode, vocoder, audio out, with a loop arrow returning from audio back to control channel." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9.5" fill="currentColor" text-anchor="middle">
+    <rect x="8"   y="44" width="74" height="34" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="45" y="58">control</text><text x="45" y="70">channel</text>
+    <rect x="98"  y="44" width="64" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="130" y="58">grant</text><text x="130" y="70">seen</text>
+    <rect x="178" y="44" width="64" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="210" y="58">tune</text><text x="210" y="70">voice ch</text>
+    <rect x="258" y="44" width="64" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="290" y="58">demod/</text><text x="290" y="70">decode</text>
+    <rect x="338" y="44" width="64" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="370" y="64">vocoder</text>
+    <rect x="418" y="44" width="74" height="34" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="455" y="58">audio out</text><text x="455" y="70">+ record</text>
+    <g stroke="currentColor" stroke-width="1.2">
+      <line x1="82" y1="61" x2="97" y2="61"/><line x1="162" y1="61" x2="177" y2="61"/><line x1="242" y1="61" x2="257" y2="61"/>
+      <line x1="322" y1="61" x2="337" y2="61"/><line x1="402" y1="61" x2="417" y2="61"/>
+    </g>
+    <path d="M455 44 C455 18, 45 18, 45 42" fill="none" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 3" marker-end="url(#lp)"/>
+    <text x="250" y="14" font-size="9">control channel keeps reading — ready for the next grant ↺</text>
+  </g>
+  <defs><marker id="lp" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The trunking loop: the control channel is decoded continuously, each grant spins up a voice-channel decode and vocoder, and the engine returns to wait for the next grant — following many calls at once.</figcaption>
+</figure>
+
+## Watching the whole thing live
+
+The **[web console](/web.html)** lets you watch every stage at once, which is the
+fastest way to confirm the pipeline is healthy:
+
+| Stage | Where to watch | Healthy sign |
+|-------|----------------|--------------|
+| Control channel decoded | [CC Activity](/cc-activity.html) | Affiliations and grants scrolling steadily |
+| Grant seen | [CC Activity](/cc-activity.html) | A `grant` row: TG ← radio @ frequency |
+| Voice channel followed | Active-call view | A call appears with a live audio meter |
+| Who's transmitting | [Radio IDs](/radio-ids.html) | The source radio ID labelled on the call |
+| Audio out | Active-call view | Audible playback, a written recording |
+
+If you want the engineering view of this same flow — the components and data paths
+behind the panels — the **[architecture](/architecture.html)** page lays it out. When a
+stage *doesn't* light up, this table doubles as a troubleshooting starting point.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — it reads the grant on the control channel, then tunes the named voice channel." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does GopherTrunk know which voice channel to tune for a new call?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It scans every voice channel until it hears audio</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The control-channel grant names the assigned voice channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses the same frequency as the last call</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- The **control channel is decoded continuously** — the running map of every call.
+- Each **grant** names a talkgroup and voice channel; GopherTrunk **tunes and decodes**
+  that channel.
+- The **[vocoder](/learn/rf-sdr/vocoders/)** reconstructs audio from the decoded frames.
+- Audio is **played and recorded**, tagged with talkgroup, radio ID, and timestamp.
+- Reading the control channel in parallel lets GopherTrunk **follow many calls at once**.
+- The **[web console](/web.html)** shows every stage live, which doubles as a health check.
+
+Next, we tackle the hardest real-world case: a system spread across multiple sites and
+simulcast transmitters, in [multi-site & simulcast in
+practice](multisite-and-simulcast-in-practice/).

--- a/docs/learn/digital-trunking/framing-fec-interleaving.md
+++ b/docs/learn/digital-trunking/framing-fec-interleaving.md
@@ -1,0 +1,158 @@
+---
+slug: framing-fec-interleaving
+title: "Framing, error correction & interleaving"
+description: Raw bits are never sent bare. Sync patterns, forward error correction, interleaving, and CRC are what let digital voice survive fading that would only hiss in analog.
+keywords: forward error correction, FEC, interleaving, framing, sync pattern, Golay code, Hamming code, BCH, trellis code, Viterbi, Reed-Solomon, CRC, burst errors, digital trunking
+level: advanced
+status: full
+prereq:
+  - digital-modulation-for-trunking
+  - voice-to-bits-vocoders
+faq:
+  - q: What is forward error correction?
+    a: Forward error correction adds carefully structured redundant bits to the data before transmission so the receiver can detect and fix a limited number of errors without asking for a retransmission. Digital radio relies on it because there is no time to request retries in a live voice stream. Codes like Hamming, Golay, BCH, trellis, and Reed-Solomon each fix errors in different ways.
+  - q: What is interleaving and why is it used?
+    a: Interleaving scrambles the order of bits before transmission and unscrambles them at the receiver. A fade or noise burst on the air corrupts a run of consecutive bits, but after de-interleaving those errors are spread thinly across many code words, where the error correction can fix them. Without interleaving a single burst could overwhelm the FEC in one spot.
+  - q: What is the difference between FEC and a CRC?
+    a: Forward error correction repairs bit errors so the data can be used. A cyclic redundancy check (CRC) only detects whether errors remain — it cannot fix them. Systems use FEC to recover the data and a CRC afterward to verify integrity, discarding or flagging a frame that still fails the check.
+  - q: Why can digital survive fading that just makes analog hiss?
+    a: In analog the noise rides straight into the audio. In digital, framing, error correction, and interleaving work together so the receiver can reconstruct the exact original bits even after some are corrupted. As long as the damage stays under the code's limit, the recovered voice is perfect, where analog would already be noisy.
+---
+
+# Framing, error correction & interleaving
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Raw bits are **never sent bare**. They're packed into **frames** and **bursts** marked
+by **sync patterns**, protected by **forward error correction (FEC)** — Hamming, Golay,
+BCH, trellis/Viterbi, Reed–Solomon — that lets the decoder *fix* bit errors, and
+**interleaved** so a fade spreads its damage thinly enough for the FEC to recover.
+A **CRC** then checks integrity. Together these are exactly what let digital voice
+**survive fading** that would leave analog hissing. This structure is also why a
+demodulated bitstream needs a whole [decode pipeline](/learn/rf-sdr/demodulation-pipeline/)
+before it becomes audio.
+</div>
+
+You now have bits from the vocoder and a modulation to carry them. But if you simply
+threw those bits on the air, the first fade would corrupt them and the vocoder would
+produce garbage. Every digital system instead wraps its bits in protective structure.
+Understanding that structure explains both how digital beats fading and why decoding
+is more than just "read the symbols."
+
+## Framing: structure and sync
+
+Bits are organised into **frames** (and, in time-slotted systems,
+[bursts](tdma-vs-fdma/)) — fixed-length packages with defined fields for voice, for
+signalling, and for housekeeping. The receiver has to know *where* each frame begins,
+and it finds out from a **sync pattern**: a known, fixed sequence of symbols placed at
+the frame boundary. The decoder slides along the incoming symbols looking for that
+pattern; when it matches, frame alignment is locked and every field afterward sits at a
+known offset.
+
+Sync patterns do double duty as a fingerprint. Because each system uses its own sync
+words, recognising the pattern is one of the first ways to **identify** what you're
+hearing — a theme we return to in the system-identification lessons.
+
+## Forward error correction: fixing, not just finding
+
+A live voice stream can't pause to ask for a retransmission, so digital radio repairs
+errors **in place** with **forward error correction**. FEC adds structured redundant
+bits so the decoder can work out what the original bits *must* have been, even when
+some arrived wrong. Different jobs call for different codes:
+
+| Code | What it's good at |
+|------|-------------------|
+| Hamming | fixes a single bit error in a small block — cheap, common |
+| Golay | corrects several errors in a short word — used on critical control fields |
+| BCH | configurable multi-error correction on a block |
+| Trellis / Viterbi | corrects a continuous bitstream by tracking the most likely sequence |
+| Reed–Solomon | corrects whole corrupted *symbols*, strong against bursts |
+
+Systems mix these. A P25 voice frame, for instance, protects different fields with
+different codes — the most important bits (the ones that say *which channel a call went
+to*) get the strongest protection, because losing them loses the call.
+
+## Interleaving: defeating burst errors
+
+There's a catch. FEC codes are usually strongest against errors that are **spread
+out**, and weakest when many errors land **together** — which is exactly what a fade or
+a noise burst produces. **Interleaving** solves this by shuffling the bit order before
+transmission and reversing the shuffle at the receiver.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 170" role="img" aria-label="A diagram showing a burst of errors hitting consecutive transmitted bits, then de-interleaving spreading those errors thinly across several code words so error correction can fix each one." xmlns="http://www.w3.org/2000/svg">
+  <text x="20" y="30" font-size="11" fill="currentColor">on the air — a fade hits consecutive bits:</text>
+  <g>
+    <rect x="20" y="40" width="180" height="22" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <rect x="92" y="40" width="44" height="22" fill="currentColor" fill-opacity="0.35"/>
+    <text x="114" y="56" text-anchor="middle" font-size="10" fill="currentColor">burst</text>
+  </g>
+  <text x="20" y="100" font-size="11" fill="currentColor">after de-interleaving — errors spread across code words:</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="112" width="110" height="24" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <rect x="40" y="112" width="14" height="24" fill="currentColor" fill-opacity="0.35"/>
+    <text x="75" y="128">word 1</text>
+    <rect x="140" y="112" width="110" height="24" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <rect x="180" y="112" width="14" height="24" fill="currentColor" fill-opacity="0.35"/>
+    <text x="195" y="128">word 2</text>
+    <rect x="260" y="112" width="110" height="24" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <rect x="300" y="112" width="14" height="24" fill="currentColor" fill-opacity="0.35"/>
+    <text x="315" y="128">word 3</text>
+    <rect x="380" y="112" width="110" height="24" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <rect x="420" y="112" width="14" height="24" fill="currentColor" fill-opacity="0.35"/>
+    <text x="435" y="128">word 4</text>
+  </g>
+  <line x1="114" y1="62" x2="114" y2="110" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3"/>
+</svg>
+<figcaption>A fade corrupts a run of consecutive bits. Because the bits were interleaved, de-interleaving scatters that damage thinly across several code words — few enough errors per word that the FEC fixes each one.</figcaption>
+</figure>
+
+After de-interleaving, a single on-air burst that wiped out twenty consecutive bits
+becomes one or two errors in each of many code words — well within what the FEC can
+repair. Interleaving and FEC are a team: neither alone survives the bursty,
+fading-prone mobile channel, but together they're formidable.
+
+## CRC: the final integrity check
+
+FEC *fixes* errors; a **CRC** (cyclic redundancy check) only *detects* whether any
+remain. After error correction, the decoder recomputes the CRC over the recovered bits
+and compares it to the transmitted check value. A match means the frame is trustworthy;
+a mismatch means damage got through, and the system flags, repeats, or discards the
+frame rather than acting on bad data — important when the frame is a channel-grant that
+would send a receiver to the wrong frequency.
+
+## Why this is the whole point
+
+Stack it up and the picture is clear. Where analog lets noise leak straight into the
+audio, digital wraps voice in **sync, FEC, interleaving, and CRC** so the receiver can
+reconstruct the **exact original bits** even after the channel mangles them. As long as
+the damage stays under the codes' limits, the recovered voice is *perfect* — and the
+moment it exceeds them, you hit the [digital cliff](analog-vs-digital-voice/) from two
+lessons back. All of this is unwound inside the
+[demodulation pipeline](/learn/rf-sdr/demodulation-pipeline/), downstream of the
+[clock recovery](/learn/rf-sdr/clock-recovery/) that finds the symbols in the first
+place.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — interleaving spreads a burst across many code words so FEC can fix each one." markdown="0">
+  <p class="knowledge-check__q">Quick check: why do digital systems interleave bits before transmission?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">To encrypt the data</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">To spread a burst of errors thinly so error correction can fix them</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">To make the signal use less bandwidth</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Bits are packed into **frames/bursts** marked by **sync patterns** that the decoder
+  locks onto (and that fingerprint the system).
+- **FEC** — Hamming, Golay, BCH, trellis/Viterbi, Reed–Solomon — **fixes** bit errors
+  in place, with the most important fields protected most strongly.
+- **Interleaving** scatters a burst across many code words so the FEC can recover it.
+- A **CRC** detects any errors that survived, so the system never acts on bad data.
+- Together these let digital **survive fading** where analog would only hiss — until
+  the cliff.
+
+Next, we see how a single channel can carry more than one call at once:
+[TDMA vs. FDMA](tdma-vs-fdma/).

--- a/docs/learn/digital-trunking/glossary.md
+++ b/docs/learn/digital-trunking/glossary.md
@@ -1,0 +1,364 @@
+---
+slug: glossary
+title: Glossary of digital & trunked radio terms
+description: Plain-language definitions of digital and trunked radio terms — control channel, talkgroup, vocoder, P25, DMR, TETRA, NXDN, FEC, encryption and more — cross-linked to lessons.
+keywords: trunked radio glossary, P25 terms, DMR glossary, control channel, talkgroup, vocoder, NAC, color code, TDMA, FDMA, P25 Phase 2, digital radio dictionary
+level: beginner
+status: full
+---
+
+# Glossary of digital & trunked radio terms
+
+Every term used across the [Digital & Trunked Radio path](/learn/digital-trunking/),
+defined in plain language and linked to the lesson where it's explained in full.
+Skim it as a refresher, or use your browser's find (Ctrl/Cmd-F) to jump to a word.
+Terms are grouped by theme and ordered roughly from concepts to specific systems.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">How to use this page</span>
+This is a reference, not a reading order. If you're new, start with
+[why radio went digital](/learn/digital-trunking/why-radio-went-digital/) and follow
+the path; come back here whenever a piece of jargon trips you up. Terms link to the
+lesson that explains them, and many also have a live panel in the app you can watch.
+</div>
+
+## Trunking concepts
+
+**Trunking** — A system where many user groups share a small pool of frequencies,
+with a computer assigning a free channel to each call on demand and reclaiming it
+afterward. See [Conventional vs trunked](/learn/digital-trunking/conventional-vs-trunked/)
+and [Birth of trunking](/learn/digital-trunking/birth-of-trunking/)
+
+**Conventional radio** — Non-trunked radio where each group uses a fixed, permanent
+frequency. Simple to scan, but wasteful of spectrum. See
+[Conventional vs trunked](/learn/digital-trunking/conventional-vs-trunked/)
+
+**Control channel** — The data-only frequency that coordinates a trunked system,
+announcing call setups and the voice channel each is assigned to. GopherTrunk decodes
+it first. See [The control channel](/learn/digital-trunking/the-control-channel/) and
+the [CC Activity panel](/cc-activity.html)
+
+**Voice / traffic channel** — A frequency temporarily assigned to carry an actual
+call. Released back to the pool when the call ends. See
+[The control channel](/learn/digital-trunking/the-control-channel/)
+
+**Talkgroup** — A virtual channel — a number with a label, like "Police Dispatch" —
+identifying a group of users. You follow talkgroups, not frequencies. See
+[Talkgroups, IDs & affiliation](/learn/digital-trunking/talkgroups-ids-affiliation/)
+
+**Radio ID / Unit ID** — The unique identifier of an individual radio transmitting on
+a system, distinct from the talkgroup it's using. See
+[Talkgroups, IDs & affiliation](/learn/digital-trunking/talkgroups-ids-affiliation/)
+and the [Radio IDs panel](/radio-ids.html)
+
+**Affiliation / Registration** — A radio registering with the trunked system over the
+control channel when it powers on or changes talkgroups, so the system knows it's
+active and where to route calls. See
+[Talkgroups, IDs & affiliation](/learn/digital-trunking/talkgroups-ids-affiliation/)
+
+**Channel grant** — The control-channel message that tells radios "this talkgroup,
+go to this voice channel." The event that starts every call. See
+[Anatomy of a call](/learn/digital-trunking/anatomy-of-a-call/)
+
+**Hang time** — A short interval after a transmission ends during which the system
+keeps the voice channel reserved for the talkgroup, so a quick reply doesn't need a
+fresh grant. See [Anatomy of a call](/learn/digital-trunking/anatomy-of-a-call/)
+
+**Message trunking** — A grant strategy where a voice channel stays assigned to a
+talkgroup for an entire conversation (including hang time), not just one
+transmission. See [Trunking flavors](/learn/digital-trunking/trunking-flavors/)
+
+**Transmission trunking** — A grant strategy where the voice channel is released the
+instant each transmission ends, so every push-to-talk needs a new grant. More
+efficient, but harder to follow. See
+[Trunking flavors](/learn/digital-trunking/trunking-flavors/)
+
+**Dedicated control channel** — A trunking design where one frequency is permanently
+set aside to carry only control data. Most large P25 and Motorola systems work this
+way. See [Trunking flavors](/learn/digital-trunking/trunking-flavors/)
+
+**Distributed control channel** — A design where the control role rotates among
+channels or shares time with voice, rather than living on one fixed frequency. Common
+in DMR Tier III and some LTR-style systems. See
+[Trunking flavors](/learn/digital-trunking/trunking-flavors/)
+
+## Sites, coverage & roaming
+
+**Site** — One physical transmitter location (one set of towers and channels) within
+a larger system. A system can have many sites. See
+[Sites, simulcast & roaming](/learn/digital-trunking/sites-simulcast-roaming/)
+
+**Simulcast** — Several transmitters broadcasting the *same* signal on the *same*
+frequency at once, time-aligned to cover a wide area as if it were one site. Powerful,
+but the overlapping signals can stress a decoder. See
+[Sites, simulcast & roaming](/learn/digital-trunking/sites-simulcast-roaming/) and
+[Multisite & simulcast in practice](/learn/digital-trunking/multisite-and-simulcast-in-practice/)
+
+**Roaming** — A radio automatically moving from one site to another as the user
+travels, re-affiliating at each new site. See
+[Sites, simulcast & roaming](/learn/digital-trunking/sites-simulcast-roaming/)
+
+**WACN (Wide Area Communications Network)** — In P25, a top-level identifier for a
+network operator's whole system-of-systems. Combined with the System ID it uniquely
+names a network. See
+[Identifying the system](/learn/digital-trunking/identifying-the-system/)
+
+**System ID** — A number identifying a particular trunked system, used (with the WACN
+in P25) to tell one system apart from another on the air. See
+[Identifying the system](/learn/digital-trunking/identifying-the-system/)
+
+**RFSS (RF Sub-System)** — A P25 grouping of one or more sites under common control,
+sitting between the whole system and an individual site. See
+[Sites, simulcast & roaming](/learn/digital-trunking/sites-simulcast-roaming/)
+
+**NAC (Network Access Code)** — A 12-bit code carried in every P25 frame, acting like
+a "squelch code" so receivers ignore signals from other systems on the same
+frequency. See
+[Identifying the system](/learn/digital-trunking/identifying-the-system/)
+
+**Color code** — DMR's equivalent of the NAC: a small number (0–15) that distinguishes
+co-channel systems so radios only act on their own. See
+[Identifying the system](/learn/digital-trunking/identifying-the-system/)
+
+## Digital voice & vocoders
+
+**Vocoder** — A speech codec that analyzes voice and compresses it into tiny data
+frames for transmission, then reconstructs it at the other end. See
+[Voice to bits: vocoders](/learn/digital-trunking/voice-to-bits-vocoders/) and the
+[Vocoders panel](/vocoders.html)
+
+**IMBE (Improved Multi-Band Excitation)** — The vocoder used by P25 Phase 1,
+encoding voice at 4.4 kbit/s plus error correction. See
+[Voice to bits: vocoders](/learn/digital-trunking/voice-to-bits-vocoders/)
+
+**AMBE+2** — A later, more efficient vocoder used by DMR, NXDN, and P25 Phase 2,
+fitting voice into a smaller data rate. See
+[Voice to bits: vocoders](/learn/digital-trunking/voice-to-bits-vocoders/)
+
+**ACELP (Algebraic Code-Excited Linear Prediction)** — The vocoder family used by
+TETRA, a different lineage from the MBE codecs above. See
+[Voice to bits: vocoders](/learn/digital-trunking/voice-to-bits-vocoders/)
+
+**Analog voice** — Voice sent as a continuous FM signal, which degrades gradually with
+distance and noise. Contrast with digital voice, which is crisp until it fails. See
+[Analog vs digital voice](/learn/digital-trunking/analog-vs-digital-voice/)
+
+## Modulation for trunked radio
+
+**C4FM (Compatible 4-level FM)** — The four-level FSK used by P25 Phase 1 and the
+basis of DMR's modulation. See
+[Digital modulation for trunking](/learn/digital-trunking/digital-modulation-for-trunking/)
+
+**CQPSK / LSM (Linear Simulcast Modulation)** — A phase-and-amplitude (linear) way of
+sending the same P25 Phase 1 symbols as C4FM, designed to behave better on simulcast
+systems. See
+[Digital modulation for trunking](/learn/digital-trunking/digital-modulation-for-trunking/)
+
+**π/4-DQPSK** — The differential phase-shift keying used by P25 Phase 2 and TETRA,
+sending two bits per symbol by shifting phase. See
+[Digital modulation for trunking](/learn/digital-trunking/digital-modulation-for-trunking/)
+
+**4FSK (four-level FSK)** — Frequency-shift keying with four tone levels, carrying two
+bits per symbol; underlies C4FM, DMR, and NXDN. See
+[Digital modulation for trunking](/learn/digital-trunking/digital-modulation-for-trunking/)
+and the [Constellation panel](/constellation.html)
+
+**GMSK (Gaussian Minimum-Shift Keying)** — A smoothed frequency-shift modulation used
+by D-STAR (and many other digital systems) that keeps the signal spectrally tidy. See
+[Digital modulation for trunking](/learn/digital-trunking/digital-modulation-for-trunking/)
+
+**Symbol rate** — How many symbols per second a signal sends; with bits-per-symbol it
+sets the bit rate. P25 and DMR run at 4800 symbols/s. See
+[Digital modulation for trunking](/learn/digital-trunking/digital-modulation-for-trunking/)
+and the [Symbol scope](/symbol-scope.html)
+
+**FDMA (Frequency-Division Multiple Access)** — Giving each call its own narrow
+frequency channel. P25 Phase 1 and NXDN are FDMA. See
+[TDMA vs FDMA](/learn/digital-trunking/tdma-vs-fdma/)
+
+**TDMA (Time-Division Multiple Access)** — Splitting one frequency into repeating time
+slots so several calls share it. DMR and P25 Phase 2 are TDMA. See
+[TDMA vs FDMA](/learn/digital-trunking/tdma-vs-fdma/)
+
+**Time slot** — One of the alternating time windows on a TDMA channel; DMR has two
+(slot 1 and slot 2), each able to carry a separate call. See
+[TDMA vs FDMA](/learn/digital-trunking/tdma-vs-fdma/)
+
+## Framing, error control & decoding
+
+**Frame / burst** — A fixed-size package of bits sent over the air, containing voice
+or data plus sync and signaling. DMR calls its slot-sized unit a burst. See
+[Framing, FEC & interleaving](/learn/digital-trunking/framing-fec-interleaving/)
+
+**Forward error correction (FEC)** — Extra redundant bits added before transmission so
+the receiver can fix errors without asking for a resend — what lets digital voice
+survive noise. See [Framing, FEC & interleaving](/learn/digital-trunking/framing-fec-interleaving/)
+
+**Interleaving** — Scrambling the order of bits before sending so that a short burst of
+interference damages many separate, recoverable bits instead of one unrecoverable
+chunk. See [Framing, FEC & interleaving](/learn/digital-trunking/framing-fec-interleaving/)
+
+**CRC (Cyclic Redundancy Check)** — A checksum attached to a frame so the receiver can
+tell whether the bits arrived intact. See
+[Framing, FEC & interleaving](/learn/digital-trunking/framing-fec-interleaving/)
+
+**BER (Bit Error Rate)** — The fraction of received bits that are wrong; a key health
+metric for a decode, climbing as the signal degrades. See
+[Troubleshooting a decode](/learn/digital-trunking/troubleshooting-a-decode/)
+
+**Digital cliff** — The point where a digital signal stops gracefully degrading and
+suddenly fails completely: clear audio one moment, silence the next. See
+[Analog vs digital voice](/learn/digital-trunking/analog-vs-digital-voice/)
+
+## Security & control
+
+**Encryption** — Scrambling voice or data so only authorized radios can recover it;
+encrypted talkgroups can be detected but not decoded. See
+[Encryption & authentication](/learn/digital-trunking/encryption-and-authentication/)
+and the [DMR encryption panel](/dmr-encryption.html)
+
+**AES-256** — A strong, standardized encryption cipher (256-bit key) used by P25 and
+others for secure traffic; not breakable by monitoring. See
+[Encryption & authentication](/learn/digital-trunking/encryption-and-authentication/)
+
+**DES-OFB** — An older 56-bit DES cipher in output-feedback mode, once common on P25;
+weak by modern standards but still seen in the field. See
+[Encryption & authentication](/learn/digital-trunking/encryption-and-authentication/)
+
+**ADP (Advanced Digital Privacy)** — Motorola's RC4-based 40-bit encryption option,
+lighter than AES and intended as basic privacy rather than strong security. See
+[Encryption & authentication](/learn/digital-trunking/encryption-and-authentication/)
+
+**Authentication** — A system verifying that a radio is a legitimate, authorized unit
+before granting it service, separate from encrypting the traffic itself. See
+[Encryption & authentication](/learn/digital-trunking/encryption-and-authentication/)
+
+**Stun / Kill** — Over-the-air commands a system can send to disable a radio
+temporarily (stun) or permanently (kill), used when a unit is lost or stolen. See
+[Encryption & authentication](/learn/digital-trunking/encryption-and-authentication/)
+
+## P25 (Project 25)
+
+**P25 (Project 25)** — A North American suite of standards for public-safety digital
+radio, defining both conventional and trunked operation. See
+[P25 Phase 1](/learn/digital-trunking/p25-phase-1/)
+
+**P25 Phase 1** — The first generation of P25: FDMA, 12.5 kHz channels, C4FM
+modulation, and the IMBE vocoder. See
+[P25 Phase 1](/learn/digital-trunking/p25-phase-1/)
+
+**P25 Phase 2** — The newer generation: two-slot TDMA on a 12.5 kHz channel
+(effectively 6.25 kHz per call) using π/4-DQPSK and the AMBE+2 vocoder. See
+[P25 Phase 2](/learn/digital-trunking/p25-phase-2/)
+
+**TSBK (Trunking Signaling Block)** — The control-channel message format that carries
+P25 trunking signaling — grants, affiliations, and system data. See
+[Control-channel signaling](/learn/digital-trunking/control-channel-signaling/)
+
+**LDU (Logical Data Unit)** — A P25 Phase 1 voice frame structure (LDU1/LDU2) that
+packages IMBE voice along with embedded signaling and link control. See
+[P25 Phase 1](/learn/digital-trunking/p25-phase-1/)
+
+## DMR
+
+**DMR (Digital Mobile Radio)** — An ETSI standard for digital land-mobile radio using
+two-slot TDMA on 12.5 kHz channels, popular for business and amateur use. See
+[DMR Tier II & III](/learn/digital-trunking/dmr-tier-2-3/)
+
+**Tier II** — Conventional (non-trunked) DMR: licensed two-slot TDMA repeaters with no
+central trunking controller. See
+[DMR Tier II & III](/learn/digital-trunking/dmr-tier-2-3/)
+
+**Tier III** — Trunked DMR, adding a control-channel-driven trunking layer on top of
+DMR's TDMA. See [DMR Tier II & III](/learn/digital-trunking/dmr-tier-2-3/)
+
+**CSBK (Control Signaling Block)** — DMR's signaling message unit, used for trunking
+control and other system messages — DMR's counterpart to P25's TSBK. See
+[Control-channel signaling](/learn/digital-trunking/control-channel-signaling/)
+
+## TETRA
+
+**TETRA (Terrestrial Trunked Radio)** — A European ETSI standard for trunked digital
+radio, using four-slot TDMA and π/4-DQPSK, common for public safety and transit
+outside North America. See [TETRA](/learn/digital-trunking/tetra/)
+
+**TMO (Trunked Mode Operation)** — TETRA radios operating through the infrastructure
+(sites and controllers), the normal trunked mode. See
+[TETRA](/learn/digital-trunking/tetra/)
+
+**DMO (Direct Mode Operation)** — TETRA (and DMR) radios talking directly to each
+other without infrastructure, like a walkie-talkie. See
+[TETRA](/learn/digital-trunking/tetra/)
+
+## Other digital standards
+
+**NXDN** — A narrowband FDMA digital standard (6.25 kHz) developed by Icom and Kenwood,
+available in conventional and trunked forms. See [NXDN](/learn/digital-trunking/nxdn/)
+
+**dPMR (digital Private Mobile Radio)** — An ETSI 6.25 kHz FDMA standard closely
+related to NXDN, aimed at light commercial use. See
+[dPMR, D-STAR & YSF](/learn/digital-trunking/dpmr-dstar-ysf/)
+
+**D-STAR** — An amateur-radio digital voice and data standard (developed with Icom)
+using GMSK and the AMBE vocoder. See
+[dPMR, D-STAR & YSF](/learn/digital-trunking/dpmr-dstar-ysf/)
+
+**System Fusion / YSF (Yaesu System Fusion)** — Yaesu's amateur C4FM digital voice
+system, also known as YSF. See
+[dPMR, D-STAR & YSF](/learn/digital-trunking/dpmr-dstar-ysf/)
+
+## Legacy & proprietary systems
+
+**SmartNet / SmartZone** — Motorola's earlier trunking systems: SmartNet for a single
+site, SmartZone adding multi-site networking, both using an analog or digital voice
+payload. See [Motorola SmartNet](/learn/digital-trunking/motorola-smartnet/)
+
+**Type I / Type II** — Two Motorola trunking fleet-management schemes. Type I uses
+fleet/subfleet addressing; Type II uses flat talkgroup IDs and is far more common. See
+[Motorola SmartNet](/learn/digital-trunking/motorola-smartnet/)
+
+**EDACS (Enhanced Digital Access Communications System)** — A GE/Ericsson/Harris
+trunking system known for fast channel access and a distinctive control channel. See
+[EDACS, LTR & MPT-1327](/learn/digital-trunking/edacs-ltr-mpt1327/)
+
+**ProVoice** — The digital voice option layered onto EDACS systems, using the AMBE
+vocoder. See [EDACS, LTR & MPT-1327](/learn/digital-trunking/edacs-ltr-mpt1327/)
+
+**LTR (Logic Trunked Radio)** — An EF Johnson trunking scheme with *distributed*
+control — signaling is embedded on each channel rather than a dedicated control
+channel. See [EDACS, LTR & MPT-1327](/learn/digital-trunking/edacs-ltr-mpt1327/)
+
+**Passport** — A proprietary trunking extension of LTR developed by Trident/SmarTrunk,
+adding features on top of the LTR scheme. See
+[EDACS, LTR & MPT-1327](/learn/digital-trunking/edacs-ltr-mpt1327/)
+
+**MPT-1327** — A British signaling standard for analog trunked radio, widely used
+internationally before digital systems took over. See
+[EDACS, LTR & MPT-1327](/learn/digital-trunking/edacs-ltr-mpt1327/)
+
+## Standards bodies
+
+**APCO (Association of Public-Safety Communications Officials)** — The North American
+body that drove the creation of Project 25 (the "APCO-25" name). See
+[Standards & bodies](/learn/digital-trunking/standards-and-bodies/)
+
+**ETSI (European Telecommunications Standards Institute)** — The standards body behind
+DMR, TETRA, and dPMR. See [Standards & bodies](/learn/digital-trunking/standards-and-bodies/)
+
+**TIA (Telecommunications Industry Association)** — The U.S. standards organization
+that publishes the P25 (TIA-102) document suite. See
+[Standards & bodies](/learn/digital-trunking/standards-and-bodies/)
+
+**ITU (International Telecommunication Union)** — The UN agency that allocates spectrum
+and sets worldwide radio regulations within which all these systems operate. See
+[Standards & bodies](/learn/digital-trunking/standards-and-bodies/)
+
+**DMR Association** — The industry group that promotes DMR interoperability and
+maintains shared identifier resources for the standard. See
+[Standards & bodies](/learn/digital-trunking/standards-and-bodies/)
+
+---
+
+Didn't find a term? It's probably explained in one of the
+[Digital & Trunked Radio lessons](/learn/digital-trunking/) — or open an
+[issue on GitHub](https://github.com/MattCheramie/GopherTrunk/issues) and we'll add it.

--- a/docs/learn/digital-trunking/identifying-the-system.md
+++ b/docs/learn/digital-trunking/identifying-the-system.md
@@ -1,0 +1,156 @@
+---
+slug: identifying-the-system
+title: Identifying what you're hearing
+description: Tell trunked systems apart before you decode — read channel bandwidth on the waterfall, symbol rate, constellation shape, and audio cadence to recognise P25, DMR, NXDN and TETRA at a glance.
+keywords: identify trunked system, channel bandwidth, 6.25 kHz, 12.5 kHz, 25 kHz, symbol rate, constellation shape, waterfall, P25 vs DMR, NXDN, TETRA, system recognition
+level: intermediate
+status: full
+prereq:
+  - digital-modulation-for-trunking
+  - finding-the-control-channel
+faq:
+  - q: Can I tell which system I'm hearing before decoding it?
+    a: Often yes. Channel bandwidth on the waterfall, the symbol rate, the shape of the constellation, and the cadence of the audio all give the system away. A 12.5 kHz carrier with a four-point constellation is likely P25 Phase 1 or DMR; a 6.25 kHz carrier points to NXDN or P25 Phase 2; a wider 25 kHz channel with a phase ring suggests TETRA. These clues narrow the field before you commit to a decoder.
+  - q: What does channel bandwidth tell me about a system?
+    a: Bandwidth reflects how much spectrum each carrier occupies, which is set by the standard. P25 Phase 1 and DMR use 12.5 kHz channels; NXDN and P25 Phase 2 squeeze into 6.25 kHz; older analog and some wideband systems use 25 kHz; TETRA uses 25 kHz shared by four time slots. Measuring the carrier width on the waterfall is the fastest first cut.
+  - q: How does the constellation help me identify a system?
+    a: Different modulations draw different shapes. C4FM and 4FSK show four horizontal levels or a four-point pattern; π/4-DQPSK draws a ring of eight phase points; CQPSK shows a tighter four-corner QPSK pattern. The constellation, eye diagram and histogram together confirm the modulation family, which maps onto a short list of candidate systems.
+  - q: Why bother identifying before decoding?
+    a: Picking the wrong decoder wastes time and can make a perfectly good signal look broken. A quick visual identification — bandwidth, symbol rate, constellation, cadence — tells you which decoder to try first, so you lock faster and avoid chasing a non-existent fault. It is the difference between a confident guess and trial-and-error.
+gophertrunk_links:
+  - title: Constellation
+    url: /constellation.html
+    note: read the symbol pattern to spot the modulation family.
+  - title: Eye diagram
+    url: /eye-diagram.html
+    note: count symbol levels and judge timing on an unknown signal.
+  - title: Histogram
+    url: /histogram.html
+    note: see how received levels cluster to confirm 2-level vs 4-level.
+---
+
+# Identifying what you're hearing
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+You can often name a system *before* decoding it by reading four clues. **Channel
+bandwidth** on the [waterfall](/learn/rf-sdr/fft-and-waterfall/) — **6.25, 12.5, or
+25 kHz** — is the fastest first cut. **Symbol rate** and the **constellation shape**
+narrow the modulation family: a four-level pattern means **C4FM or 4FSK** (P25, DMR),
+a phase ring means **π/4-DQPSK** (TETRA). The **audio cadence** — bursty TDMA versus a
+continuous stream — confirms it. GopherTrunk's [constellation](/constellation.html),
+[eye diagram](/eye-diagram.html) and [histogram](/histogram.html) make every one of
+these visible, so identification becomes a glance rather than a guess.
+</div>
+
+Before GopherTrunk can follow a system, it needs to know *which* system. Sometimes a
+database tells you; often you're staring at an unknown carrier on the waterfall and
+have to work it out. The good news is that digital trunking uses only a [handful of
+modulations](digital-modulation-for-trunking/), and each leaves fingerprints you can
+read with the scopes.
+
+## Clue 1 — channel bandwidth on the waterfall
+
+The width of a carrier on the [FFT and waterfall](/learn/rf-sdr/fft-and-waterfall/) is
+fixed by the standard, so it's the quickest first cut. Zoom in until a single carrier
+fills the display and estimate how many kilohertz of spectrum it occupies:
+
+- **6.25 kHz** — a narrow carrier. Think **NXDN** or **P25 Phase 2** (which packs two
+  voice channels into this width using TDMA).
+- **12.5 kHz** — the workhorse width. Think **P25 Phase 1** or **DMR** (DMR fits two
+  TDMA slots here).
+- **25 kHz** — wide. Older analog/wideband channels, or **TETRA** (one 25 kHz carrier
+  shared by four time slots).
+
+Bandwidth alone rarely pins the exact system, but it eliminates most candidates in a
+second. A 6.25 kHz carrier is never P25 Phase 1; a 25 kHz carrier is never DMR.
+
+## Clue 2 — symbol rate and constellation shape
+
+Now look at the recovered symbols on the [constellation](/constellation.html) and
+[eye diagram](/eye-diagram.html). The *symbol rate* sets how fast the eye opens and
+closes, and the *shape* reveals the modulation family:
+
+- **Four horizontal levels** (or a four-point cluster) — **4-level FSK**: C4FM (P25
+  Phase 1) or 4FSK (DMR, NXDN). The [histogram](/histogram.html) shows four distinct
+  peaks.
+- **A ring of phase points** — **π/4-DQPSK** (TETRA): the constellation rotates in
+  quarter-pi steps and traces a rosette rather than fixed levels.
+- **A tight four-corner QPSK box** — **CQPSK/LSM**, the linear cousin P25 simulcast
+  transmitters use.
+
+A clean lock draws tight clusters and a wide-open eye; smearing means you're close to
+the noise floor — useful information, but don't mistake a weak-signal smear for the
+wrong modulation. The [histogram](/histogram.html) is the tie-breaker: count the
+peaks, and a two-versus-four-level question answers itself.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 170" role="img" aria-label="Three constellation sketches side by side: four horizontal levels labelled 4-level FSK, a ring of phase points labelled pi over 4 DQPSK, and a four-corner box labelled CQPSK." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <!-- 4FSK -->
+    <text x="90" y="22" font-weight="600">4-level FSK</text>
+    <text x="90" y="36" font-size="8.5">C4FM / 4FSK — P25 P1, DMR, NXDN</text>
+    <line x1="40" y1="130" x2="140" y2="130" stroke="currentColor" stroke-opacity="0.4"/>
+    <g fill="currentColor"><circle cx="90" cy="62" r="4"/><circle cx="90" cy="86" r="4"/><circle cx="90" cy="110" r="4"/><circle cx="90" cy="50" r="4"/></g>
+    <!-- DQPSK -->
+    <text x="270" y="22" font-weight="600">π/4-DQPSK</text>
+    <text x="270" y="36" font-size="8.5">TETRA — phase ring</text>
+    <g fill="currentColor"><circle cx="270" cy="55" r="3.5"/><circle cx="300" cy="68" r="3.5"/><circle cx="313" cy="98" r="3.5"/><circle cx="300" cy="128" r="3.5"/><circle cx="270" cy="141" r="3.5"/><circle cx="240" cy="128" r="3.5"/><circle cx="227" cy="98" r="3.5"/><circle cx="240" cy="68" r="3.5"/></g>
+    <!-- CQPSK -->
+    <text x="450" y="22" font-weight="600">CQPSK / LSM</text>
+    <text x="450" y="36" font-size="8.5">P25 simulcast — QPSK box</text>
+    <g fill="currentColor"><circle cx="420" cy="68" r="4"/><circle cx="480" cy="68" r="4"/><circle cx="420" cy="128" r="4"/><circle cx="480" cy="128" r="4"/></g>
+  </g>
+</svg>
+<figcaption>The constellation gives away the modulation family at a glance: four levels for FSK systems, a rosette ring for TETRA's π/4-DQPSK, a four-corner box for CQPSK simulcast.</figcaption>
+</figure>
+
+## Clue 3 — audio and burst cadence
+
+Even without decoding, the *rhythm* of a signal helps. **FDMA** systems (P25 Phase 1,
+NXDN, conventional DMR carriers) put one continuous transmission on the channel for the
+duration of a call. **[TDMA](tdma-vs-fdma/)** systems (P25 Phase 2, DMR, TETRA) chop the
+carrier into time slots, so on the waterfall and in the symbol stream you see a
+*pulsing* pattern — bursts with gaps — even during a single conversation. A steady
+solid trace versus a stuttering one is a strong TDMA-versus-FDMA tell.
+
+## Putting the clues together
+
+No single clue is decisive, but two or three together usually name the system. Use this
+recognition table as a field guide:
+
+| System | Channel bandwidth | Modulation | Access | Telltale |
+|--------|-------------------|------------|--------|----------|
+| **P25 Phase 1** | 12.5 kHz | C4FM (or CQPSK simulcast) | FDMA | Four levels, continuous trace, 4800 sym/s |
+| **P25 Phase 2** | 6.25 kHz equiv. | H-CPM / TDMA | TDMA (2-slot) | Narrow channel, pulsing bursts |
+| **DMR** | 12.5 kHz | 4FSK | TDMA (2-slot) | Four levels *and* slotting on one 12.5 kHz carrier |
+| **NXDN** | 6.25 / 12.5 kHz | 4FSK | FDMA | Very narrow carrier, four levels, continuous |
+| **TETRA** | 25 kHz | π/4-DQPSK | TDMA (4-slot) | Phase-ring constellation, wide channel, strong slotting |
+| **Analog / wideband** | 25 kHz | FM | — | No symbol structure; fuzzy noise-like spectrum |
+
+Read it top to bottom: bandwidth eliminates rows, the constellation shape confirms the
+modulation, and the burst cadence settles TDMA versus FDMA. For the protocol details
+behind each row, the [protocol landscape](/learn/rf-sdr/protocol-landscape/) lesson is
+the deeper reference.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a 12.5 kHz carrier with four levels and visible time-slot bursts is DMR." markdown="0">
+  <p class="knowledge-check__q">Quick check: you see a 12.5 kHz carrier with a four-level constellation that pulses in bursts during a single call. Best guess?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">TETRA</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">DMR</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Analog wideband FM</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Channel bandwidth** (6.25 / 12.5 / 25 kHz) on the waterfall is the fastest first cut.
+- The **constellation shape** names the modulation: four levels for FSK, a ring for
+  π/4-DQPSK, a box for CQPSK.
+- The **[histogram](/histogram.html)** confirms 2-level versus 4-level by counting peaks.
+- **Burst cadence** separates pulsing **TDMA** systems from continuous **FDMA** ones.
+- Two or three clues together usually name the system before you decode a single bit.
+
+Next, we'll find the one frequency worth monitoring — locating and confirming the
+[control channel](finding-the-control-channel/).

--- a/docs/learn/digital-trunking/index.md
+++ b/docs/learn/digital-trunking/index.md
@@ -1,0 +1,30 @@
+---
+layout: learn-hub
+learn_path: digital-trunking
+permalink: /learn/digital-trunking/
+title: Learn Digital & Trunked Radio — from analog roots to decoding every system
+description: A free, structured learning path on digital and digital-trunking radio systems — the history of trunking and digital voice, the end-to-end digital signal chain, and every trunked system GopherTrunk decodes (P25, DMR, TETRA, NXDN, Motorola, EDACS, LTR, MPT-1327).
+keywords: digital trunking, trunked radio tutorial, P25 explained, DMR trunking, TETRA, NXDN, Motorola trunking, control channel, talkgroup, learn digital radio, GopherTrunk
+---
+
+Trunked radio is the part of the hobby that scares people off — control
+channels, talkgroups, P25 Phase 2, simulcast — and it doesn't have to. Every one
+of those ideas is simple once you see *why* it exists and meet it in order. This
+path does exactly that, twice over: it tells the **history** of how radio learned
+to share channels and went digital, then walks the **digital signal end to end**
+before taking each **trunking system** in turn.
+
+**Who this is for.** Anyone who wants to understand and follow digital trunked
+systems — scanner hobbyists, new GopherTrunk operators, and the merely curious.
+You don't need a licence or any math. If radio itself is new to you, the
+companion **[RF & SDR path](/learn/rf-sdr/)** covers waves, IQ, and SDR setup;
+this path links back to it for those fundamentals instead of repeating them.
+
+**How the path works.** Six modules build from story to practice. Module 1 is the
+history; Module 2 walks the digital chain from voice to bits to symbols; Module 3
+covers the trunking mechanics every system shares; Modules 4–5 take the systems
+one by one (P25 and DMR in depth, then TETRA, NXDN, Motorola, and the legacy
+families); and Module 6 puts it to work in GopherTrunk — finding a control
+channel, following calls, and fixing a decode that won't lock. Mark lessons
+complete as you go; your progress is saved in your browser. **[Start with lesson
+1: Why radio went digital](why-radio-went-digital/)**

--- a/docs/learn/digital-trunking/motorola-smartnet.md
+++ b/docs/learn/digital-trunking/motorola-smartnet.md
@@ -1,0 +1,151 @@
+---
+slug: motorola-smartnet
+title: "Motorola SmartNet / SmartZone & Type II"
+description: Motorola SmartNet, SmartZone, and Type II explained — a 3600 bps digital control channel coordinating analog FM voice, Type I/II/IIi addressing, multi-site networking.
+keywords: Motorola SmartNet, SmartZone, Type II, Type I, Type IIi, 3600 bps control channel, analog trunking, fleet subfleet, talkgroup ID, proprietary trunking, multi-site
+level: intermediate
+status: full
+prereq:
+  - analog-trunking-era
+  - control-channel-signaling
+  - talkgroups-ids-affiliation
+faq:
+  - q: What is Motorola SmartNet?
+    a: SmartNet is Motorola's proprietary analog trunking system. It uses a digital control channel running at 3600 bps to coordinate calls, but the voice itself is ordinary analog FM. SmartZone is the multi-site extension that networks several SmartNet sites together. Both remain very widespread despite being decades old.
+  - q: What is the difference between Type I, Type II, and Type IIi?
+    a: They are addressing schemes. Type I organises radios by fleet, subfleet, and a size code — a hierarchical scheme. Type II uses flat numeric talkgroup IDs with no fleet structure, which is simpler and more common. Type IIi is a hybrid that supports both Type I and Type II radios on the same system during transitions.
+  - q: Is SmartNet digital or analog?
+    a: It is a mix. The control channel is digital — a 3600 bps data stream that announces calls and assigns voice channels. The voice traffic itself is analog FM, the same as a conventional analog radio. So it is analog trunking coordinated by digital signaling, not a fully digital system like P25 or DMR.
+  - q: Can GopherTrunk follow SmartNet systems?
+    a: Yes. GopherTrunk decodes the 3600 bps control channel to learn which talkgroup is being granted which voice channel, then follows the analog voice. Because the control channel is the map, the same follow-the-control-channel approach used for digital systems applies, even though the voice is analog FM.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch the 3600 bps SmartNet control-channel messages decode in real time.
+  - title: Radio IDs
+    url: /radio-ids.html
+    note: see which radios and talkgroups are active on a SmartNet system.
+---
+
+# Motorola SmartNet / SmartZone & Type II
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**SmartNet** is Motorola's **proprietary analog trunking** family, still very widespread.
+A **3600 bps digital control channel** coordinates the system, but the **voice is plain
+analog FM** — digital signaling, analog audio. Radios are addressed by **Type I**
+(fleet/subfleet/size-code), **Type II** (flat talkgroup IDs), or **Type IIi** (a hybrid).
+**SmartZone** extends it across **multiple sites**. It is *not* an open standard, but it's
+everywhere, and **GopherTrunk decodes the 3600 bps control channel** to follow calls the
+same way it follows a digital system.
+
+</div>
+
+You met the era of [analog trunking](analog-trunking-era/) earlier. SmartNet is its most
+successful survivor: a Motorola design from the 1980s–90s that, despite being decades old
+and proprietary, still carries an enormous amount of traffic across North America.
+
+## Digital control, analog voice
+
+The defining idea of SmartNet is the split between *how it's coordinated* and *what it
+carries*:
+
+- The **control channel** is **digital** — a continuous **3600 bps** data stream. It does
+  exactly what a control channel does in any [trunked system](conventional-vs-trunked/):
+  registers radios, takes call requests, and broadcasts grants telling a talkgroup which
+  voice channel to use.
+- The **voice channels** are **analog FM** — the same modulation as a conventional analog
+  radio. Once a radio is granted a channel, the audio there is ordinary FM you could tune by
+  hand.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 180" role="img" aria-label="A SmartNet system: a digital 3600 bps control channel at top issuing a grant, pointing to one of several analog FM voice channels below." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="460" height="40" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+  <text x="270" y="38" text-anchor="middle" font-size="13" fill="currentColor" font-weight="600">Control channel — digital, 3600 bps</text>
+  <text x="270" y="53" text-anchor="middle" font-size="10" fill="currentColor">“Talkgroup 1808 → voice channel 5”</text>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="110" width="100" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="90" y="130">Voice 4</text>
+    <text x="90" y="143" font-size="8">analog FM</text>
+    <rect x="160" y="110" width="100" height="40" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.5"/>
+    <text x="210" y="130">Voice 5</text>
+    <text x="210" y="143" font-size="8">analog FM — active</text>
+    <rect x="280" y="110" width="100" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="330" y="130">Voice 6</text>
+    <text x="330" y="143" font-size="8">analog FM</text>
+    <rect x="400" y="110" width="100" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="450" y="130">Voice 7</text>
+    <text x="450" y="143" font-size="8">analog FM</text>
+  </g>
+  <line x1="270" y1="60" x2="210" y2="108" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#sn)"/>
+  <defs><marker id="sn" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>SmartNet coordinates with a digital 3600 bps control channel but carries ordinary analog FM voice — so you decode the data to follow the audio.</figcaption>
+</figure>
+
+This is why SmartNet sits in this *digital* learning path even though its voice is analog:
+the *signaling* is digital, and following the control channel is exactly the skill the rest
+of the path teaches.
+
+## Type I, Type II, and Type IIi addressing
+
+How a SmartNet system labels its users evolved over time, giving three addressing schemes
+you'll encounter:
+
+| Scheme | How radios are addressed | Character |
+|--------|--------------------------|-----------|
+| **Type I** | **Fleet / subfleet / size-code** hierarchy | Older, structured; size code partitions the ID space into fleets and subfleets |
+| **Type II** | **Flat numeric talkgroup IDs** | Simpler and most common; just a talkgroup number, no fleet structure |
+| **Type IIi** | **Hybrid** of Type I and Type II | Supports both radio types on one system during a migration |
+
+**Type II** is the one you'll meet most. Its flat [talkgroup
+IDs](talkgroups-ids-affiliation/) map cleanly onto the talkgroup model you already know —
+a number with a label, like "1808 — County Fire Dispatch." Type I's fleet/subfleet/size-code
+scheme is a holdover that takes a little decoding to map back to a meaningful unit, which is
+why you sometimes see Type I IDs written in a fleet-subfleet-ID notation.
+
+## SmartZone — going multi-site
+
+A single SmartNet site covers one area. **SmartZone** is Motorola's extension that
+**networks several sites together** into one logical system, so a radio can roam between
+sites and stay reachable on the same talkgroup. This is the same multi-site idea you'll see
+again in [sites, simulcast & roaming](sites-simulcast-roaming/) — a wide-area network built
+from many sites, each with its own control channel, stitched together by the back-end
+network.
+
+## Proprietary, but everywhere
+
+It's worth being clear: SmartNet/SmartZone is a **proprietary Motorola system**, not an open
+standard like [P25](p25-phase-1/) or the [ETSI](standards-and-bodies/) standards. There's no
+public specification you can simply read; understanding it came largely from the
+scanner-enthusiast community reverse-engineering the [control-channel
+signaling](control-channel-signaling/).
+
+So why does so much of it remain? Cost and inertia. These systems were expensive to build,
+they work reliably, and many agencies kept them running for decades — sometimes as a
+stepping stone before migrating to P25. The result is that SmartNet remains one of the most
+commonly encountered trunking systems in North America, and **GopherTrunk decodes its
+3600 bps control channel** so you can follow it like any other.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — SmartNet's control channel is digital, but the voice it grants is analog FM." markdown="0">
+  <p class="knowledge-check__q">Quick check: on a Motorola SmartNet system, what kind of signal carries the actual voice?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Digital 4FSK like P25</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Analog FM</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">TDMA time slots</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **SmartNet** is Motorola's **proprietary analog trunking** family, still very widespread.
+- A **3600 bps digital control channel** coordinates calls, but the **voice is analog FM**.
+- Addressing comes in **Type I** (fleet/subfleet/size-code), **Type II** (flat talkgroup
+  IDs), and **Type IIi** (hybrid); Type II is most common.
+- **SmartZone** networks **multiple sites** into one roaming-capable system.
+- It is **not an open standard**, but **GopherTrunk decodes the control channel** to follow
+  it like any trunked system.
+
+Next, three more legacy families you'll still run into: [EDACS, LTR &
+MPT-1327](edacs-ltr-mpt1327/).

--- a/docs/learn/digital-trunking/multisite-and-simulcast-in-practice.md
+++ b/docs/learn/digital-trunking/multisite-and-simulcast-in-practice.md
@@ -1,0 +1,156 @@
+---
+slug: multisite-and-simulcast-in-practice
+title: Multi-site & simulcast in practice
+description: Handle multi-site and simulcast systems with GopherTrunk — pick the closest site's control channel, recognise and mitigate simulcast distortion with a better antenna, site bias and careful gain, and know the limits of coverage.
+keywords: multi-site trunking, simulcast distortion, simulcast decoding, choosing a site, control channel selection, antenna for simulcast, gain for simulcast, coverage limits, site roaming
+level: advanced
+status: full
+prereq:
+  - sites-simulcast-roaming
+  - following-a-system-end-to-end
+faq:
+  - q: Which site's control channel should I monitor on a multi-site system?
+    a: The closest or strongest site you can hear cleanly. Each site has its own control channel and its own coverage area, so monitoring the site nearest you gives the strongest signal and the traffic most relevant to your location. If you can hear several, pick the one with the cleanest constellation and most reliable lock, not necessarily the loudest.
+  - q: What is simulcast distortion and why does it hurt decoding?
+    a: Simulcast systems transmit the same signal from several towers at once on the same frequency. Where their coverage overlaps, the signals arrive at slightly different times and combine, smearing the waveform much like multipath. This distortion fuzzes the constellation and raises the error rate even when the raw signal is strong, which is why simulcast is one of the hardest cases to decode.
+  - q: How do I mitigate simulcast distortion?
+    a: Bias your reception toward a single transmitter. A directional antenna aimed at the nearest tower, careful siting to favour one site, and conservative gain to avoid overload all reduce the blend of competing copies. You can't remove simulcast distortion entirely, but making one transmitter dominate cleans up the constellation enough to lock.
+  - q: What if a system covers more area than I can hear?
+    a: You simply can't follow what doesn't reach your antenna. A wide-area system may have sites whose control channels are below your noise floor; you'll only follow the traffic on sites you can receive. Improving the antenna and its placement extends your reach, but geography and the system's design set a hard ceiling on coverage.
+gophertrunk_links:
+  - title: Tuning (receiver meters)
+    url: /tuning.html
+    note: judge lock quality per site while choosing which to monitor.
+  - title: Demod calibration
+    url: /demod-calibration.html
+    note: tune the demodulator to wring a lock out of a smeared simulcast signal.
+---
+
+# Multi-site & simulcast in practice
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Big systems span **multiple sites**, each with its own control channel and coverage
+area — so monitor the **closest, cleanest site** you can hear, not necessarily the
+loudest. **Simulcast** sites transmit the same frequency from several towers at once;
+where coverage overlaps the copies blend and **smear the constellation**, much like
+[multipath](/learn/rf-sdr/propagation/). You can't erase that distortion, but you can
+**bias reception toward one transmitter** with a directional antenna, careful siting, and
+conservative gain. And accept the hard limit: a system that **covers more area than you
+can hear** will only ever give you the sites that reach your antenna.
+</div>
+
+The [sites, simulcast and roaming](sites-simulcast-roaming/) lesson explained the
+architecture; this one is about *operating* against it. Multi-site and simulcast are the
+two situations where a perfectly configured system still fights you, so it's worth
+knowing the practical moves.
+
+## Choosing which site to monitor
+
+A multi-site system has **one control channel per site**, each covering its own area. You
+can only lock one control channel per receiver, so the question is *which*. The answer is
+the **closest, cleanest site you can hear** — usually the one nearest you, because it
+arrives strongest and carries the traffic most relevant to your location.
+
+"Cleanest" matters as much as "loudest." Tune each candidate site's control channel and
+compare lock quality on the [tuning meters](/tuning.html) and
+[constellation](/constellation.html): a slightly weaker site with a tight, stable
+constellation will decode more reliably than a louder one that's smeared by simulcast or
+overload. Pick the one that *locks best*, then let GopherTrunk follow that site's calls.
+
+## What simulcast distortion looks like
+
+[Simulcast](sites-simulcast-roaming/) sites broadcast the **same signal from several
+towers simultaneously on the same frequency** — a design that extends coverage cheaply
+but punishes receivers in the overlap zones. There, copies from different towers arrive
+at **slightly different times** and combine, smearing the waveform the same way
+[multipath](/learn/rf-sdr/propagation/) does.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 180" role="img" aria-label="Two towers each sending the same signal to a receiver in the middle. The two paths have different lengths, so the copies arrive at different times and combine into a smeared waveform." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <!-- towers -->
+    <path d="M60 120 L52 60 L68 60 Z" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="60" y="138">Tower A</text>
+    <path d="M480 120 L472 60 L488 60 Z" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="480" y="138">Tower B</text>
+    <!-- receiver -->
+    <circle cx="270" cy="95" r="8" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1.3"/><text x="270" y="120">receiver</text>
+    <!-- paths -->
+    <line x1="62" y1="62" x2="262" y2="92" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3"/>
+    <line x1="478" y1="62" x2="278" y2="92" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3"/>
+    <text x="160" y="64" font-size="8.5">copy 1 (short path)</text>
+    <text x="378" y="64" font-size="8.5">copy 2 (long path — arrives later)</text>
+    <!-- smeared result -->
+    <text x="270" y="158" font-size="9">copies combine → smeared symbols, fuzzy constellation</text>
+  </g>
+</svg>
+<figcaption>In the overlap zone, the same signal arrives from two towers at slightly different times. The copies add up into a smeared waveform — the constellation fuzzes even though the raw signal is strong.</figcaption>
+</figure>
+
+The tell is a **strong signal meter but a fuzzy constellation** and a stubbornly high
+error rate. Raising gain won't help — the problem isn't weakness, it's the blend of
+competing copies.
+
+## Mitigating it — bias toward one transmitter
+
+You can't remove simulcast distortion, but you can make **one tower dominate** so its copy
+overwhelms the others:
+
+- **A directional antenna** aimed at the nearest tower is the single biggest win — it
+  amplifies one copy and rejects the others.
+- **Careful siting** — moving the antenna so terrain or buildings favour one site — has
+  the same effect for free.
+- **Conservative gain** keeps the strong, blended signal from also **overloading** the
+  front end, which would pile distortion on distortion. Set gain just high enough for a
+  clean lock, no more.
+- **[Demod calibration](/demod-calibration.html)** can help the demodulator wring a lock
+  out of a marginally smeared signal once the antenna and gain are doing their part.
+
+The goal isn't a perfect signal — it's making the constellation tight enough to decode,
+by tilting the balance toward a single transmitter. The
+[tuning-with-scopes](/learn/rf-sdr/tuning-with-scopes/) techniques are exactly how you
+read whether each change is helping.
+
+## When the system is bigger than your horizon
+
+Some systems simply **cover more area than you can hear**. A statewide network may have
+dozens of sites; from one location you'll receive only the few whose control channels
+clear your noise floor. There's no software fix for a control channel that doesn't reach
+your antenna — you follow the sites you can hear and accept the rest are out of range.
+
+Improving the **antenna and its placement** — higher, clearer, better matched — extends
+your reach and may pull in another site or two. But geography and the system's design set
+a hard ceiling. Knowing that ceiling exists stops you from chasing a "fault" that's really
+just distance.
+
+| Situation | Symptom | Practical move |
+|-----------|---------|----------------|
+| Several sites audible | Multiple control channels lock | Monitor the **closest, cleanest** site |
+| In a simulcast overlap | Strong meter, **fuzzy constellation** | Directional antenna, favour one tower, lower gain |
+| Front-end overloaded | Smearing *and* ghost signals | **Reduce gain**, add attenuation |
+| Site out of range | No lock on a known control channel | Better antenna/placement, or accept it's too far |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a strong meter with a fuzzy constellation is the classic simulcast overlap; bias toward one tower." markdown="0">
+  <p class="knowledge-check__q">Quick check: the signal meter is strong but the constellation is fuzzy and won't lock. On a simulcast system, what's the best first move?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Increase the gain to push through the fuzz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Use a directional antenna to favour one tower</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Switch to a different talkgroup</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A multi-site system has **one control channel per site** — monitor the **closest,
+  cleanest** one you can hear.
+- **Simulcast** overlap **smears the constellation** even when the signal is strong — like
+  [multipath](/learn/rf-sdr/propagation/).
+- Mitigate by **biasing toward one transmitter**: directional antenna, careful siting,
+  conservative gain.
+- **[Demod calibration](/demod-calibration.html)** can squeeze a lock out of a marginally
+  smeared signal.
+- A system **bigger than your horizon** gives you only the sites that reach your antenna —
+  that's a hard limit, not a fault.
+
+Last in the module: a systematic checklist for when a system still won't decode, in
+[troubleshooting a digital decode](troubleshooting-a-decode/).

--- a/docs/learn/digital-trunking/nxdn.md
+++ b/docs/learn/digital-trunking/nxdn.md
@@ -1,0 +1,149 @@
+---
+slug: nxdn
+title: "NXDN"
+description: NXDN explained — the narrowband 4FSK FDMA standard from Icom and Kenwood, with NXDN48 at 6.25 kHz and NXDN96 at 12.5 kHz, AMBE+2 voice, and Type-C trunking.
+keywords: NXDN, NXDN48, NXDN96, NEXEDGE, IDAS, 4FSK FDMA, 6.25 kHz, narrowband digital, AMBE+2, Type-C trunking, Icom Kenwood, common air interface
+level: intermediate
+status: full
+prereq:
+  - digital-modulation-for-trunking
+  - identifying-the-system
+faq:
+  - q: What is NXDN?
+    a: NXDN is a narrowband digital land-mobile-radio standard developed jointly by Icom and Kenwood. It uses 4FSK FDMA in very narrow channels — 6.25 kHz (NXDN48) or 12.5 kHz (NXDN96) — with the AMBE+2 vocoder. It comes in conventional and trunked forms and is branded NEXEDGE by Kenwood and IDAS by Icom.
+  - q: What is the difference between NXDN48 and NXDN96?
+    a: They are the two channel options of the same standard. NXDN48 runs at 2400 symbols/s in a 6.25 kHz channel for maximum spectrum efficiency. NXDN96 runs at 4800 symbols/s in a 12.5 kHz channel for higher throughput. Both use the same 4FSK modulation and AMBE+2 voice; they differ in width and bit rate.
+  - q: Who uses NXDN?
+    a: NXDN is common in business and industrial radio — utilities, transport, security, and similar — and appears in some public-safety and government deployments. Because it is very narrow, it suits operators who want to fit many channels into limited spectrum. You'll meet it both conventionally and as Type-C trunked systems.
+  - q: How do I recognise NXDN on the air?
+    a: Its defining trait is how narrow it is, especially NXDN48 at 6.25 kHz — a thin sliver on the waterfall, narrower than DMR or P25. It is 4FSK like those systems, so the surest identification comes from letting a decoder read the signaling once it locks the channel.
+gophertrunk_links:
+  - title: Status
+    url: /status.html
+    note: which protocols GopherTrunk decodes and how completely.
+  - title: Symbol scope
+    url: /symbol-scope.html
+    note: inspect the narrow 4FSK symbols of an NXDN channel.
+---
+
+# NXDN
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**NXDN** is a **narrowband 4FSK FDMA** standard developed by **Icom and Kenwood**. It comes
+in two widths: **NXDN48** (**6.25 kHz**, 2400 symbols/s) and **NXDN96** (**12.5 kHz**, 4800
+symbols/s), both using the **AMBE+2** vocoder. It supports **conventional** and **trunked**
+(Type-C) operation and is sold as **NEXEDGE** by Kenwood and **IDAS** by Icom. It's common
+in **business and industrial** radio, with some public-safety use. Its signature is being
+**very narrow** — NXDN48 is one of the thinnest signals you'll see on the waterfall. Its
+close ETSI cousin **[dPMR](dpmr-dstar-ysf/)** works almost identically.
+</div>
+
+After the 25 kHz bulk of [TETRA](tetra/), NXDN is the opposite extreme: one of the
+narrowest digital voice standards in regular use. Where TETRA spread its calls wide, NXDN
+squeezes them into a sliver of spectrum.
+
+## What NXDN is
+
+NXDN grew out of a joint effort by **Icom** and **Kenwood** to define an open *common air
+interface* for narrowband digital radio. The result is **FDMA** — each call gets its own
+frequency, no time slots — using **4FSK**, the same four-level frequency modulation you met
+in [digital modulation for trunking](digital-modulation-for-trunking/) and that P25 and DMR
+also use. Voice rides on the **[AMBE+2](/learn/rf-sdr/vocoders/)** vocoder.
+
+Because the two vendors sell it under their own names, you'll see NXDN behind several
+brands:
+
+| Brand | Vendor | Notes |
+|-------|--------|-------|
+| **NEXEDGE** | Kenwood | Kenwood's NXDN product line |
+| **IDAS** | Icom | Icom's NXDN product line |
+| **NXDN** | (the standard) | The common air interface both implement |
+
+It's the same protocol underneath — a NEXEDGE radio and an IDAS radio speak NXDN to each
+other.
+
+## NXDN48 and NXDN96
+
+The standard defines **two channel options**, and the names come from the bit rate:
+
+| Variant | Channel width | Symbol rate | Spirit |
+|---------|---------------|-------------|--------|
+| **NXDN48** | **6.25 kHz** | **2400 symbols/s** | maximum spectrum efficiency |
+| **NXDN96** | **12.5 kHz** | **4800 symbols/s** | higher throughput |
+
+NXDN48's **6.25 kHz** channel is the headline feature — it fits *two* channels into the
+space a single 12.5 kHz DMR or P25 channel uses, which is why it's prized where spectrum is
+tight. NXDN96 trades that efficiency for a faster channel in a conventional 12.5 kHz slot.
+Both use the same 4FSK and AMBE+2; only the width and rate change.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A width comparison showing NXDN48 at 6.25 kHz as a thin block, NXDN96 and DMR/P25 at 12.5 kHz as wider blocks, and TETRA at 25 kHz as the widest." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <text x="260" y="20" text-anchor="middle" font-weight="600">Channel width, to scale</text>
+    <rect x="40" y="40" width="40" height="28" fill="currentColor" fill-opacity="0.30" stroke="currentColor" stroke-width="1"/>
+    <text x="60" y="84" text-anchor="middle" font-size="9">NXDN48</text>
+    <text x="60" y="96" text-anchor="middle" font-size="8">6.25 kHz</text>
+    <rect x="120" y="40" width="80" height="28" fill="currentColor" fill-opacity="0.20" stroke="currentColor" stroke-width="1"/>
+    <text x="160" y="84" text-anchor="middle" font-size="9">NXDN96</text>
+    <text x="160" y="96" text-anchor="middle" font-size="8">12.5 kHz</text>
+    <rect x="240" y="40" width="80" height="28" fill="currentColor" fill-opacity="0.20" stroke="currentColor" stroke-width="1"/>
+    <text x="280" y="84" text-anchor="middle" font-size="9">DMR / P25 P1</text>
+    <text x="280" y="96" text-anchor="middle" font-size="8">12.5 kHz</text>
+    <rect x="360" y="40" width="120" height="28" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/>
+    <text x="420" y="84" text-anchor="middle" font-size="9">TETRA</text>
+    <text x="420" y="96" text-anchor="middle" font-size="8">25 kHz</text>
+    <text x="260" y="130" text-anchor="middle" font-size="9">NXDN48 is a thin sliver — that narrowness is its signature.</text>
+  </g>
+</svg>
+<figcaption>NXDN48 at 6.25 kHz is one of the narrowest digital voice signals you'll encounter — about half the width of a DMR or P25 channel.</figcaption>
+</figure>
+
+## Conventional and trunked
+
+NXDN runs in both styles you met earlier in [conventional vs
+trunked](conventional-vs-trunked/):
+
+- **Conventional** — a fixed channel that a group always uses, common for small business and
+  industrial fleets.
+- **Trunked** — NXDN's trunking is called **Type-C**, with a [control
+  channel](the-control-channel/) granting traffic channels just like the systems you've
+  studied. GopherTrunk follows the control channel to track [talkgroups and
+  IDs](talkgroups-ids-affiliation/).
+
+## Recognising it, and its cousin dPMR
+
+The easiest tell is **width**. NXDN48's 6.25 kHz channel is one of the thinnest signals on
+the [waterfall](/learn/rf-sdr/fft-and-waterfall/) — much narrower than DMR or P25. It *is* 4FSK
+like those systems, so width alone won't fully distinguish it; the reliable answer comes
+from letting the decoder read the [signaling](identifying-the-system/) once it locks.
+
+NXDN has a very close European relative, **dPMR**, an ETSI standard that also does 6.25 kHz
+4FSK FDMA. They are separate standards but so similar in footprint that they're easy to
+confuse — we cover dPMR alongside D-STAR and System Fusion in [dPMR, D-STAR & System
+Fusion](dpmr-dstar-ysf/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — NXDN48 is a 6.25 kHz 4FSK FDMA channel, about half a DMR channel's width." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is the most distinctive thing about NXDN48 on the air?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It is a wide 25 kHz channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It is very narrow — only 6.25 kHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses phase modulation, not 4FSK</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **NXDN** is a **narrowband 4FSK FDMA** standard from **Icom and Kenwood**, branded
+  **IDAS** and **NEXEDGE**.
+- **NXDN48** is **6.25 kHz** (2400 symbols/s); **NXDN96** is **12.5 kHz** (4800 symbols/s);
+  both use **AMBE+2**.
+- It runs **conventional** and **trunked** (**Type-C**), used mostly in business and
+  industry with some public safety.
+- Its signature is being **very narrow** — though confirming it usually means letting the
+  decoder read the signaling.
+- Its ETSI cousin **dPMR** is nearly identical in footprint.
+
+Next, we turn to a North-American giant that's still everywhere — Motorola's analog
+trunking family: [SmartNet / SmartZone & Type II](motorola-smartnet/).

--- a/docs/learn/digital-trunking/p25-phase-1.md
+++ b/docs/learn/digital-trunking/p25-phase-1.md
@@ -1,0 +1,218 @@
+---
+slug: p25-phase-1
+title: "P25 Phase 1"
+description: P25 Phase 1 explained in depth — C4FM modulation, the NAC, WACN and System ID, TSBKs on the control channel, LDU1/LDU2 voice frames, IMBE, and how GopherTrunk follows it.
+keywords: P25, Project 25, APCO 25, TIA-102, C4FM, NAC, WACN, System ID, TSBK, LDU1, LDU2, IMBE, P25 Phase 1, trunking control channel
+level: intermediate
+status: full
+prereq:
+  - digital-modulation-for-trunking
+  - control-channel-signaling
+faq:
+  - q: What is P25 Phase 1?
+    a: P25 Phase 1 is the original digital mode of APCO Project 25, the open standard family (TIA-102) used by most North-American public-safety agencies. It uses C4FM four-level FSK in a 12.5 kHz FDMA channel, running 4800 symbols per second for a 9600 bps stream, and carries voice with the IMBE vocoder. It is the workhorse you meet most often on US police and fire systems.
+  - q: What is a NAC in P25?
+    a: The NAC, or Network Access Code, is a 12-bit value carried in every P25 frame. It works like a digital CTCSS tone — a radio ignores traffic whose NAC does not match the one it is programmed for, so several systems can share a frequency without hearing each other. GopherTrunk reads the NAC to confirm it is locked to the right system.
+  - q: What are TSBKs?
+    a: TSBKs (Trunking Signaling Blocks) are the data messages a P25 control channel broadcasts continuously. They announce group and unit call grants, channel assignments, affiliations, registrations and system parameters. By decoding the stream of TSBKs, GopherTrunk learns which talkgroup is starting a call and which voice channel it was assigned.
+  - q: What is the difference between LDU1 and LDU2?
+    a: LDU1 and LDU2 are the two halves of a P25 voice superframe. Each Logical Data Unit carries nine IMBE voice frames plus embedded signaling — LDU1 carries the Link Control word (talkgroup, source ID, service options) and LDU2 carries the encryption sync. Together they let a receiver decode audio while continuously confirming who is talking.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch the live stream of TSBKs the control channel broadcasts.
+  - title: Constellation
+    url: /constellation.html
+    note: confirm a clean C4FM lock by the four symbol points.
+  - title: Vocoders
+    url: /vocoders.html
+    note: see how GopherTrunk renders IMBE voice frames to audio.
+---
+
+# P25 Phase 1
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**P25 Phase 1** is the dominant North-American public-safety digital standard, defined
+by **APCO Project 25 / TIA-102**. It is **FDMA** in a **12.5 kHz** channel using
+**C4FM** four-level FSK — **4800 symbols/s × 2 bits = 9600 bps** — and carries voice
+with the **IMBE** vocoder. Every frame carries a **NAC**, a digital CTCSS that keeps
+systems apart, and the system is identified by its **WACN** and **System ID**. The
+control channel broadcasts **TSBKs** that grant calls; voice rides in **LDU1/LDU2**
+superframes carrying IMBE plus link control. **GopherTrunk decodes the control channel
+first**, then follows each grant to the voice channel.
+</div>
+
+You met the [modulations of digital trunking](digital-modulation-for-trunking/) and how
+a [control channel signals](control-channel-signaling/) calls. P25 Phase 1 is where all
+of it comes together into the single most common digital system you will track in North
+America. This lesson opens it up end to end.
+
+## What P25 is, and who runs it
+
+**Project 25** (P25, sometimes APCO-25) is an *open* suite of standards published as the
+**TIA-102** series. "Open" matters: unlike a proprietary vendor system, the air
+interface is documented, so radios from different manufacturers interoperate and
+independent decoders can follow it. It was created for **public safety** — police, fire,
+EMS — with a deliberate emphasis on coverage, reliability and graceful behaviour at the
+edge of range, where a fire-ground radio still has to be intelligible.
+
+**Phase 1** is the original digital mode. It is a straightforward **FDMA** design: each
+call gets its own **12.5 kHz** frequency channel, exactly like the conventional channels
+it replaced, but the voice and signaling are digital. That simplicity is part of why it
+became the backbone of US public-safety radio.
+
+## The physical layer: C4FM in 12.5 kHz
+
+P25 Phase 1 transmits with **C4FM** — Continuous 4-level FM, a four-level
+[FSK](/learn/rf-sdr/digital-modulation/). The carrier sits at one of four small
+deviations per symbol, and because four levels carry **two bits** each (a *dibit*), the
+**4800 symbols/s** symbol rate yields a **9600 bps** stream.
+
+| Parameter | P25 Phase 1 |
+|-----------|-------------|
+| Standard | APCO Project 25 / TIA-102 |
+| Access method | FDMA (one call per frequency) |
+| Channel width | 12.5 kHz |
+| Modulation | C4FM (also CQPSK/LSM for simulcast) |
+| Symbol rate | 4800 symbols/s |
+| Bit rate | 9600 bps |
+| Vocoder | IMBE (7200 bps incl. FEC) |
+| System access control | NAC (12-bit) |
+
+Because C4FM is **constant-envelope** — only the frequency changes, never the amplitude —
+it runs on the cheap, efficient nonlinear amplifiers in handheld radios. Infrastructure
+that has to **simulcast** the same channel from many overlapping transmitters instead
+uses **CQPSK/LSM**, a linear cousin engineered to land on the *same* four-point
+constellation. On GopherTrunk's **[Constellation panel](/constellation.html)** a healthy
+Phase 1 signal shows four tight points; smearing toward the centre is your cue that
+[SNR](/learn/rf-sdr/decibels/), tuning, or clock recovery needs attention.
+
+## How a P25 frame is addressed: NAC, WACN and System ID
+
+A P25 system needs a way to keep itself separate from neighbours on the same frequency,
+and to identify itself uniquely. Three identifiers do this work:
+
+- **NAC (Network Access Code)** — a **12-bit** code in *every* frame, voice or control.
+  It behaves like a **digital CTCSS**: a radio (or GopherTrunk) ignores any frame whose
+  NAC does not match, so two systems can share a frequency without interfering with each
+  other's squelch. It is the first thing a decoder checks to confirm it is on the right
+  system.
+- **WACN (Wide Area Communications Network)** — a 20-bit identifier for the *network*
+  operator, unique enough to distinguish statewide systems from one another.
+- **System ID** — a 12-bit number identifying the *system* within that WACN.
+
+Together the **WACN + System ID** name a system globally, while the **NAC** is the quick
+per-frame filter. GopherTrunk surfaces these in its activity panels so you can confirm
+at a glance that you are locked to the system you intended.
+
+## The control channel: a river of TSBKs
+
+The control channel is a Phase 1 C4FM carrier that never carries voice — only a
+continuous stream of data. Its unit of work is the **TSBK**, the **Trunking Signaling
+Block**: a fixed-size message that announces something about the system. There are many
+TSBK opcodes, but the ones a follower cares about most are:
+
+- **Group Voice Channel Grant** — "talkgroup X is now on voice channel N." This is the
+  message that tells GopherTrunk where to point a receiver.
+- **Unit-to-Unit grants** — a private call between two individual radios.
+- **Registration / affiliation / location** — radios announcing themselves, which keeps
+  the [Radio IDs](/radio-ids.html) view populated.
+- **System parameters** — the WACN, System ID, the channel-to-frequency mapping, and
+  status broadcasts that let a newcomer learn the whole system from the control channel
+  alone.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 220" role="img" aria-label="A P25 Phase 1 flow. A control channel at top emits TSBK messages. A grant message points down to a voice channel where an LDU1 and LDU2 superframe carry IMBE voice frames." xmlns="http://www.w3.org/2000/svg">
+  <rect x="30" y="20" width="480" height="44" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+  <text x="270" y="40" text-anchor="middle" font-size="13" fill="currentColor" font-weight="600">Control channel — stream of TSBKs (C4FM, data only)</text>
+  <text x="270" y="56" text-anchor="middle" font-size="10" fill="currentColor">“Group Voice Grant: TG 4521 → channel 9”</text>
+  <line x1="270" y1="64" x2="270" y2="104" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#p25a)"/>
+  <g font-size="10" fill="currentColor">
+    <rect x="60" y="108" width="180" height="86" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="150" y="126" text-anchor="middle" font-weight="600">LDU1</text>
+    <text x="150" y="142" text-anchor="middle" font-size="9">9 × IMBE voice frames</text>
+    <text x="150" y="156" text-anchor="middle" font-size="9">+ Link Control</text>
+    <text x="150" y="170" text-anchor="middle" font-size="9">(talkgroup, source ID)</text>
+    <text x="150" y="184" text-anchor="middle" font-size="9">+ low-speed data</text>
+    <rect x="300" y="108" width="180" height="86" rx="5" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="1.5"/>
+    <text x="390" y="126" text-anchor="middle" font-weight="600">LDU2</text>
+    <text x="390" y="142" text-anchor="middle" font-size="9">9 × IMBE voice frames</text>
+    <text x="390" y="156" text-anchor="middle" font-size="9">+ encryption sync</text>
+    <text x="390" y="170" text-anchor="middle" font-size="9">(algorithm, key, MI)</text>
+    <text x="390" y="184" text-anchor="middle" font-size="9">+ low-speed data</text>
+  </g>
+  <text x="270" y="212" text-anchor="middle" font-size="11" fill="currentColor">LDU1 + LDU2 = one voice superframe, repeating for the call's duration.</text>
+  <defs><marker id="p25a" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A TSBK grant on the control channel hands the call to a voice channel, where repeating LDU1/LDU2 superframes carry IMBE voice plus embedded link control and encryption sync.</figcaption>
+</figure>
+
+## Voice frames: LDU1 and LDU2
+
+When a grant fires, the call lands on a voice channel as a repeating **voice superframe**
+built from two **Logical Data Units**. Each LDU carries **nine IMBE voice frames** — so a
+superframe is eighteen frames of audio — interleaved with embedded signaling:
+
+- **LDU1** carries the **Link Control (LC)** word: the talkgroup, the source unit ID, and
+  the service options (including the *encrypted* flag). This repeats so a receiver tuning
+  in mid-call quickly learns who is talking.
+- **LDU2** carries the **encryption sync** — the algorithm ID, key ID and Message
+  Indicator needed to decrypt a protected call.
+
+Both units also carry **low-speed data** and heavy forward error correction, so the call
+keeps identifying itself and stays intelligible even as the signal fades. The voice
+payload is **IMBE**, the [vocoder](/learn/rf-sdr/vocoders/) whose core patents have
+expired — which is why GopherTrunk ships a pure-Go IMBE decoder and renders Phase 1 audio
+end to end without external libraries (see [Vocoders](/vocoders.html)).
+
+## Clear vs encrypted
+
+A Phase 1 call is **clear** unless the LDU1 service options flag it encrypted. When it is,
+the LDU2 encryption sync names the algorithm (commonly AES-256 or DES on public-safety
+systems) and key. GopherTrunk reads the encrypted flag from the link control *before*
+voice even starts, logs the call as encrypted, and still captures the protected frames —
+but without the (operator-supplied, legally held) key the audio stays unintelligible.
+This is the same known-key-only posture covered in [encryption and
+authentication](encryption-and-authentication/).
+
+## How GopherTrunk follows a Phase 1 system
+
+The procedure is exactly the trunking pattern, made concrete:
+
+1. **Lock the control channel.** Acquire C4FM, recover the clock, and confirm the **NAC**,
+   **WACN** and **System ID** match the intended system.
+2. **Decode TSBKs.** Read the continuous stream on the
+   **[CC Activity](/cc-activity.html)** panel, building a live map of talkgroups, units
+   and the channel-to-frequency table.
+3. **Follow a grant.** On a Group Voice Channel Grant, tune a receiver to the assigned
+   voice channel.
+4. **Decode voice.** Lock the LDU1/LDU2 superframes, extract IMBE frames, render them to
+   audio, and read the link control to confirm the talkgroup and source ID.
+5. **Release and repeat.** When the call ends, return to the control channel and follow
+   the next grant.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — the 12-bit NAC works like a digital CTCSS, filtering frames by system." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the P25 NAC do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Sets the voice channel frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Acts like a digital CTCSS that keeps systems apart on a shared frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Selects the vocoder</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **P25 Phase 1** is the open APCO/TIA-102 standard dominating North-American public
+  safety: **FDMA, 12.5 kHz, C4FM, 9600 bps, IMBE**.
+- The **NAC** is a per-frame digital CTCSS; **WACN + System ID** name the system globally.
+- The control channel broadcasts **TSBKs**, of which **Group Voice Channel Grants** are
+  what a follower acts on.
+- Voice rides in **LDU1/LDU2** superframes — eighteen IMBE frames plus link control and
+  encryption sync.
+- GopherTrunk **locks the control channel, decodes TSBKs, follows grants, and renders
+  IMBE** to audio.
+
+Next, we see how P25 doubled its capacity by moving the traffic channels to TDMA:
+[P25 Phase 2](p25-phase-2/).

--- a/docs/learn/digital-trunking/p25-phase-2.md
+++ b/docs/learn/digital-trunking/p25-phase-2.md
@@ -1,0 +1,159 @@
+---
+slug: p25-phase-2
+title: "P25 Phase 2: TDMA"
+description: P25 Phase 2 explained — two-slot TDMA traffic channels for double voice capacity, H-DQPSK/H-CPM modulation, the AMBE+2 half-rate vocoder, ISCH sync, and what changes for a decoder.
+keywords: P25 Phase 2, TDMA, H-DQPSK, H-CPM, AMBE+2, ISCH, two-slot, 6.25 kHz equivalent, P25 traffic channel, half-rate vocoder, time slot
+level: advanced
+status: full
+prereq:
+  - p25-phase-1
+  - tdma-vs-fdma
+faq:
+  - q: What does P25 Phase 2 add over Phase 1?
+    a: Phase 2 puts two-slot TDMA on the traffic channels, so a single 12.5 kHz voice channel carries two simultaneous calls — about 6.25 kHz of spectrum per call. It doubles voice capacity without needing new frequencies. The control channel usually stays a Phase 1 C4FM channel, so a system is effectively Phase 1 signaling with Phase 2 traffic.
+  - q: What modulation does P25 Phase 2 use?
+    a: Phase 2 traffic channels use a phase-modulated scheme — H-DQPSK on the inbound (subscriber-to-system) link and H-CPM on the outbound link — rather than the C4FM of Phase 1. These are engineered for the tight timing a two-slot TDMA channel needs. The control channel typically remains C4FM.
+  - q: What vocoder does P25 Phase 2 use?
+    a: Phase 2 uses the AMBE+2 half-rate vocoder instead of Phase 1's IMBE. Half-rate voice fits two conversations into the bits of one Phase 1 channel, which is what makes the two-slot TDMA capacity gain possible. AMBE+2 is patent-encumbered, unlike the now-expired IMBE patents.
+  - q: Why must a Phase 2 decoder track two time slots?
+    a: Because a single Phase 2 traffic frequency interleaves two independent calls in alternating time slots. A decoder has to recover slot timing from the ISCH and demultiplex the bursts, treating each slot as its own voice stream. Locking the frequency is not enough — you must lock the slot.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: the Phase 1 control channel that still grants Phase 2 calls.
+  - title: Symbol scope
+    url: /symbol-scope.html
+    note: inspect the recovered symbols on a TDMA traffic channel.
+  - title: Vocoders
+    url: /vocoders.html
+    note: see how GopherTrunk maps Phase 2 grants to the AMBE+2 decoder.
+---
+
+# P25 Phase 2: TDMA
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**P25 Phase 2** doubles voice capacity by putting **two-slot TDMA** on the traffic
+channels: one **12.5 kHz** frequency now carries **two simultaneous calls** — roughly
+**6.25 kHz equivalent** each. Traffic uses a **phase-modulated** scheme (**H-DQPSK**
+inbound, **H-CPM** outbound), not C4FM, and the **AMBE+2 half-rate** vocoder instead of
+IMBE. Crucially, the **control channel usually stays a Phase 1 C4FM channel** — so the
+signaling is Phase 1 and only the *traffic* is TDMA. For a decoder, the new job is
+**tracking two time slots per frequency**, recovering slot timing from the **ISCH**.
+</div>
+
+[P25 Phase 1](p25-phase-1/) gave each call its own 12.5 kHz frequency. That is clean but
+spectrum-hungry, and busy metropolitan systems ran out of channels. **Phase 2** is the
+answer: keep the same frequencies, but fit two calls on each traffic channel using
+[TDMA](tdma-vs-fdma/).
+
+## The capacity idea: two calls, one frequency
+
+In Phase 2 a traffic channel is divided in **time** into **two slots** that alternate in
+rapid turns. Two independent calls share the frequency — one in each slot — so a 12.5 kHz
+channel does the work of two. The standard often describes this as **6.25 kHz
+equivalent** per call: not that the channel is physically narrower, but that each
+conversation consumes half the channel's time, achieving the same spectral efficiency as
+a 6.25 kHz channel would.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 180" role="img" aria-label="A two-slot TDMA frame for P25 Phase 2. A single frequency is divided into alternating slot 1 and slot 2 bursts in time, with an ISCH sync marker between bursts. Slot 1 carries call A, slot 2 carries call B." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <text x="260" y="20" text-anchor="middle" font-weight="600">One Phase 2 traffic frequency — two time slots</text>
+    <line x1="30" y1="150" x2="490" y2="150" stroke="currentColor" stroke-opacity="0.4"/>
+    <text x="260" y="170" text-anchor="middle" font-size="9">time →</text>
+    <rect x="40" y="60" width="90" height="70" fill="currentColor" fill-opacity="0.30" stroke="currentColor" stroke-width="0.8"/><text x="85" y="92" text-anchor="middle" font-size="9">Slot 1</text><text x="85" y="106" text-anchor="middle" font-size="9">call A</text>
+    <rect x="130" y="60" width="14" height="70" fill="currentColor" fill-opacity="0.55"/><text x="137" y="48" text-anchor="middle" font-size="8">ISCH</text>
+    <rect x="144" y="60" width="90" height="70" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="0.8"/><text x="189" y="92" text-anchor="middle" font-size="9">Slot 2</text><text x="189" y="106" text-anchor="middle" font-size="9">call B</text>
+    <rect x="234" y="60" width="14" height="70" fill="currentColor" fill-opacity="0.55"/>
+    <rect x="248" y="60" width="90" height="70" fill="currentColor" fill-opacity="0.30" stroke="currentColor" stroke-width="0.8"/><text x="293" y="92" text-anchor="middle" font-size="9">Slot 1</text><text x="293" y="106" text-anchor="middle" font-size="9">call A</text>
+    <rect x="338" y="60" width="14" height="70" fill="currentColor" fill-opacity="0.55"/>
+    <rect x="352" y="60" width="90" height="70" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="0.8"/><text x="397" y="92" text-anchor="middle" font-size="9">Slot 2</text><text x="397" y="106" text-anchor="middle" font-size="9">call B</text>
+  </g>
+</svg>
+<figcaption>Two independent calls (A and B) interleave in alternating time slots on a single Phase 2 frequency. The ISCH sync between bursts is what lets a decoder recover slot timing and demultiplex them.</figcaption>
+</figure>
+
+## The modulation changes — but not on the control channel
+
+To fit a clean two-slot burst structure, Phase 2 traffic channels drop C4FM in favour of
+a **phase-modulated** scheme: **H-DQPSK** (Harmonized Differential QPSK) on the inbound
+link from subscriber to system, and **H-CPM** (Harmonized Continuous Phase Modulation) on
+the outbound link from system to subscriber. These are tuned for the precise timing a
+shared TDMA channel demands.
+
+The important subtlety: in nearly all deployments the **control channel stays a Phase 1
+C4FM channel**. A Phase 2 system is therefore *Phase 1 signaling with Phase 2 traffic* —
+the same [TSBK](control-channel-signaling/) grants you already know, but the channels they
+point to are TDMA. This is also why Phase 2 systems remain compatible with the wider P25
+world and why a follower's control-channel logic is essentially unchanged.
+
+## Half-rate voice: AMBE+2
+
+Two calls in the bits of one means each call gets **half the data rate**, so Phase 2
+swaps Phase 1's IMBE for the **AMBE+2 half-rate** [vocoder](/learn/rf-sdr/vocoders/). The
+same family of math, but compressing voice into roughly half the bits — exactly what a
+single TDMA slot can carry. Unlike IMBE, whose core patents have expired, **AMBE+2 is
+patent-encumbered**; GopherTrunk ships a pure-Go AMBE+2 decoder by default but the patent
+risk falls on the deployer (see [Vocoders](/vocoders.html)). Phase 2 grants map to the
+`ambe2` vocoder in GopherTrunk's protocol table.
+
+| Aspect | Phase 1 | Phase 2 |
+|--------|---------|---------|
+| Traffic access | FDMA | 2-slot TDMA |
+| Calls per 12.5 kHz | 1 | 2 |
+| Spectral efficiency | 12.5 kHz/call | ≈6.25 kHz/call equiv. |
+| Traffic modulation | C4FM | H-DQPSK / H-CPM |
+| Control channel | C4FM | usually C4FM (Phase 1) |
+| Vocoder | IMBE (full-rate) | AMBE+2 (half-rate) |
+
+## Slot structure and ISCH
+
+A Phase 2 frequency carries a repeating sequence of **bursts**, alternating between the
+two slots. To make sense of the stream a receiver must know *which slot it is looking at*
+and *where each burst begins*. That synchronization comes from the **ISCH**
+(Inter-Slot Signaling CHannel) embedded in the burst structure: it provides the sync and
+slot-identification markers a decoder uses to align to the frame, distinguish slot 1 from
+slot 2, and carry per-slot signaling. Lose ISCH sync and the two calls smear into noise;
+hold it and each slot becomes a clean, independent voice stream.
+
+## What changes for a decoder
+
+For GopherTrunk the control-channel side barely changes — it is still reading Phase 1
+TSBK grants. The traffic side is where Phase 2 demands more:
+
+- **Demodulate a different scheme.** The traffic channel is H-DQPSK/H-CPM, not C4FM, so
+  the symbol recovery differs from Phase 1. You can still inspect recovered symbols on the
+  **[Symbol scope](/symbol-scope.html)**.
+- **Recover slot timing.** Lock the **ISCH**, find the burst boundaries, and identify
+  which slot is which.
+- **Demultiplex two calls.** Treat **each slot as its own voice stream**, decoding
+  AMBE+2 separately per slot, because a single grant's frequency may host a second,
+  unrelated call in the other slot.
+- **Map grants to slots.** A Phase 2 grant references not just a frequency but a *slot*,
+  so the follower tunes the frequency and then selects the correct time slot.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Phase 2 traffic is two-slot TDMA, so one 12.5 kHz channel carries two calls." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does P25 Phase 2 double voice capacity?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">By adding more frequencies to the pool</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">By putting two-slot TDMA on each traffic channel</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">By switching the control channel to AMBE+2</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **P25 Phase 2** adds **two-slot TDMA** on the traffic channels, doubling capacity to
+  **two calls per 12.5 kHz** (≈6.25 kHz equivalent each).
+- Traffic uses **H-DQPSK/H-CPM** phase modulation; the **control channel usually stays
+  Phase 1 C4FM**, so signaling is unchanged.
+- Voice uses the **AMBE+2 half-rate** vocoder instead of IMBE.
+- The **ISCH** provides the sync and slot identification a decoder needs to demultiplex
+  the two slots.
+- For a decoder the new work is **tracking two time slots per frequency** and decoding
+  each as its own stream.
+
+Next we cross to the other dominant digital standard, with its own three-tier story:
+[DMR Tier II & Tier III](dmr-tier-2-3/).

--- a/docs/learn/digital-trunking/sites-simulcast-roaming.md
+++ b/docs/learn/digital-trunking/sites-simulcast-roaming.md
@@ -1,0 +1,152 @@
+---
+slug: sites-simulcast-roaming
+title: "Sites, simulcast & roaming: multi-site systems"
+description: How large trunked systems use many sites for coverage, why simulcast transmitters on the same frequency can distort reception, how voting and roaming work, and which control channel to monitor.
+keywords: multi-site trunking, simulcast, voting receiver, roaming, registration, control channel per site, WACN, system ID, RFSS, site ID, P25, simulcast distortion
+level: advanced
+status: full
+prereq:
+  - control-channel-signaling
+  - digital-modulation-for-trunking
+faq:
+  - q: What is simulcast?
+    a: Simulcast is when several transmitters broadcast the same channel on the same frequency at the same time, carefully time-aligned, to blanket a wide area. It saves spectrum and gives seamless coverage. But a receiver located between two simulcast transmitters hears overlapping copies that can interfere, distorting the signal and making it hard to decode.
+  - q: Why is simulcast hard to receive?
+    a: Because a receiver midway between two simulcast transmitters gets two copies of the signal arriving at slightly different times and strengths. They combine into a distorted waveform whose constellation smears, even when both signals are strong. Moving the antenna, or using a linear modulation designed for simulcast, helps the copies combine more cleanly.
+  - q: What is roaming on a trunked system?
+    a: Roaming is a radio moving between sites in a multi-site system. As it travels, the radio re-registers and affiliates at each new site over that site's control channel, so the network knows where to deliver its calls. To a monitor, this means a radio may appear and disappear from different sites as it moves.
+  - q: Which control channel should I monitor on a multi-site system?
+    a: Each site has its own control channel, so you monitor the site whose coverage you're in and whose signal you receive most cleanly. The identifiers in the signaling — such as the site ID and system identifiers — confirm which site you're locked to. A neighbor that's stronger may be a better choice.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: read the site and system identifiers in the control-channel signaling.
+  - title: Constellation
+    url: /constellation.html
+    note: spot the smeared constellation that simulcast distortion produces.
+---
+
+# Sites, simulcast & roaming: multi-site systems
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Large trunked systems span many **sites** for coverage, and **each site has its own
+control channel**. **Simulcast** broadcasts the same channel from several transmitters on
+the **same frequency**, time-aligned — efficient, but a receiver *between* two simulcast
+transmitters hears overlapping copies that **distort** the signal even when it's strong.
+**Voting/receiver sites** handle the uplink; **roaming** radios **re-register** at each
+site as they move. In P25, identifiers like **WACN**, **System ID**, **RFSS**, and **Site
+ID** pin down exactly which site and system you're hearing — which guides *which control
+channel to monitor*.
+
+</div>
+
+A real public-safety system rarely lives on one tower. It's a network of **sites** stitched
+together, and that structure introduces three things you need to understand to monitor it
+well: how sites relate, why **simulcast** can wreck reception, and how **roaming** works.
+
+## Many sites, one system
+
+Coverage over a county or a state requires more transmitters than a single site can
+provide, so a large system is built from many **sites**, each covering an area. Critically,
+**each site runs its own control channel**. A radio camps on the control channel of the
+site it's currently in; as it moves, it switches to a neighbor's control channel.
+
+For a monitor this has a direct consequence: **you choose a site**. You lock the control
+channel of the site whose coverage you're in and whose signal you receive cleanly. The
+[control-channel signaling](control-channel-signaling/) you decode is *that site's* view of
+the system, and its **adjacent-site broadcasts** tell you where the neighbors are.
+
+## P25 identifiers: WACN, System ID, RFSS, Site
+
+How do you know *which* site and system you've actually locked? The signaling carries a
+hierarchy of identifiers. In P25 the key ones are:
+
+| Identifier | Scope | Meaning |
+|------------|-------|---------|
+| WACN | Network | Wide Area Communications Network — the largest grouping |
+| System ID | System | A specific system within the WACN |
+| RFSS | Subsystem | RF Sub-System — a grouping of sites |
+| Site ID | Site | The individual site (tower) you're hearing |
+
+Together these uniquely place the control channel you're locked to within the larger
+network. Reading them in **[CC Activity](/cc-activity.html)** is how you confirm you're on
+the right system and site rather than a same-frequency neighbor.
+
+## Simulcast and its distortion
+
+Within a site, coverage is sometimes provided by **simulcast**: *several transmitters* all
+broadcasting the **same channel on the same frequency at the same time**, precisely
+time-aligned. This blankets a large area with one channel and is very spectrum-efficient.
+
+The catch is for a receiver located **between** transmitters. It hears **overlapping
+copies** of the signal arriving at slightly different times and strengths. Those copies
+combine into a distorted waveform — even when every transmitter is strong, the
+**constellation smears** and the decoder struggles. This is *simulcast distortion*, and
+it's a signal-quality problem, not a weak-signal problem.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 200" role="img" aria-label="A diagram showing two simulcast transmitters broadcasting the same frequency, with a receiver located between them hearing two overlapping copies that combine into a distorted signal." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="40" width="90" height="30" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.5"/>
+    <text x="85" y="59">Site Tx A</text>
+    <rect x="410" y="40" width="90" height="30" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.5"/>
+    <text x="455" y="59">Site Tx B</text>
+    <text x="270" y="34" font-size="9">both on the same frequency, time-aligned</text>
+    <circle cx="270" cy="150" r="10" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="270" y="180">receiver in the middle</text>
+  </g>
+  <line x1="120" y1="70" x2="262" y2="142" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <line x1="420" y1="70" x2="278" y2="142" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="270" y="116" text-anchor="middle" font-size="9" fill="currentColor">two copies arrive slightly offset → distortion</text>
+</svg>
+<figcaption>Simulcast transmitters share a frequency to cover a wide area. A receiver between them hears overlapping copies that combine into a distorted waveform — the classic simulcast smear, visible on the constellation.</figcaption>
+</figure>
+
+This is exactly why systems sometimes use a **linear modulation** like
+[CQPSK/LSM](digital-modulation-for-trunking/) for simulcast: it lets the overlapping copies
+combine more cleanly. When you can't lock a strong-but-smeared signal, the
+**[Constellation panel](/constellation.html)** usually shows the simulcast fingerprint, and
+moving the antenna even a little can help by changing which copy dominates.
+
+## Voting and roaming
+
+Two more pieces complete the multi-site picture.
+
+The **uplink** (radios talking back to the system) is handled by **voting**: multiple
+**receiver sites** listen for a radio, and the system "votes" for whichever copy is
+cleanest, so a radio is heard well across the coverage area. You decode the **downlink**, so
+voting mostly explains why the *infrastructure* hears mobiles so reliably.
+
+**Roaming** is a radio moving between sites. As it travels out of one site's coverage and
+into another's, it **re-registers and re-affiliates** on the new site's
+[control channel](control-channel-signaling/), so the network keeps routing its calls
+correctly. To a monitor, a roaming radio appears to come and go across sites — and it's a
+reminder that the *site you monitor* determines which radios and calls you see.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — overlapping same-frequency copies combine into a distorted waveform even when strong." markdown="0">
+  <p class="knowledge-check__q">Quick check: why is a strong simulcast signal sometimes still hard to decode?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The control channel is missing</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Overlapping same-frequency copies combine into a distorted waveform</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The signal is too weak to detect</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- Large systems span many **sites**, and **each site has its own control channel** — you
+  pick one to monitor.
+- **Simulcast** shares a frequency across transmitters; a receiver between them hears
+  **distorting** overlapping copies.
+- A **linear modulation** (CQPSK/LSM) helps simulcast copies combine cleanly; the
+  constellation reveals the smear.
+- **Voting** receiver sites handle the uplink; **roaming** radios **re-register** at each
+  new site.
+- In P25, **WACN / System ID / RFSS / Site ID** pin down exactly which site and system
+  you're hearing.
+
+Next, the last piece of how trunking works: [encryption and
+authentication](encryption-and-authentication/) — and what a decoder can and cannot do
+about them.

--- a/docs/learn/digital-trunking/standards-and-bodies.md
+++ b/docs/learn/digital-trunking/standards-and-bodies.md
@@ -1,0 +1,116 @@
+---
+slug: standards-and-bodies
+title: "Standards & who sets them: APCO, ETSI, TIA & the DMRA"
+description: Who writes radio standards — APCO, the TIA-102 suite for P25, ETSI for TETRA and DMR, the DMR Association, and the ITU — plus open vs proprietary systems and why it matters.
+keywords: APCO, TIA-102, ETSI, DMR Association, DMRA, ITU, P25 standard, TETRA standard, DMR standard, open vs proprietary, interoperability, mutual aid
+level: beginner
+status: full
+prereq:
+  - the-digital-leap
+faq:
+  - q: Who writes the P25 standard?
+    a: P25 was driven by APCO (the Association of Public-Safety Communications Officials) and standardized by the TIA (Telecommunications Industry Association) as the TIA-102 suite of documents. That suite defines everything from the air interface to encryption, which is what makes P25 a true open, multi-vendor standard.
+  - q: What is the difference between an open and a proprietary system?
+    a: An open standard is published so any vendor can build compatible equipment, which enables interoperability and competition — P25 is the classic example. A proprietary system is controlled by one company and only works with its gear or licensees, such as Motorola Type II or Connect Plus. Open standards make multi-vendor and mutual-aid operation far easier.
+  - q: What does ETSI standardize?
+    a: ETSI (the European Telecommunications Standards Institute) publishes the standards for both TETRA and DMR. The DMR Association then promotes interoperability among DMR vendors on top of the ETSI specification. So TETRA and DMR are European-rooted open standards, even though they are used worldwide.
+  - q: Why do open standards matter for public safety?
+    a: Because emergencies cross agency and jurisdiction lines. When everyone's equipment follows the same open standard, radios from different vendors and agencies can talk to each other directly, which is essential for mutual aid. Proprietary systems can lock an agency to a single vendor and complicate cross-agency communication.
+gophertrunk_links:
+  - title: Status
+    url: /status.html
+    note: which standardized protocols GopherTrunk decodes.
+---
+
+# Standards & who sets them: APCO, ETSI, TIA & the DMRA
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Behind every protocol is a body that writes the rules. **APCO** drove **P25**, which the
+**TIA** publishes as the **TIA-102** suite. **ETSI** standardizes both **TETRA** and
+**DMR**, with the **DMR Association (DMRA)** promoting interoperability on top. The **ITU**
+sets the global frame above them all. The key split is **open multi-vendor standards** like
+P25 versus **proprietary systems** like Motorola Type II or Connect Plus. Open standards
+matter because they enable **interoperability** and **mutual aid** — radios from different
+vendors and agencies that can actually talk to each other.
+</div>
+
+You've met the protocols; this short lesson steps back to ask who *makes* them and why the
+answer affects whether two agencies can talk during an emergency. It's also where you learn
+to read a spec number when one turns up in the wild.
+
+## The bodies that write the rules
+
+A handful of organizations stand behind the standards in this path:
+
+- **APCO** — the Association of Public-Safety Communications Officials. APCO drove **Project
+  25 (P25)** to give North-American public safety an *open* standard, born of frustration
+  with proprietary analog systems that couldn't interoperate.
+- **TIA** — the Telecommunications Industry Association. The TIA turned the P25 requirements
+  into the **TIA-102** suite of published documents, which defines the air interface,
+  vocoder, encryption, and more.
+- **ETSI** — the European Telecommunications Standards Institute. ETSI publishes the
+  standards for both **TETRA** and **DMR**.
+- **DMR Association (DMRA)** — an industry group that promotes **interoperability** between
+  DMR vendors on top of the ETSI specification, so that equipment from different makers
+  actually works together.
+- **ITU** — the International Telecommunication Union, the United Nations body that
+  coordinates spectrum and the broad global framework all of the above operate within.
+
+| Body | Scope | Standards |
+|------|-------|-----------|
+| APCO | North-American public safety requirements | P25 (Project 25) |
+| TIA | Publishes the P25 documents | **TIA-102** suite |
+| ETSI | European standards (used worldwide) | TETRA, DMR |
+| DMR Association | DMR interoperability | DMR profiles |
+| ITU | Global spectrum & framework | Recommendations |
+
+## Open vs proprietary
+
+The most consequential distinction here isn't *which* body, but *how open* the result is.
+
+An **open standard** is published in full, so **any vendor** can build compatible
+equipment. **P25** is the textbook example: because TIA-102 is public, agencies can buy
+radios and infrastructure from multiple manufacturers and have them interoperate. That
+breeds competition, lower prices, and — crucially — the ability for different agencies'
+radios to talk to each other.
+
+A **proprietary system** is controlled by a single company. **Motorola Type II** and
+**Connect Plus** are examples: they work with that vendor's gear (or licensees), and the
+details aren't openly published. Proprietary systems can be excellent and feature-rich, but
+they can lock an agency to one supplier and complicate cross-agency communication.
+
+This is why a protocol's openness shows up everywhere downstream, including in how
+[GopherTrunk](/status.html) and other software can support it: open specifications are far
+easier to implement against than reverse-engineered proprietary ones.
+
+## Why open standards matter: interoperability and mutual aid
+
+Emergencies don't respect boundaries. A wildfire pulls in county, state, and federal crews;
+a highway crash brings police, fire, and EMS from neighbouring jurisdictions. If each agency
+runs an incompatible system, they can't coordinate on the radio when it matters most. **Open
+standards** solve this: when everyone's equipment follows the same published specification,
+radios from different vendors and different agencies can join the same talkgroup directly.
+That's **mutual aid**, and it's the central reason North-American public safety pushed so
+hard for an open P25.
+
+## Reading a spec number
+
+When you meet a standard reference, you can usually decode it at a glance. A number like
+**TIA-102.xxxx** belongs to the P25 family — the TIA-102 suite is organized into documents,
+each covering a slice such as the air interface or encryption. ETSI numbers (often beginning
+**ETSI TS** or **ETSI EN**) identify TETRA and DMR specifications similarly. You rarely need
+to *read* the document itself, but recognizing the prefix tells you instantly which standard
+family someone is talking about, and that's enough to orient yourself.
+
+## Recap
+
+- **APCO** drove **P25**; the **TIA** publishes it as the **TIA-102** suite.
+- **ETSI** standardizes **TETRA** and **DMR**; the **DMR Association** adds interoperability profiles; the **ITU** sets the global frame.
+- The key split is **open multi-vendor standards** (P25) vs **proprietary systems** (Motorola Type II, Connect Plus).
+- Open standards enable **interoperability** and **mutual aid** — different vendors' and agencies' radios talking directly.
+- A spec's prefix (TIA-102, ETSI TS/EN) tells you which standard family it belongs to.
+
+That completes the history module. The next module turns to how digital voice itself
+works, starting with [Analog vs digital
+voice](/learn/digital-trunking/analog-vs-digital-voice/).

--- a/docs/learn/digital-trunking/talkgroups-ids-affiliation.md
+++ b/docs/learn/digital-trunking/talkgroups-ids-affiliation.md
@@ -1,0 +1,143 @@
+---
+slug: talkgroups-ids-affiliation
+title: "Talkgroups, radio IDs & affiliation"
+description: A talkgroup is a virtual channel; a radio ID identifies the individual unit; affiliation registers a radio so the system knows which talkgroup it monitors — and why you follow talkgroups, not frequencies.
+keywords: talkgroup, radio ID, unit ID, affiliation, registration, group call, individual call, private call, emergency, trunking identity, virtual channel
+level: intermediate
+status: full
+prereq:
+  - conventional-vs-trunked
+  - what-is-trunking
+faq:
+  - q: What is a talkgroup?
+    a: A talkgroup is a virtual channel — a number with a label like "PD Dispatch" or "Fire Ground 2" — that identifies a group of users. Everyone in a talkgroup hears each other's calls no matter which voice channel the system assigns. On a trunked system you follow talkgroups rather than frequencies, because the frequency changes from call to call.
+  - q: What is a radio ID or unit ID?
+    a: A radio ID, also called a unit ID or source ID, is a number that identifies an individual radio on the system. Every transmission carries the ID of the radio that sent it, so you can see which specific unit is talking, not just which group. IDs are usually mapped to aliases like a badge number or vehicle in databases.
+  - q: What is affiliation?
+    a: Affiliation, or registration, is how a radio tells the system which talkgroup it is monitoring. When a radio powers on or changes talkgroups, it sends an affiliation message on the control channel. This lets the system route calls only to sites where members are listening, and it gives a monitor a live picture of who is active.
+  - q: What is the difference between a group call and a private call?
+    a: A group call goes to a whole talkgroup — everyone affiliated to it hears the audio. A private or individual call is one radio calling another by its radio ID, heard only by those two units. Most traffic on public-safety systems is group calls; private calls and emergency declarations also appear in the control-channel data.
+gophertrunk_links:
+  - title: Radio IDs
+    url: /radio-ids.html
+    note: see which individual radios are affiliating and transmitting on the system.
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch affiliation and call messages stream by on the control channel.
+---
+
+# Talkgroups, radio IDs & affiliation
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **talkgroup** is a *virtual channel* — a number plus a label like "PD Dispatch" — that
+binds a group of users together regardless of which frequency a call lands on. A **radio
+ID** (unit ID) identifies the *individual* radio behind each transmission. **Affiliation**
+(registration) is the message a radio sends to tell the system *which talkgroup it's
+monitoring*, which both routes calls and gives a monitor a live who's-active picture.
+Calls can be **group**, **individual/private**, or flagged **emergency**. Because
+frequencies change per call, **you follow talkgroups, not frequencies**.
+
+</div>
+
+A trunked system constantly moves conversations across its channel pool, so it needs
+*stable identities* to make sense of it all. Three identities matter, and once you know
+them, the [control-channel data](control-channel-signaling/) stops looking like noise.
+
+## Talkgroups — the virtual channel
+
+A **talkgroup** is the unit of organisation users actually think in. It's a **number**
+(say, 101) paired with a **label** ("Police Dispatch"). Every member of a talkgroup hears
+every call to that talkgroup, no matter which physical voice channel the system assigns.
+The talkgroup is *virtual* precisely because the frequency underneath it is not fixed —
+the system may grant channel 3 for one call and channel 7 for the next.
+
+This is why, on a trunked system, **you follow talkgroups, not frequencies**. You decide
+you want "Fire Dispatch" and let the software chase the frequency for you. In GopherTrunk
+you lock, prioritise, or mute *talkgroups*, and the control-channel follower handles the
+hopping underneath.
+
+## Radio IDs — the individual unit
+
+Where a talkgroup names a *group*, a **radio ID** (also **unit ID** or **source ID**)
+names a *single radio*. Every transmission on a trunked system carries the ID of the radio
+that keyed up, so you can see not just "Dispatch is busy" but "unit 1147 is transmitting to
+Dispatch." Systems and databases map these numbers to aliases — a badge number, a vehicle,
+a dispatcher console — so a stream of IDs becomes a roster of who's on the air.
+
+GopherTrunk surfaces these in the **[Radio IDs](/radio-ids.html)** panel, letting you watch
+individual units appear, affiliate, and transmit across the system.
+
+## Affiliation — registering interest
+
+How does the system know who's listening to "Fire Dispatch" so it can route a call there?
+Through **affiliation**, also called **registration**. When a radio powers on, joins a
+site, or turns its channel selector to a new talkgroup, it sends an **affiliation message**
+on the [control channel](/learn/digital-trunking/the-control-channel/) declaring *which talkgroup it now monitors*.
+
+Affiliation serves the system: it can grant a voice channel only at sites where members are
+actually present, saving capacity. It also serves *you*: because radios announce themselves
+this way, the control channel is a steady stream of information about which units and
+talkgroups are active right now — visible in GopherTrunk's
+**[CC Activity](/cc-activity.html)** and **[Radio IDs](/radio-ids.html)** panels even
+before any voice is keyed.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 200" role="img" aria-label="A diagram showing two radios affiliating to a talkgroup over the control channel. Each radio has its own radio ID, and both belong to talkgroup 101 labelled PD Dispatch." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="20" width="460" height="34" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+  <text x="270" y="41" text-anchor="middle" font-size="12" fill="currentColor" font-weight="600">Control channel — affiliation messages</text>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="60" y="110" width="110" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="115" y="130">Radio ID 1147</text>
+    <text x="115" y="145" font-size="9">"monitoring TG 101"</text>
+    <rect x="370" y="110" width="110" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="425" y="130">Radio ID 2093</text>
+    <text x="425" y="145" font-size="9">"monitoring TG 101"</text>
+    <rect x="210" y="110" width="120" height="44" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.5"/>
+    <text x="270" y="130">TG 101</text>
+    <text x="270" y="145" font-size="9">"PD Dispatch"</text>
+  </g>
+  <line x1="115" y1="108" x2="160" y2="56" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <line x1="425" y1="108" x2="380" y2="56" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3"/>
+  <text x="270" y="184" text-anchor="middle" font-size="11" fill="currentColor">Each radio has its own ID; affiliation binds it to a talkgroup.</text>
+</svg>
+<figcaption>Two radios, each with its own radio ID, affiliate to the same talkgroup. The system now knows where to deliver TG 101's calls — and a monitor can see both units are active.</figcaption>
+</figure>
+
+## Group, private, and emergency calls
+
+Not every call goes to a whole group. The control-channel signalling distinguishes a few
+kinds:
+
+| Call type | Goes to | Notes |
+|-----------|---------|-------|
+| Group call | A whole talkgroup | The common case; all affiliated members hear it |
+| Individual / private call | One specific radio ID | Unit-to-unit, like a phone call between two radios |
+| Emergency | A talkgroup, flagged urgent | A radio raises an emergency; the system prioritises it |
+
+A **group call** is the everyday traffic — dispatch to a unit, units to each other within a
+talkgroup. An **individual (private) call** is one radio addressing another by its radio
+ID, heard only by those two. An **emergency** is a group call carrying an urgent flag,
+which the system prioritises and which usually stands out clearly in the control-channel
+log. All three are announced in the same data stream you decode, so you can see them coming.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — you follow the talkgroup; the system moves it across voice channels." markdown="0">
+  <p class="knowledge-check__q">Quick check: to hear a particular group of users on a trunked system, what do you follow?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Their radio IDs one by one</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Their talkgroup</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A single fixed frequency</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **talkgroup** is a virtual channel — a number and label that binds a group of users.
+- A **radio ID** (unit ID) identifies the *individual* radio behind each transmission.
+- **Affiliation** registers a radio's chosen talkgroup so the system can route calls.
+- Calls can be **group**, **individual/private**, or flagged **emergency**.
+- You **follow talkgroups, not frequencies**, because the frequency changes per call.
+
+Next, we trace a single call from start to finish — the
+[anatomy of a trunked call](anatomy-of-a-call/): request, grant, and release.

--- a/docs/learn/digital-trunking/tdma-vs-fdma.md
+++ b/docs/learn/digital-trunking/tdma-vs-fdma.md
@@ -1,0 +1,142 @@
+---
+slug: tdma-vs-fdma
+title: "TDMA vs. FDMA: fitting more calls on a channel"
+description: FDMA gives one call per frequency; TDMA splits a frequency into time slots so several calls share it. How DMR, P25 Phase 2, and TETRA multiply capacity, and what it means for a decoder.
+keywords: TDMA, FDMA, time slot, channel access, DMR two slot, P25 Phase 2, TETRA four slot, 6.25 kHz equivalent, capacity, time division, slot tracking, digital trunking
+level: intermediate
+status: full
+prereq:
+  - framing-fec-interleaving
+faq:
+  - q: What is the difference between TDMA and FDMA?
+    a: FDMA, frequency-division multiple access, gives each call its own frequency, so one channel carries one conversation. TDMA, time-division multiple access, splits a single frequency into repeating time slots, so several calls take turns on the same frequency. TDMA packs more calls into the same spectrum at the cost of more complex timing.
+  - q: Which trunking systems use TDMA and which use FDMA?
+    a: P25 Phase 1 and NXDN are FDMA, one call per frequency. DMR and P25 Phase 2 use two-slot TDMA, so two calls share a channel. TETRA uses four-slot TDMA. Knowing which a system uses tells you how many simultaneous calls a single voice frequency can carry.
+  - q: How does two-slot TDMA give 6.25 kHz-equivalent capacity?
+    a: A DMR or P25 Phase 2 channel is 12.5 kHz wide but carries two independent voice paths in alternating time slots. Two calls in 12.5 kHz works out to the same spectrum per call as a 6.25 kHz channel would provide, which is why these systems are described as 6.25 kHz-equivalent.
+  - q: What does TDMA mean for a decoder?
+    a: With TDMA the decoder must track which time slot it is looking at, because slot 1 and slot 2 can carry entirely different calls and talkgroups. It demodulates the whole channel continuously but separates the bursts by slot, following one call in slot 1 while another runs in slot 2.
+---
+
+# TDMA vs. FDMA: fitting more calls on a channel
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**FDMA** (frequency-division multiple access) puts **one call per frequency** — the way
+**P25 Phase 1** and **NXDN** work. **TDMA** (time-division multiple access) splits one
+frequency into **repeating time slots** so several calls share it: **DMR** and **P25
+Phase 2** use **2 slots**, **TETRA** uses **4**. Two voice paths in a 12.5 kHz channel
+works out to roughly **6.25 kHz-equivalent** capacity per call. For a decoder, TDMA
+adds a job: you must **track which slot** a call is in, because each slot can carry a
+different conversation and talkgroup.
+</div>
+
+The last lesson packed bits into frames and bursts. This lesson asks the next
+question: how do many users share a limited set of frequencies *at the same instant*?
+There are two answers, and a system's choice between them shapes its capacity, its
+channel plan, and how you decode it.
+
+## FDMA: one call per frequency
+
+**FDMA** is the straightforward approach: every call gets its **own frequency** for its
+duration. A trunked FDMA system still shares frequencies *over time* — the
+[control channel](the-control-channel/) hands a free one to each call and reclaims it
+afterward — but at any single moment, one frequency carries exactly one conversation.
+**P25 Phase 1** and **NXDN** are FDMA.
+
+FDMA is simple to reason about and simple to decode: tune the voice frequency and the
+call is *there*, the only one on it. The downside is capacity. To carry more
+simultaneous calls you need more frequencies, and spectrum is the scarce, expensive
+resource trunking exists to conserve.
+
+## TDMA: many calls per frequency
+
+**TDMA** squeezes more out of each frequency by dividing **time**. The channel is cut
+into short, repeating **time slots**, and each slot is an independent path. Slot 1 and
+slot 2 alternate continuously, so two calls run on the *same frequency* without ever
+colliding — each simply uses its own slots. **DMR** and **P25 Phase 2** use **two
+slots**; **TETRA** uses **four**.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A timeline of one TDMA frequency divided into alternating time slots. The top row shows slot 1 bursts carrying call A; the bottom row shows slot 2 bursts carrying call B; together they fill one frequency." xmlns="http://www.w3.org/2000/svg">
+  <text x="20" y="28" font-size="11" fill="currentColor" font-weight="600">One 12.5 kHz frequency, two time slots:</text>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="45" width="60" height="30" rx="3" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.3"/><text x="50" y="64">A</text>
+    <rect x="80" y="45" width="60" height="30" rx="3" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/><text x="110" y="64">B</text>
+    <rect x="140" y="45" width="60" height="30" rx="3" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.3"/><text x="170" y="64">A</text>
+    <rect x="200" y="45" width="60" height="30" rx="3" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/><text x="230" y="64">B</text>
+    <rect x="260" y="45" width="60" height="30" rx="3" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.3"/><text x="290" y="64">A</text>
+    <rect x="320" y="45" width="60" height="30" rx="3" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/><text x="350" y="64">B</text>
+    <rect x="380" y="45" width="60" height="30" rx="3" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.3"/><text x="410" y="64">A</text>
+    <rect x="440" y="45" width="60" height="30" rx="3" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/><text x="470" y="64">B</text>
+  </g>
+  <text x="20" y="100" font-size="10" fill="currentColor">slot 1 (call A) ▦</text>
+  <text x="200" y="100" font-size="10" fill="currentColor">slot 2 (call B) ▦</text>
+  <line x1="20" y1="115" x2="500" y2="115" stroke="currentColor" stroke-opacity="0.4" marker-end="url(#t1)"/>
+  <text x="260" y="135" text-anchor="middle" font-size="10" fill="currentColor">time →</text>
+  <defs><marker id="t1" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A single TDMA frequency alternates between slot 1 (call A) and slot 2 (call B). Two independent conversations share one frequency by taking turns faster than the ear can notice.</figcaption>
+</figure>
+
+The slots cycle far faster than a conversation, and the vocoder frames are buffered so
+neither talker hears a gap — each call sounds continuous even though it's only
+on the air half (or a quarter) of the time.
+
+## The capacity win
+
+The payoff is spectrum efficiency. A DMR or P25 Phase 2 channel is **12.5 kHz** wide
+but carries **two** voice paths. Two calls in 12.5 kHz is the same amount of spectrum
+per call as a **6.25 kHz** channel would give — which is why these systems are marketed
+as **"6.25 kHz-equivalent."** TETRA's four slots in its channel push the sharing
+further still.
+
+| System | Access | Slots | Calls per voice frequency |
+|--------|--------|-------|---------------------------|
+| P25 Phase 1 | FDMA | 1 | 1 |
+| NXDN | FDMA | 1 | 1 |
+| DMR | TDMA | 2 | 2 |
+| P25 Phase 2 | TDMA | 2 | 2 |
+| TETRA | TDMA | 4 | 4 |
+
+This is one of the headline reasons systems migrate from P25 Phase 1 to Phase 2:
+**double the voice capacity** on the same frequencies, without buying more spectrum.
+
+## What TDMA means for a decoder
+
+FDMA is easy on a decoder — tune the frequency, decode the one call. TDMA adds a
+crucial extra job: **slot tracking**. The decoder demodulates the whole channel
+continuously, but it must sort the incoming bursts by slot, because **slot 1 and slot 2
+can be entirely different calls**, with different talkgroups and radio IDs. Follow the
+wrong slot and you'd splice two conversations together.
+
+Practically, this means a TDMA channel grant from the
+[control channel](the-control-channel/) specifies not just a frequency but a **slot**,
+and the decoder honours both. GopherTrunk handles this internally when it follows a
+DMR or P25 Phase 2 call — it locks the right frequency *and* the right slot — but it's
+worth knowing it's happening, because a system that decodes on one slot and not the
+other is a slot-tracking symptom, not a tuning one.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — TDMA splits a frequency into repeating time slots, so several calls share it." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does TDMA fit more than one call on a single frequency?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It gives each call a slightly different frequency</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It splits the frequency into repeating time slots the calls take turns using</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It compresses both calls into one vocoder stream</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **FDMA** gives **one call per frequency** — used by P25 Phase 1 and NXDN.
+- **TDMA** splits a frequency into **repeating time slots** — DMR and P25 Phase 2 use
+  **2**, TETRA uses **4**.
+- Two voice paths in a 12.5 kHz channel ≈ **6.25 kHz-equivalent**, the capacity win
+  behind Phase 1 → Phase 2 migration.
+- A TDMA decoder must **track which slot** a call is in, because each slot is a separate
+  conversation.
+- A channel grant on TDMA names both a **frequency and a slot**.
+
+Next, we meet the channel that coordinates all of this:
+[the control channel](the-control-channel/), the system's heartbeat.

--- a/docs/learn/digital-trunking/tetra.md
+++ b/docs/learn/digital-trunking/tetra.md
@@ -1,0 +1,152 @@
+---
+slug: tetra
+title: "TETRA"
+description: TETRA explained — the ETSI EN 300 392 standard for European and global public safety, with four-slot TDMA in 25 kHz, π/4-DQPSK, ACELP voice, TMO and DMO.
+keywords: TETRA, Terrestrial Trunked Radio, ETSI EN 300 392, four-slot TDMA, pi/4-DQPSK, ACELP vocoder, TMO, DMO, 25 kHz channel, public safety Europe, trunked mode, direct mode
+level: intermediate
+status: full
+prereq:
+  - digital-modulation-for-trunking
+  - tdma-vs-fdma
+faq:
+  - q: What is TETRA?
+    a: TETRA (Terrestrial Trunked Radio) is an ETSI digital trunking standard, defined in EN 300 392, used heavily by public safety, transport, and industry outside North America. It uses four-slot TDMA in a 25 kHz channel with π/4-DQPSK modulation and an ACELP voice codec. It is a complete trunked system with strong support for group calls, direct mode, and encryption.
+  - q: Why do I rarely hear TETRA in the United States?
+    a: TETRA was developed in Europe and its standard 25 kHz channels and frequency plan did not fit cleanly into US allocations or the FCC narrowbanding push toward 12.5 kHz and below. North American public safety standardised on P25 instead. TETRA dominates Europe, much of Asia, the Middle East, Africa, and Latin America, but it is uncommon on US airwaves.
+  - q: How wide is a TETRA channel on the waterfall?
+    a: A TETRA carrier occupies 25 kHz, noticeably wider than the 12.5 kHz of P25 Phase 1 or DMR. That extra width is a useful first clue when you spot one on the waterfall — a single fat 25 kHz block carrying four interleaved time slots rather than a narrow 12.5 kHz lane.
+  - q: What is the difference between TMO and DMO?
+    a: TMO (Trunked Mode Operation) is the normal mode where radios talk through the infrastructure — base stations and the switching network — using the control channel. DMO (Direct Mode Operation) lets two radios talk directly to each other without any infrastructure, like a walkie-talkie, for when units are out of network range.
+gophertrunk_links:
+  - title: Status
+    url: /status.html
+    note: which protocols GopherTrunk decodes and how completely.
+  - title: Constellation
+    url: /constellation.html
+    note: watch the π/4-DQPSK symbol cloud when inspecting a TETRA carrier.
+---
+
+# TETRA
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**TETRA** (Terrestrial Trunked Radio) is the **ETSI EN 300 392** standard that dominates
+**public safety and commercial radio outside North America** — across Europe, Asia, the
+Middle East, and beyond. It packs **four TDMA slots into a 25 kHz channel** using
+**π/4-DQPSK** at **18000 symbols/s** (36 kbps gross) with an **ACELP** voice codec.
+Radios work in **TMO** (through the network) or **DMO** (radio-to-radio, no
+infrastructure), and **encryption is routine**. On the waterfall it is **notably wider —
+25 kHz** — than P25 or DMR, and you'll **rarely meet it in the US**, where P25 won out.
+</div>
+
+You met TETRA briefly in the [protocol landscape](/learn/rf-sdr/protocol-landscape/). Here
+is the full picture: a mature, feature-rich trunked standard that most of the world's
+emergency services run on, even though it barely registers on North American airwaves.
+
+## Where TETRA came from
+
+TETRA was designed by **ETSI**, the European Telecommunications Standards Institute, and
+published as the **EN 300 392** family of specifications in the 1990s. The goal was a
+single open digital standard for *professional mobile radio* — the kind of mission-critical
+network police, fire, ambulance, railways, airports, and utilities depend on. It succeeded
+spectacularly outside the US: national public-safety networks across Europe, large parts of
+Asia, the Middle East, Africa, and Latin America are TETRA. Think of it as the
+rough-equivalent role that [P25](p25-phase-1/) plays in North America, filling the same
+public-safety niche with a different rulebook.
+
+## How the air interface works
+
+TETRA's physical layer is its most distinctive trait. A carrier is **25 kHz wide** and
+carries **four time slots** in a TDMA frame, so up to four calls (or signaling plus three
+calls) share one frequency by taking turns — the same time-sharing idea you met in
+[TDMA vs FDMA](tdma-vs-fdma/), but with *four* slots rather than DMR's two.
+
+- **Modulation:** **π/4-DQPSK** — a differential four-phase scheme. Each symbol carries two
+  bits, and the constellation rotates by a quarter-turn between symbols, which keeps the
+  envelope from passing through zero and eases the transmitter's amplifier. This is *not*
+  the [4FSK](digital-modulation-for-trunking/) of P25 and DMR; it's phase modulation, and on
+  the [constellation](/constellation.html) it shows up as a ring of points rather than four
+  frequency levels.
+- **Symbol rate:** **18000 symbols/s**, giving a **36 kbps** gross channel rate (2 bits per
+  symbol). Split four ways, each slot gets a useful sub-rate for voice and signaling.
+- **Voice codec:** **ACELP** (Algebraic Code-Excited Linear Prediction), a different family
+  from the [AMBE/IMBE vocoders](/learn/rf-sdr/vocoders/) used by P25 and DMR. ACELP is the same
+  general technique behind many cellphone codecs of the era.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 170" role="img" aria-label="A single 25 kHz TETRA carrier shown as a wide block split into four time slots labelled 1 through 4, with a note that one slot carries control and the others carry calls." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="11" fill="currentColor">
+    <text x="260" y="22" text-anchor="middle" font-weight="600">One TETRA carrier — 25 kHz, four TDMA slots</text>
+    <rect x="40" y="50" width="440" height="50" rx="6" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="150" y1="50" x2="150" y2="100" stroke="currentColor" stroke-opacity="0.5"/>
+    <line x1="260" y1="50" x2="260" y2="100" stroke="currentColor" stroke-opacity="0.5"/>
+    <line x1="370" y1="50" x2="370" y2="100" stroke="currentColor" stroke-opacity="0.5"/>
+    <text x="95" y="80" text-anchor="middle" font-size="10">Slot 1</text>
+    <text x="205" y="80" text-anchor="middle" font-size="10">Slot 2</text>
+    <text x="315" y="80" text-anchor="middle" font-size="10">Slot 3</text>
+    <text x="425" y="80" text-anchor="middle" font-size="10">Slot 4</text>
+    <text x="95" y="94" text-anchor="middle" font-size="8">control</text>
+    <text x="205" y="94" text-anchor="middle" font-size="8">call</text>
+    <text x="315" y="94" text-anchor="middle" font-size="8">call</text>
+    <text x="425" y="94" text-anchor="middle" font-size="8">call</text>
+    <text x="40" y="125" font-size="9">25 kHz — wider than P25/DMR's 12.5 kHz</text>
+    <text x="260" y="150" text-anchor="middle" font-size="10">π/4-DQPSK at 18000 symbols/s → 36 kbps gross, shared four ways</text>
+  </g>
+</svg>
+<figcaption>A TETRA carrier is one fat 25 kHz block carrying four interleaved time slots — wider than the narrow channels P25 and DMR use, which is your first visual clue.</figcaption>
+</figure>
+
+## TMO and DMO
+
+TETRA radios operate in two modes:
+
+- **TMO — Trunked Mode Operation.** The normal case: radios register with and talk through
+  the **infrastructure** (base stations linked to a switching and management network),
+  coordinated by a [control channel](the-control-channel/). This gives you all the trunking
+  benefits — group calls, individual calls, priority, area-wide coverage.
+- **DMO — Direct Mode Operation.** Radios talk **directly to one another** with no
+  infrastructure at all, like a simplex walkie-talkie. Crews use DMO when they're out of
+  network coverage or want a local tactical channel that doesn't load the network.
+
+The distinction matters for monitoring: a DMO conversation never touches a control channel,
+so there's no central signaling to follow — you'd watch the simplex frequency directly.
+
+## Why it's wide, and why that helps you
+
+The headline practical fact is **bandwidth**. A TETRA carrier is **25 kHz**, double the
+12.5 kHz of P25 Phase 1 or a DMR channel. On the [waterfall](/learn/rf-sdr/fft-and-waterfall/)
+that fat block stands out, and combined with the *phase*-modulated constellation (a ring,
+not four FSK levels) it's a reasonable bet you're looking at TETRA rather than a 4FSK
+system — especially if you're outside North America.
+
+## Encryption is common
+
+Unlike many systems where clear voice is the default, **encryption is routine on TETRA**.
+The standard defines both **air-interface encryption** (scrambling the whole radio link,
+including signaling) and **end-to-end encryption** for the most sensitive users. Where it's
+enabled, you'll see a healthy control channel and active traffic slots but get no
+intelligible audio — the same wall you met in [encryption and
+authentication](encryption-and-authentication/). That's expected on a lot of TETRA networks.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — TETRA uses 25 kHz channels with four TDMA slots and π/4-DQPSK." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes a TETRA carrier stand out on the waterfall compared with P25 or DMR?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It is much narrower, around 6.25 kHz</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It is wider — a 25 kHz block</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses 4FSK with four frequency levels</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **TETRA** is the **ETSI EN 300 392** trunked standard that dominates public safety and
+  commercial radio **outside North America**.
+- It uses **four-slot TDMA in a 25 kHz channel** with **π/4-DQPSK** at **18000 symbols/s**
+  (36 kbps) and the **ACELP** voice codec.
+- Radios run in **TMO** (through the network) or **DMO** (direct, no infrastructure).
+- It is **wider** than P25/DMR — a 25 kHz block — and uses *phase* rather than frequency
+  modulation, both handy identification clues.
+- **Encryption is common**, so don't be surprised by active-but-silent TETRA traffic.
+
+Next we cross back to a narrowband North-American favourite and its global cousins: [NXDN](nxdn/).

--- a/docs/learn/digital-trunking/the-control-channel.md
+++ b/docs/learn/digital-trunking/the-control-channel.md
@@ -1,0 +1,154 @@
+---
+slug: the-control-channel
+title: "The control channel: the system's heartbeat"
+description: A dedicated control channel carries only data, continuously, and is the map of a whole trunked system — broadcasting identity, channel grants, and neighbors. Why you decode it first.
+keywords: control channel, trunking control channel, channel grant, system identity, neighbor sites, distributed control, sub-audible signaling, LTR, P25 control channel, DMR control channel, GopherTrunk
+level: intermediate
+status: full
+prereq:
+  - tdma-vs-fdma
+  - what-is-trunking
+faq:
+  - q: What is a control channel?
+    a: A control channel is one frequency in a trunked system that carries a continuous stream of data rather than voice. It announces the system's identity and parameters, grants voice channels to calls as they happen, and lists neighboring sites. To follow a trunked system you decode the control channel first, because it tells you where every call goes.
+  - q: Why do you decode the control channel before anything else?
+    a: Because it is the map of the whole system. Without it you would have a list of frequencies but no way to know which one carries which call at any moment. The control channel announces each channel grant in real time, so decoding it is what lets a scanner follow conversations as they hop across voice channels.
+  - q: Do all trunked systems have a dedicated control channel?
+    a: No. Systems like P25, DMR Tier 3, and Motorola's networks use a dedicated control channel that does nothing but signaling. Older or simpler systems such as LTR use distributed or sub-audible control, embedding signaling within the voice channels themselves rather than dedicating a frequency to it.
+  - q: What kinds of messages does a control channel carry?
+    a: It carries system-identity and parameter broadcasts, registration and affiliation messages from radios, channel grants that assign a call to a voice frequency and slot, neighbor-site lists for roaming, and status or paging messages. A monitor reads the channel grants to follow calls and the identity broadcasts to recognize the system.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: watch the raw control-channel messages GopherTrunk decodes in real time.
+  - title: Radio IDs
+    url: /radio-ids.html
+    note: see which radios are registering and transmitting on the system.
+---
+
+# The control channel: the system's heartbeat
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **control channel** is one frequency that carries only **data**, **continuously** —
+never voice. It is the **map of the whole system**: it broadcasts the system's
+**identity** and parameters, hands out **channel grants** that send each call to a
+voice frequency (and slot), and lists **neighbor sites** for roaming. You **decode it
+first** because without it you have frequencies but no idea which carries which call.
+Not every system has a dedicated one — **LTR** uses distributed, sub-audible control
+instead. This is why **GopherTrunk locks the control channel before it can follow a
+single call**.
+</div>
+
+You've now seen the pieces of a digital trunked signal — vocoders, modulation, framing,
+and the choice between FDMA and TDMA. This lesson ties Module 2 together by introducing
+the one channel that **coordinates** all of it. If trunking has a single beating heart,
+this is it. (The [RF & SDR what-is-trunking lesson](/learn/rf-sdr/what-is-trunking/)
+covers the trunking idea broadly; here we focus on the control channel itself.)
+
+## A channel that carries only data
+
+On a trunked system, one frequency is set aside to carry a **constant stream of data**
+and **no voice at all**. While voice channels sit idle between calls, the control
+channel never stops talking — it is the always-on signaling bus that every radio on the
+system listens to. That continuous data is what lets the system assign and reclaim
+voice channels [on demand](conventional-vs-trunked/), and what lets a monitor follow along.
+
+Because it's always transmitting, the control channel is also the **easiest part of the
+system to find and lock**: it's a steady digital carrier on a known frequency, not a
+bursty voice channel that comes and goes. Find it once and the whole system opens up.
+
+## The map of the whole system
+
+The control channel earns the title "map" because it broadcasts everything you need to
+understand and follow the system:
+
+| Message type | What it tells you |
+|--------------|-------------------|
+| System identity / parameters | which system this is, its ID, and how to interpret its channels |
+| Registration / affiliation | which radios are on the system and active |
+| Channel grant | a call is starting — go to this voice frequency (and slot) |
+| Neighbor-site list | the adjacent sites a radio can roam to |
+| Status / paging | individual calls, alerts, and short data |
+
+The **channel grant** is the one a monitor lives on: it's the message that says
+*"talkgroup 101 is now on voice channel 3"* (and, on a [TDMA](tdma-vs-fdma/) system,
+*which slot*). Read those in real time and you always know where every conversation is.
+The **identity** broadcasts let you recognise the system, and the **neighbor list** is
+how multi-site roaming works, both topics later in the path.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 200" role="img" aria-label="A diagram with a control channel at top broadcasting a continuous data stream, and arrows pointing to system identity, channel grants, and a neighbor-site list, with a grant directing a call to one voice channel in a pool below." xmlns="http://www.w3.org/2000/svg">
+  <rect x="40" y="18" width="460" height="40" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+  <text x="270" y="35" text-anchor="middle" font-size="13" fill="currentColor" font-weight="600">Control channel (data only, continuous)</text>
+  <text x="270" y="51" text-anchor="middle" font-size="10" fill="currentColor">identity · grants · neighbors · affiliation</text>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="40" y="100" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="85" y="121">Voice 1</text>
+    <rect x="150" y="100" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.5"/>
+    <text x="195" y="116">Voice 2</text>
+    <text x="195" y="129" font-size="9">TG 101 active</text>
+    <rect x="260" y="100" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="305" y="121">Voice 3</text>
+    <rect x="370" y="100" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.5"/>
+    <text x="415" y="121">Voice 4</text>
+  </g>
+  <line x1="200" y1="58" x2="195" y2="98" stroke="currentColor" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#cc)"/>
+  <text x="270" y="178" text-anchor="middle" font-size="11" fill="currentColor">A grant directs each call to a free voice channel; the CC keeps broadcasting.</text>
+  <defs><marker id="cc" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The control channel continuously broadcasts identity, grants, and neighbor lists. A channel grant points a call at a free voice channel — follow the grants and you follow the whole system.</figcaption>
+</figure>
+
+## Why you decode it first
+
+Everything routes through the control channel, so it is the **single most important
+thing to decode**. Lock onto it and read its stream, and you learn the instant any
+talkgroup starts a call, which voice channel (and slot) it was assigned, which
+[radio ID](/radio-ids.html) is transmitting, and the system's identity. With that map,
+a follower can point a receiver at the right voice channel at the right moment, capture
+the call, and be ready for the next grant — across the whole channel pool.
+
+Lose the control channel and you're **blind**: the voice channels still carry audio,
+but you have no way to know which is which or who's on it. This is why so much of
+operating a trunk-tracker comes down to getting a clean, solid lock on the control
+channel — watch the raw stream in GopherTrunk's
+**[CC Activity panel](/cc-activity.html)**.
+
+## Not every system has a dedicated one
+
+The dedicated control channel is the model used by P25, DMR Tier 3, TETRA, and the
+big Motorola networks — but it isn't universal. Simpler or older systems use
+**distributed** or **sub-audible** control: instead of dedicating a frequency, they
+embed the signaling *within the voice channels themselves*, often below the audible
+range. **LTR** is the classic example — it has **no dedicated control channel** at all;
+each repeater carries its own low-rate signaling alongside the voice.
+
+For a monitor, the difference is fundamental. On a dedicated-control system you find
+*one* frequency and the whole system unfolds. On a distributed-control system there's
+no single map to lock — you read the signaling spread across the channels. Knowing
+which kind you're facing is the first step in identifying any system, which is exactly
+where Module 3 and beyond pick up.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Correct — the control channel is the map, so you decode it first to know where calls go." markdown="0">
+  <p class="knowledge-check__q">Quick check: why does a trunk-tracker decode the control channel before the voice channels?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because it carries the clearest audio</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Because it's the map that says which voice channel each call is on</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Because it uses a simpler modulation</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **control channel** carries only **data**, **continuously** — never voice.
+- It's the **map** of the system: identity, **channel grants**, neighbor sites, and
+  affiliation.
+- You **decode it first** because without it you can't tell which voice channel carries
+  which call.
+- Its always-on data makes it the **easiest part of the system to find and lock**.
+- Not all systems have one — **LTR** uses distributed, sub-audible control instead.
+
+That closes Module 2. The next module opens with the distinction that started it all:
+[conventional vs. trunked](conventional-vs-trunked/).

--- a/docs/learn/digital-trunking/the-digital-leap.md
+++ b/docs/learn/digital-trunking/the-digital-leap.md
@@ -1,0 +1,129 @@
+---
+slug: the-digital-leap
+title: "The digital leap: P25, TETRA & DMR are born"
+description: How three regions answered the same need differently — APCO P25 in North America, TETRA in Europe, DMR worldwide — plus NXDN and Tetrapol, and why the world fragmented.
+keywords: digital leap, APCO Project 25, P25, TETRA, DMR, NXDN, Tetrapol, vocoder, forward error correction, digital encryption, land mobile radio standards
+level: intermediate
+status: full
+prereq:
+  - analog-trunking-era
+faq:
+  - q: What did digital voice add over analog trunking?
+    a: Three big things. A vocoder turns speech into a compact stream of bits, forward error correction protects those bits so audio stays clean to the edge of coverage, and encryption can be built in rather than bolted on. Together they delivered clearer fringe audio, more capacity, and real privacy on top of the trunking model the analog era had already proven.
+  - q: Why are there so many competing digital standards?
+    a: Different regions answered the same need on their own timelines and through their own standards bodies. North America produced APCO Project 25 through the TIA, Europe produced TETRA through ETSI, and ETSI later produced DMR as a lower-cost option, with NXDN and Tetrapol filling other niches. No single global mandate existed, so the world fragmented.
+  - q: What is the difference between P25, TETRA, and DMR?
+    a: P25 is the North-American public-safety standard, TETRA is a feature-rich European public-safety and transport standard, and DMR is a later, lower-cost ETSI standard widely used in business and amateur radio. They differ in modulation, channel structure, and vocoder, but all three are digital trunking standards built on the same core ideas.
+  - q: Is one digital standard better than the others?
+    a: They were optimized for different goals, so better depends on the use. P25 emphasizes North-American public-safety interoperability, TETRA emphasizes rich features and fast call setup, and DMR emphasizes low cost and simplicity. Each won in the market and region it was designed for rather than one displacing the rest.
+gophertrunk_links:
+  - title: Vocoders
+    url: /vocoders.html
+    note: the speech codecs that made digital voice possible.
+  - title: Status
+    url: /status.html
+    note: which digital standards GopherTrunk decodes.
+---
+
+# The digital leap: P25, TETRA & DMR are born
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Through the **1990s–2000s**, three regions answered the same need differently. **APCO
+Project 25 (P25)** came from North America via the **TIA**; **TETRA** came from Europe via
+**ETSI**; and **DMR**, also from ETSI, arrived later as a **lower-cost** option — joined by
+**NXDN** and **Tetrapol**. Digital voice added three things on top of trunking: a
+**vocoder** to turn speech into bits, **forward error correction** to keep audio clean, and
+**built-in encryption**. Because each region moved on its own timeline through its own
+standards body, the world **fragmented** into competing standards.
+</div>
+
+The analog trunking era proved you could share channels efficiently. The digital leap kept
+that model and replaced the *voice* layer — finally cashing in the promises from the very
+first lesson. This is where the names you'll spend the rest of the path with are born.
+
+## What "digital" actually added
+
+The trunking machinery — controller, channel pool, control channel — carried over almost
+unchanged. What changed was the voice. Three new ingredients defined the leap:
+
+- **A vocoder.** Instead of sending the analog voice waveform, the radio runs speech through
+  a [vocoder](/learn/rf-sdr/digital-voice/) that compresses it into a small stream of bits.
+  This is what lets a voice fit into a narrow digital channel.
+- **Forward error correction.** Extra protective bits let the receiver detect and repair
+  errors, so the audio stays full and clear right up to the edge of coverage instead of
+  fading into hiss.
+- **Built-in encryption.** With voice already in bits, scrambling it for privacy becomes a
+  natural option rather than an awkward analog hack.
+
+Lay those over trunking and you get the modern digital trunked system: efficient channel
+sharing *and* clean, private, capacity-rich voice.
+
+## Three regions, three answers
+
+The striking thing about the digital leap is that there was no single global standard.
+Different regions, working through different bodies, solved the same problem in parallel.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 540 150" role="img" aria-label="A timeline arrow from the 1990s to the 2000s with P25 and TETRA appearing earlier and DMR appearing later, plus NXDN and Tetrapol." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="100" x2="510" y2="100" stroke="currentColor" stroke-width="1.5" marker-end="url(#ar)"/>
+  <text x="40" y="125" font-size="10" fill="currentColor">1990s</text>
+  <text x="430" y="125" font-size="10" fill="currentColor">2000s →</text>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <line x1="110" y1="100" x2="110" y2="60" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="60" y="38" width="100" height="24" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <text x="110" y="54">P25 (TIA)</text>
+    <line x1="210" y1="100" x2="210" y2="76" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="160" y="66" width="100" height="22" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <text x="210" y="81" font-size="9">TETRA (ETSI)</text>
+    <line x1="350" y1="100" x2="350" y2="60" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="305" y="38" width="90" height="24" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <text x="350" y="54" font-size="9">NXDN</text>
+    <line x1="450" y1="100" x2="450" y2="76" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="405" y="66" width="100" height="22" rx="4" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/>
+    <text x="455" y="81" font-size="9">DMR (ETSI)</text>
+  </g>
+  <defs><marker id="ar" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A rough timeline: P25 and TETRA emerged first in the 1990s, with NXDN and the lower-cost DMR following. Dates are approximate — the point is the parallel, region-by-region rollout.</figcaption>
+</figure>
+
+**APCO Project 25 (P25)** is the North-American answer, developed through **APCO** and
+standardized by the **TIA**. It targets **public safety** and emphasizes interoperability
+across vendors and agencies — a deliberate response to the proprietary analog systems that
+couldn't talk to each other.
+
+**TETRA (Terrestrial Trunked Radio)** is the European answer, standardized by **ETSI**. It's
+a feature-rich, four-slot TDMA system built for public safety and transport, with fast call
+setup and strong group-calling support, widespread outside North America.
+
+**DMR (Digital Mobile Radio)**, also from **ETSI**, came **later and at lower cost**. Its
+two-slot TDMA design and modest hardware made it spread far beyond public safety into
+**business and amateur** radio, where it's now ubiquitous.
+
+Alongside the big three, **NXDN** (a narrowband 6.25 kHz standard) and **Tetrapol** (a
+French-origin public-safety system) filled additional niches.
+
+## Why the world fragmented
+
+It's tempting to ask why everyone didn't just agree on one standard. The honest answer is
+timing and governance. There was no global mandate forcing convergence, and each region had
+its own **standards body**, its own incumbent vendors, its own regulatory deadlines, and its
+own definition of the problem. North America prioritized public-safety interoperability and
+got P25. Europe prioritized a rich feature set and got TETRA. The market wanted something
+cheaper and got DMR. Each standard won where it was designed to win, and the result is the
+patchwork you'll navigate for the rest of this path — the same patchwork
+[GopherTrunk](/status.html) was built to decode across.
+
+## Recap
+
+- The digital leap kept the trunking model and replaced the **voice** layer.
+- It added three things: a **vocoder**, **forward error correction**, and **built-in encryption**.
+- Three regions answered in parallel: **P25** (North America, TIA), **TETRA** (Europe, ETSI), and the later, lower-cost **DMR** (ETSI), plus **NXDN** and **Tetrapol**.
+- No global mandate existed, so the world **fragmented** into competing standards, each winning in its own region and use.
+
+To make sense of who writes these standards and why open ones matter, the next lesson
+is [Standards & who sets them](/learn/digital-trunking/standards-and-bodies/). You can also
+jump straight to the deep dives on [P25 Phase 1](/learn/digital-trunking/p25-phase-1/),
+[DMR Tier II/III](/learn/digital-trunking/dmr-tier-2-3/), or
+[TETRA](/learn/digital-trunking/tetra/).

--- a/docs/learn/digital-trunking/troubleshooting-a-decode.md
+++ b/docs/learn/digital-trunking/troubleshooting-a-decode.md
@@ -1,0 +1,139 @@
+---
+slug: troubleshooting-a-decode
+title: Troubleshooting a digital decode
+description: A symptom-to-cause-to-fix checklist for trunked decoding — wrong control channel, gain too low or overloading, frequency and PPM error, simulcast distortion, encryption, weak signal, or the wrong system type configured.
+keywords: troubleshoot trunked decode, control channel won't lock, gain overload, PPM error, simulcast distortion, encryption silent calls, weak signal, wrong system type, decode checklist, no audio
+level: advanced
+status: full
+prereq:
+  - multisite-and-simulcast-in-practice
+  - encryption-and-authentication
+faq:
+  - q: My trunked system won't decode — where do I start?
+    a: Work a checklist in order rather than guessing. Confirm you're on the right control channel, that gain isn't too low or overloading, that frequency/PPM is correct so the signal lands on channel, and that the configured system type matches. Each failure has a distinct symptom, so matching what you see to the checklist points you straight at the cause.
+  - q: Calls are listed but play back silent — what's wrong?
+    a: That's almost always encryption, not a fault. If the control channel decodes and grants appear but the audio is silent or garbled, the talkgroup is likely encrypted, which can't be decoded. Check whether other talkgroups produce audio; if they do, your hardware and config are fine and the silent one is encrypted.
+  - q: How do I know if my gain is wrong?
+    a: Too-low gain buries the signal in noise — a weak meter and a constellation lost in the floor. Too-high gain overloads the front end, smearing the spectrum and spraying ghost signals even on a strong signal. Aim for just enough gain to lift the signal cleanly above the noise without clipping the ADC.
+  - q: Can GopherTrunk decode encrypted traffic?
+    a: No. Encryption scrambles the voice payload with a key only authorised radios hold, and without that key the audio cannot be recovered by any receiver. GopherTrunk will still show the grant metadata — talkgroup, radio ID, the encryption flag — but the audio stays silent. This is a fundamental limit, not a bug.
+gophertrunk_links:
+  - title: Demod calibration
+    url: /demod-calibration.html
+    note: fix lock and constellation problems on the control channel.
+  - title: Voice calibration
+    url: /voice-calibration.html
+    note: clean up decoded audio once the system locks.
+  - title: Constellation
+    url: /constellation.html
+    note: read at a glance which stage is breaking.
+---
+
+# Troubleshooting a digital decode
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+When a trunked system won't decode, **work a checklist, don't guess**. The usual
+culprits are: monitoring the **wrong control channel**, **gain too low** (buried in noise)
+or **too high** (overload), a **frequency/PPM error** that lands the signal off channel,
+**simulcast distortion**, **encryption** (silent calls — *not fixable*), a signal that's
+simply **too weak**, or the **wrong system type** configured. Each has a distinct symptom,
+so match what you see to its cause and apply the fix. The
+[scopes](/learn/rf-sdr/tuning-with-scopes/) turn most of this from guesswork into a glance.
+</div>
+
+You've assembled the whole pipeline; now here's how to find the one stage that's broken
+when a system stays stubbornly silent. This builds directly on the SDR-level [calibration
+and troubleshooting](/learn/rf-sdr/calibration-troubleshooting/) lesson, applied to the
+trunking-specific failures.
+
+## The checklist — symptom → cause → fix
+
+Read down the **Symptom** column until one matches what you're seeing, then apply the fix:
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| No lock; [CC Activity](/cc-activity.html) stays empty | **Wrong control channel** | Re-check the frequency against a database or [Hunt](/hunt.html); try the alternate control channel |
+| Signal buried in noise, weak meter | **Gain too low** or **signal too weak** | Raise [gain](/learn/rf-sdr/gain-and-agc/); improve antenna/placement |
+| Smeared spectrum, ghost signals, strong meter | **Gain too high — overload** | **Reduce gain**, add attenuation |
+| Strong signal, **constellation slowly rotating** | **Frequency / PPM error** | Set the correct [PPM](/learn/rf-sdr/calibration-troubleshooting/) correction |
+| Strong meter but **fuzzy constellation**, won't lock | **Simulcast distortion** | Directional antenna, favour one site, lower gain ([multi-site lesson](multisite-and-simulcast-in-practice/)) |
+| Locks but **no calls / no grants** | **Wrong system type** or parameters | Confirm the configured protocol matches; re-check system details |
+| **Calls listed but silent or garbled** | **Encryption** | Expected — [encrypted](encryption-and-authentication/) talkgroup, **not fixable** |
+| Audio decodes but sounds wrong | **Voice level / clarity** | [Voice calibration](/voice-calibration.html) |
+
+The trick is discipline: change **one thing at a time** and watch the
+[constellation](/constellation.html) and [CC Activity](/cc-activity.html) react, so you
+know which fix actually worked.
+
+## Walking the common cases
+
+A few of these deserve a closer look, because they're the ones newcomers misdiagnose.
+
+**Wrong control channel.** The most common cause of "nothing decodes." If
+[CC Activity](/cc-activity.html) is empty and the carrier *looks* like a control channel
+(solid, never quiet), you may be on a voice channel of the system, an alternate control
+channel that's currently inactive, or simply the wrong frequency. Re-confirm against a
+database or re-run [Hunt](/hunt.html). Many systems publish more than one control-channel
+frequency — try the alternates.
+
+**Gain, both ways.** Too *little* gain leaves the signal in the [noise
+floor](/learn/rf-sdr/decibels/); too *much* **overloads** the front end and sprays
+distortion even on a strong signal. The overload tell is *ghost signals* — copies of a
+carrier appearing where no transmitter exists — and a smeared spectrum. Back gain down
+until the ghosts vanish, then nudge up only as far as a clean lock needs.
+
+**Frequency / PPM error.** A cheap dongle's oscillator error lands the signal off the
+channel centre. The classic symptom is a **strong signal whose constellation slowly
+rotates** and never quite locks. The fix is [PPM
+correction](/learn/rf-sdr/calibration-troubleshooting/), which shifts the radio back onto
+frequency. [Demod calibration](/demod-calibration.html) is where you tune this in.
+
+**Encryption — the one you can't fix.** If the control channel decodes, grants appear,
+the [radio ID](/radio-ids.html) and talkgroup show, but the audio is silent or garbled,
+the talkgroup is **encrypted**. No receiver can recover encrypted voice without the key.
+Confirm by checking whether *other* talkgroups on the same system produce audio — if they
+do, your chain is healthy and the silent one is simply encrypted. This is a
+[fundamental limit](encryption-and-authentication/), not a bug to chase.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — grants visible but silent audio, while other talkgroups work, means the talkgroup is encrypted." markdown="0">
+  <p class="knowledge-check__q">Quick check: the control channel decodes, grants and radio IDs appear, but one talkgroup's calls play back silent while others work. Most likely cause?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Gain is set too low</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">That talkgroup is encrypted</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The wrong control channel is configured</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Suspect hardware last
+
+As with SDR-level [troubleshooting](/learn/rf-sdr/calibration-troubleshooting/), almost
+every problem is **config or signal**, not hardware. Only after the checklist comes up
+empty should you try a different USB port or cable, let the dongle warm up, or test a
+known-good system to prove the chain. If a system that decodes elsewhere fails only on
+your dongle, *then* consider the hardware — otherwise it's antenna, gain, PPM, control
+channel, or system type, roughly in that order.
+
+## Recap
+
+- **Work the checklist in order** — each failure has a distinct symptom.
+- **Wrong control channel** is the top cause of "nothing decodes" — re-confirm or
+  [Hunt](/hunt.html) it, and try alternates.
+- **Gain** fails both ways: too low buries the signal, too high **overloads** and sprays
+  ghosts.
+- A **rotating constellation** means a **PPM/frequency** error — calibrate it.
+- **Calls listed but silent** is **encryption** — expected and not fixable.
+- Suspect **hardware last**, after config and signal check out.
+
+## You've finished the path — now go use it
+
+That's the whole journey: from why radio went digital, through trunking's architecture
+and the major protocols, to **operating GopherTrunk** against real systems — identifying
+them, finding the control channel, following calls end to end, handling multi-site and
+simulcast, and troubleshooting when it fights you. You now have a mental model of every
+stage, which is exactly what turns settings-poking into reasoning.
+
+Keep the **[glossary](glossary/)** open whenever a term needs a refresher, and head to
+**[getting started](/getting-started.html)** to put all of this into practice on a real
+system. Well done — you've earned the lock.

--- a/docs/learn/digital-trunking/trunking-flavors.md
+++ b/docs/learn/digital-trunking/trunking-flavors.md
@@ -1,0 +1,141 @@
+---
+slug: trunking-flavors
+title: "Trunking flavors: dedicated vs. distributed, message vs. transmission"
+description: The two axes that classify trunked systems — dedicated vs. distributed control channels, and message vs. transmission trunking — and how each choice changes what you monitor and how.
+keywords: dedicated control channel, distributed control, LTR, Passport, message trunking, transmission trunking, hang time, P25, DMR Tier III, EDACS, SmartNet, trunking types
+level: intermediate
+status: full
+prereq:
+  - control-channel-signaling
+  - conventional-vs-trunked
+faq:
+  - q: What is the difference between dedicated and distributed control?
+    a: A dedicated control channel is one frequency reserved full-time to carry trunking data, used by P25, DMR Tier III, EDACS, and SmartNet. Distributed control instead spreads the trunking data across every repeater, with no separate control frequency, as in LTR and Passport. Dedicated systems give a single channel to lock onto; distributed systems require watching the sub-audible data on the active repeaters.
+  - q: What is message trunking?
+    a: Message trunking holds a voice channel for an entire conversation, including the pauses between transmissions, releasing it only after a hang-time once the exchange truly ends. It keeps a back-and-forth on one channel, which is simpler to follow but ties up a channel slightly longer.
+  - q: What is transmission trunking?
+    a: Transmission trunking releases the voice channel after each individual transmission, so the next over in the same conversation may be granted a different channel. It packs more conversations into the pool but means a single exchange can hop channels, which the control channel announces with each new grant.
+  - q: How do these choices affect monitoring?
+    a: With a dedicated control channel you lock one frequency and read every grant. With distributed control there's no single channel, so a tracker watches the data riding on the repeaters themselves. Transmission trunking makes individual conversations hop more, so following relies even more on reading every grant in real time.
+gophertrunk_links:
+  - title: CC Activity
+    url: /cc-activity.html
+    note: see how often grants appear, which reveals message vs. transmission trunking behavior.
+  - title: Status
+    url: /status.html
+    note: check which trunking types GopherTrunk decodes.
+---
+
+# Trunking flavors: dedicated vs. distributed, message vs. transmission
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+Trunked systems split along **two independent axes**. First, *where the control data
+lives*: a **dedicated control channel** (P25, DMR Tier III, EDACS, SmartNet) reserves one
+frequency for data, while **distributed control** (LTR, Passport) rides the data on each
+repeater with **no separate control channel**. Second, *when the channel is freed*:
+**message trunking** holds a channel for a whole conversation (pauses included);
+**transmission trunking** releases it after *each transmission*, so a single exchange can
+hop channels. These choices change **what you lock onto** and **how a call moves**.
+
+</div>
+
+By now you can read a [control channel](control-channel-signaling/) and follow a
+[call](anatomy-of-a-call/). But not all trunked systems are built the same way. Two simple
+axes classify nearly all of them, and together they explain a lot about how a given system
+behaves on the air — and how you monitor it.
+
+## Axis 1 — dedicated vs. distributed control
+
+The first question is *where the trunking data lives*.
+
+A **dedicated control channel** sets aside **one frequency** to carry signaling full-time,
+never voice. This is the model you've studied so far, and it's used by **P25**, **DMR Tier
+III**, **EDACS**, and Motorola **SmartNet/Type II**. The appeal for a monitor is obvious:
+there's a *single channel to lock onto*, and it announces everything.
+
+**Distributed control** takes the opposite approach: there is **no separate control
+frequency**. Instead, the trunking data is spread across **every repeater** in the system,
+typically as a low-rate sub-audible data stream alongside (or between) the voice. **LTR**
+(Logic Trunked Radio) and **Passport** work this way. Each repeater advertises its own
+status, and radios piece the system together from whichever repeaters they can hear.
+
+For monitoring, the difference is real: a dedicated system gives you one obvious target,
+whereas a distributed system has no control channel to park on — a tracker must watch the
+data riding on the *active repeaters* to know what's happening.
+
+## Axis 2 — message vs. transmission trunking
+
+The second question is *when the voice channel is released*.
+
+In **message trunking**, the system holds the granted voice channel for an **entire
+conversation** — through the natural pauses between overs — releasing it only after a
+**hang-time** once the exchange truly ends. A back-and-forth stays on one channel from
+start to finish. This is simpler to follow: one grant, one channel, until release.
+
+In **transmission trunking**, the channel is released after **each individual
+transmission**. When the other party replies, the system grants a channel again — possibly
+a *different* one. This squeezes more conversations into the pool, since channels aren't
+tied up during pauses, but it means a single exchange can **hop channels**, with the control
+channel issuing a fresh grant for each over.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 560 170" role="img" aria-label="Two timelines comparing message trunking, which holds one channel across pauses, with transmission trunking, which releases the channel after each over and may grant a different one." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor">
+    <text x="30" y="30" font-weight="600">Message trunking</text>
+    <rect x="30" y="40" width="80" height="20" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="0.8"/><text x="70" y="54" text-anchor="middle" font-size="8">over 1</text>
+    <rect x="110" y="40" width="40" height="20" fill="none" stroke="currentColor" stroke-width="0.6" stroke-dasharray="3 2"/><text x="130" y="54" text-anchor="middle" font-size="7">pause</text>
+    <rect x="150" y="40" width="80" height="20" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="0.8"/><text x="190" y="54" text-anchor="middle" font-size="8">over 2</text>
+    <text x="250" y="54" font-size="8">all on channel 3</text>
+
+    <text x="30" y="100" font-weight="600">Transmission trunking</text>
+    <rect x="30" y="110" width="80" height="20" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="0.8"/><text x="70" y="124" text-anchor="middle" font-size="8">over 1 (ch 3)</text>
+    <rect x="110" y="110" width="40" height="20" fill="none" stroke="currentColor" stroke-width="0.6"/><text x="130" y="124" text-anchor="middle" font-size="7">freed</text>
+    <rect x="150" y="110" width="80" height="20" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="0.8"/><text x="190" y="124" text-anchor="middle" font-size="8">over 2 (ch 7)</text>
+    <text x="250" y="124" font-size="8">re-granted, may move</text>
+  </g>
+</svg>
+<figcaption>Message trunking keeps a conversation on one channel through its pauses; transmission trunking releases the channel after each over, so the next over may be granted a different channel.</figcaption>
+</figure>
+
+## The two axes combined
+
+The axes are independent, so a system has one choice on each. The matrix below shows the
+combination and what it means for monitoring:
+
+| | Dedicated control channel | Distributed control |
+|---|---|---|
+| **Message trunking** | One CC to lock; calls stay put on a channel (e.g. many P25/SmartNet configs) | No CC; data on repeaters, conversation stays on one repeater (e.g. LTR) |
+| **Transmission trunking** | One CC to lock; follow each grant as overs may hop channels | No CC; watch repeater data; overs may move between repeaters |
+
+Practically: **dedicated** systems give you a single control channel to find and lock —
+most of the digital systems in this path. **Distributed** systems make you watch the
+repeaters themselves. And wherever **transmission trunking** is in play, following a
+conversation leans even harder on reading *every* grant the moment it appears, because the
+channel keeps moving. Watching grant frequency in
+**[CC Activity](/cc-activity.html)** is a quick way to sense which behavior a system shows.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — distributed control has no separate control channel; the data rides on each repeater." markdown="0">
+  <p class="knowledge-check__q">Quick check: which describes a system like LTR with distributed control?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">One reserved frequency carries all trunking data</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">No separate control channel — data rides on each repeater</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It cannot be trunked at all</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Dedicated control** reserves one frequency for data (P25, DMR Tier III, EDACS,
+  SmartNet) — one channel to lock.
+- **Distributed control** (LTR, Passport) spreads data across repeaters with **no separate
+  control channel**.
+- **Message trunking** holds a channel for the whole conversation, pauses included.
+- **Transmission trunking** releases the channel after each over, so an exchange can **hop
+  channels**.
+- The axes are independent, and each choice changes **what you lock onto** and **how a call
+  moves**.
+
+Next, we scale up to real deployments: [sites, simulcast and
+roaming](sites-simulcast-roaming/) in multi-site systems.

--- a/docs/learn/digital-trunking/voice-to-bits-vocoders.md
+++ b/docs/learn/digital-trunking/voice-to-bits-vocoders.md
@@ -1,0 +1,166 @@
+---
+slug: voice-to-bits-vocoders
+title: "From voice to bits: vocoders"
+description: How a vocoder models speech to squeeze it into a few kbps — IMBE for P25 Phase 1, AMBE+2 for P25 Phase 2 and DMR, ACELP for TETRA, and how a frame becomes audio again.
+keywords: vocoder, voice coder, IMBE, AMBE+2, ACELP, DVSI, P25 vocoder, DMR vocoder, TETRA codec, speech model, low bitrate codec, digital voice
+level: advanced
+status: full
+prereq:
+  - analog-vs-digital-voice
+faq:
+  - q: What is a vocoder?
+    a: A vocoder, or voice coder, is a codec that compresses speech by modelling how the vocal tract produces sound rather than sampling the audio waveform. It extracts a small set of parameters per short frame — pitch, voicing, and spectral shape — and sends only those. The decoder runs the model in reverse to synthesise speech that resembles the talker, fitting voice into a few kilobits per second.
+  - q: What vocoders do P25 and DMR use?
+    a: P25 Phase 1 uses IMBE at roughly 7200 bps including its error correction, of which about 4400 bps is the actual voice description. P25 Phase 2 and DMR use AMBE+2, which carries useful speech at roughly half that net rate so it fits in a time slot. TETRA uses an ACELP-family codec instead.
+  - q: Why are these vocoders proprietary?
+    a: IMBE and the AMBE family are developed and licensed by Digital Voice Systems, Inc. (DVSI) and are protected by patents, so manufacturers and software must license them. That is why open decoders historically struggled with digital voice audio and why a built-in vocoder is a notable feature of a scanner.
+  - q: Does GopherTrunk include a vocoder?
+    a: Yes. GopherTrunk includes a vocoder so it can turn the recovered voice frames back into audio you can hear, rather than only showing metadata. Without a vocoder you would decode the control channel and see talkgroups but hear nothing.
+gophertrunk_links:
+  - title: Vocoders
+    url: /vocoders.html
+    note: see and configure the codec GopherTrunk uses to make audio.
+  - title: Voice calibration
+    url: /voice-calibration.html
+    note: dial in the cleanest reconstructed speech.
+---
+
+# From voice to bits: vocoders
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+A **vocoder** ("voice coder") compresses speech by **modelling how it's produced**
+rather than sampling the waveform, squeezing a voice into a few **kbps**. Different
+systems use different vocoders: **IMBE** in P25 Phase 1 (~7200 bps including error
+correction, ~4400 bps of net voice), **AMBE+2** in P25 Phase 2 and DMR (roughly half
+that net rate, so it fits a time slot), and an **ACELP**-family codec in TETRA. The
+IMBE and AMBE codecs are **proprietary (DVSI)**, which is why a decoder needs a
+licensed implementation. **GopherTrunk includes a vocoder**, so it can reconstruct
+audio from the recovered frames rather than only showing metadata.
+</div>
+
+The previous lesson said voice becomes "a few kilobits per second." This lesson is
+about the device that performs that miracle — and why digital voice has the timbre it
+does. See the [RF & SDR vocoder lesson](/learn/rf-sdr/vocoders/) for the companion
+treatment; here we focus on the specific codecs the trunked systems use.
+
+## What a vocoder actually does
+
+An ordinary audio codec like MP3 starts from the *sound* and compresses it. A
+**vocoder** starts somewhere stranger: it assumes the sound is **human speech** and
+fits a model of the human vocal tract to it. Speech is produced by an excitation —
+either a buzzing of the vocal cords (voiced sounds like vowels) or a turbulent hiss
+(unvoiced sounds like "s") — passed through the resonant filter of the mouth and
+throat. A vocoder measures that process a few dozen times a second.
+
+For each short **frame** of speech (typically around 20 ms), the encoder extracts a
+compact description:
+
+- the **pitch** (how fast the vocal cords are vibrating),
+- the **voicing** (which parts of the sound are buzz vs. hiss), and
+- the **spectral shape** (the resonances of the vocal tract).
+
+It sends only those parameters. There is no waveform on the air at all — just a recipe
+for re-creating one. That is why the squeeze is so dramatic: full phone-quality audio
+is about **64 kbps**, but the *description* of how to make similar-sounding speech is
+a small fraction of that.
+
+## The vocoders you'll meet
+
+Digital trunking standardised on a short list of vocoders, and which one a system uses
+is part of that system's identity.
+
+| System | Vocoder | Approx. rate | Notes |
+|--------|---------|--------------|-------|
+| P25 Phase 1 | IMBE | ~7200 bps gross, ~4400 bps net voice | FDMA, one call per channel |
+| P25 Phase 2 | AMBE+2 | roughly half IMBE's net rate | fits a TDMA time slot |
+| DMR | AMBE+2 | low-rate variant per slot | two slots per channel |
+| TETRA | ACELP family | low bitrate | different codec lineage |
+
+**IMBE** (Improved Multi-Band Excitation) is the P25 Phase 1 codec. Of its roughly
+**7200 bps**, a large share is error-correction overhead; the actual voice description
+is around **4400 bps**. **AMBE+2** (Advanced Multi-Band Excitation) is the
+successor used by P25 Phase 2 and DMR. It carries usable speech at roughly **half**
+IMBE's net rate, which is what lets two voice paths share one channel via time-slots —
+the subject of a later lesson. **TETRA** took a different path entirely, using an
+**ACELP**-family codec (a code-excited linear-prediction design from the same family
+as many cellphone codecs).
+
+A consequence worth remembering: because the vocoder *is* part of the system
+definition, you cannot decode P25 Phase 2 voice with an IMBE-only decoder, or vice
+versa. The bits mean nothing without the matching model.
+
+## Reconstructing a frame into audio
+
+At the receiver, after [demodulation](/learn/rf-sdr/demodulation-pipeline/) and error
+correction hand over a clean frame of vocoder parameters, the decoder runs the model
+**in reverse**:
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 520 150" role="img" aria-label="A pipeline showing a vocoder frame of parameters feeding an excitation generator and a vocal-tract filter, which combine to produce a 20-millisecond chunk of synthesised speech." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="55" width="110" height="40" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.5"/>
+  <text x="75" y="72" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">vocoder frame</text>
+  <text x="75" y="86" text-anchor="middle" font-size="9" fill="currentColor">pitch · voicing · shape</text>
+  <rect x="180" y="20" width="120" height="38" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="240" y="43" text-anchor="middle" font-size="10" fill="currentColor">excitation (buzz/hiss)</text>
+  <rect x="180" y="92" width="120" height="38" rx="6" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="240" y="115" text-anchor="middle" font-size="10" fill="currentColor">vocal-tract filter</text>
+  <rect x="350" y="55" width="150" height="40" rx="6" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.5"/>
+  <text x="425" y="72" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">~20 ms of speech</text>
+  <text x="425" y="86" text-anchor="middle" font-size="9" fill="currentColor">played back as audio</text>
+  <line x1="130" y1="75" x2="178" y2="39" stroke="currentColor" stroke-width="1.5" marker-end="url(#a2)"/>
+  <line x1="130" y1="75" x2="178" y2="111" stroke="currentColor" stroke-width="1.5" marker-end="url(#a2)"/>
+  <line x1="300" y1="39" x2="348" y2="68" stroke="currentColor" stroke-width="1.5" marker-end="url(#a2)"/>
+  <line x1="300" y1="111" x2="348" y2="82" stroke="currentColor" stroke-width="1.5" marker-end="url(#a2)"/>
+  <defs><marker id="a2" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The decoder builds an excitation from the pitch and voicing parameters, shapes it with the vocal-tract filter, and outputs a short chunk of synthesised speech. Stitch the chunks together and you have continuous audio.</figcaption>
+</figure>
+
+The decoder generates the **excitation** (a buzz at the coded pitch, or a hiss for
+unvoiced sounds), passes it through a filter set to the coded **spectral shape**, and
+produces about 20 ms of audio. Repeat ~50 times a second and the chunks blend into
+continuous speech. Because every frame is *synthesised* from a model, the output sounds
+like the talker but never exactly reproduces them — the source of the robotic or
+"underwater" character from the last lesson, and the reason an unusual voice or heavy
+background noise can confuse the model.
+
+## Why this matters for a decoder
+
+Two things follow from all this. First, the vocoders that matter here —
+**IMBE** and **AMBE+2** — are **proprietary**, developed and licensed by **DVSI**.
+Decoding their bits is only half the job; turning those bits into audio needs a
+licensed implementation, which is why playable digital voice was scarce in open tools
+for years. Second, a scanner that *only* decoded the control channel would show you
+talkgroups and IDs but stay silent.
+
+**GopherTrunk includes a vocoder**, so once it follows a call to its voice channel it
+can reconstruct and play the audio — see the [Vocoders panel](/vocoders.html) to view
+the active codec and [Voice calibration](/voice-calibration.html) to tune for the
+cleanest result.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a vocoder models how speech is produced and sends only the parameters." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does a vocoder compress speech into a few kbps?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It samples the waveform at a very low rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It models how speech is produced and sends only the parameters</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It removes silence and sends the rest unchanged</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- A **vocoder** models how speech is produced and sends only **pitch, voicing, and
+  spectral shape** per frame.
+- **IMBE** carries P25 Phase 1 (~7200 bps gross, ~4400 bps net voice); **AMBE+2**
+  carries P25 Phase 2 and DMR at roughly half the net rate.
+- **TETRA** uses an **ACELP**-family codec from a different lineage.
+- The IMBE/AMBE codecs are **proprietary (DVSI)**, so a decoder needs a licensed
+  implementation.
+- The decoder **synthesises** each frame, which is why digital voice sounds modelled —
+  and **GopherTrunk includes a vocoder** to produce that audio.
+
+Next, we move from the bits to how they ride the air:
+[digital modulation for trunking](digital-modulation-for-trunking/) — C4FM, π/4-DQPSK,
+and CQPSK.

--- a/docs/learn/digital-trunking/why-radio-went-digital.md
+++ b/docs/learn/digital-trunking/why-radio-went-digital.md
@@ -1,0 +1,134 @@
+---
+slug: why-radio-went-digital
+title: Why radio went digital
+description: Why two-way radio moved from analog FM to digital — spectrum congestion, no privacy, limited capacity, no data, and fringe static drove the shift, plus FCC narrowbanding.
+keywords: why radio went digital, analog FM two-way radio, spectrum congestion, FCC narrowbanding, refarming, 12.5 kHz, digital radio benefits, land mobile radio, encryption, talkgroups
+level: beginner
+status: full
+prereq:
+  - analog-modulation
+faq:
+  - q: Why did two-way radio move from analog to digital?
+    a: Analog FM ran out of room. Spectrum got congested, there was no privacy, capacity was limited to one conversation per channel, and there was almost no way to carry data. Digital answered all of those at once — more users per slice of spectrum, encryption, data, and audio that stays clean to the edge of coverage. Regulators also pushed the change by forcing narrower channels.
+  - q: What is FCC narrowbanding?
+    a: Narrowbanding (part of spectrum refarming) was an FCC mandate that pushed many land-mobile users from 25 kHz channels down to 12.5 kHz, fitting more channels into the same band. Squeezing analog FM into half the width hurts its audio, so the rule nudged operators toward digital modes that are designed to work in narrow channels.
+  - q: Does digital audio really sound better at the fringe?
+    a: At the edge of coverage it usually does. Analog FM degrades gracefully into hiss and static as the signal weakens, so you strain to understand it. Digital voice stays clear and full-volume right up until the error correction can no longer keep up, at which point it drops out abruptly rather than fading into noise.
+  - q: Is analog radio gone?
+    a: No. Plenty of analog FM and analog trunked systems are still on the air, and GopherTrunk decodes several of them. But new public-safety and commercial deployments are overwhelmingly digital, and the long-term trend is one-directional toward P25, DMR, TETRA, and similar standards.
+gophertrunk_links:
+  - title: Vocoders
+    url: /vocoders.html
+    note: see the digital voice codecs that replaced analog FM audio.
+---
+
+# Why radio went digital
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+For decades, **analog FM** two-way radio was simple, rugged, and good enough — one
+conversation per frequency, audio that anyone could receive. But pressure piled up:
+**spectrum congestion**, **no privacy**, **limited capacity**, almost **no data**, and
+audio that **decays into static at the fringe**. Regulators added **FCC narrowbanding**
+(refarming toward **12.5 kHz** channels), which analog handles poorly. **Digital** answered
+every complaint at once — more users per slice of spectrum, **clean audio to the edge of
+coverage**, **encryption**, **data**, and **talkgroups**. That promise is the reason this
+whole learning path exists.
+</div>
+
+This is where the story starts. Every system you'll meet later — P25, DMR, TETRA,
+NXDN — exists because the analog world ran into walls it couldn't climb. Understand
+those walls and the rest of the path stops being a parade of acronyms and becomes a
+set of answers to obvious problems.
+
+## The analog FM era, and what it did well
+
+For most of the twentieth century, professional two-way radio meant **analog FM**.
+A police officer, a taxi dispatcher, and a utility crew all keyed up a handset and
+talked, and the [frequency modulation](/learn/rf-sdr/analog-modulation/) carried their
+voice on a single dedicated frequency. It was beautifully simple. There was nothing to
+boot, nothing to negotiate — power on, pick a channel, talk. Any compatible receiver in
+range heard you instantly, which made coordination during emergencies trivial.
+
+Analog FM also degrades *gracefully*. As a signal weakens, it slides into hiss, but a
+trained ear can pull meaning out of surprisingly noisy audio. For a long time that was a
+feature, not a bug: better a scratchy call than no call.
+
+## The walls analog ran into
+
+The trouble was that the world wanted more than "one channel, one conversation, in the
+clear." Five pressures built up over time:
+
+- **Spectrum congestion.** Radio spectrum is finite and shared. As agencies and
+  businesses multiplied, the usable bands filled. Giving every group a permanent
+  frequency simply ran out of frequencies to give.
+- **No privacy.** Anyone with a scanner could hear everything. Sensitive police, medical,
+  or commercial traffic went out in the clear, because analog FM has no real way to
+  scramble voice without wrecking it.
+- **Limited capacity.** One channel carried exactly one call at a time. A busy frequency
+  meant users waited their turn, and you couldn't squeeze a second conversation into the
+  same slice of spectrum.
+- **Almost no data.** Modern operations want text, GPS locations, unit IDs, and status
+  messages. Analog FM was built for voice and bolts data on awkwardly, if at all.
+- **Fringe degradation.** That graceful fade is also a liability. At the edge of coverage,
+  a critical call can dissolve into static exactly when you most need to understand it.
+
+## Regulatory pressure: narrowbanding
+
+On top of those, regulators pushed. To relieve congestion, the **FCC** mandated
+**narrowbanding** — part of a broader *refarming* of the land-mobile bands — moving many
+users from 25 kHz channels down to **12.5 kHz**, and eyeing 6.25 kHz beyond that. Halving
+a channel's width fits more channels into the same band, but it also starves analog FM:
+crammed into half the room, FM audio gets thinner and noisier. The rules didn't *require*
+digital, but they tilted the field steeply toward modes engineered to work in narrow
+channels — which is precisely what the new digital standards were.
+
+## What digital promised
+
+Digital voice radio answered the entire list at once, which is why it won.
+
+| Analog pain point | What digital delivered |
+|-------------------|------------------------|
+| Spectrum congestion | More users per slice of spectrum, especially with time slots |
+| No privacy | Built-in **encryption** options |
+| Limited capacity | Two or more calls per channel via TDMA |
+| Almost no data | Native **data** — text, GPS, unit status, IDs |
+| Fringe static | **Clean audio to the edge of coverage**, then a clean cutoff |
+| Fixed per-group frequencies | **Talkgroups** — virtual channels you follow instead of frequencies |
+
+The mechanism behind clean fringe audio is worth a pause. Instead of sending the voltage
+of a voice waveform, digital radio turns speech into **bits** with a
+[vocoder](/learn/rf-sdr/digital-voice/), then protects those bits with error correction.
+As long as the receiver can recover the bits, the audio sounds full and clear — there's no
+"slightly noisy" in between. When the link finally fails, it drops out rather than fading,
+which is a very different experience from analog hiss.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — digital keeps audio clean until the bits can no longer be recovered, then cuts out." markdown="0">
+  <p class="knowledge-check__q">Quick check: how does digital voice behave differently from analog FM at the fringe of coverage?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It gets gradually noisier, like FM hiss</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It stays clean until the bits fail, then drops out</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It automatically switches to a louder frequency</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Why this frames the whole path
+
+Hold onto this list of motivations, because every later lesson is really a detailed
+answer to one of them. *More users per channel* leads to TDMA and trunking. *Privacy*
+leads to encryption and authentication. *Data* leads to control-channel signalling and
+talkgroups. *Clean fringe audio* leads to vocoders and forward error correction. The
+standards differ in the details, but they were all chasing the same prize: do more, more
+privately, more efficiently, with the same scarce spectrum.
+
+## Recap
+
+- **Analog FM** two-way radio was simple and rugged — one conversation per frequency, heard by anyone.
+- It hit walls: **congestion**, **no privacy**, **limited capacity**, **no data**, and **fringe static**.
+- **FCC narrowbanding** (refarming toward **12.5 kHz**) added pressure that analog FM handles poorly.
+- **Digital** answered all of it — more users per slice of spectrum, **encryption**, **data**, **talkgroups**, and **clean audio to the edge of coverage**.
+- These motivations frame every lesson that follows in this path.
+
+Next, we'll see the first big idea that squeezed far more users onto the same
+spectrum — sharing channels — in [The birth of trunking](/learn/digital-trunking/birth-of-trunking/).


### PR DESCRIPTION
Add a new structured learning path covering digital and digital-trunking
radio systems, parallel in depth and format to the existing RF & SDR path.

The path opens with a brief history of digital radio and trunking, then
teaches the digital signal end to end — vocoders, modulation, framing,
control channels — before covering each trunking system GopherTrunk
decodes (P25 Phase 1/2 and DMR in depth; TETRA, NXDN, Motorola, EDACS,
LTR, MPT-1327, dPMR, D-STAR, YSF more briefly), and finishing with
hands-on decoding in GopherTrunk.

- 6 modules, 31 lessons + glossary, all status: full
- register the path in _data/learn.yml (drives the /learn/ chooser, hub
  grid, prev/next nav, and llms.txt automatically)
- add the learn/digital-trunking defaults scope in _config.yml
- add the hub index.md and all lesson markdown files

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RNJw2gEui3odKBFRpzRter