### PR TITLE
fix(p25): correct U_REG_RSP decode and stop empty capture files

### DIFF
--- a/cmd/gophertrunk/integration_cc_test.go
+++ b/cmd/gophertrunk/integration_cc_test.go
@@ -182,7 +182,25 @@ WaitLoop:
 	// system label can be "unknown" when the phase1 LockState's
 	// SystemName isn't populated; that's fine — the metric
 	// family + value pair is what we assert.
-	body := scrape(t, base+"/metrics")
+	// The metrics handler is a separate bus subscriber, so the cc-locked
+	// gauge can lag the cc.locked event this test received on its own
+	// subscription. Poll /metrics until the gauge family appears (set by the
+	// KindCCLocked handler in internal/metrics/prom.go) instead of racing it
+	// with a single scrape — on a loaded -race CI runner the handler hadn't
+	// updated the gauge yet when this test scraped once.
+	var body string
+	mDeadline := time.Now().Add(5 * time.Second)
+	for {
+		body = scrape(t, base+"/metrics")
+		if strings.Contains(body, `gophertrunk_control_channel_locked{system=`) &&
+			strings.Contains(body, `gophertrunk_events_total{kind="cc.locked"} 1`) {
+			break
+		}
+		if time.Now().After(mDeadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 	if !strings.Contains(body, "gophertrunk_control_channel_locked{") {
 		t.Errorf("/metrics missing gophertrunk_control_channel_locked gauge family:\n%s", body)
 	}

--- a/cmd/gophertrunk/integration_test.go
+++ b/cmd/gophertrunk/integration_test.go
@@ -143,6 +143,20 @@ func TestDaemonEndToEnd(t *testing.T) {
 		t.Errorf("talkgroup_alpha = %v, want FIRE-DISP", got)
 	}
 
+	// Feed a bit of PCM into the recorder so it actually writes a WAV.
+	// Capture files are opened lazily on the first audio sample (a call with
+	// no audio leaves nothing on disk), so an end-to-end recording needs
+	// real samples — the recorder created the session from the CallStart
+	// above; wait for it, then write a short tone.
+	waitRecorderSession(t, d, "VOICE-1")
+	pcm := make([]int16, 8000) // 1 s @ 8 kHz
+	for i := range pcm {
+		pcm[i] = int16((i % 200) * 80) // non-silent ramp; any audio opens the WAV
+	}
+	if err := d.recorder.WritePCM("VOICE-1", pcm); err != nil {
+		t.Fatalf("WritePCM: %v", err)
+	}
+
 	// Recordings directory should now contain a WAV under
 	// Alpha/FIRE-DISP/...
 	waitForRecording(t, cfg.Recordings.Dir, "FIRE-DISP", 2*time.Second)
@@ -184,6 +198,21 @@ func TestDaemonEndToEnd(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Errorf("metrics never surfaced %s", want)
+}
+
+// waitRecorderSession blocks until the daemon's recorder has opened a session
+// for serial (the CallStart is delivered asynchronously over the bus, so the
+// session may not exist the instant the publish returns).
+func waitRecorderSession(t *testing.T, d *Daemon, serial string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if d.recorder != nil && d.recorder.HasSession(serial) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("recorder never opened a session for %q", serial)
 }
 
 func waitForRecording(t *testing.T, root, alpha string, timeout time.Duration) {

--- a/internal/hunt/accumulate.go
+++ b/internal/hunt/accumulate.go
@@ -63,11 +63,22 @@ func Accumulate(dst *DiscoveredSystem, obs Observation) {
 		return
 	}
 
-	// Harvest identity from the lock payload first, then from every event
-	// payload (the network/RFSS-status TSBKs ride in events, not the lock).
 	if dst.Identity == nil {
 		dst.Identity = map[string]any{}
 	}
+	// Fold the decoder's accumulated topology FIRST — it is the
+	// authoritative source of WACN/SYSID/RFSS/Site (NSB-corroborated by
+	// majority vote). harvestIdentity uses "first non-zero wins", so the
+	// topology must seed those fields before per-unit events (registration /
+	// affiliation) get a chance to: a single bogus event must never override
+	// the corroborated system identity (the floating WACN/SysID in the field
+	// report). Topology also carries neighbors + band plan, which never ride
+	// on events. This still runs before site placement so RFSS/Site stay
+	// authoritative there too.
+	foldTopology(dst, obs.Result.Topology)
+
+	// Then harvest identity from the lock payload and every event payload to
+	// fill in anything the topology left at zero.
 	var ccFreq uint32
 	if lk := obs.Result.Lock; lk != nil {
 		ccFreq = lk.FrequencyHz
@@ -76,10 +87,6 @@ func Accumulate(dst *DiscoveredSystem, obs Observation) {
 	for _, ev := range obs.Result.Events {
 		harvestIdentity(dst, ev.Fields)
 	}
-	// Fold the decoder's accumulated topology (the only source of
-	// WACN/SYSID/RFSS/Site + neighbors + band plan — these never ride on
-	// events). This runs before site placement so RFSS/Site are authoritative.
-	foldTopology(dst, obs.Result.Topology)
 
 	// Fall back to the capture's nominal center when the lock didn't carry an
 	// absolute frequency (baseband captures lock at 0 Hz).

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1468,9 +1468,13 @@ func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse, nac
 		Payload: trunking.UnitRegistration{
 			System:   c.systemName,
 			Protocol: "p25",
-			SourceID: u.SourceID,
-			WACN:     u.WACN,
-			SystemID: u.SystemID,
+			SourceID: u.SourceAddress, // the registering radio's unit ID
+			// U_REG_RSP carries no WACN, and its System ID has proven
+			// unreliable to recover per-message; take both from the
+			// NSB-corroborated network model so they match the System
+			// Identity panel instead of floating per registration.
+			WACN:     net.WACN,
+			SystemID: net.SystemID,
 			Response: trunking.RegistrationResponse(u.Response),
 			RFSSID:   net.RFSS,
 			SiteID:   net.Site,
@@ -1480,7 +1484,8 @@ func (c *ControlChannel) publishUnitRegistration(u UnitRegistrationResponse, nac
 	})
 	c.log.Debug("p25: registration",
 		"system", c.systemName, "nac", nac,
-		"src", u.SourceID, "wacn", u.WACN, "sysid", u.SystemID,
+		"src", u.SourceAddress, "wuid", u.SourceID,
+		"wacn", net.WACN, "sysid", net.SystemID,
 		"rsp", u.Response)
 }
 

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -687,16 +687,13 @@ func TestControlChannelPublishesUnitRegistration(t *testing.T) {
 	sub := bus.Subscribe()
 	defer sub.Close()
 
-	// Feed an RFSS Status Broadcast first (RFSS=2, Site=9) so the
-	// registration event stamps the serving site (issue #698).
+	// U_REG_RSP carries no WACN and an unreliable per-message System ID, so
+	// the registration event takes WACN/SystemID from the NSB-corroborated
+	// network model. Feed a Network Status Broadcast (WACN 0xABCDE, SystemID
+	// 0x123) and an RFSS Status Broadcast (RFSS=2, Site=9) first so the model
+	// is populated and the event stamps the serving site (issue #698).
+	nsbTSBK := TSBK{LB: true, Opcode: OpNetworkStatusBroadcast, Payload: [8]byte{0x00, 0xAB, 0xCD, 0xE1, 0x23, 0x00, 0x00, 0x00}}
 	rfssTSBK := TSBK{LB: true, Opcode: OpRFSSStatusBroadcast, Payload: [8]byte{0x09, 0x01, 0x23, 0x02, 0x09, 0x00, 0x00, 0x00}}
-	rfssStream := buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, rfssTSBK)
-
-	// Response = accepted (0), WACN = 0xBEE08, SystemID = 0x534,
-	// SourceID = 0x112233.
-	payload := [8]byte{0x00, 0xBE, 0xE0, 0x85, 0x34, 0x11, 0x22, 0x33}
-	tsbk := TSBK{LB: true, Opcode: OpUnitRegistrationResponse, Payload: payload}
-	stream := buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, tsbk)
 
 	cc := New(Options{
 		Bus:         bus,
@@ -704,45 +701,59 @@ func TestControlChannelPublishesUnitRegistration(t *testing.T) {
 		FrequencyHz: 851_000_000,
 		Now:         func() time.Time { return time.Unix(1_700_000_002, 0).UTC() },
 	})
-	cc.Process(rfssStream, 0)
-	cc.Process(stream, 0)
+	cc.Process(buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, nsbTSBK), 0)
+	cc.Process(buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, rfssTSBK), 0)
 
-	var got *trunking.UnitRegistration
-	deadline := time.After(time.Second)
-	for got == nil {
+	// Two registrations from different radios — the per-message Source ID
+	// (WUID) and Source Address bytes differ, but the reported WACN/SystemID
+	// must stay pinned to the network identity (no floating). byte0=0x00 ->
+	// Response accepted; bytes 2-4 = WUID; bytes 5-7 = Source Address.
+	reg1 := TSBK{LB: true, Opcode: OpUnitRegistrationResponse, Payload: [8]byte{0x00, 0x00, 0xAA, 0x11, 0x22, 0x11, 0x22, 0x33}}
+	reg2 := TSBK{LB: true, Opcode: OpUnitRegistrationResponse, Payload: [8]byte{0x00, 0x00, 0xBB, 0xCC, 0xDD, 0x44, 0x55, 0x66}}
+	cc.Process(buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, reg1), 0)
+	cc.Process(buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, reg2), 0)
+
+	var regs []trunking.UnitRegistration
+	deadline := time.After(2 * time.Second)
+	for len(regs) < 2 {
 		select {
 		case ev := <-sub.C:
 			if ev.Kind == events.KindUnitRegistration {
-				u := ev.Payload.(trunking.UnitRegistration)
-				got = &u
+				regs = append(regs, ev.Payload.(trunking.UnitRegistration))
 			}
 		case <-deadline:
-			t.Fatal("no registration event published")
+			t.Fatalf("got %d registration events, want 2", len(regs))
 		}
 	}
-	if got.System != "TestSys" || got.Protocol != "p25" {
-		t.Errorf("identity = %s/%s", got.System, got.Protocol)
-	}
-	if got.SourceID != 0x112233 {
-		t.Errorf("SourceID = %06X, want 112233", got.SourceID)
-	}
-	if got.WACN != 0xBEE08 {
-		t.Errorf("WACN = %05X, want BEE08", got.WACN)
-	}
-	if got.SystemID != 0x534 {
-		t.Errorf("SystemID = %03X, want 534", got.SystemID)
-	}
-	if got.Response != trunking.RegistrationAccepted {
-		t.Errorf("Response = %v, want accepted", got.Response)
-	}
-	if got.RFSSID != 2 || got.SiteID != 9 {
-		t.Errorf("site = RFSS %d / Site %d, want 2/9", got.RFSSID, got.SiteID)
-	}
-	if got.NAC != 0x222 {
-		t.Errorf("NAC = %03X, want 222", got.NAC)
-	}
-	if got.At.Unix() != 1_700_000_002 {
-		t.Errorf("At = %v, want injected Now", got.At)
+
+	wantSrc := []uint32{0x112233, 0x445566}
+	for i, got := range regs {
+		if got.System != "TestSys" || got.Protocol != "p25" {
+			t.Errorf("reg %d identity = %s/%s", i, got.System, got.Protocol)
+		}
+		if got.SourceID != wantSrc[i] {
+			t.Errorf("reg %d SourceID = %06X, want %06X", i, got.SourceID, wantSrc[i])
+		}
+		// The whole point: identity is pinned to the NSB, not the per-radio
+		// payload bytes, so it is identical for both registrations.
+		if got.WACN != 0xABCDE {
+			t.Errorf("reg %d WACN = %05X, want ABCDE (from NSB)", i, got.WACN)
+		}
+		if got.SystemID != 0x123 {
+			t.Errorf("reg %d SystemID = %03X, want 123 (from NSB)", i, got.SystemID)
+		}
+		if got.Response != trunking.RegistrationAccepted {
+			t.Errorf("reg %d Response = %v, want accepted", i, got.Response)
+		}
+		if got.RFSSID != 2 || got.SiteID != 9 {
+			t.Errorf("reg %d site = RFSS %d / Site %d, want 2/9", i, got.RFSSID, got.SiteID)
+		}
+		if got.NAC != 0x222 {
+			t.Errorf("reg %d NAC = %03X, want 222", i, got.NAC)
+		}
+		if got.At.Unix() != 1_700_000_002 {
+			t.Errorf("reg %d At = %v, want injected Now", i, got.At)
+		}
 	}
 }
 

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -401,27 +401,39 @@ func ParseGroupAffiliationResponse(p [8]byte) GroupAffiliationResponse {
 }
 
 // UnitRegistrationResponse (opcode 0x2C) — published when a radio
-// completes (or is denied) registration on a site. Payload layout
-// follows OP25's reference decoder (`trunk_p25.py`):
+// completes (or is denied) registration on a site. Payload layout per
+// TIA-102.AABF, cross-checked against SDRTrunk's UnitRegistrationResponse
+// (…/tsbk/standard/osp/UnitRegistrationResponse.java).
 //
-//	byte 0:        bits 1-0 = Registration Response Value
-//	bytes 1-3 + top nibble of byte 3: WACN (20 bits)
-//	bottom nibble of byte 3 + byte 4: System ID (12 bits)
-//	bytes 5-7:     Source ID (24 bits) — the radio's WUID
+// The message does NOT carry a WACN — SDRTrunk's own decoder notes "we
+// don't know what the WACN is from this message". The system identity
+// comes from the Network Status Broadcast (0x3B), not from here. The
+// earlier layout that read a 20-bit "WACN" from bytes 1-3 and a System ID
+// from bytes 3-4 was wrong: those bytes are actually the assigned WUID,
+// which differs for every radio — the cause of the "floating" WACN/SysID
+// in the field report.
+//
+// Absolute TSBK bit indices map to the 8 argument bytes p[0..7]
+// (payload bit 0 = TSBK bit 16):
+//
+//	byte 0 bits 5-4          : Registration Response Value (RV)
+//	byte 0 bits 3-0 + byte 1 : System ID (12 bits)
+//	bytes 2-4               : Source ID — the assigned working unit ID (WUID)
+//	bytes 5-7               : Source Address — the registering radio's unit ID
 type UnitRegistrationResponse struct {
-	Response uint8
-	WACN     uint32 // 20-bit
-	SystemID uint16 // 12-bit
-	SourceID uint32 // 24-bit
+	Response      uint8
+	SystemID      uint16 // 12-bit
+	SourceID      uint32 // 24-bit assigned WUID
+	SourceAddress uint32 // 24-bit registering radio
 }
 
 // ParseUnitRegistrationResponse decodes payload bytes for opcode 0x2C.
 func ParseUnitRegistrationResponse(p [8]byte) UnitRegistrationResponse {
 	return UnitRegistrationResponse{
-		Response: p[0] & 0x03,
-		WACN:     uint32(p[1])<<12 | uint32(p[2])<<4 | uint32(p[3])>>4,
-		SystemID: uint16(p[3]&0x0F)<<8 | uint16(p[4]),
-		SourceID: uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+		Response:      (p[0] >> 4) & 0x03,
+		SystemID:      uint16(p[0]&0x0F)<<8 | uint16(p[1]),
+		SourceID:      uint32(p[2])<<16 | uint32(p[3])<<8 | uint32(p[4]),
+		SourceAddress: uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
 	}
 }
 

--- a/internal/radio/p25/phase1/tsbk_test.go
+++ b/internal/radio/p25/phase1/tsbk_test.go
@@ -137,23 +137,27 @@ func TestParseGroupAffiliationResponse(t *testing.T) {
 }
 
 func TestParseUnitRegistrationResponse(t *testing.T) {
-	// Response = 0x0 (accepted). WACN = 0xBEE08 (20-bit) packed as
-	// byte1 = 0xBE, byte2 = 0xE0, top nibble of byte3 = 0x8.
-	// SystemID = 0x534 (12-bit) packed as bottom nibble of byte3 = 0x5,
-	// byte4 = 0x34. Source = 0x112233.
-	p := [8]byte{0x00, 0xBE, 0xE0, 0x85, 0x34, 0x11, 0x22, 0x33}
+	// Layout per TIA-102.AABF / SDRTrunk: U_REG_RSP carries NO WACN.
+	// byte0 bits 5-4 = Response, byte0 bits 3-0 + byte1 = System ID,
+	// bytes 2-4 = Source ID (assigned WUID), bytes 5-7 = Source Address.
+	//
+	// byte0 = 0x15 -> Response = (0x15>>4)&3 = 1 (failed), SystemID high
+	// nibble = 0x5; byte1 = 0x34 -> SystemID = 0x534.
+	// bytes 2-4 = 0xAA BB CC -> SourceID (WUID) = 0xAABBCC.
+	// bytes 5-7 = 0x11 22 33 -> SourceAddress = 0x112233.
+	p := [8]byte{0x15, 0x34, 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33}
 	u := ParseUnitRegistrationResponse(p)
-	if u.Response != 0x0 {
-		t.Errorf("Response = %X, want 0", u.Response)
-	}
-	if u.WACN != 0xBEE08 {
-		t.Errorf("WACN = %05X, want BEE08", u.WACN)
+	if u.Response != 0x1 {
+		t.Errorf("Response = %X, want 1", u.Response)
 	}
 	if u.SystemID != 0x534 {
 		t.Errorf("SystemID = %03X, want 534", u.SystemID)
 	}
-	if u.SourceID != 0x112233 {
-		t.Errorf("SourceID = %06X, want 112233", u.SourceID)
+	if u.SourceID != 0xAABBCC {
+		t.Errorf("SourceID (WUID) = %06X, want AABBCC", u.SourceID)
+	}
+	if u.SourceAddress != 0x112233 {
+		t.Errorf("SourceAddress = %06X, want 112233", u.SourceAddress)
 	}
 }
 

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -400,12 +400,24 @@ func (r *Recorder) sessionForWrite(serial string, callID uint64) *recordingSessi
 		return nil
 	}
 	if s.wav == nil {
-		ns := r.buildSession(s.cs, time.Now().UTC())
-		if ns == nil {
+		// A dormant post-segment park carries only cs+callID with no paths
+		// yet, so prepare a fresh session for it under a new timestamp. A
+		// session prepared by handleStart already has its paths/vocoder and
+		// just needs its files opened on this first write.
+		if s.wavPath == "" {
+			ns := r.buildSession(s.cs, time.Now().UTC())
+			if ns == nil {
+				return nil
+			}
+			r.sessions[serial] = ns
+			s = ns
+		}
+		if err := r.openSessionFiles(s); err != nil {
+			// The WAV couldn't be created — drop the session so we don't
+			// retry on every frame. Nothing partial lands on disk.
+			delete(r.sessions, serial)
 			return nil
 		}
-		r.sessions[serial] = ns
-		s = ns
 	}
 	return s
 }
@@ -598,11 +610,14 @@ func (r *Recorder) handleEncryptionUpdate(deviceSerial string, encrypted bool) {
 		"device", deviceSerial, "wav", s.wavPath)
 }
 
-// buildSession opens the WAV (+ optional .raw sidecar + vocoder) for a
-// call, naming the files from cs but timestamped at startedAt (which
-// differs from cs.StartedAt for a per-transmission segment roll).
-// Returns nil on a fatal open error (already logged). The caller holds
-// r.mu and registers the returned session.
+// buildSession prepares a recording session for a call: it makes the output
+// directory, instantiates the vocoder, picks the WAV sample rate, and
+// resolves the .wav / .raw paths (named from cs but timestamped at startedAt,
+// which differs from cs.StartedAt for a per-transmission segment roll). It
+// deliberately does NOT open the files — that happens lazily on the first
+// write (openSessionFiles) so a call with no audio leaves nothing on disk.
+// Returns nil on a fatal error (already logged). The caller holds r.mu and
+// registers the returned session.
 func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *recordingSession {
 	dir := r.directoryFor(cs)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -645,31 +660,50 @@ func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *rec
 				"recordings_sample_rate", r.sampleRate)
 		}
 	}
