### PR TITLE
Add Software Development domain to the Reference encyclopedia

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -51,6 +51,8 @@ groups:
     items:
       - title: Encyclopedia overview
         url: /reference/
+      - title: "RF & SDR"
+        url: /reference/#domain-rf-sdr
       - title: RF & signal fundamentals
         url: /reference/#rf-fundamentals
       - title: Modulation
@@ -71,6 +73,20 @@ groups:
         url: /reference/#people
       - title: Organizations
         url: /reference/#organizations
+      - title: "Software Development"
+        url: /reference/#domain-software-dev
+      - title: Programming languages
+        url: /reference/#programming-languages
+      - title: Language internals & execution
+        url: /reference/#language-internals
+      - title: Concurrency & execution models
+        url: /reference/#concurrency-execution
+      - title: Paradigms & design patterns
+        url: /reference/#paradigms-design
+      - title: Principles & code quality
+        url: /reference/#principles-quality
+      - title: Testing, tooling & delivery
+        url: /reference/#testing-delivery
       - title: A–Z index
         url: /reference/#a-z
   - label: About

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -1,8 +1,14 @@
 # GopherTrunk Reference — encyclopedia single source of truth.
 #
-# Drives: the reference hub (docs/reference/index.md) category grid + A–Z index,
-# the article breadcrumb category label (docs/_layouts/reference.html), and the
-# "Reference" section of docs/llms.txt.
+# Drives: the reference hub (docs/reference/index.md) domain/category grid +
+# A–Z index, the article breadcrumb domain + category labels
+# (docs/_layouts/reference.html), and the "Reference" section of docs/llms.txt.
+#
+# Structure: domains → categories → entries. A domain is a top-level subject
+# area (RF & SDR, Software Development, …); each domain holds categories, and
+# each category holds entries. Category ids are unique across the whole file —
+# an article's `category:` front matter names a category id, and the domain is
+# derived from whichever domain contains that category.
 #
 # Adding an entry:
 #   1. Append it under the right category's `entries:` list below.
@@ -14,246 +20,350 @@
 #      the site-wide autolinker (docs/reference-terms.json). Omit it for common
 #      words (frequency, gain, phase, …) to avoid noisy false matches.
 #
-# Keep `slug` stable once published — it is the URL (/reference/<slug>/).
+# Adding a domain: append a new entry under `domains:` with id, label, blurb,
+# and its own `categories:` list. The hub, nav, breadcrumbs, and llms.txt pick
+# it up automatically.
+#
+# Keep `slug` and category `id` stable once published — they are URLs and anchors.
 
 intro: >
   The GopherTrunk Reference is a plain-language encyclopedia of the terms,
-  technologies, algorithms, people, hardware, and organizations behind radio and
-  software-defined radio. Each article is a standalone, long-form definition — no
-  lesson order, no exercises, just information — cross-linked to related entries
-  and to the learning path. Browse by category or jump to the A–Z index.
+  technologies, algorithms, people, hardware, organizations, and software behind
+  radio, software-defined radio, and the craft of building software itself. Each
+  article is a standalone, long-form definition — no lesson order, no exercises,
+  just information — cross-linked to related entries and to the learning paths.
+  Browse by domain and category, or jump to the A–Z index.
 
-categories:
-  - id: rf-fundamentals
-    label: RF & signal fundamentals
-    blurb: The physical quantities and units that describe radio waves and signal power.
-    entries:
-      - { slug: electromagnetic-spectrum, title: Electromagnetic spectrum, type: term }
-      - { slug: radio-wave, title: Radio wave, type: term }
-      - { slug: frequency, title: Frequency, type: term }
-      - { slug: wavelength, title: Wavelength, type: term }
-      - { slug: amplitude, title: Amplitude, type: term }
-      - { slug: phase, title: Phase, type: term }
-      - { slug: carrier-wave, title: Carrier wave, type: term }
-      - { slug: modulation, title: Modulation, type: term }
-      - { slug: bandwidth, title: Bandwidth, type: term }
-      - { slug: decibel, title: Decibel (dB), type: term }
-      - { slug: dbm, title: dBm, type: term }
-      - { slug: dbfs, title: dBFS, type: term }
-      - { slug: signal-to-noise-ratio, title: Signal-to-noise ratio (SNR), type: term }
-      - { slug: noise-floor, title: Noise floor, type: term }
-      - { slug: attenuation, title: Attenuation, type: term }
-      - { slug: path-loss, title: Path loss, type: term }
-      - { slug: frequency-bands, title: Frequency bands (HF/VHF/UHF), type: term }
+domains:
+  - id: rf-sdr
+    label: "RF & SDR"
+    blurb: Radio, signals, SDR, DSP, the protocols GopherTrunk decodes, and the people and bodies behind them.
+    categories:
+      - id: rf-fundamentals
+        label: RF & signal fundamentals
+        blurb: The physical quantities and units that describe radio waves and signal power.
+        entries:
+          - { slug: electromagnetic-spectrum, title: Electromagnetic spectrum, type: term }
+          - { slug: radio-wave, title: Radio wave, type: term }
+          - { slug: frequency, title: Frequency, type: term }
+          - { slug: wavelength, title: Wavelength, type: term }
+          - { slug: amplitude, title: Amplitude, type: term }
+          - { slug: phase, title: Phase, type: term }
+          - { slug: carrier-wave, title: Carrier wave, type: term }
+          - { slug: modulation, title: Modulation, type: term }
+          - { slug: bandwidth, title: Bandwidth, type: term }
+          - { slug: decibel, title: Decibel (dB), type: term }
+          - { slug: dbm, title: dBm, type: term }
+          - { slug: dbfs, title: dBFS, type: term }
+          - { slug: signal-to-noise-ratio, title: Signal-to-noise ratio (SNR), type: term }
+          - { slug: noise-floor, title: Noise floor, type: term }
+          - { slug: attenuation, title: Attenuation, type: term }
+          - { slug: path-loss, title: Path loss, type: term }
+          - { slug: frequency-bands, title: Frequency bands (HF/VHF/UHF), type: term }
 
-  - id: antennas-propagation
-    label: Antennas & propagation
-    blurb: How energy radiates from an antenna and travels to your receiver.
-    entries:
-      - { slug: antenna, title: Antenna, type: term }
-      - { slug: dipole-antenna, title: Dipole antenna, type: term }
-      - { slug: antenna-gain, title: Antenna gain, type: term }
-      - { slug: polarization, title: Polarization, type: term }
-      - { slug: standing-wave-ratio, title: Standing wave ratio (SWR), type: term }
-      - { slug: radio-propagation, title: Radio propagation, type: term }
-      - { slug: multipath-propagation, title: Multipath propagation, type: term }
-      - { slug: radio-horizon, title: Radio horizon, type: term }
-      - { slug: ionospheric-propagation, title: Ionospheric propagation, type: term }
+      - id: antennas-propagation
+        label: Antennas & propagation
+        blurb: How energy radiates from an antenna and travels to your receiver.
+        entries:
+          - { slug: antenna, title: Antenna, type: term }
+          - { slug: dipole-antenna, title: Dipole antenna, type: term }
+          - { slug: antenna-gain, title: Antenna gain, type: term }
+          - { slug: polarization, title: Polarization, type: term }
+          - { slug: standing-wave-ratio, title: Standing wave ratio (SWR), type: term }
+          - { slug: radio-propagation, title: Radio propagation, type: term }
+          - { slug: multipath-propagation, title: Multipath propagation, type: term }
+          - { slug: radio-horizon, title: Radio horizon, type: term }
+          - { slug: ionospheric-propagation, title: Ionospheric propagation, type: term }
 
-  - id: modulation
-    label: Modulation
-    blurb: The schemes that put information onto a carrier — analog and digital.
-    entries:
-      - { slug: amplitude-modulation, title: Amplitude modulation (AM), type: technology }
-      - { slug: frequency-modulation, title: Frequency modulation (FM), type: technology }
-      - { slug: single-sideband, title: Single sideband (SSB), type: technology }
-      - { slug: frequency-shift-keying, title: Frequency-shift keying (FSK), type: technology }
-      - { slug: phase-shift-keying, title: Phase-shift keying (PSK), type: technology }
-      - { slug: quadrature-amplitude-modulation, title: Quadrature amplitude modulation (QAM), type: technology }
-      - { slug: c4fm, title: C4FM, type: technology }
-      - { slug: cqpsk, title: CQPSK, type: technology }
-      - { slug: gmsk, title: GMSK, type: technology }
-      - { slug: afsk, title: AFSK, type: technology }
-      - { slug: ffsk, title: FFSK, type: technology }
-      - { slug: symbol-rate, title: Symbol rate (baud), type: term }
-      - { slug: constellation-diagram, title: Constellation diagram, type: term }
-      - { slug: eye-diagram, title: Eye diagram, type: term }
-      - { slug: pi-4-dqpsk, title: π/4-DQPSK, type: technology }
-      - { slug: gfsk, title: GFSK, type: technology }
-      - { slug: nrzi, title: NRZI, type: term }
-      - { slug: dibit, title: Dibit, type: term }
-      - { slug: pulse-shaping, title: Pulse shaping, type: term }
+      - id: modulation
+        label: Modulation
+        blurb: The schemes that put information onto a carrier — analog and digital.
+        entries:
+          - { slug: amplitude-modulation, title: Amplitude modulation (AM), type: technology }
+          - { slug: frequency-modulation, title: Frequency modulation (FM), type: technology }
+          - { slug: single-sideband, title: Single sideband (SSB), type: technology }
+          - { slug: frequency-shift-keying, title: Frequency-shift keying (FSK), type: technology }
+          - { slug: phase-shift-keying, title: Phase-shift keying (PSK), type: technology }
+          - { slug: quadrature-amplitude-modulation, title: Quadrature amplitude modulation (QAM), type: technology }
+          - { slug: c4fm, title: C4FM, type: technology }
+          - { slug: cqpsk, title: CQPSK, type: technology }
+          - { slug: gmsk, title: GMSK, type: technology }
+          - { slug: afsk, title: AFSK, type: technology }
+          - { slug: ffsk, title: FFSK, type: technology }
+          - { slug: symbol-rate, title: Symbol rate (baud), type: term }
+          - { slug: constellation-diagram, title: Constellation diagram, type: term }
+          - { slug: eye-diagram, title: Eye diagram, type: term }
+          - { slug: pi-4-dqpsk, title: π/4-DQPSK, type: technology }
+          - { slug: gfsk, title: GFSK, type: technology }
+          - { slug: nrzi, title: NRZI, type: term }
+          - { slug: dibit, title: Dibit, type: term }
+          - { slug: pulse-shaping, title: Pulse shaping, type: term }
 
-  - id: sdr-dsp
-    label: SDR & DSP
-    blurb: Software-defined radio and the digital signal processing between IQ and bits.
-    entries:
-      - { slug: software-defined-radio, title: Software-defined radio (SDR), type: technology }
-      - { slug: iq-data, title: IQ data, type: term }
-      - { slug: analog-to-digital-converter, title: Analog-to-digital converter (ADC), type: term }
-      - { slug: sample-rate, title: Sample rate, type: term }
-      - { slug: nyquist-theorem, title: Nyquist–Shannon sampling theorem, type: term }
-      - { slug: aliasing, title: Aliasing, type: term }
-      - { slug: superheterodyne-receiver, title: Superheterodyne receiver, type: term }
-      - { slug: local-oscillator, title: Local oscillator, type: term }
-      - { slug: digital-down-converter, title: Digital down-converter (DDC), type: term }
-      - { slug: decimation, title: Decimation, type: term }
-      - { slug: digital-filter, title: Digital filter, type: term }
-      - { slug: cic-filter, title: CIC filter, type: algorithm }
-      - { slug: root-raised-cosine-filter, title: Root-raised-cosine filter, type: algorithm }
-      - { slug: matched-filter, title: Matched filter, type: algorithm }
-      - { slug: automatic-gain-control, title: Automatic gain control (AGC), type: term }
-      - { slug: demodulation, title: Demodulation, type: term }
-      - { slug: clock-recovery, title: Clock recovery, type: term }
-      - { slug: costas-loop, title: Costas loop, type: algorithm }
-      - { slug: cma-equalizer, title: CMA equalizer, type: algorithm }
-      - { slug: ppm-frequency-correction, title: PPM frequency correction, type: term }
-      - { slug: numerically-controlled-oscillator, title: Numerically controlled oscillator (NCO), type: term }
-      - { slug: fir-filter, title: FIR filter, type: algorithm }
-      - { slug: iir-filter, title: IIR filter, type: algorithm }
-      - { slug: intermediate-frequency, title: Intermediate frequency (IF), type: term }
-      - { slug: baseband, title: Baseband, type: term }
-      - { slug: channelizer, title: Channelizer, type: algorithm }
-      - { slug: resampler, title: Resampler, type: algorithm }
-      - { slug: automatic-frequency-control, title: Automatic frequency control (AFC), type: term }
-      - { slug: dc-offset, title: DC offset (DC spike), type: term }
+      - id: sdr-dsp
+        label: SDR & DSP
+        blurb: Software-defined radio and the digital signal processing between IQ and bits.
+        entries:
+          - { slug: software-defined-radio, title: Software-defined radio (SDR), type: technology }
+          - { slug: iq-data, title: IQ data, type: term }
+          - { slug: analog-to-digital-converter, title: Analog-to-digital converter (ADC), type: term }
+          - { slug: sample-rate, title: Sample rate, type: term }
+          - { slug: nyquist-theorem, title: Nyquist–Shannon sampling theorem, type: term }
+          - { slug: aliasing, title: Aliasing, type: term }
+          - { slug: superheterodyne-receiver, title: Superheterodyne receiver, type: term }
+          - { slug: local-oscillator, title: Local oscillator, type: term }
+          - { slug: digital-down-converter, title: Digital down-converter (DDC), type: term }
+          - { slug: decimation, title: Decimation, type: term }
+          - { slug: digital-filter, title: Digital filter, type: term }
+          - { slug: cic-filter, title: CIC filter, type: algorithm }
+          - { slug: root-raised-cosine-filter, title: Root-raised-cosine filter, type: algorithm }
+          - { slug: matched-filter, title: Matched filter, type: algorithm }
+          - { slug: automatic-gain-control, title: Automatic gain control (AGC), type: term }
+          - { slug: demodulation, title: Demodulation, type: term }
+          - { slug: clock-recovery, title: Clock recovery, type: term }
+          - { slug: costas-loop, title: Costas loop, type: algorithm }
+          - { slug: cma-equalizer, title: CMA equalizer, type: algorithm }
+          - { slug: ppm-frequency-correction, title: PPM frequency correction, type: term }
+          - { slug: numerically-controlled-oscillator, title: Numerically controlled oscillator (NCO), type: term }
+          - { slug: fir-filter, title: FIR filter, type: algorithm }
+          - { slug: iir-filter, title: IIR filter, type: algorithm }
+          - { slug: intermediate-frequency, title: Intermediate frequency (IF), type: term }
+          - { slug: baseband, title: Baseband, type: term }
+          - { slug: channelizer, title: Channelizer, type: algorithm }
+          - { slug: resampler, title: Resampler, type: algorithm }
+          - { slug: automatic-frequency-control, title: Automatic frequency control (AFC), type: term }
+          - { slug: dc-offset, title: DC offset (DC spike), type: term }
 
-  - id: algorithms
-    label: Transforms & algorithms
-    blurb: The mathematics of spectra, error correction, and timing recovery.
-    entries:
-      - { slug: fourier-transform, title: Fourier transform, type: algorithm }
-      - { slug: fast-fourier-transform, title: Fast Fourier transform (FFT), type: algorithm }
-      - { slug: viterbi-algorithm, title: Viterbi algorithm, type: algorithm }
-      - { slug: convolutional-code, title: Convolutional code, type: algorithm }
-      - { slug: reed-solomon-code, title: Reed–Solomon code, type: algorithm }
-      - { slug: bch-code, title: BCH code, type: algorithm }
-      - { slug: golay-code, title: Golay code, type: algorithm }
-      - { slug: hamming-code, title: Hamming code, type: algorithm }
-      - { slug: cyclic-redundancy-check, title: Cyclic redundancy check (CRC), type: algorithm }
-      - { slug: trellis-coded-modulation, title: Trellis-coded modulation, type: algorithm }
-      - { slug: forward-error-correction, title: Forward error correction (FEC), type: term }
-      - { slug: interleaving, title: Interleaving, type: algorithm }
-      - { slug: scrambling, title: Scrambling (whitening), type: algorithm }
-      - { slug: gardner-timing-recovery, title: Gardner timing recovery, type: algorithm }
-      - { slug: mueller-muller-timing-recovery, title: Mueller–Müller timing recovery, type: algorithm }
-      - { slug: multi-band-excitation, title: Multi-band excitation (MBE), type: algorithm }
-      - { slug: compact-position-reporting, title: Compact position reporting (CPR), type: algorithm }
-      - { slug: rc4-cipher, title: RC4 (ARC4) cipher, type: algorithm }
-      - { slug: bptc, title: BPTC, type: algorithm }
-      - { slug: dtmf, title: DTMF, type: term }
+      - id: algorithms
+        label: Transforms & algorithms
+        blurb: The mathematics of spectra, error correction, and timing recovery.
+        entries:
+          - { slug: fourier-transform, title: Fourier transform, type: algorithm }
+          - { slug: fast-fourier-transform, title: Fast Fourier transform (FFT), type: algorithm }
+          - { slug: viterbi-algorithm, title: Viterbi algorithm, type: algorithm }
+          - { slug: convolutional-code, title: Convolutional code, type: algorithm }
+          - { slug: reed-solomon-code, title: Reed–Solomon code, type: algorithm }
+          - { slug: bch-code, title: BCH code, type: algorithm }
+          - { slug: golay-code, title: Golay code, type: algorithm }
+          - { slug: hamming-code, title: Hamming code, type: algorithm }
+          - { slug: cyclic-redundancy-check, title: Cyclic redundancy check (CRC), type: algorithm }
+          - { slug: trellis-coded-modulation, title: Trellis-coded modulation, type: algorithm }
+          - { slug: forward-error-correction, title: Forward error correction (FEC), type: term }
+          - { slug: interleaving, title: Interleaving, type: algorithm }
+          - { slug: scrambling, title: Scrambling (whitening), type: algorithm }
+          - { slug: gardner-timing-recovery, title: Gardner timing recovery, type: algorithm }
+          - { slug: mueller-muller-timing-recovery, title: Mueller–Müller timing recovery, type: algorithm }
+          - { slug: multi-band-excitation, title: Multi-band excitation (MBE), type: algorithm }
+          - { slug: compact-position-reporting, title: Compact position reporting (CPR), type: algorithm }
+          - { slug: rc4-cipher, title: RC4 (ARC4) cipher, type: algorithm }
+          - { slug: bptc, title: BPTC, type: algorithm }
+          - { slug: dtmf, title: DTMF, type: term }
 
-  - id: trunked-radio
-    label: Trunked radio
-    blurb: The concepts that let many users share a pool of channels.
-    entries:
-      - { slug: trunked-radio, title: Trunked radio, type: term }
-      - { slug: conventional-radio, title: Conventional radio, type: term }
-      - { slug: control-channel, title: Control channel, type: term }
-      - { slug: voice-channel, title: Voice channel, type: term }
-      - { slug: talkgroup, title: Talkgroup, type: term }
-      - { slug: affiliation, title: Affiliation, type: term }
-      - { slug: fdma, title: FDMA, type: term }
-      - { slug: tdma, title: TDMA, type: term }
-      - { slug: channel-grant, title: Channel grant, type: term }
-      - { slug: radio-id, title: Radio ID, type: term }
-      - { slug: tsbk, title: TSBK, type: term }
-      - { slug: csbk, title: CSBK, type: term }
-      - { slug: rest-channel, title: Rest channel, type: term }
+      - id: trunked-radio
+        label: Trunked radio
+        blurb: The concepts that let many users share a pool of channels.
+        entries:
+          - { slug: trunked-radio, title: Trunked radio, type: term }
+          - { slug: conventional-radio, title: Conventional radio, type: term }
+          - { slug: control-channel, title: Control channel, type: term }
+          - { slug: voice-channel, title: Voice channel, type: term }
+          - { slug: talkgroup, title: Talkgroup, type: term }
+          - { slug: affiliation, title: Affiliation, type: term }
+          - { slug: fdma, title: FDMA, type: term }
+          - { slug: tdma, title: TDMA, type: term }
+          - { slug: channel-grant, title: Channel grant, type: term }
+          - { slug: radio-id, title: Radio ID, type: term }
+          - { slug: tsbk, title: TSBK, type: term }
+          - { slug: csbk, title: CSBK, type: term }
+          - { slug: rest-channel, title: Rest channel, type: term }
 
-  - id: protocols
-    label: Protocols & standards
-    blurb: The digital and analog systems GopherTrunk decodes, in one uniform format.
-    entries:
-      - { slug: project-25, title: "Project 25 (P25)", type: protocol }
-      - { slug: p25-phase-1, title: P25 Phase 1, type: protocol }
-      - { slug: p25-phase-2, title: P25 Phase 2, type: protocol }
-      - { slug: dmr, title: Digital Mobile Radio (DMR), type: protocol }
-      - { slug: dmr-tier-1, title: DMR Tier I, type: protocol }
-      - { slug: dmr-tier-2, title: DMR Tier II, type: protocol }
-      - { slug: dmr-tier-3, title: DMR Tier III, type: protocol }
-      - { slug: nxdn, title: NXDN, type: protocol }
-      - { slug: dpmr, title: dPMR, type: protocol }
-      - { slug: tetra, title: TETRA, type: protocol }
-      - { slug: motorola-type-ii, title: Motorola Type II, type: protocol }
-      - { slug: edacs, title: EDACS, type: protocol }
-      - { slug: ltr, title: LTR (Logic Trunked Radio), type: protocol }
-      - { slug: mpt-1327, title: MPT 1327, type: protocol }
-      - { slug: d-star, title: D-STAR, type: protocol }
-      - { slug: system-fusion-ysf, title: System Fusion (YSF), type: protocol }
-      - { slug: m17, title: M17, type: protocol }
-      - { slug: pocsag, title: POCSAG, type: protocol }
-      - { slug: flex, title: FLEX, type: protocol }
-      - { slug: ais, title: Automatic Identification System (AIS), type: protocol }
-      - { slug: ads-b, title: ADS-B, type: protocol }
-      - { slug: aprs, title: APRS, type: protocol }
-      - { slug: ax25, title: AX.25, type: protocol }
-      - { slug: dsc, title: Digital Selective Calling (DSC), type: protocol }
-      - { slug: mdc1200, title: MDC-1200, type: protocol }
-      - { slug: mode-s, title: Mode S, type: protocol }
-      - { slug: provoice, title: ProVoice, type: protocol }
-      - { slug: capacity-plus, title: Capacity Plus, type: protocol }
-      - { slug: lora, title: LoRa, type: protocol }
+      - id: protocols
+        label: Protocols & standards
+        blurb: The digital and analog systems GopherTrunk decodes, in one uniform format.
+        entries:
+          - { slug: project-25, title: "Project 25 (P25)", type: protocol }
+          - { slug: p25-phase-1, title: P25 Phase 1, type: protocol }
+          - { slug: p25-phase-2, title: P25 Phase 2, type: protocol }
+          - { slug: dmr, title: Digital Mobile Radio (DMR), type: protocol }
+          - { slug: dmr-tier-1, title: DMR Tier I, type: protocol }
+          - { slug: dmr-tier-2, title: DMR Tier II, type: protocol }
+          - { slug: dmr-tier-3, title: DMR Tier III, type: protocol }
+          - { slug: nxdn, title: NXDN, type: protocol }
+          - { slug: dpmr, title: dPMR, type: protocol }
+          - { slug: tetra, title: TETRA, type: protocol }
+          - { slug: motorola-type-ii, title: Motorola Type II, type: protocol }
+          - { slug: edacs, title: EDACS, type: protocol }
+          - { slug: ltr, title: LTR (Logic Trunked Radio), type: protocol }
+          - { slug: mpt-1327, title: MPT 1327, type: protocol }
+          - { slug: d-star, title: D-STAR, type: protocol }
+          - { slug: system-fusion-ysf, title: System Fusion (YSF), type: protocol }
+          - { slug: m17, title: M17, type: protocol }
+          - { slug: pocsag, title: POCSAG, type: protocol }
+          - { slug: flex, title: FLEX, type: protocol }
+          - { slug: ais, title: Automatic Identification System (AIS), type: protocol }
+          - { slug: ads-b, title: ADS-B, type: protocol }
+          - { slug: aprs, title: APRS, type: protocol }
+          - { slug: ax25, title: AX.25, type: protocol }
+          - { slug: dsc, title: Digital Selective Calling (DSC), type: protocol }
+          - { slug: mdc1200, title: MDC-1200, type: protocol }
+          - { slug: mode-s, title: Mode S, type: protocol }
+          - { slug: provoice, title: ProVoice, type: protocol }
+          - { slug: capacity-plus, title: Capacity Plus, type: protocol }
+          - { slug: lora, title: LoRa, type: protocol }
 
-  - id: voice-coding
-    label: Voice coding
-    blurb: The vocoders that compress speech into a few kilobits per second.
-    entries:
-      - { slug: vocoder, title: Vocoder, type: technology }
-      - { slug: imbe, title: IMBE, type: technology }
-      - { slug: ambe, title: AMBE, type: technology }
-      - { slug: ambe-plus-2, title: AMBE+2, type: technology }
-      - { slug: codec2, title: Codec 2, type: technology }
+      - id: voice-coding
+        label: Voice coding
+        blurb: The vocoders that compress speech into a few kilobits per second.
+        entries:
+          - { slug: vocoder, title: Vocoder, type: technology }
+          - { slug: imbe, title: IMBE, type: technology }
+          - { slug: ambe, title: AMBE, type: technology }
+          - { slug: ambe-plus-2, title: AMBE+2, type: technology }
+          - { slug: codec2, title: Codec 2, type: technology }
 
-  - id: hardware
-    label: Hardware
-    blurb: SDR dongles, tuner chips, and front-end components.
-    entries:
-      - { slug: rtl-sdr, title: RTL-SDR, type: hardware }
-      - { slug: rtl2832u, title: RTL2832U, type: hardware }
-      - { slug: r820t-tuner, title: R820T / R820T2 tuner, type: hardware }
-      - { slug: hackrf, title: HackRF One, type: hardware }
-      - { slug: airspy, title: Airspy, type: hardware }
-      - { slug: airspy-hf-plus, title: Airspy HF+, type: hardware }
-      - { slug: upconverter, title: Upconverter, type: hardware }
-      - { slug: low-noise-amplifier, title: Low-noise amplifier (LNA), type: hardware }
-      - { slug: bias-tee, title: Bias tee, type: hardware }
-      - { slug: soapysdr, title: SoapySDR, type: technology }
-      - { slug: rtl-tcp, title: rtl_tcp, type: technology }
-      - { slug: zadig, title: Zadig, type: hardware }
-      - { slug: saw-filter, title: SAW filter, type: hardware }
-      - { slug: coaxial-cable, title: Coaxial cable, type: hardware }
+      - id: hardware
+        label: Hardware
+        blurb: SDR dongles, tuner chips, and front-end components.
+        entries:
+          - { slug: rtl-sdr, title: RTL-SDR, type: hardware }
+          - { slug: rtl2832u, title: RTL2832U, type: hardware }
+          - { slug: r820t-tuner, title: R820T / R820T2 tuner, type: hardware }
+          - { slug: hackrf, title: HackRF One, type: hardware }
+          - { slug: airspy, title: Airspy, type: hardware }
+          - { slug: airspy-hf-plus, title: Airspy HF+, type: hardware }
+          - { slug: upconverter, title: Upconverter, type: hardware }
+          - { slug: low-noise-amplifier, title: Low-noise amplifier (LNA), type: hardware }
+          - { slug: bias-tee, title: Bias tee, type: hardware }
+          - { slug: soapysdr, title: SoapySDR, type: technology }
+          - { slug: rtl-tcp, title: rtl_tcp, type: technology }
+          - { slug: zadig, title: Zadig, type: hardware }
+          - { slug: saw-filter, title: SAW filter, type: hardware }
+          - { slug: coaxial-cable, title: Coaxial cable, type: hardware }
 
-  - id: people
-    label: People
-    blurb: Scientists and engineers whose work underpins radio and SDR.
-    entries:
-      - { slug: heinrich-hertz, title: Heinrich Hertz, type: person }
-      - { slug: james-clerk-maxwell, title: James Clerk Maxwell, type: person }
-      - { slug: guglielmo-marconi, title: Guglielmo Marconi, type: person }
-      - { slug: joseph-fourier, title: Joseph Fourier, type: person }
-      - { slug: harry-nyquist, title: Harry Nyquist, type: person }
-      - { slug: claude-shannon, title: Claude Shannon, type: person }
-      - { slug: edwin-armstrong, title: Edwin Armstrong, type: person }
-      - { slug: andrew-viterbi, title: Andrew Viterbi, type: person }
-      - { slug: richard-hamming, title: Richard Hamming, type: person }
-      - { slug: reginald-fessenden, title: Reginald Fessenden, type: person }
-      - { slug: john-costas, title: John P. Costas, type: person }
-      - { slug: fred-gardner, title: Floyd M. Gardner, type: person }
+      - id: people
+        label: People
+        blurb: Scientists and engineers whose work underpins radio and SDR.
+        entries:
+          - { slug: heinrich-hertz, title: Heinrich Hertz, type: person }
+          - { slug: james-clerk-maxwell, title: James Clerk Maxwell, type: person }
+          - { slug: guglielmo-marconi, title: Guglielmo Marconi, type: person }
+          - { slug: joseph-fourier, title: Joseph Fourier, type: person }
+          - { slug: harry-nyquist, title: Harry Nyquist, type: person }
+          - { slug: claude-shannon, title: Claude Shannon, type: person }
+          - { slug: edwin-armstrong, title: Edwin Armstrong, type: person }
+          - { slug: andrew-viterbi, title: Andrew Viterbi, type: person }
+          - { slug: richard-hamming, title: Richard Hamming, type: person }
+          - { slug: reginald-fessenden, title: Reginald Fessenden, type: person }
+          - { slug: john-costas, title: John P. Costas, type: person }
+          - { slug: fred-gardner, title: Floyd M. Gardner, type: person }
 
