### PR TITLE
p25: flag bit-error-corrupted talker aliases as unreliable (#711)

### DIFF
--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -390,6 +390,7 @@ func mergeRIDLivePB(p *apiv1.RID, u trunking.UnitActivity) *apiv1.RID {
 	p.Protocol = u.Protocol
 	p.LastTalkgroup = u.Talkgroup
 	p.TalkerAlias = u.TalkerAlias
+	p.TalkerAliasUnreliable = u.TalkerAliasUnreliable
 	if !u.TalkerAliasAt.IsZero() {
 		p.TalkerAliasAt = u.TalkerAliasAt.UTC().Format(time.RFC3339)
 	}

--- a/internal/api/pb/v1/rid.pb.go
+++ b/internal/api/pb/v1/rid.pb.go
@@ -51,8 +51,12 @@ type RID struct {
 	CallCount     uint64 `protobuf:"varint,17,opt,name=call_count,json=callCount,proto3" json:"call_count,omitempty"`
 	FirstSeen     string `protobuf:"bytes,18,opt,name=first_seen,json=firstSeen,proto3" json:"first_seen,omitempty"` // RFC3339
 	LastSeen      string `protobuf:"bytes,19,opt,name=last_seen,json=lastSeen,proto3" json:"last_seen,omitempty"`    // RFC3339
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// talker_alias_unreliable flags an over-the-air alias whose decode
+	// passed CRC but held non-ASCII-printable characters (#711); a client
+	// should render it as suspect.
+	TalkerAliasUnreliable bool `protobuf:"varint,20,opt,name=talker_alias_unreliable,json=talkerAliasUnreliable,proto3" json:"talker_alias_unreliable,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *RID) Reset() {
@@ -216,6 +220,13 @@ func (x *RID) GetLastSeen() string {
 		return x.LastSeen
 	}
 	return ""
+}
+
+func (x *RID) GetTalkerAliasUnreliable() bool {
+	if x != nil {
+		return x.TalkerAliasUnreliable
+	}
+	return false
 }
 
 type ListRIDsRequest struct {
@@ -650,7 +661,7 @@ var File_rid_proto protoreflect.FileDescriptor
 
 const file_rid_proto_rawDesc = "" +
 	"\n" +
-	"\trid.proto\x12\x0egophertrunk.v1\"\x8c\x04\n" +
+	"\trid.proto\x12\x0egophertrunk.v1\"\xc4\x04\n" +
 	"\x03RID\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\rR\x02id\x12\x14\n" +
 	"\x05alias\x18\x02 \x01(\tR\x05alias\x12 \n" +
@@ -675,7 +686,8 @@ const file_rid_proto_rawDesc = "" +
 	"call_count\x18\x11 \x01(\x04R\tcallCount\x12\x1d\n" +
 	"\n" +
 	"first_seen\x18\x12 \x01(\tR\tfirstSeen\x12\x1b\n" +
-	"\tlast_seen\x18\x13 \x01(\tR\blastSeen\"\x11\n" +
+	"\tlast_seen\x18\x13 \x01(\tR\blastSeen\x126\n" +
+	"\x17talker_alias_unreliable\x18\x14 \x01(\bR\x15talkerAliasUnreliable\"\x11\n" +
 	"\x0fListRIDsRequest\";\n" +
 	"\x10ListRIDsResponse\x12'\n" +
 	"\x04rids\x18\x01 \x03(\v2\x13.gophertrunk.v1.RIDR\x04rids\"\x1f\n" +

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -253,7 +253,11 @@ type RIDDTO struct {
 	LastTalkgroup uint32    `json:"last_talkgroup,omitempty"`
 	TalkerAlias   string    `json:"talker_alias,omitempty"`
 	TalkerAliasAt time.Time `json:"talker_alias_at,omitempty"`
-	CallCount     uint64    `json:"call_count,omitempty"`
+	// TalkerAliasUnreliable flags an over-the-air alias whose decode
+	// passed CRC but held non-ASCII-printable characters (#711); a
+	// client should render it as suspect.
+	TalkerAliasUnreliable bool   `json:"talker_alias_unreliable,omitempty"`
+	CallCount             uint64 `json:"call_count,omitempty"`
 	FirstSeen     time.Time `json:"first_seen,omitempty"`
 	LastSeen      time.Time `json:"last_seen,omitempty"`
 }
@@ -288,6 +292,7 @@ func mergeRIDLive(dto *RIDDTO, u trunking.UnitActivity) *RIDDTO {
 	dto.LastTalkgroup = u.Talkgroup
 	dto.TalkerAlias = u.TalkerAlias
 	dto.TalkerAliasAt = u.TalkerAliasAt
+	dto.TalkerAliasUnreliable = u.TalkerAliasUnreliable
 	dto.CallCount = u.CallCount
 	dto.FirstSeen = u.FirstSeen
 	dto.LastSeen = u.LastSeen

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -256,10 +256,10 @@ type RIDDTO struct {
 	// TalkerAliasUnreliable flags an over-the-air alias whose decode
 	// passed CRC but held non-ASCII-printable characters (#711); a
 	// client should render it as suspect.
-	TalkerAliasUnreliable bool   `json:"talker_alias_unreliable,omitempty"`
-	CallCount             uint64 `json:"call_count,omitempty"`
-	FirstSeen     time.Time `json:"first_seen,omitempty"`
-	LastSeen      time.Time `json:"last_seen,omitempty"`
+	TalkerAliasUnreliable bool      `json:"talker_alias_unreliable,omitempty"`
+	CallCount             uint64    `json:"call_count,omitempty"`
+	FirstSeen             time.Time `json:"first_seen,omitempty"`
+	LastSeen              time.Time `json:"last_seen,omitempty"`
 }
 
 func ridToDTO(r *trunking.RID) *RIDDTO {

--- a/internal/radio/p25/motorola/alias.go
+++ b/internal/radio/p25/motorola/alias.go
@@ -86,16 +86,49 @@ func DecodeAliasBytes(encoded []byte) []byte {
 	return decoded
 }
 
-// CleanAlias trims to printable ASCII, dropping control characters and
-// the 0x00 high bytes of UTF-16 BE ASCII characters.
-func CleanAlias(raw []byte) string {
-	out := make([]byte, 0, len(raw))
-	for _, b := range raw {
-		if b >= 0x20 && b < 0x7F {
-			out = append(out, b)
+// DecodeAlias renders the decoded cipher output — a UTF-16 BE character
+// sequence — as a printable-ASCII string and reports whether the decode
+// looks reliable.
+//
+// reliable is false when the stream holds any character outside
+// printable ASCII: a non-zero UTF-16 high byte, a control/DEL low byte,
+// a non-NUL after the trailing NUL padding has started, or an odd
+// trailing byte that can't form a UTF-16 unit. Those are the hallmark
+// of bit-error corruption that survived the CRC (#711), so a caller
+// should surface the result as suspect rather than as a confirmed name.
+//
+// The returned string is still the best-effort printable-ASCII rendering
+// (corrupt characters dropped) so an operator has something to display
+// alongside the unreliable flag. ASCII characters arrive as a 0x00 high
+// byte plus the character; those high bytes and any trailing NUL padding
+// are expected and do not make the decode unreliable.
+func DecodeAlias(raw []byte) (alias string, reliable bool) {
+	reliable = true
+	out := make([]byte, 0, len(raw)/2)
+	for i := 0; i+1 < len(raw); i += 2 {
+		hi, lo := raw[i], raw[i+1]
+		if hi == 0 && lo == 0 {
+			// NUL: expected only as trailing padding. Anything other
+			// than NUL after it means the stream is corrupt.
+			for j := i + 2; j+1 < len(raw); j += 2 {
+				if raw[j] != 0 || raw[j+1] != 0 {
+					reliable = false
+					break
+				}
+			}
+			break
+		}
+		if hi == 0 && lo >= 0x20 && lo < 0x7F {
+			out = append(out, lo)
+		} else {
+			reliable = false
 		}
 	}
-	return string(out)
+	// An odd trailing byte can't form a UTF-16 unit — treat as corruption.
+	if len(raw)%2 == 1 {
+		reliable = false
+	}
+	return string(out), reliable
 }
 
 // Message framing field sizes.
@@ -113,6 +146,11 @@ type Message struct {
 	SystemID uint16
 	RadioID  uint32
 	Alias    string
+	// AliasReliable reports whether the decoded alias is all printable
+	// ASCII. When false the decode contains non-ASCII-printable
+	// characters — a hallmark of bit-error corruption that survived the
+	// CRC — and callers should surface the alias as suspect (#711).
+	AliasReliable bool
 	// CRCOK reports whether the trailing CRC-16/GSM matched. It is
 	// advisory: the CRC parameters are inferred from open-source
 	// decoders and not yet confirmed against a committed real-frame
@@ -144,7 +182,7 @@ func DecodeMessage(msg []byte) (Message, bool) {
 
 	wacn, sysID, rid := decodeSUID(msg)
 	encoded := msg[encStart : encStart+encByteLen]
-	alias := CleanAlias(DecodeAliasBytes(encoded))
+	alias, aliasReliable := DecodeAlias(DecodeAliasBytes(encoded))
 
 	// CRC-16/GSM over everything before the trailing 16-bit CRC field.
 	crcBytes := CRCBits / 8
@@ -153,11 +191,12 @@ func DecodeMessage(msg []byte) (Message, bool) {
 	crcOK := crc16GSM(body) == want
 
 	return Message{
-		WACN:     wacn,
-		SystemID: sysID,
-		RadioID:  rid,
-		Alias:    alias,
-		CRCOK:    crcOK,
+		WACN:          wacn,
+		SystemID:      sysID,
+		RadioID:       rid,
+		Alias:         alias,
+		AliasReliable: aliasReliable,
+		CRCOK:         crcOK,
 	}, true
 }
 

--- a/internal/radio/p25/motorola/alias_test.go
+++ b/internal/radio/p25/motorola/alias_test.go
@@ -28,11 +28,66 @@ func TestDecodeAliasBytesEmpty(t *testing.T) {
 	}
 }
 
-func TestCleanAliasFiltersControl(t *testing.T) {
-	// UTF-16 BE "Hi" = 00 48 00 69 ; control bytes and NULs dropped.
-	got := CleanAlias([]byte{0x00, 0x48, 0x00, 0x69, 0x01, 0x7F})
-	if got != "Hi" {
-		t.Errorf("CleanAlias = %q, want %q", got, "Hi")
+func TestDecodeAlias(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          []byte
+		wantAlias    string
+		wantReliable bool
+	}{
+		{
+			// UTF-16 BE "Hi" = 00 48 00 69 — clean printable ASCII.
+			name:         "clean ascii",
+			raw:          []byte{0x00, 0x48, 0x00, 0x69},
+			wantAlias:    "Hi",
+			wantReliable: true,
+		},
+		{
+			// Trailing NUL padding is expected and stays reliable.
+			name:         "trailing nul padding",
+			raw:          []byte{0x00, 0x48, 0x00, 0x69, 0x00, 0x00},
+			wantAlias:    "Hi",
+			wantReliable: true,
+		},
+		{
+			// U+017F (ſ) is non-ASCII — best-effort "Hi" but unreliable.
+			name:         "non-ascii latin codepoint",
+			raw:          []byte{0x00, 0x48, 0x00, 0x69, 0x01, 0x7F},
+			wantAlias:    "Hi",
+			wantReliable: false,
+		},
+		{
+			// U+4E2D (中) — the CJK mojibake the reporter saw (#711).
+			name:         "cjk codepoint",
+			raw:          []byte{0x4E, 0x2D},
+			wantAlias:    "",
+			wantReliable: false,
+		},
+		{
+			// A control low byte (0x01) is corruption.
+			name:         "control low byte",
+			raw:          []byte{0x00, 0x48, 0x00, 0x01},
+			wantAlias:    "H",
+			wantReliable: false,
+		},
+		{
+			// An odd trailing byte can't form a UTF-16 unit.
+			name:         "odd length",
+			raw:          []byte{0x00, 0x48, 0x00},
+			wantAlias:    "H",
+			wantReliable: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alias, reliable := DecodeAlias(tt.raw)
+			if alias != tt.wantAlias {
+				t.Errorf("alias = %q, want %q", alias, tt.wantAlias)
+			}
+			if reliable != tt.wantReliable {
+				t.Errorf("reliable = %v, want %v", reliable, tt.wantReliable)
+			}
+		})
 	}
 }
 
@@ -62,6 +117,27 @@ func TestDecodeMessageSUID(t *testing.T) {
 	}
 	if msg.RadioID != 200062 {
 		t.Errorf("RadioID = %d, want 200062", msg.RadioID)
+	}
+}
+
+// TestDecodeMessagePopulatesAliasReliable guards that DecodeMessage
+// actually computes and assigns AliasReliable from the decoded alias,
+// rather than leaving it at its zero value.
+func TestDecodeMessagePopulatesAliasReliable(t *testing.T) {
+	suid := []byte{0xBE, 0xE0, 0x01, 0x64, 0x03, 0x0D, 0x7E}
+	encoded := []byte{0x12, 0x34, 0x56, 0x78} // arbitrary cipher bytes
+	full := append(append([]byte{}, suid...), encoded...)
+	full = append(full, 0x00, 0x00) // CRC placeholder
+	msg, ok := DecodeMessage(full)
+	if !ok {
+		t.Fatal("DecodeMessage returned ok=false")
+	}
+	wantAlias, wantReliable := DecodeAlias(DecodeAliasBytes(encoded))
+	if msg.Alias != wantAlias {
+		t.Errorf("Alias = %q, want %q", msg.Alias, wantAlias)
+	}
+	if msg.AliasReliable != wantReliable {
+		t.Errorf("AliasReliable = %v, want %v", msg.AliasReliable, wantReliable)
 	}
 }
 

--- a/internal/radio/p25/phase1/motorola_alias.go
+++ b/internal/radio/p25/phase1/motorola_alias.go
@@ -135,12 +135,15 @@ func NewMotorolaTalkerAliasBuf(now func() time.Time) *MotorolaTalkerAliasBuf {
 // LCOTalkerAliasBlock2 (0x17, what Motorola uses as a data block).
 // Other LCOs are ignored.
 //
-// Returns (alias, true) when the header + every data block has
-// arrived with consistent sequence numbers; ("", false) otherwise.
-// Repeated emission of the same alias inside one sequence is
+// Returns (alias, true, reliable) when the header + every data block
+// has arrived with consistent sequence numbers; ("", false, false)
+// otherwise. reliable is false when the decoded alias contains
+// non-ASCII-printable characters (bit-error corruption surviving the
+// CRC, #711) — the alias is still returned so it can be surfaced as
+// suspect. Repeated emission of the same alias inside one sequence is
 // suppressed — a new header (different sequence number) resets the
 // dedupe fingerprint.
-func (b *MotorolaTalkerAliasBuf) AddFragment(lcf uint8, content [lcContentOctets]byte) (string, bool) {
+func (b *MotorolaTalkerAliasBuf) AddFragment(lcf uint8, content [lcContentOctets]byte) (string, bool, bool) {
 	now := b.now()
 	if !b.lastUpdate.IsZero() && now.Sub(b.lastUpdate) > motorolaAliasStaleAfter {
 		b.resetExceptEmitted()
@@ -150,7 +153,7 @@ func (b *MotorolaTalkerAliasBuf) AddFragment(lcf uint8, content [lcContentOctets
 		count := content[4]
 		seq := content[7] >> 4
 		if count == 0 || count > motorolaMaxBlocks {
-			return "", false
+			return "", false, false
 		}
 		// A header with a different sequence number is a new alias
 		// transmission — drop any in-flight data blocks from the
@@ -169,7 +172,7 @@ func (b *MotorolaTalkerAliasBuf) AddFragment(lcf uint8, content [lcContentOctets
 		seq := content[3] >> 4
 		if blockNum == 0 || !b.haveHeader || seq != b.sequence ||
 			blockNum > b.blockCount {
-			return "", false
+			return "", false, false
 		}
 		// Fragment = low nibble of octet 3 (4 bits) + octets 4..8
 		// (40 bits) = 44 bits total. Pack into 6 bytes left-aligned
@@ -179,30 +182,30 @@ func (b *MotorolaTalkerAliasBuf) AddFragment(lcf uint8, content [lcContentOctets
 		copy(frag[1:6], content[4:9]) // 40 bits of payload
 		b.blocks[blockNum-1] = frag
 	default:
-		return "", false
+		return "", false, false
 	}
 	b.lastUpdate = now
 
 	if !b.haveHeader {
-		return "", false
+		return "", false, false
 	}
 	for _, blk := range b.blocks {
 		if blk == nil {
-			return "", false
+			return "", false, false
 		}
 	}
 
 	bits := assembleMotorolaBitStream(b.blocks)
-	alias := decodeMotorolaAlias(bits)
+	alias, reliable := decodeMotorolaAlias(bits)
 	if alias == "" {
-		return "", false
+		return "", false, false
 	}
 	h := aliasFingerprint(alias)
 	if h == b.emittedHash {
-		return "", false
+		return "", false, false
 	}
 	b.emittedHash = h
-	return alias, true
+	return alias, true, reliable
 }
 
 // Reset clears the buffer including the de-duplication fingerprint
@@ -268,18 +271,19 @@ func aliasFingerprint(s string) uint64 {
 }
 
 // decodeMotorolaAlias extracts the encoded alias bytes from the
-// reassembled bit stream, runs them through the proprietary
-// per-byte cipher, then filters the decoded UTF-16 BE characters
-// to printable ASCII via cleanAlias. Empty result on too-short
-// input or all-non-printable decoded bytes.
-func decodeMotorolaAlias(bits []byte) string {
+// reassembled bit stream, runs them through the proprietary per-byte
+// cipher, then renders the decoded UTF-16 BE characters to printable
+// ASCII via decodeAlias. It returns (alias, reliable); reliable is
+// false when the decode holds non-ASCII-printable characters (#711).
+// Empty alias on too-short input or all-non-printable decoded bytes.
+func decodeMotorolaAlias(bits []byte) (string, bool) {
 	totalBits := len(bits) * 8
 	// Encoded alias starts at bit motorolaSUIDBits (after WACN +
 	// System + Radio ID) and runs until motorolaCRCBits before the
 	// end. Must be byte-aligned and at least 2 bytes (one decoded
 	// character).
 	if totalBits < motorolaSUIDBits+motorolaCRCBits+16 {
-		return ""
+		return "", false
 	}
 	aliasBits := totalBits - motorolaSUIDBits - motorolaCRCBits
 	if aliasBits%8 != 0 {
@@ -291,9 +295,9 @@ func decodeMotorolaAlias(bits []byte) string {
 	encStart := motorolaSUIDBits / 8 // SUID is exactly 7 bytes
 	encByteLen := aliasBits / 8
 	if encStart+encByteLen > len(bits) {
-		return ""
+		return "", false
 	}
 	encoded := bits[encStart : encStart+encByteLen]
 	decoded := decodeAliasBytes(encoded)
-	return cleanAlias(decoded)
+	return decodeAlias(decoded)
 }

--- a/internal/radio/p25/phase1/motorola_alias_cipher.go
+++ b/internal/radio/p25/phase1/motorola_alias_cipher.go
@@ -11,3 +11,11 @@ import "github.com/MattCheramie/GopherTrunk/internal/radio/p25/motorola"
 func decodeAliasBytes(encoded []byte) []byte {
 	return motorola.DecodeAliasBytes(encoded)
 }
+
+// decodeAlias renders the decoded UTF-16 BE bytes as a printable-ASCII
+// string and reports whether the decode is reliable (all printable
+// ASCII). A thin package-local alias over motorola.DecodeAlias, kept
+// alongside decodeAliasBytes so phase1 call sites stay package-local.
+func decodeAlias(raw []byte) (string, bool) {
+	return motorola.DecodeAlias(raw)
+}

--- a/internal/radio/p25/phase1/motorola_alias_test.go
+++ b/internal/radio/p25/phase1/motorola_alias_test.go
@@ -46,18 +46,18 @@ func makeDataBlockContent(blockNum, seq uint8, fragment [6]byte) [lcContentOctet
 func TestMotorolaTalkerAliasBufRejectsBadHeaderCount(t *testing.T) {
 	b := NewMotorolaTalkerAliasBuf(nil)
 	// block_count = 0 is meaningless.
-	if _, ok := b.AddFragment(LCOTalkerAliasHeader, makeHeaderContent(20202, 0, 5)); ok {
+	if _, ok, _ := b.AddFragment(LCOTalkerAliasHeader, makeHeaderContent(20202, 0, 5)); ok {
 		t.Error("zero block_count should not emit")
 	}
 	// block_count over the safety cap is rejected.
-	if _, ok := b.AddFragment(LCOTalkerAliasHeader, makeHeaderContent(20202, 100, 5)); ok {
+	if _, ok, _ := b.AddFragment(LCOTalkerAliasHeader, makeHeaderContent(20202, 100, 5)); ok {
 		t.Error("over-cap block_count should not emit")
 	}
 }
 
 func TestMotorolaTalkerAliasBufRejectsDataBlockWithoutHeader(t *testing.T) {
 	b := NewMotorolaTalkerAliasBuf(nil)
-	if _, ok := b.AddFragment(LCOTalkerAliasBlock2, makeDataBlockContent(1, 5, [6]byte{})); ok {
+	if _, ok, _ := b.AddFragment(LCOTalkerAliasBlock2, makeDataBlockContent(1, 5, [6]byte{})); ok {
 		t.Error("data block without prior header should not emit")
 	}
 }
@@ -74,7 +74,7 @@ func TestMotorolaTalkerAliasBufRejectsMismatchedSequence(t *testing.T) {
 	// because block_number > block_count check would let it through —
 	// instead, the wrong sequences fail the seq check and don't
 	// populate b.blocks. So the buffer is still incomplete.
-	if _, ok := b.AddFragment(LCOTalkerAliasBlock2, makeDataBlockContent(3, 5, [6]byte{})); ok {
+	if _, ok, _ := b.AddFragment(LCOTalkerAliasBlock2, makeDataBlockContent(3, 5, [6]byte{})); ok {
 		t.Error("emission with non-matching-sequence data blocks should not fire")
 	}
 }
@@ -90,7 +90,7 @@ func TestMotorolaTalkerAliasBufNewHeaderResetsBlocks(t *testing.T) {
 	// must be cleared, otherwise the second sequence's emission
 	// gate would fire prematurely.
 	b.AddFragment(LCOTalkerAliasHeader, makeHeaderContent(20202, 2, 7))
-	if _, ok := b.AddFragment(LCOTalkerAliasBlock2, makeDataBlockContent(1, 7, [6]byte{})); ok {
+	if _, ok, _ := b.AddFragment(LCOTalkerAliasBlock2, makeDataBlockContent(1, 7, [6]byte{})); ok {
 		t.Error("emission fired before both new-sequence data blocks arrived")
 	}
 }
@@ -103,7 +103,7 @@ func TestMotorolaTalkerAliasBufStaleEviction(t *testing.T) {
 	// Far past the staleness window — the partial reassembly is
 	// dropped on the next call.
 	clk = clk.Add(motorolaAliasStaleAfter + time.Second)
-	if _, ok := b.AddFragment(LCOTalkerAliasBlock2, makeDataBlockContent(2, 5, [6]byte{})); ok {
+	if _, ok, _ := b.AddFragment(LCOTalkerAliasBlock2, makeDataBlockContent(2, 5, [6]byte{})); ok {
 		t.Error("emission fired after stale eviction")
 	}
 }
@@ -112,11 +112,11 @@ func TestMotorolaTalkerAliasBufIgnoresUnrelatedLCO(t *testing.T) {
 	b := NewMotorolaTalkerAliasBuf(nil)
 	// LCO 0x16 is the TIA-102 BLOCK1; the Motorola form does not
 	// use it, so the assembler must drop it on the floor.
-	if _, ok := b.AddFragment(LCOTalkerAliasBlock1, [lcContentOctets]byte{}); ok {
+	if _, ok, _ := b.AddFragment(LCOTalkerAliasBlock1, [lcContentOctets]byte{}); ok {
 		t.Error("LCO 0x16 must not emit (Motorola form skips BLOCK1)")
 	}
 	// Non-talker-alias LCO is also a no-op.
-	if _, ok := b.AddFragment(LCOGroupVoiceChannelUser, [lcContentOctets]byte{}); ok {
+	if _, ok, _ := b.AddFragment(LCOGroupVoiceChannelUser, [lcContentOctets]byte{}); ok {
 		t.Error("non-talker-alias LCO must not emit")
 	}
 }
@@ -180,7 +180,7 @@ func TestDecodeMotorolaAliasTooShortReturnsEmpty(t *testing.T) {
 	// Less than SUID (56 bits) + CRC (16 bits) + one encoded char
 	// (8 bits) = 80 bits = 10 bytes.
 	short := make([]byte, 9)
-	if got := decodeMotorolaAlias(short); got != "" {
+	if got, _ := decodeMotorolaAlias(short); got != "" {
 		t.Errorf("decodeMotorolaAlias(short) = %q, want empty", got)
 	}
 }

--- a/internal/radio/p25/phase1/tdulc_test.go
+++ b/internal/radio/p25/phase1/tdulc_test.go
@@ -83,7 +83,7 @@ func TestTDULCFeedsMotorolaAliasBuf(t *testing.T) {
 	// HEADER 0x15: MFID 0x90, TG 0x7777=30583, blocks 7, format 1,
 	// reserved 0, seq nibble 9 + checksum.
 	header := [lcContentOctets]byte{0x15, 0x90, 0x77, 0x77, 0x07, 0x01, 0x00, 0x99, 0x02}
-	if _, ok := buf.AddFragment(LCOTalkerAliasHeader, header); ok {
+	if _, ok, _ := buf.AddFragment(LCOTalkerAliasHeader, header); ok {
 		t.Fatal("header alone should not complete an alias")
 	}
 	if buf.blockCount != 7 {
@@ -99,7 +99,7 @@ func TestTDULCFeedsMotorolaAliasBuf(t *testing.T) {
 	// DATA BLOCK 1 of seq 9: 17 90 01 9B EE 00 16 43 10. Octet 2 =
 	// block number 1; octet 3 high nibble = seq 9.
 	data := [lcContentOctets]byte{0x17, 0x90, 0x01, 0x9B, 0xEE, 0x00, 0x16, 0x43, 0x10}
-	if _, ok := buf.AddFragment(LCOTalkerAliasBlock2, data); ok {
+	if _, ok, _ := buf.AddFragment(LCOTalkerAliasBlock2, data); ok {
 		t.Fatal("only 1 of 7 blocks present; alias must not complete")
 	}
 	if buf.blocks[0] == nil {

--- a/internal/radio/p25/phase2/talker_alias.go
+++ b/internal/radio/p25/phase2/talker_alias.go
@@ -263,8 +263,10 @@ func (p MACPDU) AsMotorolaAliasData() (MotorolaAliasData, bool) {
 // MotorolaAliasAssembler reassembles the real Motorola FACCH-S talker
 // alias for one active call. Construct one per voice chain; it is
 // single-goroutine like phase1.MotorolaTalkerAliasBuf. AddHeader /
-// AddData return (alias, sourceRID, true) once the header and every
-// data block of the same sequence have arrived.
+// AddData return (alias, sourceRID, reliable, true) once the header and
+// every data block of the same sequence have arrived. reliable is false
+// when the decoded alias holds non-ASCII-printable characters (bit-error
+// corruption surviving the CRC, #711).
 type MotorolaAliasAssembler struct {
 	now func() time.Time
 
@@ -287,10 +289,10 @@ func NewMotorolaAliasAssembler(now func() time.Time) *MotorolaAliasAssembler {
 
 // AddHeader feeds a decoded alias header. A header with a new sequence
 // resets any in-flight data blocks.
-func (a *MotorolaAliasAssembler) AddHeader(h MotorolaAliasHeader) (string, uint32, bool) {
+func (a *MotorolaAliasAssembler) AddHeader(h MotorolaAliasHeader) (string, uint32, bool, bool) {
 	a.evictStale()
 	if h.BlockCount == 0 || h.BlockCount > aliasMaxBlocks {
-		return "", 0, false
+		return "", 0, false, false
 	}
 	if !a.haveHeader || h.Sequence != a.sequence {
 		a.blocks = make(map[uint8][]byte)
@@ -305,11 +307,11 @@ func (a *MotorolaAliasAssembler) AddHeader(h MotorolaAliasHeader) (string, uint3
 
 // AddData feeds a decoded alias data block. Blocks whose sequence
 // doesn't match the current header are ignored.
-func (a *MotorolaAliasAssembler) AddData(d MotorolaAliasData) (string, uint32, bool) {
+func (a *MotorolaAliasAssembler) AddData(d MotorolaAliasData) (string, uint32, bool, bool) {
 	a.evictStale()
 	if !a.haveHeader || d.Sequence != a.sequence || d.BlockNumber == 0 ||
 		d.BlockNumber > a.blockCount {
-		return "", 0, false
+		return "", 0, false, false
 	}
 	a.blocks[d.BlockNumber] = append([]byte(nil), d.Fragment...)
 	a.updated = a.now()
@@ -318,24 +320,26 @@ func (a *MotorolaAliasAssembler) AddData(d MotorolaAliasData) (string, uint32, b
 
 // tryComplete reassembles and decodes once the header and every data
 // block are present.
-func (a *MotorolaAliasAssembler) tryComplete() (string, uint32, bool) {
+func (a *MotorolaAliasAssembler) tryComplete() (string, uint32, bool, bool) {
 	if !a.haveHeader || len(a.blocks) < int(a.blockCount) {
-		return "", 0, false
+		return "", 0, false, false
 	}
 	msg := append([]byte(nil), a.header...)
 	for i := uint8(1); i <= a.blockCount; i++ {
 		b, ok := a.blocks[i]
 		if !ok {
-			return "", 0, false
+			return "", 0, false, false
 		}
 		msg = append(msg, b...)
 	}
 	decoded, ok := motorola.DecodeMessage(msg)
 	if !ok {
-		return "", 0, false
+		return "", 0, false, false
 	}
 	a.reset()
-	return decoded.Alias, decoded.RadioID, true
+	// An empty alias (all-non-printable decode) still completes so the
+	// source RID is reported; the publish path drops the empty alias.
+	return decoded.Alias, decoded.RadioID, decoded.AliasReliable, true
 }
 
 func (a *MotorolaAliasAssembler) evictStale() {

--- a/internal/radio/p25/phase2/talker_alias_test.go
+++ b/internal/radio/p25/phase2/talker_alias_test.go
@@ -137,15 +137,15 @@ func TestMotorolaAliasAssemblerYieldsRID(t *testing.T) {
 	a := NewMotorolaAliasAssembler(nil)
 
 	h, _ := macPDU(t, aliasHeaderMSG...).AsMotorolaAliasHeader()
-	if _, _, done := a.AddHeader(h); done {
+	if _, _, _, done := a.AddHeader(h); done {
 		t.Fatal("header alone (2 blocks pending) must not complete")
 	}
 	d1, _ := macPDU(t, aliasData1MSG...).AsMotorolaAliasData()
-	if _, _, done := a.AddData(d1); done {
+	if _, _, _, done := a.AddData(d1); done {
 		t.Fatal("1 of 2 blocks must not complete")
 	}
 	d2, _ := macPDU(t, aliasData2MSG...).AsMotorolaAliasData()
-	_, rid, done := a.AddData(d2)
+	_, rid, _, done := a.AddData(d2)
 	if !done {
 		t.Fatal("both blocks present should complete the alias")
 	}
@@ -158,7 +158,7 @@ func TestMotorolaAliasAssemblerWrongOpcodeRejected(t *testing.T) {
 	// A 0x95 PDU before any header must not complete or panic.
 	d, _ := macPDU(t, aliasData1MSG...).AsMotorolaAliasData()
 	a := NewMotorolaAliasAssembler(nil)
-	if _, _, done := a.AddData(d); done {
+	if _, _, _, done := a.AddData(d); done {
 		t.Error("data before header must not complete")
 	}
 }

--- a/internal/trunking/affiliation.go
+++ b/internal/trunking/affiliation.go
@@ -129,5 +129,10 @@ type TalkerAlias struct {
 	Protocol string // "p25-phase2"
 	SourceID uint32 // radio unit the alias names
 	Alias    string // the reassembled display name
-	At       time.Time
+	// Unreliable is true when the decode passed CRC but the reassembled
+	// alias held non-ASCII-printable characters — a hallmark of
+	// bit-error corruption (#711). Consumers should surface it as
+	// suspect rather than as a confirmed name.
+	Unreliable bool
+	At         time.Time
 }

--- a/internal/trunking/affiliation_tracker.go
+++ b/internal/trunking/affiliation_tracker.go
@@ -39,6 +39,10 @@ type UnitActivity struct {
 	// from any operator-assigned alias in the RIDDB.
 	TalkerAlias   string    `json:"talker_alias,omitempty"`
 	TalkerAliasAt time.Time `json:"talker_alias_at,omitempty"`
+	// TalkerAliasUnreliable is true when the stored alias decode passed
+	// CRC but held non-ASCII-printable characters (bit-error
+	// corruption, #711); a consumer should render it as suspect.
+	TalkerAliasUnreliable bool `json:"talker_alias_unreliable,omitempty"`
 }
 
 // AffiliationTracker maintains a live, protocol-agnostic table of which
@@ -138,7 +142,7 @@ func (t *AffiliationTracker) handle(ev events.Event) {
 		}
 	case events.KindTalkerAlias:
 		if a, ok := ev.Payload.(TalkerAlias); ok && a.SourceID != 0 && a.Alias != "" {
-			t.observeAlias(a.SourceID, a.System, a.Protocol, a.Alias)
+			t.observeAlias(a.SourceID, a.System, a.Protocol, a.Alias, a.Unreliable)
 		}
 	case events.KindCallSourceUpdate:
 		// In-call source RID backfill (P25 Phase 2 traffic-channel
@@ -187,7 +191,7 @@ func (t *AffiliationTracker) observe(radioID, talkgroup uint32, system, protocol
 // observeAlias records an over-the-air talker alias for the given
 // unit. Refreshes LastSeen so a passive alias broadcast keeps the
 // unit alive in the table even without a fresh grant.
-func (t *AffiliationTracker) observeAlias(radioID uint32, system, protocol, alias string) {
+func (t *AffiliationTracker) observeAlias(radioID uint32, system, protocol, alias string, unreliable bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	u := t.units[radioID]
@@ -202,6 +206,7 @@ func (t *AffiliationTracker) observeAlias(radioID uint32, system, protocol, alia
 		u.Protocol = protocol
 	}
 	u.TalkerAlias = alias
+	u.TalkerAliasUnreliable = unreliable
 	u.TalkerAliasAt = t.now()
 	u.LastSeen = t.now()
 }

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -147,20 +147,22 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	// Shared by the LDU1 link-control path and the TDULC terminator
 	// path — Motorola systems carry these 0x15/0x17 LCs on either
 	// (#376), so both feed the same buffer and publish identically.
-	publishMotorolaAlias := func(alias string) {
-		if lastSourceID == 0 {
+	publishMotorolaAlias := func(alias string, reliable bool) {
+		if lastSourceID == 0 || alias == "" {
 			return
 		}
 		c.log.Info("composer: p25p1 motorola talker alias",
-			"system", system, "serial", serial, "src", lastSourceID, "alias", alias)
+			"system", system, "serial", serial, "src", lastSourceID, "alias", alias,
+			"unreliable", !reliable)
 		c.bus.Publish(events.Event{
 			Kind: events.KindTalkerAlias,
 			Payload: trunking.TalkerAlias{
-				System:   system,
-				Protocol: "p25-phase1",
-				SourceID: lastSourceID,
-				Alias:    alias,
-				At:       time.Now(),
+				System:     system,
+				Protocol:   "p25-phase1",
+				SourceID:   lastSourceID,
+				Alias:      alias,
+				Unreliable: !reliable,
+				At:         time.Now(),
 			},
 		})
 	}
@@ -210,8 +212,8 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 					if lcf, content, _, terr := phase1.ExtractTDULCLinkControl(ldu); terr == nil {
 						switch {
 						case phase1.IsTalkerAliasLCO(lcf):
-							if alias, ok := aliasBuf.AddFragment(lcf, content); ok {
-								publishMotorolaAlias(alias)
+							if alias, ok, reliable := aliasBuf.AddFragment(lcf, content); ok {
+								publishMotorolaAlias(alias, reliable)
 							}
 						case lcf == phase1.LCOGroupVoiceChannelUser:
 							// A terminator LCO-0 can carry the source ID;
@@ -312,8 +314,8 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 				lcf := content[0]
 				switch {
 				case phase1.IsTalkerAliasLCO(lcf):
-					if alias, ok := aliasBuf.AddFragment(lcf, content); ok {
-						publishMotorolaAlias(alias)
+					if alias, ok, reliable := aliasBuf.AddFragment(lcf, content); ok {
+						publishMotorolaAlias(alias, reliable)
 					}
 				default:
 					if lc, _, lerr := phase1.ParseLinkControl(blocks); lerr == nil {

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -193,7 +193,11 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 					if f, ok := pdu.AsTalkerAliasFragment(); ok {
 						alias, src, complete := aliasAsm.Add(f)
 						if complete {
-							c.publishP25Phase2TalkerAlias(system, src, alias)
+							// Generic working-model fragment path (plain ASCII,
+							// not the validated Motorola cipher) — treat as
+							// reliable; the corruption check applies to the
+							// Motorola FACCH-S decode below (#711).
+							c.publishP25Phase2TalkerAlias(system, src, alias, true)
 						}
 						continue
 					}
@@ -202,14 +206,14 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 					// and the source RID falls out of the decoded message
 					// prefix (#376).
 					if h, ok := pdu.AsMotorolaAliasHeader(); ok {
-						if alias, src, complete := motorolaAliasAsm.AddHeader(h); complete {
-							c.publishP25Phase2TalkerAlias(system, src, alias)
+						if alias, src, reliable, complete := motorolaAliasAsm.AddHeader(h); complete {
+							c.publishP25Phase2TalkerAlias(system, src, alias, reliable)
 						}
 						continue
 					}
 					if d, ok := pdu.AsMotorolaAliasData(); ok {
-						if alias, src, complete := motorolaAliasAsm.AddData(d); complete {
-							c.publishP25Phase2TalkerAlias(system, src, alias)
+						if alias, src, reliable, complete := motorolaAliasAsm.AddData(d); complete {
+							c.publishP25Phase2TalkerAlias(system, src, alias, reliable)
 						}
 						continue
 					}
@@ -264,22 +268,23 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 // for the voice-channel MAC dispatch path: a completed alias the
 // composer reassembled off the traffic channel surfaces on the bus
 // with the same payload shape as one decoded on the CC.
-func (c *Composer) publishP25Phase2TalkerAlias(system string, sourceID uint32, alias string) {
-	if c.bus == nil {
+func (c *Composer) publishP25Phase2TalkerAlias(system string, sourceID uint32, alias string, reliable bool) {
+	if c.bus == nil || alias == "" {
 		return
 	}
 	c.bus.Publish(events.Event{
 		Kind: events.KindTalkerAlias,
 		Payload: trunking.TalkerAlias{
-			System:   system,
-			Protocol: "p25-phase2",
-			SourceID: sourceID,
-			Alias:    alias,
-			At:       time.Now().UTC(),
+			System:     system,
+			Protocol:   "p25-phase2",
+			SourceID:   sourceID,
+			Alias:      alias,
+			Unreliable: !reliable,
+			At:         time.Now().UTC(),
 		},
 	})
 	c.log.Info("composer: p25p2 talker alias",
-		"system", system, "src", sourceID, "alias", alias)
+		"system", system, "src", sourceID, "alias", alias, "unreliable", !reliable)
 }
 
 // publishP25Phase2CallSource publishes a KindCallSourceUpdate event so

--- a/proto/rid.proto
+++ b/proto/rid.proto
@@ -33,6 +33,10 @@ message RID {
   uint64 call_count      = 17;
   string first_seen      = 18; // RFC3339
   string last_seen       = 19; // RFC3339
+  // talker_alias_unreliable flags an over-the-air alias whose decode
+  // passed CRC but held non-ASCII-printable characters (#711); a client
+  // should render it as suspect.
+  bool   talker_alias_unreliable = 20;
 }
 
 message ListRIDsRequest {}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -73,6 +73,7 @@ export interface RIDDTO {
   last_talkgroup?: number;
   talker_alias?: string;
   talker_alias_at?: string;
+  talker_alias_unreliable?: boolean;
   call_count?: number;
   first_seen?: string;
   last_seen?: string;

--- a/web/src/panels/RadioIDs.tsx
+++ b/web/src/panels/RadioIDs.tsx
@@ -127,11 +127,19 @@ export function RadioIDs() {
       {
         key: "talker_alias",
         header: "Talker alias",
-        render: (r) => (
-          <span className="text-xs">
-            {r.talker_alias ?? <span className="text-muted">—</span>}
-          </span>
-        ),
+        render: (r) =>
+          r.talker_alias == null ? (
+            <span className="text-muted">—</span>
+          ) : r.talker_alias_unreliable ? (
+            <span
+              className="text-xs italic text-warn"
+              title="Decode unreliable — passed CRC but contains non-printable characters (possible bit errors)"
+            >
+              {r.talker_alias} ⚠
+            </span>
+          ) : (
+            <span className="text-xs">{r.talker_alias}</span>
+          ),
         sort: (a, b) =>
           (a.talker_alias ?? "").localeCompare(b.talker_alias ?? ""),
         className: "hidden md:table-cell",
@@ -229,7 +237,13 @@ export function RadioIDs() {
           <div className="grid grid-cols-2 gap-3">
             <DetailField
               label="Talker alias"
-              value={selected.talker_alias ?? "—"}
+              value={
+                selected.talker_alias == null
+                  ? "—"
+                  : selected.talker_alias_unreliable
+                    ? `${selected.talker_alias} ⚠ (decode unreliable)`
+                    : selected.talker_alias
+              }
             />
             <DetailField
               label="Last system"


### PR DESCRIPTION
## Summary

Addresses **issue #711** from the over-the-air decode angle: flag P25 talker aliases that were corrupted by bit errors which survived the CRC, so the UI/API can mark them as **unreliable** rather than displaying mojibake as if it were a real alias.

This is complementary to the already-merged **#744**, which the maintainer landed after re-diagnosing one reporter's case as an *import* problem (UTF-16/BOM SDRTrunk alias files) and fixed at the loader layer. This branch instead hardens the **OTA decode** path: aliases assembled from received frames are validated for bit-error corruption signatures and surfaced with an `unreliable` flag end-to-end (Motorola alias decode, P25 phase 1/phase 2 talker alias, affiliation tracking, and the gRPC/REST RID surface).

## Changes

- `internal/radio/p25/motorola/alias.go` (+test): detect bit-error corruption that survives the CRC; recover best-effort printable text and mark the decode unreliable.
- `internal/radio/p25/phase1/motorola_alias*.go`, `internal/radio/p25/phase2/talker_alias*.go`: thread the unreliable signal through both phases.
- `internal/trunking/affiliation*.go`, `internal/voice/composer/p25p1_voice.go` / `p25p2_voice.go`: respect the flag.
- `internal/api/{types,grpc}.go`, `internal/api/pb/v1/rid.pb.go`: expose `unreliable` on the RID surface.

## Note

Opened per maintainer direction as a complement to #744 (import-layer fix). Branch was 35 commits behind `main` but **merges cleanly** (no conflicts). Worth confirming the API/proto additions don't overlap awkwardly with anything that landed after the branch was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016eCpLSbASpifGjkdeuF8kf)_