### PR TITLE
docs: post-release v0.4.9 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,86 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.4.9] — 2026-06-21
+
+A field-driven bug-fix release built around six issues reported on a live P25
+Phase 1 system, plus follow-up audio plumbing and import hardening. The
+headline fix closes a **cross-call audio-bleed window in the live PCM fan-out**:
+the earlier on-disk CallID fence didn't cover the streaming tap, so a reused
+wideband voice-tap serial could relabel a draining call's audio with the next
+call's talkgroup. The web **Scanner tab no longer crashes** on a null
+systems/channels payload, **trunked hunts now converge** on identity and
+topology instead of timing out in a 3 s dwell, and discovery stops inventing
+bogus talkgroups from unit-to-unit / telephone / SNDCP-data grants. On the side:
+RID and talkgroup **alias imports are hardened against mojibake** (UTF-16/BOM
+SDRTrunk exports are transcoded and non-printable runes stripped), `sdr list`
+**prints full HackRF serials** with a bounded `--probe`, and the gRPC API can
+finally **stream raw IMBE/AMBE+2 vocoder frames** to `include_raw` subscribers.
+
+### Added
+- **Raw vocoder frame streaming over gRPC** (#746). The
+  `AudioSubFilter.IncludeRaw` flag was a near no-op — `WriteRawFrame` was never
+  wired into the publisher, so raw IMBE / AMBE+2 frames stayed recorder-only. A
+  new raw tap mirrors the decoded-PCM path and fans the verbatim frame (plus
+  vocoder name and CallID) to the audio publisher before decode, so it fires
+  even for protocols with no in-process decoder (ProVoice, encrypted) where the
+  raw bytes are the only audio. Raw is purely additive — PCM-only clients
+  (including the WebUI) are unaffected, and the cross-call fence applies at both
+  the publisher and recorder layers.
+- **Monitor-minutes field on the blind-sweep hunt form** (#746). Only the
+  parse-control-channel form sent `monitor_seconds`; the blind-sweep payload
+  omitted it, so a sweep could never engage the converge-and-stop monitor
+  (backend default 0 = off). The sweep form now carries a "Monitor (minutes,
+  0 = off)" field, so a sweep that locks a control channel can monitor it until
+  identity, neighbors, and band plan settle.
+
+### Changed
+- **`sdr list` shows full HackRF serials and bounds `--probe`** (#745). The
+  fixed-width SERIAL column front-truncated to 16 chars, which for a HackRF cut
+  off the meaningful tail of its 32-hex part_id+serial and left only the
+  all-zero prefix (reported as `0000000000000000`); TUNER and PRODUCT were
+  clipped too. Columns now size to the widest value present, and each
+  `--probe` open+info+close is wrapped in a bounded helper so a wedged device
+  can't hang the command. Adds a Linux (udev) setup section to the HackRF doc.
+- **RID / talkgroup alias imports hardened against mojibake** (#744, issue
+  #711). A shared sanitization layer is wired into both the RID and talkgroup
+  CSV/JSON loaders: a UTF-16 (LE/BE) or UTF-8 BOM is honoured and transcoded to
+  plain UTF-8 (neutralising Windows/SDRTrunk exports), and text fields are
+  reduced to printable ASCII, dropping control chars, NULs, and non-ASCII
+  mojibake. BOM-less ASCII/UTF-8 passes through untouched. Promotes
+  `golang.org/x/text` to a direct require.
+- **Trunked hunts default to the converge-and-stop monitor** (#743). The web
+  hunt previously ran a 3 s buffered dwell; P25 status broadcasts cycle too
+  slowly to land in 3 s, so only NAC surfaced. A trunked hunt now defaults to
+  the streaming monitor that ends early once identity + topology settle.
+
+### Fixed
+- **Cross-call audio bleed when a voice-tap serial is reused** (#743). The
+  on-disk CallID fence guarded only the WAV; the live PCM fan-out (recorder
+  decodedTap → AudioPublisher) was keyed purely by device serial, so a reused
+  wideband voice-tap serial leaked the previous call's still-draining audio to
+  subscribers filtered on the new call's talkgroup. The session's CallID is now
+  threaded through to `WritePCMForCall`, which drops a frame whose CallID no
+  longer matches the serial's bound call.
+- **Web Scanner tab crash on a null payload** (#743, #746). A nil Go slice
+  marshals to JSON `null`; the Scanner tab dereferenced `systems.length` /
+  `channels.length` and crashed with "Cannot read properties of null". The
+  `/api/v1/scanner` payload now emits `[]` and the frontend null-guards the
+  reads, with frontend tests covering both the null-shaped and populated
+  snapshots.
+- **Hunt identity/neighbors stuck on "awaiting status broadcasts"** (#743).
+  Beyond defaulting to the streaming monitor, topology folding no longer drops
+  a legitimate `RFSS=0` / `Site=0`.
+- **Bogus talkgroup from non-group grants** (#743). Unit-to-unit / telephone /
+  SNDCP-data grants publish a 24-bit target unit as the grant "group", and
+  discovery was recording every grant group as a talkgroup. These grants are
+  now flagged Individual and skipped when building the hunt talkgroup list (the
+  frequency is still recorded on the site).
+- **Spurious talkgroup↔frequency association** (#743). The per-talkgroup
+  frequency list is dropped — on a trunked system the traffic channel is
+  assigned dynamically per call, so a talkgroup has no fixed frequency. The
+  site's distinct voice-channel pool is unchanged.
+
 ## [v0.4.8] — 2026-06-20
 
 This release is dominated by a **six-phase operator-console overhaul** that

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.4.8
+VERSION=v0.4.9
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.4.8" -%}
+  {%- assign ver = "v0.4.9" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.4.9.md
+++ b/docs/announcements/v0.4.9.md
@@ -1,0 +1,59 @@
+# GopherTrunk v0.4.9 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.4.9 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.9
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.4.9 — a field-driven bug-fix release: closes a cross-call audio-bleed window in the live PCM fan-out, stops the web Scanner tab crashing on a null payload, makes trunked hunts actually converge on identity + topology, hardens RID/talkgroup alias imports against mojibake, prints full HackRF serials, and streams raw IMBE/AMBE+2 vocoder frames over gRPC
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.4.9 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+This one is built around six issues reported on a live P25 Phase 1 system, plus follow-up audio plumbing and import hardening.
+
+**What's new since v0.4.8:**
+
+* **No more cross-call audio bleed** (#743). The earlier on-disk CallID fence didn't cover the streaming tap, so a reused wideband voice-tap serial could relabel a draining call's audio with the next call's talkgroup. The session CallID is now threaded through the live PCM fan-out, dropping any frame whose CallID no longer matches the bound call.
+* **Web Scanner tab no longer crashes** (#743, #746). A nil Go slice marshalled to JSON `null` and the panel dereferenced `systems.length` / `channels.length`. The payload now emits `[]`, the frontend null-guards the reads, and there's test coverage for both shapes.
+* **Trunked hunts converge instead of timing out** (#743). P25 status broadcasts cycle too slowly to land in the old 3 s dwell, so only NAC surfaced. A trunked hunt now defaults to the streaming converge-and-stop monitor that ends early once identity + topology settle — and the blind-sweep form gained a matching "Monitor (minutes)" field (#746).
+* **No more bogus talkgroups** (#743). Unit-to-unit / telephone / SNDCP-data grants publish a target unit as the grant "group"; discovery was recording those as talkgroups. They're now flagged Individual and skipped, and the spurious per-talkgroup frequency list (meaningless on a dynamically-assigned trunk) is gone.
+* **Alias imports hardened against mojibake** (#744) — UTF-16/BOM SDRTrunk exports are transcoded to UTF-8 and non-printable runes stripped across both RID and talkgroup CSV/JSON loaders.
+* **`sdr list` prints full HackRF serials** (#745) — columns size to the widest value instead of truncating to 16 chars (which left only the all-zero prefix), and `--probe` is bounded so a wedged device can't hang the command.
+* **Raw vocoder frame streaming over gRPC** (#746) — `include_raw` subscribers finally receive verbatim IMBE / AMBE+2 frames, even for protocols with no in-process decoder (ProVoice, encrypted) where the raw bytes are the only audio. Purely additive; PCM-only clients are unaffected.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.9
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.4.9 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+A field-driven bug-fix release built around six issues from a live P25 Phase 1 system.
+
+**What's new since v0.4.8:**
+- **No cross-call audio bleed** (#743) — the session CallID is now threaded through the live PCM fan-out, so a reused voice-tap serial can't leak a draining call's audio to the next call's talkgroup.
+- **Scanner tab no longer crashes** (#743, #746) — null `systems`/`channels` payloads are normalized to `[]` and null-guarded, with test coverage.
+- **Trunked hunts converge** (#743) — default to the streaming converge-and-stop monitor instead of a 3 s dwell; blind-sweep gains a "Monitor (minutes)" field (#746).
+- **No bogus talkgroups** (#743) — unit-to-unit / telephone / SNDCP grants are flagged Individual and skipped; the meaningless per-talkgroup frequency list is dropped.
+- **Alias imports hardened** (#744) — UTF-16/BOM SDRTrunk exports transcoded, mojibake stripped (RID + talkgroup, CSV + JSON).
+- **`sdr list` full HackRF serials** (#745) — columns size to fit; `--probe` is bounded so a wedged device can't hang.
+- **Raw vocoder frames over gRPC** (#746) — `include_raw` subs get verbatim IMBE/AMBE+2, including ProVoice/encrypted. Additive; PCM-only clients unaffected.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.4.9>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow tagged **v0.4.9** (published 2026-06-21 as a prerelease). This syncs the docs to match.

## Changes

- **`CHANGELOG.md`** — promote `[Unreleased]` → `## [v0.4.9] — 2026-06-21` with a summary plus Added/Changed/Fixed entries for everything that shipped since v0.4.8, and a fresh empty `[Unreleased]` block above it:
  - cross-call audio-bleed fix in the live PCM fan-out, web Scanner null-payload crash, trunked hunts defaulting to the converge-and-stop monitor, bogus-talkgroup / spurious TG-frequency cleanup (#743)
  - mojibake-hardened RID/talkgroup alias imports (#744)
  - full-width HackRF serials + bounded `sdr list --probe` (#745)
  - raw IMBE/AMBE+2 vocoder-frame gRPC streaming + blind-sweep monitor-minutes field (#746)
- **`README.md`** — bump the Linux quick-install `VERSION` to v0.4.9.
- **`docs/_includes/latest-version.html`** — bump the GitHub Pages fallback tag to v0.4.9 (drives `downloads.md` dynamically).
- **`docs/announcements/v0.4.9.md`** — new social-blurb drafts (Reddit + Discord).

## Left intentionally unchanged

- `web/*/package.json` are pinned at `0.1.0` and don't track the app release.
- `build-in-the-open-prompt.md` and dated `_posts/` entries reference older versions as historical prose, not live version pointers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J1Xgt8ezRrVfoeFCpLinGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1Xgt8ezRrVfoeFCpLinGQ)_