### PR TITLE
web: operator-console interface overhaul (navigation, feedback, design system, a11y)

### DIFF
--- a/web/configbuilder/src/styles.css
+++ b/web/configbuilder/src/styles.css
@@ -23,6 +23,18 @@ body {
   margin: 0;
 }
 
+/* Respect the OS "reduce motion" setting (parity with the main console). */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 .card {
   @apply rounded-lg border border-white/10 bg-panel p-4;
 }

--- a/web/siglab/src/styles.css
+++ b/web/siglab/src/styles.css
@@ -23,6 +23,18 @@ body {
   margin: 0;
 }
 
+/* Respect the OS "reduce motion" setting (parity with the main console). */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 .card {
   @apply rounded-lg border border-white/10 bg-panel p-4;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -55,7 +55,6 @@ export function App() {
   const setConfigPath = useShared((s) => s.setConfigPath);
   const configPath = useShared((s) => s.configPath);
   const appendEvents = useShared((s) => s.appendEvents);
-  const lastError = useShared((s) => s.lastError);
   const setError = useShared((s) => s.setError);
 
   // No-config nudge: when the daemon runs without a -config file
@@ -201,22 +200,6 @@ export function App() {
 
       <AudioPlayer />
       <InstallPrompt />
-
-      {lastError && (
-        <div
-          role="alert"
-          className="fixed bottom-20 sm:bottom-3 left-3 right-3 sm:left-auto sm:max-w-sm z-40 panel bg-err/15 border-err/40 text-err p-3 text-sm flex items-start gap-2"
-        >
-          <span className="flex-1">{lastError}</span>
-          <button
-            className="text-xs underline"
-            onClick={() => setError(null)}
-            aria-label="Dismiss error"
-          >
-            dismiss
-          </button>
-        </div>
-      )}
     </AppShell>
   );
 }

--- a/web/src/components/ConfirmModal.tsx
+++ b/web/src/components/ConfirmModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface Props {
   title: string;
@@ -23,7 +24,7 @@ export function ConfirmModal({
 }: Props) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const dialogRef = useFocusTrap<HTMLDivElement>(true);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -32,10 +33,6 @@ export function ConfirmModal({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [busy, onCancel]);
-
-  useEffect(() => {
-    dialogRef.current?.focus();
-  }, []);
 
   async function commit() {
     setBusy(true);

--- a/web/src/components/DataTable.test.tsx
+++ b/web/src/components/DataTable.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DataTable, type Column } from "./DataTable";
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+const columns: Column<Item>[] = [
+  {
+    key: "id",
+    header: "ID",
+    render: (r) => <span>{r.id}</span>,
+    sort: (a, b) => a.id - b.id,
+  },
+  {
+    key: "name",
+    header: "Name",
+    render: (r) => <span>{r.name}</span>,
+    sort: (a, b) => a.name.localeCompare(b.name),
+  },
+];
+
+function rows(n: number): Item[] {
+  return Array.from({ length: n }, (_, i) => ({ id: i + 1, name: `item-${i + 1}` }));
+}
+
+describe("DataTable", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders rows (backward compatible defaults)", () => {
+    render(
+      <DataTable rows={rows(3)} columns={columns} rowKey={(r) => String(r.id)} />,
+    );
+    expect(screen.getByText("item-1")).toBeInTheDocument();
+    expect(screen.getByText("item-3")).toBeInTheDocument();
+  });
+
+  it("shows the empty message when there are no rows", () => {
+    render(
+      <DataTable
+        rows={[]}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        emptyMessage="Nothing here"
+      />,
+    );
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+
+  it("filters via the built-in search box", async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTable
+        rows={rows(5)}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        searchable
+        searchAccessor={(r) => r.name}
+      />,
+    );
+    await user.type(screen.getByLabelText("Search table"), "item-3");
+    expect(screen.getByText("item-3")).toBeInTheDocument();
+    expect(screen.queryByText("item-1")).toBeNull();
+  });
+
+  it("paginates and steps pages", async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTable
+        rows={rows(25)}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        defaultSortKey="id"
+        pageSize={10}
+      />,
+    );
+    // First page shows 1..10, not 11.
+    expect(screen.getByText("item-10")).toBeInTheDocument();
+    expect(screen.queryByText("item-11")).toBeNull();
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Next/i }));
+    expect(screen.getByText("item-11")).toBeInTheDocument();
+    expect(screen.queryByText("item-10")).toBeNull();
+  });
+
+  it("renders a row-actions cell whose clicks don't trigger row click", async () => {
+    const user = userEvent.setup();
+    const onRowClick = vi.fn();
+    const onAction = vi.fn();
+    render(
+      <DataTable
+        rows={rows(1)}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        onRowClick={onRowClick}
+        rowActions={(r) => (
+          <button onClick={() => onAction(r.id)}>act</button>
+        )}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "act" }));
+    expect(onAction).toHaveBeenCalledWith(1);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("shows skeleton rows while loading with no data", () => {
+    render(
+      <DataTable
+        rows={[]}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        loading
+      />,
+    );
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+  });
+
+  it("hides and persists a column via the column menu", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <DataTable
+        rows={rows(2)}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        tableId="test-table"
+      />,
+    );
+    // Open the <details> menu and uncheck "Name".
+    await user.click(screen.getByText("Columns"));
+    const menuItem = screen.getByLabelText("Name");
+    await user.click(menuItem);
+    expect(screen.queryByRole("columnheader", { name: /Name/ })).toBeNull();
+
+    // Remount: the hidden column stays hidden (persisted).
+    unmount();
+    render(
+      <DataTable
+        rows={rows(2)}
+        columns={columns}
+        rowKey={(r) => String(r.id)}
+        tableId="test-table"
+      />,
+    );
+    expect(screen.queryByRole("columnheader", { name: /Name/ })).toBeNull();
+  });
+});

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -1,4 +1,8 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Input } from "./ui/Input";
+import { EmptyState } from "./ui/EmptyState";
+import { SkeletonRows } from "./ui/Skeleton";
+import { prefs } from "../store/prefs";
 
 export interface Column<T> {
   key: string;
@@ -7,6 +11,9 @@ export interface Column<T> {
   sort?: (a: T, b: T) => number;
   className?: string;
   headerClassName?: string;
+  /** Set false to keep a column out of the column-visibility menu (it
+   *  stays always-visible). Defaults to true. */
+  hideable?: boolean;
 }
 
 interface Props<T> {
@@ -21,6 +28,24 @@ interface Props<T> {
   // (used by Events to show payload JSON inline).
   renderExpansion?: (row: T) => React.ReactNode;
   expandedKey?: string | null;
+
+  // --- Phase 4 additions (all optional, backward compatible) ---
+
+  /** Show a built-in search box that filters rows by `searchAccessor`. */
+  searchable?: boolean;
+  /** Returns the haystack string a row is matched against when searching. */
+  searchAccessor?: (row: T) => string;
+  searchPlaceholder?: string;
+  /** Enable pagination at this page size. Omit to render every row. */
+  pageSize?: number;
+  /** Render skeleton rows instead of the empty message while true. */
+  loading?: boolean;
+  /** Trailing inline-action cell per row (clicks don't trigger onRowClick). */
+  rowActions?: (row: T) => React.ReactNode;
+  /** Extra controls rendered in the toolbar beside the search box. */
+  toolbar?: React.ReactNode;
+  /** Stable id enabling the column-visibility menu + its persistence. */
+  tableId?: string;
 }
 
 export function DataTable<T>({
@@ -33,6 +58,14 @@ export function DataTable<T>({
   emptyMessage = "No data.",
   renderExpansion,
   expandedKey,
+  searchable,
+  searchAccessor,
+  searchPlaceholder = "Search…",
+  pageSize,
+  loading,
+  rowActions,
+  toolbar,
+  tableId,
 }: Props<T>) {
   const [sortKey, setSortKey] = useState<string | null>(
     defaultSortKey ?? null,
@@ -40,16 +73,62 @@ export function DataTable<T>({
   const [sortDir, setSortDir] = useState<"asc" | "desc">(
     defaultSortDirection,
   );
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(0);
+
+  // Column visibility (only when a tableId opts in). Persisted per table.
+  const showColumnMenu = !!tableId;
+  const [hiddenCols, setHiddenCols] = useState<Set<string>>(() =>
+    tableId ? new Set(prefs.tableHiddenColumns(tableId)) : new Set(),
+  );
+
+  function toggleColumn(key: string) {
+    if (!tableId) return;
+    setHiddenCols((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      prefs.setTableHiddenColumns(tableId, [...next]);
+      return next;
+    });
+  }
+
+  const visibleColumns = useMemo(
+    () => columns.filter((c) => !hiddenCols.has(c.key)),
+    [columns, hiddenCols],
+  );
+
+  const searched = useMemo(() => {
+    if (!searchable || !searchAccessor || !query.trim()) return rows;
+    const needle = query.toLowerCase();
+    return rows.filter((r) => searchAccessor(r).toLowerCase().includes(needle));
+  }, [rows, searchable, searchAccessor, query]);
 
   const sorted = useMemo(() => {
-    if (!sortKey) return rows;
+    if (!sortKey) return searched;
     const col = columns.find((c) => c.key === sortKey);
-    if (!col?.sort) return rows;
-    const copy = rows.slice();
+    if (!col?.sort) return searched;
+    const copy = searched.slice();
     copy.sort(col.sort);
     if (sortDir === "desc") copy.reverse();
     return copy;
-  }, [rows, columns, sortKey, sortDir]);
+  }, [searched, columns, sortKey, sortDir]);
+
+  const pageCount = pageSize ? Math.max(1, Math.ceil(sorted.length / pageSize)) : 1;
+  // Keep the page index valid as the row set shrinks/grows.
+  useEffect(() => {
+    if (page > pageCount - 1) setPage(pageCount - 1);
+  }, [page, pageCount]);
+  // A new search resets to the first page.
+  useEffect(() => {
+    setPage(0);
+  }, [query]);
+
+  const pageRows = useMemo(() => {
+    if (!pageSize) return sorted;
+    const start = page * pageSize;
+    return sorted.slice(start, start + pageSize);
+  }, [sorted, pageSize, page]);
 
   function toggleSort(key: string) {
     if (sortKey === key) {
@@ -60,74 +139,148 @@ export function DataTable<T>({
     }
   }
 
-  if (rows.length === 0) {
-    return <p className="text-muted text-sm">{emptyMessage}</p>;
-  }
+  const hasToolbar = searchable || !!toolbar || showColumnMenu;
+  const totalCols = visibleColumns.length + (rowActions ? 1 : 0);
 
   return (
-    <div className="panel overflow-hidden">
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead className="bg-panel/80 text-xs uppercase tracking-wider text-muted">
-            <tr>
-              {columns.map((c) => {
-                const sortable = !!c.sort;
-                const active = sortKey === c.key;
-                return (
-                  <th
-                    key={c.key}
-                    scope="col"
-                    className={`px-3 py-2 text-left font-medium ${
-                      c.headerClassName ?? ""
-                    } ${sortable ? "cursor-pointer select-none" : ""}`}
-                    onClick={sortable ? () => toggleSort(c.key) : undefined}
-                    aria-sort={
-                      !sortable
-                        ? undefined
-                        : active
-                          ? sortDir === "asc"
-                            ? "ascending"
-                            : "descending"
-                          : "none"
-                    }
-                  >
-                    <span className="inline-flex items-center gap-1">
-                      {c.header}
-                      {sortable && (
-                        <span
-                          aria-hidden
-                          className={active ? "text-accent" : "opacity-40"}
-                        >
-                          {active ? (sortDir === "asc" ? "▲" : "▼") : "⇅"}
+    <div className="space-y-2">
+      {hasToolbar && (
+        <div className="flex items-center gap-2 flex-wrap">
+          {searchable && (
+            <Input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={searchPlaceholder}
+              aria-label="Search table"
+              className="w-full sm:max-w-xs"
+            />
+          )}
+          {toolbar}
+          <div className="ml-auto flex items-center gap-2">
+            {searchable && query && (
+              <span className="text-xs text-muted">
+                {sorted.length} of {rows.length}
+              </span>
+            )}
+            {showColumnMenu && (
+              <ColumnMenu
+                columns={columns}
+                hidden={hiddenCols}
+                onToggle={toggleColumn}
+              />
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="panel overflow-hidden">
+        {loading && rows.length === 0 ? (
+          <div className="p-3">
+            <SkeletonRows rows={pageSize ? Math.min(pageSize, 8) : 6} />
+          </div>
+        ) : sorted.length === 0 ? (
+          <EmptyState message={emptyMessage} />
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-panel/80 text-xs uppercase tracking-wider text-muted">
+                <tr>
+                  {visibleColumns.map((c) => {
+                    const sortable = !!c.sort;
+                    const active = sortKey === c.key;
+                    return (
+                      <th
+                        key={c.key}
+                        scope="col"
+                        className={`px-3 py-2 text-left font-medium ${
+                          c.headerClassName ?? ""
+                        } ${sortable ? "cursor-pointer select-none" : ""}`}
+                        onClick={sortable ? () => toggleSort(c.key) : undefined}
+                        aria-sort={
+                          !sortable
+                            ? undefined
+                            : active
+                              ? sortDir === "asc"
+                                ? "ascending"
+                                : "descending"
+                              : "none"
+                        }
+                      >
+                        <span className="inline-flex items-center gap-1">
+                          {c.header}
+                          {sortable && (
+                            <span
+                              aria-hidden
+                              className={active ? "text-accent" : "opacity-40"}
+                            >
+                              {active ? (sortDir === "asc" ? "▲" : "▼") : "⇅"}
+                            </span>
+                          )}
                         </span>
-                      )}
-                    </span>
-                  </th>
-                );
-              })}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-panel">
-            {sorted.map((row, i) => {
-              const key = rowKey(row, i);
-              const expanded = expandedKey === key;
-              return (
-                <Row
-                  key={key}
-                  row={row}
-                  columns={columns}
-                  onClick={
-                    onRowClick ? () => onRowClick(row, key) : undefined
-                  }
-                  expansion={
-                    renderExpansion && expanded ? renderExpansion(row) : null
-                  }
-                />
-              );
-            })}
-          </tbody>
-        </table>
+                      </th>
+                    );
+                  })}
+                  {rowActions && (
+                    <th scope="col" className="px-3 py-2 text-right font-medium">
+                      <span className="sr-only">Actions</span>
+                    </th>
+                  )}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-panel">
+                {pageRows.map((row, i) => {
+                  const key = rowKey(row, i);
+                  const expanded = expandedKey === key;
+                  return (
+                    <Row
+                      key={key}
+                      row={row}
+                      columns={visibleColumns}
+                      colSpan={totalCols}
+                      rowActions={rowActions}
+                      onClick={
+                        onRowClick ? () => onRowClick(row, key) : undefined
+                      }
+                      expansion={
+                        renderExpansion && expanded ? renderExpansion(row) : null
+                      }
+                    />
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
+
+      {pageSize && sorted.length > pageSize && (
+        <div className="flex items-center justify-between gap-2 text-xs text-muted">
+          <span>
+            {page * pageSize + 1}–{Math.min((page + 1) * pageSize, sorted.length)}{" "}
+            of {sorted.length}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              className="btn-ghost !min-h-0 !py-1 text-xs"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+            >
+              ‹ Prev
+            </button>
+            <span>
+              {page + 1} / {pageCount}
+            </span>
+            <button
+              className="btn-ghost !min-h-0 !py-1 text-xs"
+              onClick={() => setPage((p) => Math.min(pageCount - 1, p + 1))}
+              disabled={page >= pageCount - 1}
+            >
+              Next ›
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -135,11 +288,15 @@ export function DataTable<T>({
 function Row<T>({
   row,
   columns,
+  colSpan,
+  rowActions,
   onClick,
   expansion,
 }: {
   row: T;
   columns: Column<T>[];
+  colSpan: number;
+  rowActions?: (row: T) => React.ReactNode;
   onClick?: () => void;
   expansion: React.ReactNode | null;
 }) {
@@ -169,17 +326,63 @@ function Row<T>({
             {c.render(row)}
           </td>
         ))}
+        {rowActions && (
+          // Stop propagation so action clicks don't also fire the row's
+          // onClick (e.g. opening the detail modal).
+          <td
+            className="px-3 py-2 align-top text-right whitespace-nowrap"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {rowActions(row)}
+          </td>
+        )}
       </tr>
       {expansion && (
         <tr>
-          <td
-            colSpan={columns.length}
-            className="px-3 pb-3 pt-0 bg-panel/30 text-xs"
-          >
+          <td colSpan={colSpan} className="px-3 pb-3 pt-0 bg-panel/30 text-xs">
             {expansion}
           </td>
         </tr>
       )}
     </>
+  );
+}
+
+// ColumnMenu is a native <details> popover listing the hideable columns
+// as checkboxes. <details> gives us open/close + Escape + accessibility
+// without click-away bookkeeping.
+function ColumnMenu<T>({
+  columns,
+  hidden,
+  onToggle,
+}: {
+  columns: Column<T>[];
+  hidden: Set<string>;
+  onToggle: (key: string) => void;
+}) {
+  const hideable = columns.filter((c) => c.hideable !== false);
+  if (hideable.length === 0) return null;
+  return (
+    <details className="relative">
+      <summary className="btn-ghost !min-h-0 !py-1 text-xs cursor-pointer list-none">
+        Columns
+      </summary>
+      <div className="absolute right-0 z-30 mt-1 w-48 panel bg-bg p-2 space-y-1 shadow-lg">
+        {hideable.map((c) => (
+          <label
+            key={c.key}
+            className="flex items-center gap-2 text-sm px-1 py-0.5"
+          >
+            <input
+              type="checkbox"
+              className="h-4 w-4"
+              checked={!hidden.has(c.key)}
+              onChange={() => onToggle(c.key)}
+            />
+            <span>{c.header}</span>
+          </label>
+        ))}
+      </div>
+    </details>
   );
 }

--- a/web/src/components/DetailModal.test.tsx
+++ b/web/src/components/DetailModal.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DetailModal } from "./DetailModal";
+
+describe("DetailModal accessibility", () => {
+  it("exposes a labelled modal dialog", () => {
+    render(
+      <DetailModal title="Talkgroup 42" onClose={() => {}}>
+        <button>first</button>
+        <button>second</button>
+      </DetailModal>,
+    );
+    const dialog = screen.getByRole("dialog", { name: "Talkgroup 42" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+  });
+
+  it("moves focus into the dialog on open", () => {
+    render(
+      <DetailModal title="Detail" onClose={() => {}}>
+        <button>first</button>
+      </DetailModal>,
+    );
+    // Focus lands inside the dialog (first focusable or the panel itself).
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  it("closes on Escape", async () => {
+    const user = userEvent.setup();
+    let closed = false;
+    render(
+      <DetailModal title="Detail" onClose={() => (closed = true)}>
+        <button>first</button>
+      </DetailModal>,
+    );
+    await user.keyboard("{Escape}");
+    expect(closed).toBe(true);
+  });
+
+  it("traps Tab within the dialog", async () => {
+    const user = userEvent.setup();
+    render(
+      <DetailModal title="Detail" onClose={() => {}}>
+        <button>first</button>
+        <button>second</button>
+      </DetailModal>,
+    );
+    // Tabbing past the last focusable wraps back into the dialog rather
+    // than escaping to the document body.
+    await user.tab();
+    await user.tab();
+    await user.tab();
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+});

--- a/web/src/components/DetailModal.tsx
+++ b/web/src/components/DetailModal.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
+import { useFocusTrap } from "../hooks/useFocusTrap";
 
 interface Props {
   title: string;
@@ -11,7 +12,7 @@ interface Props {
 // on phones. Mirrors internal/tui/detail.go in spirit: read-only deep
 // view for a single row.
 export function DetailModal({ title, subtitle, onClose, children }: Props) {
-  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const dialogRef = useFocusTrap<HTMLDivElement>(true);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
@@ -20,10 +21,6 @@ export function DetailModal({ title, subtitle, onClose, children }: Props) {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [onClose]);
-
-  useEffect(() => {
-    dialogRef.current?.focus();
-  }, []);
 
   return (
     <div

--- a/web/src/components/shell/AppShell.tsx
+++ b/web/src/components/shell/AppShell.tsx
@@ -4,6 +4,7 @@ import { BottomNav } from "./BottomNav";
 import { MobileDrawer } from "./MobileDrawer";
 import { TopBar } from "./TopBar";
 import { CommandPalette } from "../CommandPalette";
+import { ToastViewport } from "../ui/ToastViewport";
 import { useIsDesktop } from "../../hooks/useMediaQuery";
 import { prefs } from "../../store/prefs";
 
@@ -71,6 +72,7 @@ export function AppShell({ children }: Props) {
         open={paletteOpen}
         onClose={() => setPaletteOpen(false)}
       />
+      <ToastViewport />
     </div>
   );
 }

--- a/web/src/components/shell/AppShell.tsx
+++ b/web/src/components/shell/AppShell.tsx
@@ -56,6 +56,14 @@ export function AppShell({ children }: Props) {
 
   return (
     <div className="min-h-full flex">
+      {/* Keyboard users can jump straight past the nav chrome. Visually
+          hidden until focused. */}
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[90] focus:panel focus:px-3 focus:py-2 focus:text-sm"
+      >
+        Skip to content
+      </a>
       <Sidebar collapsed={collapsed} onToggleCollapse={toggleCollapse} />
 
       <div className="flex-1 flex flex-col min-w-0">
@@ -63,7 +71,9 @@ export function AppShell({ children }: Props) {
           onOpenMore={() => setDrawerOpen(true)}
           onOpenPalette={() => setPaletteOpen(true)}
         />
-        <main className="flex-1 p-3 sm:p-4 pb-24 sm:pb-4">{children}</main>
+        <main id="main" className="flex-1 p-3 sm:p-4 pb-24 sm:pb-4">
+          {children}
+        </main>
       </div>
 
       <BottomNav onOpenMore={() => setDrawerOpen(true)} />

--- a/web/src/components/ui/Badge.tsx
+++ b/web/src/components/ui/Badge.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+type Tone = "neutral" | "ok" | "warn" | "err";
+
+interface Props {
+  children: ReactNode;
+  tone?: Tone;
+  className?: string;
+  title?: string;
+}
+
+const TONE_CLASS: Record<Tone, string> = {
+  neutral: "pill",
+  ok: "pill-ok",
+  warn: "pill-warn",
+  err: "pill-err",
+};
+
+// Badge wraps the existing .pill* status-chip classes in a typed
+// component. Drop-in for <span className="pill-ok">.
+export function Badge({ children, tone = "neutral", className = "", title }: Props) {
+  return (
+    <span className={`${TONE_CLASS[tone]} ${className}`} title={title}>
+      {children}
+    </span>
+  );
+}

--- a/web/src/components/ui/Button.tsx
+++ b/web/src/components/ui/Button.tsx
@@ -1,0 +1,39 @@
+import { forwardRef, type ButtonHTMLAttributes } from "react";
+import { Spinner } from "./Spinner";
+
+type Variant = "primary" | "ghost" | "danger";
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  /** When true, shows a spinner and disables the button. */
+  loading?: boolean;
+}
+
+const VARIANT_CLASS: Record<Variant, string> = {
+  primary: "btn-primary",
+  ghost: "btn-ghost",
+  danger: "btn-danger",
+};
+
+// Button wraps the existing .btn-* utility classes in a typed component
+// and adds a `loading` state (spinner + disabled) so mutations across
+// the app get consistent pending feedback. Falls back to the same
+// markup the hand-rolled <button className="btn-primary"> sites use, so
+// it's a drop-in replacement.
+export const Button = forwardRef<HTMLButtonElement, Props>(function Button(
+  { variant = "primary", loading = false, disabled, children, className = "", ...rest },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      className={`${VARIANT_CLASS[variant]} ${className}`}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      {...rest}
+    >
+      {loading && <Spinner className="h-4 w-4" />}
+      {children}
+    </button>
+  );
+});

--- a/web/src/components/ui/Card.tsx
+++ b/web/src/components/ui/Card.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  /** Optional section title rendered as a .panel-title header. */
+  title?: ReactNode;
+  /** Optional right-aligned header actions (buttons, status). */
+  actions?: ReactNode;
+  /** Padding preset. "none" lets the caller own padding (e.g. tables). */
+  padding?: "none" | "sm" | "md";
+}
+
+const PAD: Record<NonNullable<Props["padding"]>, string> = {
+  none: "",
+  sm: "p-3",
+  md: "p-4",
+};
+
+// Card is the elevated container primitive built on the surface tokens.
+// It supersedes ad-hoc `.panel p-4` blocks and gives an optional
+// title/actions header for consistency.
+export function Card({ children, className = "", title, actions, padding = "md" }: Props) {
+  return (
+    <section className={`card ${PAD[padding]} ${className}`}>
+      {(title || actions) && (
+        <header className="flex items-center justify-between gap-3 mb-3">
+          {title && <h3 className="panel-title">{title}</h3>}
+          {actions && <div className="flex items-center gap-2">{actions}</div>}
+        </header>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/web/src/components/ui/Checkbox.tsx
+++ b/web/src/components/ui/Checkbox.tsx
@@ -1,0 +1,20 @@
+import { forwardRef, type InputHTMLAttributes, type ReactNode } from "react";
+
+interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, "type"> {
+  label: ReactNode;
+}
+
+// Checkbox is a labelled checkbox row matching the app's existing
+// `<label><input type=checkbox/></label>` pattern, with the 44px touch
+// target from the coarse-pointer rule in styles.css.
+export const Checkbox = forwardRef<HTMLInputElement, Props>(function Checkbox(
+  { label, className = "", ...rest },
+  ref,
+) {
+  return (
+    <label className={`flex items-center gap-3 text-sm ${className}`}>
+      <input ref={ref} type="checkbox" className="h-5 w-5" {...rest} />
+      <span>{label}</span>
+    </label>
+  );
+});

--- a/web/src/components/ui/EmptyState.tsx
+++ b/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  /** Primary message. */
+  message: ReactNode;
+  /** Optional decorative glyph above the message. */
+  icon?: ReactNode;
+  /** Optional call-to-action (e.g. a Button). */
+  action?: ReactNode;
+  className?: string;
+}
+
+// EmptyState replaces the repeated muted "No data." paragraph with a
+// centered, optionally actionable placeholder.
+export function EmptyState({ message, icon, action, className = "" }: Props) {
+  return (
+    <div className={`text-center text-sm text-muted py-8 px-4 ${className}`}>
+      {icon && (
+        <div className="text-2xl mb-2 opacity-60" aria-hidden>
+          {icon}
+        </div>
+      )}
+      <p className="max-w-md mx-auto">{message}</p>
+      {action && <div className="mt-3">{action}</div>}
+    </div>
+  );
+}

--- a/web/src/components/ui/Field.test.tsx
+++ b/web/src/components/ui/Field.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Field } from "./Field";
+import { Input } from "./Input";
+
+describe("Field", () => {
+  it("associates the label with the control", () => {
+    render(
+      <Field label="Server URL">
+        {(p) => <Input {...p} defaultValue="x" />}
+      </Field>,
+    );
+    expect(screen.getByLabelText("Server URL")).toBeInTheDocument();
+  });
+
+  it("wires aria-invalid and describes the error", () => {
+    render(
+      <Field label="Frequency" error="must be > 0">
+        {(p) => <Input {...p} />}
+      </Field>,
+    );
+    const input = screen.getByLabelText("Frequency");
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    const msg = screen.getByText("must be > 0");
+    expect(msg).toHaveAttribute("role", "alert");
+    expect(input.getAttribute("aria-describedby")).toBe(msg.id);
+  });
+
+  it("shows hint text when there is no error", () => {
+    render(
+      <Field label="Limit" hint="defaults to 200">
+        {(p) => <Input {...p} />}
+      </Field>,
+    );
+    const hint = screen.getByText("defaults to 200");
+    expect(hint).not.toHaveAttribute("role", "alert");
+    expect(screen.getByLabelText("Limit")).not.toHaveAttribute("aria-invalid");
+  });
+});

--- a/web/src/components/ui/Field.tsx
+++ b/web/src/components/ui/Field.tsx
@@ -1,0 +1,48 @@
+import { useId, type ReactNode } from "react";
+
+interface Props {
+  label: ReactNode;
+  /** Inline validation error; when set the control is marked invalid. */
+  error?: string | null;
+  /** Helper/hint text shown below the control when there's no error. */
+  hint?: ReactNode;
+  /** Render-prop receiving the wiring to spread onto the control:
+   *  id + aria-describedby + aria-invalid. */
+  children: (props: {
+    id: string;
+    "aria-describedby"?: string;
+    "aria-invalid"?: true;
+  }) => ReactNode;
+  className?: string;
+}
+
+// Field is the label + control + message wrapper. It wires up id,
+// aria-describedby, and aria-invalid so inline validation is accessible
+// and the error/hint is associated with the input. Callers spread the
+// render-prop args onto their <Input>/<Select>/<Checkbox>.
+export function Field({ label, error, hint, children, className = "" }: Props) {
+  const id = useId();
+  const msgId = `${id}-msg`;
+  const hasMsg = !!error || !!hint;
+  return (
+    <div className={`space-y-1 ${className}`}>
+      <label htmlFor={id} className="block text-sm font-medium">
+        {label}
+      </label>
+      {children({
+        id,
+        "aria-describedby": hasMsg ? msgId : undefined,
+        "aria-invalid": error ? true : undefined,
+      })}
+      {hasMsg && (
+        <p
+          id={msgId}
+          className={`text-xs ${error ? "text-err" : "text-muted"}`}
+          role={error ? "alert" : undefined}
+        >
+          {error ?? hint}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/ui/Input.tsx
+++ b/web/src/components/ui/Input.tsx
@@ -1,0 +1,22 @@
+import { forwardRef, type InputHTMLAttributes } from "react";
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+  invalid?: boolean;
+}
+
+// Input wraps the .input utility. `invalid` (or aria-invalid) paints the
+// error border so field-level validation reads clearly.
+export const Input = forwardRef<HTMLInputElement, Props>(function Input(
+  { className = "", invalid, ...rest },
+  ref,
+) {
+  const isInvalid = invalid || rest["aria-invalid"] === true;
+  return (
+    <input
+      ref={ref}
+      className={`input ${isInvalid ? "border-err focus:border-err focus:ring-err" : ""} ${className}`}
+      aria-invalid={isInvalid || undefined}
+      {...rest}
+    />
+  );
+});

--- a/web/src/components/ui/PageHeader.tsx
+++ b/web/src/components/ui/PageHeader.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from "react";
+
+interface Props {
+  title: ReactNode;
+  /** Optional muted subtitle/description under the title. */
+  subtitle?: ReactNode;
+  /** Right-aligned actions (filters, buttons, status chips, counts). */
+  actions?: ReactNode;
+  className?: string;
+}
+
+// PageHeader standardizes the per-panel `<header><h2>…</h2>…</header>`
+// that every panel hand-rolled, so titles, counts, and actions line up
+// consistently across the app.
+export function PageHeader({ title, subtitle, actions, className = "" }: Props) {
+  return (
+    <header className={`flex items-start justify-between gap-3 flex-wrap ${className}`}>
+      <div className="min-w-0">
+        <h2 className="text-xl font-semibold tracking-tight">{title}</h2>
+        {subtitle && <p className="text-sm text-muted">{subtitle}</p>}
+      </div>
+      {actions && (
+        <div className="flex items-center gap-2 shrink-0">{actions}</div>
+      )}
+    </header>
+  );
+}

--- a/web/src/components/ui/Section.test.tsx
+++ b/web/src/components/ui/Section.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Section } from "./Section";
+import { Button } from "./Button";
+
+describe("Section", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders children when expanded by default", () => {
+    render(
+      <Section id="test-a" title="Scan">
+        <p>body content</p>
+      </Section>,
+    );
+    expect(screen.getByText("body content")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Scan/i })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+  });
+
+  it("honors defaultCollapsed", () => {
+    render(
+      <Section id="test-b" title="Advanced" defaultCollapsed>
+        <p>hidden body</p>
+      </Section>,
+    );
+    expect(screen.queryByText("hidden body")).toBeNull();
+  });
+
+  it("toggles and persists the collapsed state", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(
+      <Section id="persist-me" title="Group">
+        <p>content</p>
+      </Section>,
+    );
+    await user.click(screen.getByRole("button", { name: /Group/i }));
+    expect(screen.queryByText("content")).toBeNull();
+
+    // Remount: the collapsed state should be restored from prefs.
+    unmount();
+    render(
+      <Section id="persist-me" title="Group">
+        <p>content</p>
+      </Section>,
+    );
+    expect(screen.queryByText("content")).toBeNull();
+  });
+});
+
+describe("Button loading", () => {
+  it("disables and marks busy while loading", () => {
+    render(
+      <Button loading onClick={() => {}}>
+        Save
+      </Button>,
+    );
+    const btn = screen.getByRole("button", { name: /Save/i });
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute("aria-busy", "true");
+  });
+});

--- a/web/src/components/ui/Section.tsx
+++ b/web/src/components/ui/Section.tsx
@@ -1,0 +1,74 @@
+import { useId, useState, type ReactNode } from "react";
+import { prefs } from "../../store/prefs";
+
+interface Props {
+  /** Stable id used to persist the open/closed state across visits. */
+  id: string;
+  title: ReactNode;
+  /** Optional muted description under the title. */
+  description?: ReactNode;
+  /** Optional right-aligned header content (status, count). */
+  actions?: ReactNode;
+  defaultCollapsed?: boolean;
+  children: ReactNode;
+  className?: string;
+}
+
+// Section is a titled, collapsible group whose open/closed state
+// persists per id. Used to break the dense Hunt/Scanner/Settings forms
+// into scannable, foldable groups (Phase 5).
+export function Section({
+  id,
+  title,
+  description,
+  actions,
+  defaultCollapsed = false,
+  children,
+  className = "",
+}: Props) {
+  const [collapsed, setCollapsed] = useState(() =>
+    prefs.sectionCollapsed(id, defaultCollapsed),
+  );
+  const bodyId = useId();
+
+  function toggle() {
+    setCollapsed((c) => {
+      const next = !c;
+      prefs.setSectionCollapsed(id, next);
+      return next;
+    });
+  }
+
+  return (
+    <section className={`card ${className}`}>
+      <header className="flex items-center gap-3 p-3 sm:p-4">
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={!collapsed}
+          aria-controls={bodyId}
+          className="flex items-center gap-2 flex-1 text-left"
+        >
+          <span
+            aria-hidden
+            className={`text-muted transition-transform ${collapsed ? "" : "rotate-90"}`}
+          >
+            ▶
+          </span>
+          <span className="min-w-0">
+            <span className="block font-medium">{title}</span>
+            {description && (
+              <span className="block text-xs text-muted">{description}</span>
+            )}
+          </span>
+        </button>
+        {actions && <div className="flex items-center gap-2">{actions}</div>}
+      </header>
+      {!collapsed && (
+        <div id={bodyId} className="px-3 sm:px-4 pb-4 pt-0 space-y-3">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/components/ui/Select.tsx
+++ b/web/src/components/ui/Select.tsx
@@ -1,0 +1,16 @@
+import { forwardRef, type SelectHTMLAttributes } from "react";
+
+type Props = SelectHTMLAttributes<HTMLSelectElement>;
+
+// Select wraps the .input utility for native <select>, keeping form
+// controls visually consistent.
+export const Select = forwardRef<HTMLSelectElement, Props>(function Select(
+  { className = "", children, ...rest },
+  ref,
+) {
+  return (
+    <select ref={ref} className={`input ${className}`} {...rest}>
+      {children}
+    </select>
+  );
+});

--- a/web/src/components/ui/Skeleton.tsx
+++ b/web/src/components/ui/Skeleton.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  className?: string;
+}
+
+// Skeleton is a single shimmering placeholder block. Compose several to
+// stand in for loading cards/rows.
+export function Skeleton({ className = "h-4 w-full" }: Props) {
+  return (
+    <div
+      className={`animate-pulse rounded bg-surface3/60 ${className}`}
+      aria-hidden
+    />
+  );
+}
+
+// SkeletonRows renders `rows` placeholder lines — handy for tables/lists
+// while the first fetch is in flight.
+export function SkeletonRows({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="space-y-2" role="status" aria-label="Loading">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className="h-8 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/ui/Spinner.tsx
+++ b/web/src/components/ui/Spinner.tsx
@@ -1,0 +1,40 @@
+interface Props {
+  /** Tailwind size classes, e.g. "h-4 w-4". Defaults to a small inline
+   *  spinner sized to match button text. */
+  className?: string;
+  label?: string;
+}
+
+// Spinner: a minimal CSS spinner for inline-loading and busy states.
+// `currentColor` so it inherits the surrounding text color.
+export function Spinner({ className = "h-4 w-4", label }: Props) {
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      className="inline-flex items-center"
+    >
+      <svg
+        className={`animate-spin ${className}`}
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden
+      >
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+        />
+      </svg>
+      <span className="sr-only">{label ?? "Loading"}</span>
+    </span>
+  );
+}

--- a/web/src/components/ui/StaleIndicator.tsx
+++ b/web/src/components/ui/StaleIndicator.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+interface Props {
+  stale: boolean;
+  lastUpdated: number | null;
+}
+
+// StaleIndicator turns the silent "keep the old snapshot on a failed
+// poll" behavior into something the operator can see: a small chip that
+// distinguishes "the data on screen is current" from "the daemon went
+// quiet and you're looking at the last good snapshot from N s ago".
+export function StaleIndicator({ stale, lastUpdated }: Props) {
+  // Re-render once a second while stale so the age counts up.
+  const [, force] = useState(0);
+  useEffect(() => {
+    if (!stale) return;
+    const t = window.setInterval(() => force((n) => n + 1), 1_000);
+    return () => window.clearInterval(t);
+  }, [stale]);
+
+  if (!stale) return null;
+
+  const age =
+    lastUpdated != null
+      ? `${Math.max(0, Math.round((Date.now() - lastUpdated) / 1000))}s ago`
+      : "unknown";
+
+  return (
+    <span className="pill-warn" title={`Last good update ${age}`}>
+      reconnecting · {age}
+    </span>
+  );
+}

--- a/web/src/components/ui/ToastViewport.test.tsx
+++ b/web/src/components/ui/ToastViewport.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ToastViewport } from "./ToastViewport";
+import { useShared, type ToastKind } from "../../store/shared";
+
+function notify(kind: ToastKind, message: string, ttlMs?: number) {
+  act(() => {
+    useShared.getState().notify(kind, message, ttlMs);
+  });
+}
+
+describe("ToastViewport", () => {
+  beforeEach(() => {
+    useShared.setState({ toasts: [] });
+  });
+
+  it("renders nothing when there are no toasts", () => {
+    const { container } = render(<ToastViewport />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders enqueued toasts", () => {
+    render(<ToastViewport />);
+    notify("success", "It worked", 0);
+    expect(screen.getByText("It worked")).toBeInTheDocument();
+  });
+
+  it("marks errors as assertive alerts and info as status", () => {
+    render(<ToastViewport />);
+    notify("error", "Bad thing", 0);
+    notify("info", "FYI", 0);
+    expect(screen.getByText("Bad thing").closest("[role]")).toHaveAttribute(
+      "role",
+      "alert",
+    );
+    expect(screen.getByText("FYI").closest("[role]")).toHaveAttribute(
+      "role",
+      "status",
+    );
+  });
+
+  it("dismisses a toast when the dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<ToastViewport />);
+    notify("info", "dismiss me", 0);
+    expect(screen.getByText("dismiss me")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: /Dismiss notification/i }),
+    );
+    expect(screen.queryByText("dismiss me")).toBeNull();
+  });
+});

--- a/web/src/components/ui/ToastViewport.tsx
+++ b/web/src/components/ui/ToastViewport.tsx
@@ -1,0 +1,54 @@
+import { useShared, type ToastKind } from "../../store/shared";
+
+// ToastViewport renders the stack of transient notifications. It sits
+// once at the app root (in AppShell) and replaces the old single
+// `lastError` strip. Success/info use a polite live region; errors and
+// warnings are assertive so screen readers announce them promptly.
+const KIND_CLASS: Record<ToastKind, string> = {
+  success: "bg-ok/15 border-ok/40 text-ok",
+  info: "bg-accent/15 border-accent/40 text-accent",
+  warning: "bg-warn/15 border-warn/40 text-warn",
+  error: "bg-err/15 border-err/40 text-err",
+};
+
+const KIND_ICON: Record<ToastKind, string> = {
+  success: "✓",
+  info: "ℹ",
+  warning: "!",
+  error: "✕",
+};
+
+export function ToastViewport() {
+  const toasts = useShared((s) => s.toasts);
+  const dismissToast = useShared((s) => s.dismissToast);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div
+      className="fixed z-[80] bottom-20 sm:bottom-3 left-3 right-3 sm:left-auto sm:max-w-sm flex flex-col gap-2 pointer-events-none"
+      aria-live="polite"
+    >
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          role={t.kind === "error" || t.kind === "warning" ? "alert" : "status"}
+          className={`panel border p-3 text-sm flex items-start gap-2 pointer-events-auto ${KIND_CLASS[t.kind]}`}
+        >
+          <span aria-hidden className="font-semibold leading-5">
+            {KIND_ICON[t.kind]}
+          </span>
+          <span className="flex-1 break-words">{t.message}</span>
+          <button
+            type="button"
+            className="text-xs underline shrink-0"
+            onClick={() => dismissToast(t.id)}
+            aria-label="Dismiss notification"
+          >
+            dismiss
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/web/src/hooks/useDataPoll.test.ts
+++ b/web/src/hooks/useDataPoll.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useDataPoll } from "./useDataPoll";
+
+describe("useDataPoll", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fetches on mount and delivers the first snapshot", async () => {
+    const onData = vi.fn();
+    const fetcher = vi.fn().mockResolvedValue([1, 2, 3]);
+    const { result } = renderHook(() =>
+      useDataPoll({ fetcher, onData, intervalMs: 1000 }),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(onData).toHaveBeenCalledWith([1, 2, 3]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not re-deliver an unchanged snapshot", async () => {
+    const onData = vi.fn();
+    const fetcher = vi.fn().mockResolvedValue([1, 2, 3]);
+    renderHook(() => useDataPoll({ fetcher, onData, intervalMs: 1000 }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    // Two fetches, but only one delivery — the payload never changed.
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(onData).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers a changed snapshot", async () => {
+    const onData = vi.fn();
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce([1])
+      .mockResolvedValueOnce([1, 2]);
+    renderHook(() => useDataPoll({ fetcher, onData, intervalMs: 1000 }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(onData).toHaveBeenCalledTimes(2);
+    expect(onData).toHaveBeenLastCalledWith([1, 2]);
+  });
+
+  it("marks data stale when a poll fails after a good fetch", async () => {
+    const onData = vi.fn();
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce([1])
+      .mockRejectedValueOnce(new Error("network down"));
+    const { result } = renderHook(() =>
+      useDataPoll({ fetcher, onData, intervalMs: 1000 }),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.stale).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(result.current.stale).toBe(true);
+    expect(result.current.error).toBe("network down");
+  });
+
+  it("refresh triggers an immediate fetch", async () => {
+    const onData = vi.fn();
+    const fetcher = vi.fn().mockResolvedValue([1]);
+    const { result } = renderHook(() =>
+      useDataPoll({ fetcher, onData, intervalMs: 100000 }),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.refresh();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/web/src/hooks/useDataPoll.ts
+++ b/web/src/hooks/useDataPoll.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface PollState {
+  /** True until the first response (success or failure) arrives. */
+  loading: boolean;
+  /** Message from the most recent failed fetch, else null. */
+  error: string | null;
+  /** True when we hold a previous good snapshot but the latest fetch
+   *  failed — i.e. the data on screen may be out of date. */
+  stale: boolean;
+  /** Epoch ms of the last successful fetch, or null. */
+  lastUpdated: number | null;
+  /** Force an immediate refresh outside the interval. */
+  refresh: () => void;
+}
+
+interface Options<T> {
+  /** Fetches a fresh snapshot. Should reject on error. */
+  fetcher: () => Promise<T>;
+  /** Receives a snapshot only when it differs from the last one — this
+   *  is what kills the poll-induced re-render flicker. */
+  onData: (data: T) => void;
+  intervalMs: number;
+  /** Pause polling when false (e.g. panel not visible). Default true. */
+  enabled?: boolean;
+  /** When this value changes the loop restarts and refetches at once
+   *  (and the change-detection cache is cleared). Pass the connection
+   *  identity — e.g. the daemon base URL — so switching servers swaps
+   *  the data immediately instead of after the next interval. */
+  resetKey?: string | number;
+}
+
+// useDataPoll centralizes the setInterval + cancel-flag pattern that
+// every panel hand-rolled, and adds the loading/error/stale bookkeeping
+// the old code lacked. Critically, it compares each snapshot against the
+// last and only invokes `onData` when the payload actually changed, so a
+// steady stream of identical polls no longer thrashes the store and
+// re-renders the table.
+export function useDataPoll<T>({
+  fetcher,
+  onData,
+  intervalMs,
+  enabled = true,
+  resetKey,
+}: Options<T>): PollState {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stale, setStale] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+
+  // Keep the latest callbacks in refs so changing their identity (a new
+  // inline fetcher each render) doesn't tear down and restart the poll
+  // loop — only `intervalMs`/`enabled` should do that.
+  const fetcherRef = useRef(fetcher);
+  const onDataRef = useRef(onData);
+  fetcherRef.current = fetcher;
+  onDataRef.current = onData;
+
+  // Serialized form of the last delivered snapshot, for change detection.
+  const lastSerialized = useRef<string | null>(null);
+  const tick = useRef(0);
+
+  const run = useCallback(async () => {
+    try {
+      const data = await fetcherRef.current();
+      const serialized = JSON.stringify(data);
+      if (serialized !== lastSerialized.current) {
+        lastSerialized.current = serialized;
+        onDataRef.current(data);
+      }
+      setError(null);
+      setStale(false);
+      setLastUpdated(Date.now());
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : "request failed";
+      setError(msg);
+      // Only "stale" if we already showed good data; otherwise it's a
+      // plain initial-load error.
+      setStale(lastSerialized.current !== null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const refresh = useCallback(() => {
+    void run();
+  }, [run]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    // A new connection target invalidates the change-detection cache so
+    // the next server's data is always delivered, even if it happens to
+    // serialize identically to the previous server's.
+    lastSerialized.current = null;
+    setLoading(true);
+    let cancelled = false;
+    const myTick = ++tick.current;
+    const guarded = async () => {
+      if (cancelled || myTick !== tick.current) return;
+      await run();
+    };
+    void guarded();
+    const t = window.setInterval(guarded, intervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(t);
+    };
+  }, [enabled, intervalMs, run, resetKey]);
+
+  return { loading, error, stale, lastUpdated, refresh };
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,13 +4,13 @@ import { HashRouter } from "react-router-dom";
 import { registerSW } from "virtual:pwa-register";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { prefs } from "./store/prefs";
+import { prefs, themeAttr } from "./store/prefs";
 import "./styles.css";
 
-// Apply the stored theme before the first render so the UI never
-// flashes the default palette.
-document.documentElement.dataset.theme =
-  prefs.theme() === "monochrome" ? "mono" : "dark";
+// Apply the stored theme + density before the first render so the UI
+// never flashes the default palette or spacing.
+document.documentElement.dataset.theme = themeAttr(prefs.theme());
+document.documentElement.dataset.density = prefs.density();
 
 // Register the service worker. autoUpdate strategy: if a new bundle
 // is deployed, Workbox swaps it in on the next reload — no user

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -5,6 +5,7 @@ import { Column, DataTable } from "../components/DataTable";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { DetailField, DetailModal } from "../components/DetailModal";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
+import { PageHeader } from "../components/ui/PageHeader";
 import type { ActiveCallDTO } from "../api/types";
 import { formatP25Algorithm, formatP25KeyID } from "../api/p25Algorithm";
 import { useDataPoll } from "../hooks/useDataPoll";
@@ -140,15 +141,17 @@ export function Active() {
 
   return (
     <div className="space-y-3">
-      <header className="flex items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold">Active calls</h2>
-        <div className="flex items-center gap-2">
-          <StaleIndicator stale={stale} lastUpdated={lastUpdated} />
-          <span className="text-xs text-muted">
-            {activeCalls.length} in flight
-          </span>
-        </div>
-      </header>
+      <PageHeader
+        title="Active calls"
+        actions={
+          <>
+            <StaleIndicator stale={stale} lastUpdated={lastUpdated} />
+            <span className="text-xs text-muted">
+              {activeCalls.length} in flight
+            </span>
+          </>
+        }
+      />
 
       <DataTable
         rows={activeCalls}

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -159,6 +159,13 @@ export function Active() {
         rowKey={(r) => `${r.device_serial}-${r.started_at}`}
         defaultSortKey="elapsed"
         defaultSortDirection="desc"
+        searchable
+        searchAccessor={(r) =>
+          [r.grant.group_id, r.talkgroup?.alpha_tag, r.grant.system, r.device_serial]
+            .filter(Boolean)
+            .join(" ")
+        }
+        searchPlaceholder="Search active calls…"
         onRowClick={(r) => setSelected(r)}
         emptyMessage="No calls right now. Active grants show up here as soon as the daemon allocates a voice device."
       />

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -4,8 +4,10 @@ import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { DetailField, DetailModal } from "../components/DetailModal";
+import { StaleIndicator } from "../components/ui/StaleIndicator";
 import type { ActiveCallDTO } from "../api/types";
 import { formatP25Algorithm, formatP25KeyID } from "../api/p25Algorithm";
+import { useDataPoll } from "../hooks/useDataPoll";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -21,45 +23,34 @@ export function Active() {
   const cfg = useShared(selectClientConfig);
   const canMutate = useShared(selectCanMutate);
   const setError = useShared((s) => s.setError);
+  const notify = useShared((s) => s.notify);
   const activeCalls = useShared((s) => s.activeCalls);
   const setActiveCalls = useShared((s) => s.setActiveCalls);
   const [selected, setSelected] = useState<ActiveCallDTO | null>(null);
   const [confirmEnd, setConfirmEnd] = useState<ActiveCallDTO | null>(null);
   const [now, setNow] = useState(() => Date.now());
 
+  const { stale, lastUpdated, refresh } = useDataPoll({
+    fetcher: () => api.activeCalls(cfg),
+    onData: setActiveCalls,
+    intervalMs: POLL_INTERVAL_MS,
+    resetKey: cfg.baseURL,
+  });
+
   async function endCall(call: ActiveCallDTO) {
     try {
       await writes.endCall(cfg, call.device_serial);
       // Optimistically refresh the active list so the UI doesn't show
       // the ended call for the next poll cycle.
-      const fresh = await api.activeCalls(cfg);
-      setActiveCalls(fresh);
+      refresh();
       setSelected(null);
+      notify("success", `Ended call on ${call.device_serial}`);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "end-call request failed");
       throw e;
     }
     setConfirmEnd(null);
   }
-
-  useEffect(() => {
-    let cancel = false;
-    const refresh = async () => {
-      try {
-        const data = await api.activeCalls(cfg);
-        if (!cancel) setActiveCalls(data);
-      } catch {
-        // Toast strip surfaces request errors elsewhere; keep the
-        // previous snapshot rather than blanking the table.
-      }
-    };
-    refresh();
-    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
-    return () => {
-      cancel = true;
-      window.clearInterval(t);
-    };
-  }, [cfg, setActiveCalls]);
 
   // Tick once a second so the elapsed-time column updates even when
   // no API response has come back yet.
@@ -151,7 +142,12 @@ export function Active() {
     <div className="space-y-3">
       <header className="flex items-center justify-between gap-3">
         <h2 className="text-xl font-semibold">Active calls</h2>
-        <span className="text-xs text-muted">{activeCalls.length} in flight</span>
+        <div className="flex items-center gap-2">
+          <StaleIndicator stale={stale} lastUpdated={lastUpdated} />
+          <span className="text-xs text-muted">
+            {activeCalls.length} in flight
+          </span>
+        </div>
       </header>
 
       <DataTable

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -19,6 +19,7 @@ export function History() {
   const cfg = useShared(selectClientConfig);
   const canMutate = useShared(selectCanMutate);
   const setGlobalError = useShared((s) => s.setError);
+  const notify = useShared((s) => s.notify);
 
   const [rows, setRows] = useState<CallRow[]>([]);
   const [loading, setLoading] = useState(false);
@@ -344,6 +345,7 @@ export function History() {
               // Refresh the current view so the user sees the result.
               const fresh = await api.history(cfg, filter);
               setRows(fresh);
+              notify("success", "Retention sweep complete");
             } catch (e: unknown) {
               setGlobalError(
                 e instanceof Error ? e.message : "retention sweep failed",

--- a/web/src/panels/History.tsx
+++ b/web/src/panels/History.tsx
@@ -239,12 +239,17 @@ export function History() {
         rowKey={(r) => String(r.id)}
         defaultSortKey="started"
         defaultSortDirection="desc"
-        onRowClick={(r) => setSelected(r)}
-        emptyMessage={
-          loading
-            ? "loading…"
-            : "No calls in the daemon's call log for this filter."
+        loading={loading}
+        pageSize={50}
+        searchable
+        searchAccessor={(r) =>
+          [r.group_id, r.talkgroup_alpha, r.system, r.source_id]
+            .filter(Boolean)
+            .join(" ")
         }
+        searchPlaceholder="Search loaded calls…"
+        onRowClick={(r) => setSelected(r)}
+        emptyMessage="No calls in the daemon's call log for this filter."
       />
 
       {selected && (

--- a/web/src/panels/Hunt.test.tsx
+++ b/web/src/panels/Hunt.test.tsx
@@ -47,6 +47,8 @@ describe("Hunt panel", () => {
     // Wait for the initial status poll to settle.
     await waitFor(() => expect(api.hunt).toHaveBeenCalled());
 
+    // Blind sweep is collapsed by default — open it first.
+    await userEvent.click(screen.getByRole("button", { name: /blind sweep/i }));
     await userEvent.type(screen.getByPlaceholderText("00000001"), "dongle-7");
     await userEvent.type(screen.getByPlaceholderText("p25"), "p25");
     await userEvent.click(screen.getByRole("button", { name: /start hunt/i }));

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { api } from "../api/client";
 import { writes } from "../api/write";
 import type {
@@ -8,6 +8,15 @@ import type {
   HuntStatus,
 } from "../api/types";
 import { selectCanMutate, selectClientConfig, useShared } from "../store/shared";
+import { PageHeader } from "../components/ui/PageHeader";
+import { Card } from "../components/ui/Card";
+import { Section } from "../components/ui/Section";
+import { Badge } from "../components/ui/Badge";
+import { Button } from "../components/ui/Button";
+import { Field } from "../components/ui/Field";
+import { Input } from "../components/ui/Input";
+import { Select } from "../components/ui/Select";
+import { Checkbox } from "../components/ui/Checkbox";
 
 const POLL_INTERVAL_MS = 2_000;
 
@@ -26,6 +35,19 @@ const CC_PROTOCOLS: { value: string; label: string }[] = [
   { value: "tetra", label: "TETRA" },
   { value: "ysf", label: "System Fusion (YSF)" },
 ];
+
+// Shared table cell classes for the read-only result tables below.
+const TH = "px-3 py-2 text-left font-medium";
+const TD = "px-3 py-2";
+const THEAD = "bg-panel/80 text-xs uppercase tracking-wider text-muted";
+
+function HuntTable({ children }: { children: ReactNode }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">{children}</table>
+    </div>
+  );
+}
 
 // sortSignals returns a copy of the inventory sorted by the chosen column
 // (frequency ascending, class alphabetical, or SNR descending).
@@ -219,173 +241,342 @@ export function Hunt() {
   const exportBase = `${cfg.baseURL}/api/v1/hunt/export`;
 
   return (
-    <div className="panel hunt-panel">
-      <h2>Hunt — discover an unknown system</h2>
+    <div className="space-y-4 max-w-5xl">
+      <PageHeader
+        title="Hunt"
+        subtitle="Discover an unknown system"
+        actions={
+          running ? (
+            <Badge tone="ok">running ●</Badge>
+          ) : (
+            <Badge>{status?.state ?? "idle"}</Badge>
+          )
+        }
+      />
 
-      <section className="hunt-controls hunt-ccparse">
-        <h3>Parse a control channel</h3>
-        <p className="hint">
-          Point straight at a known trunked control-channel frequency and decode
-          it. The band plan, talkgroups and system identity below fill in as the
-          CC is read — longer listening (or re-running) discovers more talkgroups
-          and neighbor sites. Each second buffers ~19 MB of IQ, so prefer
-          re-running over very long dwells — or set <em>Monitor</em> below to
-          stream the CC in real time (bounded memory) for minutes at a time.
+      {!canMutate && (
+        <div className="rounded-md border border-warn/40 bg-warn/15 px-4 py-2 text-sm text-warn">
+          Mutations are read-only on this connection (no auth token) — start a
+          daemon with write access to run a hunt.
+        </div>
+      )}
+
+      {/* Quick start: the most common task, expanded by default. */}
+      <Section
+        id="hunt-ccparse"
+        title="Parse a control channel"
+        description="Already know a control-channel frequency? Decode it directly — no sweep."
+      >
+        <p className="text-xs text-muted">
+          The band plan, talkgroups and identity below fill in as the CC is read.
+          Each second buffers ~19 MB of IQ, so prefer re-running over long dwells —
+          or set <em>Monitor</em> to stream the CC in real time (bounded memory).
         </p>
-        <label>
-          Protocol
-          <select value={ccProto} onChange={(e) => setCCProto(e.target.value)}>
-            {CC_PROTOCOLS.map((p) => (
-              <option key={p.value} value={p.value}>
-                {p.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label>
-          CC frequency (MHz)
-          <input
-            value={ccFreq}
-            onChange={(e) => setCCFreq(e.target.value)}
-            placeholder="851.0125"
-          />
-        </label>
-        <label>
-          Listen for (seconds)
-          <input
-            type="number"
-            min={1}
-            step={1}
-            value={ccDwell}
-            onChange={(e) => setCCDwell(Number(e.target.value))}
-          />
-        </label>
-        <label>
-          Monitor (minutes, 0 = off)
-          <input
-            type="number"
-            min={0}
-            step={1}
-            value={ccMonitorMin}
-            onChange={(e) => setCCMonitorMin(Number(e.target.value))}
-          />
-          <span className="hint">
-            Streams the control channel and stops early once identity, neighbors
-            and band plan settle (capped at this many minutes).
-          </span>
-        </label>
-        <div className="hunt-buttons">
-          <button onClick={parseCC} disabled={!canMutate || running}>
-            Parse control channel
-          </button>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Field label="Protocol">
+            {(p) => (
+              <Select
+                {...p}
+                className="w-full"
+                value={ccProto}
+                onChange={(e) => setCCProto(e.target.value)}
+              >
+                {CC_PROTOCOLS.map((proto) => (
+                  <option key={proto.value} value={proto.value}>
+                    {proto.label}
+                  </option>
+                ))}
+              </Select>
+            )}
+          </Field>
+          <Field label="CC frequency (MHz)">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                value={ccFreq}
+                onChange={(e) => setCCFreq(e.target.value)}
+                placeholder="851.0125"
+                inputMode="decimal"
+              />
+            )}
+          </Field>
+          <Field label="Listen for (seconds)">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                type="number"
+                min={1}
+                step={1}
+                value={ccDwell}
+                onChange={(e) => setCCDwell(Number(e.target.value))}
+              />
+            )}
+          </Field>
+          <Field
+            label="Monitor (minutes, 0 = off)"
+            hint="Streams the CC and stops once identity, neighbors and band plan settle."
+          >
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                type="number"
+                min={0}
+                step={1}
+                value={ccMonitorMin}
+                onChange={(e) => setCCMonitorMin(Number(e.target.value))}
+              />
+            )}
+          </Field>
         </div>
-      </section>
+        <Button onClick={parseCC} disabled={!canMutate || running}>
+          Parse control channel
+        </Button>
+      </Section>
 
-      <section className="hunt-status">
-        <div>
-          State: <strong>{status?.state ?? "idle"}</strong>
-          {running ? " ●" : ""}
+      {/* Blind sweep: advanced; collapsed by default to keep the panel calm. */}
+      <Section
+        id="hunt-sweep"
+        title="Blind sweep"
+        description="Don't know the frequencies? Sweep a band or a candidate list."
+        defaultCollapsed
+      >
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Field label="Bands (MHz, low:high, comma-separated)">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                value={bands}
+                onChange={(e) => setBands(e.target.value)}
+                placeholder="851:869"
+              />
+            )}
+          </Field>
+          <Field label="Candidates (MHz, comma-separated — skips the sweep)">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                value={candidates}
+                onChange={(e) => setCandidates(e.target.value)}
+                placeholder="851.0125, 853.5125"
+              />
+            )}
+          </Field>
+          <Field label="Name">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="New County P25"
+              />
+            )}
+          </Field>
+          <Field label="State">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                value={stateCode}
+                onChange={(e) => setStateCode(e.target.value)}
+                placeholder="AZ"
+              />
+            )}
+          </Field>
+          <Field label="County">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                value={county}
+                onChange={(e) => setCounty(e.target.value)}
+                placeholder="Maricopa"
+              />
+            )}
+          </Field>
+          <Field label="SDR serial (optional — auto-selects a spare)">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                value={serial}
+                onChange={(e) => setSerial(e.target.value)}
+                placeholder="00000001"
+              />
+            )}
+          </Field>
+          <Field label="Protocol (optional — default auto-identifies)">
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                value={protocol}
+                onChange={(e) => setProtocol(e.target.value)}
+                placeholder="p25"
+              />
+            )}
+          </Field>
         </div>
-        {status?.phase ? (
+
+        <div className="pt-2 space-y-2 border-t border-line">
+          <p className="text-xs uppercase tracking-wider text-muted">
+            Survey &amp; advanced options
+          </p>
+          <Checkbox
+            label="Survey mode — classify & decode every signal (analog, paging, trunking)"
+            checked={survey}
+            onChange={(e) => setSurvey(e.target.checked)}
+          />
+          {survey && (
+            <Checkbox
+              label="Classify only — skip decoding (fast inventory)"
+              checked={classifyOnly}
+              onChange={(e) => setClassifyOnly(e.target.checked)}
+            />
+          )}
+          {survey && (
+            <Checkbox
+              label="Persist survey — stream carriers to a crash-safe NDJSON file"
+              checked={persistSurvey}
+              onChange={(e) => setPersistSurvey(e.target.checked)}
+            />
+          )}
+          {survey && persistSurvey && (
+            <Checkbox
+              label="Resume — skip frequencies already surveyed in that file"
+              checked={resume}
+              onChange={(e) => setResume(e.target.checked)}
+            />
+          )}
+          <Checkbox
+            label="Auto-gain — recommend the best front-end gain after the run (needs a dedicated SDR)"
+            checked={autoGain}
+            onChange={(e) => setAutoGain(e.target.checked)}
+          />
+        </div>
+
+        <div className="flex gap-2 pt-1">
+          <Button onClick={start} disabled={!canMutate || running}>
+            Start hunt
+          </Button>
+          <Button variant="ghost" onClick={stop} disabled={!canMutate || !running}>
+            Stop
+          </Button>
+        </div>
+      </Section>
+
+      {/* Live status. */}
+      <Card title="Status">
+        <div className="space-y-1 text-sm">
           <div>
-            Phase: {status.phase}
-            {status.detail ? ` — ${status.detail}` : ""}
+            State: <strong>{status?.state ?? "idle"}</strong>
+            {running ? " ●" : ""}
           </div>
-        ) : null}
-        {status?.error ? <div className="error">Error: {status.error}</div> : null}
-        {status?.mode ? (
-          <div>
-            Mode: <strong>{status.mode}</strong>
-          </div>
-        ) : null}
-        {status?.system_name ? (
-          <div>
-            Discovered: <strong>{status.system_name}</strong> — {status.sites} site(s),{" "}
-            {status.talkgroups} talkgroup(s)
-          </div>
-        ) : status?.mode === "survey" ? null : (
-          <div>No system discovered yet.</div>
-        )}
-      </section>
+          {status?.phase && (
+            <div className="text-muted">
+              Phase: {status.phase}
+              {status.detail ? ` — ${status.detail}` : ""}
+            </div>
+          )}
+          {status?.error && <div className="text-err">Error: {status.error}</div>}
+          {status?.mode && (
+            <div>
+              Mode: <strong>{status.mode}</strong>
+            </div>
+          )}
+          {status?.system_name ? (
+            <div>
+              Discovered: <strong>{status.system_name}</strong> — {status.sites}{" "}
+              site(s), {status.talkgroups} talkgroup(s)
+            </div>
+          ) : status?.mode === "survey" ? null : (
+            <div className="text-muted">No system discovered yet.</div>
+          )}
+        </div>
+      </Card>
 
       {status?.system &&
       (status.system.wacn || status.system.system_id || status.system.nac) ? (
-        <section className="hunt-identity">
-          <h3>System identity</h3>
-          <table>
+        <Card title="System identity">
+          <HuntTable>
             <tbody>
               <tr>
-                <th>Protocol</th>
-                <td>{status.system.protocol || "—"}</td>
-                <th>WACN</th>
-                <td>{hexUpper(status.system.wacn)}</td>
+                <th className={TH}>Protocol</th>
+                <td className={TD}>{status.system.protocol || "—"}</td>
+                <th className={TH}>WACN</th>
+                <td className={TD}>{hexUpper(status.system.wacn)}</td>
               </tr>
               <tr>
-                <th>System ID</th>
-                <td>{hexUpper(status.system.system_id)}</td>
-                <th>NAC</th>
-                <td>{hexUpper(status.system.nac)}</td>
+                <th className={TH}>System ID</th>
+                <td className={TD}>{hexUpper(status.system.system_id)}</td>
+                <th className={TH}>NAC</th>
+                <td className={TD}>{hexUpper(status.system.nac)}</td>
               </tr>
               {status.system.confidence ? (
                 <tr>
-                  <th>Confidence</th>
-                  <td colSpan={3}>{(status.system.confidence * 100).toFixed(0)}%</td>
+                  <th className={TH}>Confidence</th>
+                  <td className={TD} colSpan={3}>
+                    {(status.system.confidence * 100).toFixed(0)}%
+                  </td>
                 </tr>
               ) : null}
             </tbody>
-          </table>
-        </section>
+          </HuntTable>
+        </Card>
       ) : null}
 
       {status?.system?.band_plan && status.system.band_plan.length > 0 ? (
-        <section className="hunt-bandplan">
-          <h3>Band plan ({status.system.band_plan.length})</h3>
-          <table>
-            <thead>
+        <Card title={`Band plan (${status.system.band_plan.length})`}>
+          <HuntTable>
+            <thead className={THEAD}>
               <tr>
-                <th>Channel ID</th>
-                <th>Base (MHz)</th>
-                <th>Spacing (kHz)</th>
-                <th>BW (kHz)</th>
-                <th>TX offset (MHz)</th>
+                <th className={TH}>Channel ID</th>
+                <th className={TH}>Base (MHz)</th>
+                <th className={TH}>Spacing (kHz)</th>
+                <th className={TH}>BW (kHz)</th>
+                <th className={TH}>TX offset (MHz)</th>
               </tr>
             </thead>
             <tbody>
               {status.system.band_plan.map((b) => (
-                <tr key={b.channel_id}>
-                  <td>{b.channel_id}</td>
-                  <td>{(b.base_hz / 1e6).toFixed(5)}</td>
-                  <td>{(b.spacing_hz / 1e3).toFixed(3)}</td>
-                  <td>{b.bandwidth_hz ? (b.bandwidth_hz / 1e3).toFixed(1) : "—"}</td>
-                  <td>{b.tx_offset_hz ? (b.tx_offset_hz / 1e6).toFixed(4) : "—"}</td>
+                <tr key={b.channel_id} className="border-t border-panel">
+                  <td className={TD}>{b.channel_id}</td>
+                  <td className={TD}>{(b.base_hz / 1e6).toFixed(5)}</td>
+                  <td className={TD}>{(b.spacing_hz / 1e3).toFixed(3)}</td>
+                  <td className={TD}>{b.bandwidth_hz ? (b.bandwidth_hz / 1e3).toFixed(1) : "—"}</td>
+                  <td className={TD}>{b.tx_offset_hz ? (b.tx_offset_hz / 1e6).toFixed(4) : "—"}</td>
                 </tr>
               ))}
             </tbody>
-          </table>
-        </section>
+          </HuntTable>
+        </Card>
       ) : null}
 
       {status?.system?.talkgroups && status.system.talkgroups.length > 0 ? (
-        <section className="hunt-talkgroups">
-          <h3>Talkgroups ({status.system.talkgroups.length})</h3>
-          <table>
-            <thead>
+        <Card title={`Talkgroups (${status.system.talkgroups.length})`}>
+          <HuntTable>
+            <thead className={THEAD}>
               <tr>
-                <th>Dec</th>
-                <th>Hex</th>
-                <th>Encrypted</th>
-                <th>Activity</th>
-                <th>Frequencies</th>
+                <th className={TH}>Dec</th>
+                <th className={TH}>Hex</th>
+                <th className={TH}>Encrypted</th>
+                <th className={TH}>Activity</th>
+                <th className={TH}>Frequencies</th>
               </tr>
             </thead>
             <tbody>
               {status.system.talkgroups.map((tg) => (
-                <tr key={tg.dec}>
-                  <td>{tg.dec}</td>
-                  <td>{tg.hex}</td>
-                  <td>{tg.encrypted ? "🔒" : "—"}</td>
-                  <td>{tg.count}</td>
-                  <td>
+                <tr key={tg.dec} className="border-t border-panel">
+                  <td className={TD}>{tg.dec}</td>
+                  <td className={TD}>{tg.hex}</td>
+                  <td className={TD}>{tg.encrypted ? "🔒" : "—"}</td>
+                  <td className={TD}>{tg.count}</td>
+                  <td className={TD}>
                     {tg.frequencies && tg.frequencies.length > 0
                       ? tg.frequencies.map((h) => (h / 1e6).toFixed(4)).join(", ")
                       : "—"}
@@ -393,36 +584,35 @@ export function Hunt() {
                 </tr>
               ))}
             </tbody>
-          </table>
-        </section>
+          </HuntTable>
+        </Card>
       ) : null}
 
       {status?.system?.sites && status.system.sites.length > 0 ? (
-        <section className="hunt-sites">
-          <h3>Sites ({status.system.sites.length})</h3>
-          <table>
-            <thead>
+        <Card title={`Sites (${status.system.sites.length})`}>
+          <HuntTable>
+            <thead className={THEAD}>
               <tr>
-                <th>Site</th>
-                <th>RFSS</th>
-                <th>Control channels</th>
-                <th>Neighbors</th>
-                <th>Voice channels</th>
+                <th className={TH}>Site</th>
+                <th className={TH}>RFSS</th>
+                <th className={TH}>Control channels</th>
+                <th className={TH}>Neighbors</th>
+                <th className={TH}>Voice channels</th>
               </tr>
             </thead>
             <tbody>
               {status.system.sites.map((site, i) => (
-                <tr key={`${site.rfss}-${site.site_id}-${i}`}>
-                  <td>{site.site_name || site.site_id || "—"}</td>
-                  <td>{site.rfss ?? "—"}</td>
-                  <td>
+                <tr key={`${site.rfss}-${site.site_id}-${i}`} className="border-t border-panel">
+                  <td className={TD}>{site.site_name || site.site_id || "—"}</td>
+                  <td className={TD}>{site.rfss ?? "—"}</td>
+                  <td className={TD}>
                     {site.control_channels && site.control_channels.length > 0
                       ? site.control_channels
                           .map((c) => `${(c.frequency_hz / 1e6).toFixed(4)}${c.is_control ? "*" : ""}`)
                           .join(", ")
                       : "—"}
                   </td>
-                  <td>
+                  <td className={TD}>
                     {site.neighbors && site.neighbors.length > 0
                       ? site.neighbors
                           .map((n) => {
@@ -434,7 +624,7 @@ export function Hunt() {
                           .join(", ")
                       : "—"}
                   </td>
-                  <td>
+                  <td className={TD}>
                     {site.voice_channels && site.voice_channels.length > 0
                       ? site.voice_channels.map((h) => (h / 1e6).toFixed(4)).join(", ")
                       : "—"}
@@ -442,186 +632,142 @@ export function Hunt() {
                 </tr>
               ))}
             </tbody>
-          </table>
-        </section>
+          </HuntTable>
+        </Card>
       ) : null}
 
       {status?.reports && status.reports.length > 0 ? (
-        <section className="hunt-reports">
-          <h3>Captures ({status.reports.length})</h3>
-          <table>
-            <thead>
+        <Card title={`Captures (${status.reports.length})`}>
+          <HuntTable>
+            <thead className={THEAD}>
               <tr>
-                <th>Control freq</th>
-                <th>Protocol</th>
-                <th>Result</th>
-                <th>TGs</th>
+                <th className={TH}>Control freq</th>
+                <th className={TH}>Protocol</th>
+                <th className={TH}>Result</th>
+                <th className={TH}>TGs</th>
               </tr>
             </thead>
             <tbody>
               {status.reports.map((rep, i) => (
-                <tr key={`${rep.control_hz}-${i}`}>
-                  <td>{rep.control_hz ? `${(rep.control_hz / 1e6).toFixed(4)} MHz` : "—"}</td>
-                  <td>{rep.protocol || "—"}</td>
-                  <td>{captureResult(rep)}</td>
-                  <td>{rep.talkgroups ?? "—"}</td>
+                <tr key={`${rep.control_hz}-${i}`} className="border-t border-panel">
+                  <td className={TD}>{rep.control_hz ? `${(rep.control_hz / 1e6).toFixed(4)} MHz` : "—"}</td>
+                  <td className={TD}>{rep.protocol || "—"}</td>
+                  <td className={TD}>{captureResult(rep)}</td>
+                  <td className={TD}>{rep.talkgroups ?? "—"}</td>
                 </tr>
               ))}
             </tbody>
-          </table>
-        </section>
+          </HuntTable>
+        </Card>
       ) : null}
 
       {status?.signals && status.signals.length > 0 ? (
-        <section className="hunt-signals">
-          <h3>Signals ({status.signals.length})</h3>
-          <table>
-            <thead>
+        <Card title={`Signals (${status.signals.length})`}>
+          <HuntTable>
+            <thead className={THEAD}>
               <tr>
-                <th onClick={() => setSortBy("freq")} style={{ cursor: "pointer" }}>
+                <th className={`${TH} cursor-pointer`} onClick={() => setSortBy("freq")}>
                   Frequency{sortBy === "freq" ? " ▾" : ""}
                 </th>
-                <th onClick={() => setSortBy("class")} style={{ cursor: "pointer" }}>
+                <th className={`${TH} cursor-pointer`} onClick={() => setSortBy("class")}>
                   Class{sortBy === "class" ? " ▾" : ""}
                 </th>
-                <th>BW (kHz)</th>
-                <th onClick={() => setSortBy("snr")} style={{ cursor: "pointer" }}>
+                <th className={TH}>BW (kHz)</th>
+                <th className={`${TH} cursor-pointer`} onClick={() => setSortBy("snr")}>
                   SNR (dB){sortBy === "snr" ? " ▾" : ""}
                 </th>
-                <th>Decode</th>
+                <th className={TH}>Decode</th>
               </tr>
             </thead>
             <tbody>
               {sortSignals(status.signals, sortBy).map((sig) => (
-                <tr key={sig.freq_hz}>
-                  <td>{(sig.freq_hz / 1e6).toFixed(4)} MHz</td>
-                  <td>{sig.class}</td>
-                  <td>{(sig.occupied_bw_hz / 1e3).toFixed(1)}</td>
-                  <td>{sig.snr_db.toFixed(1)}</td>
-                  <td>{signalDetail(sig)}</td>
+                <tr key={sig.freq_hz} className="border-t border-panel">
+                  <td className={TD}>{(sig.freq_hz / 1e6).toFixed(4)} MHz</td>
+                  <td className={TD}>{sig.class}</td>
+                  <td className={TD}>{(sig.occupied_bw_hz / 1e3).toFixed(1)}</td>
+                  <td className={TD}>{sig.snr_db.toFixed(1)}</td>
+                  <td className={TD}>{signalDetail(sig)}</td>
                 </tr>
               ))}
             </tbody>
-          </table>
-        </section>
+          </HuntTable>
+        </Card>
       ) : null}
 
-      <section className="hunt-controls">
-        <label>
-          Bands (MHz, low:high, comma-separated)
-          <input value={bands} onChange={(e) => setBands(e.target.value)} placeholder="851:869" />
-        </label>
-        <label>
-          Candidates (MHz, comma-separated — skips the sweep)
-          <input
-            value={candidates}
-            onChange={(e) => setCandidates(e.target.value)}
-            placeholder="851.0125, 853.5125"
-          />
-        </label>
-        <label>
-          Name
-          <input value={name} onChange={(e) => setName(e.target.value)} placeholder="New County P25" />
-        </label>
-        <label>
-          State
-          <input value={stateCode} onChange={(e) => setStateCode(e.target.value)} placeholder="AZ" />
-        </label>
-        <label>
-          County
-          <input value={county} onChange={(e) => setCounty(e.target.value)} placeholder="Maricopa" />
-        </label>
-        <label>
-          SDR serial (optional — auto-selects a spare, else borrows control)
-          <input value={serial} onChange={(e) => setSerial(e.target.value)} placeholder="00000001" />
-        </label>
-        <label>
-          Protocol (optional — default auto-identifies)
-          <input value={protocol} onChange={(e) => setProtocol(e.target.value)} placeholder="p25" />
-        </label>
-        <label className="hunt-survey-toggle">
-          <input type="checkbox" checked={survey} onChange={(e) => setSurvey(e.target.checked)} />
-          Survey mode — classify &amp; decode every signal (analog, paging, trunking)
-        </label>
-        {survey ? (
-          <label className="hunt-survey-toggle">
-            <input
-              type="checkbox"
-              checked={classifyOnly}
-              onChange={(e) => setClassifyOnly(e.target.checked)}
-            />
-            Classify only — skip decoding (fast inventory)
-          </label>
-        ) : null}
-        {survey ? (
-          <label className="hunt-survey-toggle">
-            <input
-              type="checkbox"
-              checked={persistSurvey}
-              onChange={(e) => setPersistSurvey(e.target.checked)}
-            />
-            Persist survey — stream carriers to a crash-safe NDJSON file
-          </label>
-        ) : null}
-        {survey && persistSurvey ? (
-          <label className="hunt-survey-toggle">
-            <input type="checkbox" checked={resume} onChange={(e) => setResume(e.target.checked)} />
-            Resume — skip frequencies already surveyed in that file
-          </label>
-        ) : null}
-        <label className="hunt-survey-toggle">
-          <input type="checkbox" checked={autoGain} onChange={(e) => setAutoGain(e.target.checked)} />
-          Auto-gain — after the run, recommend the best front-end gain (needs a dedicated SDR)
-        </label>
-        <div className="hunt-buttons">
-          <button onClick={start} disabled={!canMutate || running}>
-            Start hunt
-          </button>
-          <button onClick={stop} disabled={!canMutate || !running}>
-            Stop
-          </button>
-        </div>
-      </section>
-
-      {status?.system_name ? (
-        <section className="hunt-export">
-          <span>Export:</span>
-          <a href={`${exportBase}?format=bundle`}>GopherTrunk bundle</a>
-          <a href={`${exportBase}?format=trunk-recorder`}>trunk-recorder</a>
-          <a href={`${exportBase}?format=rr`}>RadioReference package</a>
-        </section>
-      ) : null}
-
-      {status?.signals && status.signals.length > 0 ? (
-        <section className="hunt-export">
-          <span>Survey:</span>
-          <a href={`${cfg.baseURL}/api/v1/hunt/survey?format=json`}>signals JSON</a>
-          <a href={`${cfg.baseURL}/api/v1/hunt/survey?format=csv`}>signals CSV</a>
-        </section>
-      ) : null}
-
-      {status?.system_name ? (
-        <section className="hunt-rr">
-          <h3>RadioReference</h3>
-          <div className="hunt-rr-controls">
-            <label>
-              County id (ctid)
-              <input value={rrCounty} onChange={(e) => setRRCounty(e.target.value)} placeholder="e.g. 1234" />
-            </label>
-            <label>
-              or System id(s)
-              <input value={rrSID} onChange={(e) => setRRSID(e.target.value)} placeholder="comma-separated SIDs" />
-            </label>
-            <button onClick={checkRR} disabled={rrBusy || (!rrCounty.trim() && !rrSID.trim())}>
-              {rrBusy ? "Checking…" : "Cross-reference"}
-            </button>
+      {(status?.system_name || (status?.signals && status.signals.length > 0)) && (
+        <Card title="Export">
+          <div className="flex flex-wrap gap-2">
+            {status?.system_name && (
+              <>
+                <a className="btn-ghost text-xs" href={`${exportBase}?format=bundle`}>
+                  GopherTrunk bundle
+                </a>
+                <a className="btn-ghost text-xs" href={`${exportBase}?format=trunk-recorder`}>
+                  trunk-recorder
+                </a>
+                <a className="btn-ghost text-xs" href={`${exportBase}?format=rr`}>
+                  RadioReference package
+                </a>
+              </>
+            )}
+            {status?.signals && status.signals.length > 0 && (
+              <>
+                <a className="btn-ghost text-xs" href={`${cfg.baseURL}/api/v1/hunt/survey?format=json`}>
+                  survey JSON
+                </a>
+                <a className="btn-ghost text-xs" href={`${cfg.baseURL}/api/v1/hunt/survey?format=csv`}>
+                  survey CSV
+                </a>
+              </>
+            )}
           </div>
-          {rrReport ? (
-            <div className="hunt-rr-result">
+        </Card>
+      )}
+
+      {status?.system_name ? (
+        <Section
+          id="hunt-rr"
+          title="Cross-reference RadioReference"
+          description="Compare the discovered system against RadioReference by county or system id."
+          defaultCollapsed
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <Field label="County id (ctid)">
+              {(p) => (
+                <Input
+                  {...p}
+                  className="w-full"
+                  value={rrCounty}
+                  onChange={(e) => setRRCounty(e.target.value)}
+                  placeholder="e.g. 1234"
+                />
+              )}
+            </Field>
+            <Field label="or System id(s)">
+              {(p) => (
+                <Input
+                  {...p}
+                  className="w-full"
+                  value={rrSID}
+                  onChange={(e) => setRRSID(e.target.value)}
+                  placeholder="comma-separated SIDs"
+                />
+              )}
+            </Field>
+          </div>
+          <Button
+            loading={rrBusy}
+            onClick={checkRR}
+            disabled={rrBusy || (!rrCounty.trim() && !rrSID.trim())}
+          >
+            Cross-reference
+          </Button>
+          {rrReport && (
+            <div className="text-sm space-y-2">
               {rrReport.hints && rrReport.hints.length > 0 ? (
                 <>
-                  <h4>Possible existing systems</h4>
-                  <ul>
+                  <h4 className="font-medium">Possible existing systems</h4>
+                  <ul className="list-disc pl-5 space-y-1">
                     {rrReport.hints.map((h, i) => (
                       <li key={i}>
                         SID {h.sid} — {h.name} ({(h.confidence * 100).toFixed(0)}%): {h.reason}
@@ -630,17 +776,17 @@ export function Hunt() {
                   </ul>
                 </>
               ) : (
-                <p>No existing match among {rrReport.compared} system(s).</p>
+                <p className="text-muted">No existing match among {rrReport.compared} system(s).</p>
               )}
-              {rrReport.diff ? (
+              {rrReport.diff && (
                 <>
-                  <h4>
+                  <h4 className="font-medium">
                     Differences vs RadioReference (SID {rrReport.diff.sid}, {rrReport.diff.name})
                   </h4>
-                  {rrReport.diff.freq_offsets && rrReport.diff.freq_offsets.length > 0 ? (
+                  {rrReport.diff.freq_offsets && rrReport.diff.freq_offsets.length > 0 && (
                     <div>
                       <strong>Frequency offsets:</strong>
-                      <ul>
+                      <ul className="list-disc pl-5">
                         {rrReport.diff.freq_offsets.map((o, i) => (
                           <li key={i}>
                             {(o.discovered_hz / 1e6).toFixed(4)} vs {(o.rr_hz / 1e6).toFixed(4)} MHz (
@@ -650,55 +796,52 @@ export function Hunt() {
                         ))}
                       </ul>
                     </div>
-                  ) : null}
-                  {rrReport.diff.freqs_not_in_rr && rrReport.diff.freqs_not_in_rr.length > 0 ? (
+                  )}
+                  {rrReport.diff.freqs_not_in_rr && rrReport.diff.freqs_not_in_rr.length > 0 && (
                     <div>
                       <strong>Frequencies not in RadioReference:</strong>{" "}
                       {rrReport.diff.freqs_not_in_rr.map((f) => (f / 1e6).toFixed(4)).join(", ")} MHz
                     </div>
-                  ) : null}
-                  {rrReport.diff.talkgroups_not_in_rr && rrReport.diff.talkgroups_not_in_rr.length > 0 ? (
+                  )}
+                  {rrReport.diff.talkgroups_not_in_rr && rrReport.diff.talkgroups_not_in_rr.length > 0 && (
                     <div>
                       <strong>Talkgroups not in RadioReference:</strong>{" "}
                       {rrReport.diff.talkgroups_not_in_rr.join(", ")}
                     </div>
-                  ) : null}
+                  )}
                 </>
-              ) : null}
+              )}
             </div>
-          ) : null}
-        </section>
+          )}
+        </Section>
       ) : null}
 
       {status?.gain_recommendations && status.gain_recommendations.length > 0 ? (
-        <section className="hunt-gain">
-          <h3>Auto-gain recommendations</h3>
-          <table>
-            <thead>
+        <Card title="Auto-gain recommendations">
+          <HuntTable>
+            <thead className={THEAD}>
               <tr>
-                <th>Control channel</th>
-                <th>Best gain (dB)</th>
-                <th>Error rate</th>
-                <th>Locked</th>
+                <th className={TH}>Control channel</th>
+                <th className={TH}>Best gain (dB)</th>
+                <th className={TH}>Error rate</th>
+                <th className={TH}>Locked</th>
               </tr>
             </thead>
             <tbody>
               {status.gain_recommendations.map((g, i) => (
-                <tr key={i}>
-                  <td>{(g.freq_hz / 1e6).toFixed(4)} MHz</td>
-                  <td>{(g.best_gain_tenth_db / 10).toFixed(1)}</td>
-                  <td>{g.best_error_rate.toFixed(3)}</td>
-                  <td>{g.locked ? "yes" : "no"}</td>
+                <tr key={i} className="border-t border-panel">
+                  <td className={TD}>{(g.freq_hz / 1e6).toFixed(4)} MHz</td>
+                  <td className={TD}>{(g.best_gain_tenth_db / 10).toFixed(1)}</td>
+                  <td className={TD}>{g.best_error_rate.toFixed(3)}</td>
+                  <td className={TD}>{g.locked ? "yes" : "no"}</td>
                 </tr>
               ))}
             </tbody>
-          </table>
-        </section>
-      ) : null}
-      {status?.gain_note ? <p className="hint">Auto-gain: {status.gain_note}</p> : null}
-
-      {!canMutate ? (
-        <p className="hint">Mutations are read-only on this connection (no auth token).</p>
+          </HuntTable>
+          {status.gain_note && (
+            <p className="text-xs text-muted mt-2">Auto-gain: {status.gain_note}</p>
+          )}
+        </Card>
       ) : null}
     </div>
   );

--- a/web/src/panels/Metrics.tsx
+++ b/web/src/panels/Metrics.tsx
@@ -189,7 +189,11 @@ export function Metrics() {
 
       <section className="panel p-4">
         <h3 className="panel-title mb-3">Trend (last ~5 min)</h3>
-        <div className="h-64">
+        <div
+          className="h-64"
+          role="img"
+          aria-label="Line chart of daemon counters over the last five minutes. The curated counters below give the current values as text."
+        >
           <Line data={chartData} options={chartOptions} />
         </div>
       </section>

--- a/web/src/panels/RadioIDs.test.tsx
+++ b/web/src/panels/RadioIDs.test.tsx
@@ -111,7 +111,7 @@ describe("RadioIDs panel", () => {
       expect(screen.getByText("CHIEF")).toBeInTheDocument();
     });
 
-    const search = screen.getByPlaceholderText(/Filter by id, alias/);
+    const search = screen.getByPlaceholderText(/Search by id, alias/);
     await userEvent.type(search, "eng");
     // Only the live row whose talker_alias matches survives.
     expect(screen.queryByText("CHIEF")).not.toBeInTheDocument();

--- a/web/src/panels/RadioIDs.tsx
+++ b/web/src/panels/RadioIDs.tsx
@@ -3,6 +3,7 @@ import { api } from "../api/client";
 import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
+import { PageHeader } from "../components/ui/PageHeader";
 import type { CallRow, RIDDTO } from "../api/types";
 import {
   selectCanMutate,
@@ -24,7 +25,6 @@ export function RadioIDs() {
   const setRIDs = useShared((s) => s.setRIDs);
 
   const [selected, setSelected] = useState<RIDDTO | null>(null);
-  const [filter, setFilter] = useState("");
   const [history, setHistory] = useState<CallRow[]>([]);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -88,23 +88,6 @@ export function RadioIDs() {
       setBusy(false);
     }
   }
-
-  const filtered = useMemo(() => {
-    if (!filter.trim()) return rids;
-    const needle = filter.toLowerCase();
-    return rids.filter((r) => {
-      const idStr = String(r.id);
-      return (
-        idStr.includes(needle) ||
-        (r.alias ?? "").toLowerCase().includes(needle) ||
-        (r.talker_alias ?? "").toLowerCase().includes(needle) ||
-        (r.description ?? "").toLowerCase().includes(needle) ||
-        (r.tag ?? "").toLowerCase().includes(needle) ||
-        (r.group ?? "").toLowerCase().includes(needle) ||
-        (r.owner ?? "").toLowerCase().includes(needle)
-      );
-    });
-  }, [rids, filter]);
 
   const columns: Column<RIDDTO>[] = useMemo(
     () => [
@@ -176,32 +159,31 @@ export function RadioIDs() {
 
   return (
     <div className="space-y-3">
-      <header className="flex items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold">Radio IDs</h2>
-        <span className="text-xs text-muted">
-          {filtered.length} of {rids.length}
-        </span>
-      </header>
-
-      <input
-        type="search"
-        className="input w-full sm:max-w-xs"
-        placeholder="Filter by id, alias, talker alias, group, owner…"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-        aria-label="Filter radio IDs"
+      <PageHeader
+        title="Radio IDs"
+        actions={
+          <span className="text-xs text-muted">{rids.length} total</span>
+        }
       />
 
       <DataTable
-        rows={filtered}
+        rows={rids}
         columns={columns}
         rowKey={(r) => String(r.id)}
         defaultSortKey="id"
+        tableId="rids"
+        searchable
+        searchAccessor={(r) =>
+          [r.id, r.alias, r.talker_alias, r.description, r.tag, r.group, r.owner]
+            .filter(Boolean)
+            .join(" ")
+        }
+        searchPlaceholder="Search by id, alias, talker alias, group, owner…"
         onRowClick={(r) => setSelected(r)}
         emptyMessage={
           rids.length === 0
             ? "No radio IDs observed yet — load an rid_alias_file or wait for the affiliation tracker to surface live IDs."
-            : "No radio IDs match the filter."
+            : "No radio IDs match the search."
         }
       />
 

--- a/web/src/panels/Scanner.tsx
+++ b/web/src/panels/Scanner.tsx
@@ -2,6 +2,10 @@ import { useEffect, useState } from "react";
 import { api } from "../api/client";
 import { writes } from "../api/write";
 import { ConfirmModal } from "../components/ConfirmModal";
+import { PageHeader } from "../components/ui/PageHeader";
+import { Card } from "../components/ui/Card";
+import { Button } from "../components/ui/Button";
+import { Badge } from "../components/ui/Badge";
 import type {
   ConvChannelStatusDTO,
   SystemHuntStatusDTO,
@@ -77,40 +81,40 @@ export function Scanner() {
 
   return (
     <div className="space-y-4">
-      <header className="flex items-center justify-between gap-3 flex-wrap">
-        <h2 className="text-xl font-semibold">Scanner cockpit</h2>
-        <div className="flex items-center gap-2 text-xs">
-          <span className="text-muted uppercase tracking-wider">scan_mode</span>
-          <span className="font-mono">{scanner.scan_mode}</span>
-          {canMutate && (
-            <button
-              className="btn-ghost text-xs"
-              onClick={() =>
-                setConfirm({
-                  title: `Switch scan mode to "${scanner.scan_mode === "all" ? "list" : "all"}"?`,
-                  message:
-                    scanner.scan_mode === "all"
-                      ? "list mode only listens for talkgroups marked Scan=true."
-                      : "all mode listens for every talkgroup the daemon knows about.",
-                  onConfirm: () =>
-                    wrap("set_scan_mode", () =>
-                      writes.setScanMode(
-                        cfg,
-                        scanner.scan_mode === "all" ? "list" : "all",
+      <PageHeader
+        title="Scanner cockpit"
+        subtitle={`${scanner.tg_scan_count} of ${scanner.tg_total} talkgroups eligible`}
+        actions={
+          <div className="flex items-center gap-2 text-xs">
+            <span className="text-muted uppercase tracking-wider">scan_mode</span>
+            <span className="font-mono">{scanner.scan_mode}</span>
+            {canMutate && (
+              <Button
+                variant="ghost"
+                className="text-xs"
+                onClick={() =>
+                  setConfirm({
+                    title: `Switch scan mode to "${scanner.scan_mode === "all" ? "list" : "all"}"?`,
+                    message:
+                      scanner.scan_mode === "all"
+                        ? "list mode only listens for talkgroups marked Scan=true."
+                        : "all mode listens for every talkgroup the daemon knows about.",
+                    onConfirm: () =>
+                      wrap("set_scan_mode", () =>
+                        writes.setScanMode(
+                          cfg,
+                          scanner.scan_mode === "all" ? "list" : "all",
+                        ),
                       ),
-                    ),
-                })
-              }
-            >
-              flip
-            </button>
-          )}
-        </div>
-      </header>
-
-      <p className="text-xs text-muted">
-        {scanner.tg_scan_count} of {scanner.tg_total} talkgroups eligible
-      </p>
+                  })
+                }
+              >
+                flip
+              </Button>
+            )}
+          </div>
+        }
+      />
 
       <Hunt
         systems={scanner.systems}
@@ -168,8 +172,7 @@ function Hunt({
   const cfg = useShared(selectClientConfig);
 
   return (
-    <section className="panel p-4">
-      <h3 className="panel-title mb-3">Trunked-system hunter</h3>
+    <Card title="Trunked-system hunter">
       {systems.length === 0 ? (
         <p className="text-muted text-sm">No trunked systems configured.</p>
       ) : (
@@ -255,7 +258,7 @@ function Hunt({
           ))}
         </ul>
       )}
-    </section>
+    </Card>
   );
 }
 
@@ -273,17 +276,16 @@ function Conventional({
   const cfg = useShared(selectClientConfig);
   if (!conv.enabled) {
     return (
-      <section className="panel p-4">
-        <h3 className="panel-title mb-2">Conventional FM scanner</h3>
+      <Card title="Conventional FM scanner">
         <p className="text-muted text-sm">disabled (no scanner channels configured).</p>
-      </section>
+      </Card>
     );
   }
 
   return (
-    <section className="panel p-4 space-y-3">
-      <header className="flex items-center justify-between gap-3">
-        <h3 className="panel-title">Conventional FM scanner</h3>
+    <Card
+      title="Conventional FM scanner"
+      actions={
         <div className="flex items-center gap-2 text-xs">
           <span className="font-mono">{conv.state ?? "—"}</span>
           {conv.device_serial && (
@@ -310,8 +312,8 @@ function Conventional({
             </>
           )}
         </div>
-      </header>
-
+      }
+    >
       {conv.channels.length === 0 ? (
         <p className="text-muted text-sm">No channels in the conv scanner list.</p>
       ) : (
@@ -399,7 +401,7 @@ function Conventional({
           </table>
         </div>
       )}
-    </section>
+    </Card>
   );
 }
 
@@ -442,8 +444,7 @@ function ManualTune({
   }
 
   return (
-    <section className="panel p-4">
-      <h3 className="panel-title mb-3">Manual VFO tune</h3>
+    <Card title="Manual VFO tune">
       <form
         onSubmit={submit}
         className="grid grid-cols-2 sm:grid-cols-6 gap-2 items-end"
@@ -512,20 +513,20 @@ function ManualTune({
         Accepts MHz / kHz / Hz with the unit (e.g. "154.250 MHz") or a
         bare integer in Hz.
       </p>
-    </section>
+    </Card>
   );
 }
 
 function StatePill({ state }: { state: string }) {
-  const map: Record<string, string> = {
-    locked: "pill-ok",
-    hunting: "pill-warn",
-    held: "pill",
-    failed: "pill-err",
-    idle: "pill",
-  };
-  const cls = map[state] ?? "pill";
-  return <span className={cls}>{state}</span>;
+  const tone =
+    state === "locked"
+      ? "ok"
+      : state === "hunting"
+        ? "warn"
+        : state === "failed"
+          ? "err"
+          : "neutral";
+  return <Badge tone={tone}>{state}</Badge>;
 }
 
 function timeOnly(ts: string): string {

--- a/web/src/panels/Settings.tsx
+++ b/web/src/panels/Settings.tsx
@@ -7,7 +7,7 @@ import type {
   RuntimeDTO,
   SettingsPatch,
 } from "../api/types";
-import { prefs, type Theme } from "../store/prefs";
+import { prefs, themeAttr, type Density, type Theme } from "../store/prefs";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -20,6 +20,7 @@ import {
 // magically bypass server auth.
 export function Settings() {
   const [theme, setTheme] = useState<Theme>(prefs.theme());
+  const [density, setDensity] = useState<Density>(prefs.density());
   const writeMode = useShared((s) => s.writeMode);
   const setWriteMode = useShared((s) => s.setWriteMode);
   const canMutate = useShared(selectCanMutate);
@@ -32,7 +33,13 @@ export function Settings() {
   const onTheme = (t: Theme) => {
     setTheme(t);
     prefs.setTheme(t);
-    document.documentElement.dataset.theme = t === "monochrome" ? "mono" : "dark";
+    document.documentElement.dataset.theme = themeAttr(t);
+  };
+
+  const onDensity = (d: Density) => {
+    setDensity(d);
+    prefs.setDensity(d);
+    document.documentElement.dataset.density = d;
   };
 
   return (
@@ -59,22 +66,39 @@ export function Settings() {
         </button>
       </section>
 
-      <section className="panel p-4 space-y-3">
-        <h3 className="panel-title">Theme</h3>
-        <div className="flex gap-2">
-          {(["dark", "monochrome"] as const).map((t) => (
-            <button
-              key={t}
-              className={
-                theme === t
-                  ? "btn-primary"
-                  : "btn-ghost"
-              }
-              onClick={() => onTheme(t)}
-            >
-              {t}
-            </button>
-          ))}
+      <section className="panel p-4 space-y-4">
+        <div className="space-y-2">
+          <h3 className="panel-title">Theme</h3>
+          <div className="flex flex-wrap gap-2">
+            {(["dark", "monochrome", "light"] as const).map((t) => (
+              <button
+                key={t}
+                className={theme === t ? "btn-primary" : "btn-ghost"}
+                aria-pressed={theme === t}
+                onClick={() => onTheme(t)}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="space-y-2">
+          <h3 className="panel-title">Density</h3>
+          <div className="flex flex-wrap gap-2">
+            {(["comfortable", "compact"] as const).map((d) => (
+              <button
+                key={d}
+                className={density === d ? "btn-primary" : "btn-ghost"}
+                aria-pressed={density === d}
+                onClick={() => onDensity(d)}
+              >
+                {d}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-muted">
+            Compact tightens table rows for monitoring many calls at once.
+          </p>
         </div>
       </section>
 

--- a/web/src/panels/Settings.tsx
+++ b/web/src/panels/Settings.tsx
@@ -8,6 +8,9 @@ import type {
   SettingsPatch,
 } from "../api/types";
 import { prefs, themeAttr, type Density, type Theme } from "../store/prefs";
+import { PageHeader } from "../components/ui/PageHeader";
+import { Card } from "../components/ui/Card";
+import { Section } from "../components/ui/Section";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -44,12 +47,10 @@ export function Settings() {
 
   return (
     <div className="space-y-4 max-w-2xl">
-      <header>
-        <h2 className="text-xl font-semibold">Settings</h2>
-        <p className="text-sm text-muted">
-          Stored locally in your browser; nothing is sent to the daemon.
-        </p>
-      </header>
+      <PageHeader
+        title="Settings"
+        subtitle="Stored locally in your browser; nothing is sent to the daemon."
+      />
 
       <section className="panel p-4 space-y-3">
         <h3 className="panel-title">Server</h3>
@@ -174,6 +175,8 @@ interface FieldSpec {
   label: string;
   type: "string" | "number" | "bool";
   restart?: boolean;
+  /** Plain-language tooltip for the Go-struct-derived field name. */
+  help?: string;
   read: (r: RuntimeDTO) => string;
 }
 
@@ -183,6 +186,7 @@ function liveConfigFields(): FieldSpec[] {
       field: "log.level",
       label: "Log level",
       type: "string",
+      help: "Verbosity of the daemon log: debug, info, warn, or error.",
       read: (r) => r.log_level ?? "info",
     },
     {
@@ -190,24 +194,28 @@ function liveConfigFields(): FieldSpec[] {
       label: "Log format",
       type: "string",
       restart: true,
+      help: "Log output encoding: text (human) or json (machine-parseable).",
       read: (r) => r.log_format ?? "text",
     },
     {
       field: "audio.volume",
       label: "Audio volume (0..1)",
       type: "number",
+      help: "Master output gain for the live audio stream, 0 (silent) to 1 (full).",
       read: (r) => String(r.audio?.volume ?? 0.8),
     },
     {
       field: "audio.muted",
       label: "Audio muted",
       type: "bool",
+      help: "Silence the live audio stream without changing the volume level.",
       read: (r) => String(r.audio?.muted ?? false),
     },
     {
       field: "scanner.scan_mode",
       label: "Scanner scan mode (all|list)",
       type: "string",
+      help: "all = every known talkgroup; list = only talkgroups marked Scan.",
       read: (r) =>
         (r["scanner_scan_mode"] as string | undefined) ?? "all",
     },
@@ -216,6 +224,7 @@ function liveConfigFields(): FieldSpec[] {
       label: "Recordings directory",
       type: "string",
       restart: true,
+      help: "Filesystem path where call WAV recordings are written.",
       read: (r) => (r["recording_dir"] as string | undefined) ?? "",
     },
     {
@@ -223,6 +232,7 @@ function liveConfigFields(): FieldSpec[] {
       label: "Recordings sample rate (Hz)",
       type: "number",
       restart: true,
+      help: "Sample rate of saved WAV files (typically 8000 for voice).",
       read: (r) => String(r["recording_sample_rate"] ?? 8000),
     },
     {
@@ -230,6 +240,7 @@ function liveConfigFields(): FieldSpec[] {
       label: "SDR sample rate (Hz)",
       type: "number",
       restart: true,
+      help: "Front-end capture bandwidth in samples/sec (e.g. 2400000 = 2.4 MHz).",
       read: (r) => String(r["sdr_sample_rate"] ?? 2_400_000),
     },
     {
@@ -237,6 +248,7 @@ function liveConfigFields(): FieldSpec[] {
       label: "Metrics enabled",
       type: "bool",
       restart: true,
+      help: "Expose the Prometheus /metrics endpoint for monitoring.",
       read: (r) => String(r.metrics_enabled ?? false),
     },
   ];
@@ -272,25 +284,23 @@ function LiveConfigSection() {
 
   if (!runtime) {
     return (
-      <section className="panel p-4 space-y-3">
-        <h3 className="panel-title">Live config</h3>
+      <Card title="Live config">
         <p className="text-sm text-muted">Loading runtime…</p>
-      </section>
+      </Card>
     );
   }
 
   const cfgPath = (runtime["config_path"] as string | undefined) ?? "";
   if (!cfgPath) {
     return (
-      <section className="panel p-4 space-y-3">
-        <h3 className="panel-title">Live config</h3>
+      <Card title="Live config">
         <div className="text-sm panel bg-warn/15 border-warn/40 text-warn p-3">
           The daemon is running without a <code>-config</code> file, so
           <code> PATCH /api/v1/settings</code> returns 503. Restart with
           <code> -config /path/to/config.yaml</code> to enable inline
           edits.
         </div>
-      </section>
+      </Card>
     );
   }
 
@@ -318,8 +328,7 @@ function LiveConfigSection() {
   }
 
   return (
-    <section className="panel p-4 space-y-3">
-      <h3 className="panel-title">Live config</h3>
+    <Section id="settings-liveconfig" title="Live config">
       <p className="text-xs text-muted">
         Backed by <code>{cfgPath}</code>. Edits land in config.yaml with
         comments preserved; hot-reloadable knobs apply immediately,
@@ -343,7 +352,18 @@ function LiveConfigSection() {
           {fields.map((f) => (
             <tr key={f.field} className="border-t border-panel">
               <td className="py-2 pr-3 text-muted whitespace-nowrap">
-                {f.label}
+                <span className="inline-flex items-center gap-1">
+                  {f.label}
+                  {f.help && (
+                    <span
+                      className="text-muted/70 cursor-help"
+                      title={f.help}
+                      aria-label={f.help}
+                    >
+                      ⓘ
+                    </span>
+                  )}
+                </span>
                 {f.restart && (
                   <span className="ml-2 text-xs text-warn">
                     [restart]
@@ -402,7 +422,7 @@ function LiveConfigSection() {
           ))}
         </tbody>
       </table>
-    </section>
+    </Section>
   );
 }
 

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { api } from "../api/client";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
+import { PageHeader } from "../components/ui/PageHeader";
 import type {
   DMRBandPlanDTO,
   DMRBandPlanLearnedDTO,
@@ -65,7 +66,6 @@ export function Systems() {
   const setScanner = useShared((s) => s.setScanner);
   const events = useShared((s) => s.events);
   const [selected, setSelected] = useState<SystemDTO | null>(null);
-  const [filter, setFilter] = useState("");
 
   useEffect(() => {
     let cancel = false;
@@ -88,16 +88,6 @@ export function Systems() {
       window.clearInterval(t);
     };
   }, [cfg, setSystems, setScanner]);
-
-  const filtered = useMemo(() => {
-    if (!filter.trim()) return systems;
-    const needle = filter.toLowerCase();
-    return systems.filter(
-      (s) =>
-        s.name.toLowerCase().includes(needle) ||
-        s.protocol.toLowerCase().includes(needle),
-    );
-  }, [systems, filter]);
 
   const columns: Column<SystemDTO>[] = useMemo(
     () => [
@@ -156,32 +146,26 @@ export function Systems() {
 
   return (
     <div className="space-y-3">
-      <header className="flex items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold">Systems</h2>
-        <span className="text-xs text-muted">
-          {filtered.length} of {systems.length}
-        </span>
-      </header>
-
-      <input
-        type="search"
-        className="input w-full sm:max-w-xs"
-        placeholder="Filter by name or protocol…"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-        aria-label="Filter systems"
+      <PageHeader
+        title="Systems"
+        actions={
+          <span className="text-xs text-muted">{systems.length} total</span>
+        }
       />
 
       <DataTable
-        rows={filtered}
+        rows={systems}
         columns={columns}
         rowKey={(r) => r.name}
         defaultSortKey="name"
+        searchable
+        searchAccessor={(s) => `${s.name} ${s.protocol}`}
+        searchPlaceholder="Search by name or protocol…"
         onRowClick={(r) => setSelected(r)}
         emptyMessage={
           systems.length === 0
             ? "No trunked systems configured."
-            : "No systems match the filter."
+            : "No systems match the search."
         }
       />
 

--- a/web/src/panels/Talkgroups.tsx
+++ b/web/src/panels/Talkgroups.tsx
@@ -4,6 +4,8 @@ import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
+import { PageHeader } from "../components/ui/PageHeader";
+import { Badge } from "../components/ui/Badge";
 import type { TalkgroupDTO } from "../api/types";
 import { useDataPoll } from "../hooks/useDataPoll";
 import {
@@ -108,10 +110,10 @@ export function Talkgroups() {
         header: "Flags",
         render: (r) => (
           <div className="flex flex-wrap gap-1">
-            {r.scan && <span className="pill-ok">scan</span>}
-            {r.lockout && <span className="pill-err">lock</span>}
+            {r.scan && <Badge tone="ok">scan</Badge>}
+            {r.lockout && <Badge tone="err">lock</Badge>}
             {r.priority != null && r.priority > 0 && (
-              <span className="pill-warn">pri</span>
+              <Badge tone="warn">pri</Badge>
             )}
           </div>
         ),
@@ -122,15 +124,17 @@ export function Talkgroups() {
 
   return (
     <div className="space-y-3">
-      <header className="flex items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold">Talkgroups</h2>
-        <div className="flex items-center gap-2">
-          <StaleIndicator stale={stale} lastUpdated={lastUpdated} />
-          <span className="text-xs text-muted">
-            {filtered.length} of {talkgroups.length}
-          </span>
-        </div>
-      </header>
+      <PageHeader
+        title="Talkgroups"
+        actions={
+          <>
+            <StaleIndicator stale={stale} lastUpdated={lastUpdated} />
+            <span className="text-xs text-muted">
+              {filtered.length} of {talkgroups.length}
+            </span>
+          </>
+        }
+      />
 
       <input
         type="search"

--- a/web/src/panels/Talkgroups.tsx
+++ b/web/src/panels/Talkgroups.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { api } from "../api/client";
 import { writes } from "../api/write";
 import { Column, DataTable } from "../components/DataTable";
 import { DetailField, DetailModal } from "../components/DetailModal";
+import { StaleIndicator } from "../components/ui/StaleIndicator";
 import type { TalkgroupDTO } from "../api/types";
+import { useDataPoll } from "../hooks/useDataPoll";
 import {
   selectCanMutate,
   selectClientConfig,
@@ -19,11 +21,19 @@ export function Talkgroups() {
   const cfg = useShared(selectClientConfig);
   const canMutate = useShared(selectCanMutate);
   const setError = useShared((s) => s.setError);
+  const notify = useShared((s) => s.notify);
   const talkgroups = useShared((s) => s.talkgroups);
   const setTalkgroups = useShared((s) => s.setTalkgroups);
   const [selected, setSelected] = useState<TalkgroupDTO | null>(null);
   const [filter, setFilter] = useState("");
   const [busy, setBusy] = useState(false);
+
+  const { stale, lastUpdated } = useDataPoll({
+    fetcher: () => api.talkgroups(cfg),
+    onData: setTalkgroups,
+    intervalMs: POLL_INTERVAL_MS,
+    resetKey: cfg.baseURL,
+  });
 
   async function patch(id: number, body: { priority?: number; lockout?: boolean; scan?: boolean }) {
     setBusy(true);
@@ -35,6 +45,7 @@ export function Talkgroups() {
         talkgroups.map((t) => (t.id === id ? { ...t, ...updated } : t)),
       );
       setSelected((s) => (s && s.id === id ? { ...s, ...updated } : s));
+      notify("success", `Updated talkgroup ${id}`);
     } catch (e: unknown) {
       setError(
         e instanceof Error ? e.message : "talkgroup update failed",
@@ -43,24 +54,6 @@ export function Talkgroups() {
       setBusy(false);
     }
   }
-
-  useEffect(() => {
-    let cancel = false;
-    const refresh = async () => {
-      try {
-        const data = await api.talkgroups(cfg);
-        if (!cancel) setTalkgroups(data);
-      } catch {
-        // Keep the previous snapshot.
-      }
-    };
-    refresh();
-    const t = window.setInterval(refresh, POLL_INTERVAL_MS);
-    return () => {
-      cancel = true;
-      window.clearInterval(t);
-    };
-  }, [cfg, setTalkgroups]);
 
   const filtered = useMemo(() => {
     if (!filter.trim()) return talkgroups;
@@ -131,9 +124,12 @@ export function Talkgroups() {
     <div className="space-y-3">
       <header className="flex items-center justify-between gap-3">
         <h2 className="text-xl font-semibold">Talkgroups</h2>
-        <span className="text-xs text-muted">
-          {filtered.length} of {talkgroups.length}
-        </span>
+        <div className="flex items-center gap-2">
+          <StaleIndicator stale={stale} lastUpdated={lastUpdated} />
+          <span className="text-xs text-muted">
+            {filtered.length} of {talkgroups.length}
+          </span>
+        </div>
       </header>
 
       <input
@@ -187,8 +183,13 @@ export function Talkgroups() {
           </div>
           {canMutate ? (
             <div className="pt-3 border-t border-panel space-y-3">
-              <p className="text-xs uppercase tracking-wider text-muted">
+              <p className="text-xs uppercase tracking-wider text-muted flex items-center gap-2">
                 Mutations
+                {busy && (
+                  <span className="text-accent normal-case tracking-normal">
+                    saving…
+                  </span>
+                )}
               </p>
               <label className="flex items-center gap-3 text-sm">
                 <input

--- a/web/src/panels/Talkgroups.tsx
+++ b/web/src/panels/Talkgroups.tsx
@@ -27,7 +27,6 @@ export function Talkgroups() {
   const talkgroups = useShared((s) => s.talkgroups);
   const setTalkgroups = useShared((s) => s.setTalkgroups);
   const [selected, setSelected] = useState<TalkgroupDTO | null>(null);
-  const [filter, setFilter] = useState("");
   const [busy, setBusy] = useState(false);
 
   const { stale, lastUpdated } = useDataPoll({
@@ -56,21 +55,6 @@ export function Talkgroups() {
       setBusy(false);
     }
   }
-
-  const filtered = useMemo(() => {
-    if (!filter.trim()) return talkgroups;
-    const needle = filter.toLowerCase();
-    return talkgroups.filter((t) => {
-      const idStr = String(t.id);
-      return (
-        idStr.includes(needle) ||
-        (t.alpha_tag ?? "").toLowerCase().includes(needle) ||
-        (t.description ?? "").toLowerCase().includes(needle) ||
-        (t.tag ?? "").toLowerCase().includes(needle) ||
-        (t.group ?? "").toLowerCase().includes(needle)
-      );
-    });
-  }, [talkgroups, filter]);
 
   const columns: Column<TalkgroupDTO>[] = useMemo(
     () => [
@@ -130,31 +114,54 @@ export function Talkgroups() {
           <>
             <StaleIndicator stale={stale} lastUpdated={lastUpdated} />
             <span className="text-xs text-muted">
-              {filtered.length} of {talkgroups.length}
+              {talkgroups.length} total
             </span>
           </>
         }
       />
 
-      <input
-        type="search"
-        className="input w-full sm:max-w-xs"
-        placeholder="Filter by id, alpha tag, group, tag…"
-        value={filter}
-        onChange={(e) => setFilter(e.target.value)}
-        aria-label="Filter talkgroups"
-      />
-
       <DataTable
-        rows={filtered}
+        rows={talkgroups}
         columns={columns}
         rowKey={(r) => String(r.id)}
         defaultSortKey="id"
+        tableId="talkgroups"
+        searchable
+        searchAccessor={(r) =>
+          [r.id, r.alpha_tag, r.description, r.tag, r.group]
+            .filter(Boolean)
+            .join(" ")
+        }
+        searchPlaceholder="Search by id, alpha tag, group, tag…"
+        rowActions={
+          canMutate
+            ? (r) => (
+                <span className="inline-flex gap-1">
+                  <button
+                    className={r.scan ? "pill-ok" : "pill"}
+                    disabled={busy}
+                    title="Toggle scan"
+                    onClick={() => patch(r.id, { scan: !r.scan })}
+                  >
+                    scan
+                  </button>
+                  <button
+                    className={r.lockout ? "pill-err" : "pill"}
+                    disabled={busy}
+                    title="Toggle lockout"
+                    onClick={() => patch(r.id, { lockout: !r.lockout })}
+                  >
+                    lock
+                  </button>
+                </span>
+              )
+            : undefined
+        }
         onRowClick={(r) => setSelected(r)}
         emptyMessage={
           talkgroups.length === 0
             ? "No talkgroups configured."
-            : "No talkgroups match the filter."
+            : "No talkgroups match the search."
         }
       />
 

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -148,6 +148,22 @@ export const prefs = {
     writeLS(`gt.ui.section.${id}`, collapsed ? "1" : "0");
   },
 
+  /** Per-table hidden-column keys, so column-visibility choices stick.
+   *  Stored as a JSON array under a per-tableId key. */
+  tableHiddenColumns(tableId: string): string[] {
+    const raw = readLS(`gt.table.${tableId}.hidden`);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter((k) => typeof k === "string") : [];
+    } catch {
+      return [];
+    }
+  },
+  setTableHiddenColumns(tableId: string, keys: string[]) {
+    writeLS(`gt.table.${tableId}.hidden`, JSON.stringify(keys));
+  },
+
   writeMode(): boolean {
     return readLS(LS_KEYS.writeMode) === "1";
   },

--- a/web/src/store/prefs.ts
+++ b/web/src/store/prefs.ts
@@ -51,8 +51,14 @@ const SS_KEYS = {
   noConfigDismissed: "gt.ui.noConfigDismissed",
 } as const;
 
-export type Theme = "dark" | "monochrome";
+export type Theme = "dark" | "monochrome" | "light";
 export type Density = "comfortable" | "compact";
+
+// Maps a stored Theme to the `data-theme` attribute value the CSS uses
+// ("monochrome" → "mono"). Centralized so main.tsx and Settings agree.
+export function themeAttr(theme: Theme): string {
+  return theme === "monochrome" ? "mono" : theme;
+}
 
 function readLS(key: string): string | null {
   try {
@@ -129,6 +135,17 @@ export const prefs = {
   },
   setSidebarCollapsed(collapsed: boolean) {
     writeLS(LS_KEYS.sidebarCollapsed, collapsed ? "1" : "0");
+  },
+
+  /** Per-id collapsible-section state, so operators' open/closed layout
+   *  sticks across visits. `defaultCollapsed` is returned when unset. */
+  sectionCollapsed(id: string, defaultCollapsed = false): boolean {
+    const raw = readLS(`gt.ui.section.${id}`);
+    if (raw === null) return defaultCollapsed;
+    return raw === "1";
+  },
+  setSectionCollapsed(id: string, collapsed: boolean) {
+    writeLS(`gt.ui.section.${id}`, collapsed ? "1" : "0");
   },
 
   writeMode(): boolean {

--- a/web/src/store/shared.toasts.test.ts
+++ b/web/src/store/shared.toasts.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { useShared } from "./shared";
+
+describe("toast notifications", () => {
+  beforeEach(() => {
+    useShared.setState({ toasts: [], lastError: null });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("enqueues a toast and returns its id", () => {
+    const id = useShared.getState().notify("success", "saved");
+    const toasts = useShared.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toMatchObject({ id, kind: "success", message: "saved" });
+  });
+
+  it("dismisses a toast by id", () => {
+    const id = useShared.getState().notify("info", "hello");
+    useShared.getState().dismissToast(id);
+    expect(useShared.getState().toasts).toHaveLength(0);
+  });
+
+  it("auto-dismisses after the kind's TTL", () => {
+    vi.useFakeTimers();
+    useShared.getState().notify("success", "saved");
+    expect(useShared.getState().toasts).toHaveLength(1);
+    vi.advanceTimersByTime(4_000);
+    expect(useShared.getState().toasts).toHaveLength(0);
+  });
+
+  it("routes setError through an error toast and keeps lastError", () => {
+    useShared.getState().setError("boom");
+    expect(useShared.getState().lastError).toBe("boom");
+    const toasts = useShared.getState().toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].kind).toBe("error");
+    expect(toasts[0].message).toBe("boom");
+  });
+
+  it("does not enqueue a toast when setError clears the error", () => {
+    useShared.getState().setError(null);
+    expect(useShared.getState().toasts).toHaveLength(0);
+    expect(useShared.getState().lastError).toBeNull();
+  });
+
+  it("stacks multiple toasts", () => {
+    useShared.getState().notify("success", "a");
+    useShared.getState().notify("error", "b");
+    expect(useShared.getState().toasts.map((t) => t.message)).toEqual(["a", "b"]);
+  });
+});

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -22,6 +22,25 @@ import { prefs } from "./prefs";
 
 export type ConnectionStatus = "idle" | "connecting" | "open" | "closed";
 
+export type ToastKind = "success" | "error" | "info" | "warning";
+
+export interface Toast {
+  id: string;
+  kind: ToastKind;
+  message: string;
+}
+
+// Default time-to-live per kind. Errors and warnings linger longer so
+// the operator has time to read them; success/info are transient.
+const TOAST_TTL_MS: Record<ToastKind, number> = {
+  success: 4_000,
+  info: 4_000,
+  warning: 7_000,
+  error: 8_000,
+};
+
+let toastSeq = 0;
+
 interface SharedState {
   serverURL: string | null;
   token: string | null;
@@ -52,8 +71,12 @@ interface SharedState {
    *  snapshot has been fetched. Sourced from /api/v1/runtime. */
   configPath: string | null;
 
-  /** Last error surfaced from any request, for the toast strip. */
+  /** Last error surfaced from any request. Retained for compatibility;
+   *  `setError` now also enqueues an error toast. */
   lastError: string | null;
+
+  /** Transient notifications shown by the ToastViewport. */
+  toasts: Toast[];
 
   setCredentials(url: string | null, token: string | null, persist: boolean): void;
   setConnected(open: boolean): void;
@@ -72,6 +95,10 @@ interface SharedState {
   setConfigPath(path: string | null): void;
   appendEvents(evs: EventDTO[]): void;
   setError(msg: string | null): void;
+  /** Enqueue a toast. Returns the toast id (so callers can dismiss it
+   *  early if needed). Auto-dismisses after a kind-dependent TTL. */
+  notify(kind: ToastKind, message: string, ttlMs?: number): string;
+  dismissToast(id: string): void;
   reset(): void;
 }
 
@@ -98,6 +125,7 @@ export const useShared = create<SharedState>((set, get) => ({
   configPath: null,
 
   lastError: null,
+  toasts: [],
 
   setCredentials(url, token, persist) {
     prefs.setServerURL(url);
@@ -184,7 +212,23 @@ export const useShared = create<SharedState>((set, get) => ({
     set(patched ? { events: next, activeCalls } : { events: next });
   },
   setError(msg) {
+    // Retain lastError for any readers, and surface non-null errors as
+    // a toast so every existing setError(...) call site now gives the
+    // operator visible feedback.
     set({ lastError: msg });
+    if (msg) get().notify("error", msg);
+  },
+  notify(kind, message, ttlMs) {
+    const id = `t${++toastSeq}`;
+    set({ toasts: [...get().toasts, { id, kind, message }] });
+    const ttl = ttlMs ?? TOAST_TTL_MS[kind];
+    if (ttl > 0 && typeof window !== "undefined") {
+      window.setTimeout(() => get().dismissToast(id), ttl);
+    }
+    return id;
+  },
+  dismissToast(id) {
+    set({ toasts: get().toasts.filter((t) => t.id !== id) });
   },
   reset() {
     set({
@@ -203,6 +247,7 @@ export const useShared = create<SharedState>((set, get) => ({
       hiddenTabs: [],
       configPath: null,
       lastError: null,
+      toasts: [],
     });
   },
 }));

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -89,6 +89,20 @@ body {
   overscroll-behavior: none;
 }
 
+/* Respect the OS "reduce motion" setting: drop transitions/animations
+   (drawer slides, toast fades, spinner, section chevrons) to a hair so
+   motion-sensitive operators aren't jolted. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Touch targets: every interactive element should be at least 44px tall on
    coarse pointers (per Apple HIG / Material). */
 @media (pointer: coarse) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3,7 +3,8 @@
 @tailwind utilities;
 
 /* Theme tokens. Swap these via the `data-theme` attribute on <html>;
-   the Settings panel toggles between "dark" (default) and "mono". */
+   the Settings panel toggles between "dark" (default), "mono", and
+   "light". Density is a separate axis on `data-density`. */
 :root,
 [data-theme="dark"] {
   --gt-bg: 15 23 42;        /* slate-900 */
@@ -14,6 +15,12 @@
   --gt-ok: 34 197 94;       /* green-500 */
   --gt-warn: 234 179 8;     /* yellow-500 */
   --gt-err: 244 63 94;      /* rose-500 */
+  /* Surface elevation + hairline tokens so cards, sidebar, and popovers
+     read as distinct layers instead of hard-coding bg-panel/60. */
+  --gt-surface-1: 15 23 42; /* base, = bg */
+  --gt-surface-2: 30 41 59; /* raised panel, = panel */
+  --gt-surface-3: 51 65 85; /* slate-700, hover/active */
+  --gt-border: 51 65 85;    /* slate-700 hairline */
   color-scheme: dark;
 }
 
@@ -26,7 +33,36 @@
   --gt-ok: 235 235 235;
   --gt-warn: 235 235 235;
   --gt-err: 235 235 235;
+  --gt-surface-1: 17 17 17;
+  --gt-surface-2: 33 33 33;
+  --gt-surface-3: 51 51 51;
+  --gt-border: 64 64 64;
   color-scheme: dark;
+}
+
+[data-theme="light"] {
+  --gt-bg: 241 245 249;     /* slate-100 page */
+  --gt-panel: 226 232 240;  /* slate-200 — card fill + hairlines */
+  --gt-muted: 100 116 139;  /* slate-500 */
+  --gt-fg: 15 23 42;        /* slate-900 text */
+  --gt-accent: 2 132 199;   /* sky-600 — darker for contrast on light */
+  --gt-ok: 22 163 74;       /* green-600 */
+  --gt-warn: 202 138 4;     /* yellow-600 */
+  --gt-err: 220 38 38;      /* red-600 */
+  --gt-surface-1: 241 245 249; /* base */
+  --gt-surface-2: 255 255 255; /* raised card = white */
+  --gt-surface-3: 226 232 240; /* hover */
+  --gt-border: 203 213 225; /* slate-300 hairline */
+  color-scheme: light;
+}
+
+/* Density axis. Compact tightens table rows for operators monitoring
+   many calls; comfortable (default) keeps touch-friendly spacing. */
+:root {
+  --gt-row-pad-y: 0.5rem;
+}
+[data-density="compact"] {
+  --gt-row-pad-y: 0.25rem;
 }
 
 html,
@@ -65,10 +101,22 @@ body {
   }
 }
 
+/* Compact density tightens table rows. Scoped to tables so it doesn't
+   disturb form controls; the attribute+element selector outranks the
+   Tailwind py-* utility on the cells. */
+[data-density="compact"] table td,
+[data-density="compact"] table th {
+  padding-top: var(--gt-row-pad-y);
+  padding-bottom: var(--gt-row-pad-y);
+}
+
 /* Reusable utilities. */
 @layer components {
   .panel {
     @apply rounded-lg bg-panel/60 border border-panel ring-1 ring-white/5 shadow-sm;
+  }
+  .card {
+    @apply rounded-lg bg-surface2 border border-line shadow-sm;
   }
   .panel-title {
     @apply text-sm font-medium text-muted uppercase tracking-wider;

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -18,6 +18,13 @@ export default {
         ok: "rgb(var(--gt-ok) / <alpha-value>)",
         warn: "rgb(var(--gt-warn) / <alpha-value>)",
         err: "rgb(var(--gt-err) / <alpha-value>)",
+        // Surface elevation + hairline tokens (Phase 3 token refresh).
+        // In dark/mono these map onto the existing palette so nothing
+        // shifts; the light theme and new UI primitives rely on them.
+        surface: "rgb(var(--gt-surface-1) / <alpha-value>)",
+        surface2: "rgb(var(--gt-surface-2) / <alpha-value>)",
+        surface3: "rgb(var(--gt-surface-3) / <alpha-value>)",
+        line: "rgb(var(--gt-border) / <alpha-value>)",
       },
       fontFamily: {
         mono: [


### PR DESCRIPTION
## Summary

A staged overhaul of the web operator console driven by a deep review of its formatting, organization, friction points, and mobile behavior. Six independent, fully-verified phases. The headline fix: **21 of 25 panels were unreachable on a phone** (the mobile bottom nav only rendered the first 4 tabs and the desktop overflow row was `hidden sm:flex`), and **6 DSP panels were in no tab list at all** — orphaned on every device. All 31 panels are now reachable everywhere.

The stack is unchanged (React 18 + TS + Vite + Tailwind, embedded into the daemon via `//go:embed`). Everything is additive and backward-compatible during migration — the existing `@layer` utility classes and `DataTable` call sites keep working, and the issue #290 render-loop discipline (single event-stream open per connect) is preserved.

## What changed, by phase

**1 — App shell + grouped navigation** *(fixes the mobile gap)*
A single nav registry (`web/src/nav/registry.ts`) drives four surfaces: a collapsible desktop sidebar, a mobile bottom nav (4 primaries + "More"), a full mobile drawer, and a ⌘K command palette. The 31 routes are organized into six groups (Live Ops, Discovery, Signals & DSP, Decoders & Logs, Database, System). The daemon's `hidden_tabs` filter and the Config Builder external link are preserved. `TabBar` retired.

**2 — Feedback system**
A toast queue replaces the single manually-dismissed error strip; `setError` now also enqueues an error toast, so every existing call site gets visible feedback. New `useDataPoll` hook centralizes the per-panel `setInterval` pattern, adds loading/error/stale bookkeeping, and only re-renders on changed payloads (kills poll flicker). Mutations get success toasts + pending state; a "reconnecting · Ns ago" chip distinguishes stale data from a live freeze.

**3 — UI primitives + token refresh**
Extracted `Button`, `Card`, `Badge`, `Input`, `Select`, `Checkbox`, `Field` (accessible label + `aria-invalid`/`describedby`), `PageHeader`, `EmptyState`, `Skeleton`, `Section`, `ToastViewport`, `Spinner`, `StaleIndicator`. Tokens gain a **light theme**, semantic surface/border tokens (mapped onto the existing palette in dark/mono so nothing shifts), and a **density axis**; Settings exposes a 3-way theme + density toggle, applied live and pre-render.

**4 — DataTable overhaul**
Opt-in, backward-compatible: built-in search, pagination, loading skeletons, inline row actions (1-click talkgroup lockout — no modal), a persisted column-visibility menu. Talkgroups / Radio IDs / Systems drop bespoke filter state; Active / History gain search.

**5 — Dense-panel onboarding**
**Hunt rebuilt** on the primitives, removing long-standing styling debt where it referenced undefined CSS classes (`hunt-panel`, `hunt-controls`, `hint`) and rendered with browser-default controls — now a "Parse a control channel" quick-start, a collapsed "Blind sweep" advanced section, and result Cards. Scanner's three sub-panels moved to Cards; Settings' Live config is collapsible with plain-language tooltips on Go-struct field names.

**6 — Accessibility & cross-SPA polish**
Focus traps on `DetailModal`/`ConfirmModal` (Tab cycles within the dialog, focus restored on close); skip-to-content link to `<main id="main">`; `prefers-reduced-motion` (mirrored into the configbuilder + siglab SPAs); `role="img"` + label on the Metrics chart.

## Verification

Every phase was verified before pushing:
- `npm run typecheck` — clean
- `npm test` — **266 tests pass** (grew from ~233; new suites for the nav registry, app shell, toasts, `useDataPoll`, primitives, `DataTable`, and modal a11y)
- `npm run build` for all three SPAs (`web`, `configbuilder`, `siglab`)
- `go build ./web/... ./internal/api/...` — the `//go:embed` bundle still compiles into the daemon

## Notes / deferred

- **Light theme is unverified visually** — the SPA gates on a live daemon connection (ConnectScreen), so I couldn't eyeball it headless. The color choices are reasonable but worth a pass when running locally.
- **Full light-theme port of configbuilder/siglab is deferred** — they hardcode colors (`text-slate-900`, `bg-black`) that need a visual audit before theming cleanly. They did get the reduced-motion a11y rule.
- For large lists I implemented **pagination** rather than virtualization (robust + dependency-free; hand-rolled `<table>` windowing with variable row heights is fragile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UKhGXtKeLz7erywkSu93sv)_