### PR TITLE
widebandt2: detect shared-front-end overload on wideband captures (#749)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1579,10 +1579,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			// raw entry.Device: the iqtap broker doesn't forward the optional
 			// ActualSampleRate() extension. Mirrors the CC decoder above.
 			effectiveRate := effectiveStreamRate(log, entry.Device, entry.Info.Serial, cfg.SDR.SampleRate)
-			// Per-channel IQ-power gauge. Same typed-nil guard as the CC
-			// decoder above: a nil *metrics.Metrics wrapped in the interface
-			// still tests non-nil inside the engine, so hand it over only
-			// when the concrete pointer is alive.
+			// Per-channel + whole-capture IQ-power diagnostics (issue #749).
+			// Same typed-nil guard as the CC decoder above: a nil
+			// *metrics.Metrics wrapped in the interface still tests non-nil
+			// inside the engine, so hand it over only when the concrete
+			// pointer is alive.
 			var wbIQObs widebandt2.IQPowerObserver
 			if d.metrics != nil {
 				wbIQObs = d.metrics
@@ -1596,6 +1597,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				TunerStrategy: devCfg.TunerStrategy,
 				Channels:      channels,
 				Systems:       d.systems,
+				Serial:        entry.Info.Serial,
 				Metrics:       wbIQObs,
 			})
 			if err != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -247,6 +247,31 @@ sdr:
     # channel only; voice grants still route to the daemon's physical
     # voice pool (a role: voice SDR alongside the wideband dongle).
     #
+    # MULTI-SITE P25: to monitor several SITES of one P25 system at once,
+    # list each site's control channel as its own channels: entry (all
+    # pointing at the same system). Every tap decodes in parallel out of
+    # the one capture — they are NOT hunted one-at-a-time. Per-site names
+    # come from the system's sites: mapping (RFSS/Site → name) further down.
+    #
+    # SHARED FRONT END (issue #749): every tap on a dongle shares one
+    # antenna, one centre frequency and one gain. The channelizer is
+    # gain-flat across taps, so if one site decodes and its siblings sit at
+    # the noise floor, that is real RF — a weak/distant site at this centre
+    # and gain, or (just as common) a STRONG site overloading the shared
+    # ADC and raising the noise floor for everything else. Symptoms and fix:
+    #   - Watch each tap's level on gophertrunk_sdr_iq_power_dbfs (labelled
+    #     "<system> @ <freq> MHz") and the whole capture on
+    #     gophertrunk_sdr_wideband_input_iq_power_dbfs /
+    #     gophertrunk_sdr_wideband_input_clip_ratio. A tap far below the input
+    #     power, or a non-zero input clip ratio, is logged as a throttled WARN too.
+    #   - If the input clip ratio is non-zero, LOWER the gain or add
+    #     attenuation (do NOT raise gain) — a hot site is desensitising the
+    #     receiver. Set gain in TENTHS of a dB ("gain: 600" = 60 dB, which
+    #     is very high for a wideband capture; try a lower value first).
+    #   - A genuinely weak distant site may simply not survive a shared
+    #     capture optimised for a stronger one — give it a dedicated dongle
+    #     (role: control or its own role: wideband) if it matters.
+    #
     # Constraints (validated at load time):
     #   - serial must match a discovered dongle
     #   - every channel frequency_hz must be within

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -47,6 +47,32 @@ band or in tough RF environments. For the lower bands, the
 GopherTrunk supports Airspy receivers for demanding reception where an RTL-SDR's
 bandwidth or sensitivity falls short.
 