-	wavPath := filepath.Join(dir, base+".wav")
-	wav, err := NewWavFile(wavPath, s.sampleRate)
-	if err != nil {
-		r.log.Error("recorder: open wav", "path", wavPath, "err", err)
-		if s.vocoder != nil {
-			_ = s.vocoder.Close()
-		}
-		return nil
-	}
-	s.wav = wav
-	s.wavPath = wavPath
+	s.wavPath = filepath.Join(dir, base+".wav")
 	// ProVoice and DMR voice grants always get a sidecar — neither has
 	// an in-process vocoder, so the .raw file is the only capture of
 	// the call.
 	if r.writeRaw || cs.Grant.ProVoice || dmrVoiceProtocol(cs.Grant.Protocol) {
-		rawPath := filepath.Join(dir, base+".raw")
-		raw, err := os.Create(rawPath)
+		s.rawPath = filepath.Join(dir, base+".raw")
+		s.rawWanted = true
+	}
+	// The on-disk files are NOT opened here — they are created lazily on the
+	// first write (openSessionFiles). A grant that never yields audio (a
+	// dead-key, an immediately-aborted encrypted call, or a tap that never
+	// emits a frame) therefore leaves nothing on disk, instead of a 44-byte
+	// header-only .wav and a 0-byte .raw.
+	return s
+}
+
+// openSessionFiles opens a prepared session's WAV (and .raw sidecar, when
+// wanted) if they aren't open yet. Called from the write path on the first
+// sample/frame so empty calls never touch disk. Idempotent: a no-op once the
+// WAV is open. On WAV-open failure the vocoder is closed and an error is
+// returned so the caller drops the frame.
+func (r *Recorder) openSessionFiles(s *recordingSession) error {
+	if s.wav != nil {
+		return nil
+	}
+	wav, err := NewWavFile(s.wavPath, s.sampleRate)
+	if err != nil {
+		r.log.Error("recorder: open wav", "path", s.wavPath, "err", err)
+		if s.vocoder != nil {
+			_ = s.vocoder.Close()
+			s.vocoder = nil
+		}
+		return err
+	}
+	s.wav = wav
+	if s.rawWanted && s.raw == nil {
+		raw, err := os.Create(s.rawPath)
 		if err != nil {
-			r.log.Error("recorder: open raw", "path", rawPath, "err", err)
+			r.log.Error("recorder: open raw", "path", s.rawPath, "err", err)
 		} else {
 			s.raw = raw
-			s.rawPath = rawPath
 		}
 	}
-	return s
+	return nil
 }
 
 // handleSegment finalizes the current recording at a per-transmission
