### PR TITLE
hunt/p25: diagnose blank identity, fix decode-phase SDR overrun, clarify low-power WARN

### DIFF
--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -353,6 +353,9 @@ func finishHunt(rep *diag.Reporter, sys *hunt.DiscoveredSystem, reports []hunt.C
 			if r.Verdict != "" {
 				fmt.Fprintf(os.Stderr, "hunt:     ↳ %s\n", r.Verdict)
 			}
+			if r.IdentityNote != "" {
+				fmt.Fprintf(os.Stderr, "hunt:     ⚠ %s\n", r.IdentityNote)
+			}
 		}
 	}
 	// Resolve the output directory up front so the survey inventory and any

--- a/cmd/gophertrunk/hunt_iqsource.go
+++ b/cmd/gophertrunk/hunt_iqsource.go
@@ -3,25 +3,40 @@ package main
 import (
 	"context"
 	"fmt"
+	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
 )
 
+// iqSlackDepth is the number of IQ chunks the forwarder buffers between the raw
+// SDR delivery channel and Capture. It is pure slack: its only job is to absorb
+// brief scheduling jitter so a momentary stall doesn't drop RF. Sustained
+// overload (a multi-second decode of a captured dwell) still drops here — by
+// design — because the forwarder keeps reading the SDR regardless, which is
+// what prevents the server-side "Received overrun message".
+const iqSlackDepth = 64
+
 // streamIQSource adapts a continuous <-chan []complex64 IQ stream (from a live
-// SDR device or an iqtap broker) to hunt.IQSource. A rolling buffer backs
-// Capture; Tune retunes the underlying source and flushes the in-flight
-// transient so the next Capture sees only settled IQ at the new center. It is
-// the shared core behind both the standalone device path and the daemon broker
-// path.
+// SDR device or an iqtap broker) to hunt.IQSource. A forwarder goroutine drains
+// the raw stream into a bounded slack queue (bufCh) so the SDR/SoapyRemote is
+// read in real time even while the hunt loop is busy decoding a captured dwell;
+// Capture pulls from the slack queue. Tune retunes the underlying source and
+// flushes the in-flight transient so the next Capture sees only settled IQ at
+// the new center. It is the shared core behind both the standalone device path
+// and the daemon broker path.
 type streamIQSource struct {
 	ch      <-chan []complex64
 	tune    func(uint32) error
 	rate    func() uint32
 	setGain func(int) error // nil on the shared-SDR broker path (gain control unavailable)
-	pending []complex64
 	settle  time.Duration
+
+	bufCh   chan []complex64 // slack queue: forwarder → Capture
+	pending []complex64      // Capture-side leftover (< n) carried between calls
+	dropped atomic.Uint64    // chunks dropped at bufCh when decode falls behind real time
 }
 
 func (s *streamIQSource) SampleRateHz() uint32 { return s.rate() }
@@ -36,17 +51,54 @@ func (s *streamIQSource) SetGain(tenthDB int) error {
 	return s.setGain(tenthDB)
 }
 
