### PR TITLE
trunking: harden RID/talkgroup alias imports against mojibake

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/prometheus/client_golang v1.23.2
 	golang.org/x/sys v0.42.0
+	golang.org/x/text v0.34.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
@@ -68,7 +69,6 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.51.0 // indirect
-	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/trunking/rid.go
+++ b/internal/trunking/rid.go
@@ -117,7 +117,7 @@ func (d *RIDDB) Len() int {
 // Alias / Alpha Tag, Description, Tag, Group, Owner, Priority,
 // Lockout, Watch, Icon.
 func (d *RIDDB) LoadCSV(r io.Reader) (int, error) {
-	cr := csv.NewReader(r)
+	cr := csv.NewReader(decodeReader(r))
 	cr.TrimLeadingSpace = true
 	cr.FieldsPerRecord = -1
 	header, err := cr.Read()
@@ -224,21 +224,21 @@ func (d *RIDDB) LoadJSON(r io.Reader) (int, error) {
 		Icon        string `json:"icon,omitempty"`
 	}
 	var arr []ridRaw
-	if err := json.NewDecoder(r).Decode(&arr); err != nil {
+	if err := json.NewDecoder(decodeReader(r)).Decode(&arr); err != nil {
 		return 0, fmt.Errorf("trunking: decode rid json: %w", err)
 	}
 	for _, raw := range arr {
 		rid := &RID{
 			ID:          raw.ID,
-			Alias:       raw.Alias,
-			Description: raw.Description,
-			Tag:         raw.Tag,
-			Group:       raw.Group,
-			Owner:       raw.Owner,
+			Alias:       sanitizeText(raw.Alias),
+			Description: sanitizeText(raw.Description),
+			Tag:         sanitizeText(raw.Tag),
+			Group:       sanitizeText(raw.Group),
+			Owner:       sanitizeText(raw.Owner),
 			Priority:    raw.Priority,
 			Lockout:     raw.Lockout,
 			Watch:       true,
-			Icon:        raw.Icon,
+			Icon:        sanitizeText(raw.Icon),
 		}
 		if raw.Watch != nil {
 			rid.Watch = *raw.Watch

--- a/internal/trunking/rid_test.go
+++ b/internal/trunking/rid_test.go
@@ -3,6 +3,9 @@ package trunking
 import (
 	"strings"
 	"testing"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
 
 func TestRIDDBLookup(t *testing.T) {
@@ -194,5 +197,46 @@ func TestLoadRIDJSONInvalid(t *testing.T) {
 	d := NewRIDDB()
 	if _, err := d.LoadJSON(strings.NewReader("{not json")); err == nil {
 		t.Error("expected error for malformed JSON")
+	}
+}
+
+// TestLoadRIDCSVUTF16 proves a SDRTrunk-style UTF-16LE-with-BOM export is
+// transcoded to clean UTF-8 instead of read as interleaved-NUL mojibake.
+func TestLoadRIDCSVUTF16(t *testing.T) {
+	const csv = "Decimal,Alias\n900007,DISPATCH\n"
+	enc := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder()
+	b, _, err := transform.Bytes(enc, []byte(csv))
+	if err != nil {
+		t.Fatalf("encode utf16: %v", err)
+	}
+	d := NewRIDDB()
+	if _, err := d.LoadCSV(strings.NewReader(string(b))); err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	r := d.Lookup(900007)
+	if r == nil || r.Alias != "DISPATCH" {
+		t.Errorf("utf16 import = %+v, want Alias=DISPATCH", r)
+	}
+}
+
+// TestLoadRIDStripsMojibake proves non-ASCII junk in alias fields is dropped
+// rather than surfaced verbatim in the UI (issue #711).
+func TestLoadRIDStripsMojibake(t *testing.T) {
+	csv := "Decimal,Alias\n900007,DIS中PATCH\n"
+	d := NewRIDDB()
+	if _, err := d.LoadCSV(strings.NewReader(csv)); err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	if r := d.Lookup(900007); r == nil || r.Alias != "DISPATCH" {
+		t.Errorf("csv mojibake = %+v, want Alias=DISPATCH", r)
+	}
+
+	js := `[{"id":900008,"alias":"UN中IT","owner":"Sgt"}]`
+	d2 := NewRIDDB()
+	if _, err := d2.LoadJSON(strings.NewReader(js)); err != nil {
+		t.Fatalf("LoadJSON: %v", err)
+	}
+	if r := d2.Lookup(900008); r == nil || r.Alias != "UNIT" || r.Owner != "Sgt" {
+		t.Errorf("json mojibake = %+v, want Alias=UNIT Owner=Sgt", r)
 	}
 }

--- a/internal/trunking/talkgroup.go
+++ b/internal/trunking/talkgroup.go
@@ -133,7 +133,7 @@ func (d *TalkgroupDB) Len() int {
 // inferred when Priority is set to a sentinel "L" value, matching common
 // community CSVs.
 func (d *TalkgroupDB) LoadCSV(r io.Reader) (int, error) {
-	cr := csv.NewReader(r)
+	cr := csv.NewReader(decodeReader(r))
 	cr.TrimLeadingSpace = true
 	cr.FieldsPerRecord = -1
 	header, err := cr.Read()
@@ -276,24 +276,24 @@ func (d *TalkgroupDB) LoadJSON(r io.Reader) (int, error) {
 		Icon        string `json:"icon"`
 	}
 	var arr []talkGroupRaw
-	if err := json.NewDecoder(r).Decode(&arr); err != nil {
+	if err := json.NewDecoder(decodeReader(r)).Decode(&arr); err != nil {
 		return 0, fmt.Errorf("trunking: decode json: %w", err)
 	}
 	for _, raw := range arr {
 		tg := &TalkGroup{
 			ID:          raw.ID,
-			AlphaTag:    raw.AlphaTag,
-			Description: raw.Description,
-			Tag:         raw.Tag,
-			Group:       raw.Group,
-			Mode:        raw.Mode,
+			AlphaTag:    sanitizeText(raw.AlphaTag),
+			Description: sanitizeText(raw.Description),
+			Tag:         sanitizeText(raw.Tag),
+			Group:       sanitizeText(raw.Group),
+			Mode:        sanitizeText(raw.Mode),
 			Priority:    raw.Priority,
 			Lockout:     raw.Lockout,
 			Scan:        true,
 			Stream:      true,
 			Record:      true,
 			Mute:        raw.Mute,
-			Icon:        raw.Icon,
+			Icon:        sanitizeText(raw.Icon),
 		}
 		if raw.Scan != nil {
 			tg.Scan = *raw.Scan
@@ -309,10 +309,16 @@ func (d *TalkgroupDB) LoadJSON(r io.Reader) (int, error) {
 	return len(arr), nil
 }
 
+// field returns the first present column among names, trimmed and reduced to
+// printable ASCII. Both the RID and talkgroup CSV loaders read every text
+// column through here, so sanitizing at this chokepoint strips imported
+// mojibake from all of them. The numeric ID column is read directly (not via
+// field), and the boolean/priority columns only ever hold ASCII digits or
+// y/n tokens, so sanitizing is a no-op for them.
 func field(row []string, idx map[string]int, names ...string) string {
 	for _, n := range names {
 		if i, ok := idx[n]; ok && i < len(row) {
-			return strings.TrimSpace(row[i])
+			return sanitizeText(strings.TrimSpace(row[i]))
 		}
 	}
 	return ""

--- a/internal/trunking/talkgroup_test.go
+++ b/internal/trunking/talkgroup_test.go
@@ -3,6 +3,8 @@ package trunking
 import (
 	"strings"
 	"testing"
+
+	"golang.org/x/text/encoding/unicode"
 )
 
 func TestTalkgroupDBLookup(t *testing.T) {
@@ -198,5 +200,32 @@ func TestLoadJSONDefaultsScanWhenAbsent(t *testing.T) {
 	}
 	if !d.Lookup(3).Scan {
 		t.Errorf("TG 3 Scan = false, want true (explicit true)")
+	}
+}
+
+// TestLoadCSVUTF16AndMojibake proves a UTF-16-with-BOM talkgroup export is
+// transcoded and that non-ASCII junk in text fields is stripped (issue #711
+// import hardening, talkgroup parity with the RID loader).
+func TestLoadCSVUTF16AndMojibake(t *testing.T) {
+	const csv = "Decimal,Alpha Tag\n1001,FIRE中DISP\n"
+	b := encodeUTF16(t, csv, unicode.LittleEndian)
+	d := NewTalkgroupDB()
+	if _, err := d.LoadCSV(strings.NewReader(string(b))); err != nil {
+		t.Fatalf("LoadCSV: %v", err)
+	}
+	if tg := d.Lookup(1001); tg == nil || tg.AlphaTag != "FIREDISP" {
+		t.Errorf("utf16+mojibake = %+v, want AlphaTag=FIREDISP", tg)
+	}
+}
+
+func TestLoadJSONStripsMojibake(t *testing.T) {
+	js := `[{"id":2002,"alpha_tag":"OP中S","description":"junkhere"}]`
+	d := NewTalkgroupDB()
+	if _, err := d.LoadJSON(strings.NewReader(js)); err != nil {
+		t.Fatalf("LoadJSON: %v", err)
+	}
+	tg := d.Lookup(2002)
+	if tg == nil || tg.AlphaTag != "OPS" || tg.Description != "junkhere" {
+		t.Errorf("json mojibake = %+v, want AlphaTag=OPS Description=junkhere", tg)
 	}
 }

--- a/internal/trunking/textsanitize.go
+++ b/internal/trunking/textsanitize.go
@@ -1,0 +1,37 @@
+package trunking
+
+import (
+	"io"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+// decodeReader wraps r so a UTF-16 (LE or BE) or UTF-8 byte-order mark is
+// honoured and transcoded to plain UTF-8, with a leading UTF-8 BOM stripped.
+// Files with no BOM (plain ASCII/UTF-8) pass through unchanged.
+//
+// SDRTrunk and other Windows-born tools frequently export alias files as
+// UTF-16-with-BOM; read as bytes those decode to interleaved-NUL mojibake.
+// Normalising at the reader boundary means every loader (CSV and JSON, file
+// and reader) gets clean UTF-8 before parsing.
+func decodeReader(r io.Reader) io.Reader {
+	// UTF-8 by default; BOMOverride switches to UTF-16 LE/BE when their BOM
+	// is present and consumes a leading UTF-8 BOM.
+	dec := unicode.BOMOverride(unicode.UTF8.NewDecoder())
+	return transform.NewReader(r, dec)
+}
+
+// sanitizeText reduces s to printable ASCII (0x20..0x7E), dropping control
+// characters, NULs, and any non-ASCII rune. Radio aliases are ASCII in
+// practice, so this strips the CJK / private-use mojibake seen in junk
+// SDRTrunk imports without losing real operator data.
+func sanitizeText(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if b := s[i]; b >= 0x20 && b < 0x7F {
+			out = append(out, b)
+		}
+	}
+	return string(out)
+}

--- a/internal/trunking/textsanitize_test.go
+++ b/internal/trunking/textsanitize_test.go
@@ -1,0 +1,89 @@
+package trunking
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
+)
+
+func TestSanitizeText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain ascii", "CPL-SMITH", "CPL-SMITH"},
+		{"strips cjk", "AB中CD", "ABCD"},
+		{"strips private use", "POLICE", "POLICE"},
+		{"strips control and nul", "A\x00B\tC\r\nD", "ABCD"},
+		{"keeps printable punctuation", "Cpl. Smith #5 (K-9)", "Cpl. Smith #5 (K-9)"},
+		{"all junk", "中文\x00", ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeText(tc.in); got != tc.want {
+				t.Errorf("sanitizeText(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// encodeUTF16 returns s encoded with a BOM in the given endianness, mimicking
+// a Windows/SDRTrunk export.
+func encodeUTF16(t *testing.T, s string, endian unicode.Endianness) []byte {
+	t.Helper()
+	enc := unicode.UTF16(endian, unicode.UseBOM).NewEncoder()
+	b, _, err := transform.Bytes(enc, []byte(s))
+	if err != nil {
+		t.Fatalf("encode utf16: %v", err)
+	}
+	return b
+}
+
+func TestDecodeReader(t *testing.T) {
+	const want = "Decimal,Alias\n900007,DISPATCH\n"
+
+	t.Run("plain ascii passthrough", func(t *testing.T) {
+		got := readAll(t, decodeReader(strings.NewReader(want)))
+		if got != want {
+			t.Errorf("ascii: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("utf8 bom stripped", func(t *testing.T) {
+		in := append([]byte{0xEF, 0xBB, 0xBF}, []byte(want)...)
+		got := readAll(t, decodeReader(strings.NewReader(string(in))))
+		if got != want {
+			t.Errorf("utf8-bom: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("utf16le bom transcoded", func(t *testing.T) {
+		in := encodeUTF16(t, want, unicode.LittleEndian)
+		got := readAll(t, decodeReader(strings.NewReader(string(in))))
+		if got != want {
+			t.Errorf("utf16le: got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("utf16be bom transcoded", func(t *testing.T) {
+		in := encodeUTF16(t, want, unicode.BigEndian)
+		got := readAll(t, decodeReader(strings.NewReader(string(in))))
+		if got != want {
+			t.Errorf("utf16be: got %q, want %q", got, want)
+		}
+	})
+}
+
+func readAll(t *testing.T, r io.Reader) string {
+	t.Helper()
+	b, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
Issue #711's reporter saw raw CJK/private-use mojibake in the web UI's
RID alias column. The latest issue comment corrected the diagnosis: this
was not an over-the-air decode bug but an import problem — an SDRTrunk
alias file (UTF-16/BOM encoded, or already containing garbled runes) was
loaded and displayed verbatim because the loaders did no encoding
handling or text validation.

Add a shared sanitization layer used by both the RID and talkgroup
loaders:

- decodeReader honours a UTF-16 (LE/BE) or UTF-8 BOM and transcodes to
  plain UTF-8, neutralising Windows/SDRTrunk exports; BOM-less ASCII/UTF-8
  passes through untouched.
- sanitizeText reduces text fields to printable ASCII, dropping control
  chars, NULs, and non-ASCII mojibake.

Both are wired into LoadCSV/LoadJSON for RID and talkgroup. CSV text
columns are cleaned at the shared field() chokepoint; JSON fields are
sanitized on assignment. Promotes golang.org/x/text to a direct require.

Adds tests covering UTF-16-with-BOM transcoding, BOM passthrough, and
mojibake stripping across both loaders and both formats.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012VWbJJg1C3gT6NQTQkn3Qw