### PR TITLE
feat(sdr): add ka9q-radio as a channelized network SDR source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **ka9q-radio network SDR source** (`sdr.ka9q_radio`, #765). Consume a channel
+  from a remote ka9q-radio `radiod` instance over IP multicast, in pure Go.
+  radiod runs fast-convolution downconverters on a front end and multicasts each
+  channel as RTP; a channel in raw "linear" IQ mode (output_channels = 2) is
+  mounted as a virtual tuner, so one well-sited radiod can feed many GopherTrunk
+  decoders across a LAN. The driver discovers the channel's IQ multicast group,
+  sample rate and encoding by polling radiod's status group, resolves `.local`
+  instance names via mDNS, retunes via RADIO_FREQUENCY commands, and decodes
+  s16/f32 (either byte order) IQ payloads. Configure under `sdr.ka9q_radio`
+  with the status group `addr` and channel `ssrc`; see `config.example.yaml`.
+
 ## [v0.5.0] — 2026-06-22
 
 A feature release headlined by a **standalone P25 Phase 2 talker-alias

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -49,6 +49,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/iqtap"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/ka9qradio"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtltcp"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/soapyremote"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/wbvoice"
@@ -929,6 +930,41 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			if len(sspecs) > 0 {
 				sdr.Register(soapyremote.New(sspecs, log))
 				log.Info("soapy_remote endpoints mounted", "count", len(sspecs))
+			}
+		}
+		// Mount ka9q-radio channels as virtual tuners. Same lazy pattern as
+		// rtl_tcp / soapy_remote: the driver resolves the status group (mDNS)
+		// and polls for the channel inside Pool.Open, so a down/misconfigured
+		// radiod surfaces as a warning rather than blocking startup. radiod
+		// owns the front-end gain/ppm, so only role is carried in the Hint.
+		if len(cfg.SDR.Ka9qRadio) > 0 {
+			kspecs := make([]ka9qradio.Spec, 0, len(cfg.SDR.Ka9qRadio))
+			for _, k := range cfg.SDR.Ka9qRadio {
+				if k.Addr == "" || k.SSRC == 0 {
+					log.Warn("daemon: ka9q_radio entry missing addr/ssrc; skipping")
+					continue
+				}
+				kspecs = append(kspecs, ka9qradio.Spec{
+					Addr:           k.Addr,
+					SSRC:           k.SSRC,
+					Serial:         k.Serial,
+					Role:           k.Role,
+					DataAddr:       k.Data,
+					SampleRate:     k.SampleRate,
+					Encoding:       k.Encoding,
+					Channels:       k.Channels,
+					ConnectTimeout: time.Duration(k.ConnectTimeoutMs) * time.Millisecond,
+				})
+				if k.Serial != "" {
+					hints = append(hints, sdr.Hint{
+						Serial: k.Serial,
+						Role:   sdr.ParseRole(k.Role),
+					})
+				}
+			}
+			if len(kspecs) > 0 {
+				sdr.Register(ka9qradio.New(kspecs, log))
+				log.Info("ka9q_radio channels mounted", "count", len(kspecs))
 			}
 		}
 		if err := d.pool.OpenWith(sdr.PoolOpenOptions{

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -469,6 +469,32 @@ sdr:
   #     bias_tee: false             # best-effort (driver-dependent)
   #     connect_timeout_ms: 3000
 
+  # ka9q-radio channels. radiod (https://github.com/ka9q/ka9q-radio)
+  # runs fast-convolution downconverters on a front end (RX888, Airspy,
+  # RTL-SDR, …) and multicasts each channel as RTP/IP. A channel in raw
+  # "linear" IQ mode (output_channels = 2) streams interleaved complex
+  # samples GopherTrunk can demodulate directly, so one well-sited radiod
+  # can feed many decoders across a LAN. Each entry mounts one channel,
+  # addressed by its RTP SSRC. The driver polls radiod's status multicast
+  # group (port 5006) to discover the channel's IQ multicast group,
+  # sample rate and encoding, and resolves `.local` instance names via
+  # mDNS. Pre-configure the channel in radiod@.conf; this consumes (and
+  # retunes) an existing channel. Plaintext multicast — trusted LANs only.
+  #
+  # ka9q_radio:
+  #   - addr: "hf.local"            # status+command group: mDNS name or
+  #                                 #  literal "239.x.x.x:5006" (default :5006)
+  #     ssrc: 162550                # channel's RTP SSRC (required, non-zero)
+  #     serial: "ka9q-wx"           # generator fills this from addr+ssrc if blank
+  #     role: control               # control | voice | auto
+  #     # The fields below are optional overrides that skip the status poll.
+  #     # Leave them blank to auto-discover everything from radiod.
+  #     data: ""                    # pin IQ group "239.x.x.x:5004" (default :5004)
+  #     sample_rate: 0              # pin channel IQ rate in Hz
+  #     encoding: ""                # pin wire encoding: s16be|s16le|f32le|f32be
+  #     channels: 0                 # pin output channels (2 for raw IQ)
+  #     connect_timeout_ms: 3000
+
 # Paging decoders. The pocsag / flex lists each dedicate one SDR to a
 # single paging frequency: the SDR is tuned directly to FrequencyHz
 # (full sample-rate IQ, no DDC). The wideband list groups several

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -712,6 +712,16 @@ type SDRConfig struct {
 	// pool device. Plaintext like rtl_tcp — use on trusted networks
 	// only or through an SSH/wireguard tunnel.
 	SoapyRemote []SoapyRemoteConfig `yaml:"soapy_remote"`
+	// Ka9qRadio lists channels from remote ka9q-radio `radiod` instances to
+	// mount as virtual tuners. radiod runs fast-convolution downconverters on
+	// a front end and multicasts each channel as RTP over IP; a channel in raw
+	// "linear" IQ mode (output_channels=2) streams interleaved complex samples
+	// GopherTrunk can demodulate directly. Each entry becomes one pool device
+	// addressed by the channel's RTP SSRC. The driver discovers the channel's
+	// IQ multicast group / sample rate / encoding by polling radiod's status
+	// group, and resolves `.local` instance names via mDNS. Plaintext
+	// multicast like rtl_tcp / soapy_remote — use on trusted LANs (issue #765).
+	Ka9qRadio []Ka9qRadioConfig `yaml:"ka9q_radio"`
 	// WatchdogIntervalMs governs the periodic USB-disconnect
 	// watchdog that the SDR pool runs while the daemon is up. It
 	// polls the registered drivers, surfaces serials that vanish
@@ -872,6 +882,41 @@ func (s SoapyRemoteConfig) DeviceArgs() (map[string]string, error) {
 		return nil, nil
 	}
 	return args, nil
+}
+
+// Ka9qRadioConfig describes one ka9q-radio `radiod` channel to expose as a
+// virtual tuner. Addr (the status multicast group) and SSRC are required;
+// Serial / Role follow the same semantics as the local SDR devices block. The
+// optional Data / SampleRate / Encoding / Channels fields pin the channel
+// parameters and skip the status-group poll that otherwise discovers them.
+type Ka9qRadioConfig struct {
+	// Addr is the status+command multicast group: an mDNS name like
+	// "hf.local" / "hf.local:5006", or a literal "239.1.2.3:5006". A missing
+	// port defaults to 5006. Required.
+	Addr string `yaml:"addr"`
+	// SSRC selects the channel within the radiod instance (the channel's RTP
+	// SSRC, e.g. 162550 for 162.550 MHz). Required, non-zero.
+	SSRC uint32 `yaml:"ssrc"`
+	// Serial is the virtual device serial reported on the pool's
+	// /api/v1/devices snapshot. Empty generates one from Addr+SSRC.
+	Serial string `yaml:"serial"`
+	// Role hints the pool's role assignment: control|voice|auto.
+	Role string `yaml:"role"`
+	// Data optionally pins the IQ multicast group ("239.4.5.6:5004"),
+	// skipping discovery of the data socket from the status poll. A missing
+	// port defaults to 5004.
+	Data string `yaml:"data"`
+	// SampleRate optionally pins the channel's IQ rate (Hz), skipping
+	// OUTPUT_SAMPRATE discovery.
+	SampleRate uint32 `yaml:"sample_rate"`
+	// Encoding optionally pins the wire sample encoding: s16be|s16le|f32le|
+	// f32be (raw IQ encodings), skipping OUTPUT_ENCODING discovery.
+	Encoding string `yaml:"encoding"`
+	// Channels optionally pins the output channel count (2 for raw IQ).
+	Channels int `yaml:"channels"`
+	// ConnectTimeoutMs caps mDNS resolution and the status poll in
+	// milliseconds. Zero picks the driver default (3000).
+	ConnectTimeoutMs int `yaml:"connect_timeout_ms"`
 }
 
 type DeviceConfig struct {
@@ -1806,7 +1851,48 @@ func (c Config) validateSDR() []error {
 		}
 		seenSerials[s.Serial] = i
 	}
+	// Validate ka9q-radio channels. Addr + SSRC are required; role, encoding
+	// and serial collisions follow the same rules as the blocks above.
+	for i, k := range c.SDR.Ka9qRadio {
+		if err := validateKa9qFields(i, k); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		if k.Serial == "" {
+			continue
+		}
+		if prev, dup := seenSerials[k.Serial]; dup {
+			errs = append(errs, fmt.Errorf(
+				"sdr.ka9q_radio[%d]: serial %q collides with sdr.devices[%d]",
+				i, k.Serial, prev))
+			continue
+		}
+		seenSerials[k.Serial] = i
+	}
 	return errs
+}
+
+func validateKa9qFields(i int, k Ka9qRadioConfig) error {
+	if k.Addr == "" {
+		return fmt.Errorf("sdr.ka9q_radio[%d]: addr is required (mDNS name or host:port)", i)
+	}
+	if k.SSRC == 0 {
+		return fmt.Errorf("sdr.ka9q_radio[%d]: ssrc is required (non-zero)", i)
+	}
+	switch k.Role {
+	case "", "control", "voice", "auto":
+	default:
+		return fmt.Errorf("sdr.ka9q_radio[%d]: role must be control|voice|auto", i)
+	}
+	switch k.Encoding {
+	case "", "s16be", "s16le", "f32le", "f32be":
+	default:
+		return fmt.Errorf("sdr.ka9q_radio[%d]: encoding must be s16be|s16le|f32le|f32be", i)
+	}
+	if k.Channels != 0 && k.Channels != 1 && k.Channels != 2 {
+		return fmt.Errorf("sdr.ka9q_radio[%d]: channels must be 1 or 2", i)
+	}
+	return nil
 }
 
 func validateRTLTCPFields(i int, r RTLTCPConfig) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -336,6 +336,15 @@ func TestValidate(t *testing.T) {
 		{"soapy stream_window too small", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamWindow: 1024}}}}, true},
 		{"soapy stream_window too large", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamWindow: 512 << 20}}}}, true},
 		{"soapy stream_window below mtu", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 1 << 20, StreamWindow: 1 << 16}}}}, true},
