### PR TITLE
p25: recover System ID from adjacent-site broadcasts (0x3C)

### DIFF
--- a/internal/hunt/decode.go
+++ b/internal/hunt/decode.go
@@ -158,14 +158,25 @@ func identityNote(res *siglab.Result) string {
 	if res == nil || !res.Locked || res.Topology == nil {
 		return ""
 	}
-	if res.Topology.WACN != 0 || res.Topology.SystemID != 0 {
-		return "" // identity resolved
+	if res.Topology.WACN != 0 && res.Topology.SystemID != 0 {
+		return "" // identity fully resolved
 	}
 	d, ok := res.Detail.(*siglab.P25P1Detail)
 	if !ok || d.CCStats == nil {
 		return "" // not the P25 deep path
 	}
 	cc := d.CCStats
+	if res.Topology.SystemID != 0 && res.Topology.WACN == 0 {
+		// System ID recovered (voted from adjacent-site broadcasts), but WACN
+		// is still blank: NET_STS_BCST (0x3B) is the only P25 message that
+		// carries it, and this system never transmitted it. Widening the dwell
+		// won't help if the system simply doesn't emit the NSB.
+		return fmt.Sprintf("System ID resolved from adjacent-site broadcasts, but WACN is "+
+			"unavailable: the Network Status Broadcast (NSB, 0x3B) that carries it was never "+
+			"decoded (saw NSB×%d, RFSS×%d, adjacent×%d, TSBK×%d) — if the system never emits "+
+			"the NSB, the WACN cannot be recovered",
+			cc.NetStatusSeen, cc.RFSSStatusSeen, cc.AdjacentSeen, cc.TSBKDecoded)
+	}
 	if cc.NetStatusSeen > 0 {
 		// NSB decoded but yielded no WACN — a parse problem, not a capture gap.
 		return fmt.Sprintf("identity unresolved despite %d Network Status Broadcast(s): "+

--- a/internal/hunt/identity_note_test.go
+++ b/internal/hunt/identity_note_test.go
@@ -53,6 +53,20 @@ func TestIdentityNote(t *testing.T) {
 			wantHas: "Network Status Broadcast",
 		},
 		{
+			name: "System ID resolved from adjacent, WACN still missing",
+			res: &siglab.Result{
+				Locked:   true,
+				Topology: &siglab.TopologySnapshot{SystemID: 0x2C1}, // WACN zero
+				Detail: &siglab.P25P1Detail{CCStats: &siglab.CCStatsBreakdown{
+					TSBKDecoded:    2134,
+					RFSSStatusSeen: 0,
+					AdjacentSeen:   147,
+					NetStatusSeen:  0,
+				}},
+			},
+			wantHas: "WACN is unavailable",
+		},
+		{
 			name: "NSB decoded but no WACN parsed",
 			res: &siglab.Result{
 				Locked:   true,

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1142,6 +1142,9 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 	case OpAdjacentSiteStatusBroadcast:
 		atomic.AddInt64(&c.stats.AdjacentSeen, 1)
 		c.netModel.ApplyAdjacentSite(ParseAdjacentSiteStatusBroadcast(t.Payload))
+		// On systems that never emit 0x3B/0x3A, the adjacent broadcast is
+		// the only System ID source — publish so it reaches the SiteTracker/API.
+		c.publishSiteUpdate()
 	case OpGroupAffiliationResponse:
 		c.publishAffiliation(ParseGroupAffiliationResponse(t.Payload), nac)
 	case OpUnitRegistrationResponse:
@@ -1476,7 +1479,11 @@ func (c *ControlChannel) publishVoiceGrant(g voiceGrant, nac uint16) {
 // channels. Skipped until the site has actually been identified.
 func (c *ControlChannel) publishSiteUpdate() {
 	net := c.netModel.Snapshot()
-	if net.RFSS == 0 && net.Site == 0 {
+	// Publish once any identity scalar is known. A system that never emits
+	// 0x3A/0x3B can still surface its System ID (voted from adjacent-site
+	// broadcasts) with RFSS/Site left zero — overlayLiveIdentity lifts
+	// SystemID independently of RFSS/Site.
+	if net.RFSS == 0 && net.Site == 0 && net.SystemID == 0 && net.WACN == 0 {
 		return
 	}
 	c.bus.Publish(events.Event{

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -170,10 +170,21 @@ func (m *NetworkModel) ApplySecondaryControlChannelExplicit(s SecondaryControlCh
 
 // ApplyAdjacentSite folds an Adjacent Site Status Broadcast (0x3C) in,
 // de-duplicating by (RFSS, Site) and keeping the latest channel info.
+//
+// The neighbour's System ID is also voted into the identity tally: every site
+// of a P25 system shares one System ID, so an adjacent site names our own.
+// This is the only System ID source on systems that emit 0x3C but never the
+// Network/RFSS status broadcasts (0x3B/0x3A) — without it WACN/SysID/RFSS/Site
+// all stay blank even on a healthy, locked control channel (matches OP25/
+// SDRtrunk, which corroborate System ID from adjacent broadcasts). RFSS/Site
+// are deliberately NOT voted: they describe the neighbour, not the camped site.
 func (m *NetworkModel) ApplyAdjacentSite(a AdjacentSiteStatusBroadcast) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.ensure()
+	if a.SystemID != 0 {
+		m.sysidVotes[a.SystemID]++
+	}
 	key := neighborKey{RFSS: a.RFSS, Site: a.Site}
 	m.neighborData[key] = NeighborSite{RFSS: a.RFSS, Site: a.Site, ChannelID: a.ChannelID, ChannelNumber: a.ChannelNumber}
 }

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -81,6 +81,32 @@ func TestNetworkModelAccumulates(t *testing.T) {
 	}
 }
 
+func TestNetworkModelAdjacentSystemID(t *testing.T) {
+	// A system that emits adjacent-site broadcasts (0x3C) but never the
+	// Network/RFSS status broadcasts (0x3B/0x3A) must still surface its System
+	// ID — every site of a P25 system shares one. RFSS/Site name the neighbour,
+	// not the camped site, so they (and WACN) stay zero. Regression for the
+	// "no WACN/System ID" field report on systems that suppress 0x3B/0x3A.
+	var m NetworkModel
+	for i := 0; i < 3; i++ {
+		m.ApplyAdjacentSite(AdjacentSiteStatusBroadcast{
+			SystemID: 0x2C1, RFSS: 1, Site: 8, ChannelID: 1, ChannelNumber: 300})
+	}
+	cfg := m.Snapshot()
+	if cfg.SystemID != 0x2C1 {
+		t.Errorf("SystemID = %#x, want 0x2C1 (voted from adjacent broadcast)", cfg.SystemID)
+	}
+	if cfg.WACN != 0 {
+		t.Errorf("WACN = %#x, want 0 (adjacent carries no WACN)", cfg.WACN)
+	}
+	if cfg.RFSS != 0 || cfg.Site != 0 {
+		t.Errorf("RFSS/Site = %d/%d, want 0/0 (adjacent names the neighbour, not the camped site)", cfg.RFSS, cfg.Site)
+	}
+	if len(cfg.Neighbors) != 1 {
+		t.Errorf("Neighbors = %v, want 1", cfg.Neighbors)
+	}
+}
+
 func TestNetworkModelPrimaryControlChannel(t *testing.T) {
 	var m NetworkModel
 	// The camped site advertises its primary CC (2-1620) in repeated RFSS/
@@ -353,6 +379,51 @@ func TestControlChannelPublishesSiteUpdate(t *testing.T) {
 			// Broadcast carry SystemID 0x123 for these payloads.
 			if u.WACN != 0xABCDE || u.SystemID != 0x123 {
 				t.Fatalf("site update network ids wrong: %+v", u)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no KindSiteUpdate published within deadline")
+		}
+	}
+}
+
+func TestControlChannelPublishesSiteUpdateFromAdjacentOnly(t *testing.T) {
+	// A system that never emits 0x3B/0x3A but does emit adjacent-site
+	// broadcasts (0x3C) must still publish a SiteUpdate carrying the System ID
+	// it shares with the named neighbour. WACN and the camped RFSS/Site stay
+	// zero — they have no source here. Mirrors the hunt_ver50 field report.
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	const ccHz = 450125000
+	cc := New(Options{Bus: bus, SystemName: "Main_Site_1", FrequencyHz: ccHz})
+
+	// Adjacent Site Status Broadcast: byte0 LRA, bytes1-2 System ID (0x2C1),
+	// byte3 RFSS, byte4 Site, bytes5-6 the neighbour's channel.
+	adj := TSBK{Opcode: OpAdjacentSiteStatusBroadcast, Payload: [8]byte{0x00, 0x02, 0xC1, 0x03, 0x09, 0x10, 0x2C}}
+	cc.Process(buildLockedStreamWithTSBK(10, 0x2C1, DUIDTrunkingSignaling, adj), 0)
+
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindSiteUpdate {
+				continue
+			}
+			u, ok := ev.Payload.(trunking.SiteUpdate)
+			if !ok {
+				t.Fatalf("KindSiteUpdate payload is %T, want trunking.SiteUpdate", ev.Payload)
+			}
+			if u.SystemID != 0x2C1 {
+				t.Fatalf("site update SystemID = %#x, want 0x2C1", u.SystemID)
+			}
+			if u.WACN != 0 {
+				t.Fatalf("site update WACN = %#x, want 0 (no NSB)", u.WACN)
+			}
+			if u.RFSSID != 0 || u.SiteID != 0 {
+				t.Fatalf("site update RFSS/Site = %d/%d, want 0/0 (camped site unknown)", u.RFSSID, u.SiteID)
 			}
 			return
 		case <-deadline:


### PR DESCRIPTION
Systems that never transmit Network/RFSS Status Broadcasts (0x3B/0x3A) left
the web "Network identity" panel stuck on "Awaiting status broadcasts" for
WACN/System ID/RFSS/Site even on a healthy, locked control channel — the
identity was sourced only from those two opcodes. Such a system (Main_Site_1,
NAC 705 in the hunt_ver50 field report) still emits Adjacent Site Status
Broadcasts (0x3C) ~147x, which carry the System ID every site of a P25 system
shares.

- network.go: ApplyAdjacentSite now votes the neighbour's System ID into the
  identity tally (RFSS/Site/WACN are NOT voted — they describe the neighbour,
  not the camped site). Majority vote keeps it robust against a corrupt frame.
- control.go: the 0x3C dispatch case publishes a SiteUpdate, and
  publishSiteUpdate's gate now fires once any identity scalar is known, so a
  System-ID-only system reaches the SiteTracker/API/web (overlayLiveIdentity
  already lifts SystemID independently of RFSS/Site).
- hunt/decode.go: identityNote now explains, when System ID resolved but WACN
  did not, that WACN is unavailable because the NSB (0x3B) was never decoded —
  the system simply doesn't transmit the only message that carries it.

WACN and the camped RFSS/Site remain blank for this system: no decoder can
recover them when 0x3B/0x3A are never sent.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FfLMKJMFynEUPGCDB7RsL6