### PR TITLE
fix: hunt identity/neighbors, bogus TG, TG-freq, scanner crash, voice-tap bleed

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -3515,6 +3515,27 @@ func (f fanoutSink) WritePCM(serial string, samples []int16) error {
 	return nil
 }
 
+// WritePCMForCall fans decoded PCM plus the call's CallID out to the contained
+// sinks. Call-aware sinks (the audio publisher) use the CallID to fence a stale
+// frame from the call that previously held a reused voice-tap serial — the
+// live-stream complement of the recorder's WAV fence (voice-tap mix-up). Sinks
+// that don't implement it (tone-out) still get the plain PCM. The recorder
+// selects this path via the voice.DecodedPCMCallSink assertion on its decoded
+// tap; without it the live fan-out would drop back to serial-only WritePCM and
+// the bleed guard would be inert in the daemon.
+func (f fanoutSink) WritePCMForCall(serial string, callID uint64, samples []int16) error {
+	for _, s := range f {
+		if cs, ok := s.(interface {
+			WritePCMForCall(string, uint64, []int16) error
+		}); ok {
+			_ = cs.WritePCMForCall(serial, callID, samples)
+		} else {
+			_ = s.WritePCM(serial, samples)
+		}
+	}
+	return nil
+}
+
 // WriteRawFrame fans raw IMBE / AMBE frames out to every contained
 // sink that implements the rawFrameSink shape — currently just the
 // recorder. Sinks that don't (tone-out, live player, audio publisher)

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -17,6 +17,13 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
+// defaultHuntMonitorSeconds is the streaming long-dwell cap applied to a
+// trunked-system hunt when the caller doesn't specify one. Converge-and-stop
+// (internal/hunt/monitor.go) normally ends the dwell well before this once the
+// site's identity, neighbors and band plan have settled; the cap only bounds a
+// site whose status broadcasts never fully arrive.
+const defaultHuntMonitorSeconds = 120
+
 // huntCockpit adapts the daemon's hunt.Manager to the api.HuntCockpit surface
 // (GET /api/v1/hunt + start/stop/export/commit). It mirrors scannerCockpit.
 type huntCockpit struct {
@@ -128,6 +135,17 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 	}
 	if req.SweepDwellMs > 0 {
 		opts.SweepDwell = msToDuration(req.SweepDwellMs, 0)
+	}
+	// A trunked-system hunt needs the streaming long-dwell monitor to see the
+	// site's slow-cycling status broadcasts (Network Status / RFSS Status /
+	// adjacent sites) — they rarely land inside the short buffered identify
+	// dwell, so a default hunt would surface NAC + talkgroups but leave
+	// WACN/SystemID/RFSS/Site and neighbors "awaiting status broadcasts". Opt
+	// into the monitor by default; converge-and-stop ends it early (typically
+	// well under the cap) once identity + topology settle. Survey runs and
+	// explicit caller overrides are left untouched.
+	if !req.Survey && opts.MonitorSeconds <= 0 {
+		opts.MonitorSeconds = defaultHuntMonitorSeconds
 	}
 	return c.mgr.Start(opts)
 }

