### PR TITLE
sdr list: show full HackRF serial and bound --probe

### DIFF
--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
 	"github.com/MattCheramie/GopherTrunk/internal/diag"
@@ -417,30 +418,88 @@ func listSDRs(args []string) {
 				fmt.Fprintf(os.Stderr, "probe %s[%d]: %v\n", infos[i].Driver, infos[i].Index, err)
 				continue
 			}
-			dev, err := d.Open(infos[i].Index)
+			probed, err := probeDevice(d, infos[i].Index, probeTimeout)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "probe %s[%d]: %v\n", infos[i].Driver, infos[i].Index, err)
 				continue
 			}
-			probed := dev.Info()
 			infos[i].TunerName = probed.TunerName
 			infos[i].Gains = probed.Gains
-			_ = dev.Close()
 		}
 	}
 
-	fmt.Printf("%-8s  %-3s  %-16s  %-8s  %-8s  gains(0.1 dB)\n", "DRIVER", "IDX", "SERIAL", "TUNER", "PRODUCT")
-	for _, i := range infos {
-		fmt.Printf("%-8s  %-3d  %-16s  %-8s  %-8s  %v\n",
-			i.Driver, i.Index, truncate(i.Serial, 16), truncate(i.TunerName, 8), truncate(i.Product, 8), i.Gains)
+	fmt.Print(formatSDRTable(infos))
+}
+
+// probeTimeout bounds how long a single device's open+info+close may take
+// during `sdr list --probe`. Each USB control transfer inside Open already
+// carries its own 1 s timeout, but the open as a whole is otherwise
+// unbounded: a wedged device or transport (firmware that NAKs, a clone in a
+// bad state, a stalled control ioctl) would hang the command with no output.
+// This deadline guarantees `--probe` always returns.
+const probeTimeout = 5 * time.Second
+
+// probeDevice opens drv[idx], reads its Info, and closes it, all bounded by
+// timeout. The open/info/close runs on a goroutine so a device that wedges
+// can't block the caller: on timeout we return an error and let the
+// goroutine finish (and close the handle) on its own — harmless for a
+// short-lived CLI. Driver.Open takes no context, so the bound has to live
+// here at the call site rather than inside the driver.
+func probeDevice(drv sdr.Driver, idx int, timeout time.Duration) (sdr.Info, error) {
+	type result struct {
+		info sdr.Info
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		dev, err := drv.Open(idx)
+		if err != nil {
+			done <- result{err: err}
+			return
+		}
+		info := dev.Info()
+		_ = dev.Close()
+		done <- result{info: info}
+	}()
+	select {
+	case r := <-done:
+		return r.info, r.err
+	case <-time.After(timeout):
+		return sdr.Info{}, fmt.Errorf("timed out after %s", timeout)
 	}
 }
 
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
+// formatSDRTable renders the `sdr list` table with per-column widths sized
+// to the widest value actually present (header label or any row), so values
+// like a HackRF's 32-hex serial or the full "MAX2839+MAX5864" tuner string
+// print in full instead of being silently truncated. The trailing gains
+// column is free-form.
+func formatSDRTable(infos []sdr.Info) string {
+	const (
+		hDriver  = "DRIVER"
+		hIndex   = "IDX"
+		hSerial  = "SERIAL"
+		hTuner   = "TUNER"
+		hProduct = "PRODUCT"
+	)
+	wDriver, wIndex, wSerial, wTuner, wProduct :=
+		len(hDriver), len(hIndex), len(hSerial), len(hTuner), len(hProduct)
+	for _, i := range infos {
+		wDriver = max(wDriver, len(i.Driver))
+		wIndex = max(wIndex, len(strconv.Itoa(i.Index)))
+		wSerial = max(wSerial, len(i.Serial))
+		wTuner = max(wTuner, len(i.TunerName))
+		wProduct = max(wProduct, len(i.Product))
 	}
-	return s[:n]
+	var b strings.Builder
+	rowFmt := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%v\n",
+		wDriver, wIndex, wSerial, wTuner, wProduct)
+	fmt.Fprintf(&b, "%-*s  %-*s  %-*s  %-*s  %-*s  gains(0.1 dB)\n",
+		wDriver, hDriver, wIndex, hIndex, wSerial, hSerial, wTuner, hTuner, wProduct, hProduct)
+	for _, i := range infos {
+		fmt.Fprintf(&b, rowFmt, i.Driver, strconv.Itoa(i.Index), i.Serial, i.TunerName, i.Product, i.Gains)
+	}
+	return b.String()
 }
 
 // pickConfigInteractive is the DiscoverOptions.Pick callback for

