### PR TITLE
docs: post-release v0.5.0 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.0] — 2026-06-22
+
+A feature release headlined by a **standalone P25 Phase 2 talker-alias
+signalling follower**: on Phase 2 systems the alias rides the traffic
+channel's FACCH-S MAC signalling during hangtime, so on a busy multi-site
+system — where most grants never get a voice tap and encrypted calls tear
+down before hangtime — it was almost never decoded. A new signalling-only
+follower allocates lightweight DDC taps on a `role: wideband` dongle and
+harvests the alias off the traffic channel independent of the voice pool, the
+way SDRTrunk does with two SDRs. Alongside it, a new **decode-activity-gated
+power log** gives the wideband engine an opt-in, per-channel IQ-power
+diagnostic that only records windows where a protocol is actually decoding —
+the "decoding but the signal is marginal" view — instead of spamming every
+idle or off-band channel.
+
 ### Added
 - **P25 Phase 2 talker-alias signalling follower** (`signalling_taps`, #376).
   On Phase 2 systems the talker alias rides the traffic channel's FACCH-S MAC

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.4.9
+VERSION=v0.5.0
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.4.9" -%}
+  {%- assign ver = "v0.5.0" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.0.md
+++ b/docs/announcements/v0.5.0.md
@@ -1,0 +1,55 @@
+# GopherTrunk v0.5.0 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.0 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.0
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.0 — a standalone P25 Phase 2 talker-alias follower harvests aliases off the traffic-channel FACCH-S signalling (no voice tap needed, the way SDRTrunk does with two SDRs), plus a decode-activity-gated power log, shared-front-end overload detection, and a P25 network-configuration / activity-summary report
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.0 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+This release is headlined by a standalone P25 Phase 2 talker-alias follower and a set of wideband-engine diagnostics.
+
+**What's new since v0.4.9:**
+
+* **P25 Phase 2 talker-alias signalling follower** (#376). On Phase 2 the alias rides the traffic channel's FACCH-S MAC signalling during hangtime, not the control channel — so on a busy multi-site system, where most grants never get a voice tap and encrypted calls tear down before hangtime, it was almost never decoded. A new signalling-only follower allocates lightweight DDC taps on a `role: wideband` dongle and harvests the alias off the traffic channel independent of the voice pool — the way SDRTrunk does with two SDRs. Enable it per wideband device with `signalling_taps: N` (2–4 suits a busy Phase 2 system); decoded aliases bind onto the RID automatically.
+* **Decode-activity-gated power log** (`log.power_log`). An opt-in, rotating per-channel IQ-power log for the wideband engine that only records windows where a protocol (DMR Tier II/III, P25 Phase 1/2) is actually decoding, so idle and off-band channels never appear. Defaults to logging only low-power weak-signal windows — the "decoding but marginal" diagnostic — with `all_windows: true` for a full power time-series.
+* **Shared-front-end overload detection** (#749). The wideband engine now flags shared-front-end (RTL-SDR / HackRF) overload on wideband captures, so a swamped tuner shows up as a diagnostic instead of silent decode loss.
+* **P25 network-configuration / activity-summary report** (#758) across the CLI, web, and API surfaces — a consolidated view of system identity, topology, and observed activity.
+* **Hunt diagnostics + reliability** (#757) — blank-identity hunts are diagnosed, a decode-phase SDR overrun is fixed, and low-power WARNs are clarified.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.0
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.0 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+Headlined by a standalone P25 Phase 2 talker-alias follower plus wideband-engine diagnostics.
+
+**What's new since v0.4.9:**
+- **P25 Phase 2 talker-alias follower** (#376) — harvests the alias off the traffic channel's FACCH-S signalling with no voice tap, the way SDRTrunk does with two SDRs. Enable per wideband device with `signalling_taps: N` (2–4 for a busy system); aliases bind onto the RID automatically.
+- **Decode-activity-gated power log** (`log.power_log`) — opt-in per-channel IQ-power log gated on actual decode activity, so idle/off-band channels never appear; defaults to weak-signal windows only.
+- **Shared-front-end overload detection** (#749) — wideband captures now flag a swamped RTL-SDR/HackRF front end instead of losing decodes silently.
+- **P25 network-config / activity-summary report** (#758) across CLI, web, and API.
+- **Hunt diagnostics** (#757) — blank identity diagnosed, decode-phase SDR overrun fixed, low-power WARN clarified.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.0>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
Promote the [Unreleased] entries (P25 Phase 2 talker-alias signalling
follower #376 and the decode-activity-gated power log) into a dated
[v0.5.0] — 2026-06-22 section with a release summary, bump the README
quick-start VERSION and the latest-version.html fallback tag to v0.5.0,
and add the v0.5.0 social-announcement drafts.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X5UdtnaXA5ntSPTcpuPYY2