+// forward continuously drains the raw SDR/broker channel into the slack queue so
+// the device is read at real-time rate even while the hunt loop is decoding a
+// previously captured dwell. Without this, nothing reads s.ch during the
+// (multi-second) decode phase, the driver's delivery channel backs up, and
+// SoapyRemote logs "Received overrun message". When the slack queue is full —
+// decode is sustainedly behind real time — the newest chunk is dropped rather
+// than blocking ingestion; the next Tune discards the gap anyway. The goroutine
+// exits when ctx is cancelled or the raw stream closes.
+func (s *streamIQSource) forward(ctx context.Context) {
+	defer close(s.bufCh)
+	var lastLogAt time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case chunk, ok := <-s.ch:
+			if !ok {
+				return
+			}
+			select {
+			case s.bufCh <- chunk:
+			default:
+				// Slack queue full: drop and keep draining s.ch so the SDR
+				// never blocks. Rate-limit the warning to once per second.
+				n := s.dropped.Add(1)
+				if now := time.Now(); now.Sub(lastLogAt) >= time.Second {
+					slog.Default().Warn("hunt: decode falling behind real time; dropping buffered IQ (the SDR is still drained, so this is a CPU/throughput limit, not an RF overrun)",
+						"dropped_total", n)
+					lastLogAt = now
+				}
+			}
+		}
+	}
+}
+
 func (s *streamIQSource) Tune(centerHz uint32) error {
 	if err := s.tune(centerHz); err != nil {
 		return err
 	}
-	// Discard buffered + in-flight samples captured before/at the retune.
+	// Discard buffered + in-flight samples captured before/at the retune: empty
+	// the slack queue and keep discarding for the settle window so the next
+	// Capture sees only IQ produced after the retune transient.
 	s.pending = nil
 	deadline := time.NewTimer(s.settle)
 	defer deadline.Stop()
 	for {
 		select {
-		case <-s.ch:
+		case <-s.bufCh:
 			// drain
 		case <-deadline.C:
 			return nil
@@ -59,7 +111,7 @@ func (s *streamIQSource) Capture(ctx context.Context, n int) ([]complex64, error
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case chunk, ok := <-s.ch:
+		case chunk, ok := <-s.bufCh:
 			if !ok {
 				out := s.pending
 				s.pending = nil
@@ -74,31 +126,41 @@ func (s *streamIQSource) Capture(ctx context.Context, n int) ([]complex64, error
 }
 
 // newDeviceIQSource opens a continuous IQ stream on a raw SDR device (standalone
-// CLI live hunt). The caller's ctx governs the stream lifetime.
+// CLI live hunt). The caller's ctx governs both the stream and the forwarder
+// goroutine lifetime.
 func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*streamIQSource, error) {
 	ch, err := dev.StreamIQ(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return &streamIQSource{
+	s := &streamIQSource{
 		ch:      ch,
 		tune:    dev.SetCenterFreq,
 		rate:    func() uint32 { return rate },
 		setGain: dev.SetGain,
 		settle:  50 * time.Millisecond,
-	}, nil
+		bufCh:   make(chan []complex64, iqSlackDepth),
+	}
+	go s.forward(ctx)
+	return s, nil
 }
 
 // newBrokerIQSource adapts a daemon iqtap.Broker (sharing a live SDR with the
 // rest of the pipeline) to hunt.IQSource via a secondary subscription. Tune
 // routes through the broker so its cached center stays consistent with the
-// spectrum/rigctld views. Close the returned subscriber when the run ends.
+// spectrum/rigctld views. Close the returned subscriber when the run ends — that
+// closes the broker's delivery channel, which stops the forwarder goroutine.
 func newBrokerIQSource(broker *iqtap.Broker) (*streamIQSource, *iqtap.Subscriber) {
 	sub := broker.Subscribe()
-	return &streamIQSource{
+	s := &streamIQSource{
 		ch:     sub.C,
 		tune:   broker.SetCenterFreq,
 		rate:   broker.SampleRateHz,
 		settle: 50 * time.Millisecond,
-	}, sub
+		bufCh:  make(chan []complex64, iqSlackDepth),
+	}
+	// Teardown is driven by sub.Close() closing sub.C; the forwarder returns
+	// when the channel closes, so context.Background is sufficient here.
+	go s.forward(context.Background())
+	return s, sub
 }

--- a/cmd/gophertrunk/hunt_iqsource_test.go
+++ b/cmd/gophertrunk/hunt_iqsource_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// newTestStreamSource wires a streamIQSource to a caller-controlled raw channel
+// and launches the forwarder, mirroring the constructors without an SDR.
+func newTestStreamSource(t *testing.T, ch <-chan []complex64) *streamIQSource {
+	t.Helper()
+	s := &streamIQSource{
+		ch:     ch,
+		tune:   func(uint32) error { return nil },
+		rate:   func() uint32 { return 48_000 },
+		settle: 0,
+		bufCh:  make(chan []complex64, iqSlackDepth),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go s.forward(ctx)
+	return s
+}
+
+// TestStreamIQSourceDrainsDuringDecodeStall is the core overrun-fix guarantee:
+// the forwarder keeps reading the raw SDR channel even while the consumer is
+// busy (the "decode" phase), so the producer never blocks. Without the
+// forwarder, a producer sending more than one chunk between Captures would
+// block — exactly the back-pressure that makes SoapyRemote log "Received
+// overrun message".
+func TestStreamIQSourceDrainsDuringDecodeStall(t *testing.T) {
+	raw := make(chan []complex64)
+	s := newTestStreamSource(t, raw)
+
+	// Simulate the decode phase: no Capture/Tune calls for a moment while the
+	// producer keeps delivering. Every send must complete (be drained) within
+	// the deadline; a block here would be the overrun bug.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < iqSlackDepth*4; i++ {
+			raw <- []complex64{complex(float32(i), 0)}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("producer blocked: forwarder did not keep draining the raw stream during the decode stall")
+	}
+
+	// Over-supply beyond the slack depth must have dropped, not blocked.
+	if got := s.dropped.Load(); got == 0 {
+		t.Fatal("expected some dropped chunks once the slack queue filled, got 0")
+	}
+}
+
+// TestStreamIQSourceCaptureServesFromBuffer verifies Capture assembles exactly
+// n samples from the forwarded chunks and carries the leftover to the next call.
+func TestStreamIQSourceCaptureServesFromBuffer(t *testing.T) {
+	raw := make(chan []complex64, 8)
+	s := newTestStreamSource(t, raw)
+
+	// Three chunks of two samples each = six samples available.
+	for i := 0; i < 3; i++ {
+		raw <- []complex64{complex(float32(2*i), 0), complex(float32(2*i+1), 0)}
+	}
+
+	got, err := s.Capture(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if len(got) != 5 {
+		t.Fatalf("Capture returned %d samples, want 5", len(got))
+	}
+	for i, v := range got {
+		if real(v) != float32(i) {
+			t.Fatalf("sample %d = %v, want %d (FIFO order broken)", i, real(v), i)
+		}
+	}
+	// The 6th sample is leftover; a follow-up Capture(1) must return it.
+	rest, err := s.Capture(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("Capture(leftover): %v", err)
+	}
+	if len(rest) != 1 || real(rest[0]) != 5 {
+		t.Fatalf("leftover = %v, want [5]", rest)
+	}
+}
+
+// TestStreamIQSourceCaptureContextCancel ensures Capture honours ctx when the
+// buffer can never reach n.
+func TestStreamIQSourceCaptureContextCancel(t *testing.T) {
+	raw := make(chan []complex64)
+	s := newTestStreamSource(t, raw)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := s.Capture(ctx, 4); err == nil {
+		t.Fatal("Capture with cancelled context returned nil error, want ctx.Err()")
+	}
+}
+
+// TestStreamIQSourceForwarderStopsOnClose ensures closing the raw stream closes
+// the slack queue, which Capture surfaces as a graceful end-of-stream.
+func TestStreamIQSourceForwarderStopsOnClose(t *testing.T) {
+	raw := make(chan []complex64)
+	s := newTestStreamSource(t, raw)
+	close(raw)
+
+	// Drain whatever the forwarder forwards, then expect a closed bufCh giving
+	// back the partial (empty) buffer without blocking.
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("Capture did not return after the raw stream closed")
+		default:
+		}
+		out, err := s.Capture(context.Background(), 4)
+		if err != nil {
+			t.Fatalf("Capture: %v", err)
+		}
+		if len(out) < 4 {
+			return // stream ended, partial returned
+		}
+	}
+}

--- a/internal/hunt/decode.go
+++ b/internal/hunt/decode.go
@@ -139,6 +139,40 @@ func decodeAndAccumulate(sys *DiscoveredSystem, r io.ReadSeeker, source string, 
 	if res.Signal != nil {
 		rep.ErrorRate = res.Signal.DecodeErrorRate
 	}
+	rep.IdentityNote = identityNote(res)
+	if rep.IdentityNote != "" {
+		log.Warn("hunt: "+rep.IdentityNote, "path", source)
+	}
 	rep.Talkgroups = len(sys.Talkgroups) - before
 	return rep
+}
+
+// identityNote explains, for a locked P25 control channel whose WACN/System ID
+// are still blank, *why* — by reporting which identity broadcasts decoded. The
+// Network Status Broadcast (NSB, opcode 0x3B) is the only P25 Phase 1 message
+// carrying WACN, and the RFSS Status Broadcast (0x3A) is the only other source
+// of System ID; if neither lands in the captured window the identity is simply
+// absent, not withheld. It returns "" when identity resolved, the capture
+// didn't lock, or it isn't P25 — there is nothing to explain.
+func identityNote(res *siglab.Result) string {
+	if res == nil || !res.Locked || res.Topology == nil {
+		return ""
+	}
+	if res.Topology.WACN != 0 || res.Topology.SystemID != 0 {
+		return "" // identity resolved
+	}
+	d, ok := res.Detail.(*siglab.P25P1Detail)
+	if !ok || d.CCStats == nil {
+		return "" // not the P25 deep path
+	}
+	cc := d.CCStats
+	if cc.NetStatusSeen > 0 {
+		// NSB decoded but yielded no WACN — a parse problem, not a capture gap.
+		return fmt.Sprintf("identity unresolved despite %d Network Status Broadcast(s): "+
+			"NSB decoded but WACN/System ID parsed as zero", cc.NetStatusSeen)
+	}
+	return fmt.Sprintf("identity unresolved: the Network Status Broadcast (NSB, 0x3B) that carries "+
+		"WACN+System ID never decoded (saw RFSS×%d, adjacent×%d, TSBK×%d) — "+
+		"widen --dwell-seconds or use --monitor-seconds to catch the periodic NSB",
+		cc.RFSSStatusSeen, cc.AdjacentSeen, cc.TSBKDecoded)
 }

--- a/internal/hunt/discover.go
+++ b/internal/hunt/discover.go
@@ -60,6 +60,11 @@ type CaptureReport struct {
 	// Verdict is the wideband survey's system-level summary line (set only by
 	// DiscoverWideband). Empty for single-carrier captures.
 	Verdict string `json:"verdict,omitempty"`
+	// IdentityNote explains a locked P25 capture whose WACN/System ID are still
+	// blank — naming which identity broadcasts decoded so the operator knows
+	// whether to widen the dwell or improve the signal. Empty when identity
+	// resolved (or the capture isn't a locked P25 control channel).
+	IdentityNote string `json:"identity_note,omitempty"`
 }
 
 // Discover folds every capture into a single DiscoveredSystem. Captures whose

--- a/internal/hunt/identity_note_test.go
+++ b/internal/hunt/identity_note_test.go
@@ -1,0 +1,89 @@
+package hunt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+func TestIdentityNote(t *testing.T) {
+	tests := []struct {
+		name      string
+		res       *siglab.Result
+		wantEmpty bool
+		wantHas   string
+	}{
+		{
+			name:      "nil result",
+			res:       nil,
+			wantEmpty: true,
+		},
+		{
+			name:      "not locked",
+			res:       &siglab.Result{Locked: false, Topology: &siglab.TopologySnapshot{}},
+			wantEmpty: true,
+		},
+		{
+			name:      "no topology",
+			res:       &siglab.Result{Locked: true},
+			wantEmpty: true,
+		},
+		{
+			name: "identity resolved",
+			res: &siglab.Result{
+				Locked:   true,
+				Topology: &siglab.TopologySnapshot{WACN: 0xABCDE, SystemID: 0x123},
+				Detail:   &siglab.P25P1Detail{CCStats: &siglab.CCStatsBreakdown{}},
+			},
+			wantEmpty: true,
+		},
+		{
+			name: "locked but NSB never decoded",
+			res: &siglab.Result{
+				Locked:   true,
+				Topology: &siglab.TopologySnapshot{}, // WACN/SystemID zero
+				Detail: &siglab.P25P1Detail{CCStats: &siglab.CCStatsBreakdown{
+					TSBKDecoded:    40,
+					RFSSStatusSeen: 0,
+					AdjacentSeen:   3,
+					NetStatusSeen:  0,
+				}},
+			},
+			wantHas: "Network Status Broadcast",
+		},
+		{
+			name: "NSB decoded but no WACN parsed",
+			res: &siglab.Result{
+				Locked:   true,
+				Topology: &siglab.TopologySnapshot{},
+				Detail: &siglab.P25P1Detail{CCStats: &siglab.CCStatsBreakdown{
+					NetStatusSeen: 2,
+				}},
+			},
+			wantHas: "parsed as zero",
+		},
+		{
+			name: "not P25 (no detail)",
+			res: &siglab.Result{
+				Locked:   true,
+				Topology: &siglab.TopologySnapshot{},
+			},
+			wantEmpty: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := identityNote(tt.res)
+			if tt.wantEmpty {
+				if got != "" {
+					t.Fatalf("identityNote = %q, want empty", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tt.wantHas) {
+				t.Fatalf("identityNote = %q, want substring %q", got, tt.wantHas)
+			}
+		})
+	}
+}

--- a/internal/hunt/monitor.go
+++ b/internal/hunt/monitor.go
@@ -181,6 +181,10 @@ func monitorCandidate(ctx context.Context, sys *DiscoveredSystem, src IQSource, 
 	if res.Signal != nil {
 		rep.ErrorRate = res.Signal.DecodeErrorRate
 	}
+	rep.IdentityNote = identityNote(res)
+	if rep.IdentityNote != "" {
+		log.Warn("hunt: "+rep.IdentityNote, "path", source)
+	}
 	rep.Talkgroups = len(sys.Talkgroups) - before
 	return rep
 }

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -156,6 +156,14 @@ type ControlChannel struct {
 // surface as events.KindDecodeError on the bus, but the bus event
 // is sampled by tests / Prometheus and may miss frames a synchronous
 // snapshot needs.
+// NetStatusSeen, RFSSStatusSeen, and AdjacentSeen count how many of the
+// system-identity broadcasts decoded: the Network Status Broadcast (0x3B,
+// the sole carrier of WACN + System ID), the RFSS Status Broadcast (0x3A,
+// System ID), and the Adjacent Site Status Broadcast (0x3C, neighbours).
+// They let the hunt / signal-lab layers explain *why* WACN/System ID are
+// blank — a locked control channel with TSBKDecoded > 0 but NetStatusSeen
+// == 0 means the periodic NSB simply never landed in the captured window
+// (too-short dwell or marginal signal), not that the system withholds it.
 type CCStats struct {
 	NIDTrusted        int64
 	NIDMarginal       int64
@@ -163,6 +171,9 @@ type CCStats struct {
 	TSBKDecoded       int64
 	TSBKTrellisFailed int64
 	TSBKCRCFailed     int64
+	NetStatusSeen     int64
+	RFSSStatusSeen    int64
+	AdjacentSeen      int64
 }
 
 // NetworkSnapshot returns the system topology accumulated from the
@@ -189,6 +200,9 @@ func (c *ControlChannel) Stats() CCStats {
 		TSBKDecoded:       atomic.LoadInt64(&c.stats.TSBKDecoded),
 		TSBKTrellisFailed: atomic.LoadInt64(&c.stats.TSBKTrellisFailed),
 		TSBKCRCFailed:     atomic.LoadInt64(&c.stats.TSBKCRCFailed),
+		NetStatusSeen:     atomic.LoadInt64(&c.stats.NetStatusSeen),
+		RFSSStatusSeen:    atomic.LoadInt64(&c.stats.RFSSStatusSeen),
+		AdjacentSeen:      atomic.LoadInt64(&c.stats.AdjacentSeen),
 	}
 }
 
@@ -1041,8 +1055,10 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 			dataCall: true, individual: true,
 		}, nac)
 	case OpNetworkStatusBroadcast:
+		atomic.AddInt64(&c.stats.NetStatusSeen, 1)
 		c.netModel.ApplyNetworkStatus(ParseNetworkStatusBroadcast(t.Payload))
 	case OpRFSSStatusBroadcast:
+		atomic.AddInt64(&c.stats.RFSSStatusSeen, 1)
 		c.netModel.ApplyRFSSStatus(ParseRFSSStatusBroadcast(t.Payload))
 		c.publishSiteUpdate()
 	case OpSecondaryControlChannel:
@@ -1050,6 +1066,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 	case OpSecondaryControlChannelExpl:
 		c.netModel.ApplySecondaryControlChannelExplicit(ParseSecondaryControlChannelBroadcastExplicit(t.Payload))
 	case OpAdjacentSiteStatusBroadcast:
+		atomic.AddInt64(&c.stats.AdjacentSeen, 1)
 		c.netModel.ApplyAdjacentSite(ParseAdjacentSiteStatusBroadcast(t.Payload))
 	case OpGroupAffiliationResponse:
 		c.publishAffiliation(ParseGroupAffiliationResponse(t.Payload), nac)

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -757,6 +757,37 @@ func TestControlChannelPublishesUnitRegistration(t *testing.T) {
 	}
 }
 
+func TestControlChannelCountsIdentityBroadcasts(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	cc := New(Options{
+		Bus:         bus,
+		SystemName:  "TestSys",
+		FrequencyHz: 851_000_000,
+	})
+
+	nsb := TSBK{LB: true, Opcode: OpNetworkStatusBroadcast, Payload: [8]byte{0x00, 0xAB, 0xCD, 0xE1, 0x23, 0x00, 0x00, 0x00}}
+	rfss := TSBK{LB: true, Opcode: OpRFSSStatusBroadcast, Payload: [8]byte{0x09, 0x01, 0x23, 0x02, 0x09, 0x00, 0x00, 0x00}}
+	adj := TSBK{LB: true, Opcode: OpAdjacentSiteStatusBroadcast, Payload: [8]byte{0x00, 0x02, 0x0A, 0x01, 0x23, 0x00, 0x64, 0x00}}
+
+	// Two NSBs, one RFSS, three adjacent-site broadcasts.
+	for _, tb := range []TSBK{nsb, nsb, rfss, adj, adj, adj} {
+		cc.Process(buildLockedStreamWithTSBK(10, 0x222, DUIDTrunkingSignaling, tb), 0)
+	}
+
+	s := cc.Stats()
+	if s.NetStatusSeen != 2 {
+		t.Errorf("NetStatusSeen = %d, want 2", s.NetStatusSeen)
+	}
+	if s.RFSSStatusSeen != 1 {
+		t.Errorf("RFSSStatusSeen = %d, want 1", s.RFSSStatusSeen)
+	}
+	if s.AdjacentSeen != 3 {
+		t.Errorf("AdjacentSeen = %d, want 3", s.AdjacentSeen)
+	}
+}
+
 func TestControlChannelGrantBeforeIdentifierUpdateEmitsDecodeError(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -200,6 +200,13 @@ type Engine struct {
 	// lastDiagAt is the wall-clock time the per-channel diagnostics were
 	// last flushed. Owned by the Run pump goroutine.
 	lastDiagAt time.Time
+	// widebandPwr accumulates the raw wideband input power (before
+	// channelization) across one diagnostics window, drained alongside the
+	// per-channel powers. It distinguishes a dead front end (wideband input
+	// also low ⇒ antenna/gain/cable) from a misplaced channel (wideband input
+	// healthy but this channel low ⇒ carrier outside the captured passband or
+	// the wrong frequency) when a low-power WARN fires. Owned by the Run pump.
+	widebandPwr iqpower.Accumulator
 }
 
 // channelProcessor is the per-channel dibit consumer. DMR Tier II's
@@ -595,6 +602,7 @@ func (e *Engine) Run(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
+			e.widebandPwr.Add(chunk)
 			e.bank.Process(chunk)
 			e.maybeLogDiagnostics(e.now())
 		}
@@ -626,6 +634,14 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 	}
 	e.lastDiagAt = now
 
+	// Drain the wideband input power once per window. When a per-channel WARN
+	// fires, a healthy wideband input localises the fault for the operator: the
+	// front end is fine, so the dead channel is outside the captured passband
+	// (CenterFreqHz ± SampleRateHz/2) or tuned to the wrong frequency — not an
+	// antenna/gain/cable problem.
+	wbDbFS, wbSamples := e.widebandPwr.MeanDbFSAndReset()
+	wbHealthy := wbSamples > 0 && wbDbFS >= iqpower.LowPowerThresholdDbFS
+
 	debug := e.log.Enabled(context.Background(), slog.LevelDebug)
 	for _, ec := range e.channels {
 		if ec.pwr.Samples() == 0 {
@@ -637,8 +653,13 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 		}
 		if dbfs < iqpower.LowPowerThresholdDbFS {
 			if now.Sub(ec.pwLowLogAt) >= lowPowerWarnInterval {
-				e.log.Warn("widebandt2: channel iq power very low — check antenna, gain, USB cable",
-					"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag, "dbfs", dbfs)
+				hint := "check antenna, gain, USB cable"
+				if wbHealthy {
+					hint = "wideband input is healthy — this carrier is likely outside the captured passband or tuned to the wrong frequency"
+				}
+				e.log.Warn("widebandt2: channel iq power very low — "+hint,
+					"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag,
+					"dbfs", dbfs, "wideband_input_dbfs", wbDbFS)
 				ec.pwLowLogAt = now
 			}
 		} else if debug {

--- a/internal/scanner/widebandt2/engine_lowpower_hint_test.go
+++ b/internal/scanner/widebandt2/engine_lowpower_hint_test.go
@@ -1,0 +1,91 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/iqpower"
+)
+
+// loudIQ returns a chunk near full scale; quietIQ returns near silence. Both
+// feed iqpower.Accumulator directly so the test controls the per-channel vs
+// wideband-input power split without going through the DSP chain.
+func loudIQ(n int) []complex64 {
+	c := make([]complex64, n)
+	for i := range c {
+		c[i] = complex(0.5, 0.5)
+	}
+	return c
+}
+
+func quietIQ(n int) []complex64 {
+	c := make([]complex64, n)
+	for i := range c {
+		c[i] = complex(1e-4, 0)
+	}
+	return c
+}
+
+// runDiag builds a one-channel Engine, loads the accumulators, and flushes one
+// diagnostics window, returning the captured WARN record (if any).
+func runDiag(t *testing.T, chanIQ, widebandIQ []complex64) (capturedRecord, bool) {
+	t.Helper()
+	handler, recs, mu := newRecordingHandler()
+	ec := &engineChannel{freqHz: 450_125_000, sysName: "Main_Site_1", protoTag: "p25-phase1"}
+	ec.pwr.Add(chanIQ)
+	e := &Engine{
+		log:      slog.New(handler),
+		channels: []*engineChannel{ec},
+		now:      time.Now,
+	}
+	e.widebandPwr.Add(widebandIQ)
+
+	// First call seeds lastDiagAt; the second (a full Window later) flushes.
+	base := time.Unix(1_700_000_000, 0)
+	e.maybeLogDiagnostics(base)
+	e.maybeLogDiagnostics(base.Add(iqpower.Window + time.Second))
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, r := range *recs {
+		if r.level == slog.LevelWarn && strings.Contains(r.msg, "iq power very low") {
+			return r, true
+		}
+	}
+	return capturedRecord{}, false
+}
+
+// TestLowPowerHintOffBand: a healthy wideband input but a dead channel points
+// the operator at an off-band / wrong-frequency carrier, not the antenna — and
+// the WARN now carries the wideband input level for context.
+func TestLowPowerHintOffBand(t *testing.T) {
+	const n = 4096
+	r, ok := runDiag(t, quietIQ(n), loudIQ(n))
+	if !ok {
+		t.Fatal("expected a low-power WARN, got none")
+	}
+	if !strings.Contains(r.msg, "outside the captured passband") {
+		t.Errorf("WARN msg = %q, want the off-band hint", r.msg)
+	}
+	if _, has := r.attrs["wideband_input_dbfs"]; !has {
+		t.Errorf("WARN missing wideband_input_dbfs attr; attrs=%v", r.attrs)
+	}
+	if wb, ok := r.attrs["wideband_input_dbfs"].(float64); !ok || wb < -55 {
+		t.Errorf("wideband_input_dbfs = %v, want a healthy (>= -55) level", r.attrs["wideband_input_dbfs"])
+	}
+}
+
+// TestLowPowerHintDeadFrontEnd: when the wideband input is also dead, the hint
+// stays on the antenna/gain/cable front end.
+func TestLowPowerHintDeadFrontEnd(t *testing.T) {
+	const n = 4096
+	r, ok := runDiag(t, quietIQ(n), quietIQ(n))
+	if !ok {
+		t.Fatal("expected a low-power WARN, got none")
+	}
+	if !strings.Contains(r.msg, "antenna") {
+		t.Errorf("WARN msg = %q, want the antenna/gain/cable hint", r.msg)
+	}
+}

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -84,6 +84,9 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 				TSBKDecoded:       s.TSBKDecoded,
 				TSBKTrellisFailed: s.TSBKTrellisFailed,
 				TSBKCRCFailed:     s.TSBKCRCFailed,
+				NetStatusSeen:     s.NetStatusSeen,
+				RFSSStatusSeen:    s.RFSSStatusSeen,
+				AdjacentSeen:      s.AdjacentSeen,
 			}
 		},
 		topology: func() *TopologySnapshot { return p25Topology(cc.NetworkSnapshot(), cc.BandPlanSnapshot()) },

--- a/internal/siglab/p25detail.go
+++ b/internal/siglab/p25detail.go
@@ -43,6 +43,12 @@ type CCStatsBreakdown struct {
 	TSBKDecoded       int64 `json:"tsbk_decoded" yaml:"tsbk_decoded"`
 	TSBKTrellisFailed int64 `json:"tsbk_trellis_failed" yaml:"tsbk_trellis_failed"`
 	TSBKCRCFailed     int64 `json:"tsbk_crc_failed" yaml:"tsbk_crc_failed"`
+	// NetStatusSeen, RFSSStatusSeen, and AdjacentSeen count the identity
+	// broadcasts decoded (0x3B / 0x3A / 0x3C). NetStatusSeen == 0 on a locked
+	// CC explains a blank WACN/System ID: the periodic NSB never landed.
+	NetStatusSeen  int64 `json:"net_status_seen" yaml:"net_status_seen"`
+	RFSSStatusSeen int64 `json:"rfss_status_seen" yaml:"rfss_status_seen"`
+	AdjacentSeen   int64 `json:"adjacent_seen" yaml:"adjacent_seen"`
 }
 
 // ReceiverState is one snapshot of the P25 receiver's internal loops at a

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -172,6 +172,9 @@ export interface CaptureReport {
   skipped?: boolean;
   skip_reason?: string;
   error?: string;
+  // identity_note explains a locked P25 capture whose WACN/System ID are still
+  // blank (e.g. the Network Status Broadcast never decoded in the dwell).
+  identity_note?: string;
 }
 
 // DiscoveredSystem mirrors hunt.DiscoveredSystem — the map a completed hunt

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -72,7 +72,8 @@ function captureResult(rep: CaptureReport): string {
   if (rep.skipped) return `skipped${rep.skip_reason ? ` — ${rep.skip_reason}` : ""}`;
   if (rep.error) return `error — ${rep.error}`;
   if (rep.locked) {
-    return `locked${rep.confidence ? ` · conf ${(rep.confidence * 100).toFixed(0)}%` : ""}`;
+    const base = `locked${rep.confidence ? ` · conf ${(rep.confidence * 100).toFixed(0)}%` : ""}`;
+    return rep.identity_note ? `${base} · ⚠ ${rep.identity_note}` : base;
   }
   return "no lock";
 }


### PR DESCRIPTION
## Why

A Motorola P25 field retest (`Main_Site_1`, CC 450.125 MHz, `p25-phase1`) surfaced three issues after #751:

1. **WACN / System ID show nothing.** The old floating values were the buggy registration bytes (correctly removed by #751), but no real identity appears. The hypothesis was "Motorola broadcasts identity in different opcodes."
2. **`Received overrun message`** from SoapyRemote while hunting, plus a bare `channel iq power very low … dbfs=-76` WARN — at only 6.25 Msps, not a hardware limit.

### What the investigation found (spec + SDRTrunk + this codebase)

- **WACN lives only in the Network Status Broadcast (NSB, 0x3B)** for P25 Phase 1; System ID also rides the RFSS Status Broadcast (0x3A). **No Motorola (MFID 0x90) opcode carries either** — the "different opcodes" theory is a dead end. NSB/RFSS are already dispatched regardless of MFID. Blank identity therefore means the NSB/RFSS **never decoded in the captured window** (the rarer-broadcast asymmetry vs. the neighbour 0x3C that *did* show points at decode starvation), not that the system withholds them.
- **The overrun is ours.** `streamIQSource` (`cmd/gophertrunk/hunt_iqsource.go`) holds a *continuous* SDR stream, but nothing drains it during the multi-second decode phase, so the driver backs up. `ccdecoder` already solved this with a background `forwardIQ` drainer; Hunt's source lacked one.
- **−76 dBFS is computed correctly** — but the WARN couldn't tell a dead front end from a channel that's simply outside the captured passband.

## Changes

- **p25phase1** (`internal/radio/p25/phase1/control.go`): count identity broadcasts — `NetStatusSeen` (0x3B) / `RFSSStatusSeen` (0x3A) / `AdjacentSeen` (0x3C) — in `CCStats`, threaded through `siglab.CCStatsBreakdown`.
- **hunt** (`internal/hunt/decode.go`, `monitor.go`, `discover.go`): surface an `IdentityNote` on a locked P25 capture whose WACN/System ID are still blank, naming which broadcasts decoded and advising a wider `--dwell-seconds` / `--monitor-seconds`. Shown in the CLI report (`cmd/gophertrunk/hunt.go`), the web Hunt panel (`web/src/panels/Hunt.tsx`), and a WARN. Covers both the buffered and streaming decode paths.
- **hunt IQ source** (`cmd/gophertrunk/hunt_iqsource.go`): a forwarder goroutine continuously drains the raw SDR/broker stream into a bounded slack queue (drop-on-full), so the device is read in real time even while a captured dwell is decoding — mirroring the ccdecoder `forwardIQ` pattern. Prevents server-side overruns.
- **widebandt2** (`internal/scanner/widebandt2/engine.go`): report the wideband input level alongside the per-channel low-power WARN and localise the fault — a healthy input with a dead channel means the carrier is outside the captured passband, not a bad antenna.

## Tests

- Broadcast-seen counters increment for 0x3B / 0x3A / 0x3C.
- `identityNote` across resolved / NSB-never-decoded / NSB-decoded-but-zero / non-P25 cases.
- Forwarder keeps draining during a decode stall, drops on overflow, serves `Capture` from the buffer, and honours ctx/close — race-clean.
- Low-power hint selection for off-band vs. dead-front-end.

`go build ./...`, `go vet`, and the touched-package suites pass.

## Honest caveat

No code change can invent WACN where the system never emits a decodable NSB. This PR makes the capture path keep up (so the NSB *can* land) and tells the operator clearly when it's missing. Closing the field report out needs a **DEBUG-level run log** (does 0x3B ever decode?) and a **raw IQ capture** of the control channel (is the carrier in-band, what's the true level?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDHPrYvsgFVbmGt1GZQHEm)_