@@ -934,7 +968,13 @@ type recordingSession struct {
 	vocoder     Vocoder
 	vocoderName string
 	sampleRate  uint32
-	startedAt   time.Time
+	// rawWanted records whether this call should get a .raw sidecar once
+	// its files are opened. The decision is made when the session is
+	// prepared (buildSession) but the file itself is created lazily on the
+	// first frame (openSessionFiles), so a call with no audio never leaves a
+	// 0-byte .raw behind.
+	rawWanted bool
+	startedAt time.Time
 	// callID is the Grant.CallID of the call this session records. Frames
 	// arriving via WriteRawFrameForCall with a different non-zero callID are
 	// dropped (see sessionForWrite) so a reused tap serial can't bleed the

--- a/internal/voice/recorder_idle_test.go
+++ b/internal/voice/recorder_idle_test.go
@@ -140,6 +140,85 @@ func TestRecorderSuppressesAllIdleRecording(t *testing.T) {
 	}
 }
 
+// TestRecorderNoAudioLeavesNoFiles: a call that starts and ends without a
+// single frame must leave nothing on disk — no 44-byte header-only .wav and
+// no 0-byte .raw — and publish no CallComplete. Capture files are opened
+// lazily on the first write, so a no-audio call never touches the filesystem.
+func TestRecorderNoAudioLeavesNoFiles(t *testing.T) {
+	vc := &vocoderCapture{}
+	DefaultRegistry.Register("stat-stub-noaudio", func() (Vocoder, error) {
+		v := &statStubVocoder{voicedPerFrame: true}
+		vc.set(v)
+		return v, nil
+	})
+
+	bus := events.NewBus(16)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		WriteRaw:           true, // exercise the .raw sidecar path too
+		VocoderForProtocol: map[string]string{"test-noaudio": "stat-stub-noaudio"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-noaudio", GroupID: 7, SourceID: 9},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitSession(t, r, "VOICE-1", true)
+
+	// No frames written at all, then the call ends.
+	wavPath := filepath.Join(dir, "S", "7", "20260505T000000Z_src9.wav")
+	rawPath := filepath.Join(dir, "S", "7", "20260505T000000Z_src9.raw")
+	if _, err := os.Stat(wavPath); !os.IsNotExist(err) {
+		t.Errorf("WAV %s must not exist before any audio is written; stat err = %v", wavPath, err)
+	}
+	if _, err := os.Stat(rawPath); !os.IsNotExist(err) {
+		t.Errorf("raw %s must not exist before any audio is written; stat err = %v", rawPath, err)
+	}
+
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: cs.Grant, DeviceSerial: "VOICE-1",
+		StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+		Reason: trunking.EndReasonNormal,
+	}})
+	waitSession(t, r, "VOICE-1", false)
+
+	if _, err := os.Stat(wavPath); !os.IsNotExist(err) {
+		t.Errorf("no-audio WAV %s must not be created; stat err = %v", wavPath, err)
+	}
+	if _, err := os.Stat(rawPath); !os.IsNotExist(err) {
+		t.Errorf("no-audio raw %s must not be created; stat err = %v", rawPath, err)
+	}
+
+	timeout := time.After(200 * time.Millisecond)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindCallComplete {
+				t.Fatal("no-audio call must not publish CallComplete")
+			}
+		case <-timeout:
+			return
+		}
+	}
+}
+
 // TestRecorderCallIDFenceDropsStaleFrames: a frame tagged with a CallID that
 // doesn't match the open session is dropped before it reaches the vocoder —
 // the voice-tap mix-up fence.


