### PR TITLE
sdr: fix HackRF serial display, bound --probe, and Windows/daemon device discovery

### DIFF
--- a/cmd/gophertrunk/sdr_doctor.go
+++ b/cmd/gophertrunk/sdr_doctor.go
@@ -8,13 +8,38 @@ import (
 	"runtime"
 	"text/tabwriter"
 
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/hackrf"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/purego"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
 )
 
-// runSDRDoctor implements `gophertrunk sdr doctor`. It iterates the
-// librtlsdr VID/PID whitelist, asks the platform inspector which
-// kernel/Windows function driver is bound to each matching dongle,
+// doctorDevice is one VID/PID the doctor inspects for driver binding.
+type doctorDevice struct {
+	VID  uint16
+	PID  uint16
+	Name string
+}
+
+// knownDoctorDevices is the union of every pure-Go USB SDR's VID/PID
+// table the doctor knows how to diagnose: RTL-SDR plus HackRF. Windows
+// binds a function driver per VID/PID at plug time, so the doctor has to
+// check each identity to tell the operator whether WinUSB is bound. A
+// HackRF that appears in `sdr list` but fails to open shows up here with
+// the wrong-driver hint instead of being invisible to the doctor.
+func knownDoctorDevices() []doctorDevice {
+	var out []doctorDevice
+	for _, d := range purego.KnownVIDPIDs() {
+		out = append(out, doctorDevice{VID: d.VID, PID: d.PID, Name: d.Name})
+	}
+	for _, d := range hackrf.KnownVIDPIDs() {
+		out = append(out, doctorDevice{VID: d.VID, PID: d.PID, Name: d.Name})
+	}
+	return out
+}
+
+// runSDRDoctor implements `gophertrunk sdr doctor`. It iterates the known
+// USB SDR VID/PID list (RTL-SDR + HackRF), asks the platform inspector
+// which kernel/Windows function driver is bound to each matching dongle,
 // and prints a row per device with an actionable next step. Read-only:
 // never opens or claims a USB device, so safe to run as a regular
 // user alongside a live daemon.