--- a/internal/api/audio_publisher.go
+++ b/internal/api/audio_publisher.go
@@ -191,6 +191,23 @@ func (p *AudioPublisher) Stats() AudioPublisherStats {
 // The frame is built lazily on the first matching subscriber so the
 // no-subscriber and no-match paths stay allocation-free.
 func (p *AudioPublisher) WritePCM(deviceSerial string, samples []int16) error {
+	return p.writePCM(deviceSerial, 0, samples)
+}
+
+// WritePCMForCall is WritePCM plus the CallID the PCM was decoded for. It
+// satisfies voice.DecodedPCMCallSink so the recorder's decoded-audio tap can
+// fence a stale frame from the call that previously held a reused voice-tap
+// serial: when the live grant for the serial has already flipped to a newer
+// call (its CallStart updated p.grants), PCM still draining from the older call
+// would otherwise be fanned out labelled with — and leaked to subscribers
+// filtered on — the new call's talkgroup. Dropping the mismatched frame closes
+// that cross-call audio-bleed window. A zero CallID on either side matches
+// (un-stamped / synthetic / analog calls), preserving WritePCM's behaviour.
+func (p *AudioPublisher) WritePCMForCall(deviceSerial string, callID uint64, samples []int16) error {
+	return p.writePCM(deviceSerial, callID, samples)
+}
+
+func (p *AudioPublisher) writePCM(deviceSerial string, callID uint64, samples []int16) error {
 	if p == nil || len(samples) == 0 {
 		return nil
 	}
@@ -200,6 +217,12 @@ func (p *AudioPublisher) WritePCM(deviceSerial string, samples []int16) error {
 		return nil
 	}
 	grant, haveGrant := p.grants[deviceSerial]
+	// Cross-call fence: this PCM belongs to callID, but the serial's live
+	// grant has moved on to a different call. Drop rather than mislabel the
+	// old call's tail as the new call's audio.
+	if haveGrant && callID != 0 && grant.CallID != 0 && callID != grant.CallID {
+		return nil
+	}
 
 	var frame *apiv1.AudioFrame // built on first match
 	for sub := range p.subs {

--- a/internal/api/audio_publisher_test.go
+++ b/internal/api/audio_publisher_test.go
@@ -250,6 +250,60 @@ func TestAudioPublisher_CallEndClearsGrant(t *testing.T) {
 	})
 }
 
+// waitForCallID blocks until the publisher's grant for serial has the given
+// CallID — used to sequence a tap-serial reuse so the test drives WritePCMForCall
+// only after the serial's bound call has actually flipped.
+func waitForCallID(t *testing.T, pub *AudioPublisher, serial string, callID uint64) {
+	t.Helper()
+	waitFor(t, 200*time.Millisecond, func() bool {
+		pub.mu.RLock()
+		defer pub.mu.RUnlock()
+		return pub.grants[serial].CallID == callID
+	})
+}
+
+// TestAudioPublisher_WritePCMForCallFencesStaleCall reproduces the voice-tap
+// audio bleed: a wideband tap serial is reused for a new call, so the
+// publisher's grant for that serial flips to the new call (TG 200, CallID 2)
+// while the old call's PCM (CallID 1) is still draining. The stale frame must be
+// dropped — not fanned to a TG-200 subscriber labelled as the new call.
+func TestAudioPublisher_WritePCMForCallFencesStaleCall(t *testing.T) {
+	pub, bus := mkPublisher(t)
+	publishCallStart(t, pub, bus, "tap-0", trunking.Grant{GroupID: 100, CallID: 1})
+
+	sub := pub.Subscribe(AudioSubFilter{TalkgroupIDs: []uint32{200}})
+	defer pub.Unsubscribe(sub)
+
+	// The new call binds the same tap serial.
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: trunking.Grant{GroupID: 200, CallID: 2}, DeviceSerial: "tap-0",
+	}})
+	waitForCallID(t, pub, "tap-0", 2)
+
+	// Old call's tail (CallID 1) must NOT reach the TG-200 subscriber.
+	if err := pub.WritePCMForCall("tap-0", 1, []int16{1, 2, 3}); err != nil {
+		t.Fatalf("WritePCMForCall stale: %v", err)
+	}
+	select {
+	case f := <-sub.ch:
+		t.Fatalf("TG-200 subscriber received stale CallID-1 audio (group_id=%d) — bleed not fenced", f.GetGrant().GroupId)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The current call's audio (CallID 2) flows to the matching subscriber.
+	if err := pub.WritePCMForCall("tap-0", 2, []int16{4, 5, 6}); err != nil {
+		t.Fatalf("WritePCMForCall current: %v", err)
+	}
+	select {
+	case f := <-sub.ch:
+		if f.GetGrant().GroupId != 200 {
+			t.Errorf("group_id = %d, want 200", f.GetGrant().GroupId)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("TG-200 subscriber received no current-call frame")
+	}
+}
+
 func TestAudioPublisher_UnsubscribeIsIdempotent(t *testing.T) {
 	pub, _ := mkPublisher(t)
 	sub := pub.Subscribe(AudioSubFilter{})

--- a/internal/api/handlers_scanner.go
+++ b/internal/api/handlers_scanner.go
@@ -14,12 +14,28 @@ import (
 // instead of a 503.
 func (s *Server) handleScannerStatus(w http.ResponseWriter, _ *http.Request) {
 	if s.scanner == nil {
-		writeJSON(w, http.StatusOK, ScannerStatus{
+		writeJSON(w, http.StatusOK, normalizeScannerStatus(ScannerStatus{
 			ScanMode: "all",
-		})
+		}))
 		return
 	}
-	writeJSON(w, http.StatusOK, s.scanner.Status())
+	writeJSON(w, http.StatusOK, normalizeScannerStatus(s.scanner.Status()))
+}
+
+// normalizeScannerStatus guarantees the slice fields marshal as JSON arrays
+// rather than null. A nil Go slice encodes to `null`, which the web Scanner
+// tab then dereferences (`systems.length` / `channels.length`) and crashes the
+// whole panel behind the error boundary ("Cannot read properties of null").
+// Emitting `[]` keeps the wire contract array-typed regardless of whether any
+// systems / conventional channels are configured.
+func normalizeScannerStatus(st ScannerStatus) ScannerStatus {
+	if st.Systems == nil {
+		st.Systems = []SystemHuntStatusDTO{}
+	}
+	if st.Conventional.Channels == nil {
+		st.Conventional.Channels = []ConvChannelStatusDTO{}
+	}
+	return st
 }
 
 // scannerSetModeRequest is the PATCH /api/v1/scanner body shape.

--- a/internal/api/handlers_scanner_test.go
+++ b/internal/api/handlers_scanner_test.go
@@ -171,6 +171,39 @@ func TestScannerStatus_AlwaysOK(t *testing.T) {
 	}
 }
 
+// TestScannerStatus_EmptySlicesMarshalAsArrays pins the fix for the web
+// Scanner-tab crash: a nil Go slice encodes to JSON `null`, which the frontend
+// dereferences (systems.length / channels.length) and crashes the whole panel.
+// The handler must emit `[]` so the wire contract stays array-typed even with
+// no systems / conventional channels configured.
+func TestScannerStatus_EmptySlicesMarshalAsArrays(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	// Status with nil Systems and nil Conventional.Channels (the default).
+	cock := &fakeCockpit{status: ScannerStatus{ScanMode: "all"}}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Scanner: cock})
+	defer teardown()
+	resp, err := http.Get(base + "/api/v1/scanner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(raw["systems"]); got != "[]" {
+		t.Errorf("systems = %s, want []", got)
+	}
+	var conv map[string]json.RawMessage
+	if err := json.Unmarshal(raw["conventional"], &conv); err != nil {
+		t.Fatal(err)
+	}
+	if got := string(conv["channels"]); got != "[]" {
+		t.Errorf("conventional.channels = %s, want []", got)
+	}
+}
+
 func TestScannerStatus_NoCockpitReturnsEmpty(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/hunt/accumulate.go
+++ b/internal/hunt/accumulate.go
@@ -133,13 +133,19 @@ func Accumulate(dst *DiscoveredSystem, obs Observation) {
 		if g.GroupID == 0 {
 			continue
 		}
-		freqHz := g.FrequencyHz
-		if freqHz == 0 {
-			if hz, ok := dst.bandPlanFreq(g.ChannelID, g.ChannelNum); ok {
-				freqHz = hz
+		// Individual grants (unit-to-unit / telephone / data) carry a 24-bit
+		// destination unit in GroupID, not a talkgroup — listing them produces
+		// phantom >16-bit "talkgroups" (the bogus 140957 in the field report).
+		// They still occupy a voice channel, so the frequency is recorded on
+		// the site below, just not attributed to a talkgroup.
+		if g.Individual {
+			if freqHz := grantFreq(dst, g); freqHz != 0 {
+				dst.addVoiceChannel(rfss, site, freqHz)
 			}
+			continue
 		}
-		dst.addTalkgroup(g.GroupID, g.Encrypted, freqHz, at)
+		freqHz := grantFreq(dst, g)
+		dst.addTalkgroup(g.GroupID, g.Encrypted, at)
 		if freqHz != 0 {
 			dst.addVoiceChannel(rfss, site, freqHz)
 		}
@@ -160,6 +166,9 @@ func foldTopology(dst *DiscoveredSystem, t *siglab.TopologySnapshot) {
 	if dst.SystemID == 0 && t.SystemID != 0 {
 		dst.SystemID = uint16(t.SystemID)
 	}
+	// setIdentity records the first non-zero observation of an optional
+	// identity field — a zero means "absent" for these (DMR ColorCode, NXDN
+	// RAN, …) so it never overwrites a real value.
 	setIdentity := func(key string, v uint64) {
 		if v == 0 {
 			return
@@ -168,8 +177,21 @@ func foldTopology(dst *DiscoveredSystem, t *siglab.TopologySnapshot) {
 			dst.Identity[key] = v
 		}
 	}
-	setIdentity("RFSS", uint64(t.RFSS))
-	setIdentity("Site", uint64(t.Site))
+	// RFSS and Site are special: zero is a LEGITIMATE value (single-RFSS /
+	// site-0 systems are common), so once the topology has actually
+	// identified the camped site, record them even when zero — otherwise a
+	// real RFSS=0 / Site=0 reads as "unknown" and the site is mis-placed.
+	// Gate on the snapshot carrying real site identity so a band-plan-only
+	// snapshot (no status broadcast yet) doesn't write a premature (0,0).
+	hasSiteIdentity := t.WACN != 0 || t.SystemID != 0 || t.RFSS != 0 || t.Site != 0 || t.LRA != 0
+	if hasSiteIdentity {
+		if _, present := dst.Identity["RFSS"]; !present {
+			dst.Identity["RFSS"] = uint64(t.RFSS)
+		}
+		if _, present := dst.Identity["Site"]; !present {
+			dst.Identity["Site"] = uint64(t.Site)
+		}
+	}
 	setIdentity("LRA", uint64(t.LRA))
 	setIdentity("ColorCode", uint64(t.ColorCode))
 	setIdentity("RAN", uint64(t.RAN))
@@ -186,6 +208,20 @@ func foldTopology(dst *DiscoveredSystem, t *siglab.TopologySnapshot) {
 			TxOffsetHz:  e.TxOffsetHz,
 		})
 	}
+}
+
+// grantFreq resolves the voice-channel frequency a grant landed on: the
+// frequency the decoder already resolved at grant time, else the accumulated
+// band plan applied to the grant's (ChannelID, ChannelNum). Returns 0 when
+// neither resolves (band plan not yet seen).
+func grantFreq(dst *DiscoveredSystem, g siglab.GrantRecord) uint32 {
+	if g.FrequencyHz != 0 {
+		return g.FrequencyHz
+	}
+	if hz, ok := dst.bandPlanFreq(g.ChannelID, g.ChannelNum); ok {
+		return hz
+	}
+	return 0
 }
 
 // appendUniqueFreq appends hz to s unless already present.

--- a/internal/hunt/accumulate_test.go
+++ b/internal/hunt/accumulate_test.go
@@ -70,6 +70,57 @@ func TestAccumulate_IdentityAndTalkgroups(t *testing.T) {
 	}
 }
 
+// TestAccumulate_SkipsIndividualGrants: a unit-to-unit / telephone grant
+// carries a 24-bit destination unit in GroupID (the field-reported bogus
+// 140957), not a talkgroup. It must NOT become a talkgroup — only the group
+// grant (TG 100) does — while still being recorded as a site voice channel.
+func TestAccumulate_SkipsIndividualGrants(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	r := fakeResult(851012500, map[string]any{"RFSS": uint8(1), "Site": uint8(2)})
+	r.Grants = []siglab.GrantRecord{
+		{GroupID: 100, FrequencyHz: 851_500_000},                      // group call → talkgroup
+		{GroupID: 140957, FrequencyHz: 851_975_000, Individual: true}, // unit-to-unit target → not a TG
+	}
+	Accumulate(sys, Observation{Protocol: "p25", Confidence: 0.9, Result: r})
+
+	if len(sys.Talkgroups) != 1 || sys.Talkgroups[0].Dec != 100 {
+		t.Fatalf("talkgroups = %+v, want exactly [100] (no bogus 140957)", sys.Talkgroups)
+	}
+	// The individual call's frequency is still a real site voice channel.
+	vc := sys.Sites[0].VoiceChannels
+	if len(vc) != 2 {
+		t.Errorf("site voice channels = %+v, want both grant freqs recorded", vc)
+	}
+}
+
+// TestAccumulate_RecordsZeroRFSSSite: a single-RFSS system (RFSS=0, Site=0)
+// that has decoded identity (WACN/SystemID) must place its site at (0,0) and
+// record RFSS/Site=0 in the Identity map rather than dropping them as "unknown".
+func TestAccumulate_RecordsZeroRFSSSite(t *testing.T) {
+	sys := &DiscoveredSystem{}
+	r := fakeResult(450125000, nil, 204)
+	r.Topology = &siglab.TopologySnapshot{
+		WACN:     0xBEE99,
+		SystemID: 0x49A,
+		RFSS:     0,
+		Site:     0,
+	}
+	Accumulate(sys, Observation{Protocol: "p25", Confidence: 0.9, Result: r})
+
+	if sys.RFSS() != 0 || sys.SiteNum() != 0 {
+		t.Errorf("RFSS/Site = %d/%d, want 0/0", sys.RFSS(), sys.SiteNum())
+	}
+	if _, ok := sys.Identity["RFSS"]; !ok {
+		t.Error("RFSS should be recorded (present) even when zero, once identity is known")
+	}
+	if _, ok := sys.Identity["Site"]; !ok {
+		t.Error("Site should be recorded (present) even when zero, once identity is known")
+	}
+	if len(sys.Sites) != 1 || sys.Sites[0].RFSS != 0 || sys.Sites[0].SiteID != 0 {
+		t.Errorf("sites = %+v, want one site at (0,0)", sys.Sites)
+	}
+}
+
 func TestAccumulate_Idempotent_DedupesSites(t *testing.T) {
 	sys := &DiscoveredSystem{}
 	obs := Observation{

--- a/internal/hunt/system.go
+++ b/internal/hunt/system.go
@@ -94,10 +94,6 @@ type DiscoveredTalkgroup struct {
 	Encrypted bool      `json:"encrypted,omitempty"`
 	Count     int       `json:"count"`
 	FirstSeen time.Time `json:"first_seen"`
-	// Frequencies are the distinct voice-channel frequencies (Hz) observed
-	// carrying this talkgroup, resolved from each grant against the band
-	// plan. Empty until a grant for this talkgroup resolves a frequency.
-	Frequencies []uint32 `json:"frequencies,omitempty"`
 }
 
 // NeighborRef is an adjacent site advertised by the control channel.
@@ -171,33 +167,28 @@ func (s *DiscoveredSystem) addControlChannel(rfss, siteID uint8, hz uint32, conf
 	})
 }
 
-// addTalkgroup records (or bumps the activity count of) a talkgroup. A
-// non-zero freqHz is merged into the talkgroup's observed voice-channel
-// frequencies, de-duplicated.
-func (s *DiscoveredSystem) addTalkgroup(dec uint32, encrypted bool, freqHz uint32, at time.Time) {
+// addTalkgroup records (or bumps the activity count of) a talkgroup. The
+// voice-channel frequency a grant landed on is NOT attributed to the
+// talkgroup: on a trunked system the traffic channel is assigned dynamically
+// per call, so a talkgroup has no fixed frequency. The distinct voice
+// frequencies the site uses are recorded on the site (addVoiceChannel).
+func (s *DiscoveredSystem) addTalkgroup(dec uint32, encrypted bool, at time.Time) {
 	for i := range s.Talkgroups {
 		if s.Talkgroups[i].Dec == dec {
 			s.Talkgroups[i].Count++
 			if encrypted {
 				s.Talkgroups[i].Encrypted = true
 			}
-			if freqHz != 0 {
-				s.Talkgroups[i].Frequencies = appendUniqueFreq(s.Talkgroups[i].Frequencies, freqHz)
-			}
 			return
 		}
 	}
-	tg := DiscoveredTalkgroup{
+	s.Talkgroups = append(s.Talkgroups, DiscoveredTalkgroup{
 		Dec:       dec,
 		Hex:       fmt.Sprintf("%x", dec),
 		Encrypted: encrypted,
 		Count:     1,
 		FirstSeen: at,
-	}
-	if freqHz != 0 {
-		tg.Frequencies = []uint32{freqHz}
-	}
-	s.Talkgroups = append(s.Talkgroups, tg)
+	})
 }
 
 // addVoiceChannel records a voice/traffic-channel frequency observed on
@@ -262,10 +253,6 @@ func (s *DiscoveredSystem) sortAll() {
 		sort.Slice(vc, func(a, b int) bool { return vc[a] < vc[b] })
 	}
 	sort.Slice(s.Talkgroups, func(i, j int) bool { return s.Talkgroups[i].Dec < s.Talkgroups[j].Dec })
-	for i := range s.Talkgroups {
-		fr := s.Talkgroups[i].Frequencies
-		sort.Slice(fr, func(a, b int) bool { return fr[a] < fr[b] })
-	}
 	sort.Slice(s.BandPlan, func(i, j int) bool { return s.BandPlan[i].ChannelID < s.BandPlan[j].ChannelID })
 	// Resolve neighbour control-channel frequencies now that the band plan is
 	// fully accumulated (it may be incomplete on any single observation).

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1022,6 +1022,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		c.publishVoiceGrant(voiceGrant{
 			groupID: g.TargetID, sourceID: g.SourceID,
 			channelID: g.ChannelID, channelNumber: g.ChannelNumber,
+			individual: true,
 		}, nac)
 	case OpUnitToUnitAnswerRequest:
 		c.publishUnitToUnitRequest(ParseUnitToUnitAnswerRequest(t.Payload), nac)
@@ -1030,13 +1031,14 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		c.publishVoiceGrant(voiceGrant{
 			groupID: g.TargetID, channelID: g.ChannelID,
 			channelNumber: g.ChannelNumber, serviceOptions: g.ServiceOptions,
+			individual: true,
 		}, nac)
 	case OpSNDCPDataChannelGrant:
 		g := ParseSNDCPDataChannelGrant(t.Payload)
 		c.publishVoiceGrant(voiceGrant{
 			groupID: g.TargetID, channelID: g.ChannelID,
 			channelNumber: g.ChannelNumber, serviceOptions: g.ServiceOptions,
-			dataCall: true,
+			dataCall: true, individual: true,
 		}, nac)
 	case OpNetworkStatusBroadcast:
 		c.netModel.ApplyNetworkStatus(ParseNetworkStatusBroadcast(t.Payload))
@@ -1292,6 +1294,10 @@ type voiceGrant struct {
 	channelNumber  uint16
 	serviceOptions uint8
 	dataCall       bool
+	// individual marks a unit-to-unit / telephone / SNDCP-data grant whose
+	// groupID is a 24-bit destination unit, not a 16-bit talkgroup. Carried
+	// onto trunking.Grant.Individual so discovery never lists it as a TG.
+	individual bool
 }
 
 // publishVoiceGrant resolves a grant's channel through the band plan
@@ -1354,6 +1360,7 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 			Encrypted:          so.Encrypted(),
 			Emergency:          so.Emergency(),
 			DataCall:           g.dataCall,
+			Individual:         g.individual,
 			P25Phase1DemodMode: c.p25Phase1DemodMode,
 			P25Phase2Decode:    p2dec,
 			At:                 c.now(),

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -45,6 +45,66 @@ func buildLockedStreamWithTSBK(offset int, nac uint16, duid DUID, tsbk TSBK) []u
 	return out
 }
 
+// TestControlChannelGrantIndividualFlag verifies that a group voice grant is
+// published as a talkgroup call (Individual=false) while a unit-to-unit grant
+// — whose "group" field is actually a 24-bit target radio ID — is flagged
+// Individual=true so downstream discovery never lists it as a talkgroup (the
+// bogus TG 140957 field report).
+func TestControlChannelGrantIndividualFlag(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	identTSBK := TSBK{LB: false, Opcode: OpIdentifierUpdate}
+	identTSBK.Payload = AssembleIdentifierUpdate(IdentifierUpdate{
+		ChannelID: 1,
+		SpacingHz: 12_500,
+		BaseHz:    450_000_000,
+	})
+	// Group grant payload: svc opts, channel (ID 1 / num 0x010), group 204, src.
+	groupPayload := [8]byte{
+		0x00,                  // service options
+		(1 << 4) | 0x00, 0x10, // channel = ID 1, number 0x010
+		0x00, 0xCC, // group address = 204
+		0x00, 0x04, 0xD2, // source id
+	}
+	groupTSBK := TSBK{LB: false, Opcode: OpGroupVoiceChannelGrant, Payload: groupPayload}
+	// Target 140957 is a 24-bit radio ID, not a talkgroup.
+	uuTSBK := TSBK{LB: true, Opcode: OpUnitToUnitVoiceChannelGrant}
+	uuTSBK.Payload = AssembleUnitToUnitVoiceChannelGrant(UnitToUnitVoiceChannelGrant{
+		ChannelID: 1, ChannelNumber: 0x011, TargetID: 140957, SourceID: 5678,
+	})
+
+	cc := New(Options{Bus: bus, SystemName: "Main_Site_1", FrequencyHz: 450_125_000})
+	s1 := buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, identTSBK)
+	s2 := buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, groupTSBK)
+	s3 := buildLockedStreamWithTSBK(0, 0x293, DUIDTrunkingSignaling, uuTSBK)
+	cc.Process(s1, 0)
+	cc.Process(s2, len(s1))
+	cc.Process(s3, len(s1)+len(s2))
+
+	byGroup := map[uint32]trunking.Grant{}
+	deadline := time.After(2 * time.Second)
+	for len(byGroup) < 2 {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindGrant {
+				g := ev.Payload.(trunking.Grant)
+				byGroup[g.GroupID] = g
+			}
+		case <-deadline:
+			t.Fatalf("only saw grants %v, want 204 + 140957", byGroup)
+		}
+	}
+	if g, ok := byGroup[204]; !ok || g.Individual {
+		t.Errorf("group grant 204: ok=%v Individual=%v, want present and false", ok, g.Individual)
+	}
+	if g, ok := byGroup[140957]; !ok || !g.Individual {
+		t.Errorf("unit-to-unit grant 140957: ok=%v Individual=%v, want present and true", ok, g.Individual)
+	}
+}
+
 func TestControlChannelEmitsLockOnTSDU(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/siglab/result.go
+++ b/internal/siglab/result.go
@@ -87,6 +87,10 @@ type GrantRecord struct {
 	FrequencyHz uint32  `json:"frequency_hz" yaml:"frequency_hz"`
 	Encrypted   bool    `json:"encrypted" yaml:"encrypted"`
 	Emergency   bool    `json:"emergency" yaml:"emergency"`
+	// Individual mirrors trunking.Grant.Individual: the GroupID is a
+	// unit-to-unit / telephone / data destination, not a talkgroup. Hunt
+	// skips these when accumulating the talkgroup list.
+	Individual bool `json:"individual,omitempty" yaml:"individual,omitempty"`
 }
 
 // EventRecord is one bus event captured generically — Kind plus the
@@ -161,6 +165,7 @@ func (c *collector) observe(ev events.Event) {
 				FrequencyHz: g.FrequencyHz,
 				Encrypted:   g.Encrypted,
 				Emergency:   g.Emergency,
+				Individual:  g.Individual,
 			})
 		}
 	case events.KindDecodeError:

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -64,6 +64,16 @@ type Grant struct {
 	AlgorithmID uint8
 	KeyID       uint16
 	DataCall    bool // false = voice call (default)
+	// Individual marks a grant whose GroupID is NOT a talkgroup but an
+	// individual destination — a unit-to-unit target radio (WUID), a
+	// telephone-interconnect target, or an SNDCP data unit. P25 group
+	// talkgroups are 16-bit; these targets are 24-bit subscriber addresses,
+	// so recording them as "talkgroups" produces phantom >16-bit entries
+	// (e.g. a unit-to-unit call surfacing as bogus TG 140957). Discovery /
+	// hunt skips individual grants when building the talkgroup list. False
+	// (the default) for group calls and Motorola patch grants, which ARE
+	// talkgroups.
+	Individual bool
 	// ProVoice marks the grant as an EDACS ProVoice (digital) call. The
 	// vocoder is patent + trade-secret encumbered so we cannot ship a
 	// built-in decoder; the recorder treats this flag as a directive to

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -97,6 +97,18 @@ type DecodedPCMSink interface {
 	WritePCM(deviceSerial string, samples []int16) error
 }
 
+// DecodedPCMCallSink is the call-aware extension of DecodedPCMSink: it carries
+// the CallID the decoded PCM belongs to so the live fan-out can fence a stale
+// frame from a previous call on a reused voice-tap serial — the same
+// cross-call audio-bleed guard sessionForWrite applies to the WAV. Wideband
+// voice taps reuse a fixed pool of serials, so without this the live stream
+// labels (and leaks) an old call's draining audio with the next call's
+// talkgroup. A sink implementing this is preferred over plain WritePCM in
+// WriteRawFrame's fan-out; sinks that don't implement it still get WritePCM.
+type DecodedPCMCallSink interface {
+	WritePCMForCall(deviceSerial string, callID uint64, samples []int16) error
+}
+
 // SetDecodedPCMSink wires the live-audio tap that receives PCM decoded
 // from digital vocoder frames. Call once during daemon construction
 // before Run/any calls start; it is not safe to change concurrently
@@ -429,9 +441,17 @@ func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byt
 		// calls WritePCM for them — so without this the live audio
 		// path is silent while recordings play fine (issue #598). Runs
 		// outside r.mu (sessionForWrite released it), so the tap is
-		// free to take its own locks.
+		// free to take its own locks. Hand the session's CallID to a
+		// call-aware sink so the live stream is fenced by the same identity
+		// the WAV used — closing the cross-call bleed window when a tap
+		// serial is reused (the samples already passed sessionForWrite's
+		// CallID check, so s.callID is authoritative for this audio).
 		if r.decodedTap != nil {
-			_ = r.decodedTap.WritePCM(deviceSerial, samples)
+			if cs, ok := r.decodedTap.(DecodedPCMCallSink); ok {
+				_ = cs.WritePCMForCall(deviceSerial, s.callID, samples)
+			} else {
+				_ = r.decodedTap.WritePCM(deviceSerial, samples)
+			}
 		}
 	}
 	return nil

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -618,6 +618,83 @@ func (f *fakeDecodedTap) snapshot() (calls, total int, last string) {
 	return f.calls, f.total, f.last
 }
 