+## Wideband multi-site monitoring
+
+An Airspy pinned to `role: wideband` can channelize several control channels —
+including multiple **sites** of one P25 system — out of a single IQ capture, all
+decoded in parallel. List each site's control channel as its own `channels:`
+entry (see `config.example.yaml`).
+
+Every tap shares one antenna, one centre frequency and one gain, and the
+channelizer is **gain-flat across taps**. So if one site decodes cleanly while
+the others sit at the noise floor, the cause is RF, not the DDC:
+
+- **Front-end overload.** A strong (often hilltop) site can drive the shared ADC
+  into clipping, raising the noise floor and burying weaker sites. Gain is in
+  **tenths of a dB** — `gain: 600` means 60 dB, very high for a wideband capture.
+  If `gophertrunk_sdr_wideband_input_clip_ratio` is non-zero (a throttled WARN
+  also fires), **lower the gain or add attenuation** — do not raise it.
+- **A genuinely weak/distant site** may not survive a capture optimised for a
+  stronger one. Give it a dedicated dongle if it matters.
+
+Diagnostics: each tap's level is on `gophertrunk_sdr_iq_power_dbfs` labelled
+`<system> @ <freq> MHz`; the whole capture is on
+`gophertrunk_sdr_wideband_input_iq_power_dbfs{serial}` and
+`gophertrunk_sdr_wideband_input_clip_ratio{serial}`. Compare a tap against the
+whole-capture power to tell a weak site apart from a decode problem, and watch
+the clip ratio for overload.
+
 ## Sources
 
 [^wiki]: [Software-defined radio](https://en.wikipedia.org/wiki/Software-defined_radio) — Wikipedia, for background on Airspy-class high-performance VHF/UHF SDR receivers.

--- a/internal/metrics/prom.go
+++ b/internal/metrics/prom.go
@@ -51,11 +51,19 @@ type Metrics struct {
 	iqPowerDbFS    *prometheus.GaugeVec // by system; mean IQ power on the control SDR
 	iqDCRatioDb    *prometheus.GaugeVec // by system; DC-bin power relative to total IQ power, in dB (issue #402)
 	iqClipRatio    *prometheus.GaugeVec // by system; fraction of IQ samples pinned to the ADC rail (issue #402)
-	usbReconnects  *prometheus.CounterVec
-	decodeErrors   *prometheus.CounterVec
-	sdrAttached    *prometheus.GaugeVec
-	versionInfo    *prometheus.GaugeVec
-	sdrSnap        *sdrSnapshotCollector
+	// Whole-capture wideband diagnostics (issue #749). A role: wideband dongle
+	// channelizes several control channels out of one IQ capture; every tap
+	// shares the same antenna + gain. Per-tap level rides the existing
+	// iq_power_dbfs gauge (labelled "<system> @ <freq>"); these two cover the
+	// whole capture so front-end overload — which buries every tap at once —
+	// is visible where a per-tap gauge can't show it.
+	wbInputPowerDbFS *prometheus.GaugeVec // by serial; mean pre-DDC IQ power of the whole wideband capture
+	wbInputClipRatio *prometheus.GaugeVec // by serial; fraction of wideband IQ samples pinned to the ADC rail
+	usbReconnects    *prometheus.CounterVec
+	decodeErrors     *prometheus.CounterVec
+	sdrAttached      *prometheus.GaugeVec
+	versionInfo      *prometheus.GaugeVec
+	sdrSnap          *sdrSnapshotCollector
 
 	// tetraViterbiCorrections is the opt-in (metrics.detailed_fec)
 	// TETRA §8.3.1 FEC correction-depth histogram. Nil unless detailed
@@ -204,6 +212,24 @@ func New(bus *events.Bus, pool Snapshotter, version string, detailedFEC bool) (*
 		Help:      "Fraction of control-SDR IQ samples pinned to the ADC rail (window ~= 1 s). 0 = no clipping; a sustained value above ~0.002 means front-end overload — reduce gain or add attenuation, do not raise gain (issue #402).",
 	}, []string{"system"})
 
+	// Pre-DDC power of the whole wideband capture (issue #749). The reference
+	// each per-tap iq_power_dbfs reading is compared against, and — with
+	// wideband_input_clip_ratio — the signal that a strong site is overloading
+	// the shared front end and burying the weaker taps.
+	m.wbInputPowerDbFS = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "sdr",
+		Name:      "wideband_input_iq_power_dbfs",
+		Help:      "Mean pre-DDC IQ power of the whole wideband capture in dBFS (window ~= 1 s), per dongle serial (issue #749).",
+	}, []string{"serial"})
+
+	m.wbInputClipRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: namespace,
+		Subsystem: "sdr",
+		Name:      "wideband_input_clip_ratio",
+		Help:      "Fraction of wideband IQ samples pinned to the ADC rail (window ~= 1 s), per dongle serial. A sustained value above ~0.002 means a strong site is overloading the shared front end and burying weaker taps — reduce gain or add attenuation, do not raise gain (issue #749).",
+	}, []string{"serial"})
+
 	m.usbReconnects = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: namespace,
 		Subsystem: "sdr",