+		// ka9q_radio: addr + ssrc required; role/encoding/channels constrained.
+		{"ka9q ok", Config{SDR: SDRConfig{Ka9qRadio: []Ka9qRadioConfig{{Addr: "hf.local", SSRC: 162550}}}}, false},
+		{"ka9q ok full", Config{SDR: SDRConfig{Ka9qRadio: []Ka9qRadioConfig{{Addr: "239.1.2.3:5006", SSRC: 1, Role: "control", Encoding: "f32le", Channels: 2}}}}, false},
+		{"ka9q missing addr", Config{SDR: SDRConfig{Ka9qRadio: []Ka9qRadioConfig{{SSRC: 1}}}}, true},
+		{"ka9q missing ssrc", Config{SDR: SDRConfig{Ka9qRadio: []Ka9qRadioConfig{{Addr: "hf.local"}}}}, true},
+		{"ka9q bad role", Config{SDR: SDRConfig{Ka9qRadio: []Ka9qRadioConfig{{Addr: "hf.local", SSRC: 1, Role: "nope"}}}}, true},
+		{"ka9q bad encoding", Config{SDR: SDRConfig{Ka9qRadio: []Ka9qRadioConfig{{Addr: "hf.local", SSRC: 1, Encoding: "opus"}}}}, true},
+		{"ka9q bad channels", Config{SDR: SDRConfig{Ka9qRadio: []Ka9qRadioConfig{{Addr: "hf.local", SSRC: 1, Channels: 3}}}}, true},
+		{"ka9q serial collides", Config{SDR: SDRConfig{Devices: []DeviceConfig{{Serial: "x"}}, Ka9qRadio: []Ka9qRadioConfig{{Addr: "hf.local", SSRC: 1, Serial: "x"}}}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -91,6 +91,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SDRConfig.Devices":            {Help: "Locally-attached USB SDR dongles, selected by serial."},
 	"SDRConfig.RTLTCP":             {Label: "rtl_tcp sources", Help: "Remote rtl_tcp endpoints mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
 	"SDRConfig.SoapyRemote":        {Label: "SoapyRemote sources", Help: "Remote SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, RTL) mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
+	"SDRConfig.Ka9qRadio":          {Label: "ka9q-radio sources", Help: "Channels from remote ka9q-radio radiod instances mounted as virtual tuners over IP multicast. Plaintext — trusted LANs only."},
 	"SDRConfig.WatchdogIntervalMs": {Help: "USB-disconnect watchdog poll interval (ms). 0 = default 30 s; negative disables it."},
 	"SDRConfig.Autotune":           {Label: "Autotune", Help: "Track each dongle's carrier-frequency error on locked P25 Phase 1 control + voice and apply a digital correction so the demod's AFC starts near lock. Never rewrites hardware ppm — logs a suggested value. Off by default; safe to leave on."},
 
@@ -137,6 +138,16 @@ var fieldMetas = map[string]FieldMeta{
 	"SoapyRemoteConfig.Gain":             {Help: "Tuner gain: 'auto'/empty for AGC, else tenths of a dB."},
 	"SoapyRemoteConfig.BiasTee":          {Label: "Bias-tee", Help: "Toggle the remote device's bias-tee (best-effort)."},
 	"SoapyRemoteConfig.ConnectTimeoutMs": {Help: "TCP dial timeout in ms. 0 = driver default (3000)."},
+
+	"Ka9qRadioConfig.Addr":             {Label: "Address", Help: "ka9q-radio status+command multicast group: an mDNS name like hf.local (or hf.local:5006), or a literal 239.x.x.x:5006. Missing port defaults to 5006. Required."},
+	"Ka9qRadioConfig.SSRC":             {Label: "SSRC", Help: "Channel's RTP SSRC within the radiod instance (e.g. 162550). Required, non-zero."},
+	"Ka9qRadioConfig.Serial":           {Help: "Virtual device serial reported by the pool. Empty derives one from the address + SSRC."},
+	"Ka9qRadioConfig.Role":             {Help: "Pool role hint: control / voice / auto.", Options: roleOpts()},
+	"Ka9qRadioConfig.Data":             {Label: "Data group", Help: "Optional: pin the IQ multicast group (239.x.x.x:5004), skipping status-poll discovery. Missing port defaults to 5004."},
+	"Ka9qRadioConfig.SampleRate":       {Label: "Sample rate", Hz: true, Help: "Optional: pin the channel IQ rate in Hz, skipping OUTPUT_SAMPRATE discovery."},
+	"Ka9qRadioConfig.Encoding":         {Help: "Optional: pin the wire sample encoding, skipping OUTPUT_ENCODING discovery.", Options: opts("", "(auto-discover)", "s16be", "s16be", "s16le", "s16le", "f32le", "f32le", "f32be", "f32be")},
+	"Ka9qRadioConfig.Channels":         {Help: "Optional: pin the output channel count (2 for raw IQ)."},
+	"Ka9qRadioConfig.ConnectTimeoutMs": {Help: "mDNS resolution / status-poll timeout in ms. 0 = driver default (3000)."},
 
 	// ---- Trunking ----------------------------------------------------------
 	"TrunkingConfig.Systems":           {Help: "Trunked radio networks to follow. Add by hand, by RadioReference browse, or by PDF/CSV import."},

--- a/internal/sdr/ka9qradio/driver.go
+++ b/internal/sdr/ka9qradio/driver.go
@@ -1,0 +1,516 @@
+package ka9qradio
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand"
+	"net"
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+
+	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// DriverName is the sdr.Driver name registered with the pool.
+const DriverName = "ka9qradio"
+
+// DefaultConnectTimeout caps mDNS resolution and the status poll. radiod
+// usually lives on the same LAN; a fast failure beats a hang on a misconfigured
+// address.
+const DefaultConnectTimeout = 3 * time.Second
+
+var errClosed = errors.New("ka9qradio: device closed")
+
+// Spec names one radiod channel to expose as a virtual tuner.
+type Spec struct {
+	// Addr is the status+command multicast group: an mDNS name like
+	// "hf.local" / "hf.local:5006", or a literal "239.1.2.3:5006". A missing
+	// port defaults to 5006. Required.
+	Addr string
+	// SSRC selects the channel within the radiod instance. Required.
+	SSRC uint32
+	// Serial is the virtual device serial the pool reports. Empty generates
+	// one from Addr+SSRC so multi-channel configs stay unique.
+	Serial string
+	// Role hints the pool's role assignment: "control" | "voice" | "auto".
+	Role string
+	// DataAddr optionally pins the IQ multicast group ("239.4.5.6:5004"),
+	// skipping discovery of OUTPUT_DATA_DEST_SOCKET from the status poll. A
+	// missing port defaults to 5004.
+	DataAddr string
+	// SampleRate optionally pins the channel's IQ rate (Hz), skipping
+	// OUTPUT_SAMPRATE discovery. Required if Encoding is also pinned and no
+	// poll is wanted.
+	SampleRate uint32
+	// Encoding optionally pins the wire sample encoding ("s16be"|"s16le"|
+	// "f32le"|"f32be"), skipping OUTPUT_ENCODING discovery.
+	Encoding string
+	// Channels optionally pins the output channel count (2 for raw IQ).
+	Channels int
+	// ConnectTimeout overrides DefaultConnectTimeout when non-zero.
+	ConnectTimeout time.Duration
+}
+
+// Driver implements sdr.Driver over a set of radiod channels.
+type Driver struct {
+	specs []Spec
+	log   *slog.Logger
+}
+
+// New builds a Driver over the given channels.
+func New(specs []Spec, log *slog.Logger) *Driver {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Driver{specs: specs, log: log}
+}
+
+// Name implements sdr.Driver.
+func (d *Driver) Name() string { return DriverName }
+
+// Enumerate returns one Info per configured channel without probing — a radiod
+// that's momentarily down stays in the pool and surfaces its error at Open,
+// matching the rtltcp / soapyremote drivers.
+func (d *Driver) Enumerate() ([]sdr.Info, error) {
+	out := make([]sdr.Info, 0, len(d.specs))
+	for i, spec := range d.specs {
+		if spec.Addr == "" {
+			continue
+		}
+		out = append(out, sdr.Info{
+			Driver:    DriverName,
+			Index:     i,
+			Serial:    serialFor(spec, i),
+			Product:   "ka9q-radio",
+			TunerName: "ka9q-radio",
+		})
+	}
+	return out, nil
+}
+
+// Open resolves the status group (mDNS for .local names), learns the channel's
+// data socket / sample rate / encoding via a status poll (unless pinned in the
+// Spec), joins the IQ multicast group, and returns a streaming Device.
+func (d *Driver) Open(idx int) (sdr.Device, error) {
+	if idx < 0 || idx >= len(d.specs) {
+		return nil, fmt.Errorf("ka9qradio: index %d out of range", idx)
+	}
+	spec := d.specs[idx]
+	if spec.Addr == "" {
+		return nil, errors.New("ka9qradio: spec missing Addr")
+	}
+	if spec.SSRC == 0 {
+		return nil, errors.New("ka9qradio: spec missing SSRC")
+	}
+	timeout := spec.ConnectTimeout
+	if timeout <= 0 {
+		timeout = DefaultConnectTimeout
+	}
+
+	statusGroup, err := resolveAddr(spec.Addr, defaultStatusPort, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine the channel parameters: prefer the pinned Spec overrides, else
+	// poll the status group for them.
+	dataAddr, hasData, err := pinnedDataAddr(spec)
+	if err != nil {
+		return nil, err
+	}
+	enc, encPinned, err := pinnedEncoding(spec)
+	if err != nil {
+		return nil, err
+	}
+	sampleRate := spec.SampleRate
+	channels := spec.Channels
+
+	if !hasData || !encPinned || sampleRate == 0 {
+		st, err := pollStatus(statusGroup, spec.SSRC, timeout)
+		if err != nil {
+			return nil, fmt.Errorf("ka9qradio: status poll %s ssrc %d: %w", spec.Addr, spec.SSRC, err)
+		}
+		if !hasData {
+			if !st.hasDataDest {
+				return nil, fmt.Errorf("ka9qradio: status for ssrc %d carried no data socket", spec.SSRC)
+			}
+			dataAddr, hasData = st.dataDest, true
+		}
+		if !encPinned {
+			enc = st.encoding
+		}
+		if sampleRate == 0 {
+			sampleRate = st.sampleRate
+		}
+		if channels == 0 {
+			channels = st.channels
+		}
+	}
+
+	if !isIQEncoding(enc) {
+		return nil, fmt.Errorf("ka9qradio: channel encoding %s is not raw IQ (configure a linear/IQ channel)", enc)
+	}
+	if sampleRate == 0 {
+		return nil, errors.New("ka9qradio: could not determine sample rate")
+	}
+	if channels != 0 && channels != 2 {
+		d.log.Warn("ka9qradio: channel is not 2-channel IQ; treating payload as interleaved I,Q anyway",
+			"ssrc", spec.SSRC, "channels", channels)
+	}
+
+	dataConn, err := joinMulticast(dataAddr)
+	if err != nil {
+		return nil, fmt.Errorf("ka9qradio: join data group %s: %w", dataAddr, err)
+	}
+	// A connected UDP socket for sending retune commands to the status group.
+	cmdConn, err := net.DialUDP(udpNetwork(statusGroup), nil, udpAddr(statusGroup))
+	if err != nil {
+		dataConn.Close()
+		return nil, fmt.Errorf("ka9qradio: command socket: %w", err)
+	}
+
+	info := sdr.Info{
+		Driver:    DriverName,
+		Index:     idx,
+		Serial:    serialFor(spec, idx),
+		Product:   "ka9q-radio",
+		TunerName: "ka9q-radio",
+	}
+	d.log.Info("ka9qradio: connected",
+		"status", statusGroup.String(),
+		"data", dataAddr.String(),
+		"ssrc", spec.SSRC,
+		"samprate", sampleRate,
+		"encoding", enc.String())
+
+	return &device{
+		info:       info,
+		addr:       spec.Addr,
+		ssrc:       spec.SSRC,
+		sampleRate: sampleRate,
+		enc:        enc,
+		dataConn:   dataConn,
+		cmdConn:    cmdConn,
+		log:        d.log,
+	}, nil
+}
+
+// device implements sdr.Device on top of a joined IQ multicast group plus a
+// command socket aimed at the status group.
+type device struct {
+	info       sdr.Info
+	addr       string
+	ssrc       uint32
+	sampleRate uint32
+	enc        encoding
+	log        *slog.Logger
+
+	mu       sync.Mutex
+	dataConn *net.UDPConn
+	cmdConn  *net.UDPConn
+	closed   bool
+}
+
+func (d *device) Info() sdr.Info { return d.info }
+
+// ActualSampleRate reports the rate radiod actually streams (learned from the
+// status poll or pinned in config). The daemon's effectiveStreamRate probes
+// this so every per-channel DDC and symbol clock is built from the delivered
+// rate, not the pool's requested rate (issue #402).
+func (d *device) ActualSampleRate() (uint32, error) { return d.sampleRate, nil }
+
+// SetSampleRate is a no-op: the channel's rate is fixed by radiod's
+// configuration. The pool calls this at open and must not fail, and the real
+// rate is reported via ActualSampleRate.
+func (d *device) SetSampleRate(uint32) error { return nil }
+
+// SetGain / SetPPM / SetBiasTee are front-end concerns owned by radiod, not the
+// downstream consumer, so they no-op (matching soapy_remote's best-effort
+// stance on knobs the backend doesn't expose).
+func (d *device) SetGain(int) error     { return nil }
+func (d *device) SetPPM(int) error      { return nil }
+func (d *device) SetBiasTee(bool) error { return nil }
+
+// SetCenterFreq retunes the radiod channel by sending a RADIO_FREQUENCY command
+// to the status group. radiod ignores it if the channel is locked.
+func (d *device) SetCenterFreq(hz uint32) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed || d.cmdConn == nil {
+		return errClosed
+	}
+	pkt := buildSetFreq(d.ssrc, rand.Uint32(), float64(hz))
+	_ = d.cmdConn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	if _, err := d.cmdConn.Write(pkt); err != nil {
+		return fmt.Errorf("ka9qradio: send retune: %w", err)
+	}
+	_ = d.cmdConn.SetWriteDeadline(time.Time{})
+	return nil
+}
+
+func (d *device) Close() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	var err error
+	if d.dataConn != nil {
+		err = d.dataConn.Close()
+	}
+	if d.cmdConn != nil {
+		_ = d.cmdConn.Close()
+	}
+	return err
+}
+
+// StreamIQ reads RTP datagrams off the IQ multicast group, decodes each
+// payload to complex64, and emits one chunk per packet. The channel closes when
+// the context cancels or the socket closes.
+func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	d.mu.Lock()
+	if d.closed || d.dataConn == nil {
+		d.mu.Unlock()
+		return nil, errClosed
+	}
+	conn := d.dataConn
+	enc := d.enc
+	ssrc := d.ssrc
+	d.mu.Unlock()
+
+	out := make(chan []complex64, 16)
+	go func() {
+		defer close(out)
+		// Guard the reader so a decode panic surfaces as a logged stream
+		// close (→ ccdecoder retry) instead of crashing the daemon (issue #492).
+		defer gtlog.Recover(d.log, "ka9qradio-stream", nil)
+		buf := make([]byte, 65536)
+		var rtpState struct {
+			have bool
+			seq  uint16
+		}
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
+			n, _, err := conn.ReadFromUDP(buf)
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) {
+					return
+				}
+				if ne, ok := err.(net.Error); ok && ne.Timeout() {
+					// No data in the window; loop to re-check ctx.
+					continue
+				}
+				d.log.Debug("ka9qradio: stream read", "addr", d.addr, "err", err)
+				return
+			}
+			hdr, off, err := parseRTP(buf[:n])
+			if err != nil {
+				d.log.Debug("ka9qradio: bad RTP packet", "err", err)
+				continue
+			}
+			// radiod sends one SSRC per data group, but guard against a
+			// crossed/misconfigured group by dropping foreign SSRCs.
+			if hdr.ssrc != ssrc {
+				continue
+			}
+			if rtpState.have {
+				if gap := int16(hdr.seq - rtpState.seq - 1); gap != 0 {
+					d.log.Debug("ka9qradio: RTP sequence gap", "expected", rtpState.seq+1, "got", hdr.seq)
+				}
+			}
+			rtpState.have = true
+			rtpState.seq = hdr.seq
+
+			samples, err := decodeIQ(buf[off:n], enc)
+			if err != nil {
+				d.log.Debug("ka9qradio: decode", "err", err)
+				continue
+			}
+			if len(samples) == 0 {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case out <- samples:
+			}
+		}
+	}()
+	return out, nil
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func serialFor(spec Spec, idx int) string {
+	if spec.Serial != "" {
+		return spec.Serial
+	}
+	return fmt.Sprintf("ka9q-%s-%d", sanitizeAddr(spec.Addr), spec.SSRC)
+}
+
+func sanitizeAddr(addr string) string {
+	out := make([]byte, 0, len(addr))
+	for i := 0; i < len(addr); i++ {
+		c := addr[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9', c == '-', c == '_':
+			out = append(out, c)
+		default:
+			out = append(out, '_')
+		}
+	}
+	return string(out)
+}
+
+// resolveAddr turns a Spec address (mDNS name or literal, with optional port)
+// into a netip.AddrPort, applying defaultPort when none is given.
+func resolveAddr(addr string, defaultPort uint16, timeout time.Duration) (netip.AddrPort, error) {
+	host, port, err := splitHostPort(addr, defaultPort)
+	if err != nil {
+		return netip.AddrPort{}, err
+	}
+	if ip, perr := netip.ParseAddr(host); perr == nil {
+		return netip.AddrPortFrom(ip, port), nil
+	}
+	if strings.HasSuffix(strings.ToLower(host), ".local") {
+		ip, merr := resolveMDNS(host, timeout)
+		if merr != nil {
+			return netip.AddrPort{}, merr
+		}
+		return netip.AddrPortFrom(ip, port), nil
+	}
+	// Fall back to the system resolver for non-.local hostnames.
+	ips, lerr := net.LookupHost(host)
+	if lerr != nil || len(ips) == 0 {
+		return netip.AddrPort{}, fmt.Errorf("ka9qradio: resolve %q: %w", host, lerr)
+	}
+	ip, perr := netip.ParseAddr(ips[0])
+	if perr != nil {
+		return netip.AddrPort{}, fmt.Errorf("ka9qradio: resolve %q: %w", host, perr)
+	}
+	return netip.AddrPortFrom(ip, port), nil
+}
+
+// splitHostPort splits "host", "host:port", or "[v6]:port" into a host and
+// port, defaulting the port when absent.
+func splitHostPort(addr string, defaultPort uint16) (string, uint16, error) {
+	if !strings.Contains(addr, ":") || (strings.Count(addr, ":") > 1 && !strings.Contains(addr, "]")) {
+		// Bare host (incl. bare IPv6 with no brackets/port).
+		return addr, defaultPort, nil
+	}
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, fmt.Errorf("ka9qradio: bad addr %q: %w", addr, err)
+	}
+	p, err := net.LookupPort("udp", portStr)
+	if err != nil {
+		return "", 0, fmt.Errorf("ka9qradio: bad port in %q: %w", addr, err)
+	}
+	return host, uint16(p), nil
+}
+
+func pinnedDataAddr(spec Spec) (netip.AddrPort, bool, error) {
+	if spec.DataAddr == "" {
+		return netip.AddrPort{}, false, nil
+	}
+	ap, err := resolveAddr(spec.DataAddr, defaultDataPort, spec.ConnectTimeout)
+	if err != nil {
+		return netip.AddrPort{}, false, err
+	}
+	return ap, true, nil
+}
+
+func pinnedEncoding(spec Spec) (encoding, bool, error) {
+	if spec.Encoding == "" {
+		return encNone, false, nil
+	}
+	enc, ok := parseEncoding(spec.Encoding)
+	if !ok {
+		return encNone, false, fmt.Errorf("ka9qradio: unknown encoding %q", spec.Encoding)
+	}
+	return enc, true, nil
+}
+
+func udpNetwork(ap netip.AddrPort) string {
+	if ap.Addr().Is4() || ap.Addr().Is4In6() {
+		return "udp4"
+	}
+	return "udp6"
+}
+
+func udpAddr(ap netip.AddrPort) *net.UDPAddr {
+	return &net.UDPAddr{IP: ap.Addr().AsSlice(), Port: int(ap.Port())}
+}
+
+// joinMulticast opens a UDP socket bound to the group's port and joins the
+// multicast group on the default interface.
+func joinMulticast(ap netip.AddrPort) (*net.UDPConn, error) {
+	conn, err := net.ListenMulticastUDP(udpNetwork(ap), nil, udpAddr(ap))
+	if err != nil {
+		return nil, err
+	}
+	// A generous read buffer absorbs scheduling jitter at high IQ rates.
+	_ = conn.SetReadBuffer(1 << 21) // 2 MiB
+	return conn, nil
+}
+
+// pollStatus joins the status group, sends a poll for ssrc, and returns the
+// first matching status reply. Retries the poll a few times within timeout
+// since the first datagram can be lost on a freshly-joined group.
+func pollStatus(group netip.AddrPort, ssrc uint32, timeout time.Duration) (channelStatus, error) {
+	conn, err := joinMulticast(group)
+	if err != nil {
+		return channelStatus{}, fmt.Errorf("join status group: %w", err)
+	}
+	defer conn.Close()
+
+	dst := udpAddr(group)
+	deadline := time.Now().Add(timeout)
+	buf := make([]byte, 65536)
+	nextPoll := time.Now()
+	for time.Now().Before(deadline) {
+		if !time.Now().Before(nextPoll) {
+			if _, err := conn.WriteToUDP(buildPoll(ssrc, rand.Uint32()), dst); err != nil {
+				return channelStatus{}, fmt.Errorf("send poll: %w", err)
+			}
+			nextPoll = time.Now().Add(250 * time.Millisecond)
+		}
+		_ = conn.SetReadDeadline(minTime(nextPoll, deadline))
+		n, _, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Timeout() {
+				continue
+			}
+			return channelStatus{}, err
+		}
+		if n == 0 || buf[0] != pktStatus {
+			continue // commands (incl. our own echoes) aren't status replies
+		}
+		st, perr := parseStatus(buf[:n])
+		if perr != nil {
+			continue
+		}
+		if st.hasSSRC && st.ssrc == ssrc {
+			return st, nil
+		}
+	}
+	return channelStatus{}, errors.New("timed out waiting for status reply")
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}

