### PR TITLE
wideband: fix DDC/channelizer decode at sample rates above 2.5 MS/s (#764)

### DIFF
--- a/internal/dsp/tuner/ddc.go
+++ b/internal/dsp/tuner/ddc.go
@@ -49,13 +49,31 @@ func (n *nco) renorm() {
 
 // DDCBank is a Bank built from one independent NCO mixer + rational
 // polyphase resampler per tap. CPU cost is O(N_taps · N_samples).
+//
+// At high input rates a shared integer decimation stage runs once over the
+// wideband stream (amortised across every tap) to bring it down to redRateHz
+// before the per-tap NCO + resampler. This bounds the per-tap cost to the rate
+// the single-stage resampler was tuned for (~2.5 MS/s) instead of letting a
+// 208:1 single-stage decimation run per tap at the full input rate, which
+// starved the live wideband pump goroutine and dropped samples at the hardware
+// layer when the rate was raised above 2.5 MS/s (issue #764). Below
+// ddcDecimateFloorHz·2 there is no shared stage and the path is byte-for-byte
+// identical to the pre-#764 behaviour.
 type DDCBank struct {
 	inRateHz    float64
+	redRateHz   float64 // rate after the shared decimation stage (== inRateHz when predec is nil)
 	outRateHz   float64
 	actualOutHz float64
 	guardFrac   float64
 	taps        []*ddcTap
-	mixBuf      []complex64
+
+	// predec is the shared decimate-by-D resampler applied to every chunk
+	// before the per-tap mixers. A decimating dsp.Resampler (L=1, M=D) only
+	// computes the kept output samples, so the shared cost is far below the
+	// per-tap resamplers it offloads. Nil when inRateHz is at/below the floor.
+	predec *dsp.Resampler
+	decBuf []complex64 // reduced-rate scratch reused across Process calls
+	mixBuf []complex64
 }
 
 type ddcTap struct {
@@ -72,13 +90,47 @@ type ddcTap struct {
 // alias roll-off; AddTap rejects offsets outside the usable band. A typical
 // value is 0.05 (5%).
 func NewDDCBank(inRateHz, outRateHz, guardFrac float64) *DDCBank {
-	l, m := rationalRatio(outRateHz, inRateHz)
+	redRateHz, decim := buildSharedDecimator(inRateHz)
+	l, m := rationalRatio(outRateHz, redRateHz)
 	return &DDCBank{
 		inRateHz:    inRateHz,
+		redRateHz:   redRateHz,
 		outRateHz:   outRateHz,
-		actualOutHz: inRateHz * float64(l) / float64(m),
+		actualOutHz: redRateHz * float64(l) / float64(m),
 		guardFrac:   guardFrac,
+		predec:      decim,
 	}
+}
+
+// ddcDecimateFloorHz is the lowest reduced rate the shared decimator targets.
+// Halving stops while the next halving would still leave the rate at/above
+// this floor, so the reduced rate lands in [floor, 2·floor). 2.5 MS/s keeps
+// the usable band ≥ ±1.1 MHz (after the 5% guard) and the per-tap resampler
+// ratio in the same regime the single-stage path was tuned for.
+const ddcDecimateFloorHz = 2_500_000.0
+
+// buildSharedDecimator picks the power-of-two decimation D that brings inRateHz
+// down to the [floor, 2·floor) window and returns the reduced rate plus a
+// shared decimate-by-D resampler (nil when inRateHz is already below 2·floor,
+// leaving the legacy single-stage path untouched). The decimating resampler
+// computes only the kept outputs, so the shared cost is bounded by the reduced
+// rate, not the full input rate. tapsPerBranch mirrors the per-tap
+// anti-aliasing convention (ddcStopbandTaps taps per unit of decimation).
+func buildSharedDecimator(inRateHz float64) (redRateHz float64, predec *dsp.Resampler) {
+	red := inRateHz
+	d := 1
+	for red/2 >= ddcDecimateFloorHz {
+		red /= 2
+		d *= 2
+	}
+	if d == 1 {
+		return inRateHz, nil
+	}
+	tapsPerBranch := ddcStopbandTaps * d
+	if tapsPerBranch < ddcMinTapsPerBranch {
+		tapsPerBranch = ddcMinTapsPerBranch
+	}
+	return red, dsp.NewResampler(1, d, tapsPerBranch, ddcKaiserBeta)
 }
 
 // AddTap registers a new tap at the given offset.
@@ -86,14 +138,14 @@ func (b *DDCBank) AddTap(offsetHz float64, sink SinkFunc) error {
 	if !b.offsetInBand(offsetHz) {
 		return ErrOffsetOutOfBand
 	}
-	l, m := rationalRatio(b.outRateHz, b.inRateHz)
+	l, m := rationalRatio(b.outRateHz, b.redRateHz)
 	tapsPerBranch := (ddcStopbandTaps*m + l - 1) / l
 	if tapsPerBranch < ddcMinTapsPerBranch {
 		tapsPerBranch = ddcMinTapsPerBranch
 	}
 	tap := &ddcTap{
 		offsetHz:  offsetHz,
-		nco:       newNCO(offsetHz, b.inRateHz),
+		nco:       newNCO(offsetHz, b.redRateHz),
 		resampler: dsp.NewResampler(l, m, tapsPerBranch, ddcKaiserBeta),
 		sink:      sink,
 	}
@@ -101,8 +153,13 @@ func (b *DDCBank) AddTap(offsetHz float64, sink SinkFunc) error {
 	return nil
 }
 
+// offsetInBand tests the offset against the usable band AFTER the shared
+// decimation cascade. A tap beyond the reduced Nyquist would alias once the
+// cascade narrows the band, so it is rejected here rather than silently
+// folded. The 2.5 MS/s reduced-rate floor keeps this band ≥ ±1.1 MHz, wider
+// than anything the analog front end actually delivers at these offsets.
 func (b *DDCBank) offsetInBand(offsetHz float64) bool {
-	half := b.inRateHz * (0.5 - b.guardFrac)
+	half := b.redRateHz * (0.5 - b.guardFrac)
 	return offsetHz >= -half && offsetHz <= half
 }
 
@@ -115,13 +172,21 @@ func (b *DDCBank) Process(src []complex64) {
 		}
 		return
 	}
-	if cap(b.mixBuf) < len(src) {
-		b.mixBuf = make([]complex64, len(src))
+	// Run the shared decimator once; every tap mixes the reduced-rate stream.
+	// When there is no shared stage (low input rate) this is src itself, so
+	// the per-tap path is unchanged from the pre-#764 behaviour.
+	wide := src
+	if b.predec != nil {
+		b.decBuf = b.predec.Process(b.decBuf, src)
+		wide = b.decBuf
+	}
+	if cap(b.mixBuf) < len(wide) {
+		b.mixBuf = make([]complex64, len(wide))
 	} else {
-		b.mixBuf = b.mixBuf[:len(src)]
+		b.mixBuf = b.mixBuf[:len(wide)]
 	}
 	for _, t := range b.taps {
-		mixInto(b.mixBuf, src, t.nco)
+		mixInto(b.mixBuf, wide, t.nco)
 		t.outBuf = t.resampler.Process(t.outBuf, b.mixBuf)
 		t.sink(t.outBuf)
 	}
@@ -151,8 +216,11 @@ func (b *DDCBank) InputRateHz() float64 { return b.inRateHz }
 // symbol clocks from this value, not the nominal target.
 func (b *DDCBank) OutputRateHz() float64 { return b.actualOutHz }
 
-// Reset clears every tap's NCO and resampler state.
+// Reset clears the shared decimator plus every tap's NCO and resampler state.
 func (b *DDCBank) Reset() {
+	if b.predec != nil {
+		b.predec.Reset()
+	}
 	for _, t := range b.taps {
 		t.nco.reset()
 		t.resampler.Reset()

--- a/internal/dsp/tuner/ddc_test.go
+++ b/internal/dsp/tuner/ddc_test.go
@@ -310,3 +310,125 @@ func TestRationalRatioReduces(t *testing.T) {
 		}
 	}
 }
+
+// TestDDCBankHighRateMultiTapReporterOffsets is the issue #764 regression: a
+// wideband Airspy run at 10 MS/s with four closely-spaced control-channel taps
+// must extract every carrier cleanly. Before the shared-decimation fix the
+// per-tap single-stage 208:1 resampler starved the live pump goroutine and the
+// off-center taps went deaf; here we assert the DSP recovers all four tones.
+func TestDDCBankHighRateMultiTapReporterOffsets(t *testing.T) {
+	const (
+		inRate  = 10_000_000.0
+		outRate = 48_000.0
+	)
+	// The reporter's four MMR taps, offsets from the 420.9 MHz capture center.
+	offsets := []float64{-887_500, -862_500, -812_500, +937_500}
+	b := NewDDCBank(inRate, outRate, 0.05)
+	collected := make(map[float64]*[]complex64, len(offsets))
+	for _, off := range offsets {
+		off := off
+		buf := &[]complex64{}
+		collected[off] = buf
+		if err := b.AddTap(off, func(out []complex64) {
+			*buf = append(*buf, out...)
+		}); err != nil {
+			t.Fatalf("AddTap(%.0f): %v", off, err)
+		}
+	}
+
+	gen := newToneGen(inRate, 0.2, offsets...)
+	for i := 0; i < 24; i++ {
+		b.Process(gen.Next(8192))
+	}
+
+	for off, bufPtr := range collected {
+		buf := *bufPtr
+		if len(buf) < 512 {
+			t.Fatalf("tap %.0f: too few samples (%d)", off, len(buf))
+		}
+		settled := buf[len(buf)/2:]
+		if frac := powerNearDC(settled, outRate, 500); frac < 0.80 {
+			t.Errorf("tap %.0f Hz: only %.1f%% of power within ±500 Hz of DC", off, frac*100)
+		}
+	}
+}
+
+// TestDDCBankDecimationFactorSelection locks the shared cascade's reduced-rate
+// choice and confirms the emitted per-tap rate stays exactly 48 kHz for the
+// wideband rates the engine accepts (issue #764).
+func TestDDCBankDecimationFactorSelection(t *testing.T) {
+	const outRate = 48_000.0
+	cases := []struct {
+		inRate    float64
+		wantRed   float64
+		wantDecim bool // true ⇒ a shared decimator is built
+	}{
+		{2_400_000, 2_400_000, false},
+		{2_500_000, 2_500_000, false},
+		{4_000_000, 4_000_000, false},
+		{5_000_000, 2_500_000, true},
+		{8_000_000, 4_000_000, true},
+		{10_000_000, 2_500_000, true},
+		{16_000_000, 4_000_000, true},
+		{20_000_000, 2_500_000, true},
+	}
+	for _, c := range cases {
+		red, predec := buildSharedDecimator(c.inRate)
+		if red != c.wantRed || (predec != nil) != c.wantDecim {
+			t.Errorf("buildSharedDecimator(%.0f) = red %.0f / predec!=nil %v, want red %.0f / %v",
+				c.inRate, red, predec != nil, c.wantRed, c.wantDecim)
+		}
+		b := NewDDCBank(c.inRate, outRate, 0.05)
+		if got := b.OutputRateHz(); got != outRate {
+			t.Errorf("rate %.0f Hz: OutputRateHz %.4f != %.0f", c.inRate, got, outRate)
+		}
+	}
+}
+
+// TestDDCBankRejectsBeyondReducedNyquist confirms the in-band check tracks the
+// post-decimation band: at 10 MS/s the usable half-band collapses from the raw
+// ±4.75 MHz to ±2.5e6·0.45 = ±1.125 MHz, so an offset that fit the raw band
+// but not the reduced one is rejected rather than silently aliased (#764).
+func TestDDCBankRejectsBeyondReducedNyquist(t *testing.T) {
+	b := NewDDCBank(10_000_000, 48_000, 0.05)
+	if err := b.AddTap(2_000_000, func([]complex64) {}); !errors.Is(err, ErrOffsetOutOfBand) {
+		t.Errorf("offset beyond reduced Nyquist: want ErrOffsetOutOfBand, got %v", err)
+	}
+	if err := b.AddTap(1_000_000, func([]complex64) {}); err != nil {
+		t.Errorf("offset inside reduced band should succeed, got %v", err)
+	}
+}
+
+// TestDDCBankLowRateBuildsNoDecimator guards the byte-for-byte unchanged path:
+// at the legacy 2.4 MS/s rate the shared cascade must be empty so the per-tap
+// behaviour is identical to the pre-#764 code.
+func TestDDCBankLowRateBuildsNoDecimator(t *testing.T) {
+	b := NewDDCBank(2_400_000, 48_000, 0.05)
+	if b.predec != nil {
+		t.Error("2.4 MS/s should build no shared decimator")
+	}
+	if b.redRateHz != 2_400_000 {
+		t.Errorf("2.4 MS/s reduced rate = %.0f, want 2400000 (unchanged)", b.redRateHz)
+	}
+}
+
+// BenchmarkDDCBankProcess10MHz4Taps quantifies the per-Process cost at the
+// reporter's 10 MS/s / 4-tap config: the shared cascade replaces four
+// full-rate 208:1 resamplers with one halfband cascade plus four reduced-rate
+// resamplers, which is what keeps the live pump goroutine real-time (#764).
+func BenchmarkDDCBankProcess10MHz4Taps(b *testing.B) {
+	const inRate = 10_000_000.0
+	offsets := []float64{-887_500, -862_500, -812_500, +937_500}
+	bank := NewDDCBank(inRate, 48_000, 0.05)
+	for _, off := range offsets {
+		if err := bank.AddTap(off, func([]complex64) {}); err != nil {
+			b.Fatalf("AddTap(%.0f): %v", off, err)
+		}
+	}
+	gen := newToneGen(inRate, 0.2, offsets...)
+	chunk := gen.Next(8192)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bank.Process(chunk)
+	}
+}

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -108,11 +108,25 @@ const guardFrac = 0.05
 // above it, ChannelizerBank's shared wide-band filter pays off.
 const strategyAutoThreshold = 6
 
-// channelizerBins is the bin count NewChannelizerBank uses when
-// strategy=="polyphase" or auto picks it. Power of two, large
-// enough that 12.5 kHz DMR repeater spacing maps to distinct bins
-// inside a 2.4 MS/s IQ band: 2_400_000 / 16 = 150 kHz per bin.
-const channelizerBins = 16
+// channelizerBinWidthHz is the target per-bin width the polyphase
+// channelizer aims for. 16 bins across a 2.4 MS/s IQ band gives 150 kHz
+// per bin — wide enough that 12.5 kHz DMR repeater spacing maps to
+// distinct bins, narrow enough that the shared anti-alias filter is sharp.
+// channelizerBinsFor keeps this width roughly constant as the sample rate
+// rises, so a 10 MS/s band gets ~64 bins instead of 16 (625 kHz) bins that
+// collapse adjacent carriers together (issue #764).
+const channelizerBinWidthHz = 150_000.0
+
+// channelizerBinsFor returns the channelizer bin count for an IQ sample
+// rate: the power of two that lands closest to channelizerBinWidthHz per
+// bin, floored at 16 so low rates behave exactly as before.
+func channelizerBinsFor(sampleRateHz uint32) int {
+	bins := 16
+	for float64(sampleRateHz)/float64(bins*2) >= channelizerBinWidthHz {
+		bins *= 2
+	}
+	return bins
+}
 
 // channelizerTapsPerBranch and channelizerKaiserBeta match the
 // channelizer package's own test defaults — wideband-clean
@@ -343,7 +357,7 @@ func New(opts Options) (*Engine, error) {
 		bank = tuner.NewDDCBank(float64(opts.SampleRateHz), narrowbandRateHz, guardFrac)
 	case "polyphase":
 		bank = tuner.NewChannelizerBank(float64(opts.SampleRateHz), narrowbandRateHz, guardFrac,
-			channelizerBins, channelizerTapsPerBranch, channelizerKaiserBeta)
+			channelizerBinsFor(opts.SampleRateHz), channelizerTapsPerBranch, channelizerKaiserBeta)
 	default:
 		return nil, fmt.Errorf("widebandt2: unknown tuner strategy %q", strategy)
 	}

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -217,6 +217,91 @@ func TestEngineStrategyAuto(t *testing.T) {
 	})
 }
 
+// TestChannelizerBinsFor locks the sample-rate-scaled bin count: 16 bins at
+// the legacy 2.4 MS/s rate (≈150 kHz/bin, unchanged), growing with the rate so
+// the per-bin width stays near channelizerBinWidthHz instead of ballooning to
+// 625 kHz at 10 MS/s and collapsing adjacent carriers (issue #764).
+func TestChannelizerBinsFor(t *testing.T) {
+	cases := []struct {
+		rate uint32
+		want int
+	}{
+		{2_400_000, 16},
+		{2_500_000, 16},
+		{5_000_000, 32},
+		{10_000_000, 64},
+		{20_000_000, 128},
+	}
+	for _, c := range cases {
+		if got := channelizerBinsFor(c.rate); got != c.want {
+			t.Errorf("channelizerBinsFor(%d) = %d, want %d (bin width %.0f kHz)",
+				c.rate, got, c.want, float64(c.rate)/float64(got)/1e3)
+		}
+	}
+}
+
+// TestEngineHighRateChannelizerDistinctBins is the channelizer half of issue
+// #764: a 10 MS/s polyphase survey with carriers 200 kHz apart must place each
+// in a distinct bin. With the old fixed 16 bins the bin width is 625 kHz and
+// the carriers collide (AddTap → ErrBinAlreadyClaimed, engine construction
+// fails); with the scaled bin count they land in separate bins.
+func TestEngineHighRateChannelizerDistinctBins(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	channels := []ChannelConfig{}
+	for i := -3; i <= 3; i++ {
+		channels = append(channels, ChannelConfig{
+			FrequencyHz: uint32(int64(453_500_000) + int64(i)*200_000),
+			SystemName:  "x",
+		})
+	}
+	e, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 10_000_000, CenterFreqHz: 453_500_000,
+		TunerStrategy: "polyphase",
+		Channels:      channels,
+		Systems:       []trunking.System{t2System("x")},
+	})
+	if err != nil {
+		t.Fatalf("10 MS/s polyphase with 200 kHz spacing should build distinct bins, got: %v", err)
+	}
+	if e.Strategy() != "polyphase" {
+		t.Errorf("strategy = %q, want polyphase", e.Strategy())
+	}
+}
+
+// TestEngineHighRateReporterTapsInBand is the DDC half of issue #764: the
+// reporter's four closely-spaced P25 control taps at a 10 MS/s capture must all
+// be accepted by the auto-selected DDC bank (they sit inside the post-decimation
+// usable band), rather than being rejected or routed to a channelizer that
+// cannot separate sub-bin spacing.
+func TestEngineHighRateReporterTapsInBand(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+	const center = 420_900_000
+	offsets := []int64{-887_500, -862_500, -812_500, +937_500}
+	channels := make([]ChannelConfig, 0, len(offsets))
+	systems := make([]trunking.System, 0, len(offsets))
+	for i, off := range offsets {
+		freq := uint32(int64(center) + off)
+		name := "mmr" + string(rune('a'+i))
+		channels = append(channels, ChannelConfig{FrequencyHz: freq, SystemName: name})
+		systems = append(systems, p25Phase1System(name, freq))
+	}
+	e, err := New(Options{
+		Device: dev, Bus: bus, SampleRateHz: 10_000_000, CenterFreqHz: center,
+		Channels: channels,
+		Systems:  systems,
+	})
+	if err != nil {
+		t.Fatalf("reporter's 4 taps at 10 MS/s should construct, got: %v", err)
+	}
+	if e.Strategy() != "auto(ddc)" {
+		t.Errorf("strategy = %q, want auto(ddc) (closely-spaced taps need per-tap DDC)", e.Strategy())
+	}
+}
+
 func TestEngineStrategyExplicit(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/siglab/wideband.go
+++ b/internal/siglab/wideband.go
@@ -25,10 +25,25 @@ const (
 
 	// pickStrategy mirror (widebandt2): DDC ≤ 6 taps, polyphase above.
 	wbStrategyAutoThreshold = 6
-	wbChannelizerBins       = 16
 	wbChannelizerTaps       = 16
 	wbChannelizerKaiserBeta = 9.0
+
+	// wbChannelizerBinWidthHz mirrors widebandt2.channelizerBinWidthHz: the
+	// target per-bin width the channelizer bin count is scaled to so a wide
+	// (e.g. 10 MS/s) survey gets enough bins to keep adjacent carriers in
+	// distinct bins instead of the fixed-16 collapse (issue #764).
+	wbChannelizerBinWidthHz = 150_000.0
 )
+
+// wbChannelizerBinsFor mirrors widebandt2.channelizerBinsFor: the power of
+// two closest to wbChannelizerBinWidthHz per bin, floored at 16.
+func wbChannelizerBinsFor(inRateHz float64) int {
+	bins := 16
+	for inRateHz/float64(bins*2) >= wbChannelizerBinWidthHz {
+		bins *= 2
+	}
+	return bins
+}
 
 // WidebandConfig configures a wideband multi-carrier survey: the whole-capture
 // sample rate + format, the channel rate each carrier is decimated to, and the
@@ -389,7 +404,7 @@ func newBank(strategy string, nTaps int, inRateHz, outRateHz, guardFrac float64)
 	}
 	if usePoly {
 		return tuner.NewChannelizerBank(inRateHz, outRateHz, guardFrac,
-			wbChannelizerBins, wbChannelizerTaps, wbChannelizerKaiserBeta), "polyphase"
+			wbChannelizerBinsFor(inRateHz), wbChannelizerTaps, wbChannelizerKaiserBeta), "polyphase"
 	}
 	return tuner.NewDDCBank(inRateHz, outRateHz, guardFrac), "ddc"
 }

