### PR TITLE
p25: expand TSBK opcode coverage, stop tiny-file spam, fence voice-tap mix-up

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -3564,6 +3564,34 @@ func (f fanoutSink) WriteRawFrameWithErrors(serial string, frame []byte, correct
 	return nil
 }
 
+// WriteRawFrameForCall fans a raw frame plus its FEC corrected-bit count
+// AND the call's CallID out to the contained sinks. The recorder uses the
+// CallID to fence a stale frame from the call that previously held the tap
+// serial (voice-tap mix-up). fanoutSink MUST implement this: the P25 Phase 1
+// voice chain selects it via `c.sink.(callAwareRawSink)`; without it the
+// chain falls back to WriteRawFrameWithErrors and the fence is inert in the
+// daemon. Sinks that only speak the older shapes still get the frame, just
+// without the CallID guard.
+func (f fanoutSink) WriteRawFrameForCall(serial string, callID uint64, frame []byte, correctedBits int) error {
+	for _, s := range f {
+		switch rs := s.(type) {
+		case interface {
+			WriteRawFrameForCall(string, uint64, []byte, int) error
+		}:
+			_ = rs.WriteRawFrameForCall(serial, callID, frame, correctedBits)
+		case interface {
+			WriteRawFrameWithErrors(string, []byte, int) error
+		}:
+			_ = rs.WriteRawFrameWithErrors(serial, frame, correctedBits)
+		case interface {
+			WriteRawFrame(string, []byte) error
+		}:
+			_ = rs.WriteRawFrame(serial, frame)
+		}
+	}
+	return nil
+}
+
 // toneProfilesFromConfig converts the YAML config shape into the
 // internal toneout.Profile shape, parsing duration strings.
 func toneProfilesFromConfig(in []config.ToneProfileConfig) ([]toneout.Profile, error) {

--- a/docs/specs/p25-tsbk-opcodes.md
+++ b/docs/specs/p25-tsbk-opcodes.md
@@ -30,27 +30,37 @@ walk-throughs (e.g. UU_V_REQ → UU_ANS_REQ → UU_ANS_RSP call setup).
 | 0x05 | `UU_ANS_REQ` | Unit-to-Unit Answer Request | ✅ (standard MFID only) |
 | 0x06 | `UU_V_CH_GRANT_UPDT` | Unit-to-Unit Voice Channel Grant Update | — |
 | 0x08 | `TELE_INT_CH_GRANT` | Telephone Interconnect Voice Channel Grant | ✅ grant |
+| 0x09 | `TELE_INT_CH_GRANT_UPDT` | Telephone Interconnect Voice Channel Grant Update | — |
 | 0x0A | `TELE_INT_ANS_REQ` | Telephone Interconnect Answer Request | — |
 | 0x14 | `SNDCP_DAT_CH_GRANT` | SNDCP Data Channel Grant | ✅ grant |
+| 0x15 | `SNDCP_DAT_PAGE_REQ` | SNDCP Data Channel Page Request | — |
+| 0x16 | `SNDCP_DAT_CH_ANN_EXP` | SNDCP Data Channel Announcement — Explicit | — |
 | 0x18 | `STS_UPDT` | Status Update | — |
 | 0x1A | `STS_Q` | Status Query | — |
 | 0x1C | `MSG_UPDT` | Message Update | — |
 | 0x1D | `RAD_MON_CMD` | Radio Unit Monitor Command | — |
+| 0x1E | `RAD_MON_ENH_CMD` | Radio Unit Monitor Enhanced Command | — |
 | 0x1F | `CALL_ALRT` | Call Alert | — |
 | 0x20 | `ACK_RSP_FNE` | Acknowledge Response — FNE | — |
 | 0x21 | `QUE_RSP` | Queued Response | — |
 | 0x24 | `EXT_FNCT_CMD` | Extended Function Command | — |
 | 0x27 | `DENY_RSP` | Deny Response | — |
 | 0x28 | `GRP_AFF_RSP` | Group Affiliation Response | ✅ affiliation |
+| 0x29 | `SCCB_EXP` | Secondary Control Channel Broadcast — Explicit | ✅ topology |
 | 0x2A | `GRP_AFF_Q` | Group Affiliation Query | — |
 | 0x2B | `LOC_REG_RSP` | Location Registration Response | — |
 | 0x2C | `U_REG_RSP` | Unit Registration Response | ✅ registration |
 | 0x2D | `U_REG_CMD` | Unit Registration Command | — |
+| 0x2E | `AUTH_CMD` | Authentication Command | — |
 | 0x2F | `U_DE_REG_ACK` | Unit De-Registration Acknowledge | — |
+| 0x30 | `SYNC_BCST` | TDMA Synchronisation Broadcast | — |
 | 0x33 | `IDEN_UP_TDMA` | Identifier Update for TDMA | ✅ band plan |
 | 0x34 | `IDEN_UP_VU` | Identifier Update — VHF/UHF | ✅ band plan |
 | 0x35 | `PROT_PARM_UPDT` | Protection Parameter Update | — |
-| 0x39 | `SCCB_EXP` | Secondary Control Channel Broadcast — Explicit | ✅ topology |
+| 0x36 | `ROAM_ADDR_CMD` | Roaming Address Command | — |
+| 0x37 | `ROAM_ADDR_UPDT` | Roaming Address Update | — |
+| 0x38 | `SYS_SRV_BCST` | System Service Broadcast | — |
+| 0x39 | `SCCB` | Secondary Control Channel Broadcast | ✅ topology |
 | 0x3A | `RFSS_STS_BCST` | RFSS Status Broadcast | ✅ topology |
 | 0x3B | `NET_STS_BCST` | Network Status Broadcast (WACN + System ID) | ✅ topology |
 | 0x3C | `ADJ_STS_BCST` | Adjacent Site Status Broadcast (neighbours) | ✅ topology |
@@ -60,9 +70,15 @@ walk-throughs (e.g. UU_V_REQ → UU_ANS_REQ → UU_ANS_RSP call setup).
 "Dispatched" marks opcodes the control channel acts on (`dispatchTSBK` in
 [`control.go`](../../internal/radio/p25/phase1/control.go)); the rest are
 decoded enough to log at debug and otherwise ignored. The
-standard-broadcast/band-plan opcodes (`0x33/0x34/0x39/0x3A/0x3B/0x3C/0x3D`) are
-dispatched **regardless of MFID**, because they live in the standard TIA
+standard-broadcast/band-plan opcodes (`0x29/0x33/0x34/0x39/0x3A/0x3B/0x3C/0x3D`)
+are dispatched **regardless of MFID**, because they live in the standard TIA
 namespace on every vendor's control channel.
+
+Note `0x29` is the *explicit* Secondary Control Channel Broadcast (separate
+transmit/receive channels); `0x39` is the non-explicit variant. Earlier
+revisions of this decoder mislabelled `0x39` as `SCCB_EXP` — the explicit
+message is `0x29`, decoded by `ParseSecondaryControlChannelBroadcastExplicit`
+and folded into the topology via `NetworkModel.ApplySecondaryControlChannelExplicit`.
 
 ## UU_ANS_REQ (0x05) note
 

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1045,6 +1045,8 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		c.publishSiteUpdate()
 	case OpSecondaryControlChannel:
 		c.netModel.ApplySecondaryControlChannel(ParseSecondaryControlChannelBroadcast(t.Payload))
+	case OpSecondaryControlChannelExpl:
+		c.netModel.ApplySecondaryControlChannelExplicit(ParseSecondaryControlChannelBroadcastExplicit(t.Payload))
 	case OpAdjacentSiteStatusBroadcast:
 		c.netModel.ApplyAdjacentSite(ParseAdjacentSiteStatusBroadcast(t.Payload))
 	case OpGroupAffiliationResponse:
@@ -1159,7 +1161,8 @@ const (
 func isStandardBroadcastOpcode(op Opcode) bool {
 	switch op {
 	case OpIdentifierUpdate, OpIdentifierUpdateVUHF, OpIdentifierUpdateTDMA,
-		OpSecondaryControlChannel, OpRFSSStatusBroadcast,
+		OpSecondaryControlChannel, OpSecondaryControlChannelExpl,
+		OpRFSSStatusBroadcast,
 		OpNetworkStatusBroadcast, OpAdjacentSiteStatusBroadcast:
 		return true
 	default:

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -136,6 +136,15 @@ func (m *NetworkModel) ApplySecondaryControlChannel(s SecondaryControlChannelBro
 	}
 }
 
+// ApplySecondaryControlChannelExplicit folds an explicit Secondary Control
+// Channel Broadcast (0x29) in. Only the transmit (downlink) channel is the
+// one a receiver tunes to, so only it is recorded in the secondary list.
+func (m *NetworkModel) ApplySecondaryControlChannelExplicit(s SecondaryControlChannelBroadcastExplicit) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.secondary = upsertChannel(m.secondary, Channel{s.TxChannelID, s.TxChannelNumber})
+}
+
 // ApplyAdjacentSite folds an Adjacent Site Status Broadcast (0x3C) in,
 // de-duplicating by (RFSS, Site) and keeping the latest channel info.
 func (m *NetworkModel) ApplyAdjacentSite(a AdjacentSiteStatusBroadcast) {

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -39,6 +39,23 @@ func TestNetworkModelAccumulates(t *testing.T) {
 	}
 }
 
+func TestNetworkModelSecondaryControlChannelExplicit(t *testing.T) {
+	var m NetworkModel
+	// The explicit SCCB (0x29) records only its transmit (downlink)
+	// channel — the one a receiver tunes to.
+	m.ApplySecondaryControlChannelExplicit(SecondaryControlChannelBroadcastExplicit{
+		TxChannelID: 1, TxChannelNumber: 100,
+		RxChannelID: 1, RxChannelNumber: 200,
+	})
+	cfg := m.Snapshot()
+	if len(cfg.Secondary) != 1 {
+		t.Fatalf("Secondary = %v, want 1 (downlink only)", cfg.Secondary)
+	}
+	if cfg.Secondary[0] != (Channel{1, 100}) {
+		t.Errorf("Secondary[0] = %+v, want {1 100}", cfg.Secondary[0])
+	}
+}
+
 // TestControlChannelAccumulatesTopology drives status-broadcast TSBKs
 // through the control channel and checks NetworkSnapshot reflects them.
 func TestControlChannelAccumulatesTopology(t *testing.T) {
@@ -56,9 +73,14 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 		Payload: [8]byte{9, 0x01, 0x23, 4, 7}}
 	adj := TSBK{Opcode: OpAdjacentSiteStatusBroadcast,
 		Payload: AssembleAdjacentSiteStatusBroadcast(AdjacentSiteStatusBroadcast{RFSS: 4, Site: 8, ChannelID: 1, ChannelNumber: 300})}
+	// Explicit Secondary Control Channel Broadcast (0x29): its transmit
+	// (downlink) channel must surface in the topology's secondary list.
+	sccbExp := TSBK{Opcode: OpSecondaryControlChannelExpl,
+		Payload: AssembleSecondaryControlChannelBroadcastExplicit(SecondaryControlChannelBroadcastExplicit{
+			RFSS: 4, Site: 7, TxChannelID: 1, TxChannelNumber: 0x123, RxChannelID: 1, RxChannelNumber: 0x456})}
 
 	base := 0
-	for _, tsbk := range []TSBK{nsb, rfss, adj} {
+	for _, tsbk := range []TSBK{nsb, rfss, adj, sccbExp} {
 		cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk), base)
 		base += 1 << 20
 	}
@@ -69,6 +91,9 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 	}
 	if len(cfg.Neighbors) != 1 || cfg.Neighbors[0].Site != 8 {
 		t.Errorf("neighbours = %v, want one site-8 entry", cfg.Neighbors)
+	}
+	if len(cfg.Secondary) != 1 || cfg.Secondary[0] != (Channel{1, 0x123}) {
+		t.Errorf("secondary = %v, want one downlink {1 0x123} from SCCB_EXP", cfg.Secondary)
 	}
 }
 

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -23,27 +23,37 @@ const (
 	OpUnitToUnitAnswerRequest      Opcode = 0x05 // UU_ANS_REQ
 	OpUnitToUnitVoiceChannelUpdate Opcode = 0x06 // UU_V_CH_GRANT_UPDT
 	OpTelephoneInterconnectGrant   Opcode = 0x08 // TELE_INT_CH_GRANT
+	OpTelephoneInterconnectUpdate  Opcode = 0x09 // TELE_INT_CH_GRANT_UPDT
 	OpTelephoneAnswerRequest       Opcode = 0x0A // TELE_INT_ANS_REQ
 	OpSNDCPDataChannelGrant        Opcode = 0x14 // SNDCP_DAT_CH_GRANT
+	OpSNDCPDataPageRequest         Opcode = 0x15 // SNDCP_DAT_PAGE_REQ
+	OpSNDCPDataChannelAnnExplicit  Opcode = 0x16 // SNDCP_DAT_CH_ANN_EXP
 	OpStatusUpdate                 Opcode = 0x18 // STS_UPDT
 	OpStatusQuery                  Opcode = 0x1A // STS_Q
 	OpMessageUpdate                Opcode = 0x1C // MSG_UPDT
 	OpRadioUnitMonitor             Opcode = 0x1D // RAD_MON_CMD
+	OpRadioUnitMonitorEnhanced     Opcode = 0x1E // RAD_MON_ENH_CMD
 	OpCallAlert                    Opcode = 0x1F // CALL_ALRT
 	OpAcknowledgeResponse          Opcode = 0x20 // ACK_RSP_FNE
 	OpQueuedResponse               Opcode = 0x21 // QUE_RSP
 	OpExtendedFunctionCommand      Opcode = 0x24 // EXT_FNCT_CMD
 	OpDenyResponse                 Opcode = 0x27 // DENY_RSP
 	OpGroupAffiliationResponse     Opcode = 0x28 // GRP_AFF_RSP
+	OpSecondaryControlChannelExpl  Opcode = 0x29 // SCCB_EXP
 	OpGroupAffiliationQuery        Opcode = 0x2A // GRP_AFF_Q
 	OpLocationRegistrationResponse Opcode = 0x2B // LOC_REG_RSP
 	OpUnitRegistrationResponse     Opcode = 0x2C // U_REG_RSP
 	OpUnitRegistrationCommand      Opcode = 0x2D // U_REG_CMD
+	OpAuthenticationCommand        Opcode = 0x2E // AUTH_CMD
 	OpDeregistrationAck            Opcode = 0x2F // U_DE_REG_ACK
+	OpSyncBroadcast                Opcode = 0x30 // SYNC_BCST
 	OpIdentifierUpdateTDMA         Opcode = 0x33 // IDEN_UP_TDMA
 	OpIdentifierUpdateVUHF         Opcode = 0x34 // IDEN_UP_VU
 	OpProtectionParamUpdate        Opcode = 0x35 // PROT_PARM_UPDT
-	OpSecondaryControlChannel      Opcode = 0x39 // SCCB_EXP
+	OpRoamingAddressCommand        Opcode = 0x36 // ROAM_ADDR_CMD
+	OpRoamingAddressUpdate         Opcode = 0x37 // ROAM_ADDR_UPDT
+	OpSystemServiceBroadcast       Opcode = 0x38 // SYS_SRV_BCST
+	OpSecondaryControlChannel      Opcode = 0x39 // SCCB
 	OpRFSSStatusBroadcast          Opcode = 0x3A // RFSS_STS_BCST
 	OpNetworkStatusBroadcast       Opcode = 0x3B // NET_STS_BCST
 	OpAdjacentSiteStatusBroadcast  Opcode = 0x3C // ADJ_STS_BCST
@@ -71,10 +81,16 @@ func (o Opcode) String() string {
 		return "UU_V_CH_GRANT_UPDT"
 	case OpTelephoneInterconnectGrant:
 		return "TELE_INT_CH_GRANT"
+	case OpTelephoneInterconnectUpdate:
+		return "TELE_INT_CH_GRANT_UPDT"
 	case OpTelephoneAnswerRequest:
 		return "TELE_INT_ANS_REQ"
 	case OpSNDCPDataChannelGrant:
 		return "SNDCP_DAT_CH_GRANT"
+	case OpSNDCPDataPageRequest:
+		return "SNDCP_DAT_PAGE_REQ"
+	case OpSNDCPDataChannelAnnExplicit:
+		return "SNDCP_DAT_CH_ANN_EXP"
 	case OpStatusUpdate:
 		return "STS_UPDT"
 	case OpStatusQuery:
@@ -83,6 +99,8 @@ func (o Opcode) String() string {
 		return "MSG_UPDT"
 	case OpRadioUnitMonitor:
 		return "RAD_MON_CMD"
+	case OpRadioUnitMonitorEnhanced:
+		return "RAD_MON_ENH_CMD"
 	case OpCallAlert:
 		return "CALL_ALRT"
 	case OpAcknowledgeResponse:
@@ -95,6 +113,8 @@ func (o Opcode) String() string {
 		return "DENY_RSP"
 	case OpGroupAffiliationResponse:
 		return "GRP_AFF_RSP"
+	case OpSecondaryControlChannelExpl:
+		return "SCCB_EXP"
 	case OpGroupAffiliationQuery:
 		return "GRP_AFF_Q"
 	case OpLocationRegistrationResponse:
@@ -103,16 +123,26 @@ func (o Opcode) String() string {
 		return "U_REG_RSP"
 	case OpUnitRegistrationCommand:
 		return "U_REG_CMD"
+	case OpAuthenticationCommand:
+		return "AUTH_CMD"
 	case OpDeregistrationAck:
 		return "U_DE_REG_ACK"
+	case OpSyncBroadcast:
+		return "SYNC_BCST"
 	case OpIdentifierUpdateTDMA:
 		return "IDEN_UP_TDMA"
 	case OpIdentifierUpdateVUHF:
 		return "IDEN_UP_VU"
 	case OpProtectionParamUpdate:
 		return "PROT_PARM_UPDT"
+	case OpRoamingAddressCommand:
+		return "ROAM_ADDR_CMD"
+	case OpRoamingAddressUpdate:
+		return "ROAM_ADDR_UPDT"
+	case OpSystemServiceBroadcast:
+		return "SYS_SRV_BCST"
 	case OpSecondaryControlChannel:
-		return "SCCB_EXP"
+		return "SCCB"
 	case OpRFSSStatusBroadcast:
 		return "RFSS_STS_BCST"
 	case OpNetworkStatusBroadcast:
@@ -482,6 +512,55 @@ func AssembleSecondaryControlChannelBroadcast(s SecondaryControlChannelBroadcast
 	p[0], p[1] = s.RFSS, s.Site
 	binary.BigEndian.PutUint16(p[2:4], uint16(s.ChannelAID&0x0F)<<12|s.ChannelANumber&0x0FFF)
 	binary.BigEndian.PutUint16(p[4:6], uint16(s.ChannelBID&0x0F)<<12|s.ChannelBNumber&0x0FFF)
+	return p
+}
+
+// SecondaryControlChannelBroadcastExplicit (opcode 0x29) announces an
+// alternate control channel for the site with explicit, separate transmit
+// (downlink) and receive (uplink) channels — unlike the non-explicit SCCB
+// (0x39) which carries two same-direction channels. Payload layout per
+// TIA-102.AABC / SDRTrunk's SecondaryControlChannelBroadcastExplicit:
+//
+//	byte 0    : RFSS ID
+//	byte 1    : Site ID
+//	bytes 2-3 : transmit (downlink) channel (4-bit ID + 12-bit number)
+//	byte 4    : reserved
+//	bytes 5-6 : receive (uplink) channel (4-bit ID + 12-bit number)
+//	byte 7    : system service class
+//
+// The transmit channel is the downlink a receiver tunes to, so that is the
+// one folded into the topology's secondary-control-channel list.
+type SecondaryControlChannelBroadcastExplicit struct {
+	RFSS, Site      uint8
+	TxChannelID     uint8
+	TxChannelNumber uint16
+	RxChannelID     uint8
+	RxChannelNumber uint16
+	ServiceClass    uint8
+}
+
+// ParseSecondaryControlChannelBroadcastExplicit decodes payload for opcode 0x29.
+func ParseSecondaryControlChannelBroadcastExplicit(p [8]byte) SecondaryControlChannelBroadcastExplicit {
+	tx := binary.BigEndian.Uint16(p[2:4])
+	rx := binary.BigEndian.Uint16(p[5:7])
+	return SecondaryControlChannelBroadcastExplicit{
+		RFSS:            p[0],
+		Site:            p[1],
+		TxChannelID:     uint8(tx >> 12),
+		TxChannelNumber: tx & 0x0FFF,
+		RxChannelID:     uint8(rx >> 12),
+		RxChannelNumber: rx & 0x0FFF,
+		ServiceClass:    p[7],
+	}
+}
+
+// AssembleSecondaryControlChannelBroadcastExplicit is the inverse; for tests.
+func AssembleSecondaryControlChannelBroadcastExplicit(s SecondaryControlChannelBroadcastExplicit) [8]byte {
+	var p [8]byte
+	p[0], p[1] = s.RFSS, s.Site
+	binary.BigEndian.PutUint16(p[2:4], uint16(s.TxChannelID&0x0F)<<12|s.TxChannelNumber&0x0FFF)
+	binary.BigEndian.PutUint16(p[5:7], uint16(s.RxChannelID&0x0F)<<12|s.RxChannelNumber&0x0FFF)
+	p[7] = s.ServiceClass
 	return p
 }
 

--- a/internal/radio/p25/phase1/tsbk_test.go
+++ b/internal/radio/p25/phase1/tsbk_test.go
@@ -234,11 +234,39 @@ func TestOpcodeString(t *testing.T) {
 		OpUnitToUnitAnswerRequest: "UU_ANS_REQ",
 		OpRFSSStatusBroadcast:     "RFSS_STS_BCST",
 		OpNetworkStatusBroadcast:  "NET_STS_BCST",
+		// Newly-named standard OSPs that previously fell through to
+		// OSP(0xNN). 0x16 / 0x29 are the two the field log showed as
+		// "unhandled tsbk payload".
+		OpSNDCPDataChannelAnnExplicit: "SNDCP_DAT_CH_ANN_EXP",
+		OpSecondaryControlChannelExpl: "SCCB_EXP",
+		OpTelephoneInterconnectUpdate: "TELE_INT_CH_GRANT_UPDT",
+		OpAuthenticationCommand:       "AUTH_CMD",
+		OpSyncBroadcast:               "SYNC_BCST",
+		OpSystemServiceBroadcast:      "SYS_SRV_BCST",
+		// 0x39 was mislabelled SCCB_EXP; it is the non-explicit SCCB
+		// (the explicit variant is 0x29 above).
+		OpSecondaryControlChannel: "SCCB",
 		Opcode(0x42):              "OSP(0x42)",
 	}
 	for op, want := range cases {
 		if got := op.String(); got != want {
 			t.Errorf("Opcode(%02X).String() = %s, want %s", uint8(op), got, want)
 		}
+	}
+}
+
+func TestSecondaryControlChannelBroadcastExplicitRoundTrip(t *testing.T) {
+	in := SecondaryControlChannelBroadcastExplicit{
+		RFSS:            4,
+		Site:            0x2E,
+		TxChannelID:     0xF,
+		TxChannelNumber: 0x065,
+		RxChannelID:     0xE,
+		RxChannelNumber: 0x123,
+		ServiceClass:    0x70,
+	}
+	got := ParseSecondaryControlChannelBroadcastExplicit(AssembleSecondaryControlChannelBroadcastExplicit(in))
+	if got != in {
+		t.Errorf("explicit SCCB round-trip = %+v, want %+v", got, in)
 	}
 }

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -572,8 +572,11 @@ func (e *Engine) startCall(d *VoiceDevice, g Grant, tg *TalkGroup) {
 	e.mu.Unlock()
 	e.bus.Publish(events.Event{
 		Kind: events.KindCallStart,
+		// Publish ac.Grant, not the caller's g: Bind stamped it with a
+		// fresh CallID the voice chain + recorder use to fence cross-call
+		// audio bleed on a reused tap serial.
 		Payload: CallStart{
-			Grant:        g,
+			Grant:        ac.Grant,
 			Talkgroup:    tg,
 			DeviceSerial: d.Serial,
 			StartedAt:    ac.StartedAt,

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -93,6 +93,17 @@ type Grant struct {
 	// channel when publishing the grant; zero on non-Phase-2 grants.
 	P25Phase2Decode P25Phase2Decode
 	At              time.Time
+	// CallID is a process-monotonic identifier the voice pool assigns when
+	// it binds a device to this grant (VoicePool.Bind); a real handoff
+	// (VoicePool.Retune) preserves it so a followed call keeps one identity.
+	// It lets the downstream voice chain tag each decoded frame with the
+	// call it belongs to and the recorder reject a frame whose CallID
+	// doesn't match the open session — closing the cross-call audio-bleed
+	// window when a voice-tap serial is immediately reused for the next
+	// call. Zero on grants that never went through the voice pool (synthetic
+	// / conventional follows); a zero-vs-zero match is a no-op, preserving
+	// prior behaviour.
+	CallID uint64
 }
 
 // P25Phase2Decode is the protocol-neutral mirror of

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -3,6 +3,7 @@ package trunking
 import (
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -27,6 +28,12 @@ type VoicePool struct {
 	// Bind retries SetCenterFreq once. Wired in by the daemon via
 	// SetReacquire; nil = no retry, current behaviour. See issue #345.
 	reacquire ReacquireFunc
+	// callSeq is a process-monotonic counter that assigns each bound call a
+	// unique Grant.CallID, used by the voice chain + recorder to fence
+	// cross-call audio bleed when a tap serial is reused. Starts at 0; the
+	// first Bind hands out CallID 1, so a real CallID is always non-zero and
+	// distinguishable from an un-bound (synthetic) grant's zero.
+	callSeq atomic.Uint64
 }
 
 // ReacquireFunc asks the SDR pool to re-open the device with the
@@ -219,6 +226,10 @@ func (p *VoicePool) Bind(d *VoiceDevice, g Grant, tg *TalkGroup, now time.Time) 
 			return nil, err2
 		}
 	}
+	// Stamp a fresh, process-unique CallID so the voice chain can tag this
+	// call's decoded frames and the recorder can reject a stale frame from
+	// the call that previously held this serial.
+	g.CallID = p.callSeq.Add(1)
 	ac := &ActiveCall{
 		Device:      d,
 		Grant:       g,
@@ -270,6 +281,10 @@ func (p *VoicePool) Retune(serial string, g Grant, now time.Time) error {
 		}
 	}
 	p.mu.Lock()
+	// A handoff continues the same call, so preserve its CallID across the
+	// grant replacement (the new grant from the control channel carries no
+	// CallID of its own).
+	g.CallID = ac.Grant.CallID
 	ac.Grant = g
 	ac.LastHeardAt = now
 	p.mu.Unlock()

--- a/internal/trunking/voicepool_test.go
+++ b/internal/trunking/voicepool_test.go
@@ -91,6 +91,35 @@ func TestPoolBindRetunesDevice(t *testing.T) {
 	}
 }
 
+func TestPoolBindAssignsUniqueCallIDRetunePreserves(t *testing.T) {
+	p, _ := mkPool(2)
+	a := p.Devices()[0]
+	b := p.Devices()[1]
+	ac1, err := p.Bind(a, Grant{FrequencyHz: 1}, nil, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ac2, err := p.Bind(b, Grant{FrequencyHz: 2}, nil, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ac1.Grant.CallID == 0 || ac2.Grant.CallID == 0 {
+		t.Fatalf("Bind must assign a non-zero CallID: %d, %d", ac1.Grant.CallID, ac2.Grant.CallID)
+	}
+	if ac1.Grant.CallID == ac2.Grant.CallID {
+		t.Errorf("two binds shared CallID %d; must be unique", ac1.Grant.CallID)
+	}
+	// A handoff (Retune) continues the same call: the new grant carries no
+	// CallID, but the call's identity must be preserved.
+	want := ac1.Grant.CallID
+	if err := p.Retune(a.Serial, Grant{FrequencyHz: 3}, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if ac1.Grant.CallID != want {
+		t.Errorf("Retune changed CallID to %d, want preserved %d", ac1.Grant.CallID, want)
+	}
+}
+
 func TestPoolReleaseReturnsActiveCall(t *testing.T) {
 	p, _ := mkPool(1)
 	d := p.FindFree()

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -485,7 +485,7 @@ func (c *Composer) handleStart(parent context.Context, cs trunking.CallStart) {
 		}
 		go c.runP25Phase2VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, macCfg, iqCh, rateHzF, ch.done)
 	case isP25P1Voice:
-		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.P25Phase1DemodMode, cs.Grant.GroupID, cs.Grant.PatchedGroups, ch.done)
+		go c.runP25Phase1VoiceChain(chainCtx, cs.DeviceSerial, cs.Grant.System, iqCh, rateHzF, cs.Grant.P25Phase1DemodMode, cs.Grant.GroupID, cs.Grant.CallID, cs.Grant.PatchedGroups, ch.done)
 	default:
 		// Analog FM has no symbol clock to drift, so the rounded integer
 		// rate is fine; keep its uint32 signature unchanged.

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -35,6 +35,16 @@ type errAwareRawSink interface {
 	WriteRawFrameWithErrors(deviceSerial string, frame []byte, correctedBits int) error
 }
 
+// callAwareRawSink is the richest sink: it carries the per-frame FEC
+// corrected-bit count AND the call identity (Grant.CallID) the frame was
+// decoded for, so the recorder can reject a stale frame from the call that
+// previously held this tap serial (the voice-tap mix-up fence). The recorder
+// implements it; a chain that finds the sink supports it routes frames here
+// in preference to errAwareRawSink, falling back when it doesn't.
+type callAwareRawSink interface {
+	WriteRawFrameForCall(deviceSerial string, callID uint64, frame []byte, correctedBits int) error
+}
+
 // runDMRVoiceChain consumes IQ for one DMR voice call. It decimates
 // the wideband IQ to a DMR-symbol-friendly rate, recovers the dibit
 // stream with the shared DMR receiver, assembles A–F voice

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -58,7 +58,7 @@ func (c *Composer) resolveP25Phase1DemodMode(serial, mode string) p25p1rx.DemodM
 // The recorder maps protocol "p25" to the pure-Go IMBE vocoder
 // (voice.DefaultVocoderForProtocol), so WriteRawFrame here decodes each
 // 11-byte frame to PCM and into the call's WAV.
-func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system string, iqCh <-chan []complex64, iqHz float64, demodMode string, grantTG uint32, patched []uint32, done chan<- struct{}) {
+func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system string, iqCh <-chan []complex64, iqHz float64, demodMode string, grantTG uint32, callID uint64, patched []uint32, done chan<- struct{}) {
 	defer close(done)
 	defer gtlog.Recover(c.log, "voice-chain-p25p1:"+serial, nil)
 
@@ -121,6 +121,10 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	// ers, when the sink supports it, carries the per-frame FEC corrected-bit
 	// count to the IMBE decoder's adaptive smoothing (P25 Phase 1 only).
 	ers, _ := c.sink.(errAwareRawSink)
+	// cas, when the sink supports it, additionally carries this call's
+	// CallID so the recorder fences stale frames from a previous call on a
+	// reused tap serial (voice-tap mix-up). Preferred over ers when present.
+	cas, _ := c.sink.(callAwareRawSink)
 	// lastES is the last Encryption Sync this chain published on the
 	// bus. The voice frame stream carries one ES per LDU2 (every ~180
 	// ms), but ALGID/KID rarely change inside a single call — gate the
@@ -278,12 +282,17 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 					}
 					// Hand the per-frame corrected-bit count to the IMBE
 					// decoder (via the recorder) so its adaptive smoothing can
-					// track the channel error rate; fall back to the plain
-					// write for sinks that don't support it.
+					// track the channel error rate; the call-aware path also
+					// fences stale frames on a reused serial. Fall back through
+					// errAwareRawSink then the plain write for sinks that don't
+					// support the richer shapes.
 					var werr error
-					if ers != nil {
+					switch {
+					case cas != nil:
+						werr = cas.WriteRawFrameForCall(serial, callID, f, frameErrs[i])
+					case ers != nil:
 						werr = ers.WriteRawFrameWithErrors(serial, f, frameErrs[i])
-					} else {
+					default:
 						werr = rs.WriteRawFrame(serial, f)
 					}
 					if werr != nil {

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -1,6 +1,7 @@
 package imbe
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math"
 	"math/rand"
@@ -195,6 +196,14 @@ type callStats struct {
 	bad       int
 	repeated  int
 
+	// b_0 range + first-frame capture for the all-idle diagnostic. b0Seen
+	// guards the first-write of min/max; firstFrameHex holds the first
+	// frame's raw bytes as hex.
+	b0Seen        bool
+	b0Min         int
+	b0Max         int
+	firstFrameHex string
+
 	goodFrames    int
 	f0Sum         float64
 	f0Min         float64
@@ -283,6 +292,23 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	out := make([]int16, mbe.SamplesPerFrame)
 	pcm := make([]float64, mbe.SamplesPerFrame)
 	d.stats.frames++
+
+	// Track the raw b_0 range + capture the first frame for the all-idle
+	// diagnostic (see callStats / VoiceStats). Done for every frame,
+	// before the disposition switch, so even bad/idle frames are counted.
+	b0 := int(b0FromInfo(info))
+	if !d.stats.b0Seen {
+		d.stats.b0Seen = true
+		d.stats.b0Min, d.stats.b0Max = b0, b0
+		d.stats.firstFrameHex = hex.EncodeToString(frame)
+	} else {
+		if b0 < d.stats.b0Min {
+			d.stats.b0Min = b0
+		}
+		if b0 > d.stats.b0Max {
+			d.stats.b0Max = b0
+		}
+	}
 
 	// Consume the corrected-bit count set by SetFrameErrors (0 if the caller
 	// doesn't supply one) and advance the adaptive-smoothing error-rate
@@ -619,9 +645,16 @@ func (d *Decoder) VoiceStats() (voice.VoiceStats, bool) {
 		IdleMuted:      s.idleMuted,
 		Bad:            s.bad,
 		Repeated:       s.repeated,
+		MinB0:          -1,
+		MaxB0:          -1,
+		FirstFrameHex:  s.firstFrameHex,
 		MaxPreClipPeak: s.maxPreClipPeak,
 		ClipSamples:    s.clipSamples,
 		TotalSamples:   s.sampleCount,
+	}
+	if s.b0Seen {
+		vs.MinB0 = s.b0Min
+		vs.MaxB0 = s.b0Max
 	}
 	if s.goodFrames > 0 {
 		g := float64(s.goodFrames)

--- a/internal/voice/imbe/params.go
+++ b/internal/voice/imbe/params.go
@@ -108,6 +108,21 @@ var ErrInvalidFundamental = errors.New("imbe: invalid fundamental-frequency para
 // first value that escapes it. See Header.IdleTone.
 const IdleToneMaxB0 = 7
 
+// b0FromInfo reads the fundamental-frequency parameter b_0 from its
+// scattered positions {0..5, 85, 86} in the 88-bit info buffer (6
+// contiguous high bits + 2 trailing bits, packed MSB-first). The caller
+// must pass a buffer of at least InfoBits bytes (one bit per byte).
+func b0FromInfo(info []byte) uint {
+	return uint(info[0])<<7 |
+		uint(info[1])<<6 |
+		uint(info[2])<<5 |
+		uint(info[3])<<4 |
+		uint(info[4])<<3 |
+		uint(info[5])<<2 |
+		uint(info[85])<<1 |
+		uint(info[86])
+}
+
 // UnpackHeader reads b_0 from its scattered positions in the 88-bit
 // info buffer and derives ω₀ + L + K per TIA-102.BABA §5.3.
 // Returns ErrInvalidFundamental for unusable b_0 values; returns
@@ -118,16 +133,7 @@ func UnpackHeader(info []byte) (Header, error) {
 	if len(info) != InfoBits {
 		return Header{}, fmt.Errorf("%w, got %d", ErrInfoLength, len(info))
 	}
-	// b_0 spans positions {0..5, 85, 86} — 6 contiguous high bits +
-	// 2 trailing bits. Pack MSB-first.
-	b0 := uint(info[0])<<7 |
-		uint(info[1])<<6 |
-		uint(info[2])<<5 |
-		uint(info[3])<<4 |
-		uint(info[4])<<3 |
-		uint(info[5])<<2 |
-		uint(info[85])<<1 |
-		uint(info[86])
+	b0 := b0FromInfo(info)
 	if b0 > 207 {
 		if b0 >= 216 && b0 <= 219 {
 			return Header{Silent: true}, nil

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -322,7 +322,7 @@ func (r *Recorder) Run(ctx context.Context) error {
 // session is open for that device the samples are dropped (the demod
 // pipeline can race ahead of the CallStart event).
 func (r *Recorder) WritePCM(deviceSerial string, samples []int16) error {
-	s := r.sessionForWrite(deviceSerial)
+	s := r.sessionForWrite(deviceSerial, 0)
 	if s == nil {
 		return nil
 	}
@@ -333,11 +333,21 @@ func (r *Recorder) WritePCM(deviceSerial string, samples []int16) error {
 // the next per-transmission segment file when the session is dormant
 // (parked after a KindCallSegment roll). Returns nil when no session is
 // open for the device.
-func (r *Recorder) sessionForWrite(serial string) *recordingSession {
+//
+// callID fences a stale frame from the call that previously held this
+// serial: when it is non-zero and the open session's CallID is non-zero
+// and they differ, the frame is rejected (returns nil) WITHOUT reopening
+// a dormant session, so a mismatched frame can't even spawn an empty
+// file. A zero on either side matches (un-stamped / synthetic calls),
+// preserving prior behaviour for callers that pass 0.
+func (r *Recorder) sessionForWrite(serial string, callID uint64) *recordingSession {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	s, ok := r.sessions[serial]
 	if !ok {
+		return nil
+	}
+	if callID != 0 && s.callID != 0 && callID != s.callID {
 		return nil
 	}
 	if s.wav == nil {
@@ -366,7 +376,17 @@ func (r *Recorder) sessionForWrite(serial string) *recordingSession {
 // Frames for a session without either output (no sidecar, no
 // vocoder) are dropped silently.
 func (r *Recorder) WriteRawFrame(deviceSerial string, frame []byte) error {
-	return r.writeRawFrame(deviceSerial, frame, 0, false)
+	return r.writeRawFrame(deviceSerial, 0, frame, 0, false)
+}
+
+// WriteRawFrameForCall is WriteRawFrameWithErrors plus the call identity
+// (Grant.CallID) the frame was decoded for. A frame whose callID doesn't
+// match the open session is dropped, fencing the cross-call audio-bleed
+// window when a voice-tap serial is reused for the next call before the
+// previous chain has fully drained. Digital voice chains that know their
+// call's CallID call this in preference to WriteRawFrameWithErrors.
+func (r *Recorder) WriteRawFrameForCall(deviceSerial string, callID uint64, frame []byte, correctedBits int) error {
+	return r.writeRawFrame(deviceSerial, callID, frame, correctedBits, true)
 }
 
 // WriteRawFrameWithErrors is WriteRawFrame plus the channel FEC
@@ -375,11 +395,11 @@ func (r *Recorder) WriteRawFrame(deviceSerial string, frame []byte) error {
 // before Decode so adaptive smoothing can estimate the channel error rate.
 // Callers without an error count use WriteRawFrame.
 func (r *Recorder) WriteRawFrameWithErrors(deviceSerial string, frame []byte, correctedBits int) error {
-	return r.writeRawFrame(deviceSerial, frame, correctedBits, true)
+	return r.writeRawFrame(deviceSerial, 0, frame, correctedBits, true)
 }
 
-func (r *Recorder) writeRawFrame(deviceSerial string, frame []byte, correctedBits int, haveErrs bool) error {
-	s := r.sessionForWrite(deviceSerial)
+func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byte, correctedBits int, haveErrs bool) error {
+	s := r.sessionForWrite(deviceSerial, callID)
 	if s == nil {
 		return nil
 	}
@@ -519,7 +539,7 @@ func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *rec
 	nameCS := cs
 	nameCS.StartedAt = startedAt
 	base := r.basenameFor(nameCS)
-	s := &recordingSession{startedAt: startedAt, cs: cs}
+	s := &recordingSession{startedAt: startedAt, cs: cs, callID: cs.Grant.CallID}
 	// Instantiate a vocoder for the protocol if one is mapped. This must
 	// happen before the WAV is opened so the header rate can track the
 	// vocoder's native output rate (below). Construction failure (unknown
@@ -593,7 +613,7 @@ func (r *Recorder) handleSegment(seg trunking.CallSegment) {
 	// Park a dormant session: keeps the call's identity so the next write
 	// opens the next segment file, without creating an empty trailing
 	// file if no further audio arrives before the call ends.
-	r.sessions[seg.DeviceSerial] = &recordingSession{cs: s.cs}
+	r.sessions[seg.DeviceSerial] = &recordingSession{cs: s.cs, callID: s.callID}
 	r.mu.Unlock()
 	if cc != nil {
 		r.normalizeIfEnabled(cc.AudioPath)
@@ -620,9 +640,21 @@ func (r *Recorder) normalizeIfEnabled(wavPath string) {
 // nil returned. Caller holds r.mu and publishes after releasing it.
 func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt time.Time, reason trunking.EndReason) *trunking.CallComplete {
 	dataBytes := s.wav.DataBytes()
+	vs, haveStats := r.voiceStatsFor(s)
 	r.logVoiceStats(serial, s)
 	if err := s.close(); err != nil {
 		r.log.Error("recorder: close session", "err", err)
+	}
+	// A vocoder-decoded call that produced no real speech (every frame was
+	// idle/silent/bad — voiced+unvoiced == 0) is a dead-key/idle carrier:
+	// the WAV holds only muted silence, so it's worthless and, in
+	// per-transmission mode, the dominant source of tiny-file spam. Remove
+	// both outputs and publish no CallComplete. Scoped to StatProvider
+	// vocoders (the pure-Go IMBE decoder) — analog and ProVoice/DMR can't be
+	// classified here and keep the dataBytes behaviour below.
+	if haveStats && vs.Voiced+vs.Unvoiced == 0 {
+		r.removeSessionFiles(s)
+		return nil
 	}
 	// No PCM decoded into the WAV — nothing to stream. The files are left
 	// in place: a digital call (ProVoice / DMR / pre-vocoder) keeps its
@@ -644,6 +676,21 @@ func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt ti
 	}
 }
 
+// removeSessionFiles deletes a session's WAV and .raw sidecar from disk.
+// Used to discard a recording that captured no useful audio (a dead-key /
+// idle-only call) so it doesn't spam the recordings tree. The session must
+// already be closed. Mirrors the removal in handleEncryptionUpdate.
+func (r *Recorder) removeSessionFiles(s *recordingSession) {
+	for _, p := range []string{s.wavPath, s.rawPath} {
+		if p == "" {
+			continue
+		}
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			r.log.Warn("recorder: removing empty recording", "path", p, "err", err)
+		}
+	}
+}
+
 // voiceClipWarnPct is the output-clipping rate above which the per-call
 // voice summary escalates to WARN: a non-trivial fraction of samples
 // hitting the limiter means the vocoder gain is too hot (the signature of
@@ -658,12 +705,8 @@ const voiceClipWarnPct = 0.5
 // output is clipping. A vocoder that doesn't implement StatProvider, or a
 // call with no frames, produces nothing.
 func (r *Recorder) logVoiceStats(serial string, s *recordingSession) {
-	sp, ok := s.vocoder.(StatProvider)
+	vs, ok := r.voiceStatsFor(s)
 	if !ok {
-		return
-	}
-	vs, have := sp.VoiceStats()
-	if !have || vs.Frames == 0 {
 		return
 	}
 	args := []any{
@@ -682,11 +725,40 @@ func (r *Recorder) logVoiceStats(serial string, s *recordingSession) {
 		"crest", round2(vs.CrestFactor),
 		"clip_pct", round2(vs.ClipPct()),
 	}
+	// No decodable speech: every frame was idle/silent/bad (the call
+	// produced no voiced OR unvoiced audio). Escalate to WARN with the b_0
+	// range + first raw frame so an operator can tell a genuine dead-key
+	// (b_0 varying within the idle corner [0,7]) from empty/zero frames
+	// reaching the vocoder — a mistuned tap or extraction bug (b_0 pinned
+	// at 0). The recording itself is suppressed by finalizeLocked.
+	if vs.Voiced+vs.Unvoiced == 0 {
+		r.log.Warn("recorder: no decodable speech — likely dead-key/idle carrier or mistuned tap",
+			append(args,
+				"min_b0", vs.MinB0, "max_b0", vs.MaxB0,
+				"first_frame_hex", vs.FirstFrameHex)...)
+		return
+	}
 	if vs.ClipPct() > voiceClipWarnPct {
 		r.log.Warn("recorder: voice audio quality — output clipping (vocoder gain too hot)", args...)
 		return
 	}
 	r.log.Debug("recorder: voice audio quality", args...)
+}
+
+// voiceStatsFor returns the session vocoder's per-call VoiceStats when the
+// vocoder implements StatProvider and has decoded at least one frame. It is
+// the shared accessor for the per-call quality log and the empty-recording
+// suppression in finalizeLocked.
+func (r *Recorder) voiceStatsFor(s *recordingSession) (VoiceStats, bool) {
+	sp, ok := s.vocoder.(StatProvider)
+	if !ok {
+		return VoiceStats{}, false
+	}
+	vs, have := sp.VoiceStats()
+	if !have || vs.Frames == 0 {
+		return VoiceStats{}, false
+	}
+	return vs, true
 }
 
 func round1(v float64) float64 { return math.Round(v*10) / 10 }
@@ -790,6 +862,12 @@ type recordingSession struct {
 	vocoderName string
 	sampleRate  uint32
 	startedAt   time.Time
+	// callID is the Grant.CallID of the call this session records. Frames
+	// arriving via WriteRawFrameForCall with a different non-zero callID are
+	// dropped (see sessionForWrite) so a reused tap serial can't bleed the
+	// previous call's audio into this one. Preserved across per-transmission
+	// segment rolls (the dormant session carries the same cs).
+	callID uint64
 	// cs is the originating CallStart, retained so a per-transmission
 	// segment roll (KindCallSegment) can open the next file with the same
 	// grant/talkgroup under a new timestamp. A session with wav == nil is

--- a/internal/voice/recorder_idle_test.go
+++ b/internal/voice/recorder_idle_test.go
@@ -1,0 +1,199 @@
+package voice
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// statStubVocoder is a Vocoder + StatProvider test double. Decode returns
+// silence and counts calls; VoiceStats reports a configurable frame
+// classification so tests can drive the recorder's empty-recording
+// suppression (all idle/silent ⇒ Voiced+Unvoiced == 0).
+type statStubVocoder struct {
+	mu             sync.Mutex
+	decodes        int
+	voicedPerFrame bool // when true, each decoded frame counts as voiced
+}
+
+func (v *statStubVocoder) Name() string   { return "stat-stub" }
+func (v *statStubVocoder) FrameSize() int { return 11 }
+func (v *statStubVocoder) Reset()         {}
+func (v *statStubVocoder) Close() error   { return nil }
+func (v *statStubVocoder) ResetStats()    {}
+
+func (v *statStubVocoder) Decode(frame []byte) ([]int16, error) {
+	v.mu.Lock()
+	v.decodes++
+	v.mu.Unlock()
+	return make([]int16, 160), nil
+}
+
+func (v *statStubVocoder) decodeCount() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.decodes
+}
+
+func (v *statStubVocoder) VoiceStats() (VoiceStats, bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	if v.decodes == 0 {
+		return VoiceStats{}, false
+	}
+	vs := VoiceStats{Frames: v.decodes, MinB0: -1, MaxB0: -1}
+	if v.voicedPerFrame {
+		vs.Voiced = v.decodes
+	} else {
+		// All frames idle-muted: no real speech.
+		vs.IdleMuted = v.decodes
+	}
+	return vs, true
+}
+
+// vocoderCapture safely hands the recorder-constructed stub back to the
+// test goroutine (the factory runs on the recorder's Run goroutine).
+type vocoderCapture struct {
+	mu sync.Mutex
+	v  *statStubVocoder
+}
+
+func (c *vocoderCapture) set(v *statStubVocoder) { c.mu.Lock(); c.v = v; c.mu.Unlock() }
+func (c *vocoderCapture) get() *statStubVocoder  { c.mu.Lock(); defer c.mu.Unlock(); return c.v }
+
+// TestRecorderSuppressesAllIdleRecording: a vocoder call that decodes no
+// real speech (every frame idle-muted ⇒ Voiced+Unvoiced == 0) must have its
+// WAV removed and publish no CallComplete — the tiny-file-spam fix.
+func TestRecorderSuppressesAllIdleRecording(t *testing.T) {
+	vc := &vocoderCapture{}
+	DefaultRegistry.Register("stat-stub-idle", func() (Vocoder, error) {
+		v := &statStubVocoder{voicedPerFrame: false}
+		vc.set(v)
+		return v, nil
+	})
+
+	bus := events.NewBus(16)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"test-idle": "stat-stub-idle"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	// Watch for CallComplete; an all-idle call must not publish one.
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-idle", GroupID: 7, SourceID: 9},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitSession(t, r, "VOICE-1", true)
+
+	for i := 0; i < 5; i++ {
+		if err := r.WriteRawFrame("VOICE-1", make([]byte, 11)); err != nil {
+			t.Fatalf("WriteRawFrame: %v", err)
+		}
+	}
+
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: cs.Grant, DeviceSerial: "VOICE-1",
+		StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+		Reason: trunking.EndReasonNormal,
+	}})
+	waitSession(t, r, "VOICE-1", false)
+
+	wavPath := filepath.Join(dir, "S", "7", "20260505T000000Z_src9.wav")
+	if _, err := os.Stat(wavPath); !os.IsNotExist(err) {
+		t.Errorf("all-idle WAV %s should have been removed; stat err = %v", wavPath, err)
+	}
+
+	// Drain the bus briefly and assert no CallComplete fired.
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallComplete {
+				t.Fatal("all-idle call must not publish CallComplete")
+			}
+		case <-timeout:
+			return
+		}
+	}
+}
+
+// TestRecorderCallIDFenceDropsStaleFrames: a frame tagged with a CallID that
+// doesn't match the open session is dropped before it reaches the vocoder —
+// the voice-tap mix-up fence.
+func TestRecorderCallIDFenceDropsStaleFrames(t *testing.T) {
+	vc := &vocoderCapture{}
+	DefaultRegistry.Register("stat-stub-voiced", func() (Vocoder, error) {
+		v := &statStubVocoder{voicedPerFrame: true}
+		vc.set(v)
+		return v, nil
+	})
+
+	bus := events.NewBus(16)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"test-voiced": "stat-stub-voiced"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	const wantCallID = 42
+	cs := trunking.CallStart{
+		Grant: trunking.Grant{
+			System: "S", Protocol: "test-voiced", GroupID: 7, SourceID: 9, CallID: wantCallID,
+		},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitSession(t, r, "VOICE-1", true)
+
+	// A stale frame from a different call must be dropped.
+	if err := r.WriteRawFrameForCall("VOICE-1", wantCallID+1, make([]byte, 11), 0); err != nil {
+		t.Fatalf("stale WriteRawFrameForCall: %v", err)
+	}
+	// The matching frame must be decoded.
+	if err := r.WriteRawFrameForCall("VOICE-1", wantCallID, make([]byte, 11), 0); err != nil {
+		t.Fatalf("matching WriteRawFrameForCall: %v", err)
+	}
+
+	v := vc.get()
+	if v == nil {
+		t.Fatal("vocoder was never constructed")
+	}
+	if got := v.decodeCount(); got != 1 {
+		t.Errorf("vocoder decoded %d frames; want 1 (stale frame must be fenced)", got)
+	}
+}

--- a/internal/voice/stats.go
+++ b/internal/voice/stats.go
@@ -38,6 +38,19 @@ type VoiceStats struct {
 	MinAGCGain  float64 // min applied gain (loudest input frames)
 	MaxAGCGain  float64 // max applied gain (quietest input frames)
 
+	// Fundamental-frequency parameter (b_0) range over all frames. b_0 is
+	// the raw codebook index the IMBE header carries; the idle-carrier
+	// corner is b_0 ≤ 7. When a call decodes to all-idle (Voiced+Unvoiced
+	// == 0), these disambiguate a genuine low-modulation dead-key (b_0
+	// varying within [0,7]) from empty/zero frames reaching the vocoder —
+	// a mistuned tap or extraction bug (b_0 pinned at 0). MaxB0 == 0 with
+	// frames > 0 means every frame's b_0 was 0.
+	MinB0 int // smallest b_0 seen across all frames (−1 when no frames)
+	MaxB0 int // largest b_0 seen across all frames (−1 when no frames)
+	// FirstFrameHex is the first raw 11-byte vocoder frame as hex, captured
+	// for diagnostics so an all-idle capture can be inspected off-line.
+	FirstFrameHex string
+
 	// Output amplitude health.
 	MaxPreClipPeak float64 // largest pre-clip sample magnitude (int16 units)
 	OutputRMS      float64 // RMS of the int16 output across the call


### PR DESCRIPTION
Addresses four field-reported issues on a live Motorola P25 Phase 1 system.

TSBK opcode coverage
- Name the standard OSPs that were logging as OSP(0xNN)/unhandled, incl.
  the two seen in the field: 0x16 SNDCP_DAT_CH_ANN_EXP and 0x29 SCCB_EXP.
- Field-decode 0x29 (Secondary Control Channel Broadcast — Explicit) and
  fold its downlink channel into the network topology, dispatched
  regardless of MFID like the other standard broadcasts.
- Fix the 0x39 mislabel: it is the non-explicit SCCB; the explicit variant
  is 0x29 (per TIA / SDRTrunk / OP25).

Stop tiny-file spam
- Suppress empty/all-muted recordings: a vocoder call that decodes no real
  speech (voiced+unvoiced == 0 — all idle-muted/silent) now has its WAV/raw
  removed and publishes no CallComplete, instead of leaving a silent file
  that, in per-transmission mode, was the dominant source of tiny files.

Voice-quality diagnostics
- Track the per-call b_0 range + first raw frame and escalate an all-idle
  call to a WARN line, so a genuine dead-key (b_0 varying in [0,7]) can be
  told apart from empty/zero frames reaching the vocoder (b_0 pinned at 0,
  i.e. a mistuned tap or extraction bug).

Voice-tap mix-up
- Assign each bound call a process-unique Grant.CallID (VoicePool.Bind;
  preserved across Retune handoffs) and thread it to the recorder, which
  drops frames whose CallID doesn't match the open session — closing the
  cross-call audio-bleed window when a tap serial is reused. Wired via a
  new, additive callAwareRawSink so existing sink shapes are unaffected.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013tau22Gt6EVZcyQZmtgW9M