### PR TITLE
p25: add network-configuration / activity-summary report across all surfaces

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -3800,6 +3800,11 @@ type sitesProvider struct{ t *trunking.SiteTracker }
 
 func (s sitesProvider) Sites() []trunking.SiteInfo { return s.t.Snapshot() }
 
+// Report forwards the SiteTracker's live network-configuration report so the
+// API's optional api.NetworkReporter capability resolves through the adapter
+// (GET /api/v1/systems/{name}/report).
+func (s sitesProvider) Report(system string) (string, bool) { return s.t.Report(system) }
+
 // wrapBasebandRecorders replaces the Device of every pool entry whose
 // serial appears in baseband.record with a RecordingDevice, teeing its
 // live IQ to a WAV recording. Runs once at construction, before any

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -81,7 +81,7 @@ func runHunt(args []string) {
 	location := fs.String("location", "", "free-form location (e.g. \"Phoenix, AZ\")")
 
 	out := fs.String("out", "", "output directory (default: ./hunt-<timestamp>)")
-	formats := fs.String("formats", "bundle,trunk-recorder,rr", "comma-separated export formats: bundle,trunk-recorder,rr")
+	formats := fs.String("formats", "bundle,trunk-recorder,rr", "comma-separated export formats: bundle,trunk-recorder,rr,summary")
 
 	noRR := fs.Bool("no-rr", false, "skip the RadioReference duplicate check even if a key is configured")
 	rrKey := fs.String("rr-key", "", "RadioReference API key (else GOPHERTRUNK_RR_KEY env). Enables the read-only duplicate check.")
@@ -100,7 +100,7 @@ func runHunt(args []string) {
 
 USAGE:
   gophertrunk hunt -in <capture> [-in <capture> …] [-format u8|f32] [-sample-rate Hz]
-                  [-protocol <p>] [-out <dir>] [-formats bundle,trunk-recorder,rr]
+                  [-protocol <p>] [-out <dir>] [-formats bundle,trunk-recorder,rr,summary]
                   [-name N] [-state XX] [-county C] [-commit -config config.yaml]
 
 EXAMPLES:

--- a/cmd/gophertrunk/siglab_render.go
+++ b/cmd/gophertrunk/siglab_render.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
 // renderResultText writes a human-readable summary of a siglab.Result to w —
@@ -64,6 +65,10 @@ func renderResultText(w io.Writer, r *siglab.Result) {
 		renderP25Detail(w, d)
 	case *siglab.ProtocolDetail:
 		renderProtocolDetail(w, d)
+	}
+	if r.Topology != nil && !r.Topology.Empty() {
+		fmt.Fprintln(w, "----")
+		trunking.RenderNetworkReport(w, trunking.ReportFromTopology(r.Topology))
 	}
 	if r.Verdict != nil {
 		renderVerdict(w, r.Verdict)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -139,6 +139,34 @@ func (s *Server) handleGetSystem(w http.ResponseWriter, r *http.Request) {
 	s.writeError(w, http.StatusNotFound, "system not found")
 }
 
+// handleGetSystemReport serves GET /api/v1/systems/{name}/report: the live
+// human-readable P25 network-configuration report (WACN/SysID/NAC, the camped
+// site's control channels and neighbours, and the band plan) rendered from the
+// SiteTracker's latest topology snapshot. A configured-but-quiet system returns
+// an empty report with available=false; an entirely unknown system 404s.
+func (s *Server) handleGetSystemReport(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	var report string
+	available := false
+	if reporter, ok := s.sites.(NetworkReporter); ok {
+		report, available = reporter.Report(name)
+	}
+	if !available {
+		known := false
+		for _, sys := range s.systems {
+			if sys.Name == name {
+				known = true
+				break
+			}
+		}
+		if !known {
+			s.writeError(w, http.StatusNotFound, "system not found")
+			return
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"system": name, "report": report, "available": available})
+}
+
 // overlayLiveIdentity fills WACN/SystemID/RFSS/Site on dto from the live
 // SiteTracker snapshot (the same data behind GET /api/v1/sites) for the
 // matching system. Network identity (WACN/SYSID/RFSS/Site) is decoded from

--- a/internal/api/handlers_systems_report_test.go
+++ b/internal/api/handlers_systems_report_test.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// fakeReporter is a SitesProvider that also implements NetworkReporter.
+type fakeReporter struct {
+	sites  []trunking.SiteInfo
+	report string
+	ok     bool
+}
+
+func (f fakeReporter) Sites() []trunking.SiteInfo   { return f.sites }
+func (f fakeReporter) Report(string) (string, bool) { return f.report, f.ok }
+
+func TestGetSystemReport(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	systems := []trunking.System{{Name: "MMR"}}
+	prov := fakeReporter{report: "P25 Network Configuration — MMR\nNetwork\n  WACN:BEE00[781824]", ok: true}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: systems, Sites: prov})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/systems/MMR/report")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		System    string `json:"system"`
+		Report    string `json:"report"`
+		Available bool   `json:"available"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.Available || !strings.Contains(body.Report, "WACN:BEE00") {
+		t.Errorf("report not returned: %+v", body)
+	}
+}
+
+// A configured-but-quiet system returns 200 with available=false rather than 404.
+func TestGetSystemReportQuiet(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	systems := []trunking.System{{Name: "MMR"}}
+	prov := fakeReporter{ok: false}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: systems, Sites: prov})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/systems/MMR/report")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Available bool `json:"available"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Available {
+		t.Error("quiet system should report available=false")
+	}
+}
+
+// An entirely unknown system 404s.
+func TestGetSystemReportUnknown(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{Bus: bus})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/systems/nope/report")
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -441,6 +441,15 @@ type SitesProvider interface {
 	Sites() []trunking.SiteInfo
 }
 
+// NetworkReporter is the optional capability a SitesProvider may implement to
+// render the live, human-readable network-configuration report for a system
+// (the SiteTracker does). GET /api/v1/systems/{name}/report uses it when the
+// wired provider supports it; the report reflects the most recently camped site
+// of the system. The bool is false when no topology has been observed yet.
+type NetworkReporter interface {
+	Report(system string) (string, bool)
+}
+
 // HistoryFilter mirrors storage.HistoryFilter for the api layer's
 // purposes (passed through to whatever HistoryQuery implementation the
 // daemon wires up).
@@ -942,6 +951,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/diag/banner", s.handleDiagBanner)
 	mux.HandleFunc("GET /api/v1/systems", s.handleListSystems)
 	mux.HandleFunc("GET /api/v1/systems/{name}", s.handleGetSystem)
+	mux.HandleFunc("GET /api/v1/systems/{name}/report", s.handleGetSystemReport)
 	mux.HandleFunc("GET /api/v1/talkgroups", s.handleListTalkgroups)
 	mux.HandleFunc("GET /api/v1/talkgroups/{id}", s.handleGetTalkgroup)
 	mux.HandleFunc("GET /api/v1/calls/active", s.handleActiveCalls)

--- a/internal/hunt/export.go
+++ b/internal/hunt/export.go
@@ -19,6 +19,9 @@ const (
 	FormatTrunkRecorder
 	// FormatRR is a human-readable RadioReference.com submission package.
 	FormatRR
+	// FormatSummary is the human-readable P25 network-configuration / activity
+	// summary report (GopherTrunk's equivalent of SDRtrunk's network monitor).
+	FormatSummary
 )
 
 // String renders the format as the value operators type on the CLI.
@@ -28,6 +31,8 @@ func (f Format) String() string {
 		return "trunk-recorder"
 	case FormatRR:
 		return "rr"
+	case FormatSummary:
+		return "summary"
 	default:
 		return "bundle"
 	}
@@ -40,6 +45,8 @@ func (f Format) FileExtension() string {
 		return "json"
 	case FormatRR:
 		return "md"
+	case FormatSummary:
+		return "txt"
 	default:
 		return "csv"
 	}
@@ -54,8 +61,10 @@ func ParseFormat(s string) (Format, error) {
 		return FormatTrunkRecorder, nil
 	case "rr", "radioreference", "submission":
 		return FormatRR, nil
+	case "summary", "txt", "report":
+		return FormatSummary, nil
 	default:
-		return FormatBundle, fmt.Errorf("hunt: unknown export format %q (want bundle|trunk-recorder|rr)", s)
+		return FormatBundle, fmt.Errorf("hunt: unknown export format %q (want bundle|trunk-recorder|rr|summary)", s)
 	}
 }
 