-  - id: organizations
-    label: Organizations & standards bodies
-    blurb: The bodies that allocate spectrum and write the standards.
-    entries:
-      - { slug: itu, title: International Telecommunication Union (ITU), type: organization }
-      - { slug: fcc, title: Federal Communications Commission (FCC), type: organization }
-      - { slug: etsi, title: ETSI, type: organization }
-      - { slug: tia, title: Telecommunications Industry Association (TIA), type: organization }
-      - { slug: apco-international, title: APCO International, type: organization }
-      - { slug: icao, title: ICAO, type: organization }
-      - { slug: dvsi, title: Digital Voice Systems (DVSI), type: organization }
-      - { slug: m17-project, title: M17 Project, type: organization }
-      - { slug: radioreference, title: RadioReference, type: organization }
-      - { slug: ofcom, title: Ofcom, type: organization }
-      - { slug: rtca, title: RTCA, type: organization }
-      - { slug: eurocae, title: EUROCAE, type: organization }
+      - id: organizations
+        label: Organizations & standards bodies
+        blurb: The bodies that allocate spectrum and write the standards.
+        entries:
+          - { slug: itu, title: International Telecommunication Union (ITU), type: organization }
+          - { slug: fcc, title: Federal Communications Commission (FCC), type: organization }
+          - { slug: etsi, title: ETSI, type: organization }
+          - { slug: tia, title: Telecommunications Industry Association (TIA), type: organization }
+          - { slug: apco-international, title: APCO International, type: organization }
+          - { slug: icao, title: ICAO, type: organization }
+          - { slug: dvsi, title: Digital Voice Systems (DVSI), type: organization }
+          - { slug: m17-project, title: M17 Project, type: organization }
+          - { slug: radioreference, title: RadioReference, type: organization }
+          - { slug: ofcom, title: Ofcom, type: organization }
+          - { slug: rtca, title: RTCA, type: organization }
+          - { slug: eurocae, title: EUROCAE, type: organization }
+
+  - id: software-dev
+    label: "Software Development"
+    blurb: Programming languages and the concepts, paradigms, and practices of building software — the craft behind GopherTrunk itself.
+    categories:
+      - id: programming-languages
+        label: Programming languages
+        blurb: The languages used to build software, from systems languages to scripting and the historical pioneers.
+        entries:
+          - { slug: go-language, title: Go, type: language }
+          - { slug: python-language, title: Python, type: language }
+          - { slug: javascript-language, title: JavaScript, type: language }
+          - { slug: typescript-language, title: TypeScript, type: language }
+          - { slug: c-language, title: C, type: language }
+          - { slug: cpp-language, title: C++, type: language }
+          - { slug: rust-language, title: Rust, type: language }
+          - { slug: java-language, title: Java, type: language }
+          - { slug: csharp-language, title: C#, type: language }
+          - { slug: swift-language, title: Swift, type: language }
+          - { slug: kotlin-language, title: Kotlin, type: language }
+          - { slug: ruby-language, title: Ruby, type: language }
+          - { slug: php-language, title: PHP, type: language }
+          - { slug: r-language, title: R, type: language }
+          - { slug: julia-language, title: Julia, type: language }
+          - { slug: matlab-language, title: MATLAB, type: language }
+          - { slug: fortran-language, title: FORTRAN, type: language }
+          - { slug: cobol-language, title: COBOL, type: language }
+          - { slug: lisp-language, title: LISP, type: language }
+
+      - id: language-internals
+        label: Language internals & execution
+        blurb: How source code becomes a running program — compilation, interpretation, memory, and types.
+        entries:
+          - { slug: compiler, title: Compiler, type: concept }
+          - { slug: interpreter, title: Interpreter, type: concept }
+          - { slug: bytecode, title: Bytecode, type: concept }
+          - { slug: jit-compilation, title: JIT vs AOT compilation, type: concept }
+          - { slug: garbage-collection, title: Garbage collection, type: concept }
+          - { slug: memory-management, title: Memory management, type: concept }
+          - { slug: type-system, title: Type system, type: concept }
+          - { slug: static-vs-dynamic-typing, title: Static vs dynamic typing, type: concept }
+          - { slug: cross-compilation, title: Cross-compilation, type: concept }
+          - { slug: static-binary, title: Static binary, type: concept }
+
+      - id: concurrency-execution
+        label: Concurrency & execution models
+        blurb: How programs do more than one thing at a time.
+        entries:
+          - { slug: concurrency, title: Concurrency vs parallelism, type: concept }
+          - { slug: threads, title: Threads, type: concept }
+          - { slug: async-programming, title: Asynchronous programming, type: concept }
+          - { slug: goroutines, title: Goroutines, type: concept }
+
+      - id: paradigms-design
+        label: Paradigms & design patterns
+        blurb: Styles of organizing code and reusable solutions to recurring problems.
+        entries:
+          - { slug: object-oriented-programming, title: Object-oriented programming, type: concept }
+          - { slug: functional-programming, title: Functional programming, type: concept }
+          - { slug: imperative-programming, title: Imperative programming, type: concept }
+          - { slug: declarative-programming, title: Declarative programming, type: concept }
+          - { slug: design-patterns, title: Design patterns, type: concept }
+          - { slug: creational-patterns, title: Creational patterns, type: concept }
+          - { slug: structural-patterns, title: Structural patterns, type: concept }
+          - { slug: behavioral-patterns, title: Behavioral patterns, type: concept }
+          - { slug: abstraction, title: Abstraction, type: concept }
+          - { slug: coupling-and-cohesion, title: Coupling & cohesion, type: concept }
+
+      - id: principles-quality
+        label: Principles & code quality
+        blurb: The guidelines that separate maintainable software from a mess.
+        entries:
+          - { slug: solid, title: SOLID, type: concept }
+          - { slug: dry-kiss-yagni, title: DRY, KISS & YAGNI, type: concept }
+          - { slug: clean-code, title: Clean code, type: concept }
+          - { slug: refactoring, title: Refactoring, type: concept }
+          - { slug: error-handling, title: Error handling, type: concept }
+          - { slug: api, title: API, type: concept }
+
+      - id: testing-delivery
+        label: Testing, tooling & delivery
+        blurb: Verifying that software works and getting it into users' hands.
+        entries:
+          - { slug: unit-testing, title: Unit testing, type: concept }
+          - { slug: integration-testing, title: Integration testing, type: concept }
+          - { slug: end-to-end-testing, title: End-to-end testing, type: concept }
+          - { slug: test-driven-development, title: Test-driven development (TDD), type: concept }
+          - { slug: mocking, title: Mocking, type: concept }
+          - { slug: code-coverage, title: Code coverage, type: concept }
+          - { slug: ci-cd, title: CI/CD, type: concept }
+          - { slug: build-systems, title: Build systems, type: concept }
+          - { slug: package-manager, title: Package manager & dependency management, type: concept }
+          - { slug: semantic-versioning, title: Semantic versioning, type: concept }
+          - { slug: rest, title: REST, type: concept }
+          - { slug: version-control, title: Version control, type: concept }

--- a/docs/_layouts/reference-hub.html
+++ b/docs/_layouts/reference-hub.html
@@ -8,8 +8,10 @@ layout: default
 {%- endcomment -%}
 {%- assign ref = site.data.reference -%}
 {%- assign all_entries = "" | split: "" -%}
-{%- for cat in ref.categories -%}
-  {%- for e in cat.entries -%}{%- assign all_entries = all_entries | push: e -%}{%- endfor -%}
+{%- for d in ref.domains -%}
+  {%- for cat in d.categories -%}
+    {%- for e in cat.entries -%}{%- assign all_entries = all_entries | push: e -%}{%- endfor -%}
+  {%- endfor -%}
 {%- endfor -%}
 {%- assign sorted = all_entries | sort_natural: "title" -%}
 {%- assign total = all_entries | size -%}
@@ -32,23 +34,33 @@ layout: default
 
     <article class="prose prose--wide ref-intro">{{ content }}</article>
 
-    <div class="ref-categories">
-      {%- for cat in ref.categories -%}
-        <section class="ref-category" id="{{ cat.id }}">
-          <div class="ref-category__head">
-            <h2 class="ref-category__title">{{ cat.label }}</h2>
-            <p class="ref-category__blurb">{{ cat.blurb }}</p>
-          </div>
-          <ul class="ref-grid">
-            {%- for e in cat.entries -%}
-              <li class="ref-card">
-                <a href="{{ '/reference/' | append: e.slug | append: '/' | relative_url }}">
-                  <span class="ref-card__title">{{ e.title }}</span>
-                  <span class="ref-tag ref-tag--{{ e.type }}">{{ e.type }}</span>
-                </a>
-              </li>
+    <div class="ref-domains">
+      {%- for d in ref.domains -%}
+        <section class="ref-domain" id="domain-{{ d.id }}">
+          <header class="ref-domain__head">
+            <h2 class="ref-domain__title">{{ d.label }}</h2>
+            {%- if d.blurb -%}<p class="ref-domain__blurb">{{ d.blurb }}</p>{%- endif -%}
+          </header>
+          <div class="ref-categories">
+            {%- for cat in d.categories -%}
+              <section class="ref-category" id="{{ cat.id }}">
+                <div class="ref-category__head">
+                  <h3 class="ref-category__title">{{ cat.label }}</h3>
+                  <p class="ref-category__blurb">{{ cat.blurb }}</p>
+                </div>
+                <ul class="ref-grid">
+                  {%- for e in cat.entries -%}
+                    <li class="ref-card">
+                      <a href="{{ '/reference/' | append: e.slug | append: '/' | relative_url }}">
+                        <span class="ref-card__title">{{ e.title }}</span>
+                        <span class="ref-tag ref-tag--{{ e.type }}">{{ e.type }}</span>
+                      </a>
+                    </li>
+                  {%- endfor -%}
+                </ul>
+              </section>
             {%- endfor -%}
-          </ul>
+          </div>
         </section>
       {%- endfor -%}
     </div>

--- a/docs/_layouts/reference.html
+++ b/docs/_layouts/reference.html
@@ -14,9 +14,17 @@ layout: default
 
 {%- assign all_entries = "" | split: "" -%}
 {%- assign cat_label = "" -%}
-{%- for cat in site.data.reference.categories -%}
-  {%- if cat.id == page.category -%}{%- assign cat_label = cat.label -%}{%- endif -%}
-  {%- for e in cat.entries -%}{%- assign all_entries = all_entries | push: e -%}{%- endfor -%}
+{%- assign domain_label = "" -%}
+{%- assign domain_id = "" -%}
+{%- for d in site.data.reference.domains -%}
+  {%- for cat in d.categories -%}
+    {%- if cat.id == page.category -%}
+      {%- assign cat_label = cat.label -%}
+      {%- assign domain_label = d.label -%}
+      {%- assign domain_id = d.id -%}
+    {%- endif -%}
+    {%- for e in cat.entries -%}{%- assign all_entries = all_entries | push: e -%}{%- endfor -%}
+  {%- endfor -%}
 {%- endfor -%}
 {%- assign is_protocol = false -%}
 {%- if page.entry_type == "protocol" -%}{%- assign is_protocol = true -%}{%- endif -%}
@@ -27,6 +35,9 @@ layout: default
       <ol>
         <li><a href="{{ '/' | relative_url }}">Home</a></li>
         <li><a href="{{ '/reference/' | relative_url }}">Reference</a></li>
+        {%- if domain_label != "" -%}
+          <li><a href="{{ '/reference/#domain-' | append: domain_id | relative_url }}">{{ domain_label }}</a></li>
+        {%- endif -%}
         {%- if cat_label != "" -%}
           <li><a href="{{ '/reference/#' | append: page.category | relative_url }}">{{ cat_label }}</a></li>
         {%- endif -%}

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1264,6 +1264,17 @@ a.category-chip:hover {
 .ref-hero__meta { font-size: 0.92rem; color: var(--fg-muted); margin: 0; }
 .ref-intro { margin: 0 auto 2rem; }
 
+/* ---------- Domains (top-level grouping above categories) ---------- */
+.ref-domains { margin-bottom: 1rem; }
+.ref-domain { margin: 0 0 3rem; }
+.ref-domain__head {
+  margin-bottom: 1.25rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid var(--border);
+}
+.ref-domain__title { font-size: clamp(1.5rem, 3vw, 1.9rem); font-weight: 700; letter-spacing: -0.01em; margin: 0 0 0.25rem; }
+.ref-domain__blurb { margin: 0; max-width: 46rem; color: var(--fg-muted); }
+
 .ref-categories { margin-bottom: 2.5rem; }
 .ref-category { margin: 0 0 2rem; }
 .ref-category__head { margin-bottom: 0.75rem; }
@@ -1300,7 +1311,9 @@ a.category-chip:hover {
   background: var(--bg-elev);
 }
 .ref-tag--protocol { color: var(--accent); border-color: var(--accent); }
+.ref-tag--language { color: var(--accent); border-color: var(--accent); font-weight: 600; }
 .ref-tag--person { font-style: italic; }
+.ref-tag--concept { font-style: italic; }
 
 /* ---------- A–Z index ---------- */
 .ref-az { border-top: 1px solid var(--border); padding-top: 1.5rem; }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -30,12 +30,15 @@ Start: {{ base | absolute_url }}
 
 ## Reference (encyclopedia)
 
-Long-form, encyclopedia-style articles defining radio and SDR terms, technologies,
-algorithms, people, hardware, and organizations. Browse: {{ '/reference/' | absolute_url }}
-{% for cat in site.data.reference.categories %}
-### {{ cat.label }}
+Long-form, encyclopedia-style articles defining radio, SDR, and software-development
+terms, technologies, algorithms, languages, concepts, people, hardware, and
+organizations. Browse: {{ '/reference/' | absolute_url }}
+{% for d in site.data.reference.domains %}
+### {{ d.label }}
+{% for cat in d.categories %}
+#### {{ cat.label }}
 {% for e in cat.entries %}- [{{ e.title }}]({{ '/reference/' | append: e.slug | append: '/' | absolute_url }}){% endfor %}
-{% endfor %}
+{% endfor %}{% endfor %}
 
 ## Getting started with GopherTrunk
 - [What is GopherTrunk?]({{ '/getting-started.html' | absolute_url }}): conceptual overview of the scanner and its interfaces.

--- a/docs/reference/abstraction.md
+++ b/docs/reference/abstraction.md
@@ -1,0 +1,72 @@
+---
+slug: abstraction
+title: Abstraction
+entry_type: concept
+category: paradigms-design
+description: Abstraction is exposing a simple interface that describes what something does while hiding how it does it, enforced through encapsulation and information hiding.
+keywords: abstraction, encapsulation, information hiding, interface, contract, leaky abstraction, what vs how, modularity, software design
+aka: []
+autolink: true
+infobox:
+  - { label: Type, value: "Software design principle" }
+  - { label: Key idea, value: "Expose a clean what, hide the messy how" }
+  - { label: Enforced by, value: "Encapsulation / information hiding" }
+  - { label: Payoff, value: "Less to hold in your head; freedom to change internals" }
+  - { label: Failure mode, value: "Leaky abstraction" }
+  - { label: Related, value: "Coupling, cohesion, OOP" }
+see_also: [coupling-and-cohesion, object-oriented-programming, design-patterns, solid, declarative-programming, type-system]
+related_lessons:
+  - { title: "Abstraction, coupling & cohesion", url: /learn/intro-software-dev/abstraction-coupling/ }
+external:
+  - { title: "Abstraction (computer science) — Wikipedia", url: https://en.wikipedia.org/wiki/Abstraction_(computer_science) }
+---
+
+**Abstraction** means exposing a simple interface that describes *what* something does
+while hiding *how* it does it. When you call `sort()`, you depend on the promise ("returns
+sorted output"), not on whether it uses quicksort or mergesort.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A caller depends only on a clean interface contract, while the messy implementation details behind it stay hidden and free to change." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="80" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="60" y="74">caller</text>
+    <line x1="100" y1="70" x2="160" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="160" y="30" width="40" height="80" rx="4" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="180" y="22" font-size="8">interface</text><text x="180" y="74">what</text>
+    <rect x="240" y="20" width="180" height="100" rx="6" fill="none" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 3"/><text x="330" y="14" font-size="8">hidden how</text>
+    <circle cx="285" cy="50" r="10" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="330" cy="80" r="10" fill="none" stroke="currentColor" stroke-width="1"/><circle cx="380" cy="48" r="10" fill="none" stroke="currentColor" stroke-width="1"/>
+    <line x1="285" y1="50" x2="330" y2="80" stroke="currentColor" stroke-width="0.9"/><line x1="330" y1="80" x2="380" y2="48" stroke="currentColor" stroke-width="0.9"/>
+    <text x="330" y="115" font-size="8" fill-opacity="0.7">free to change</text>
+  </g>
+</svg>
+<figcaption>The caller depends on a clean contract; everything behind it stays hidden and free to change.</figcaption>
+</figure>
+
+## What it buys you
+
+Good abstractions shrink the amount you have to hold in your head: instead of reasoning
+about a thousand lines of filter math, you reason about a single operation with a clear
+name and contract. They also keep [coupling](/reference/coupling-and-cohesion/) low —
+callers depend on the *what*, so the *how* is free to change without breaking them. This is
+the foundation of [object-oriented](/reference/object-oriented-programming/) interfaces,
+[declarative](/reference/declarative-programming/) styles, and most
+[design patterns](/reference/design-patterns/), and it underpins the dependency-inversion
+idea in [SOLID](/reference/solid/).
+
+## Information hiding and encapsulation
+
+Abstraction only holds if the internals stay genuinely hidden. **Information hiding** is
+the discipline of keeping a module's internal state and helpers private, exposing only the
+interface; **encapsulation** is the language mechanism that enforces it — private fields,
+unexported names, access modifiers. Anything you expose, someone will depend on, so the
+rule of thumb is to **expose as little as possible**. A small public surface is a small set
+of promises you must keep, closely tied to the language's
+[type system](/reference/type-system/) and visibility rules.
+
+## Leaky abstractions
+
+No abstraction is perfect. A **leaky abstraction** is one whose hidden details surface
+anyway, forcing the caller to know what was supposed to be hidden — a "local file"
+interface that mysteriously stalls on a network path, or an ORM you can ignore until a
+query is slow. Joel Spolsky's "Law of Leaky Abstractions" holds that all non-trivial
+abstractions leak to some degree. You cannot eliminate leaks, but you can manage them:
+document assumptions, surface failures explicitly rather than misbehaving silently, and
+keep the abstraction honest about what it promises.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,0 +1,67 @@
+---
+slug: api
+title: API
+entry_type: concept
+category: principles-quality
+description: An API (application programming interface) is a defined contract through which one piece of software exposes its capabilities to another, hiding implementation details behind a stable set of operations.
+keywords: API, application programming interface, contract, interface, library API, web API, REST, endpoints, abstraction, backward compatibility
+aka: [API "application programming interface"]
+autolink: true
+infobox:
+  - { label: Category, value: "Software interface / contract" }
+  - { label: Stands for, value: "Application Programming Interface" }
+  - { label: Kinds, value: "Library, OS, web/HTTP APIs" }
+  - { label: Web style, value: "REST, GraphQL, gRPC" }
+  - { label: Key property, value: "Stable contract, hidden implementation" }
+see_also: [rest, abstraction, error-handling, semantic-versioning, package-manager, coupling-and-cohesion, solid]
+related_lessons:
+  - { title: "Errors, edge cases & defensive programming", url: /learn/intro-software-dev/robustness-and-errors/ }
+external:
+  - { title: "API — Wikipedia", url: https://en.wikipedia.org/wiki/API }
+---
+
+**An API** (application programming interface) is a defined contract through which one
+piece of software exposes its capabilities to another, hiding its implementation behind
+a stable set of operations.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A client calls an API, which is a contract in front of a provider's hidden implementation." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="45" width="80" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="66">client</text>
+    <line x1="100" y1="63" x2="180" y2="63" stroke="currentColor" stroke-width="1.1"/><text x="140" y="55" font-size="8">calls</text>
+    <rect x="180" y="35" width="70" height="56" rx="5" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.4"/><text x="215" y="60">API</text><text x="215" y="74" font-size="8">contract</text>
+    <line x1="250" y1="63" x2="330" y2="63" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="330" y="40" width="110" height="46" rx="5" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/><text x="385" y="60">implementation</text><text x="385" y="74" font-size="8">(hidden)</text>
+  </g>
+</svg>
+<figcaption>An API is the published contract a client calls; the provider's implementation stays hidden behind it.</figcaption>
+</figure>
+
+## What an API is
+
+An API is a form of [abstraction](/reference/abstraction/): it specifies *what* a
+component does — the operations, their inputs and outputs, and the rules for using them
+— without revealing *how* it does it. That separation lets the provider change the
+implementation freely as long as the contract holds, and lets the consumer build against
+a stable surface. APIs come in several flavors:
+
+- **Library / package APIs** — the public functions, types, and methods a code library
+  exposes to programs that import it.
+- **Operating-system APIs** — the system calls a program uses to talk to the kernel.
+- **Web APIs** — operations a service exposes over the network, commonly in the
+  [REST](/reference/rest/) style over HTTP, or via GraphQL or gRPC.
+
+A good API is small and role-focused (the [interface segregation](/reference/solid/)
+idea), consistent, and clear about how it reports failures — its
+[error-handling](/reference/error-handling/) contract is part of the interface.
+
+## Why APIs matter
+
+APIs are the seams that let large systems be built from independently developed parts.
+Because callers depend only on the contract, an API reduces
+[coupling](/reference/coupling-and-cohesion/) between components and teams. That stability
+is also a promise: once others build on your API, changing it can break them, which is
+why backward compatibility and [semantic versioning](/reference/semantic-versioning/)
+matter so much — a major version bump signals a breaking change to the contract. The
+same discipline governs the public surface of a reusable library distributed through a
+[package manager](/reference/package-manager/).

--- a/docs/reference/async-programming.md
+++ b/docs/reference/async-programming.md
@@ -1,0 +1,69 @@
+---
+slug: async-programming
+title: Asynchronous programming
+entry_type: concept
+category: concurrency-execution
+description: Asynchronous programming runs many tasks concurrently on a single thread using an event loop, where a task yields control whenever it waits on something slow.
+keywords: asynchronous programming, async await, event loop, non-blocking, I/O bound, coroutine, future, promise, concurrency
+aka: ["async", "async/await"]
+autolink: true
+infobox:
+  - { label: Category, value: Concurrency model }
+  - { label: Mechanism, value: "Event loop + cooperative yielding" }
+  - { label: Best for, value: "I/O-bound work (waiting)" }
+  - { label: Weak for, value: "CPU-bound work" }
+  - { label: Keyword pair, value: "async / await" }
+  - { label: Examples, value: "JavaScript, Python asyncio, C#, Rust" }
+see_also: [concurrency, threads, goroutines, javascript-language, python-language, csharp-language]
+related_lessons:
+  - { title: "Concurrency and parallelism", url: /learn/intro-software-dev/concurrency-models/ }
+  - { title: "Concurrency and pipelines", url: /learn/intro-software-dev/concurrency-and-pipelines/ }
+external:
+  - { title: "Asynchronous I/O — Wikipedia", url: https://en.wikipedia.org/wiki/Asynchronous_I/O }
+---
+
+**Asynchronous programming** runs many tasks [concurrently](/reference/concurrency/) on
+a single thread using an *event loop*: whenever a task waits on something slow, it
+yields control back to the loop, which runs other ready tasks until the slow thing
+finishes.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="An event loop dispatches a task, which yields on await and lets another ready task run, then resumes when its result arrives." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <circle cx="90" cy="65" r="34" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="90" y="62" font-size="8">event</text><text x="90" y="74" font-size="8">loop</text>
+    <line x1="124" y1="55" x2="180" y2="40" stroke="currentColor" stroke-width="1.1"/><text x="155" y="34" font-size="8">run</text>
+    <rect x="180" y="28" width="90" height="24" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="225" y="44" font-size="8">task A</text>
+    <line x1="270" y1="40" x2="320" y2="40" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 3"/><text x="300" y="33" font-size="7">await</text>
+    <rect x="320" y="28" width="110" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="375" y="44" font-size="7">waiting (I/O)</text>
+    <line x1="124" y1="78" x2="180" y2="95" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="180" y="83" width="90" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="225" y="99" font-size="8">task B runs</text>
+  </g>
+</svg>
+<figcaption>When a task hits an await, it yields to the loop, which runs another ready task until the result arrives.</figcaption>
+</figure>
+
+## How it works
+
+Code marks slow operations with `await`. When a task reaches one, it suspends and hands
+the single thread back to the event loop, which picks another task that is ready to make
+progress; when the awaited operation completes, the loop resumes the original task where
+it left off. No operating-system [thread](/reference/threads/) is blocked sitting idle,
+so one thread can keep thousands of in-flight operations moving. Because there is only
+one thread of execution, there is no shared-memory data race between the tasks.
+
+## Trade-offs
+
+Async excels at **I/O-bound** work — thousands of concurrent network connections or
+disk reads on a single thread — because such workloads spend most of their time waiting,
+not computing. It does little for **CPU-bound** work: a long computation still hogs the
+single thread and blocks every other task, since cooperative scheduling only switches at
+`await` points. Async code can also be harder to reason about, and a blocking call
+slipped into an async path stalls everything.
+
+## In practice
+
+[JavaScript](/reference/javascript-language/) (Node.js and the browser),
+[Python](/reference/python-language/) (`asyncio`), [C#](/reference/csharp-language/),
+and Rust all offer `async`/`await`. For CPU-bound parallelism you reach instead for
+[threads](/reference/threads/) or lightweight tasks like
+[goroutines](/reference/goroutines/), which can spread work across cores.

--- a/docs/reference/behavioral-patterns.md
+++ b/docs/reference/behavioral-patterns.md
@@ -1,0 +1,76 @@
+---
+slug: behavioral-patterns
+title: Behavioral patterns
+entry_type: concept
+category: paradigms-design
+description: Behavioral patterns are the Gang of Four family that governs how objects interact and divide responsibility at runtime, keeping the communicating parties loosely coupled.
+keywords: behavioral patterns, observer pattern, strategy pattern, state pattern, command, iterator, template method, publish subscribe, state machine, gang of four, design patterns
+aka: []
+autolink: true
+infobox:
+  - { label: Type, value: "Design pattern family (GoF)" }
+  - { label: Problem solved, value: "How objects interact and share work" }
+  - { label: Members, value: "Observer, Strategy, State, Command, Iterator, Template Method" }
+  - { label: Focus, value: "Communication and flow of control" }
+  - { label: Benefit, value: "Loose coupling between collaborators" }
+  - { label: Sibling families, value: "Creational, structural" }
+see_also: [design-patterns, creational-patterns, structural-patterns, object-oriented-programming, coupling-and-cohesion, solid, abstraction]
+related_lessons:
+  - { title: "Behavioral patterns: observer, strategy, state", url: /learn/intro-software-dev/behavioral-patterns/ }
+external:
+  - { title: "Behavioral pattern — Wikipedia", url: https://en.wikipedia.org/wiki/Behavioral_pattern }
+---
+
+**Behavioral patterns** are the [Gang of Four](/reference/design-patterns/) family that
+handles the question once objects exist and are connected: *how do they talk to each other
+and divide up the work?* They are about communication and responsibility at runtime.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A subject publishes an event to several observers at once, while a context delegates work to a swappable strategy or state object." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="80" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="60" y="74">subject</text>
+    <line x1="100" y1="60" x2="150" y2="30" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="70" x2="150" y2="70" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="80" x2="150" y2="110" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="18" width="90" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="195" y="33">observer</text>
+    <rect x="150" y="58" width="90" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="195" y="73">observer</text>
+    <rect x="150" y="98" width="90" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="195" y="113">observer</text>
+    <rect x="300" y="40" width="90" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="345" y="59">FmDemod</text>
+    <rect x="300" y="80" width="90" height="30" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="345" y="99">AmDemod</text>
+    <text x="345" y="30" font-size="8" fill-opacity="0.7">swappable strategy</text>
+  </g>
+</svg>
+<figcaption>A subject notifies many observers at once, while a context delegates to a swappable strategy or state object.</figcaption>
+</figure>
+
+## What they are for
+
+The hard part of a running program is rarely a single object — it is the *interactions*.
+When a call is decoded, the UI, the logger, and the recorder all need to know; when the
+user picks a mode, the right algorithm must run; when a follower moves from idle to active,
+its whole behaviour changes. Handling each with ad-hoc code scatters logic and tightens
+[coupling](/reference/coupling-and-cohesion/). Behavioral patterns give these interactions
+a clean, named shape that keeps the parties from depending too directly on each other.
+
+## The main members
+
+- **Observer** — a one-to-many dependency where a *subject* notifies all its *observers*
+  when it changes, without knowing who is listening; the basis of publish/subscribe and UI
+  events.
+- **Strategy** — a family of interchangeable algorithms behind a common interface,
+  swappable at runtime (pick FM, AM, or SSB demodulation without branching logic).
+- **State** — each state is its own object owning its behaviour and transitions, so the
+  object appears to change its class; the object-oriented expression of a state machine.
+- **Command** — wraps a request as an object so it can be queued, logged, or undone.
+- **Iterator** — exposes the elements of a collection one at a time without revealing its
+  structure.
+- **Template Method** — a base class fixes the skeleton of an algorithm and lets subclasses
+  fill in steps.
+
+## A common thread
+
+Observer, Strategy, and State all let you add reactions, algorithms, or states by adding
+classes rather than editing existing code — the open/closed principle from
+[SOLID](/reference/solid/) in action. They rely on programming to an
+[interface](/reference/abstraction/), just like the sibling
+[creational](/reference/creational-patterns/) and
+[structural](/reference/structural-patterns/) families catalogued under
+[design patterns](/reference/design-patterns/).

--- a/docs/reference/build-systems.md
+++ b/docs/reference/build-systems.md
@@ -1,0 +1,70 @@
+---
+slug: build-systems
+title: Build systems
+entry_type: concept
+category: testing-delivery
+description: A build system is the tooling that transforms source code plus dependencies into a runnable artifact — compiling, linking, and packaging — ideally as a deterministic, reproducible function of its inputs.
+keywords: build systems, build tool, Make, Makefile, compile, link, go build, Cargo, npm, Maven, Gradle, artifact, reproducible build
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Developer tooling" }
+  - { label: Job, value: "Source + deps → runnable artifact" }
+  - { label: Classic tool, value: "Make / Makefile" }
+  - { label: Language tools, value: "go build, Cargo, npm, Maven, Gradle" }
+  - { label: Ideal, value: "Deterministic, reproducible output" }
+see_also: [compiler, package-manager, ci-cd, semantic-versioning, static-binary, cross-compilation, version-control]
+related_lessons:
+  - { title: "Build systems, CI/CD & automation", url: /learn/intro-software-dev/build-and-ci-cd/ }
+external:
+  - { title: "Build automation — Wikipedia", url: https://en.wikipedia.org/wiki/Build_automation }
+---
+
+**A build system** is the tooling that transforms source code plus its dependencies into
+a runnable artifact — compiling, linking, and packaging — ideally as a deterministic
+function of its inputs.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="Source files and dependencies feed into a build step that produces a single runnable artifact." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="22" width="80" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="60" y="41">source</text>
+    <rect x="20" y="68" width="80" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="60" y="87">dependencies</text>
+    <line x1="100" y1="37" x2="160" y2="55" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="83" x2="160" y2="65" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="160" y="42" width="90" height="36" rx="5" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.4"/><text x="205" y="64">build</text>
+    <line x1="250" y1="60" x2="320" y2="60" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="320" y="42" width="120" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="380" y="64">artifact</text>
+  </g>
+</svg>
+<figcaption>A build is a function from source and dependencies to a runnable artifact.</figcaption>
+</figure>
+
+## What a build does
+
+A build transforms source into something runnable. The exact steps vary by language but
+the idea is universal: a [compiler](/reference/compiler/) translates source into machine
+code or bytecode, and a *linker* stitches the pieces into an executable. **Make** and its
+descendants are the classic orchestrators — a `Makefile` declares targets and their
+dependencies, and `make` rebuilds only what changed. That principle (describe outputs in
+terms of inputs, rebuild only the stale parts) underlies nearly every build tool since.
+Modern ecosystems wrap this per language: `go build`, `cargo build`, `npm`/`yarn`, Maven,
+and Gradle each know their language's conventions so you rarely hand-write build steps.
+
+## Reproducibility
+
+The common thread is that a build is a *function* from source (plus dependencies) to an
+artifact, and the more deterministic that function, the more you can trust and automate
+it. **Reproducible builds** mean the same source and the same pinned dependencies always
+produce a bit-for-bit identical artifact, regardless of who builds it or when. That
+depends on pinned inputs, which is why a build system works hand in hand with a
+[package manager](/reference/package-manager/) and its lockfiles — without pinned inputs,
+you can't have a reproducible output. Many builds also support
+[cross-compilation](/reference/cross-compilation/), emitting a
+[static binary](/reference/static-binary/) for other platforms from one machine.
+
+## Where it fits
+
+The build sits at the heart of a [CI/CD](/reference/ci-cd/) pipeline: on every push from
+[version control](/reference/version-control/), the build runs, the
+[tests](/reference/unit-testing/) follow, and a successful run yields a versioned artifact
+ready to release under [semantic versioning](/reference/semantic-versioning/). A
+deterministic build is what makes that whole chain trustworthy.

--- a/docs/reference/bytecode.md
+++ b/docs/reference/bytecode.md
@@ -1,0 +1,68 @@
+---
+slug: bytecode
+title: Bytecode
+entry_type: concept
+category: language-internals
+description: Bytecode is a compact, portable instruction set produced by a compiler and executed by a virtual machine rather than directly by hardware.
+keywords: bytecode, virtual machine, VM, intermediate representation, JVM, CPython, .pyc, IL, portable instructions
+aka: [bytecode]
+autolink: true
+infobox:
+  - { label: Category, value: Intermediate representation }
+  - { label: Produced by, value: "A compiler" }
+  - { label: Run by, value: "A virtual machine (VM)" }
+  - { label: Property, value: "Portable across platforms" }
+  - { label: Examples, value: "JVM bytecode, CPython .pyc, .NET IL" }
+  - { label: Trade-off, value: "Portability vs VM overhead" }
+see_also: [compiler, interpreter, jit-compilation, java-language, python-language, csharp-language]
+related_lessons:
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+  - { title: "Packaging and distribution", url: /learn/intro-software-dev/packaging-and-distribution/ }
+external:
+  - { title: "Bytecode — Wikipedia", url: https://en.wikipedia.org/wiki/Bytecode }
+---
+
+**Bytecode** is a compact, portable instruction set that sits between human-readable
+source and raw machine code: a [compiler](/reference/compiler/) produces it, and a
+*virtual machine* (VM) executes it rather than the CPU running it directly.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="Source compiles to bytecode, which a virtual machine runs on any platform." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="45" width="70" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="55" y="69">source</text>
+    <line x1="90" y1="65" x2="140" y2="65" stroke="currentColor" stroke-width="1.1"/><text x="115" y="57" font-size="8">compile</text>
+    <rect x="140" y="45" width="80" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="180" y="69">bytecode</text>
+    <line x1="220" y1="65" x2="270" y2="65" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="270" y="45" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="310" y="63">virtual</text><text x="310" y="75">machine</text>
+    <line x1="350" y1="65" x2="400" y2="65" stroke="currentColor" stroke-width="1.1"/><text x="378" y="57" font-size="8">any OS</text>
+    <rect x="400" y="50" width="40" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="420" y="69">run</text>
+  </g>
+</svg>
+<figcaption>The same bytecode runs on any machine that has the matching virtual machine installed.</figcaption>
+</figure>
+
+## How it works
+
+Rather than emit instructions for a specific processor, the compiler emits bytecode —
+a low-level program for an idealized, abstract machine. At run time the VM reads that
+bytecode and either [interprets](/reference/interpreter/) it or, with
+[JIT compilation](/reference/jit-compilation/), translates the hot parts to native
+code. Because the bytecode targets the VM and not the hardware, the *same* bytecode
+file runs unchanged on any platform where the VM is available.
+
+## Trade-offs
+
+The big win is **portability**: you ship one set of bytecode and it runs anywhere the
+VM is installed, sidestepping the per-platform builds that native
+[compilation](/reference/compiler/) requires. The cost is the VM layer — interpreting
+bytecode adds overhead, and the user must have the runtime installed rather than a
+self-contained [static binary](/reference/static-binary/). Bytecode is also more
+compact and faster to load than re-parsing source each time.
+
+## In practice
+
+[Java](/reference/java-language/) and other JVM languages compile to JVM bytecode;
+[Python](/reference/python-language/) caches `.pyc` bytecode for its VM; and
+[C#](/reference/csharp-language/) and the rest of .NET compile to an intermediate
+language (IL). This bytecode-plus-VM design is what lets these languages promise
+"write once, run anywhere."

--- a/docs/reference/c-language.md
+++ b/docs/reference/c-language.md
@@ -1,0 +1,72 @@
+---
+slug: c-language
+title: C
+entry_type: language
+category: programming-languages
+description: C is a small, fast, statically typed compiled language with manual memory management that sits at the core of nearly every operating system, language runtime and embedded device.
+keywords: C, C programming, compiled, manual memory management, pointers, systems programming, embedded, Unix, K&R
+aka: [C]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Imperative, procedural, structured" }
+  - { label: Typing, value: "Static, weak" }
+  - { label: Appeared, value: "1972 (Bell Labs)" }
+  - { label: Designed by, value: "Dennis Ritchie" }
+  - { label: Compilation, value: "Ahead-of-time to native machine code" }
+  - { label: Memory, value: "Manual (malloc / free)" }
+  - { label: Notable uses, value: "Operating systems, drivers, embedded, runtimes" }
+see_also: [compiler, memory-management, cpp-language, rust-language, go-language, static-binary, type-system]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
+external:
+  - { title: "C (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/C_(programming_language) }
+  - { title: "C reference — cppreference", url: https://en.cppreference.com/w/c }
+---
+
+**C** is a small, fast, statically typed compiled language created at Bell Labs in the
+1970s. It is the bedrock of modern computing: almost every operating system, language
+runtime and embedded device has C at its core.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="C source is compiled and linked ahead of time into a native executable; the programmer manages memory by hand with malloc and free." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="64" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="52" y="74">.c source</text>
+    <line x1="84" y1="70" x2="124" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="104" y="62" font-size="8">compile</text>
+    <rect x="124" y="50" width="70" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="159" y="74">object</text>
+    <line x1="194" y1="70" x2="234" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="214" y="62" font-size="8">link</text>
+    <rect x="234" y="50" width="86" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="277" y="68">native</text><text x="277" y="80">executable</text>
+    <line x1="277" y1="90" x2="277" y2="112" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 3"/>
+    <text x="277" y="128" font-size="8" fill-opacity="0.7">manual malloc / free</text>
+  </g>
+</svg>
+<figcaption>C compiles straight to native code; memory is allocated and freed by hand.</figcaption>
+</figure>
+
+## Overview
+
+C [compiles](/reference/compiler/) ahead of time directly to native machine code, with a
+tiny runtime and almost no abstraction between the code and the hardware. It is
+[statically typed](/reference/type-system/), gives the programmer direct access to memory
+through pointers, and is portable across virtually every platform. That minimalism is the
+point: C is small enough to learn the whole language, and fast and predictable enough to
+build everything else on top of.
+
+## Strengths and trade-offs
+
+C's strengths are speed, ubiquity, portability and a tiny footprint — it runs where
+nothing else will. The cost is **safety**: [memory management](/reference/memory-management/)
+is fully manual, so buffer overflows, use-after-free and dangling pointers are easy to
+write and account for whole categories of security bugs that C does nothing to prevent.
+It is also low-level, with few of the conveniences modern languages offer. These risks
+are exactly what later languages set out to address —
+[C++](/reference/cpp-language/) adds higher-level abstractions over the same model, while
+[Rust](/reference/rust-language/) keeps the speed but enforces memory safety at compile
+time.
+
+## Where it's used
+
+C remains the default for operating-system kernels, device drivers, language runtimes,
+and tight embedded work where every byte and cycle counts. Its stable, minimal interface
+also makes it the common tongue that other languages bind to when they need to call
+native code.

--- a/docs/reference/ci-cd.md
+++ b/docs/reference/ci-cd.md
@@ -1,0 +1,77 @@
+---
+slug: ci-cd
+title: CI/CD
+entry_type: concept
+category: testing-delivery
+description: CI/CD is the practice of automatically building and testing code on every change (continuous integration) and then automating its path to release (continuous delivery/deployment) through a versioned pipeline.
+keywords: CI/CD, continuous integration, continuous delivery, continuous deployment, pipeline, build, test, deploy, GitHub Actions, automation, artifacts
+aka: [continuous integration "CI","CD", CI/CD]
+autolink: true
+infobox:
+  - { label: Category, value: "Automation / delivery practice" }
+  - { label: CI, value: "Build & test on every push" }
+  - { label: CD, value: "Continuous Delivery / Deployment" }
+  - { label: Pipeline, value: "lint → build → test → package → deploy" }
+  - { label: Tools, value: "GitHub Actions, GitLab CI, Jenkins" }
+see_also: [build-systems, version-control, unit-testing, integration-testing, end-to-end-testing, package-manager, semantic-versioning]
+related_lessons:
+  - { title: "GitHub Actions & CI/CD", url: /learn/git/github-actions/ }
+  - { title: "Build systems & CI/CD", url: /learn/intro-software-dev/build-and-ci-cd/ }
+external:
+  - { title: "CI/CD — Wikipedia", url: https://en.wikipedia.org/wiki/CI/CD }
+---
+
+**CI/CD** is the practice of automatically building and testing code on every change
+(continuous integration) and then automating its path to release (continuous
+delivery/deployment) through a versioned pipeline.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A pipeline flowing from commit to build to test to deploy, each stage gating the next." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="14" y="42" width="84" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="56" y="63">commit</text>
+    <line x1="98" y1="59" x2="130" y2="59" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="130" y="42" width="84" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="172" y="63">build</text>
+    <line x1="214" y1="59" x2="246" y2="59" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="246" y="42" width="84" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="288" y="63">test</text>
+    <line x1="330" y1="59" x2="362" y2="59" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="362" y="42" width="84" height="34" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.4"/><text x="404" y="63">deploy</text>
+  </g>
+</svg>
+<figcaption>A CI/CD pipeline carries each commit through build, test, and deploy, with every stage gating the next.</figcaption>
+</figure>
+
+## Continuous Integration
+
+**Continuous Integration (CI)** automatically builds and runs the
+[test suite](/reference/unit-testing/) on *every push* (and every pull request). A CI
+server watches the repository in [version control](/reference/version-control/); when a
+change lands it checks out the code, installs the pinned dependencies via the
+[build system](/reference/build-systems/), compiles it, and runs the tests. If anything
+fails, the team learns within minutes — while the change is fresh and small. The name
+comes from *integrating* everyone's work frequently into the shared main line instead of
+letting branches drift and merging in one painful "big bang." CI is the automated
+enforcement of "don't break the build."
+
+## Continuous Delivery and Deployment
+
+CI gets you a tested build; CD carries it toward release.
+
+- **Continuous Delivery** keeps the build always in a *releasable* state — packaged and
+  staged — with a human choosing *when* to ship.
+- **Continuous Deployment** removes even that gate: every change that passes the full
+  pipeline ships to production automatically.
+
+The distinction is just where the human stands. Which you want depends on risk tolerance
+and how good your [tests](/reference/integration-testing/) are.
+
+## Pipelines and artifacts
+
+The whole automated sequence is a **pipeline** — staged steps like lint → build → test →
+package → deploy, each gating the next, and typically defined in a YAML file committed to
+the repo so the process itself is versioned. A successful run produces an **artifact** (a
+binary, container image, or installer) that is stored, versioned with
+[semantic versioning](/reference/semantic-versioning/), and promoted unchanged through
+environments. On GitHub the common tool is **GitHub Actions**, which can run the pipeline,
+fan out across a build matrix, run [end-to-end tests](/reference/end-to-end-testing/), and
+publish release binaries through a [package manager](/reference/package-manager/) or
+release page — only when everything is green.

--- a/docs/reference/clean-code.md
+++ b/docs/reference/clean-code.md
@@ -1,0 +1,67 @@
+---
+slug: clean-code
+title: Clean code
+entry_type: concept
+category: principles-quality
+description: Clean code is the discipline of writing programs optimized for the reader — clear names, small focused functions, why-not-what comments, and consistent style — because code is read far more often than it is written.
+keywords: clean code, readable code, code readability, intention-revealing names, small functions, code comments, code style, maintainable code, naming
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Code quality / readability" }
+  - { label: Core idea, value: "Code is read more than written" }
+  - { label: Pillars, value: "Names, small functions, why-comments, style" }
+  - { label: Tools, value: "Formatters & linters (gofmt, Prettier, Black)" }
+  - { label: Enemy, value: "Cleverness" }
+see_also: [refactoring, dry-kiss-yagni, solid, abstraction, coupling-and-cohesion, unit-testing]
+related_lessons:
+  - { title: "Writing readable code", url: /learn/intro-software-dev/clean-code/ }
+external:
+  - { title: "Robert C. Martin — Wikipedia", url: https://en.wikipedia.org/wiki/Robert_C._Martin }
+---
+
+**Clean code** is the discipline of writing programs optimized for the reader rather
+than the writer, because code is read far more often than it is written — by reviewers,
+future maintainers, and you, months later.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="Code written once is read many times by reviewer, debugger, and future self." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="45" width="80" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="60" y="60">written</text><text x="60" y="72" font-size="8">once</text>
+    <line x1="100" y1="62" x2="150" y2="40" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="62" x2="150" y2="62" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="62" x2="150" y2="84" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="26" width="120" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="210" y="42">read: reviewer</text>
+    <rect x="150" y="52" width="120" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="210" y="68">read: debugger</text>
+    <rect x="150" y="78" width="120" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="210" y="94">read: future you</text>
+    <text x="360" y="66" font-size="11">read &gt;&gt; written</text>
+  </g>
+</svg>
+<figcaption>A line is written once and read many times — so optimize for the reader.</figcaption>
+</figure>
+
+## Core habits
+
+The everyday habits of clean code all flow from one fact: the reader's time is what you
+are optimizing.
+
+- **Intention-revealing names.** A good name says *what* something is and *why* it
+  exists without forcing a detour into the implementation. `sampleRateHz` cannot be
+  misread; `sr` can. Encode units, avoid cryptic abbreviations and noise words, and
+  pick one word per concept.
+- **Small, focused functions.** A function should do one thing at one level of
+  [abstraction](/reference/abstraction/). If you can't name it without "and," or it
+  doesn't fit on a screen, it's probably hiding a smaller function. Extracting steps
+  turns stale comments into self-documenting names.
+- **Comments explain *why*, not *what*.** Names and structure already show the *what*;
+  reserve comments for intent, trade-offs, and non-obvious constraints. A comment that
+  merely narrates the next line will drift and eventually lie.
+- **Consistent style.** Lean on formatters and linters (`gofmt`, Prettier, Black,
+  `rustfmt`) so attention goes to logic, not layout, and diffs stay small.
+
+## The cost of cleverness
+
+Clever, compact code shifts cost from the writer, who understood it in the moment, to
+every future reader who must reverse-engineer it. As Brian Kernighan warned, debugging
+is harder than writing, so code written as cleverly as possible is code you can't debug.
+The genuinely hard skill is making complex logic *look* simple. Clean code is closely
+tied to [DRY, KISS and YAGNI](/reference/dry-kiss-yagni/) and [SOLID](/reference/solid/),
+and improving it after the fact is the work of [refactoring](/reference/refactoring/).

--- a/docs/reference/cobol-language.md
+++ b/docs/reference/cobol-language.md
@@ -1,0 +1,66 @@
+---
+slug: cobol-language
+title: COBOL
+entry_type: language
+category: programming-languages
+description: COBOL (1959) is an English-like high-level language built for business data processing; shaped by Grace Hopper, it still runs huge amounts of banking and government software.
+keywords: COBOL, business data processing, Grace Hopper, English-like syntax, mainframe, banking, legacy code, high-level language
+aka: [Cobol]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Imperative, procedural" }
+  - { label: Typing, value: "Static, strong" }
+  - { label: Appeared, value: "1959 (CODASYL committee)" }
+  - { label: Designed by, value: "Committee; influenced by Grace Hopper" }
+  - { label: Compilation, value: "Compiled to native code" }
+  - { label: Memory, value: "Static (no garbage collector)" }
+  - { label: Notable uses, value: "Banking, government, mainframe business systems" }
+see_also: [fortran-language, lisp-language, c-language, compiler, imperative-programming, type-system, java-language]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "The birth of programming languages", url: /learn/intro-software-dev/birth-of-languages/ }
+external:
+  - { title: "COBOL — Wikipedia", url: https://en.wikipedia.org/wiki/COBOL }
+  - { title: "GnuCOBOL", url: https://gnucobol.sourceforge.io/ }
+---
+
+**COBOL** (COmmon Business-Oriented Language), introduced in 1959, is a deliberately
+English-like high-level language built for business data processing. Shaped by the
+work of Grace Hopper and a committee, it still runs huge amounts of banking and
+government software today.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="English-like COBOL statements are compiled and run on a mainframe to process business records like payroll and accounts." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="48" width="110" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="75" y="66">ADD PAY</text><text x="75" y="80">TO TOTAL.</text>
+    <line x1="130" y1="70" x2="185" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="185" y="48" width="90" height="44" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="230" y="74">mainframe</text>
+    <line x1="275" y1="70" x2="330" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="330" y="48" width="110" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="385" y="66">business</text><text x="385" y="80">records</text>
+  </g>
+</svg>
+<figcaption>COBOL's English-like syntax was meant to make business logic readable; it still drives mainframe data processing.</figcaption>
+</figure>
+
+## History
+
+COBOL used English-like syntax on purpose, so business processes would be readable by
+non-specialists, not just programmers. A [compiler](/reference/compiler/) translates
+those verbose, statement-style programs into machine code. It was standardised by a
+committee under pressure from the U.S. government to create a common business language,
+and Grace Hopper's earlier work on English-like programming heavily influenced its
+design. It became, alongside [FORTRAN](/reference/fortran-language/) for science and
+[LISP](/reference/lisp-language/) for AI, one of the defining languages of the first
+era of high-level programming.
+
+## Legacy and use today
+
+COBOL is [statically typed](/reference/type-system/),
+[imperative](/reference/imperative-programming/), and compiled to native code without a
+[garbage collector](/reference/garbage-collection/). Astonishingly, vast amounts of
+banking, insurance, and government software still run on it, processing daily
+transactions on mainframes. That is also its core problem: the code is decades old,
+the pool of programmers who know it is shrinking, and its verbosity and age make it a
+poor fit for new work, which has largely moved to languages like
+[Java](/reference/java-language/) and [C](/reference/c-language/). Its endurance is a
+reminder that working software rarely gets rewritten just because it is old.

--- a/docs/reference/code-coverage.md
+++ b/docs/reference/code-coverage.md
@@ -1,0 +1,69 @@
+---
+slug: code-coverage
+title: Code coverage
+entry_type: concept
+category: testing-delivery
+description: Code coverage measures the percentage of a codebase exercised by its test suite — which lines, branches, or functions ran — a useful signal for finding untested code but not a guarantee of correctness.
+keywords: code coverage, test coverage, line coverage, branch coverage, coverage percentage, untested code, false confidence, software testing
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Software testing metric" }
+  - { label: Measures, value: "Code exercised by the test suite" }
+  - { label: Granularity, value: "Line, branch, function" }
+  - { label: Good for, value: "Finding untested code" }
+  - { label: Caveat, value: "A floor, not a proof of correctness" }
+see_also: [unit-testing, integration-testing, end-to-end-testing, test-driven-development, mocking, ci-cd, refactoring]
+related_lessons:
+  - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
+external:
+  - { title: "Code coverage — Wikipedia", url: https://en.wikipedia.org/wiki/Code_coverage }
+---
+
+**Code coverage** measures the percentage of a codebase exercised by its test suite —
+which lines, branches, or functions ran — a useful signal for finding untested code, but
+not a guarantee of correctness.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A bar of code lines, most shaded as covered by tests and a few left uncovered, summing to a coverage percentage." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="40" width="50" height="34" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="70" y="40" width="50" height="34" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="120" y="40" width="50" height="34" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="170" y="40" width="50" height="34" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="220" y="40" width="50" height="34" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3 3"/>
+    <text x="145" y="90" font-size="8">covered</text><text x="245" y="90" font-size="8" fill-opacity="0.6">untested</text>
+    <text x="370" y="62" font-size="13">80%</text>
+  </g>
+</svg>
+<figcaption>Coverage reports how much code ran during tests — here 80% — but not whether the tests checked the right things.</figcaption>
+</figure>
+
+## What it measures
+
+Coverage tools instrument the code and record which parts executed while the
+[tests](/reference/unit-testing/) ran, reported as a percentage. Common granularities are
+**line coverage** (which lines ran), **branch coverage** (which sides of each
+conditional ran), and **function coverage**. The metric is genuinely useful for *finding
+untested code*: a module sitting at 0% is a red flag, and watching coverage shows where to
+aim the next tests. Coverage is typically computed in a [CI/CD](/reference/ci-cd/)
+pipeline so the number is tracked on every change.
+
+## Its limits
+
+Coverage is widely misread. It measures whether a line *ran*, not whether your test
+*checked* anything meaningful about it. You can reach 100% with tests that assert
+nothing, miss every edge case, or compare against wrong expected values — and heavy
+[mocking](/reference/mocking/) can inflate the number without real assurance. High
+coverage with weak assertions is false confidence. Treat coverage as a **floor** — a
+signal for gaps — never as a target to chase or a proof of correctness. A smaller suite
+of sharp, well-asserted tests beats a sprawling one written to game a number.
+
+## In context
+
+Coverage spans every layer of the test pyramid — [unit](/reference/unit-testing/),
+[integration](/reference/integration-testing/), and
+[end-to-end](/reference/end-to-end-testing/) tests all contribute. It is a by-product of
+disciplines like [test-driven development](/reference/test-driven-development/), not their
+purpose, and it gives [refactoring](/reference/refactoring/) confidence by showing which
+code a change's safety net actually protects.

--- a/docs/reference/compiler.md
+++ b/docs/reference/compiler.md
@@ -1,0 +1,71 @@
+---
+slug: compiler
+title: Compiler
+entry_type: concept
+category: language-internals
+description: A compiler is a program that translates source code into another form — usually machine code or bytecode — ahead of time, before the program runs.
+keywords: compiler, compilation, ahead of time, AOT, machine code, optimization, native binary, source code, build step
+aka: [compiler, AOT compiler]
+autolink: true
+infobox:
+  - { label: Category, value: Language tooling }
+  - { label: Input, value: "Source code" }
+  - { label: Output, value: "Machine code or bytecode" }
+  - { label: When it runs, value: "Ahead of time, before execution" }
+  - { label: Trade-off, value: "Build step & per-platform output vs fast, optimized code" }
+  - { label: Compiled languages, value: "C, C++, Rust, Go" }
+see_also: [interpreter, bytecode, jit-compilation, static-binary, cross-compilation, type-system, c-language, rust-language, go-language]
+related_lessons:
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Compiler — Wikipedia", url: https://en.wikipedia.org/wiki/Compiler }
+---
+
+**A compiler** is a program that translates source code written for humans into a
+form a machine can run — typically native machine code — doing the work *ahead of
+time*, before the program is ever executed.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="Source code passes through a compiler once, producing machine code the CPU runs directly each time." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="45" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="69">source code</text>
+    <line x1="100" y1="65" x2="160" y2="65" stroke="currentColor" stroke-width="1.1"/><text x="130" y="57" font-size="8">translate</text>
+    <rect x="160" y="45" width="80" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="200" y="69">compiler</text>
+    <line x1="240" y1="65" x2="300" y2="65" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="300" y="45" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="340" y="63">machine</text><text x="340" y="75">code</text>
+    <line x1="380" y1="65" x2="430" y2="65" stroke="currentColor" stroke-width="1.1"/><text x="410" y="57" font-size="8">CPU</text>
+  </g>
+</svg>
+<figcaption>A compiler does the translation once, up front; the resulting machine code runs directly on the CPU.</figcaption>
+</figure>
+
+## How it works
+
+A compiler reads the entire source program, checks it (including its
+[types](/reference/type-system/)), and emits an equivalent program in a lower-level
+language. Classic *ahead-of-time* (AOT) compilers such as those for
+[C](/reference/c-language/), [C++](/reference/cpp-language/),
+[Rust](/reference/rust-language/), and [Go](/reference/go-language/) produce native
+machine code packaged as an executable. Other compilers target
+[bytecode](/reference/bytecode/) for a virtual machine instead. Along the way the
+compiler optimizes — inlining calls, vectorizing loops, eliminating dead code — so
+the output often runs far faster than a naive translation would.
+
+## Trade-offs
+
+Because the translation happens once, the CPU runs native instructions with no
+per-operation overhead, and performance is predictable from run to run. The price is
+a **build step** between editing and running, and output that is usually tied to one
+platform — a binary built for x86-64 Linux will not run on an ARM Mac without
+recompiling (see [cross-compilation](/reference/cross-compilation/)). This contrasts
+with an [interpreter](/reference/interpreter/), which skips the build step but pays
+overhead on every run, and with [JIT compilation](/reference/jit-compilation/), which
+moves the translation to run time.
+
+## In practice
+
+Compiled languages dominate systems software, where speed and a self-contained
+[static binary](/reference/static-binary/) matter. GopherTrunk is compiled by the Go
+toolchain into a single native executable, which is why it ships without requiring any
+runtime on the target machine.

--- a/docs/reference/concurrency.md
+++ b/docs/reference/concurrency.md
@@ -1,0 +1,73 @@
+---
+slug: concurrency
+title: Concurrency vs parallelism
+entry_type: concept
+category: concurrency-execution
+description: Concurrency is structuring a program so multiple tasks can make independent progress, while parallelism is actually running multiple computations at the same instant on multiple cores.
+keywords: concurrency, parallelism, threads, async, goroutines, channels, data race, event loop, multiple cores
+aka: ["concurrency", "parallelism"]
+autolink: true
+infobox:
+  - { label: Category, value: Execution model }
+  - { label: Concurrency, value: "Dealing with many tasks at once (structure)" }
+  - { label: Parallelism, value: "Doing many things at once (execution)" }
+  - { label: Needs multiple cores, value: "Parallelism yes; concurrency no" }
+  - { label: Common models, value: "Threads, async/await, channels, actors" }
+  - { label: The core hazard, value: "Data races" }
+see_also: [threads, async-programming, goroutines, go-language, rust-language, javascript-language]
+related_lessons:
+  - { title: "Concurrency and parallelism", url: /learn/intro-software-dev/concurrency-models/ }
+  - { title: "Concurrency and pipelines", url: /learn/intro-software-dev/concurrency-and-pipelines/ }
+external:
+  - { title: "Concurrency (computer science) — Wikipedia", url: https://en.wikipedia.org/wiki/Concurrency_(computer_science) }
+---
+
+**Concurrency** is structuring a program so that multiple tasks can be in progress and
+advance independently; **parallelism** is actually running multiple computations at the
+same instant. Concurrency is about structure; parallelism is about execution, and the
+two are related but not the same.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="Concurrency interleaves two tasks on one core; parallelism runs them at the same time on two cores." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="115" y="18" font-size="8" fill-opacity="0.7">concurrency (1 core)</text>
+    <rect x="20" y="28" width="40" height="22" rx="3" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="40" y="43" font-size="7">A</text>
+    <rect x="62" y="28" width="40" height="22" rx="3" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="82" y="43" font-size="7">B</text>
+    <rect x="104" y="28" width="40" height="22" rx="3" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="124" y="43" font-size="7">A</text>
+    <rect x="146" y="28" width="40" height="22" rx="3" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="166" y="43" font-size="7">B</text>
+    <text x="115" y="80" font-size="8" fill-opacity="0.7">parallelism (2 cores)</text>
+    <rect x="20" y="88" width="120" height="22" rx="3" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="80" y="103" font-size="7">task A</text>
+    <rect x="20" y="112" width="120" height="14" rx="3" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="80" y="123" font-size="7">task B</text>
+    <text x="300" y="70" font-size="8" fill-opacity="0.7">structure vs execution</text>
+  </g>
+</svg>
+<figcaption>Concurrency interleaves tasks (even on one core); parallelism runs them at the same instant on several cores.</figcaption>
+</figure>
+
+## The distinction
+
+Even on a single CPU core, a concurrent program can interleave work — run task A, pause
+it while it waits for I/O, switch to task B — so the tasks *deal with* progress
+together. Parallelism *does* several things at once and therefore requires multiple
+cores. You can have concurrency without parallelism (one core juggling tasks), and a
+good concurrency model makes tasks the runtime can *also* run in parallel when cores
+are available. As Rob Pike put it: concurrency is a way to structure things; if it
+works, parallelism may be a free bonus.
+
+## Models and the shared hazard
+
+Languages offer different concurrency models: OS [threads](/reference/threads/) with
+locks, single-threaded [async/await](/reference/async-programming/) event loops, Go's
+[goroutines](/reference/goroutines/) and channels, and the share-nothing actor model.
+What they are all really fighting is the **data race** — two tasks touching the same
+memory with at least one writing, with no synchronization, producing undefined results.
+Each model is, at heart, a different strategy for avoiding unsynchronized shared writes.
+
+## In practice
+
+The right model follows the workload. **I/O-bound** work — waiting on networks or disks
+— favors async or lightweight tasks like [goroutines](/reference/goroutines/);
+**CPU-bound** work like DSP favors real parallelism across cores; fault-tolerant
+systems favor actors. A streaming radio pipeline in [Go](/reference/go-language/) runs
+capture, DSP, and decode stages concurrently and lets the runtime spread them across
+cores in parallel.

--- a/docs/reference/coupling-and-cohesion.md
+++ b/docs/reference/coupling-and-cohesion.md
@@ -1,0 +1,80 @@
+---
+slug: coupling-and-cohesion
+title: Coupling & cohesion
+entry_type: concept
+category: paradigms-design
+description: Coupling measures how much one module depends on another and cohesion measures how focused a single module is; good design aims for loose coupling and high cohesion.
+keywords: coupling, cohesion, loose coupling, high cohesion, modularity, dependency, single responsibility, big ball of mud, software design
+aka: [coupling and cohesion "loose coupling, high cohesion"]
+autolink: true
+infobox:
+  - { label: Type, value: "Software design principle" }
+  - { label: Coupling, value: "How much modules depend on each other (between)" }
+  - { label: Cohesion, value: "How focused a single module is (within)" }
+  - { label: The goal, value: "Loose coupling + high cohesion" }
+  - { label: Failure mode, value: "Big ball of mud" }
+  - { label: Related, value: "Abstraction, SOLID, design patterns" }
+see_also: [abstraction, object-oriented-programming, design-patterns, solid, structural-patterns, behavioral-patterns]
+related_lessons:
+  - { title: "Abstraction, coupling & cohesion", url: /learn/intro-software-dev/abstraction-coupling/ }
+external:
+  - { title: "Coupling (computer programming) — Wikipedia", url: https://en.wikipedia.org/wiki/Coupling_(computer_programming) }
+---
+
+**Coupling** measures how much one module depends on another — how entangled they are —
+while **cohesion** measures how focused a single module is — how well its parts belong
+together. The central slogan of modular design is: aim for **loose coupling and high
+cohesion**.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Loose coupling shows modules connected by few narrow lines through a clean interface, while tight coupling shows many tangled connections between internals." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="115" y="16" font-size="8" fill-opacity="0.7">loose coupling</text>
+    <rect x="30" y="50" width="60" height="44" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="60" y="76">A</text>
+    <rect x="150" y="50" width="60" height="44" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="180" y="76">B</text>
+    <line x1="90" y1="72" x2="150" y2="72" stroke="currentColor" stroke-width="1.3"/>
+    <text x="350" y="16" font-size="8" fill-opacity="0.7">tight coupling</text>
+    <rect x="280" y="50" width="60" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="310" y="76">C</text>
+    <rect x="380" y="50" width="60" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="410" y="76">D</text>
+    <line x1="340" y1="58" x2="380" y2="58" stroke="currentColor" stroke-width="1"/><line x1="340" y1="68" x2="380" y2="78" stroke="currentColor" stroke-width="1"/><line x1="340" y1="78" x2="380" y2="62" stroke="currentColor" stroke-width="1"/><line x1="340" y1="86" x2="380" y2="86" stroke="currentColor" stroke-width="1"/>
+  </g>
+</svg>
+<figcaption>Loose coupling links modules through one narrow interface; tight coupling tangles their internals together.</figcaption>
+</figure>
+
+## Coupling: dependence between modules
+
+Tightly coupled modules know each other's internals, so a change in one forces a change in
+the other. Loosely coupled modules interact only through narrow, stable interfaces, so each
+can change behind its contract without disturbing its neighbours. A rough spectrum from
+worse to better: **content coupling** (one module reaches into another's state),
+**shared global state** (invisible dependencies through globals), and **data coupling**
+(passing exactly the data needed through a clean interface — the goal). Loose coupling is
+what makes code testable, reusable, and safe to change, and it leans directly on
+[abstraction](/reference/abstraction/) and the dependency-inversion idea in
+[SOLID](/reference/solid/).
+
+## Cohesion: focus within a module
+
+Where coupling is *between* modules, cohesion is *within* one: how well do its parts belong
+together? A highly cohesive module does one well-defined job, and everything in it serves
+that job. A low-cohesion module is a grab-bag — a `Utils` class that validates emails,
+parses dates, and resizes images has no coherent reason to exist as a unit. High cohesion
+is the same idea as the single-responsibility principle: each module focused on one reason
+to change, making it easy to name, understand, and modify.
+
+## Why they go together
+
+| | Loose coupling | High cohesion |
+|---|---|---|
+| **Scope** | Between modules | Within a module |
+| **Means** | Few, narrow dependencies | One focused responsibility |
+| **Payoff** | Local changes, easy testing | Clear purpose, simple to reason about |
+
+When both hold, modules behave like well-designed components: self-contained, with clear
+connectors. When coupling is tight or cohesion is low, you get the dreaded "big ball of
+mud" where nothing can move without everything moving. Most
+[design patterns](/reference/design-patterns/) — especially the
+[structural](/reference/structural-patterns/) and
+[behavioral](/reference/behavioral-patterns/) families — exist precisely to push a design
+toward this loose-coupling, high-cohesion ideal.

--- a/docs/reference/cpp-language.md
+++ b/docs/reference/cpp-language.md
@@ -1,0 +1,69 @@
+---
+slug: cpp-language
+title: C++
+entry_type: language
+category: programming-languages
+description: C++ extends C with objects, templates, generics and RAII, offering C-level performance alongside high-level abstractions at the cost of considerable complexity.
+keywords: C++, cpp, RAII, templates, generics, object-oriented, systems programming, game engines, DSP, STL
+aka: [C++, cpp, "C plus plus"]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Multi-paradigm: procedural, object-oriented, generic" }
+  - { label: Typing, value: "Static, strong (with weak corners from C)" }
+  - { label: Appeared, value: "1985 (Bell Labs)" }
+  - { label: Designed by, value: "Bjarne Stroustrup" }
+  - { label: Compilation, value: "Ahead-of-time to native machine code" }
+  - { label: Memory, value: "Manual, but managed via RAII / smart pointers" }
+  - { label: Notable uses, value: "Game engines, browsers, trading, DSP" }
+see_also: [c-language, rust-language, object-oriented-programming, memory-management, compiler, type-system, go-language]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
+external:
+  - { title: "C++ — Wikipedia", url: https://en.wikipedia.org/wiki/C%2B%2B }
+  - { title: "C++ reference — cppreference", url: https://en.cppreference.com/w/cpp }
+---
+
+**C++** is a statically typed, compiled language that extends [C](/reference/c-language/)
+with objects, templates, generics, RAII and a large standard library. It can match C's
+performance while offering far higher-level abstractions.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="C++ adds object-oriented and generic abstractions and RAII-managed resources on top of C's native compilation model." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="48" width="80" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="66">C core</text><text x="60" y="80" font-size="8">native, fast</text>
+    <line x1="100" y1="70" x2="140" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="120" y="62" font-size="8">adds</text>
+    <rect x="140" y="22" width="92" height="22" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="186" y="37">classes / OOP</text>
+    <rect x="140" y="58" width="92" height="22" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="186" y="73">templates</text>
+    <rect x="140" y="94" width="92" height="22" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="186" y="109">RAII</text>
+    <line x1="232" y1="33" x2="272" y2="69" stroke="currentColor" stroke-width="1.1"/><line x1="232" y1="69" x2="272" y2="69" stroke="currentColor" stroke-width="1.1"/><line x1="232" y1="105" x2="272" y2="69" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="272" y="52" width="92" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="318" y="74">compiled C++</text>
+  </g>
+</svg>
+<figcaption>C++ layers objects, generics and RAII over C's fast native model — power at the price of complexity.</figcaption>
+</figure>
+
+## Overview
+
+C++ [compiles](/reference/compiler/) ahead of time to native code like
+[C](/reference/c-language/), but adds [object-oriented](/reference/object-oriented-programming/)
+features, compile-time generics through templates, and the Standard Template Library.
+Its signature idiom is RAII — tying resource lifetimes to object scope — which gives a
+disciplined approach to [memory management](/reference/memory-management/) and, with
+smart pointers, much of the safety of automatic management without a garbage collector.
+
+## Strengths and trade-offs
+
+The strength is reach: C++ delivers C-level performance while letting you build large,
+abstracted systems, which is why it dominates game engines, browsers, high-frequency
+trading and serious DSP. The drawback is **complexity** — the language is vast, with
+decades of accumulated features and sharp edges, and it inherits C's memory-safety risks
+unless you are disciplined. It is genuinely hard to master. For new systems work where
+safety is paramount, [Rust](/reference/rust-language/) is increasingly chosen as an
+alternative that keeps the speed without the same footguns.
+
+## Where it's used
+
+C++ is the workhorse of performance-critical software with rich logic: game engines,
+web browsers, trading systems, scientific and signal-processing code, and other domains
+where both raw speed and high-level structure are required at once.

--- a/docs/reference/creational-patterns.md
+++ b/docs/reference/creational-patterns.md
@@ -1,0 +1,72 @@
+---
+slug: creational-patterns
+title: Creational patterns
+entry_type: concept
+category: paradigms-design
+description: Creational patterns are the Gang of Four family that controls how objects get made, isolating creation logic so callers depend on interfaces rather than concrete classes.
+keywords: creational patterns, factory pattern, factory method, builder pattern, singleton, abstract factory, prototype, object creation, gang of four, design patterns
+aka: []
+autolink: true
+infobox:
+  - { label: Type, value: "Design pattern family (GoF)" }
+  - { label: Problem solved, value: "How objects get created" }
+  - { label: Members, value: "Factory Method, Abstract Factory, Builder, Singleton, Prototype" }
+  - { label: Benefit, value: "Decouple callers from concrete classes" }
+  - { label: Watch for, value: "Singleton (often an anti-pattern)" }
+  - { label: Sibling families, value: "Structural, behavioral" }
+see_also: [design-patterns, structural-patterns, behavioral-patterns, object-oriented-programming, coupling-and-cohesion, solid, abstraction]
+related_lessons:
+  - { title: "Creational patterns: factory, builder, singleton", url: /learn/intro-software-dev/creational-patterns/ }
+external:
+  - { title: "Creational pattern — Wikipedia", url: https://en.wikipedia.org/wiki/Creational_pattern }
+---
+
+**Creational patterns** are the [Gang of Four](/reference/design-patterns/) family that
+put a layer between "I need an object" and "here is exactly how it gets built," so the
+rest of the code does not hard-code which concrete class to instantiate.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A caller asks a factory for an object and receives one through a common interface, without naming any concrete class." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="55" width="70" height="30" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="55" y="74">caller</text>
+    <line x1="90" y1="70" x2="130" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="110" y="62" font-size="8">asks</text>
+    <rect x="130" y="50" width="90" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="175" y="68">factory</text><text x="175" y="80" font-size="8">decides type</text>
+    <line x1="220" y1="70" x2="260" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="260" y="20" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="310" y="35">P25Decoder</text>
+    <rect x="260" y="58" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="310" y="73">DmrDecoder</text>
+    <rect x="260" y="96" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="310" y="111">NxdnDecoder</text>
+    <text x="310" y="135" font-size="8" fill-opacity="0.7">returned as Decoder</text>
+  </g>
+</svg>
+<figcaption>A factory chooses the concrete type and returns it behind a common interface, so callers stay decoupled.</figcaption>
+</figure>
+
+## The problem they solve
+
+When code says `new ConcreteThing(...)` directly, two things get baked in: the *decision*
+of which type to use and the *details* of how to construct it. That binding hurts when the
+type should depend on runtime input, construction is complicated, or you want exactly one
+shared instance. Creational patterns isolate that logic so callers depend on an
+[interface](/reference/abstraction/), reducing [coupling](/reference/coupling-and-cohesion/)
+and honouring the open/closed principle from [SOLID](/reference/solid/).
+
+## The main members
+
+- **Factory / Factory Method** — create and return an object through a common interface so
+  the caller never names the concrete class; Factory Method defers the choice to a
+  subclass-overridable step.
+- **Abstract Factory** — create whole *families* of related objects (a matching decoder,
+  filter, and display for a mode).
+- **Builder** — assemble one complex object step by step with named, chainable steps,
+  ideal when a single constructor would be an unreadable wall of arguments.
+- **Prototype** — create new objects by cloning an existing instance.
+- **Singleton** — guarantee one shared instance with global access.
+
+## Notes and caveats
+
+Use a **Factory** when *which* type varies; use a **Builder** when *how* one complex
+object is built varies — they compose well, since a factory can use a builder internally.
+**Singleton** is often an anti-pattern: it is global mutable state in disguise, with hidden
+dependencies and poor testability, so prefer passing a shared instance in explicitly. The
+sibling families are [structural patterns](/reference/structural-patterns/) (arranging
+objects) and [behavioral patterns](/reference/behavioral-patterns/) (coordinating them).

--- a/docs/reference/cross-compilation.md
+++ b/docs/reference/cross-compilation.md
@@ -1,0 +1,70 @@
+---
+slug: cross-compilation
+title: Cross-compilation
+entry_type: concept
+category: language-internals
+description: Cross-compilation is building an executable on one platform that is meant to run on a different platform, such as producing a Windows binary from a Linux host.
+keywords: cross-compilation, cross compiler, target platform, host platform, toolchain, GOOS GOARCH, build target, portability
+aka: ["cross-compiling", "cross compiler"]
+autolink: true
+infobox:
+  - { label: Category, value: Build process }
+  - { label: Host, value: "Machine you build on" }
+  - { label: Target, value: "Machine the output runs on" }
+  - { label: Used for, value: "Releasing for many OS/CPU combinations" }
+  - { label: First-class in, value: "Go (GOOS / GOARCH)" }
+  - { label: Common with, value: "Embedded and mobile development" }
+see_also: [compiler, static-binary, go-language, rust-language, c-language]
+related_lessons:
+  - { title: "Packaging and distribution", url: /learn/intro-software-dev/packaging-and-distribution/ }
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+external:
+  - { title: "Cross compiler — Wikipedia", url: https://en.wikipedia.org/wiki/Cross_compiler }
+---
+
+**Cross-compilation** is building an executable on one platform — the *host* — that is
+meant to run on a *different* platform — the *target* — such as producing a Windows or
+macOS binary from a Linux machine without ever touching those operating systems.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="One source tree compiled on a Linux host produces binaries targeting Linux, macOS, and Windows." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="68">source on</text><text x="60" y="80">Linux host</text>
+    <line x1="100" y1="70" x2="150" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="50" width="80" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="190" y="74">compiler</text>
+    <line x1="230" y1="62" x2="290" y2="28" stroke="currentColor" stroke-width="1.1"/><line x1="230" y1="70" x2="290" y2="70" stroke="currentColor" stroke-width="1.1"/><line x1="230" y1="78" x2="290" y2="112" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="290" y="14" width="120" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="350" y="31">Linux binary</text>
+    <rect x="290" y="57" width="120" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="350" y="74">macOS binary</text>
+    <rect x="290" y="100" width="120" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="350" y="117">Windows binary</text>
+  </g>
+</svg>
+<figcaption>One host compiles binaries for several target operating systems and CPU architectures.</figcaption>
+</figure>
+
+## How it works
+
+A normal [compiler](/reference/compiler/) emits machine code for the machine it runs
+on. A cross-compiling toolchain instead targets a chosen operating system and CPU
+architecture, generating code and linking against the right libraries for that target.
+The output is a binary that will not run on the host but will run on the target. This
+is essential whenever the target cannot easily build for itself — embedded devices,
+phones, or simply a release pipeline that produces every platform's download from one
+build machine.
+
+## Trade-offs
+
+Cross-compilation removes the need to own or maintain a machine of every target type,
+making multi-platform releases a single automated step. The complications come from
+*platform-specific dependencies*: code that links against C libraries or calls
+operating-system APIs may need matching target headers and libraries, and that setup
+can be fiddly. Languages with little native dependency and a pure toolchain cross-compile
+most smoothly, especially when they also emit a [static binary](/reference/static-binary/).
+
+## In practice
+
+[Go](/reference/go-language/) makes cross-compilation a one-line affair — setting
+`GOOS` and `GOARCH` builds for any supported platform from any host — which is part of
+why GopherTrunk can ship Linux, macOS, and Windows downloads from one build.
+[Rust](/reference/rust-language/) supports many targets through its toolchain, and
+[C](/reference/c-language/) cross-compiles with dedicated toolchains, though external
+dependencies make it more involved.

--- a/docs/reference/csharp-language.md
+++ b/docs/reference/csharp-language.md
@@ -1,0 +1,71 @@
+---
+slug: csharp-language
+title: C#
+entry_type: language
+category: programming-languages
+description: C# is Microsoft's statically typed, garbage-collected, JIT-compiled language on the .NET platform, the backbone of Windows enterprise software and, via Unity, much of the game industry.
+keywords: C#, C sharp, csharp, .NET, CLR, JIT, garbage collection, Unity, enterprise, Microsoft, managed language
+aka: ["C#", "C sharp", csharp]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Multi-paradigm: object-oriented, functional, imperative" }
+  - { label: Typing, value: "Static, strong (with dynamic opt-in)" }
+  - { label: Appeared, value: "2000 (Microsoft)" }
+  - { label: Designed by, value: "Anders Hejlsberg; Microsoft" }
+  - { label: Compilation, value: "Compiled to IL bytecode, JIT-compiled on the CLR" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Notable uses, value: "Windows enterprise software, games (Unity), web backends" }
+see_also: [java-language, jit-compilation, bytecode, garbage-collection, typescript-language, object-oriented-programming, type-system]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+external:
+  - { title: "C Sharp (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/C_Sharp_(programming_language) }
+  - { title: "The C# programming language — Microsoft", url: https://learn.microsoft.com/en-us/dotnet/csharp/ }
+---
+
+**C#** (pronounced "C sharp") is Microsoft's statically typed, garbage-collected,
+object-oriented language for the .NET platform. It is closely comparable to
+[Java](/reference/java-language/) — a managed, JIT-compiled language with a large
+ecosystem — with arguably more modern language features.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="C# source compiles to intermediate-language bytecode that the .NET CLR JIT-compiles to native code, with garbage-collected memory." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="70" height="38" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="55" y="74">.cs source</text>
+    <line x1="90" y1="71" x2="130" y2="71" stroke="currentColor" stroke-width="1.1"/><text x="110" y="63" font-size="8">compile</text>
+    <rect x="130" y="52" width="86" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="173" y="68">IL bytecode</text>
+    <line x1="216" y1="71" x2="256" y2="71" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="256" y="46" width="80" height="50" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="296" y="66">.NET CLR</text><text x="296" y="80" font-size="8">JIT + GC</text>
+    <line x1="336" y1="71" x2="376" y2="71" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="376" y="52" width="64" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="408" y="74">native</text>
+  </g>
+</svg>
+<figcaption>C# compiles to IL bytecode that the .NET runtime JIT-compiles to native code, with automatic memory management.</figcaption>
+</figure>
+
+## Overview
+
+C# compiles to intermediate-language [bytecode](/reference/bytecode/) that the .NET
+Common Language Runtime (CLR) [JIT-compiles](/reference/jit-compilation/) to native code
+at runtime. It is [statically typed](/reference/type-system/),
+[garbage-collected](/reference/garbage-collection/), and broadly
+[object-oriented](/reference/object-oriented-programming/) with strong functional
+features. Its lead designer, Anders Hejlsberg, also went on to create
+[TypeScript](/reference/typescript-language/), and the two share a family resemblance in
+their type systems.
+
+## Strengths and trade-offs
+
+C#'s strengths are a modern, expressive language design, a big ecosystem, and excellent
+tooling, with trade-offs very similar to [Java](/reference/java-language/): managed
+execution means convenience and safety at the price of a runtime, slower cold starts and
+higher memory use than native code. Historically the platform was Windows-centric, but
+.NET is now genuinely cross-platform, running on Linux and macOS as well.
+
+## Where it's used
+
+C# is the backbone of Windows enterprise software and a major language for web backends
+and cloud services on .NET. Through the **Unity** engine it also underpins a large share
+of the game industry. As with Java, the practical choice between the two often comes down
+to ecosystem and platform rather than the languages themselves.

--- a/docs/reference/declarative-programming.md
+++ b/docs/reference/declarative-programming.md
@@ -1,0 +1,67 @@
+---
+slug: declarative-programming
+title: Declarative programming
+entry_type: concept
+category: paradigms-design
+description: Declarative programming describes the result you want and lets the system figure out the steps, covering functional, logic, query, and configuration styles.
+keywords: declarative programming, declarative, SQL, logic programming, Prolog, what not how, functional programming, configuration, markup, paradigm
+aka: []
+autolink: true
+infobox:
+  - { label: Type, value: "Programming paradigm" }
+  - { label: Key idea, value: "Describe what you want, not how" }
+  - { label: Families, value: "Functional, logic, query, config/markup" }
+  - { label: Examples, value: "SQL, Prolog, HTML/CSS, REST APIs" }
+  - { label: Trade-off, value: "Brevity vs control over execution" }
+  - { label: Contrast with, value: "Imperative programming" }
+see_also: [imperative-programming, functional-programming, object-oriented-programming, rest, abstraction]
+related_lessons:
+  - { title: "Paradigms & language families", url: /learn/intro-software-dev/language-families/ }
+external:
+  - { title: "Declarative programming — Wikipedia", url: https://en.wikipedia.org/wiki/Declarative_programming }
+---
+
+**Declarative programming** flips the question from *how* to *what*: you describe the
+result you want and let the system figure out the steps needed to produce it.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A declarative request describing a desired result is handed to an engine, which plans and executes the hidden steps to produce the result." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="48" width="120" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="80" y="66">what you want</text><text x="80" y="80" font-size="8">SELECT ... WHERE</text>
+    <line x1="140" y1="70" x2="190" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="190" y="40" width="110" height="60" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="245" y="64">engine plans</text><text x="245" y="78" font-size="8">the how</text>
+    <line x1="300" y1="70" x2="350" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="350" y="48" width="90" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="395" y="74">result</text>
+  </g>
+</svg>
+<figcaption>You declare the desired result; the engine chooses and runs the steps to achieve it.</figcaption>
+</figure>
+
+## Families of declarative code
+
+Declarative is a broad umbrella. [Functional programming](/reference/functional-programming/)
+is one family — you describe transformations, not state changes. Beyond it:
+
+- **Query languages** — SQL declares *what* rows you want; the database plans *how* to
+  fetch them, never telling the engine which index to scan.
+- **Logic programming** — Prolog states facts and rules, then poses queries, and the
+  engine searches for solutions that satisfy them.
+- **Markup and config** — HTML, CSS, and infrastructure tools declare a desired structure
+  or end-state rather than a procedure.
+- **APIs** — a [REST](/reference/rest/) request declares the resource you want, leaving
+  the server to fulfil it.
+
+## Trade-offs
+
+Declarative code is often shorter and harder to get subtly wrong, because there are fewer
+moving parts of explicit state to manage. The cost is giving up fine control over
+execution: when a SQL query is slow or a constraint solver picks a poor path, you may need
+to peek behind the [abstraction](/reference/abstraction/) to understand what it generated.
+
+## Versus imperative
+
+The clean contrast is with [imperative programming](/reference/imperative-programming/),
+which spells out an ordered sequence of state changes. Reach for declarative style when
+*what* you want is clearer than *how* to get it — querying data, describing
+infrastructure, or expressing rules — and reach for imperative when you need precise
+control over each step.

--- a/docs/reference/design-patterns.md
+++ b/docs/reference/design-patterns.md
@@ -1,0 +1,68 @@
+---
+slug: design-patterns
+title: Design patterns
+entry_type: concept
+category: paradigms-design
+description: A design pattern is a named, reusable solution to a recurring software design problem, catalogued most famously by the Gang of Four into creational, structural, and behavioral families.
+keywords: design patterns, gang of four, GoF, creational structural behavioral, software design, anti-pattern, reusable solution, Christopher Alexander
+aka: [design patterns "GoF patterns"]
+autolink: true
+infobox:
+  - { label: Type, value: "Software design concept" }
+  - { label: Key idea, value: "Named, reusable solution to a recurring problem" }
+  - { label: Canonical source, value: "Gang of Four (1994), 23 patterns" }
+  - { label: Three families, value: "Creational, structural, behavioral" }
+  - { label: Not, value: "Copy-paste code; it's a template + vocabulary" }
+  - { label: Watch for, value: "Golden hammer anti-pattern (overuse)" }
+see_also: [creational-patterns, structural-patterns, behavioral-patterns, object-oriented-programming, abstraction, coupling-and-cohesion, solid]
+related_lessons:
+  - { title: "What is a design pattern?", url: /learn/intro-software-dev/what-are-patterns/ }
+external:
+  - { title: "Software design pattern — Wikipedia", url: https://en.wikipedia.org/wiki/Software_design_pattern }
+---
+
+**Design patterns** are named, reusable descriptions of solutions to problems that recur
+in software design — not finished code you paste in, but templates for arranging classes,
+objects, and responsibilities so a design stays flexible.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="The Gang of Four catalogue of 23 patterns splits into three families: creational, structural, and behavioral." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="160" y="14" width="140" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="230" y="33">GoF: 23 patterns</text>
+    <line x1="230" y1="44" x2="80" y2="78" stroke="currentColor" stroke-width="1.1"/><line x1="230" y1="44" x2="230" y2="78" stroke="currentColor" stroke-width="1.1"/><line x1="230" y1="44" x2="380" y2="78" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="20" y="80" width="120" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="80" y="100">creational</text><text x="80" y="114" font-size="8">making</text>
+    <rect x="170" y="80" width="120" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="230" y="100">structural</text><text x="230" y="114" font-size="8">arranging</text>
+    <rect x="320" y="80" width="120" height="44" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="380" y="100">behavioral</text><text x="380" y="114" font-size="8">coordinating</text>
+  </g>
+</svg>
+<figcaption>The Gang of Four sorted 23 patterns into three families by the kind of problem each solves.</figcaption>
+</figure>
+
+## A pattern is a template and a vocabulary
+
+Each pattern has four rough parts: a **name**, a **problem** it applies to, a general
+**solution** (an arrangement of classes and objects, not a specific implementation), and
+the **consequences** you accept by using it. Because the solution is general, the same
+pattern looks different in [Java](/reference/java-language/), [Go](/reference/go-language/),
+and [Python](/reference/python-language/) — you reuse the *design*, not the bytes. The
+most underrated benefit is communication: saying "put a facade over the DSP chain"
+conveys a whole design decision in one word.
+
+## The Gang of Four families
+
+The idea came from architecture (Christopher Alexander), but software's canonical source
+is the 1994 book *Design Patterns* by the **"Gang of Four" (GoF)** — Gamma, Helm, Johnson,
+and Vlissides — which catalogued **23 patterns** for [object-oriented](/reference/object-oriented-programming/)
+design. They split into three families:
+
+- [Creational patterns](/reference/creational-patterns/) — how objects get *made* (Factory, Builder, Singleton).
+- [Structural patterns](/reference/structural-patterns/) — how objects are *arranged* (Adapter, Facade, Decorator).
+- [Behavioral patterns](/reference/behavioral-patterns/) — how objects *coordinate* (Observer, Strategy, State).
+
+## Why and when to use them
+
+Most patterns exist to manage [abstraction](/reference/abstraction/) and keep
+[coupling](/reference/coupling-and-cohesion/) low, and many are concrete ways to honour
+[SOLID](/reference/solid/), especially the open/closed principle. But every pattern adds
+indirection. Forcing one where it is not needed is the "golden hammer" anti-pattern; the
+skill is judging when a real problem calls for one rather than memorising all 23.

--- a/docs/reference/dry-kiss-yagni.md
+++ b/docs/reference/dry-kiss-yagni.md
@@ -1,0 +1,63 @@
+---
+slug: dry-kiss-yagni
+title: DRY, KISS & YAGNI
+entry_type: concept
+category: principles-quality
+description: DRY, KISS and YAGNI are three software-design heuristics — don't repeat yourself, keep it simple, and you aren't gonna need it — that keep code lean, simple, and free of speculative complexity.
+keywords: DRY, KISS, YAGNI, don't repeat yourself, keep it simple, you aren't gonna need it, separation of concerns, over-engineering, wrong abstraction, design heuristics
+aka: [DRY, KISS, YAGNI]
+autolink: true
+infobox:
+  - { label: Category, value: "Software design heuristics" }
+  - { label: DRY, value: "Don't Repeat Yourself" }
+  - { label: KISS, value: "Keep It Simple" }
+  - { label: YAGNI, value: "You Aren't Gonna Need It" }
+  - { label: Prevents, value: "Drift, complexity, over-engineering" }
+see_also: [solid, clean-code, refactoring, abstraction, coupling-and-cohesion, design-patterns]
+related_lessons:
+  - { title: "DRY, KISS, YAGNI & separation of concerns", url: /learn/intro-software-dev/dry-kiss-yagni/ }
+external:
+  - { title: "Don't repeat yourself — Wikipedia", url: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself }
+---
+
+**DRY, KISS and YAGNI** are three of software's most-quoted design heuristics — short
+slogans that pack hard-won judgement about keeping code lean, simple, and free of
+speculative complexity.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="Three heuristics: DRY one home for each fact, KISS simplest solution, YAGNI build only what you need." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="35" width="120" height="50" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="80" y="55" font-size="12">DRY</text><text x="80" y="72">one home per fact</text>
+    <rect x="170" y="35" width="120" height="50" rx="6" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="230" y="55" font-size="12">KISS</text><text x="230" y="72">simplest that works</text>
+    <rect x="320" y="35" width="120" height="50" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="380" y="55" font-size="12">YAGNI</text><text x="380" y="72">build only what's needed</text>
+  </g>
+</svg>
+<figcaption>Three heuristics that together hold back drift, complexity, and over-engineering.</figcaption>
+</figure>
+
+## The three heuristics
+
+- **DRY — Don't Repeat Yourself.** Every piece of *knowledge* should have a single,
+  authoritative home. If a rule or constant appears in five places, a change means
+  editing all five — and missing one is a bug. The crucial nuance: DRY is about
+  knowledge, not characters. Two snippets that look alike but encode different facts
+  are not a violation, and merging them creates the "wrong abstraction," which Sandi
+  Metz noted is far costlier than duplication.
+- **KISS — Keep It Simple.** The simplest design that solves the *actual* problem is
+  almost always best. Complexity is a cost you pay forever in comprehension and bugs.
+  Match the complexity of the solution to the complexity of the problem, and not a
+  notch more.
+- **YAGNI — You Aren't Gonna Need It.** Build things when you actually need them, not
+  when you merely foresee needing them. Speculative machinery for an imagined future is
+  usually dead weight — extra code to read, test, and maintain, often guessing wrong.
+
+## Why they matter
+
+The three reinforce each other and a fourth idea, **separation of concerns**: skipping
+speculative features (YAGNI) keeps today's design simple (KISS), and clean seams
+between responsibilities let you deduplicate (DRY) correctly. They are the everyday
+antidote to over-engineering and the foundation beneath [SOLID](/reference/solid/),
+[clean code](/reference/clean-code/), and disciplined [refactoring](/reference/refactoring/).
+Like all heuristics they are guidelines, not laws — the skill is knowing when *not* to
+apply them, such as resisting a premature [abstraction](/reference/abstraction/) on the
+first duplication.

--- a/docs/reference/end-to-end-testing.md
+++ b/docs/reference/end-to-end-testing.md
@@ -1,0 +1,70 @@
+---
+slug: end-to-end-testing
+title: End-to-end testing
+entry_type: concept
+category: testing-delivery
+description: End-to-end (E2E) testing drives the whole system the way a user would, from input to final output, giving the highest confidence that the product works at the cost of being slow and few.
+keywords: end-to-end testing, E2E testing, system testing, test pyramid, user flow, full stack, slow tests, high confidence, software testing
+aka: [end-to-end testing "E2E"]
+autolink: true
+infobox:
+  - { label: Category, value: "Software testing" }
+  - { label: Scope, value: "The whole system, input to output" }
+  - { label: Pyramid layer, value: "Tip — few, slow, high confidence" }
+  - { label: Perspective, value: "Exercises the system as a user" }
+  - { label: Risk, value: "Slow, brittle, costly to maintain" }
+see_also: [unit-testing, integration-testing, mocking, code-coverage, test-driven-development, ci-cd, rest]
+related_lessons:
+  - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
+external:
+  - { title: "System testing — Wikipedia", url: https://en.wikipedia.org/wiki/System_testing }
+---
+
+**End-to-end (E2E) testing** drives the whole system the way a user would, from input
+all the way to final output — the highest-confidence test, but slow and kept few.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A test exercises the full path from user input through the running system to the final output." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="14" y="40" width="70" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="49" y="61">user input</text>
+    <line x1="84" y1="57" x2="124" y2="57" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="124" y="40" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="169" y="61">frontend</text>
+    <line x1="214" y1="57" x2="254" y2="57" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="254" y="40" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="299" y="61">backend + DB</text>
+    <line x1="344" y1="57" x2="384" y2="57" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="384" y="40" width="62" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="415" y="61">output</text>
+    <text x="230" y="95" font-size="8">one test spans the whole path</text>
+  </g>
+</svg>
+<figcaption>An E2E test exercises the entire system from real input to final output, as a user experiences it.</figcaption>
+</figure>
+
+## What it is
+
+An end-to-end test treats the system as a black box and verifies a complete user-facing
+flow: it submits real input, lets the request travel through every layer — frontend,
+backend, [API](/reference/api/), database, external services — and asserts on the final
+result. Because nothing is stubbed, a passing E2E test is strong evidence the product
+*actually works* the way a user will experience it, including the integration points that
+unit and integration tests can miss.
+
+## The trade-off
+
+That confidence is expensive. E2E tests are slow (they spin up the whole system), brittle
+(any layer changing can break them), and costly to maintain. They also localize poorly:
+a failure tells you *something* broke, not *where*. For all these reasons they sit at the
+narrow *tip* of the test pyramid — you keep only a thin layer of them, covering the most
+important flows. The classic anti-pattern is the "inverted pyramid," a suite made mostly
+of slow E2E tests, which becomes slow and flaky and tells you little about the cause of
+a failure.
+
+## How it fits
+
+E2E complements the faster layers beneath it: many [unit tests](/reference/unit-testing/)
+at the base, fewer [integration tests](/reference/integration-testing/) in the middle, a
+handful of E2E on top. They are usually run in a [CI/CD](/reference/ci-cd/) pipeline
+before release rather than on every commit, and even an E2E suite may use
+[mocking](/reference/mocking/) for genuinely external dependencies. Like all tests, they
+contribute to [code coverage](/reference/code-coverage/) but are no substitute for sharp,
+well-asserted checks lower down, and they can be written test-first in the
+[TDD](/reference/test-driven-development/) spirit.

--- a/docs/reference/error-handling.md
+++ b/docs/reference/error-handling.md
@@ -1,0 +1,69 @@
+---
+slug: error-handling
+title: Error handling
+entry_type: concept
+category: principles-quality
+description: Error handling is the part of a program's design that deals with failures — exceptions, error returns, or Result types — treating errors as normal events to be validated, propagated, and recovered from rather than exceptional afterthoughts.
+keywords: error handling, exceptions, error returns, Result type, defensive programming, fail fast, graceful degradation, input validation, idempotency, robustness
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Robustness / program design" }
+  - { label: Mindset, value: "Errors are normal, not exceptional" }
+  - { label: Styles, value: "Exceptions, error returns, Result/Option" }
+  - { label: Strategies, value: "Fail fast vs fail soft" }
+  - { label: Anti-pattern, value: "Silently swallowing errors" }
+see_also: [api, clean-code, solid, unit-testing, rest, type-system]
+related_lessons:
+  - { title: "Errors, edge cases & defensive programming", url: /learn/intro-software-dev/robustness-and-errors/ }
+external:
+  - { title: "Exception handling — Wikipedia", url: https://en.wikipedia.org/wiki/Exception_handling }
+---
+
+**Error handling** is the part of a program's design that deals with failures, treating
+errors as a normal, first-class part of the system rather than an exceptional
+afterthought bolted on at the end.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="An operation branches into a success path and an error path; the error path either fails fast or fails soft." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="80" height="30" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="69">operation</text>
+    <line x1="100" y1="60" x2="150" y2="35" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="70" x2="150" y2="95" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="20" width="90" height="28" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="195" y="38">success path</text>
+    <rect x="150" y="80" width="90" height="28" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="195" y="98">error path</text>
+    <line x1="240" y1="94" x2="290" y2="72" stroke="currentColor" stroke-width="1.1"/><line x1="240" y1="94" x2="290" y2="116" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="290" y="58" width="80" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="330" y="75">fail fast</text>
+    <rect x="290" y="100" width="80" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="330" y="117">fail soft</text>
+  </g>
+</svg>
+<figcaption>Every operation has a success and an error path; the error path either stops loudly or degrades gracefully.</figcaption>
+</figure>
+
+## Styles of handling
+
+Languages represent and propagate errors differently, and each style has trade-offs:
+
+- **Exceptions** (Java, Python, C#) are thrown and unwind the stack until caught.
+  Convenient, but easy to ignore — an uncaught exception crashes the program, and a
+  signature doesn't reveal what it might throw.
+- **Explicit error returns** (Go) return an error value alongside the result; the
+  caller must decide what to do. Verbose, but the error path is impossible to overlook.
+- **Result / Option types** (Rust, many functional languages) make errors part of the
+  return type, and the [type system](/reference/type-system/) forces the caller to
+  handle both cases.
+
+The modern lean is toward explicit, visible handling. Whatever the style, the universal
+anti-pattern is swallowing an error silently — an empty `catch {}` or an ignored return
+turns a recoverable problem into a mysterious one later.
+
+## Strategies and good practice
+
+Robust error handling rests on a few habits. **Validate at the boundary** — distrust
+input the moment it enters the system, so interior code can assume well-formed values.
+Choose deliberately between **fail fast** (stop loudly on programmer bugs and broken
+invariants) and **fail soft** / graceful degradation (carry on with reduced
+functionality on expected, recoverable trouble). Make retry-able operations
+**idempotent** so a retry after an ambiguous failure can't cause duplicate work. These
+ideas shape how an [API](/reference/api/) or a [REST](/reference/rest/) service reports
+problems to its callers, and they are only trustworthy when proven under bad inputs —
+which is the job of [tests](/reference/unit-testing/).

--- a/docs/reference/fortran-language.md
+++ b/docs/reference/fortran-language.md
@@ -1,0 +1,65 @@
+---
+slug: fortran-language
+title: FORTRAN
+entry_type: language
+category: programming-languages
+description: FORTRAN (FORmula TRANslation), introduced in 1957, was the first widely used high-level language; built for scientific and numeric computing, its descendants still dominate high-performance math.
+keywords: FORTRAN, Fortran, scientific computing, numerical computing, high-level language, IBM, John Backus, formula translation, HPC
+aka: [Fortran]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Imperative, procedural, array-oriented" }
+  - { label: Typing, value: "Static, strong" }
+  - { label: Appeared, value: "1957 (IBM)" }
+  - { label: Designed by, value: "John Backus and team at IBM" }
+  - { label: Compilation, value: "Compiled to native code" }
+  - { label: Memory, value: "Manual / static (no garbage collector)" }
+  - { label: Notable uses, value: "Scientific computing, HPC, numerical libraries" }
+see_also: [cobol-language, lisp-language, c-language, julia-language, compiler, imperative-programming, type-system]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "The birth of programming languages", url: /learn/intro-software-dev/birth-of-languages/ }
+external:
+  - { title: "Fortran — Wikipedia", url: https://en.wikipedia.org/wiki/Fortran }
+  - { title: "Fortran programming language", url: https://fortran-lang.org/ }
+---
+
+**FORTRAN** (FORmula TRANslation), introduced by IBM in 1957, was the first widely
+used high-level language. Built so scientists could write formulas almost as they
+appear on paper, its descendants still dominate high-performance numerical computing.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A mathematical formula is written as FORTRAN source, compiled to native code, and run as fast numerical computation." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="74">formula</text>
+    <line x1="100" y1="70" x2="150" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="50" width="90" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="195" y="74">compiler</text>
+    <line x1="240" y1="70" x2="290" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="290" y="50" width="90" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="335" y="68">fast</text><text x="335" y="80">native math</text>
+  </g>
+</svg>
+<figcaption>FORTRAN let scientists write formulas directly; the compiler turned them into fast machine code.</figcaption>
+</figure>
+
+## History
+
+Before FORTRAN, fast code meant hand-written assembly, and many doubted a
+[compiler](/reference/compiler/) could match a human's tuned machine code. John
+Backus's team at IBM proved otherwise, and the productivity gain was so large there
+was no going back. FORTRAN focused on fast numerical computation — exactly the
+number-crunching behind filtering and demodulating signals — and it established that
+high-level languages were practical, opening the door to every language that followed.
+
+## Legacy and use today
+
+FORTRAN is [statically typed](/reference/type-system/), compiled to native code, and
+[imperative](/reference/imperative-programming/) and array-oriented in style, with no
+[garbage collector](/reference/garbage-collection/). Decades of mature, heavily
+optimised numerical libraries are written in it, and it remains in active use across
+weather modelling, physics, and high-performance computing where raw numeric
+throughput matters. Its drawbacks are those of its age: the language and much existing
+code feel dated next to modern tooling, and it is a numeric specialist rather than a
+general-purpose language. Newer numeric languages like [Julia](/reference/julia-language/)
+court its users, while [C](/reference/c-language/) became the more general
+systems-and-DSP workhorse. It shares the early-language stage with
+[COBOL](/reference/cobol-language/) and [LISP](/reference/lisp-language/).

--- a/docs/reference/functional-programming.md
+++ b/docs/reference/functional-programming.md
@@ -1,0 +1,72 @@
+---
+slug: functional-programming
+title: Functional programming
+entry_type: concept
+category: paradigms-design
+description: Functional programming (FP) treats computation as the evaluation of pure functions, favouring immutable data, higher-order functions, and composing small transformations into pipelines.
+keywords: functional programming, FP, pure functions, immutability, higher-order functions, side effects, map filter reduce, composition, declarative
+aka: [functional programming "FP"]
+autolink: true
+infobox:
+  - { label: Type, value: "Programming paradigm" }
+  - { label: Key idea, value: "Compose pure, side-effect-free functions" }
+  - { label: Favours, value: "Immutable data, higher-order functions" }
+  - { label: Benefit, value: "Easy to test and parallelise" }
+  - { label: Strong examples, value: "Lisp, Haskell, Clojure, Elixir" }
+  - { label: A kind of, value: "Declarative programming" }
+see_also: [imperative-programming, declarative-programming, object-oriented-programming, abstraction, concurrency, lisp-language, python-language]
+related_lessons:
+  - { title: "Paradigms & language families", url: /learn/intro-software-dev/language-families/ }
+external:
+  - { title: "Functional programming — Wikipedia", url: https://en.wikipedia.org/wiki/Functional_programming }
+---
+
+**Functional programming** (**FP**) treats computation as the evaluation of functions,
+ideally **pure** ones — functions that always return the same output for the same input
+and have no side effects.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Input data flows through a chain of pure functions — map, filter, reduce — each producing a new value without mutating shared state." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="55" width="55" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="47" y="74">input</text>
+    <line x1="75" y1="70" x2="110" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="110" y="52" width="60" height="36" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="140" y="73">map</text>
+    <line x1="170" y1="70" x2="200" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="200" y="52" width="60" height="36" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="230" y="73">filter</text>
+    <line x1="260" y1="70" x2="290" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="290" y="52" width="60" height="36" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="320" y="73">reduce</text>
+    <line x1="350" y1="70" x2="385" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="385" y="55" width="55" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="412" y="74">output</text>
+    <text x="230" y="118" font-size="8" fill-opacity="0.7">no shared state mutated</text>
+  </g>
+</svg>
+<figcaption>Data flows through a pipeline of pure functions, each producing a new value rather than mutating shared state.</figcaption>
+</figure>
+
+## Core ideas
+
+Pure functions are easy to test, reason about, and run in parallel, because they cannot
+interfere with each other. FP favours **immutable data**, **higher-order functions**
+(functions that take or return other functions), and composing small transformations
+into pipelines — `map`, `filter`, and `reduce` are its everyday vocabulary. Because pure
+code has no hidden state to corrupt, it sidesteps an entire class of bugs and meshes well
+with [concurrency](/reference/concurrency/).
+
+## The mutable-vs-pure axis
+
+FP contrasts sharply with [imperative programming](/reference/imperative-programming/),
+which says "change this variable, then that one." Functional code instead says "produce a
+new value from old values." FP is one branch of
+[declarative programming](/reference/declarative-programming/): you describe
+transformations rather than spelling out step-by-step state changes. This makes it a
+natural fit for dataflow problems where each stage is a clean transformation.
+
+## In practice
+
+[Lisp](/reference/lisp-language/) is the original functional language; Haskell is purely
+functional, while Clojure, Elixir, and Scala lean functional. Most mainstream languages —
+[Python](/reference/python-language/),
+[JavaScript](/reference/javascript-language/), and others — now offer functional tools
+alongside [object-oriented](/reference/object-oriented-programming/) features, so the
+paradigm is usually a style you choose per piece of code rather than a whole language you
+adopt.

--- a/docs/reference/garbage-collection.md
+++ b/docs/reference/garbage-collection.md
@@ -1,0 +1,69 @@
+---
+slug: garbage-collection
+title: Garbage collection
+entry_type: concept
+category: language-internals
+description: Garbage collection (GC) is automatic memory management that reclaims heap memory a program can no longer reach, freeing developers from manual allocation and freeing at the cost of some runtime overhead.
+keywords: garbage collection, GC, automatic memory management, heap, mark and sweep, generational, reference counting, memory leak, stop-the-world
+aka: [garbage collection, GC]
+autolink: true
+infobox:
+  - { label: Category, value: Memory management }
+  - { label: Frees developer from, value: Manual allocate / free }
+  - { label: Common strategies, value: "Mark-and-sweep, generational, reference counting" }
+  - { label: Trade-off, value: "Safety & convenience vs pause time / overhead" }
+  - { label: Garbage-collected, value: "Go, Java, Python, C#, JavaScript" }
+  - { label: Opposite of, value: "Manual memory management (C, C++)" }
+see_also: [memory-management, static-binary, compiler, go-language, java-language, c-language, type-system]
+related_lessons:
+  - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Garbage collection (computer science) — Wikipedia", url: https://en.wikipedia.org/wiki/Garbage_collection_(computer_science) }
+---
+
+**Garbage collection** (**GC**) is a form of automatic [memory management](/reference/memory-management/)
+in which the language runtime reclaims memory the program can no longer reach, so the
+programmer never has to free it by hand.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Root references reach some heap objects, which the collector keeps; objects with no path from the roots are unreachable and reclaimed." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="55" width="50" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="45" y="74">roots</text>
+    <circle cx="160" cy="40" r="18" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.3"/><text x="160" y="43">live</text>
+    <circle cx="160" cy="100" r="18" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.3"/><text x="160" y="103">live</text>
+    <circle cx="250" cy="70" r="18" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.3"/><text x="250" y="73">live</text>
+    <line x1="70" y1="65" x2="142" y2="45" stroke="currentColor" stroke-width="1.1"/><line x1="70" y1="75" x2="142" y2="98" stroke="currentColor" stroke-width="1.1"/><line x1="178" y1="45" x2="232" y2="65" stroke="currentColor" stroke-width="1.1"/>
+    <circle cx="360" cy="40" r="18" fill="none" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 3"/><text x="360" y="43" fill-opacity="0.6">freed</text>
+    <circle cx="360" cy="100" r="18" fill="none" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 3"/><text x="360" y="103" fill-opacity="0.6">freed</text>
+    <text x="360" y="135" font-size="8" fill-opacity="0.7">unreachable → reclaimed</text>
+  </g>
+</svg>
+<figcaption>The collector keeps objects reachable from the program's roots and reclaims the rest.</figcaption>
+</figure>
+
+## How it works
+
+The runtime periodically determines which heap objects are still reachable by
+following references from a set of *roots* (stack variables, globals, registers).
+Anything with no path from the roots is garbage and its memory is reclaimed. Common
+strategies include **mark-and-sweep** (mark reachable objects, sweep the rest),
+**generational** collection (collect short-lived objects more often), and
+**reference counting** (track how many references point at each object).
+
+## Trade-offs
+
+GC eliminates entire classes of bugs that plague manual memory code — use-after-free,
+double-free, and many memory leaks — and removes a great deal of boilerplate. The price
+is runtime overhead and occasional pauses (historically "stop-the-world" collections),
+which is why latency-sensitive and systems languages such as [C](/reference/c-language/)
+and [C++](/reference/cpp-language/) leave memory to the programmer, and why
+[Rust](/reference/rust-language/) achieves safety at compile time without a collector
+at all.
+
+## In practice
+
+Most mainstream languages are garbage-collected, including [Go](/reference/go-language/),
+[Java](/reference/java-language/), [Python](/reference/python-language/), and C#. Their
+collectors have grown sophisticated enough that GC pauses are a non-issue for the vast
+majority of applications.

--- a/docs/reference/go-language.md
+++ b/docs/reference/go-language.md
@@ -1,0 +1,75 @@
+---
+slug: go-language
+title: Go
+entry_type: language
+category: programming-languages
+description: Go (Golang) is a statically typed, compiled language from Google designed for simple, reliable, concurrent systems software; it builds to a single static binary and has goroutines and channels built in.
+keywords: Go, Golang, goroutines, channels, garbage collection, static binary, concurrency, Google, compiled language, cross-compilation
+aka: [Go, Golang]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Imperative, concurrent, structured" }
+  - { label: Typing, value: "Static, strong, inferred" }
+  - { label: Appeared, value: "2009 (Google)" }
+  - { label: Designed by, value: "Robert Griesemer, Rob Pike, Ken Thompson" }
+  - { label: Compilation, value: "Ahead-of-time to a native static binary" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Concurrency, value: "Goroutines + channels (CSP)" }
+  - { label: Notable uses, value: "GopherTrunk, Docker, Kubernetes" }
+see_also: [goroutines, garbage-collection, concurrency, static-binary, cross-compilation, compiler, type-system, c-language, rust-language]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+  - { title: "Concurrency models", url: /learn/intro-software-dev/concurrency-models/ }
+external:
+  - { title: "Go (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Go_(programming_language) }
+  - { title: "The Go programming language", url: https://go.dev/ }
+---
+
+**Go** (often called **Golang** after its website) is a statically typed, compiled
+programming language created at Google for building simple, reliable, and efficient
+systems software. GopherTrunk itself is written in Go.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Source files compile ahead of time into one static binary that runs many concurrent goroutines communicating over a channel." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="60" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="50" y="74">.go files</text>
+    <line x1="80" y1="70" x2="120" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="100" y="62" font-size="8">build</text>
+    <rect x="120" y="50" width="80" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="160" y="68">static</text><text x="160" y="80">binary</text>
+    <line x1="200" y1="70" x2="240" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="240" y="20" width="70" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="275" y="35">goroutine</text>
+    <rect x="240" y="58" width="70" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="275" y="73">goroutine</text>
+    <rect x="240" y="96" width="70" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="275" y="111">goroutine</text>
+    <line x1="330" y1="31" x2="370" y2="69" stroke="currentColor" stroke-width="1.1"/><line x1="330" y1="69" x2="370" y2="69" stroke="currentColor" stroke-width="1.1"/><line x1="330" y1="107" x2="370" y2="69" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="370" y="55" width="70" height="28" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="405" y="72">channel</text>
+  </g>
+</svg>
+<figcaption>Go compiles ahead of time into one self-contained binary that runs many lightweight goroutines communicating over channels.</figcaption>
+</figure>
+
+## Overview
+
+Go pairs the performance of a [compiled](/reference/compiler/) language with the
+simplicity of a deliberately small syntax. Programs build [ahead of time](/reference/jit-compilation/)
+into a single [static binary](/reference/static-binary/) with no runtime dependency,
+which you can drop onto any matching machine and run. That same toolchain makes
+[cross-compilation](/reference/cross-compilation/) — building a Windows or macOS
+binary from a Linux host — a one-line affair.
+
+## Key characteristics
+
+Go's headline feature is first-class [concurrency](/reference/concurrency/): cheap
+[goroutines](/reference/goroutines/) and channels make concurrent stream processing
+natural. It is [garbage-collected](/reference/garbage-collection/), so there is no
+manual memory management, and it has a [static type system](/reference/type-system/)
+with inference that keeps code terse. The trade-offs are real — the garbage collector
+introduces brief pauses, raw numeric throughput trails [C](/reference/c-language/) and
+[Rust](/reference/rust-language/), and the minimalist design (generics arrived only in
+2022) can feel limiting.
+
+## Why GopherTrunk uses it
+
+A self-contained static binary ships effortlessly to Linux, macOS, and Windows with no
+installer or shared libraries, and goroutines map cleanly onto the many concurrent
+decode pipelines an SDR scanner runs at once — making Go a strong fit for
+infrastructure, network services, CLIs, and stream engines like this one.

--- a/docs/reference/goroutines.md
+++ b/docs/reference/goroutines.md
@@ -1,0 +1,73 @@
+---
+slug: goroutines
+title: Goroutines
+entry_type: concept
+category: concurrency-execution
+description: A goroutine is a lightweight task managed by the Go runtime, which multiplexes many of them onto a few OS threads and has them communicate over channels.
+keywords: goroutine, Go, channel, CSP, communicating sequential processes, lightweight thread, scheduler, concurrency, share by communicating
+aka: [goroutines]
+autolink: true
+infobox:
+  - { label: Category, value: Concurrency primitive }
+  - { label: Language, value: "Go" }
+  - { label: Managed by, value: "The Go runtime, not the OS" }
+  - { label: Cost, value: "Tiny stacks — hundreds of thousands are cheap" }
+  - { label: Communicate via, value: "Channels (CSP)" }
+  - { label: Slogan, value: "Share memory by communicating" }
+see_also: [concurrency, threads, async-programming, go-language, garbage-collection]
+related_lessons:
+  - { title: "Concurrency and parallelism", url: /learn/intro-software-dev/concurrency-models/ }
+  - { title: "Concurrency and pipelines", url: /learn/intro-software-dev/concurrency-and-pipelines/ }
+external:
+  - { title: "Go (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Go_(programming_language)#Concurrency }
+---
+
+**A goroutine** is a lightweight task managed by the [Go](/reference/go-language/)
+runtime rather than the operating system. They are so cheap that you can run hundreds of
+thousands at once, and they communicate over *channels* instead of sharing memory
+directly.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="The Go runtime multiplexes many goroutines onto a few OS threads, and goroutines pass values through a channel." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="18" width="80" height="20" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="60" y="32" font-size="8">goroutine</text>
+    <rect x="20" y="44" width="80" height="20" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="60" y="58" font-size="8">goroutine</text>
+    <rect x="20" y="70" width="80" height="20" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="60" y="84" font-size="8">goroutine</text>
+    <rect x="20" y="96" width="80" height="20" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="60" y="110" font-size="8">goroutine</text>
+    <line x1="100" y1="28" x2="160" y2="55" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="54" x2="160" y2="60" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="80" x2="160" y2="72" stroke="currentColor" stroke-width="1.1"/><line x1="100" y1="106" x2="160" y2="78" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="160" y="48" width="90" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="205" y="63" font-size="8">runtime</text><text x="205" y="76" font-size="7">few OS threads</text>
+    <line x1="250" y1="66" x2="310" y2="66" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="310" y="50" width="120" height="32" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="370" y="70" font-size="8">channel</text>
+  </g>
+</svg>
+<figcaption>The Go runtime multiplexes many cheap goroutines onto a few OS threads; channels carry values between them.</figcaption>
+</figure>
+
+## How it works
+
+You start a goroutine by prefixing a function call with `go`. Each begins with a tiny
+stack that grows as needed, and the Go runtime's scheduler multiplexes many goroutines
+onto a small pool of OS [threads](/reference/threads/), so they cost almost nothing
+compared with one OS thread per task. Goroutines coordinate through **channels** — typed
+pipes where one goroutine sends a value and another receives it. The channel handles
+synchronization, so there is no explicit lock and no data race on the data that flows
+through it. This is the *Communicating Sequential Processes* (CSP) model, captured by the
+slogan: "Do not communicate by sharing memory; share memory by communicating."
+
+## Trade-offs
+
+Goroutines make concurrent **pipelines** natural to express and are cheap enough that you
+can spawn one per connection or per work item without worrying about cost. The runtime
+can spread them across cores for real [parallelism](/reference/concurrency/) when work is
+CPU-bound, and channels make whole categories of race bugs impossible by design. The
+trade-offs are the small runtime scheduler overhead and the [garbage
+collector](/reference/garbage-collection/) that supports them, plus the discipline of
+choosing channels over shared state.
+
+## In practice
+
+Goroutines and channels are central to [Go](/reference/go-language/)'s character and a
+big reason it is common in networked and streaming systems. In GopherTrunk they map
+cleanly onto the concurrent decode pipelines an SDR scanner runs at once — a capture
+stage feeding a DSP stage feeding a decode stage, each a goroutine, glued together by
+channels.

--- a/docs/reference/imperative-programming.md
+++ b/docs/reference/imperative-programming.md
@@ -1,0 +1,69 @@
+---
+slug: imperative-programming
+title: Imperative programming
+entry_type: concept
+category: paradigms-design
+description: Imperative programming is the paradigm of telling the computer how to do something as an ordered sequence of statements that change state, closely mirroring how the hardware works.
+keywords: imperative programming, procedural programming, statements, mutable state, control flow, loops, assignment, paradigm, procedures
+aka: []
+autolink: true
+infobox:
+  - { label: Type, value: "Programming paradigm" }
+  - { label: Key idea, value: "Step-by-step statements that change state" }
+  - { label: Defining trait, value: "Mutable state, ordered execution" }
+  - { label: Sub-style, value: "Procedural (organised into procedures)" }
+  - { label: Strong examples, value: "C, Go, Fortran, COBOL" }
+  - { label: Contrast with, value: "Declarative programming" }
+see_also: [declarative-programming, functional-programming, object-oriented-programming, memory-management, c-language, go-language, fortran-language]
+related_lessons:
+  - { title: "Paradigms & language families", url: /learn/intro-software-dev/language-families/ }
+external:
+  - { title: "Imperative programming — Wikipedia", url: https://en.wikipedia.org/wiki/Imperative_programming }
+---
+
+**Imperative programming** is the oldest and most direct paradigm: you tell the computer
+*how* to do something as an ordered sequence of statements that change state — assign a
+value, loop, increment a counter, branch on a condition.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A counter variable is initialised then mutated step by step through ordered statements until a loop completes." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="55" width="90" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="75" y="74">total = 0</text>
+    <line x1="120" y1="70" x2="150" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="55" width="110" height="30" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="205" y="74">total += i</text>
+    <line x1="260" y1="70" x2="290" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="290" y="55" width="90" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="335" y="74">i &lt; n ?</text>
+    <path d="M335 85 L335 110 L205 110 L205 85" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="270" y="124" font-size="8">loop back (mutate again)</text>
+    <line x1="380" y1="70" x2="420" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="420" y="62" font-size="8">done</text>
+  </g>
+</svg>
+<figcaption>State is initialised then mutated step by step; the order of statements is what determines the result.</figcaption>
+</figure>
+
+## Core ideas
+
+The defining trait of imperative code is **mutable state**: variables change over time,
+and the order of statements matters. This mirrors how the hardware actually works — the
+CPU executes one instruction after another, updating registers and memory — which is why
+it feels natural and why early languages were imperative. That same power is the risk:
+many subtle bugs come from state changing when or where you did not expect.
+
+## Procedural programming
+
+**Procedural** programming is imperative code organised into reusable *procedures*
+(functions). Instead of one long script, you factor work into named routines that call
+each other. [C](/reference/c-language/) is the classic procedural language, and
+[Fortran](/reference/fortran-language/) and [COBOL](/reference/cobol-language/) are early
+examples. Procedural style pairs naturally with manual
+[memory management](/reference/memory-management/) and tight performance loops.
+
+## When it fits
+
+Reach for imperative or procedural style when you are close to the hardware or in a tight
+performance loop, where you want exact control over each operation.
+[Go](/reference/go-language/) is mostly procedural with lightweight interfaces. It
+contrasts with [declarative programming](/reference/declarative-programming/), which
+describes *what* you want rather than *how*, and with
+[functional programming](/reference/functional-programming/), which avoids mutable state
+altogether. Most languages are multi-paradigm, so an imperative inner loop often sits
+inside [object-oriented](/reference/object-oriented-programming/) or functional code.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,13 +1,15 @@
 ---
 layout: reference-hub
-title: GopherTrunk Reference — RF & SDR encyclopedia
-description: A plain-language encyclopedia of radio and software-defined-radio terms, technologies, algorithms, people, hardware, and organizations — long-form reference articles, cross-linked and browsable by category or A–Z.
-keywords: RF encyclopedia, SDR reference, radio terms, P25 DMR TETRA reference, vocoder, IQ data, modulation, trunked radio, DefinedTerm
+title: GopherTrunk Reference — RF, SDR & software-development encyclopedia
+description: A plain-language encyclopedia spanning radio and software-defined radio (terms, technologies, algorithms, people, hardware, organizations) and software development (programming languages and core concepts) — long-form reference articles, cross-linked and browsable by domain, category, or A–Z.
+keywords: RF encyclopedia, SDR reference, radio terms, P25 DMR TETRA reference, programming languages reference, software development encyclopedia, compiler garbage collection, Go Python Rust, DefinedTerm
 permalink: /reference/
 autolink: false
 ---
 
 Looking for a quick definition? The [glossary](/learn/rf-sdr/glossary/) has one-line
-entries. Want to *learn* in order? Start the [learning path](/learn/rf-sdr/). This
-**reference** is the long-form, neutral encyclopedia: each article defines and
-explains one topic in depth and links to everything related.
+entries. Want to *learn* in order? Start a learning path —
+[RF & SDR](/learn/rf-sdr/) or [intro to software development](/learn/intro-software-dev/).
+This **reference** is the long-form, neutral encyclopedia: each article defines and
+explains one topic in depth and links to everything related. Entries are grouped
+into **domains** — RF & SDR and Software Development — each with its own categories.

--- a/docs/reference/integration-testing.md
+++ b/docs/reference/integration-testing.md
@@ -1,0 +1,68 @@
+---
+slug: integration-testing
+title: Integration testing
+entry_type: concept
+category: testing-delivery
+description: Integration testing checks that several components work correctly together — exercising the real seams between them, such as a parser feeding a decoder or code talking to a database.
+keywords: integration testing, integration test, test pyramid, component interaction, seams, database testing, software testing, middle layer
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Software testing" }
+  - { label: Scope, value: "Several components working together" }
+  - { label: Pyramid layer, value: "Middle — some, medium speed" }
+  - { label: Exercises, value: "Real seams between components" }
+  - { label: Run by, value: "CI pipelines" }
+see_also: [unit-testing, end-to-end-testing, mocking, code-coverage, test-driven-development, ci-cd, rest]
+related_lessons:
+  - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
+external:
+  - { title: "Integration testing — Wikipedia", url: https://en.wikipedia.org/wiki/Integration_testing }
+---
+
+**Integration testing** checks that several components work correctly *together*,
+exercising the real seams between them — a parser feeding a decoder, or code talking to a
+database.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="Three components connected in sequence, with the joins between them highlighted as what integration tests exercise." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="45" width="90" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="65" y="66">component A</text>
+    <line x1="110" y1="63" x2="160" y2="63" stroke="currentColor" stroke-width="1.6"/><circle cx="135" cy="63" r="4" fill="currentColor"/>
+    <rect x="160" y="45" width="90" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="205" y="66">component B</text>
+    <line x1="250" y1="63" x2="300" y2="63" stroke="currentColor" stroke-width="1.6"/><circle cx="275" cy="63" r="4" fill="currentColor"/>
+    <rect x="300" y="45" width="90" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="345" y="66">database</text>
+    <text x="205" y="100" font-size="8">tests the joins, not just each box</text>
+  </g>
+</svg>
+<figcaption>Integration tests exercise the seams where components meet, not just each component alone.</figcaption>
+</figure>
+
+## What it is
+
+Where a [unit test](/reference/unit-testing/) isolates one piece, an integration test
+deliberately wires several pieces together and checks that the *combination* behaves
+correctly. The bugs it catches live in the joins — mismatched assumptions about data
+formats, wrong ordering, broken contracts between an [API](/reference/api/) and its
+caller, or a query that doesn't match the schema. These tests often use real
+collaborators (a real database, a real file format) precisely because the seam is the
+thing under test, though they may still stub out slow or external systems via
+[mocking](/reference/mocking/).
+
+## Where it sits
+
+Integration tests form the *middle* layer of the test pyramid: fewer than unit tests and
+slower, because they exercise real interactions rather than one isolated function. That
+trade-off is deliberate — they give more end-to-end-like confidence than a unit test
+while remaining faster and more targeted than a full
+[end-to-end test](/reference/end-to-end-testing/). A healthy suite has a wide base of
+unit tests, a smaller band of integration tests, and only a thin tip of E2E.
+
+## In practice
+
+Like all tests, integration tests only protect you if they run automatically. A
+[CI/CD](/reference/ci-cd/) pipeline builds the code and runs the full suite on every
+push, so a broken seam is caught within minutes. They contribute to
+[code coverage](/reference/code-coverage/) and complement the
+[test-driven development](/reference/test-driven-development/) habit of specifying
+behavior before building it.

--- a/docs/reference/interpreter.md
+++ b/docs/reference/interpreter.md
@@ -1,0 +1,70 @@
+---
+slug: interpreter
+title: Interpreter
+entry_type: concept
+category: language-internals
+description: An interpreter is a program that reads source code (or bytecode) and executes it directly at run time, rather than compiling it to a native binary first.
+keywords: interpreter, interpreted language, run time, bytecode, virtual machine, CPython, REPL, dynamic execution
+aka: [interpreter]
+autolink: true
+infobox:
+  - { label: Category, value: Language tooling }
+  - { label: Input, value: "Source code or bytecode" }
+  - { label: When it runs, value: "At run time, statement by statement" }
+  - { label: Trade-off, value: "Flexibility & fast iteration vs slower execution" }
+  - { label: Needs on target, value: "The interpreter installed" }
+  - { label: Interpreted languages, value: "Python, Ruby, classic JavaScript" }
+see_also: [compiler, bytecode, jit-compilation, static-vs-dynamic-typing, python-language, ruby-language, javascript-language]
+related_lessons:
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Interpreter (computing) — Wikipedia", url: https://en.wikipedia.org/wiki/Interpreter_(computing) }
+---
+
+**An interpreter** is a program that reads source code and executes it directly,
+statement by statement, every time the program runs — instead of translating the
+whole program to a native binary ahead of time the way a [compiler](/reference/compiler/)
+does.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="An interpreter reads source statements one at a time and runs each immediately." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="20" width="70" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="55" y="35">line 1</text>
+    <rect x="20" y="54" width="70" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="55" y="69">line 2</text>
+    <rect x="20" y="88" width="70" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="55" y="103">line 3</text>
+    <line x1="90" y1="31" x2="190" y2="60" stroke="currentColor" stroke-width="1.1"/><line x1="90" y1="65" x2="190" y2="65" stroke="currentColor" stroke-width="1.1"/><line x1="90" y1="99" x2="190" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="190" y="48" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="235" y="69">interpreter</text>
+    <line x1="280" y1="65" x2="340" y2="65" stroke="currentColor" stroke-width="1.1"/><text x="310" y="57" font-size="8">runs now</text>
+    <rect x="340" y="48" width="90" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="385" y="69">result</text>
+  </g>
+</svg>
+<figcaption>The interpreter reads each statement and executes it immediately, with no separate build step.</figcaption>
+</figure>
+
+## How it works
+
+A pure interpreter walks the source program and performs each operation as it
+encounters it. In practice most modern "interpreted" languages take a half-step
+first: they compile the source to compact [bytecode](/reference/bytecode/) for a
+*virtual machine*, and the VM interprets that bytecode. CPython, for example,
+compiles `.py` files to `.pyc` bytecode and runs it on the Python VM. Either way,
+translation happens during execution rather than once up front.
+
+## Trade-offs
+
+Interpretation inverts the compiled story. Execution is **slower**, because the
+interpreter adds overhead to every operation, and the user must have the interpreter
+installed. In exchange you get **fast iteration** — no separate build step, so you
+edit and re-run instantly — and **flexibility**, including the runtime dynamism that
+[dynamic typing](/reference/static-vs-dynamic-typing/) allows and interactive
+read-eval-print loops (REPLs). [JIT compilation](/reference/jit-compilation/) is a
+hybrid that keeps the portable bytecode but compiles hot paths to native code to
+recover speed.
+
+## In practice
+
+[Python](/reference/python-language/), [Ruby](/reference/ruby-language/), and classic
+[JavaScript](/reference/javascript-language/) are the canonical interpreted languages.
+Their flexibility and quick edit-run cycle make them popular for scripting, data work,
+and rapid prototyping, where developer speed matters more than raw execution speed.

--- a/docs/reference/java-language.md
+++ b/docs/reference/java-language.md
@@ -1,0 +1,72 @@
+---
+slug: java-language
+title: Java
+entry_type: language
+category: programming-languages
+description: Java is a statically typed, garbage-collected, JIT-compiled language that runs on the JVM, offering real cross-platform portability and a massive, mature enterprise ecosystem.
+keywords: Java, JVM, bytecode, JIT, garbage collection, enterprise, Android, write once run anywhere, object-oriented
+aka: [Java]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Object-oriented, imperative, generic" }
+  - { label: Typing, value: "Static, strong" }
+  - { label: Appeared, value: "1995 (Sun Microsystems)" }
+  - { label: Designed by, value: "James Gosling; Sun Microsystems" }
+  - { label: Compilation, value: "Compiled to bytecode, JIT-compiled on the JVM" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Notable uses, value: "Enterprise systems, Android backends, big data" }
+see_also: [csharp-language, jit-compilation, bytecode, garbage-collection, kotlin-language, object-oriented-programming, type-system]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+external:
+  - { title: "Java (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Java_(programming_language) }
+  - { title: "The Java platform — Oracle", url: https://www.java.com/ }
+---
+
+**Java** is a statically typed, garbage-collected, object-oriented language that
+compiles to bytecode and runs on the Java Virtual Machine (JVM), giving it genuine
+"write once, run anywhere" portability across platforms.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Java source compiles once to portable bytecode, which the JVM JIT-compiles to native code on each platform at runtime." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="70" height="38" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="55" y="74">.java</text>
+    <line x1="90" y1="71" x2="128" y2="71" stroke="currentColor" stroke-width="1.1"/><text x="109" y="63" font-size="8">javac</text>
+    <rect x="128" y="52" width="78" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="167" y="74">bytecode</text>
+    <line x1="206" y1="71" x2="244" y2="71" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="244" y="46" width="70" height="50" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="279" y="66">JVM</text><text x="279" y="80" font-size="8">JIT + GC</text>
+    <line x1="314" y1="60" x2="356" y2="42" stroke="currentColor" stroke-width="1.1"/><line x1="314" y1="82" x2="356" y2="100" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="356" y="28" width="84" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="398" y="45">Windows</text>
+    <rect x="356" y="88" width="84" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="398" y="105">Linux / mac</text>
+  </g>
+</svg>
+<figcaption>Java compiles once to portable bytecode; each platform's JVM JIT-compiles it to native code at runtime.</figcaption>
+</figure>
+
+## Overview
+
+Java source compiles to platform-independent [bytecode](/reference/bytecode/), which the
+JVM [JIT-compiles](/reference/jit-compilation/) to native code as the program runs. It is
+[statically typed](/reference/type-system/), thoroughly
+[object-oriented](/reference/object-oriented-programming/), and
+[garbage-collected](/reference/garbage-collection/). The combination of a portable
+runtime, strong tooling and decades of libraries has made it one of the most widely
+deployed languages in large-scale software.
+
+## Strengths and trade-offs
+
+Java's strengths are a massive, mature ecosystem, strong tooling, real cross-platform
+portability and battle-tested reliability at scale. The common criticisms are that it is
+**verbose** and ceremony-heavy, and that the JVM brings slower startup and higher memory
+use than native code. Modern Java has modernised considerably, and on the same platform
+[Kotlin](/reference/kotlin-language/) offers a more concise alternative that interoperates
+fully with Java code.
+
+## Where it's used
+
+Java runs enormous enterprise systems, Android backends, big-data platforms and
+long-lived business applications. Its closest counterpart is [C#](/reference/csharp-language/)
+on .NET, which shares almost the same managed, JIT-compiled, garbage-collected design;
+the choice between them is usually about ecosystem and platform rather than language
+merit.

--- a/docs/reference/javascript-language.md
+++ b/docs/reference/javascript-language.md
@@ -1,0 +1,71 @@
+---
+slug: javascript-language
+title: JavaScript
+entry_type: language
+category: programming-languages
+description: JavaScript is a dynamically typed, JIT-compiled language that runs natively in every web browser and, via Node.js, on servers, making it the de facto language of the web.
+keywords: JavaScript, JS, ECMAScript, Node.js, npm, browser, dynamic typing, JIT, web, V8
+aka: [JavaScript, JS, ECMAScript]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Multi-paradigm: event-driven, functional, object-oriented" }
+  - { label: Typing, value: "Dynamic, weak (loose) typing" }
+  - { label: Appeared, value: "1995 (Netscape)" }
+  - { label: Designed by, value: "Brendan Eich" }
+  - { label: Compilation, value: "JIT-compiled by modern engines (e.g. V8)" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Notable uses, value: "Web front-ends, Node.js servers, tooling" }
+see_also: [typescript-language, jit-compilation, garbage-collection, static-vs-dynamic-typing, async-programming, python-language, type-system]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Type systems", url: /learn/intro-software-dev/type-systems/ }
+external:
+  - { title: "JavaScript — Wikipedia", url: https://en.wikipedia.org/wiki/JavaScript }
+  - { title: "MDN: JavaScript", url: https://developer.mozilla.org/en-US/docs/Web/JavaScript }
+---
+
+**JavaScript** (JS) is a dynamically typed, garbage-collected programming language and
+the only language that runs natively in every web browser; with Node.js it also runs on
+servers, letting one language cover the whole stack.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="JavaScript runs in both the browser and on the server via Node.js, drawing on the npm ecosystem." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="170" y="54" width="120" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="230" y="75">JavaScript</text>
+    <line x1="170" y1="71" x2="110" y2="40" stroke="currentColor" stroke-width="1.1"/>
+    <line x1="290" y1="71" x2="350" y2="40" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="40" y="22" width="80" height="32" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="80" y="42">browser</text>
+    <rect x="340" y="22" width="90" height="32" rx="4" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="385" y="42">Node.js</text>
+    <line x1="230" y1="88" x2="230" y2="110" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="180" y="110" width="100" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="230" y="126">npm ecosystem</text>
+  </g>
+</svg>
+<figcaption>JavaScript runs in the browser and on the server (Node.js), sharing the vast npm ecosystem.</figcaption>
+</figure>
+
+## Overview
+
+Modern JavaScript engines such as V8 [JIT-compile](/reference/jit-compilation/) the
+language to native code at runtime, so it is far faster than its scripting origins
+suggest. It is [dynamically typed](/reference/static-vs-dynamic-typing/) and
+[garbage-collected](/reference/garbage-collection/), with an event-driven,
+[asynchronous](/reference/async-programming/) model at its core that suits I/O-bound web
+work. The standard is formally called ECMAScript, and the npm registry is among the
+largest package ecosystems in existence.
+
+## Strengths and trade-offs
+
+Its defining strength is ubiquity: it is the one language guaranteed to run in every
+browser, and with Node.js you can write both client and server in it. The drawbacks are
+decades of quirky design decisions and famously loose, weak typing that lets subtle bugs
+slip through at runtime. [TypeScript](/reference/typescript-language/) — JavaScript with
+a static [type system](/reference/type-system/) layered on top — addresses the typing
+problem and compiles back down to plain JavaScript, which is why it has become the
+default for serious front-end and Node projects.
+
+## Where it's used
+
+JavaScript powers virtually all interactive web front-ends, a large share of server
+backends through Node.js, and much of modern build tooling. For larger codebases teams
+increasingly write [TypeScript](/reference/typescript-language/) and ship the compiled
+JavaScript, but the runtime everywhere remains JavaScript itself.

--- a/docs/reference/jit-compilation.md
+++ b/docs/reference/jit-compilation.md
@@ -1,0 +1,70 @@
+---
+slug: jit-compilation
+title: JIT vs AOT compilation
+entry_type: concept
+category: language-internals
+description: JIT (just-in-time) compilation translates code to native machine code while a program runs, while AOT (ahead-of-time) compilation does all the translation before the program ships.
+keywords: JIT compilation, AOT compilation, just in time, ahead of time, hot path, HotSpot, V8, warm up, native code
+aka: ["JIT", "AOT"]
+autolink: true
+infobox:
+  - { label: Category, value: Compilation strategy }
+  - { label: AOT, value: "Translate to native code before shipping" }
+  - { label: JIT, value: "Translate hot paths to native code while running" }
+  - { label: JIT trade-off, value: "Near-native speed vs slow warm-up & memory" }
+  - { label: AOT examples, value: "C, Rust, Go" }
+  - { label: JIT examples, value: "JVM, V8, .NET" }
+see_also: [compiler, interpreter, bytecode, static-binary, java-language, javascript-language, go-language]
+related_lessons:
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Just-in-time compilation — Wikipedia", url: https://en.wikipedia.org/wiki/Just-in-time_compilation }
+---
+
+**Just-in-time (JIT) compilation** translates code to native machine code *while the
+program runs*, optimizing the parts it observes executing most; **ahead-of-time (AOT)
+compilation** does all of that translation up front, before the program ever ships.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A JIT runs bytecode in a VM, detects a frequently-run hot path, and compiles it to native code on the fly." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="70" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="55" y="74">bytecode</text>
+    <line x1="90" y1="70" x2="140" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="140" y="50" width="70" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="175" y="74">VM runs</text>
+    <line x1="210" y1="70" x2="260" y2="40" stroke="currentColor" stroke-width="1.1"/><text x="240" y="30" font-size="8">hot path</text>
+    <rect x="260" y="20" width="90" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="305" y="39">JIT compile</text>
+    <line x1="350" y1="35" x2="400" y2="60" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="360" y="58" width="80" height="30" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="400" y="77">native code</text>
+  </g>
+</svg>
+<figcaption>A JIT runs bytecode, spots a frequently-executed "hot" path, and compiles it to native code on the fly.</figcaption>
+</figure>
+
+## How it works
+
+An [AOT](/reference/compiler/) compiler produces a finished native binary — the
+approach [C](/reference/c-language/), [Rust](/reference/rust-language/), and
+[Go](/reference/go-language/) take. A JIT instead ships portable
+[bytecode](/reference/bytecode/) that a virtual machine begins
+[interpreting](/reference/interpreter/); as it runs, the JIT spots frequently
+executed ("hot") sections, compiles them to native machine code, and can optimize
+based on what it actually observes — types, branch directions, inlining
+opportunities. The result is often near-native steady-state speed.
+
+## Trade-offs
+
+AOT gives **instant startup** and predictable performance, and can produce a
+self-contained [static binary](/reference/static-binary/). A JIT trades that for
+**slower startup** (the engine must warm up before hot paths are optimized) and
+**higher memory use** (it holds both bytecode and generated native code). A
+long-running server happily pays the warm-up to gain peak throughput; a short-lived
+command-line tool may exit before warm-up pays off, so AOT often suits it better.
+
+## In practice
+
+The [JVM](/reference/java-language/) JIT-compiles bytecode via HotSpot, V8 powers
+[JavaScript](/reference/javascript-language/) in Chrome and Node.js, and .NET
+JIT-compiles its intermediate language. The lines blur: Java is AOT-compiled to
+bytecode *and* JIT-compiled to native code, and tools like GraalVM can AOT-compile
+traditionally JIT'd languages for instant startup.

--- a/docs/reference/julia-language.md
+++ b/docs/reference/julia-language.md
@@ -1,0 +1,63 @@
+---
+slug: julia-language
+title: Julia
+entry_type: language
+category: programming-languages
+description: Julia is a high-performance, dynamically typed language for numerical and scientific computing that aims to be as fast as C while as easy to write as Python.
+keywords: Julia, scientific computing, numerical computing, high performance, JIT, multiple dispatch, dynamic typing, data science
+aka: [Julia]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Multiple dispatch, functional, imperative" }
+  - { label: Typing, value: "Dynamic with optional type annotations" }
+  - { label: Appeared, value: "2012 (MIT)" }
+  - { label: Designed by, value: "Jeff Bezanson, Stefan Karpinski, Viral Shah, Alan Edelman" }
+  - { label: Compilation, value: "Just-in-time (JIT) to native code" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Notable uses, value: "Numerical/scientific computing, data science" }
+see_also: [python-language, r-language, matlab-language, jit-compilation, static-vs-dynamic-typing, garbage-collection, compiler]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Julia (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Julia_(programming_language) }
+  - { title: "The Julia programming language", url: https://julialang.org/ }
+---
+
+**Julia** is a high-performance, dynamically typed language designed for numerical and
+scientific computing, aiming to be as fast as [C](/reference/c-language/) while as
+easy to write as [Python](/reference/python-language/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Python-like Julia source is JIT compiled to native code, reaching speeds close to C." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="90" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="65" y="68">easy</text><text x="65" y="80">.jl code</text>
+    <line x1="110" y1="70" x2="175" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="142" y="62" font-size="8">JIT</text>
+    <rect x="175" y="50" width="100" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="225" y="68">native</text><text x="225" y="80">machine code</text>
+    <line x1="275" y1="70" x2="340" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="340" y="50" width="100" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="390" y="68">C-class</text><text x="390" y="80">speed</text>
+  </g>
+</svg>
+<figcaption>Julia JIT-compiles high-level code to native machine code, chasing C-level speed from a Python-like syntax.</figcaption>
+</figure>
+
+## Overview
+
+Julia was created to end the "two-language problem," where scientists prototype in a
+convenient language and then rewrite hot paths in a fast one. It compiles
+[just in time](/reference/jit-compilation/) to native code, and its **multiple
+dispatch** model — choosing a method based on the types of all arguments — lets
+generic, readable code specialise into tight machine code. The result is high-level
+syntax that can rival compiled languages on numeric workloads.
+
+## Key characteristics
+
+Julia is dynamically typed with optional annotations (see
+[static vs dynamic typing](/reference/static-vs-dynamic-typing/)) and
+[garbage-collected](/reference/garbage-collection/). Its drawbacks are practical: the
+**ecosystem is smaller** than Python's or R's, and JIT compilation causes "time to
+first plot" latency, where the first run of new code pays a compilation cost. For
+numerical and scientific work it competes with [Python](/reference/python-language/)
+(broader libraries), [R](/reference/r-language/) (statistics depth), and
+[MATLAB](/reference/matlab-language/) (mature, licensed engineering tooling), trading a
+younger ecosystem for performance and openness.

--- a/docs/reference/kotlin-language.md
+++ b/docs/reference/kotlin-language.md
@@ -1,0 +1,65 @@
+---
+slug: kotlin-language
+title: Kotlin
+entry_type: language
+category: programming-languages
+description: Kotlin is a statically typed, concise JVM language from JetBrains that interoperates fully with Java and is Google's preferred language for Android development.
+keywords: Kotlin, JVM, Android, JetBrains, null safety, coroutines, Java interoperability, statically typed, bytecode
+aka: [Kotlin]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Object-oriented, functional, imperative" }
+  - { label: Typing, value: "Static, strong, inferred" }
+  - { label: Appeared, value: "2011 (JetBrains)" }
+  - { label: Designed by, value: "JetBrains" }
+  - { label: Compilation, value: "Compiled to JVM bytecode (also JS/native)" }
+  - { label: Memory, value: "Garbage-collected (JVM)" }
+  - { label: Notable uses, value: "Android apps, server back ends, multiplatform" }
+see_also: [java-language, type-system, bytecode, jit-compilation, garbage-collection, object-oriented-programming, functional-programming]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Type systems", url: /learn/intro-software-dev/type-systems/ }
+external:
+  - { title: "Kotlin (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Kotlin_(programming_language) }
+  - { title: "Kotlin programming language", url: https://kotlinlang.org/ }
+---
+
+**Kotlin** is a statically typed, concise programming language from JetBrains that
+runs on the Java Virtual Machine, interoperates fully with [Java](/reference/java-language/),
+and is Google's preferred language for Android development.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Kotlin and Java source both compile to JVM bytecode, which the Java Virtual Machine runs, showing their interoperability." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="20" width="80" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="60" y="41">.kt files</text>
+    <rect x="20" y="86" width="80" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="107">.java files</text>
+    <line x1="100" y1="37" x2="180" y2="62" stroke="currentColor" stroke-width="1.1"/>
+    <line x1="100" y1="103" x2="180" y2="78" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="180" y="52" width="90" height="36" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="225" y="74">bytecode</text>
+    <line x1="270" y1="70" x2="320" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="320" y="50" width="120" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="380" y="74">JVM runs it</text>
+  </g>
+</svg>
+<figcaption>Kotlin and Java both compile to JVM bytecode, so the two can call each other freely in one project.</figcaption>
+</figure>
+
+## Overview
+
+Kotlin compiles to the same JVM [bytecode](/reference/bytecode/) as Java and is
+executed by the same [JIT-compiling](/reference/jit-compilation/) runtime, so it
+inherits Java's mature ecosystem, libraries, and tooling while shedding much of the
+language's verbosity. A Kotlin file can call Java code and vice versa, which let
+teams adopt it incrementally rather than rewriting. Beyond the JVM, Kotlin can also
+target JavaScript and native binaries, enabling shared "multiplatform" code.
+
+## Key characteristics
+
+Kotlin's [type system](/reference/type-system/) is static with strong inference, and
+its standout feature is **null safety**: the type system distinguishes nullable from
+non-nullable references, catching a whole class of null-pointer errors at compile
+time. It blends [object-oriented](/reference/object-oriented-programming/) and
+[functional](/reference/functional-programming/) styles, and its coroutines provide
+lightweight asynchronous concurrency. The honest drawbacks: it still depends on the
+JVM's [garbage collector](/reference/garbage-collection/) and startup overhead, the
+non-JVM targets are less mature, and compile times can lag Java's. Its centre of
+gravity remains Android and JVM back-end work rather than general-purpose ubiquity.

--- a/docs/reference/lisp-language.md
+++ b/docs/reference/lisp-language.md
@@ -1,0 +1,69 @@
+---
+slug: lisp-language
+title: LISP
+entry_type: language
+category: programming-languages
+description: LISP (1958) is one of the oldest high-level languages; it treats code and data as the same kind of list, pioneered the functional style, and became the language of early AI research.
+keywords: LISP, Lisp, functional programming, symbolic computing, artificial intelligence, John McCarthy, S-expressions, macros, code as data
+aka: [Lisp]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Functional, symbolic, multi-paradigm" }
+  - { label: Typing, value: "Dynamic, strong" }
+  - { label: Appeared, value: "1958 (MIT)" }
+  - { label: Designed by, value: "John McCarthy" }
+  - { label: Compilation, value: "Interpreted or compiled (varies by dialect)" }
+  - { label: Memory, value: "Garbage-collected (pioneered GC)" }
+  - { label: Notable uses, value: "AI research, symbolic computing, language design" }
+see_also: [fortran-language, cobol-language, functional-programming, garbage-collection, interpreter, static-vs-dynamic-typing, python-language]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "The birth of programming languages", url: /learn/intro-software-dev/birth-of-languages/ }
+external:
+  - { title: "Lisp (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Lisp_(programming_language) }
+  - { title: "Common Lisp", url: https://common-lisp.net/ }
+---
+
+**LISP** (LISt Processor), created by John McCarthy in 1958, is one of the oldest
+high-level languages. It treats code and data as the same kind of list, pioneered the
+[functional](/reference/functional-programming/) style, and became the language of
+early artificial-intelligence research.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A nested parenthesised LISP expression is shown as a tree of lists, illustrating that code and data share one structure." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="55" width="120" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="80" y="76">(+ 1 (* 2 3))</text>
+    <line x1="140" y1="72" x2="180" y2="72" stroke="currentColor" stroke-width="1.1"/>
+    <circle cx="230" cy="40" r="14" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="230" y="43">+</text>
+    <circle cx="290" cy="90" r="14" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="290" y="93">1</text>
+    <circle cx="360" cy="90" r="14" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="360" y="93">*</text>
+    <circle cx="330" cy="40" r="13" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="330" y="43">2</text>
+    <circle cx="420" cy="40" r="13" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="420" y="43">3</text>
+    <line x1="230" y1="54" x2="285" y2="78" stroke="currentColor" stroke-width="1"/><line x1="240" y1="48" x2="352" y2="80" stroke="currentColor" stroke-width="1"/>
+    <line x1="356" y1="78" x2="334" y2="52" stroke="currentColor" stroke-width="1"/><line x1="364" y1="78" x2="416" y2="52" stroke="currentColor" stroke-width="1"/>
+  </g>
+</svg>
+<figcaption>A LISP expression is a nested list; because code and data share one form, programs can manipulate programs.</figcaption>
+</figure>
+
+## History
+
+LISP took a path entirely different from its contemporaries
+[FORTRAN](/reference/fortran-language/) and [COBOL](/reference/cobol-language/).
+Programs are written as parenthesised lists, and crucially the *code* is itself a list
+— so a LISP program can read, build, and transform other LISP programs as ordinary
+data. From that idea came macros, the functional style, automatic
+[garbage collection](/reference/garbage-collection/) (which LISP pioneered), and the
+interactive read-eval-print loop. It became the working language of early AI labs and
+seeded ideas that mainstream languages adopted only decades later.
+
+## Legacy and use today
+
+LISP is dynamically typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/)),
+runs [interpreted](/reference/interpreter/) or compiled depending on the dialect, and
+survives in families like Common Lisp, Scheme, and Clojure. Its honest drawbacks are
+real: the parenthesis-heavy syntax is an acquired taste, and its mainstream use is
+niche today. But its influence is enormous — first-class functions, garbage
+collection, and treating code as data have all flowed into modern languages such as
+[Python](/reference/python-language/) and JavaScript, making LISP one of the most
+quietly influential designs in computing.

--- a/docs/reference/matlab-language.md
+++ b/docs/reference/matlab-language.md
@@ -1,0 +1,65 @@
+---
+slug: matlab-language
+title: MATLAB
+entry_type: language
+category: programming-languages
+description: MATLAB is a commercial, matrix-oriented language and environment for engineering, signal processing, and control systems, superb for DSP prototyping but proprietary and licensed.
+keywords: MATLAB, matrix, signal processing, DSP, control systems, engineering, numerical computing, Simulink, proprietary, licensed
+aka: [MATLAB]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Imperative, array/matrix-oriented" }
+  - { label: Typing, value: "Dynamic, weak" }
+  - { label: Appeared, value: "1984 (MathWorks)" }
+  - { label: Designed by, value: "Cleve Moler; MathWorks" }
+  - { label: Compilation, value: "Interpreted (with JIT in the runtime)" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Notable uses, value: "DSP, control systems, engineering analysis" }
+see_also: [julia-language, python-language, r-language, interpreter, fast-fourier-transform, software-defined-radio, static-vs-dynamic-typing]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Matching the language to the domain", url: /learn/intro-software-dev/language-for-the-domain/ }
+external:
+  - { title: "MATLAB — Wikipedia", url: https://en.wikipedia.org/wiki/MATLAB }
+  - { title: "MATLAB (MathWorks)", url: https://www.mathworks.com/products/matlab.html }
+---
+
+**MATLAB** is a commercial, matrix-oriented language and environment from MathWorks
+built for engineering, signal processing, and control systems. It is superb for DSP
+prototyping but proprietary and licensed.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A signal enters MATLAB, which applies matrix and FFT operations to produce a frequency spectrum plot." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="70" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="55" y="74">signal</text>
+    <line x1="90" y1="70" x2="150" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="44" width="120" height="52" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="210" y="66">MATLAB:</text><text x="210" y="80">matrices, FFT</text>
+    <line x1="270" y1="70" x2="330" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="330" y="40" width="110" height="60" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+    <line x1="342" y1="92" x2="428" y2="92" stroke="currentColor" stroke-width="1"/><line x1="342" y1="92" x2="342" y2="50" stroke="currentColor" stroke-width="1"/>
+    <path d="M348 88 L362 60 L376 80 L390 54 L404 78 L420 66" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  </g>
+</svg>
+<figcaption>MATLAB treats data as matrices and excels at signal-processing analysis like the FFT and its spectra.</figcaption>
+</figure>
+
+## Overview
+
+MATLAB ("matrix laboratory") was designed around the matrix as its native data type,
+which makes linear-algebra and signal code read almost like the mathematics it
+implements. It pairs the language with a full interactive environment, deep numerical
+libraries, toolboxes for control, communications and DSP, and Simulink for
+model-based design. That makes it a favourite for **DSP prototyping** and the kind of
+[fast Fourier transform](/reference/fast-fourier-transform/) work that underlies
+[software-defined radio](/reference/software-defined-radio/).
+
+## Key characteristics
+
+MATLAB is dynamically typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/))
+and [interpreted](/reference/interpreter/) with a JIT in its runtime. Its great
+drawback is that it is **proprietary and licensed**: it costs money, toolboxes are sold
+separately, and code is tied to a vendor's runtime rather than an open ecosystem. It
+is also a specialist rather than a general-purpose language. For overlapping work,
+open alternatives include [Python](/reference/python-language/) with NumPy/SciPy, the
+faster [Julia](/reference/julia-language/), and [R](/reference/r-language/) for
+statistics — each trading MATLAB's polished, licensed tooling for openness.

--- a/docs/reference/memory-management.md
+++ b/docs/reference/memory-management.md
@@ -1,0 +1,71 @@
+---
+slug: memory-management
+title: Memory management
+entry_type: concept
+category: language-internals
+description: Memory management is how a program hands out memory when it needs it and reclaims it when done, ranging from manual allocation to garbage collection to compile-time ownership.
+keywords: memory management, stack and heap, manual memory, malloc free, garbage collection, ownership, borrow checker, memory leak, use after free
+aka: [memory management]
+autolink: true
+infobox:
+  - { label: Category, value: Runtime resource handling }
+  - { label: Regions, value: "Stack (auto) and heap (managed)" }
+  - { label: Strategies, value: "Manual, garbage collection, ownership" }
+  - { label: Key axis, value: "Safety vs control vs determinism" }
+  - { label: Manual, value: "C, C++" }
+  - { label: Automatic, value: "Go, Java, Python (GC); Rust (ownership)" }
+see_also: [garbage-collection, type-system, static-binary, c-language, cpp-language, rust-language, go-language]
+related_lessons:
+  - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Memory management — Wikipedia", url: https://en.wikipedia.org/wiki/Memory_management }
+---
+
+**Memory management** is how a running program obtains memory to hold its data and
+reclaims it once that data is no longer needed — a defining characteristic of a
+language that shapes its safety, speed, and fitness for real-time work.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A program uses a fast auto-freed stack and a flexible heap that must be reclaimed manually, by garbage collection, or by ownership." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="30" width="110" height="80" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="85" y="24" font-size="8">stack</text>
+    <line x1="40" y1="50" x2="130" y2="50" stroke="currentColor" stroke-width="1"/><line x1="40" y1="68" x2="130" y2="68" stroke="currentColor" stroke-width="1"/><line x1="40" y1="86" x2="130" y2="86" stroke="currentColor" stroke-width="1"/><text x="85" y="104" font-size="7" fill-opacity="0.7">auto-freed</text>
+    <rect x="320" y="30" width="110" height="80" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.3"/><text x="375" y="24" font-size="8">heap</text>
+    <circle cx="355" cy="58" r="10" fill="none" stroke="currentColor" stroke-width="1.1"/><circle cx="395" cy="50" r="10" fill="none" stroke="currentColor" stroke-width="1.1"/><circle cx="378" cy="84" r="10" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="375" y="104" font-size="7" fill-opacity="0.7">must be reclaimed</text>
+    <line x1="140" y1="70" x2="320" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="230" y="62" font-size="8">allocate</text>
+  </g>
+</svg>
+<figcaption>The stack is fast and freed automatically; the flexible heap is where the hard reclamation problems live.</figcaption>
+</figure>
+
+## Stack vs heap
+
+A program's memory splits into two regions. The **stack** holds local variables and
+function call frames; a frame is pushed on a call and popped on return, so its memory
+is freed automatically and allocation is nearly free — but everything on it must have a
+size known at compile time and lives only as long as its function. The **heap** is a
+flexible pool for data whose size or lifetime is not known up front; it must be
+allocated and eventually released, and **all the hard memory problems live on the
+heap** because something must decide when each piece is no longer needed.
+
+## Three strategies
+
+Languages differ chiefly in how they reclaim heap memory.
+**Manual management** — [C](/reference/c-language/) and [C++](/reference/cpp-language/)
+— gives you `malloc`/`free` and total control, but risks leaks, use-after-free, double
+frees, and buffer overflows. **[Garbage collection](/reference/garbage-collection/)** —
+[Go](/reference/go-language/), [Java](/reference/java-language/),
+[Python](/reference/python-language/) — automatically frees unreachable memory,
+eliminating whole bug classes at the cost of occasional, non-deterministic pauses.
+**Ownership** — [Rust](/reference/rust-language/) — uses a compile-time borrow checker
+to free memory at known scope exits, achieving safety with no garbage collector and
+deterministic timing.
+
+## Why it matters
+
+The key axis for real-time work is *determinism*. Manual and ownership models reclaim
+memory at predictable moments, so a software-defined radio pipeline never stalls
+mid-buffer; garbage collection can pause at an unpredictable
+moment and drop samples. This is why tight DSP gravitates toward C or Rust, while a
+GC'd language like Go is fine for the control and orchestration layers around it.

--- a/docs/reference/mocking.md
+++ b/docs/reference/mocking.md
@@ -1,0 +1,70 @@
+---
+slug: mocking
+title: Mocking
+entry_type: concept
+category: testing-delivery
+description: Mocking is the use of test doubles — mocks, fakes, and stubs — that stand in for a unit's real dependencies so it can be tested in isolation, deterministically and without hitting real networks, databases, or hardware.
+keywords: mocking, mock, test double, fake, stub, isolation, dependency injection, deterministic tests, unit testing, software testing
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Software testing technique" }
+  - { label: Purpose, value: "Isolate a unit from its dependencies" }
+  - { label: Doubles, value: "Mock, fake, stub" }
+  - { label: Enabled by, value: "Dependency inversion / interfaces" }
+  - { label: Benefit, value: "Fast, deterministic tests" }
+see_also: [unit-testing, integration-testing, end-to-end-testing, test-driven-development, code-coverage, solid, ci-cd]
+related_lessons:
+  - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
+external:
+  - { title: "Mock object — Wikipedia", url: https://en.wikipedia.org/wiki/Mock_object }
+---
+
+**Mocking** is the use of *test doubles* — stand-ins for a unit's real dependencies — so
+the unit can be [tested](/reference/unit-testing/) in isolation, deterministically and
+without touching real networks, databases, or hardware.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="Code under test calls a test double standing in for a real dependency such as a database or radio." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="48" width="100" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="70" y="65">code under</text><text x="70" y="78">test</text>
+    <line x1="120" y1="68" x2="180" y2="68" stroke="currentColor" stroke-width="1.1"/><text x="150" y="60" font-size="8">calls</text>
+    <rect x="180" y="48" width="100" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.4" stroke-dasharray="4 3"/><text x="230" y="65">test double</text><text x="230" y="78" font-size="8">mock / fake / stub</text>
+    <line x1="280" y1="68" x2="340" y2="68" stroke="currentColor" stroke-width="1.1" stroke-dasharray="2 3"/>
+    <rect x="340" y="48" width="100" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.5"/><text x="390" y="65" fill-opacity="0.55">real DB /</text><text x="390" y="78" font-size="8" fill-opacity="0.55">radio (skipped)</text>
+  </g>
+</svg>
+<figcaption>A test double replaces the real dependency so the unit runs fast and deterministically.</figcaption>
+</figure>
+
+## Kinds of test double
+
+"Mocking" is the everyday umbrella term, but there are distinct kinds of double:
+
+- **Fake** — a lightweight working implementation, for example a sample source that
+  replays a file instead of reading a live device.
+- **Stub** — simply returns canned, pre-programmed responses, with no logic of its own.
+- **Mock** — records *how* it was called and lets the test assert that the code
+  interacted with it correctly (it called `send()` once, with these arguments).
+
+The right double depends on what you're testing: a stub or fake when you only need the
+dependency to be *present*, a mock when the interaction itself is the behavior under test.
+
+## Why it works
+
+Mocking depends on the [dependency inversion](/reference/solid/) idea: if your code
+talks to an *interface* rather than a concrete class, a test can inject a double in place
+of the real thing. That is what makes [unit tests](/reference/unit-testing/) fast and
+deterministic — no flaky network, no slow database, no hardware in the loop. Good seams
+make code mockable, and mockable code tends to be well-designed code, which is why
+mocking pairs so naturally with [test-driven development](/reference/test-driven-development/).
+
+## When not to mock
+
+Doubles have a cost: a test that mocks everything verifies your code against your
+*assumptions* about a dependency, not the real one. That is exactly the gap
+[integration tests](/reference/integration-testing/) and
+[end-to-end tests](/reference/end-to-end-testing/) fill by using real collaborators. Over-
+mocking also inflates [code coverage](/reference/code-coverage/) without real assurance.
+Mock at the boundaries of slow or external systems; let higher layers, run in
+[CI/CD](/reference/ci-cd/), exercise the real seams.

--- a/docs/reference/object-oriented-programming.md
+++ b/docs/reference/object-oriented-programming.md
@@ -1,0 +1,71 @@
+---
+slug: object-oriented-programming
+title: Object-oriented programming
+entry_type: concept
+category: paradigms-design
+description: Object-oriented programming (OOP) is a paradigm that bundles state and the behaviour that acts on it into objects, organised around encapsulation, inheritance, and polymorphism.
+keywords: object-oriented programming, OOP, objects, classes, encapsulation, inheritance, polymorphism, composition, methods, paradigm
+aka: [object-oriented programming "OOP"]
+autolink: true
+infobox:
+  - { label: Type, value: "Programming paradigm" }
+  - { label: Key idea, value: "Bundle state + behaviour into objects" }
+  - { label: Pillars, value: "Encapsulation, inheritance, polymorphism" }
+  - { label: Prefer, value: "Composition over deep inheritance" }
+  - { label: Strong examples, value: "Java, C#, Ruby, Python" }
+  - { label: Contrast with, value: "Functional, imperative" }
+see_also: [functional-programming, imperative-programming, abstraction, coupling-and-cohesion, design-patterns, java-language, csharp-language, ruby-language]
+related_lessons:
+  - { title: "Paradigms & language families", url: /learn/intro-software-dev/language-families/ }
+external:
+  - { title: "Object-oriented programming — Wikipedia", url: https://en.wikipedia.org/wiki/Object-oriented_programming }
+---
+
+**Object-oriented programming** (**OOP**) is a paradigm that bundles state and the
+behaviour that acts on it into **objects** — units that combine *fields* (data) with
+*methods* (functions that operate on that data).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="An object encapsulates private data behind public methods, and several objects share one interface so callers can treat them uniformly." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="30" width="120" height="80" rx="6" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="80" y="24" font-size="8">object</text>
+    <circle cx="80" cy="62" r="16" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.2"/><text x="80" y="65">data</text>
+    <text x="80" y="98" font-size="8">methods (public)</text>
+    <line x1="140" y1="70" x2="200" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="170" y="62" font-size="8">interface</text>
+    <rect x="200" y="20" width="100" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="250" y="35">Shape.area()</text>
+    <rect x="200" y="58" width="100" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="250" y="73">Circle.area()</text>
+    <rect x="200" y="96" width="100" height="24" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="250" y="111">Square.area()</text>
+    <line x1="300" y1="70" x2="350" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="350" y="56" width="90" height="28" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="395" y="73">caller</text>
+  </g>
+</svg>
+<figcaption>An object hides its data behind methods, and shared interfaces let callers treat different types uniformly.</figcaption>
+</figure>
+
+## Core ideas
+
+OOP rests on a few pillars. **Encapsulation** hides an object's internal data behind a
+clean interface, the foundation of [abstraction](/reference/abstraction/) and information
+hiding. **Inheritance** derives specialised types from general ones, and
+**polymorphism** lets you treat different types uniformly through a shared interface —
+calling `area()` without knowing whether the object is a circle or a square. These
+combine to keep [coupling](/reference/coupling-and-cohesion/) low: callers depend on a
+contract, not a concrete class.
+
+## When it fits
+
+OOP shines when a problem decomposes naturally into "things" with identity and lifecycle
+— a `User`, a `Connection`, a tuned `Receiver`. Languages such as
+[Java](/reference/java-language/), [C#](/reference/csharp-language/),
+[Ruby](/reference/ruby-language/), and [Python](/reference/python-language/) support it
+strongly. Most of the Gang of Four [design patterns](/reference/design-patterns/) are
+expressed in object-oriented terms.
+
+## Trade-offs
+
+Critics note that overusing inheritance creates rigid, tangled hierarchies, which is why
+modern OOP leans on **composition** ("has-a") over deep inheritance ("is-a"). Many
+languages are multi-paradigm: the same codebase can mix object-oriented structure with
+[functional](/reference/functional-programming/) transformations and
+[imperative](/reference/imperative-programming/) inner loops, choosing the style that
+fits each part of the problem.

--- a/docs/reference/package-manager.md
+++ b/docs/reference/package-manager.md
@@ -1,0 +1,69 @@
+---
+slug: package-manager
+title: Package manager & dependency management
+entry_type: concept
+category: testing-delivery
+description: A package manager automates declaring, resolving, fetching, and pinning the external libraries a project depends on, using lockfiles to make dependency resolution reproducible.
+keywords: package manager, dependency management, dependencies, lockfile, go modules, Cargo, npm, pip, transitive dependencies, reproducible, version resolution
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Developer tooling" }
+  - { label: Job, value: "Declare, resolve, fetch, pin dependencies" }
+  - { label: Reproducibility, value: "Lockfiles pin exact versions" }
+  - { label: Examples, value: "go modules, Cargo, npm, pip" }
+  - { label: Versioning, value: "Uses semantic versioning ranges" }
+see_also: [build-systems, semantic-versioning, ci-cd, api, version-control, static-binary]
+related_lessons:
+  - { title: "Build systems, CI/CD & automation", url: /learn/intro-software-dev/build-and-ci-cd/ }
+external:
+  - { title: "Package manager — Wikipedia", url: https://en.wikipedia.org/wiki/Package_manager }
+---
+
+**A package manager** automates declaring, resolving, fetching, and pinning the external
+libraries a project depends on, using lockfiles to make dependency resolution
+reproducible.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A project manifest lists dependencies; the package manager resolves and fetches them, and a lockfile pins exact versions." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="42" width="80" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="60">manifest</text><text x="60" y="72" font-size="8">"needs v1.x"</text>
+    <line x1="100" y1="60" x2="150" y2="60" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="42" width="100" height="36" rx="5" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.4"/><text x="200" y="60">resolve +</text><text x="200" y="72" font-size="8">fetch</text>
+    <line x1="250" y1="60" x2="300" y2="60" stroke="currentColor" stroke-width="1.1"/>
+    <circle cx="330" cy="42" r="12" fill="none" stroke="currentColor" stroke-width="1.2"/><circle cx="362" cy="60" r="12" fill="none" stroke="currentColor" stroke-width="1.2"/><circle cx="330" cy="78" r="12" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <text x="345" y="103" font-size="8">deps (+ transitive)</text>
+    <rect x="392" y="48" width="56" height="24" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="420" y="63" font-size="8">lockfile</text>
+  </g>
+</svg>
+<figcaption>A manifest declares needs; the package manager resolves, fetches, and pins them in a lockfile.</figcaption>
+</figure>
+
+## What it does
+
+Almost no project is self-contained — you stand on libraries written by others. A package
+manager (Go modules, Cargo, npm, pip, and so on) records what your project needs in a
+manifest and fetches it, including the *transitive* dependencies your direct dependencies
+pull in. The libraries you depend on expose their capabilities through an
+[API](/reference/api/), and the package manager's job is to get a compatible set of them
+onto your machine and, with the [build system](/reference/build-systems/), into your
+program.
+
+## Lockfiles and reproducibility
+
+A subtlety lurks here: a requirement like "version 1.x" can resolve to different exact
+versions over time, the classic "works on my machine" problem. The fix is a **lockfile**
+(`go.sum`, `Cargo.lock`, `package-lock.json`, `poetry.lock`) that pins the *exact* version
+— often with a checksum — of every dependency, direct and transitive. Commit the lockfile,
+and everyone, plus every [CI/CD](/reference/ci-cd/) run, installs a byte-for-byte
+identical dependency tree. That is the foundation of a reproducible build: without pinned
+inputs you can't have a reproducible output, which is why the lockfile lives in
+[version control](/reference/version-control/) alongside the code.
+
+## Versioning and trust
+
+Dependency ranges and lockfiles both rest on [semantic versioning](/reference/semantic-versioning/):
+the version number tells the resolver (and you) whether an upgrade is a safe patch, a
+backward-compatible feature, or a breaking major change. Package managers also distribute
+*your* library outward — publishing a versioned package others can depend on — which is
+why a stable, well-versioned API matters as much for what you ship as for what you consume.

--- a/docs/reference/php-language.md
+++ b/docs/reference/php-language.md
@@ -1,0 +1,65 @@
+---
+slug: php-language
+title: PHP
+entry_type: language
+category: programming-languages
+description: PHP is a dynamic, interpreted scripting language built for the web back end, ubiquitous on shared hosting, historically inconsistent but substantially modernized in versions 7 and 8.
+keywords: PHP, web back end, server-side scripting, dynamic typing, interpreted, WordPress, Laravel, Zend Engine, JIT
+aka: [PHP]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Imperative, object-oriented, scripting" }
+  - { label: Typing, value: "Dynamic, weak (optional type hints)" }
+  - { label: Appeared, value: "1995 (Rasmus Lerdorf)" }
+  - { label: Designed by, value: "Rasmus Lerdorf; later a community/Zend effort" }
+  - { label: Compilation, value: "Interpreted (bytecode + JIT since PHP 8)" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Notable uses, value: "Web back ends, WordPress, CMSes" }
+see_also: [javascript-language, interpreter, static-vs-dynamic-typing, garbage-collection, jit-compilation, bytecode, rest]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+external:
+  - { title: "PHP — Wikipedia", url: https://en.wikipedia.org/wiki/PHP }
+  - { title: "PHP: Hypertext Preprocessor", url: https://www.php.net/ }
+---
+
+**PHP** is a dynamic, [interpreted](/reference/interpreter/) scripting language built
+for the web back end. It is one of the most widely deployed languages on the
+internet, historically criticised for inconsistency, but substantially modernised in
+versions 7 and 8.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A browser request hits a web server running PHP, which generates an HTML page and sends it back." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="70" height="36" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="55" y="74">browser</text>
+    <line x1="90" y1="62" x2="160" y2="62" stroke="currentColor" stroke-width="1.1"/><text x="125" y="55" font-size="8">request</text>
+    <rect x="160" y="44" width="120" height="52" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="220" y="66">server runs</text><text x="220" y="80">PHP</text>
+    <line x1="160" y1="82" x2="90" y2="82" stroke="currentColor" stroke-width="1.1"/><text x="125" y="100" font-size="8">HTML page</text>
+    <line x1="280" y1="70" x2="340" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="340" y="50" width="100" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="390" y="74">database</text>
+  </g>
+</svg>
+<figcaption>PHP runs on the web server, builds an HTML response per request, and hands it back to the browser.</figcaption>
+</figure>
+
+## Overview
+
+PHP was designed to be embedded directly in web pages, and that origin shaped its
+ecosystem: it ships with nearly every shared web host, which made it the default for
+a huge share of the web. WordPress, much of the world's content-management software,
+and major sites are built on it, and modern frameworks like Laravel and Symfony bring
+disciplined structure. It serves dynamic pages and [REST](/reference/rest/) APIs,
+typically run per request by the server.
+
+## Key characteristics
+
+PHP is dynamically and weakly typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/)),
+[garbage-collected](/reference/garbage-collection/), and compiles to
+[bytecode](/reference/bytecode/) that an engine executes — with an optional
+[JIT](/reference/jit-compilation/) added in PHP 8. Its reputation for **inconsistency**
+is earned: the standard library has irregular function names and argument orders, and
+older code mixed logic with HTML freely. Versions 7 and 8 changed the picture
+considerably, adding real performance gains, optional type declarations, and cleaner
+language features, though its weak typing and accumulated history still draw criticism.
+Like [JavaScript](/reference/javascript-language/), it is hard to avoid on the web.

--- a/docs/reference/python-language.md
+++ b/docs/reference/python-language.md
@@ -1,0 +1,73 @@
+---
+slug: python-language
+title: Python
+entry_type: language
+category: programming-languages
+description: Python is a dynamically typed, interpreted, general-purpose language prized for readability and a vast ecosystem, and is the default tool for data science, machine learning, scripting and automation.
+keywords: Python, CPython, dynamic typing, interpreted, data science, machine learning, NumPy, pandas, PyTorch, GIL, scripting
+aka: [Python, CPython]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Multi-paradigm: imperative, object-oriented, functional" }
+  - { label: Typing, value: "Dynamic, strong, duck-typed (optional hints)" }
+  - { label: Appeared, value: "1991 (CWI, Netherlands)" }
+  - { label: Designed by, value: "Guido van Rossum" }
+  - { label: Compilation, value: "Compiled to bytecode, run on an interpreter (CPython)" }
+  - { label: Memory, value: "Garbage-collected (reference counting + cycle detection)" }
+  - { label: Notable uses, value: "Data science, ML, scripting, automation, web backends" }
+see_also: [interpreter, bytecode, garbage-collection, static-vs-dynamic-typing, javascript-language, julia-language, r-language, type-system]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Python (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Python_(programming_language) }
+  - { title: "The Python programming language", url: https://www.python.org/ }
+---
+
+**Python** is a dynamically typed, interpreted, general-purpose programming language
+designed for readability, with a deliberately clean syntax and one of the largest
+library ecosystems of any language.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Python source is compiled to bytecode and executed by the interpreter, with heavy work delegated to fast native libraries." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="64" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="52" y="74">.py source</text>
+    <line x1="84" y1="70" x2="124" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="104" y="62" font-size="8">compile</text>
+    <rect x="124" y="50" width="70" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="159" y="74">bytecode</text>
+    <line x1="194" y1="70" x2="234" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="234" y="50" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="274" y="68">interpreter</text><text x="274" y="80" font-size="8">(CPython)</text>
+    <line x1="314" y1="70" x2="354" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="334" y="62" font-size="8">calls</text>
+    <rect x="354" y="50" width="86" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="397" y="68">native libs</text><text x="397" y="80" font-size="8">NumPy / C</text>
+  </g>
+</svg>
+<figcaption>Python compiles to bytecode for an interpreter and leans on fast native libraries for heavy numeric work.</figcaption>
+</figure>
+
+## Overview
+
+Python source is compiled to [bytecode](/reference/bytecode/) and run by an
+[interpreter](/reference/interpreter/) — most commonly CPython, the reference
+implementation. It uses [dynamic typing](/reference/static-vs-dynamic-typing/) with
+optional type hints, and is [garbage-collected](/reference/garbage-collection/) through
+reference counting plus a cycle detector. The result is a language that is quick to
+write and forgiving to learn, which is why it is a common first language and the glue
+of choice for automation and scripting.
+
+## Strengths and trade-offs
+
+Python's strengths are readability, a gentle learning curve, and an enormous ecosystem —
+libraries such as NumPy, pandas and PyTorch make it the default for data science,
+machine learning and scientific computing. The trade-offs are real: pure-Python loops
+are **slow** compared with [compiled](/reference/compiler/) languages, and the global
+interpreter lock (GIL) limits true multithreaded CPU [parallelism](/reference/concurrency/)
+in the standard interpreter. The usual remedy is to delegate heavy work to native
+libraries written in [C](/reference/c-language/), keeping the convenient Python layer on
+top.
+
+## Where it's used
+
+Python dominates data science, machine learning and scientific computing, and is a
+mainstay of scripting, automation, glue code and web backends. Its speed limits rarely
+matter for scripts or for workloads that push the real computation into native code; in
+the niche where raw numeric throughput is decisive, alternatives like
+[Julia](/reference/julia-language/) or a compiled language are reached for instead.

--- a/docs/reference/r-language.md
+++ b/docs/reference/r-language.md
@@ -1,0 +1,66 @@
+---
+slug: r-language
+title: R
+entry_type: language
+category: programming-languages
+description: R is a dynamic, interpreted language specialised for statistics, data analysis, and plotting, beloved by statisticians and researchers but less suited to general programming.
+keywords: R language, statistics, data analysis, statistical computing, plotting, data science, CRAN, dynamic typing, interpreted
+aka: [R]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Functional, dynamic, array-oriented" }
+  - { label: Typing, value: "Dynamic, weak" }
+  - { label: Appeared, value: "1993 (University of Auckland)" }
+  - { label: Designed by, value: "Ross Ihaka, Robert Gentleman" }
+  - { label: Compilation, value: "Interpreted" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Notable uses, value: "Statistics, research, data visualisation" }
+see_also: [python-language, julia-language, matlab-language, interpreter, static-vs-dynamic-typing, garbage-collection, functional-programming]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Matching the language to the domain", url: /learn/intro-software-dev/language-for-the-domain/ }
+external:
+  - { title: "R (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/R_(programming_language) }
+  - { title: "The R Project for Statistical Computing", url: https://www.r-project.org/ }
+---
+
+**R** is a dynamic, [interpreted](/reference/interpreter/) language specialised for
+statistics, data analysis, and plotting. It is beloved by statisticians and
+researchers, and is excellent for analysis and visualisation but less suited to
+general-purpose programming.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="A data table flows into R for statistical analysis, which produces a plotted chart." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="70" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="55" y="68">data</text><text x="55" y="80">table</text>
+    <line x1="90" y1="70" x2="150" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="46" width="110" height="48" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="205" y="66">R: stats</text><text x="205" y="80">&amp; models</text>
+    <line x1="260" y1="70" x2="320" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="320" y="40" width="120" height="60" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/>
+    <line x1="332" y1="92" x2="428" y2="92" stroke="currentColor" stroke-width="1"/><line x1="332" y1="92" x2="332" y2="50" stroke="currentColor" stroke-width="1"/>
+    <path d="M338 86 L360 70 L382 78 L404 56 L422 60" fill="none" stroke="currentColor" stroke-width="1.3"/>
+  </g>
+</svg>
+<figcaption>R turns tabular data into statistical models and publication-quality plots.</figcaption>
+</figure>
+
+## Overview
+
+R grew out of the academic statistics community and remains organised around that
+work. Its data frames, vectorised operations, and enormous library of statistical
+methods make it a natural fit for exploratory analysis, modelling, and producing
+charts. Packages distributed through CRAN cover an extraordinary range of statistical
+and domain-specific techniques, and tools like ggplot2 are renowned for the quality
+of their graphics.
+
+## Key characteristics
+
+R is dynamically typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/)),
+[interpreted](/reference/interpreter/), and [garbage-collected](/reference/garbage-collection/),
+with a [functional](/reference/functional-programming/) and array-oriented bent. Its
+strengths are also its limits: it is purpose-built for statistics, so it is less
+comfortable as a general-purpose language, and pure-R loops are **slow**, pushing heavy
+work into vectorised or native code. For numerical and data work it competes with
+[Python](/reference/python-language/) (which has a larger general ecosystem) and the
+faster [Julia](/reference/julia-language/); for engineering signal work many reach for
+[MATLAB](/reference/matlab-language/) instead.

--- a/docs/reference/refactoring.md
+++ b/docs/reference/refactoring.md
@@ -1,0 +1,71 @@
+---
+slug: refactoring
+title: Refactoring
+entry_type: concept
+category: principles-quality
+description: Refactoring is the disciplined practice of restructuring existing code to improve its design, readability, and maintainability without changing its external behavior.
+keywords: refactoring, code refactoring, restructuring code, technical debt, code smell, behavior-preserving, extract function, rename, design improvement
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Code quality practice" }
+  - { label: Definition, value: "Change structure, not behavior" }
+  - { label: Safety net, value: "Tests (especially unit tests)" }
+  - { label: Triggers, value: "Code smells, technical debt" }
+  - { label: Popularized by, value: "Martin Fowler" }
+see_also: [clean-code, dry-kiss-yagni, solid, unit-testing, test-driven-development, abstraction, coupling-and-cohesion]
+related_lessons:
+  - { title: "Writing readable code", url: /learn/intro-software-dev/clean-code/ }
+external:
+  - { title: "Code refactoring — Wikipedia", url: https://en.wikipedia.org/wiki/Code_refactoring }
+---
+
+**Refactoring** is the disciplined practice of restructuring existing code to improve
+its design, readability, and maintainability *without* changing its external behavior.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="Tangled code is restructured into clean code while the observable behavior, the output, stays the same." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="35" width="90" height="60" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="65" y="58">tangled</text><text x="65" y="72">code</text>
+    <path d="M30 86 L45 80 L60 90 L75 82 L100 88" fill="none" stroke="currentColor" stroke-width="1"/>
+    <line x1="110" y1="65" x2="160" y2="65" stroke="currentColor" stroke-width="1.2"/><text x="135" y="56" font-size="8">refactor</text>
+    <rect x="160" y="35" width="90" height="60" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="205" y="58">clean</text><text x="205" y="72">code</text>
+    <line x1="250" y1="65" x2="300" y2="65" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="300" y="48" width="140" height="34" rx="5" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/><text x="370" y="69">same behavior</text>
+  </g>
+</svg>
+<figcaption>Refactoring changes a program's internal structure while its observable behavior stays fixed.</figcaption>
+</figure>
+
+## What it is
+
+The defining constraint is behavior preservation: a refactor reorganizes the *how*
+while keeping the *what* identical. Typical moves — popularized by Martin Fowler's
+catalog — include renaming for clarity, extracting a function or class, inlining a
+needless indirection, removing duplication, and breaking up a class that has taken on
+too many responsibilities. Each is a small, safe step rather than a sweeping rewrite.
+Refactoring is triggered by *code smells*: duplication, long functions, large classes,
+tangled dependencies, and other signals that the code resists change. Left
+unaddressed, those smells accumulate as **technical debt** that slows every future
+change.
+
+## Why tests matter
+
+Because a refactor must not alter behavior, you need a way to prove it didn't — and that
+is the job of [tests](/reference/unit-testing/). A solid suite of fast
+[unit tests](/reference/unit-testing/) (run automatically by [CI/CD](/reference/ci-cd/))
+lets you restructure boldly and catch any accidental behavior change in seconds. This is
+also why refactoring is the third beat of the
+[test-driven development](/reference/test-driven-development/) cycle: red, green, then
+*refactor* on a green suite.
+
+## How it connects
+
+Refactoring is how the quality principles get applied to code that already exists. You
+refactor toward [clean code](/reference/clean-code/), toward
+[DRY, KISS and YAGNI](/reference/dry-kiss-yagni/), and toward
+[SOLID](/reference/solid/) — improving names, reducing
+[coupling](/reference/coupling-and-cohesion/), and introducing the right
+[abstraction](/reference/abstraction/) only once it has proven itself. Done
+continuously in small steps, it keeps a codebase healthy; deferred indefinitely, it
+becomes a costly rewrite.

--- a/docs/reference/rest.md
+++ b/docs/reference/rest.md
@@ -1,0 +1,75 @@
+---
+slug: rest
+title: REST
+entry_type: concept
+category: testing-delivery
+description: REST is an architectural style for web APIs in which clients act on named resources, identified by URLs, using standard HTTP verbs over a stateless protocol.
+keywords: REST, RESTful, web API, HTTP verbs, resources, stateless, GET POST PUT DELETE, endpoints, JSON, Roy Fielding
+aka: [REST "representational state transfer"]
+autolink: true
+infobox:
+  - { label: Category, value: "Web API architectural style" }
+  - { label: Stands for, value: "Representational State Transfer" }
+  - { label: Built on, value: "HTTP" }
+  - { label: Verbs, value: "GET, POST, PUT, PATCH, DELETE" }
+  - { label: Key trait, value: "Stateless, resource-oriented" }
+see_also: [api, error-handling, semantic-versioning, end-to-end-testing, integration-testing, version-control]
+related_lessons:
+  - { title: "Errors, edge cases & defensive programming", url: /learn/intro-software-dev/robustness-and-errors/ }
+external:
+  - { title: "REST — Wikipedia", url: https://en.wikipedia.org/wiki/REST }
+---
+
+**REST** (Representational State Transfer) is an architectural style for web
+[APIs](/reference/api/) in which clients act on named *resources*, identified by URLs,
+using standard HTTP verbs over a stateless protocol.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A client sends HTTP verbs GET, POST, PUT, DELETE to a server's resource URLs." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="45" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="69">client</text>
+    <line x1="100" y1="50" x2="340" y2="50" stroke="currentColor" stroke-width="1"/><text x="220" y="44" font-size="8">GET /messages</text>
+    <line x1="100" y1="63" x2="340" y2="63" stroke="currentColor" stroke-width="1"/><text x="220" y="59" font-size="8">POST /messages</text>
+    <line x1="100" y1="76" x2="340" y2="76" stroke="currentColor" stroke-width="1"/><text x="220" y="72" font-size="8">PUT /messages/42</text>
+    <line x1="100" y1="89" x2="340" y2="89" stroke="currentColor" stroke-width="1"/><text x="220" y="85" font-size="8">DELETE /messages/42</text>
+    <rect x="340" y="45" width="100" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="390" y="63">server</text><text x="390" y="76" font-size="8">resources</text>
+  </g>
+</svg>
+<figcaption>A REST client acts on resource URLs using standard HTTP verbs.</figcaption>
+</figure>
+
+## The core ideas
+
+REST, described by Roy Fielding, organizes an API around a handful of constraints:
+
+- **Resources and URLs.** Everything is a resource — a message, a user, a device — each
+  identified by a URL like `/messages/42`. The URL names the *thing*, not the action.
+- **Standard verbs.** The HTTP method says what to do: `GET` reads, `POST` creates, `PUT`
+  / `PATCH` updates, `DELETE` removes. Reusing the protocol's verbs keeps the surface
+  small and predictable.
+- **Stateless.** Each request carries everything the server needs; the server keeps no
+  per-client session between requests, which makes REST services easy to scale.
+- **Representations.** A resource is transferred in some representation, today most often
+  JSON, that the client and server agree on.
+
+REST also leans on HTTP status codes (200, 404, 500) as its
+[error-handling](/reference/error-handling/) contract, telling the client at the protocol
+level whether a request succeeded.
+
+## Why it's common
+
+REST became the default web-API style because it builds on HTTP that every client and
+server already speaks, requires no special tooling, and maps cleanly onto how people think
+about data ("the message at this address"). Its statelessness makes services simpler to
+cache, load-balance, and scale. Alternatives like GraphQL and gRPC exist and fit some
+problems better, but REST remains the lingua franca of web services.
+
+## In practice
+
+A REST API is still an [API](/reference/api/), so its stability is a promise to callers:
+breaking changes warrant a new major version under
+[semantic versioning](/reference/semantic-versioning/), often expressed as a versioned path
+like `/v2/messages`. Because REST endpoints are where many systems meet, they are a prime
+target for [integration tests](/reference/integration-testing/) and
+[end-to-end tests](/reference/end-to-end-testing/) that exercise real requests against the
+running service.

--- a/docs/reference/ruby-language.md
+++ b/docs/reference/ruby-language.md
@@ -1,0 +1,64 @@
+---
+slug: ruby-language
+title: Ruby
+entry_type: language
+category: programming-languages
+description: Ruby is a dynamic, object-oriented, interpreted language designed for programmer happiness and readability, best known for the Ruby on Rails web framework.
+keywords: Ruby, Ruby on Rails, dynamic typing, object-oriented, interpreted, scripting, Matz, developer happiness, metaprogramming
+aka: [Ruby]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Object-oriented, dynamic, scripting" }
+  - { label: Typing, value: "Dynamic, strong, duck-typed" }
+  - { label: Appeared, value: "1995 (Japan)" }
+  - { label: Designed by, value: "Yukihiro \"Matz\" Matsumoto" }
+  - { label: Compilation, value: "Interpreted (bytecode VM, JIT in recent versions)" }
+  - { label: Memory, value: "Garbage-collected" }
+  - { label: Notable uses, value: "Web back ends (Rails), scripting, automation" }
+see_also: [python-language, object-oriented-programming, interpreter, static-vs-dynamic-typing, garbage-collection, bytecode, package-manager]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+external:
+  - { title: "Ruby (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Ruby_(programming_language) }
+  - { title: "Ruby programming language", url: https://www.ruby-lang.org/ }
+---
+
+**Ruby** is a dynamic, [object-oriented](/reference/object-oriented-programming/),
+[interpreted](/reference/interpreter/) language created by Yukihiro "Matz" Matsumoto
+with an explicit goal of programmer happiness, and it is best known as the language
+behind the Ruby on Rails web framework.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Concise Ruby source runs through an interpreter, which produces a working web application." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="60" y="68">readable</text><text x="60" y="80">.rb code</text>
+    <line x1="100" y1="70" x2="160" y2="70" stroke="currentColor" stroke-width="1.1"/><text x="130" y="62" font-size="8">run</text>
+    <rect x="160" y="50" width="100" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="210" y="74">interpreter</text>
+    <line x1="260" y1="70" x2="320" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="320" y="50" width="120" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="380" y="68">web app</text><text x="380" y="80">(Rails)</text>
+  </g>
+</svg>
+<figcaption>Ruby code is read and executed by an interpreter; Rails is the framework that made it famous.</figcaption>
+</figure>
+
+## Overview
+
+Ruby prizes readability and expressiveness over raw speed. Its syntax reads almost
+like English, nearly everything is an object, and its flexible metaprogramming lets
+libraries build clean, domain-specific interfaces. That power is what made **Ruby on
+Rails** so influential: the framework's "convention over configuration" approach let
+small teams ship web applications fast, and it shaped a generation of web frameworks
+in other languages. Gems, installed through the RubyGems [package manager](/reference/package-manager/),
+provide a large library ecosystem.
+
+## Key characteristics
+
+Ruby is dynamically typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/))
+and [garbage-collected](/reference/garbage-collection/), with code run by a
+[bytecode](/reference/bytecode/) virtual machine that has gained a JIT in recent
+releases. The trade-offs are well known: like other dynamic languages such as
+[Python](/reference/python-language/), it is comparatively **slow** in CPU-bound work
+and its loose typing lets some bugs reach runtime. Its popularity has cooled from the
+Rails peak, and its centre of gravity stays in web back ends, scripting, and
+automation rather than systems or numeric work.

--- a/docs/reference/rust-language.md
+++ b/docs/reference/rust-language.md
@@ -1,0 +1,70 @@
+---
+slug: rust-language
+title: Rust
+entry_type: language
+category: programming-languages
+description: Rust is a compiled systems language whose borrow checker enforces memory safety at compile time with no garbage collector, delivering C-level performance at the cost of a steep learning curve.
+keywords: Rust, borrow checker, ownership, memory safety, systems programming, no garbage collector, WebAssembly, data races, cargo
+aka: [Rust]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Multi-paradigm: imperative, functional, concurrent" }
+  - { label: Typing, value: "Static, strong, inferred" }
+  - { label: Appeared, value: "2010 (Mozilla; 1.0 in 2015)" }
+  - { label: Designed by, value: "Graydon Hoare; Mozilla" }
+  - { label: Compilation, value: "Ahead-of-time to native machine code (LLVM)" }
+  - { label: Memory, value: "Ownership + borrow checking (no GC)" }
+  - { label: Notable uses, value: "Systems, CLIs, WebAssembly, safety-critical components" }
+see_also: [c-language, cpp-language, go-language, memory-management, compiler, concurrency, type-system]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
+external:
+  - { title: "Rust (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Rust_(programming_language) }
+  - { title: "The Rust programming language", url: https://www.rust-lang.org/ }
+---
+
+**Rust** is a statically typed, compiled systems language designed to be fast *and*
+safe: its borrow checker enforces memory safety at compile time, eliminating whole
+classes of bugs without a garbage collector or runtime cost.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="The Rust compiler's borrow checker verifies ownership and borrowing rules at compile time; code that passes is memory-safe with no garbage collector." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="50" width="64" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="52" y="74">.rs source</text>
+    <line x1="84" y1="70" x2="124" y2="70" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="124" y="46" width="96" height="48" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="172" y="66">borrow</text><text x="172" y="78">checker</text>
+    <line x1="220" y1="58" x2="262" y2="40" stroke="currentColor" stroke-width="1.1"/><text x="290" y="38" font-size="8">pass</text>
+    <line x1="220" y1="82" x2="262" y2="104" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 3"/><text x="296" y="110" font-size="8" fill-opacity="0.7">reject unsafe</text>
+    <rect x="320" y="28" width="120" height="32" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="380" y="44">safe native binary</text><text x="380" y="55" font-size="8">no GC</text>
+  </g>
+</svg>
+<figcaption>Rust's borrow checker proves memory safety at compile time, then emits a native binary with no garbage collector.</figcaption>
+</figure>
+
+## Overview
+
+Rust [compiles](/reference/compiler/) ahead of time to native machine code, with
+performance that rivals [C](/reference/c-language/) and [C++](/reference/cpp-language/).
+Its defining idea is **ownership**: each value has a single owner, and a compile-time
+borrow checker enforces strict rules about how references may be shared and mutated.
+Code that violates those rules simply does not compile, which rules out use-after-free,
+double-free and data races — providing [memory](/reference/memory-management/) safety and
+safe [concurrency](/reference/concurrency/) without a [garbage collector](/reference/garbage-collection/).
+
+## Strengths and trade-offs
+
+The payoff is memory safety *and* speed at the same time, with no runtime collector and
+no GC pauses. The price is a **steep learning curve** — the borrow checker is famously
+hard to satisfy at first and forces you to think carefully about lifetimes and ownership.
+The ecosystem, while growing fast, is younger than C's or C++'s, and compile times can be
+long. The trade is deliberate: more friction up front in exchange for fewer whole classes
+of bugs later.
+
+## Where it's used
+
+Rust is increasingly chosen for new systems software, command-line tools, WebAssembly
+targets, and safety-critical components — places that want C-level control without C's
+memory hazards. It is not so much replacing [C](/reference/c-language/) and
+[C++](/reference/cpp-language/) as competing with them for new work, with the three
+expected to coexist for a long time.

--- a/docs/reference/semantic-versioning.md
+++ b/docs/reference/semantic-versioning.md
@@ -1,0 +1,70 @@
+---
+slug: semantic-versioning
+title: Semantic versioning
+entry_type: concept
+category: testing-delivery
+description: Semantic versioning (SemVer) is a MAJOR.MINOR.PATCH numbering convention in which the version number communicates the nature of each change — breaking, backward-compatible feature, or bug fix.
+keywords: semantic versioning, SemVer, MAJOR MINOR PATCH, version number, breaking change, backward compatible, release versioning, dependency ranges, tags
+aka: [semantic versioning "SemVer"]
+autolink: true
+infobox:
+  - { label: Category, value: "Versioning convention" }
+  - { label: Format, value: "MAJOR.MINOR.PATCH (e.g. 2.4.1)" }
+  - { label: MAJOR, value: "Breaking change" }
+  - { label: MINOR, value: "Backward-compatible feature" }
+  - { label: PATCH, value: "Backward-compatible bug fix" }
+see_also: [package-manager, api, build-systems, ci-cd, version-control]
+related_lessons:
+  - { title: "Releases & tags", url: /learn/git/releases-and-tags/ }
+external:
+  - { title: "Software versioning — Wikipedia", url: https://en.wikipedia.org/wiki/Software_versioning }
+---
+
+**Semantic versioning** (SemVer) is a `MAJOR.MINOR.PATCH` numbering convention in which
+the version number itself communicates the nature of each change — breaking,
+backward-compatible feature, or bug fix.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A version number 2.4.1 broken into MAJOR for breaking changes, MINOR for features, and PATCH for fixes." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="230" y="38" font-size="24" fill="currentColor">2 . 4 . 1</text>
+    <line x1="150" y1="46" x2="150" y2="62" stroke="currentColor" stroke-width="1"/><text x="150" y="78">MAJOR</text><text x="150" y="92" font-size="8">breaking</text>
+    <line x1="230" y1="46" x2="230" y2="62" stroke="currentColor" stroke-width="1"/><text x="230" y="78">MINOR</text><text x="230" y="92" font-size="8">feature</text>
+    <line x1="310" y1="46" x2="310" y2="62" stroke="currentColor" stroke-width="1"/><text x="310" y="78">PATCH</text><text x="310" y="92" font-size="8">bug fix</text>
+  </g>
+</svg>
+<figcaption>Each position in MAJOR.MINOR.PATCH signals a different kind of change.</figcaption>
+</figure>
+
+## The rules
+
+Under SemVer you bump exactly one part of the version per release, by the nature of the
+change:
+
+| Bump | When | Example |
+| --- | --- | --- |
+| PATCH | Backward-compatible bug fix | 1.4.2 → 1.4.3 |
+| MINOR | Backward-compatible new feature | 1.4.3 → 1.5.0 |
+| MAJOR | Breaking, backward-incompatible change | 1.5.0 → 2.0.0 |
+
+A user reading `1.5.0 → 1.5.1` knows it is a safe update; `1.x → 2.0` warns them to read
+the release notes. Pre-`1.0.0` versions are treated as unstable, and suffixes like
+`-rc.1` or `-beta` mark pre-releases. That single convention prevents a great deal of
+confusion about whether an upgrade is safe.
+
+## Why it matters
+
+SemVer turns a version string into a *contract* about compatibility, which is what makes
+automated [dependency management](/reference/package-manager/) possible: a manifest can
+safely request "compatible with 1.4" and let the resolver accept newer 1.x releases but
+not a breaking 2.0. The "breaking change" that triggers a MAJOR bump is precisely a change
+to a published [API](/reference/api/) — its operations, types, or behavior — so SemVer and
+good API design go hand in hand.
+
+## In practice
+
+A release is usually a tagged commit in [version control](/reference/version-control/),
+and a [CI/CD](/reference/ci-cd/) pipeline often builds and publishes the versioned
+artifacts automatically when a tag is pushed. The version baked into the
+[build](/reference/build-systems/) and printed by the program lets users and maintainers
+identify exactly which release they are running.

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -1,0 +1,67 @@
+---
+slug: solid
+title: SOLID
+entry_type: concept
+category: principles-quality
+description: SOLID is a set of five object-oriented design principles — single responsibility, open/closed, Liskov substitution, interface segregation, and dependency inversion — aimed at code that is easy to change without breaking.
+keywords: SOLID principles, single responsibility, open closed, Liskov substitution, interface segregation, dependency inversion, object-oriented design, software design
+aka: [SOLID]
+autolink: true
+infobox:
+  - { label: Category, value: "Object-oriented design principles" }
+  - { label: Popularized by, value: "Robert C. Martin" }
+  - { label: Letters, value: "SRP, OCP, LSP, ISP, DIP" }
+  - { label: Goal, value: "Code that's easy to change and test" }
+  - { label: Nature, value: "Heuristics, not laws" }
+see_also: [dry-kiss-yagni, clean-code, refactoring, abstraction, coupling-and-cohesion, object-oriented-programming, design-patterns]
+related_lessons:
+  - { title: "SOLID & object-oriented design", url: /learn/intro-software-dev/solid/ }
+external:
+  - { title: "SOLID — Wikipedia", url: https://en.wikipedia.org/wiki/SOLID }
+---
+
+**SOLID** is a set of five [object-oriented](/reference/object-oriented-programming/)
+design principles, popularized by Robert C. Martin, that all aim at one outcome: code
+that is easy to change without breaking.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="The five SOLID letters: single responsibility, open/closed, Liskov substitution, interface segregation, dependency inversion." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="14" y="40" width="80" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="54" y="56" font-size="14">S</text><text x="54" y="72">single resp.</text>
+    <rect x="102" y="40" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="142" y="56" font-size="14">O</text><text x="142" y="72">open/closed</text>
+    <rect x="190" y="40" width="80" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="230" y="56" font-size="14">L</text><text x="230" y="72">Liskov sub.</text>
+    <rect x="278" y="40" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="318" y="56" font-size="14">I</text><text x="318" y="72">interface seg.</text>
+    <rect x="366" y="40" width="80" height="40" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="406" y="56" font-size="14">D</text><text x="406" y="72">dependency inv.</text>
+  </g>
+</svg>
+<figcaption>The five SOLID principles, each a heuristic for one-job, loosely coupled design.</figcaption>
+</figure>
+
+## The five principles
+
+- **S — Single Responsibility Principle.** A unit of code should have one reason to
+  change — it answers to a single concern. Mixing parsing, business rules, and
+  storage in one class means a change to one risks breaking the others.
+- **O — Open/Closed Principle.** Software should be open for extension but closed for
+  modification: add new behavior by writing a new implementation, not by editing
+  existing, tested code. An abstraction with multiple implementations is the usual
+  mechanism.
+- **L — Liskov Substitution Principle.** A subtype must be usable anywhere its base
+  type is expected, honoring the parent's contract — its expectations, guarantees, and
+  invariants — not just its method signatures.
+- **I — Interface Segregation Principle.** Clients shouldn't be forced to depend on
+  methods they don't use. Many small, role-focused interfaces beat one fat one.
+- **D — Dependency Inversion Principle.** High-level logic should depend on
+  [abstractions](/reference/abstraction/), not concrete details, with implementations
+  supplied from outside (dependency injection).
+
+## Why it matters
+
+Together the principles reduce [coupling](/reference/coupling-and-cohesion/) and make
+code flexible and [testable](/reference/unit-testing/): when logic depends on an
+interface rather than a concrete class, a test can pass in a fake. SOLID overlaps
+heavily with [DRY, KISS and YAGNI](/reference/dry-kiss-yagni/) and underpins many
+[design patterns](/reference/design-patterns/) — but it is a toolbox of heuristics,
+not a law. Applied dogmatically it causes as much over-engineering as it prevents;
+reach for these principles to diagnose code that resists change or testing, not to
+satisfy a checklist. They are a frequent target of [refactoring](/reference/refactoring/).

--- a/docs/reference/static-binary.md
+++ b/docs/reference/static-binary.md
@@ -1,0 +1,72 @@
+---
+slug: static-binary
+title: Static binary
+entry_type: concept
+category: language-internals
+description: A static binary is an executable that bundles all the code it needs at build time, so it runs without depending on shared libraries or a separate runtime on the target machine.
+keywords: static binary, static linking, dynamic linking, shared library, self-contained executable, no dependencies, distribution, deployment
+aka: ["static binary", "statically linked binary"]
+autolink: true
+infobox:
+  - { label: Category, value: Executable packaging }
+  - { label: Definition, value: "Executable with dependencies bundled in" }
+  - { label: Contrast, value: "Dynamically linked binary" }
+  - { label: Benefit, value: "Runs with no external runtime or libraries" }
+  - { label: Cost, value: "Larger file, rebuild to update a dependency" }
+  - { label: Common in, value: "Go, Rust, C" }
+see_also: [compiler, cross-compilation, jit-compilation, go-language, rust-language, c-language]
+related_lessons:
+  - { title: "Packaging and distribution", url: /learn/intro-software-dev/packaging-and-distribution/ }
+  - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
+external:
+  - { title: "Static library — Wikipedia", url: https://en.wikipedia.org/wiki/Static_library }
+---
+
+**A static binary** is an executable that bundles all the code it needs at build time,
+so it runs on its own — no shared libraries to find, no interpreter or runtime to
+install on the target machine.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="A static binary contains its libraries inside it and runs alone, unlike a dynamic binary that depends on external shared libraries." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="95" y="20" font-size="8" fill-opacity="0.7">static</text>
+    <rect x="40" y="28" width="110" height="60" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.3"/><text x="95" y="46">app code</text>
+    <rect x="55" y="54" width="36" height="24" rx="3" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="73" y="69" font-size="7">lib A</text>
+    <rect x="99" y="54" width="36" height="24" rx="3" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="117" y="69" font-size="7">lib B</text>
+    <text x="95" y="104" font-size="7" fill-opacity="0.7">runs alone</text>
+    <text x="345" y="20" font-size="8" fill-opacity="0.7">dynamic</text>
+    <rect x="290" y="40" width="80" height="40" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="330" y="64">app code</text>
+    <line x1="370" y1="50" x2="410" y2="40" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 3"/><line x1="370" y1="70" x2="410" y2="80" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 3"/>
+    <rect x="410" y="28" width="40" height="24" rx="3" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="430" y="43" font-size="7">lib A</text>
+    <rect x="410" y="68" width="40" height="24" rx="3" fill="none" stroke="currentColor" stroke-width="1.1"/><text x="430" y="83" font-size="7">lib B</text>
+  </g>
+</svg>
+<figcaption>A static binary carries its libraries inside it; a dynamic one depends on shared libraries present on the machine.</figcaption>
+</figure>
+
+## How it works
+
+When a [compiler](/reference/compiler/) builds a program, it links in the libraries the
+code calls. With **dynamic linking** those libraries stay separate and are loaded from
+the system at run time, so the binary depends on the right versions being installed.
+With **static linking** the linker copies the needed library code directly into the
+executable, producing one self-contained file. The result needs nothing external — not
+even a language runtime, unlike [bytecode](/reference/bytecode/) that requires a virtual
+machine.
+
+## Trade-offs
+
+The payoff is **deployment simplicity**: copy one file to a matching machine and run
+it, with no installer, no dependency hunt, and no "works on my machine" version skew.
+The costs are a **larger file** (every dependency is included) and that updating a
+bundled library means rebuilding the binary rather than patching a shared one. Paired
+with [cross-compilation](/reference/cross-compilation/), a static binary makes
+shipping for many platforms a single, clean step.
+
+## In practice
+
+[Go](/reference/go-language/) produces a static binary by default, which is a major
+reason it suits CLIs, network services, and tools like GopherTrunk that ship to users
+who just want to run them. [Rust](/reference/rust-language/) and
+[C](/reference/c-language/) can link statically as well, trading file size for the same
+dependency-free convenience.

--- a/docs/reference/static-vs-dynamic-typing.md
+++ b/docs/reference/static-vs-dynamic-typing.md
@@ -1,0 +1,75 @@
+---
+slug: static-vs-dynamic-typing
+title: Static vs dynamic typing
+entry_type: concept
+category: language-internals
+description: Static typing checks the types of values at compile time before a program runs, while dynamic typing checks them at run time as each operation executes.
+keywords: static typing, dynamic typing, compile time, run time, type checking, type inference, gradual typing, duck typing, strong typing
+aka: ["static typing", "dynamic typing"]
+autolink: true
+infobox:
+  - { label: Category, value: Typing discipline }
+  - { label: The axis, value: "When types are checked" }
+  - { label: Static, value: "At compile time, before running" }
+  - { label: Dynamic, value: "At run time, per operation" }
+  - { label: Static examples, value: "C, Rust, Go, Java" }
+  - { label: Dynamic examples, value: "Python, Ruby, JavaScript" }
+see_also: [type-system, compiler, interpreter, typescript-language, python-language, go-language, rust-language]
+related_lessons:
+  - { title: "Type systems and safety", url: /learn/intro-software-dev/type-systems/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Type system — Wikipedia", url: https://en.wikipedia.org/wiki/Type_system#Static_and_dynamic_type_checking_in_practice }
+---
+
+**Static versus dynamic typing** is about *when* a language checks the types of its
+values: a **statically typed** language checks at compile time, before the program
+runs, while a **dynamically typed** language checks at run time, as each operation
+executes.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="Static typing checks types during the build step before running; dynamic typing checks each operation while the program runs." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="115" y="20" font-size="8" fill-opacity="0.7">static</text>
+    <rect x="20" y="28" width="70" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="55" y="47">source</text>
+    <line x1="90" y1="43" x2="130" y2="43" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="130" y="28" width="80" height="30" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="170" y="47">check + run</text>
+    <text x="115" y="80" font-size="8" fill-opacity="0.7">dynamic</text>
+    <rect x="20" y="88" width="70" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="55" y="107">source</text>
+    <line x1="90" y1="103" x2="130" y2="103" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="130" y="88" width="60" height="30" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="160" y="107">run...</text>
+    <line x1="190" y1="103" x2="230" y2="103" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="230" y="88" width="90" height="30" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="275" y="107">check on use</text>
+  </g>
+</svg>
+<figcaption>Static typing checks before the program runs; dynamic typing checks each operation as it executes.</figcaption>
+</figure>
+
+## How they differ
+
+Under **static typing**, the [compiler](/reference/compiler/) knows the type of every
+variable and rejects code that misuses it before you can run it — passing a string
+where a number is expected is a build error. Under **dynamic typing**, a variable can
+hold a string now and a number later; the [interpreter](/reference/interpreter/) only
+complains when an actual operation is invalid. This is a separate question from *how
+strictly* a language enforces types (strong versus weak), so the two axes combine:
+Rust is static and strong, Python dynamic and strong, JavaScript dynamic and weak.
+
+## Trade-offs
+
+Static typing catches **whole classes of bugs at compile time** — wrong types, missing
+methods, broken refactors — and makes APIs self-documenting, which is why large,
+long-lived codebases drift toward it. The cost is ceremony and some rigidity, though
+[type inference](/reference/type-system/) removes most of the annotation burden.
+Dynamic typing offers **flexibility and less ceremony** — quick scripts, duck typing,
+runtime metaprogramming — at the risk of type errors that hide until that line runs.
+
+## In practice
+
+[C](/reference/c-language/), [Rust](/reference/rust-language/),
+[Go](/reference/go-language/), and Java are statically typed;
+[Python](/reference/python-language/), [Ruby](/reference/ruby-language/), and
+[JavaScript](/reference/javascript-language/) are dynamic. *Gradual typing* bridges the
+two: [TypeScript](/reference/typescript-language/) and Python type hints add optional,
+checkable types to dynamic languages, keeping flexibility where you want it and adding
+guarantees where the code is critical.

--- a/docs/reference/structural-patterns.md
+++ b/docs/reference/structural-patterns.md
@@ -1,0 +1,69 @@
+---
+slug: structural-patterns
+title: Structural patterns
+entry_type: concept
+category: paradigms-design
+description: Structural patterns are the Gang of Four family that composes classes and objects into larger structures, mostly through wrapping, while keeping the parts loosely coupled.
+keywords: structural patterns, adapter pattern, facade pattern, decorator pattern, proxy, composite, bridge, wrapper, composition, gang of four, design patterns
+aka: []
+autolink: true
+infobox:
+  - { label: Type, value: "Design pattern family (GoF)" }
+  - { label: Problem solved, value: "How objects are composed into structures" }
+  - { label: Members, value: "Adapter, Facade, Decorator, Proxy, Composite, Bridge" }
+  - { label: Common mechanism, value: "One object wraps another" }
+  - { label: Benefit, value: "Flexible assembly, loose coupling" }
+  - { label: Sibling families, value: "Creational, behavioral" }
+see_also: [design-patterns, creational-patterns, behavioral-patterns, object-oriented-programming, coupling-and-cohesion, abstraction, solid]
+related_lessons:
+  - { title: "Structural patterns: adapter, facade, decorator", url: /learn/intro-software-dev/structural-patterns/ }
+external:
+  - { title: "Structural pattern — Wikipedia", url: https://en.wikipedia.org/wiki/Structural_pattern }
+---
+
+**Structural patterns** are the [Gang of Four](/reference/design-patterns/) family that
+answers *how do objects fit together into larger structures?* — mostly by taking objects
+that already exist and arranging them so the whole stays flexible.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Three structural shapes: an adapter wrapping one object to change its interface, a facade fronting many parts, and a decorator stacking wrappers." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="40" width="100" height="60" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><rect x="50" y="58" width="40" height="24" rx="3" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/><text x="70" y="34" font-size="8">adapter</text><text x="70" y="113" font-size="8">wraps 1</text>
+    <rect x="180" y="40" width="100" height="60" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="230" y="34" font-size="8">facade</text><rect x="190" y="62" width="22" height="18" rx="2" fill="none" stroke="currentColor" stroke-width="1"/><rect x="219" y="62" width="22" height="18" rx="2" fill="none" stroke="currentColor" stroke-width="1"/><rect x="248" y="62" width="22" height="18" rx="2" fill="none" stroke="currentColor" stroke-width="1"/><text x="230" y="113" font-size="8">fronts many</text>
+    <rect x="340" y="40" width="100" height="60" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><rect x="352" y="50" width="76" height="40" rx="3" fill="none" stroke="currentColor" stroke-width="1"/><rect x="364" y="60" width="52" height="20" rx="2" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1"/><text x="390" y="34" font-size="8">decorator</text><text x="390" y="113" font-size="8">stacks</text>
+  </g>
+</svg>
+<figcaption>Adapter wraps one object to change its interface, Facade fronts many parts, and Decorator stacks wrappers.</figcaption>
+</figure>
+
+## What they are for
+
+Real systems are assembled from parts written at different times by different people — a
+third-party driver, your own code, a UI toolkit. Getting them to cooperate without welding
+them tightly together is the recurring problem these patterns address. They share a family
+resemblance: most involve one object **wrapping** another, and all lean on programming to
+an [interface](/reference/abstraction/) so dependencies point at the contract rather than
+concrete classes, keeping [coupling](/reference/coupling-and-cohesion/) low.
+
+## The main members
+
+- **Adapter** — converts one object's interface into the one a client expects; the
+  universal travel plug of software, wrapping a single object to fix *compatibility*.
+- **Facade** — a brand-new, simpler interface in front of a whole subsystem, fixing
+  *complexity* by offering one easy entry point.
+- **Decorator** — wraps an object with the *same* interface to add behavior (logging,
+  gain) that stacks in any order at runtime, avoiding a subclass explosion.
+- **Proxy** — stands in for another object to control access, add caching, or defer work.
+- **Composite** — treats individual objects and groups of them uniformly through one
+  interface.
+- **Bridge** — separates an abstraction from its implementation so they vary independently.
+
+## A subtle distinction
+
+Adapter and Decorator look structurally identical — both wrap an object — but the *intent*
+differs: Adapter changes the interface to make things fit, while Decorator keeps the
+interface the same and adds behavior. Knowing the pattern *names* is exactly what lets a
+team distinguish them when discussing a design. The sibling families are
+[creational patterns](/reference/creational-patterns/) (making objects) and
+[behavioral patterns](/reference/behavioral-patterns/) (coordinating them), and all three
+support the open/closed principle from [SOLID](/reference/solid/).

--- a/docs/reference/swift-language.md
+++ b/docs/reference/swift-language.md
@@ -1,0 +1,70 @@
+---
+slug: swift-language
+title: Swift
+entry_type: language
+category: programming-languages
+description: Swift is Apple's modern, statically typed, compiled language for iOS and macOS development; it is clean, fast and memory-safe, but its centre of gravity is Apple's platforms.
+keywords: Swift, Apple, iOS, macOS, ARC, automatic reference counting, compiled, memory safety, LLVM, mobile
+aka: [Swift]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Multi-paradigm: object-oriented, functional, protocol-oriented" }
+  - { label: Typing, value: "Static, strong, inferred" }
+  - { label: Appeared, value: "2014 (Apple)" }
+  - { label: Designed by, value: "Chris Lattner; Apple" }
+  - { label: Compilation, value: "Ahead-of-time to native machine code (LLVM)" }
+  - { label: Memory, value: "Automatic reference counting (ARC)" }
+  - { label: Notable uses, value: "iOS and macOS apps, Apple-platform software" }
+see_also: [kotlin-language, rust-language, memory-management, compiler, type-system, object-oriented-programming, c-language]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
+external:
+  - { title: "Swift (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Swift_(programming_language) }
+  - { title: "The Swift programming language — Apple", url: https://www.swift.org/ }
+---
+
+**Swift** is Apple's modern, statically typed, compiled language for building iOS and
+macOS applications. It is clean and fast and prioritises safety, but its centre of
+gravity remains Apple's platforms.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="Swift source compiles ahead of time to native code via LLVM, with memory managed automatically by reference counting, primarily targeting Apple platforms." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="74" height="38" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="57" y="74">.swift source</text>
+    <line x1="94" y1="71" x2="134" y2="71" stroke="currentColor" stroke-width="1.1"/><text x="114" y="63" font-size="8">LLVM</text>
+    <rect x="134" y="52" width="86" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="177" y="68">native code</text>
+    <line x1="220" y1="71" x2="260" y2="71" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="260" y="46" width="80" height="50" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="300" y="66">runtime</text><text x="300" y="80" font-size="8">ARC</text>
+    <line x1="340" y1="71" x2="380" y2="71" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="380" y="52" width="60" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="410" y="68">iOS /</text><text x="410" y="80">macOS</text>
+  </g>
+</svg>
+<figcaption>Swift compiles to native code via LLVM, manages memory with reference counting, and targets Apple's platforms.</figcaption>
+</figure>
+
+## Overview
+
+Swift [compiles](/reference/compiler/) ahead of time to native machine code through LLVM,
+giving it performance well beyond Apple's earlier Objective-C in many cases. It is
+[statically typed](/reference/type-system/) with type inference, supports
+[object-oriented](/reference/object-oriented-programming/) and functional styles, and
+manages [memory](/reference/memory-management/) automatically through Automatic Reference
+Counting (ARC) rather than a tracing garbage collector. The language emphasises safety —
+clear handling of optionals and [errors](/reference/error-handling/) is built into the
+design.
+
+## Strengths and trade-offs
+
+Swift's strengths are a clean, modern syntax, strong safety guarantees and good native
+performance, with first-class tooling on Apple's platforms. The main trade-off is reach:
+although Swift is open source and runs on Linux and elsewhere, its ecosystem, libraries
+and tooling are overwhelmingly centred on Apple, so it is far less common off those
+platforms. In that respect it parallels [Kotlin](/reference/kotlin-language/), the modern
+mobile language tied instead to the JVM and Android.
+
+## Where it's used
+
+Swift is the primary language for iOS, iPadOS, macOS, watchOS and tvOS application
+development, and for most new software written for Apple's ecosystem. Outside that world
+it sees comparatively little use.

--- a/docs/reference/test-driven-development.md
+++ b/docs/reference/test-driven-development.md
@@ -1,0 +1,72 @@
+---
+slug: test-driven-development
+title: Test-driven development (TDD)
+entry_type: concept
+category: testing-delivery
+description: Test-driven development (TDD) is a practice in which you write a failing test first, then write just enough code to make it pass, then refactor — the "red, green, refactor" cycle.
+keywords: test-driven development, TDD, red green refactor, test first, failing test, design through tests, Kent Beck, software testing
+aka: [test-driven development "TDD"]
+autolink: true
+infobox:
+  - { label: Category, value: "Development practice" }
+  - { label: Cycle, value: "Red → Green → Refactor" }
+  - { label: Order, value: "Test first, then code" }
+  - { label: Popularized by, value: "Kent Beck" }
+  - { label: Benefit, value: "Clarifies intent before building" }
+see_also: [unit-testing, integration-testing, end-to-end-testing, mocking, code-coverage, refactoring, ci-cd]
+related_lessons:
+  - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
+external:
+  - { title: "Test-driven development — Wikipedia", url: https://en.wikipedia.org/wiki/Test-driven_development }
+---
+
+**Test-driven development (TDD)** flips the usual order of work: you write a failing test
+*first*, then write just enough code to make it pass, then refactor — the rhythm known as
+"red, green, refactor."
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="The TDD cycle: write a failing red test, write code to make it green, then refactor, and repeat." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <circle cx="90" cy="65" r="34" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="90" y="62" font-size="11">RED</text><text x="90" y="76" font-size="8">failing test</text>
+    <line x1="124" y1="65" x2="196" y2="65" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="230" cy="65" r="34" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.4"/><text x="230" y="62" font-size="11">GREEN</text><text x="230" y="76" font-size="8">make it pass</text>
+    <line x1="264" y1="65" x2="336" y2="65" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="370" cy="65" r="34" fill="none" stroke="currentColor" stroke-width="1.4"/><text x="370" y="62" font-size="10">REFACTOR</text><text x="370" y="76" font-size="8">clean up</text>
+    <path d="M370 99 C300 130 160 130 90 99" fill="none" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 3"/><text x="230" y="126" font-size="8">repeat</text>
+  </g>
+</svg>
+<figcaption>The red-green-refactor loop: fail first, pass minimally, then improve the design.</figcaption>
+</figure>
+
+## The cycle
+
+TDD proceeds in tight loops, popularized by Kent Beck:
+
+- **Red** — write a small test for behavior that doesn't exist yet, and watch it fail.
+  A test that passes *before* you write the code is testing nothing, so the failure is
+  proof the test is real.
+- **Green** — write the simplest code that makes the test pass, resisting the urge to
+  build more than the test demands.
+- **Refactor** — with a green suite as a safety net, clean up the code —
+  [refactoring](/reference/refactoring/) toward better names and structure without
+  changing behavior, confident any regression turns the suite red.
+
+Then repeat for the next slice of behavior.
+
+## Why it helps
+
+Writing the test first forces you to clarify *what* the code should do — its contract and
+edge cases — before deciding *how* to build it, which tends to produce simpler, more
+[testable](/reference/unit-testing/) designs. The discipline also guarantees that every
+piece of code is covered by a test that genuinely exercises it, and it pairs naturally
+with continuous [CI/CD](/reference/ci-cd/) since the suite is always meant to be green.
+
+## In practice
+
+TDD is most associated with [unit tests](/reference/unit-testing/) but the same test-first
+rhythm applies to [integration](/reference/integration-testing/) and
+[end-to-end](/reference/end-to-end-testing/) levels, and it often relies on
+[mocking](/reference/mocking/) to isolate the unit under test. It is a valuable
+discipline rather than a mandate — even teams that don't follow it strictly benefit from
+specifying behavior up front. Note that the [code coverage](/reference/code-coverage/) it
+produces is a by-product, not the goal: well-asserted tests matter more than the number.

--- a/docs/reference/threads.md
+++ b/docs/reference/threads.md
@@ -1,0 +1,70 @@
+---
+slug: threads
+title: Threads
+entry_type: concept
+category: concurrency-execution
+description: A thread is an independent flow of execution within a process; multiple threads share the process's memory and can run on different CPU cores at once.
+keywords: thread, OS thread, process, shared memory, lock, mutex, data race, deadlock, parallelism, context switch
+aka: ["thread", "OS thread"]
+autolink: true
+infobox:
+  - { label: Category, value: Execution unit }
+  - { label: Lives in, value: "A process" }
+  - { label: Shares, value: "The process's memory" }
+  - { label: Managed by, value: "The operating system" }
+  - { label: Parallel, value: "Yes, across CPU cores" }
+  - { label: Main hazards, value: "Data races, deadlocks" }
+see_also: [concurrency, async-programming, goroutines, memory-management, c-language, rust-language]
+related_lessons:
+  - { title: "Concurrency and parallelism", url: /learn/intro-software-dev/concurrency-models/ }
+  - { title: "Concurrency and pipelines", url: /learn/intro-software-dev/concurrency-and-pipelines/ }
+external:
+  - { title: "Thread (computing) — Wikipedia", url: https://en.wikipedia.org/wiki/Thread_(computing) }
+---
+
+**A thread** is an independent flow of execution inside a process. The operating system
+can give one process several threads that share the same memory and run on different
+CPU cores at the same time — the oldest and most direct route to
+[parallelism](/reference/concurrency/).
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="One process contains shared memory and three threads of execution running within it." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="30" y="20" width="400" height="90" rx="6" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="70" y="35" font-size="8" fill-opacity="0.7">process</text>
+    <rect x="50" y="48" width="100" height="44" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.2"/><text x="100" y="66">shared</text><text x="100" y="78">memory</text>
+    <line x1="150" y1="60" x2="200" y2="55" stroke="currentColor" stroke-width="1.1"/><line x1="150" y1="70" x2="200" y2="75" stroke="currentColor" stroke-width="1.1"/><line x1="150" y1="80" x2="200" y2="95" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="200" y="44" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="250" y="59" font-size="8">thread 1</text>
+    <rect x="200" y="69" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="250" y="84" font-size="8">thread 2</text>
+    <rect x="320" y="56" width="100" height="22" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="370" y="71" font-size="8">thread 3</text>
+  </g>
+</svg>
+<figcaption>One process, several threads — all sharing the same memory, which is exactly where the danger lies.</figcaption>
+</figure>
+
+## How it works
+
+A process starts with one thread and can spawn more, and the OS scheduler hands each
+thread time on a core. Because threads in a process share its
+[memory](/reference/memory-management/), they communicate simply by reading and writing
+the same variables — fast and powerful, but the source of the danger. When two threads
+touch the same data and at least one writes, with no coordination, you have a **data
+race**, and the result is undefined: a half-updated value, a counter that loses
+increments, a crash that appears once a week.
+
+## Trade-offs
+
+Threads are genuinely parallel and map directly onto hardware cores, so they suit
+CPU-bound work. The traditional fix for races is a **lock** (mutex): only one thread may
+hold the lock and touch the shared data at a time. Locks work but bring their own
+hazards — **deadlock** (two threads each waiting on a lock the other holds), forgotten
+locks, and contention that erodes performance. OS threads are also relatively heavy, so
+running hundreds of thousands of them is impractical.
+
+## In practice
+
+[C](/reference/c-language/), [C++](/reference/cpp-language/),
+[Rust](/reference/rust-language/), and Java expose OS threads directly, with Rust's type
+system preventing many data races at compile time. To avoid heavy threads and explicit
+locks, other models build on top of them: [async/await](/reference/async-programming/)
+multiplexes tasks onto a single thread, and [goroutines](/reference/goroutines/)
+multiplex many lightweight tasks onto a few OS threads.

--- a/docs/reference/type-system.md
+++ b/docs/reference/type-system.md
@@ -1,0 +1,73 @@
+---
+slug: type-system
+title: Type system
+entry_type: concept
+category: language-internals
+description: A type system is the set of rules a language uses to track the types of values and decide which operations are allowed, catching certain mistakes before or during execution.
+keywords: type system, type checking, static typing, dynamic typing, strong typing, type inference, generics, type safety, null safety
+aka: [type system]
+autolink: true
+infobox:
+  - { label: Category, value: Language semantics }
+  - { label: Purpose, value: "Track value types, allow only valid operations" }
+  - { label: When checked, value: "Compile time (static) or run time (dynamic)" }
+  - { label: Strictness, value: "Strong vs weak coercion" }
+  - { label: Reduces ceremony via, value: "Type inference" }
+  - { label: Trade-off, value: "Safety up front vs flexibility & brevity" }
+see_also: [static-vs-dynamic-typing, compiler, interpreter, memory-management, rust-language, typescript-language, go-language]
+related_lessons:
+  - { title: "Type systems and safety", url: /learn/intro-software-dev/type-systems/ }
+  - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
+external:
+  - { title: "Type system — Wikipedia", url: https://en.wikipedia.org/wiki/Type_system }
+---
+
+**A type system** is the set of rules a language uses to track the type of every value
+— integer, string, list, a `Receiver` object — and decide which operations are allowed,
+catching whole classes of mistakes that would otherwise surface as bugs.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 120" role="img" aria-label="A type checker accepts an operation on matching types and rejects one that mixes incompatible types." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="25" width="60" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="50" y="42">int + int</text>
+    <line x1="80" y1="38" x2="150" y2="50" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="20" y="75" width="60" height="26" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="50" y="92">int + str</text>
+    <line x1="80" y1="88" x2="150" y2="62" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="150" y="40" width="90" height="34" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="195" y="61">type check</text>
+    <line x1="240" y1="50" x2="310" y2="35" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="310" y="20" width="90" height="28" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="355" y="38">accepted</text>
+    <line x1="240" y1="64" x2="310" y2="82" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="310" y="68" width="90" height="28" rx="4" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3 3"/><text x="355" y="86" fill-opacity="0.7">rejected</text>
+  </g>
+</svg>
+<figcaption>The type checker permits operations on compatible types and rejects ones that mix incompatible types.</figcaption>
+</figure>
+
+## How it works
+
+The type system assigns a type to each value and to the inputs and outputs of every
+operation, then verifies that uses line up. *When* it checks is the
+[static-versus-dynamic](/reference/static-vs-dynamic-typing/) axis: a
+[compiled](/reference/compiler/) language usually checks at compile time, while a
+[dynamic](/reference/interpreter/) language checks at run time as each operation
+executes. A separate axis is *how strictly* it enforces types — **strong** systems
+refuse to silently mix a string and a number, **weak** ones coerce. **Type inference**
+lets the compiler deduce types from context, so you get checking without spelling out
+every annotation.
+
+## Trade-offs
+
+A richer type system pays for itself by turning run-time surprises into compile errors:
+wrong-type arguments, calling a method that does not exist, forgetting to handle a
+null, and broken refactors all get caught for free. Expressive features — generics,
+sum types, and Option/Result types — let you "make illegal states unrepresentable."
+The cost is ceremony, some rigidity, and slower prototyping. A throwaway script barely
+benefits; a large, long-lived, multi-author system benefits enormously.
+
+## In practice
+
+[Rust](/reference/rust-language/), [Go](/reference/go-language/), and Java pair static
+checking with inference; [TypeScript](/reference/typescript-language/) adds a checkable
+type layer over JavaScript. In domains like radio software, wrapping a frequency and a
+sample rate in distinct types makes unit-confusion bugs impossible to compile rather
+than merely unlikely.

--- a/docs/reference/typescript-language.md
+++ b/docs/reference/typescript-language.md
@@ -1,0 +1,71 @@
+---
+slug: typescript-language
+title: TypeScript
+entry_type: language
+category: programming-languages
+description: TypeScript is JavaScript with a static type system layered on top; it compiles to plain JavaScript and has become the default for large front-end and Node.js codebases.
+keywords: TypeScript, TS, static typing, type system, JavaScript, transpile, compile, Microsoft, type safety
+aka: [TypeScript, TS]
+autolink: true
+infobox:
+  - { label: Paradigm, value: "Multi-paradigm: object-oriented, functional, event-driven" }
+  - { label: Typing, value: "Static, structural, gradual (over dynamic JS)" }
+  - { label: Appeared, value: "2012 (Microsoft)" }
+  - { label: Designed by, value: "Anders Hejlsberg, Microsoft" }
+  - { label: Compilation, value: "Compiled (transpiled) to JavaScript; types erased" }
+  - { label: Memory, value: "Garbage-collected (via the JS runtime)" }
+  - { label: Notable uses, value: "Front-end apps, Node.js backends, large codebases" }
+see_also: [javascript-language, type-system, static-vs-dynamic-typing, compiler, csharp-language, jit-compilation, error-handling]
+related_lessons:
+  - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
+  - { title: "Type systems", url: /learn/intro-software-dev/type-systems/ }
+external:
+  - { title: "TypeScript — Wikipedia", url: https://en.wikipedia.org/wiki/TypeScript }
+  - { title: "The TypeScript programming language", url: https://www.typescriptlang.org/ }
+---
+
+**TypeScript** is a statically typed superset of [JavaScript](/reference/javascript-language/):
+it adds an optional [type system](/reference/type-system/) on top of JavaScript and
+compiles down to plain JavaScript that runs anywhere JavaScript does.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 140" role="img" aria-label="TypeScript source is type-checked and compiled to plain JavaScript, which runs in the browser or Node.js." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="78" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="59" y="68">.ts source</text><text x="59" y="80" font-size="8">+ types</text>
+    <line x1="98" y1="71" x2="140" y2="71" stroke="currentColor" stroke-width="1.1"/><text x="119" y="63" font-size="8">tsc</text>
+    <rect x="140" y="52" width="92" height="38" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="186" y="68">type check</text><text x="186" y="80" font-size="8">+ erase types</text>
+    <line x1="232" y1="71" x2="274" y2="71" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="274" y="52" width="78" height="38" rx="5" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="313" y="74">.js output</text>
+    <line x1="352" y1="71" x2="394" y2="71" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="394" y="52" width="50" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="419" y="74">runs</text>
+  </g>
+</svg>
+<figcaption>TypeScript type-checks at build time, then erases the types and emits plain JavaScript.</figcaption>
+</figure>
+
+## Overview
+
+TypeScript exists to fix JavaScript's biggest weakness — its loose
+[dynamic typing](/reference/static-vs-dynamic-typing/). You annotate code with types,
+the `tsc` [compiler](/reference/compiler/) checks them at build time, and then the types
+are *erased*: the emitted output is ordinary JavaScript with no runtime type system of
+its own. Memory and execution are still handled by the JavaScript runtime, so TypeScript
+adds safety without changing how the program runs.
+
+## Strengths and trade-offs
+
+The static type layer catches a large class of bugs before the code runs, improves
+editor tooling and autocompletion, and makes large codebases far easier to refactor and
+maintain. The costs are a build/compile step that plain JavaScript does not need, time
+spent writing and maintaining type annotations, and the fact that types are only checked
+at compile time — they cannot guarantee anything about untyped data arriving at runtime,
+so [error handling](/reference/error-handling/) at boundaries still matters. The
+gradual, structural design (its lead designer also created [C#](/reference/csharp-language/))
+lets teams adopt it incrementally.
+
+## Where it's used
+
+TypeScript has become the default for serious front-end frameworks and Node.js backends,
+and for any JavaScript codebase large enough that loose typing becomes a liability.
+Because it compiles to plain [JavaScript](/reference/javascript-language/), it runs
+everywhere JavaScript runs and interoperates freely with existing JS libraries.

--- a/docs/reference/unit-testing.md
+++ b/docs/reference/unit-testing.md
@@ -1,0 +1,64 @@
+---
+slug: unit-testing
+title: Unit testing
+entry_type: concept
+category: testing-delivery
+description: Unit testing checks a single small piece of code — one function or class — in isolation, forming the fast, numerous base of the test pyramid.
+keywords: unit testing, unit test, test pyramid, isolation, test doubles, fast tests, assertions, regression, software testing
+aka: []
+autolink: true
+infobox:
+  - { label: Category, value: "Software testing" }
+  - { label: Scope, value: "One function or class in isolation" }
+  - { label: Pyramid layer, value: "Base — many, fast, focused" }
+  - { label: Needs, value: "Mocks/fakes for dependencies" }
+  - { label: Run by, value: "CI on every push" }
+see_also: [integration-testing, end-to-end-testing, test-driven-development, mocking, code-coverage, ci-cd, refactoring]
+related_lessons:
+  - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
+external:
+  - { title: "Unit testing — Wikipedia", url: https://en.wikipedia.org/wiki/Unit_testing }
+---
+
+**Unit testing** checks a single small piece of code — one function or class — in
+isolation, forming the fast, numerous base of the test pyramid.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 130" role="img" aria-label="The test pyramid with a wide unit-testing base, a narrower integration layer, and a small end-to-end tip." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <path d="M230 20 L290 60 L170 60 Z" fill="none" stroke="currentColor" stroke-width="1.3"/><text x="230" y="50" font-size="8">E2E</text>
+    <path d="M170 60 L290 60 L320 95 L140 95 Z" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="1.3"/><text x="230" y="82">integration</text>
+    <path d="M140 95 L320 95 L355 125 L105 125 Z" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.4"/><text x="230" y="115">unit (many, fast)</text>
+  </g>
+</svg>
+<figcaption>Unit tests form the wide base of the test pyramid — many, fast, and focused.</figcaption>
+</figure>
+
+## What it is
+
+A unit test exercises the smallest meaningful piece of behavior on its own, asserting
+that for a given input the unit produces the expected output. Because each test targets
+one unit, a failure points straight at the broken code. Unit tests are *fast* — a good
+suite runs thousands in seconds — and that speed is what lets a developer run them
+constantly and lets [CI/CD](/reference/ci-cd/) run them on every push. They are also the
+safety net that makes [refactoring](/reference/refactoring/) safe: restructure freely,
+and a red test catches any accidental behavior change instantly.
+
+## Isolation
+
+The "unit" in unit testing means the piece is tested *in isolation* from its
+collaborators — no real network, database, or hardware in the loop. Standing in for
+those dependencies is the job of [mocking](/reference/mocking/) and other test doubles
+(fakes and stubs). This is where the [dependency inversion](/reference/solid/) idea pays
+off: if your code depends on an interface rather than a concrete dependency, a test can
+inject a fake and run deterministically. Good seams make code testable, and testable
+code tends to be well-designed code.
+
+## In the bigger picture
+
+Unit tests sit at the base of the pyramid beneath fewer
+[integration tests](/reference/integration-testing/) and a thin layer of
+[end-to-end tests](/reference/end-to-end-testing/). They are the kind of test
+[test-driven development](/reference/test-driven-development/) writes first, and the kind
+[code coverage](/reference/code-coverage/) most directly measures — though coverage shows
+only which lines *ran*, not whether the assertions checked anything meaningful.

--- a/docs/reference/version-control.md
+++ b/docs/reference/version-control.md
@@ -1,0 +1,73 @@
+---
+slug: version-control
+title: Version control
+entry_type: concept
+category: testing-delivery
+description: Version control is a system that records snapshots of a project's files over time so you can recall any earlier state, see who changed what and why, and collaborate without overwriting each other's work.
+keywords: version control, VCS, Git, distributed version control, centralized, SVN, Mercurial, commit, branch, history, source control
+aka: [version control "VCS"]
+autolink: true
+infobox:
+  - { label: Category, value: "Developer tooling / collaboration" }
+  - { label: Records, value: "Snapshots (commits) over time" }
+  - { label: Designs, value: "Local, centralized, distributed" }
+  - { label: Dominant tool, value: "Git (distributed)" }
+  - { label: Others, value: "Mercurial, Subversion (SVN)" }
+see_also: [ci-cd, build-systems, package-manager, semantic-versioning, refactoring]
+related_lessons:
+  - { title: "What is version control?", url: /learn/git/what-is-version-control/ }
+external:
+  - { title: "Version control — Wikipedia", url: https://en.wikipedia.org/wiki/Version_control }
+---
+
+**Version control** is a system that records snapshots of a project's files over time, so
+you can recall any earlier state, see who changed what and why, and collaborate without
+overwriting each other's work.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 110" role="img" aria-label="A timeline of commits, each a snapshot, with a branch splitting off and merging back." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <line x1="30" y1="60" x2="430" y2="60" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="60" cy="60" r="8" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+    <circle cx="140" cy="60" r="8" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+    <circle cx="220" cy="60" r="8" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+    <circle cx="340" cy="60" r="8" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+    <circle cx="410" cy="60" r="8" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+    <path d="M220 60 C260 30 290 30 300 30" fill="none" stroke="currentColor" stroke-width="1.1"/><circle cx="300" cy="30" r="7" fill="none" stroke="currentColor" stroke-width="1.2"/><path d="M300 30 C320 30 330 60 340 60" fill="none" stroke="currentColor" stroke-width="1.1"/>
+    <text x="230" y="95" font-size="8">commits over time, with a branch that merges back</text>
+  </g>
+</svg>
+<figcaption>Version control strings snapshots into a history you can travel along, branch, and merge.</figcaption>
+</figure>
+
+## What it solves
+
+Without version control, keeping old versions means copying and renaming whole folders —
+`report_final_v2_FINAL.docx` — and merging a teammate's edits becomes copy-paste and hope.
+A version control system replaces that with one working copy and a complete, queryable
+**history** alongside it. Each meaningful point is recorded as a **commit**: a snapshot of
+the project plus a message saying what changed and why. With that history you can restore
+an earlier state, see who changed each line, branch off to try a risky idea safely, and
+understand why a line exists by reading the commit that introduced it.
+
+## Centralized vs distributed
+
+Version control evolved through three designs. **Local** tools tracked files on a single
+machine. **Centralized** systems (CVS, Subversion/SVN) keep the history on one server that
+everyone checks in and out of — enabling collaboration, but with a single point of failure
+and a network dependency for most operations. **Distributed** systems (Git, Mercurial)
+give every contributor a *full clone* of the repository, history and all, so you can
+commit, browse, and branch offline, and no single server's loss erases the work. Git,
+built in 2005 for the Linux kernel, won on speed, cheap branching, integrity by content
+hashing, and a thriving ecosystem of hosts like GitHub.
+
+## Why it underpins everything
+
+Version control is the backbone of modern development. It is what a
+[CI/CD](/reference/ci-cd/) pipeline watches — every push triggers a
+[build](/reference/build-systems/) and [test](/reference/unit-testing/) run. It stores the
+lockfiles that make [dependency management](/reference/package-manager/) reproducible, and
+it holds the tags that mark each release under
+[semantic versioning](/reference/semantic-versioning/). Its safety net is also what makes
+bold [refactoring](/reference/refactoring/) practical: any change can be reviewed,
+reverted, or compared against history.


### PR DESCRIPTION
Restructure the encyclopedia from a flat category list into a two-level
Domain → Category → Entry model so it can hold more than RF, and build out
a full Software Development domain.

Data model & templates:
- _data/reference.yml: wrap the 11 existing RF categories under a new
  "RF & SDR" domain (category ids unchanged), add a "Software Development"
  domain with 6 categories. Per-article `category:` front matter is
  unchanged; the domain is derived from whichever domain owns a category.
- reference-hub.html: render domain sections wrapping the category grid,
  with `#domain-<id>` anchors; global A–Z and DefinedTermSet unchanged.
- reference.html: domain-aware breadcrumb
  (Home › Reference › Domain › Category › Title).
- nav.yml: add domain anchors plus the new software-dev categories.
- llms.txt: domain-nested listing.
- style.scss: .ref-domain* styles and .ref-tag--language / --concept.
- reference/index.md: copy updated for both domains.

New content (61 entries):
- Programming languages (19): Go, Python, JavaScript, TypeScript, C, C++,
  Rust, Java, C#, Swift, Kotlin, Ruby, PHP, R, Julia, MATLAB, FORTRAN,
  COBOL, LISP.
- Concepts (42) across language internals, concurrency, paradigms &
  design patterns, principles & quality, and testing/tooling/delivery.

Each article follows the existing protocol-page format (infobox, see_also,
related_lessons into the learning paths, external refs, autolink) and is
cross-linked within the domain. Verified with a local Jekyll build:
240 entries, clean breadcrumbs for both domains, no broken see_also or
inline links, autolinker and search index updated.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D2ojNc8f4QLCjapa7Zu9Sc