@@ -268,6 +294,8 @@ func New(bus *events.Bus, pool Snapshotter, version string, detailedFEC bool) (*
 		m.iqPowerDbFS,
 		m.iqDCRatioDb,
 		m.iqClipRatio,
+		m.wbInputPowerDbFS,
+		m.wbInputClipRatio,
 		m.usbReconnects,
 		m.decodeErrors,
 		m.sdrAttached,
@@ -464,6 +492,34 @@ func (m *Metrics) ClearIQClipRatio(system string) {
 		return
 	}
 	m.iqClipRatio.DeleteLabelValues(system)
+}
+
+// RecordWidebandInputPowerDbFS sets the whole-capture power gauge for a
+// wideband dongle (issue #749).
+func (m *Metrics) RecordWidebandInputPowerDbFS(serial string, dbfs float64) {
+	if serial == "" {
+		serial = "unknown"
+	}
+	m.wbInputPowerDbFS.WithLabelValues(serial).Set(dbfs)
+}
+
+// RecordWidebandInputClipRatio sets the whole-capture clip-ratio gauge for a
+// wideband dongle (issue #749).
+func (m *Metrics) RecordWidebandInputClipRatio(serial string, ratio float64) {
+	if serial == "" {
+		serial = "unknown"
+	}
+	m.wbInputClipRatio.WithLabelValues(serial).Set(ratio)
+}
+
+// ClearWidebandInput drops both whole-capture gauge series for a dongle.
+// Called when the wideband engine tears down.
+func (m *Metrics) ClearWidebandInput(serial string) {
+	if serial == "" {
+		serial = "unknown"
+	}
+	m.wbInputPowerDbFS.DeleteLabelValues(serial)
+	m.wbInputClipRatio.DeleteLabelValues(serial)
 }
 
 // RecordUSBReconnect increments the reconnect counter for the supplied SDR.

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -130,14 +130,20 @@ type ChannelConfig struct {
 }
 
 // IQPowerObserver is the minimal metrics surface the engine uses to
-// publish its per-channel window-averaged dBFS gauge. internal/metrics.Metrics
-// satisfies it; nil disables the gauge while leaving the throttled
-// low-power WARN and the DEBUG decode-activity summary in place. Declared
-// locally (rather than imported from ccdecoder) so this scanner package
-// doesn't depend on another.
+// publish its per-channel window-averaged dBFS gauge plus the whole-capture
+// power / clip diagnostics (issue #749). internal/metrics.Metrics satisfies
+// it; nil disables the gauges while leaving the throttled WARNs and the DEBUG
+// decode-activity summary in place. Declared locally (rather than imported
+// from ccdecoder) so this scanner package doesn't depend on another.
 type IQPowerObserver interface {
 	RecordIQPowerDbFS(system string, dbfs float64)
 	ClearIQPowerDbFS(system string)
+	// Whole-capture diagnostics, labelled by dongle serial. The per-tap
+	// gauge above can't surface front-end overload (a strong site clipping
+	// the shared ADC raises the floor for every tap) — these can.
+	RecordWidebandInputPowerDbFS(serial string, dbfs float64)
+	RecordWidebandInputClipRatio(serial string, ratio float64)
+	ClearWidebandInput(serial string)
 }
 
 // Options bundles the inputs Engine needs at construction time.