@@ -77,6 +86,8 @@ func WriteWithRRDiff(w io.Writer, sys *DiscoveredSystem, f Format, hints []Dupli
 		return writeTrunkRecorder(w, sys)
 	case FormatRR:
 		return writeRR(w, sys, hints, diff)
+	case FormatSummary:
+		return writeSummary(w, sys)
 	default:
 		return fmt.Errorf("hunt: unsupported format %d", f)
 	}

--- a/internal/hunt/export_test.go
+++ b/internal/hunt/export_test.go
@@ -40,6 +40,7 @@ func TestParseFormat(t *testing.T) {
 		"bundle": FormatBundle, "csv": FormatBundle, "": FormatBundle,
 		"trunk-recorder": FormatTrunkRecorder, "tr": FormatTrunkRecorder,
 		"rr": FormatRR, "radioreference": FormatRR,
+		"summary": FormatSummary, "txt": FormatSummary, "report": FormatSummary,
 	}
 	for in, want := range cases {
 		got, err := ParseFormat(in)
@@ -53,6 +54,37 @@ func TestParseFormat(t *testing.T) {
 	}
 	if _, err := ParseFormat("nope"); err == nil {
 		t.Error("ParseFormat(nope) expected error")
+	}
+}
+
+func TestFormatSummaryMetadata(t *testing.T) {
+	if FormatSummary.String() != "summary" {
+		t.Errorf("String() = %q, want summary", FormatSummary.String())
+	}
+	if FormatSummary.FileExtension() != "txt" {
+		t.Errorf("FileExtension() = %q, want txt", FormatSummary.FileExtension())
+	}
+}
+
+func TestWriteSummary_StructureAndContent(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, sampleSystem(), FormatSummary, nil); err != nil {
+		t.Fatalf("Write(summary): %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"P25 Network Configuration — Example P25 System",
+		"WACN:BEE99[",
+		"NAC:4D2[",
+		"RFSS:1[1] SITE:1[1]",
+		// First control channel is the primary; the second is rendered as a
+		// secondary CC (frequency only — hunt keeps no band-plan coordinates).
+		"PRI CONTROL CHANNEL DOWNLINK:851.012500 MHz",
+		"SEC CONTROL CHANNEL DOWNLINK:851.262500 MHz",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q\n--- full ---\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/hunt/report.go
+++ b/internal/hunt/report.go
@@ -1,0 +1,79 @@
+package hunt
+
+import (
+	"io"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// NetworkReport flattens the discovered system into the protocol-neutral
+// trunking.NetworkReport the shared renderer consumes. Unlike the single-site
+// CLI/daemon path, a DiscoveredSystem aggregates several sites, so it emits one
+// ReportSite per DiscoveredSite under a shared identity header + shared band
+// plan. Control channels are stored as resolved frequencies (no band-plan
+// coordinates), so site control channels carry a downlink frequency only;
+// neighbours keep their (id, number) and get an uplink derived from the matching
+// band's transmit offset.
+func (s *DiscoveredSystem) NetworkReport() trunking.NetworkReport {
+	offsets := make(map[uint8]int64, len(s.BandPlan))
+	for _, b := range s.BandPlan {
+		offsets[b.ChannelID] = b.TxOffsetHz
+	}
+
+	r := trunking.NetworkReport{
+		Name:     s.DisplayName(),
+		Protocol: s.Protocol,
+		WACN:     s.WACN,
+		SystemID: uint32(s.SystemID),
+		NAC:      s.NAC,
+	}
+	for _, st := range s.Sites {
+		rs := trunking.ReportSite{RFSS: st.RFSS, Site: st.SiteID}
+		primarySet := false
+		for _, ch := range st.ControlChannels {
+			if !ch.IsControl {
+				continue
+			}
+			c := trunking.ReportChannel{DownlinkHz: ch.FrequencyHz}
+			if !primarySet {
+				rs.PrimaryCC = c
+				primarySet = true
+			} else {
+				rs.SecondaryCC = append(rs.SecondaryCC, c)
+			}
+		}
+		for _, hz := range st.Secondary {
+			rs.SecondaryCC = append(rs.SecondaryCC, trunking.ReportChannel{DownlinkHz: hz})
+		}
+		for _, n := range st.Neighbors {
+			c := trunking.ReportChannel{ChannelID: n.ChannelID, ChannelNumber: n.ChannelNumber, DownlinkHz: n.FrequencyHz}
+			if n.FrequencyHz != 0 {
+				if off, ok := offsets[n.ChannelID]; ok && off != 0 {
+					if up := int64(n.FrequencyHz) + off; up > 0 {
+						c.UplinkHz = uint32(up)
+					}
+				}
+			}
+			rs.Neighbors = append(rs.Neighbors, trunking.ReportNeighbor{RFSS: n.RFSS, Site: n.Site, Channel: c})
+		}
+		r.Sites = append(r.Sites, rs)
+	}
+	for _, b := range s.BandPlan {
+		r.Bands = append(r.Bands, trunking.ReportBand{
+			ChannelID:   b.ChannelID,
+			BaseHz:      b.BaseHz,
+			SpacingHz:   b.SpacingHz,
+			BandwidthHz: b.BandwidthHz,
+			TxOffsetHz:  b.TxOffsetHz,
+		})
+	}
+	return r
+}
+
+// writeSummary renders the human-readable network-configuration report for the
+// discovered system. Callers (WriteWithRRDiff) sortAll() first so neighbour
+// frequencies are resolved and site order is stable.
+func writeSummary(w io.Writer, sys *DiscoveredSystem) error {
+	trunking.RenderNetworkReport(w, sys.NetworkReport())
+	return nil
+}

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -44,6 +44,10 @@ type ControlChannel struct {
 	now        func() time.Time
 	locked     bool
 	lastNAC    uint16
+	// lastSiteLog dedupes the concise site-configuration log line so an
+	// established site logs once and re-logs only when its identity / primary
+	// control channel materially changes (see logSiteIdentity).
+	lastSiteLog siteLogKey
 	// lastNoHitsAt throttles the "no FSW hits" debug log so the chunk-rate
 	// emission doesn't flood at debug level. See Process for the rationale.
 	lastNoHitsAt time.Time
@@ -187,6 +191,76 @@ func (c *ControlChannel) NetworkSnapshot() NetworkConfig {
 // lets the signal-lab / hunt layers fully document a discovered P25 system.
 func (c *ControlChannel) BandPlanSnapshot() []IdentifierUpdate {
 	return c.bandPlan.Snapshot()
+}
+
+// LastNAC returns the NAC of the most recent corrected NID. Zero before the
+// control channel locks. Used to stamp the network-configuration report.
+func (c *ControlChannel) LastNAC() uint16 { return c.lastNAC }
+
+// SystemName returns the operator-assigned system name, if any.
+func (c *ControlChannel) SystemName() string { return c.systemName }
+
+// TopologySnapshot builds the protocol-neutral topology snapshot for this
+// control channel: identity, primary/secondary control channels, neighbours,
+// and band plan, with every channel's downlink frequency resolved through the
+// accumulated band plan. It is the single source the siglab engine and the live
+// ccdecoder pipeline both surface (the latter via trunking.TopologyProvider),
+// and the input to the human-readable network-configuration report. Returns nil
+// when nothing usable has been observed yet.
+func (c *ControlChannel) TopologySnapshot() *trunking.TopologySnapshot {
+	net := c.netModel.Snapshot()
+	t := &trunking.TopologySnapshot{
+		SystemName: c.systemName,
+		Protocol:   "p25",
+		WACN:       net.WACN,
+		SystemID:   uint32(net.SystemID),
+		NAC:        c.lastNAC,
+		RFSS:       net.RFSS,
+		Site:       net.Site,
+		LRA:        net.LRA,
+	}
+	if net.PrimaryCC.ChannelID != 0 || net.PrimaryCC.ChannelNumber != 0 {
+		t.PrimaryCC = c.channelRef(net.PrimaryCC)
+	}
+	for _, s := range net.Secondary {
+		t.Secondary = append(t.Secondary, *c.channelRef(s))
+	}
+	for _, n := range net.Neighbors {
+		ref := trunking.TopoNeighborRef{
+			RFSS:          n.RFSS,
+			Site:          n.Site,
+			ChannelID:     n.ChannelID,
+			ChannelNumber: n.ChannelNumber,
+		}
+		if hz, err := c.bandPlan.Frequency(n.ChannelID, n.ChannelNumber); err == nil {
+			ref.FrequencyHz = hz
+		}
+		t.Neighbors = append(t.Neighbors, ref)
+	}
+	for _, u := range c.bandPlan.Snapshot() {
+		t.BandPlan = append(t.BandPlan, trunking.TopoBandPlanSlot{
+			ChannelID:   u.ChannelID,
+			BaseHz:      u.BaseHz,
+			SpacingHz:   u.SpacingHz,
+			BandwidthHz: u.BandwidthHz,
+			TxOffsetHz:  u.TxOffsetHz,
+			AccessTDMA:  u.AccessTDMA,
+		})
+	}
+	if t.Empty() {
+		return nil
+	}
+	return t
+}
+
+// channelRef resolves a (band-plan ID, channel number) pair into a
+// TopoChannelRef, attaching the downlink frequency when the band plan is known.
+func (c *ControlChannel) channelRef(ch Channel) *trunking.TopoChannelRef {
+	ref := &trunking.TopoChannelRef{ChannelID: ch.ChannelID, ChannelNumber: ch.ChannelNumber}
+	if hz, err := c.bandPlan.Frequency(ch.ChannelID, ch.ChannelNumber); err == nil {
+		ref.FrequencyHz = hz
+	}
+	return ref
 }
 
 // Stats returns a snapshot of the per-frame outcome counters. Safe
@@ -1414,9 +1488,46 @@ func (c *ControlChannel) publishSiteUpdate() {
 			ControlChannelHz: c.freqHz,
 			WACN:             net.WACN,
 			SystemID:         net.SystemID,
+			Topology:         c.TopologySnapshot(),
 			At:               c.now(),
 		},
 	})
+	c.logSiteIdentity(net)
+}
+
+// siteLogKey is the dedupe key for the concise site-configuration log line.
+type siteLogKey struct {
+	wacn  uint32
+	sysid uint16
+	nac   uint16
+	rfss  uint8
+	site  uint8
+	cc    Channel
+}
+
+// logSiteIdentity emits a concise, human-readable site-configuration line the
+// first time the camped site's identity is known and again whenever it
+// materially changes — the live-daemon equivalent of the network-configuration
+// report (cf. trunk-recorder's "Decoding System ID … WACN … NAC …" startup
+// lines). It runs on the Process goroutine that owns netModel/bandPlan, so it
+// reads them without a data race; the full multi-line report is rendered off
+// the same TopologySnapshot by the CLI / hunt / API surfaces. Identity values
+// are logged in hex to match how P25 systems are referenced in the field.
+func (c *ControlChannel) logSiteIdentity(net NetworkConfig) {
+	key := siteLogKey{net.WACN, net.SystemID, c.lastNAC, net.RFSS, net.Site, net.PrimaryCC}
+	if key == c.lastSiteLog {
+		return
+	}
+	c.lastSiteLog = key
+	c.log.Info("p25 site configuration",
+		"system", c.systemName,
+		"wacn", fmt.Sprintf("%X", net.WACN),
+		"sysid", fmt.Sprintf("%X", net.SystemID),
+		"nac", fmt.Sprintf("%X", c.lastNAC),
+		"rfss", net.RFSS,
+		"site", net.Site,
+		"cc_hz", c.freqHz,
+	)
 }
 
 // drainPendingGrants re-publishes every voice grant that arrived for

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -43,11 +43,12 @@ type NeighborSite struct {
 
 // NetworkConfig is a snapshot of the accumulated system topology.
 type NetworkConfig struct {
-	WACN      uint32 // 20-bit Wide-Area Communication Network ID
-	SystemID  uint16 // 12-bit System ID
-	RFSS      uint8  // RF Sub-System ID of the camped site
-	Site      uint8  // Site ID of the camped site
-	LRA       uint8  // Location Registration Area
+	WACN      uint32  // 20-bit Wide-Area Communication Network ID
+	SystemID  uint16  // 12-bit System ID
+	RFSS      uint8   // RF Sub-System ID of the camped site
+	Site      uint8   // Site ID of the camped site
+	LRA       uint8   // Location Registration Area
+	PrimaryCC Channel // primary control channel of the camped site (zero when unseen)
 	Secondary []Channel
 	Neighbors []NeighborSite
 }
@@ -70,6 +71,12 @@ type NetworkModel struct {
 	siteVotes  map[uint8]int
 	lraVotes   map[uint8]int
 
+	// Primary control channel vote tally — the (id, number) the camped
+	// site advertises in its Network/RFSS status broadcasts. Voted (not
+	// last-write-wins) for the same corroboration reason as the identity
+	// scalars: a corrupt-but-CRC-passing 0x3A/0x3B must not poison it.
+	primaryVotes map[Channel]int
+
 	// Secondary control channels — de-duplicated on first sight (a
 	// secondary CC is low-risk and not part of the corroboration scope).
 	secondary []Channel
@@ -86,6 +93,7 @@ func (m *NetworkModel) ensure() {
 		m.rfssVotes = map[uint8]int{}
 		m.siteVotes = map[uint8]int{}
 		m.lraVotes = map[uint8]int{}
+		m.primaryVotes = map[Channel]int{}
 		m.neighborData = map[neighborKey]NeighborSite{}
 	}
 }
@@ -106,6 +114,7 @@ func (m *NetworkModel) ApplyNetworkStatus(n NetworkStatusBroadcast) {
 	if n.LRA != 0 {
 		m.lraVotes[n.LRA]++
 	}
+	m.votePrimary(n.ChannelID, n.ChannelNumber)
 }
 
 // ApplyRFSSStatus folds an RFSS Status Broadcast (0x3A) in.
@@ -123,6 +132,20 @@ func (m *NetworkModel) ApplyRFSSStatus(r RFSSStatusBroadcast) {
 	if r.LRA != 0 {
 		m.lraVotes[r.LRA]++
 	}
+	m.votePrimary(r.ChannelID, r.ChannelNumber)
+}
+
+// votePrimary records a primary-control-channel observation. A zero
+// (id, number) carries no information (channel 0-0 is the "no channel"
+// sentinel used across these broadcasts), so it never gets a vote and
+// cannot out-rank a real channel seen the same number of times. Caller
+// holds m.mu.
+func (m *NetworkModel) votePrimary(id uint8, number uint16) {
+	if id == 0 && number == 0 {
+		return
+	}
+	m.ensure()
+	m.primaryVotes[Channel{ChannelID: id, ChannelNumber: number}]++
 }
 
 // ApplySecondaryControlChannel folds a Secondary Control Channel
@@ -167,6 +190,7 @@ func (m *NetworkModel) Snapshot() NetworkConfig {
 		RFSS:      majority(m.rfssVotes),
 		Site:      majority(m.siteVotes),
 		LRA:       majority(m.lraVotes),
+		PrimaryCC: majorityChannel(m.primaryVotes),
 		Secondary: append([]Channel(nil), m.secondary...),
 	}
 	for _, n := range m.neighborData {
@@ -190,6 +214,22 @@ func majority[K ~uint8 | ~uint16 | ~uint32](votes map[K]int) K {
 	for k, c := range votes {
 		if c > bestCount || (c == bestCount && k > best) {
 			best, bestCount = k, c
+		}
+	}
+	return best
+}
+
+// majorityChannel returns the most-observed Channel in a vote tally, or the
+// zero Channel when the tally is empty. Channel is a struct so it can't use the
+// scalar-constrained majority generic; ties are broken deterministically by the
+// larger (ChannelID, ChannelNumber) so map iteration order doesn't matter.
+func majorityChannel(votes map[Channel]int) Channel {
+	var best Channel
+	bestCount := 0
+	for ch, c := range votes {
+		if c > bestCount || (c == bestCount && (ch.ChannelID > best.ChannelID ||
+			(ch.ChannelID == best.ChannelID && ch.ChannelNumber > best.ChannelNumber))) {
+			best, bestCount = ch, c
 		}
 	}
 	return best

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -1,12 +1,54 @@
 package phase1
 
 import (
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// TestControlChannelTopologySnapshot drives identity / band-plan / secondary /
+// neighbour state into a control channel and checks TopologySnapshot maps it,
+// resolving each channel's downlink frequency through the band plan. This is
+// the single builder both the siglab engine and the live ccdecoder pipeline use.
+func TestControlChannelTopologySnapshot(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cc := New(Options{Bus: bus, Log: slog.Default(), SystemName: "Main", FrequencyHz: 851_100_000})
+	cc.lastNAC = 0x2C1
+	cc.bandPlan.Apply(IdentifierUpdate{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500, BandwidthHz: 12_500, TxOffsetHz: -45_000_000})
+	cc.netModel.ApplyNetworkStatus(NetworkStatusBroadcast{WACN: 0xBEE99, SystemID: 0x49A, ChannelID: 1, ChannelNumber: 8})
+	cc.netModel.ApplyRFSSStatus(RFSSStatusBroadcast{SystemID: 0x49A, RFSS: 1, Site: 2, LRA: 0x0C, ChannelID: 1, ChannelNumber: 8})
+	cc.netModel.ApplySecondaryControlChannel(SecondaryControlChannelBroadcast{ChannelAID: 1, ChannelANumber: 100})
+	cc.netModel.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{RFSS: 1, Site: 3, ChannelID: 1, ChannelNumber: 200})
+
+	snap := cc.TopologySnapshot()
+	if snap == nil {
+		t.Fatal("TopologySnapshot returned nil for a populated control channel")
+	}
+	if snap.Protocol != "p25" || snap.SystemName != "Main" || snap.NAC != 0x2C1 {
+		t.Errorf("metadata = proto %q name %q nac %X", snap.Protocol, snap.SystemName, snap.NAC)
+	}
+	if snap.WACN != 0xBEE99 || snap.SystemID != 0x49A || snap.RFSS != 1 || snap.Site != 2 || snap.LRA != 0x0C {
+		t.Errorf("identity = %+v", snap)
+	}
+	// Primary CC 1-8 resolves to 851_000_000 + 8*12_500 = 851_100_000.
+	if snap.PrimaryCC == nil || snap.PrimaryCC.FrequencyHz != 851_100_000 {
+		t.Errorf("PrimaryCC = %+v, want freq 851100000", snap.PrimaryCC)
+	}
+	// Secondary 1-100 → 852_250_000; neighbour 1-200 → 853_500_000.
+	if len(snap.Secondary) != 1 || snap.Secondary[0].FrequencyHz != 852_250_000 {
+		t.Errorf("Secondary = %+v", snap.Secondary)
+	}
+	if len(snap.Neighbors) != 1 || snap.Neighbors[0].FrequencyHz != 853_500_000 {
+		t.Errorf("Neighbors = %+v", snap.Neighbors)
+	}
+	if len(snap.BandPlan) != 1 || snap.BandPlan[0].BaseHz != 851_000_000 {
+		t.Errorf("BandPlan = %+v", snap.BandPlan)
+	}
+}
 
 func TestNetworkModelAccumulates(t *testing.T) {
 	var m NetworkModel
@@ -36,6 +78,33 @@ func TestNetworkModelAccumulates(t *testing.T) {
 		if n.Site == 8 && n.ChannelNumber != 305 {
 			t.Errorf("site 8 neighbour not updated: %+v", n)
 		}
+	}
+}
+
+func TestNetworkModelPrimaryControlChannel(t *testing.T) {
+	var m NetworkModel
+	// The camped site advertises its primary CC (2-1620) in repeated RFSS/
+	// Network status broadcasts; a single corrupt-but-CRC-passing frame names a
+	// different channel and must not win the majority vote.
+	for i := 0; i < 3; i++ {
+		m.ApplyRFSSStatus(RFSSStatusBroadcast{SystemID: 0x2C2, RFSS: 1, Site: 1, ChannelID: 2, ChannelNumber: 1620})
+		m.ApplyNetworkStatus(NetworkStatusBroadcast{WACN: 0xBEE00, SystemID: 0x2C2, ChannelID: 2, ChannelNumber: 1620})
+	}
+	m.ApplyRFSSStatus(RFSSStatusBroadcast{SystemID: 0x2C2, RFSS: 1, Site: 1, ChannelID: 7, ChannelNumber: 9})
+
+	cfg := m.Snapshot()
+	if cfg.PrimaryCC != (Channel{ChannelID: 2, ChannelNumber: 1620}) {
+		t.Errorf("PrimaryCC = %+v, want {2 1620}", cfg.PrimaryCC)
+	}
+}
+
+func TestNetworkModelPrimaryControlChannelZeroIgnored(t *testing.T) {
+	var m NetworkModel
+	// A 0-0 channel is the "no channel" sentinel and must never be voted, so an
+	// unseen primary CC stays the zero Channel.
+	m.ApplyRFSSStatus(RFSSStatusBroadcast{SystemID: 0x2C2, RFSS: 1, Site: 1, ChannelID: 0, ChannelNumber: 0})
+	if cc := m.Snapshot().PrimaryCC; cc != (Channel{}) {
+		t.Errorf("PrimaryCC = %+v, want zero", cc)
 	}
 }
 

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -364,6 +364,14 @@ func (p *p25Phase1Pipeline) Close() error           { return nil }
 // the unexported afcReporter capability the decoder type-asserts for.
 func (p *p25Phase1Pipeline) AFCOffsetHz() float64 { return p.rx.AFCOffsetHz() }
 
+// TopologySnapshot surfaces the P25 Phase 1 system topology (identity, primary/
+// secondary control channels, neighbours, band plan) the control channel
+// accumulated from its status broadcasts. Satisfies trunking.TopologyProvider so
+// the decoder can log the network-configuration report at lock.
+func (p *p25Phase1Pipeline) TopologySnapshot() *trunking.TopologySnapshot {
+	return p.cc.TopologySnapshot()
+}
+
 // newP25Phase2Pipeline wires internal/radio/p25/phase2/receiver into
 // p25phase2.ControlChannel.Process. The receiver's DibitSink forwards
 // H-DQPSK dibits into the state machine (20-dibit outbound sync

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -89,42 +89,8 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 				AdjacentSeen:      s.AdjacentSeen,
 			}
 		},
-		topology: func() *TopologySnapshot { return p25Topology(cc.NetworkSnapshot(), cc.BandPlanSnapshot()) },
+		topology: func() *TopologySnapshot { return cc.TopologySnapshot() },
 	}, nil
-}
-
-// p25Topology converts the P25 Phase 1 network + band-plan snapshots into the
-// protocol-neutral TopologySnapshot the engine attaches to Result.
-func p25Topology(net p25phase1.NetworkConfig, plan []p25phase1.IdentifierUpdate) *TopologySnapshot {
-	t := &TopologySnapshot{
-		WACN:     net.WACN,
-		SystemID: uint32(net.SystemID),
-		RFSS:     net.RFSS,
-		Site:     net.Site,
-		LRA:      net.LRA,
-	}
-	for _, s := range net.Secondary {
-		t.Secondary = append(t.Secondary, ChannelRef{ChannelID: s.ChannelID, ChannelNumber: s.ChannelNumber})
-	}
-	for _, n := range net.Neighbors {
-		t.Neighbors = append(t.Neighbors, NeighborRef{
-			RFSS:          n.RFSS,
-			Site:          n.Site,
-			ChannelID:     n.ChannelID,
-			ChannelNumber: n.ChannelNumber,
-		})
-	}
-	for _, u := range plan {
-		t.BandPlan = append(t.BandPlan, BandPlanSlot{
-			ChannelID:   u.ChannelID,
-			BaseHz:      u.BaseHz,
-			SpacingHz:   u.SpacingHz,
-			BandwidthHz: u.BandwidthHz,
-			TxOffsetHz:  u.TxOffsetHz,
-			AccessTDMA:  u.AccessTDMA,
-		})
-	}
-	return t
 }
 
 // snapshotP25Receiver reads the P25 receiver's internal-loop state at stream

--- a/internal/siglab/topology_test.go
+++ b/internal/siglab/topology_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
 
-	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
@@ -42,46 +41,6 @@ func TestGenericPipelineTopologyAttached(t *testing.T) {
 	}
 	if res.Topology.SystemID != 0x49A || res.Topology.ColorCode != 5 {
 		t.Errorf("topology = %+v, want SystemID 49A ColorCode 5", res.Topology)
-	}
-}
-
-func TestP25TopologyMapping(t *testing.T) {
-	net := p25phase1.NetworkConfig{
-		WACN:     0xBEE99,
-		SystemID: 0x49A,
-		RFSS:     1,
-		Site:     2,
-		LRA:      0x0C,
-		Secondary: []p25phase1.Channel{
-			{ChannelID: 1, ChannelNumber: 100},
-		},
-		Neighbors: []p25phase1.NeighborSite{
-			{RFSS: 1, Site: 3, ChannelID: 1, ChannelNumber: 200},
-			{RFSS: 1, Site: 4, ChannelID: 1, ChannelNumber: 300},
-		},
-	}
-	plan := []p25phase1.IdentifierUpdate{
-		{ChannelID: 1, BaseHz: 851_000_000, SpacingHz: 12_500, BandwidthHz: 12_500, TxOffsetHz: -45_000_000},
-	}
-
-	got := p25Topology(net, plan)
-	if got.WACN != 0xBEE99 || got.SystemID != 0x49A {
-		t.Errorf("identity = WACN %X SYSID %X, want BEE99/49A", got.WACN, got.SystemID)
-	}
-	if got.RFSS != 1 || got.Site != 2 || got.LRA != 0x0C {
-		t.Errorf("RFSS/Site/LRA = %d/%d/%d, want 1/2/12", got.RFSS, got.Site, got.LRA)
-	}
-	if len(got.Secondary) != 1 || got.Secondary[0].ChannelNumber != 100 {
-		t.Errorf("secondary = %+v, want one channel 100", got.Secondary)
-	}
-	if len(got.Neighbors) != 2 || got.Neighbors[0].Site != 3 || got.Neighbors[1].Site != 4 {
-		t.Errorf("neighbors = %+v, want sites 3,4", got.Neighbors)
-	}
-	if len(got.BandPlan) != 1 || got.BandPlan[0].BaseHz != 851_000_000 || got.BandPlan[0].SpacingHz != 12_500 {
-		t.Errorf("band plan = %+v, want base 851M spacing 12.5k", got.BandPlan)
-	}
-	if got.Empty() {
-		t.Error("snapshot reported Empty despite populated fields")
 	}
 }
 

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -332,5 +332,11 @@ type SiteUpdate struct {
 	ControlChannelHz uint32
 	WACN             uint32
 	SystemID         uint16
-	At               time.Time
+	// Topology, when non-nil, is the full network-configuration snapshot of the
+	// camped site (identity + primary/secondary control channels + neighbours +
+	// band plan) as of this update. It is built on the decoder's Process
+	// goroutine and handed off here, so the SiteTracker can render the live
+	// network-configuration report without touching the decoder's internals.
+	Topology *TopologySnapshot
+	At       time.Time
 }