--- a/internal/sdr/ka9qradio/driver_test.go
+++ b/internal/sdr/ka9qradio/driver_test.go
@@ -1,0 +1,172 @@
+package ka9qradio
+
+import (
+	"context"
+	"encoding/binary"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+func testLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestEnumerate(t *testing.T) {
+	d := New([]Spec{
+		{Addr: "hf.local", SSRC: 100},
+		{Addr: "239.1.2.3:5006", SSRC: 200, Serial: "named"},
+		{Addr: "", SSRC: 300}, // skipped: no addr
+	}, testLogger())
+	infos, err := d.Enumerate()
+	if err != nil {
+		t.Fatalf("Enumerate: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("want 2 infos, got %d: %+v", len(infos), infos)
+	}
+	if infos[0].Driver != DriverName || infos[0].Serial == "" {
+		t.Fatalf("info0: %+v", infos[0])
+	}
+	if infos[1].Serial != "named" {
+		t.Fatalf("info1 serial: %+v", infos[1])
+	}
+}
+
+// newLoopbackDevice builds a device whose data socket is a local unicast UDP
+// listener, so StreamIQ can be exercised without real multicast. It returns the
+// device and the address a test sender should write RTP packets to.
+func newLoopbackDevice(t *testing.T, enc encoding, ssrc uint32) (*device, *net.UDPAddr) {
+	t.Helper()
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	dev := &device{
+		info:       sdr.Info{Driver: DriverName, Serial: "test"},
+		ssrc:       ssrc,
+		sampleRate: 24000,
+		enc:        enc,
+		dataConn:   conn,
+		log:        testLogger(),
+	}
+	t.Cleanup(func() { _ = dev.Close() })
+	return dev, conn.LocalAddr().(*net.UDPAddr)
+}
+
+func TestStreamIQLoopback(t *testing.T) {
+	const ssrc = 0xCAFE
+	dev, addr := newLoopbackDevice(t, encS16LE, ssrc)
+
+	if got, _ := dev.ActualSampleRate(); got != 24000 {
+		t.Fatalf("ActualSampleRate %d", got)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+
+	sender, err := net.DialUDP("udp4", nil, addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer sender.Close()
+
+	// One IQ sample: I=16384(->0.5), Q=-16384(->-0.5).
+	payload := make([]byte, 4)
+	binary.LittleEndian.PutUint16(payload[0:2], u16(16384))
+	binary.LittleEndian.PutUint16(payload[2:4], u16(-16384))
+
+	// A foreign SSRC that must be dropped, then our packet.
+	_, _ = sender.Write(buildRTP(96, 1, ssrc+1, payload))
+	_, _ = sender.Write(buildRTP(96, 2, ssrc, payload))
+
+	select {
+	case chunk := <-ch:
+		if len(chunk) != 1 || !closeC(chunk[0], complex(0.5, -0.5), 1e-4) {
+			t.Fatalf("got chunk %v", chunk)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for IQ chunk")
+	}
+}
+
+func TestSetCenterFreqSendsCommand(t *testing.T) {
+	// Listener stands in for the radiod status group.
+	listener, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	cmdConn, err := net.DialUDP("udp4", nil, listener.LocalAddr().(*net.UDPAddr))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	dev := &device{ssrc: 777, cmdConn: cmdConn, dataConn: nil, log: testLogger()}
+
+	if err := dev.SetCenterFreq(151000000); err != nil {
+		t.Fatalf("SetCenterFreq: %v", err)
+	}
+	buf := make([]byte, 1500)
+	_ = listener.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, err := listener.ReadFromUDP(buf)
+	if err != nil {
+		t.Fatalf("read command: %v", err)
+	}
+	if buf[0] != pktCommand {
+		t.Fatalf("not a command packet: % x", buf[:n])
+	}
+	st, err := parseStatus(buf[:n])
+	if err != nil {
+		t.Fatalf("parse command: %v", err)
+	}
+	if st.radioFreqHz != 151000000 {
+		t.Fatalf("retune freq %v", st.radioFreqHz)
+	}
+	if !st.hasSSRC || st.ssrc != 777 {
+		t.Fatalf("retune ssrc %+v", st)
+	}
+}
+
+func TestNoopSettersAndClose(t *testing.T) {
+	dev := &device{log: testLogger()}
+	if err := dev.SetSampleRate(2_400_000); err != nil {
+		t.Fatalf("SetSampleRate must not fail: %v", err)
+	}
+	for _, err := range []error{dev.SetGain(100), dev.SetPPM(5), dev.SetBiasTee(true)} {
+		if err != nil {
+			t.Fatalf("noop setter returned %v", err)
+		}
+	}
+	if err := dev.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	// Idempotent.
+	if err := dev.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
+func TestResolveAddrLiteral(t *testing.T) {
+	ap, err := resolveAddr("239.5.6.7:5006", defaultStatusPort, time.Second)
+	if err != nil {
+		t.Fatalf("resolveAddr: %v", err)
+	}
+	if ap.String() != "239.5.6.7:5006" {
+		t.Fatalf("got %s", ap)
+	}
+	// Default port applied when omitted.
+	ap, err = resolveAddr("239.5.6.7", defaultDataPort, time.Second)
+	if err != nil {
+		t.Fatalf("resolveAddr no port: %v", err)
+	}
+	if ap.Port() != defaultDataPort {
+		t.Fatalf("default port not applied: %s", ap)
+	}
+}

--- a/internal/sdr/ka9qradio/mdns.go
+++ b/internal/sdr/ka9qradio/mdns.go
@@ -1,0 +1,198 @@
+package ka9qradio
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"net"
+	"net/netip"
+	"strings"
+	"time"
+)
+
+// mDNS link-local group (RFC 6762).
+var mdnsGroup = netip.AddrPortFrom(netip.AddrFrom4([4]byte{224, 0, 0, 251}), 5353)
+
+// DNS record types / class.
+const (
+	dnsTypeA    = 1
+	dnsTypeAAAA = 28
+	dnsClassIN  = 1
+	// qClassUnicast is the top bit of the question's class, the mDNS "QU"
+	// flag asking the responder to reply unicast to our source port so a
+	// plain (non-group-joined) socket sees the answer (RFC 6762 §5.4).
+	qClassUnicast = 0x8000
+)
+
+// resolveMDNS resolves a single-label `.local` hostname (radiod registers the
+// channel's status multicast group address as the name's A record) to an IP by
+// querying the mDNS group and reading the first matching A/AAAA answer. It is a
+// deliberately small, dependency-free resolver: it sends one query for A and
+// one for AAAA, prefers the IPv4 answer (radiod groups are IPv4 239.x.x.x), and
+// gives up after timeout.
+func resolveMDNS(host string, timeout time.Duration) (netip.Addr, error) {
+	if timeout <= 0 {
+		timeout = 2 * time.Second
+	}
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("ka9qradio: mdns listen: %w", err)
+	}
+	defer conn.Close()
+
+	group := net.UDPAddr{IP: mdnsGroup.Addr().AsSlice(), Port: int(mdnsGroup.Port())}
+	for _, qt := range []uint16{dnsTypeA, dnsTypeAAAA} {
+		q, err := buildQuery(host, qt)
+		if err != nil {
+			return netip.Addr{}, err
+		}
+		if _, err := conn.WriteToUDP(q, &group); err != nil {
+			return netip.Addr{}, fmt.Errorf("ka9qradio: mdns query: %w", err)
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+	_ = conn.SetReadDeadline(deadline)
+	want := dnsName(host)
+	buf := make([]byte, 1500)
+	for time.Now().Before(deadline) {
+		n, _, err := conn.ReadFromUDP(buf)
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				break
+			}
+			// Timeout (or transient) — stop trying.
+			break
+		}
+		if addr, ok := parseAnswer(buf[:n], want); ok {
+			return addr, nil
+		}
+	}
+	return netip.Addr{}, fmt.Errorf("ka9qradio: mdns: no answer for %q", host)
+}
+
+// dnsName lowercases and trims a hostname for case-insensitive comparison.
+func dnsName(host string) string {
+	return strings.ToLower(strings.TrimSuffix(host, "."))
+}
+
+// buildQuery builds a single-question mDNS query for host with the QU bit set.
+func buildQuery(host string, qtype uint16) ([]byte, error) {
+	var b []byte
+	id := uint16(rand.Uint32())
+	b = append(b, byte(id>>8), byte(id)) // ID
+	b = append(b, 0x00, 0x00)            // flags: standard query
+	b = append(b, 0x00, 0x01)            // QDCOUNT=1
+	b = append(b, 0x00, 0x00)            // ANCOUNT
+	b = append(b, 0x00, 0x00)            // NSCOUNT
+	b = append(b, 0x00, 0x00)            // ARCOUNT
+	for _, label := range strings.Split(dnsName(host), ".") {
+		if len(label) == 0 || len(label) > 63 {
+			return nil, fmt.Errorf("ka9qradio: invalid mdns label in %q", host)
+		}
+		b = append(b, byte(len(label)))
+		b = append(b, label...)
+	}
+	b = append(b, 0x00) // root label
+	b = append(b, byte(qtype>>8), byte(qtype))
+	cls := uint16(dnsClassIN | qClassUnicast)
+	b = append(b, byte(cls>>8), byte(cls))
+	return b, nil
+}
+
+// parseAnswer scans a DNS response for the first A/AAAA record whose owner name
+// matches want, returning its address. Name compression is handled when reading
+// owner names; RDATA is read by length.
+func parseAnswer(msg []byte, want string) (netip.Addr, bool) {
+	if len(msg) < 12 {
+		return netip.Addr{}, false
+	}
+	qd := int(msg[4])<<8 | int(msg[5])
+	an := int(msg[6])<<8 | int(msg[7])
+	off := 12
+	// Skip the question section.
+	for i := 0; i < qd; i++ {
+		var ok bool
+		_, off, ok = readName(msg, off)
+		if !ok || off+4 > len(msg) {
+			return netip.Addr{}, false
+		}
+		off += 4 // QTYPE + QCLASS
+	}
+	for i := 0; i < an; i++ {
+		name, noff, ok := readName(msg, off)
+		if !ok {
+			return netip.Addr{}, false
+		}
+		off = noff
+		if off+10 > len(msg) {
+			return netip.Addr{}, false
+		}
+		rtype := int(msg[off])<<8 | int(msg[off+1])
+		rdlen := int(msg[off+8])<<8 | int(msg[off+9])
+		off += 10
+		if off+rdlen > len(msg) {
+			return netip.Addr{}, false
+		}
+		rdata := msg[off : off+rdlen]
+		off += rdlen
+		if !strings.EqualFold(name, want) {
+			continue
+		}
+		switch rtype {
+		case dnsTypeA:
+			if rdlen == 4 {
+				return netip.AddrFrom4([4]byte{rdata[0], rdata[1], rdata[2], rdata[3]}), true
+			}
+		case dnsTypeAAAA:
+			if rdlen == 16 {
+				var a [16]byte
+				copy(a[:], rdata)
+				return netip.AddrFrom16(a), true
+			}
+		}
+	}
+	return netip.Addr{}, false
+}
+
+// readName decodes a DNS name starting at off, following compression pointers,
+// and returns the dotted name plus the offset just past the name in the record
+// stream (i.e. past the first pointer, not into the pointed-to data).
+func readName(msg []byte, off int) (string, int, bool) {
+	var labels []string
+	jumped := false
+	next := off
+	// Bound the loop to the message size to defeat pointer loops.
+	for steps := 0; steps < len(msg); steps++ {
+		if off >= len(msg) {
+			return "", 0, false
+		}
+		b := int(msg[off])
+		if b == 0 {
+			off++
+			if !jumped {
+				next = off
+			}
+			return strings.Join(labels, "."), next, true
+		}
+		if b&0xc0 == 0xc0 {
+			if off+1 >= len(msg) {
+				return "", 0, false
+			}
+			ptr := (b&0x3f)<<8 | int(msg[off+1])
+			if !jumped {
+				next = off + 2
+			}
+			jumped = true
+			off = ptr
+			continue
+		}
+		off++
+		if off+b > len(msg) {
+			return "", 0, false
+		}
+		labels = append(labels, string(msg[off:off+b]))
+		off += b
+	}
+	return "", 0, false
+}

--- a/internal/sdr/ka9qradio/rtp.go
+++ b/internal/sdr/ka9qradio/rtp.go
@@ -1,0 +1,110 @@
+package ka9qradio
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+// rtpHeader is the decoded fixed RTP header (src/rtp.h struct rtp_header /
+// ntoh_rtp). Only the fields this driver uses are kept.
+type rtpHeader struct {
+	version int
+	pad     bool
+	ext     bool
+	cc      int
+	marker  bool
+	pt      uint8
+	seq     uint16
+	ts      uint32
+	ssrc    uint32
+}
+
+// parseRTP decodes the RTP header at the front of a datagram and returns the
+// header plus the offset where the payload begins, skipping any CSRC list and
+// header extension (radiod's ntoh_rtp). It validates the version and bounds so
+// a malformed packet is rejected rather than slicing out of range.
+func parseRTP(p []byte) (rtpHeader, int, error) {
+	var h rtpHeader
+	if len(p) < 12 {
+		return h, 0, fmt.Errorf("ka9qradio: RTP packet too short (%d bytes)", len(p))
+	}
+	w := binary.BigEndian.Uint32(p[0:4])
+	h.version = int(w >> 30)
+	h.pad = (w>>29)&1 != 0
+	h.ext = (w>>28)&1 != 0
+	h.cc = int((w >> 24) & 0xf)
+	h.marker = (w>>23)&1 != 0
+	h.pt = uint8((w >> 16) & 0x7f)
+	h.seq = uint16(w & 0xffff)
+	h.ts = binary.BigEndian.Uint32(p[4:8])
+	h.ssrc = binary.BigEndian.Uint32(p[8:12])
+	if h.version != 2 {
+		return h, 0, fmt.Errorf("ka9qradio: RTP version %d, want 2", h.version)
+	}
+
+	off := 12 + 4*h.cc
+	if off > len(p) {
+		return h, 0, fmt.Errorf("ka9qradio: RTP CSRC list overruns packet")
+	}
+	if h.ext {
+		if off+4 > len(p) {
+			return h, 0, fmt.Errorf("ka9qradio: RTP extension header overruns packet")
+		}
+		// Extension: 16-bit profile + 16-bit length (in 32-bit words); skip both.
+		extWords := int(binary.BigEndian.Uint16(p[off+2 : off+4]))
+		off += 4 + 4*extWords
+		if off > len(p) {
+			return h, 0, fmt.Errorf("ka9qradio: RTP extension body overruns packet")
+		}
+	}
+	return h, off, nil
+}
+
+// decodeIQ converts a raw-IQ RTP payload (interleaved I,Q in enc) to
+// normalized complex64. S16 samples are scaled by 1/32768 so they land in
+// roughly [-1, 1), matching the rtltcp / rtlsdr drivers; float samples pass
+// through unchanged (radiod already emits them near unit scale). A trailing
+// odd sample (incomplete I/Q pair) is dropped.
+func decodeIQ(payload []byte, enc encoding) ([]complex64, error) {
+	switch enc {
+	case encS16LE:
+		return decodeS16(payload, binary.LittleEndian), nil
+	case encS16BE:
+		return decodeS16(payload, binary.BigEndian), nil
+	case encF32LE:
+		return decodeF32(payload, binary.LittleEndian), nil
+	case encF32BE:
+		return decodeF32(payload, binary.BigEndian), nil
+	default:
+		return nil, fmt.Errorf("ka9qradio: encoding %s is not raw IQ", enc)
+	}
+}
+
+type byteOrder interface {
+	Uint16([]byte) uint16
+	Uint32([]byte) uint32
+}
+
+func decodeS16(p []byte, bo byteOrder) []complex64 {
+	n := len(p) / 4 // 2 bytes I + 2 bytes Q per sample
+	out := make([]complex64, n)
+	const scale = 1.0 / 32768.0
+	for i := 0; i < n; i++ {
+		iv := int16(bo.Uint16(p[4*i : 4*i+2]))
+		qv := int16(bo.Uint16(p[4*i+2 : 4*i+4]))
+		out[i] = complex(float32(iv)*scale, float32(qv)*scale)
+	}
+	return out
+}
+
+func decodeF32(p []byte, bo byteOrder) []complex64 {
+	n := len(p) / 8 // 4 bytes I + 4 bytes Q per sample
+	out := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		iv := math.Float32frombits(bo.Uint32(p[8*i : 8*i+4]))
+		qv := math.Float32frombits(bo.Uint32(p[8*i+4 : 8*i+8]))
+		out[i] = complex(iv, qv)
+	}
+	return out
+}

--- a/internal/sdr/ka9qradio/rtp_test.go
+++ b/internal/sdr/ka9qradio/rtp_test.go
@@ -1,0 +1,111 @@
+package ka9qradio
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// buildRTP assembles a minimal RTP packet (version 2, no CSRC/extension) with
+// the given payload type, sequence, ssrc and payload — enough to exercise the
+// parser and the streaming path.
+func buildRTP(pt uint8, seq uint16, ssrc uint32, payload []byte) []byte {
+	pkt := make([]byte, 12+len(payload))
+	w := uint32(2)<<30 | uint32(pt&0x7f)<<16 | uint32(seq)
+	binary.BigEndian.PutUint32(pkt[0:4], w)
+	binary.BigEndian.PutUint32(pkt[4:8], 0) // timestamp
+	binary.BigEndian.PutUint32(pkt[8:12], ssrc)
+	copy(pkt[12:], payload)
+	return pkt
+}
+
+func TestParseRTPSkipsCSRCAndExtension(t *testing.T) {
+	// version 2, extension bit set, cc=2, pt=96, seq=7.
+	pkt := make([]byte, 0, 64)
+	w := uint32(2)<<30 | uint32(1)<<28 /*ext*/ | uint32(2)<<24 /*cc*/ | uint32(96)<<16 | 7
+	var hdr [12]byte
+	binary.BigEndian.PutUint32(hdr[0:4], w)
+	binary.BigEndian.PutUint32(hdr[8:12], 0xDEADBEEF)
+	pkt = append(pkt, hdr[:]...)
+	pkt = append(pkt, make([]byte, 4*2)...) // two CSRCs
+	// Extension header: profile(2) + length(2 words) then 1 word of ext data.
+	ext := []byte{0x00, 0x00, 0x00, 0x01, 0xAA, 0xBB, 0xCC, 0xDD}
+	pkt = append(pkt, ext...)
+	payload := []byte{1, 2, 3, 4}
+	pkt = append(pkt, payload...)
+
+	h, off, err := parseRTP(pkt)
+	if err != nil {
+		t.Fatalf("parseRTP: %v", err)
+	}
+	if h.ssrc != 0xDEADBEEF || h.pt != 96 || h.seq != 7 || h.cc != 2 || !h.ext {
+		t.Fatalf("bad header: %+v", h)
+	}
+	if got := pkt[off:]; string(got) != string(payload) {
+		t.Fatalf("payload offset wrong: got % x want % x", got, payload)
+	}
+}
+
+func TestParseRTPRejects(t *testing.T) {
+	if _, _, err := parseRTP([]byte{0, 0, 0}); err == nil {
+		t.Fatal("expected error on short packet")
+	}
+	// version 1 (top two bits 01).
+	bad := buildRTP(96, 0, 0, nil)
+	bad[0] = 0x40
+	if _, _, err := parseRTP(bad); err == nil {
+		t.Fatal("expected error on bad version")
+	}
+}
+
+func TestDecodeIQ(t *testing.T) {
+	// S16LE: I=16384 (->0.5), Q=-16384 (->-0.5).
+	s16le := make([]byte, 4)
+	binary.LittleEndian.PutUint16(s16le[0:2], u16(16384))
+	binary.LittleEndian.PutUint16(s16le[2:4], u16(-16384))
+	got, err := decodeIQ(s16le, encS16LE)
+	if err != nil {
+		t.Fatalf("decodeIQ s16le: %v", err)
+	}
+	if len(got) != 1 || !closeC(got[0], complex(0.5, -0.5), 1e-4) {
+		t.Fatalf("s16le got %v", got)
+	}
+
+	// S16BE.
+	s16be := make([]byte, 4)
+	binary.BigEndian.PutUint16(s16be[0:2], u16(16384))
+	binary.BigEndian.PutUint16(s16be[2:4], u16(-16384))
+	got, _ = decodeIQ(s16be, encS16BE)
+	if len(got) != 1 || !closeC(got[0], complex(0.5, -0.5), 1e-4) {
+		t.Fatalf("s16be got %v", got)
+	}
+
+	// F32LE: pass-through.
+	f32le := make([]byte, 8)
+	binary.LittleEndian.PutUint32(f32le[0:4], math.Float32bits(0.25))
+	binary.LittleEndian.PutUint32(f32le[4:8], math.Float32bits(-0.75))
+	got, _ = decodeIQ(f32le, encF32LE)
+	if len(got) != 1 || !closeC(got[0], complex(0.25, -0.75), 1e-6) {
+		t.Fatalf("f32le got %v", got)
+	}
+
+	// Trailing odd byte dropped (3 bytes < one s16 IQ pair).
+	got, _ = decodeIQ([]byte{1, 2, 3}, encS16LE)
+	if len(got) != 0 {
+		t.Fatalf("expected no samples from short payload, got %v", got)
+	}
+
+	// Opus is not IQ.
+	if _, err := decodeIQ([]byte{0, 0}, encOpus); err == nil {
+		t.Fatal("expected error decoding opus as IQ")
+	}
+}
+
+func closeC(a, b complex64, tol float64) bool {
+	return math.Abs(float64(real(a)-real(b))) < tol && math.Abs(float64(imag(a)-imag(b))) < tol
+}
+
+// u16 reinterprets a signed 16-bit value as its unsigned wire bits. A direct
+// uint16(int16(-n)) conversion of a constant is rejected by the compiler, so
+// this non-constant helper is used in tests.
+func u16(v int16) uint16 { return uint16(v) }

--- a/internal/sdr/ka9qradio/status.go
+++ b/internal/sdr/ka9qradio/status.go
@@ -1,0 +1,489 @@
+// Package ka9qradio implements an sdr.Driver that consumes a channel from a
+// remote ka9q-radio `radiod` instance over IP multicast, in pure Go with no
+// CGO. radiod (https://github.com/ka9q/ka9q-radio) is a multichannel SDR
+// daemon that reads a front end (RX888, Airspy, RTL-SDR, …), runs
+// fast-convolution digital downconverters, and publishes each channel as an
+// RTP/IP-multicast stream. A channel configured for raw "linear" IQ output
+// (`OUTPUT_CHANNELS = 2`) emits interleaved complex samples that GopherTrunk
+// can demodulate exactly like a local dongle — so one well-sited radiod can
+// feed many decoders across a LAN (issue #765).
+//
+// Two multicast groups are involved, mirroring radiod itself:
+//
+//   - A status + command group (UDP port 5006). radiod multicasts per-channel
+//     metadata here as binary TLV (type/length/value) packets, and clients
+//     send commands to the same group. Each channel is identified by its RTP
+//     SSRC. This driver POLLs the group for its configured SSRC to learn the
+//     channel's data multicast socket, sample rate, encoding and centre
+//     frequency, and sends RADIO_FREQUENCY commands to retune (see status.go).
+//   - A data group (UDP port 5004) carrying standard RTP packets whose payload
+//     is the channel's interleaved IQ in the negotiated encoding (see rtp.go).
+//
+// radiod instances are named with mDNS `.local` hostnames whose A/AAAA record
+// is the status multicast group address; mdns.go resolves them. Plain
+// `host:port` and literal `239.x.x.x:port` addresses bypass mDNS.
+//
+// The wire formats (TLV grammar, integer/double leading-zero compression, RTP
+// header, socket TLV layout, and the status_type / encoding enums) are
+// transcribed from ka9q-radio @ main (src/status.{c,h}, src/rtp.{c,h}) so the
+// values stay byte-compatible. It is exercised by synthetic packets in the
+// tests; validate against a live radiod before relying on it.
+//
+// Limitations:
+//   - Raw IQ ("linear", OUTPUT_CHANNELS=2) channels only. Opus / μ-law / A-law
+//     / AX.25 payloads are audio/packet encodings, not IQ, and are rejected.
+//   - The operator pre-configures the channel in radiod@.conf; this driver
+//     consumes and retunes an existing channel rather than creating one.
+//   - Plaintext multicast, like rtl_tcp / soapy_remote. Use on trusted LANs.
+package ka9qradio
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"net/netip"
+)
+
+// UDP ports radiod uses by default (src/rtp.h: DEFAULT_RTP_PORT /
+// DEFAULT_STAT_PORT).
+const (
+	defaultDataPort   = 5004
+	defaultStatusPort = 5006
+)
+
+// pktType is the first byte of every status/command packet
+// (src/status.h enum pkt_type).
+const (
+	pktStatus  byte = 0
+	pktCommand byte = 1
+)
+
+// statusType is the TLV type byte (src/status.h enum status_type). The enum is
+// transcribed in full and in order: only EOL is fixed at 0 and every other
+// value is positional, so the complete list is required to keep the handful we
+// use (COMMAND_TAG, OUTPUT_SSRC, OUTPUT_DATA_DEST_SOCKET, OUTPUT_SAMPRATE,
+// RADIO_FREQUENCY, OUTPUT_CHANNELS, OUTPUT_ENCODING) at the correct offsets.
+type statusType uint8
+
+const (
+	stEOL        statusType = iota // 0: end-of-list sentinel
+	stCommandTag                   // echoes the requester's tag
+	stCmdCnt
+	stGPSTime
+
+	stDescription
+	stStatusDestSocket
+	stSetopts
+	stClearopts
+	stRTPTimesnap
+	stBinByteData
+	stInputSamprate
+	stSpectrumBase
+	stSpectrumAvg
+	stInputSamples
+	stWindowType
+	stNoiseBW
+
+	stOutputDataSourceSocket
+	stOutputDataDestSocket // multicast group:port carrying this channel's IQ
+	stOutputSSRC
+	stOutputTTL
+	stOutputSamprate // output sample rate, Hz (integer)
+	stOutputMetadataPackets
+	stOutputDataPackets
+	stOutputErrors
+
+	stCalibrate
+	stLNAGain
+	stMixerGain
+	stIFGain
+
+	stDCIOffset
+	stDCQOffset
+	stIQImbalance
+	stIQPhase
+	stDirectConversion
+
+	stRadioFrequency // channel centre frequency, Hz (double)
+	stFirstLOFrequency
+	stSecondLOFrequency
+	stShiftFrequency
+	stDopplerFrequency
+	stDopplerFrequencyRate
+
+	stLowEdge
+	stHighEdge
+	stKaiserBeta
+	stFilterBlocksize
+	stFilterFIRLength
+	stFilter2
+
+	stIFPower
+	stBasebandPower
+	stNoiseDensity
+
+	stDemodType      // 0 = linear (raw IQ), 1 = FM, 2 = WFM, 3 = spectrum
+	stOutputChannels // 1 or 2; raw IQ uses 2 (I,Q)
+	stIndependentSideband
+	stPLLEnable
+	stPLLLock
+	stPLLSquare
+	stPLLPhase
+	stPLLBW
+	stEnvelope
+	stSNRSquelch
+
+	stPLLSNR
+	stFreqOffset
+	stPeakDeviation
+	stPLTone
+
+	stAGCEnable
+	stHeadroom
+	stAGCHangtime
+	stAGCRecoveryRate
+	stFMSNR
+	stAGCThreshold
+
+	stGain
+	stOutputLevel
+	stOutputSamples
+
+	stOpusBitRate
+	stMaxdelay
+	stFilter2Blocksize
+	stFilter2FIRLength
+	stFilter2KaiserBeta
+	stSpectrumFFTN
+
+	stFilterDrops
+	stLock
+
+	stTP1
+	stTP2
+
+	stUnused4
+	stADBitsPerSample
+	stSquelchOpen
+	stSquelchClose
+	stPreset
+	stDeemphTC
+	stDeemphGain
+	stUnused3
+	stPLDeviation
+	stThreshExtend
+
+	stSpectrumShape
+	stUnused2
+	stResolutionBW
+	stBinCount
+	stCrossover
+	stBinData
+
+	stRFAtten
+	stRFGain
+	stRFAGC
+	stFELowEdge
+	stFEHighEdge
+	stFEIsReal
+	stUnused
+	stADOver
+	stRTPPT
+	stStatusInterval
+	stOutputEncoding // enum encoding of the output samples
+	stSamplesSinceOver
+	stPLLWraps
+	stRFLevelCal
+	stOpusDTX
+	stOpusApplication
+	stOpusBandwidth
+	stOpusFEC
+	stSpectrumStep
+	stSpectrumOverlap
+	stLifetime
+)
+
+// encoding is the on-wire sample encoding (src/rtp.h enum encoding).
+type encoding uint8
+
+const (
+	encNone encoding = iota // NO_ENCODING
+	encS16LE
+	encS16BE
+	encOpus
+	encF32LE
+	encAX25
+	encF16LE
+	encOpusVOIP
+	encF32BE
+	encF16BE
+	encMulaw
+	encAlaw
+)
+
+// parseEncoding maps the config/string names radiod accepts (src/rtp.c
+// parse_encoding) to the wire enum. Only the encodings that carry raw IQ are
+// meaningful here; the rest are accepted for completeness so a status reply
+// that advertises them parses, and isIQEncoding rejects them later.
+func parseEncoding(s string) (encoding, bool) {
+	switch s {
+	case "s16be", "s16", "int":
+		return encS16BE, true
+	case "s16le":
+		return encS16LE, true
+	case "f32", "float", "f32le":
+		return encF32LE, true
+	case "f32be":
+		return encF32BE, true
+	case "f16le", "f16":
+		return encF16LE, true
+	case "f16be":
+		return encF16BE, true
+	case "":
+		return encNone, true
+	default:
+		return encNone, false
+	}
+}
+
+func (e encoding) String() string {
+	switch e {
+	case encS16LE:
+		return "s16le"
+	case encS16BE:
+		return "s16be"
+	case encF32LE:
+		return "f32le"
+	case encF32BE:
+		return "f32be"
+	case encF16LE:
+		return "f16le"
+	case encF16BE:
+		return "f16be"
+	case encOpus:
+		return "opus"
+	case encOpusVOIP:
+		return "opus-voip"
+	case encAX25:
+		return "ax.25"
+	case encMulaw:
+		return "mulaw"
+	case encAlaw:
+		return "alaw"
+	default:
+		return "none"
+	}
+}
+
+// isIQEncoding reports whether an encoding carries raw IQ samples this driver
+// can decode (signed-16 or 32-bit float, either byte order). Opus/μ-law/A-law
+// are lossy audio codecs and AX.25 is packet data — none are IQ.
+func isIQEncoding(e encoding) bool {
+	switch e {
+	case encS16LE, encS16BE, encF32LE, encF32BE:
+		return true
+	default:
+		return false
+	}
+}
+
+// --- TLV codec (src/status.c) ---------------------------------------------
+//
+// Each TLV is a 1-byte type, a length field, then the value. A length < 128 is
+// a single byte; a length >= 128 is encoded as 0x80|N followed by N big-endian
+// length bytes. Integers (and the IEEE bits of floats/doubles) are big-endian
+// with leading zero bytes dropped, so a zero value is length 0.
+
+// appendTLV writes one type/length/value triple.
+func appendTLV(buf []byte, typ statusType, val []byte) []byte {
+	buf = append(buf, byte(typ))
+	n := len(val)
+	switch {
+	case n < 128:
+		buf = append(buf, byte(n))
+	case n < 1<<16:
+		buf = append(buf, 0x80|2, byte(n>>8), byte(n))
+	case n < 1<<24:
+		buf = append(buf, 0x80|3, byte(n>>16), byte(n>>8), byte(n))
+	default:
+		buf = append(buf, 0x80|4, byte(n>>24), byte(n>>16), byte(n>>8), byte(n))
+	}
+	return append(buf, val...)
+}
+
+// appendInt encodes an unsigned integer with leading-zero compression, matching
+// radiod's encode_int64.
+func appendInt(buf []byte, typ statusType, v uint64) []byte {
+	var tmp [8]byte
+	binary.BigEndian.PutUint64(tmp[:], v)
+	i := 0
+	for i < 8 && tmp[i] == 0 {
+		i++
+	}
+	return appendTLV(buf, typ, tmp[i:])
+}
+
+// appendDouble encodes a float64 as its big-endian IEEE-754 bits (compressed),
+// matching radiod's encode_double.
+func appendDouble(buf []byte, typ statusType, f float64) []byte {
+	return appendInt(buf, typ, math.Float64bits(f))
+}
+
+// appendEOL terminates a TLV list with a single null type byte.
+func appendEOL(buf []byte) []byte { return append(buf, byte(stEOL)) }
+
+// decodeUint reads a big-endian, possibly leading-zero-compressed unsigned
+// integer (radiod's decode_int64).
+func decodeUint(val []byte) uint64 {
+	var r uint64
+	for _, b := range val {
+		r = (r << 8) | uint64(b)
+	}
+	return r
+}
+
+// decodeFloat reads a compressed float or double value (radiod's decode_float):
+// up to 4 bytes is a float32, more is a float64. Both reconstruct because
+// leading-zero compression only drops high bytes.
+func decodeFloat(val []byte) float64 {
+	switch {
+	case len(val) == 0:
+		return 0
+	case len(val) <= 4:
+		return float64(math.Float32frombits(uint32(decodeUint(val))))
+	default:
+		return math.Float64frombits(decodeUint(val))
+	}
+}
+
+// decodeSocket reads an OUTPUT_DATA_DEST_SOCKET-style value: 6 bytes for IPv4
+// (4-byte addr + 2-byte port, both network order) or 18 bytes for IPv6
+// (16-byte addr + 2-byte port). The address family is inferred from the length,
+// exactly as radiod's decode_socket does.
+func decodeSocket(val []byte) (netip.AddrPort, error) {
+	switch len(val) {
+	case 6:
+		addr := netip.AddrFrom4([4]byte{val[0], val[1], val[2], val[3]})
+		port := binary.BigEndian.Uint16(val[4:6])
+		return netip.AddrPortFrom(addr, port), nil
+	case 18:
+		var a [16]byte
+		copy(a[:], val[:16])
+		addr := netip.AddrFrom16(a)
+		port := binary.BigEndian.Uint16(val[16:18])
+		return netip.AddrPortFrom(addr, port), nil
+	default:
+		return netip.AddrPort{}, fmt.Errorf("ka9qradio: socket TLV has %d bytes, want 6 or 18", len(val))
+	}
+}
+
+// tlv is one decoded type/value pair.
+type tlv struct {
+	typ statusType
+	val []byte
+}
+
+// parseTLVs walks a status/command payload (the bytes AFTER the leading
+// pkt_type byte) into its TLVs, stopping at the EOL sentinel. A truncated
+// length or value returns an error rather than reading out of bounds.
+func parseTLVs(p []byte) ([]tlv, error) {
+	var out []tlv
+	for i := 0; i < len(p); {
+		typ := statusType(p[i])
+		i++
+		if typ == stEOL {
+			break
+		}
+		if i >= len(p) {
+			return nil, fmt.Errorf("ka9qradio: truncated TLV length for type %d", typ)
+		}
+		optlen := int(p[i])
+		i++
+		if optlen&0x80 != 0 {
+			lol := optlen & 0x7f
+			if i+lol > len(p) {
+				return nil, fmt.Errorf("ka9qradio: truncated extended length")
+			}
+			optlen = 0
+			for k := 0; k < lol; k++ {
+				optlen = (optlen << 8) | int(p[i])
+				i++
+			}
+		}
+		if i+optlen > len(p) {
+			return nil, fmt.Errorf("ka9qradio: TLV type %d length %d overruns packet", typ, optlen)
+		}
+		out = append(out, tlv{typ: typ, val: p[i : i+optlen]})
+		i += optlen
+	}
+	return out, nil
+}
+
+// channelStatus is the subset of a radiod status reply this driver needs.
+type channelStatus struct {
+	ssrc        uint32
+	hasSSRC     bool
+	dataDest    netip.AddrPort
+	hasDataDest bool
+	sampleRate  uint32
+	encoding    encoding
+	channels    int
+	radioFreqHz float64
+}
+
+// parseStatus decodes a status packet (including the leading pkt_type byte) for
+// the fields this driver tracks. It does not require the packet to be a STATUS
+// (vs CMD) so the same routine can introspect either.
+func parseStatus(pkt []byte) (channelStatus, error) {
+	var st channelStatus
+	if len(pkt) == 0 {
+		return st, fmt.Errorf("ka9qradio: empty status packet")
+	}
+	tlvs, err := parseTLVs(pkt[1:])
+	if err != nil {
+		return st, err
+	}
+	for _, t := range tlvs {
+		switch t.typ {
+		case stOutputSSRC:
+			st.ssrc = uint32(decodeUint(t.val))
+			st.hasSSRC = true
+		case stOutputDataDestSocket:
+			ap, err := decodeSocket(t.val)
+			if err != nil {
+				return st, err
+			}
+			st.dataDest = ap
+			st.hasDataDest = true
+		case stOutputSamprate:
+			st.sampleRate = uint32(decodeUint(t.val))
+		case stOutputEncoding:
+			st.encoding = encoding(decodeUint(t.val))
+		case stOutputChannels:
+			st.channels = int(decodeUint(t.val))
+		case stRadioFrequency:
+			st.radioFreqHz = decodeFloat(t.val)
+		}
+	}
+	return st, nil
+}
+
+// buildPoll builds a command packet that queries the channel's current status:
+// a CMD with a command tag and the target SSRC, terminated by EOL. radiod
+// replies on the status group with a STATUS packet for that SSRC.
+func buildPoll(ssrc, tag uint32) []byte {
+	buf := []byte{pktCommand}
+	buf = appendInt(buf, stCommandTag, uint64(tag))
+	buf = appendInt(buf, stOutputSSRC, uint64(ssrc))
+	return appendEOL(buf)
+}
+
+// buildSetFreq builds a command packet that retunes the channel to hz, matching
+// the `tune` client's RADIO_FREQUENCY command.
+func buildSetFreq(ssrc, tag uint32, hz float64) []byte {
+	buf := []byte{pktCommand}
+	buf = appendInt(buf, stCommandTag, uint64(tag))
+	buf = appendInt(buf, stOutputSSRC, uint64(ssrc))
+	buf = appendDouble(buf, stRadioFrequency, hz)
+	return appendEOL(buf)
+}

--- a/internal/sdr/ka9qradio/status_test.go
+++ b/internal/sdr/ka9qradio/status_test.go
@@ -1,0 +1,133 @@
+package ka9qradio
+
+import (
+	"math"
+	"net/netip"
+	"testing"
+)
+
+func TestIntTLVRoundTrip(t *testing.T) {
+	cases := []uint64{0, 1, 255, 256, 24000, 162550000, math.MaxUint32}
+	for _, v := range cases {
+		buf := appendInt(nil, stOutputSamprate, v)
+		tlvs, err := parseTLVs(buf)
+		if err != nil {
+			t.Fatalf("parseTLVs(%d): %v", v, err)
+		}
+		if len(tlvs) != 1 || tlvs[0].typ != stOutputSamprate {
+			t.Fatalf("v=%d: unexpected tlvs %+v", v, tlvs)
+		}
+		if got := decodeUint(tlvs[0].val); got != v {
+			t.Fatalf("v=%d: decoded %d", v, got)
+		}
+	}
+	// Zero compresses to a zero-length value.
+	if buf := appendInt(nil, stOutputSSRC, 0); len(buf) != 2 || buf[1] != 0 {
+		t.Fatalf("zero not compressed: % x", buf)
+	}
+}
+
+func TestDoubleTLVRoundTrip(t *testing.T) {
+	for _, f := range []float64{0, 162550000, 446.00625e6, 1e9} {
+		buf := appendDouble(nil, stRadioFrequency, f)
+		tlvs, _ := parseTLVs(buf)
+		if len(tlvs) != 1 {
+			t.Fatalf("f=%v: tlvs %+v", f, tlvs)
+		}
+		if got := decodeFloat(tlvs[0].val); got != f {
+			t.Fatalf("f=%v: decoded %v", f, got)
+		}
+	}
+}
+
+func TestDecodeSocket(t *testing.T) {
+	// IPv4: 239.10.20.30:5004.
+	v4 := []byte{239, 10, 20, 30, 0x13, 0x8c} // 0x138c = 5004
+	ap, err := decodeSocket(v4)
+	if err != nil {
+		t.Fatalf("decodeSocket v4: %v", err)
+	}
+	if ap.String() != "239.10.20.30:5004" {
+		t.Fatalf("v4 got %s", ap)
+	}
+	// Wrong length.
+	if _, err := decodeSocket([]byte{1, 2, 3}); err == nil {
+		t.Fatal("expected error on bad socket length")
+	}
+}
+
+// buildStatusReply assembles a radiod-style STATUS packet for one channel.
+func buildStatusReply(ssrc uint32, dataIP netip.Addr, dataPort uint16, samprate uint32, enc encoding, channels int, freq float64) []byte {
+	buf := []byte{pktStatus}
+	buf = appendInt(buf, stOutputSSRC, uint64(ssrc))
+	sock := make([]byte, 6)
+	a4 := dataIP.As4()
+	copy(sock[0:4], a4[:])
+	sock[4] = byte(dataPort >> 8)
+	sock[5] = byte(dataPort)
+	buf = appendTLV(buf, stOutputDataDestSocket, sock)
+	buf = appendInt(buf, stOutputSamprate, uint64(samprate))
+	buf = appendInt(buf, stOutputEncoding, uint64(enc))
+	buf = appendInt(buf, stOutputChannels, uint64(channels))
+	buf = appendDouble(buf, stRadioFrequency, freq)
+	return appendEOL(buf)
+}
+
+func TestParseStatus(t *testing.T) {
+	pkt := buildStatusReply(162550, netip.AddrFrom4([4]byte{239, 1, 2, 3}), 5004, 24000, encF32LE, 2, 162550000)
+	st, err := parseStatus(pkt)
+	if err != nil {
+		t.Fatalf("parseStatus: %v", err)
+	}
+	if !st.hasSSRC || st.ssrc != 162550 {
+		t.Fatalf("ssrc: %+v", st)
+	}
+	if !st.hasDataDest || st.dataDest.String() != "239.1.2.3:5004" {
+		t.Fatalf("dataDest: %+v", st)
+	}
+	if st.sampleRate != 24000 || st.encoding != encF32LE || st.channels != 2 {
+		t.Fatalf("params: %+v", st)
+	}
+	if st.radioFreqHz != 162550000 {
+		t.Fatalf("freq: %v", st.radioFreqHz)
+	}
+}
+
+func TestBuildPollAndSetFreq(t *testing.T) {
+	poll := buildPoll(0x1234, 0xABCD)
+	if poll[0] != pktCommand {
+		t.Fatalf("poll not a command: % x", poll)
+	}
+	tlvs, err := parseTLVs(poll[1:])
+	if err != nil {
+		t.Fatalf("parse poll: %v", err)
+	}
+	var sawTag, sawSSRC bool
+	for _, tv := range tlvs {
+		switch tv.typ {
+		case stCommandTag:
+			sawTag = decodeUint(tv.val) == 0xABCD
+		case stOutputSSRC:
+			sawSSRC = decodeUint(tv.val) == 0x1234
+		}
+	}
+	if !sawTag || !sawSSRC {
+		t.Fatalf("poll missing tag/ssrc: %+v", tlvs)
+	}
+
+	cmd := buildSetFreq(0x1234, 1, 446006250)
+	st, err := parseStatus(cmd) // parseStatus reads any TLV packet
+	if err != nil {
+		t.Fatalf("parse setfreq: %v", err)
+	}
+	if st.radioFreqHz != 446006250 {
+		t.Fatalf("setfreq carried %v", st.radioFreqHz)
+	}
+}
+
+func TestParseTLVsTruncated(t *testing.T) {
+	// type with a length claiming more bytes than present.
+	if _, err := parseTLVs([]byte{byte(stOutputSamprate), 4, 0, 0}); err == nil {
+		t.Fatal("expected overrun error")
+	}
+}

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -107,11 +107,24 @@ export interface SoapyRemoteConfig {
   ConnectTimeoutMs: number;
 }
 
+export interface Ka9qRadioConfig {
+  Addr: string;
+  SSRC: number;
+  Serial: string;
+  Role: string;
+  Data: string;
+  SampleRate: number;
+  Encoding: string;
+  Channels: number;
+  ConnectTimeoutMs: number;
+}
+
 export interface SDRConfig {
   SampleRate: number;
   Devices: DeviceConfig[];
   RTLTCP?: RTLTCPConfig[] | null;
   SoapyRemote?: SoapyRemoteConfig[] | null;
+  Ka9qRadio?: Ka9qRadioConfig[] | null;
   [k: string]: unknown;
 }
 


### PR DESCRIPTION
Add a pure-Go sdr.Driver that consumes a channel from a remote
ka9q-radio `radiod` instance over IP multicast (issue #765). radiod
runs fast-convolution downconverters on a front end and multicasts each
channel as RTP; a channel in raw "linear" IQ mode (output_channels=2)
is mounted as a virtual tuner, so one well-sited radiod can feed many
GopherTrunk decoders across a LAN.

The driver:
- joins the channel's IQ multicast group (RTP, port 5004) and decodes
  s16/f32 (either byte order) interleaved IQ payloads to []complex64;
- polls radiod's status+command multicast group (port 5006) for the
  channel SSRC to discover the data socket, sample rate, encoding and
  centre frequency (all overridable in config to skip the poll);
- resolves `.local` radiod instance names via a small dependency-free
  mDNS resolver;
- retunes via RADIO_FREQUENCY command packets (SetCenterFreq) and
  reports the radiod-fixed rate through ActualSampleRate so per-channel
  DDCs/symbol clocks build from the delivered rate.

Wire formats (TLV grammar with leading-zero integer/double compression,
RTP header, socket TLV layout, status_type and encoding enums) are
transcribed from ka9q-radio @ main to stay byte-compatible.

Wired into config (sdr.ka9q_radio) with validation, the daemon
registration path (mirroring rtl_tcp / soapy_remote), config.example.yaml,
the field-help and web-schema registries, and the CHANGELOG. Covered by
synthetic RTP/TLV/status unit tests plus a loopback streaming test;
end-to-end verification against a live radiod is still pending.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011k1tiTVserjWBtNRts2ZmP