--- a/internal/siglab/wideband_test.go
+++ b/internal/siglab/wideband_test.go
@@ -188,3 +188,24 @@ func TestSurveyWidebandRecognizesDMRTier3(t *testing.T) {
 	}
 	t.Logf("verdict: %s", sys.Verdict)
 }
+
+// TestWBChannelizerBinsFor locks the survey path's bin scaling in step with
+// the live engine's channelizerBinsFor (issue #764): 16 bins at 2.4 MS/s,
+// growing with the rate so wide surveys keep adjacent carriers in distinct
+// bins instead of the fixed-16 collapse.
+func TestWBChannelizerBinsFor(t *testing.T) {
+	cases := []struct {
+		rate float64
+		want int
+	}{
+		{2_400_000, 16},
+		{5_000_000, 32},
+		{10_000_000, 64},
+		{20_000_000, 128},
+	}
+	for _, c := range cases {
+		if got := wbChannelizerBinsFor(c.rate); got != c.want {
+			t.Errorf("wbChannelizerBinsFor(%.0f) = %d, want %d", c.rate, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
A role: wideband dongle run above 2.5 MS/s went deaf across every tap.
Two independent rate-dependent defects were responsible.

DDC path (the reporter's 4 closely-spaced control taps, which can't use the
channelizer): the per-tap path mixed and ran a single-stage rational
resampler at the full input rate, so a 10 MS/s capture decimated 208:1 per
tap. The DSP is rate-correct, but the cost scales with the input rate (~4x at
10 MS/s vs 2.5), and the live engine runs every tap's mix + resample + receiver
inline on one pump goroutine. At 10 MS/s with 4 taps it could no longer keep
real time; the Airspy USB ring overran and dropped samples, so even the strong
center tap stopped syncing. DDCBank now runs a shared decimate-by-D stage once
over the wideband stream (a decimating dsp.Resampler, L=1/M=D, which computes
only the kept outputs) to bring it into [2.5, 5) MS/s before the per-tap
mixers. Per-tap cost is pinned to the proven ~2.5 MS/s regime regardless of
input rate, and the shared stage is cheap and amortised across taps. Below
5 MS/s no shared stage is built, so the 2.4 MS/s path is unchanged. AddTap's
in-band check now tracks the post-decimation band so an offset beyond the
reduced Nyquist is rejected rather than aliased.

Channelizer path: channelizerBins was hardcoded to 16 (sized for 2.4 MS/s ->
150 kHz bins). At 10 MS/s bins ballooned to 625 kHz and adjacent carriers
collided into one bin. Bin count now scales with the sample rate to hold the
~150 kHz width (64 bins at 10 MS/s), in both the live engine and the offline
siglab survey.

Adds DDC regression tests at the reporter's 10 MS/s / 4-tap config,
decimation-factor selection, reduced-Nyquist rejection, a low-rate no-op
guard, a Process benchmark, and engine/survey bin-scaling tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0123vPLLezrSuxEscRZtnvwP