--- a/internal/trunking/network_report.go
+++ b/internal/trunking/network_report.go
@@ -1,0 +1,240 @@
+package trunking
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// NetworkReport is the display-ready, protocol-neutral input to
+// RenderNetworkReport — GopherTrunk's equivalent of SDRtrunk's P25 network
+// configuration / activity summary. It is deliberately separate from
+// TopologySnapshot (a wire/JSON type with an Empty() attach contract): adapters
+// resolve every channel to absolute frequencies and flatten the one-site
+// (CLI/daemon) and multi-site (hunt) shapes into the same Sites slice so the
+// renderer stays pure and free of band-plan math.
+type NetworkReport struct {
+	Name     string // system name/label ("" → "(unnamed)")
+	Protocol string // "p25" etc.; uppercased in the header
+
+	// Network identity.
+	WACN     uint32
+	SystemID uint32
+	NAC      uint16
+	LRA      uint8
+
+	Sites []ReportSite // 1 for a single control channel; N for an aggregated hunt
+	Bands []ReportBand // frequency bands (band plan), system-wide
+}
+
+// ReportSite is one site's identity and control-channel topology.
+type ReportSite struct {
+	RFSS        uint8
+	Site        uint8
+	LRA         uint8
+	PrimaryCC   ReportChannel
+	SecondaryCC []ReportChannel
+	Neighbors   []ReportNeighbor
+}
+
+// ReportChannel is a control/voice channel with band-plan coordinates and
+// resolved frequencies. Coordinates may be zero (a hunt-discovered channel
+// carries only a resolved frequency); frequencies may be zero (no band plan).
+type ReportChannel struct {
+	ChannelID     uint8
+	ChannelNumber uint16
+	DownlinkHz    uint32
+	UplinkHz      uint32
+}
+
+func (c ReportChannel) empty() bool { return c == ReportChannel{} }
+
+// ReportNeighbor is an adjacent site advertised by a control channel.
+type ReportNeighbor struct {
+	RFSS    uint8
+	Site    uint8
+	Channel ReportChannel
+}
+
+// ReportBand is one P25 IDEN_UP band-plan slot.
+type ReportBand struct {
+	ChannelID   uint8
+	BaseHz      uint64
+	SpacingHz   uint32
+	BandwidthHz uint32
+	TxOffsetHz  int64
+	AccessTDMA  bool
+}
+
+// FormatNetworkReport renders r to a string.
+func FormatNetworkReport(r NetworkReport) string {
+	var b strings.Builder
+	RenderNetworkReport(&b, r)
+	return b.String()
+}
+
+// RenderNetworkReport writes the GopherTrunk-native network-configuration report
+// to w. Empty sections are suppressed; sites, neighbours and bands are emitted
+// in a stable order so the output is golden-test friendly.
+func RenderNetworkReport(w io.Writer, r NetworkReport) {
+	proto := strings.ToUpper(strings.TrimSpace(r.Protocol))
+	if proto == "" {
+		proto = "P25"
+	}
+	name := r.Name
+	if name == "" {
+		name = "(unnamed)"
+	}
+	fmt.Fprintf(w, "%s Network Configuration — %s\n", proto, name)
+
+	fmt.Fprintln(w, "Network")
+	fmt.Fprintf(w, "  WACN:%s SYSTEM:%s NAC:%s LRA:%s\n",
+		hexDec(uint64(r.WACN)), hexDec(uint64(r.SystemID)), hexDec(uint64(r.NAC)), hexDec(uint64(r.LRA)))
+
+	sites := append([]ReportSite(nil), r.Sites...)
+	sort.SliceStable(sites, func(i, j int) bool {
+		if sites[i].RFSS != sites[j].RFSS {
+			return sites[i].RFSS < sites[j].RFSS
+		}
+		return sites[i].Site < sites[j].Site
+	})
+
+	header := "Current Site"
+	if len(sites) > 1 {
+		header = "Sites"
+	}
+	for i := range sites {
+		if i == 0 || len(sites) > 1 {
+			fmt.Fprintln(w, header)
+		}
+		renderSite(w, sites[i])
+	}
+
+	if len(r.Bands) > 0 {
+		bands := append([]ReportBand(nil), r.Bands...)
+		sort.SliceStable(bands, func(i, j int) bool { return bands[i].ChannelID < bands[j].ChannelID })
+		fmt.Fprintln(w, "Frequency Bands")
+		for _, b := range bands {
+			mode := "FDMA"
+			if b.AccessTDMA {
+				mode = "TDMA"
+			}
+			fmt.Fprintf(w, "  BAND:%d %s BASE:%s BANDWIDTH:%s SPACING:%s OFFSET:%s\n",
+				b.ChannelID, mode, mhz(b.BaseHz), khz(uint64(b.BandwidthHz)), khz(uint64(b.SpacingHz)), offsetMHz(b.TxOffsetHz))
+		}
+	}
+}
+
+func renderSite(w io.Writer, s ReportSite) {
+	fmt.Fprintf(w, "  RFSS:%s SITE:%s LRA:%s\n", hexDec(uint64(s.RFSS)), hexDec(uint64(s.Site)), hexDec(uint64(s.LRA)))
+	if !s.PrimaryCC.empty() {
+		fmt.Fprintf(w, "  %s\n", channelLine("PRI CONTROL CHANNEL", s.PrimaryCC))
+	}
+	for _, c := range s.SecondaryCC {
+		fmt.Fprintf(w, "  %s\n", channelLine("SEC CONTROL CHANNEL", c))
+	}
+	neighbors := append([]ReportNeighbor(nil), s.Neighbors...)
+	sort.SliceStable(neighbors, func(i, j int) bool {
+		if neighbors[i].RFSS != neighbors[j].RFSS {
+			return neighbors[i].RFSS < neighbors[j].RFSS
+		}
+		return neighbors[i].Site < neighbors[j].Site
+	})
+	for _, n := range neighbors {
+		line := fmt.Sprintf("NEIGHBOR RFSS:%s SITE:%s CHANNEL", hexDec(uint64(n.RFSS)), hexDec(uint64(n.Site)))
+		fmt.Fprintf(w, "  %s\n", channelLine(line, n.Channel))
+	}
+}
+
+// channelLine renders "<prefix>[:<id>-<num>] DOWNLINK:<mhz> UPLINK:<mhz>",
+// omitting the coordinate token when unknown (hunt) and each frequency when
+// unresolved.
+func channelLine(prefix string, c ReportChannel) string {
+	var b strings.Builder
+	b.WriteString(prefix)
+	if c.ChannelID != 0 || c.ChannelNumber != 0 {
+		fmt.Fprintf(&b, ":%d-%d", c.ChannelID, c.ChannelNumber)
+	}
+	if c.DownlinkHz != 0 {
+		fmt.Fprintf(&b, " DOWNLINK:%s", mhz(uint64(c.DownlinkHz)))
+	}
+	if c.UplinkHz != 0 {
+		fmt.Fprintf(&b, " UPLINK:%s", mhz(uint64(c.UplinkHz)))
+	}
+	return b.String()
+}
+
+// hexDec renders a value as "HEX[decimal]" — e.g. WACN BEE00 as "BEE00[781824]".
+func hexDec(v uint64) string { return fmt.Sprintf("%X[%d]", v, v) }
+
+// mhz formats a frequency in Hz as MHz with 6 decimals (1 Hz resolution).
+func mhz(hz uint64) string { return fmt.Sprintf("%.6f MHz", float64(hz)/1e6) }
+
+// khz formats a value in Hz as kHz, trimming trailing zeros (12500 → "12.5 kHz").
+func khz(hz uint64) string {
+	return strconv.FormatFloat(float64(hz)/1e3, 'f', -1, 64) + " kHz"
+}
+
+// offsetMHz formats a signed transmit offset in Hz as MHz, keeping the sign.
+func offsetMHz(hz int64) string { return fmt.Sprintf("%+.6f MHz", float64(hz)/1e6) }
+
+// ReportFromTopology builds a single-site NetworkReport from a TopologySnapshot
+// (the CLI and live-daemon path). Uplink frequencies are derived from each
+// channel's matching band-plan transmit offset.
+func ReportFromTopology(t *TopologySnapshot) NetworkReport {
+	if t == nil {
+		return NetworkReport{}
+	}
+	offsets := make(map[uint8]int64, len(t.BandPlan))
+	for _, b := range t.BandPlan {
+		offsets[b.ChannelID] = b.TxOffsetHz
+	}
+	conv := func(id uint8, num uint16, downHz uint32) ReportChannel {
+		c := ReportChannel{ChannelID: id, ChannelNumber: num, DownlinkHz: downHz}
+		if downHz != 0 {
+			if off, ok := offsets[id]; ok && off != 0 {
+				if up := int64(downHz) + off; up > 0 {
+					c.UplinkHz = uint32(up)
+				}
+			}
+		}
+		return c
+	}
+
+	r := NetworkReport{
+		Name:     t.SystemName,
+		Protocol: t.Protocol,
+		WACN:     t.WACN,
+		SystemID: t.SystemID,
+		NAC:      t.NAC,
+		LRA:      t.LRA,
+	}
+	site := ReportSite{RFSS: t.RFSS, Site: t.Site, LRA: t.LRA}
+	if t.PrimaryCC != nil {
+		site.PrimaryCC = conv(t.PrimaryCC.ChannelID, t.PrimaryCC.ChannelNumber, t.PrimaryCC.FrequencyHz)
+	}
+	for _, s := range t.Secondary {
+		site.SecondaryCC = append(site.SecondaryCC, conv(s.ChannelID, s.ChannelNumber, s.FrequencyHz))
+	}
+	for _, n := range t.Neighbors {
+		site.Neighbors = append(site.Neighbors, ReportNeighbor{
+			RFSS:    n.RFSS,
+			Site:    n.Site,
+			Channel: conv(n.ChannelID, n.ChannelNumber, n.FrequencyHz),
+		})
+	}
+	r.Sites = []ReportSite{site}
+	for _, b := range t.BandPlan {
+		r.Bands = append(r.Bands, ReportBand{
+			ChannelID:   b.ChannelID,
+			BaseHz:      b.BaseHz,
+			SpacingHz:   b.SpacingHz,
+			BandwidthHz: b.BandwidthHz,
+			TxOffsetHz:  b.TxOffsetHz,
+			AccessTDMA:  b.AccessTDMA,
+		})
+	}
+	return r
+}

