### PR TITLE
fix(build): add @types/node to siglab so `make dist` succeeds (#684)

### DIFF
--- a/web/siglab/package-lock.json
+++ b/web/siglab/package-lock.json
@@ -25,6 +25,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/d3": "^7.4.3",
+        "@types/node": "^22.19.20",
         "@types/plotly.js-dist-min": "^2.3.4",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -6840,15 +6841,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/plotly.js": {
@@ -11882,13 +11881,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/web/siglab/package.json
+++ b/web/siglab/package.json
@@ -30,6 +30,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/d3": "^7.4.3",
+    "@types/node": "^22.19.20",
     "@types/plotly.js-dist-min": "^2.3.4",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",


### PR DESCRIPTION
web/siglab/vite.config.ts imports `node:url` (fileURLToPath) and uses
`import.meta.url`, but `@types/node` was not a direct dependency of the
siglab package. In the lockfile it appeared only as an optional peer of
vite/vitest, which `npm ci` does not install, so the `tsc --noEmit` step
of `npm run build` failed with:

    vite.config.ts:2:31 - error TS2307: Cannot find module 'node:url'
    or its corresponding type declarations.

breaking `make dist` (siglab-web-build). web/configbuilder has the same
`node:url` usage and builds fine precisely because it lists @types/node
as a direct devDependency. Mirror that here (pinned to the same
^22.19.20 major) and regenerate the lockfile so `npm ci` installs it.

web/ is unaffected (no node: imports in its vite config), so siglab was
the only package missing the dependency.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QEguueQP5BNjeF3bJT5uB9