+// fakeCallAwareTap implements DecodedPCMCallSink, recording the CallID the
+// recorder hands to each forwarded chunk so a test can confirm the live fan-out
+// is fenced by the session's call identity (voice-tap audio-bleed guard).
+type fakeCallAwareTap struct {
+	mu      sync.Mutex
+	callIDs []uint64
+}
+
+func (f *fakeCallAwareTap) WritePCM(string, []int16) error { return nil }
+func (f *fakeCallAwareTap) WritePCMForCall(_ string, callID uint64, _ []int16) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.callIDs = append(f.callIDs, callID)
+	return nil
+}
+func (f *fakeCallAwareTap) snapshot() []uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]uint64(nil), f.callIDs...)
+}
+
+// TestRecorderForwardsDecodedPCMToCallAwareTap: when the live tap implements
+// DecodedPCMCallSink, the recorder must forward the decoding session's CallID
+// so the tap can fence a stale frame from a previous call on a reused voice-tap
+// serial (the audio-bleed guard). Each forwarded chunk carries the call's CallID.
+func TestRecorderForwardsDecodedPCMToCallAwareTap(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"test-null": "null"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	tap := &fakeCallAwareTap{}
+	r.SetDecodedPCMSink(tap)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-null", GroupID: 1, CallID: 77},
+		DeviceSerial: "tap-0",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("tap-0") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// A matching call-aware frame forwards the session's CallID.
+	if err := r.WriteRawFrameForCall("tap-0", 77, make([]byte, 11), 0); err != nil {
+		t.Fatalf("WriteRawFrameForCall: %v", err)
+	}
+	// A frame from a different (stale) call is fenced by sessionForWrite before
+	// decode, so it must never reach the tap.
+	if err := r.WriteRawFrameForCall("tap-0", 999, make([]byte, 11), 0); err != nil {
+		t.Fatalf("WriteRawFrameForCall stale: %v", err)
+	}
+
+	got := tap.snapshot()
+	if len(got) != 1 || got[0] != 77 {
+		t.Errorf("forwarded callIDs = %v, want exactly [77] (stale 999 fenced)", got)
+	}
+}
+
 // TestRecorderForwardsDecodedPCMToTap: PCM the recorder decodes from
 // digital vocoder frames in WriteRawFrame must be forwarded to the
 // live-audio tap (web stream / player / tone-out). Without this the

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -200,8 +200,6 @@ export interface DiscoveredTalkgroup {
   hex: string;
   encrypted?: boolean;
   count: number;
-  // Distinct voice-channel frequencies (Hz) observed carrying this talkgroup.
-  frequencies?: number[];
 }
 
 // BandPlanEntry mirrors hunt.BandPlanEntry — one P25 IDEN_UP band-plan slot:

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -566,7 +566,6 @@ export function Hunt() {
                 <th className={TH}>Hex</th>
                 <th className={TH}>Encrypted</th>
                 <th className={TH}>Activity</th>
-                <th className={TH}>Frequencies</th>
               </tr>
             </thead>
             <tbody>
@@ -576,11 +575,6 @@ export function Hunt() {
                   <td className={TD}>{tg.hex}</td>
                   <td className={TD}>{tg.encrypted ? "🔒" : "—"}</td>
                   <td className={TD}>{tg.count}</td>
-                  <td className={TD}>
-                    {tg.frequencies && tg.frequencies.length > 0
-                      ? tg.frequencies.map((h) => (h / 1e6).toFixed(4)).join(", ")
-                      : "—"}
-                  </td>
                 </tr>
               ))}
             </tbody>

