### PR TITLE
Add single DMR simplex sample config

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1566,6 +1566,14 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			// raw entry.Device: the iqtap broker doesn't forward the optional
 			// ActualSampleRate() extension. Mirrors the CC decoder above.
 			effectiveRate := effectiveStreamRate(log, entry.Device, entry.Info.Serial, cfg.SDR.SampleRate)
+			// Per-channel IQ-power gauge. Same typed-nil guard as the CC
+			// decoder above: a nil *metrics.Metrics wrapped in the interface
+			// still tests non-nil inside the engine, so hand it over only
+			// when the concrete pointer is alive.
+			var wbIQObs widebandt2.IQPowerObserver
+			if d.metrics != nil {
+				wbIQObs = d.metrics
+			}
 			eng, err := widebandt2.New(widebandt2.Options{
 				Log:           log,
 				Bus:           d.bus,
@@ -1575,6 +1583,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				TunerStrategy: devCfg.TunerStrategy,
 				Channels:      channels,
 				Systems:       d.systems,
+				Metrics:       wbIQObs,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("daemon: widebandt2 %q: %w", devCfg.Serial, err)

--- a/internal/dsp/iqpower/iqpower.go
+++ b/internal/dsp/iqpower/iqpower.go
@@ -1,0 +1,93 @@
+// Package iqpower holds the small, reusable IQ signal-level helpers
+// shared by the decode engines for operator-facing diagnostics: a
+// window-averaged dBFS power measure plus the "looks dead" threshold.
+//
+// The dBFS computation mirrors the control-channel decoder's
+// observeIQPower (internal/scanner/ccdecoder) bit for bit — accumulate
+// |x|² over a window, divide by the sample count, clamp at a small
+// epsilon so a silent window reads "very low" instead of -Inf, and take
+// 10·log10. Extracting it here lets the wideband Tier II engine surface
+// the same per-channel signal level the ccdecoder already exposes,
+// without either package importing the other.
+package iqpower
+
+import (
+	"math"
+	"time"
+)
+
+// Window is the interval over which power is aggregated before a fresh
+// mean is reported. Mirrors ccdecoder's iqPowerWindow.
+const Window = time.Second
+
+// LowPowerThresholdDbFS is the level below which the IQ stream looks
+// dead — gain at 0, antenna disconnected, or USB stuck. Mirrors
+// ccdecoder's iqLowPowerThresholdDbFS: -55 dBFS sits well below the
+// idle-noise floor of an R820T2 at moderate gain (~-45 dBFS), so
+// legitimate weak signal doesn't trip it.
+const LowPowerThresholdDbFS = -55.0
+
+// powerEpsilon clamps the mean power so 10·log10 of a silent window
+// yields a finite "very low" reading instead of -Inf.
+const powerEpsilon = 1e-12
+
+// MeanPowerDbFS returns 10·log10(mean(|x|²)) over iq, clamped at
+// powerEpsilon. Returns the clamped floor for an empty slice.
+func MeanPowerDbFS(iq []complex64) float64 {
+	if len(iq) == 0 {
+		return 10 * math.Log10(powerEpsilon)
+	}
+	var sumSq float64
+	for _, c := range iq {
+		r := float64(real(c))
+		i := float64(imag(c))
+		sumSq += r*r + i*i
+	}
+	return dbFS(sumSq / float64(len(iq)))
+}
+
+// Accumulator folds successive sample windows so a caller pumping IQ in
+// chunks can report one mean per Window without buffering the samples.
+// It is not safe for concurrent use; the wideband engine drives it
+// inline on its single pump goroutine.
+type Accumulator struct {
+	sumSq float64
+	n     int
+}
+
+// Add folds one chunk of IQ samples into the running window.
+func (a *Accumulator) Add(iq []complex64) {
+	for _, c := range iq {
+		r := float64(real(c))
+		i := float64(imag(c))
+		a.sumSq += r*r + i*i
+	}
+	a.n += len(iq)
+}
+
+// Samples reports how many samples have accumulated since the last
+// reset. Zero means nothing has been Added — callers should skip the
+// flush rather than report the epsilon floor as a real measurement.
+func (a *Accumulator) Samples() int { return a.n }
+
+// MeanDbFSAndReset returns the window's mean power in dBFS and the
+// sample count it was computed over, then resets the accumulator for
+// the next window. With no samples it reports the clamped floor and a
+// count of 0.
+func (a *Accumulator) MeanDbFSAndReset() (dbfs float64, samples int) {
+	if a.n == 0 {
+		return dbFS(0), 0
+	}
+	dbfs = dbFS(a.sumSq / float64(a.n))
+	samples = a.n
+	a.sumSq = 0
+	a.n = 0
+	return dbfs, samples
+}
+
+func dbFS(meanPower float64) float64 {
+	if meanPower < powerEpsilon {
+		meanPower = powerEpsilon
+	}
+	return 10 * math.Log10(meanPower)
+}

--- a/internal/dsp/iqpower/iqpower_test.go
+++ b/internal/dsp/iqpower/iqpower_test.go
@@ -1,0 +1,71 @@
+package iqpower
+
+import (
+	"math"
+	"testing"
+)
+
+func TestMeanPowerDbFS(t *testing.T) {
+	// A constant unit-magnitude tone has mean |x|² = 1 → 0 dBFS.
+	tone := make([]complex64, 1000)
+	for i := range tone {
+		tone[i] = complex(1, 0)
+	}
+	if got := MeanPowerDbFS(tone); math.Abs(got) > 1e-6 {
+		t.Errorf("MeanPowerDbFS(unit tone) = %v dBFS, want ~0", got)
+	}
+
+	// Half-amplitude tone: mean power 0.25 → 10*log10(0.25) ≈ -6.0206 dB.
+	half := make([]complex64, 500)
+	for i := range half {
+		half[i] = complex(0.5, 0)
+	}
+	if got := MeanPowerDbFS(half); math.Abs(got-(-6.0206)) > 1e-3 {
+		t.Errorf("MeanPowerDbFS(half tone) = %v dBFS, want ~-6.02", got)
+	}
+
+	// Silence clamps to the epsilon floor, not -Inf.
+	silent := make([]complex64, 100)
+	floor := 10 * math.Log10(powerEpsilon)
+	if got := MeanPowerDbFS(silent); math.Abs(got-floor) > 1e-9 {
+		t.Errorf("MeanPowerDbFS(silence) = %v, want clamped floor %v", got, floor)
+	}
+
+	// Empty slice also returns the floor instead of NaN.
+	if got := MeanPowerDbFS(nil); math.Abs(got-floor) > 1e-9 {
+		t.Errorf("MeanPowerDbFS(nil) = %v, want clamped floor %v", got, floor)
+	}
+}
+
+func TestAccumulatorWindowingAndReset(t *testing.T) {
+	var a Accumulator
+	if a.Samples() != 0 {
+		t.Fatalf("fresh Accumulator Samples() = %d, want 0", a.Samples())
+	}
+
+	tone := make([]complex64, 600)
+	for i := range tone {
+		tone[i] = complex(1, 0)
+	}
+	a.Add(tone[:200])
+	a.Add(tone[200:]) // fold across two calls
+	if a.Samples() != 600 {
+		t.Errorf("Samples() = %d, want 600", a.Samples())
+	}
+
+	dbfs, n := a.MeanDbFSAndReset()
+	if n != 600 {
+		t.Errorf("drained samples = %d, want 600", n)
+	}
+	if math.Abs(dbfs) > 1e-6 {
+		t.Errorf("windowed mean = %v dBFS, want ~0", dbfs)
+	}
+
+	// Reset leaves the accumulator empty.
+	if a.Samples() != 0 {
+		t.Errorf("after reset Samples() = %d, want 0", a.Samples())
+	}
+	if _, n := a.MeanDbFSAndReset(); n != 0 {
+		t.Errorf("empty drain samples = %d, want 0", n)
+	}
+}

--- a/internal/radio/dmr/tier2/conventional.go
+++ b/internal/radio/dmr/tier2/conventional.go
@@ -16,6 +16,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
@@ -33,6 +34,27 @@ import (
 type LockState struct {
 	FrequencyHz uint32
 	ColorCode   uint8 // from the first valid slot-type decode
+}
+
+// Counters is a lock-free snapshot of one channel's decode activity,
+// read periodically by an operator-facing supervisor (the wideband
+// engine's diagnostics) to tell which stage is failing. All counts are
+// monotonic since channel construction. Purely observational — the
+// counters never gate decoding.
+//
+// Reading the four-way story:
+//   - SyncHits == 0                  → no DMR sync detected (no signal,
+//     mistune, wrong offset, or spectrum-inversion the polarity pass
+//     can't recover).
+//   - SyncHits > 0, FECPass == 0 and FECFail > 0 → sync seen but every
+//     Voice LC Header fails FEC (weak/dirty signal, clipping).
+//   - FECPass > 0                    → genuine DMR headers decoded.
+type Counters struct {
+	SyncHits uint64 // FSW matches reported by the burst-sync detector
+	Bursts   uint64 // slot-type-parsed bursts handed to IngestBurst
+	FECPass  uint64 // Voice LC Header with BPTC + RS both valid
+	FECFail  uint64 // Voice LC Header BPTC uncorrectable or RS mismatch
+	Locks    uint64 // cc.locked declarations (lifetime)
 }
 
 // LockedFrequencyHz / LockedNAC make LockState satisfy
@@ -80,6 +102,29 @@ type ConventionalChannel struct {
 	inCall  bool
 	lastTG  uint32
 	lastSrc uint32
+
+	// cnt holds the lock-free decode-activity counters exposed via
+	// Counters(). Incremented on the existing hot paths with atomic
+	// adds so any goroutine can snapshot them without taking c.mu.
+	cnt struct {
+		syncHits atomic.Uint64
+		bursts   atomic.Uint64
+		fecPass  atomic.Uint64
+		fecFail  atomic.Uint64
+		locks    atomic.Uint64
+	}
+}
+
+// Counters returns a snapshot of this channel's decode-activity
+// counters. Safe to call concurrently with the decode path.
+func (c *ConventionalChannel) Counters() Counters {
+	return Counters{
+		SyncHits: c.cnt.syncHits.Load(),
+		Bursts:   c.cnt.bursts.Load(),
+		FECPass:  c.cnt.fecPass.Load(),
+		FECFail:  c.cnt.fecFail.Load(),
+		Locks:    c.cnt.locks.Load(),
+	}
 }
 
 // Options configure a ConventionalChannel.
@@ -135,6 +180,7 @@ func New(opts Options) *ConventionalChannel {
 // don't carry a fresh FLC and CSBK bursts belong to Tier III, so they
 // fall through untouched.
 func (c *ConventionalChannel) IngestBurst(b *dmr.Burst, slot dmr.SlotType) {
+	c.cnt.bursts.Add(1)
 	switch slot.DataType {
 	case dmr.DTVoiceLCHeader:
 		c.handleVoiceHeader(b, slot)
@@ -163,6 +209,7 @@ func (c *ConventionalChannel) maybeLock(s LockState) {
 	}
 	c.locked = true
 	c.last = s
+	c.cnt.locks.Add(1)
 	c.bus.Publish(events.Event{Kind: events.KindCCLocked, Payload: s})
 	c.log.Info("dmr/tier2 cc locked",
 		"freq", s.FrequencyHz, "cc", s.ColorCode, "system", c.systemName)
@@ -191,6 +238,7 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		// recovery or a bit-ordering detail a real capture would expose —
 		// see docs/decoder-capture-needs.md. Debug level keeps it
 		// opt-in.
+		c.cnt.fecFail.Add(1)
 		c.log.Debug("dmr/tier2: voice header BPTC uncorrectable",
 			"cc", slot.ColorCode,
 			"burst_dibits", dibitDigits(b.Dibits[:]),
@@ -215,6 +263,7 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 		// roots alpha^1..3, seed 0x96) by TestRS129MatchesIndependent-
 		// ReferenceEncoder, so a real mismatch here implicates the BPTC
 		// info-bit recovery feeding it rather than the RS field itself.
+		c.cnt.fecFail.Add(1)
 		c.log.Debug("dmr/tier2: voice header RS(12,9) parity mismatch",
 			"cc", slot.ColorCode,
 			"info_hex", hex.EncodeToString(infoBytes))
@@ -227,6 +276,7 @@ func (c *ConventionalChannel) handleVoiceHeader(b *dmr.Burst, slot dmr.SlotType)
 	// BPTC + RS both passed: this is a genuine DMR transmission on the
 	// tuned frequency. Declare the lock here (not on the slot type alone)
 	// so a false sync / miscorrected slot type can't forge it.
+	c.cnt.fecPass.Add(1)
 	c.maybeLock(LockState{FrequencyHz: c.freqHz, ColorCode: slot.ColorCode})
 	flc, err := dmr.ParseFLC(infoBytes)
 	if err != nil {

--- a/internal/radio/dmr/tier2/process.go
+++ b/internal/radio/dmr/tier2/process.go
@@ -61,6 +61,7 @@ func (c *ConventionalChannel) Process(dibits []uint8, baseIdx int) int {
 	p.buf = append(p.buf, dibits...)
 
 	matches, _ := p.det.Process(nil, dibits, baseIdx)
+	c.cnt.syncHits.Add(uint64(len(matches)))
 	p.pending = append(p.pending, matches...)
 
 	bufEnd := p.bufStart + len(p.buf)

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -51,6 +51,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/iqpower"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
@@ -128,10 +129,27 @@ type ChannelConfig struct {
 	SystemName  string
 }
 
+// IQPowerObserver is the minimal metrics surface the engine uses to
+// publish its per-channel window-averaged dBFS gauge. internal/metrics.Metrics
+// satisfies it; nil disables the gauge while leaving the throttled
+// low-power WARN and the DEBUG decode-activity summary in place. Declared
+// locally (rather than imported from ccdecoder) so this scanner package
+// doesn't depend on another.
+type IQPowerObserver interface {
+	RecordIQPowerDbFS(system string, dbfs float64)
+	ClearIQPowerDbFS(system string)
+}
+
 // Options bundles the inputs Engine needs at construction time.
 type Options struct {
 	Log *slog.Logger
 	Bus *events.Bus
+
+	// Metrics, if non-nil, receives each channel's window-averaged dBFS
+	// gauge (labelled by "system @ <freqMHz>" so per-channel readings
+	// don't collide). Nil-safe: the throttled low-power WARN and the
+	// DEBUG decode-activity summary still fire without it.
+	Metrics IQPowerObserver
 
 	// Device is the wideband SDR. It is set to CenterFreqHz, then
 	// streamed continuously until Run's context cancels.
@@ -174,6 +192,14 @@ type Engine struct {
 	bank        tuner.Bank
 	channels    []*engineChannel
 	strategyTag string
+
+	// metrics is the optional per-channel dBFS gauge sink (nil-safe).
+	metrics IQPowerObserver
+	// now is the clock the diagnostics window uses; injectable for tests.
+	now func() time.Time
+	// lastDiagAt is the wall-clock time the per-channel diagnostics were
+	// last flushed. Owned by the Run pump goroutine.
+	lastDiagAt time.Time
 }
 
 // channelProcessor is the per-channel dibit consumer. DMR Tier II's
@@ -207,6 +233,19 @@ type engineChannel struct {
 	// channels (nil otherwise). Exposed via DMRTier3ControlChannel so the
 	// DMR LCN autoconfig learner can hot-swap a learned band-plan resolver.
 	dmrTier3 *tier3.ControlChannel
+
+	// pwr accumulates this channel's narrowband IQ power across one
+	// diagnostics window. Folded in the tap sink, drained by
+	// maybeLogDiagnostics — both on the single pump goroutine.
+	pwr iqpower.Accumulator
+	// tier2Cnt is the typed Tier II channel whose decode-activity counters
+	// feed the diagnostics summary (nil for non-dmr-tier2 channels).
+	tier2Cnt *tier2.ConventionalChannel
+	// lastCnt is the previous window's counter snapshot, so the summary
+	// can report per-window deltas instead of lifetime totals.
+	lastCnt tier2.Counters
+	// pwLowLogAt throttles the "iq power very low" WARN for this channel.
+	pwLowLogAt time.Time
 }
 
 // New constructs an Engine. The device is not opened or streamed
@@ -253,6 +292,10 @@ func New(opts Options) (*Engine, error) {
 		return nil, fmt.Errorf("widebandt2: unknown tuner strategy %q", strategy)
 	}
 
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
 	engine := &Engine{
 		log:         log,
 		bus:         opts.Bus,
@@ -261,6 +304,8 @@ func New(opts Options) (*Engine, error) {
 		sampleRate:  opts.SampleRateHz,
 		bank:        bank,
 		strategyTag: tag,
+		metrics:     opts.Metrics,
+		now:         now,
 	}
 
 	for _, ch := range opts.Channels {
@@ -279,6 +324,7 @@ func New(opts Options) (*Engine, error) {
 				if len(out) == 0 {
 					return
 				}
+				ec.pwr.Add(out)
 				ec.receiver.Process(out)
 			}
 		}(ec)
@@ -343,7 +389,7 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 			DeviationHz:  dmrDeviationHz,
 			ClockGain:    dmrClockGainTier2,
 		})
-		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "dmr-tier2", processor: cc, receiver: rx}, nil
+		return &engineChannel{freqHz: freqHz, sysName: sys.Name, protoTag: "dmr-tier2", processor: cc, receiver: rx, tier2Cnt: cc}, nil
 
 	case trunking.ProtocolP25:
 		if err := requireControlChannel(sys, freqHz, "p25 / Phase 1"); err != nil {
@@ -550,8 +596,79 @@ func (e *Engine) Run(ctx context.Context) error {
 				return nil
 			}
 			e.bank.Process(chunk)
+			e.maybeLogDiagnostics(e.now())
 		}
 	}
+}
+
+// lowPowerWarnInterval throttles the per-channel "iq power very low"
+// WARN so a genuinely dead stream logs once every few seconds instead
+// of every window. Matches the ccdecoder cadence (decoder.go).
+const lowPowerWarnInterval = 5 * time.Second
+
+// maybeLogDiagnostics flushes per-channel signal-power and decode-activity
+// diagnostics once per iqpower.Window. It runs inline on the Run pump
+// goroutine — the same goroutine that fed the tap sinks this window — so
+// it reads the accumulators and Tier II counters without a lock and in
+// chunk order. Cost is a wall-clock compare per chunk until the window
+// elapses; the DEBUG activity summary is gated by slog.Enabled so it
+// allocates nothing when DEBUG is off. The low-power WARN fires regardless
+// of log level — that operator feedback is the whole point (a single
+// wideband DMR channel that silently decodes nothing, issue: field report
+// VE5XAM).
+func (e *Engine) maybeLogDiagnostics(now time.Time) {
+	if e.lastDiagAt.IsZero() {
+		e.lastDiagAt = now
+		return
+	}
+	if now.Sub(e.lastDiagAt) < iqpower.Window {
+		return
+	}
+	e.lastDiagAt = now
+
+	debug := e.log.Enabled(context.Background(), slog.LevelDebug)
+	for _, ec := range e.channels {
+		if ec.pwr.Samples() == 0 {
+			continue
+		}
+		dbfs, _ := ec.pwr.MeanDbFSAndReset()
+		if e.metrics != nil {
+			e.metrics.RecordIQPowerDbFS(ec.powerLabel(), dbfs)
+		}
+		if dbfs < iqpower.LowPowerThresholdDbFS {
+			if now.Sub(ec.pwLowLogAt) >= lowPowerWarnInterval {
+				e.log.Warn("widebandt2: channel iq power very low — check antenna, gain, USB cable",
+					"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag, "dbfs", dbfs)
+				ec.pwLowLogAt = now
+			}
+		} else if debug {
+			e.log.Debug("widebandt2: channel iq power",
+				"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag, "dbfs", dbfs)
+		}
+
+		// Per-window decode-activity deltas (Tier II only for now). Lets an
+		// operator tell no-signal / signal-but-no-sync / sync-but-FEC-fail /
+		// decoding apart at a glance. Gated on DEBUG; lifetime locks total
+		// carried alongside the deltas.
+		if debug && ec.tier2Cnt != nil {
+			c := ec.tier2Cnt.Counters()
+			e.log.Debug("widebandt2: channel decode activity",
+				"freq_hz", ec.freqHz, "system", ec.sysName,
+				"sync_hits", c.SyncHits-ec.lastCnt.SyncHits,
+				"bursts", c.Bursts-ec.lastCnt.Bursts,
+				"fec_pass", c.FECPass-ec.lastCnt.FECPass,
+				"fec_fail", c.FECFail-ec.lastCnt.FECFail,
+				"locks_total", c.Locks)
+			ec.lastCnt = c
+		}
+	}
+}
+
+// powerLabel is the metrics label for this channel's dBFS gauge:
+// "<system> @ <freqMHz>" so multiple channels sharing one system name
+// don't collide on the system-keyed gauge.
+func (ec *engineChannel) powerLabel() string {
+	return fmt.Sprintf("%s @ %.4f MHz", ec.sysName, float64(ec.freqHz)/1e6)
 }
 
 // pickStrategy resolves the user-facing strategy choice into the

--- a/internal/scanner/widebandt2/engine_diag_test.go
+++ b/internal/scanner/widebandt2/engine_diag_test.go
@@ -1,0 +1,282 @@
+package widebandt2
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// steppingClock returns a monotonically increasing time, advancing by a
+// fixed step on every call. The wideband engine calls e.now() once per
+// IQ chunk in Run, so a step over half iqpower.Window guarantees the
+// per-channel diagnostics flush fires deterministically within a few
+// chunks regardless of wall-clock timing under test load.
+type steppingClock struct {
+	mu   sync.Mutex
+	t    time.Time
+	step time.Duration
+}
+
+func (c *steppingClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(c.step)
+	return c.t
+}
+
+// capturedRecord is one slog record the recordingHandler kept.
+type capturedRecord struct {
+	level slog.Level
+	msg   string
+	attrs map[string]any
+}
+
+// recordingHandler captures every emitted record so a test can assert
+// on the engine's diagnostic log lines. Enabled for all levels so the
+// DEBUG activity summary is exercised too.
+type recordingHandler struct {
+	mu   *sync.Mutex
+	recs *[]capturedRecord
+}
+
+func newRecordingHandler() (recordingHandler, *[]capturedRecord, *sync.Mutex) {
+	var mu sync.Mutex
+	recs := make([]capturedRecord, 0, 16)
+	return recordingHandler{mu: &mu, recs: &recs}, &recs, &mu
+}
+
+func (h recordingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := capturedRecord{level: r.Level, msg: r.Message, attrs: map[string]any{}}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	h.mu.Lock()
+	*h.recs = append(*h.recs, rec)
+	h.mu.Unlock()
+	return nil
+}
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
+
+// recordingPower captures RecordIQPowerDbFS calls for the metrics test.
+type recordingPower struct {
+	mu    sync.Mutex
+	calls []struct {
+		label string
+		dbfs  float64
+	}
+}
+
+func (r *recordingPower) RecordIQPowerDbFS(label string, dbfs float64) {
+	r.mu.Lock()
+	r.calls = append(r.calls, struct {
+		label string
+		dbfs  float64
+	}{label, dbfs})
+	r.mu.Unlock()
+}
+func (r *recordingPower) ClearIQPowerDbFS(string) {}
+
+// TestEngineDiagnosticsLowPowerWarns feeds a silent IQ stream and proves
+// the engine emits the throttled "iq power very low" WARN — the operator
+// feedback that was missing when a single wideband DMR channel silently
+// decoded nothing (field report VE5XAM) — and that the Tier II channel's
+// sync counter stays at zero (no false sync on silence).
+func TestEngineDiagnosticsLowPowerWarns(t *testing.T) {
+	const (
+		rateHz       = 48_000
+		centerHz     = 446_500_000
+		channelHz    = centerHz // offset 0: keep the tap inside the 48 kHz test band
+		chunkSamples = 4800
+		numChunks    = 8
+	)
+
+	silent := make([][]complex64, numChunks)
+	for i := range silent {
+		silent[i] = make([]complex64, chunkSamples) // zero-valued = silence
+	}
+	dev := newMockDevice(silent)
+
+	bus := events.NewBus(64)
+	defer bus.Close()
+
+	handler, recs, mu := newRecordingHandler()
+	clk := &steppingClock{t: time.Unix(0, 0), step: 600 * time.Millisecond}
+
+	e, err := New(Options{
+		Log:          slog.New(handler),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: rateHz,
+		CenterFreqHz: centerHz,
+		Now:          clk.now,
+		Channels:     []ChannelConfig{{FrequencyHz: channelHz, SystemName: "dmr-simplex"}},
+		Systems:      []trunking.System{t2System("dmr-simplex")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := e.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	var sawLowPower bool
+	for _, r := range *recs {
+		if r.level == slog.LevelWarn && strings.Contains(r.msg, "iq power very low") {
+			sawLowPower = true
+			if dbfs, ok := r.attrs["dbfs"].(float64); !ok || dbfs >= -55 {
+				t.Errorf("low-power WARN dbfs attr = %v (ok=%v), want < -55", r.attrs["dbfs"], ok)
+			}
+		}
+	}
+	mu.Unlock()
+	if !sawLowPower {
+		t.Errorf("expected an 'iq power very low' WARN for a silent stream, saw none")
+	}
+
+	if c := e.channels[0].tier2Cnt.Counters(); c.SyncHits != 0 {
+		t.Errorf("SyncHits on silence = %d, want 0", c.SyncHits)
+	}
+}
+
+// TestEngineDiagnosticsCountersOnDecode feeds synthesized Voice LC Header
+// IQ (same chain as the end-to-end test) and proves the Tier II decode
+// counters move: sync detected, FEC passes, lock declared. This is what
+// lets an operator distinguish "decoding fine" from the failure modes.
+func TestEngineDiagnosticsCountersOnDecode(t *testing.T) {
+	const (
+		widebandRateHz = 48_000.0
+		centerHz       = 460_000_000
+		spsWideband    = 10
+		spanSymbols    = 8
+		alpha          = 0.20
+		colorCode      = uint8(0x7)
+		groupID        = uint32(0x123)
+		sourceID       = uint32(0x456789)
+		burstRepeats   = 200
+		chunkSamples   = 4800
+	)
+
+	dibits := buildT2VoiceLCHeaderDibits(burstRepeats, colorCode, groupID, sourceID)
+	baseband := demod.ModulateC4FM(dibits, spsWideband, spanSymbols, alpha, widebandRateHz, dmrDeviationHz)
+	chunks := chunkComplex(baseband, chunkSamples)
+	dev := newMockDevice(chunks)
+
+	bus := events.NewBus(256)
+	defer bus.Close()
+	// Drain the bus so Publish never blocks the decode path.
+	sub := bus.Subscribe()
+	defer sub.Close()
+	go func() {
+		for range sub.C {
+		}
+	}()
+
+	e, err := New(Options{
+		Log:          slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: uint32(widebandRateHz),
+		CenterFreqHz: centerHz,
+		Channels:     []ChannelConfig{{FrequencyHz: centerHz, SystemName: "regional-t2"}},
+		Systems:      []trunking.System{t2System("regional-t2")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+	if err := e.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	c := e.channels[0].tier2Cnt.Counters()
+	if c.SyncHits == 0 {
+		t.Errorf("SyncHits = 0, want > 0 (no DMR sync detected on a clean signal)")
+	}
+	if c.FECPass == 0 {
+		t.Errorf("FECPass = 0, want > 0 (no Voice LC Header passed FEC)")
+	}
+	if c.Locks == 0 {
+		t.Errorf("Locks = 0, want >= 1 (cc never locked)")
+	}
+}
+
+// TestEngineDiagnosticsMetricsGauge proves a non-nil IQPowerObserver
+// receives the per-channel dBFS gauge with a frequency-qualified label.
+func TestEngineDiagnosticsMetricsGauge(t *testing.T) {
+	const (
+		rateHz       = 48_000
+		centerHz     = 446_500_000
+		channelHz    = centerHz // offset 0: a DC-ish constant stays in the tap passband
+		chunkSamples = 4800
+		numChunks    = 8
+	)
+
+	// Non-trivial constant power so the gauge reads a finite, non-floor value.
+	chunks := make([][]complex64, numChunks)
+	for i := range chunks {
+		c := make([]complex64, chunkSamples)
+		for j := range c {
+			c[j] = complex(0.25, 0.25)
+		}
+		chunks[i] = c
+	}
+	dev := newMockDevice(chunks)
+
+	bus := events.NewBus(64)
+	defer bus.Close()
+
+	obs := &recordingPower{}
+	clk := &steppingClock{t: time.Unix(0, 0), step: 600 * time.Millisecond}
+
+	e, err := New(Options{
+		Log:          slog.New(slog.NewTextHandler(discardWriter{}, nil)),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: rateHz,
+		CenterFreqHz: centerHz,
+		Now:          clk.now,
+		Metrics:      obs,
+		Channels:     []ChannelConfig{{FrequencyHz: channelHz, SystemName: "dmr-simplex"}},
+		Systems:      []trunking.System{t2System("dmr-simplex")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := e.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	obs.mu.Lock()
+	defer obs.mu.Unlock()
+	if len(obs.calls) == 0 {
+		t.Fatalf("IQPowerObserver received no RecordIQPowerDbFS calls")
+	}
+	got := obs.calls[0]
+	if !strings.Contains(got.label, "dmr-simplex") || !strings.Contains(got.label, "MHz") {
+		t.Errorf("gauge label = %q, want it to contain the system name and frequency", got.label)
+	}
+	// 0.25+0.25i → |x|² = 0.125 → ~-9.03 dBFS; assert it's finite and well
+	// above the dead-stream floor.
+	if got.dbfs < -55 || got.dbfs > 0 {
+		t.Errorf("gauge dbfs = %v, want a finite value in (-55, 0)", got.dbfs)
+	}
+}

--- a/samples/dmr-simplex/README.md
+++ b/samples/dmr-simplex/README.md
@@ -1,0 +1,67 @@
+# Single DMR simplex frequency, one RTL-SDR
+
+Monitor one DMR simplex (or hotspot) carrier with a single RTL-SDR on
+Linux. The shipped `config.yaml` targets **446.500 MHz, Color Code 1,
+Time Slot 1, Talkgroup 99**, but it works for any single DMR Tier II
+carrier — just change the frequency.
+
+## The one thing to understand first
+
+You do **not** configure Color Code, Time Slot, or Talkgroup.
+GopherTrunk decodes them off the air and reports them per call:
+
+- **Color Code** and **Time Slot** are read from every DMR burst.
+- **Talkgroup** (and source Radio ID) come from the call's Link Control.
+
+So the config only needs the **frequency** and that it's **DMR Tier II**.
+The `talkgroups-dmr.csv` file is optional cosmetics — it maps the decoded
+TG numbers (like `99`) to friendly names in the UI and recordings.
+
+## Setup (Linux)
+
+1. **Plug in the RTL-SDR** and confirm GopherTrunk sees it:
+
+   ```sh
+   gophertrunk sdr list
+   ```
+
+   Copy the dongle's serial.
+
+2. **Edit `config.yaml`** and replace `REPLACE_WITH_SERIAL` with that
+   serial. (If you only have one dongle you can leave it blank — the
+   first one found wins — but pinning the serial is more robust.)
+
+3. **Run it**, pointing at this config:
+
+   ```sh
+   gophertrunk run -config samples/dmr-simplex/config.yaml
+   ```
+
+4. Open **http://127.0.0.1:8080** in a browser for the live UI, or watch
+   the terminal: `widebandt2: starting` confirms the engine came up, and
+   a `grant` / call line fires each time someone keys up on 446.500.
+
+## Why `role: wideband` for one frequency?
+
+DMR Tier II is *conventional* — there is no trunked control channel, so
+the carrier is handed to GopherTrunk's wideband engine, which channelizes
+the dongle's IQ and runs a DMR Tier II decoder on the result. With a
+single channel that's just one down-converter tap; no extra hardware and
+no per-call retuning.
+
+The dongle is intentionally centered at **446.800 MHz**, 300 kHz above
+the carrier, so 446.500 MHz lands *off* the RTL-SDR's center-DC spike.
+Sitting a digital carrier right on DC corrupts the demod, so this offset
+matters. Any offset that keeps the carrier inside `center ± ~1.08 MHz`
+(the usable half-band at 2.4 MS/s, minus a 5% guard) is fine.
+
+## If nothing decodes
+
+- **Set the serial** correctly (`gophertrunk sdr list`).
+- **Check the antenna / gain.** Try a fixed gain instead of `"auto"`,
+  e.g. `gain: "320"` (= 32.0 dB — gains are in *tenths* of a dB here).
+- **Set `ppm`** to your dongle's measured frequency error. A few kHz of
+  drift on a cheap RTL crystal can keep DMR from locking.
+- **Set `log.level: debug`** to see lock/sync detail.
+- Confirm the frequency is right and that there's actually traffic
+  (key up your own radio on 446.500 / CC1 / TS1 / TG99 to test).

--- a/samples/dmr-simplex/config.yaml
+++ b/samples/dmr-simplex/config.yaml
@@ -1,0 +1,72 @@
+# Monitor a single DMR simplex / hotspot frequency with one RTL-SDR.
+#
+# Example target (VE5XAM): DMR simplex on 446.500 MHz, Color Code 1,
+# Time Slot 1, Talkgroup 99.
+#
+# Important: Color Code, Time Slot, and Talkgroup are NOT things you
+# configure here — GopherTrunk reads them straight off the air and
+# reports them per call. You only tell the daemon WHERE to listen
+# (the frequency) and WHAT it is (DMR Tier II conventional). The
+# talkgroups CSV just maps the decoded TG numbers (e.g. 99) to names.
+#
+# How a single DMR carrier is decoded: DMR Tier II is conventional
+# (no trunked control channel), so the carrier is fed to GopherTrunk's
+# wideband engine, which channelizes the dongle's IQ stream and runs a
+# DMR Tier II state machine on it. With one channel that's a single
+# down-converter tap — no extra hardware.
+#
+# PATHS below (storage, recordings, talkgroup CSV) resolve RELATIVE TO
+# THIS FILE's folder. Adjust if you move the file.
+
+log:
+  level: info       # bump to "debug" if nothing decodes and you want detail
+  format: text
+
+api:
+  http_addr: "127.0.0.1:8080"   # web UI / REST / SSE
+  grpc_addr: "127.0.0.1:50051"
+  auth:
+    mode: auto                  # loopback is trusted; no token needed locally
+
+metrics:
+  enabled: true
+
+storage:
+  path: "data/calls.db"
+  cc_cache_file: "data/cc-cache.json"
+
+recordings:
+  dir: "recordings"
+  sample_rate: 8000
+
+sdr:
+  # 2.4 MS/s is the RTL-SDR sweet spot. The whole DMR carrier fits in
+  # a tiny slice of this; the rest is just headroom for the channelizer.
+  sample_rate: 2_400_000
+  devices:
+    - serial: "REPLACE_WITH_SERIAL"   # run `gophertrunk sdr list` and paste yours
+      role: wideband
+      # Center the dongle ~300 kHz ABOVE the carrier so 446.500 MHz does
+      # NOT sit on the RTL-SDR's center-DC spike (which would corrupt the
+      # demod). 446.500 ends up at -300 kHz inside the IQ window — well
+      # within the usable ±1.08 MHz band at 2.4 MS/s.
+      center_freq_hz: 446_800_000
+      tuner_strategy: auto       # auto -> ddc for a single channel
+      gain: "auto"               # gains are in TENTHS of a dB if you pin one
+                                 #   (e.g. "320" = 32.0 dB). "auto" is the safe start.
+      ppm: 0                     # set your dongle's measured PPM error if you know it
+      channels:
+        - frequency_hz: 446_500_000
+          system: "dmr-simplex"
+
+trunking:
+  systems:
+    - name: "dmr-simplex"
+      protocol: dmr-tier2
+      # Tier II is conventional — there is no real control channel, but
+      # the config validator requires a non-empty list, so list the
+      # simplex carrier itself. The wideband engine ignores it for
+      # state-machine selection.
+      control_channels:
+        - 446_500_000
+      talkgroup_file: "talkgroups-dmr.csv"

--- a/samples/dmr-simplex/talkgroups-dmr.csv
+++ b/samples/dmr-simplex/talkgroups-dmr.csv
@@ -1,0 +1,3 @@
+Decimal,Alpha Tag,Description,Mode,Tag,Group
+99,TG 99,Simplex / Local Talkgroup,D,Talkgroup,Local
+9,Local,Local Repeater Wide,D,Talkgroup,Local


### PR DESCRIPTION
Adds samples/dmr-simplex/ covering the common "one RTL-SDR, one DMR
simplex/hotspot carrier" case (e.g. 446.500 MHz, CC1, TS1, TG99). DMR
Tier II is conventional, so the carrier rides the wideband engine with
a single channel; the dongle is centered off the carrier to dodge the
RTL-SDR DC spike. Includes a starter talkgroups CSV and a README that
clarifies Color Code / Time Slot / Talkgroup are decoded off the air,
not configured.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013LCerqhjudqy9KDo52Fdrm