--- a/internal/trunking/network_report_test.go
+++ b/internal/trunking/network_report_test.go
@@ -1,0 +1,113 @@
+package trunking
+
+import (
+	"strings"
+	"testing"
+)
+
+// fullReport mirrors the user's reference site: WACN BEE00 / SYSTEM 2C2 /
+// NAC 2C1, RFSS 1 / Site 1, a primary + secondary CC, one neighbour, one band.
+func fullReport() NetworkReport {
+	return NetworkReport{
+		Name:     "Main Site",
+		Protocol: "p25",
+		WACN:     0xBEE00,
+		SystemID: 0x2C2,
+		NAC:      0x2C1,
+		Sites: []ReportSite{{
+			RFSS:      1,
+			Site:      1,
+			PrimaryCC: ReportChannel{ChannelID: 2, ChannelNumber: 1620, DownlinkHz: 450125000, UplinkHz: 460687500},
+			SecondaryCC: []ReportChannel{
+				{ChannelID: 2, ChannelNumber: 1692, DownlinkHz: 450575000, UplinkHz: 460575000},
+			},
+			Neighbors: []ReportNeighbor{
+				{RFSS: 1, Site: 7, Channel: ReportChannel{ChannelID: 2, ChannelNumber: 1754, DownlinkHz: 450962500, UplinkHz: 461437500}},
+			},
+		}},
+		Bands: []ReportBand{
+			{ChannelID: 2, BaseHz: 440000000, SpacingHz: 6250, BandwidthHz: 12500, TxOffsetHz: -6400000},
+		},
+	}
+}
+
+func TestRenderNetworkReportTokens(t *testing.T) {
+	out := FormatNetworkReport(fullReport())
+	for _, want := range []string{
+		"P25 Network Configuration — Main Site",
+		"WACN:BEE00[781824]",
+		"SYSTEM:2C2[706]",
+		"NAC:2C1[705]",
+		"Current Site",
+		"RFSS:1[1] SITE:1[1]",
+		"PRI CONTROL CHANNEL:2-1620 DOWNLINK:450.125000 MHz UPLINK:460.687500 MHz",
+		"SEC CONTROL CHANNEL:2-1692 DOWNLINK:450.575000 MHz",
+		"NEIGHBOR RFSS:1[1] SITE:7[7] CHANNEL:2-1754 DOWNLINK:450.962500 MHz UPLINK:461.437500 MHz",
+		"Frequency Bands",
+		"BAND:2 FDMA BASE:440.000000 MHz BANDWIDTH:12.5 kHz SPACING:6.25 kHz OFFSET:-6.400000 MHz",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q\n--- full report ---\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderNetworkReportSuppressesEmptySections(t *testing.T) {
+	// Only identity known — no site channels, no neighbours, no bands.
+	out := FormatNetworkReport(NetworkReport{
+		Protocol: "p25", WACN: 0xBEE00, SystemID: 0x2C2, NAC: 0x2C1,
+		Sites: []ReportSite{{RFSS: 1, Site: 1}},
+	})
+	if strings.Contains(out, "Frequency Bands") {
+		t.Errorf("empty band plan should be suppressed:\n%s", out)
+	}
+	if strings.Contains(out, "CONTROL CHANNEL") || strings.Contains(out, "NEIGHBOR") {
+		t.Errorf("empty channels/neighbours should be suppressed:\n%s", out)
+	}
+	if !strings.Contains(out, "(unnamed)") {
+		t.Errorf("blank name should render as (unnamed):\n%s", out)
+	}
+}
+
+func TestRenderNetworkReportHuntFrequencyOnlyChannel(t *testing.T) {
+	// A hunt-discovered control channel carries only a resolved frequency (no
+	// band-plan coordinates), so the id-number token must be omitted.
+	out := FormatNetworkReport(NetworkReport{
+		Protocol: "p25",
+		Sites:    []ReportSite{{RFSS: 1, Site: 1, PrimaryCC: ReportChannel{DownlinkHz: 450125000}}},
+	})
+	if !strings.Contains(out, "PRI CONTROL CHANNEL DOWNLINK:450.125000 MHz") {
+		t.Errorf("frequency-only primary CC should omit the id-number token:\n%s", out)
+	}
+}
+
+func TestReportFromTopologyMapsFieldsAndUplink(t *testing.T) {
+	snap := &TopologySnapshot{
+		SystemName: "Main Site",
+		Protocol:   "p25",
+		WACN:       0xBEE00,
+		SystemID:   0x2C2,
+		NAC:        0x2C1,
+		RFSS:       1,
+		Site:       1,
+		LRA:        0,
+		PrimaryCC:  &TopoChannelRef{ChannelID: 2, ChannelNumber: 1620, FrequencyHz: 450125000},
+		Neighbors:  []TopoNeighborRef{{RFSS: 1, Site: 7, ChannelID: 2, ChannelNumber: 1754, FrequencyHz: 450962500}},
+		BandPlan:   []TopoBandPlanSlot{{ChannelID: 2, BaseHz: 440000000, SpacingHz: 6250, TxOffsetHz: -6400000}},
+	}
+	r := ReportFromTopology(snap)
+	if len(r.Sites) != 1 {
+		t.Fatalf("Sites = %d, want 1", len(r.Sites))
+	}
+	site := r.Sites[0]
+	// Uplink = downlink + band TxOffset (450125000 - 6400000 = 443725000).
+	if site.PrimaryCC.UplinkHz != 443725000 {
+		t.Errorf("primary uplink = %d, want 443725000", site.PrimaryCC.UplinkHz)
+	}
+	if r.NAC != 0x2C1 || r.WACN != 0xBEE00 || r.Name != "Main Site" {
+		t.Errorf("identity not mapped: %+v", r)
+	}
+	if len(site.Neighbors) != 1 || site.Neighbors[0].Channel.UplinkHz != 444562500 {
+		t.Errorf("neighbour uplink not derived: %+v", site.Neighbors)
+	}
+}

--- a/internal/trunking/site_tracker.go
+++ b/internal/trunking/site_tracker.go
@@ -46,6 +46,12 @@ type SiteTracker struct {
 
 	mu    sync.Mutex
 	sites map[siteKey]*SiteInfo
+	// topo holds the latest full topology snapshot per system name, so the
+	// live network-configuration report (GET /api/v1/systems/{name}/report)
+	// can be rendered without reaching into the decoder. It reflects the most
+	// recently camped site of each system (identity + that site's control
+	// channels, neighbours, and the system band plan).
+	topo map[string]*TopologySnapshot
 }
 
 // siteKey identifies a site within the tracker table.
@@ -76,6 +82,7 @@ func NewSiteTracker(opts SiteTrackerOptions) (*SiteTracker, error) {
 		now:     opts.Now,
 		runDone: make(chan struct{}),
 		sites:   make(map[siteKey]*SiteInfo),
+		topo:    make(map[string]*TopologySnapshot),
 	}
 	t.sub = opts.Bus.Subscribe()
 	return t, nil
@@ -125,7 +132,23 @@ func (t *SiteTracker) observe(u SiteUpdate) {
 	if u.SystemID != 0 {
 		s.SystemID = u.SystemID
 	}
+	if u.Topology != nil && !u.Topology.Empty() {
+		t.topo[u.System] = u.Topology
+	}
 	s.LastSeen = t.now()
+}
+
+// Report renders the human-readable network-configuration report for the named
+// system from its most recent topology snapshot. The bool is false when no
+// topology has been observed for the system yet.
+func (t *SiteTracker) Report(system string) (string, bool) {
+	t.mu.Lock()
+	snap := t.topo[system]
+	t.mu.Unlock()
+	if snap == nil {
+		return "", false
+	}
+	return FormatNetworkReport(ReportFromTopology(snap)), true
 }
 
 // Snapshot returns every tracked site, ordered by system then RFSS/Site

--- a/internal/trunking/site_tracker_test.go
+++ b/internal/trunking/site_tracker_test.go
@@ -2,6 +2,7 @@ package trunking
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,6 +51,46 @@ func TestSiteTrackerObservesSiteUpdates(t *testing.T) {
 	}
 	if s.ControlChannelHz != 420012500 || s.WACN != 0xBEE00 || s.SystemID != 0x123 {
 		t.Fatalf("site network fields wrong: %+v", s)
+	}
+}
+
+func TestSiteTrackerReportFromTopology(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	tr, err := NewSiteTracker(SiteTrackerOptions{Bus: bus})
+	if err != nil {
+		t.Fatalf("NewSiteTracker: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go tr.Run(ctx)
+	t.Cleanup(func() { cancel(); tr.Close() })
+
+	// No topology observed yet ⇒ no report.
+	if _, ok := tr.Report("MMR"); ok {
+		t.Fatal("Report should be unavailable before any topology")
+	}
+
+	bus.Publish(events.Event{
+		Kind: events.KindSiteUpdate,
+		Payload: SiteUpdate{
+			System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 450125000,
+			WACN: 0xBEE00, SystemID: 0x2C2,
+			Topology: &TopologySnapshot{
+				SystemName: "MMR", Protocol: "p25", WACN: 0xBEE00, SystemID: 0x2C2, NAC: 0x2C1,
+				RFSS: 1, Site: 1,
+				PrimaryCC: &TopoChannelRef{ChannelID: 2, ChannelNumber: 1620, FrequencyHz: 450125000},
+			},
+		},
+	})
+
+	var report string
+	waitFor(t, func() bool {
+		r, ok := tr.Report("MMR")
+		report = r
+		return ok
+	})
+	if !strings.Contains(report, "WACN:BEE00[781824]") || !strings.Contains(report, "PRI CONTROL CHANNEL:2-1620") {
+		t.Errorf("report missing expected tokens:\n%s", report)
 	}
 }
 

--- a/internal/trunking/topology.go
+++ b/internal/trunking/topology.go
@@ -22,12 +22,23 @@ package trunking
 // give single-site identity; the rest give minimal identity. Band-plan-from-air
 // is P25-only today.
 type TopologySnapshot struct {
+	// Display metadata (populated where the decoder knows it). These name the
+	// run for the human-readable network-configuration report and are not part
+	// of the topology's Empty() contract.
+	SystemName string `json:"system_name,omitempty" yaml:"system_name,omitempty"`
+	Protocol   string `json:"protocol,omitempty" yaml:"protocol,omitempty"`
+
 	// P25 identity.
 	WACN     uint32 `json:"wacn,omitempty" yaml:"wacn,omitempty"`
 	SystemID uint32 `json:"system_id,omitempty" yaml:"system_id,omitempty"`
+	NAC      uint16 `json:"nac,omitempty" yaml:"nac,omitempty"` // Network Access Code (P25)
 	RFSS     uint8  `json:"rfss,omitempty" yaml:"rfss,omitempty"`
 	Site     uint8  `json:"site,omitempty" yaml:"site,omitempty"`
 	LRA      uint8  `json:"lra,omitempty" yaml:"lra,omitempty"`
+
+	// PrimaryCC is the camped site's primary control channel (P25), with its
+	// resolved downlink frequency when the band plan was known.
+	PrimaryCC *TopoChannelRef `json:"primary_cc,omitempty" yaml:"primary_cc,omitempty"`
 
 	// Per-protocol identity (populated where applicable).
 	ColorCode    uint8  `json:"color_code,omitempty" yaml:"color_code,omitempty"`       // DMR

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -393,7 +393,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.toast(fmt.Sprintf("system: %v", msg.err))
 		} else {
-			m.openDetail("System: "+msg.s.Name, formatSystemDetail(msg.s))
+			body := formatSystemDetail(msg.s)
+			if msg.report != "" {
+				body += "\n\n" + msg.report
+			}
+			m.openDetail("System: "+msg.s.Name, body)
 		}
 
 	case talkgroupDetailResultMsg:

--- a/internal/tui/client/client.go
+++ b/internal/tui/client/client.go
@@ -217,6 +217,20 @@ func (c *Client) System(ctx context.Context, name string) (SystemDTO, error) {
 	return s, nil
 }
 
+// SystemReport calls GET /api/v1/systems/{name}/report and returns the live
+// human-readable P25 network-configuration report. Empty when the daemon has
+// not yet observed the system's topology. Used by the TUI's drill-in modal.
+func (c *Client) SystemReport(ctx context.Context, name string) (string, error) {
+	var r struct {
+		Report    string `json:"report"`
+		Available bool   `json:"available"`
+	}
+	if err := c.getJSON(ctx, "/api/v1/systems/"+url.PathEscape(name)+"/report", &r); err != nil {
+		return "", err
+	}
+	return r.Report, nil
+}
+
 // Talkgroup calls GET /api/v1/talkgroups/{id} and returns the detail
 // record for one talkgroup. Used by the TUI's drill-in modal.
 func (c *Client) Talkgroup(ctx context.Context, id uint32) (TalkgroupDTO, error) {

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -283,7 +283,13 @@ func cmdResetTone(cli *client.Client, deviceSerial string) tea.Cmd {
 func cmdFetchSystemDetail(cli *client.Client, name string) tea.Cmd {
 	return func() tea.Msg {
 		s, err := cli.System(context.Background(), name)
-		return systemDetailResultMsg{s: s, err: err}
+		if err != nil {
+			return systemDetailResultMsg{s: s, err: err}
+		}
+		// The report is best-effort: a missing/empty one must not block the
+		// detail modal, so its error is intentionally dropped.
+		report, _ := cli.SystemReport(context.Background(), name)
+		return systemDetailResultMsg{s: s, report: report}
 	}
 }
 

--- a/internal/tui/msgs.go
+++ b/internal/tui/msgs.go
@@ -96,8 +96,9 @@ type pollMutationStatusMsg struct {
 // of a Systems/Talkgroups drill-in fetch. The root model opens a
 // read-only modal on success or surfaces the error as a toast.
 type systemDetailResultMsg struct {
-	s   client.SystemDTO
-	err error
+	s      client.SystemDTO
+	report string // live network-configuration report ("" when unavailable)
+	err    error
 }
 type talkgroupDetailResultMsg struct {
 	tg  client.TalkgroupDTO


### PR DESCRIPTION
GopherTrunk already accumulates a P25 site's identity and topology
(NetworkModel/NetworkConfig, BandPlan, NAC, control-channel frequency) but
only ever surfaced it as structured logs, JSON/CSV, and events — never as the
consolidated, human-readable report SDRtrunk's P25P1NetworkConfigurationMonitor
produces. This adds that report (GopherTrunk-native styling) and wires it into
every surface from a single shared renderer.

Core:
- trunking.NetworkReport + RenderNetworkReport/FormatNetworkReport: one pure,
  golden-testable renderer over a display-ready struct (frequencies pre-resolved
  by adapters), with ReportFromTopology mapping a TopologySnapshot (uplink
  derived from each band's transmit offset).
- Capture data previously dropped: NetworkModel now majority-votes the primary
  control channel (id/number) from RFSS/Network status broadcasts; TopologySnapshot
  gains NAC / SystemName / Protocol / PrimaryCC. ControlChannel.TopologySnapshot()
  is the single builder (band-plan-resolved) the siglab engine and the live
  ccdecoder pipeline both use.

Surfaces:
- Decode CLI (analyze/replay/identify): renderResultText prints the report block.
- Hunt export: new `summary` format (-formats summary) → .txt, one site section
  per discovered site under a shared identity header + band plan.
- Live daemon: ControlChannel logs a concise, deduped "p25 site configuration"
  line as identity accumulates (runs on the Process goroutine that owns the band
  plan, so no data race; full multi-line block is unfit for slog).
- API + TUI: SiteUpdate carries the snapshot; SiteTracker keeps the latest per
  system and renders GET /api/v1/systems/{name}/report; the TUI system-detail
  modal appends it.

Tests: renderer golden + empty-section/hunt-frequency-only cases, topology
adapter + uplink derivation, NetworkModel primary-CC vote, ControlChannel
snapshot, hunt summary format/metadata + writeSummary, SiteTracker.Report, and
the report endpoint (available/quiet/unknown).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014Asv14tLTBfcgcNmXsT6w8