--- a/web/src/panels/Scanner.tsx
+++ b/web/src/panels/Scanner.tsx
@@ -117,14 +117,14 @@ export function Scanner() {
       />
 
       <Hunt
-        systems={scanner.systems}
+        systems={scanner.systems ?? []}
         canMutate={canMutate}
         onMutate={wrap}
         onConfirm={(c) => setConfirm(c)}
       />
 
       <Conventional
-        conv={scanner.conventional}
+        conv={scanner.conventional ?? { enabled: false, channels: [] }}
         canMutate={canMutate}
         onMutate={wrap}
         onConfirm={(c) => setConfirm(c)}
@@ -314,7 +314,7 @@ function Conventional({
         </div>
       }
     >
-      {conv.channels.length === 0 ? (
+      {(conv.channels ?? []).length === 0 ? (
         <p className="text-muted text-sm">No channels in the conv scanner list.</p>
       ) : (
         <div className="overflow-x-auto">
@@ -330,7 +330,7 @@ function Conventional({
               </tr>
             </thead>
             <tbody className="divide-y divide-panel">
-              {conv.channels.map((ch) => (
+              {(conv.channels ?? []).map((ch) => (
                 <tr
                   key={ch.index}
                   className={ch.active ? "bg-accent/10" : undefined}


### PR DESCRIPTION
Addresses six field-reported issues on a live P25 Phase 1 system.

Audio bleed between voice taps
- The d3ac9d8 CallID fence guarded only the on-disk WAV. The live PCM
  fan-out (recorder decodedTap → AudioPublisher) was keyed purely by
  device serial, so when a wideband voice-tap serial was reused for the
  next call the old call's still-draining audio got relabeled with — and
  leaked to subscribers filtered on — the new call's talkgroup. Thread
  the session's CallID through a new DecodedPCMCallSink (recorder →
  fanoutSink → AudioPublisher.WritePCMForCall) and drop a frame whose
  CallID no longer matches the serial's bound call.

Scanner tab crash ("Cannot read properties of null (reading 'length')")
- A nil Go slice marshals to JSON null; the web Scanner tab dereferenced
  systems.length / channels.length and crashed the panel. Normalize the
  /api/v1/scanner payload to emit [] and null-guard the frontend reads.

Hunt identity/neighbors empty ("awaiting status broadcasts")
- The web hunt ran the 3 s buffered dwell (MonitorSeconds defaulted to
  0); P25 status broadcasts cycle too slowly to land in 3 s, so only NAC
  (which rides the lock event) surfaced. Default a trunked hunt to the
  streaming converge-and-stop monitor, which ends early once identity +
  topology settle. Also stop dropping a legitimate RFSS=0 / Site=0 when
  folding topology.

Bogus talkgroup 140957
- Unit-to-unit / telephone / SNDCP-data grants publish a 24-bit target
  unit as the grant "group", and discovery recorded every grant group as
  a talkgroup. Flag these grants Individual and skip them when building
  the hunt talkgroup list (the frequency is still recorded on the site).

Talkgroup↔frequency association
- Dropped the per-talkgroup frequency list: on a trunked system the
  traffic channel is assigned dynamically per call, so a talkgroup has no
  fixed frequency. The site's distinct voice-channel pool is unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BLQxxMQnR4mNs9UhKT7oW5