### PR TITLE
Audio/scanner follow-ups: raw-frame gRPC streaming, scanner test, blind-sweep monitor

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1244,6 +1244,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		}
 		liveSinks = append(liveSinks, liveStreamSink)
 		d.recorder.SetDecodedPCMSink(fanoutSink(liveSinks))
+		// Raw vocoder frames fan straight to the publisher (the only raw
+		// consumer): include_raw subscribers get the un-decoded IMBE / AMBE
+		// bytes. This path bypasses live-loudness — that AGC only makes sense
+		// on decoded PCM, not on un-decoded codec frames.
+		d.recorder.SetRawFrameSink(d.audioPub)
 
 		var sink composer.PCMSink = d.recorder
 		if len(sinks) > 1 {
@@ -3523,6 +3528,12 @@ func (f fanoutSink) WritePCM(serial string, samples []int16) error {
 // selects this path via the voice.DecodedPCMCallSink assertion on its decoded
 // tap; without it the live fan-out would drop back to serial-only WritePCM and
 // the bleed guard would be inert in the daemon.
+//
+// Only the digital tap path needs this: it reuses a fixed pool of voice-tap
+// serials across calls. The analog/conventional FM chains feed plain WritePCM
+// (composer.runFMChain) on a stable per-channel serial that is never reused
+// across calls, so the tone-out/analog path is correct-by-construction without
+// a CallID and intentionally stays on WritePCM.
 func (f fanoutSink) WritePCMForCall(serial string, callID uint64, samples []int16) error {
 	for _, s := range f {
 		if cs, ok := s.(interface {

--- a/internal/api/audio_publisher.go
+++ b/internal/api/audio_publisher.go
@@ -60,11 +60,12 @@ const audioSubChanCap = 256
 type AudioSubFilter struct {
 	DeviceSerials []string
 	TalkgroupIDs  []uint32
-	// IncludeRaw mirrors the proto flag. Until WriteRawFrame is
-	// wired into the publisher (digital-voice raw frames are a
-	// follow-up), this just selects whether to surface PCM frames
-	// at all — false is the safe default that's never going to
-	// break a caller that didn't ask for audio.
+	// IncludeRaw mirrors the proto flag and is purely additive: false
+	// (the default, and what the WebUI sends) means PCM only; true means
+	// PCM *and* the verbatim un-decoded vocoder frames (IMBE / AMBE+2)
+	// the recorder's raw tap forwards via WriteRawFrame. Existing PCM-only
+	// callers are unaffected — raw frames are fanned solely to subscribers
+	// that opted in here.
 	IncludeRaw bool
 }
 
@@ -250,6 +251,76 @@ func (p *AudioPublisher) writePCM(deviceSerial string, callID uint64, samples []
 	return nil
 }
 
+// WriteRawFrame fans a verbatim, un-decoded vocoder frame (IMBE / AMBE+2) to
+// subscribers that asked for raw bytes (filter.IncludeRaw). It satisfies
+// voice.RawFrameSink so the recorder's raw tap can stream the same bytes it
+// writes to the .raw sidecar. vocoder is the codec name that produced the
+// session (may be empty for protocols with no in-process decoder, e.g.
+// ProVoice); it labels the wire frame but is not required.
+func (p *AudioPublisher) WriteRawFrame(deviceSerial, vocoder string, frame []byte) error {
+	return p.writeRaw(deviceSerial, 0, vocoder, frame)
+}
+
+// WriteRawFrameForCall is WriteRawFrame plus the CallID the frame was decoded
+// for. It satisfies voice.RawFrameCallSink so a raw frame still draining from
+// the call that previously held a reused voice-tap serial is fenced the same
+// way WritePCMForCall fences decoded PCM — dropped rather than fanned out
+// labelled with (and leaked to subscribers filtered on) the newer call's
+// talkgroup. A zero CallID on either side matches, preserving WriteRawFrame's
+// behaviour.
+func (p *AudioPublisher) WriteRawFrameForCall(deviceSerial string, callID uint64, vocoder string, frame []byte) error {
+	return p.writeRaw(deviceSerial, callID, vocoder, frame)
+}
+
+// writeRaw mirrors writePCM — same cross-call fence and grant-labelling /
+// skip-talkgroup-without-grant logic — but emits an AudioFrame_Raw and fans
+// only to subscribers that set IncludeRaw. Raw is purely additive: PCM-only
+// subscribers (the common case, incl. the WebUI) never see these frames.
+func (p *AudioPublisher) writeRaw(deviceSerial string, callID uint64, vocoder string, frame []byte) error {
+	if p == nil || len(frame) == 0 {
+		return nil
+	}
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if len(p.subs) == 0 {
+		return nil
+	}
+	grant, haveGrant := p.grants[deviceSerial]
+	// Cross-call fence: this raw frame belongs to callID, but the serial's
+	// live grant has moved on. Drop rather than mislabel the old call's tail.
+	if haveGrant && callID != 0 && grant.CallID != 0 && callID != grant.CallID {
+		return nil
+	}
+
+	var built *apiv1.AudioFrame // built on first matching raw subscriber
+	for sub := range p.subs {
+		// Raw is opt-in; PCM-only subscribers are skipped entirely.
+		if !sub.filter.IncludeRaw {
+			continue
+		}
+		// A talkgroup filter needs a known GroupID to evaluate; without a
+		// grant we can't prove a match, so skip rather than risk a leak.
+		if len(sub.filter.TalkgroupIDs) > 0 && !haveGrant {
+			continue
+		}
+		if !sub.filter.matches(deviceSerial, grant.GroupID) {
+			continue
+		}
+		if built == nil {
+			built = buildRawFrame(grant, deviceSerial, vocoder, frame)
+		}
+		select {
+		case sub.ch <- built:
+			p.markFanned(sub)
+		default:
+			sub.dropped.Add(uint64(len(frame)))
+			p.dropped.Add(uint64(len(frame)))
+			p.markChannelFull(sub)
+		}
+	}
+	return nil
+}
+
 // markFanned logs once, the first time a subscriber actually receives a
 // PCM frame — a cheap "live audio is flowing" signal for operators.
 func (p *AudioPublisher) markFanned(sub *audioSubscriber) {
@@ -357,6 +428,22 @@ func buildPCMFrame(grant trunking.Grant, serial string, samples []int16) *apiv1.
 			Pcm: &apiv1.PCMSamples{
 				SampleRate: 8000, // recorder writes at 8 kHz today; future: pull from composer
 				Samples:    body,
+			},
+		},
+	}
+}
+
+// buildRawFrame builds the wire-side AudioFrame for a verbatim vocoder frame.
+// We copy the byte slice so the caller (the recorder's hot path) can reuse its
+// buffer without mutating an in-flight frame, mirroring buildPCMFrame.
+func buildRawFrame(grant trunking.Grant, serial, vocoder string, frame []byte) *apiv1.AudioFrame {
+	return &apiv1.AudioFrame{
+		Grant:        grantToPB(grant),
+		DeviceSerial: serial,
+		Body: &apiv1.AudioFrame_Raw{
+			Raw: &apiv1.RawVocoderFrame{
+				Vocoder: vocoder,
+				Frame:   append([]byte(nil), frame...),
 			},
 		},
 	}

--- a/internal/api/audio_publisher_test.go
+++ b/internal/api/audio_publisher_test.go
@@ -304,6 +304,97 @@ func TestAudioPublisher_WritePCMForCallFencesStaleCall(t *testing.T) {
 	}
 }
 
+// Raw vocoder frames reach a subscriber that opted in via IncludeRaw, carrying
+// the un-decoded bytes, the codec name, and the call's grant.
+func TestAudioPublisher_RawFansToIncludeRawSubs(t *testing.T) {
+	pub, bus := mkPublisher(t)
+	publishCallStart(t, pub, bus, "VOICE-1", trunking.Grant{GroupID: 42, System: "Sys"})
+
+	sub := pub.Subscribe(AudioSubFilter{IncludeRaw: true})
+	defer pub.Unsubscribe(sub)
+
+	if err := pub.WriteRawFrame("VOICE-1", "imbe", []byte{0xDE, 0xAD, 0xBE}); err != nil {
+		t.Fatalf("WriteRawFrame: %v", err)
+	}
+	select {
+	case frame := <-sub.ch:
+		raw := frame.GetRaw()
+		if raw == nil {
+			t.Fatal("frame missing raw body (got PCM or empty)")
+		}
+		if raw.Vocoder != "imbe" {
+			t.Errorf("vocoder = %q, want imbe", raw.Vocoder)
+		}
+		if string(raw.Frame) != string([]byte{0xDE, 0xAD, 0xBE}) {
+			t.Errorf("frame bytes = %v, want DEADBE", raw.Frame)
+		}
+		if frame.GetGrant().GroupId != 42 {
+			t.Errorf("grant.group_id = %d, want 42", frame.GetGrant().GroupId)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("include_raw subscriber received no raw frame")
+	}
+}
+
+// Raw frames must NOT reach a PCM-only subscriber (IncludeRaw false). Raw is
+// purely additive — the common case (incl. the WebUI) opts out.
+func TestAudioPublisher_RawNotFannedToPCMOnlySubs(t *testing.T) {
+	pub, bus := mkPublisher(t)
+	publishCallStart(t, pub, bus, "VOICE-1", trunking.Grant{GroupID: 42})
+
+	sub := pub.Subscribe(AudioSubFilter{}) // IncludeRaw defaults false
+	defer pub.Unsubscribe(sub)
+
+	if err := pub.WriteRawFrame("VOICE-1", "imbe", []byte{1, 2, 3}); err != nil {
+		t.Fatalf("WriteRawFrame: %v", err)
+	}
+	select {
+	case f := <-sub.ch:
+		t.Fatalf("PCM-only subscriber received a raw frame (raw=%v) — IncludeRaw not honoured", f.GetRaw())
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// The raw path is fenced by CallID exactly like WritePCMForCall: a frame from
+// the call that previously held a reused tap serial is dropped once the serial's
+// grant has flipped to a newer call.
+func TestAudioPublisher_WriteRawFrameForCallFencesStaleCall(t *testing.T) {
+	pub, bus := mkPublisher(t)
+	publishCallStart(t, pub, bus, "tap-0", trunking.Grant{GroupID: 100, CallID: 1})
+
+	sub := pub.Subscribe(AudioSubFilter{IncludeRaw: true, TalkgroupIDs: []uint32{200}})
+	defer pub.Unsubscribe(sub)
+
+	// The new call binds the same tap serial.
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: trunking.Grant{GroupID: 200, CallID: 2}, DeviceSerial: "tap-0",
+	}})
+	waitForCallID(t, pub, "tap-0", 2)
+
+	// Old call's raw tail (CallID 1) must NOT reach the TG-200 subscriber.
+	if err := pub.WriteRawFrameForCall("tap-0", 1, "imbe", []byte{1, 2, 3}); err != nil {
+		t.Fatalf("WriteRawFrameForCall stale: %v", err)
+	}
+	select {
+	case f := <-sub.ch:
+		t.Fatalf("TG-200 subscriber received stale CallID-1 raw audio (group_id=%d) — bleed not fenced", f.GetGrant().GroupId)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// The current call's raw frame (CallID 2) flows through.
+	if err := pub.WriteRawFrameForCall("tap-0", 2, "imbe", []byte{4, 5, 6}); err != nil {
+		t.Fatalf("WriteRawFrameForCall current: %v", err)
+	}
+	select {
+	case f := <-sub.ch:
+		if f.GetRaw() == nil || f.GetGrant().GroupId != 200 {
+			t.Errorf("got raw=%v group_id=%d, want raw frame for TG 200", f.GetRaw(), f.GetGrant().GroupId)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("TG-200 subscriber received no current-call raw frame")
+	}
+}
+
 func TestAudioPublisher_UnsubscribeIsIdempotent(t *testing.T) {
 	pub, _ := mkPublisher(t)
 	sub := pub.Subscribe(AudioSubFilter{})

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -707,6 +707,15 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 				pcm = decimateAndConvert(audio, decim2)
 			}
 			if c.sink != nil && len(pcm) > 0 {
+				// Plain WritePCM (no CallID fence) is correct here: an
+				// analog FM chain keys on a stable per-channel physical
+				// device serial, never the reused wb:<serial>:tap-N pool
+				// the wideband engine drives (and which it restricts to
+				// digital protocols). With one chain per serial, torn down
+				// on CallEnd before the next CallStart, there is no
+				// cross-call serial reuse — so the WritePCMForCall fence the
+				// digital tap path needs would be guarding a condition that
+				// can't occur on this path.
 				_ = c.sink.WritePCM(serial, pcm)
 				lastSample = pcm[len(pcm)-1]
 				pcmWrites.Add(1)

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -77,6 +77,14 @@ type Recorder struct {
 	// tests).
 	decodedTap DecodedPCMSink
 
+	// rawTap, when set, receives the verbatim raw vocoder frames the
+	// recorder also writes to its .raw sidecar, so the gRPC audio
+	// publisher's include_raw subscribers can stream un-decoded IMBE /
+	// AMBE bytes. Wired once at daemon construction via SetRawFrameSink
+	// before Run starts, so the hot path reads it without locking. nil =
+	// no raw fan-out (analog-only callers, tests).
+	rawTap RawFrameSink
+
 	// recordDisabled gates new sessions at runtime. Toggled from
 	// the API by operators who want to stop laying down WAVs
 	// without restarting the daemon. In-flight sessions are NOT
@@ -109,12 +117,41 @@ type DecodedPCMCallSink interface {
 	WritePCMForCall(deviceSerial string, callID uint64, samples []int16) error
 }
 
+// RawFrameSink receives the verbatim, un-decoded vocoder frames (IMBE /
+// AMBE+2) the recorder also lays down as its .raw sidecar, so a live consumer
+// — the gRPC audio publisher's include_raw subscribers — can stream the raw
+// bytes without the recorder remaining the only place they exist. It carries
+// the vocoder name that produced the session so the wire frame can label its
+// codec, and unlike the decoded tap it fires even for protocols with no
+// in-process decoder (ProVoice, encrypted): the raw bytes exist even when
+// decoded PCM does not.
+type RawFrameSink interface {
+	WriteRawFrame(deviceSerial, vocoder string, frame []byte) error
+}
+
+// RawFrameCallSink is the call-aware extension of RawFrameSink: it carries the
+// CallID the raw frame belongs to so the live fan-out applies the same
+// cross-call fence the decoded tap does when a voice-tap serial is reused. A
+// sink implementing it is preferred over plain WriteRawFrame in the raw-tap
+// fan-out; sinks that don't still get WriteRawFrame.
+type RawFrameCallSink interface {
+	WriteRawFrameForCall(deviceSerial string, callID uint64, vocoder string, frame []byte) error
+}
+
 // SetDecodedPCMSink wires the live-audio tap that receives PCM decoded
 // from digital vocoder frames. Call once during daemon construction
 // before Run/any calls start; it is not safe to change concurrently
 // with WriteRawFrame.
 func (r *Recorder) SetDecodedPCMSink(s DecodedPCMSink) {
 	r.decodedTap = s
+}
+
+// SetRawFrameSink wires the live raw-frame tap that receives the verbatim
+// un-decoded vocoder frames (the gRPC audio publisher). Call once during
+// daemon construction before Run/any calls start; it is not safe to change
+// concurrently with WriteRawFrame.
+func (r *Recorder) SetRawFrameSink(s RawFrameSink) {
+	r.rawTap = s
 }
 
 // RecorderOptions configure a new Recorder.
@@ -418,6 +455,22 @@ func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byt
 	if s.raw != nil {
 		if _, err := s.raw.Write(frame); err != nil {
 			return err
+		}
+	}
+	// Fan the verbatim raw frame to the live raw tap (the gRPC audio
+	// publisher's include_raw subscribers) before any decode. Fires for
+	// every protocol with an open session — including ProVoice / encrypted
+	// calls that have no in-process decoder — since the raw bytes exist even
+	// when decoded PCM doesn't. Hands the session's CallID to a call-aware
+	// sink so the live raw stream is fenced by the same identity the WAV and
+	// decoded tap use, closing the cross-call bleed window on a reused tap
+	// serial (the frame already passed sessionForWrite's CallID check, so
+	// s.callID is authoritative for this audio).
+	if r.rawTap != nil {
+		if cs, ok := r.rawTap.(RawFrameCallSink); ok {
+			_ = cs.WriteRawFrameForCall(deviceSerial, s.callID, s.vocoderName, frame)
+		} else {
+			_ = r.rawTap.WriteRawFrame(deviceSerial, s.vocoderName, frame)
 		}
 	}
 	if s.vocoder != nil {

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -695,6 +695,98 @@ func TestRecorderForwardsDecodedPCMToCallAwareTap(t *testing.T) {
 	}
 }
 
+// fakeRawTap implements RawFrameCallSink, recording the verbatim bytes, vocoder
+// name, and CallID the recorder forwards for each raw frame so a test can
+// confirm the raw fan-out carries the codec label and is fenced by the
+// session's call identity.
+type fakeRawTap struct {
+	mu       sync.Mutex
+	callIDs  []uint64
+	vocoders []string
+	frames   [][]byte
+}
+
+func (f *fakeRawTap) WriteRawFrame(_, vocoder string, frame []byte) error {
+	return f.WriteRawFrameForCall("", 0, vocoder, frame)
+}
+func (f *fakeRawTap) WriteRawFrameForCall(_ string, callID uint64, vocoder string, frame []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.callIDs = append(f.callIDs, callID)
+	f.vocoders = append(f.vocoders, vocoder)
+	f.frames = append(f.frames, append([]byte(nil), frame...))
+	return nil
+}
+func (f *fakeRawTap) snapshot() (callIDs []uint64, vocoders []string, frames [][]byte) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]uint64(nil), f.callIDs...), append([]string(nil), f.vocoders...), f.frames
+}
+
+// TestRecorderForwardsRawFramesToTap: the recorder must forward verbatim raw
+// vocoder frames to the raw tap (the gRPC publisher's include_raw subscribers),
+// carrying the session's vocoder name and CallID, and a stale-call frame must be
+// fenced by sessionForWrite before reaching the tap — the raw complement of the
+// decoded-PCM bleed guard.
+func TestRecorderForwardsRawFramesToTap(t *testing.T) {
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"test-null": "null"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	tap := &fakeRawTap{}
+	r.SetRawFrameSink(tap)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-null", GroupID: 1, CallID: 77},
+		DeviceSerial: "tap-0",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("tap-0") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// A matching frame forwards the verbatim bytes, the session vocoder name,
+	// and the session CallID.
+	want := []byte{0xAA, 0xBB, 0xCC, 0, 0, 0, 0, 0, 0, 0, 0} // NullVocoder.FrameSize = 11
+	if err := r.WriteRawFrameForCall("tap-0", 77, want, 0); err != nil {
+		t.Fatalf("WriteRawFrameForCall: %v", err)
+	}
+	// A stale-call frame is fenced before the tap.
+	if err := r.WriteRawFrameForCall("tap-0", 999, make([]byte, 11), 0); err != nil {
+		t.Fatalf("WriteRawFrameForCall stale: %v", err)
+	}
+
+	callIDs, vocoders, frames := tap.snapshot()
+	if len(callIDs) != 1 || callIDs[0] != 77 {
+		t.Fatalf("forwarded callIDs = %v, want exactly [77] (stale 999 fenced)", callIDs)
+	}
+	if vocoders[0] != "null" {
+		t.Errorf("vocoder = %q, want null", vocoders[0])
+	}
+	if string(frames[0]) != string(want) {
+		t.Errorf("frame bytes = %v, want %v", frames[0], want)
+	}
+}
+
 // TestRecorderForwardsDecodedPCMToTap: PCM the recorder decodes from
 // digital vocoder frames in WriteRawFrame must be forwarded to the
 // live-audio tap (web stream / player / tone-out). Without this the

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -176,6 +176,7 @@ export function Hunt() {
         county: county || undefined,
         serial: serial || undefined,
         protocol: protocol || undefined,
+        monitor_seconds: ccMonitorMin > 0 ? ccMonitorMin * 60 : undefined,
       });
     } catch (e: unknown) {
       setError(e instanceof Error ? `start hunt failed: ${e.message}` : "start hunt failed");
@@ -418,6 +419,22 @@ export function Hunt() {
                 value={protocol}
                 onChange={(e) => setProtocol(e.target.value)}
                 placeholder="p25"
+              />
+            )}
+          </Field>
+          <Field
+            label="Monitor (minutes, 0 = off)"
+            hint="After the sweep locks a control channel, streams it and stops once identity, neighbors and band plan settle."
+          >
+            {(p) => (
+              <Input
+                {...p}
+                className="w-full"
+                type="number"
+                min={0}
+                step={1}
+                value={ccMonitorMin}
+                onChange={(e) => setCCMonitorMin(Number(e.target.value))}
               />
             )}
           </Field>

--- a/web/src/panels/Scanner.test.tsx
+++ b/web/src/panels/Scanner.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("../api/client", () => ({
+  api: { scanner: vi.fn() },
+}));
+
+vi.mock("../api/write", () => ({
+  writes: {
+    setScanMode: vi.fn(),
+    huntHold: vi.fn(),
+    huntResume: vi.fn(),
+    huntRetune: vi.fn(),
+    convHold: vi.fn(),
+    convResume: vi.fn(),
+    convDwell: vi.fn(),
+    convLockout: vi.fn(),
+    convUnlockout: vi.fn(),
+    manualTune: vi.fn(),
+  },
+}));
+
+import { api } from "../api/client";
+import type { ScannerStatusDTO } from "../api/types";
+import { useShared } from "../store/shared";
+import { Scanner } from "./Scanner";
+
+function resetStore() {
+  useShared.setState({
+    serverURL: "http://localhost:8080",
+    token: null,
+    writeMode: true,
+    mutations: { allow_mutations: true },
+    lastError: null,
+    scanner: null,
+  });
+}
+
+describe("Scanner panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetStore();
+  });
+
+  // Regression for the field-reported "reading 'length' of undefined" crash:
+  // the daemon can serialize a scanner snapshot with null systems/conventional
+  // (no hunt systems configured, conventional scanner absent). The panel's
+  // `systems ?? []` / `conventional ?? { … }` guards must keep it from
+  // dereferencing those nulls. Without the guards this render throws.
+  it("renders without crashing when systems and conventional are null", async () => {
+    vi.mocked(api.scanner).mockResolvedValue({
+      scan_mode: "all",
+      systems: null,
+      conventional: null,
+      tg_scan_count: 0,
+      tg_total: 0,
+    } as unknown as ScannerStatusDTO);
+
+    render(<Scanner />);
+
+    // The poll resolves, setScanner replaces the null snapshot, and the panel
+    // re-renders through the guarded branches without throwing.
+    await waitFor(() =>
+      expect(screen.getByText(/talkgroups eligible/i)).toBeInTheDocument(),
+    );
+    expect(api.scanner).toHaveBeenCalled();
+  });
+
+  // The populated path renders the header counts so the test also locks the
+  // non-null branch the guards fall through to.
+  it("renders the eligible-talkgroup counts from a populated snapshot", async () => {
+    vi.mocked(api.scanner).mockResolvedValue({
+      scan_mode: "list",
+      systems: [],
+      conventional: { enabled: false, channels: [] },
+      tg_scan_count: 7,
+      tg_total: 42,
+    });
+
+    render(<Scanner />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/7 of 42 talkgroups eligible/i)).toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Completes the adjacent follow-ups left open after the field-bug fixes in `21e7a41` (audio bleed, scanner crash, hunt identity, bogus TG, TG-frequency column). Three independent pieces, smallest first.

### 1. Scanner null-guard test (frontend)
The daemon can serialize a scanner snapshot with `null` `systems`/`conventional` (no hunt systems configured, conventional scanner absent). The `?? []` / `?? { … }` guards added in `21e7a41` prevent the reported `reading 'length' of undefined` crash but had no frontend coverage. New `Scanner.test.tsx` drives the null-shaped snapshot through the poll and asserts the panel renders, plus a populated case that locks the non-null branch. *(The test fails if the guards are removed.)*

### 2. Blind-sweep monitor field (frontend)
Only the parse-control-channel form sent `monitor_seconds`; the blind-sweep `start()` payload omitted it, so a sweep could never engage the converge-and-stop monitor (backend default is off). Threads the existing `ccMonitorMin` state into the sweep payload and adds the matching field to the blind-sweep section.

### 3. Raw vocoder frames over gRPC (`include_raw`)
`AudioSubFilter.IncludeRaw` was a near no-op — `WriteRawFrame` was never wired into the publisher, so digital raw frames (IMBE / AMBE+2) stayed recorder-only and clients asking for raw bytes got nothing. The wire message already carries the `raw` oneof variant and the handler already threads `include_raw`, so this is **pure Go plumbing — no proto regeneration**:

- **recorder**: a `RawFrameSink`/`RawFrameCallSink` tap mirroring the decoded-PCM tap; `writeRawFrame` fans the verbatim frame + vocoder name + CallID before decode, so it fires even for protocols with no in-process decoder (ProVoice, encrypted) where raw bytes are the only audio.
- **daemon**: wires the raw tap straight to the publisher (raw bypasses live-loudness, which only applies to decoded PCM).
- **publisher**: `WriteRawFrame`/`WriteRawFrameForCall` emit `AudioFrame_Raw`, reusing `writePCM`'s cross-call fence and grant-labelling but fanning only to `IncludeRaw` subscribers. Raw is **purely additive** — PCM-only clients (incl. the WebUI) are unaffected.

Also documents why the analog/tone-out path intentionally stays on plain `WritePCM`: analog FM chains key on a stable per-channel serial that is never reused across calls (only the digital wideband tap pool is), so the `WritePCMForCall` fence would guard a condition that can't occur there.

## Testing
- `go build ./...` ✅, `go test ./internal/api/... ./internal/voice/...` ✅ (incl. new publisher + recorder raw-frame fence tests)
- `npx tsc --noEmit` ✅, `npx vitest run` ✅ — 268 tests (266 + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BLQxxMQnR4mNs9UhKT7oW5)_