@@ -147,9 +153,14 @@ type Options struct {
 
 	// Metrics, if non-nil, receives each channel's window-averaged dBFS
 	// gauge (labelled by "system @ <freqMHz>" so per-channel readings
-	// don't collide). Nil-safe: the throttled low-power WARN and the
-	// DEBUG decode-activity summary still fire without it.
+	// don't collide) plus the whole-capture power / clip-ratio gauges
+	// (labelled by Serial). Nil-safe: the throttled WARNs and the DEBUG
+	// decode-activity summary still fire without it.
 	Metrics IQPowerObserver
+
+	// Serial labels this dongle's whole-capture power/clip gauges
+	// (issue #749). Empty is tolerated (labelled "unknown").
+	Serial string
 
 	// Device is the wideband SDR. It is set to CenterFreqHz, then
 	// streamed continuously until Run's context cancels.
@@ -195,6 +206,8 @@ type Engine struct {
 
 	// metrics is the optional per-channel dBFS gauge sink (nil-safe).
 	metrics IQPowerObserver
+	// serial labels the whole-capture power/clip gauges (issue #749).
+	serial string
 	// now is the clock the diagnostics window uses; injectable for tests.
 	now func() time.Time
 	// lastDiagAt is the wall-clock time the per-channel diagnostics were
@@ -207,6 +220,34 @@ type Engine struct {
 	// healthy but this channel low ⇒ carrier outside the captured passband or
 	// the wrong frequency) when a low-power WARN fires. Owned by the Run pump.
 	widebandPwr iqpower.Accumulator
+	// wbClipped / wbClipSamples count rail-pinned wideband input samples over
+	// the same window (issue #749). A strong site clipping the shared ADC is
+	// the front-end-overload failure mode the per-tap power gauge can't see —
+	// it raises the noise floor for every tap. Owned by the Run pump.
+	wbClipped     int
+	wbClipSamples int
+	// wbClipLogAt throttles the overload WARN. Owned by the Run pump.
+	wbClipLogAt time.Time
+}
+
+// iqClipThreshold is the normalized magnitude at or above which an I or Q
+// component counts as ADC rail-clipping; mirrors ccdecoder's value.
+const iqClipThreshold = 0.98
+
+// inputClipWarnRatio is the per-window clipped fraction above which the engine
+// warns that the shared front end is overloaded (issue #749). Mirrors
+// ccdecoder's iqClipWarnRatio.
+const inputClipWarnRatio = 0.002
+
+// foldInputClip counts rail-pinned samples in one wideband chunk.
+func (e *Engine) foldInputClip(chunk []complex64) {
+	for _, c := range chunk {
+		r, i := real(c), imag(c)
+		if r >= iqClipThreshold || r <= -iqClipThreshold || i >= iqClipThreshold || i <= -iqClipThreshold {
+			e.wbClipped++
+		}
+	}
+	e.wbClipSamples += len(chunk)
 }
 
 // channelProcessor is the per-channel dibit consumer. DMR Tier II's
@@ -312,6 +353,7 @@ func New(opts Options) (*Engine, error) {
 		bank:        bank,
 		strategyTag: tag,
 		metrics:     opts.Metrics,
+		serial:      opts.Serial,
 		now:         now,
 	}
 
@@ -594,6 +636,11 @@ func (e *Engine) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("widebandt2: StreamIQ: %w", err)
 	}
+	// Drop this dongle's whole-capture series on teardown so stale values
+	// don't linger in Prometheus after the engine stops (issue #749).
+	if e.metrics != nil {
+		defer e.metrics.ClearWidebandInput(e.serial)
+	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -603,6 +650,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				return nil
 			}
 			e.widebandPwr.Add(chunk)
+			e.foldInputClip(chunk)
 			e.bank.Process(chunk)
 			e.maybeLogDiagnostics(e.now())
 		}
@@ -642,6 +690,28 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 	wbDbFS, wbSamples := e.widebandPwr.MeanDbFSAndReset()
 	wbHealthy := wbSamples > 0 && wbDbFS >= iqpower.LowPowerThresholdDbFS
 