--- a/cmd/gophertrunk/sdr_list_test.go
+++ b/cmd/gophertrunk/sdr_list_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// fakeProbeDriver is a minimal sdr.Driver whose Open behaviour is supplied
+// per-test so probeDevice's timeout/error/success paths can be exercised
+// without real hardware.
+type fakeProbeDriver struct {
+	open func(idx int) (sdr.Device, error)
+}
+
+func (d *fakeProbeDriver) Name() string                     { return "fake" }
+func (d *fakeProbeDriver) Enumerate() ([]sdr.Info, error)   { return nil, nil }
+func (d *fakeProbeDriver) Open(idx int) (sdr.Device, error) { return d.open(idx) }
+
+// fakeProbeDevice reports a fixed Info and records that Close was called.
+type fakeProbeDevice struct {
+	info   sdr.Info
+	closed chan struct{}
+}
+
+func (d *fakeProbeDevice) Info() sdr.Info             { return d.info }
+func (d *fakeProbeDevice) SetCenterFreq(uint32) error { return nil }
+func (d *fakeProbeDevice) SetSampleRate(uint32) error { return nil }
+func (d *fakeProbeDevice) SetGain(int) error          { return nil }
+func (d *fakeProbeDevice) SetPPM(int) error           { return nil }
+func (d *fakeProbeDevice) SetBiasTee(bool) error      { return nil }
+func (d *fakeProbeDevice) StreamIQ(context.Context) (<-chan []complex64, error) {
+	return nil, nil
+}
+func (d *fakeProbeDevice) Close() error {
+	if d.closed != nil {
+		close(d.closed)
+	}
+	return nil
+}
+
+func TestProbeDeviceSuccess(t *testing.T) {
+	want := sdr.Info{TunerName: "MAX2839+MAX5864", Gains: []int{0, 80, 160}}
+	closed := make(chan struct{})
+	drv := &fakeProbeDriver{open: func(int) (sdr.Device, error) {
+		return &fakeProbeDevice{info: want, closed: closed}, nil
+	}}
+	got, err := probeDevice(drv, 0, time.Second)
+	if err != nil {
+		t.Fatalf("probeDevice: unexpected error: %v", err)
+	}
+	if got.TunerName != want.TunerName {
+		t.Errorf("TunerName = %q, want %q", got.TunerName, want.TunerName)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Error("Close was not called on the probed device")
+	}
+}
+
+func TestProbeDeviceOpenError(t *testing.T) {
+	wantErr := errors.New("permission denied")
+	drv := &fakeProbeDriver{open: func(int) (sdr.Device, error) {
+		return nil, wantErr
+	}}
+	if _, err := probeDevice(drv, 0, time.Second); !errors.Is(err, wantErr) {
+		t.Fatalf("probeDevice error = %v, want %v", err, wantErr)
+	}
+}
+
+// TestProbeDeviceTimeout is the regression for `sdr list --probe` hanging on a
+// wedged device: Open blocks forever, and probeDevice must still return a
+// timeout error promptly rather than blocking the caller.
+func TestProbeDeviceTimeout(t *testing.T) {
+	drv := &fakeProbeDriver{open: func(int) (sdr.Device, error) {
+		select {} // never returns
+	}}
+	start := time.Now()
+	_, err := probeDevice(drv, 0, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("probeDevice: expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error = %q, want it to mention a timeout", err.Error())
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("probeDevice took %s; should return near the 50ms timeout", elapsed)
+	}
+}
+
+// TestFormatSDRTableFullSerial is the regression for the reported bug: a
+// HackRF's full 32-hex serial (and the full tuner/product strings) must print
+// untruncated rather than being cut to the all-zero 16-char prefix.
+func TestFormatSDRTableFullSerial(t *testing.T) {
+	const serial = "0000000000000000457863c8284a625f"
+	out := formatSDRTable([]sdr.Info{{
+		Driver:    "hackrf",
+		Index:     0,
+		Serial:    serial,
+		TunerName: "MAX2839+MAX5864",
+		Product:   "HackRF One",
+		Gains:     []int{0, 80, 160, 240, 320, 400, 480, 560},
+	}})
+	for _, want := range []string{serial, "MAX2839+MAX5864", "HackRF One"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q; got:\n%s", want, out)
+		}
+	}
+	// The all-zero prefix must not appear as a standalone (truncated) column.
+	if strings.Contains(out, "0000000000000000  ") {
+		t.Errorf("serial appears truncated to its zero prefix; got:\n%s", out)
+	}
+}

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -45,3 +45,36 @@ irrelevant to receive-only scanning.
 
 For decoding trunked voice, HackRF is overkill; an [RTL-SDR](/reference/rtl-sdr/) or
 Airspy is usually the better fit, but GopherTrunk can use it as a receiver.
+
+## Setup (Linux)
+
+GopherTrunk talks to the HackRF directly over USB — no `libhackrf` or
+`hackrf-tools` install required. The one host-side step is a udev rule so
+non-root processes can open the device node. Without it, `gophertrunk sdr list`
+still shows the device (it only reads `sysfs`), but opening it — `sdr list
+--probe`, `sdr doctor`, and normal capture — fails with `permission denied` on
+`/dev/bus/usb/…`.
+
+```sh
+sudo tee /etc/udev/rules.d/20-hackrf.rules <<'EOF'
+# HackRF One / Jawbreaker / Rad1o (Great Scott Gadgets, VID 0x1d50)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="6089", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="604b", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="cc15", MODE="0666"
+EOF
+sudo udevadm control --reload
+sudo udevadm trigger
+```
+
+Unplug and re-plug the HackRF once so the rule applies to a freshly-enumerated
+device. Swap `MODE="0666"` for `MODE="0660", GROUP="plugdev"` if you'd rather
+scope access. Then confirm:
+
+```sh
+gophertrunk sdr list --probe
+```
+
+> **Serial number.** A HackRF reports a full 32-hex-digit `part_id + serial_no`
+> string — the leading 16 digits are a constant prefix (commonly all zeros) and
+> the trailing digits are the unique part. `gophertrunk sdr list` prints the
+> whole string, matching `hackrf_info`'s "Serial number".


### PR DESCRIPTION
The SERIAL column front-truncated to 16 chars, which for a HackRF cut off
the meaningful tail of its 32-hex part_id+serial string and left only the
all-zero prefix (reported as "0000000000000000"). It also clipped TUNER
("MAX2839+MAX5864" -> "MAX2839+") and PRODUCT ("HackRF One" -> "HackRF O").
Replace the fixed widths with per-column widths sized to the widest value
present so serials, tuner, and product print in full.

--probe opened each device with no overall deadline; a wedged device or
transport could hang the command with no output. Wrap each open+info+close
in a bounded probeDevice helper so the command always returns.

Add a Linux setup (udev) section to the HackRF reference doc and tests for
the table formatter and probe timeout/error/success paths.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CzGb1b3TvMKPxhcMEdhFrP