@@ -29,7 +54,7 @@ func runSDRDoctor(args []string) {
 	var rows []usb.DriverBinding
 	var failures []error
 	seen := make(map[string]bool)
-	for _, pair := range purego.KnownVIDPIDs() {
+	for _, pair := range knownDoctorDevices() {
 		bindings, err := inspector.Inspect(pair.VID, pair.PID)
 		if err != nil {
 			if errors.Is(err, usb.ErrUnsupportedPlatform) {
@@ -54,7 +79,7 @@ func runSDRDoctor(args []string) {
 	}
 
 	if len(rows) == 0 {
-		fmt.Println("No RTL-SDR dongles found.")
+		fmt.Println("No USB SDR dongles found (checked RTL-SDR and HackRF).")
 		fmt.Println("If a dongle is plugged in but missing here:")
 		switch runtime.GOOS {
 		case "windows":
@@ -62,7 +87,7 @@ func runSDRDoctor(args []string) {
 			fmt.Println("  - Re-plug into a different USB port (preferably USB 2.0 for first-time bring-up).")
 			fmt.Println("  - Run Zadig from the Start Menu and verify the dongle is listed with Options → List All Devices.")
 		case "linux":
-			fmt.Println("  - Run `lsusb` and confirm the dongle's VID:PID appears (RTL-SDR is typically 0bda:2832 or 0bda:2838).")
+			fmt.Println("  - Run `lsusb` and confirm the dongle's VID:PID appears (RTL-SDR is typically 0bda:2832 or 0bda:2838; HackRF is 1d50:6089).")
 			fmt.Println("  - Confirm /sys/bus/usb/devices exists and your user has read permission.")
 		}
 		return

--- a/cmd/gophertrunk/sdr_doctor_test.go
+++ b/cmd/gophertrunk/sdr_doctor_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+// TestKnownDoctorDevicesIncludesHackRF guards that `sdr doctor` inspects
+// HackRF VID/PIDs, not just RTL-SDR — otherwise a HackRF that fails to
+// open (the error tells the operator to run the doctor) would be invisible
+// to the very command that's supposed to diagnose its driver binding.
+func TestKnownDoctorDevicesIncludesHackRF(t *testing.T) {
+	devs := knownDoctorDevices()
+	if len(devs) == 0 {
+		t.Fatal("knownDoctorDevices returned nothing")
+	}
+	var haveHackRF, haveRTL bool
+	for _, d := range devs {
+		if d.VID == 0x1d50 && d.PID == 0x6089 {
+			haveHackRF = true
+		}
+		if d.VID == 0x0bda {
+			haveRTL = true
+		}
+	}
+	if !haveHackRF {
+		t.Error("HackRF One (1d50:6089) missing from doctor device list")
+	}
+	if !haveRTL {
+		t.Error("RTL-SDR (vid 0bda) missing from doctor device list")
+	}
+}

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -74,6 +74,53 @@ scope access. Then confirm:
 gophertrunk sdr list --probe
 ```
 
+## Setup (Windows)
+
+GopherTrunk drives the HackRF through the in-box **WinUSB** driver — no
+`libhackrf`/`hackrf-tools` and no [SoapySDR](/reference/soapysdr/) install
+required. A HackRF One advertises a Microsoft OS (WCID) descriptor, so Windows
+10/11 usually binds WinUSB automatically and it just works: plug it in and run
+
+```powershell
+gophertrunk sdr list --probe
+gophertrunk sdr doctor
+```
+
+`sdr doctor` prints a row per known SDR (RTL-SDR **and** HackRF) showing which
+function driver is bound and whether it's the expected WinUSB. If the HackRF row
+shows `STATUS BAD` — or `sdr list --probe` reports `WinUsb_Initialize failed` —
+a different driver is bound. Fix it with [Zadig](/reference/zadig/):
+
+1. Run Zadig, then **Options → List All Devices**.
+2. Select the **HackRF One** entry (Interface 0).
+3. Choose **WinUSB** as the target driver and click **Replace Driver**.
+
+If `--probe` fails with an access-denied error, another program (SDR#, GQRX,
+SDRangel, the HackRF tools) already holds the device — close it and retry.
+
+## Using the HackRF with the daemon
+
+`gophertrunk sdr list` only enumerates devices; the daemon (and the web UI
+**Devices** panel) opens the SDRs named in your `config.yaml`. If the panel says
+*"No SDRs known to the daemon"*, add the HackRF under `sdr.devices`:
+
+```yaml
+sdr:
+  sample_rate: 8_000_000
+  devices:
+    - serial: "0000000000000000457863c8284a625f"   # from `gophertrunk sdr list`
+      role: control          # or voice / wideband
+      gain: auto             # or tenths-of-dB, e.g. "320" for 32.0 dB
+      bias_tee: false
+```
+
+Copy the serial straight from `gophertrunk sdr list`. The match is
+case-insensitive and tolerant of a partial serial — a distinctive tail like
+`457863c8284a625f`, or a value captured from an older build that displayed only
+the `0000000000000000` prefix, still binds as long as it's unambiguous (the
+daemon logs when it matches by a partial serial). With multiple HackRFs, use the
+full serial so each entry pins exactly one device.
+
 > **Serial number.** A HackRF reports a full 32-hex-digit `part_id + serial_no`
 > string — the leading 16 digits are a constant prefix (commonly all zeros) and
 > the trailing digits are the unique part. `gophertrunk sdr list` prints the

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -161,6 +161,29 @@ func productForPID(pid uint16, fallback string) string {
 	return "HackRF"
 }
 
+// VIDPID is one USB identity the HackRF driver matches, exposed so
+// `gophertrunk sdr doctor` can include HackRF in its driver-binding
+// diagnostics. Mirrors the shape of purego.VIDPID so the doctor command
+// can aggregate every pure-Go USB SDR into one report.
+type VIDPID struct {
+	VID  uint16
+	PID  uint16
+	Name string
+}
+
+// KnownVIDPIDs returns the HackRF USB VID/PID variants this driver
+// matches, in the same order Enumerate scans them. Used by `sdr doctor`
+// to report which Windows function driver (WinUSB vs other) is bound to
+// a connected HackRF — the in-box default is usually WinUSB via the
+// device's WCID descriptor, but a wrong binding shows up here.
+func KnownVIDPIDs() []VIDPID {
+	return []VIDPID{
+		{vidHackRF, pidHackRFOne, pidProductNames[pidHackRFOne]},
+		{vidHackRF, pidHackRFJawbrk, pidProductNames[pidHackRFJawbrk]},
+		{vidHackRF, pidHackRFRad1o, pidProductNames[pidHackRFRad1o]},
+	}
+}
+
 // Open claims the device at idx and returns an sdr.Device. The caller
 // is responsible for calling Close.
 func (d *Driver) Open(idx int) (sdr.Device, error) {

--- a/internal/sdr/hackrf/known_test.go
+++ b/internal/sdr/hackrf/known_test.go
@@ -1,0 +1,27 @@
+package hackrf
+
+import "testing"
+
+func TestKnownVIDPIDs(t *testing.T) {
+	known := KnownVIDPIDs()
+	if len(known) == 0 {
+		t.Fatal("KnownVIDPIDs returned nothing")
+	}
+	wantPIDs := map[uint16]bool{pidHackRFOne: false, pidHackRFJawbrk: false, pidHackRFRad1o: false}
+	for _, k := range known {
+		if k.VID != vidHackRF {
+			t.Errorf("VID = %#04x, want %#04x", k.VID, vidHackRF)
+		}
+		if _, ok := wantPIDs[k.PID]; ok {
+			wantPIDs[k.PID] = true
+		}
+		if k.Name == "" {
+			t.Errorf("PID %#04x has empty Name", k.PID)
+		}
+	}
+	for pid, seen := range wantPIDs {
+		if !seen {
+			t.Errorf("PID %#04x missing from KnownVIDPIDs", pid)
+		}
+	}
+}

--- a/internal/sdr/pool.go
+++ b/internal/sdr/pool.go
@@ -206,7 +206,6 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 		return errors.New("no SDR devices discovered")
 	}
 
-	hintBySerial := map[string]Hint{}
 	controlClaimed := false
 	for _, h := range opts.Hints {
 		if h.Serial == "" {
@@ -216,20 +215,41 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 			}
 			continue
 		}
-		hintBySerial[serialKey(h.Serial)] = h
 		if h.Role == RoleControl {
 			controlClaimed = true
 		}
 	}
 
-	openedSerials := map[string]struct{}{}
-	for _, d := range all {
-		key := serialKey(d.info.Serial)
-		hint, hinted := hintBySerial[key]
+	// Resolve which hint configures each discovered device. Exact serial
+	// matches win; an unmatched hint then falls back to an unambiguous
+	// substring match so a partial serial — or one captured from a build
+	// that truncated it — still binds (see matchHintSerials).
+	deviceSerials := make([]string, len(all))
+	for i, d := range all {
+		deviceSerials[i] = d.info.Serial
+	}
+	hintSerials := make([]string, len(opts.Hints))
+	for i, h := range opts.Hints {
+		hintSerials[i] = h.Serial
+	}
+	hintForDevice, partialMatched := matchHintSerials(deviceSerials, hintSerials)
+
+	hintUsed := make([]bool, len(opts.Hints))
+	for di, d := range all {
+		hi := hintForDevice[di]
+		hinted := hi >= 0
+		var hint Hint
+		if hinted {
+			hint = opts.Hints[hi]
+		}
 		if opts.Strict && !hinted {
 			p.log.Info("skipping non-configured SDR; add its serial to sdr.devices to use it",
 				"driver", d.drv.Name(), "serial", d.info.Serial)
 			continue
+		}
+		if hinted && partialMatched[di] {
+			p.log.Info("matched configured SDR by partial serial; use the full serial from `gophertrunk sdr list` to pin it exactly",
+				"driver", d.drv.Name(), "config_serial", hint.Serial, "device_serial", d.info.Serial)
 		}
 		role := RoleAuto
 		if hinted {
@@ -268,7 +288,9 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 		}
 		entry := &PoolEntry{Driver: d.drv, Device: dev, Info: d.info, Role: role, Hint: hint}
 		p.entries = append(p.entries, entry)
-		openedSerials[key] = struct{}{}
+		if hinted {
+			hintUsed[hi] = true
+		}
 		// Include the per-device tuning in the open log so an
 		// operator can grep the boot log to confirm the value they
 		// put in config.yaml actually landed on this serial (issue
@@ -285,11 +307,12 @@ func (p *Pool) OpenWith(opts PoolOpenOptions) error {
 		p.logTunerDiag(dev, d.info)
 		p.publish(events.KindSDRAttached, entry.Snapshot(true))
 	}
-	for key, h := range hintBySerial {
-		if _, ok := openedSerials[key]; !ok {
-			p.log.Warn("configured SDR not present on the bus; check the cable / dmesg / lsusb",
-				"serial", h.Serial)
+	for hi, h := range opts.Hints {
+		if h.Serial == "" || hintUsed[hi] {
+			continue
 		}
+		p.log.Warn("configured SDR not present on the bus; check the cable / dmesg / lsusb",
+			"serial", h.Serial)
 	}
 	if len(p.entries) == 0 {
 		return errors.New("no SDR devices opened")
@@ -368,6 +391,86 @@ func serialKey(s string) string {
 	default:
 		return s
 	}
+}
+
+// minPartialSerialLen is the shortest configured serial allowed to bind a
+// device via the substring fallback in matchHintSerials. Short serials
+// (the RTL-SDR "00000001" style, or test fixtures like "S1"/"V4") must
+// match exactly; only a reasonably distinctive fragment may match a
+// longer device serial, which keeps the fallback from grabbing the wrong
+// dongle. HackRF serials are 32 hex digits, so a tail or the 16-digit
+// prefix older builds displayed comfortably clears this bar.
+const minPartialSerialLen = 6
+
+// matchHintSerials decides which hint configures each discovered device.
+// It returns hintForDevice (one entry per device — the index into
+// hintSerials of the matching hint, or -1) and partialMatched (whether
+// that binding came from the substring fallback rather than an exact
+// match, for logging).
+//
+// Exact normalized-serial matches are resolved first so existing configs
+// behave identically. Each hint still unmatched then binds to a device
+// only when its serial is a substring of exactly one still-unmatched
+// device serial — an unambiguous partial match. This lets an operator put
+// just the distinctive tail of a long serial in config, and recovers
+// configs that captured a serial from a build which truncated it (the
+// HackRF "0000000000000000" report fixed alongside this). Empty hint
+// serials never match.
+func matchHintSerials(deviceSerials, hintSerials []string) (hintForDevice []int, partialMatched []bool) {
+	hintForDevice = make([]int, len(deviceSerials))
+	partialMatched = make([]bool, len(deviceSerials))
+	for i := range hintForDevice {
+		hintForDevice[i] = -1
+	}
+	dk := make([]string, len(deviceSerials))
+	for i, s := range deviceSerials {
+		dk[i] = serialKey(s)
+	}
+	hk := make([]string, len(hintSerials))
+	for i, s := range hintSerials {
+		hk[i] = serialKey(s)
+	}
+	hintUsed := make([]bool, len(hintSerials))
+
+	// Phase 1: exact matches (preserves legacy behaviour exactly).
+	for i := range dk {
+		for j, h := range hk {
+			if h == "" || hintUsed[j] {
+				continue
+			}
+			if dk[i] == h {
+				hintForDevice[i] = j
+				hintUsed[j] = true
+				break
+			}
+		}
+	}
+
+	// Phase 2: unambiguous substring fallback for still-unmatched hints.
+	for j, h := range hk {
+		if h == "" || hintUsed[j] || len(h) < minPartialSerialLen {
+			continue
+		}
+		matches := 0
+		first := -1
+		for i := range dk {
+			if hintForDevice[i] != -1 {
+				continue
+			}
+			if strings.Contains(dk[i], h) {
+				matches++
+				if first == -1 {
+					first = i
+				}
+			}
+		}
+		if matches == 1 {
+			hintForDevice[first] = j
+			partialMatched[first] = true
+			hintUsed[j] = true
+		}
+	}
+	return hintForDevice, partialMatched
 }
 
 // applyHintSettings runs the per-device tuners after Open. Caller

--- a/internal/sdr/pool_match_test.go
+++ b/internal/sdr/pool_match_test.go
@@ -1,0 +1,84 @@
+package sdr
+
+import "testing"
+
+func TestMatchHintSerialsExact(t *testing.T) {
+	devices := []string{"AAA", "BBB"}
+	hints := []string{"BBB"}
+	got, partial := matchHintSerials(devices, hints)
+	if got[0] != -1 {
+		t.Errorf("device 0 (AAA) matched hint %d, want -1", got[0])
+	}
+	if got[1] != 0 {
+		t.Errorf("device 1 (BBB) matched hint %d, want 0", got[1])
+	}
+	if partial[1] {
+		t.Error("BBB should be an exact match, not partial")
+	}
+}
+
+// TestMatchHintSerialsLegacyTruncatedPrefix is the regression for the
+// downstream effect of the HackRF serial-truncation bug: a config that
+// captured the old 16-zero prefix must still bind the device whose full
+// serial starts with it.
+func TestMatchHintSerialsLegacyTruncatedPrefix(t *testing.T) {
+	devices := []string{"0000000000000000457863c8284a625f"}
+	hints := []string{"0000000000000000"}
+	got, partial := matchHintSerials(devices, hints)
+	if got[0] != 0 {
+		t.Fatalf("legacy-prefix hint did not bind device: got %v", got)
+	}
+	if !partial[0] {
+		t.Error("legacy-prefix bind should be flagged partial")
+	}
+}
+
+func TestMatchHintSerialsDistinctiveTail(t *testing.T) {
+	devices := []string{"0000000000000000457863c8284a625f"}
+	hints := []string{"457863c8284a625f"}
+	got, _ := matchHintSerials(devices, hints)
+	if got[0] != 0 {
+		t.Fatalf("tail hint did not bind device: got %v", got)
+	}
+}
+
+// TestMatchHintSerialsAmbiguousPartialSkipped guards against the fallback
+// grabbing the wrong dongle: two HackRFs share the all-zero prefix, so the
+// prefix must NOT bind either one.
+func TestMatchHintSerialsAmbiguousPartialSkipped(t *testing.T) {
+	devices := []string{
+		"0000000000000000457863c8284a625f",
+		"0000000000000000aabbccddeeff0011",
+	}
+	hints := []string{"0000000000000000"}
+	got, _ := matchHintSerials(devices, hints)
+	if got[0] != -1 || got[1] != -1 {
+		t.Errorf("ambiguous prefix should bind nothing, got %v", got)
+	}
+}
+
+// TestMatchHintSerialsShortNeverPartial confirms short serials only ever
+// match exactly — a fragment below minPartialSerialLen must not substring-
+// match a longer device serial.
+func TestMatchHintSerialsShortNeverPartial(t *testing.T) {
+	devices := []string{"S1X9"}
+	hints := []string{"S1"} // 2 chars, below the partial floor
+	got, _ := matchHintSerials(devices, hints)
+	if got[0] != -1 {
+		t.Errorf("short fragment should not partial-match, got %v", got)
+	}
+}
+
+func TestMatchHintSerialsExactWinsOverPartial(t *testing.T) {
+	// Device 0's serial contains hint "abcdef" as a substring, but device 1
+	// matches it exactly — exact must win and claim device 1, leaving 0 free.
+	devices := []string{"zzabcdefzz", "abcdef"}
+	hints := []string{"abcdef"}
+	got, partial := matchHintSerials(devices, hints)
+	if got[1] != 0 || partial[1] {
+		t.Errorf("exact device should win: got=%v partial=%v", got, partial)
+	}
+	if got[0] != -1 {
+		t.Errorf("substring device should be left unbound once exact wins, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a chain of HackRF issues reported from a Windows 11 user, rooted in the `sdr list` serial column truncation plus gaps in `--probe`, `sdr doctor`, and daemon device matching.

### 1. Full serial in `sdr list` (`cmd/gophertrunk/main.go`)
A HackRF reports a full 32-hex-digit `part_id + serial_no` (e.g. `0000000000000000457863c8284a625f`); the leading 16 digits are an always-zero prefix. The table front-truncated the SERIAL column to 16 chars, so it showed only `0000000000000000` — and likewise clipped `MAX2839+MAX5864` → `MAX2839+` and `HackRF One` → `HackRF O`. The printer now sizes each column to the widest value present, printing the full serial (matching `hackrf_info`), tuner, and product. Read source is unchanged on every platform (Linux sysfs `serial`, Windows device path).

### 2. Bounded `sdr list --probe` (`cmd/gophertrunk/main.go`)
`--probe` opened each device with no overall deadline, so a wedged device/transport could hang the command with no output. Each probe (open → info → close) now runs under a 5 s timeout (`probeDevice`); on timeout/error it prints the reason and moves on, so the command always returns.

### 3. `sdr doctor` covers HackRF (`cmd/gophertrunk/sdr_doctor.go`, `internal/sdr/hackrf`)
The Open-failure message tells operators to run `sdr doctor`, but the doctor only inspected RTL-SDR VID/PIDs and reported "No RTL-SDR dongles found" for a HackRF. It now also inspects HackRF (1d50:6089/604b/cc15) and reports the bound Windows function driver + WinUSB/Zadig next-step. Adds `hackrf.KnownVIDPIDs()`.

### 4. Forgiving serial matching in the pool (`internal/sdr/pool.go`)
"No SDRs known to the daemon" happens when the config serial doesn't exactly match — e.g. a value copied from the old truncated display. Pool matching keeps exact match as the priority, then falls back to an **unambiguous substring** match (config serial ≥6 chars that's a substring of exactly one still-unmatched device). A distinctive tail, or the legacy 16-zero prefix, now binds (logged as a partial match). Short serials and all strict-mode behavior are unchanged.

### 5. Docs (`docs/reference/hackrf.md`)
Added Linux (udev) and Windows (WinUSB/Zadig) setup, a daemon `config.yaml` example, and serial-format notes.

## Tests
- `formatSDRTable` full-serial / no-truncation regression
- `probeDevice` success / open-error / timeout (hang regression)
- `matchHintSerials`: exact, legacy-prefix, distinctive-tail, ambiguity-skip, short-never-partial, exact-wins-over-partial
- `hackrf.KnownVIDPIDs`, doctor `knownDoctorDevices` includes HackRF

Full `./internal/sdr/...` suite and targeted `cmd/gophertrunk` tests pass; `go build`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzGb1b3TvMKPxhcMEdhFrP)_