### PR TITLE
docs: rename Reference to "Field Guide" + add cited, blog-linked articles

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -91,14 +91,14 @@ defaults:
       learn_path: digital-trunking
       nav_group: Learn
       permalink: /learn/digital-trunking/:basename/
-  # Encyclopedia articles under /reference/ get the reference layout and nav
+  # Field Guide articles under /reference/ get the reference layout and nav
   # group automatically. The hub (reference/index.md) overrides to reference-hub.
   - scope:
       path: "reference"
       type: pages
     values:
       layout: reference
-      nav_group: Reference
+      nav_group: Field Guide
       permalink: /reference/:basename/
   # Per-category post URLs scoped to posts only — a global `permalink`
   # in _config.yml would also rewrite every existing /foo.html page to

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -47,9 +47,9 @@ groups:
         url: /learn/git/#advanced-git
       - title: "Git & GitHub · Glossary"
         url: /learn/git/glossary/
-  - label: Reference
+  - label: Field Guide
     items:
-      - title: Encyclopedia overview
+      - title: Field Guide overview
         url: /reference/
       - title: "RF & SDR"
         url: /reference/#domain-rf-sdr

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -1,6 +1,6 @@
-# GopherTrunk Reference — encyclopedia single source of truth.
+# GopherTrunk Field Guide — encyclopedia single source of truth.
 #
-# Drives: the reference hub (docs/reference/index.md) domain/category grid +
+# Drives: the Field Guide hub (docs/reference/index.md) domain/category grid +
 # A–Z index, the article breadcrumb domain + category labels
 # (docs/_layouts/reference.html), and the "Reference" section of docs/llms.txt.
 #
@@ -27,7 +27,7 @@
 # Keep `slug` and category `id` stable once published — they are URLs and anchors.
 
 intro: >
-  The GopherTrunk Reference is a plain-language encyclopedia of the terms,
+  The GopherTrunk Field Guide is a plain-language encyclopedia of the terms,
   technologies, algorithms, people, hardware, organizations, and software behind
   radio, software-defined radio, and the craft of building software itself. Each
   article is a standalone, long-form definition — no lesson order, no exercises,

--- a/docs/_includes/reference-schema.html
+++ b/docs/_includes/reference-schema.html
@@ -1,13 +1,14 @@
 {%- comment -%}
   Structured data for reference entries. Person for people; otherwise DefinedTerm
-  inside the "GopherTrunk Reference" DefinedTermSet. Always a BreadcrumbList.
-  `external` links become sameAs for authority. Kept out of head.html so the
-  homepage SoftwareApplication entity stays clean.
+  inside the "GopherTrunk Field Guide" DefinedTermSet. Always a BreadcrumbList.
+  Authoritative source URLs (from the `cite_urls` front-matter list, mirroring
+  the article's footnote sources) become sameAs for entity authority. Kept out of
+  head.html so the homepage SoftwareApplication entity stays clean.
 {%- endcomment -%}
 {%- assign page_url = page.url | absolute_url -%}
 {%- capture sameas -%}
-  {%- if page.external and page.external.size > 0 -%}
-    "sameAs": [{% for x in page.external %}{{ x.url | jsonify }}{% unless forloop.last %},{% endunless %}{% endfor %}],
+  {%- if page.cite_urls and page.cite_urls.size > 0 -%}
+    "sameAs": [{% for u in page.cite_urls %}{{ u | jsonify }}{% unless forloop.last %},{% endunless %}{% endfor %}],
   {%- endif -%}
 {%- endcapture -%}
 {%- if page.entry_type == "person" -%}
@@ -33,7 +34,7 @@
   {{ sameas }}
   "inDefinedTermSet": {
     "@type": "DefinedTermSet",
-    "name": "GopherTrunk Reference",
+    "name": "GopherTrunk Field Guide",
     "url": {{ '/reference/' | absolute_url | jsonify }}
   }
 }
@@ -45,7 +46,7 @@
   "@type": "BreadcrumbList",
   "itemListElement": [
     { "@type": "ListItem", "position": 1, "name": "Home", "item": {{ '/' | absolute_url | jsonify }} },
-    { "@type": "ListItem", "position": 2, "name": "Reference", "item": {{ '/reference/' | absolute_url | jsonify }} },
+    { "@type": "ListItem", "position": 2, "name": "Field Guide", "item": {{ '/reference/' | absolute_url | jsonify }} },
     { "@type": "ListItem", "position": 3, "name": {{ page.title | jsonify }}, "item": {{ page_url | jsonify }} }
   ]
 }

--- a/docs/_layouts/reference-hub.html
+++ b/docs/_layouts/reference-hub.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 {%- comment -%}
-  Landing page for the GopherTrunk Reference encyclopedia. Renders a category
+  Landing page for the GopherTrunk Field Guide. Renders a category
   index and a generated A–Z index from _data/reference.yml, plus DefinedTermSet
   + ItemList structured data.
 {%- endcomment -%}
@@ -21,12 +21,12 @@ layout: default
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <ol>
         <li><a href="{{ '/' | relative_url }}">Home</a></li>
-        <li><span aria-current="page">Reference</span></li>
+        <li><span aria-current="page">Field Guide</span></li>
       </ol>
     </nav>
 
     <header class="ref-hero">
-      <p class="ref-eyebrow">Encyclopedia</p>
+      <p class="ref-eyebrow">Field Guide</p>
       <h1 class="ref-hero__title">{{ page.title }}</h1>
       <p class="ref-hero__lede">{{ ref.intro }}</p>
       <p class="ref-hero__meta">{{ total }} entries · <a href="#a-z">A–Z index</a> · <a href="{{ '/learn/rf-sdr/' | relative_url }}">Learning path</a> · <a href="{{ '/learn/rf-sdr/glossary/' | relative_url }}">Glossary</a></p>
@@ -81,7 +81,7 @@ layout: default
 {
   "@context": "https://schema.org",
   "@type": "DefinedTermSet",
-  "name": "GopherTrunk Reference",
+  "name": "GopherTrunk Field Guide",
   "description": {{ ref.intro | strip_newlines | jsonify }},
   "url": {{ '/reference/' | absolute_url | jsonify }},
   "hasDefinedTerm": [

--- a/docs/_layouts/reference.html
+++ b/docs/_layouts/reference.html
@@ -2,14 +2,19 @@
 layout: default
 ---
 {%- comment -%}
-  Encyclopedia article layout for the GopherTrunk Reference. Deliberately
-  distinct from the learning hub: a definition-first article with a right-hand
-  infobox, category breadcrumb, "See also", "Related lessons", and an external
-  "References" list — no prev/next, reading time, TL;DR, or quizzes.
+  Article layout for the GopherTrunk Field Guide. Deliberately distinct from the
+  learning hub: a definition-first article with a right-hand infobox, category
+  breadcrumb, "See also", "Learn it step by step", "From the blog", and a
+  "Related links" list — no prev/next, reading time, TL;DR, or quizzes.
+
+  Sources/citations are authored as kramdown footnotes in the article body
+  (inline [^key] markers + definitions under a final "## Sources" heading); the
+  kramdown .footnotes block renders just below the body.
 
   Front matter consumed: slug, title, entry_type, category, description, aka,
   infobox (ordered list of {label,value}), see_also (slugs), related_lessons
-  ({title,url}), external ({title,url}).
+  ({title,url}), related_reading ({title,url} — blog posts), external
+  ({title,url} — related non-source links).
 {%- endcomment -%}
 
 {%- assign all_entries = "" | split: "" -%}
@@ -34,7 +39,7 @@ layout: default
     <nav class="breadcrumb" aria-label="Breadcrumb">
       <ol>
         <li><a href="{{ '/' | relative_url }}">Home</a></li>
-        <li><a href="{{ '/reference/' | relative_url }}">Reference</a></li>
+        <li><a href="{{ '/reference/' | relative_url }}">Field Guide</a></li>
         {%- if domain_label != "" -%}
           <li><a href="{{ '/reference/#domain-' | append: domain_id | relative_url }}">{{ domain_label }}</a></li>
         {%- endif -%}
@@ -45,7 +50,7 @@ layout: default
       </ol>
     </nav>
 
-    <p class="ref-eyebrow">Reference{% if page.entry_type %} · <span class="ref-eyebrow__type">{{ page.entry_type }}</span>{% endif %}</p>
+    <p class="ref-eyebrow">Field Guide{% if page.entry_type %} · <span class="ref-eyebrow__type">{{ page.entry_type }}</span>{% endif %}</p>
 
     <div class="ref-layout">
       <article class="prose ref-article" data-cta-host>
@@ -78,9 +83,20 @@ layout: default
           </section>
         {%- endif -%}
 
+        {%- if page.related_reading and page.related_reading.size > 0 -%}
+          <section class="ref-related" aria-label="Related reading">
+            <h2>From the blog</h2>
+            <ul>
+              {%- for r in page.related_reading -%}
+                <li><a href="{{ r.url | relative_url }}">{{ r.title }}</a></li>
+              {%- endfor -%}
+            </ul>
+          </section>
+        {%- endif -%}
+
         {%- if page.external and page.external.size > 0 -%}
-          <section class="ref-refs" aria-label="References and external links">
-            <h2>References &amp; external links</h2>
+          <section class="ref-refs" aria-label="Related links">
+            <h2>Related links</h2>
             <ul>
               {%- for x in page.external -%}
                 <li><a href="{{ x.url }}" rel="noopener nofollow">{{ x.title }}</a></li>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1363,6 +1363,25 @@ a.category-chip:hover {
 .ref-seealso h2, .ref-related h2, .ref-refs h2 { font-size: 1.15rem; }
 .ref-seealso ul, .ref-related ul, .ref-refs ul { margin: 0.5rem 0 0; }
 
+/* ---------- Citations / Sources (kramdown footnotes) ---------- */
+/* Inline footnote markers in the article body */
+.ref-article sup[role="doc-noteref"],
+.ref-article .footnote { font-size: 0.78em; font-weight: 600; }
+.ref-article sup[role="doc-noteref"] a,
+.ref-article a.footnote { color: var(--accent); text-decoration: none; padding: 0 0.05em; }
+/* The "Sources" list kramdown renders at the end of the body */
+.ref-article .footnotes {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: 0.9rem;
+  color: var(--fg-muted);
+}
+.ref-article .footnotes ol { margin: 0.5rem 0 0; padding-left: 1.25rem; }
+.ref-article .footnotes li { margin-bottom: 0.4rem; }
+.ref-article .footnotes li p { margin: 0; }
+.ref-article .footnotes a { word-break: break-word; }
+
 /* ---------- Auto-links (site-wide) ---------- */
 .ref-autolink {
   color: inherit;

--- a/docs/assets/js/autolink.js
+++ b/docs/assets/js/autolink.js
@@ -94,7 +94,7 @@
         a.className = 'ref-autolink';
         a.href = url;
         a.textContent = token;
-        a.title = 'Reference: ' + token;
+        a.title = 'Field Guide: ' + token;
         frag.appendChild(a);
         last = match.index + token.length;
       }

--- a/docs/learn/intro-software-dev/glossary.md
+++ b/docs/learn/intro-software-dev/glossary.md
@@ -12,6 +12,11 @@ lesson_standalone: true
 
 This is a plain-language reference for the key terms used across the Intro to Software Development path. Definitions are short on purpose; each links to the lesson that explains the idea in full. Terms are grouped by theme and roughly ordered from foundational to advanced within each group, following the shape of the path itself.
 
+> **Want the long version?** Many of these terms — every programming language and
+> core concept here — have a full, encyclopedia-style article in the
+> [GopherTrunk Field Guide](/reference/), and the first mention of a covered term on
+> any page links straight to it.
+
 ## History and hardware
 
 **Hardware** — The physical parts of a computer you can touch: chips, memory, drives, screens. Software is the instructions that run on it. See [What is software?](/learn/intro-software-dev/what-is-software/)

--- a/docs/learn/rf-sdr/glossary.md
+++ b/docs/learn/rf-sdr/glossary.md
@@ -17,7 +17,7 @@ your browser's find (Ctrl/Cmd-F) to jump to a word. Terms are grouped by theme a
 ordered roughly from fundamentals to systems.
 
 > **Want the long version?** Many of these terms have a full, encyclopedia-style
-> article in the [GopherTrunk Reference](/reference/) — and the first mention of a
+> article in the [GopherTrunk Field Guide](/reference/) — and the first mention of a
 > covered term on any page links straight to it.
 
 ## Radio wave fundamentals

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -28,7 +28,7 @@ Start: {{ base | absolute_url }}
 - [{{ path.glossary.title }}]({{ base | append: 'glossary/' | absolute_url }}): {{ path.glossary.summary }}
 {% endif %}{% endfor %}
 
-## Reference (encyclopedia)
+## Field Guide (encyclopedia)
 
 Long-form, encyclopedia-style articles defining radio, SDR, and software-development
 terms, technologies, algorithms, languages, concepts, people, hardware, and

--- a/docs/reference/abstraction.md
+++ b/docs/reference/abstraction.md
@@ -17,12 +17,12 @@ infobox:
 see_also: [coupling-and-cohesion, object-oriented-programming, design-patterns, solid, declarative-programming, type-system]
 related_lessons:
   - { title: "Abstraction, coupling & cohesion", url: /learn/intro-software-dev/abstraction-coupling/ }
-external:
-  - { title: "Abstraction (computer science) — Wikipedia", url: https://en.wikipedia.org/wiki/Abstraction_(computer_science) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Abstraction_(computer_science)
 ---
 
 **Abstraction** means exposing a simple interface that describes *what* something does
-while hiding *how* it does it. When you call `sort()`, you depend on the promise ("returns
+while hiding *how* it does it.[^wiki] When you call `sort()`, you depend on the promise ("returns
 sorted output"), not on whether it uses quicksort or mergesort.
 
 <figure class="figure" markdown="0">
@@ -56,7 +56,7 @@ idea in [SOLID](/reference/solid/).
 Abstraction only holds if the internals stay genuinely hidden. **Information hiding** is
 the discipline of keeping a module's internal state and helpers private, exposing only the
 interface; **encapsulation** is the language mechanism that enforces it — private fields,
-unexported names, access modifiers. Anything you expose, someone will depend on, so the
+unexported names, access modifiers.[^wiki] Anything you expose, someone will depend on, so the
 rule of thumb is to **expose as little as possible**. A small public surface is a small set
 of promises you must keep, closely tied to the language's
 [type system](/reference/type-system/) and visibility rules.
@@ -69,4 +69,8 @@ interface that mysteriously stalls on a network path, or an ORM you can ignore u
 query is slow. Joel Spolsky's "Law of Leaky Abstractions" holds that all non-trivial
 abstractions leak to some degree. You cannot eliminate leaks, but you can manage them:
 document assumptions, surface failures explicitly rather than misbehaving silently, and
-keep the abstraction honest about what it promises.
+keep the abstraction honest about what it promises.[^wiki]
+
+## Sources
+
+[^wiki]: [Abstraction (computer science)](https://en.wikipedia.org/wiki/Abstraction_(computer_science)) — Wikipedia, for the what-vs-how definition and the roles of information hiding and encapsulation.

--- a/docs/reference/ads-b.md
+++ b/docs/reference/ads-b.md
@@ -18,8 +18,11 @@ infobox:
 see_also: [ais, compact-position-reporting, cyclic-redundancy-check, icao]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast
 external:
-  - { title: "Automatic Dependent Surveillance–Broadcast (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast }
   - { title: "GopherTrunk ADS-B decoder", url: /adsb.html }
 ---
 
@@ -27,7 +30,7 @@ external:
 surveillance system in which aircraft continuously broadcast their **identity,
 position, altitude, and velocity** on **1090 MHz** (and 978 MHz UAT in the U.S.). It
 is the aeronautical counterpart to [AIS](/reference/ais/) and one of the most popular
-SDR applications.
+SDR applications.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="An aircraft broadcasting position and identity bursts on 1090 MHz to a ground receiver." xmlns="http://www.w3.org/2000/svg">
@@ -59,7 +62,7 @@ to a precise position from a pair of even/odd messages.
 ## History
 
 Standardised by [ICAO](/reference/icao/) with MOPS from RTCA (DO-260) and EUROCAE
-(ED-102); mandated for most controlled airspace through the 2010s–2020s.
+(ED-102); mandated for most controlled airspace through the 2010s–2020s.[^wiki]
 
 ## Deployment
 
@@ -71,3 +74,7 @@ flight-tracking networks.
 GopherTrunk detects the 1090 MHz squitters in the magnitude domain, validates the
 [CRC-24](/reference/cyclic-redundancy-check/), and decodes aircraft state. See the
 [ADS-B decoder](/adsb.html) page.
+
+## Sources
+
+[^wiki]: [Automatic Dependent Surveillance–Broadcast](https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast) — Wikipedia, for the 1090 MHz ADS-B system, Mode S Extended Squitter, CPR position coding, and ICAO/RTCA/EUROCAE standardisation.

--- a/docs/reference/affiliation.md
+++ b/docs/reference/affiliation.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [control-channel, radio-id, talkgroup, trunked-radio]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Trunked_radio_system
 ---
 
 **Affiliation** is the process by which a radio **registers** with a
 [trunked radio](/reference/trunked-radio/) system over the
 [control channel](/reference/control-channel/) when it powers on or changes
-[talkgroup](/reference/talkgroup/), so the system can route calls efficiently.
+[talkgroup](/reference/talkgroup/), so the system can route calls efficiently.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A radio sending a registration request to the system, which records it as affiliated." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +46,7 @@ active.
 
 Affiliation data lets GopherTrunk populate its Radio IDs and activity views even before
 a call begins, showing who is on the system.
+
+## Sources
+
+[^wiki]: [Trunked radio system](https://en.wikipedia.org/wiki/Trunked_radio_system) — Wikipedia, on radio registration/affiliation over the control channel.

--- a/docs/reference/afsk.md
+++ b/docs/reference/afsk.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [frequency-shift-keying, aprs, ax25, ffsk]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "Frequency-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-shift_keying }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Frequency-shift_keying
 ---
 
 **AFSK** (audio frequency-shift keying) represents bits as **audio tones** that then
-modulate a radio (usually FM). The classic case is the Bell 202 standard — 1200 Hz and
+modulate a radio (usually FM).[^wiki] The classic case is the Bell 202 standard — 1200 Hz and
 2200 Hz tones — carrying 1200 bps [APRS](/reference/aprs/) packet over
 [AX.25](/reference/ax25/).
 
@@ -44,3 +44,7 @@ bit.
 
 GopherTrunk decodes AFSK as part of its APRS pipeline, detecting the mark/space tones
 after FM demodulation.
+
+## Sources
+
+[^wiki]: [Frequency-shift keying](https://en.wikipedia.org/wiki/Frequency-shift_keying) — Wikipedia, for audio FSK and the Bell 202 mark/space tone scheme.

--- a/docs/reference/airspy-hf-plus.md
+++ b/docs/reference/airspy-hf-plus.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [airspy, rtl-sdr, upconverter, ionospheric-propagation, frequency-bands]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
-external:
-  - { title: "Airspy (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio }
+related_reading:
+  - { title: "RF Front End, Part 10: Airspy — real to complex", url: /blog/deep-dives/rf-front-end-10-airspy-real-to-complex/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software-defined_radio
 ---
 
 **Airspy HF+** is a [software-defined radio](/reference/software-defined-radio/)
 optimised for the **HF and low-VHF** [bands](/reference/frequency-bands/), with
-excellent dynamic range for receiving shortwave and weak low-band signals.
+excellent dynamic range for receiving shortwave and weak low-band signals.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for Airspy HF+ (HF + low VHF) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
@@ -42,3 +44,7 @@ reception.
 ## Relevance to SDR
 
 Choose the HF+ when HF or low-band is your target; GopherTrunk supports it as a receiver.
+
+## Sources
+
+[^wiki]: [Software-defined radio](https://en.wikipedia.org/wiki/Software-defined_radio) — Wikipedia, for background on the Airspy HF+ and HF-optimised SDR receivers.

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -15,14 +15,16 @@ infobox:
 see_also: [rtl-sdr, airspy-hf-plus, hackrf, software-defined-radio]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
-external:
-  - { title: "Airspy (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio }
+related_reading:
+  - { title: "RF Front End, Part 10: Airspy — real to complex", url: /blog/deep-dives/rf-front-end-10-airspy-real-to-complex/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software-defined_radio
 ---
 
 **Airspy** is a line of high-performance VHF/UHF
 [software-defined radio](/reference/software-defined-radio/) receivers (the R2 and the
 smaller Mini) offering better sensitivity, dynamic range, and wider
-[bandwidth](/reference/bandwidth/) than an [RTL-SDR](/reference/rtl-sdr/).
+[bandwidth](/reference/bandwidth/) than an [RTL-SDR](/reference/rtl-sdr/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for Airspy R2/Mini (~24 MHz–1.8 GHz) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +46,7 @@ band or in tough RF environments. For the lower bands, the
 
 GopherTrunk supports Airspy receivers for demanding reception where an RTL-SDR's
 bandwidth or sensitivity falls short.
+
+## Sources
+
+[^wiki]: [Software-defined radio](https://en.wikipedia.org/wiki/Software-defined_radio) — Wikipedia, for background on Airspy-class high-performance VHF/UHF SDR receivers.

--- a/docs/reference/ais.md
+++ b/docs/reference/ais.md
@@ -18,8 +18,11 @@ infobox:
 see_also: [ads-b, gmsk, tdma, itu, dsc]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Automatic_identification_system
 external:
-  - { title: "Automatic identification system (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_identification_system }
   - { title: "GopherTrunk AIS decoder", url: /ais.html }
 ---
 
@@ -27,7 +30,7 @@ external:
 ships and shore stations broadcast their **identity, position, course, and speed** on
 VHF marine frequencies. It uses [GMSK](/reference/gmsk/) modulation in a
 self-organising [TDMA](/reference/tdma/) scheme so many vessels share two channels
-without a central controller.
+without a central controller.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="Ships transmitting short position bursts in assigned time slots on a shared marine VHF channel." xmlns="http://www.w3.org/2000/svg">
@@ -57,7 +60,7 @@ traffic, the maritime counterpart to [ADS-B](/reference/ads-b/).
 ## History
 
 Standardised by the [ITU](/reference/itu/) and mandated by the IMO for SOLAS vessels
-from the early 2000s to improve collision avoidance and traffic monitoring.
+from the early 2000s to improve collision avoidance and traffic monitoring.[^wiki]
 
 ## Deployment
 
@@ -67,3 +70,7 @@ Commercial shipping, port authorities, vessel-traffic services, and hobbyist tra
 
 GopherTrunk demodulates the GMSK bursts, frames them, and decodes position reports.
 See the [AIS decoder](/ais.html) page.
+
+## Sources
+
+[^wiki]: [Automatic identification system](https://en.wikipedia.org/wiki/Automatic_identification_system) — Wikipedia, for the maritime VHF AIS system, its GMSK/SOTDMA air interface, message content, and ITU/IMO standardisation.

--- a/docs/reference/aliasing.md
+++ b/docs/reference/aliasing.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [nyquist-theorem, sample-rate, decimation, digital-filter]
 related_lessons:
   - { title: "Sample rate, bandwidth & Nyquist", url: /learn/rf-sdr/sample-rate-nyquist/ }
-external:
-  - { title: "Aliasing (Wikipedia)", url: https://en.wikipedia.org/wiki/Aliasing }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Aliasing
 ---
 
 **Aliasing** is when energy outside the bandwidth a [sample rate](/reference/sample-rate/)
 can represent gets **folded** back into the captured spectrum, appearing at a wrong
-frequency — a phantom that looks like a real signal.
+frequency — a phantom that looks like a real signal.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A captured band between Nyquist edges with a real signal inside and an out-of-band signal folding back to a false position." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +46,7 @@ inside the usable window. It also constrains the order of
 ## Relevance to SDR
 
 Recognising an alias prevents chasing signals that are not really where they appear.
+
+## Sources
+
+[^wiki]: [Aliasing](https://en.wikipedia.org/wiki/Aliasing) — Wikipedia, on out-of-band energy folding to false frequencies when undersampled.

--- a/docs/reference/ambe-plus-2.md
+++ b/docs/reference/ambe-plus-2.md
@@ -15,12 +15,14 @@ infobox:
 see_also: [vocoder, imbe, ambe, dmr, p25-phase-2, nxdn, dvsi]
 related_lessons:
   - { title: "Vocoders — IMBE & AMBE+2", url: /learn/rf-sdr/vocoders/ }
-external:
-  - { title: "Multi-Band Excitation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+related_reading:
+  - { title: "SDR Internals, Part 12: Voice coding & vocoders", url: /blog/deep-dives/sdr-internals-12-voice-coding-vocoders/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Multi-Band_Excitation
 ---
 
 **AMBE+2** is the efficient successor to [IMBE](/reference/imbe/) and
-[AMBE](/reference/ambe/) from [DVSI](/reference/dvsi/). It powers
+[AMBE](/reference/ambe/) from [DVSI](/reference/dvsi/).[^wiki] It powers
 [P25 Phase 2](/reference/p25-phase-2/), [DMR](/reference/dmr/), and
 [NXDN](/reference/nxdn/), and supports **half-rate** operation.
 
@@ -46,3 +48,7 @@ given bitrate it generally sounds cleaner than IMBE.
 
 GopherTrunk runs AMBE+2 decoding to produce audio from the most common modern digital
 voice systems.
+
+## Sources
+
+[^wiki]: [Multi-Band Excitation](https://en.wikipedia.org/wiki/Multi-Band_Excitation) — Wikipedia, on the MBE vocoder family that includes AMBE+2.

--- a/docs/reference/ambe.md
+++ b/docs/reference/ambe.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [vocoder, imbe, ambe-plus-2, multi-band-excitation, d-star, dvsi]
 related_lessons:
   - { title: "Vocoders — IMBE & AMBE+2", url: /learn/rf-sdr/vocoders/ }
-external:
-  - { title: "Multi-Band Excitation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+related_reading:
+  - { title: "SDR Internals, Part 12: Voice coding & vocoders", url: /blog/deep-dives/sdr-internals-12-voice-coding-vocoders/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Multi-Band_Excitation
 ---
 
 **AMBE** (**Advanced Multi-Band Excitation**) is a family of low-bitrate speech
 [vocoders](/reference/vocoder/) from [DVSI](/reference/dvsi/), building on the
-[MBE](/reference/multi-band-excitation/) model. It is used by
+[MBE](/reference/multi-band-excitation/) model.[^wiki] It is used by
 [D-STAR](/reference/d-star/) and EDACS ProVoice, and is the basis for the more efficient
 [AMBE+2](/reference/ambe-plus-2/).
 
@@ -43,3 +45,7 @@ kbps.
 
 GopherTrunk implements AMBE-family decoding in pure Go to render digital voice without
 proprietary hardware.
+
+## Sources
+
+[^wiki]: [Multi-Band Excitation](https://en.wikipedia.org/wiki/Multi-Band_Excitation) — Wikipedia, on the MBE vocoder family that includes AMBE.

--- a/docs/reference/amplitude-modulation.md
+++ b/docs/reference/amplitude-modulation.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [modulation, frequency-modulation, single-sideband, carrier-wave]
 related_lessons:
   - { title: "Analog modulation — AM, FM, SSB", url: /learn/rf-sdr/analog-modulation/ }
-external:
-  - { title: "Amplitude modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Amplitude_modulation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Amplitude_modulation
 ---
 
 **Amplitude modulation** (**AM**) encodes information by varying the
 [amplitude](/reference/amplitude/) of a [carrier wave](/reference/carrier-wave/) while
-its [frequency](/reference/frequency/) stays fixed. It is the oldest and simplest
+its [frequency](/reference/frequency/) stays fixed.[^wiki] It is the oldest and simplest
 [modulation](/reference/modulation/) scheme.
 
 <figure class="figure" markdown="0">
@@ -43,3 +43,7 @@ relatively noise-prone.
 AM survives where simplicity or a useful property matters — shortwave broadcast, and
 aviation VHF airband (where overlapping transmissions beat together so a controller
 notices). An SDR demodulates AM by tracking the envelope.
+
+## Sources
+
+[^wiki]: [Amplitude modulation](https://en.wikipedia.org/wiki/Amplitude_modulation) — Wikipedia, for the definition, sidebands, and uses of AM.

--- a/docs/reference/amplitude.md
+++ b/docs/reference/amplitude.md
@@ -12,11 +12,11 @@ infobox:
 see_also: [phase, decibel, dbm, amplitude-modulation, signal-to-noise-ratio]
 related_lessons:
   - { title: "What is a radio wave?", url: /learn/rf-sdr/radio-waves/ }
-external:
-  - { title: "Amplitude (Wikipedia)", url: https://en.wikipedia.org/wiki/Amplitude }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Amplitude
 ---
 
-**Amplitude** is the magnitude — the "height" — of a wave. For a
+**Amplitude** is the magnitude — the "height" — of a wave.[^wiki] For a
 [radio wave](/reference/radio-wave/) it corresponds to signal strength, which a
 receiver reports as a power level in [dBm](/reference/dbm/) or
 [dBFS](/reference/dbfs/).
@@ -44,3 +44,7 @@ Varying amplitude is the basis of [amplitude modulation](/reference/amplitude-mo
 and part of what an [IQ](/reference/iq-data/) sample encodes (its distance from the
 origin). A signal's amplitude relative to the [noise floor](/reference/noise-floor/)
 sets its [SNR](/reference/signal-to-noise-ratio/).
+
+## Sources
+
+[^wiki]: [Amplitude](https://en.wikipedia.org/wiki/Amplitude) — Wikipedia, on the magnitude of a wave's oscillation.

--- a/docs/reference/analog-to-digital-converter.md
+++ b/docs/reference/analog-to-digital-converter.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [sample-rate, nyquist-theorem, dbfs, automatic-gain-control, software-defined-radio]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
-external:
-  - { title: "Analog-to-digital converter (Wikipedia)", url: https://en.wikipedia.org/wiki/Analog-to-digital_converter }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Analog-to-digital_converter
 ---
 
 An **analog-to-digital converter** (**ADC**) measures a continuous signal many times per
-second, turning it into a stream of numbers. In an SDR it produces the
+second, turning it into a stream of numbers.[^wiki] In an SDR it produces the
 [IQ](/reference/iq-data/) samples software works on.
 
 <figure class="figure" markdown="0">
@@ -44,3 +44,7 @@ exceed it and the signal **clips** at 0 [dBFS](/reference/dbfs/).
 
 Setting [gain](/reference/automatic-gain-control/) so strong signals stay below the ADC's
 ceiling, without burying weak ones in noise, is central to clean reception.
+
+## Sources
+
+[^wiki]: [Analog-to-digital converter](https://en.wikipedia.org/wiki/Analog-to-digital_converter) — Wikipedia, on sampling a continuous signal into discrete digital values.

--- a/docs/reference/andrew-viterbi.md
+++ b/docs/reference/andrew-viterbi.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [viterbi-algorithm, convolutional-code, forward-error-correction]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Andrew Viterbi (Wikipedia)", url: https://en.wikipedia.org/wiki/Andrew_Viterbi }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Andrew_Viterbi
 ---
 
 **Andrew Viterbi** (born 1935) is an American electrical engineer who devised the
 **[Viterbi algorithm](/reference/viterbi-algorithm/)** for maximum-likelihood decoding of
-[convolutional codes](/reference/convolutional-code/), and co-founded Qualcomm.
+[convolutional codes](/reference/convolutional-code/), and co-founded Qualcomm.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A trellis with one highlighted most-likely path, the Viterbi algorithm." xmlns="http://www.w3.org/2000/svg">
@@ -35,7 +35,7 @@ external:
 ## Life and work
 
 Viterbi introduced his algorithm in 1967 as a practical way to decode convolutional
-codes; it became foundational to digital communications and storage.
+codes; it became foundational to digital communications and storage.[^wiki]
 
 ## Contribution
 
@@ -46,3 +46,7 @@ practical, improving reception at low SNR.
 
 Viterbi decoding appears throughout modern radio, from amateur [M17](/reference/m17/) to
 cellular systems.
+
+## Sources
+
+[^wiki]: [Andrew Viterbi](https://en.wikipedia.org/wiki/Andrew_Viterbi) — Wikipedia, for biography and his algorithm for decoding convolutional codes.

--- a/docs/reference/antenna-gain.md
+++ b/docs/reference/antenna-gain.md
@@ -14,14 +14,14 @@ infobox:
 see_also: [antenna, dipole-antenna, decibel, radio-propagation]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
-external:
-  - { title: "Antenna gain (Wikipedia)", url: https://en.wikipedia.org/wiki/Antenna_gain }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Antenna_gain
 ---
 
 **Antenna gain** measures how strongly an [antenna](/reference/antenna/) concentrates
 energy in a preferred direction compared with a reference. It is given in
 [decibels](/reference/decibel/): **dBi** relative to an isotropic radiator, or **dBd**
-relative to a [dipole](/reference/dipole-antenna/).
+relative to a [dipole](/reference/dipole-antenna/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 150" role="img" aria-label="An omnidirectional circular pattern on the left and a focused directional lobe on the right." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +45,7 @@ gain toward where it points at the expense of the sides.
 
 For general scanning, an omnidirectional antenna is usually best; a directional,
 high-gain antenna helps pull in one specific distant system.
+
+## Sources
+
+[^wiki]: [Antenna gain](https://en.wikipedia.org/wiki/Antenna_gain) — Wikipedia, for the definition of gain and the dBi/dBd reference units.

--- a/docs/reference/antenna.md
+++ b/docs/reference/antenna.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [dipole-antenna, antenna-gain, polarization, standing-wave-ratio, wavelength]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
-external:
-  - { title: "Antenna (radio) (Wikipedia)", url: https://en.wikipedia.org/wiki/Antenna_(radio) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Antenna_(radio)
 ---
 
 An **antenna** is a conductor that converts electrical signals into
 [radio waves](/reference/radio-wave/) and, on receive, converts passing radio waves
-back into a tiny current. It sets the ceiling on everything downstream — no receiver
+back into a tiny current.[^wiki] It sets the ceiling on everything downstream — no receiver
 can recover a signal the antenna never captured.
 
 <figure class="figure" markdown="0">
@@ -45,3 +45,7 @@ are resonance/[bandwidth](/reference/bandwidth/), [gain](/reference/antenna-gain
 
 Choosing an antenna cut for the target [band](/reference/frequency-bands/) and placing
 it high with a clear path usually improves reception more than any change at the radio.
+
+## Sources
+
+[^wiki]: [Antenna (radio)](https://en.wikipedia.org/wiki/Antenna_(radio)) — Wikipedia, for the definition and key properties of antennas.

--- a/docs/reference/apco-international.md
+++ b/docs/reference/apco-international.md
@@ -14,14 +14,15 @@ infobox:
 see_also: [project-25, tia, trunked-radio]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "APCO International (Wikipedia)", url: https://en.wikipedia.org/wiki/Association_of_Public-Safety_Communications_Officials-International }
+cite_urls:
+  - https://www.apcointl.org/
+  - https://en.wikipedia.org/wiki/Association_of_Public-Safety_Communications_Officials-International
 ---
 
 **APCO International** (the Association of Public-Safety Communications Officials) is the
-professional association for public-safety communications. With the
+professional association for public-safety communications.[^home] With the
 [TIA](/reference/tia/) it drove the creation of [Project 25](/reference/project-25/),
-sometimes called **APCO-25**.
+sometimes called **APCO-25**.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="APCO defines public-safety requirements that shaped P25." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +45,8 @@ standard for interoperability among emergency services.
 ## Relevance to SDR
 
 APCO's role explains the "APCO-25"/"P25" naming and the standard's public-safety focus.
+
+## Sources
+
+[^home]: [APCO International](https://www.apcointl.org/) — the association's official site, representing public-safety communications professionals.
+[^wiki]: [Association of Public-Safety Communications Officials-International](https://en.wikipedia.org/wiki/Association_of_Public-Safety_Communications_Officials-International) — Wikipedia, for APCO's role in the creation of P25.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -16,13 +16,13 @@ infobox:
 see_also: [rest, abstraction, error-handling, semantic-versioning, package-manager, coupling-and-cohesion, solid]
 related_lessons:
   - { title: "Errors, edge cases & defensive programming", url: /learn/intro-software-dev/robustness-and-errors/ }
-external:
-  - { title: "API — Wikipedia", url: https://en.wikipedia.org/wiki/API }
+cite_urls:
+  - https://en.wikipedia.org/wiki/API
 ---
 
 **An API** (application programming interface) is a defined contract through which one
 piece of software exposes its capabilities to another, hiding its implementation behind
-a stable set of operations.
+a stable set of operations.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A client calls an API, which is a contract in front of a provider's hidden implementation." xmlns="http://www.w3.org/2000/svg">
@@ -49,7 +49,7 @@ a stable surface. APIs come in several flavors:
   exposes to programs that import it.
 - **Operating-system APIs** — the system calls a program uses to talk to the kernel.
 - **Web APIs** — operations a service exposes over the network, commonly in the
-  [REST](/reference/rest/) style over HTTP, or via GraphQL or gRPC.
+  [REST](/reference/rest/) style over HTTP, or via GraphQL or gRPC.[^wiki]
 
 A good API is small and role-focused (the [interface segregation](/reference/solid/)
 idea), consistent, and clear about how it reports failures — its
@@ -65,3 +65,7 @@ why backward compatibility and [semantic versioning](/reference/semantic-version
 matter so much — a major version bump signals a breaking change to the contract. The
 same discipline governs the public surface of a reusable library distributed through a
 [package manager](/reference/package-manager/).
+
+## Sources
+
+[^wiki]: [API](https://en.wikipedia.org/wiki/API) — Wikipedia, for the contract definition and the kinds of API (library, OS, web).

--- a/docs/reference/aprs.md
+++ b/docs/reference/aprs.md
@@ -18,15 +18,18 @@ infobox:
 see_also: [ax25, afsk, mueller-muller-timing-recovery, cyclic-redundancy-check]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Automatic_Packet_Reporting_System
 external:
-  - { title: "Automatic Packet Reporting System (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_Packet_Reporting_System }
   - { title: "GopherTrunk APRS decoder", url: /aprs.html }
 ---
 
 **APRS** (**Automatic Packet Reporting System**) is an amateur-radio data network for
 real-time tactical information — **position, weather, telemetry, and messaging**. It
 is carried as [AX.25](/reference/ax25/) packet frames using
-[AFSK](/reference/afsk/), most commonly on 144.390 MHz in North America.
+[AFSK](/reference/afsk/), most commonly on 144.390 MHz in North America.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="An APRS packet carrying a callsign and position payload over AX.25 on 144.39 MHz." xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +59,7 @@ and mobile trackers.
 ## History
 
 Created by Bob Bruninga (WB4APR) in the 1980s–90s; it remains one of amateur radio's
-most active data modes.
+most active data modes.[^wiki]
 
 ## Deployment
 
@@ -66,3 +69,7 @@ Amateur radio worldwide via beacons, digipeaters, igates, and the APRS-IS networ
 
 GopherTrunk demodulates the AFSK, recovers AX.25 frames, and decodes APRS payloads.
 See the [APRS / AX.25 decoder](/aprs.html) page.
+
+## Sources
+
+[^wiki]: [Automatic Packet Reporting System](https://en.wikipedia.org/wiki/Automatic_Packet_Reporting_System) — Wikipedia, for the APRS data network, its AX.25/AFSK link layer, payload types, and origins.

--- a/docs/reference/async-programming.md
+++ b/docs/reference/async-programming.md
@@ -18,14 +18,16 @@ see_also: [concurrency, threads, goroutines, javascript-language, python-languag
 related_lessons:
   - { title: "Concurrency and parallelism", url: /learn/intro-software-dev/concurrency-models/ }
   - { title: "Concurrency and pipelines", url: /learn/intro-software-dev/concurrency-and-pipelines/ }
-external:
-  - { title: "Asynchronous I/O — Wikipedia", url: https://en.wikipedia.org/wiki/Asynchronous_I/O }
+related_reading:
+  - { title: "SDR Internals, Part 3: The SDR pool, streaming & concurrency", url: /blog/deep-dives/sdr-internals-03-sdr-pool-streaming-concurrency/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Asynchronous_I/O
 ---
 
 **Asynchronous programming** runs many tasks [concurrently](/reference/concurrency/) on
 a single thread using an *event loop*: whenever a task waits on something slow, it
 yields control back to the loop, which runs other ready tasks until the slow thing
-finishes.
+finishes.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="An event loop dispatches a task, which yields on await and lets another ready task run, then resumes when its result arrives." xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +50,7 @@ Code marks slow operations with `await`. When a task reaches one, it suspends an
 the single thread back to the event loop, which picks another task that is ready to make
 progress; when the awaited operation completes, the loop resumes the original task where
 it left off. No operating-system [thread](/reference/threads/) is blocked sitting idle,
-so one thread can keep thousands of in-flight operations moving. Because there is only
+so one thread can keep thousands of in-flight operations moving.[^wiki] Because there is only
 one thread of execution, there is no shared-memory data race between the tasks.
 
 ## Trade-offs
@@ -57,7 +59,7 @@ Async excels at **I/O-bound** work — thousands of concurrent network connectio
 disk reads on a single thread — because such workloads spend most of their time waiting,
 not computing. It does little for **CPU-bound** work: a long computation still hogs the
 single thread and blocks every other task, since cooperative scheduling only switches at
-`await` points. Async code can also be harder to reason about, and a blocking call
+`await` points.[^wiki] Async code can also be harder to reason about, and a blocking call
 slipped into an async path stalls everything.
 
 ## In practice
@@ -67,3 +69,7 @@ slipped into an async path stalls everything.
 and Rust all offer `async`/`await`. For CPU-bound parallelism you reach instead for
 [threads](/reference/threads/) or lightweight tasks like
 [goroutines](/reference/goroutines/), which can spread work across cores.
+
+## Sources
+
+[^wiki]: [Asynchronous I/O](https://en.wikipedia.org/wiki/Asynchronous_I/O) — Wikipedia, on non-blocking I/O and event-loop concurrency that keeps one thread handling many in-flight operations.

--- a/docs/reference/attenuation.md
+++ b/docs/reference/attenuation.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [path-loss, decibel, radio-propagation, antenna]
 related_lessons:
   - { title: "How signals travel", url: /learn/rf-sdr/propagation/ }
-external:
-  - { title: "Attenuation (Wikipedia)", url: https://en.wikipedia.org/wiki/Attenuation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Attenuation
 ---
 
 **Attenuation** is the reduction of signal strength as energy passes through a medium,
-cable, connector, or obstacle. It is expressed in [decibels](/reference/decibel/) and
+cable, connector, or obstacle.[^wiki] It is expressed in [decibels](/reference/decibel/) and
 subtracts directly from a power budget.
 
 <figure class="figure" markdown="0">
@@ -42,3 +42,7 @@ of attenuation called [path loss](/reference/path-loss/).
 
 Keeping cable runs short and connectors clean minimises attenuation between
 [antenna](/reference/antenna/) and receiver, preserving [SNR](/reference/signal-to-noise-ratio/).
+
+## Sources
+
+[^wiki]: [Attenuation](https://en.wikipedia.org/wiki/Attenuation) — Wikipedia, for the general definition and causes of signal loss.

--- a/docs/reference/automatic-frequency-control.md
+++ b/docs/reference/automatic-frequency-control.md
@@ -10,13 +10,13 @@ autolink: true
 see_also: [ppm-frequency-correction, costas-loop, demodulation, constellation-diagram]
 related_lessons:
   - { title: "Tuning for a clean lock", url: /learn/rf-sdr/tuning-with-scopes/ }
-external:
-  - { title: "Automatic frequency control (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_frequency_control }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Automatic_frequency_control
 ---
 
 **Automatic frequency control** (**AFC**) continuously measures a residual
 carrier-frequency offset and nudges the receiver to cancel it, keeping the demodulator
-centred on the signal as oscillators drift. Where [PPM correction](/reference/ppm-frequency-correction/)
+centred on the signal as oscillators drift.[^wiki] Where [PPM correction](/reference/ppm-frequency-correction/)
 fixes a static error, AFC **tracks** a changing one.
 
 <figure class="figure" markdown="0">
@@ -35,3 +35,7 @@ AFC often works alongside a [Costas loop](/reference/costas-loop/) (for phase) a
 appears in GopherTrunk's receiver telemetry as a carrier-error reading; a steadily
 **rotating [constellation](/reference/constellation-diagram/)** is the symptom AFC is
 there to remove.
+
+## Sources
+
+[^wiki]: [Automatic frequency control](https://en.wikipedia.org/wiki/Automatic_frequency_control) — Wikipedia, on tracking and cancelling carrier-frequency offset.

--- a/docs/reference/automatic-gain-control.md
+++ b/docs/reference/automatic-gain-control.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [dbfs, analog-to-digital-converter, noise-floor, ppm-frequency-correction]
 related_lessons:
   - { title: "Gain, AGC & avoiding overload", url: /learn/rf-sdr/gain-and-agc/ }
-external:
-  - { title: "Automatic gain control (Wikipedia)", url: https://en.wikipedia.org/wiki/Automatic_gain_control }
+related_reading:
+  - { title: "SDR Internals, Part 4: DSP foundations — filters, NCO & AGC", url: /blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Automatic_gain_control
 ---
 
 **Automatic gain control** (**AGC**) adjusts amplification to keep a signal at a usable
 level — high enough above the [noise floor](/reference/noise-floor/) but below the
 [ADC](/reference/analog-to-digital-converter/)'s clipping ceiling (0
-[dBFS](/reference/dbfs/)).
+[dBFS](/reference/dbfs/)).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="An input whose amplitude varies wildly, and an output of roughly constant amplitude after AGC." xmlns="http://www.w3.org/2000/svg">
@@ -43,3 +45,7 @@ well-chosen **manual gain** is often preferred.
 
 Setting gain correctly is the single setting beginners most often get wrong; see the
 gain lesson for a practical routine.
+
+## Sources
+
+[^wiki]: [Automatic gain control](https://en.wikipedia.org/wiki/Automatic_gain_control) — Wikipedia, on closed-loop gain adjustment and headroom.

--- a/docs/reference/ax25.md
+++ b/docs/reference/ax25.md
@@ -18,13 +18,15 @@ infobox:
 see_also: [aprs, afsk, cyclic-redundancy-check]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "AX.25 (Wikipedia)", url: https://en.wikipedia.org/wiki/AX.25 }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/AX.25
 ---
 
 **AX.25** is the **data-link-layer** protocol used in amateur **packet radio**. It
 adapts the telecom **HDLC** frame format with amateur **callsign addressing**, and is
-the link layer beneath [APRS](/reference/aprs/) and traditional packet networks.
+the link layer beneath [APRS](/reference/aprs/) and traditional packet networks.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="An AX.25 HDLC frame: flag, address, control, PID, information, frame-check sequence, flag." xmlns="http://www.w3.org/2000/svg">
@@ -61,7 +63,7 @@ modes.
 ## History
 
 Developed by the amateur community in the 1980s as a radio adaptation of X.25/HDLC for
-packet networks and bulletin-board systems.
+packet networks and bulletin-board systems.[^wiki]
 
 ## Deployment
 
@@ -71,3 +73,7 @@ Amateur packet radio, APRS, and store-and-forward networks.
 
 GopherTrunk recovers AX.25 frames as part of its [APRS](/reference/aprs/) pipeline. See
 the [APRS / AX.25](/aprs.html) page.
+
+## Sources
+
+[^wiki]: [AX.25](https://en.wikipedia.org/wiki/AX.25) — Wikipedia, for the amateur packet data-link protocol, its HDLC-derived framing, callsign addressing, and FCS.

--- a/docs/reference/bandwidth.md
+++ b/docs/reference/bandwidth.md
@@ -13,12 +13,12 @@ see_also: [sample-rate, nyquist-theorem, frequency, signal-to-noise-ratio]
 related_lessons:
   - { title: "Anatomy of a signal", url: /learn/rf-sdr/signal-anatomy/ }
   - { title: "Sample rate, bandwidth & Nyquist", url: /learn/rf-sdr/sample-rate-nyquist/ }
-external:
-  - { title: "Bandwidth (signal processing) (Wikipedia)", url: https://en.wikipedia.org/wiki/Bandwidth_(signal_processing) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bandwidth_(signal_processing)
 ---
 
 **Bandwidth** is the width, in hertz, of the [frequency](/reference/frequency/) range a
-signal occupies or that a receiver captures. A narrowband voice channel may be ~12.5
+signal occupies or that a receiver captures.[^wiki] A narrowband voice channel may be ~12.5
 kHz wide; an FM broadcast station ~200 kHz; Wi-Fi tens of megahertz.
 
 <figure class="figure" markdown="0">
@@ -48,3 +48,7 @@ Wider bandwidth can carry more information but uses more spectrum and demands a 
 An SDR's capture bandwidth (≈ its sample rate) sets how much spectrum you see at once.
 [Filtering and decimation](/reference/decimation/) narrow a wide capture down to a
 single channel's bandwidth.
+
+## Sources
+
+[^wiki]: [Bandwidth (signal processing)](https://en.wikipedia.org/wiki/Bandwidth_(signal_processing)) — Wikipedia, definition and measures of signal bandwidth.

--- a/docs/reference/baseband.md
+++ b/docs/reference/baseband.md
@@ -10,12 +10,12 @@ autolink: true
 see_also: [iq-data, intermediate-frequency, local-oscillator, dc-offset]
 related_lessons:
   - { title: "IQ data & complex signals", url: /learn/rf-sdr/iq-data/ }
-external:
-  - { title: "Baseband (Wikipedia)", url: https://en.wikipedia.org/wiki/Baseband }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Baseband
 ---
 
 **Baseband** is a signal centred at (or near) **zero frequency**, after the carrier has
-been mixed away. An SDR delivers **complex baseband** [IQ samples](/reference/iq-data/) —
+been mixed away.[^wiki] An SDR delivers **complex baseband** [IQ samples](/reference/iq-data/) —
 the channel shifted down to 0 Hz — which is the natural form for software to filter and
 demodulate.
 
@@ -37,3 +37,7 @@ demodulate.
 Working at complex baseband lets software represent both positive and negative
 frequencies around the centre (thanks to [IQ](/reference/iq-data/)), so the whole
 captured band is available for [filtering](/reference/digital-filter/) and demodulation.
+
+## Sources
+
+[^wiki]: [Baseband](https://en.wikipedia.org/wiki/Baseband) — Wikipedia, on signals centred near zero frequency.

--- a/docs/reference/bch-code.md
+++ b/docs/reference/bch-code.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [forward-error-correction, hamming-code, reed-solomon-code, pocsag, dsc]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "BCH code (Wikipedia)", url: https://en.wikipedia.org/wiki/BCH_code }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/BCH_code
 ---
 
 **BCH codes** (Bose–Chaudhuri–Hocquenghem) are a class of cyclic block
 [error-correction](/reference/forward-error-correction/) codes that can be constructed to
-correct a chosen number of bit errors.
+correct a chosen number of bit errors.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="A BCH codeword shown as a block of message bits followed by parity-check bits." xmlns="http://www.w3.org/2000/svg">
@@ -41,3 +43,7 @@ to locate and fix errors. [POCSAG](/reference/pocsag/) uses BCH(31,21), and
 
 BCH decoding lets GopherTrunk recover paging and signalling messages even when a few bits
 are corrupted.
+
+## Sources
+
+[^wiki]: [BCH code](https://en.wikipedia.org/wiki/BCH_code) — Wikipedia, for the cyclic code family and its designed error-correction capability.

--- a/docs/reference/behavioral-patterns.md
+++ b/docs/reference/behavioral-patterns.md
@@ -17,13 +17,14 @@ infobox:
 see_also: [design-patterns, creational-patterns, structural-patterns, object-oriented-programming, coupling-and-cohesion, solid, abstraction]
 related_lessons:
   - { title: "Behavioral patterns: observer, strategy, state", url: /learn/intro-software-dev/behavioral-patterns/ }
-external:
-  - { title: "Behavioral pattern — Wikipedia", url: https://en.wikipedia.org/wiki/Behavioral_pattern }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Behavioral_pattern
+  - https://en.wikipedia.org/wiki/Design_Patterns
 ---
 
 **Behavioral patterns** are the [Gang of Four](/reference/design-patterns/) family that
 handles the question once objects exist and are connected: *how do they talk to each other
-and divide up the work?* They are about communication and responsibility at runtime.
+and divide up the work?* They are about communication and responsibility at runtime.[^wiki][^gof]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="A subject publishes an event to several observers at once, while a context delegates work to a swappable strategy or state object." xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +49,7 @@ When a call is decoded, the UI, the logger, and the recorder all need to know; w
 user picks a mode, the right algorithm must run; when a follower moves from idle to active,
 its whole behaviour changes. Handling each with ad-hoc code scatters logic and tightens
 [coupling](/reference/coupling-and-cohesion/). Behavioral patterns give these interactions
-a clean, named shape that keeps the parties from depending too directly on each other.
+a clean, named shape that keeps the parties from depending too directly on each other.[^wiki]
 
 ## The main members
 
@@ -74,3 +75,8 @@ classes rather than editing existing code — the open/closed principle from
 [creational](/reference/creational-patterns/) and
 [structural](/reference/structural-patterns/) families catalogued under
 [design patterns](/reference/design-patterns/).
+
+## Sources
+
+[^wiki]: [Behavioral pattern](https://en.wikipedia.org/wiki/Behavioral_pattern) — Wikipedia, for the definition, the focus on communication and control flow, and members such as Observer, Strategy, and State.
+[^gof]: [Design Patterns](https://en.wikipedia.org/wiki/Design_Patterns) — Wikipedia, on the 1994 Gang of Four book that catalogued these patterns alongside the creational and structural families.

--- a/docs/reference/bias-tee.md
+++ b/docs/reference/bias-tee.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [low-noise-amplifier, antenna, rtl-sdr]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
-external:
-  - { title: "Bias tee (Wikipedia)", url: https://en.wikipedia.org/wiki/Bias_tee }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bias_tee
 ---
 
 A **bias tee** is a small network that injects **DC power onto the coax** feeding an
 antenna-mounted device — typically a [low-noise amplifier](/reference/low-noise-amplifier/)
-— while passing the RF signal through to the receiver unaffected.
+— while passing the RF signal through to the receiver unaffected.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A bias tee injecting DC power onto the coax while passing RF through to the receiver." xmlns="http://www.w3.org/2000/svg">
@@ -42,3 +42,7 @@ some [RTL-SDR](/reference/rtl-sdr/) models) have a built-in switchable bias tee.
 
 A bias tee lets you power a mast-mounted LNA without a separate cable, keeping the
 amplifier close to the [antenna](/reference/antenna/) where it does the most good.
+
+## Sources
+
+[^wiki]: [Bias tee](https://en.wikipedia.org/wiki/Bias_tee) — Wikipedia, on the RF/DC combining network that powers antenna-mounted devices over the coax.

--- a/docs/reference/bptc.md
+++ b/docs/reference/bptc.md
@@ -10,13 +10,15 @@ autolink: true
 see_also: [forward-error-correction, hamming-code, interleaving, dmr, csbk]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_mobile_radio
 ---
 
 **BPTC** (**block product turbo code**), specifically **BPTC(196,96)**, is the
 [forward-error-correction](/reference/forward-error-correction/) scheme that protects
-[DMR](/reference/dmr/) data and control bursts. It arranges bits in a grid and applies
+[DMR](/reference/dmr/) data and control bursts.[^wiki] It arranges bits in a grid and applies
 parity across **both rows and columns**, so the two passes can correct errors the other
 misses.
 
@@ -36,3 +38,7 @@ misses.
 The "product" structure plus [interleaving](/reference/interleaving/) makes BPTC robust
 against the burst errors typical of a fading mobile channel — important for the
 [CSBK](/reference/csbk/) control messages that keep a trunked DMR system coordinated.
+
+## Sources
+
+[^wiki]: [Digital mobile radio](https://en.wikipedia.org/wiki/Digital_mobile_radio) — Wikipedia, for the DMR standard whose data and control bursts BPTC(196,96) protects.

--- a/docs/reference/build-systems.md
+++ b/docs/reference/build-systems.md
@@ -16,13 +16,15 @@ infobox:
 see_also: [compiler, package-manager, ci-cd, semantic-versioning, static-binary, cross-compilation, version-control]
 related_lessons:
   - { title: "Build systems, CI/CD & automation", url: /learn/intro-software-dev/build-and-ci-cd/ }
-external:
-  - { title: "Build automation — Wikipedia", url: https://en.wikipedia.org/wiki/Build_automation }
+related_reading:
+  - { title: "Build in the Open, Part 7: GitHub Actions & which workflows", url: /blog/tutorials/build-in-the-open-07-github-actions-which-workflows/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Build_automation
 ---
 
 **A build system** is the tooling that transforms source code plus its dependencies into
 a runnable artifact — compiling, linking, and packaging — ideally as a deterministic
-function of its inputs.
+function of its inputs.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="Source files and dependencies feed into a build step that produces a single runnable artifact." xmlns="http://www.w3.org/2000/svg">
@@ -44,7 +46,7 @@ A build transforms source into something runnable. The exact steps vary by langu
 the idea is universal: a [compiler](/reference/compiler/) translates source into machine
 code or bytecode, and a *linker* stitches the pieces into an executable. **Make** and its
 descendants are the classic orchestrators — a `Makefile` declares targets and their
-dependencies, and `make` rebuilds only what changed. That principle (describe outputs in
+dependencies, and `make` rebuilds only what changed.[^wiki] That principle (describe outputs in
 terms of inputs, rebuild only the stale parts) underlies nearly every build tool since.
 Modern ecosystems wrap this per language: `go build`, `cargo build`, `npm`/`yarn`, Maven,
 and Gradle each know their language's conventions so you rarely hand-write build steps.
@@ -68,3 +70,7 @@ The build sits at the heart of a [CI/CD](/reference/ci-cd/) pipeline: on every p
 [tests](/reference/unit-testing/) follow, and a successful run yields a versioned artifact
 ready to release under [semantic versioning](/reference/semantic-versioning/). A
 deterministic build is what makes that whole chain trustworthy.
+
+## Sources
+
+[^wiki]: [Build automation](https://en.wikipedia.org/wiki/Build_automation) — Wikipedia, for build tooling, Make, and reproducible builds.

--- a/docs/reference/bytecode.md
+++ b/docs/reference/bytecode.md
@@ -18,13 +18,13 @@ see_also: [compiler, interpreter, jit-compilation, java-language, python-languag
 related_lessons:
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
   - { title: "Packaging and distribution", url: /learn/intro-software-dev/packaging-and-distribution/ }
-external:
-  - { title: "Bytecode — Wikipedia", url: https://en.wikipedia.org/wiki/Bytecode }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bytecode
 ---
 
 **Bytecode** is a compact, portable instruction set that sits between human-readable
 source and raw machine code: a [compiler](/reference/compiler/) produces it, and a
-*virtual machine* (VM) executes it rather than the CPU running it directly.
+*virtual machine* (VM) executes it rather than the CPU running it directly.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="Source compiles to bytecode, which a virtual machine runs on any platform." xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +48,7 @@ a low-level program for an idealized, abstract machine. At run time the VM reads
 bytecode and either [interprets](/reference/interpreter/) it or, with
 [JIT compilation](/reference/jit-compilation/), translates the hot parts to native
 code. Because the bytecode targets the VM and not the hardware, the *same* bytecode
-file runs unchanged on any platform where the VM is available.
+file runs unchanged on any platform where the VM is available.[^wiki]
 
 ## Trade-offs
 
@@ -57,7 +57,7 @@ VM is installed, sidestepping the per-platform builds that native
 [compilation](/reference/compiler/) requires. The cost is the VM layer — interpreting
 bytecode adds overhead, and the user must have the runtime installed rather than a
 self-contained [static binary](/reference/static-binary/). Bytecode is also more
-compact and faster to load than re-parsing source each time.
+compact and faster to load than re-parsing source each time.[^wiki]
 
 ## In practice
 
@@ -66,3 +66,7 @@ compact and faster to load than re-parsing source each time.
 [C#](/reference/csharp-language/) and the rest of .NET compile to an intermediate
 language (IL). This bytecode-plus-VM design is what lets these languages promise
 "write once, run anywhere."
+
+## Sources
+
+[^wiki]: [Bytecode](https://en.wikipedia.org/wiki/Bytecode) — Wikipedia, on bytecode as a portable instruction set produced by a compiler and executed by a virtual machine.

--- a/docs/reference/c-language.md
+++ b/docs/reference/c-language.md
@@ -19,13 +19,15 @@ see_also: [compiler, memory-management, cpp-language, rust-language, go-language
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
-external:
-  - { title: "C (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/C_(programming_language) }
-  - { title: "C reference — cppreference", url: https://en.cppreference.com/w/c }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://en.cppreference.com/w/c
+  - https://en.wikipedia.org/wiki/C_(programming_language)
 ---
 
 **C** is a small, fast, statically typed compiled language created at Bell Labs in the
-1970s. It is the bedrock of modern computing: almost every operating system, language
+1970s.[^wiki] It is the bedrock of modern computing: almost every operating system, language
 runtime and embedded device has C at its core.
 
 <figure class="figure" markdown="0">
@@ -46,7 +48,7 @@ runtime and embedded device has C at its core.
 ## Overview
 
 C [compiles](/reference/compiler/) ahead of time directly to native machine code, with a
-tiny runtime and almost no abstraction between the code and the hardware. It is
+tiny runtime and almost no abstraction between the code and the hardware.[^ref] It is
 [statically typed](/reference/type-system/), gives the programmer direct access to memory
 through pointers, and is portable across virtually every platform. That minimalism is the
 point: C is small enough to learn the whole language, and fast and predictable enough to
@@ -70,3 +72,8 @@ C remains the default for operating-system kernels, device drivers, language run
 and tight embedded work where every byte and cycle counts. Its stable, minimal interface
 also makes it the common tongue that other languages bind to when they need to call
 native code.
+
+## Sources
+
+[^ref]: [C reference](https://en.cppreference.com/w/c) — cppreference, the standard-tracking reference for the C language and library.
+[^wiki]: [C (programming language)](https://en.wikipedia.org/wiki/C_(programming_language)) — Wikipedia, for history and design background.

--- a/docs/reference/c4fm.md
+++ b/docs/reference/c4fm.md
@@ -14,15 +14,17 @@ infobox:
 see_also: [frequency-shift-keying, cqpsk, project-25, p25-phase-1, system-fusion-ysf, symbol-rate]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Project_25
 ---
 
 **C4FM** (compatible four-level FM) is the four-level
 [FSK](/reference/frequency-shift-keying/) modulation used by
 [P25 Phase 1](/reference/p25-phase-1/) and [System Fusion](/reference/system-fusion-ysf/).
 The carrier sits at one of four frequency deviations per [symbol](/reference/symbol-rate/),
-carrying 2 bits each.
+carrying 2 bits each.[^p25]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 150" role="img" aria-label="Four horizontal deviation levels labelled with dibits, and a stepped trace moving between them over time." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +47,7 @@ eyes on an [eye diagram](/reference/eye-diagram/).
 
 Recognising healthy C4FM symbols is central to decoding P25 Phase 1 and Fusion; the
 scopes reveal SNR, tuning, and timing problems at a glance.
+
+## Sources
+
+[^p25]: [Project 25](https://en.wikipedia.org/wiki/Project_25) — Wikipedia, for the C4FM modulation, symbol rate, and its use in P25 Phase 1.

--- a/docs/reference/capacity-plus.md
+++ b/docs/reference/capacity-plus.md
@@ -10,15 +10,17 @@ autolink: true
 see_also: [dmr, dmr-tier-3, rest-channel, trunked-radio, csbk]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_mobile_radio
 ---
 
 **Capacity Plus** is Motorola's proprietary **DMR trunking** mode (part of the MOTOTRBO
 family) that pools several channels and **rotates the control signalling** among them
 (see [rest channel](/reference/rest-channel/)), giving conventional [DMR](/reference/dmr/)
 trunked capacity without a separate dedicated control channel. (Capacity Max is the
-larger multi-site successor.)
+larger multi-site successor.)[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A pool of DMR channels with control rotating among them, several carrying two TDMA voice slots." xmlns="http://www.w3.org/2000/svg">
@@ -38,3 +40,7 @@ larger multi-site successor.)
 Following Capacity Plus means tracking the rotating control as it hops, then decoding the
 granted [timeslot](/reference/tdma/) — GopherTrunk's DMR support is vendor-aware of these
 Motorola grant formats.
+
+## Sources
+
+[^wiki]: [Digital mobile radio](https://en.wikipedia.org/wiki/Digital_mobile_radio) — Wikipedia, for DMR and Motorola's proprietary Capacity Plus trunking built on the DMR air interface.

--- a/docs/reference/carrier-wave.md
+++ b/docs/reference/carrier-wave.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [modulation, radio-wave, frequency, amplitude-modulation]
 related_lessons:
   - { title: "Anatomy of a signal", url: /learn/rf-sdr/signal-anatomy/ }
-external:
-  - { title: "Carrier wave (Wikipedia)", url: https://en.wikipedia.org/wiki/Carrier_wave }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Carrier_wave
 ---
 
 A **carrier wave** is a steady [radio-frequency](/reference/radio-wave/) signal at a
-single [frequency](/reference/frequency/) that conveys no information on its own. It
+single [frequency](/reference/frequency/) that conveys no information on its own.[^wiki] It
 becomes useful only when [modulation](/reference/modulation/) varies one of its
 properties in step with a message.
 
@@ -44,3 +44,7 @@ essentially the signal's [bandwidth](/reference/bandwidth/).
 Receivers tune to a carrier's frequency and then demodulate the variations around it.
 A residual carrier at zero frequency after downconversion is the familiar "DC spike"
 seen on SDR spectra.
+
+## Sources
+
+[^wiki]: [Carrier wave](https://en.wikipedia.org/wiki/Carrier_wave) — Wikipedia, on the steady reference signal modulated to convey information.

--- a/docs/reference/channel-grant.md
+++ b/docs/reference/channel-grant.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [control-channel, voice-channel, talkgroup, trunked-radio]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Trunked_radio_system
 ---
 
 A **channel grant** is the [control-channel](/reference/control-channel/) message that
 assigns a [talkgroup](/reference/talkgroup/)'s call to a specific
 [voice channel](/reference/voice-channel/) (and timeslot on
-[TDMA](/reference/tdma/) systems).
+[TDMA](/reference/tdma/) systems).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="The control channel issuing a grant message that causes affiliated radios to retune to a voice channel." xmlns="http://www.w3.org/2000/svg">
@@ -43,3 +45,7 @@ where.
 
 GopherTrunk reads grants in real time to task a receiver to the right channel/slot,
 which is how it follows conversations as they scatter across the channel pool.
+
+## Sources
+
+[^wiki]: [Trunked radio system](https://en.wikipedia.org/wiki/Trunked_radio_system) — Wikipedia, on the grant message that assigns calls to voice channels.

--- a/docs/reference/channelizer.md
+++ b/docs/reference/channelizer.md
@@ -10,12 +10,14 @@ autolink: true
 see_also: [digital-down-converter, decimation, digital-filter, software-defined-radio, control-channel]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Filter bank (Wikipedia)", url: https://en.wikipedia.org/wiki/Filter_bank }
+related_reading:
+  - { title: "SDR Internals, Part 5: Tuning & channelization", url: /blog/deep-dives/sdr-internals-05-tuning-channelization/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Filter_bank
 ---
 
 A **channelizer** splits a single wideband [IQ](/reference/iq-data/) capture into **many
-narrow channels at once**. Each output is one channel, shifted to
+narrow channels at once**.[^wiki] Each output is one channel, shifted to
 [baseband](/reference/baseband/), [filtered](/reference/digital-filter/), and
 [decimated](/reference/decimation/) — so one SDR can feed many decoders in parallel.
 
@@ -41,3 +43,7 @@ Efficient channelizers use a *polyphase filter bank* to extract evenly-spaced ch
 at once. In a trunking context this is what lets GopherTrunk watch the
 [control channel](/reference/control-channel/) while simultaneously following the
 [voice channels](/reference/voice-channel/) it assigns.
+
+## Sources
+
+[^wiki]: [Filter bank](https://en.wikipedia.org/wiki/Filter_bank) — Wikipedia, on polyphase filter banks used to split a band into channels.

--- a/docs/reference/ci-cd.md
+++ b/docs/reference/ci-cd.md
@@ -17,13 +17,15 @@ see_also: [build-systems, version-control, unit-testing, integration-testing, en
 related_lessons:
   - { title: "GitHub Actions & CI/CD", url: /learn/git/github-actions/ }
   - { title: "Build systems & CI/CD", url: /learn/intro-software-dev/build-and-ci-cd/ }
-external:
-  - { title: "CI/CD — Wikipedia", url: https://en.wikipedia.org/wiki/CI/CD }
+related_reading:
+  - { title: "Build in the Open, Part 7: GitHub Actions & which workflows", url: /blog/tutorials/build-in-the-open-07-github-actions-which-workflows/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/CI/CD
 ---
 
 **CI/CD** is the practice of automatically building and testing code on every change
 (continuous integration) and then automating its path to release (continuous
-delivery/deployment) through a versioned pipeline.
+delivery/deployment) through a versioned pipeline.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A pipeline flowing from commit to build to test to deploy, each stage gating the next." xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +52,7 @@ change lands it checks out the code, installs the pinned dependencies via the
 fails, the team learns within minutes — while the change is fresh and small. The name
 comes from *integrating* everyone's work frequently into the shared main line instead of
 letting branches drift and merging in one painful "big bang." CI is the automated
-enforcement of "don't break the build."
+enforcement of "don't break the build."[^wiki]
 
 ## Continuous Delivery and Deployment
 
@@ -75,3 +77,7 @@ environments. On GitHub the common tool is **GitHub Actions**, which can run the
 fan out across a build matrix, run [end-to-end tests](/reference/end-to-end-testing/), and
 publish release binaries through a [package manager](/reference/package-manager/) or
 release page — only when everything is green.
+
+## Sources
+
+[^wiki]: [CI/CD](https://en.wikipedia.org/wiki/CI/CD) — Wikipedia, for continuous integration, delivery, and deployment and the pipeline model.

--- a/docs/reference/cic-filter.md
+++ b/docs/reference/cic-filter.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [decimation, digital-filter, sample-rate, digital-down-converter]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Cascaded integrator–comb filter (Wikipedia)", url: https://en.wikipedia.org/wiki/Cascaded_integrator%E2%80%93comb_filter }
+related_reading:
+  - { title: "SDR Internals, Part 4: DSP foundations — filters, NCO & AGC", url: /blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Cascaded_integrator%E2%80%93comb_filter
 ---
 
 A **CIC filter** (cascaded integrator–comb) is a [digital filter](/reference/digital-filter/)
 built from only integrators and combs — **no multipliers** — making it very efficient for
-large-ratio [decimation](/reference/decimation/) or interpolation.
+large-ratio [decimation](/reference/decimation/) or interpolation.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A cascaded integrator-comb block diagram: integrators, a rate change, then comb stages." xmlns="http://www.w3.org/2000/svg">
@@ -47,3 +49,7 @@ a short compensation FIR filter.
 
 CIC filters are common in the front of an SDR channeliser, where huge decimation ratios
 must be done with minimal computation.
+
+## Sources
+
+[^wiki]: [Cascaded integrator–comb filter](https://en.wikipedia.org/wiki/Cascaded_integrator%E2%80%93comb_filter) — Wikipedia, on Hogenauer's multiplier-free decimation/interpolation structure.

--- a/docs/reference/claude-shannon.md
+++ b/docs/reference/claude-shannon.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [nyquist-theorem, harry-nyquist, signal-to-noise-ratio, forward-error-correction]
 related_lessons:
   - { title: "Sample rate, bandwidth & Nyquist", url: /learn/rf-sdr/sample-rate-nyquist/ }
-external:
-  - { title: "Claude Shannon (Wikipedia)", url: https://en.wikipedia.org/wiki/Claude_Shannon }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Claude_Shannon
 ---
 
 **Claude Shannon** (1916–2001) was an American mathematician and engineer who founded
-**information theory**, defining how much information a noisy channel can carry.
+**information theory**, defining how much information a noisy channel can carry.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="An information source passing through a noisy channel to a destination, with the channel-capacity formula." xmlns="http://www.w3.org/2000/svg">
@@ -39,7 +39,7 @@ external:
 
 His 1948 paper "A Mathematical Theory of Communication" introduced channel capacity,
 entropy, and the limits that bound any communication system — including the role of
-[SNR](/reference/signal-to-noise-ratio/).
+[SNR](/reference/signal-to-noise-ratio/).[^wiki]
 
 ## Contribution
 
@@ -51,3 +51,7 @@ work with [Nyquist](/reference/harry-nyquist/)'s underlies the
 ## Legacy
 
 Information theory governs the design of every modern digital radio.
+
+## Sources
+
+[^wiki]: [Claude Shannon](https://en.wikipedia.org/wiki/Claude_Shannon) — Wikipedia, for biography and his founding of information theory.

--- a/docs/reference/clean-code.md
+++ b/docs/reference/clean-code.md
@@ -16,13 +16,13 @@ infobox:
 see_also: [refactoring, dry-kiss-yagni, solid, abstraction, coupling-and-cohesion, unit-testing]
 related_lessons:
   - { title: "Writing readable code", url: /learn/intro-software-dev/clean-code/ }
-external:
-  - { title: "Robert C. Martin — Wikipedia", url: https://en.wikipedia.org/wiki/Robert_C._Martin }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Robert_C._Martin
 ---
 
 **Clean code** is the discipline of writing programs optimized for the reader rather
 than the writer, because code is read far more often than it is written — by reviewers,
-future maintainers, and you, months later.
+future maintainers, and you, months later.[^martin]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="Code written once is read many times by reviewer, debugger, and future self." xmlns="http://www.w3.org/2000/svg">
@@ -61,7 +61,11 @@ are optimizing.
 
 Clever, compact code shifts cost from the writer, who understood it in the moment, to
 every future reader who must reverse-engineer it. As Brian Kernighan warned, debugging
-is harder than writing, so code written as cleverly as possible is code you can't debug.
+is harder than writing, so code written as cleverly as possible is code you can't debug.[^martin]
 The genuinely hard skill is making complex logic *look* simple. Clean code is closely
 tied to [DRY, KISS and YAGNI](/reference/dry-kiss-yagni/) and [SOLID](/reference/solid/),
 and improving it after the fact is the work of [refactoring](/reference/refactoring/).
+
+## Sources
+
+[^martin]: [Robert C. Martin](https://en.wikipedia.org/wiki/Robert_C._Martin) — Wikipedia, on the author whose *Clean Code* popularized this readability discipline.

--- a/docs/reference/clock-recovery.md
+++ b/docs/reference/clock-recovery.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [gardner-timing-recovery, mueller-muller-timing-recovery, symbol-rate, eye-diagram, demodulation]
 related_lessons:
   - { title: "Clock recovery & symbol timing", url: /learn/rf-sdr/clock-recovery/ }
-external:
-  - { title: "Clock recovery (Wikipedia)", url: https://en.wikipedia.org/wiki/Clock_recovery }
+related_reading:
+  - { title: "SDR Internals, Part 7: Symbol timing & sync recovery", url: /blog/deep-dives/sdr-internals-07-symbol-timing-sync-recovery/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Clock_recovery
 ---
 
 **Clock recovery** determines a digital signal's [symbol](/reference/symbol-rate/) timing
-from the signal itself, since the transmitter's clock is not shared. It lets the receiver
+from the signal itself, since the transmitter's clock is not shared.[^wiki] It lets the receiver
 sample each symbol at its **centre**, where the [eye](/reference/eye-diagram/) is widest.
 
 <figure class="figure" markdown="0">
@@ -45,3 +47,7 @@ stay centred, tracking small clock drift. Common algorithms are
 
 Loss of symbol lock — from low SNR or [multipath](/reference/multipath-propagation/) —
 closes the eye and breaks the decode, a key thing the scopes reveal.
+
+## Sources
+
+[^wiki]: [Clock recovery](https://en.wikipedia.org/wiki/Clock_recovery) — Wikipedia, on recovering symbol timing from a received signal.

--- a/docs/reference/cma-equalizer.md
+++ b/docs/reference/cma-equalizer.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [multipath-propagation, demodulation, clock-recovery, constellation-diagram]
 related_lessons:
   - { title: "Tuning for a clean lock", url: /learn/rf-sdr/tuning-with-scopes/ }
-external:
-  - { title: "Constant modulus algorithm (Wikipedia)", url: https://en.wikipedia.org/wiki/Constant_modulus_algorithm }
+related_reading:
+  - { title: "SDR Internals, Part 8: Equalization, diversity & the FFT", url: /blog/deep-dives/sdr-internals-08-equalization-diversity-fft/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Constant_modulus_algorithm
 ---
 
 A **CMA equalizer** uses the **constant-modulus algorithm** — a blind adaptive
 [filter](/reference/digital-filter/) — to counteract
 [multipath](/reference/multipath-propagation/) distortion without needing a known training
-sequence.
+sequence.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 190" role="img" aria-label="A smeared constellation on the left and a tightened constellation on the right after equalisation." xmlns="http://www.w3.org/2000/svg">
@@ -47,3 +49,7 @@ constant-envelope modulations), undoing intersymbol interference and tightening 
 
 A CMA equalizer can rescue decoding in reflective urban environments where multipath
 otherwise smears the symbols.
+
+## Sources
+
+[^wiki]: [Constant modulus algorithm](https://en.wikipedia.org/wiki/Constant_modulus_algorithm) — Wikipedia, on the blind adaptive equalization technique.

--- a/docs/reference/coaxial-cable.md
+++ b/docs/reference/coaxial-cable.md
@@ -10,13 +10,13 @@ autolink: true
 see_also: [attenuation, path-loss, antenna, standing-wave-ratio, low-noise-amplifier]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
-external:
-  - { title: "Coaxial cable (Wikipedia)", url: https://en.wikipedia.org/wiki/Coaxial_cable }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Coaxial_cable
 ---
 
 **Coaxial cable** ("coax") carries RF between the antenna and receiver. A centre
 conductor runs inside a tubular **shield**, separated by a dielectric, which keeps the
-signal contained and the impedance constant (commonly 50 Ω). Every metre and every
+signal contained and the impedance constant (commonly 50 Ω).[^wiki] Every metre and every
 connector adds [loss](/reference/attenuation/) — and the loss grows with frequency.
 
 <figure class="figure" markdown="0">
@@ -35,3 +35,7 @@ connector adds [loss](/reference/attenuation/) — and the loss grows with frequ
 A long or low-grade cable can quietly undo a good antenna, so operators keep feedline
 short or mount a [low-noise amplifier](/reference/low-noise-amplifier/) at the antenna. A
 poor match also raises [SWR](/reference/standing-wave-ratio/).
+
+## Sources
+
+[^wiki]: [Coaxial cable](https://en.wikipedia.org/wiki/Coaxial_cable) — Wikipedia, on coax construction, characteristic impedance, and frequency-dependent loss.

--- a/docs/reference/cobol-language.md
+++ b/docs/reference/cobol-language.md
@@ -19,13 +19,15 @@ see_also: [fortran-language, lisp-language, c-language, compiler, imperative-pro
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "The birth of programming languages", url: /learn/intro-software-dev/birth-of-languages/ }
-external:
-  - { title: "COBOL — Wikipedia", url: https://en.wikipedia.org/wiki/COBOL }
-  - { title: "GnuCOBOL", url: https://gnucobol.sourceforge.io/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/COBOL
+  - https://gnucobol.sourceforge.io/
 ---
 
 **COBOL** (COmmon Business-Oriented Language), introduced in 1959, is a deliberately
-English-like high-level language built for business data processing. Shaped by the
+English-like high-level language built for business data processing.[^wiki] Shaped by the
 work of Grace Hopper and a committee, it still runs huge amounts of banking and
 government software today.
 
@@ -57,10 +59,15 @@ era of high-level programming.
 
 COBOL is [statically typed](/reference/type-system/),
 [imperative](/reference/imperative-programming/), and compiled to native code without a
-[garbage collector](/reference/garbage-collection/). Astonishingly, vast amounts of
+[garbage collector](/reference/garbage-collection/).[^impl] Astonishingly, vast amounts of
 banking, insurance, and government software still run on it, processing daily
 transactions on mainframes. That is also its core problem: the code is decades old,
 the pool of programmers who know it is shrinking, and its verbosity and age make it a
 poor fit for new work, which has largely moved to languages like
 [Java](/reference/java-language/) and [C](/reference/c-language/). Its endurance is a
 reminder that working software rarely gets rewritten just because it is old.
+
+## Sources
+
+[^wiki]: [COBOL](https://en.wikipedia.org/wiki/COBOL) — Wikipedia, for history, the 1959 origin, Grace Hopper's influence, and ongoing use.
+[^impl]: [GnuCOBOL](https://gnucobol.sourceforge.io/) — a free COBOL compiler, illustrating the compiled, statically typed implementation.

--- a/docs/reference/code-coverage.md
+++ b/docs/reference/code-coverage.md
@@ -16,13 +16,15 @@ infobox:
 see_also: [unit-testing, integration-testing, end-to-end-testing, test-driven-development, mocking, ci-cd, refactoring]
 related_lessons:
   - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
-external:
-  - { title: "Code coverage — Wikipedia", url: https://en.wikipedia.org/wiki/Code_coverage }
+related_reading:
+  - { title: "Build in the Open, Part 8: Testing — how to build and write tests", url: /blog/tutorials/build-in-the-open-08-testing-how-to-write-tests/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Code_coverage
 ---
 
 **Code coverage** measures the percentage of a codebase exercised by its test suite —
 which lines, branches, or functions ran — a useful signal for finding untested code, but
-not a guarantee of correctness.
+not a guarantee of correctness.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A bar of code lines, most shaded as covered by tests and a few left uncovered, summing to a coverage percentage." xmlns="http://www.w3.org/2000/svg">
@@ -44,7 +46,7 @@ not a guarantee of correctness.
 Coverage tools instrument the code and record which parts executed while the
 [tests](/reference/unit-testing/) ran, reported as a percentage. Common granularities are
 **line coverage** (which lines ran), **branch coverage** (which sides of each
-conditional ran), and **function coverage**. The metric is genuinely useful for *finding
+conditional ran), and **function coverage**.[^wiki] The metric is genuinely useful for *finding
 untested code*: a module sitting at 0% is a red flag, and watching coverage shows where to
 aim the next tests. Coverage is typically computed in a [CI/CD](/reference/ci-cd/)
 pipeline so the number is tracked on every change.
@@ -67,3 +69,7 @@ Coverage spans every layer of the test pyramid — [unit](/reference/unit-testin
 disciplines like [test-driven development](/reference/test-driven-development/), not their
 purpose, and it gives [refactoring](/reference/refactoring/) confidence by showing which
 code a change's safety net actually protects.
+
+## Sources
+
+[^wiki]: [Code coverage](https://en.wikipedia.org/wiki/Code_coverage) — Wikipedia, for the metric, its granularities (line, branch, function), and its limits.

--- a/docs/reference/codec2.md
+++ b/docs/reference/codec2.md
@@ -15,12 +15,14 @@ infobox:
 see_also: [vocoder, m17, ambe-plus-2, m17-project]
 related_lessons:
   - { title: "Vocoders — IMBE & AMBE+2", url: /learn/rf-sdr/vocoders/ }
-external:
-  - { title: "Codec 2 (Wikipedia)", url: https://en.wikipedia.org/wiki/Codec_2 }
+related_reading:
+  - { title: "SDR Internals, Part 12: Voice coding & vocoders", url: /blog/deep-dives/sdr-internals-12-voice-coding-vocoders/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Codec_2
 ---
 
 **Codec 2** is an open-source, **royalty-free** low-bitrate speech
-[vocoder](/reference/vocoder/) created by David Rowe. It provides intelligible voice
+[vocoder](/reference/vocoder/) created by David Rowe.[^wiki] It provides intelligible voice
 from roughly 700 bps to 3200 bps and is the patent-free alternative to
 [AMBE](/reference/ambe/)-family codecs.
 
@@ -45,3 +47,7 @@ the FreeDV digital-voice mode adopted it.
 
 Codec 2 lets fully open decoders (including M17 support) render digital voice without
 proprietary vocoder licensing.
+
+## Sources
+
+[^wiki]: [Codec 2](https://en.wikipedia.org/wiki/Codec_2) — Wikipedia, on the open-source royalty-free low-bitrate speech codec.

--- a/docs/reference/compact-position-reporting.md
+++ b/docs/reference/compact-position-reporting.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [ads-b, cyclic-redundancy-check, icao]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "Compact Position Reporting", url: https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast
 ---
 
 **Compact position reporting** (**CPR**) is the encoding [ADS-B](/reference/ads-b/) uses to
 convey an aircraft's latitude and longitude in few bits, trading a small amount of
-ambiguity for compactness.
+ambiguity for compactness.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="An even frame and an odd frame combined to resolve a globally unambiguous latitude and longitude on a grid." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +44,7 @@ reference position.
 ## Relevance to SDR
 
 An ADS-B decoder must implement CPR to turn raw messages into mappable aircraft positions.
+
+## Sources
+
+[^wiki]: [Automatic Dependent Surveillance–Broadcast](https://en.wikipedia.org/wiki/Automatic_Dependent_Surveillance%E2%80%93Broadcast) — Wikipedia, for ADS-B and its compact position-reporting encoding.

--- a/docs/reference/compiler.md
+++ b/docs/reference/compiler.md
@@ -18,13 +18,13 @@ see_also: [interpreter, bytecode, jit-compilation, static-binary, cross-compilat
 related_lessons:
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Compiler — Wikipedia", url: https://en.wikipedia.org/wiki/Compiler }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Compiler
 ---
 
 **A compiler** is a program that translates source code written for humans into a
 form a machine can run — typically native machine code — doing the work *ahead of
-time*, before the program is ever executed.
+time*, before the program is ever executed.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="Source code passes through a compiler once, producing machine code the CPU runs directly each time." xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@ language. Classic *ahead-of-time* (AOT) compilers such as those for
 machine code packaged as an executable. Other compilers target
 [bytecode](/reference/bytecode/) for a virtual machine instead. Along the way the
 compiler optimizes — inlining calls, vectorizing loops, eliminating dead code — so
-the output often runs far faster than a naive translation would.
+the output often runs far faster than a naive translation would.[^wiki]
 
 ## Trade-offs
 
@@ -58,7 +58,7 @@ Because the translation happens once, the CPU runs native instructions with no
 per-operation overhead, and performance is predictable from run to run. The price is
 a **build step** between editing and running, and output that is usually tied to one
 platform — a binary built for x86-64 Linux will not run on an ARM Mac without
-recompiling (see [cross-compilation](/reference/cross-compilation/)). This contrasts
+recompiling (see [cross-compilation](/reference/cross-compilation/)).[^wiki] This contrasts
 with an [interpreter](/reference/interpreter/), which skips the build step but pays
 overhead on every run, and with [JIT compilation](/reference/jit-compilation/), which
 moves the translation to run time.
@@ -69,3 +69,7 @@ Compiled languages dominate systems software, where speed and a self-contained
 [static binary](/reference/static-binary/) matter. GopherTrunk is compiled by the Go
 toolchain into a single native executable, which is why it ships without requiring any
 runtime on the target machine.
+
+## Sources
+
+[^wiki]: [Compiler](https://en.wikipedia.org/wiki/Compiler) — Wikipedia, on how compilers translate source ahead of time, optimize, and target machine code or bytecode.

--- a/docs/reference/concurrency.md
+++ b/docs/reference/concurrency.md
@@ -18,14 +18,16 @@ see_also: [threads, async-programming, goroutines, go-language, rust-language, j
 related_lessons:
   - { title: "Concurrency and parallelism", url: /learn/intro-software-dev/concurrency-models/ }
   - { title: "Concurrency and pipelines", url: /learn/intro-software-dev/concurrency-and-pipelines/ }
-external:
-  - { title: "Concurrency (computer science) — Wikipedia", url: https://en.wikipedia.org/wiki/Concurrency_(computer_science) }
+related_reading:
+  - { title: "SDR Internals, Part 3: The SDR pool, streaming & concurrency", url: /blog/deep-dives/sdr-internals-03-sdr-pool-streaming-concurrency/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Concurrency_(computer_science)
 ---
 
 **Concurrency** is structuring a program so that multiple tasks can be in progress and
 advance independently; **parallelism** is actually running multiple computations at the
 same instant. Concurrency is about structure; parallelism is about execution, and the
-two are related but not the same.
+two are related but not the same.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="Concurrency interleaves two tasks on one core; parallelism runs them at the same time on two cores." xmlns="http://www.w3.org/2000/svg">
@@ -51,7 +53,7 @@ it while it waits for I/O, switch to task B — so the tasks *deal with* progres
 together. Parallelism *does* several things at once and therefore requires multiple
 cores. You can have concurrency without parallelism (one core juggling tasks), and a
 good concurrency model makes tasks the runtime can *also* run in parallel when cores
-are available. As Rob Pike put it: concurrency is a way to structure things; if it
+are available.[^wiki] As Rob Pike put it: concurrency is a way to structure things; if it
 works, parallelism may be a free bonus.
 
 ## Models and the shared hazard
@@ -60,7 +62,7 @@ Languages offer different concurrency models: OS [threads](/reference/threads/) 
 locks, single-threaded [async/await](/reference/async-programming/) event loops, Go's
 [goroutines](/reference/goroutines/) and channels, and the share-nothing actor model.
 What they are all really fighting is the **data race** — two tasks touching the same
-memory with at least one writing, with no synchronization, producing undefined results.
+memory with at least one writing, with no synchronization, producing undefined results.[^wiki]
 Each model is, at heart, a different strategy for avoiding unsynchronized shared writes.
 
 ## In practice
@@ -71,3 +73,7 @@ The right model follows the workload. **I/O-bound** work — waiting on networks
 systems favor actors. A streaming radio pipeline in [Go](/reference/go-language/) runs
 capture, DSP, and decode stages concurrently and lets the runtime spread them across
 cores in parallel.
+
+## Sources
+
+[^wiki]: [Concurrency (computer science)](https://en.wikipedia.org/wiki/Concurrency_(computer_science)) — Wikipedia, on concurrency as program structure versus parallel execution and the data-race hazard.

--- a/docs/reference/constellation-diagram.md
+++ b/docs/reference/constellation-diagram.md
@@ -15,14 +15,14 @@ see_also: [iq-data, eye-diagram, phase-shift-keying, quadrature-amplitude-modula
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
   - { title: "Tuning for a clean lock", url: /learn/rf-sdr/tuning-with-scopes/ }
-external:
-  - { title: "Constellation diagram (Wikipedia)", url: https://en.wikipedia.org/wiki/Constellation_diagram }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Constellation_diagram
 ---
 
 A **constellation diagram** plots a digital signal's [symbols](/reference/symbol-rate/)
 on the [IQ](/reference/iq-data/) plane: the horizontal axis is I and the vertical axis
 is Q, so each point's angle is its [phase](/reference/phase/) and its distance from the
-origin is its [amplitude](/reference/amplitude/).
+origin is its [amplitude](/reference/amplitude/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 200" role="img" aria-label="Two four-point constellations: tight clusters labelled clean on the left, smeared clusters labelled noisy on the right." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +46,7 @@ so the *shape* of the scatter diagnoses the problem.
 
 GopherTrunk's constellation panel draws this live, making it the first tool for
 [tuning a clean lock](/learn/rf-sdr/tuning-with-scopes/).
+
+## Sources
+
+[^wiki]: [Constellation diagram](https://en.wikipedia.org/wiki/Constellation_diagram) — Wikipedia, for the IQ-plane representation and how it reflects signal quality.

--- a/docs/reference/control-channel.md
+++ b/docs/reference/control-channel.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [trunked-radio, voice-channel, channel-grant, affiliation, talkgroup]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Trunked_radio_system
 ---
 
 The **control channel** is the **data-only** frequency that coordinates a
-[trunked radio](/reference/trunked-radio/) system. It carries a continuous stream of
+[trunked radio](/reference/trunked-radio/) system.[^wiki] It carries a continuous stream of
 signalling — never voice — managing registrations, call requests, and
 [channel grants](/reference/channel-grant/).
 
@@ -48,3 +50,7 @@ affiliated radios retune to listen. It also conveys the system identity and para
 
 Decoding the control channel is the key to monitoring a trunked system — it is the map
 that tells GopherTrunk where every call goes, so it can follow them all.
+
+## Sources
+
+[^wiki]: [Trunked radio system](https://en.wikipedia.org/wiki/Trunked_radio_system) — Wikipedia, on the control channel and trunking signalling.

--- a/docs/reference/conventional-radio.md
+++ b/docs/reference/conventional-radio.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [trunked-radio, voice-channel, frequency]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Two-way radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Two-way_radio }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Two-way_radio
 ---
 
 **Conventional radio** assigns each user group its own **fixed frequency**, in contrast
-to [trunked radio](/reference/trunked-radio/). A conversation always happens on the same
+to [trunked radio](/reference/trunked-radio/).[^wiki] A conversation always happens on the same
 channel, so there is no [control channel](/reference/control-channel/) to coordinate
 assignments.
 
@@ -52,3 +54,7 @@ group is quiet.
 
 Conventional channels are scanned directly by tuning to the known frequency — no
 grant-following required. [DMR Tier II](/reference/dmr-tier-2/) is a digital example.
+
+## Sources
+
+[^wiki]: [Two-way radio](https://en.wikipedia.org/wiki/Two-way_radio) — Wikipedia, on fixed-frequency conventional two-way radio operation.

--- a/docs/reference/convolutional-code.md
+++ b/docs/reference/convolutional-code.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [viterbi-algorithm, forward-error-correction, trellis-coded-modulation, m17]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Convolutional code (Wikipedia)", url: https://en.wikipedia.org/wiki/Convolutional_code }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Convolutional_code
 ---
 
 A **convolutional code** is a [forward-error-correction](/reference/forward-error-correction/)
 code in which each output depends on a sliding window of recent input bits, set by the
-*constraint length*.
+*constraint length*.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A shift register of memory cells whose taps are XOR-combined to produce two output bits per input bit." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +47,7 @@ sequence. Puncturing can raise the code rate by omitting some output bits.
 
 Convolutional coding (K=5) protects [M17](/reference/m17/) and appears in other digital
 radio links to recover from bit errors.
+
+## Sources
+
+[^wiki]: [Convolutional code](https://en.wikipedia.org/wiki/Convolutional_code) — Wikipedia, for the sliding-window encoder, constraint length, and puncturing.

--- a/docs/reference/costas-loop.md
+++ b/docs/reference/costas-loop.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [phase-shift-keying, phase, demodulation, cma-equalizer, ppm-frequency-correction]
 related_lessons:
   - { title: "Tuning for a clean lock", url: /learn/rf-sdr/tuning-with-scopes/ }
-external:
-  - { title: "Costas loop (Wikipedia)", url: https://en.wikipedia.org/wiki/Costas_loop }
+related_reading:
+  - { title: "SDR Internals, Part 7: Symbol timing & sync recovery", url: /blog/deep-dives/sdr-internals-07-symbol-timing-sync-recovery/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Costas_loop
 ---
 
 A **Costas loop** is a phase-locked feedback structure that recovers the
 [phase](/reference/phase/) and frequency of a suppressed carrier, enabling **coherent**
 [demodulation](/reference/demodulation/) of [PSK](/reference/phase-shift-keying/) and
-related signals.
+related signals.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A feedback loop: input to a phase detector, to a loop filter, to a controlled oscillator that feeds back to the phase detector." xmlns="http://www.w3.org/2000/svg">
@@ -50,3 +52,7 @@ Costas.
 
 Carrier recovery via a Costas loop is essential to decoding phase-modulated systems and
 to stabilising a constellation that would otherwise spin.
+
+## Sources
+
+[^wiki]: [Costas loop](https://en.wikipedia.org/wiki/Costas_loop) — Wikipedia, on the carrier-recovery feedback loop for coherent PSK demodulation.

--- a/docs/reference/coupling-and-cohesion.md
+++ b/docs/reference/coupling-and-cohesion.md
@@ -17,14 +17,14 @@ infobox:
 see_also: [abstraction, object-oriented-programming, design-patterns, solid, structural-patterns, behavioral-patterns]
 related_lessons:
   - { title: "Abstraction, coupling & cohesion", url: /learn/intro-software-dev/abstraction-coupling/ }
-external:
-  - { title: "Coupling (computer programming) — Wikipedia", url: https://en.wikipedia.org/wiki/Coupling_(computer_programming) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Coupling_(computer_programming)
 ---
 
 **Coupling** measures how much one module depends on another — how entangled they are —
 while **cohesion** measures how focused a single module is — how well its parts belong
 together. The central slogan of modular design is: aim for **loose coupling and high
-cohesion**.
+cohesion**.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Loose coupling shows modules connected by few narrow lines through a clean interface, while tight coupling shows many tangled connections between internals." xmlns="http://www.w3.org/2000/svg">
@@ -49,7 +49,7 @@ the other. Loosely coupled modules interact only through narrow, stable interfac
 can change behind its contract without disturbing its neighbours. A rough spectrum from
 worse to better: **content coupling** (one module reaches into another's state),
 **shared global state** (invisible dependencies through globals), and **data coupling**
-(passing exactly the data needed through a clean interface — the goal). Loose coupling is
+(passing exactly the data needed through a clean interface — the goal).[^wiki] Loose coupling is
 what makes code testable, reusable, and safe to change, and it leans directly on
 [abstraction](/reference/abstraction/) and the dependency-inversion idea in
 [SOLID](/reference/solid/).
@@ -77,4 +77,8 @@ mud" where nothing can move without everything moving. Most
 [design patterns](/reference/design-patterns/) — especially the
 [structural](/reference/structural-patterns/) and
 [behavioral](/reference/behavioral-patterns/) families — exist precisely to push a design
-toward this loose-coupling, high-cohesion ideal.
+toward this loose-coupling, high-cohesion ideal.[^wiki]
+
+## Sources
+
+[^wiki]: [Coupling (computer programming)](https://en.wikipedia.org/wiki/Coupling_(computer_programming)) — Wikipedia, for the definition of coupling, its spectrum, and the paired loose-coupling, high-cohesion goal.

--- a/docs/reference/cpp-language.md
+++ b/docs/reference/cpp-language.md
@@ -19,13 +19,15 @@ see_also: [c-language, rust-language, object-oriented-programming, memory-manage
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
-external:
-  - { title: "C++ — Wikipedia", url: https://en.wikipedia.org/wiki/C%2B%2B }
-  - { title: "C++ reference — cppreference", url: https://en.cppreference.com/w/cpp }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://en.cppreference.com/w/cpp
+  - https://en.wikipedia.org/wiki/C%2B%2B
 ---
 
 **C++** is a statically typed, compiled language that extends [C](/reference/c-language/)
-with objects, templates, generics, RAII and a large standard library. It can match C's
+with objects, templates, generics, RAII and a large standard library.[^wiki] It can match C's
 performance while offering far higher-level abstractions.
 
 <figure class="figure" markdown="0">
@@ -47,7 +49,7 @@ performance while offering far higher-level abstractions.
 
 C++ [compiles](/reference/compiler/) ahead of time to native code like
 [C](/reference/c-language/), but adds [object-oriented](/reference/object-oriented-programming/)
-features, compile-time generics through templates, and the Standard Template Library.
+features, compile-time generics through templates, and the Standard Template Library.[^ref]
 Its signature idiom is RAII — tying resource lifetimes to object scope — which gives a
 disciplined approach to [memory management](/reference/memory-management/) and, with
 smart pointers, much of the safety of automatic management without a garbage collector.
@@ -67,3 +69,8 @@ alternative that keeps the speed without the same footguns.
 C++ is the workhorse of performance-critical software with rich logic: game engines,
 web browsers, trading systems, scientific and signal-processing code, and other domains
 where both raw speed and high-level structure are required at once.
+
+## Sources
+
+[^ref]: [C++ reference](https://en.cppreference.com/w/cpp) — cppreference, the standard-tracking reference for the C++ language and library.
+[^wiki]: [C++](https://en.wikipedia.org/wiki/C%2B%2B) — Wikipedia, for history and design background.

--- a/docs/reference/cqpsk.md
+++ b/docs/reference/cqpsk.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [phase-shift-keying, c4fm, project-25, constellation-diagram]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Project_25
 ---
 
 **CQPSK** (compatible QPSK, also linear simulcast modulation, LSM) is the linear
 [phase-modulation](/reference/phase-shift-keying/) counterpart to
 [C4FM](/reference/c4fm/) used on [P25](/reference/project-25/). It produces the **same
-symbol stream** as C4FM so a single demodulator can receive either.
+symbol stream** as C4FM so a single demodulator can receive either.[^p25]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 300 210" role="img" aria-label="A QPSK constellation with four points and arcs showing the linear phase transitions between them." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +46,7 @@ better when overlapping transmitters are received together.
 
 A P25 receiver can demodulate both C4FM and CQPSK; on the
 [constellation](/reference/constellation-diagram/) the recovered symbols look alike.
+
+## Sources
+
+[^p25]: [Project 25](https://en.wikipedia.org/wiki/Project_25) — Wikipedia, for the CQPSK/LSM linear path and its compatibility with C4FM on P25.

--- a/docs/reference/creational-patterns.md
+++ b/docs/reference/creational-patterns.md
@@ -17,13 +17,14 @@ infobox:
 see_also: [design-patterns, structural-patterns, behavioral-patterns, object-oriented-programming, coupling-and-cohesion, solid, abstraction]
 related_lessons:
   - { title: "Creational patterns: factory, builder, singleton", url: /learn/intro-software-dev/creational-patterns/ }
-external:
-  - { title: "Creational pattern — Wikipedia", url: https://en.wikipedia.org/wiki/Creational_pattern }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Creational_pattern
+  - https://en.wikipedia.org/wiki/Design_Patterns
 ---
 
 **Creational patterns** are the [Gang of Four](/reference/design-patterns/) family that
 put a layer between "I need an object" and "here is exactly how it gets built," so the
-rest of the code does not hard-code which concrete class to instantiate.
+rest of the code does not hard-code which concrete class to instantiate.[^wiki][^gof]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="A caller asks a factory for an object and receives one through a common interface, without naming any concrete class." xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +49,7 @@ of which type to use and the *details* of how to construct it. That binding hurt
 type should depend on runtime input, construction is complicated, or you want exactly one
 shared instance. Creational patterns isolate that logic so callers depend on an
 [interface](/reference/abstraction/), reducing [coupling](/reference/coupling-and-cohesion/)
-and honouring the open/closed principle from [SOLID](/reference/solid/).
+and honouring the open/closed principle from [SOLID](/reference/solid/).[^wiki]
 
 ## The main members
 
@@ -70,3 +71,8 @@ object is built varies — they compose well, since a factory can use a builder 
 dependencies and poor testability, so prefer passing a shared instance in explicitly. The
 sibling families are [structural patterns](/reference/structural-patterns/) (arranging
 objects) and [behavioral patterns](/reference/behavioral-patterns/) (coordinating them).
+
+## Sources
+
+[^wiki]: [Creational pattern](https://en.wikipedia.org/wiki/Creational_pattern) — Wikipedia, for the definition and the family members (Factory Method, Abstract Factory, Builder, Prototype, Singleton).
+[^gof]: [Design Patterns](https://en.wikipedia.org/wiki/Design_Patterns) — Wikipedia, on the 1994 Gang of Four book that established the creational/structural/behavioral grouping.

--- a/docs/reference/cross-compilation.md
+++ b/docs/reference/cross-compilation.md
@@ -18,13 +18,13 @@ see_also: [compiler, static-binary, go-language, rust-language, c-language]
 related_lessons:
   - { title: "Packaging and distribution", url: /learn/intro-software-dev/packaging-and-distribution/ }
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
-external:
-  - { title: "Cross compiler — Wikipedia", url: https://en.wikipedia.org/wiki/Cross_compiler }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Cross_compiler
 ---
 
 **Cross-compilation** is building an executable on one platform — the *host* — that is
 meant to run on a *different* platform — the *target* — such as producing a Windows or
-macOS binary from a Linux machine without ever touching those operating systems.
+macOS binary from a Linux machine without ever touching those operating systems.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="One source tree compiled on a Linux host produces binaries targeting Linux, macOS, and Windows." xmlns="http://www.w3.org/2000/svg">
@@ -46,7 +46,7 @@ macOS binary from a Linux machine without ever touching those operating systems.
 A normal [compiler](/reference/compiler/) emits machine code for the machine it runs
 on. A cross-compiling toolchain instead targets a chosen operating system and CPU
 architecture, generating code and linking against the right libraries for that target.
-The output is a binary that will not run on the host but will run on the target. This
+The output is a binary that will not run on the host but will run on the target.[^wiki] This
 is essential whenever the target cannot easily build for itself — embedded devices,
 phones, or simply a release pipeline that produces every platform's download from one
 build machine.
@@ -58,7 +58,7 @@ making multi-platform releases a single automated step. The complications come f
 *platform-specific dependencies*: code that links against C libraries or calls
 operating-system APIs may need matching target headers and libraries, and that setup
 can be fiddly. Languages with little native dependency and a pure toolchain cross-compile
-most smoothly, especially when they also emit a [static binary](/reference/static-binary/).
+most smoothly, especially when they also emit a [static binary](/reference/static-binary/).[^wiki]
 
 ## In practice
 
@@ -68,3 +68,7 @@ why GopherTrunk can ship Linux, macOS, and Windows downloads from one build.
 [Rust](/reference/rust-language/) supports many targets through its toolchain, and
 [C](/reference/c-language/) cross-compiles with dedicated toolchains, though external
 dependencies make it more involved.
+
+## Sources
+
+[^wiki]: [Cross compiler](https://en.wikipedia.org/wiki/Cross_compiler) — Wikipedia, on building executables for a target platform different from the host and why it matters for releases and embedded work.

--- a/docs/reference/csbk.md
+++ b/docs/reference/csbk.md
@@ -10,14 +10,16 @@ autolink: true
 see_also: [control-channel, channel-grant, dmr-tier-3, dmr, tsbk]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_mobile_radio
 ---
 
 A **CSBK** (**control signalling block**) is the single-block control message of
 [DMR](/reference/dmr/). On a [Tier III](/reference/dmr-tier-3/) control channel, CSBKs
 carry call requests, [channel grants](/reference/channel-grant/), and system data — the
-DMR counterpart of P25's [TSBK](/reference/tsbk/).
+DMR counterpart of P25's [TSBK](/reference/tsbk/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A DMR control channel carrying CSBK blocks, one of which grants a traffic channel and slot." xmlns="http://www.w3.org/2000/svg">
@@ -32,3 +34,7 @@ DMR counterpart of P25's [TSBK](/reference/tsbk/).
 
 CSBKs are protected by [BPTC](/reference/bptc/) coding. Following them is how a decoder
 tracks trunked DMR, just as TSBKs are followed on P25.
+
+## Sources
+
+[^wiki]: [Digital mobile radio](https://en.wikipedia.org/wiki/Digital_mobile_radio) — Wikipedia, on DMR control signalling and Tier III trunking.

--- a/docs/reference/csharp-language.md
+++ b/docs/reference/csharp-language.md
@@ -19,13 +19,15 @@ see_also: [java-language, jit-compilation, bytecode, garbage-collection, typescr
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
-external:
-  - { title: "C Sharp (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/C_Sharp_(programming_language) }
-  - { title: "The C# programming language — Microsoft", url: https://learn.microsoft.com/en-us/dotnet/csharp/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://learn.microsoft.com/en-us/dotnet/csharp/
+  - https://en.wikipedia.org/wiki/C_Sharp_(programming_language)
 ---
 
 **C#** (pronounced "C sharp") is Microsoft's statically typed, garbage-collected,
-object-oriented language for the .NET platform. It is closely comparable to
+object-oriented language for the .NET platform.[^wiki] It is closely comparable to
 [Java](/reference/java-language/) — a managed, JIT-compiled language with a large
 ecosystem — with arguably more modern language features.
 
@@ -48,7 +50,7 @@ ecosystem — with arguably more modern language features.
 
 C# compiles to intermediate-language [bytecode](/reference/bytecode/) that the .NET
 Common Language Runtime (CLR) [JIT-compiles](/reference/jit-compilation/) to native code
-at runtime. It is [statically typed](/reference/type-system/),
+at runtime.[^docs] It is [statically typed](/reference/type-system/),
 [garbage-collected](/reference/garbage-collection/), and broadly
 [object-oriented](/reference/object-oriented-programming/) with strong functional
 features. Its lead designer, Anders Hejlsberg, also went on to create
@@ -69,3 +71,8 @@ C# is the backbone of Windows enterprise software and a major language for web b
 and cloud services on .NET. Through the **Unity** engine it also underpins a large share
 of the game industry. As with Java, the practical choice between the two often comes down
 to ecosystem and platform rather than the languages themselves.
+
+## Sources
+
+[^docs]: [The C# programming language](https://learn.microsoft.com/en-us/dotnet/csharp/) — Microsoft's official C# and .NET documentation.
+[^wiki]: [C Sharp (programming language)](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)) — Wikipedia, for history and design background.

--- a/docs/reference/cyclic-redundancy-check.md
+++ b/docs/reference/cyclic-redundancy-check.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [forward-error-correction, ads-b, ais, ax25]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "Cyclic redundancy check (Wikipedia)", url: https://en.wikipedia.org/wiki/Cyclic_redundancy_check }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Cyclic_redundancy_check
 ---
 
 A **cyclic redundancy check** (**CRC**) is an error-*detection* code that appends a
-checksum computed by polynomial division over the data. A mismatch on receive flags a
+checksum computed by polynomial division over the data.[^wiki] A mismatch on receive flags a
 corrupted frame.
 
 <figure class="figure" markdown="0">
@@ -44,3 +46,7 @@ but does not correct errors. Frames failing the CRC are discarded.
 ## Relevance to SDR
 
 CRC validation ensures GopherTrunk only reports data frames that arrived intact.
+
+## Sources
+
+[^wiki]: [Cyclic redundancy check](https://en.wikipedia.org/wiki/Cyclic_redundancy_check) — Wikipedia, for the polynomial-division checksum used to detect corrupted frames.

--- a/docs/reference/d-star.md
+++ b/docs/reference/d-star.md
@@ -18,15 +18,17 @@ infobox:
 see_also: [system-fusion-ysf, m17, gmsk, ambe, vocoder]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "D-STAR (Wikipedia)", url: https://en.wikipedia.org/wiki/D-STAR }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/D-STAR
 ---
 
 **D-STAR** (**Digital Smart Technologies for Amateur Radio**) is an amateur-radio
 digital voice and data standard developed by the Japan Amateur Radio League (JARL)
 and widely implemented by **Icom**. It uses [GMSK](/reference/gmsk/) modulation and an
 [AMBE](/reference/ambe/)-family [vocoder](/reference/vocoder/) for its digital-voice
-(DV) mode.
+(DV) mode.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 440 110" role="img" aria-label="D-STAR digital voice from radio to repeater to internet gateways." xmlns="http://www.w3.org/2000/svg">
@@ -60,7 +62,7 @@ fits in a narrow 6.25 kHz channel.
 ## History
 
 Specified by the JARL around 2001 and brought to market by Icom; one of the earliest
-mainstream amateur digital-voice systems.
+mainstream amateur digital-voice systems.[^wiki]
 
 ## Deployment
 
@@ -69,3 +71,7 @@ Amateur radio worldwide, via DV repeaters, hotspots, and networked reflectors.
 ## Decoding it with GopherTrunk
 
 See [Status](/status.html) for GopherTrunk's D-STAR link-layer and voice coverage.
+
+## Sources
+
+[^wiki]: [D-STAR](https://en.wikipedia.org/wiki/D-STAR) — Wikipedia, for the JARL-developed amateur digital-voice standard, its GMSK modulation, AMBE vocoder, and reflector networking.

--- a/docs/reference/dbfs.md
+++ b/docs/reference/dbfs.md
@@ -14,14 +14,14 @@ infobox:
 see_also: [decibel, dbm, analog-to-digital-converter, automatic-gain-control]
 related_lessons:
   - { title: "Gain, AGC & avoiding overload", url: /learn/rf-sdr/gain-and-agc/ }
-external:
-  - { title: "dBFS (Wikipedia)", url: https://en.wikipedia.org/wiki/DBFS }
+cite_urls:
+  - https://en.wikipedia.org/wiki/DBFS
 ---
 
 **dBFS** (decibels relative to **full scale**) measures level inside the digital domain
 of an SDR. Here **0 dBFS is the ceiling** — the largest value the
 [ADC](/reference/analog-to-digital-converter/) can represent — and real samples sit
-below it as negative numbers.
+below it as negative numbers.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 300 150" role="img" aria-label="A vertical scale with 0 dBFS at the top as the ADC ceiling, a signal sitting below it with headroom, and the noise near the bottom." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +46,7 @@ distortion across the spectrum. Leaving headroom below 0 dBFS keeps the signal c
 [Gain](/reference/automatic-gain-control/) should be set so the strongest signal peaks
 comfortably under 0 dBFS. dBm describes the world outside the radio;
 [dBFS](/reference/dbfs/) describes the world inside it.
+
+## Sources
+
+[^wiki]: [dBFS](https://en.wikipedia.org/wiki/DBFS) — Wikipedia, decibels relative to digital full scale.

--- a/docs/reference/dbm.md
+++ b/docs/reference/dbm.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [decibel, dbfs, noise-floor, signal-to-noise-ratio]
 related_lessons:
   - { title: "Decibels & signal power", url: /learn/rf-sdr/decibels/ }
-external:
-  - { title: "dBm (Wikipedia)", url: https://en.wikipedia.org/wiki/DBm }
+cite_urls:
+  - https://en.wikipedia.org/wiki/DBm
 ---
 
 **dBm** is power expressed in [decibels](/reference/decibel/) relative to **one
 milliwatt**, making it an *absolute* measure of signal strength rather than a mere
-ratio. 0 dBm equals 1 mW; +30 dBm is 1 watt.
+ratio.[^wiki] 0 dBm equals 1 mW; +30 dBm is 1 watt.
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A dBm scale showing reference points from +30 dBm (1 watt) down to -120 dBm, with received signals in the negative range." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +45,7 @@ dBm values — and the one closer to zero is stronger (−70 dBm beats −90 dBm
 Receiver meters report signal and [noise-floor](/reference/noise-floor/) levels in dBm;
 their difference is the [SNR](/reference/signal-to-noise-ratio/) that determines whether
 a signal decodes.
+
+## Sources
+
+[^wiki]: [dBm](https://en.wikipedia.org/wiki/DBm) — Wikipedia, power referenced to one milliwatt.

--- a/docs/reference/dc-offset.md
+++ b/docs/reference/dc-offset.md
@@ -10,12 +10,12 @@ autolink: true
 see_also: [baseband, iq-data, local-oscillator, fft-and-waterfall]
 related_lessons:
   - { title: "The FFT & reading a waterfall", url: /learn/rf-sdr/fft-and-waterfall/ }
-external:
-  - { title: "DC bias (Wikipedia)", url: https://en.wikipedia.org/wiki/DC_bias }
+cite_urls:
+  - https://en.wikipedia.org/wiki/DC_bias
 ---
 
 A **DC offset** is a constant (zero-frequency) component in the [IQ](/reference/iq-data/)
-stream that shows up as a **spike in the exact centre** of the spectrum and waterfall.
+stream that shows up as a **spike in the exact centre** of the spectrum and waterfall.[^wiki]
 It is an artefact of zero-IF/[baseband](/reference/baseband/) receivers — local-oscillator
 leakage and converter bias — **not** a real signal on the air.
 
@@ -35,3 +35,7 @@ Operators avoid it by tuning slightly off-centre so the channel of interest does
 under the spike, or by enabling a DC-blocking [filter](/reference/iir-filter/). It is a
 common source of "phantom carrier" confusion for newcomers reading a
 [waterfall](/reference/fast-fourier-transform/).
+
+## Sources
+
+[^wiki]: [DC bias](https://en.wikipedia.org/wiki/DC_bias) — Wikipedia, on a constant zero-frequency component in a signal.

--- a/docs/reference/decibel.md
+++ b/docs/reference/decibel.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [dbm, dbfs, signal-to-noise-ratio, noise-floor, path-loss, antenna-gain]
 related_lessons:
   - { title: "Decibels & signal power", url: /learn/rf-sdr/decibels/ }
-external:
-  - { title: "Decibel (Wikipedia)", url: https://en.wikipedia.org/wiki/Decibel }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Decibel
 ---
 
 The **decibel** (**dB**) is a logarithmic unit expressing the ratio between two power
-levels: *dB = 10·log₁₀(P₁/P₂)*. Radio relies on it because signal powers span an
+levels: *dB = 10·log₁₀(P₁/P₂)*.[^wiki] Radio relies on it because signal powers span an
 enormous range and because gains and losses then simply **add**.
 
 <figure class="figure" markdown="0">
@@ -50,3 +50,7 @@ Absolute power is given in [dBm](/reference/dbm/); digital headroom in
 [dBFS](/reference/dbfs/). [Antenna gain](/reference/antenna-gain/),
 [path loss](/reference/path-loss/), and [SNR](/reference/signal-to-noise-ratio/) are
 all expressed in decibels.
+
+## Sources
+
+[^wiki]: [Decibel](https://en.wikipedia.org/wiki/Decibel) — Wikipedia, definition of the logarithmic ratio unit and its conventions.

--- a/docs/reference/decimation.md
+++ b/docs/reference/decimation.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [digital-filter, cic-filter, sample-rate, aliasing, digital-down-converter]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Decimation (signal processing) (Wikipedia)", url: https://en.wikipedia.org/wiki/Downsampling_(signal_processing) }
+related_reading:
+  - { title: "SDR Internals, Part 5: Tuning & channelization", url: /blog/deep-dives/sdr-internals-05-tuning-channelization/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Downsampling_(signal_processing)
 ---
 
 **Decimation** reduces a signal's [sample rate](/reference/sample-rate/) by keeping only
 every Nth sample, after a low-pass [filter](/reference/digital-filter/) removes the
-frequencies that would otherwise [alias](/reference/aliasing/).
+frequencies that would otherwise [alias](/reference/aliasing/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A dense row of samples reduced to a sparse row by keeping every fourth sample after filtering." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +46,7 @@ the pipeline must process.
 
 Decimation is what makes running [many channels](/reference/digital-down-converter/) from
 one capture computationally feasible.
+
+## Sources
+
+[^wiki]: [Decimation (signal processing)](https://en.wikipedia.org/wiki/Downsampling_(signal_processing)) — Wikipedia, on filter-then-downsample and anti-alias requirements.

--- a/docs/reference/declarative-programming.md
+++ b/docs/reference/declarative-programming.md
@@ -17,12 +17,12 @@ infobox:
 see_also: [imperative-programming, functional-programming, object-oriented-programming, rest, abstraction]
 related_lessons:
   - { title: "Paradigms & language families", url: /learn/intro-software-dev/language-families/ }
-external:
-  - { title: "Declarative programming — Wikipedia", url: https://en.wikipedia.org/wiki/Declarative_programming }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Declarative_programming
 ---
 
 **Declarative programming** flips the question from *how* to *what*: you describe the
-result you want and let the system figure out the steps needed to produce it.
+result you want and let the system figure out the steps needed to produce it.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="A declarative request describing a desired result is handed to an engine, which plans and executes the hidden steps to produce the result." xmlns="http://www.w3.org/2000/svg">
@@ -40,7 +40,7 @@ result you want and let the system figure out the steps needed to produce it.
 ## Families of declarative code
 
 Declarative is a broad umbrella. [Functional programming](/reference/functional-programming/)
-is one family — you describe transformations, not state changes. Beyond it:
+is one family — you describe transformations, not state changes.[^wiki] Beyond it:
 
 - **Query languages** — SQL declares *what* rows you want; the database plans *how* to
   fetch them, never telling the engine which index to scan.
@@ -64,4 +64,8 @@ The clean contrast is with [imperative programming](/reference/imperative-progra
 which spells out an ordered sequence of state changes. Reach for declarative style when
 *what* you want is clearer than *how* to get it — querying data, describing
 infrastructure, or expressing rules — and reach for imperative when you need precise
-control over each step.
+control over each step.[^wiki]
+
+## Sources
+
+[^wiki]: [Declarative programming](https://en.wikipedia.org/wiki/Declarative_programming) — Wikipedia, for the what-not-how definition and the functional, logic, query, and configuration families.

--- a/docs/reference/demodulation.md
+++ b/docs/reference/demodulation.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [modulation, clock-recovery, costas-loop, constellation-diagram, software-defined-radio]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Demodulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Demodulation }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Demodulation
 ---
 
 **Demodulation** recovers the original modulating information from a
 [carrier](/reference/carrier-wave/) — the inverse of
-[modulation](/reference/modulation/). For FM/[FSK](/reference/frequency-shift-keying/) it
+[modulation](/reference/modulation/).[^wiki] For FM/[FSK](/reference/frequency-shift-keying/) it
 tracks instantaneous frequency; for [PSK](/reference/phase-shift-keying/) it tracks
 [phase](/reference/phase/).
 
@@ -48,3 +50,7 @@ waveform; decoding handles the data.
 
 Choosing the matching demodulator for a signal's modulation is the core of recovering it;
 the [constellation](/reference/constellation-diagram/) visualises this stage.
+
+## Sources
+
+[^wiki]: [Demodulation](https://en.wikipedia.org/wiki/Demodulation) — Wikipedia, on recovering the modulating signal as the inverse of modulation.

--- a/docs/reference/design-patterns.md
+++ b/docs/reference/design-patterns.md
@@ -17,13 +17,14 @@ infobox:
 see_also: [creational-patterns, structural-patterns, behavioral-patterns, object-oriented-programming, abstraction, coupling-and-cohesion, solid]
 related_lessons:
   - { title: "What is a design pattern?", url: /learn/intro-software-dev/what-are-patterns/ }
-external:
-  - { title: "Software design pattern — Wikipedia", url: https://en.wikipedia.org/wiki/Software_design_pattern }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software_design_pattern
+  - https://en.wikipedia.org/wiki/Design_Patterns
 ---
 
 **Design patterns** are named, reusable descriptions of solutions to problems that recur
 in software design — not finished code you paste in, but templates for arranging classes,
-objects, and responsibilities so a design stays flexible.
+objects, and responsibilities so a design stays flexible.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="The Gang of Four catalogue of 23 patterns splits into three families: creational, structural, and behavioral." xmlns="http://www.w3.org/2000/svg">
@@ -53,7 +54,7 @@ conveys a whole design decision in one word.
 The idea came from architecture (Christopher Alexander), but software's canonical source
 is the 1994 book *Design Patterns* by the **"Gang of Four" (GoF)** — Gamma, Helm, Johnson,
 and Vlissides — which catalogued **23 patterns** for [object-oriented](/reference/object-oriented-programming/)
-design. They split into three families:
+design.[^gof] They split into three families:
 
 - [Creational patterns](/reference/creational-patterns/) — how objects get *made* (Factory, Builder, Singleton).
 - [Structural patterns](/reference/structural-patterns/) — how objects are *arranged* (Adapter, Facade, Decorator).
@@ -65,4 +66,9 @@ Most patterns exist to manage [abstraction](/reference/abstraction/) and keep
 [coupling](/reference/coupling-and-cohesion/) low, and many are concrete ways to honour
 [SOLID](/reference/solid/), especially the open/closed principle. But every pattern adds
 indirection. Forcing one where it is not needed is the "golden hammer" anti-pattern; the
-skill is judging when a real problem calls for one rather than memorising all 23.
+skill is judging when a real problem calls for one rather than memorising all 23.[^wiki]
+
+## Sources
+
+[^wiki]: [Software design pattern](https://en.wikipedia.org/wiki/Software_design_pattern) — Wikipedia, for the definition, the template/vocabulary framing, and the three families.
+[^gof]: [Design Patterns](https://en.wikipedia.org/wiki/Design_Patterns) — Wikipedia, on the 1994 Gang of Four book that catalogued the 23 object-oriented patterns.

--- a/docs/reference/dibit.md
+++ b/docs/reference/dibit.md
@@ -10,11 +10,11 @@ autolink: true
 see_also: [symbol-rate, c4fm, frequency-shift-keying, constellation-diagram]
 related_lessons:
   - { title: "Symbols, baud & bitrate", url: /learn/rf-sdr/symbols-and-baud/ }
-external:
-  - { title: "Dibit (Wikipedia)", url: https://en.wikipedia.org/wiki/Dibit }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Dibit
 ---
 
-A **dibit** is a **pair of bits** represented by one transmitted symbol. In the
+A **dibit** is a **pair of bits** represented by one transmitted symbol.[^wiki] In the
 four-level modulations used by [P25](/reference/p25-phase-1/) ([C4FM](/reference/c4fm/))
 and [DMR](/reference/dmr/) ([4FSK](/reference/frequency-shift-keying/)), each of the four
 symbol states maps to one of the four dibits `00`, `01`, `10`, `11`.
@@ -32,3 +32,7 @@ symbol states maps to one of the four dibits `00`, `01`, `10`, `11`.
 Because each symbol carries two bits, a four-level signal's **bit rate is twice its
 [symbol rate](/reference/symbol-rate/)** — which is why P25 Phase 1's 4800-baud C4FM
 runs at 9600 bits per second.
+
+## Sources
+
+[^wiki]: [Dibit](https://en.wikipedia.org/wiki/Dibit) — Wikipedia, for the two-bits-per-symbol definition.

--- a/docs/reference/digital-down-converter.md
+++ b/docs/reference/digital-down-converter.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [local-oscillator, decimation, digital-filter, iq-data, demodulation]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Digital down converter (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_down_converter }
+related_reading:
+  - { title: "SDR Internals, Part 5: Tuning & channelization", url: /blog/deep-dives/sdr-internals-05-tuning-channelization/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_down_converter
 ---
 
 A **digital down-converter** (**DDC**) shifts a chosen channel within a wideband
 [IQ](/reference/iq-data/) stream to baseband using a numerically controlled oscillator
 (a software [local oscillator](/reference/local-oscillator/)), then
-[filters](/reference/digital-filter/) and [decimates](/reference/decimation/) it.
+[filters](/reference/digital-filter/) and [decimates](/reference/decimation/) it.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 520 110" role="img" aria-label="Wideband IQ into a numerically controlled oscillator mixer, then a low-pass filter, then decimation, producing one narrow channel." xmlns="http://www.w3.org/2000/svg">
@@ -47,3 +49,7 @@ from one capture.
 
 The DDC is how GopherTrunk extracts a control channel and multiple voice channels from a
 single wideband capture.
+
+## Sources
+
+[^wiki]: [Digital down converter](https://en.wikipedia.org/wiki/Digital_down_converter) — Wikipedia, for the NCO/filter/decimate channelization architecture.

--- a/docs/reference/digital-filter.md
+++ b/docs/reference/digital-filter.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [decimation, cic-filter, root-raised-cosine-filter, matched-filter, digital-down-converter]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Digital filter (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_filter }
+related_reading:
+  - { title: "SDR Internals, Part 4: DSP foundations — filters, NCO & AGC", url: /blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_filter
 ---
 
 A **digital filter** passes some frequencies and attenuates others by performing
-arithmetic on a stream of samples — no physical components. The main families are FIR
+arithmetic on a stream of samples — no physical components.[^wiki] The main families are FIR
 (finite impulse response) and IIR (infinite impulse response).
 
 <figure class="figure" markdown="0">
@@ -46,3 +48,7 @@ Filtering is fundamental to channelising the [IQ](/reference/iq-data/) stream an
 shaping; specialised forms include the [CIC](/reference/cic-filter/),
 [root-raised-cosine](/reference/root-raised-cosine-filter/), and
 [matched](/reference/matched-filter/) filters.
+
+## Sources
+
+[^wiki]: [Digital filter](https://en.wikipedia.org/wiki/Digital_filter) — Wikipedia, on FIR/IIR families and frequency response.

--- a/docs/reference/dipole-antenna.md
+++ b/docs/reference/dipole-antenna.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [antenna, antenna-gain, polarization, wavelength]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
-external:
-  - { title: "Dipole antenna (Wikipedia)", url: https://en.wikipedia.org/wiki/Dipole_antenna }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Dipole_antenna
 ---
 
 A **dipole antenna** is a simple resonant [antenna](/reference/antenna/) made of two
 conductors fed at the centre, classically a **half [wavelength](/reference/wavelength/)**
-long. It is the reference against which other antennas' [gain](/reference/antenna-gain/)
+long.[^wiki] It is the reference against which other antennas' [gain](/reference/antenna-gain/)
 is often compared.
 
 <figure class="figure" markdown="0">
@@ -45,3 +45,7 @@ dipole. Its [polarization](/reference/polarization/) follows its orientation.
 
 A dipole (or its grounded cousin, the quarter-wave whip) cut for the target band is a
 cheap, effective receive antenna for scanning.
+
+## Sources
+
+[^wiki]: [Dipole antenna](https://en.wikipedia.org/wiki/Dipole_antenna) — Wikipedia, for the construction and radiation pattern of the half-wave dipole.

--- a/docs/reference/dmr-tier-1.md
+++ b/docs/reference/dmr-tier-1.md
@@ -19,13 +19,15 @@ infobox:
 see_also: [dmr, dmr-tier-2, dmr-tier-3, frequency-shift-keying, etsi]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_mobile_radio
 ---
 
 **DMR Tier I** is the **licence-free** tier of the [DMR](/reference/dmr/) standard,
 defined by [ETSI](/reference/etsi/) for low-power, short-range consumer and light
-commercial use without an individual user licence.
+commercial use without an individual user licence.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 360 110" role="img" aria-label="A single licence-free DMR Tier I channel at low power." xmlns="http://www.w3.org/2000/svg">
@@ -55,7 +57,7 @@ trunking is involved. Equipment is simple and inexpensive.
 ## History
 
 Tier I was specified alongside the other tiers in ETSI's DMR documents to cover the
-unlicensed consumer segment.
+unlicensed consumer segment.[^wiki]
 
 ## Deployment
 
@@ -66,3 +68,7 @@ channels; less common than Tier II in North America.
 
 Tier I traffic is conventional DMR and decodes like any [Tier II](/reference/dmr-tier-2/)
 conventional channel once tuned. See [Status](/status.html).
+
+## Sources
+
+[^wiki]: [Digital mobile radio](https://en.wikipedia.org/wiki/Digital_mobile_radio) — Wikipedia, for the ETSI DMR tier structure, including the licence-free Tier I.

--- a/docs/reference/dmr-tier-2.md
+++ b/docs/reference/dmr-tier-2.md
@@ -19,13 +19,15 @@ infobox:
 see_also: [dmr, dmr-tier-1, dmr-tier-3, tdma, ambe-plus-2]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_mobile_radio
 ---
 
 **DMR Tier II** is the **licensed, conventional** tier of the [DMR](/reference/dmr/)
 standard. It is non-trunked — each repeater pair uses fixed frequencies — but carries
-**two voice timeslots** per 12.5 kHz channel via [TDMA](/reference/tdma/).
+**two voice timeslots** per 12.5 kHz channel via [TDMA](/reference/tdma/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 140" role="img" aria-label="Two TDMA slots in a conventional DMR Tier II channel." xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +58,7 @@ allow two simultaneous conversations.
 ## History
 
 Tier II was the first widely commercialised DMR tier, popularised by Motorola's
-MOTOTRBO line from the late 2000s.
+MOTOTRBO line from the late 2000s.[^wiki]
 
 ## Deployment
 
@@ -67,3 +69,7 @@ Tier II repeaters and hotspots over the internet.
 
 GopherTrunk decodes both timeslots of a Tier II channel and renders AMBE+2 audio. For
 trunked DMR, see [Tier III](/reference/dmr-tier-3/). See [Status](/status.html).
+
+## Sources
+
+[^wiki]: [Digital mobile radio](https://en.wikipedia.org/wiki/Digital_mobile_radio) — Wikipedia, for the ETSI DMR tiers, including the licensed conventional Tier II and its two-slot TDMA.

--- a/docs/reference/dmr-tier-3.md
+++ b/docs/reference/dmr-tier-3.md
@@ -20,14 +20,16 @@ see_also: [dmr, dmr-tier-2, trunked-radio, control-channel, talkgroup, channel-g
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_mobile_radio
 ---
 
 **DMR Tier III** is the **trunked** tier of the [DMR](/reference/dmr/) standard. It
 adds a [control channel](/reference/control-channel/) and trunking signalling so many
 [talkgroups](/reference/talkgroup/) can share a pool of two-slot
-[TDMA](/reference/tdma/) channels, assigned on demand.
+[TDMA](/reference/tdma/) channels, assigned on demand.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 150" role="img" aria-label="A DMR Tier III control channel assigning two-slot TDMA traffic channels from a pool." xmlns="http://www.w3.org/2000/svg">
@@ -62,7 +64,7 @@ outside the strict Tier III standard.)
 
 Tier III trunking was standardised by [ETSI](/reference/etsi/) to give DMR a
 multi-site, high-capacity option competing with P25 and TETRA in the commercial
-market.
+market.[^wiki]
 
 ## Deployment
 
@@ -73,3 +75,7 @@ at lower cost than [TETRA](/reference/tetra/) or [P25](/reference/project-25/).
 
 GopherTrunk locks the Tier III control channel, follows CSBK channel grants to the
 assigned channel/slot, and decodes the voice. See [Status](/status.html).
+
+## Sources
+
+[^wiki]: [Digital mobile radio](https://en.wikipedia.org/wiki/Digital_mobile_radio) — Wikipedia, for the ETSI DMR tiers, including the trunked Tier III with its control channel and CSBK signalling.

--- a/docs/reference/dmr.md
+++ b/docs/reference/dmr.md
@@ -21,15 +21,17 @@ see_also: [dmr-tier-1, dmr-tier-2, dmr-tier-3, ambe-plus-2, tdma, etsi, control-
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_mobile_radio
 ---
 
 **Digital Mobile Radio** (**DMR**) is an open digital two-way-radio standard from
 [ETSI](/reference/etsi/), widely used in business, commercial, and amateur radio. It
 places **two timeslots** ([TDMA](/reference/tdma/)) in a 12.5 kHz channel using
 [4FSK](/reference/frequency-shift-keying/) modulation and the
-[AMBE+2](/reference/ambe-plus-2/) vocoder.
+[AMBE+2](/reference/ambe-plus-2/) vocoder.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 140" role="img" aria-label="Two TDMA slots in a 12.5 kHz DMR channel." xmlns="http://www.w3.org/2000/svg">
@@ -65,7 +67,7 @@ share one frequency.
 
 ## History
 
-ETSI published the DMR standard in 2005, with commercial radios following soon after.
+ETSI published the DMR standard in 2005, with commercial radios following soon after.[^wiki]
 Amateur DMR grew rapidly in the 2010s via networked repeaters and hotspots.
 
 ## Deployment
@@ -78,3 +80,7 @@ deployments use Tier III; most conventional business and ham systems are Tier II
 GopherTrunk decodes both DMR timeslots, follows Tier III trunking, and renders AMBE+2
 audio. Optional known-key [DMR encryption](/dmr-encryption.html) handling is
 documented separately. See [Status](/status.html).
+
+## Sources
+
+[^wiki]: [Digital mobile radio](https://en.wikipedia.org/wiki/Digital_mobile_radio) — Wikipedia, for the ETSI DMR standard, its two-slot TDMA air interface, the tier structure, and the AMBE+2 vocoder.

--- a/docs/reference/dpmr.md
+++ b/docs/reference/dpmr.md
@@ -18,14 +18,16 @@ infobox:
 see_also: [nxdn, frequency-shift-keying, ambe-plus-2, etsi, fdma]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "dPMR (Wikipedia)", url: https://en.wikipedia.org/wiki/DPMR }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/DPMR
 ---
 
 **dPMR** (**digital private mobile radio**) is an [ETSI](/reference/etsi/) narrowband
 standard using **6.25 kHz** [FDMA](/reference/fdma/) channels with
 [4FSK](/reference/frequency-shift-keying/) modulation. It is technically close to
-[NXDN](/reference/nxdn/) and serves the same low-cost, spectrum-efficient niche.
+[NXDN](/reference/nxdn/) and serves the same low-cost, spectrum-efficient niche.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 360 150" role="img" aria-label="Narrow 6.25 kHz FDMA channels for dPMR." xmlns="http://www.w3.org/2000/svg">
@@ -57,7 +59,7 @@ dPMR comes in licence-free (Mode 1) and licensed conventional/trunked variants. 
 ## History
 
 Standardised by ETSI in parallel with the narrowbanding push of the late 2000s as an
-open alternative for low-tier business radio.
+open alternative for low-tier business radio.[^wiki]
 
 ## Deployment
 
@@ -68,3 +70,7 @@ Used in European and international business radio; less common in North America 
 
 dPMR decodes similarly to NXDN given its shared narrowband 4FSK design. See
 [Status](/status.html).
+
+## Sources
+
+[^wiki]: [dPMR](https://en.wikipedia.org/wiki/DPMR) — Wikipedia, for the ETSI 6.25 kHz FDMA 4FSK standard and its relationship to NXDN.

--- a/docs/reference/dry-kiss-yagni.md
+++ b/docs/reference/dry-kiss-yagni.md
@@ -16,8 +16,8 @@ infobox:
 see_also: [solid, clean-code, refactoring, abstraction, coupling-and-cohesion, design-patterns]
 related_lessons:
   - { title: "DRY, KISS, YAGNI & separation of concerns", url: /learn/intro-software-dev/dry-kiss-yagni/ }
-external:
-  - { title: "Don't repeat yourself — Wikipedia", url: https://en.wikipedia.org/wiki/Don%27t_repeat_yourself }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Don%27t_repeat_yourself
 ---
 
 **DRY, KISS and YAGNI** are three of software's most-quoted design heuristics — short
@@ -38,11 +38,11 @@ speculative complexity.
 ## The three heuristics
 
 - **DRY — Don't Repeat Yourself.** Every piece of *knowledge* should have a single,
-  authoritative home. If a rule or constant appears in five places, a change means
+  authoritative home.[^wiki] If a rule or constant appears in five places, a change means
   editing all five — and missing one is a bug. The crucial nuance: DRY is about
   knowledge, not characters. Two snippets that look alike but encode different facts
   are not a violation, and merging them creates the "wrong abstraction," which Sandi
-  Metz noted is far costlier than duplication.
+  Metz noted is far costlier than duplication.[^wiki]
 - **KISS — Keep It Simple.** The simplest design that solves the *actual* problem is
   almost always best. Complexity is a cost you pay forever in comprehension and bugs.
   Match the complexity of the solution to the complexity of the problem, and not a
@@ -61,3 +61,7 @@ antidote to over-engineering and the foundation beneath [SOLID](/reference/solid
 Like all heuristics they are guidelines, not laws — the skill is knowing when *not* to
 apply them, such as resisting a premature [abstraction](/reference/abstraction/) on the
 first duplication.
+
+## Sources
+
+[^wiki]: [Don't repeat yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) — Wikipedia, for the DRY principle and the related KISS and YAGNI heuristics.

--- a/docs/reference/dsc.md
+++ b/docs/reference/dsc.md
@@ -18,15 +18,18 @@ infobox:
 see_also: [ais, ffsk, frequency-shift-keying, itu]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_selective_calling
 external:
-  - { title: "Digital selective calling (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_selective_calling }
   - { title: "GopherTrunk DSC decoder", url: /dsc.html }
 ---
 
 **DSC** (**Digital Selective Calling**) is a maritime protocol for **calling specific
 stations and broadcasting distress alerts**. Part of the Global Maritime Distress and
 Safety System (GMDSS), it sends short [FSK](/reference/frequency-shift-keying/) data
-bursts on **VHF channel 70** (156.525 MHz) and on HF.
+bursts on **VHF channel 70** (156.525 MHz) and on HF.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="A short Digital Selective Calling burst carrying a call type and the sender's maritime identity." xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +59,7 @@ automatically conveys identity and, if interfaced, GPS position. DSC complements
 ## History
 
 Standardised by the [ITU](/reference/itu/) and mandated within GMDSS from the 1990s to
-modernise distress alerting beyond voice calling.
+modernise distress alerting beyond voice calling.[^wiki]
 
 ## Deployment
 
@@ -66,3 +69,7 @@ SOLAS and recreational vessels, coast stations, and rescue coordination centres.
 
 GopherTrunk demodulates the FSK, applies the symbol-repetition error control, and
 decodes DSC messages. See the [DSC decoder](/dsc.html) page.
+
+## Sources
+
+[^wiki]: [Digital selective calling](https://en.wikipedia.org/wiki/Digital_selective_calling) — Wikipedia, for the maritime DSC protocol within GMDSS, VHF channel 70 signalling, MMSI addressing, and distress alerting.

--- a/docs/reference/dtmf.md
+++ b/docs/reference/dtmf.md
@@ -10,13 +10,13 @@ autolink: true
 see_also: [fast-fourier-transform, mdc1200]
 related_lessons:
   - { title: "Anatomy of a signal", url: /learn/rf-sdr/signal-anatomy/ }
-external:
-  - { title: "DTMF (Wikipedia)", url: https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling
 ---
 
 **DTMF** (**dual-tone multi-frequency**, "touch-tone") encodes each key as the **sum of
 two tones** — one from a low-frequency group (rows) and one from a high-frequency group
-(columns). Detecting which two tones are present identifies the digit. It appears as
+(columns).[^wiki] Detecting which two tones are present identifies the digit. It appears as
 in-band signalling on some radio systems.
 
 <figure class="figure" markdown="0">
@@ -40,3 +40,7 @@ in-band signalling on some radio systems.
 DTMF tones are detected with narrow band-pass filters or the **Goertzel algorithm** (an
 efficient single-frequency [DFT](/reference/fast-fourier-transform/)). GopherTrunk
 synthesises DTMF among other call-progress tones in its audio path.
+
+## Sources
+
+[^wiki]: [Dual-tone multi-frequency signaling](https://en.wikipedia.org/wiki/Dual-tone_multi-frequency_signaling) — Wikipedia, for the row/column tone-pair encoding of each keypad digit.

--- a/docs/reference/dvsi.md
+++ b/docs/reference/dvsi.md
@@ -14,14 +14,14 @@ infobox:
 see_also: [vocoder, imbe, ambe, ambe-plus-2, multi-band-excitation]
 related_lessons:
   - { title: "Vocoders — IMBE & AMBE+2", url: /learn/rf-sdr/vocoders/ }
-external:
-  - { title: "Digital Voice Systems (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Multi-Band_Excitation
 ---
 
 **Digital Voice Systems, Inc.** (**DVSI**) is the company that develops and licenses the
 [IMBE](/reference/imbe/) and [AMBE](/reference/ambe/) / [AMBE+2](/reference/ambe-plus-2/)
 [vocoder](/reference/vocoder/) families based on
-[multi-band excitation](/reference/multi-band-excitation/).
+[multi-band excitation](/reference/multi-band-excitation/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="DVSI develops and licenses the AMBE and IMBE vocoders used by digital systems." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +46,7 @@ is why open alternatives like [Codec 2](/reference/codec2/) exist.
 
 GopherTrunk implements the relevant vocoders in pure Go to decode digital voice, while
 respecting the patent/licensing landscape DVSI created.
+
+## Sources
+
+[^wiki]: [Multi-Band Excitation](https://en.wikipedia.org/wiki/Multi-Band_Excitation) — Wikipedia, on DVSI's IMBE/AMBE multi-band-excitation vocoders and their licensing.

--- a/docs/reference/edacs.md
+++ b/docs/reference/edacs.md
@@ -17,15 +17,17 @@ infobox:
 see_also: [trunked-radio, control-channel, motorola-type-ii, ltr, mpt-1327]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Enhanced Digital Access Communications System (Wikipedia)", url: https://en.wikipedia.org/wiki/Enhanced_Digital_Access_Communications_System }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Enhanced_Digital_Access_Communications_System
 ---
 
 **EDACS** (**Enhanced Digital Access Communications System**) is a
 [trunked-radio](/reference/trunked-radio/) system developed by GE/Ericsson (later
 M-A-COM). It uses a **dedicated [control channel](/reference/control-channel/)** that
 continuously coordinates the system, with analog FM voice or the digital **ProVoice**
-([AMBE](/reference/ambe/)) option.
+([AMBE](/reference/ambe/)) option.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 140" role="img" aria-label="EDACS dedicated control channel assigning analog or ProVoice channels." xmlns="http://www.w3.org/2000/svg">
@@ -55,7 +57,7 @@ competitor to [Motorola Type II](/reference/motorola-type-ii/).
 ## History
 
 Deployed from the 1980s by GE/Ericsson and M-A-COM for public-safety and utility
-fleets; gradually displaced by [P25](/reference/project-25/).
+fleets; gradually displaced by [P25](/reference/project-25/).[^wiki]
 
 ## Deployment
 
@@ -65,3 +67,7 @@ Legacy public-safety, utility, and transportation systems, some still operating.
 
 See the [Status](/status.html) page for GopherTrunk's EDACS coverage (control-channel
 following and supported voice modes).
+
+## Sources
+
+[^wiki]: [Enhanced Digital Access Communications System](https://en.wikipedia.org/wiki/Enhanced_Digital_Access_Communications_System) — Wikipedia, for the GE/Ericsson/M-A-COM EDACS trunking system, its dedicated control channel, and ProVoice digital option.

--- a/docs/reference/edwin-armstrong.md
+++ b/docs/reference/edwin-armstrong.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [frequency-modulation, superheterodyne-receiver, radio-wave]
 related_lessons:
   - { title: "Analog modulation — AM, FM, SSB", url: /learn/rf-sdr/analog-modulation/ }
-external:
-  - { title: "Edwin Howard Armstrong (Wikipedia)", url: https://en.wikipedia.org/wiki/Edwin_Howard_Armstrong }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Edwin_Howard_Armstrong
 ---
 
 **Edwin Armstrong** (1890–1954) was an American electrical engineer who invented several
-cornerstones of radio, most notably wide-band **[frequency modulation](/reference/frequency-modulation/)**.
+cornerstones of radio, most notably wide-band **[frequency modulation](/reference/frequency-modulation/)**.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="An FM waveform whose cycle spacing varies with the message at constant amplitude, contrasted with noisy AM." xmlns="http://www.w3.org/2000/svg">
@@ -34,7 +34,7 @@ cornerstones of radio, most notably wide-band **[frequency modulation](/referenc
 
 Armstrong devised the regenerative receiver, the
 [superheterodyne receiver](/reference/superheterodyne-receiver/) architecture still used
-today, and FM broadcasting, which dramatically improved audio quality and noise immunity.
+today, and FM broadcasting, which dramatically improved audio quality and noise immunity.[^wiki]
 
 ## Contribution
 
@@ -45,3 +45,7 @@ an SDR — and FM remains central to analog and digital voice.
 
 Armstrong's inventions shaped 20th-century radio; the superheterodyne is arguably the most
 important receiver architecture ever devised.
+
+## Sources
+
+[^wiki]: [Edwin Howard Armstrong](https://en.wikipedia.org/wiki/Edwin_Howard_Armstrong) — Wikipedia, for biography and his invention of FM and the superheterodyne receiver.

--- a/docs/reference/electromagnetic-spectrum.md
+++ b/docs/reference/electromagnetic-spectrum.md
@@ -14,15 +14,15 @@ infobox:
 see_also: [radio-wave, frequency, wavelength, frequency-bands]
 related_lessons:
   - { title: "What is a radio wave?", url: /learn/rf-sdr/radio-waves/ }
-external:
-  - { title: "Electromagnetic spectrum (Wikipedia)", url: https://en.wikipedia.org/wiki/Electromagnetic_spectrum }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Electromagnetic_spectrum
 ---
 
 The **electromagnetic spectrum** is the full range of electromagnetic radiation
 ordered by frequency (or, equivalently, wavelength). It spans from low-frequency
 [radio waves](/reference/radio-wave/) through microwaves, infrared, visible light,
 ultraviolet, X-rays, and gamma rays — all the same phenomenon vibrating at different
-rates.
+rates.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 480 110" role="img" aria-label="The electromagnetic spectrum from radio waves through microwaves, infrared, visible light, ultraviolet, X-rays and gamma rays, with the radio portion highlighted." xmlns="http://www.w3.org/2000/svg">
@@ -56,3 +56,7 @@ GHz**, which is slow enough that electronics can generate and detect it directly
 Software-defined radios operate within the radio portion of the spectrum. Where a
 signal sits in that range — its [band](/reference/frequency-bands/) — determines how it
 propagates, what antenna it needs, and what equipment can receive it.
+
+## Sources
+
+[^wiki]: [Electromagnetic spectrum](https://en.wikipedia.org/wiki/Electromagnetic_spectrum) — Wikipedia, overview of the full range of electromagnetic radiation.

--- a/docs/reference/end-to-end-testing.md
+++ b/docs/reference/end-to-end-testing.md
@@ -16,12 +16,14 @@ infobox:
 see_also: [unit-testing, integration-testing, mocking, code-coverage, test-driven-development, ci-cd, rest]
 related_lessons:
   - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
-external:
-  - { title: "System testing — Wikipedia", url: https://en.wikipedia.org/wiki/System_testing }
+related_reading:
+  - { title: "Build in the Open, Part 8: Testing — how to build and write tests", url: /blog/tutorials/build-in-the-open-08-testing-how-to-write-tests/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/System_testing
 ---
 
 **End-to-end (E2E) testing** drives the whole system the way a user would, from input
-all the way to final output — the highest-confidence test, but slow and kept few.
+all the way to final output — the highest-confidence test, but slow and kept few.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A test exercises the full path from user input through the running system to the final output." xmlns="http://www.w3.org/2000/svg">
@@ -46,7 +48,7 @@ flow: it submits real input, lets the request travel through every layer — fro
 backend, [API](/reference/api/), database, external services — and asserts on the final
 result. Because nothing is stubbed, a passing E2E test is strong evidence the product
 *actually works* the way a user will experience it, including the integration points that
-unit and integration tests can miss.
+unit and integration tests can miss.[^wiki]
 
 ## The trade-off
 
@@ -68,3 +70,7 @@ before release rather than on every commit, and even an E2E suite may use
 contribute to [code coverage](/reference/code-coverage/) but are no substitute for sharp,
 well-asserted checks lower down, and they can be written test-first in the
 [TDD](/reference/test-driven-development/) spirit.
+
+## Sources
+
+[^wiki]: [System testing](https://en.wikipedia.org/wiki/System_testing) — Wikipedia, on testing a complete, integrated system end to end as a user would.

--- a/docs/reference/error-handling.md
+++ b/docs/reference/error-handling.md
@@ -16,13 +16,13 @@ infobox:
 see_also: [api, clean-code, solid, unit-testing, rest, type-system]
 related_lessons:
   - { title: "Errors, edge cases & defensive programming", url: /learn/intro-software-dev/robustness-and-errors/ }
-external:
-  - { title: "Exception handling — Wikipedia", url: https://en.wikipedia.org/wiki/Exception_handling }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Exception_handling
 ---
 
 **Error handling** is the part of a program's design that deals with failures, treating
 errors as a normal, first-class part of the system rather than an exceptional
-afterthought bolted on at the end.
+afterthought bolted on at the end.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="An operation branches into a success path and an error path; the error path either fails fast or fails soft." xmlns="http://www.w3.org/2000/svg">
@@ -45,7 +45,7 @@ Languages represent and propagate errors differently, and each style has trade-o
 
 - **Exceptions** (Java, Python, C#) are thrown and unwind the stack until caught.
   Convenient, but easy to ignore — an uncaught exception crashes the program, and a
-  signature doesn't reveal what it might throw.
+  signature doesn't reveal what it might throw.[^wiki]
 - **Explicit error returns** (Go) return an error value alongside the result; the
   caller must decide what to do. Verbose, but the error path is impossible to overlook.
 - **Result / Option types** (Rust, many functional languages) make errors part of the
@@ -67,3 +67,7 @@ functionality on expected, recoverable trouble). Make retry-able operations
 ideas shape how an [API](/reference/api/) or a [REST](/reference/rest/) service reports
 problems to its callers, and they are only trustworthy when proven under bad inputs —
 which is the job of [tests](/reference/unit-testing/).
+
+## Sources
+
+[^wiki]: [Exception handling](https://en.wikipedia.org/wiki/Exception_handling) — Wikipedia, on error and exception handling styles and the trade-offs between them.

--- a/docs/reference/etsi.md
+++ b/docs/reference/etsi.md
@@ -14,14 +14,15 @@ infobox:
 see_also: [dmr, dpmr, tetra, itu]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "ETSI (Wikipedia)", url: https://en.wikipedia.org/wiki/ETSI }
+cite_urls:
+  - https://www.etsi.org/
+  - https://en.wikipedia.org/wiki/ETSI
 ---
 
 **ETSI** (the **European Telecommunications Standards Institute**) is an independent,
-not-for-profit standards organization whose work is used worldwide. In land-mobile radio
+not-for-profit standards organization whose work is used worldwide.[^home] In land-mobile radio
 it authored [DMR](/reference/dmr/), [dPMR](/reference/dpmr/), and
-[TETRA](/reference/tetra/).
+[TETRA](/reference/tetra/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="ETSI publishes standards that radio systems implement." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +46,8 @@ part of why DMR became so widespread and inexpensive.
 
 Several digital systems GopherTrunk decodes are ETSI standards, and their published
 specifications inform how decoders are built.
+
+## Sources
+
+[^home]: [ETSI](https://www.etsi.org/) — the institute's official site, where its telecommunications standards are published.
+[^wiki]: [ETSI](https://en.wikipedia.org/wiki/ETSI) — Wikipedia, for ETSI's role and its DMR, dPMR, and TETRA standards.

--- a/docs/reference/eurocae.md
+++ b/docs/reference/eurocae.md
@@ -10,14 +10,14 @@ autolink: true
 see_also: [ads-b, mode-s, rtca, icao]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "EUROCAE (Wikipedia)", url: https://en.wikipedia.org/wiki/EUROCAE }
+cite_urls:
+  - https://en.wikipedia.org/wiki/EUROCAE
 ---
 
 **EUROCAE** (the European Organisation for Civil Aviation Equipment) is the European
 standards body for **aviation electronics**. Its **ED-102** series mirrors
 [RTCA](/reference/rtca/)'s DO-260 [ADS-B](/reference/ads-b/) requirements for use in
-Europe, under the umbrella of [ICAO](/reference/icao/).
+Europe, under the umbrella of [ICAO](/reference/icao/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="EUROCAE publishing the ED-102 standard, the European counterpart to RTCA's DO-260 for ADS-B." xmlns="http://www.w3.org/2000/svg">
@@ -37,3 +37,7 @@ Europe, under the umbrella of [ICAO](/reference/icao/).
 
 ED-102A and DO-260B are effectively harmonised, so an ADS-B decoder built to one works
 with the other; documentation often cites both.
+
+## Sources
+
+[^wiki]: [EUROCAE](https://en.wikipedia.org/wiki/EUROCAE) — Wikipedia, on EUROCAE and its ED-102 ADS-B standards, the European counterpart to RTCA's DO-260.

--- a/docs/reference/eye-diagram.md
+++ b/docs/reference/eye-diagram.md
@@ -15,13 +15,13 @@ see_also: [constellation-diagram, clock-recovery, symbol-rate, c4fm]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
   - { title: "Tuning for a clean lock", url: /learn/rf-sdr/tuning-with-scopes/ }
-external:
-  - { title: "Eye pattern (Wikipedia)", url: https://en.wikipedia.org/wiki/Eye_pattern }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Eye_pattern
 ---
 
 An **eye diagram** overlays many short segments of a demodulated signal, each one
 symbol period long, so they stack into characteristic "eye" shapes between the symbol
-levels.
+levels.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 440 150" role="img" aria-label="An eye diagram with an open eye shape and a dashed vertical line marking the ideal sampling instant at its widest point." xmlns="http://www.w3.org/2000/svg">
@@ -47,3 +47,7 @@ each [symbol](/reference/symbol-rate/) correctly. Noise and timing
 
 GopherTrunk's eye-diagram panel shows timing and noise margin at a glance, complementing
 the [constellation](/reference/constellation-diagram/) for diagnosing a marginal signal.
+
+## Sources
+
+[^wiki]: [Eye pattern](https://en.wikipedia.org/wiki/Eye_pattern) — Wikipedia, for the overlaid-symbol-period display and what an open eye indicates.

--- a/docs/reference/fast-fourier-transform.md
+++ b/docs/reference/fast-fourier-transform.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [fourier-transform, bandwidth, sample-rate, iq-data]
 related_lessons:
   - { title: "The FFT & reading a waterfall", url: /learn/rf-sdr/fft-and-waterfall/ }
-external:
-  - { title: "Fast Fourier transform (Wikipedia)", url: https://en.wikipedia.org/wiki/Fast_Fourier_transform }
+related_reading:
+  - { title: "SDR Internals, Part 8: Equalization, diversity & the FFT", url: /blog/deep-dives/sdr-internals-08-equalization-diversity-fft/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Fast_Fourier_transform
 ---
 
 The **fast Fourier transform** (**FFT**) is an efficient algorithm for computing the
 discrete [Fourier transform](/reference/fourier-transform/), reducing the work enough to
-run many times a second in real time.
+run many times a second in real time.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A block of time samples feeding an FFT block that outputs a row of frequency bins." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +48,7 @@ finer resolution but slower updates and more CPU.
 
 The FFT drives the spectrum and waterfall displays used to find signals and spot a steady
 [control channel](/reference/control-channel/).
+
+## Sources
+
+[^wiki]: [Fast Fourier transform](https://en.wikipedia.org/wiki/Fast_Fourier_transform) — Wikipedia, for the algorithm and its efficiency over the direct DFT.

--- a/docs/reference/fcc.md
+++ b/docs/reference/fcc.md
@@ -15,13 +15,14 @@ see_also: [itu, tia, apco-international, frequency-bands]
 related_lessons:
   - { title: "Frequency, bands & the spectrum", url: /learn/rf-sdr/frequency-and-spectrum/ }
   - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
-external:
-  - { title: "Federal Communications Commission (Wikipedia)", url: https://en.wikipedia.org/wiki/Federal_Communications_Commission }
+cite_urls:
+  - https://www.fcc.gov/
+  - https://en.wikipedia.org/wiki/Federal_Communications_Commission
 ---
 
 The **Federal Communications Commission** (**FCC**) is the United States regulator of
-interstate radio, television, wire, satellite, and cable. It allocates US spectrum,
-licenses users, and sets technical rules.
+interstate radio, television, wire, satellite, and cable.[^wiki] It allocates US spectrum,
+licenses users, and sets technical rules.[^home]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="The FCC dividing the US radio spectrum into allocated service blocks." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +46,8 @@ helped push land-mobile radio toward efficient digital systems.
 
 US monitoring laws and band allocations stem from the FCC; what you may legally receive
 varies by jurisdiction (see the legal lesson).
+
+## Sources
+
+[^home]: [Federal Communications Commission](https://www.fcc.gov/) — the FCC's official site, for US spectrum allocation, licensing, and rules.
+[^wiki]: [Federal Communications Commission](https://en.wikipedia.org/wiki/Federal_Communications_Commission) — Wikipedia, for the agency's history and remit.

--- a/docs/reference/fdma.md
+++ b/docs/reference/fdma.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [tdma, trunked-radio, p25-phase-1, nxdn]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Frequency-division multiple access (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-division_multiple_access }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Frequency-division_multiple_access
 ---
 
 **FDMA** (**frequency-division multiple access**) is a channel-access method in which
-each call occupies its own [frequency](/reference/frequency/) channel.
+each call occupies its own [frequency](/reference/frequency/) channel.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 300 200" role="img" aria-label="A frequency axis split into separate stacked channels, each carrying one continuous call." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +47,7 @@ adding channels. [P25 Phase 1](/reference/p25-phase-1/), [NXDN](/reference/nxdn/
 On an FDMA system each [voice channel](/reference/voice-channel/) is a separate
 frequency the receiver tunes to; contrast with [TDMA](/reference/tdma/), which shares one
 frequency across time slots.
+
+## Sources
+
+[^wiki]: [Frequency-division multiple access](https://en.wikipedia.org/wiki/Frequency-division_multiple_access) — Wikipedia, on the one-call-per-frequency access method.

--- a/docs/reference/ffsk.md
+++ b/docs/reference/ffsk.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [afsk, frequency-shift-keying, mdc1200, dsc, mpt-1327]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "Frequency-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-shift_keying }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Frequency-shift_keying
 ---
 
 **FFSK** (fast frequency-shift keying) is a coherent form of audio
 [FSK](/reference/frequency-shift-keying/) in which the mark and space tones are exact
-integer multiples of the bit rate, so each bit contains a whole number of cycles. This
+integer multiples of the bit rate, so each bit contains a whole number of cycles.[^wiki] This
 makes detection clean and bit timing easy.
 
 <figure class="figure" markdown="0">
@@ -44,3 +44,7 @@ and [MPT 1327](/reference/mpt-1327/) control signalling, typically at 1200 bps.
 
 GopherTrunk detects FFSK bursts on analog channels to decode signalling such as PTT
 IDs and trunking control data.
+
+## Sources
+
+[^wiki]: [Frequency-shift keying](https://en.wikipedia.org/wiki/Frequency-shift_keying) — Wikipedia, for coherent/fast FSK and continuous-phase tone signalling.

--- a/docs/reference/fir-filter.md
+++ b/docs/reference/fir-filter.md
@@ -10,13 +10,15 @@ autolink: true
 see_also: [digital-filter, iir-filter, decimation, matched-filter, root-raised-cosine-filter]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Finite impulse response (Wikipedia)", url: https://en.wikipedia.org/wiki/Finite_impulse_response }
+related_reading:
+  - { title: "SDR Internals, Part 4: DSP foundations — filters, NCO & AGC", url: /blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Finite_impulse_response
 ---
 
 A **FIR** (**finite impulse response**) filter produces each output sample as a
 **weighted sum of the most recent input samples** — a tapped delay line multiplied by a
-set of coefficients (taps). It is the most common [digital filter](/reference/digital-filter/)
+set of coefficients (taps).[^wiki] It is the most common [digital filter](/reference/digital-filter/)
 in SDR because it is always stable and can have exactly linear phase.
 
 <figure class="figure" markdown="0">
@@ -38,3 +40,7 @@ in SDR because it is always stable and can have exactly linear phase.
 FIR filters are used for channel selection, [pulse shaping](/reference/pulse-shaping/),
 and as the anti-alias filter before [decimation](/reference/decimation/). Their
 coefficients directly define the [frequency response](/reference/digital-filter/).
+
+## Sources
+
+[^wiki]: [Finite impulse response](https://en.wikipedia.org/wiki/Finite_impulse_response) — Wikipedia, on the non-recursive, always-stable filter and its linear phase.

--- a/docs/reference/flex.md
+++ b/docs/reference/flex.md
@@ -17,15 +17,17 @@ infobox:
 see_also: [pocsag, frequency-shift-keying, bch-code, interleaving]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "FLEX (Wikipedia)", url: https://en.wikipedia.org/wiki/FLEX_(protocol) }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/FLEX_(protocol)
 ---
 
 **FLEX** is a high-speed one-way **paging** protocol developed by **Motorola** to
 succeed [POCSAG](/reference/pocsag/). It uses 2- or 4-level
 [FSK](/reference/frequency-shift-keying/) at up to 6400 bps, with robust
 synchronisation and [interleaving](/reference/interleaving/) that make it resilient on
-wide-area simulcast networks.
+wide-area simulcast networks.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="A FLEX frame with sync and time-multiplexed blocks, at higher rates than POCSAG." xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +58,7 @@ simulcast paging systems covering whole regions.
 ## History
 
 Introduced by Motorola in the 1990s as paging demand outgrew POCSAG's capacity; widely
-deployed by commercial paging carriers.
+deployed by commercial paging carriers.[^wiki]
 
 ## Deployment
 
@@ -66,3 +68,7 @@ Commercial wide-area paging, healthcare, and emergency notification networks.
 
 FLEX shares the FSK paging family with POCSAG; see [Status](/status.html) for current
 coverage and the [POCSAG decoder](/pocsag.html) page for the paging pipeline.
+
+## Sources
+
+[^wiki]: [FLEX](https://en.wikipedia.org/wiki/FLEX_(protocol)) — Wikipedia, for Motorola's high-speed paging protocol, its multi-level FSK rates, and time-synchronised framing.

--- a/docs/reference/fortran-language.md
+++ b/docs/reference/fortran-language.md
@@ -19,14 +19,16 @@ see_also: [cobol-language, lisp-language, c-language, julia-language, compiler, 
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "The birth of programming languages", url: /learn/intro-software-dev/birth-of-languages/ }
-external:
-  - { title: "Fortran — Wikipedia", url: https://en.wikipedia.org/wiki/Fortran }
-  - { title: "Fortran programming language", url: https://fortran-lang.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://fortran-lang.org/
+  - https://en.wikipedia.org/wiki/Fortran
 ---
 
 **FORTRAN** (FORmula TRANslation), introduced by IBM in 1957, was the first widely
-used high-level language. Built so scientists could write formulas almost as they
-appear on paper, its descendants still dominate high-performance numerical computing.
+used high-level language.[^wiki] Built so scientists could write formulas almost as they
+appear on paper, its descendants still dominate high-performance numerical computing.[^home]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="A mathematical formula is written as FORTRAN source, compiled to native code, and run as fast numerical computation." xmlns="http://www.w3.org/2000/svg">
@@ -54,7 +56,7 @@ high-level languages were practical, opening the door to every language that fol
 
 FORTRAN is [statically typed](/reference/type-system/), compiled to native code, and
 [imperative](/reference/imperative-programming/) and array-oriented in style, with no
-[garbage collector](/reference/garbage-collection/). Decades of mature, heavily
+[garbage collector](/reference/garbage-collection/).[^wiki] Decades of mature, heavily
 optimised numerical libraries are written in it, and it remains in active use across
 weather modelling, physics, and high-performance computing where raw numeric
 throughput matters. Its drawbacks are those of its age: the language and much existing
@@ -63,3 +65,8 @@ general-purpose language. Newer numeric languages like [Julia](/reference/julia-
 court its users, while [C](/reference/c-language/) became the more general
 systems-and-DSP workhorse. It shares the early-language stage with
 [COBOL](/reference/cobol-language/) and [LISP](/reference/lisp-language/).
+
+## Sources
+
+[^home]: [Fortran programming language](https://fortran-lang.org/) — official community site, documentation, and the modern Fortran ecosystem.
+[^wiki]: [Fortran](https://en.wikipedia.org/wiki/Fortran) — Wikipedia, for history, the 1957 origin, and the compiled, statically typed design.

--- a/docs/reference/forward-error-correction.md
+++ b/docs/reference/forward-error-correction.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [reed-solomon-code, bch-code, golay-code, hamming-code, convolutional-code, interleaving]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Forward error correction (Wikipedia)", url: https://en.wikipedia.org/wiki/Error_correction_code }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Error_correction_code
 ---
 
 **Forward error correction** (**FEC**) adds structured redundancy to transmitted data so
 the receiver can **correct** errors on its own, without asking for retransmission —
-essential for broadcast and one-way radio links.
+essential for broadcast and one-way radio links.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="Data plus added redundancy is transmitted; a bit is flipped in transit, and the receiver corrects it without retransmission." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +48,7 @@ a bounded number of errors, often aided by [interleaving](/reference/interleavin
 
 FEC is why a digital signal stays perfect until it abruptly fails (the "cliff effect"):
 the decoder fixes errors until it can't, after which audio drops out.
+
+## Sources
+
+[^wiki]: [Error correction code](https://en.wikipedia.org/wiki/Error_correction_code) — Wikipedia, for adding redundancy so the receiver corrects errors without retransmission.

--- a/docs/reference/fourier-transform.md
+++ b/docs/reference/fourier-transform.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [fast-fourier-transform, joseph-fourier, bandwidth, software-defined-radio]
 related_lessons:
   - { title: "The FFT & reading a waterfall", url: /learn/rf-sdr/fft-and-waterfall/ }
-external:
-  - { title: "Fourier transform (Wikipedia)", url: https://en.wikipedia.org/wiki/Fourier_transform }
+related_reading:
+  - { title: "SDR Internals, Part 8: Equalization, diversity & the FFT", url: /blog/deep-dives/sdr-internals-08-equalization-diversity-fft/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Fourier_transform
 ---
 
 The **Fourier transform** decomposes a signal into the frequencies that compose it,
-converting between the time and frequency domains. It is the mathematical foundation of
+converting between the time and frequency domains.[^wiki] It is the mathematical foundation of
 spectrum analysis, named for [Joseph Fourier](/reference/joseph-fourier/).
 
 <figure class="figure" markdown="0">
@@ -45,3 +47,7 @@ exists at each frequency. Its discrete, efficient form is the
 
 Turning [IQ](/reference/iq-data/) samples into a spectrum — and thus a waterfall — is a
 Fourier transform, the reason you can *see* signals on an SDR.
+
+## Sources
+
+[^wiki]: [Fourier transform](https://en.wikipedia.org/wiki/Fourier_transform) — Wikipedia, for the mathematical definition and time/frequency-domain background.

--- a/docs/reference/fred-gardner.md
+++ b/docs/reference/fred-gardner.md
@@ -10,13 +10,13 @@ autolink: true
 see_also: [gardner-timing-recovery, clock-recovery, mueller-muller-timing-recovery]
 related_lessons:
   - { title: "Clock recovery & symbol timing", url: /learn/rf-sdr/clock-recovery/ }
-external:
-  - { title: "Floyd M. Gardner (Wikipedia)", url: https://en.wikipedia.org/wiki/Floyd_M._Gardner }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Floyd_M._Gardner
 ---
 
 **Floyd M. Gardner** was an engineer and author whose work on phase-locked loops — and
 the **[Gardner timing-error detector](/reference/gardner-timing-recovery/)** — underpins
-modern digital **symbol-timing recovery**. His book *Phaselock Techniques* is a standard
+modern digital **symbol-timing recovery**.[^wiki] His book *Phaselock Techniques* is a standard
 reference.
 
 <figure class="figure" markdown="0">
@@ -32,3 +32,7 @@ reference.
 
 The Gardner detector is prized because it works without carrier phase lock, making it a
 common choice in SDR demodulators (it features in several GopherTrunk decoders).
+
+## Sources
+
+[^wiki]: [Floyd M. Gardner](https://en.wikipedia.org/wiki/Floyd_M._Gardner) — Wikipedia, for biography and his work on phase-locked loops and timing recovery.

--- a/docs/reference/frequency-bands.md
+++ b/docs/reference/frequency-bands.md
@@ -15,13 +15,13 @@ infobox:
 see_also: [electromagnetic-spectrum, frequency, radio-propagation, ionospheric-propagation]
 related_lessons:
   - { title: "Frequency, bands & the spectrum", url: /learn/rf-sdr/frequency-and-spectrum/ }
-external:
-  - { title: "Radio spectrum (Wikipedia)", url: https://en.wikipedia.org/wiki/Radio_spectrum }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Radio_spectrum
 ---
 
 **Frequency bands** are the conventional decade-wide divisions of the radio
 [spectrum](/reference/electromagnetic-spectrum/): VLF, LF, MF, **HF** (3–30 MHz),
-**VHF** (30–300 MHz), **UHF** (300 MHz–3 GHz), and SHF (3–30 GHz). Each behaves
+**VHF** (30–300 MHz), **UHF** (300 MHz–3 GHz), and SHF (3–30 GHz).[^wiki] Each behaves
 differently and is allocated to different uses.
 
 <figure class="figure" markdown="0">
@@ -56,3 +56,7 @@ assigning slices to broadcast, aviation, marine, public safety, and amateur use.
 
 Most trunked-radio scanning happens in VHF, UHF, and the 700/800 MHz bands. Matching
 an SDR's tuning range to the target band is the first hardware decision.
+
+## Sources
+
+[^wiki]: [Radio spectrum](https://en.wikipedia.org/wiki/Radio_spectrum) — Wikipedia, for the conventional band divisions and their frequency ranges.

--- a/docs/reference/frequency-modulation.md
+++ b/docs/reference/frequency-modulation.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [modulation, amplitude-modulation, single-sideband, frequency-shift-keying]
 related_lessons:
   - { title: "Analog modulation — AM, FM, SSB", url: /learn/rf-sdr/analog-modulation/ }
-external:
-  - { title: "Frequency modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency_modulation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Frequency_modulation
 ---
 
 **Frequency modulation** (**FM**) encodes information by varying a
 [carrier](/reference/carrier-wave/)'s [frequency](/reference/frequency/) while its
-[amplitude](/reference/amplitude/) stays constant. The amount of swing is the
+[amplitude](/reference/amplitude/) stays constant.[^wiki] The amount of swing is the
 *deviation*.
 
 <figure class="figure" markdown="0">
@@ -42,3 +42,7 @@ signal dominates a channel.
 FM broadcast (wide deviation) and narrowband FM two-way voice are everywhere; the
 latter is the analog cousin of the digital [FSK](/reference/frequency-shift-keying/)
 voice modes GopherTrunk decodes.
+
+## Sources
+
+[^wiki]: [Frequency modulation](https://en.wikipedia.org/wiki/Frequency_modulation) — Wikipedia, for the definition, deviation, and the capture effect.

--- a/docs/reference/frequency-shift-keying.md
+++ b/docs/reference/frequency-shift-keying.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [phase-shift-keying, quadrature-amplitude-modulation, c4fm, gmsk, afsk, ffsk, symbol-rate]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "Frequency-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-shift_keying }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Frequency-shift_keying
 ---
 
 **Frequency-shift keying** (**FSK**) is digital [modulation](/reference/modulation/)
 that switches a [carrier](/reference/carrier-wave/) between a fixed set of frequencies,
-one per [symbol](/reference/symbol-rate/). Two frequencies gives 2FSK; four gives 4FSK.
+one per [symbol](/reference/symbol-rate/).[^wiki] Two frequencies gives 2FSK; four gives 4FSK.
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A bit stream above, and below it a carrier that switches between a low frequency for zeros and a high frequency for ones." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +48,7 @@ symbol and is the workhorse of digital land-mobile voice — [C4FM](/reference/c
 An FSK demodulator tracks instantaneous frequency; the resulting symbol levels appear
 on the [symbol scope](/reference/eye-diagram/) and as clusters on a
 [constellation](/reference/constellation-diagram/).
+
+## Sources
+
+[^wiki]: [Frequency-shift keying](https://en.wikipedia.org/wiki/Frequency-shift_keying) — Wikipedia, for the definition and the 2FSK/4FSK variants.

--- a/docs/reference/frequency.md
+++ b/docs/reference/frequency.md
@@ -13,12 +13,12 @@ see_also: [wavelength, frequency-bands, electromagnetic-spectrum, radio-wave]
 related_lessons:
   - { title: "What is a radio wave?", url: /learn/rf-sdr/radio-waves/ }
   - { title: "Frequency, bands & the spectrum", url: /learn/rf-sdr/frequency-and-spectrum/ }
-external:
-  - { title: "Frequency (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Frequency
 ---
 
 **Frequency** is the number of cycles a periodic wave completes each second, measured
-in **hertz (Hz)**. For a [radio wave](/reference/radio-wave/) it is the quantity you
+in **hertz (Hz)**.[^wiki] For a [radio wave](/reference/radio-wave/) it is the quantity you
 tune to, and it is inversely related to [wavelength](/reference/wavelength/).
 
 <figure class="figure" markdown="0">
@@ -43,3 +43,7 @@ frequency*.
 Tuning an SDR sets the centre frequency its [local oscillator](/reference/local-oscillator/)
 mixes down to baseband. The chosen frequency, within a [band](/reference/frequency-bands/),
 determines what signal you receive.
+
+## Sources
+
+[^wiki]: [Frequency](https://en.wikipedia.org/wiki/Frequency) — Wikipedia, definition, the hertz unit, and the relationship to period and wavelength.

--- a/docs/reference/functional-programming.md
+++ b/docs/reference/functional-programming.md
@@ -17,13 +17,13 @@ infobox:
 see_also: [imperative-programming, declarative-programming, object-oriented-programming, abstraction, concurrency, lisp-language, python-language]
 related_lessons:
   - { title: "Paradigms & language families", url: /learn/intro-software-dev/language-families/ }
-external:
-  - { title: "Functional programming — Wikipedia", url: https://en.wikipedia.org/wiki/Functional_programming }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Functional_programming
 ---
 
 **Functional programming** (**FP**) treats computation as the evaluation of functions,
 ideally **pure** ones — functions that always return the same output for the same input
-and have no side effects.
+and have no side effects.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Input data flows through a chain of pure functions — map, filter, reduce — each producing a new value without mutating shared state." xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +48,7 @@ and have no side effects.
 Pure functions are easy to test, reason about, and run in parallel, because they cannot
 interfere with each other. FP favours **immutable data**, **higher-order functions**
 (functions that take or return other functions), and composing small transformations
-into pipelines — `map`, `filter`, and `reduce` are its everyday vocabulary. Because pure
+into pipelines — `map`, `filter`, and `reduce` are its everyday vocabulary.[^wiki] Because pure
 code has no hidden state to corrupt, it sidesteps an entire class of bugs and meshes well
 with [concurrency](/reference/concurrency/).
 
@@ -69,4 +69,8 @@ functional, while Clojure, Elixir, and Scala lean functional. Most mainstream la
 [JavaScript](/reference/javascript-language/), and others — now offer functional tools
 alongside [object-oriented](/reference/object-oriented-programming/) features, so the
 paradigm is usually a style you choose per piece of code rather than a whole language you
-adopt.
+adopt.[^wiki]
+
+## Sources
+
+[^wiki]: [Functional programming](https://en.wikipedia.org/wiki/Functional_programming) — Wikipedia, for the definition, pure functions and immutability, and the map/filter/reduce vocabulary.

--- a/docs/reference/garbage-collection.md
+++ b/docs/reference/garbage-collection.md
@@ -18,13 +18,13 @@ see_also: [memory-management, static-binary, compiler, go-language, java-languag
 related_lessons:
   - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Garbage collection (computer science) — Wikipedia", url: https://en.wikipedia.org/wiki/Garbage_collection_(computer_science) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)
 ---
 
 **Garbage collection** (**GC**) is a form of automatic [memory management](/reference/memory-management/)
 in which the language runtime reclaims memory the program can no longer reach, so the
-programmer never has to free it by hand.
+programmer never has to free it by hand.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Root references reach some heap objects, which the collector keeps; objects with no path from the roots are unreachable and reclaimed." xmlns="http://www.w3.org/2000/svg">
@@ -49,13 +49,13 @@ following references from a set of *roots* (stack variables, globals, registers)
 Anything with no path from the roots is garbage and its memory is reclaimed. Common
 strategies include **mark-and-sweep** (mark reachable objects, sweep the rest),
 **generational** collection (collect short-lived objects more often), and
-**reference counting** (track how many references point at each object).
+**reference counting** (track how many references point at each object).[^wiki]
 
 ## Trade-offs
 
 GC eliminates entire classes of bugs that plague manual memory code — use-after-free,
 double-free, and many memory leaks — and removes a great deal of boilerplate. The price
-is runtime overhead and occasional pauses (historically "stop-the-world" collections),
+is runtime overhead and occasional pauses (historically "stop-the-world" collections),[^wiki]
 which is why latency-sensitive and systems languages such as [C](/reference/c-language/)
 and [C++](/reference/cpp-language/) leave memory to the programmer, and why
 [Rust](/reference/rust-language/) achieves safety at compile time without a collector
@@ -67,3 +67,7 @@ Most mainstream languages are garbage-collected, including [Go](/reference/go-la
 [Java](/reference/java-language/), [Python](/reference/python-language/), and C#. Their
 collectors have grown sophisticated enough that GC pauses are a non-issue for the vast
 majority of applications.
+
+## Sources
+
+[^wiki]: [Garbage collection (computer science)](https://en.wikipedia.org/wiki/Garbage_collection_(computer_science)) — Wikipedia, on reachability-based reclamation, collection strategies, and the overhead/pause trade-offs.

--- a/docs/reference/gardner-timing-recovery.md
+++ b/docs/reference/gardner-timing-recovery.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [clock-recovery, mueller-muller-timing-recovery, symbol-rate, demodulation]
 related_lessons:
   - { title: "Clock recovery & symbol timing", url: /learn/rf-sdr/clock-recovery/ }
-external:
-  - { title: "Gardner (timing recovery) (Wikipedia)", url: https://en.wikipedia.org/wiki/Symbol_synchronization }
+related_reading:
+  - { title: "SDR Internals, Part 7: Symbol timing & sync recovery", url: /blog/deep-dives/sdr-internals-07-symbol-timing-sync-recovery/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Symbol_synchronization
 ---
 
 **Gardner timing recovery** is a feedback algorithm that estimates
 [symbol-timing](/reference/clock-recovery/) error using samples at the symbol and
-half-symbol instants. A useful property is that it works **independently of carrier
+half-symbol instants.[^wiki] A useful property is that it works **independently of carrier
 phase**.
 
 <figure class="figure" markdown="0">
@@ -43,3 +45,7 @@ widest, tracking small clock drift.
 
 Gardner recovery is a common choice in SDR demodulators for locking symbol timing on PSK
 and QAM signals.
+
+## Sources
+
+[^wiki]: [Symbol synchronization](https://en.wikipedia.org/wiki/Symbol_synchronization) — Wikipedia, for symbol-timing recovery including the Gardner timing-error detector.

--- a/docs/reference/gfsk.md
+++ b/docs/reference/gfsk.md
@@ -10,13 +10,15 @@ autolink: true
 see_also: [frequency-shift-keying, gmsk, pulse-shaping, ais]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "Frequency-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency-shift_keying#Gaussian_frequency-shift_keying }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Frequency-shift_keying#Gaussian_frequency-shift_keying
 ---
 
 **GFSK** (**Gaussian frequency-shift keying**) is [frequency-shift keying](/reference/frequency-shift-keying/)
 in which the data is passed through a **Gaussian filter** before it shifts the carrier,
-rounding off the otherwise abrupt frequency steps. This smoothing narrows the
+rounding off the otherwise abrupt frequency steps.[^wiki] This smoothing narrows the
 transmitted spectrum, so GFSK fits more signals into less bandwidth.
 
 <figure class="figure" markdown="0">
@@ -39,3 +41,7 @@ modulation index). It is widely used where spectral efficiency matters at low co
 
 For SDR decoding, GFSK is handled like other FSK with a matched filter tuned to the
 Gaussian pulse shape, followed by [symbol-timing recovery](/reference/clock-recovery/).
+
+## Sources
+
+[^wiki]: [Frequency-shift keying — Gaussian frequency-shift keying](https://en.wikipedia.org/wiki/Frequency-shift_keying#Gaussian_frequency-shift_keying) — Wikipedia, for the Gaussian-filtered FSK definition.

--- a/docs/reference/gmsk.md
+++ b/docs/reference/gmsk.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [frequency-shift-keying, ais, d-star, root-raised-cosine-filter]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "Minimum-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Minimum-shift_keying }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Minimum-shift_keying
 ---
 
 **GMSK** (Gaussian minimum-shift keying) is a continuous-phase
 [FSK](/reference/frequency-shift-keying/) variant in which the data is passed through a
 Gaussian filter before modulation, smoothing phase transitions for a **compact
-spectrum** and constant envelope.
+spectrum** and constant envelope.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A smooth continuous phase trajectory with no abrupt jumps, illustrating Gaussian-filtered MSK." xmlns="http://www.w3.org/2000/svg">
@@ -42,3 +44,7 @@ limits bandwidth. These traits made GMSK the choice for GSM cellular and for
 
 A GMSK demodulator recovers the underlying frequency/phase transitions; GopherTrunk
 uses one in its AIS pipeline.
+
+## Sources
+
+[^wiki]: [Minimum-shift keying](https://en.wikipedia.org/wiki/Minimum-shift_keying) — Wikipedia, for MSK/GMSK, Gaussian shaping, and the constant-envelope property.

--- a/docs/reference/go-language.md
+++ b/docs/reference/go-language.md
@@ -21,14 +21,17 @@ related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
   - { title: "Concurrency models", url: /learn/intro-software-dev/concurrency-models/ }
-external:
-  - { title: "Go (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Go_(programming_language) }
-  - { title: "The Go programming language", url: https://go.dev/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://go.dev/ref/spec
+  - https://go.dev/
+  - https://en.wikipedia.org/wiki/Go_(programming_language)
 ---
 
 **Go** (often called **Golang** after its website) is a statically typed, compiled
 programming language created at Google for building simple, reliable, and efficient
-systems software. GopherTrunk itself is written in Go.
+systems software.[^wiki] GopherTrunk itself is written in Go.
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Source files compile ahead of time into one static binary that runs many concurrent goroutines communicating over a channel." xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +53,7 @@ systems software. GopherTrunk itself is written in Go.
 ## Overview
 
 Go pairs the performance of a [compiled](/reference/compiler/) language with the
-simplicity of a deliberately small syntax. Programs build [ahead of time](/reference/jit-compilation/)
+simplicity of a deliberately small syntax.[^spec] Programs build [ahead of time](/reference/jit-compilation/)
 into a single [static binary](/reference/static-binary/) with no runtime dependency,
 which you can drop onto any matching machine and run. That same toolchain makes
 [cross-compilation](/reference/cross-compilation/) — building a Windows or macOS
@@ -60,7 +63,7 @@ binary from a Linux host — a one-line affair.
 
 Go's headline feature is first-class [concurrency](/reference/concurrency/): cheap
 [goroutines](/reference/goroutines/) and channels make concurrent stream processing
-natural. It is [garbage-collected](/reference/garbage-collection/), so there is no
+natural.[^home] It is [garbage-collected](/reference/garbage-collection/), so there is no
 manual memory management, and it has a [static type system](/reference/type-system/)
 with inference that keeps code terse. The trade-offs are real — the garbage collector
 introduces brief pauses, raw numeric throughput trails [C](/reference/c-language/) and
@@ -73,3 +76,9 @@ A self-contained static binary ships effortlessly to Linux, macOS, and Windows w
 installer or shared libraries, and goroutines map cleanly onto the many concurrent
 decode pipelines an SDR scanner runs at once — making Go a strong fit for
 infrastructure, network services, CLIs, and stream engines like this one.
+
+## Sources
+
+[^spec]: [The Go Programming Language Specification](https://go.dev/ref/spec) — the authoritative definition of the language and its type system.
+[^home]: [The Go programming language](https://go.dev/) — official site, documentation, and the goroutine/channel concurrency model.
+[^wiki]: [Go (programming language)](https://en.wikipedia.org/wiki/Go_(programming_language)) — Wikipedia, for history and design background.

--- a/docs/reference/golay-code.md
+++ b/docs/reference/golay-code.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [forward-error-correction, hamming-code, reed-solomon-code, dmr, m17]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Binary Golay code (Wikipedia)", url: https://en.wikipedia.org/wiki/Binary_Golay_code }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Binary_Golay_code
 ---
 
 The **Golay code** is a remarkably efficient block
-[error-correction](/reference/forward-error-correction/) code. The binary Golay(23,12)
+[error-correction](/reference/forward-error-correction/) code.[^wiki] The binary Golay(23,12)
 and extended Golay(24,12) correct up to three bit errors in a short codeword.
 
 <figure class="figure" markdown="0">
@@ -40,3 +42,7 @@ into few bits, making it ideal for small but critical control fields.
 
 Golay coding protects link-control and signalling fields in [DMR](/reference/dmr/),
 [P25](/reference/project-25/), and [M17](/reference/m17/).
+
+## Sources
+
+[^wiki]: [Binary Golay code](https://en.wikipedia.org/wiki/Binary_Golay_code) — Wikipedia, for the perfect (23,12) and extended (24,12) three-error-correcting codes.

--- a/docs/reference/goroutines.md
+++ b/docs/reference/goroutines.md
@@ -18,14 +18,16 @@ see_also: [concurrency, threads, async-programming, go-language, garbage-collect
 related_lessons:
   - { title: "Concurrency and parallelism", url: /learn/intro-software-dev/concurrency-models/ }
   - { title: "Concurrency and pipelines", url: /learn/intro-software-dev/concurrency-and-pipelines/ }
-external:
-  - { title: "Go (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Go_(programming_language)#Concurrency }
+related_reading:
+  - { title: "SDR Internals, Part 3: The SDR pool, streaming & concurrency", url: /blog/deep-dives/sdr-internals-03-sdr-pool-streaming-concurrency/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Go_(programming_language)#Concurrency
 ---
 
 **A goroutine** is a lightweight task managed by the [Go](/reference/go-language/)
 runtime rather than the operating system. They are so cheap that you can run hundreds of
 thousands at once, and they communicate over *channels* instead of sharing memory
-directly.
+directly.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="The Go runtime multiplexes many goroutines onto a few OS threads, and goroutines pass values through a channel." xmlns="http://www.w3.org/2000/svg">
@@ -48,11 +50,11 @@ directly.
 You start a goroutine by prefixing a function call with `go`. Each begins with a tiny
 stack that grows as needed, and the Go runtime's scheduler multiplexes many goroutines
 onto a small pool of OS [threads](/reference/threads/), so they cost almost nothing
-compared with one OS thread per task. Goroutines coordinate through **channels** — typed
+compared with one OS thread per task.[^wiki] Goroutines coordinate through **channels** — typed
 pipes where one goroutine sends a value and another receives it. The channel handles
 synchronization, so there is no explicit lock and no data race on the data that flows
 through it. This is the *Communicating Sequential Processes* (CSP) model, captured by the
-slogan: "Do not communicate by sharing memory; share memory by communicating."
+slogan: "Do not communicate by sharing memory; share memory by communicating."[^wiki]
 
 ## Trade-offs
 
@@ -71,3 +73,7 @@ big reason it is common in networked and streaming systems. In GopherTrunk they 
 cleanly onto the concurrent decode pipelines an SDR scanner runs at once — a capture
 stage feeding a DSP stage feeding a decode stage, each a goroutine, glued together by
 channels.
+
+## Sources
+
+[^wiki]: [Go (programming language) — Concurrency](https://en.wikipedia.org/wiki/Go_(programming_language)#Concurrency) — Wikipedia, on goroutines, channels, and Go's CSP-based "share memory by communicating" model.

--- a/docs/reference/guglielmo-marconi.md
+++ b/docs/reference/guglielmo-marconi.md
@@ -15,13 +15,13 @@ infobox:
 see_also: [heinrich-hertz, reginald-fessenden, radio-wave]
 related_lessons:
   - { title: "What is a radio wave?", url: /learn/rf-sdr/radio-waves/ }
-external:
-  - { title: "Guglielmo Marconi (Wikipedia)", url: https://en.wikipedia.org/wiki/Guglielmo_Marconi }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Guglielmo_Marconi
 ---
 
 **Guglielmo Marconi** (1874–1937) was an Italian inventor and entrepreneur who turned
 [Hertz](/reference/heinrich-hertz/)'s laboratory waves into **practical long-distance
-radiotelegraphy**.
+radiotelegraphy**.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A signal arcing across a curved ocean from a transmitter in Europe to a receiver in North America." xmlns="http://www.w3.org/2000/svg">
@@ -47,4 +47,8 @@ industry.
 ## Legacy
 
 Marconi shared the 1909 Nobel Prize in Physics and is widely regarded as a father of
-radio communication.
+radio communication.[^wiki]
+
+## Sources
+
+[^wiki]: [Guglielmo Marconi](https://en.wikipedia.org/wiki/Guglielmo_Marconi) — Wikipedia, for biography and his pioneering of practical wireless telegraphy.

--- a/docs/reference/hackrf.md
+++ b/docs/reference/hackrf.md
@@ -16,14 +16,16 @@ infobox:
 see_also: [rtl-sdr, airspy, software-defined-radio]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
-external:
-  - { title: "HackRF (Wikipedia)", url: https://en.wikipedia.org/wiki/HackRF_One }
+related_reading:
+  - { title: "RF Front End, Part 11: HackRF One", url: /blog/deep-dives/rf-front-end-11-hackrf-one/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/HackRF_One
 ---
 
 **HackRF One** is an open-source, wideband, half-duplex
 [software-defined radio](/reference/software-defined-radio/) transceiver from Great Scott
 Gadgets, covering **1 MHz to 6 GHz** with up to ~20 MHz bandwidth and the ability to
-**transmit**.
+**transmit**.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for HackRF One (~1 MHz–6 GHz) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
@@ -125,3 +127,7 @@ full serial so each entry pins exactly one device.
 > string — the leading 16 digits are a constant prefix (commonly all zeros) and
 > the trailing digits are the unique part. `gophertrunk sdr list` prints the
 > whole string, matching `hackrf_info`'s "Serial number".
+
+## Sources
+
+[^wiki]: [HackRF One](https://en.wikipedia.org/wiki/HackRF_One) — Wikipedia, on the HackRF One wideband half-duplex transceiver and its specifications.

--- a/docs/reference/hamming-code.md
+++ b/docs/reference/hamming-code.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [forward-error-correction, golay-code, bch-code, richard-hamming, cyclic-redundancy-check]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Hamming code (Wikipedia)", url: https://en.wikipedia.org/wiki/Hamming_code }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Hamming_code
 ---
 
 **Hamming codes** are simple block [error-correction](/reference/forward-error-correction/)
 codes that correct **single-bit** errors (and detect two) using a handful of parity-check
-bits. They are named for [Richard Hamming](/reference/richard-hamming/).
+bits.[^wiki] They are named for [Richard Hamming](/reference/richard-hamming/).
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="Data bits interspersed with parity bits, with brackets showing each parity bit covering a set of data bits." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +46,7 @@ digital radio link control.
 
 Hamming coding protects small control fields in several digital protocols, contributing to
 robust decoding.
+
+## Sources
+
+[^wiki]: [Hamming code](https://en.wikipedia.org/wiki/Hamming_code) — Wikipedia, for the parity-check construction, syndrome decoding, and Richard Hamming's origin.

--- a/docs/reference/harry-nyquist.md
+++ b/docs/reference/harry-nyquist.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [nyquist-theorem, sample-rate, claude-shannon, aliasing]
 related_lessons:
   - { title: "Sample rate, bandwidth & Nyquist", url: /learn/rf-sdr/sample-rate-nyquist/ }
-external:
-  - { title: "Harry Nyquist (Wikipedia)", url: https://en.wikipedia.org/wiki/Harry_Nyquist }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Harry_Nyquist
 ---
 
 **Harry Nyquist** (1889–1976) was a Swedish-American engineer at Bell Labs whose work on
 the maximum signalling rate of a channel underlies the
-[sampling theorem](/reference/nyquist-theorem/) at the heart of digital radio.
+[sampling theorem](/reference/nyquist-theorem/) at the heart of digital radio.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A sine wave sampled at just over two points per cycle, illustrating the Nyquist sampling rate." xmlns="http://www.w3.org/2000/svg">
@@ -37,7 +37,7 @@ the maximum signalling rate of a channel underlies the
 Nyquist studied how fast pulses could be sent over a channel without interference,
 establishing the relationship between [bandwidth](/reference/bandwidth/) and
 [sample rate](/reference/sample-rate/) later formalised with
-[Claude Shannon](/reference/claude-shannon/).
+[Claude Shannon](/reference/claude-shannon/).[^wiki]
 
 ## Contribution
 
@@ -47,3 +47,7 @@ The Nyquist rate — sampling at twice the bandwidth — tells engineers how fas
 ## Legacy
 
 His name marks the boundary every SDR respects to avoid [aliasing](/reference/aliasing/).
+
+## Sources
+
+[^wiki]: [Harry Nyquist](https://en.wikipedia.org/wiki/Harry_Nyquist) — Wikipedia, for biography and his work on sampling and signalling theory.

--- a/docs/reference/heinrich-hertz.md
+++ b/docs/reference/heinrich-hertz.md
@@ -15,13 +15,13 @@ infobox:
 see_also: [james-clerk-maxwell, guglielmo-marconi, radio-wave, frequency, electromagnetic-spectrum]
 related_lessons:
   - { title: "What is a radio wave?", url: /learn/rf-sdr/radio-waves/ }
-external:
-  - { title: "Heinrich Hertz (Wikipedia)", url: https://en.wikipedia.org/wiki/Heinrich_Hertz }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Heinrich_Hertz
 ---
 
 **Heinrich Hertz** (1857–1894) was a German physicist who first conclusively
 **demonstrated electromagnetic waves**, experimentally confirming
-[James Clerk Maxwell](/reference/james-clerk-maxwell/)'s theory.
+[James Clerk Maxwell](/reference/james-clerk-maxwell/)'s theory.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A spark gap on the left radiating waves to a loop receiver on the right, illustrating Hertz's proof of radio waves." xmlns="http://www.w3.org/2000/svg">
@@ -42,9 +42,13 @@ light — proving they were electromagnetic.
 ## Contribution
 
 His experiments turned Maxwell's mathematics into observed fact, opening the door to
-radio communication.
+radio communication.[^wiki]
 
 ## Legacy
 
 The SI unit of [frequency](/reference/frequency/), the **hertz (Hz)**, is named in his
 honour — fitting, given he proved the [radio wave](/reference/radio-wave/) exists.
+
+## Sources
+
+[^wiki]: [Heinrich Hertz](https://en.wikipedia.org/wiki/Heinrich_Hertz) — Wikipedia, for biography and his proof of electromagnetic waves.

--- a/docs/reference/icao.md
+++ b/docs/reference/icao.md
@@ -14,13 +14,14 @@ infobox:
 see_also: [ads-b, compact-position-reporting, itu]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "International Civil Aviation Organization (Wikipedia)", url: https://en.wikipedia.org/wiki/International_Civil_Aviation_Organization }
+cite_urls:
+  - https://www.icao.int/
+  - https://en.wikipedia.org/wiki/International_Civil_Aviation_Organization
 ---
 
 **ICAO** (the **International Civil Aviation Organization**) is the United Nations agency
 that standardises international civil aviation, including the
-**[ADS-B](/reference/ads-b/)** surveillance system and Mode S transponders.
+**[ADS-B](/reference/ads-b/)** surveillance system and Mode S transponders.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="ICAO sets aviation standards including ADS-B." xmlns="http://www.w3.org/2000/svg">
@@ -38,8 +39,13 @@ that standardises international civil aviation, including the
 ## Overview
 
 ICAO sets the framework that regional bodies (RTCA in the US, EUROCAE in Europe) detail
-into the MOPS aircraft must meet, driving the worldwide rollout of ADS-B.
+into the MOPS aircraft must meet, driving the worldwide rollout of ADS-B.[^home]
 
 ## Relevance to SDR
 
 ICAO standards define the 1090 MHz signals an SDR receives when tracking aircraft.
+
+## Sources
+
+[^home]: [International Civil Aviation Organization](https://www.icao.int/) — ICAO's official site, for international civil-aviation standards including ADS-B.
+[^wiki]: [International Civil Aviation Organization](https://en.wikipedia.org/wiki/International_Civil_Aviation_Organization) — Wikipedia, for ICAO's role and standards.

--- a/docs/reference/iir-filter.md
+++ b/docs/reference/iir-filter.md
@@ -10,12 +10,14 @@ autolink: true
 see_also: [fir-filter, digital-filter, automatic-gain-control]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Infinite impulse response (Wikipedia)", url: https://en.wikipedia.org/wiki/Infinite_impulse_response }
+related_reading:
+  - { title: "SDR Internals, Part 4: DSP foundations — filters, NCO & AGC", url: /blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Infinite_impulse_response
 ---
 
 An **IIR** (**infinite impulse response**) filter computes each output from both recent
-**inputs and past outputs** — it has **feedback**. That recursion achieves a sharp
+**inputs and past outputs** — it has **feedback**.[^wiki] That recursion achieves a sharp
 frequency response with far fewer coefficients than a [FIR filter](/reference/fir-filter/),
 at the cost of nonlinear phase and a need to watch stability.
 
@@ -39,3 +41,7 @@ IIR designs (often built from cascaded *biquad* sections) suit narrowband tasks 
 DC blocking and the loop filters in [AGC](/reference/automatic-gain-control/) and
 [timing recovery](/reference/clock-recovery/), where efficiency matters more than phase
 linearity.
+
+## Sources
+
+[^wiki]: [Infinite impulse response](https://en.wikipedia.org/wiki/Infinite_impulse_response) — Wikipedia, on the recursive, feedback-based filter and its stability trade-offs.

--- a/docs/reference/imbe.md
+++ b/docs/reference/imbe.md
@@ -15,13 +15,15 @@ infobox:
 see_also: [vocoder, ambe, ambe-plus-2, multi-band-excitation, p25-phase-1, dvsi]
 related_lessons:
   - { title: "Vocoders — IMBE & AMBE+2", url: /learn/rf-sdr/vocoders/ }
-external:
-  - { title: "Multi-Band Excitation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+related_reading:
+  - { title: "SDR Internals, Part 12: Voice coding & vocoders", url: /blog/deep-dives/sdr-internals-12-voice-coding-vocoders/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Multi-Band_Excitation
 ---
 
 **IMBE** (**Improved Multi-Band Excitation**) is the [vocoder](/reference/vocoder/) of
 [P25 Phase 1](/reference/p25-phase-1/), part of the
-[MBE](/reference/multi-band-excitation/) codec family from [DVSI](/reference/dvsi/).
+[MBE](/reference/multi-band-excitation/) codec family from [DVSI](/reference/dvsi/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A speech spectrum split into frequency bands, each marked voiced or unvoiced, as in multi-band excitation." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +46,7 @@ audio sample.
 
 GopherTrunk decodes IMBE frames from P25 Phase 1 and synthesises audio. Its successor,
 [AMBE+2](/reference/ambe-plus-2/), is used by newer systems.
+
+## Sources
+
+[^wiki]: [Multi-Band Excitation](https://en.wikipedia.org/wiki/Multi-Band_Excitation) — Wikipedia, on the MBE vocoder family that includes IMBE.

--- a/docs/reference/imperative-programming.md
+++ b/docs/reference/imperative-programming.md
@@ -17,13 +17,13 @@ infobox:
 see_also: [declarative-programming, functional-programming, object-oriented-programming, memory-management, c-language, go-language, fortran-language]
 related_lessons:
   - { title: "Paradigms & language families", url: /learn/intro-software-dev/language-families/ }
-external:
-  - { title: "Imperative programming — Wikipedia", url: https://en.wikipedia.org/wiki/Imperative_programming }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Imperative_programming
 ---
 
 **Imperative programming** is the oldest and most direct paradigm: you tell the computer
 *how* to do something as an ordered sequence of statements that change state — assign a
-value, loop, increment a counter, branch on a condition.
+value, loop, increment a counter, branch on a condition.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="A counter variable is initialised then mutated step by step through ordered statements until a loop completes." xmlns="http://www.w3.org/2000/svg">
@@ -52,7 +52,7 @@ many subtle bugs come from state changing when or where you did not expect.
 
 **Procedural** programming is imperative code organised into reusable *procedures*
 (functions). Instead of one long script, you factor work into named routines that call
-each other. [C](/reference/c-language/) is the classic procedural language, and
+each other.[^wiki] [C](/reference/c-language/) is the classic procedural language, and
 [Fortran](/reference/fortran-language/) and [COBOL](/reference/cobol-language/) are early
 examples. Procedural style pairs naturally with manual
 [memory management](/reference/memory-management/) and tight performance loops.
@@ -66,4 +66,8 @@ contrasts with [declarative programming](/reference/declarative-programming/), w
 describes *what* you want rather than *how*, and with
 [functional programming](/reference/functional-programming/), which avoids mutable state
 altogether. Most languages are multi-paradigm, so an imperative inner loop often sits
-inside [object-oriented](/reference/object-oriented-programming/) or functional code.
+inside [object-oriented](/reference/object-oriented-programming/) or functional code.[^wiki]
+
+## Sources
+
+[^wiki]: [Imperative programming](https://en.wikipedia.org/wiki/Imperative_programming) — Wikipedia, for the definition, the role of mutable state and ordered execution, and the procedural sub-style.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,8 +1,8 @@
 ---
 layout: reference-hub
-title: GopherTrunk Reference — RF, SDR & software-development encyclopedia
-description: A plain-language encyclopedia spanning radio and software-defined radio (terms, technologies, algorithms, people, hardware, organizations) and software development (programming languages and core concepts) — long-form reference articles, cross-linked and browsable by domain, category, or A–Z.
-keywords: RF encyclopedia, SDR reference, radio terms, P25 DMR TETRA reference, programming languages reference, software development encyclopedia, compiler garbage collection, Go Python Rust, DefinedTerm
+title: GopherTrunk Field Guide — the RF, SDR & software-development encyclopedia
+description: A plain-language field guide spanning radio and software-defined radio (terms, technologies, algorithms, people, hardware, organizations) and software development (programming languages and core concepts) — long-form, cited reference articles, cross-linked and browsable by domain, category, or A–Z.
+keywords: RF encyclopedia, SDR field guide, radio terms, P25 DMR TETRA reference, programming languages reference, software development encyclopedia, compiler garbage collection, Go Python Rust, DefinedTerm
 permalink: /reference/
 autolink: false
 ---
@@ -10,6 +10,7 @@ autolink: false
 Looking for a quick definition? The [glossary](/learn/rf-sdr/glossary/) has one-line
 entries. Want to *learn* in order? Start a learning path —
 [RF & SDR](/learn/rf-sdr/) or [intro to software development](/learn/intro-software-dev/).
-This **reference** is the long-form, neutral encyclopedia: each article defines and
-explains one topic in depth and links to everything related. Entries are grouped
-into **domains** — RF & SDR and Software Development — each with its own categories.
+This **Field Guide** is the long-form, neutral encyclopedia: each article defines and
+explains one topic in depth, cites its sources, and links to everything related.
+Entries are grouped into **domains** — RF & SDR and Software Development — each with
+its own categories.

--- a/docs/reference/integration-testing.md
+++ b/docs/reference/integration-testing.md
@@ -16,13 +16,15 @@ infobox:
 see_also: [unit-testing, end-to-end-testing, mocking, code-coverage, test-driven-development, ci-cd, rest]
 related_lessons:
   - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
-external:
-  - { title: "Integration testing — Wikipedia", url: https://en.wikipedia.org/wiki/Integration_testing }
+related_reading:
+  - { title: "Build in the Open, Part 8: Testing — how to build and write tests", url: /blog/tutorials/build-in-the-open-08-testing-how-to-write-tests/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Integration_testing
 ---
 
 **Integration testing** checks that several components work correctly *together*,
 exercising the real seams between them — a parser feeding a decoder, or code talking to a
-database.
+database.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="Three components connected in sequence, with the joins between them highlighted as what integration tests exercise." xmlns="http://www.w3.org/2000/svg">
@@ -52,7 +54,7 @@ thing under test, though they may still stub out slow or external systems via
 ## Where it sits
 
 Integration tests form the *middle* layer of the test pyramid: fewer than unit tests and
-slower, because they exercise real interactions rather than one isolated function. That
+slower, because they exercise real interactions rather than one isolated function.[^wiki] That
 trade-off is deliberate — they give more end-to-end-like confidence than a unit test
 while remaining faster and more targeted than a full
 [end-to-end test](/reference/end-to-end-testing/). A healthy suite has a wide base of
@@ -66,3 +68,7 @@ push, so a broken seam is caught within minutes. They contribute to
 [code coverage](/reference/code-coverage/) and complement the
 [test-driven development](/reference/test-driven-development/) habit of specifying
 behavior before building it.
+
+## Sources
+
+[^wiki]: [Integration testing](https://en.wikipedia.org/wiki/Integration_testing) — Wikipedia, for the definition and its place between unit and end-to-end tests.

--- a/docs/reference/interleaving.md
+++ b/docs/reference/interleaving.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [forward-error-correction, reed-solomon-code, bch-code, multipath-propagation]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Interleaving (Wikipedia)", url: https://en.wikipedia.org/wiki/Interleaving_(data) }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Interleaving_(data)
 ---
 
 **Interleaving** reorders bits or symbols before transmission and restores their order on
 receive, so that a **burst** of errors (from fading or interference) is spread thinly
-across many codewords rather than overwhelming one.
+across many codewords rather than overwhelming one.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="Bits written into a matrix by rows and read out by columns, so that a burst of errors is spread across many codewords." xmlns="http://www.w3.org/2000/svg">
@@ -49,3 +51,7 @@ receiver de-interleaves before decoding.
 
 Interleaving makes digital radio robust to [multipath](/reference/multipath-propagation/)
 fading and short interference bursts.
+
+## Sources
+
+[^wiki]: [Interleaving (data)](https://en.wikipedia.org/wiki/Interleaving_(data)) — Wikipedia, for reordering data to spread burst errors across codewords.

--- a/docs/reference/intermediate-frequency.md
+++ b/docs/reference/intermediate-frequency.md
@@ -10,13 +10,13 @@ autolink: true
 see_also: [superheterodyne-receiver, local-oscillator, baseband, analog-to-digital-converter]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
-external:
-  - { title: "Intermediate frequency (Wikipedia)", url: https://en.wikipedia.org/wiki/Intermediate_frequency }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Intermediate_frequency
 ---
 
 The **intermediate frequency** (**IF**) is the fixed, lower frequency that a
 [superheterodyne receiver](/reference/superheterodyne-receiver/) shifts the wanted
-signal down to before filtering and digitising. Mixing the variable input frequency to a
+signal down to before filtering and digitising.[^wiki] Mixing the variable input frequency to a
 **constant IF** lets the receiver use one well-designed filter regardless of the tuned
 channel.
 
@@ -37,3 +37,7 @@ channel.
 Many SDRs use a **low-IF** or **zero-IF** ([baseband](/reference/baseband/)) architecture,
 where the IF is at or near 0 Hz — convenient for the [ADC](/reference/analog-to-digital-converter/)
 but introducing a [DC offset](/reference/dc-offset/) artefact to manage.
+
+## Sources
+
+[^wiki]: [Intermediate frequency](https://en.wikipedia.org/wiki/Intermediate_frequency) — Wikipedia, on superheterodyne downconversion to a fixed IF.

--- a/docs/reference/interpreter.md
+++ b/docs/reference/interpreter.md
@@ -18,14 +18,14 @@ see_also: [compiler, bytecode, jit-compilation, static-vs-dynamic-typing, python
 related_lessons:
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Interpreter (computing) — Wikipedia", url: https://en.wikipedia.org/wiki/Interpreter_(computing) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Interpreter_(computing)
 ---
 
 **An interpreter** is a program that reads source code and executes it directly,
 statement by statement, every time the program runs — instead of translating the
 whole program to a native binary ahead of time the way a [compiler](/reference/compiler/)
-does.
+does.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="An interpreter reads source statements one at a time and runs each immediately." xmlns="http://www.w3.org/2000/svg">
@@ -49,13 +49,13 @@ encounters it. In practice most modern "interpreted" languages take a half-step
 first: they compile the source to compact [bytecode](/reference/bytecode/) for a
 *virtual machine*, and the VM interprets that bytecode. CPython, for example,
 compiles `.py` files to `.pyc` bytecode and runs it on the Python VM. Either way,
-translation happens during execution rather than once up front.
+translation happens during execution rather than once up front.[^wiki]
 
 ## Trade-offs
 
 Interpretation inverts the compiled story. Execution is **slower**, because the
 interpreter adds overhead to every operation, and the user must have the interpreter
-installed. In exchange you get **fast iteration** — no separate build step, so you
+installed.[^wiki] In exchange you get **fast iteration** — no separate build step, so you
 edit and re-run instantly — and **flexibility**, including the runtime dynamism that
 [dynamic typing](/reference/static-vs-dynamic-typing/) allows and interactive
 read-eval-print loops (REPLs). [JIT compilation](/reference/jit-compilation/) is a
@@ -68,3 +68,7 @@ recover speed.
 [JavaScript](/reference/javascript-language/) are the canonical interpreted languages.
 Their flexibility and quick edit-run cycle make them popular for scripting, data work,
 and rapid prototyping, where developer speed matters more than raw execution speed.
+
+## Sources
+
+[^wiki]: [Interpreter (computing)](https://en.wikipedia.org/wiki/Interpreter_(computing)) — Wikipedia, on how interpreters execute source or bytecode at run time and their trade-offs versus compilation.

--- a/docs/reference/ionospheric-propagation.md
+++ b/docs/reference/ionospheric-propagation.md
@@ -14,14 +14,14 @@ infobox:
 see_also: [radio-propagation, frequency-bands, airspy-hf-plus]
 related_lessons:
   - { title: "Frequency, bands & the spectrum", url: /learn/rf-sdr/frequency-and-spectrum/ }
-external:
-  - { title: "Skywave (Wikipedia)", url: https://en.wikipedia.org/wiki/Skywave }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Skywave
 ---
 
 **Ionospheric propagation** (skywave) is the refraction of
 [HF](/reference/frequency-bands/) [radio waves](/reference/radio-wave/) by ionised
 layers of the upper atmosphere, allowing signals to "skip" over the horizon for
-hundreds or thousands of kilometres.
+hundreds or thousands of kilometres.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 150" role="img" aria-label="An HF signal leaving a transmitter, refracting off the ionosphere layer, and returning to a distant receiver." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +46,7 @@ ionosphere rather than reflecting, so they stay line-of-sight.
 Receiving HF skip needs an HF-capable radio such as the
 [Airspy HF+](/reference/airspy-hf-plus/) or an [upconverter](/reference/upconverter/),
 since a basic [RTL-SDR](/reference/rtl-sdr/) does not tune HF directly.
+
+## Sources
+
+[^wiki]: [Skywave](https://en.wikipedia.org/wiki/Skywave) — Wikipedia, on ionospheric refraction of HF radio waves and long-distance skip propagation.

--- a/docs/reference/iq-data.md
+++ b/docs/reference/iq-data.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [software-defined-radio, phase, amplitude, constellation-diagram, sample-rate]
 related_lessons:
   - { title: "IQ data & complex signals", url: /learn/rf-sdr/iq-data/ }
-external:
-  - { title: "In-phase and quadrature components (Wikipedia)", url: https://en.wikipedia.org/wiki/In-phase_and_quadrature_components }
+related_reading:
+  - { title: "SDR Internals, Part 1: What is software-defined radio?", url: /blog/deep-dives/sdr-internals-01-what-is-software-defined-radio/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/In-phase_and_quadrature_components
 ---
 
 **IQ data** is the stream of paired numbers an SDR produces — **I** (in-phase) and **Q**
 (quadrature, 90° apart). Together each pair captures both the
 [amplitude](/reference/amplitude/) and [phase](/reference/phase/) of the signal at that
-instant.
+instant.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 260 220" role="img" aria-label="The IQ plane with I horizontal and Q vertical; an arrow to a point shows amplitude as length and phase as angle." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +48,7 @@ IQ also lets a receiver distinguish frequencies above and below the tuned centre
 
 Everything GopherTrunk does begins with the IQ stream from the radio: tuning, filtering,
 demodulation, and the scopes all operate on it.
+
+## Sources
+
+[^wiki]: [In-phase and quadrature components](https://en.wikipedia.org/wiki/In-phase_and_quadrature_components) — Wikipedia, on representing a signal as paired I and Q components.

--- a/docs/reference/itu.md
+++ b/docs/reference/itu.md
@@ -14,13 +14,14 @@ infobox:
 see_also: [fcc, etsi, icao, frequency-bands]
 related_lessons:
   - { title: "Frequency, bands & the spectrum", url: /learn/rf-sdr/frequency-and-spectrum/ }
-external:
-  - { title: "International Telecommunication Union (Wikipedia)", url: https://en.wikipedia.org/wiki/International_Telecommunication_Union }
+cite_urls:
+  - https://www.itu.int/
+  - https://en.wikipedia.org/wiki/International_Telecommunication_Union
 ---
 
 The **International Telecommunication Union** (**ITU**) is the United Nations specialised
-agency for information and communication technologies. It coordinates the **global radio
-[spectrum](/reference/frequency-bands/)** and publishes the Radio Regulations.
+agency for information and communication technologies.[^wiki] It coordinates the **global radio
+[spectrum](/reference/frequency-bands/)** and publishes the Radio Regulations.[^home]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="The ITU dividing the radio spectrum into allocated service blocks worldwide." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +46,8 @@ the [FCC](/reference/fcc/) implement. ITU recommendations also define systems su
 
 The ITU's allocations are why specific signals live in specific bands worldwide, shaping
 where you tune.
+
+## Sources
+
+[^home]: [International Telecommunication Union](https://www.itu.int/) — the ITU's official site, for the Radio Regulations and global spectrum coordination.
+[^wiki]: [International Telecommunication Union](https://en.wikipedia.org/wiki/International_Telecommunication_Union) — Wikipedia, for the agency's history and role.

--- a/docs/reference/james-clerk-maxwell.md
+++ b/docs/reference/james-clerk-maxwell.md
@@ -15,13 +15,13 @@ infobox:
 see_also: [heinrich-hertz, electromagnetic-spectrum, radio-wave]
 related_lessons:
   - { title: "What is a radio wave?", url: /learn/rf-sdr/radio-waves/ }
-external:
-  - { title: "James Clerk Maxwell (Wikipedia)", url: https://en.wikipedia.org/wiki/James_Clerk_Maxwell }
+cite_urls:
+  - https://en.wikipedia.org/wiki/James_Clerk_Maxwell
 ---
 
 **James Clerk Maxwell** (1831–1879) was a Scottish physicist whose equations unified
 electricity, magnetism, and light, **predicting electromagnetic waves** that travel at
-the speed of light.
+the speed of light.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="Oscillating electric and magnetic fields at right angles forming a travelling electromagnetic wave." xmlns="http://www.w3.org/2000/svg">
@@ -41,9 +41,13 @@ changing electric and magnetic fields sustain one another and propagate as waves
 ## Contribution
 
 His theory predicted the [electromagnetic spectrum](/reference/electromagnetic-spectrum/)
-decades before radio existed; [Heinrich Hertz](/reference/heinrich-hertz/) later proved it.
+decades before radio existed; [Heinrich Hertz](/reference/heinrich-hertz/) later proved it.[^wiki]
 
 ## Legacy
 
 Maxwell's equations remain the foundation of all radio engineering, including
 [software-defined radio](/reference/software-defined-radio/).
+
+## Sources
+
+[^wiki]: [James Clerk Maxwell](https://en.wikipedia.org/wiki/James_Clerk_Maxwell) — Wikipedia, for biography and his equations predicting electromagnetic waves.

--- a/docs/reference/java-language.md
+++ b/docs/reference/java-language.md
@@ -19,14 +19,16 @@ see_also: [csharp-language, jit-compilation, bytecode, garbage-collection, kotli
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
-external:
-  - { title: "Java (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Java_(programming_language) }
-  - { title: "The Java platform — Oracle", url: https://www.java.com/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.java.com/
+  - https://en.wikipedia.org/wiki/Java_(programming_language)
 ---
 
 **Java** is a statically typed, garbage-collected, object-oriented language that
 compiles to bytecode and runs on the Java Virtual Machine (JVM), giving it genuine
-"write once, run anywhere" portability across platforms.
+"write once, run anywhere" portability across platforms.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Java source compiles once to portable bytecode, which the JVM JIT-compiles to native code on each platform at runtime." xmlns="http://www.w3.org/2000/svg">
@@ -47,7 +49,7 @@ compiles to bytecode and runs on the Java Virtual Machine (JVM), giving it genui
 ## Overview
 
 Java source compiles to platform-independent [bytecode](/reference/bytecode/), which the
-JVM [JIT-compiles](/reference/jit-compilation/) to native code as the program runs. It is
+JVM [JIT-compiles](/reference/jit-compilation/) to native code as the program runs.[^home] It is
 [statically typed](/reference/type-system/), thoroughly
 [object-oriented](/reference/object-oriented-programming/), and
 [garbage-collected](/reference/garbage-collection/). The combination of a portable
@@ -70,3 +72,8 @@ long-lived business applications. Its closest counterpart is [C#](/reference/csh
 on .NET, which shares almost the same managed, JIT-compiled, garbage-collected design;
 the choice between them is usually about ecosystem and platform rather than language
 merit.
+
+## Sources
+
+[^home]: [The Java platform](https://www.java.com/) — Oracle's official Java site and runtime documentation.
+[^wiki]: [Java (programming language)](https://en.wikipedia.org/wiki/Java_(programming_language)) — Wikipedia, for history and design background.

--- a/docs/reference/javascript-language.md
+++ b/docs/reference/javascript-language.md
@@ -19,14 +19,16 @@ see_also: [typescript-language, jit-compilation, garbage-collection, static-vs-d
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Type systems", url: /learn/intro-software-dev/type-systems/ }
-external:
-  - { title: "JavaScript — Wikipedia", url: https://en.wikipedia.org/wiki/JavaScript }
-  - { title: "MDN: JavaScript", url: https://developer.mozilla.org/en-US/docs/Web/JavaScript }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://developer.mozilla.org/en-US/docs/Web/JavaScript
+  - https://en.wikipedia.org/wiki/JavaScript
 ---
 
 **JavaScript** (JS) is a dynamically typed, garbage-collected programming language and
 the only language that runs natively in every web browser; with Node.js it also runs on
-servers, letting one language cover the whole stack.
+servers, letting one language cover the whole stack.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="JavaScript runs in both the browser and on the server via Node.js, drawing on the npm ecosystem." xmlns="http://www.w3.org/2000/svg">
@@ -47,7 +49,7 @@ servers, letting one language cover the whole stack.
 
 Modern JavaScript engines such as V8 [JIT-compile](/reference/jit-compilation/) the
 language to native code at runtime, so it is far faster than its scripting origins
-suggest. It is [dynamically typed](/reference/static-vs-dynamic-typing/) and
+suggest.[^mdn] It is [dynamically typed](/reference/static-vs-dynamic-typing/) and
 [garbage-collected](/reference/garbage-collection/), with an event-driven,
 [asynchronous](/reference/async-programming/) model at its core that suits I/O-bound web
 work. The standard is formally called ECMAScript, and the npm registry is among the
@@ -69,3 +71,8 @@ JavaScript powers virtually all interactive web front-ends, a large share of ser
 backends through Node.js, and much of modern build tooling. For larger codebases teams
 increasingly write [TypeScript](/reference/typescript-language/) and ship the compiled
 JavaScript, but the runtime everywhere remains JavaScript itself.
+
+## Sources
+
+[^mdn]: [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript) — MDN Web Docs, the reference documentation for the language and its runtime behaviour.
+[^wiki]: [JavaScript](https://en.wikipedia.org/wiki/JavaScript) — Wikipedia, for history and design background.

--- a/docs/reference/jit-compilation.md
+++ b/docs/reference/jit-compilation.md
@@ -18,13 +18,13 @@ see_also: [compiler, interpreter, bytecode, static-binary, java-language, javasc
 related_lessons:
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Just-in-time compilation — Wikipedia", url: https://en.wikipedia.org/wiki/Just-in-time_compilation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Just-in-time_compilation
 ---
 
 **Just-in-time (JIT) compilation** translates code to native machine code *while the
 program runs*, optimizing the parts it observes executing most; **ahead-of-time (AOT)
-compilation** does all of that translation up front, before the program ever ships.
+compilation** does all of that translation up front, before the program ever ships.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A JIT runs bytecode in a VM, detects a frequently-run hot path, and compiles it to native code on the fly." xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +50,7 @@ approach [C](/reference/c-language/), [Rust](/reference/rust-language/), and
 [interpreting](/reference/interpreter/); as it runs, the JIT spots frequently
 executed ("hot") sections, compiles them to native machine code, and can optimize
 based on what it actually observes — types, branch directions, inlining
-opportunities. The result is often near-native steady-state speed.
+opportunities. The result is often near-native steady-state speed.[^wiki]
 
 ## Trade-offs
 
@@ -59,7 +59,7 @@ self-contained [static binary](/reference/static-binary/). A JIT trades that for
 **slower startup** (the engine must warm up before hot paths are optimized) and
 **higher memory use** (it holds both bytecode and generated native code). A
 long-running server happily pays the warm-up to gain peak throughput; a short-lived
-command-line tool may exit before warm-up pays off, so AOT often suits it better.
+command-line tool may exit before warm-up pays off, so AOT often suits it better.[^wiki]
 
 ## In practice
 
@@ -68,3 +68,7 @@ The [JVM](/reference/java-language/) JIT-compiles bytecode via HotSpot, V8 power
 JIT-compiles its intermediate language. The lines blur: Java is AOT-compiled to
 bytecode *and* JIT-compiled to native code, and tools like GraalVM can AOT-compile
 traditionally JIT'd languages for instant startup.
+
+## Sources
+
+[^wiki]: [Just-in-time compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation) — Wikipedia, on JIT translating hot paths to native code at run time and how it contrasts with ahead-of-time compilation.

--- a/docs/reference/john-costas.md
+++ b/docs/reference/john-costas.md
@@ -10,12 +10,12 @@ autolink: true
 see_also: [costas-loop, phase-shift-keying, single-sideband, demodulation]
 related_lessons:
   - { title: "Clock recovery & symbol timing", url: /learn/rf-sdr/clock-recovery/ }
-external:
-  - { title: "John P. Costas (Wikipedia)", url: https://en.wikipedia.org/wiki/John_P._Costas_(engineer) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/John_P._Costas_(engineer)
 ---
 
 **John P. Costas** was an American engineer best known for the **[Costas loop](/reference/costas-loop/)**,
-a phase-locked carrier-recovery circuit he devised in the 1950s. It made coherent
+a phase-locked carrier-recovery circuit he devised in the 1950s.[^wiki] It made coherent
 reception of suppressed-carrier signals (such as [SSB](/reference/single-sideband/) and
 later [PSK](/reference/phase-shift-keying/)) practical.
 
@@ -36,3 +36,7 @@ later [PSK](/reference/phase-shift-keying/)) practical.
 
 The Costas loop remains a standard building block in digital receivers, including the
 carrier recovery used when demodulating phase-modulated digital-voice systems.
+
+## Sources
+
+[^wiki]: [John P. Costas (engineer)](https://en.wikipedia.org/wiki/John_P._Costas_(engineer)) — Wikipedia, for biography and his invention of the Costas loop.

--- a/docs/reference/joseph-fourier.md
+++ b/docs/reference/joseph-fourier.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [fourier-transform, fast-fourier-transform, frequency]
 related_lessons:
   - { title: "The FFT & reading a waterfall", url: /learn/rf-sdr/fft-and-waterfall/ }
-external:
-  - { title: "Joseph Fourier (Wikipedia)", url: https://en.wikipedia.org/wiki/Joseph_Fourier }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Joseph_Fourier
 ---
 
 **Joseph Fourier** (1768–1830) was a French mathematician and physicist who showed that
 functions can be represented as sums of sinusoids — the insight behind the
-[Fourier transform](/reference/fourier-transform/).
+[Fourier transform](/reference/fourier-transform/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A complex waveform shown as the sum of several simple sine waves." xmlns="http://www.w3.org/2000/svg">
@@ -36,7 +36,7 @@ functions can be represented as sums of sinusoids — the insight behind the
 ## Life and work
 
 Studying heat conduction, Fourier introduced what became Fourier series and analysis,
-decomposing complex signals into simple frequency components.
+decomposing complex signals into simple frequency components.[^wiki]
 
 ## Contribution
 
@@ -46,3 +46,7 @@ an [FFT](/reference/fast-fourier-transform/) performs.
 ## Legacy
 
 Every spectrum display and waterfall in an SDR is, at heart, Fourier's idea made digital.
+
+## Sources
+
+[^wiki]: [Joseph Fourier](https://en.wikipedia.org/wiki/Joseph_Fourier) — Wikipedia, for biography and his work on Fourier series and analysis.

--- a/docs/reference/julia-language.md
+++ b/docs/reference/julia-language.md
@@ -19,14 +19,16 @@ see_also: [python-language, r-language, matlab-language, jit-compilation, static
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Julia (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Julia_(programming_language) }
-  - { title: "The Julia programming language", url: https://julialang.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://julialang.org/
+  - https://en.wikipedia.org/wiki/Julia_(programming_language)
 ---
 
 **Julia** is a high-performance, dynamically typed language designed for numerical and
 scientific computing, aiming to be as fast as [C](/reference/c-language/) while as
-easy to write as [Python](/reference/python-language/).
+easy to write as [Python](/reference/python-language/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Python-like Julia source is JIT compiled to native code, reaching speeds close to C." xmlns="http://www.w3.org/2000/svg">
@@ -47,17 +49,22 @@ Julia was created to end the "two-language problem," where scientists prototype 
 convenient language and then rewrite hot paths in a fast one. It compiles
 [just in time](/reference/jit-compilation/) to native code, and its **multiple
 dispatch** model — choosing a method based on the types of all arguments — lets
-generic, readable code specialise into tight machine code. The result is high-level
+generic, readable code specialise into tight machine code.[^home] The result is high-level
 syntax that can rival compiled languages on numeric workloads.
 
 ## Key characteristics
 
 Julia is dynamically typed with optional annotations (see
 [static vs dynamic typing](/reference/static-vs-dynamic-typing/)) and
-[garbage-collected](/reference/garbage-collection/). Its drawbacks are practical: the
+[garbage-collected](/reference/garbage-collection/).[^home] Its drawbacks are practical: the
 **ecosystem is smaller** than Python's or R's, and JIT compilation causes "time to
 first plot" latency, where the first run of new code pays a compilation cost. For
 numerical and scientific work it competes with [Python](/reference/python-language/)
 (broader libraries), [R](/reference/r-language/) (statistics depth), and
 [MATLAB](/reference/matlab-language/) (mature, licensed engineering tooling), trading a
 younger ecosystem for performance and openness.
+
+## Sources
+
+[^home]: [The Julia programming language](https://julialang.org/) — official site, documentation, and the multiple-dispatch and JIT model.
+[^wiki]: [Julia (programming language)](https://en.wikipedia.org/wiki/Julia_(programming_language)) — Wikipedia, for history, origins, and design goals.

--- a/docs/reference/kotlin-language.md
+++ b/docs/reference/kotlin-language.md
@@ -19,14 +19,16 @@ see_also: [java-language, type-system, bytecode, jit-compilation, garbage-collec
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Type systems", url: /learn/intro-software-dev/type-systems/ }
-external:
-  - { title: "Kotlin (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Kotlin_(programming_language) }
-  - { title: "Kotlin programming language", url: https://kotlinlang.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://kotlinlang.org/
+  - https://en.wikipedia.org/wiki/Kotlin_(programming_language)
 ---
 
 **Kotlin** is a statically typed, concise programming language from JetBrains that
 runs on the Java Virtual Machine, interoperates fully with [Java](/reference/java-language/),
-and is Google's preferred language for Android development.
+and is Google's preferred language for Android development.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Kotlin and Java source both compile to JVM bytecode, which the Java Virtual Machine runs, showing their interoperability." xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +50,7 @@ and is Google's preferred language for Android development.
 Kotlin compiles to the same JVM [bytecode](/reference/bytecode/) as Java and is
 executed by the same [JIT-compiling](/reference/jit-compilation/) runtime, so it
 inherits Java's mature ecosystem, libraries, and tooling while shedding much of the
-language's verbosity. A Kotlin file can call Java code and vice versa, which let
+language's verbosity.[^home] A Kotlin file can call Java code and vice versa, which let
 teams adopt it incrementally rather than rewriting. Beyond the JVM, Kotlin can also
 target JavaScript and native binaries, enabling shared "multiplatform" code.
 
@@ -57,9 +59,14 @@ target JavaScript and native binaries, enabling shared "multiplatform" code.
 Kotlin's [type system](/reference/type-system/) is static with strong inference, and
 its standout feature is **null safety**: the type system distinguishes nullable from
 non-nullable references, catching a whole class of null-pointer errors at compile
-time. It blends [object-oriented](/reference/object-oriented-programming/) and
+time.[^home] It blends [object-oriented](/reference/object-oriented-programming/) and
 [functional](/reference/functional-programming/) styles, and its coroutines provide
 lightweight asynchronous concurrency. The honest drawbacks: it still depends on the
 JVM's [garbage collector](/reference/garbage-collection/) and startup overhead, the
 non-JVM targets are less mature, and compile times can lag Java's. Its centre of
 gravity remains Android and JVM back-end work rather than general-purpose ubiquity.
+
+## Sources
+
+[^home]: [Kotlin programming language](https://kotlinlang.org/) — official site, documentation, and the null-safety and multiplatform feature set.
+[^wiki]: [Kotlin (programming language)](https://en.wikipedia.org/wiki/Kotlin_(programming_language)) — Wikipedia, for history, origins, and Android adoption.

--- a/docs/reference/lisp-language.md
+++ b/docs/reference/lisp-language.md
@@ -19,13 +19,15 @@ see_also: [fortran-language, cobol-language, functional-programming, garbage-col
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "The birth of programming languages", url: /learn/intro-software-dev/birth-of-languages/ }
-external:
-  - { title: "Lisp (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Lisp_(programming_language) }
-  - { title: "Common Lisp", url: https://common-lisp.net/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Lisp_(programming_language)
+  - https://common-lisp.net/
 ---
 
 **LISP** (LISt Processor), created by John McCarthy in 1958, is one of the oldest
-high-level languages. It treats code and data as the same kind of list, pioneered the
+high-level languages.[^wiki] It treats code and data as the same kind of list, pioneered the
 [functional](/reference/functional-programming/) style, and became the language of
 early artificial-intelligence research.
 
@@ -61,9 +63,14 @@ seeded ideas that mainstream languages adopted only decades later.
 
 LISP is dynamically typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/)),
 runs [interpreted](/reference/interpreter/) or compiled depending on the dialect, and
-survives in families like Common Lisp, Scheme, and Clojure. Its honest drawbacks are
+survives in families like Common Lisp, Scheme, and Clojure.[^home] Its honest drawbacks are
 real: the parenthesis-heavy syntax is an acquired taste, and its mainstream use is
 niche today. But its influence is enormous — first-class functions, garbage
 collection, and treating code as data have all flowed into modern languages such as
 [Python](/reference/python-language/) and JavaScript, making LISP one of the most
 quietly influential designs in computing.
+
+## Sources
+
+[^wiki]: [Lisp (programming language)](https://en.wikipedia.org/wiki/Lisp_(programming_language)) — Wikipedia, for history, the 1958 origin, and the code-as-data design.
+[^home]: [Common Lisp](https://common-lisp.net/) — the Common Lisp community hub, a major surviving dialect with documentation and implementations.

--- a/docs/reference/local-oscillator.md
+++ b/docs/reference/local-oscillator.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [superheterodyne-receiver, digital-down-converter, frequency, ppm-frequency-correction]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
-external:
-  - { title: "Local oscillator (Wikipedia)", url: https://en.wikipedia.org/wiki/Local_oscillator }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Local_oscillator
 ---
 
 A **local oscillator** (**LO**) is a tunable reference signal mixed with the incoming
-signal to shift a chosen band down toward baseband. **Tuning a receiver is just changing
+signal to shift a chosen band down toward baseband.[^wiki] **Tuning a receiver is just changing
 the LO frequency.**
 
 <figure class="figure" markdown="0">
@@ -47,3 +47,7 @@ oscillator performs the same shift digitally inside a
 
 The LO sets which part of the spectrum lands in the ADC's window, so its accuracy and
 stability directly affect tuning.
+
+## Sources
+
+[^wiki]: [Local oscillator](https://en.wikipedia.org/wiki/Local_oscillator) — Wikipedia, on the tunable reference tone a mixer uses to shift a band down.

--- a/docs/reference/lora.md
+++ b/docs/reference/lora.md
@@ -10,14 +10,16 @@ autolink: true
 see_also: [frequency-shift-keying, bandwidth, signal-to-noise-ratio]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "LoRa (Wikipedia)", url: https://en.wikipedia.org/wiki/LoRa }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/LoRa
 ---
 
 **LoRa** is a low-power, long-range modulation that encodes data as **chirps** —
 frequency sweeps that ramp across the channel. Chirp spread spectrum gives LoRa
 excellent sensitivity (it decodes well below the [noise floor](/reference/noise-floor/)),
-making it popular for low-rate IoT telemetry in ISM bands.
+making it popular for low-rate IoT telemetry in ISM bands.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A spectrogram showing repeated rising frequency sweeps (chirps), the signature of LoRa." xmlns="http://www.w3.org/2000/svg">
@@ -35,3 +37,7 @@ A receiver "de-chirps" by multiplying with a reference sweep, collapsing each ch
 tone whose frequency encodes the symbol. LoRa is unrelated to the trunked-voice systems
 GopherTrunk targets, but is a common sight on the [waterfall](/reference/fast-fourier-transform/)
 in the 433/868/915 MHz ISM bands.
+
+## Sources
+
+[^wiki]: [LoRa](https://en.wikipedia.org/wiki/LoRa) — Wikipedia, for the chirp-spread-spectrum modulation, its sensitivity, and ISM-band use.

--- a/docs/reference/low-noise-amplifier.md
+++ b/docs/reference/low-noise-amplifier.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [noise-floor, signal-to-noise-ratio, superheterodyne-receiver, bias-tee, antenna]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
-external:
-  - { title: "Low-noise amplifier (Wikipedia)", url: https://en.wikipedia.org/wiki/Low-noise_amplifier }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Low-noise_amplifier
 ---
 
 A **low-noise amplifier** (**LNA**) boosts a weak [antenna](/reference/antenna/) signal
 **early** in the [receive chain](/reference/superheterodyne-receiver/), adding as little
-noise as possible. Because later stages add their own noise, amplifying first preserves
+noise as possible.[^wiki] Because later stages add their own noise, amplifying first preserves
 [SNR](/reference/signal-to-noise-ratio/).
 
 <figure class="figure" markdown="0">
@@ -46,3 +46,7 @@ coax by a [bias tee](/reference/bias-tee/).
 
 An antenna-mounted LNA can meaningfully improve reception of weak signals, especially
 with lossy cable runs — but watch for overload from strong nearby transmitters.
+
+## Sources
+
+[^wiki]: [Low-noise amplifier](https://en.wikipedia.org/wiki/Low-noise_amplifier) — Wikipedia, on LNAs, noise figure, and their role in setting receiver sensitivity.

--- a/docs/reference/ltr.md
+++ b/docs/reference/ltr.md
@@ -17,14 +17,16 @@ infobox:
 see_also: [trunked-radio, control-channel, motorola-type-ii, edacs, mpt-1327]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Logic Trunked Radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Logic_Trunked_Radio }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Logic_Trunked_Radio
 ---
 
 **LTR** (**Logic Trunked Radio**) is a simple, low-cost trunking protocol from
 **E.F. Johnson**. Unlike systems with a dedicated [control channel](/reference/control-channel/),
 LTR is **distributed**: trunking data rides **subaudibly on each voice channel**, so
-every channel carries its own low-speed signalling.
+every channel carries its own low-speed signalling.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 130" role="img" aria-label="Several LTR channels, each carrying analog voice plus its own embedded subaudible signalling — no dedicated control channel." xmlns="http://www.w3.org/2000/svg">
@@ -52,7 +54,7 @@ cheap to deploy but trickier to monitor than control-channel systems.
 ## History
 
 Introduced by E.F. Johnson and widely used for business/SMR trunking; variants
-include LTR-Net and PassPort.
+include LTR-Net and PassPort.[^wiki]
 
 ## Deployment
 
@@ -62,3 +64,7 @@ in North America.
 ## Decoding it with GopherTrunk
 
 See [Status](/status.html) for GopherTrunk's handling of LTR's subaudible signalling.
+
+## Sources
+
+[^wiki]: [Logic Trunked Radio](https://en.wikipedia.org/wiki/Logic_Trunked_Radio) — Wikipedia, for the E.F. Johnson LTR distributed trunking scheme and its subaudible per-channel signalling.

--- a/docs/reference/m17-project.md
+++ b/docs/reference/m17-project.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [m17, codec2, vocoder]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "M17 Project", url: https://m17project.org/ }
+cite_urls:
+  - https://m17project.org/
 ---
 
 The **M17 Project** is an open-source community that develops the royalty-free
 **[M17](/reference/m17/)** amateur digital-voice protocol along with open hardware and
-software implementations.
+software implementations.[^home]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="The open-source M17 Project maintains the royalty-free M17 protocol." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +45,7 @@ licensing constraints, adopting the open [Codec 2](/reference/codec2/)
 
 The project's openness makes fully free M17 decoders possible, including GopherTrunk's
 link-layer support.
+
+## Sources
+
+[^home]: [M17 Project](https://m17project.org/) — the project's official site, home of the royalty-free M17 protocol and open implementations.

--- a/docs/reference/m17.md
+++ b/docs/reference/m17.md
@@ -19,16 +19,18 @@ see_also: [codec2, frequency-shift-keying, convolutional-code, golay-code, m17-p
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
   - { title: "Vocoders — IMBE & AMBE+2", url: /learn/rf-sdr/vocoders/ }
-external:
-  - { title: "M17 (Wikipedia)", url: https://en.wikipedia.org/wiki/M17_(amateur_radio) }
-  - { title: "M17 Project", url: https://m17project.org/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://m17project.org/
+  - https://en.wikipedia.org/wiki/M17_(amateur_radio)
 ---
 
 **M17** is an **open-source** amateur digital-voice and data protocol created by the
 [M17 Project](/reference/m17-project/). Its defining choice is the **royalty-free
 [Codec 2](/reference/codec2/)** vocoder, making it a fully patent-free alternative to
 [AMBE](/reference/ambe/)-based systems like [DMR](/reference/dmr/) and
-[D-STAR](/reference/d-star/).
+[D-STAR](/reference/d-star/).[^proj][^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="An M17 stream frame with sync, callsign metadata, and a Codec 2 voice payload." xmlns="http://www.w3.org/2000/svg">
@@ -60,7 +62,7 @@ voice and packet/stream data, with internet reflectors for linking.
 ## History
 
 Started in 2019 as a community project to build a modern, open amateur protocol free
-of vocoder licensing constraints.
+of vocoder licensing constraints.[^proj]
 
 ## Deployment
 
@@ -70,3 +72,8 @@ Growing amateur use via M17-capable firmware, hotspots, and reflectors.
 
 GopherTrunk decodes the M17 link layer (callsigns, mode, stream metadata). See
 [M17 link layer](/m17.html) and [Status](/status.html).
+
+## Sources
+
+[^proj]: [M17 Project](https://m17project.org/) — the official open-source project site for the M17 protocol, Codec 2 usage, and specifications.
+[^wiki]: [M17 (amateur radio)](https://en.wikipedia.org/wiki/M17_(amateur_radio)) — Wikipedia, for background on the open M17 digital-voice protocol and its 4FSK air interface.

--- a/docs/reference/matched-filter.md
+++ b/docs/reference/matched-filter.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [root-raised-cosine-filter, digital-filter, signal-to-noise-ratio, demodulation]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Matched filter (Wikipedia)", url: https://en.wikipedia.org/wiki/Matched_filter }
+related_reading:
+  - { title: "SDR Internals, Part 4: DSP foundations — filters, NCO & AGC", url: /blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Matched_filter
 ---
 
 A **matched filter** is the linear filter that maximises
-[SNR](/reference/signal-to-noise-ratio/) against a *known* signal shape. Its impulse
+[SNR](/reference/signal-to-noise-ratio/) against a *known* signal shape.[^wiki] Its impulse
 response is a time-reversed copy of the pulse it is matched to.
 
 <figure class="figure" markdown="0">
@@ -47,3 +49,7 @@ filter.
 Matched filtering is a standard receive step that improves
 [demodulation](/reference/demodulation/) of weak digital signals such as
 [AIS](/reference/ais/) and [APRS](/reference/aprs/).
+
+## Sources
+
+[^wiki]: [Matched filter](https://en.wikipedia.org/wiki/Matched_filter) — Wikipedia, on the SNR-optimal time-reversed correlation filter.

--- a/docs/reference/matlab-language.md
+++ b/docs/reference/matlab-language.md
@@ -19,13 +19,15 @@ see_also: [julia-language, python-language, r-language, interpreter, fast-fourie
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Matching the language to the domain", url: /learn/intro-software-dev/language-for-the-domain/ }
-external:
-  - { title: "MATLAB — Wikipedia", url: https://en.wikipedia.org/wiki/MATLAB }
-  - { title: "MATLAB (MathWorks)", url: https://www.mathworks.com/products/matlab.html }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.mathworks.com/products/matlab.html
+  - https://en.wikipedia.org/wiki/MATLAB
 ---
 
 **MATLAB** is a commercial, matrix-oriented language and environment from MathWorks
-built for engineering, signal processing, and control systems. It is superb for DSP
+built for engineering, signal processing, and control systems.[^wiki] It is superb for DSP
 prototyping but proprietary and licensed.
 
 <figure class="figure" markdown="0">
@@ -47,7 +49,7 @@ prototyping but proprietary and licensed.
 
 MATLAB ("matrix laboratory") was designed around the matrix as its native data type,
 which makes linear-algebra and signal code read almost like the mathematics it
-implements. It pairs the language with a full interactive environment, deep numerical
+implements.[^home] It pairs the language with a full interactive environment, deep numerical
 libraries, toolboxes for control, communications and DSP, and Simulink for
 model-based design. That makes it a favourite for **DSP prototyping** and the kind of
 [fast Fourier transform](/reference/fast-fourier-transform/) work that underlies
@@ -56,10 +58,15 @@ model-based design. That makes it a favourite for **DSP prototyping** and the ki
 ## Key characteristics
 
 MATLAB is dynamically typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/))
-and [interpreted](/reference/interpreter/) with a JIT in its runtime. Its great
+and [interpreted](/reference/interpreter/) with a JIT in its runtime.[^home] Its great
 drawback is that it is **proprietary and licensed**: it costs money, toolboxes are sold
 separately, and code is tied to a vendor's runtime rather than an open ecosystem. It
 is also a specialist rather than a general-purpose language. For overlapping work,
 open alternatives include [Python](/reference/python-language/) with NumPy/SciPy, the
 faster [Julia](/reference/julia-language/), and [R](/reference/r-language/) for
 statistics — each trading MATLAB's polished, licensed tooling for openness.
+
+## Sources
+
+[^home]: [MATLAB (MathWorks)](https://www.mathworks.com/products/matlab.html) — official product site, documentation, and the matrix environment and toolboxes.
+[^wiki]: [MATLAB](https://en.wikipedia.org/wiki/MATLAB) — Wikipedia, for history, origins, and design background.

--- a/docs/reference/mdc1200.md
+++ b/docs/reference/mdc1200.md
@@ -17,15 +17,18 @@ infobox:
 see_also: [ffsk, radio-id, frequency-shift-keying]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/MDC-1200
 external:
-  - { title: "MDC-1200 (Wikipedia)", url: https://en.wikipedia.org/wiki/MDC-1200 }
   - { title: "GopherTrunk MDC1200 decoder", url: /mdc1200.html }
 ---
 
 **MDC-1200** (Motorola Data Communications) is an **in-band signalling** system that
 sends a short **1200 bps [FFSK](/reference/ffsk/)** data burst over an otherwise
 **analog FM** voice channel. It conveys a transmitting radio's unit ID (PTT
-ID / ANI), plus emergency and status signalling.
+ID / ANI), plus emergency and status signalling.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="An analog transmission with a short MDC-1200 data burst at the start carrying the unit ID." xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +59,7 @@ Emergency and status features ride on the same signalling.
 ## History
 
 Developed by Motorola for conventional and trunked analog systems as a lightweight
-data-signalling layer; widely used by public-safety and business fleets.
+data-signalling layer; widely used by public-safety and business fleets.[^wiki]
 
 ## Deployment
 
@@ -67,3 +70,7 @@ public-safety conventional channels.
 
 GopherTrunk detects the FFSK burst on analog channels and decodes the unit ID and
 flags. See the [MDC1200 decoder](/mdc1200.html) page.
+
+## Sources
+
+[^wiki]: [MDC-1200](https://en.wikipedia.org/wiki/MDC-1200) — Wikipedia, for Motorola's in-band FFSK signalling system, its PTT-ID/ANI, and emergency/status features.

--- a/docs/reference/memory-management.md
+++ b/docs/reference/memory-management.md
@@ -18,13 +18,13 @@ see_also: [garbage-collection, type-system, static-binary, c-language, cpp-langu
 related_lessons:
   - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Memory management — Wikipedia", url: https://en.wikipedia.org/wiki/Memory_management }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Memory_management
 ---
 
 **Memory management** is how a running program obtains memory to hold its data and
 reclaims it once that data is no longer needed — a defining characteristic of a
-language that shapes its safety, speed, and fitness for real-time work.
+language that shapes its safety, speed, and fitness for real-time work.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A program uses a fast auto-freed stack and a flexible heap that must be reclaimed manually, by garbage collection, or by ownership." xmlns="http://www.w3.org/2000/svg">
@@ -47,14 +47,14 @@ is freed automatically and allocation is nearly free — but everything on it mu
 size known at compile time and lives only as long as its function. The **heap** is a
 flexible pool for data whose size or lifetime is not known up front; it must be
 allocated and eventually released, and **all the hard memory problems live on the
-heap** because something must decide when each piece is no longer needed.
+heap** because something must decide when each piece is no longer needed.[^wiki]
 
 ## Three strategies
 
 Languages differ chiefly in how they reclaim heap memory.
 **Manual management** — [C](/reference/c-language/) and [C++](/reference/cpp-language/)
 — gives you `malloc`/`free` and total control, but risks leaks, use-after-free, double
-frees, and buffer overflows. **[Garbage collection](/reference/garbage-collection/)** —
+frees, and buffer overflows.[^wiki] **[Garbage collection](/reference/garbage-collection/)** —
 [Go](/reference/go-language/), [Java](/reference/java-language/),
 [Python](/reference/python-language/) — automatically frees unreachable memory,
 eliminating whole bug classes at the cost of occasional, non-deterministic pauses.
@@ -69,3 +69,7 @@ memory at predictable moments, so a software-defined radio pipeline never stalls
 mid-buffer; garbage collection can pause at an unpredictable
 moment and drop samples. This is why tight DSP gravitates toward C or Rust, while a
 GC'd language like Go is fine for the control and orchestration layers around it.
+
+## Sources
+
+[^wiki]: [Memory management](https://en.wikipedia.org/wiki/Memory_management) — Wikipedia, on stack versus heap, manual allocation, and automatic reclamation strategies.

--- a/docs/reference/mocking.md
+++ b/docs/reference/mocking.md
@@ -16,13 +16,15 @@ infobox:
 see_also: [unit-testing, integration-testing, end-to-end-testing, test-driven-development, code-coverage, solid, ci-cd]
 related_lessons:
   - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
-external:
-  - { title: "Mock object — Wikipedia", url: https://en.wikipedia.org/wiki/Mock_object }
+related_reading:
+  - { title: "Build in the Open, Part 8: Testing — how to build and write tests", url: /blog/tutorials/build-in-the-open-08-testing-how-to-write-tests/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Mock_object
 ---
 
 **Mocking** is the use of *test doubles* — stand-ins for a unit's real dependencies — so
 the unit can be [tested](/reference/unit-testing/) in isolation, deterministically and
-without touching real networks, databases, or hardware.
+without touching real networks, databases, or hardware.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="Code under test calls a test double standing in for a real dependency such as a database or radio." xmlns="http://www.w3.org/2000/svg">
@@ -45,7 +47,7 @@ without touching real networks, databases, or hardware.
   replays a file instead of reading a live device.
 - **Stub** — simply returns canned, pre-programmed responses, with no logic of its own.
 - **Mock** — records *how* it was called and lets the test assert that the code
-  interacted with it correctly (it called `send()` once, with these arguments).
+  interacted with it correctly (it called `send()` once, with these arguments).[^wiki]
 
 The right double depends on what you're testing: a stub or fake when you only need the
 dependency to be *present*, a mock when the interaction itself is the behavior under test.
@@ -68,3 +70,7 @@ Doubles have a cost: a test that mocks everything verifies your code against you
 mocking also inflates [code coverage](/reference/code-coverage/) without real assurance.
 Mock at the boundaries of slow or external systems; let higher layers, run in
 [CI/CD](/reference/ci-cd/), exercise the real seams.
+
+## Sources
+
+[^wiki]: [Mock object](https://en.wikipedia.org/wiki/Mock_object) — Wikipedia, for test doubles (mocks, fakes, stubs) and how they isolate a unit.

--- a/docs/reference/mode-s.md
+++ b/docs/reference/mode-s.md
@@ -10,15 +10,18 @@ autolink: true
 see_also: [ads-b, compact-position-reporting, cyclic-redundancy-check, icao]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Secondary_surveillance_radar#Mode_S
 external:
-  - { title: "Secondary surveillance radar — Mode S (Wikipedia)", url: https://en.wikipedia.org/wiki/Secondary_surveillance_radar#Mode_S }
   - { title: "GopherTrunk ADS-B decoder", url: /adsb.html }
 ---
 
 **Mode S** (mode select) is the selective-addressing aviation transponder protocol on
 **1090 MHz** that carries each aircraft's unique **24-bit ICAO address** and forms the
 foundation of [ADS-B](/reference/ads-b/). Messages are 56- or 112-bit frames protected
-by a [CRC-24](/reference/cyclic-redundancy-check/).
+by a [CRC-24](/reference/cyclic-redundancy-check/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A Mode S frame: a short pulse preamble followed by a data block of address and payload ending in a CRC." xmlns="http://www.w3.org/2000/svg">
@@ -36,3 +39,7 @@ by a [CRC-24](/reference/cyclic-redundancy-check/).
 ADS-B is carried in *extended squitter* (DF17/18) Mode S frames whose payload includes
 identity, position, and velocity. GopherTrunk decodes these (via a BEAST upstream or
 native demod) into tracked aircraft — see the [ADS-B](/adsb.html) page.
+
+## Sources
+
+[^wiki]: [Secondary surveillance radar — Mode S](https://en.wikipedia.org/wiki/Secondary_surveillance_radar#Mode_S) — Wikipedia, for the Mode S selective-addressing transponder protocol, its 24-bit ICAO address, frame sizes, and CRC.

--- a/docs/reference/modulation.md
+++ b/docs/reference/modulation.md
@@ -13,14 +13,14 @@ see_also: [carrier-wave, amplitude-modulation, frequency-modulation, phase-shift
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
   - { title: "Analog modulation — AM, FM, SSB", url: /learn/rf-sdr/analog-modulation/ }
-external:
-  - { title: "Modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Modulation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Modulation
 ---
 
 **Modulation** is the process of varying a property of a
 [carrier wave](/reference/carrier-wave/) — its [amplitude](/reference/amplitude/),
 [frequency](/reference/frequency/), or [phase](/reference/phase/) — in step with a
-message so that information can travel over radio.
+message so that information can travel over radio.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 170" role="img" aria-label="A message wave, then an AM version whose height follows the message, then an FM version whose spacing follows the message." xmlns="http://www.w3.org/2000/svg">
@@ -47,3 +47,7 @@ modulation switches the carrier between discrete states (symbols):
 Choosing the matching demodulator for a signal's modulation is the heart of decoding.
 The same three carrier properties reappear as the axes of the
 [IQ](/reference/iq-data/) plane.
+
+## Sources
+
+[^wiki]: [Modulation](https://en.wikipedia.org/wiki/Modulation) — Wikipedia, overview of analog and digital modulation methods.

--- a/docs/reference/motorola-type-ii.md
+++ b/docs/reference/motorola-type-ii.md
@@ -19,15 +19,17 @@ see_also: [trunked-radio, control-channel, edacs, ltr, talkgroup, radio-id]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Motorola Type II (Wikipedia)", url: https://en.wikipedia.org/wiki/Motorola_Type_II }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Motorola_Type_II
 ---
 
 **Motorola Type II** is a classic **analog trunked-radio** family (SmartNet /
 SmartZone) that pairs a **digital [control channel](/reference/control-channel/)**
 with **analog FM** voice channels. It was the dominant trunking technology for
 public-safety and business fleets before the migration to digital
-[P25](/reference/project-25/).
+[P25](/reference/project-25/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 140" role="img" aria-label="Motorola Type II digital control channel assigning analog voice channels." xmlns="http://www.w3.org/2000/svg">
@@ -59,7 +61,7 @@ itself is analog FM. Each transmitting radio carries a [radio ID](/reference/rad
 ## History
 
 Introduced by Motorola in the 1980s (SmartNet), later extended with multi-site
-SmartZone, and ubiquitous through the 1990s–2000s.
+SmartZone, and ubiquitous through the 1990s–2000s.[^wiki]
 
 ## Deployment
 
@@ -70,3 +72,7 @@ some remain in service.
 
 GopherTrunk decodes the Type II control channel and follows grants to the analog
 voice channels. See [Status](/status.html).
+
+## Sources
+
+[^wiki]: [Motorola Type II](https://en.wikipedia.org/wiki/Motorola_Type_II) — Wikipedia, for the SmartNet/SmartZone analog trunking family, its digital control channel, and talkgroup/radio-ID signalling.

--- a/docs/reference/mpt-1327.md
+++ b/docs/reference/mpt-1327.md
@@ -17,15 +17,17 @@ infobox:
 see_also: [trunked-radio, control-channel, ffsk, ltr, edacs]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "MPT-1327 (Wikipedia)", url: https://en.wikipedia.org/wiki/MPT-1327 }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/MPT-1327
 ---
 
 **MPT 1327** is an analog [trunked-radio](/reference/trunked-radio/) signalling
 standard that originated in the United Kingdom. It uses a **dedicated
 [control channel](/reference/control-channel/)** carrying **1200 bps
 [FFSK](/reference/ffsk/)** data to manage analog FM voice channels, and became a
-common international trunking standard.
+common international trunking standard.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 140" role="img" aria-label="MPT 1327 FFSK control channel assigning analog voice channels." xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +58,7 @@ adopted open alternative to proprietary systems like
 ## History
 
 Published in the UK in the 1980s; deployed across Europe, Asia, Africa, and
-Australasia for commercial and government trunking.
+Australasia for commercial and government trunking.[^wiki]
 
 ## Deployment
 
@@ -66,3 +68,7 @@ standards take over.
 ## Decoding it with GopherTrunk
 
 See [Status](/status.html) for GopherTrunk's MPT 1327 control-channel support.
+
+## Sources
+
+[^wiki]: [MPT-1327](https://en.wikipedia.org/wiki/MPT-1327) — Wikipedia, for the UK-originated analog trunking signalling standard, its FFSK control channel, and international adoption.

--- a/docs/reference/mueller-muller-timing-recovery.md
+++ b/docs/reference/mueller-muller-timing-recovery.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [clock-recovery, gardner-timing-recovery, symbol-rate, ais, aprs]
 related_lessons:
   - { title: "Clock recovery & symbol timing", url: /learn/rf-sdr/clock-recovery/ }
-external:
-  - { title: "Symbol synchronization (Wikipedia)", url: https://en.wikipedia.org/wiki/Symbol_synchronization }
+related_reading:
+  - { title: "SDR Internals, Part 7: Symbol timing & sync recovery", url: /blog/deep-dives/sdr-internals-07-symbol-timing-sync-recovery/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Symbol_synchronization
 ---
 
 **Mueller–Müller timing recovery** is a decision-directed symbol-timing algorithm that
-needs only **one sample per symbol**, making it computationally efficient.
+needs only **one sample per symbol**, making it computationally efficient.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A symbol waveform sampled once per symbol, with successive samples used to estimate and correct timing." xmlns="http://www.w3.org/2000/svg">
@@ -41,3 +43,7 @@ decisions to start.
 
 GopherTrunk uses Mueller–Müller recovery in decoders such as [AIS](/reference/ais/),
 [APRS](/reference/aprs/), and signalling pipelines.
+
+## Sources
+
+[^wiki]: [Symbol synchronization](https://en.wikipedia.org/wiki/Symbol_synchronization) — Wikipedia, for decision-directed symbol-timing recovery such as the Mueller–Müller method.

--- a/docs/reference/multi-band-excitation.md
+++ b/docs/reference/multi-band-excitation.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [vocoder, imbe, ambe, ambe-plus-2, dvsi]
 related_lessons:
   - { title: "Vocoders — IMBE & AMBE+2", url: /learn/rf-sdr/vocoders/ }
-external:
-  - { title: "Multi-Band Excitation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multi-Band_Excitation }
+related_reading:
+  - { title: "SDR Internals, Part 12: Voice coding & vocoders", url: /blog/deep-dives/sdr-internals-12-voice-coding-vocoders/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Multi-Band_Excitation
 ---
 
 **Multi-band excitation** (**MBE**) is a speech-modelling method that represents a voice
 by its pitch and a decision, per frequency band, of whether that band is *voiced*
-(pitched) or *unvoiced* (noisy), plus the spectral envelope.
+(pitched) or *unvoiced* (noisy), plus the spectral envelope.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A speech spectrum divided into frequency bands, each independently declared voiced or unvoiced." xmlns="http://www.w3.org/2000/svg">
@@ -43,3 +45,7 @@ at a few kbps. MBE underlies the [IMBE](/reference/imbe/) and [AMBE](/reference/
 
 Understanding MBE explains why decoded digital voice can sound robotic and why bit errors
 produce characteristic warbles.
+
+## Sources
+
+[^wiki]: [Multi-Band Excitation](https://en.wikipedia.org/wiki/Multi-Band_Excitation) — Wikipedia, for the speech model with per-band voiced/unvoiced decisions underlying IMBE/AMBE.

--- a/docs/reference/multipath-propagation.md
+++ b/docs/reference/multipath-propagation.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [radio-propagation, cma-equalizer, clock-recovery, radio-horizon]
 related_lessons:
   - { title: "How signals travel", url: /learn/rf-sdr/propagation/ }
-external:
-  - { title: "Multipath propagation (Wikipedia)", url: https://en.wikipedia.org/wiki/Multipath_propagation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Multipath_propagation
 ---
 
 **Multipath propagation** occurs when a signal reaches the receiver by several paths at
-once — directly and via reflections off buildings, terrain, and vehicles. The copies
+once — directly and via reflections off buildings, terrain, and vehicles.[^wiki] The copies
 arrive slightly out of step and add or cancel.
 
 <figure class="figure" markdown="0">
@@ -45,3 +45,7 @@ degrading decoding. Moving the antenna a short distance can change multipath mar
 Multipath is a common reason a strong signal still won't decode; an
 [equalizer](/reference/cma-equalizer/) and good [clock recovery](/reference/clock-recovery/)
 help combat it.
+
+## Sources
+
+[^wiki]: [Multipath propagation](https://en.wikipedia.org/wiki/Multipath_propagation) — Wikipedia, on multiple-path arrival, fading, and intersymbol interference.

--- a/docs/reference/noise-floor.md
+++ b/docs/reference/noise-floor.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [signal-to-noise-ratio, dbm, low-noise-amplifier, attenuation]
 related_lessons:
   - { title: "Decibels & signal power", url: /learn/rf-sdr/decibels/ }
-external:
-  - { title: "Noise floor (Wikipedia)", url: https://en.wikipedia.org/wiki/Noise_floor }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Noise_floor
 ---
 
 The **noise floor** is the constant background level of random energy present in any
-receiver — thermal noise in the electronics plus environmental RF. It is measured in
+receiver — thermal noise in the electronics plus environmental RF.[^wiki] It is measured in
 [dBm](/reference/dbm/) and sets the bar a signal must clear.
 
 <figure class="figure" markdown="0">
@@ -42,3 +42,7 @@ signal is only useful when it pokes above it; the margin is the
 
 A [low-noise amplifier](/reference/low-noise-amplifier/) and a quiet install lower the
 effective floor, while nearby electronics (USB, chargers, LED lighting) raise it.
+
+## Sources
+
+[^wiki]: [Noise floor](https://en.wikipedia.org/wiki/Noise_floor) — Wikipedia, the background noise level in a measurement system.

--- a/docs/reference/nrzi.md
+++ b/docs/reference/nrzi.md
@@ -10,13 +10,13 @@ autolink: true
 see_also: [ax25, aprs, ais, frequency-shift-keying, clock-recovery]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Non-return-to-zero (Wikipedia)", url: https://en.wikipedia.org/wiki/Non-return-to-zero#NRZI }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Non-return-to-zero#NRZI
 ---
 
 **NRZI** (**non-return-to-zero inverted**) is a line code in which each bit is conveyed
 by **whether the signal level changes**, not by the level itself: conventionally a `0`
-causes a transition and a `1` causes none (or vice-versa). It is used by
+causes a transition and a `1` causes none (or vice-versa).[^wiki] It is used by
 [AX.25](/reference/ax25/)/[APRS](/reference/aprs/) and [AIS](/reference/ais/).
 
 <figure class="figure" markdown="0">
@@ -34,3 +34,7 @@ Because NRZI ties bits to transitions, combining it with **bit stuffing** (as
 [HDLC](/reference/ax25/) does) guarantees regular edges, which keeps the receiver's
 [clock recovery](/reference/clock-recovery/) locked even through long runs of identical
 data bits.
+
+## Sources
+
+[^wiki]: [Non-return-to-zero — NRZI](https://en.wikipedia.org/wiki/Non-return-to-zero#NRZI) — Wikipedia, for the transition-based line-code definition.

--- a/docs/reference/numerically-controlled-oscillator.md
+++ b/docs/reference/numerically-controlled-oscillator.md
@@ -10,13 +10,15 @@ autolink: true
 see_also: [digital-down-converter, local-oscillator, decimation, iq-data]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Numerically controlled oscillator (Wikipedia)", url: https://en.wikipedia.org/wiki/Numerically-controlled_oscillator }
+related_reading:
+  - { title: "SDR Internals, Part 4: DSP foundations — filters, NCO & AGC", url: /blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Numerically-controlled_oscillator
 ---
 
 A **numerically controlled oscillator** (**NCO**) generates a digital sine and cosine
 of any programmable frequency from a **phase accumulator** — a counter that adds a fixed
-step each sample and looks up the corresponding sine value. It is the software
+step each sample and looks up the corresponding sine value.[^wiki] It is the software
 equivalent of a [local oscillator](/reference/local-oscillator/) and the tunable mixer
 inside a [digital down-converter](/reference/digital-down-converter/).
 
@@ -39,3 +41,7 @@ inside a [digital down-converter](/reference/digital-down-converter/).
 Changing the accumulator's step instantly retunes the NCO, which is how an SDR
 **digitally tunes** to a channel: multiply the [IQ](/reference/iq-data/) stream by the
 NCO's output to shift that channel to [baseband](/reference/baseband/) before filtering.
+
+## Sources
+
+[^wiki]: [Numerically-controlled oscillator](https://en.wikipedia.org/wiki/Numerically-controlled_oscillator) — Wikipedia, on phase-accumulator-based digital frequency synthesis.

--- a/docs/reference/nxdn.md
+++ b/docs/reference/nxdn.md
@@ -18,14 +18,16 @@ infobox:
 see_also: [dpmr, frequency-shift-keying, ambe-plus-2, trunked-radio, control-channel]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "NXDN (Wikipedia)", url: https://en.wikipedia.org/wiki/NXDN }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/NXDN
 ---
 
 **NXDN** is a **narrowband** digital land-mobile radio standard jointly developed by
 **Kenwood** (NEXEDGE) and **Icom** (IDAS). It uses [4FSK](/reference/frequency-shift-keying/)
 in very narrow 6.25 kHz channels (or 12.5 kHz) and the
-[AMBE+2](/reference/ambe-plus-2/) vocoder.
+[AMBE+2](/reference/ambe-plus-2/) vocoder.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 360 150" role="img" aria-label="Narrow 6.25 kHz FDMA channels for NXDN." xmlns="http://www.w3.org/2000/svg">
@@ -59,7 +61,7 @@ channels. It supports both conventional operation and trunking with a
 ## History
 
 Introduced in the late 2000s as Kenwood and Icom's common air interface for
-narrowband digital business radio.
+narrowband digital business radio.[^wiki]
 
 ## Deployment
 
@@ -70,3 +72,7 @@ Common in business, transport, and utility fleets, especially where regulators r
 
 GopherTrunk decodes NXDN voice and follows trunked NXDN control channels. See
 [Status](/status.html).
+
+## Sources
+
+[^wiki]: [NXDN](https://en.wikipedia.org/wiki/NXDN) — Wikipedia, for the Kenwood/Icom narrowband 4FSK air interface, channel widths, and the AMBE+2 vocoder.

--- a/docs/reference/nyquist-theorem.md
+++ b/docs/reference/nyquist-theorem.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [sample-rate, aliasing, bandwidth, harry-nyquist, claude-shannon]
 related_lessons:
   - { title: "Sample rate, bandwidth & Nyquist", url: /learn/rf-sdr/sample-rate-nyquist/ }
-external:
-  - { title: "Nyquist–Shannon sampling theorem (Wikipedia)", url: https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem
 ---
 
 The **Nyquist–Shannon sampling theorem** states that to represent a signal without loss
-you must sample at least **twice its [bandwidth](/reference/bandwidth/)**. For IQ
+you must sample at least **twice its [bandwidth](/reference/bandwidth/)**.[^wiki] For IQ
 sampling, the practical takeaway is that usable bandwidth ≈
 [sample rate](/reference/sample-rate/).
 
@@ -44,3 +44,7 @@ frequencies.
 It is named for [Harry Nyquist](/reference/harry-nyquist/) and
 [Claude Shannon](/reference/claude-shannon/), and it sets the floor on the sample rate
 needed to capture a given channel.
+
+## Sources
+
+[^wiki]: [Nyquist–Shannon sampling theorem](https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem) — Wikipedia, on the minimum sampling rate for lossless representation.

--- a/docs/reference/object-oriented-programming.md
+++ b/docs/reference/object-oriented-programming.md
@@ -17,13 +17,13 @@ infobox:
 see_also: [functional-programming, imperative-programming, abstraction, coupling-and-cohesion, design-patterns, java-language, csharp-language, ruby-language]
 related_lessons:
   - { title: "Paradigms & language families", url: /learn/intro-software-dev/language-families/ }
-external:
-  - { title: "Object-oriented programming — Wikipedia", url: https://en.wikipedia.org/wiki/Object-oriented_programming }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Object-oriented_programming
 ---
 
 **Object-oriented programming** (**OOP**) is a paradigm that bundles state and the
 behaviour that acts on it into **objects** — units that combine *fields* (data) with
-*methods* (functions that operate on that data).
+*methods* (functions that operate on that data).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="An object encapsulates private data behind public methods, and several objects share one interface so callers can treat them uniformly." xmlns="http://www.w3.org/2000/svg">
@@ -48,7 +48,7 @@ OOP rests on a few pillars. **Encapsulation** hides an object's internal data be
 clean interface, the foundation of [abstraction](/reference/abstraction/) and information
 hiding. **Inheritance** derives specialised types from general ones, and
 **polymorphism** lets you treat different types uniformly through a shared interface —
-calling `area()` without knowing whether the object is a circle or a square. These
+calling `area()` without knowing whether the object is a circle or a square.[^wiki] These
 combine to keep [coupling](/reference/coupling-and-cohesion/) low: callers depend on a
 contract, not a concrete class.
 
@@ -64,8 +64,12 @@ expressed in object-oriented terms.
 ## Trade-offs
 
 Critics note that overusing inheritance creates rigid, tangled hierarchies, which is why
-modern OOP leans on **composition** ("has-a") over deep inheritance ("is-a"). Many
+modern OOP leans on **composition** ("has-a") over deep inheritance ("is-a").[^wiki] Many
 languages are multi-paradigm: the same codebase can mix object-oriented structure with
 [functional](/reference/functional-programming/) transformations and
 [imperative](/reference/imperative-programming/) inner loops, choosing the style that
 fits each part of the problem.
+
+## Sources
+
+[^wiki]: [Object-oriented programming](https://en.wikipedia.org/wiki/Object-oriented_programming) — Wikipedia, for the definition, the pillars (encapsulation, inheritance, polymorphism), and the composition-over-inheritance guidance.

--- a/docs/reference/ofcom.md
+++ b/docs/reference/ofcom.md
@@ -11,14 +11,15 @@ see_also: [fcc, itu, frequency-bands]
 related_lessons:
   - { title: "Frequency, bands & the spectrum", url: /learn/rf-sdr/frequency-and-spectrum/ }
   - { title: "Legal & ethical monitoring", url: /learn/rf-sdr/legal-ethical/ }
-external:
-  - { title: "Ofcom (Wikipedia)", url: https://en.wikipedia.org/wiki/Ofcom }
+cite_urls:
+  - https://www.ofcom.org.uk/
+  - https://en.wikipedia.org/wiki/Ofcom
 ---
 
 **Ofcom** (the Office of Communications) is the **United Kingdom's communications
-regulator**. It allocates and licenses radio spectrum and sets the rules for its use —
+regulator**.[^wiki] It allocates and licenses radio spectrum and sets the rules for its use —
 the UK counterpart to the United States' [FCC](/reference/fcc/), working within the
-global framework set by the [ITU](/reference/itu/).
+global framework set by the [ITU](/reference/itu/).[^home]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="The ITU framework within which Ofcom regulates UK spectrum and licenses users." xmlns="http://www.w3.org/2000/svg">
@@ -39,3 +40,8 @@ global framework set by the [ITU](/reference/itu/).
 Whether and what you may legally receive depends on national rules; in the UK those are
 Ofcom's. See the [legal &amp; ethical monitoring](/learn/rf-sdr/legal-ethical/) lesson, and always
 check the regulator for your own jurisdiction.
+
+## Sources
+
+[^home]: [Ofcom](https://www.ofcom.org.uk/) — the UK communications regulator's official site, for spectrum allocation and licensing.
+[^wiki]: [Ofcom](https://en.wikipedia.org/wiki/Ofcom) — Wikipedia, for Ofcom's role as the UK communications regulator.

--- a/docs/reference/p25-phase-1.md
+++ b/docs/reference/p25-phase-1.md
@@ -20,13 +20,15 @@ see_also: [project-25, p25-phase-2, c4fm, imbe, fdma, control-channel]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Project_25
 ---
 
 **P25 Phase 1** is the first-generation air interface of [Project 25](/reference/project-25/),
 using **[FDMA](/reference/fdma/)** — one conversation per 12.5 kHz channel — with
-[C4FM](/reference/c4fm/) modulation and the [IMBE](/reference/imbe/) vocoder.
+[C4FM](/reference/c4fm/) modulation and the [IMBE](/reference/imbe/) vocoder.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 360 150" role="img" aria-label="Stacked 12.5 kHz FDMA channels each carrying one P25 Phase 1 call." xmlns="http://www.w3.org/2000/svg">
@@ -66,7 +68,7 @@ demodulator can handle both transmit paths.
 
 Phase 1 documents were published by the [TIA](/reference/tia/) starting in the
 mid-1990s and saw broad public-safety adoption through the 2000s as agencies migrated
-from analog and proprietary systems.
+from analog and proprietary systems.[^wiki]
 
 ## Deployment
 
@@ -79,3 +81,7 @@ GopherTrunk demodulates the C4FM symbols, recovers the IMBE frames, and synthesi
 audio. The [constellation](/reference/constellation-diagram/) and
 [eye diagram](/reference/eye-diagram/) views help confirm a clean lock. See
 [Status](/status.html) for details.
+
+## Sources
+
+[^wiki]: [Project 25](https://en.wikipedia.org/wiki/Project_25) — Wikipedia, for the P25 Phase 1 FDMA air interface, C4FM/CQPSK modulation, the IMBE vocoder, and TIA standardisation.

--- a/docs/reference/p25-phase-2.md
+++ b/docs/reference/p25-phase-2.md
@@ -19,13 +19,15 @@ see_also: [project-25, p25-phase-1, ambe-plus-2, tdma, control-channel]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
   - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
-external:
-  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Project_25
 ---
 
 **P25 Phase 2** is the second-generation air interface of [Project 25](/reference/project-25/),
 using **two-slot [TDMA](/reference/tdma/)** to carry two simultaneous voice
-conversations in a single 12.5 kHz channel — effectively 6.25 kHz per call.
+conversations in a single 12.5 kHz channel — effectively 6.25 kHz per call.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 140" role="img" aria-label="Two TDMA slots in a 12.5 kHz channel for P25 Phase 2." xmlns="http://www.w3.org/2000/svg">
@@ -63,7 +65,7 @@ slots.
 
 Phase 2 was standardised by the [TIA](/reference/tia/) to follow narrowbanding and
 spectrum-efficiency mandates, and has been deployed on large metropolitan and
-statewide systems since the early 2010s.
+statewide systems since the early 2010s.[^wiki]
 
 ## Deployment
 
@@ -74,3 +76,7 @@ at a premium, frequently mixed with Phase 1 on the same network.
 
 GopherTrunk follows the control channel, tunes to the assigned Phase 2 traffic
 channel and slot, and decodes the AMBE+2 voice. See [Status](/status.html).
+
+## Sources
+
+[^wiki]: [Project 25](https://en.wikipedia.org/wiki/Project_25) — Wikipedia, for the P25 Phase 2 two-slot TDMA air interface, H-DQPSK/H-CPM modulation, the AMBE+2 vocoder, and TIA standardisation.

--- a/docs/reference/package-manager.md
+++ b/docs/reference/package-manager.md
@@ -16,13 +16,13 @@ infobox:
 see_also: [build-systems, semantic-versioning, ci-cd, api, version-control, static-binary]
 related_lessons:
   - { title: "Build systems, CI/CD & automation", url: /learn/intro-software-dev/build-and-ci-cd/ }
-external:
-  - { title: "Package manager — Wikipedia", url: https://en.wikipedia.org/wiki/Package_manager }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Package_manager
 ---
 
 **A package manager** automates declaring, resolving, fetching, and pinning the external
 libraries a project depends on, using lockfiles to make dependency resolution
-reproducible.
+reproducible.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A project manifest lists dependencies; the package manager resolves and fetches them, and a lockfile pins exact versions." xmlns="http://www.w3.org/2000/svg">
@@ -44,7 +44,7 @@ reproducible.
 Almost no project is self-contained — you stand on libraries written by others. A package
 manager (Go modules, Cargo, npm, pip, and so on) records what your project needs in a
 manifest and fetches it, including the *transitive* dependencies your direct dependencies
-pull in. The libraries you depend on expose their capabilities through an
+pull in.[^wiki] The libraries you depend on expose their capabilities through an
 [API](/reference/api/), and the package manager's job is to get a compatible set of them
 onto your machine and, with the [build system](/reference/build-systems/), into your
 program.
@@ -67,3 +67,7 @@ the version number tells the resolver (and you) whether an upgrade is a safe pat
 backward-compatible feature, or a breaking major change. Package managers also distribute
 *your* library outward — publishing a versioned package others can depend on — which is
 why a stable, well-versioned API matters as much for what you ship as for what you consume.
+
+## Sources
+
+[^wiki]: [Package manager](https://en.wikipedia.org/wiki/Package_manager) — Wikipedia, for dependency declaration, resolution, fetching, and lockfile-based reproducibility.

--- a/docs/reference/path-loss.md
+++ b/docs/reference/path-loss.md
@@ -15,12 +15,12 @@ see_also: [attenuation, radio-propagation, decibel, signal-to-noise-ratio]
 related_lessons:
   - { title: "How signals travel", url: /learn/rf-sdr/propagation/ }
   - { title: "Decibels & signal power", url: /learn/rf-sdr/decibels/ }
-external:
-  - { title: "Path loss (Wikipedia)", url: https://en.wikipedia.org/wiki/Path_loss }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Path_loss
 ---
 
 **Path loss** is the [attenuation](/reference/attenuation/) a signal experiences
-travelling from transmitter to receiver. It is dominated by the spreading of energy
+travelling from transmitter to receiver.[^wiki] It is dominated by the spreading of energy
 over distance, plus losses from terrain, buildings, and foliage.
 
 <figure class="figure" markdown="0">
@@ -46,3 +46,7 @@ total 100+ dB over a few kilometres, which is why link budgets are done in
 Path loss explains why a distant or obstructed system arrives near the
 [noise floor](/reference/noise-floor/), and why antenna height and a clear path
 ([propagation](/reference/radio-propagation/)) matter so much.
+
+## Sources
+
+[^wiki]: [Path loss](https://en.wikipedia.org/wiki/Path_loss) — Wikipedia, for the definition and distance/frequency dependence of propagation loss.

--- a/docs/reference/phase-shift-keying.md
+++ b/docs/reference/phase-shift-keying.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [frequency-shift-keying, quadrature-amplitude-modulation, cqpsk, phase, costas-loop, constellation-diagram]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "Phase-shift keying (Wikipedia)", url: https://en.wikipedia.org/wiki/Phase-shift_keying }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Phase-shift_keying
 ---
 
 **Phase-shift keying** (**PSK**) is digital [modulation](/reference/modulation/) that
 switches a [carrier](/reference/carrier-wave/)'s [phase](/reference/phase/) between
-fixed angles while amplitude stays constant. Two phases is BPSK; four is QPSK (2 bits
+fixed angles while amplitude stays constant.[^wiki] Two phases is BPSK; four is QPSK (2 bits
 per symbol).
 
 <figure class="figure" markdown="0">
@@ -45,3 +47,7 @@ efficient.
 
 [P25 Phase 2](/reference/p25-phase-2/) uses a PSK variant, and many satellite and
 broadcast links are PSK; tracking phase accurately is key to decoding them.
+
+## Sources
+
+[^wiki]: [Phase-shift keying](https://en.wikipedia.org/wiki/Phase-shift_keying) — Wikipedia, for the definition and the BPSK/QPSK variants.

--- a/docs/reference/phase.md
+++ b/docs/reference/phase.md
@@ -12,12 +12,12 @@ infobox:
 see_also: [amplitude, iq-data, phase-shift-keying, constellation-diagram]
 related_lessons:
   - { title: "IQ data & complex signals", url: /learn/rf-sdr/iq-data/ }
-external:
-  - { title: "Phase (waves) (Wikipedia)", url: https://en.wikipedia.org/wiki/Phase_(waves) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Phase_(waves)
 ---
 
 **Phase** is the position of a point within the cycle of a wave, expressed in degrees
-(0–360°) or radians. Two waves of the same [frequency](/reference/frequency/) can
+(0–360°) or radians.[^wiki] Two waves of the same [frequency](/reference/frequency/) can
 differ in phase, meaning one is shifted in time relative to the other.
 
 <figure class="figure" markdown="0">
@@ -43,3 +43,7 @@ jumping the phase between fixed values encodes data — the basis of
 Tracking phase is essential to demodulating PSK and QAM signals; a
 [Costas loop](/reference/costas-loop/) recovers the carrier phase so symbols land
 correctly on the [constellation](/reference/constellation-diagram/).
+
+## Sources
+
+[^wiki]: [Phase (waves)](https://en.wikipedia.org/wiki/Phase_(waves)) — Wikipedia, on the position within a wave's cycle and phase difference.

--- a/docs/reference/php-language.md
+++ b/docs/reference/php-language.md
@@ -19,13 +19,15 @@ see_also: [javascript-language, interpreter, static-vs-dynamic-typing, garbage-c
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
-external:
-  - { title: "PHP — Wikipedia", url: https://en.wikipedia.org/wiki/PHP }
-  - { title: "PHP: Hypertext Preprocessor", url: https://www.php.net/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.php.net/
+  - https://en.wikipedia.org/wiki/PHP
 ---
 
 **PHP** is a dynamic, [interpreted](/reference/interpreter/) scripting language built
-for the web back end. It is one of the most widely deployed languages on the
+for the web back end.[^wiki] It is one of the most widely deployed languages on the
 internet, historically criticised for inconsistency, but substantially modernised in
 versions 7 and 8.
 
@@ -47,7 +49,7 @@ versions 7 and 8.
 
 PHP was designed to be embedded directly in web pages, and that origin shaped its
 ecosystem: it ships with nearly every shared web host, which made it the default for
-a huge share of the web. WordPress, much of the world's content-management software,
+a huge share of the web.[^home] WordPress, much of the world's content-management software,
 and major sites are built on it, and modern frameworks like Laravel and Symfony bring
 disciplined structure. It serves dynamic pages and [REST](/reference/rest/) APIs,
 typically run per request by the server.
@@ -57,9 +59,14 @@ typically run per request by the server.
 PHP is dynamically and weakly typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/)),
 [garbage-collected](/reference/garbage-collection/), and compiles to
 [bytecode](/reference/bytecode/) that an engine executes — with an optional
-[JIT](/reference/jit-compilation/) added in PHP 8. Its reputation for **inconsistency**
+[JIT](/reference/jit-compilation/) added in PHP 8.[^home] Its reputation for **inconsistency**
 is earned: the standard library has irregular function names and argument orders, and
 older code mixed logic with HTML freely. Versions 7 and 8 changed the picture
 considerably, adding real performance gains, optional type declarations, and cleaner
 language features, though its weak typing and accumulated history still draw criticism.
 Like [JavaScript](/reference/javascript-language/), it is hard to avoid on the web.
+
+## Sources
+
+[^home]: [PHP: Hypertext Preprocessor](https://www.php.net/) — official site, documentation, and the engine, bytecode, and JIT details.
+[^wiki]: [PHP](https://en.wikipedia.org/wiki/PHP) — Wikipedia, for history, design background, and web ubiquity.

--- a/docs/reference/pi-4-dqpsk.md
+++ b/docs/reference/pi-4-dqpsk.md
@@ -10,14 +10,16 @@ autolink: true
 see_also: [phase-shift-keying, cqpsk, constellation-diagram, tetra]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "π/4-QPSK (Wikipedia)", url: https://en.wikipedia.org/wiki/Phase-shift_keying#%CF%80/4%E2%80%93QPSK }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Phase-shift_keying#%CF%80/4%E2%80%93QPSK
 ---
 
 **π/4-DQPSK** (π/4-shifted differential quadrature [phase-shift keying](/reference/phase-shift-keying/))
 is a four-symbol phase modulation in which the constellation is **rotated by 45° (π/4)
 every symbol** and information is carried in the *change* of phase rather than its
-absolute value. It is the air-interface modulation of [TETRA](/reference/tetra/).
+absolute value.[^wiki] It is the air-interface modulation of [TETRA](/reference/tetra/).
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 240 240" role="img" aria-label="An eight-point constellation formed by two QPSK sets offset by 45 degrees, as used by pi/4-DQPSK." xmlns="http://www.w3.org/2000/svg">
@@ -42,3 +44,7 @@ envelope more constant and easier to amplify efficiently.
 Differential encoding means the receiver only needs to measure phase *changes*, so it
 tolerates a constant carrier-phase offset without an absolute phase reference. This
 robustness is why TETRA and several other professional systems adopted it.
+
+## Sources
+
+[^wiki]: [Phase-shift keying — π/4–QPSK](https://en.wikipedia.org/wiki/Phase-shift_keying#%CF%80/4%E2%80%93QPSK) — Wikipedia, for the differential π/4-shifted QPSK definition.

--- a/docs/reference/pocsag.md
+++ b/docs/reference/pocsag.md
@@ -17,15 +17,18 @@ infobox:
 see_also: [flex, frequency-shift-keying, bch-code, demodulation]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/POCSAG
 external:
-  - { title: "POCSAG (Wikipedia)", url: https://en.wikipedia.org/wiki/POCSAG }
   - { title: "GopherTrunk POCSAG decoder", url: /pocsag.html }
 ---
 
 **POCSAG** (the **CCIR Radiopaging Code No. 1**) is the classic one-way **paging**
 protocol used worldwide to deliver numeric and alphanumeric messages to pagers. It is
 a simple asynchronous **2-level [FSK](/reference/frequency-shift-keying/)** scheme,
-still in active use by hospitals, fire/EMS, and industry.
+still in active use by hospitals, fire/EMS, and industry.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="A POCSAG transmission: preamble, sync codeword, then batches of address and message codewords." xmlns="http://www.w3.org/2000/svg">
@@ -56,7 +59,7 @@ are protected by a [BCH(31,21)](/reference/bch-code/) code plus a parity bit.
 ## History
 
 Developed by the British Post Office and standardised by the CCIR in the early 1980s;
-it became the dominant global paging code.
+it became the dominant global paging code.[^wiki]
 
 ## Deployment
 
@@ -67,3 +70,7 @@ uses POCSAG.
 
 GopherTrunk demodulates the FSK, recovers codewords, and decodes numeric/alphanumeric
 messages. See the [POCSAG decoder](/pocsag.html) page.
+
+## Sources
+
+[^wiki]: [POCSAG](https://en.wikipedia.org/wiki/POCSAG) — Wikipedia, for the CCIR Radiopaging Code No. 1, its FSK bit rates, BCH coding, and codeword/batch structure.

--- a/docs/reference/polarization.md
+++ b/docs/reference/polarization.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [antenna, dipole-antenna, radio-propagation, antenna-gain]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
-external:
-  - { title: "Polarization (waves) (Wikipedia)", url: https://en.wikipedia.org/wiki/Polarization_(waves) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Polarization_(waves)
 ---
 
 **Polarization** is the orientation of a [radio wave](/reference/radio-wave/)'s
 electric field, determined by how the transmitting [antenna](/reference/antenna/) is
-mounted — vertical, horizontal, or circular.
+mounted — vertical, horizontal, or circular.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="A vertically oriented wave on the left and a horizontally oriented wave on the right, showing polarization." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +45,7 @@ polarized, while FM broadcast is often horizontal or circular.
 
 A vertical antenna is the safe default for scanning land-mobile and trunked systems,
 matching their vertical polarization.
+
+## Sources
+
+[^wiki]: [Polarization (waves)](https://en.wikipedia.org/wiki/Polarization_(waves)) — Wikipedia, on the orientation of a wave's electric field and polarization types.

--- a/docs/reference/ppm-frequency-correction.md
+++ b/docs/reference/ppm-frequency-correction.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [local-oscillator, frequency, costas-loop, constellation-diagram]
 related_lessons:
   - { title: "Calibration & troubleshooting", url: /learn/rf-sdr/calibration-troubleshooting/ }
-external:
-  - { title: "Frequency error (Wikipedia)", url: https://en.wikipedia.org/wiki/Clock_drift }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Clock_drift
 ---
 
 **PPM frequency correction** compensates for the small error in an SDR's reference
 oscillator, measured in **parts per million**, so signals land on their **true
-frequency**. At UHF a 30 PPM error is several kilohertz — more than a channel's width.
+frequency**.[^wiki] At UHF a 30 PPM error is several kilohertz — more than a channel's width.
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 150" role="img" aria-label="A signal sitting off the channel centre due to oscillator error, and the same signal centred after PPM correction." xmlns="http://www.w3.org/2000/svg">
@@ -49,3 +49,7 @@ so warm-up matters.
 A wrong PPM produces the classic *rotating
 [constellation](/reference/constellation-diagram/)* that won't lock — fixed by
 calibration, not a better antenna.
+
+## Sources
+
+[^wiki]: [Clock drift](https://en.wikipedia.org/wiki/Clock_drift) — Wikipedia, on oscillator frequency error and drift measured in parts per million.

--- a/docs/reference/project-25.md
+++ b/docs/reference/project-25.md
@@ -21,8 +21,11 @@ see_also: [p25-phase-1, p25-phase-2, c4fm, imbe, ambe-plus-2, trunked-radio, con
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Project_25
 external:
-  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
   - { title: "GopherTrunk decoder status", url: /status.html }
 ---
 
@@ -30,7 +33,7 @@ external:
 **digital land-mobile radio** developed for public-safety and government users in
 North America. It defines how radios, repeaters, and trunked systems carry digital
 voice and data, with the explicit goal of interoperability between equipment from
-different manufacturers.
+different manufacturers.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="P25 Phase 1 shown as FDMA channels and Phase 2 as two-slot TDMA." xmlns="http://www.w3.org/2000/svg">
@@ -70,7 +73,7 @@ Both phases can be deployed conventionally or as a trunked system coordinated by
 ## History
 
 P25 standardisation began in the late 1980s under [APCO](/reference/apco-international/),
-with Phase 1 documents published by the [TIA](/reference/tia/) from the mid-1990s.
+with Phase 1 documents published by the [TIA](/reference/tia/) from the mid-1990s.[^wiki]
 Phase 2 followed to address spectrum-efficiency mandates, introducing TDMA so two
 voice conversations could share one 12.5 kHz channel.
 
@@ -88,3 +91,7 @@ follows channel grants to voice channels, and runs the matching vocoder to produ
 audio. See the [protocol landscape lesson](/learn/rf-sdr/protocol-landscape/) for how P25
 compares with other systems, and the [Status](/status.html) page for current
 coverage.
+
+## Sources
+
+[^wiki]: [Project 25](https://en.wikipedia.org/wiki/Project_25) — Wikipedia, for P25 history, the Phase 1/Phase 2 air interfaces, and the TIA/APCO standardisation.

--- a/docs/reference/provoice.md
+++ b/docs/reference/provoice.md
@@ -10,14 +10,16 @@ autolink: true
 see_also: [edacs, ambe, vocoder, trunked-radio]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Enhanced Digital Access Communications System (Wikipedia)", url: https://en.wikipedia.org/wiki/Enhanced_Digital_Access_Communications_System }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Enhanced_Digital_Access_Communications_System
 ---
 
 **ProVoice** is the **digital-voice option for [EDACS](/reference/edacs/)** trunked
 systems (GE/Ericsson, later M/A-COM). It replaces EDACS's analog FM voice with a digital
 [AMBE](/reference/ambe/)-family [vocoder](/reference/vocoder/) while keeping the EDACS
-control-channel signalling.
+control-channel signalling.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="An EDACS control channel assigning a voice channel that carries digital ProVoice AMBE frames instead of analog FM." xmlns="http://www.w3.org/2000/svg">
@@ -34,3 +36,7 @@ control-channel signalling.
 Because ProVoice uses a proprietary vocoder, decoding it has historically required
 licensed components; the EDACS trunking layer itself is followed the same way regardless
 of whether the voice is analog or ProVoice.
+
+## Sources
+
+[^wiki]: [Enhanced Digital Access Communications System](https://en.wikipedia.org/wiki/Enhanced_Digital_Access_Communications_System) — Wikipedia, for EDACS and its ProVoice digital-voice option using an AMBE-family vocoder.

--- a/docs/reference/pulse-shaping.md
+++ b/docs/reference/pulse-shaping.md
@@ -10,13 +10,13 @@ autolink: true
 see_also: [root-raised-cosine-filter, bandwidth, symbol-rate, matched-filter]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "Pulse shaping (Wikipedia)", url: https://en.wikipedia.org/wiki/Pulse_shaping }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Pulse_shaping
 ---
 
 **Pulse shaping** is filtering each transmitted symbol's pulse so the signal occupies
 **less bandwidth** and successive symbols don't smear into one another
-(inter-symbol interference). Sharp rectangular pulses spray energy into adjacent
+(inter-symbol interference).[^wiki] Sharp rectangular pulses spray energy into adjacent
 channels; a shaped pulse keeps it contained.
 
 <figure class="figure" markdown="0">
@@ -38,3 +38,7 @@ channels; a shaped pulse keeps it contained.
 The most common choice is the [root-raised-cosine filter](/reference/root-raised-cosine-filter/),
 split between transmitter and receiver so that together they form a Nyquist filter with
 zero inter-symbol interference at the sampling instants.
+
+## Sources
+
+[^wiki]: [Pulse shaping](https://en.wikipedia.org/wiki/Pulse_shaping) — Wikipedia, for the bandwidth-limiting and inter-symbol-interference rationale.

--- a/docs/reference/python-language.md
+++ b/docs/reference/python-language.md
@@ -19,14 +19,16 @@ see_also: [interpreter, bytecode, garbage-collection, static-vs-dynamic-typing, 
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Python (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Python_(programming_language) }
-  - { title: "The Python programming language", url: https://www.python.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.python.org/
+  - https://en.wikipedia.org/wiki/Python_(programming_language)
 ---
 
 **Python** is a dynamically typed, interpreted, general-purpose programming language
 designed for readability, with a deliberately clean syntax and one of the largest
-library ecosystems of any language.
+library ecosystems of any language.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Python source is compiled to bytecode and executed by the interpreter, with heavy work delegated to fast native libraries." xmlns="http://www.w3.org/2000/svg">
@@ -47,7 +49,7 @@ library ecosystems of any language.
 
 Python source is compiled to [bytecode](/reference/bytecode/) and run by an
 [interpreter](/reference/interpreter/) — most commonly CPython, the reference
-implementation. It uses [dynamic typing](/reference/static-vs-dynamic-typing/) with
+implementation.[^home] It uses [dynamic typing](/reference/static-vs-dynamic-typing/) with
 optional type hints, and is [garbage-collected](/reference/garbage-collection/) through
 reference counting plus a cycle detector. The result is a language that is quick to
 write and forgiving to learn, which is why it is a common first language and the glue
@@ -71,3 +73,8 @@ mainstay of scripting, automation, glue code and web backends. Its speed limits 
 matter for scripts or for workloads that push the real computation into native code; in
 the niche where raw numeric throughput is decisive, alternatives like
 [Julia](/reference/julia-language/) or a compiled language are reached for instead.
+
+## Sources
+
+[^home]: [The Python programming language](https://www.python.org/) — official site, documentation, and the CPython reference implementation.
+[^wiki]: [Python (programming language)](https://en.wikipedia.org/wiki/Python_(programming_language)) — Wikipedia, for history and design background.

--- a/docs/reference/quadrature-amplitude-modulation.md
+++ b/docs/reference/quadrature-amplitude-modulation.md
@@ -14,14 +14,16 @@ infobox:
 see_also: [phase-shift-keying, frequency-shift-keying, constellation-diagram, signal-to-noise-ratio, iq-data]
 related_lessons:
   - { title: "Digital modulation & constellations", url: /learn/rf-sdr/digital-modulation/ }
-external:
-  - { title: "Quadrature amplitude modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Quadrature_amplitude_modulation }
+related_reading:
+  - { title: "SDR Internals, Part 6: Demodulation", url: /blog/deep-dives/sdr-internals-06-demodulation/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Quadrature_amplitude_modulation
 ---
 
 **Quadrature amplitude modulation** (**QAM**) varies **both** the
 [phase](/reference/phase/) and [amplitude](/reference/amplitude/) of a carrier, packing
 many states into the [IQ](/reference/iq-data/) plane — 16-QAM (4 bits/symbol), 64-QAM,
-and higher.
+and higher.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 240 240" role="img" aria-label="A 16-QAM constellation: a four-by-four grid of points on the IQ plane." xmlns="http://www.w3.org/2000/svg">
@@ -48,3 +50,7 @@ the states sit closer together, so QAM needs a higher
 
 QAM appears in Wi-Fi, cable, and LTE rather than scanner voice traffic, but the same
 [constellation](/reference/constellation-diagram/) idea applies to reading its quality.
+
+## Sources
+
+[^wiki]: [Quadrature amplitude modulation](https://en.wikipedia.org/wiki/Quadrature_amplitude_modulation) — Wikipedia, for the definition and the higher-order QAM/SNR trade-off.

--- a/docs/reference/r-language.md
+++ b/docs/reference/r-language.md
@@ -19,13 +19,15 @@ see_also: [python-language, julia-language, matlab-language, interpreter, static
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Matching the language to the domain", url: /learn/intro-software-dev/language-for-the-domain/ }
-external:
-  - { title: "R (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/R_(programming_language) }
-  - { title: "The R Project for Statistical Computing", url: https://www.r-project.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.r-project.org/
+  - https://en.wikipedia.org/wiki/R_(programming_language)
 ---
 
 **R** is a dynamic, [interpreted](/reference/interpreter/) language specialised for
-statistics, data analysis, and plotting. It is beloved by statisticians and
+statistics, data analysis, and plotting.[^wiki] It is beloved by statisticians and
 researchers, and is excellent for analysis and visualisation but less suited to
 general-purpose programming.
 
@@ -47,7 +49,7 @@ general-purpose programming.
 ## Overview
 
 R grew out of the academic statistics community and remains organised around that
-work. Its data frames, vectorised operations, and enormous library of statistical
+work.[^home] Its data frames, vectorised operations, and enormous library of statistical
 methods make it a natural fit for exploratory analysis, modelling, and producing
 charts. Packages distributed through CRAN cover an extraordinary range of statistical
 and domain-specific techniques, and tools like ggplot2 are renowned for the quality
@@ -57,10 +59,15 @@ of their graphics.
 
 R is dynamically typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/)),
 [interpreted](/reference/interpreter/), and [garbage-collected](/reference/garbage-collection/),
-with a [functional](/reference/functional-programming/) and array-oriented bent. Its
+with a [functional](/reference/functional-programming/) and array-oriented bent.[^home] Its
 strengths are also its limits: it is purpose-built for statistics, so it is less
 comfortable as a general-purpose language, and pure-R loops are **slow**, pushing heavy
 work into vectorised or native code. For numerical and data work it competes with
 [Python](/reference/python-language/) (which has a larger general ecosystem) and the
 faster [Julia](/reference/julia-language/); for engineering signal work many reach for
 [MATLAB](/reference/matlab-language/) instead.
+
+## Sources
+
+[^home]: [The R Project for Statistical Computing](https://www.r-project.org/) — official site, documentation, and the CRAN ecosystem.
+[^wiki]: [R (programming language)](https://en.wikipedia.org/wiki/R_(programming_language)) — Wikipedia, for history, origins, and statistical focus.

--- a/docs/reference/r820t-tuner.md
+++ b/docs/reference/r820t-tuner.md
@@ -15,14 +15,16 @@ infobox:
 see_also: [rtl-sdr, rtl2832u, superheterodyne-receiver, local-oscillator]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
-external:
-  - { title: "RTL-SDR (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR }
+related_reading:
+  - { title: "RF Front End, Part 7: RTL-SDR / RTL2832U bring-up", url: /blog/deep-dives/rf-front-end-07-rtlsdr-rtl2832u-bringup/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR
 ---
 
 The **R820T** and improved **R820T2** (and related R828D) from Rafael Micro are the most
 common tuner chips paired with the [RTL2832U](/reference/rtl2832u/) in
 [RTL-SDR](/reference/rtl-sdr/) dongles. They provide the RF front-end and
-mixer/[local oscillator](/reference/local-oscillator/).
+mixer/[local oscillator](/reference/local-oscillator/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="The tuner's role: RF in, mixed with a local oscillator, low-IF out to the ADC." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +48,7 @@ overload behaviour.
 
 The tuner sets the dongle's frequency range and much of its noise performance, important
 when chasing weak signals.
+
+## Sources
+
+[^wiki]: [RTL-SDR](https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR) — Wikipedia, on the R820T/R820T2 tuners commonly paired with the RTL2832U.

--- a/docs/reference/radio-horizon.md
+++ b/docs/reference/radio-horizon.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [radio-propagation, frequency-bands, antenna]
 related_lessons:
   - { title: "How signals travel", url: /learn/rf-sdr/propagation/ }
-external:
-  - { title: "Radio horizon (Wikipedia)", url: https://en.wikipedia.org/wiki/Line-of-sight_propagation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Line-of-sight_propagation
 ---
 
 The **radio horizon** is the farthest point a line-of-sight signal reaches before the
-Earth's curvature gets in the way. It lies slightly beyond the visual horizon because
+Earth's curvature gets in the way.[^wiki] It lies slightly beyond the visual horizon because
 the atmosphere refracts radio waves a little.
 
 <figure class="figure" markdown="0">
@@ -43,3 +43,7 @@ towers and hilltops and why getting a receive antenna up high extends range at
 
 For line-of-sight bands, antenna height is often the most effective way to reach more
 distant systems.
+
+## Sources
+
+[^wiki]: [Line-of-sight propagation](https://en.wikipedia.org/wiki/Line-of-sight_propagation) — Wikipedia, on the radio horizon, Earth curvature, and atmospheric refraction.

--- a/docs/reference/radio-id.md
+++ b/docs/reference/radio-id.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [talkgroup, affiliation, control-channel, mdc1200]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Trunked_radio_system
 ---
 
 A **radio ID** (unit ID) is the unique identifier of an individual radio on a system,
-distinct from the [talkgroup](/reference/talkgroup/) it is using. It appears in
+distinct from the [talkgroup](/reference/talkgroup/) it is using.[^wiki] It appears in
 [control-channel](/reference/control-channel/) signalling and in analog in-band schemes
 like [MDC1200](/reference/mdc1200/).
 
@@ -44,3 +46,7 @@ ID, so a monitor can see *which unit* is talking, not just which group.
 
 GopherTrunk's Radio IDs view merges live radio IDs with any alias catalogue, letting you
 track individual units across a system.
+
+## Sources
+
+[^wiki]: [Trunked radio system](https://en.wikipedia.org/wiki/Trunked_radio_system) — Wikipedia, on subscriber/unit identifiers in trunking signalling.

--- a/docs/reference/radio-propagation.md
+++ b/docs/reference/radio-propagation.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [multipath-propagation, radio-horizon, ionospheric-propagation, path-loss, frequency-bands]
 related_lessons:
   - { title: "How signals travel", url: /learn/rf-sdr/propagation/ }
-external:
-  - { title: "Radio propagation (Wikipedia)", url: https://en.wikipedia.org/wiki/Radio_propagation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Radio_propagation
 ---
 
 **Radio propagation** describes how [radio waves](/reference/radio-wave/) travel from
 transmitter to receiver, including line-of-sight travel, reflection, diffraction, and
-atmospheric effects.
+atmospheric effects.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 150" role="img" aria-label="A curved earth with a tall transmitter tower and a receiver, a straight line-of-sight path, and an obstacle blocking a lower path." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +45,7 @@ distances. Loss along the way is [path loss](/reference/path-loss/).
 
 Understanding propagation explains why antenna height and a clear path often matter
 more than the radio, and why a distant hilltop system can beat a closer obstructed one.
+
+## Sources
+
+[^wiki]: [Radio propagation](https://en.wikipedia.org/wiki/Radio_propagation) — Wikipedia, on line-of-sight, reflection, diffraction, and atmospheric propagation.

--- a/docs/reference/radio-wave.md
+++ b/docs/reference/radio-wave.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [electromagnetic-spectrum, frequency, wavelength, carrier-wave, modulation]
 related_lessons:
   - { title: "What is a radio wave?", url: /learn/rf-sdr/radio-waves/ }
-external:
-  - { title: "Radio wave (Wikipedia)", url: https://en.wikipedia.org/wiki/Radio_wave }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Radio_wave
 ---
 
 A **radio wave** is electromagnetic radiation whose [frequency](/reference/frequency/)
-lies in the radio range of the [electromagnetic spectrum](/reference/electromagnetic-spectrum/).
+lies in the radio range of the [electromagnetic spectrum](/reference/electromagnetic-spectrum/).[^wiki]
 Radio waves travel at the speed of light and carry information wirelessly when their
 [amplitude](/reference/amplitude/), frequency, or [phase](/reference/phase/) is varied
 — a process called [modulation](/reference/modulation/).
@@ -46,3 +46,7 @@ the passing field back into a tiny current that a receiver amplifies and decodes
 
 Radio waves are the raw input to any receiver. An SDR digitises a slice of them into
 [IQ data](/reference/iq-data/) for software to process.
+
+## Sources
+
+[^wiki]: [Radio wave](https://en.wikipedia.org/wiki/Radio_wave) — Wikipedia, on radio-frequency electromagnetic radiation and its use for wireless communication.

--- a/docs/reference/radioreference.md
+++ b/docs/reference/radioreference.md
@@ -10,14 +10,14 @@ autolink: true
 see_also: [trunked-radio, control-channel, talkgroup, project-25]
 related_lessons:
   - { title: "Finding & identifying systems", url: /learn/rf-sdr/finding-systems/ }
-external:
-  - { title: "RadioReference.com", url: https://www.radioreference.com/ }
+cite_urls:
+  - https://www.radioreference.com/
 ---
 
 **RadioReference** is the largest community-maintained **database of radio systems** —
 frequencies, [trunked-system](/reference/trunked-radio/) types,
 [control channels](/reference/control-channel/), and [talkgroups](/reference/talkgroup/),
-catalogued by location. It is the usual first stop when deciding what to monitor.
+catalogued by location. It is the usual first stop when deciding what to monitor.[^home]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="RadioReference cataloguing systems that an operator looks up to configure a scanner." xmlns="http://www.w3.org/2000/svg">
@@ -39,3 +39,7 @@ For most populated areas, the local systems are already documented on RadioRefer
 you can look up a system's control-channel frequency and talkgroup list rather than
 discovering them from scratch. GopherTrunk can [import](/import.html) these details
 directly.
+
+## Sources
+
+[^home]: [RadioReference.com](https://www.radioreference.com/) — the official RadioReference site, the community database of radio systems, frequencies, and talkgroups.

--- a/docs/reference/rc4-cipher.md
+++ b/docs/reference/rc4-cipher.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [scrambling, dmr, forward-error-correction]
 related_lessons:
   - { title: "Encryption & what you can decode", url: /learn/rf-sdr/encryption/ }
-external:
-  - { title: "RC4 (Wikipedia)", url: https://en.wikipedia.org/wiki/RC4 }
+cite_urls:
+  - https://en.wikipedia.org/wiki/RC4
 ---
 
 **RC4** (also **ARC4**) is a stream cipher that generates a pseudo-random keystream from a
-secret key and XORs it with the data. It provides the "Enhanced Privacy" encryption option
+secret key and XORs it with the data.[^wiki] It provides the "Enhanced Privacy" encryption option
 on some [DMR](/reference/dmr/) systems.
 
 <figure class="figure" markdown="0">
@@ -47,3 +47,7 @@ secret — so without the key the voice cannot be recovered.
 RC4 illustrates the line between reversible whitening and true encryption: GopherTrunk can
 descramble whitening but cannot decode encrypted voice without the key. See
 [DMR encryption](/dmr-encryption.html).
+
+## Sources
+
+[^wiki]: [RC4](https://en.wikipedia.org/wiki/RC4) — Wikipedia, for the stream cipher and its key-derived keystream XORed with the data.

--- a/docs/reference/reed-solomon-code.md
+++ b/docs/reference/reed-solomon-code.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [forward-error-correction, bch-code, golay-code, interleaving]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Reed–Solomon error correction (Wikipedia)", url: https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction
 ---
 
 **Reed–Solomon** is a block [error-correction](/reference/forward-error-correction/) code
 that works on multi-bit **symbols** rather than individual bits, making it especially good
-at correcting **bursts** of errors.
+at correcting **bursts** of errors.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A codeword of data symbols followed by parity symbols, with the parity able to correct a burst of damaged symbols." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +47,7 @@ across codewords.
 Reed–Solomon protects parts of [P25](/reference/project-25/) and
 [DMR](/reference/dmr/) (and is ubiquitous in storage and broadcast), helping the decoder
 recover data on marginal signals.
+
+## Sources
+
+[^wiki]: [Reed–Solomon error correction](https://en.wikipedia.org/wiki/Reed%E2%80%93Solomon_error_correction) — Wikipedia, for the symbol-oriented block code and burst-error correction.

--- a/docs/reference/refactoring.md
+++ b/docs/reference/refactoring.md
@@ -16,12 +16,12 @@ infobox:
 see_also: [clean-code, dry-kiss-yagni, solid, unit-testing, test-driven-development, abstraction, coupling-and-cohesion]
 related_lessons:
   - { title: "Writing readable code", url: /learn/intro-software-dev/clean-code/ }
-external:
-  - { title: "Code refactoring — Wikipedia", url: https://en.wikipedia.org/wiki/Code_refactoring }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Code_refactoring
 ---
 
 **Refactoring** is the disciplined practice of restructuring existing code to improve
-its design, readability, and maintainability *without* changing its external behavior.
+its design, readability, and maintainability *without* changing its external behavior.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="Tangled code is restructured into clean code while the observable behavior, the output, stays the same." xmlns="http://www.w3.org/2000/svg">
@@ -43,7 +43,7 @@ The defining constraint is behavior preservation: a refactor reorganizes the *ho
 while keeping the *what* identical. Typical moves — popularized by Martin Fowler's
 catalog — include renaming for clarity, extracting a function or class, inlining a
 needless indirection, removing duplication, and breaking up a class that has taken on
-too many responsibilities. Each is a small, safe step rather than a sweeping rewrite.
+too many responsibilities. Each is a small, safe step rather than a sweeping rewrite.[^wiki]
 Refactoring is triggered by *code smells*: duplication, long functions, large classes,
 tangled dependencies, and other signals that the code resists change. Left
 unaddressed, those smells accumulate as **technical debt** that slows every future
@@ -69,3 +69,7 @@ refactor toward [clean code](/reference/clean-code/), toward
 [abstraction](/reference/abstraction/) only once it has proven itself. Done
 continuously in small steps, it keeps a codebase healthy; deferred indefinitely, it
 becomes a costly rewrite.
+
+## Sources
+
+[^wiki]: [Code refactoring](https://en.wikipedia.org/wiki/Code_refactoring) — Wikipedia, for the behavior-preserving definition and Martin Fowler's catalog of refactorings.

--- a/docs/reference/reginald-fessenden.md
+++ b/docs/reference/reginald-fessenden.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [amplitude-modulation, guglielmo-marconi, carrier-wave]
 related_lessons:
   - { title: "Analog modulation — AM, FM, SSB", url: /learn/rf-sdr/analog-modulation/ }
-external:
-  - { title: "Reginald Fessenden (Wikipedia)", url: https://en.wikipedia.org/wiki/Reginald_Fessenden }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Reginald_Fessenden
 ---
 
 **Reginald Fessenden** (1866–1932) was a Canadian-American inventor credited with some of
 the first **audio radio transmissions**, moving radio beyond Morse code to voice using
-[amplitude modulation](/reference/amplitude-modulation/).
+[amplitude modulation](/reference/amplitude-modulation/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A carrier whose amplitude envelope follows a voice waveform, illustrating the first AM voice transmission." xmlns="http://www.w3.org/2000/svg">
@@ -34,7 +34,7 @@ the first **audio radio transmissions**, moving radio beyond Morse code to voice
 ## Life and work
 
 Where early wireless sent spark-gap pulses, Fessenden championed continuous-wave radio and
-the heterodyne principle, transmitting speech and music in the early 1900s.
+the heterodyne principle, transmitting speech and music in the early 1900s.[^wiki]
 
 ## Contribution
 
@@ -45,3 +45,7 @@ design.
 
 Fessenden is remembered as a pioneer of voice radio, complementing
 [Marconi](/reference/guglielmo-marconi/)'s telegraphy.
+
+## Sources
+
+[^wiki]: [Reginald Fessenden](https://en.wikipedia.org/wiki/Reginald_Fessenden) — Wikipedia, for biography and his pioneering of AM voice radio.

--- a/docs/reference/resampler.md
+++ b/docs/reference/resampler.md
@@ -10,12 +10,14 @@ autolink: true
 see_also: [sample-rate, decimation, digital-filter, nyquist-theorem]
 related_lessons:
   - { title: "Sample rate, bandwidth & Nyquist", url: /learn/rf-sdr/sample-rate-nyquist/ }
-external:
-  - { title: "Sample-rate conversion (Wikipedia)", url: https://en.wikipedia.org/wiki/Sample-rate_conversion }
+related_reading:
+  - { title: "SDR Internals, Part 5: Tuning & channelization", url: /blog/deep-dives/sdr-internals-05-tuning-channelization/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Sample-rate_conversion
 ---
 
 A **resampler** converts a sample stream from one [sample rate](/reference/sample-rate/)
-to another. SDRs rarely produce exactly the rate a decoder wants (a P25 channel needs a
+to another.[^wiki] SDRs rarely produce exactly the rate a decoder wants (a P25 channel needs a
 multiple of 4800 baud, say), so a resampler bridges the two — by a whole-number ratio or
 a fractional one.
 
@@ -36,3 +38,7 @@ a fractional one.
 Resampling combines interpolation, filtering, and [decimation](/reference/decimation/);
 done carelessly it causes [aliasing](/reference/aliasing/), so a resampler always
 includes an anti-alias [filter](/reference/digital-filter/).
+
+## Sources
+
+[^wiki]: [Sample-rate conversion](https://en.wikipedia.org/wiki/Sample-rate_conversion) — Wikipedia, on converting a stream between sample rates.

--- a/docs/reference/rest-channel.md
+++ b/docs/reference/rest-channel.md
@@ -10,13 +10,15 @@ autolink: true
 see_also: [control-channel, channel-grant, trunked-radio, capacity-plus, dmr]
 related_lessons:
   - { title: "Finding & identifying systems", url: /learn/rf-sdr/finding-systems/ }
-external:
-  - { title: "Digital mobile radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Digital_mobile_radio }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital_mobile_radio
 ---
 
 A **rest channel** is the channel currently carrying control signalling in trunked
 systems that **rotate the control function around the pool** rather than dedicate one
-frequency to it. When a call is assigned to the current rest channel, control moves to
+frequency to it.[^wiki] When a call is assigned to the current rest channel, control moves to
 another idle channel — the new rest channel.
 
 <figure class="figure" markdown="0">
@@ -39,3 +41,7 @@ another idle channel — the new rest channel.
 Rotating control (used by Motorola [Capacity Plus](/reference/capacity-plus/) and some
 DMR systems) complicates monitoring: a scanner must follow the rest channel as it hops,
 rather than camping on one fixed [control channel](/reference/control-channel/).
+
+## Sources
+
+[^wiki]: [Digital mobile radio](https://en.wikipedia.org/wiki/Digital_mobile_radio) — Wikipedia, on DMR trunking modes that rotate the control (rest) channel.

--- a/docs/reference/rest.md
+++ b/docs/reference/rest.md
@@ -16,13 +16,13 @@ infobox:
 see_also: [api, error-handling, semantic-versioning, end-to-end-testing, integration-testing, version-control]
 related_lessons:
   - { title: "Errors, edge cases & defensive programming", url: /learn/intro-software-dev/robustness-and-errors/ }
-external:
-  - { title: "REST — Wikipedia", url: https://en.wikipedia.org/wiki/REST }
+cite_urls:
+  - https://en.wikipedia.org/wiki/REST
 ---
 
 **REST** (Representational State Transfer) is an architectural style for web
 [APIs](/reference/api/) in which clients act on named *resources*, identified by URLs,
-using standard HTTP verbs over a stateless protocol.
+using standard HTTP verbs over a stateless protocol.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A client sends HTTP verbs GET, POST, PUT, DELETE to a server's resource URLs." xmlns="http://www.w3.org/2000/svg">
@@ -40,7 +40,7 @@ using standard HTTP verbs over a stateless protocol.
 
 ## The core ideas
 
-REST, described by Roy Fielding, organizes an API around a handful of constraints:
+REST, described by Roy Fielding, organizes an API around a handful of constraints:[^wiki]
 
 - **Resources and URLs.** Everything is a resource — a message, a user, a device — each
   identified by a URL like `/messages/42`. The URL names the *thing*, not the action.
@@ -73,3 +73,7 @@ like `/v2/messages`. Because REST endpoints are where many systems meet, they ar
 target for [integration tests](/reference/integration-testing/) and
 [end-to-end tests](/reference/end-to-end-testing/) that exercise real requests against the
 running service.
+
+## Sources
+
+[^wiki]: [REST](https://en.wikipedia.org/wiki/REST) — Wikipedia, for the architectural style, its constraints, and Roy Fielding's role in defining it.

--- a/docs/reference/richard-hamming.md
+++ b/docs/reference/richard-hamming.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [hamming-code, forward-error-correction, golay-code]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Richard Hamming (Wikipedia)", url: https://en.wikipedia.org/wiki/Richard_Hamming }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Richard_Hamming
 ---
 
 **Richard Hamming** (1915–1998) was an American mathematician who created the first
 practical **error-correcting codes** — the [Hamming codes](/reference/hamming-code/) —
-launching the field of coding theory.
+launching the field of coding theory.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="Data bits with interspersed parity bits that detect and correct a single error." xmlns="http://www.w3.org/2000/svg">
@@ -35,7 +35,7 @@ launching the field of coding theory.
 
 Frustrated by computers halting on detected errors, Hamming devised codes that could
 *correct* single-bit errors automatically, and defined the "Hamming distance" measuring
-how many bits differ between codewords.
+how many bits differ between codewords.[^wiki]
 
 ## Contribution
 
@@ -45,3 +45,7 @@ on which all reliable digital radio depends.
 ## Legacy
 
 Hamming codes and their descendants protect data across radio, storage, and networking.
+
+## Sources
+
+[^wiki]: [Richard Hamming](https://en.wikipedia.org/wiki/Richard_Hamming) — Wikipedia, for biography and his creation of the first practical error-correcting codes.

--- a/docs/reference/root-raised-cosine-filter.md
+++ b/docs/reference/root-raised-cosine-filter.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [matched-filter, digital-filter, symbol-rate, eye-diagram]
 related_lessons:
   - { title: "Filtering & decimation", url: /learn/rf-sdr/filtering-decimation/ }
-external:
-  - { title: "Root-raised-cosine filter (Wikipedia)", url: https://en.wikipedia.org/wiki/Root-raised-cosine_filter }
+related_reading:
+  - { title: "SDR Internals, Part 4: DSP foundations — filters, NCO & AGC", url: /blog/deep-dives/sdr-internals-04-dsp-foundations-filters-nco-agc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Root-raised-cosine_filter
 ---
 
 A **root-raised-cosine** (**RRC**) filter is a pulse-shaping
-[filter](/reference/digital-filter/) applied at both transmitter and receiver. Split
+[filter](/reference/digital-filter/) applied at both transmitter and receiver.[^wiki] Split
 across the link, the two halves combine into a raised-cosine response that limits
 bandwidth while minimising **intersymbol interference**.
 
@@ -44,3 +46,7 @@ maximising SNR at the sampling instant — visible as a clean
 
 Applying the correct RRC is part of demodulating digital signals that use it, sharpening
 [symbol](/reference/symbol-rate/) decisions.
+
+## Sources
+
+[^wiki]: [Root-raised-cosine filter](https://en.wikipedia.org/wiki/Root-raised-cosine_filter) — Wikipedia, on split RRC pulse shaping and the matched-filter pair.

--- a/docs/reference/rtca.md
+++ b/docs/reference/rtca.md
@@ -10,14 +10,14 @@ autolink: true
 see_also: [ads-b, mode-s, icao, eurocae]
 related_lessons:
   - { title: "Other signals you'll meet", url: /learn/rf-sdr/other-signals/ }
-external:
-  - { title: "RTCA (Wikipedia)", url: https://en.wikipedia.org/wiki/RTCA }
+cite_urls:
+  - https://en.wikipedia.org/wiki/RTCA
 ---
 
 **RTCA** is a United States standards organization for **aviation electronics**. Its
 **DO-260** series of Minimum Operational Performance Standards (MOPS) defines the
 [ADS-B](/reference/ads-b/) requirements that aircraft transponders must meet, alongside
-the international standards from [ICAO](/reference/icao/).
+the international standards from [ICAO](/reference/icao/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="RTCA publishing the DO-260 standard that defines ADS-B transponder behaviour." xmlns="http://www.w3.org/2000/svg">
@@ -37,3 +37,7 @@ the international standards from [ICAO](/reference/icao/).
 
 RTCA's DO-260B is the ADS-B specification most often cited in decoder documentation; its
 European counterpart is [EUROCAE](/reference/eurocae/)'s ED-102A.
+
+## Sources
+
+[^wiki]: [RTCA](https://en.wikipedia.org/wiki/RTCA) — Wikipedia, on RTCA and its DO-260 MOPS defining ADS-B performance requirements.

--- a/docs/reference/rtl-sdr.md
+++ b/docs/reference/rtl-sdr.md
@@ -16,14 +16,17 @@ infobox:
 see_also: [rtl2832u, r820t-tuner, hackrf, airspy, upconverter, software-defined-radio]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
+related_reading:
+  - { title: "RF Front End, Part 7: RTL-SDR / RTL2832U bring-up", url: /blog/deep-dives/rf-front-end-07-rtlsdr-rtl2832u-bringup/ }
 external:
-  - { title: "RTL-SDR (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR }
   - { title: "GopherTrunk hardware guide", url: /hardware.html }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR
 ---
 
 **RTL-SDR** is a family of inexpensive USB [software-defined radio](/reference/software-defined-radio/)
 receivers built around the [RTL2832U](/reference/rtl2832u/) chip — originally a DVB-T TV
-tuner that hobbyists discovered could stream raw [IQ](/reference/iq-data/) samples.
+tuner that hobbyists discovered could stream raw [IQ](/reference/iq-data/) samples.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A frequency coverage bar for RTL-SDR (~24 MHz–1.7 GHz) on an axis from about 0 to 6 gigahertz." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +49,7 @@ range, but more than enough to follow most VHF/UHF trunked systems.
 The RTL-SDR is the ideal entry point and the baseline GopherTrunk targets. For HF, add an
 [upconverter](/reference/upconverter/) or use an [Airspy HF+](/reference/airspy-hf-plus/);
 see the [hardware guide](/hardware.html).
+
+## Sources
+
+[^wiki]: [RTL-SDR](https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR) — Wikipedia, on the DVB-T-dongle origins and capabilities of RTL-SDR.

--- a/docs/reference/rtl-tcp.md
+++ b/docs/reference/rtl-tcp.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [rtl-sdr, soapysdr, iq-data, software-defined-radio]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
-external:
-  - { title: "rtl-sdr (osmocom)", url: https://osmocom.org/projects/rtl-sdr/wiki }
+cite_urls:
+  - https://osmocom.org/projects/rtl-sdr/wiki
 ---
 
 **rtl_tcp** is a small server that streams raw [IQ](/reference/iq-data/) samples from an
 [RTL-SDR](/reference/rtl-sdr/) over a **TCP** connection, letting the dongle be used from
-another machine on the network.
+another machine on the network.[^osmo]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A dongle on a remote computer streaming IQ over the network to GopherTrunk on another machine." xmlns="http://www.w3.org/2000/svg">
@@ -45,3 +45,7 @@ A common setup runs rtl_tcp on a Raspberry Pi right at the [antenna](/reference/
 
 GopherTrunk can attach to an rtl_tcp (or [SoapyRemote](/reference/soapysdr/)) source,
 treating a remote dongle like a local one.
+
+## Sources
+
+[^osmo]: [rtl-sdr (osmocom)](https://osmocom.org/projects/rtl-sdr/wiki) — the Osmocom rtl-sdr project wiki, home of rtl_tcp and the RTL-SDR driver tools.

--- a/docs/reference/rtl2832u.md
+++ b/docs/reference/rtl2832u.md
@@ -15,13 +15,15 @@ infobox:
 see_also: [rtl-sdr, r820t-tuner, analog-to-digital-converter]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
-external:
-  - { title: "RTL-SDR (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR }
+related_reading:
+  - { title: "RF Front End, Part 7: RTL-SDR / RTL2832U bring-up", url: /blog/deep-dives/rf-front-end-07-rtlsdr-rtl2832u-bringup/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR
 ---
 
 The **RTL2832U** is the Realtek demodulator and USB-bridge chip at the core of
 [RTL-SDR](/reference/rtl-sdr/) dongles. Its undocumented raw-[IQ](/reference/iq-data/)
-output mode is what turned cheap DVB-T tuners into software-defined radios.
+output mode is what turned cheap DVB-T tuners into software-defined radios.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="Block diagram: antenna into a tuner chip, into the RTL2832U ADC and demodulator, out over USB as IQ samples." xmlns="http://www.w3.org/2000/svg">
@@ -47,3 +49,7 @@ interface; it is paired with a separate tuner chip such as the
 
 GopherTrunk drives RTL2832U-based devices through a pure-Go USB driver with no C
 dependencies.
+
+## Sources
+
+[^wiki]: [RTL-SDR](https://en.wikipedia.org/wiki/Software-defined_radio#RTL-SDR) — Wikipedia, on the RTL2832U demodulator/USB-bridge chip and its raw-IQ output mode.

--- a/docs/reference/ruby-language.md
+++ b/docs/reference/ruby-language.md
@@ -19,15 +19,17 @@ see_also: [python-language, object-oriented-programming, interpreter, static-vs-
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
-external:
-  - { title: "Ruby (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Ruby_(programming_language) }
-  - { title: "Ruby programming language", url: https://www.ruby-lang.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.ruby-lang.org/
+  - https://en.wikipedia.org/wiki/Ruby_(programming_language)
 ---
 
 **Ruby** is a dynamic, [object-oriented](/reference/object-oriented-programming/),
 [interpreted](/reference/interpreter/) language created by Yukihiro "Matz" Matsumoto
 with an explicit goal of programmer happiness, and it is best known as the language
-behind the Ruby on Rails web framework.
+behind the Ruby on Rails web framework.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Concise Ruby source runs through an interpreter, which produces a working web application." xmlns="http://www.w3.org/2000/svg">
@@ -46,7 +48,7 @@ behind the Ruby on Rails web framework.
 
 Ruby prizes readability and expressiveness over raw speed. Its syntax reads almost
 like English, nearly everything is an object, and its flexible metaprogramming lets
-libraries build clean, domain-specific interfaces. That power is what made **Ruby on
+libraries build clean, domain-specific interfaces.[^home] That power is what made **Ruby on
 Rails** so influential: the framework's "convention over configuration" approach let
 small teams ship web applications fast, and it shaped a generation of web frameworks
 in other languages. Gems, installed through the RubyGems [package manager](/reference/package-manager/),
@@ -57,8 +59,13 @@ provide a large library ecosystem.
 Ruby is dynamically typed (see [static vs dynamic typing](/reference/static-vs-dynamic-typing/))
 and [garbage-collected](/reference/garbage-collection/), with code run by a
 [bytecode](/reference/bytecode/) virtual machine that has gained a JIT in recent
-releases. The trade-offs are well known: like other dynamic languages such as
+releases.[^home] The trade-offs are well known: like other dynamic languages such as
 [Python](/reference/python-language/), it is comparatively **slow** in CPU-bound work
 and its loose typing lets some bugs reach runtime. Its popularity has cooled from the
 Rails peak, and its centre of gravity stays in web back ends, scripting, and
 automation rather than systems or numeric work.
+
+## Sources
+
+[^home]: [Ruby programming language](https://www.ruby-lang.org/) — official site, documentation, and the dynamic object model and runtime.
+[^wiki]: [Ruby (programming language)](https://en.wikipedia.org/wiki/Ruby_(programming_language)) — Wikipedia, for history, Matz's design goals, and Rails.

--- a/docs/reference/rust-language.md
+++ b/docs/reference/rust-language.md
@@ -19,14 +19,16 @@ see_also: [c-language, cpp-language, go-language, memory-management, compiler, c
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
-external:
-  - { title: "Rust (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Rust_(programming_language) }
-  - { title: "The Rust programming language", url: https://www.rust-lang.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.rust-lang.org/
+  - https://en.wikipedia.org/wiki/Rust_(programming_language)
 ---
 
 **Rust** is a statically typed, compiled systems language designed to be fast *and*
 safe: its borrow checker enforces memory safety at compile time, eliminating whole
-classes of bugs without a garbage collector or runtime cost.
+classes of bugs without a garbage collector or runtime cost.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="The Rust compiler's borrow checker verifies ownership and borrowing rules at compile time; code that passes is memory-safe with no garbage collector." xmlns="http://www.w3.org/2000/svg">
@@ -45,7 +47,7 @@ classes of bugs without a garbage collector or runtime cost.
 ## Overview
 
 Rust [compiles](/reference/compiler/) ahead of time to native machine code, with
-performance that rivals [C](/reference/c-language/) and [C++](/reference/cpp-language/).
+performance that rivals [C](/reference/c-language/) and [C++](/reference/cpp-language/).[^home]
 Its defining idea is **ownership**: each value has a single owner, and a compile-time
 borrow checker enforces strict rules about how references may be shared and mutated.
 Code that violates those rules simply does not compile, which rules out use-after-free,
@@ -68,3 +70,8 @@ targets, and safety-critical components — places that want C-level control wit
 memory hazards. It is not so much replacing [C](/reference/c-language/) and
 [C++](/reference/cpp-language/) as competing with them for new work, with the three
 expected to coexist for a long time.
+
+## Sources
+
+[^home]: [The Rust programming language](https://www.rust-lang.org/) — official site, documentation, and the ownership/borrow-checker model.
+[^wiki]: [Rust (programming language)](https://en.wikipedia.org/wiki/Rust_(programming_language)) — Wikipedia, for history and design background.

--- a/docs/reference/sample-rate.md
+++ b/docs/reference/sample-rate.md
@@ -14,11 +14,11 @@ infobox:
 see_also: [bandwidth, nyquist-theorem, aliasing, decimation, analog-to-digital-converter]
 related_lessons:
   - { title: "Sample rate, bandwidth & Nyquist", url: /learn/rf-sdr/sample-rate-nyquist/ }
-external:
-  - { title: "Sampling (signal processing) (Wikipedia)", url: https://en.wikipedia.org/wiki/Sampling_(signal_processing) }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Sampling_(signal_processing)
 ---
 
-**Sample rate** is how many [IQ](/reference/iq-data/) samples per second an SDR produces.
+**Sample rate** is how many [IQ](/reference/iq-data/) samples per second an SDR produces.[^wiki]
 With complex sampling, the **captured [bandwidth](/reference/bandwidth/) is approximately
 equal to the sample rate** — an RTL-SDR at 2.4 MSa/s sees about 2.4 MHz at once.
 
@@ -42,3 +42,7 @@ capture down to one channel.
 
 For trunk-tracking, choose a rate that just covers the channels you follow — not the
 widest possible span.
+
+## Sources
+
+[^wiki]: [Sampling (signal processing)](https://en.wikipedia.org/wiki/Sampling_(signal_processing)) — Wikipedia, on samples per second and the captured bandwidth they represent.

--- a/docs/reference/saw-filter.md
+++ b/docs/reference/saw-filter.md
@@ -10,12 +10,12 @@ autolink: true
 see_also: [low-noise-amplifier, ads-b, bandwidth, attenuation]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
-external:
-  - { title: "Surface acoustic wave (Wikipedia)", url: https://en.wikipedia.org/wiki/Surface_acoustic_wave }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Surface_acoustic_wave
 ---
 
 A **SAW** (**surface acoustic wave**) filter is a compact, sharp **band-pass** filter
-built on a piezoelectric substrate. In an SDR front end it acts as a preselector —
+built on a piezoelectric substrate.[^wiki] In an SDR front end it acts as a preselector —
 passing only the wanted band and strongly rejecting out-of-band signals that would
 otherwise overload the receiver.
 
@@ -35,3 +35,7 @@ otherwise overload the receiver.
 ADS-B receive chains commonly add a 1090 MHz SAW filter (often with a
 [low-noise amplifier](/reference/low-noise-amplifier/)) so nearby cellular and broadcast
 transmitters don't desensitise the [front end](/reference/superheterodyne-receiver/).
+
+## Sources
+
+[^wiki]: [Surface acoustic wave](https://en.wikipedia.org/wiki/Surface_acoustic_wave) — Wikipedia, on the surface-acoustic-wave devices used to build compact sharp band-pass filters.

--- a/docs/reference/scrambling.md
+++ b/docs/reference/scrambling.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [clock-recovery, rc4-cipher, forward-error-correction, demodulation]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Scrambler (Wikipedia)", url: https://en.wikipedia.org/wiki/Scrambler }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Scrambler
 ---
 
 **Scrambling** (**whitening**) XORs data with a *public* pseudo-random sequence to break
 up long runs of identical bits, which helps [clock recovery](/reference/clock-recovery/)
-and keeps the spectrum balanced. It is **not** encryption.
+and keeps the spectrum balanced.[^wiki] It is **not** encryption.
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A data stream XORed with a pseudo-random sequence to produce a whitened stream with no long runs." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +44,7 @@ guarantees frequent transitions for timing and avoids a DC bias, regardless of t
 
 Recognising that whitening is reversible (unlike [RC4](/reference/rc4-cipher/) encryption)
 explains why a scrambled-but-unencrypted signal still decodes.
+
+## Sources
+
+[^wiki]: [Scrambler](https://en.wikipedia.org/wiki/Scrambler) — Wikipedia, for XOR-with-pseudo-random whitening to balance the spectrum and aid clock recovery.

--- a/docs/reference/semantic-versioning.md
+++ b/docs/reference/semantic-versioning.md
@@ -16,13 +16,16 @@ infobox:
 see_also: [package-manager, api, build-systems, ci-cd, version-control]
 related_lessons:
   - { title: "Releases & tags", url: /learn/git/releases-and-tags/ }
-external:
-  - { title: "Software versioning — Wikipedia", url: https://en.wikipedia.org/wiki/Software_versioning }
+related_reading:
+  - { title: "Build in the Open, Part 11: Releases, pre-release, SemVer & changelogs", url: /blog/tutorials/build-in-the-open-11-releases-prerelease-semver-changelogs/ }
+cite_urls:
+  - https://semver.org/
+  - https://en.wikipedia.org/wiki/Software_versioning
 ---
 
 **Semantic versioning** (SemVer) is a `MAJOR.MINOR.PATCH` numbering convention in which
 the version number itself communicates the nature of each change — breaking,
-backward-compatible feature, or bug fix.
+backward-compatible feature, or bug fix.[^semver]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A version number 2.4.1 broken into MAJOR for breaking changes, MINOR for features, and PATCH for fixes." xmlns="http://www.w3.org/2000/svg">
@@ -50,7 +53,7 @@ change:
 A user reading `1.5.0 → 1.5.1` knows it is a safe update; `1.x → 2.0` warns them to read
 the release notes. Pre-`1.0.0` versions are treated as unstable, and suffixes like
 `-rc.1` or `-beta` mark pre-releases. That single convention prevents a great deal of
-confusion about whether an upgrade is safe.
+confusion about whether an upgrade is safe.[^semver]
 
 ## Why it matters
 
@@ -67,4 +70,9 @@ A release is usually a tagged commit in [version control](/reference/version-con
 and a [CI/CD](/reference/ci-cd/) pipeline often builds and publishes the versioned
 artifacts automatically when a tag is pushed. The version baked into the
 [build](/reference/build-systems/) and printed by the program lets users and maintainers
-identify exactly which release they are running.
+identify exactly which release they are running.[^wiki]
+
+## Sources
+
+[^semver]: [Semantic Versioning 2.0.0](https://semver.org/) — the authoritative SemVer specification defining MAJOR.MINOR.PATCH and pre-release suffixes.
+[^wiki]: [Software versioning](https://en.wikipedia.org/wiki/Software_versioning) — Wikipedia, for versioning schemes and release-tagging practice.

--- a/docs/reference/signal-to-noise-ratio.md
+++ b/docs/reference/signal-to-noise-ratio.md
@@ -14,12 +14,12 @@ infobox:
 see_also: [noise-floor, decibel, dbm, demodulation]
 related_lessons:
   - { title: "Decibels & signal power", url: /learn/rf-sdr/decibels/ }
-external:
-  - { title: "Signal-to-noise ratio (Wikipedia)", url: https://en.wikipedia.org/wiki/Signal-to-noise_ratio }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Signal-to-noise_ratio
 ---
 
 **Signal-to-noise ratio** (**SNR**) is the gap, in [decibels](/reference/decibel/),
-between a signal's power and the [noise floor](/reference/noise-floor/). It is the
+between a signal's power and the [noise floor](/reference/noise-floor/).[^wiki] It is the
 single best predictor of whether a signal will decode.
 
 <figure class="figure" markdown="0">
@@ -45,3 +45,7 @@ below which [demodulation](/reference/demodulation/) starts dropping symbols.
 
 Improving SNR — better antenna, placement, correct gain — is usually what moves a
 marginal signal from un-decodable to clean.
+
+## Sources
+
+[^wiki]: [Signal-to-noise ratio](https://en.wikipedia.org/wiki/Signal-to-noise_ratio) — Wikipedia, definition and significance of SNR.

--- a/docs/reference/single-sideband.md
+++ b/docs/reference/single-sideband.md
@@ -14,14 +14,14 @@ infobox:
 see_also: [amplitude-modulation, modulation, frequency-bands, ionospheric-propagation]
 related_lessons:
   - { title: "Analog modulation — AM, FM, SSB", url: /learn/rf-sdr/analog-modulation/ }
-external:
-  - { title: "Single-sideband modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Single-sideband_modulation }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Single-sideband_modulation
 ---
 
 **Single sideband** (**SSB**) is a refined form of
 [amplitude modulation](/reference/amplitude-modulation/) that removes the
 [carrier](/reference/carrier-wave/) and one of the two redundant sidebands,
-transmitting only **one sideband** — upper (USB) or lower (LSB).
+transmitting only **one sideband** — upper (USB) or lower (LSB).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A double-sideband AM spectrum with carrier and two sidebands on the left, an arrow, and an SSB spectrum with only one sideband on the right." xmlns="http://www.w3.org/2000/svg">
@@ -54,3 +54,7 @@ voices sound distorted.
 
 SSB is the backbone of long-distance HF voice; receiving it needs an HF-capable SDR and
 accurate tuning to reinsert the missing carrier.
+
+## Sources
+
+[^wiki]: [Single-sideband modulation](https://en.wikipedia.org/wiki/Single-sideband_modulation) — Wikipedia, for the suppressed-carrier definition and bandwidth/power efficiency.

--- a/docs/reference/soapysdr.md
+++ b/docs/reference/soapysdr.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [rtl-tcp, software-defined-radio, rtl-sdr, airspy]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
-external:
-  - { title: "SoapySDR (project)", url: https://github.com/pothosware/SoapySDR }
+cite_urls:
+  - https://github.com/pothosware/SoapySDR
 ---
 
 **SoapySDR** is a vendor-neutral hardware-abstraction library that exposes a **common
 API** across many [software-defined radios](/reference/software-defined-radio/), so
-applications can support diverse devices without per-vendor code.
+applications can support diverse devices without per-vendor code.[^proj]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="Applications calling a common SoapySDR layer that drives several different SDR devices through plugin modules." xmlns="http://www.w3.org/2000/svg">
@@ -46,3 +46,7 @@ the antenna.
 
 SoapySDR-style remoting (alongside [rtl_tcp](/reference/rtl-tcp/)) lets GopherTrunk use
 radios that live on a separate host.
+
+## Sources
+
+[^proj]: [SoapySDR](https://github.com/pothosware/SoapySDR) — the project repository, documenting the vendor-neutral SDR abstraction API and SoapyRemote.

--- a/docs/reference/software-defined-radio.md
+++ b/docs/reference/software-defined-radio.md
@@ -15,13 +15,15 @@ infobox:
 see_also: [iq-data, analog-to-digital-converter, superheterodyne-receiver, rtl-sdr, demodulation]
 related_lessons:
   - { title: "What is software-defined radio?", url: /learn/rf-sdr/what-is-sdr/ }
-external:
-  - { title: "Software-defined radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Software-defined_radio }
+related_reading:
+  - { title: "SDR Internals, Part 1: What is software-defined radio?", url: /blog/deep-dives/sdr-internals-01-what-is-software-defined-radio/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software-defined_radio
 ---
 
 **Software-defined radio** (**SDR**) moves the functions that were once fixed hardware —
 tuning, filtering, [demodulation](/reference/demodulation/) — into **software** operating
-on digitised [IQ samples](/reference/iq-data/). The hardware does only enough to convert a
+on digitised [IQ samples](/reference/iq-data/).[^wiki] The hardware does only enough to convert a
 slice of spectrum into numbers.
 
 <figure class="figure" markdown="0">
@@ -48,3 +50,7 @@ decode many protocols.
 
 GopherTrunk is the software half of an SDR, specialised for digital trunked radio. The
 hardware (e.g. [RTL-SDR](/reference/rtl-sdr/)) is almost interchangeable.
+
+## Sources
+
+[^wiki]: [Software-defined radio](https://en.wikipedia.org/wiki/Software-defined_radio) — Wikipedia, on the architecture that moves radio functions into software.

--- a/docs/reference/solid.md
+++ b/docs/reference/solid.md
@@ -16,13 +16,13 @@ infobox:
 see_also: [dry-kiss-yagni, clean-code, refactoring, abstraction, coupling-and-cohesion, object-oriented-programming, design-patterns]
 related_lessons:
   - { title: "SOLID & object-oriented design", url: /learn/intro-software-dev/solid/ }
-external:
-  - { title: "SOLID — Wikipedia", url: https://en.wikipedia.org/wiki/SOLID }
+cite_urls:
+  - https://en.wikipedia.org/wiki/SOLID
 ---
 
 **SOLID** is a set of five [object-oriented](/reference/object-oriented-programming/)
 design principles, popularized by Robert C. Martin, that all aim at one outcome: code
-that is easy to change without breaking.
+that is easy to change without breaking.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="The five SOLID letters: single responsibility, open/closed, Liskov substitution, interface segregation, dependency inversion." xmlns="http://www.w3.org/2000/svg">
@@ -53,7 +53,7 @@ that is easy to change without breaking.
   methods they don't use. Many small, role-focused interfaces beat one fat one.
 - **D — Dependency Inversion Principle.** High-level logic should depend on
   [abstractions](/reference/abstraction/), not concrete details, with implementations
-  supplied from outside (dependency injection).
+  supplied from outside (dependency injection).[^wiki]
 
 ## Why it matters
 
@@ -65,3 +65,7 @@ heavily with [DRY, KISS and YAGNI](/reference/dry-kiss-yagni/) and underpins man
 not a law. Applied dogmatically it causes as much over-engineering as it prevents;
 reach for these principles to diagnose code that resists change or testing, not to
 satisfy a checklist. They are a frequent target of [refactoring](/reference/refactoring/).
+
+## Sources
+
+[^wiki]: [SOLID](https://en.wikipedia.org/wiki/SOLID) — Wikipedia, for the five principles, their history, and Robert C. Martin's role in popularizing them.

--- a/docs/reference/standing-wave-ratio.md
+++ b/docs/reference/standing-wave-ratio.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [antenna, dipole-antenna, attenuation]
 related_lessons:
   - { title: "Antennas 101", url: /learn/rf-sdr/antennas/ }
-external:
-  - { title: "Standing wave ratio (Wikipedia)", url: https://en.wikipedia.org/wiki/Standing_wave_ratio }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Standing_wave_ratio
 ---
 
 **Standing wave ratio** (**SWR**, often VSWR) measures how well an
 [antenna](/reference/antenna/) is impedance-matched to its feedline and radio at a
-given [frequency](/reference/frequency/). A perfect match is 1:1.
+given [frequency](/reference/frequency/).[^wiki] A perfect match is 1:1.
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A forward wave travelling toward an antenna and a smaller reflected wave returning from a mismatch." xmlns="http://www.w3.org/2000/svg">
@@ -42,3 +42,7 @@ for receive-only SDR use it mainly costs a little signal.
 
 A reasonably matched, resonant antenna delivers more signal to the SDR than a
 mismatched one, helping [SNR](/reference/signal-to-noise-ratio/).
+
+## Sources
+
+[^wiki]: [Standing wave ratio](https://en.wikipedia.org/wiki/Standing_wave_ratio) — Wikipedia, on impedance matching, reflected power, and VSWR.

--- a/docs/reference/static-binary.md
+++ b/docs/reference/static-binary.md
@@ -18,13 +18,13 @@ see_also: [compiler, cross-compilation, jit-compilation, go-language, rust-langu
 related_lessons:
   - { title: "Packaging and distribution", url: /learn/intro-software-dev/packaging-and-distribution/ }
   - { title: "Compiled vs interpreted languages", url: /learn/intro-software-dev/compiled-vs-interpreted/ }
-external:
-  - { title: "Static library — Wikipedia", url: https://en.wikipedia.org/wiki/Static_library }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Static_library
 ---
 
 **A static binary** is an executable that bundles all the code it needs at build time,
 so it runs on its own — no shared libraries to find, no interpreter or runtime to
-install on the target machine.
+install on the target machine.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A static binary contains its libraries inside it and runs alone, unlike a dynamic binary that depends on external shared libraries." xmlns="http://www.w3.org/2000/svg">
@@ -52,14 +52,14 @@ the system at run time, so the binary depends on the right versions being instal
 With **static linking** the linker copies the needed library code directly into the
 executable, producing one self-contained file. The result needs nothing external — not
 even a language runtime, unlike [bytecode](/reference/bytecode/) that requires a virtual
-machine.
+machine.[^wiki]
 
 ## Trade-offs
 
 The payoff is **deployment simplicity**: copy one file to a matching machine and run
 it, with no installer, no dependency hunt, and no "works on my machine" version skew.
 The costs are a **larger file** (every dependency is included) and that updating a
-bundled library means rebuilding the binary rather than patching a shared one. Paired
+bundled library means rebuilding the binary rather than patching a shared one.[^wiki] Paired
 with [cross-compilation](/reference/cross-compilation/), a static binary makes
 shipping for many platforms a single, clean step.
 
@@ -70,3 +70,7 @@ reason it suits CLIs, network services, and tools like GopherTrunk that ship to 
 who just want to run them. [Rust](/reference/rust-language/) and
 [C](/reference/c-language/) can link statically as well, trading file size for the same
 dependency-free convenience.
+
+## Sources
+
+[^wiki]: [Static library](https://en.wikipedia.org/wiki/Static_library) — Wikipedia, on static linking that copies library code into the executable versus dynamic linking against shared libraries.

--- a/docs/reference/static-vs-dynamic-typing.md
+++ b/docs/reference/static-vs-dynamic-typing.md
@@ -18,14 +18,14 @@ see_also: [type-system, compiler, interpreter, typescript-language, python-langu
 related_lessons:
   - { title: "Type systems and safety", url: /learn/intro-software-dev/type-systems/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Type system — Wikipedia", url: https://en.wikipedia.org/wiki/Type_system#Static_and_dynamic_type_checking_in_practice }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Type_system#Static_and_dynamic_type_checking_in_practice
 ---
 
 **Static versus dynamic typing** is about *when* a language checks the types of its
 values: a **statically typed** language checks at compile time, before the program
 runs, while a **dynamically typed** language checks at run time, as each operation
-executes.
+executes.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="Static typing checks types during the build step before running; dynamic typing checks each operation while the program runs." xmlns="http://www.w3.org/2000/svg">
@@ -53,7 +53,7 @@ where a number is expected is a build error. Under **dynamic typing**, a variabl
 hold a string now and a number later; the [interpreter](/reference/interpreter/) only
 complains when an actual operation is invalid. This is a separate question from *how
 strictly* a language enforces types (strong versus weak), so the two axes combine:
-Rust is static and strong, Python dynamic and strong, JavaScript dynamic and weak.
+Rust is static and strong, Python dynamic and strong, JavaScript dynamic and weak.[^wiki]
 
 ## Trade-offs
 
@@ -62,7 +62,7 @@ methods, broken refactors — and makes APIs self-documenting, which is why larg
 long-lived codebases drift toward it. The cost is ceremony and some rigidity, though
 [type inference](/reference/type-system/) removes most of the annotation burden.
 Dynamic typing offers **flexibility and less ceremony** — quick scripts, duck typing,
-runtime metaprogramming — at the risk of type errors that hide until that line runs.
+runtime metaprogramming — at the risk of type errors that hide until that line runs.[^wiki]
 
 ## In practice
 
@@ -73,3 +73,7 @@ runtime metaprogramming — at the risk of type errors that hide until that line
 two: [TypeScript](/reference/typescript-language/) and Python type hints add optional,
 checkable types to dynamic languages, keeping flexibility where you want it and adding
 guarantees where the code is critical.
+
+## Sources
+
+[^wiki]: [Type system — static and dynamic type checking](https://en.wikipedia.org/wiki/Type_system#Static_and_dynamic_type_checking_in_practice) — Wikipedia, on when type checking happens and how the static/dynamic axis combines with strong/weak typing.

--- a/docs/reference/structural-patterns.md
+++ b/docs/reference/structural-patterns.md
@@ -17,13 +17,14 @@ infobox:
 see_also: [design-patterns, creational-patterns, behavioral-patterns, object-oriented-programming, coupling-and-cohesion, abstraction, solid]
 related_lessons:
   - { title: "Structural patterns: adapter, facade, decorator", url: /learn/intro-software-dev/structural-patterns/ }
-external:
-  - { title: "Structural pattern — Wikipedia", url: https://en.wikipedia.org/wiki/Structural_pattern }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Structural_pattern
+  - https://en.wikipedia.org/wiki/Design_Patterns
 ---
 
 **Structural patterns** are the [Gang of Four](/reference/design-patterns/) family that
 answers *how do objects fit together into larger structures?* — mostly by taking objects
-that already exist and arranging them so the whole stays flexible.
+that already exist and arranging them so the whole stays flexible.[^wiki][^gof]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="Three structural shapes: an adapter wrapping one object to change its interface, a facade fronting many parts, and a decorator stacking wrappers." xmlns="http://www.w3.org/2000/svg">
@@ -43,7 +44,7 @@ third-party driver, your own code, a UI toolkit. Getting them to cooperate witho
 them tightly together is the recurring problem these patterns address. They share a family
 resemblance: most involve one object **wrapping** another, and all lean on programming to
 an [interface](/reference/abstraction/) so dependencies point at the contract rather than
-concrete classes, keeping [coupling](/reference/coupling-and-cohesion/) low.
+concrete classes, keeping [coupling](/reference/coupling-and-cohesion/) low.[^wiki]
 
 ## The main members
 
@@ -67,3 +68,8 @@ team distinguish them when discussing a design. The sibling families are
 [creational patterns](/reference/creational-patterns/) (making objects) and
 [behavioral patterns](/reference/behavioral-patterns/) (coordinating them), and all three
 support the open/closed principle from [SOLID](/reference/solid/).
+
+## Sources
+
+[^wiki]: [Structural pattern](https://en.wikipedia.org/wiki/Structural_pattern) — Wikipedia, for the definition, the wrapping mechanism, and members such as Adapter, Facade, and Decorator.
+[^gof]: [Design Patterns](https://en.wikipedia.org/wiki/Design_Patterns) — Wikipedia, on the 1994 Gang of Four book that grouped patterns into creational, structural, and behavioral families.

--- a/docs/reference/superheterodyne-receiver.md
+++ b/docs/reference/superheterodyne-receiver.md
@@ -14,14 +14,14 @@ infobox:
 see_also: [local-oscillator, digital-down-converter, analog-to-digital-converter, software-defined-radio]
 related_lessons:
   - { title: "How an SDR receiver works", url: /learn/rf-sdr/sdr-receiver/ }
-external:
-  - { title: "Superheterodyne receiver (Wikipedia)", url: https://en.wikipedia.org/wiki/Superheterodyne_receiver }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Superheterodyne_receiver
 ---
 
 A **superheterodyne receiver** uses a mixer driven by a
 [local oscillator](/reference/local-oscillator/) to shift a chosen band **down** to a
 fixed intermediate frequency (IF) — or to baseband — where it is easier to filter and
-detect.
+detect.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 540 110" role="img" aria-label="Receiver chain: antenna, RF amplifier, mixer fed by a local oscillator, IF filter, then detector." xmlns="http://www.w3.org/2000/svg">
@@ -49,3 +49,7 @@ fixed IF. SDR quadrature front-ends apply the same idea, mixing to baseband as
 
 Understanding the mixer/LO explains why "tuning" an SDR is simply setting a number, and
 how a [digital down-converter](/reference/digital-down-converter/) does it in software.
+
+## Sources
+
+[^wiki]: [Superheterodyne receiver](https://en.wikipedia.org/wiki/Superheterodyne_receiver) — Wikipedia, on mixing a band down to a fixed intermediate frequency.

--- a/docs/reference/swift-language.md
+++ b/docs/reference/swift-language.md
@@ -19,13 +19,15 @@ see_also: [kotlin-language, rust-language, memory-management, compiler, type-sys
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Memory management across languages", url: /learn/intro-software-dev/memory-management/ }
-external:
-  - { title: "Swift (programming language) — Wikipedia", url: https://en.wikipedia.org/wiki/Swift_(programming_language) }
-  - { title: "The Swift programming language — Apple", url: https://www.swift.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.swift.org/
+  - https://en.wikipedia.org/wiki/Swift_(programming_language)
 ---
 
 **Swift** is Apple's modern, statically typed, compiled language for building iOS and
-macOS applications. It is clean and fast and prioritises safety, but its centre of
+macOS applications.[^wiki] It is clean and fast and prioritises safety, but its centre of
 gravity remains Apple's platforms.
 
 <figure class="figure" markdown="0">
@@ -46,7 +48,7 @@ gravity remains Apple's platforms.
 ## Overview
 
 Swift [compiles](/reference/compiler/) ahead of time to native machine code through LLVM,
-giving it performance well beyond Apple's earlier Objective-C in many cases. It is
+giving it performance well beyond Apple's earlier Objective-C in many cases.[^home] It is
 [statically typed](/reference/type-system/) with type inference, supports
 [object-oriented](/reference/object-oriented-programming/) and functional styles, and
 manages [memory](/reference/memory-management/) automatically through Automatic Reference
@@ -68,3 +70,8 @@ mobile language tied instead to the JVM and Android.
 Swift is the primary language for iOS, iPadOS, macOS, watchOS and tvOS application
 development, and for most new software written for Apple's ecosystem. Outside that world
 it sees comparatively little use.
+
+## Sources
+
+[^home]: [The Swift programming language](https://www.swift.org/) — official site, documentation, and the language and toolchain.
+[^wiki]: [Swift (programming language)](https://en.wikipedia.org/wiki/Swift_(programming_language)) — Wikipedia, for history and design background.

--- a/docs/reference/symbol-rate.md
+++ b/docs/reference/symbol-rate.md
@@ -14,11 +14,11 @@ infobox:
 see_also: [frequency-shift-keying, phase-shift-keying, quadrature-amplitude-modulation, bandwidth, clock-recovery]
 related_lessons:
   - { title: "Symbols, baud & bitrate", url: /learn/rf-sdr/symbols-and-baud/ }
-external:
-  - { title: "Symbol rate (Wikipedia)", url: https://en.wikipedia.org/wiki/Symbol_rate }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Symbol_rate
 ---
 
-**Symbol rate** (**baud**) is the number of modulation symbols transmitted per second.
+**Symbol rate** (**baud**) is the number of modulation symbols transmitted per second.[^wiki]
 It differs from bit rate whenever each symbol carries more than one bit.
 
 <figure class="figure" markdown="0">
@@ -43,3 +43,7 @@ need more [bandwidth](/reference/bandwidth/).
 
 The symbol rate sets the rhythm that [clock recovery](/reference/clock-recovery/) must
 lock to, and the minimum capture [bandwidth](/reference/bandwidth/) for a clean decode.
+
+## Sources
+
+[^wiki]: [Symbol rate](https://en.wikipedia.org/wiki/Symbol_rate) — Wikipedia, for the baud definition and the bit-rate relationship.

--- a/docs/reference/system-fusion-ysf.md
+++ b/docs/reference/system-fusion-ysf.md
@@ -17,14 +17,16 @@ infobox:
 see_also: [d-star, m17, c4fm, ambe, vocoder]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "System Fusion (Wikipedia)", url: https://en.wikipedia.org/wiki/System_Fusion }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/System_Fusion
 ---
 
 **System Fusion** (**Yaesu System Fusion**, **YSF**) is Yaesu's amateur digital-voice
 system, using [C4FM](/reference/c4fm/) modulation and an [AMBE](/reference/ambe/)-family
 [vocoder](/reference/vocoder/). It is notable for automatically mixing digital and
-analog users on the same repeater.
+analog users on the same repeater.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 440 110" role="img" aria-label="System Fusion digital voice linked over WIRES-X rooms." xmlns="http://www.w3.org/2000/svg">
@@ -58,7 +60,7 @@ smoothing the transition for clubs. The WIRES-X network links Fusion repeaters a
 ## History
 
 Introduced by Yaesu in the mid-2010s as its entry into amateur digital voice,
-competing with [D-STAR](/reference/d-star/) and amateur [DMR](/reference/dmr/).
+competing with [D-STAR](/reference/d-star/) and amateur [DMR](/reference/dmr/).[^wiki]
 
 ## Deployment
 
@@ -68,3 +70,7 @@ Amateur radio, via Fusion repeaters, hotspots, and WIRES-X rooms.
 
 YSF shares C4FM modulation with [P25 Phase 1](/reference/p25-phase-1/); see
 [Status](/status.html) for GopherTrunk's coverage.
+
+## Sources
+
+[^wiki]: [System Fusion](https://en.wikipedia.org/wiki/System_Fusion) — Wikipedia, for Yaesu's amateur C4FM digital-voice system, its analog/digital mixing, and WIRES-X linking.

--- a/docs/reference/talkgroup.md
+++ b/docs/reference/talkgroup.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [trunked-radio, control-channel, voice-channel, radio-id, affiliation]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Talkgroup (Wikipedia)", url: https://en.wikipedia.org/wiki/Talkgroup }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Talkgroup
 ---
 
 A **talkgroup** is a virtual channel in a [trunked radio](/reference/trunked-radio/)
-system — a numbered label identifying a group of users such as "Police Dispatch."
+system — a numbered label identifying a group of users such as "Police Dispatch."[^wiki]
 Members hear each other no matter which physical [voice channel](/reference/voice-channel/)
 the system assigns to a given call.
 
@@ -46,3 +48,7 @@ frequency-hopping underneath.
 
 In GopherTrunk you follow talkgroups, not frequencies; each is shown with the
 transmitting [radio ID](/reference/radio-id/).
+
+## Sources
+
+[^wiki]: [Talkgroup](https://en.wikipedia.org/wiki/Talkgroup) — Wikipedia, on the talkgroup as a virtual channel in trunked systems.

--- a/docs/reference/tdma.md
+++ b/docs/reference/tdma.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [fdma, trunked-radio, p25-phase-2, dmr, tetra]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Time-division multiple access (Wikipedia)", url: https://en.wikipedia.org/wiki/Time-division_multiple_access }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Time-division_multiple_access
 ---
 
 **TDMA** (**time-division multiple access**) splits one [frequency](/reference/frequency/)
 into rapid, repeating **timeslots**, so two or more calls share the channel by taking
-turns.
+turns.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 360 150" role="img" aria-label="A single frequency channel divided along time into repeating slots, alternating between two calls." xmlns="http://www.w3.org/2000/svg">
@@ -48,3 +50,7 @@ follow the correct slot as well as the frequency.
 
 On a TDMA system a single granted [voice channel](/reference/voice-channel/) can carry
 two simultaneous calls, so GopherTrunk decodes the relevant slot of the assigned channel.
+
+## Sources
+
+[^wiki]: [Time-division multiple access](https://en.wikipedia.org/wiki/Time-division_multiple_access) — Wikipedia, on sharing one frequency via repeating timeslots.

--- a/docs/reference/test-driven-development.md
+++ b/docs/reference/test-driven-development.md
@@ -16,13 +16,15 @@ infobox:
 see_also: [unit-testing, integration-testing, end-to-end-testing, mocking, code-coverage, refactoring, ci-cd]
 related_lessons:
   - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
-external:
-  - { title: "Test-driven development — Wikipedia", url: https://en.wikipedia.org/wiki/Test-driven_development }
+related_reading:
+  - { title: "Build in the Open, Part 8: Testing — how to build and write tests", url: /blog/tutorials/build-in-the-open-08-testing-how-to-write-tests/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Test-driven_development
 ---
 
 **Test-driven development (TDD)** flips the usual order of work: you write a failing test
 *first*, then write just enough code to make it pass, then refactor — the rhythm known as
-"red, green, refactor."
+"red, green, refactor."[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="The TDD cycle: write a failing red test, write code to make it green, then refactor, and repeat." xmlns="http://www.w3.org/2000/svg">
@@ -40,7 +42,7 @@ external:
 
 ## The cycle
 
-TDD proceeds in tight loops, popularized by Kent Beck:
+TDD proceeds in tight loops, popularized by Kent Beck:[^wiki]
 
 - **Red** — write a small test for behavior that doesn't exist yet, and watch it fail.
   A test that passes *before* you write the code is testing nothing, so the failure is
@@ -70,3 +72,7 @@ rhythm applies to [integration](/reference/integration-testing/) and
 discipline rather than a mandate — even teams that don't follow it strictly benefit from
 specifying behavior up front. Note that the [code coverage](/reference/code-coverage/) it
 produces is a by-product, not the goal: well-asserted tests matter more than the number.
+
+## Sources
+
+[^wiki]: [Test-driven development](https://en.wikipedia.org/wiki/Test-driven_development) — Wikipedia, for the red-green-refactor cycle and Kent Beck's role in popularizing it.

--- a/docs/reference/tetra.md
+++ b/docs/reference/tetra.md
@@ -20,15 +20,17 @@ see_also: [trunked-radio, tdma, phase-shift-keying, control-channel, etsi]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Terrestrial Trunked Radio (Wikipedia)", url: https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio }
+related_reading:
+  - { title: "SDR Internals, Part 10: Protocol decoders & state machines", url: /blog/deep-dives/sdr-internals-10-protocol-decoders-state-machines/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio
 ---
 
 **TETRA** (**Terrestrial Trunked Radio**) is an [ETSI](/reference/etsi/) digital
 [trunked-radio](/reference/trunked-radio/) standard built for public-safety and
 professional users, especially in Europe and much of the world outside North America.
 It uses **four-slot [TDMA](/reference/tdma/)** and π/4-DQPSK
-([phase-shift keying](/reference/phase-shift-keying/)).
+([phase-shift keying](/reference/phase-shift-keying/)).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 380 140" role="img" aria-label="Four TDMA slots in a 25 kHz TETRA carrier." xmlns="http://www.w3.org/2000/svg">
@@ -58,7 +60,7 @@ timeslots per 25 kHz carrier give high capacity.
 ## History
 
 Standardised by ETSI from the mid-1990s; adopted broadly by European emergency
-services, transport, and military/government users.
+services, transport, and military/government users.[^wiki]
 
 ## Deployment
 
@@ -70,3 +72,7 @@ dominates public safety.
 
 TETRA uses a distinct modulation and vocoder; consult the [Status](/status.html) page
 for GopherTrunk's current TETRA coverage.
+
+## Sources
+
+[^wiki]: [Terrestrial Trunked Radio](https://en.wikipedia.org/wiki/Terrestrial_Trunked_Radio) — Wikipedia, for the ETSI TETRA standard, its four-slot TDMA air interface, π/4-DQPSK modulation, and the ACELP vocoder.

--- a/docs/reference/threads.md
+++ b/docs/reference/threads.md
@@ -18,14 +18,16 @@ see_also: [concurrency, async-programming, goroutines, memory-management, c-lang
 related_lessons:
   - { title: "Concurrency and parallelism", url: /learn/intro-software-dev/concurrency-models/ }
   - { title: "Concurrency and pipelines", url: /learn/intro-software-dev/concurrency-and-pipelines/ }
-external:
-  - { title: "Thread (computing) — Wikipedia", url: https://en.wikipedia.org/wiki/Thread_(computing) }
+related_reading:
+  - { title: "SDR Internals, Part 3: The SDR pool, streaming & concurrency", url: /blog/deep-dives/sdr-internals-03-sdr-pool-streaming-concurrency/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Thread_(computing)
 ---
 
 **A thread** is an independent flow of execution inside a process. The operating system
 can give one process several threads that share the same memory and run on different
 CPU cores at the same time — the oldest and most direct route to
-[parallelism](/reference/concurrency/).
+[parallelism](/reference/concurrency/).[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="One process contains shared memory and three threads of execution running within it." xmlns="http://www.w3.org/2000/svg">
@@ -49,7 +51,7 @@ thread time on a core. Because threads in a process share its
 the same variables — fast and powerful, but the source of the danger. When two threads
 touch the same data and at least one writes, with no coordination, you have a **data
 race**, and the result is undefined: a half-updated value, a counter that loses
-increments, a crash that appears once a week.
+increments, a crash that appears once a week.[^wiki]
 
 ## Trade-offs
 
@@ -58,7 +60,7 @@ CPU-bound work. The traditional fix for races is a **lock** (mutex): only one th
 hold the lock and touch the shared data at a time. Locks work but bring their own
 hazards — **deadlock** (two threads each waiting on a lock the other holds), forgotten
 locks, and contention that erodes performance. OS threads are also relatively heavy, so
-running hundreds of thousands of them is impractical.
+running hundreds of thousands of them is impractical.[^wiki]
 
 ## In practice
 
@@ -68,3 +70,7 @@ system preventing many data races at compile time. To avoid heavy threads and ex
 locks, other models build on top of them: [async/await](/reference/async-programming/)
 multiplexes tasks onto a single thread, and [goroutines](/reference/goroutines/)
 multiplex many lightweight tasks onto a few OS threads.
+
+## Sources
+
+[^wiki]: [Thread (computing)](https://en.wikipedia.org/wiki/Thread_(computing)) — Wikipedia, on threads as flows of execution sharing process memory, plus data races, locks, and deadlock.

--- a/docs/reference/tia.md
+++ b/docs/reference/tia.md
@@ -14,13 +14,14 @@ infobox:
 see_also: [project-25, apco-international, etsi]
 related_lessons:
   - { title: "The digital protocol landscape", url: /learn/rf-sdr/protocol-landscape/ }
-external:
-  - { title: "Telecommunications Industry Association (Wikipedia)", url: https://en.wikipedia.org/wiki/Telecommunications_Industry_Association }
+cite_urls:
+  - https://www.tiaonline.org/
+  - https://en.wikipedia.org/wiki/Telecommunications_Industry_Association
 ---
 
 The **Telecommunications Industry Association** (**TIA**) is a US standards organization
 that, together with [APCO](/reference/apco-international/), develops the
-**[Project 25](/reference/project-25/)** suite of public-safety digital radio standards.
+**[Project 25](/reference/project-25/)** suite of public-safety digital radio standards.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 100" role="img" aria-label="TIA publishes the TIA-102 standards that define P25." xmlns="http://www.w3.org/2000/svg">
@@ -38,9 +39,14 @@ that, together with [APCO](/reference/apco-international/), develops the
 ## Overview
 
 TIA publishes the P25 documents defining its air interfaces, vocoders, and interfaces,
-enabling multi-vendor interoperability for North American public safety.
+enabling multi-vendor interoperability for North American public safety.[^home]
 
 ## Relevance to SDR
 
 The TIA's P25 standards underpin the most common public-safety systems GopherTrunk
 decodes.
+
+## Sources
+
+[^home]: [Telecommunications Industry Association](https://www.tiaonline.org/) — the TIA's official site, publisher of the TIA-102 (P25) standards suite.
+[^wiki]: [Telecommunications Industry Association](https://en.wikipedia.org/wiki/Telecommunications_Industry_Association) — Wikipedia, for the TIA's role and its P25 work with APCO.

--- a/docs/reference/trellis-coded-modulation.md
+++ b/docs/reference/trellis-coded-modulation.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [convolutional-code, viterbi-algorithm, forward-error-correction, project-25]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Trellis modulation (Wikipedia)", url: https://en.wikipedia.org/wiki/Trellis_modulation }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Trellis_modulation
 ---
 
 **Trellis-coded modulation** (**TCM**) integrates
 [convolutional coding](/reference/convolutional-code/) with the modulation symbol mapping,
-so coding gain is achieved without extra bandwidth.
+so coding gain is achieved without extra bandwidth.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A small trellis whose transitions map onto points of a constellation, combining coding and modulation." xmlns="http://www.w3.org/2000/svg">
@@ -47,3 +49,7 @@ data.
 
 TCM improves decoding robustness on the protocols that use it, recovering data at lower
 SNR than uncoded modulation.
+
+## Sources
+
+[^wiki]: [Trellis modulation](https://en.wikipedia.org/wiki/Trellis_modulation) — Wikipedia, for combining convolutional coding with the constellation mapping for coding gain.

--- a/docs/reference/trunked-radio.md
+++ b/docs/reference/trunked-radio.md
@@ -15,13 +15,15 @@ infobox:
 see_also: [conventional-radio, control-channel, voice-channel, talkgroup, channel-grant, fdma, tdma]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Trunked_radio_system
 ---
 
 **Trunked radio** is a system architecture in which many user groups share a small pool
 of frequencies, with a computer assigning a free channel to each call for its duration
-and reclaiming it afterward. A [control channel](/reference/control-channel/)
+and reclaiming it afterward.[^wiki] A [control channel](/reference/control-channel/)
 coordinates the whole system.
 
 <figure class="figure" markdown="0">
@@ -54,3 +56,7 @@ few channels can serve many groups.
 To monitor a trunked system you decode the control channel first, then follow grants —
 exactly what GopherTrunk does for [P25](/reference/project-25/),
 [DMR Tier III](/reference/dmr-tier-3/), and others.
+
+## Sources
+
+[^wiki]: [Trunked radio system](https://en.wikipedia.org/wiki/Trunked_radio_system) — Wikipedia, on trunking architecture and control-channel coordination.

--- a/docs/reference/tsbk.md
+++ b/docs/reference/tsbk.md
@@ -10,12 +10,14 @@ autolink: true
 see_also: [control-channel, channel-grant, project-25, p25-phase-1, csbk]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Project 25 (Wikipedia)", url: https://en.wikipedia.org/wiki/Project_25 }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Project_25
 ---
 
 A **TSBK** (**trunking signalling block**) is the unit of control-channel signalling in
-[P25](/reference/project-25/). Each TSBK is a short, error-protected message on the
+[P25](/reference/project-25/).[^wiki] Each TSBK is a short, error-protected message on the
 [control channel](/reference/control-channel/) carrying one piece of system business — a
 [channel grant](/reference/channel-grant/), a registration, an affiliation, or a system
 parameter.
@@ -35,3 +37,7 @@ Decoding TSBKs is exactly how a scanner follows a P25 system: read the grant TSB
 retune to the assigned [voice channel](/reference/voice-channel/) in step with the radios.
 P25 Phase 2 uses *MAC PDU* messages for the same role. DMR's equivalent is the
 [CSBK](/reference/csbk/).
+
+## Sources
+
+[^wiki]: [Project 25](https://en.wikipedia.org/wiki/Project_25) — Wikipedia, on the P25 standard and its control-channel signalling.

--- a/docs/reference/type-system.md
+++ b/docs/reference/type-system.md
@@ -18,13 +18,13 @@ see_also: [static-vs-dynamic-typing, compiler, interpreter, memory-management, r
 related_lessons:
   - { title: "Type systems and safety", url: /learn/intro-software-dev/type-systems/ }
   - { title: "Performance vs productivity", url: /learn/intro-software-dev/performance-vs-productivity/ }
-external:
-  - { title: "Type system — Wikipedia", url: https://en.wikipedia.org/wiki/Type_system }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Type_system
 ---
 
 **A type system** is the set of rules a language uses to track the type of every value
 — integer, string, list, a `Receiver` object — and decide which operations are allowed,
-catching whole classes of mistakes that would otherwise surface as bugs.
+catching whole classes of mistakes that would otherwise surface as bugs.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 120" role="img" aria-label="A type checker accepts an operation on matching types and rejects one that mixes incompatible types." xmlns="http://www.w3.org/2000/svg">
@@ -53,13 +53,13 @@ operation, then verifies that uses line up. *When* it checks is the
 executes. A separate axis is *how strictly* it enforces types — **strong** systems
 refuse to silently mix a string and a number, **weak** ones coerce. **Type inference**
 lets the compiler deduce types from context, so you get checking without spelling out
-every annotation.
+every annotation.[^wiki]
 
 ## Trade-offs
 
 A richer type system pays for itself by turning run-time surprises into compile errors:
 wrong-type arguments, calling a method that does not exist, forgetting to handle a
-null, and broken refactors all get caught for free. Expressive features — generics,
+null, and broken refactors all get caught for free.[^wiki] Expressive features — generics,
 sum types, and Option/Result types — let you "make illegal states unrepresentable."
 The cost is ceremony, some rigidity, and slower prototyping. A throwaway script barely
 benefits; a large, long-lived, multi-author system benefits enormously.
@@ -71,3 +71,7 @@ checking with inference; [TypeScript](/reference/typescript-language/) adds a ch
 type layer over JavaScript. In domains like radio software, wrapping a frequency and a
 sample rate in distinct types makes unit-confusion bugs impossible to compile rather
 than merely unlikely.
+
+## Sources
+
+[^wiki]: [Type system](https://en.wikipedia.org/wiki/Type_system) — Wikipedia, on type checking, the static/dynamic and strong/weak axes, type inference, and type safety.

--- a/docs/reference/typescript-language.md
+++ b/docs/reference/typescript-language.md
@@ -19,14 +19,16 @@ see_also: [javascript-language, type-system, static-vs-dynamic-typing, compiler,
 related_lessons:
   - { title: "A tour of today's major languages", url: /learn/intro-software-dev/language-tour/ }
   - { title: "Type systems", url: /learn/intro-software-dev/type-systems/ }
-external:
-  - { title: "TypeScript — Wikipedia", url: https://en.wikipedia.org/wiki/TypeScript }
-  - { title: "The TypeScript programming language", url: https://www.typescriptlang.org/ }
+related_reading:
+  - { title: "Build in the Open, Part 2: Choosing your language, platforms & stack", url: /blog/tutorials/build-in-the-open-02-choosing-language-platforms-stack/ }
+cite_urls:
+  - https://www.typescriptlang.org/
+  - https://en.wikipedia.org/wiki/TypeScript
 ---
 
 **TypeScript** is a statically typed superset of [JavaScript](/reference/javascript-language/):
 it adds an optional [type system](/reference/type-system/) on top of JavaScript and
-compiles down to plain JavaScript that runs anywhere JavaScript does.
+compiles down to plain JavaScript that runs anywhere JavaScript does.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 140" role="img" aria-label="TypeScript source is type-checked and compiled to plain JavaScript, which runs in the browser or Node.js." xmlns="http://www.w3.org/2000/svg">
@@ -49,7 +51,7 @@ TypeScript exists to fix JavaScript's biggest weakness — its loose
 [dynamic typing](/reference/static-vs-dynamic-typing/). You annotate code with types,
 the `tsc` [compiler](/reference/compiler/) checks them at build time, and then the types
 are *erased*: the emitted output is ordinary JavaScript with no runtime type system of
-its own. Memory and execution are still handled by the JavaScript runtime, so TypeScript
+its own.[^home] Memory and execution are still handled by the JavaScript runtime, so TypeScript
 adds safety without changing how the program runs.
 
 ## Strengths and trade-offs
@@ -69,3 +71,8 @@ TypeScript has become the default for serious front-end frameworks and Node.js b
 and for any JavaScript codebase large enough that loose typing becomes a liability.
 Because it compiles to plain [JavaScript](/reference/javascript-language/), it runs
 everywhere JavaScript runs and interoperates freely with existing JS libraries.
+
+## Sources
+
+[^home]: [The TypeScript programming language](https://www.typescriptlang.org/) — official site, documentation, and the `tsc` compiler and type system.
+[^wiki]: [TypeScript](https://en.wikipedia.org/wiki/TypeScript) — Wikipedia, for history and design background.

--- a/docs/reference/unit-testing.md
+++ b/docs/reference/unit-testing.md
@@ -16,12 +16,14 @@ infobox:
 see_also: [integration-testing, end-to-end-testing, test-driven-development, mocking, code-coverage, ci-cd, refactoring]
 related_lessons:
   - { title: "Testing — unit, integration & beyond", url: /learn/intro-software-dev/testing/ }
-external:
-  - { title: "Unit testing — Wikipedia", url: https://en.wikipedia.org/wiki/Unit_testing }
+related_reading:
+  - { title: "Build in the Open, Part 8: Testing — how to build and write tests", url: /blog/tutorials/build-in-the-open-08-testing-how-to-write-tests/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Unit_testing
 ---
 
 **Unit testing** checks a single small piece of code — one function or class — in
-isolation, forming the fast, numerous base of the test pyramid.
+isolation, forming the fast, numerous base of the test pyramid.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="The test pyramid with a wide unit-testing base, a narrower integration layer, and a small end-to-end tip." xmlns="http://www.w3.org/2000/svg">
@@ -38,7 +40,7 @@ isolation, forming the fast, numerous base of the test pyramid.
 
 A unit test exercises the smallest meaningful piece of behavior on its own, asserting
 that for a given input the unit produces the expected output. Because each test targets
-one unit, a failure points straight at the broken code. Unit tests are *fast* — a good
+one unit, a failure points straight at the broken code.[^wiki] Unit tests are *fast* — a good
 suite runs thousands in seconds — and that speed is what lets a developer run them
 constantly and lets [CI/CD](/reference/ci-cd/) run them on every push. They are also the
 safety net that makes [refactoring](/reference/refactoring/) safe: restructure freely,
@@ -62,3 +64,7 @@ Unit tests sit at the base of the pyramid beneath fewer
 [test-driven development](/reference/test-driven-development/) writes first, and the kind
 [code coverage](/reference/code-coverage/) most directly measures — though coverage shows
 only which lines *ran*, not whether the assertions checked anything meaningful.
+
+## Sources
+
+[^wiki]: [Unit testing](https://en.wikipedia.org/wiki/Unit_testing) — Wikipedia, for the definition, isolation, and the test-pyramid context.

--- a/docs/reference/upconverter.md
+++ b/docs/reference/upconverter.md
@@ -14,13 +14,13 @@ infobox:
 see_also: [rtl-sdr, airspy-hf-plus, frequency-bands, local-oscillator]
 related_lessons:
   - { title: "Frequency, bands & the spectrum", url: /learn/rf-sdr/frequency-and-spectrum/ }
-external:
-  - { title: "Upconverter (Wikipedia)", url: https://en.wikipedia.org/wiki/Frequency_mixer }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Frequency_mixer
 ---
 
 An **upconverter** is an external device that **shifts HF signals up** into the tuning
 range of a VHF/UHF SDR such as an [RTL-SDR](/reference/rtl-sdr/), letting radios that
-cannot tune [HF](/reference/frequency-bands/) directly receive shortwave.
+cannot tune [HF](/reference/frequency-bands/) directly receive shortwave.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A low HF input shifted upward by a fixed offset into the RTL-SDR's tunable range." xmlns="http://www.w3.org/2000/svg">
@@ -44,3 +44,7 @@ tune. Software subtracts the offset to show true frequencies.
 
 An upconverter is the budget route to HF on an RTL-SDR; a dedicated
 [Airspy HF+](/reference/airspy-hf-plus/) is the higher-performance alternative.
+
+## Sources
+
+[^wiki]: [Frequency mixer](https://en.wikipedia.org/wiki/Frequency_mixer) — Wikipedia, on the mixing principle an upconverter uses to shift HF up into a VHF/UHF tuning range.

--- a/docs/reference/version-control.md
+++ b/docs/reference/version-control.md
@@ -16,13 +16,15 @@ infobox:
 see_also: [ci-cd, build-systems, package-manager, semantic-versioning, refactoring]
 related_lessons:
   - { title: "What is version control?", url: /learn/git/what-is-version-control/ }
-external:
-  - { title: "Version control — Wikipedia", url: https://en.wikipedia.org/wiki/Version_control }
+related_reading:
+  - { title: "Build in the Open, Part 4: Git & GitHub fundamentals", url: /blog/tutorials/build-in-the-open-04-git-github-fundamentals-web-interface/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Version_control
 ---
 
 **Version control** is a system that records snapshots of a project's files over time, so
 you can recall any earlier state, see who changed what and why, and collaborate without
-overwriting each other's work.
+overwriting each other's work.[^wiki]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A timeline of commits, each a snapshot, with a branch splitting off and merging back." xmlns="http://www.w3.org/2000/svg">
@@ -59,7 +61,7 @@ and a network dependency for most operations. **Distributed** systems (Git, Merc
 give every contributor a *full clone* of the repository, history and all, so you can
 commit, browse, and branch offline, and no single server's loss erases the work. Git,
 built in 2005 for the Linux kernel, won on speed, cheap branching, integrity by content
-hashing, and a thriving ecosystem of hosts like GitHub.
+hashing, and a thriving ecosystem of hosts like GitHub.[^wiki]
 
 ## Why it underpins everything
 
@@ -71,3 +73,7 @@ it holds the tags that mark each release under
 [semantic versioning](/reference/semantic-versioning/). Its safety net is also what makes
 bold [refactoring](/reference/refactoring/) practical: any change can be reviewed,
 reverted, or compared against history.
+
+## Sources
+
+[^wiki]: [Version control](https://en.wikipedia.org/wiki/Version_control) — Wikipedia, for the centralized-vs-distributed designs and Git's history.

--- a/docs/reference/viterbi-algorithm.md
+++ b/docs/reference/viterbi-algorithm.md
@@ -14,12 +14,14 @@ infobox:
 see_also: [convolutional-code, trellis-coded-modulation, forward-error-correction, andrew-viterbi, m17]
 related_lessons:
   - { title: "The demodulation pipeline", url: /learn/rf-sdr/demodulation-pipeline/ }
-external:
-  - { title: "Viterbi algorithm (Wikipedia)", url: https://en.wikipedia.org/wiki/Viterbi_algorithm }
+related_reading:
+  - { title: "SDR Internals, Part 9: Framing & forward error correction", url: /blog/deep-dives/sdr-internals-09-framing-fec/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Viterbi_algorithm
 ---
 
 The **Viterbi algorithm** efficiently finds the most likely sequence of states through a
-trellis, given noisy observations. It is the standard way to decode
+trellis, given noisy observations.[^wiki] It is the standard way to decode
 [convolutional codes](/reference/convolutional-code/), named for
 [Andrew Viterbi](/reference/andrew-viterbi/).
 
@@ -43,3 +45,7 @@ transmitted bits even with errors.
 
 Viterbi decoding is used in error-corrected digital systems such as
 [M17](/reference/m17/) and various trunked-radio components to drive down the error rate.
+
+## Sources
+
+[^wiki]: [Viterbi algorithm](https://en.wikipedia.org/wiki/Viterbi_algorithm) — Wikipedia, for the maximum-likelihood trellis decoder and its origin.

--- a/docs/reference/vocoder.md
+++ b/docs/reference/vocoder.md
@@ -17,13 +17,16 @@ related_lessons:
   - { title: "Vocoders — IMBE & AMBE+2", url: /learn/rf-sdr/vocoders/ }
   - { title: "Analog vs. digital voice", url: /learn/rf-sdr/digital-voice/ }
 external:
-  - { title: "Vocoder (Wikipedia)", url: https://en.wikipedia.org/wiki/Vocoder }
   - { title: "GopherTrunk vocoders", url: /vocoders.html }
+related_reading:
+  - { title: "SDR Internals, Part 12: Voice coding & vocoders", url: /blog/deep-dives/sdr-internals-12-voice-coding-vocoders/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Vocoder
 ---
 
 A **vocoder** (voice coder) is a speech codec that compresses voice into a few kilobits
 per second by **modelling how speech is produced** — pitch, voicing, and spectral shape
-— rather than recording the waveform. It is what makes
+— rather than recording the waveform.[^wiki] It is what makes
 [digital voice](/learn/rf-sdr/digital-voice/) radio possible.
 
 <figure class="figure" markdown="0">
@@ -51,3 +54,7 @@ is why digital voice can sound slightly robotic, especially on a weak signal.
 Decoding digital voice requires running the **matching** vocoder — [IMBE](/reference/imbe/)
 for [P25 Phase 1](/reference/p25-phase-1/), [AMBE+2](/reference/ambe-plus-2/) for DMR and
 P25 Phase 2, or [Codec 2](/reference/codec2/) for [M17](/reference/m17/).
+
+## Sources
+
+[^wiki]: [Vocoder](https://en.wikipedia.org/wiki/Vocoder) — Wikipedia, on speech coding that models how voice is produced.

--- a/docs/reference/voice-channel.md
+++ b/docs/reference/voice-channel.md
@@ -14,13 +14,15 @@ infobox:
 see_also: [control-channel, trunked-radio, channel-grant, talkgroup]
 related_lessons:
   - { title: "What is trunked radio?", url: /learn/rf-sdr/what-is-trunking/ }
-external:
-  - { title: "Trunked radio system (Wikipedia)", url: https://en.wikipedia.org/wiki/Trunked_radio_system }
+related_reading:
+  - { title: "SDR Internals, Part 11: The trunking engine & event bus", url: /blog/deep-dives/sdr-internals-11-trunking-engine-event-bus/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Trunked_radio_system
 ---
 
 A **voice channel** (or traffic channel) is a frequency that a
 [trunked radio](/reference/trunked-radio/) system **temporarily assigns** to carry one
-call. When the call ends, the channel returns to the pool for reuse.
+call.[^wiki] When the call ends, the channel returns to the pool for reuse.
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 130" role="img" aria-label="A pool of voice channels over time, each lighting up briefly for a call then going idle." xmlns="http://www.w3.org/2000/svg">
@@ -43,3 +45,7 @@ may land on a different voice channel entirely.
 
 GopherTrunk tunes a receiver to the granted voice channel to capture the audio, then
 returns to await the next assignment — following many calls from one capture.
+
+## Sources
+
+[^wiki]: [Trunked radio system](https://en.wikipedia.org/wiki/Trunked_radio_system) — Wikipedia, on per-call voice (traffic) channel assignment.

--- a/docs/reference/wavelength.md
+++ b/docs/reference/wavelength.md
@@ -14,11 +14,11 @@ infobox:
 see_also: [frequency, radio-wave, antenna, dipole-antenna]
 related_lessons:
   - { title: "What is a radio wave?", url: /learn/rf-sdr/radio-waves/ }
-external:
-  - { title: "Wavelength (Wikipedia)", url: https://en.wikipedia.org/wiki/Wavelength }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Wavelength
 ---
 
-**Wavelength** (λ) is the physical distance a wave covers in one complete cycle. For a
+**Wavelength** (λ) is the physical distance a wave covers in one complete cycle.[^wiki] For a
 [radio wave](/reference/radio-wave/) it is inversely proportional to
 [frequency](/reference/frequency/): higher frequency means shorter wavelength.
 
@@ -48,3 +48,7 @@ Since radio travels at the speed of light, *λ = c / f*. A handy approximation i
 Wavelength sets [antenna](/reference/antenna/) size (a quarter-wave whip is λ/4) and
 influences how signals bend around obstacles, making it central to antenna choice and
 [propagation](/reference/radio-propagation/).
+
+## Sources
+
+[^wiki]: [Wavelength](https://en.wikipedia.org/wiki/Wavelength) — Wikipedia, on the spatial period of a wave and its inverse relation to frequency.

--- a/docs/reference/zadig.md
+++ b/docs/reference/zadig.md
@@ -10,14 +10,14 @@ autolink: true
 see_also: [rtl-sdr, rtl2832u, rtl-tcp, soapysdr]
 related_lessons:
   - { title: "SDR hardware — RTL-SDR, HackRF, Airspy", url: /learn/rf-sdr/sdr-hardware/ }
-external:
-  - { title: "Zadig", url: https://zadig.akeo.ie/ }
+cite_urls:
+  - https://zadig.akeo.ie/
 ---
 
 **Zadig** is a small Windows utility that installs the generic **WinUSB** driver onto an
 SDR dongle. Out of the box, Windows binds an [RTL-SDR](/reference/rtl-sdr/) to its
 TV-tuner (DVB-T) driver; Zadig replaces that with WinUSB so SDR software can talk to the
-device directly.
+device directly.[^home]
 
 <figure class="figure" markdown="0">
 <svg viewBox="0 0 460 110" role="img" aria-label="A dongle's default TV-tuner driver being replaced by the WinUSB driver via Zadig." xmlns="http://www.w3.org/2000/svg">
@@ -35,3 +35,7 @@ device directly.
 
 GopherTrunk's Windows installer bundles Zadig to automate this step. On Linux and macOS
 the equivalent access is handled by libusb/IOKit without a separate tool.
+
+## Sources
+
+[^home]: [Zadig](https://zadig.akeo.ie/) — the official Zadig site, the USB driver installer that swaps a dongle's driver for WinUSB.


### PR DESCRIPTION
## Summary

Follow-up to the merged Reference work (#738). Two documentation commits that were stranded on `claude/software-dev-reference-docs-rdez8u` (which was 30 commits behind `main`), rebased cleanly onto current `main`.

- **Rename "encyclopedia" → "Field Guide"** across the reference section's display name (nav label, hub + article breadcrumbs/eyebrows, `DefinedTermSet`/`BreadcrumbList` schema names, `llms.txt` header, autolink tooltip, search `nav_group`, hub/index + `reference.yml` copy). URLs and internal identifiers are unchanged.
- **Citations for the 61 Software Development articles**: inline kramdown footnotes (`[^key]`) on substantive claims + a "## Sources" section, backed by real, verifiable sources (official docs/specs + Wikipedia). The article layout renders the kramdown `.footnotes` block as the Sources list; the former "References & external links" section is repurposed to "Related links"; schema `sameAs` reads a machine-only `cite_urls` list.
- **Citations for the 179 RF & SDR articles**: the same citation model applied; each article's authoritative links migrated out of `external` into footnote sources + `cite_urls`. Genuine internal links stay in `external` as "Related links". No prose reworded — markers only.
- **"From the blog" linkage** (`related_reading`) wires articles to matching deep-dive posts.

## Conflict resolution

One conflict during the rebase: `docs/reference/hackrf.md`. `main` had since added Linux/Windows/daemon **Setup** sections (HackRF Windows support). Resolved by keeping main's new Setup sections and appending the new `## Sources` footnote section after them; the `cite_urls` frontmatter and inline `[^wiki]` marker merged cleanly.

## Verification

Original branch was verified with a local Jekyll build (footnotes render under Sources, breadcrumbs/eyebrows read "Field Guide", search group renamed, blog links resolve). A fresh local Jekyll build is recommended before merge to confirm the resolved `hackrf.md` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016eCpLSbASpifGjkdeuF8kf)_