+	// Whole-capture clip ratio over the same window (issue #749). A non-zero
+	// value means a strong site is pinning the shared ADC rail — front-end
+	// overload, which raises the noise floor and buries the weaker taps. This
+	// is the "only one site decodes" failure mode the per-tap power gauge
+	// can't surface on its own.
+	var wbClip float64
+	if e.wbClipSamples > 0 {
+		wbClip = float64(e.wbClipped) / float64(e.wbClipSamples)
+	}
+	wbOverloaded := wbClip > inputClipWarnRatio
+	e.wbClipped, e.wbClipSamples = 0, 0
+	if e.metrics != nil && wbSamples > 0 {
+		e.metrics.RecordWidebandInputPowerDbFS(e.serial, wbDbFS)
+		e.metrics.RecordWidebandInputClipRatio(e.serial, wbClip)
+	}
+	if wbOverloaded && now.Sub(e.wbClipLogAt) >= lowPowerWarnInterval {
+		// The fix is less RF, not more: reduce gain or add attenuation.
+		e.log.Warn("widebandt2: wideband front end overloaded — IQ pinned to the ADC rail; a strong site is clipping the shared ADC and burying weaker taps. Reduce gain or add attenuation (do NOT raise gain). issue #749",
+			"serial", e.serial, "clip_ratio", wbClip, "wideband_input_dbfs", wbDbFS)
+		e.wbClipLogAt = now
+	}
+
 	debug := e.log.Enabled(context.Background(), slog.LevelDebug)
 	for _, ec := range e.channels {
 		if ec.pwr.Samples() == 0 {
@@ -654,7 +724,13 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 		if dbfs < iqpower.LowPowerThresholdDbFS {
 			if now.Sub(ec.pwLowLogAt) >= lowPowerWarnInterval {
 				hint := "check antenna, gain, USB cable"
-				if wbHealthy {
+				switch {
+				case wbOverloaded:
+					// All taps share this front end, so don't blame the cable:
+					// a stronger site is clipping the shared ADC and burying
+					// this one (issue #749). Reduce gain, don't raise it.
+					hint = "wideband front end is overloaded (clipping) — a stronger co-channel is burying this site; reduce gain or add attenuation, do NOT raise gain"
+				case wbHealthy:
 					hint = "wideband input is healthy — this carrier is likely outside the captured passband or tuned to the wrong frequency"
 				}
 				e.log.Warn("widebandt2: channel iq power very low — "+hint,

--- a/internal/scanner/widebandt2/engine_diag_test.go
+++ b/internal/scanner/widebandt2/engine_diag_test.go
@@ -67,13 +67,18 @@ func (h recordingHandler) Handle(_ context.Context, r slog.Record) error {
 func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
 func (h recordingHandler) WithGroup(string) slog.Handler      { return h }
 
-// recordingPower captures RecordIQPowerDbFS calls for the metrics test.
+// recordingPower captures RecordIQPowerDbFS calls for the metrics test, plus
+// the whole-capture power / clip gauges (issue #749).
 type recordingPower struct {
 	mu    sync.Mutex
 	calls []struct {
 		label string
 		dbfs  float64
 	}
+	inputDbFS    float64
+	inputClip    float64
+	gotInput     bool
+	inputCleared bool
 }
 
 func (r *recordingPower) RecordIQPowerDbFS(label string, dbfs float64) {
@@ -85,6 +90,21 @@ func (r *recordingPower) RecordIQPowerDbFS(label string, dbfs float64) {
 	r.mu.Unlock()
 }
 func (r *recordingPower) ClearIQPowerDbFS(string) {}
+func (r *recordingPower) RecordWidebandInputPowerDbFS(_ string, dbfs float64) {
+	r.mu.Lock()
+	r.inputDbFS, r.gotInput = dbfs, true
+	r.mu.Unlock()
+}
+func (r *recordingPower) RecordWidebandInputClipRatio(_ string, ratio float64) {
+	r.mu.Lock()
+	r.inputClip = ratio
+	r.mu.Unlock()
+}
+func (r *recordingPower) ClearWidebandInput(_ string) {
+	r.mu.Lock()
+	r.inputCleared = true
+	r.mu.Unlock()
+}
 
 // TestEngineDiagnosticsLowPowerWarns feeds a silent IQ stream and proves
 // the engine emits the throttled "iq power very low" WARN — the operator
@@ -278,5 +298,86 @@ func TestEngineDiagnosticsMetricsGauge(t *testing.T) {
 	// above the dead-stream floor.
 	if got.dbfs < -55 || got.dbfs > 0 {
 		t.Errorf("gauge dbfs = %v, want a finite value in (-55, 0)", got.dbfs)
+	}
+}
+
+// TestEngineDiagnosticsOverloadWarns feeds a rail-pinned IQ stream and proves
+// the engine flags shared-front-end overload (issue #749): the whole-capture
+// clip-ratio gauge fires, a throttled overload WARN is logged with reduce-gain
+// guidance (never "USB cable"), and the input gauges are cleared on teardown.
+func TestEngineDiagnosticsOverloadWarns(t *testing.T) {
+	const (
+		rateHz       = 48_000
+		centerHz     = 446_500_000
+		channelHz    = centerHz
+		chunkSamples = 4800
+		numChunks    = 8
+	)
+
+	// Every sample pinned to the rail (|component| = 0.99 >= iqClipThreshold).
+	clipped := make([][]complex64, numChunks)
+	for i := range clipped {
+		c := make([]complex64, chunkSamples)
+		for j := range c {
+			c[j] = complex(0.99, 0.99)
+		}
+		clipped[i] = c
+	}
+	dev := newMockDevice(clipped)
+
+	bus := events.NewBus(64)
+	defer bus.Close()
+
+	handler, recs, mu := newRecordingHandler()
+	obs := &recordingPower{}
+	clk := &steppingClock{t: time.Unix(0, 0), step: 600 * time.Millisecond}
+
+	e, err := New(Options{
+		Log:          slog.New(handler),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: rateHz,
+		CenterFreqHz: centerHz,
+		Now:          clk.now,
+		Metrics:      obs,
+		Serial:       "AIRSPY-1",
+		Channels:     []ChannelConfig{{FrequencyHz: channelHz, SystemName: "dmr-simplex"}},
+		Systems:      []trunking.System{t2System("dmr-simplex")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := e.Run(ctx); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	mu.Lock()
+	var sawOverload bool
+	for _, r := range *recs {
+		if r.level == slog.LevelWarn && strings.Contains(r.msg, "overloaded") {
+			sawOverload = true
+			if strings.Contains(r.msg, "USB cable") {
+				t.Error("overload WARN must not blame the USB cable on a shared front end")
+			}
+		}
+	}
+	mu.Unlock()
+	if !sawOverload {
+		t.Error("expected a wideband front-end overload WARN, got none")
+	}
+
+	obs.mu.Lock()
+	defer obs.mu.Unlock()
+	if !obs.gotInput {
+		t.Error("whole-capture input power gauge was never recorded")
+	}
+	if obs.inputClip <= inputClipWarnRatio {
+		t.Errorf("input clip ratio = %v, want > %v (every sample clipped)", obs.inputClip, inputClipWarnRatio)
+	}
+	if !obs.inputCleared {
+		t.Error("input gauges not cleared on engine teardown")
 	}
 }


### PR DESCRIPTION
Part of #749. Rebased onto latest `main`.

> The routing half of #749 (excluding wideband-hosted control channels from the sequential cc-hunt so multiple P25 sites decode in parallel) already merged via #750, and `main` has since added per-channel wideband decode diagnostics (#758-era work). This PR is rebased on top of both and now contains only the **net-new** piece they don't cover: shared-front-end **overload** detection.

## Why

After the parallel-decode fix, a follow-up field report showed only the strongest site (a hilltop) decoding off one wideband Airspy while the other three sat ~14 dB lower and never locked. I confirmed the **DDC is gain-flat across taps** — the prototype LPF is DC-normalised to unity (`internal/dsp/filter/fir.go`), all taps share `L/M/taps/beta`, and the NCO is a unit-magnitude rotation — so that deficit can't come from the channelizer. It's real RF: a weak/distant site, or (as here, with `gain: 600` = 60 dB) a strong co-channel **clipping the shared ADC** and raising the noise floor for every tap.

Main's per-channel low-power WARN couldn't name that second case (its hint assumes a misplaced/out-of-band carrier).

## What

- Count rail-pinned **wideband-input** samples per diagnostics window and publish `gophertrunk_sdr_wideband_input_iq_power_dbfs{serial}` + `gophertrunk_sdr_wideband_input_clip_ratio{serial}`.
- Throttled **overload WARN** when the clip ratio is sustained — "reduce gain or add attenuation, do NOT raise gain".
- Enrich the per-tap low-power hint to point at overload (not the USB cable) when the capture is clipping.
- Per-tap level keeps riding the existing `iq_power_dbfs` gauge (labelled `<system> @ <freq> MHz`) from main's diagnostics; input gauges are cleared on teardown.
- Docs: multi-site wideband pattern + gain/overload guidance in `config.example.yaml` and `docs/reference/airspy.md`.
- Tests: extended the diagnostics observer for the new gauges + an overload-warning test.

`go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NJjqjQqG8R2AHTkCz9Yei