### PR TITLE
scanner: decode wideband-hosted control channels in parallel, not via the sequential hunt (#749)

### DIFF
--- a/cmd/gophertrunk/cchunt_systems_test.go
+++ b/cmd/gophertrunk/cchunt_systems_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestCchuntSystems locks issue #749: control-channel frequencies hosted on a
+// `role: wideband` device (decoded in parallel by widebandt2) must be removed
+// from the sequential cchunt supervisor's hunt set, and a system whose control
+// channels are ALL wideband-hosted must be dropped entirely.
+func TestCchuntSystems(t *testing.T) {
+	// helper: find a system by name in a result slice.
+	find := func(systems []trunking.System, name string) (trunking.System, bool) {
+		for _, s := range systems {
+			if s.Name == name {
+				return s, true
+			}
+		}
+		return trunking.System{}, false
+	}
+	wbDevice := func(serial string, ccs ...uint32) config.DeviceConfig {
+		d := config.DeviceConfig{Serial: serial, Role: "wideband", CenterFreqHz: 420_900_000}
+		for _, f := range ccs {
+			d.Channels = append(d.Channels, config.DeviceChannelConfig{FrequencyHz: f, System: "MMR"})
+		}
+		return d
+	}
+
+	t.Run("all CCs wideband-hosted drops the system", func(t *testing.T) {
+		systems := []trunking.System{{
+			Name:            "MMR",
+			Protocol:        trunking.ProtocolP25,
+			ControlChannels: []uint32{420_012_500, 420_037_500, 420_087_500, 421_837_500},
+		}}
+		dev := wbDevice("AIRSPY", 420_012_500, 420_037_500, 420_087_500, 421_837_500)
+		got := cchuntSystems(systems, []config.DeviceConfig{dev})
+		if _, ok := find(got, "MMR"); ok {
+			t.Fatalf("MMR should be dropped (all 4 CCs wideband-hosted); got %d systems", len(got))
+		}
+	})
+
+	t.Run("partial leaves only non-wideband CCs and does not mutate input", func(t *testing.T) {
+		systems := []trunking.System{{
+			Name:            "MMR",
+			Protocol:        trunking.ProtocolP25,
+			ControlChannels: []uint32{420_012_500, 420_037_500, 420_087_500, 421_837_500},
+		}}
+		dev := wbDevice("AIRSPY", 420_012_500, 420_037_500)
+		got := cchuntSystems(systems, []config.DeviceConfig{dev})
+		mmr, ok := find(got, "MMR")
+		if !ok {
+			t.Fatal("MMR should survive (2 of 4 CCs still need hunting)")
+		}
+		want := []uint32{420_087_500, 421_837_500}
+		if len(mmr.ControlChannels) != len(want) {
+			t.Fatalf("filtered CCs = %v, want %v", mmr.ControlChannels, want)
+		}
+		for i := range want {
+			if mmr.ControlChannels[i] != want[i] {
+				t.Fatalf("filtered CCs = %v, want %v", mmr.ControlChannels, want)
+			}
+		}
+		// Aliasing guard: the input slice must be untouched (it is shared with
+		// the config-backed backing array elsewhere in the daemon).
+		if got := len(systems[0].ControlChannels); got != 4 {
+			t.Fatalf("input ControlChannels was mutated: len = %d, want 4", got)
+		}
+	})
+
+	t.Run("non-control wideband channel changes nothing", func(t *testing.T) {
+		systems := []trunking.System{{
+			Name:            "MMR",
+			Protocol:        trunking.ProtocolP25,
+			ControlChannels: []uint32{420_012_500, 420_037_500},
+		}}
+		// A wideband channel frequency that is NOT one of MMR's control_channels.
+		dev := config.DeviceConfig{
+			Serial: "AIRSPY", Role: "wideband", CenterFreqHz: 420_900_000,
+			Channels: []config.DeviceChannelConfig{{FrequencyHz: 420_500_000, System: "MMR"}},
+		}
+		got := cchuntSystems(systems, []config.DeviceConfig{dev})
+		mmr, ok := find(got, "MMR")
+		if !ok || len(mmr.ControlChannels) != 2 {
+			t.Fatalf("MMR CCs = %v, want both retained", mmr.ControlChannels)
+		}
+	})
+
+	t.Run("no wideband device passes through unchanged", func(t *testing.T) {
+		systems := []trunking.System{{
+			Name:            "MMR",
+			Protocol:        trunking.ProtocolP25,
+			ControlChannels: []uint32{420_012_500, 420_037_500},
+		}}
+		dev := config.DeviceConfig{Serial: "RTL", Role: "control"}
+		got := cchuntSystems(systems, []config.DeviceConfig{dev})
+		mmr, ok := find(got, "MMR")
+		if !ok || len(mmr.ControlChannels) != 2 {
+			t.Fatalf("MMR CCs = %v, want unchanged", mmr.ControlChannels)
+		}
+	})
+
+	t.Run("two wideband devices union to cover all CCs", func(t *testing.T) {
+		systems := []trunking.System{{
+			Name:            "MMR",
+			Protocol:        trunking.ProtocolP25,
+			ControlChannels: []uint32{420_012_500, 420_037_500, 420_087_500, 421_837_500},
+		}}
+		devA := wbDevice("AIRSPY-A", 420_012_500, 420_037_500)
+		devB := wbDevice("AIRSPY-B", 420_087_500, 421_837_500)
+		got := cchuntSystems(systems, []config.DeviceConfig{devA, devB})
+		if _, ok := find(got, "MMR"); ok {
+			t.Fatal("MMR should be dropped (union of two wideband devices covers all CCs)")
+		}
+	})
+
+	t.Run("same frequency on a different system is not filtered", func(t *testing.T) {
+		const shared = 420_012_500
+		systems := []trunking.System{
+			{Name: "MMR", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{shared}},
+			{Name: "OTHER", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{shared}},
+		}
+		// Only MMR's frequency is wideband-hosted.
+		dev := wbDevice("AIRSPY", shared)
+		got := cchuntSystems(systems, []config.DeviceConfig{dev})
+		if _, ok := find(got, "MMR"); ok {
+			t.Error("MMR should be dropped (its only CC is wideband-hosted)")
+		}
+		other, ok := find(got, "OTHER")
+		if !ok || len(other.ControlChannels) != 1 || other.ControlChannels[0] != shared {
+			t.Errorf("OTHER must keep its CC %d (same freq, different system); got %v", shared, other.ControlChannels)
+		}
+	})
+}

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1312,7 +1312,15 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	// registered factory would leave its system in `state=hunting`
 	// (the connector skips the retune) rather than emitting
 	// `cchunt.failed`.
-	if d.pool != nil && len(d.systems) > 0 {
+	//
+	// Systems whose control channels live on a `role: wideband` device are
+	// decoded in parallel by widebandt2; cchuntSystems strips those
+	// frequencies so the single-tuner hunt doesn't redundantly (and serially)
+	// fight the parallel path (issue #749). When every system is fully
+	// wideband-hosted the filtered list is empty and the supervisor — along
+	// with its ccdecoder connector — is not built at all.
+	cchSystems := cchuntSystems(d.systems, cfg.SDR.Devices)
+	if d.pool != nil && len(cchSystems) > 0 {
 		cchEnabled := cfg.Scanner.CCHunt.Enabled || cfg.Scanner.CCHunt == (config.CCHuntConfig{})
 		if cchEnabled {
 			controlEntry := d.pool.FirstByRole(sdr.RoleControl)
@@ -1373,7 +1381,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					Log:            log,
 					Tuner:          cchTuner,
 					Cache:          d.ccCache,
-					Systems:        d.systems,
+					Systems:        cchSystems,
 					Dwell:          msToDuration(cfg.Scanner.CCHunt.DwellMs, 3*time.Second),
 					InitialBackoff: msToDuration(cfg.Scanner.CCHunt.BackoffMs, 5*time.Second),
 					MaxBackoff:     msToDuration(cfg.Scanner.CCHunt.MaxBackoffMs, 60*time.Second),
@@ -3369,6 +3377,74 @@ func isControlChannel(sys trunking.System, freqHz uint32) bool {
 		}
 	}
 	return false
+}
+
+// cchuntSystems returns the systems the sequential cchunt supervisor should
+// hunt, with any control-channel frequency that is already hosted on a
+// `role: wideband` device's `channels:` list removed (issue #749).
+//
+// A wideband dongle decodes every one of its configured channels in parallel
+// (internal/scanner/widebandt2), so a P25 system whose sites each have their
+// own wideband-hosted control channel is already covered simultaneously. The
+// single-tuner cchunt hunt, by contrast, treats a system's control_channels as
+// one-CC-per-system ALTERNATES — it locks the first that works and parks,
+// sticky to the last lock via cc-cache.json. Letting it also hunt those
+// frequencies makes a multi-site wideband config behave like single-site
+// hunting (sites "take turns", one never wins). Filtering them out hands those
+// sites exclusively to the parallel widebandt2 path.
+//
+// Control channels NOT hosted on a wideband device (true alternates, or systems
+// with no wideband coverage) are left for cchunt to hunt as before. A system
+// whose control channels are ALL wideband-hosted is dropped entirely — passing
+// it with an empty ControlChannels slice would fail trunking.System.Validate in
+// the per-round Hunter and mark the system failed forever.
+func cchuntSystems(systems []trunking.System, devices []config.DeviceConfig) []trunking.System {
+	// Wideband-hosted (system, frequency) pairs. Pairing by system name (not
+	// frequency alone) avoids filtering a coincidentally-equal frequency that
+	// belongs to a different, non-wideband system. Unions across every
+	// wideband device so split-across-dongles topologies are handled.
+	wb := make(map[string]map[uint32]bool)
+	for _, dev := range devices {
+		if dev.Role != "wideband" {
+			continue
+		}
+		for _, ch := range dev.Channels {
+			if wb[ch.System] == nil {
+				wb[ch.System] = make(map[uint32]bool)
+			}
+			wb[ch.System][ch.FrequencyHz] = true
+		}
+	}
+	if len(wb) == 0 {
+		return systems
+	}
+	out := make([]trunking.System, 0, len(systems))
+	for _, sys := range systems {
+		hosted := wb[sys.Name]
+		if len(hosted) == 0 {
+			out = append(out, sys)
+			continue
+		}
+		// Allocate a fresh slice: d.systems[i].ControlChannels aliases the
+		// config's backing array (daemon.go assigns sys.ControlChannels
+		// directly), and that slice is read by the trunking engine, spectrum
+		// provider, and /api/v1/sites. Mutating it in place would corrupt them.
+		filtered := make([]uint32, 0, len(sys.ControlChannels))
+		for _, cc := range sys.ControlChannels {
+			if !hosted[cc] {
+				filtered = append(filtered, cc)
+			}
+		}
+		if len(filtered) == 0 {
+			// Every control channel is wideband-hosted — widebandt2 owns this
+			// system. Drop it from the cchunt set entirely.
+			continue
+		}
+		cp := sys
+		cp.ControlChannels = filtered
+		out = append(out, cp)
+	}
+	return out
 }
 
 // buildVirtualVoiceTuners spins up one wbvoice.VirtualTuner per voice tap

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -288,6 +288,35 @@ sdr:
     # Honours `p25_phase1_demod_mode` (c4fm vs cqpsk / LSM) on the
     # system entry just like a dedicated CC dongle.
     #
+    # MULTIPLE SITES IN PARALLEL (issue #749): a P25 system with
+    # several sites — each broadcasting its own control channel —
+    # decodes all of them SIMULTANEOUSLY when you list each site's
+    # control channel as a separate `channels:` entry on a wideband
+    # dongle (on the same dongle if they fit one IQ window, or split
+    # across dongles otherwise). Each channel gets its own tap +
+    # Phase 1 state machine, so every site locks and grants
+    # independently — no taking turns. Any control-channel frequency
+    # hosted this way is automatically excluded from the sequential,
+    # single-tuner cc-hunt below, so a wideband site is never starved
+    # by the round-robin hunter. Example: all four sites of "MMR"
+    # decoded at once from one Airspy —
+    # - serial: "AIRSPY SN:637862DC2E8449D7"
+    #   role: wideband
+    #   center_freq_hz: 420_900_000
+    #   voice_taps: 4
+    #   channels:
+    #     - frequency_hz: 420_012_500   # Melbourne / CBD
+    #       system: "MMR"
+    #     - frequency_hz: 420_037_500   # 120 Collins Street
+    #       system: "MMR"
+    #     - frequency_hz: 420_087_500   # Mt Anakie
+    #       system: "MMR"
+    #     - frequency_hz: 421_837_500   # Mt Blackwood
+    #       system: "MMR"
+    # (List every one of these frequencies in the system's
+    # control_channels too — see the systems section below — and add a
+    # `sites:` mapping there to give each RFSS/Site a human name.)
+    #
     # `voice_taps: N` (0 disables; no hard upper bound) lets the
     # same SDR host N concurrent voice grants without a separate
     # `role: voice` dongle: each grant whose frequency falls inside
@@ -624,6 +653,22 @@ trunking:
   systems:
     - name: "Example-P25"
       protocol: p25
+      # control_channels lists every candidate control channel for the
+      # system. How they are used depends on the SDR topology:
+      #   * Single-tuner deployment (a `role: control` dongle): the
+      #     cc-hunt supervisor treats them as ALTERNATES — it hunts them
+      #     in turn and locks the first that works, staying sticky to the
+      #     last lock (persisted in cc-cache.json). Only one is decoded at
+      #     a time, which is correct when the entries are standby CCs for
+      #     ONE site.
+      #   * Multi-site / wideband deployment: if a system spans several
+      #     SITES (each with its own control channel) and you want them
+      #     decoded SIMULTANEOUSLY, list each site's control channel here
+      #     AND as a `channels:` entry on a `role: wideband` dongle (see
+      #     the SDR section). The wideband path decodes them all in
+      #     parallel and those frequencies are dropped from the sequential
+      #     cc-hunt, so no site is starved (issue #749). Pair this with the
+      #     `sites:` mapping below to label each RFSS/Site.
       control_channels:
         - 851_000_000
         - 852_000_000


### PR DESCRIPTION
A `role: wideband` device with multiple control channels (one per P25 site,
all in one system) only decoded one site at a time — sites took turns and one
never won. Two control-channel decode paths were both wired with the full
systems list: widebandt2 already decodes every wideband channel in parallel,
while the cc-hunt supervisor runs a sequential single-tuner round-robin that
treats a system's control_channels as one-CC alternates and stays sticky to the
last lock (cc-cache.json). The two competed, and the sequential path serialized
coverage.

Add cchuntSystems() to strip any control-channel frequency hosted on a
`role: wideband` device from the supervisor's hunt set (dropping a system whose
control channels are all wideband-hosted, since an empty ControlChannels would
fail the per-round Hunter's Validate). Wideband sites are now owned exclusively
by the parallel path; true alternates and non-wideband systems still hunt as
before. The helper allocates a fresh ControlChannels slice to avoid corrupting
the config-backed slice shared with the trunking engine, spectrum provider, and
/api/v1/sites. When every system is fully wideband-hosted the supervisor (and
its ccdecoder connector) is no longer built.

Document the multi-site wideband pattern and the alternates-vs-parallel
distinction in config.example.yaml; add table-driven coverage for the helper.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014NJjqjQqG8R2AHTkCz9Yei