### PR DESCRIPTION
Two field-reported bugs in the Hunt/trunking path:

1. Floating/bogus WACN and System ID on P25 registrations. The Unit
   Registration Response (TSBK opcode 0x2C) was decoded with the Network
   Status Broadcast layout, inventing a 20-bit "WACN" that the message
   does not carry. Per TIA-102.AABF (and SDRTrunk, whose decoder notes it
   cannot recover a WACN here), U_REG_RSP holds: Response (bits 18-19),
   System ID (20-31), Source ID/assigned WUID (32-55) and Source Address
   (56-79) — no WACN. The bytes previously read as WACN/SystemID are the
   per-radio WUID, which is why the values floated every registration and
   poisoned Hunt's System Identity panel via harvestIdentity.

   - ParseUnitRegistrationResponse now uses the correct bitfields and
     exposes SourceID (WUID) + SourceAddress separately; the WACN field is
     removed.
   - Registration events take WACN/SystemID from the NSB-corroborated
     network-model snapshot (as SiteUpdate already does), so they match
     the System Identity panel and stay stable.
   - Hunt's Accumulate folds the authoritative topology before harvesting
     identity from per-unit events, so a single event can never override
     the corroborated WACN/SystemID.

2. 44-byte header-only .wav and 0-byte .raw files for calls that never
   produced audio. Capture files were opened eagerly at CallStart. They
   are now opened lazily on the first sample/frame (openSessionFiles),
   reusing the existing dormant-session path, so a no-audio call leaves
   nothing on disk.

Tests updated/added for the corrected U_REG_RSP vector, registration
identity sourced from a preceding NSB (constant across radios), and a
no-audio call leaving no files.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QDHPrYvsgFVbmGt1GZQHEm