### PR TITLE
docs: post-release v0.4.8 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,106 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.4.8] — 2026-06-20
+
+This release is dominated by a **six-phase operator-console overhaul** that
+rebuilds the web UI's navigation, feedback, primitives, tables, dense panels,
+and accessibility from the ground up. The flat tab bar is replaced by a
+registry-driven app shell — a collapsible desktop sidebar, a mobile bottom nav
++ drawer, and a ⌘K/Ctrl-K command palette — that reaches all 31 routes,
+including six DSP panels that were previously unreachable except by URL. On top
+of that: a toast notification system with a shared polling hook that kills
+re-render flicker and shows reconnect state, a reusable primitive layer with a
+new light theme and a comfortable/compact density axis, a DataTable with
+built-in search / pagination / inline actions / column visibility, regrouped
+Hunt / Scanner / Settings panels, and a pass over focus traps, a skip link,
+reduced-motion, and chart labelling (mirrored into the Signal Lab and Config
+Builder SPAs). On the decode side, **P25 TSBK coverage** gains named standard
+OSPs and a field-decoded Secondary Control Channel Broadcast — Explicit (0x29),
+empty/all-muted recordings are suppressed to stop tiny-file spam, and a
+per-call ID closes a cross-call audio-bleed window. The docs grow a new
+**Digital & Trunked Radio** learning path and a **Software Development** domain
+in the Reference encyclopedia.
+
+### Added
+- **Web console navigation overhaul — app shell + grouped nav + command
+  palette** (#736). A single nav registry feeds four surfaces — a collapsible
+  desktop sidebar, a mobile bottom nav (4 primaries + More), a full mobile
+  drawer, and a ⌘K/Ctrl-K command palette — organizing all 31 routes into six
+  groups (Live Ops, Discovery, Signals & DSP, Decoders & Logs, Database,
+  System). This rescues 21 panels that were stranded behind a hidden mobile
+  overflow row and six DSP panels (constellation, symbols, eye, mixer, tuning,
+  histogram) that were in no tab list at all. The daemon's `hidden_tabs` filter
+  and the Config Builder external link are preserved.
+- **Notification + feedback system** (#739). A toast queue with kind-based
+  auto-dismiss replaces the single manually-dismissed error strip; every
+  existing `setError(...)` now surfaces a visible toast. A shared `useDataPoll`
+  hook centralizes the poll/cancel pattern, only re-renders when a snapshot
+  actually changed (killing poll-induced flicker), and shows a
+  "reconnecting · Ns ago" chip when the daemon goes quiet. Mutations gain
+  visible "saving…" / success states.
+- **Reusable UI primitive layer + light theme + density axis** (#739). A
+  `components/ui/` set (Card, Badge, Input, Select, Checkbox, Field, PageHeader,
+  EmptyState, Skeleton, Section, Button, Spinner, ToastViewport) lets panels
+  stop hand-rolling controls. Design tokens gain a `[data-theme="light"]` theme
+  (Settings now offers a dark/mono/light toggle) and a `[data-density]` axis
+  (comfortable/compact), both applied pre-render and persisted.
+- **DataTable overhaul** (#739). The shared table gains opt-in, backward-
+  compatible built-in search, pagination, loading skeletons, an inline
+  row-actions cell, a toolbar slot, and a persisted column-visibility menu.
+  Talkgroups, Radio IDs, Systems, Active, and History adopt these; Talkgroups
+  also gets inline scan/lockout quick-toggles.
+- **"Digital & Trunked Radio" learning path** (#737). A new structured path
+  under `/learn/` — 6 modules, 31 lessons + glossary — covering digital radio
+  and trunking end to end: a brief history, the digital signal chain (vocoders,
+  modulation, framing, control channels), each trunking system GopherTrunk
+  decodes (P25 Phase 1/2 and DMR in depth; TETRA, NXDN, Motorola, EDACS, LTR,
+  MPT-1327, dPMR, D-STAR, YSF more briefly), and hands-on decoding. Registered
+  in `_data/learn.yml`, so the chooser, hub, lesson nav, and `llms.txt` pick it
+  up automatically.
+- **"Software Development" domain in the Reference encyclopedia** (#738). The
+  encyclopedia is restructured from a flat category list into a two-level
+  Domain → Category → Entry model (the 11 existing RF categories move under an
+  "RF & SDR" domain unchanged), and a full Software Development domain is built
+  out: 61 new entries across 6 categories — 19 programming languages plus 42
+  concepts spanning language internals, concurrency, paradigms & design
+  patterns, principles & quality, and testing/tooling/delivery — each
+  cross-linked and wired into the learning paths.
+- **P25 Secondary Control Channel Broadcast — Explicit (0x29) decode** (#740).
+  The explicit SCCB is now field-decoded and its downlink channel folded into
+  the network topology (dispatched regardless of MFID like the other standard
+  broadcasts), and the standard OSPs that were logging as `OSP(0xNN)`/unhandled
+  — including 0x16 `SNDCP_DAT_CH_ANN_EXP` and 0x29 `SCCB_EXP` — are now named.
+
+### Changed
+- **Dense panels regrouped onto the primitives** (#739). Hunt is rebuilt on the
+  UI primitives (clearing long-standing styling debt where it referenced
+  undefined CSS classes), split into a "Parse a control channel" quick-start, a
+  collapsed "Blind sweep" advanced section, and result Cards. Scanner's three
+  sub-panels move to Cards with state pills; Settings becomes a collapsible
+  Section with a plain-language tooltip on each config field.
+- **Accessibility & cross-SPA polish** (#739). DetailModal and ConfirmModal now
+  trap focus and restore it to the trigger on close; a visually-hidden "Skip to
+  content" link jumps past the nav chrome; a `prefers-reduced-motion` rule
+  neutralizes transitions (mirrored into the Config Builder and Signal Lab
+  SPAs); and the Metrics trend chart gains `role="img"` + an aria-label.
+
+### Fixed
+- **P25 opcode 0x39 was mislabelled** (#740). 0x39 is the non-explicit SCCB;
+  the explicit variant is 0x29 (per TIA / SDRTrunk / OP25). The two are now
+  named correctly.
+- **Empty/all-muted recordings no longer spam tiny files** (#740). A vocoder
+  call that decodes no real speech (voiced + unvoiced == 0 — all idle-muted)
+  now has its WAV/raw removed and publishes no `CallComplete`, instead of
+  leaving a silent file that, in per-transmission mode, was the dominant source
+  of tiny files. A per-call b₀ range + escalated WARN line lets a genuine
+  dead-key be told apart from empty frames reaching the vocoder.
+- **Cross-call audio bleed when a voice-tap serial is reused** (#740). Each
+  bound call now gets a process-unique `Grant.CallID` (preserved across Retune
+  handoffs) threaded to the recorder, which drops frames whose CallID doesn't
+  match the open session — closing the window where a reused tap could bleed one
+  call's audio into another.
+
 ## [v0.4.7] — 2026-06-19
 
 This release sharpens **P25 discovery accuracy** and **identity corroboration**.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.4.7
+VERSION=v0.4.8
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.4.7" -%}
+  {%- assign ver = "v0.4.8" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.4.8.md
+++ b/docs/announcements/v0.4.8.md
@@ -1,0 +1,57 @@
+# GopherTrunk v0.4.8 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.4.8 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.8
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.4.8 — a six-phase web operator-console overhaul (registry-driven nav + ⌘K command palette, toast feedback, light theme, searchable/paginated tables, a11y), plus expanded P25 TSBK decoding, an end of tiny silent-file spam, and a new Digital & Trunked Radio learning path
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.4.8 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.4.7:**
+
+* **Web operator-console overhaul (six phases).** The flat tab bar is gone. A registry-driven app shell now reaches all 31 panels through a collapsible desktop sidebar, a mobile bottom nav + drawer, and a ⌘K/Ctrl-K command palette — rescuing 21 panels that were stranded behind a hidden mobile overflow row and six DSP panels that were previously unreachable except by URL.
+* **Visible feedback + no more silent freezes.** A toast notification system replaces the single error strip, and a shared polling hook shows a "reconnecting · Ns ago" chip when the daemon goes quiet (and kills the poll-induced re-render flicker). Mutations show "saving…" + success states.
+* **Light theme + density axis + a primitive layer.** A new light theme joins dark/mono, a comfortable/compact density toggle tightens table rows, and a reusable Card/Badge/Input/Field/Section primitive set lets panels stop hand-rolling controls.
+* **Tables that scale.** The shared DataTable gains built-in search, pagination, loading skeletons, inline row actions (e.g. Talkgroups scan/lockout quick-toggles), and a persisted column-visibility menu.
+* **Accessibility pass.** Focus traps + focus restore on modals, a "Skip to content" link, `prefers-reduced-motion` support (mirrored into the Signal Lab and Config Builder SPAs), and a labelled trend chart.
+* **P25 TSBK coverage** (#740) — standard OSPs that logged as `OSP(0xNN)`/unhandled are now named, the Secondary Control Channel Broadcast — Explicit (0x29) is field-decoded into the topology, and the 0x39 mislabel is fixed.
+* **No more tiny silent-file spam** (#740) — calls that decode no real speech are dropped instead of leaving a silent WAV, and a per-call ID closes a cross-call audio-bleed window when a voice-tap serial is reused.
+* Plus a new **Digital & Trunked Radio** learning path (#737, 6 modules / 31 lessons) and a **Software Development** domain in the Reference encyclopedia (#738, 61 new entries).
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.8
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.4.8 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.4.7:**
+- **Web console overhaul (6 phases).** Registry-driven app shell — desktop sidebar, mobile bottom nav + drawer, and a ⌘K/Ctrl-K command palette — reaches all 31 panels, including six DSP panels that were previously URL-only.
+- **Visible feedback.** Toast notifications replace the lone error strip; a shared polling hook shows a "reconnecting · Ns ago" chip instead of silently freezing, and kills re-render flicker.
+- **Light theme + density + primitives.** New light theme, comfortable/compact density toggle, and a reusable Card/Badge/Input/Field/Section set.
+- **Scalable tables.** DataTable gains search, pagination, loading skeletons, inline row actions, and a persisted column-visibility menu.
+- **A11y pass.** Modal focus traps, a skip link, `prefers-reduced-motion` (mirrored into the siglab/configbuilder SPAs), and a labelled chart.
+- **P25 TSBK coverage** (#740) — named standard OSPs, field-decoded SCCB-Explicit (0x29), fixed 0x39 mislabel.
+- **No tiny silent-file spam** (#740) — empty/all-muted calls are dropped; a per-call ID closes a cross-call audio-bleed window on reused taps.
+- Plus a **Digital & Trunked Radio** learning path (#737) and a **Software Development** Reference domain (#738).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.8>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow tagged v0.4.8, so sync the docs to match:

- CHANGELOG: promote [Unreleased] to [v0.4.8] (2026-06-20) and backfill the
  user-visible changes that shipped without a changelog entry — the six-phase
  web operator-console overhaul (app shell + ⌘K nav #736, feedback/toasts, UI
  primitives + light theme, DataTable search/pagination, dense-panel regroup,
  a11y polish #739), expanded P25 TSBK coverage with the SCCB-Explicit (0x29)
  decode and the 0x39 mislabel fix, suppression of empty/all-muted tiny-file
  recordings and the cross-call audio-bleed fix (#740), the new Digital &
  Trunked Radio learning path (#737), and the Software Development domain in
  the Reference encyclopedia (#738). A fresh empty [Unreleased] block sits
  above the versioned heading.
- README: bump the Linux quick-install VERSION to v0.4.8.
- latest-version.html: bump the GitHub Pages fallback tag to v0.4.8.
- announcements: add the v0.4.8 social blurb drafts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WbayjbUyx4wBgVjbv7vmLt