### PR TITLE
Add "Intro to Hardware" learning path

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -91,6 +91,14 @@ defaults:
       learn_path: digital-trunking
       nav_group: Learn
       permalink: /learn/digital-trunking/:basename/
+  - scope:
+      path: "learn/intro-hardware"
+      type: pages
+    values:
+      layout: lesson
+      learn_path: intro-hardware
+      nav_group: Learn
+      permalink: /learn/intro-hardware/:basename/
   # Field Guide articles under /reference/ get the reference layout and nav
   # group automatically. The hub (reference/index.md) overrides to reference-hub.
   - scope:

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -1038,3 +1038,234 @@ paths:
       minutes: 12
       level: beginner
       status: full
+
+  - id: intro-hardware
+    label: "Intro to Hardware"
+    title: "Intro to Hardware — from the cloud to the microcontroller"
+    tagline: "The hardware a developer actually chooses between — servers, PCs, phones, single-board computers, and microcontrollers — what each is for, what runs on it, and how to pick."
+    start_slug: what-is-hardware
+    workload: "PT6H"
+    intro: >
+      Every project runs on something. This path is a guided tour of the hardware
+      a developer chooses between — from a few dollars of shared web hosting up
+      through VPSes, dedicated and home servers, the desktops and laptops you
+      build on, the phones and tablets you ship to, and down to single-board
+      computers and the tiny microcontrollers like the Arduino and ESP32. For
+      each one you'll learn what it's for, the programming languages it runs, and
+      its real strengths and drawbacks. The final module turns all of that into a
+      practical way to decide which platform — often several working together —
+      is right for your project. Examples lean on GopherTrunk, the kind of
+      software-defined-radio software that can live on anything from a laptop to a
+      Raspberry Pi by the antenna.
+    modules:
+      - id: foundations
+        label: "Module 1 — Hardware Foundations"
+        blurb: "The ideas every later module leans on: what hardware is, the parts inside every computer, the spectrum from cloud to microcontroller, and the trade-offs that drive every choice."
+        lessons:
+          - slug: what-is-hardware
+            title: What is computer hardware?
+            summary: Hardware vs. software, what counts as a computer, and why the same job can run on a server or a chip the size of a stamp — the one idea everything else builds on.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: building-blocks
+            title: CPU, memory, storage & I/O
+            summary: The four building blocks inside every computer, from a data center to a microcontroller, and how their size and speed define what a device can do.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: hardware-spectrum
+            title: The hardware spectrum — cloud to microcontroller
+            summary: A single map of every platform in this path, ordered by power, cost, and how much of it you control, so the rest of the path has a frame to hang on.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: languages-and-hardware
+            title: Programming languages & where they run
+            summary: Why a web host runs PHP and Python while a microcontroller runs C — how hardware shapes which languages are practical, and what "runs on" really means.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: cost-power-performance
+            title: Cost, power & performance trade-offs
+            summary: The handful of trade-offs — money, electricity, performance, control, and effort — that recur in every hardware decision you'll make.
+            minutes: 8
+            level: beginner
+            status: full
+
+      - id: servers
+        label: "Module 2 — Servers & Hosting"
+        blurb: "Where software runs for other people: the ladder from cheap shared web hosting, through VPSes and dedicated servers, to a server humming in your own home."
+        lessons:
+          - slug: web-hosting
+            title: Web & shared hosting
+            summary: The cheapest way to put something online — what shared hosting gives you, what it hides, the languages it runs, and where it stops being enough.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: vps
+            title: Virtual private servers (VPS)
+            summary: Your own slice of a server with root access — how virtualization carves one machine into many, what you can run, and the responsibility that comes with it.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: dedicated-servers
+            title: Dedicated servers
+            summary: A whole physical machine that's yours alone — when raw, uncontended performance is worth the price, and what changes when nothing is shared.
+            minutes: 8
+            level: intermediate
+            status: full
+          - slug: home-servers
+            title: Home servers & self-hosting
+            summary: Running your own server on your own internet — the freedom, the costs nobody mentions, and why a Raspberry Pi or old PC can be a perfect first server.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: personal-computers
+        label: "Module 3 — Personal Computers"
+        blurb: "The machines you build software on: the trade between a fixed, powerful desktop and a portable laptop, and how to choose the one you'll work on every day."
+        lessons:
+          - slug: desktop-computers
+            title: Desktop computers
+            summary: The most power per dollar, endlessly upgradable, and going nowhere — what desktops are for, what they run, and where they shine for a developer.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: laptops
+            title: Laptops
+            summary: A whole computer you can carry — the portability-for-power trade, battery and thermal limits, and why most developers work on one anyway.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: choosing-a-dev-machine
+            title: Choosing your development machine
+            summary: Desktop, laptop, or both — matching your machine to how and where you work, and the specs that actually matter for writing software.
+            minutes: 8
+            level: intermediate
+            status: full
+
+      - id: mobile
+        label: "Module 4 — Mobile Devices"
+        blurb: "The computers in everyone's pocket and bag: what smartphones and tablets are good at, what they're not, and what it takes to build software for them."
+        lessons:
+          - slug: smartphones
+            title: Smartphones
+            summary: The most widespread computer on earth — its sensors and constraints, the platforms and languages behind apps, and why it's a target, not a dev machine.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: tablets
+            title: Tablets
+            summary: The big-screen cousin of the phone — where the extra size pays off, where tablets sit between phone and laptop, and what runs on them.
+            minutes: 7
+            level: beginner
+            status: full
+          - slug: developing-for-mobile
+            title: Developing for mobile devices
+            summary: Native, cross-platform, or web — the ways to build a mobile app, the languages and toolchains each uses, and the trade-offs between them.
+            minutes: 10
+            level: intermediate
+            status: full
+
+      - id: single-board-computers
+        label: "Module 5 — Single-Board Computers"
+        blurb: "A complete computer on one small board: what an SBC like the Raspberry Pi is, what it's brilliant at, how you program it, and where its limits begin."
+        lessons:
+          - slug: what-is-an-sbc
+            title: What is a single-board computer?
+            summary: A real, Linux-running computer the size of a credit card — how an SBC differs from both a PC and a microcontroller, and why GPIO pins change everything.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: raspberry-pi-and-family
+            title: The Raspberry Pi & its alternatives
+            summary: The board that defined the category, plus the rivals worth knowing — Pi Zero to Pi 5, Jetson, Rock, and BeagleBone — and how to tell them apart.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: programming-an-sbc
+            title: Programming & running software on an SBC
+            summary: It's just Linux — Python, C, Go, and the same tools you use on a PC, plus talking to the physical world through the GPIO header.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: sbc-use-cases-and-limits
+            title: SBC use cases, strengths & drawbacks
+            summary: Home labs, media servers, robots, and edge sensors — where SBCs win, and the heat, power, storage, and reliability limits that decide when to reach for something else.
+            minutes: 8
+            level: intermediate
+            status: full
+
+      - id: microcontrollers
+        label: "Module 6 — Microcontrollers"
+        blurb: "The tiny chips that run the physical world: what a microcontroller is, the Arduino that made them approachable, the wireless ESP32, and how you program them."
+        lessons:
+          - slug: what-is-a-microcontroller
+            title: What is a microcontroller?
+            summary: A whole computer on one cheap, low-power chip with no operating system — how it differs from an SBC, and why it boots in milliseconds and runs for years.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: arduino
+            title: Arduino & the maker ecosystem
+            summary: The board and language that made microcontrollers approachable — what Arduino is, the sketch model, and the enormous ecosystem that grew around it.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: esp32
+            title: ESP32 & wireless microcontrollers
+            summary: A microcontroller with Wi-Fi and Bluetooth built in for a couple of dollars — why it powers most DIY smart-home gadgets and the Internet of Things.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: mcu-programming-and-tradeoffs
+            title: "Programming microcontrollers: languages, use cases & limits"
+            summary: C/C++, MicroPython, and Rust on bare metal — the use cases microcontrollers own, and the tight memory, power, and tooling limits you design around.
+            minutes: 9
+            level: intermediate
+            status: full
+
+      - id: choosing-hardware
+        label: "Module 7 — Choosing the Right Hardware"
+        blurb: "Everything applied: turn a project's needs into the platform — or, more often, the combination of platforms — that fits it best, with a repeatable framework and worked examples."
+        lessons:
+          - slug: start-with-requirements
+            title: Start with your requirements
+            summary: Before you pick a board or a host, pin down what the project actually needs — performance, connectivity, power, budget, and where it has to live.
+            minutes: 8
+            level: beginner
+            status: full
+          - slug: matching-hardware-to-project
+            title: Matching hardware to the project type
+            summary: Websites, apps, data crunching, automation, sensors, and robots — the platforms each kind of project tends to reach for, and why.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: combining-tiers
+            title: "Combining tiers: device, server & cloud"
+            summary: Real systems rarely live on one platform — how a microcontroller, an SBC, and a server team up, and where to draw the line between them.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: decision-framework
+            title: A practical decision framework
+            summary: A repeatable checklist for turning requirements into a hardware choice, including the questions that quickly rule platforms in or out.
+            minutes: 10
+            level: advanced
+            status: full
+          - slug: worked-examples
+            title: "Worked examples: picking hardware for real projects"
+            summary: The framework applied end to end to several projects — a blog, a smart-home sensor, a home media server, and a GopherTrunk scanner — to make it concrete.
+            minutes: 10
+            level: advanced
+            status: full
+
+    # Standalone reference, not part of the sequential path (no prev/next slot).
+    glossary:
+      slug: glossary
+      title: Glossary of hardware terms
+      summary: Plain-language definitions for every hardware term in the learning path, cross-linked to the lessons.
+      minutes: 12
+      level: beginner
+      status: full

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -2,8 +2,8 @@
 layout: learn-index
 title: Learn
 lede: Free, structured learning paths that take you from complete beginner to confident practitioner — one short, self-contained lesson at a time.
-description: Free, structured GopherTrunk learning paths — radio & SDR fundamentals, a complete Git & GitHub course, and an intro to software development — taking you from beginner to expert one short lesson at a time.
-keywords: GopherTrunk learn, SDR tutorial, learn git, github tutorial, radio fundamentals, learn software development, programming for beginners, free courses
+description: Free, structured GopherTrunk learning paths — radio & SDR fundamentals, a complete Git & GitHub course, an intro to software development, digital & trunked radio, and an intro to hardware — taking you from beginner to expert one short lesson at a time.
+keywords: GopherTrunk learn, SDR tutorial, learn git, github tutorial, radio fundamentals, learn software development, programming for beginners, learn computer hardware, hardware for developers, free courses
 permalink: /learn/
 ---
 

--- a/docs/learn/intro-hardware/arduino.md
+++ b/docs/learn/intro-hardware/arduino.md
@@ -1,0 +1,99 @@
+---
+slug: arduino
+title: Arduino & the maker ecosystem
+description: Arduino is the open-source board and language that made microcontrollers approachable. Learn the sketch model, the blink program, and the ecosystem around it.
+keywords: arduino, arduino uno, arduino ide, arduino sketch, setup loop, maker electronics, microcontroller for beginners, arduino shields, ATmega328
+level: beginner
+status: full
+faq:
+  - q: "What exactly is Arduino?"
+    a: "Arduino is three things bundled together: open-source **boards** (like the Uno and Nano) built around a microcontroller, the free **Arduino IDE** you write code in, and a friendly **C++ library** that hides the chip's low-level details behind simple commands like `digitalWrite()` and `delay()`. Together they turned bare-metal microcontroller programming into something a beginner can pick up in an afternoon."
+  - q: "What is a \"sketch\" in Arduino?"
+    a: "A **sketch** is just what Arduino calls a program. Every sketch has two functions: `setup()`, which runs once when the board powers on, and `loop()`, which runs over and over forever afterward. That `setup()` then `loop()` shape mirrors how a microcontroller actually works — initialize once, then repeat the main job endlessly — which is why it's such an effective teaching model."
+  - q: "Are Arduino boards powerful enough for real projects?"
+    a: "For their niche, yes — but know the limits. The classic Uno uses an 8-bit ATmega328 with just **2 KB of RAM** running at 16 MHz, which is plenty for reading sensors and blinking lights but not for video, heavy math, or networking. For wireless or more compute you step up to a board like the **ESP32**, which uses the same Arduino tooling but adds Wi-Fi and far more power."
+---
+# Arduino & the maker ecosystem
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Arduino made microcontrollers approachable** — open-source boards, a simple IDE, and a friendly C++ library bundled together. **The sketch model** — every program has a `setup()` that runs once and a `loop()` that repeats forever. **A huge ecosystem** — shields, sensors, libraries, and a vast community made it the standard on-ramp for beginners.
+</div>
+
+In the last lesson you met the microcontroller: a whole computer on one bare-metal chip. Programming one *used* to mean wrestling with datasheets, special hardware programmers, and raw registers. Arduino changed that. It took the same chips and wrapped them in tools simple enough for a complete beginner — and in doing so it created the modern maker movement. This lesson covers what Arduino is, the sketch model at its heart, and the ecosystem that grew up around it.
+
+## What Arduino actually is
+
+Arduino isn't a single product — it's a whole approach made of three parts that work together:
+
+- **Open-source boards.** The classic **Uno** and the smaller **Nano** are the famous ones, built around Microchip's 8-bit ATmega microcontrollers. Because the designs are open, dozens of compatible boards exist too.
+- **The Arduino IDE.** A free, beginner-friendly editor where you write, compile, and upload code with a single click — no separate toolchain to assemble.
+- **A friendly C++ library.** This is the quiet hero. It hides the chip's intimidating low-level registers behind plain-English commands, so turning on a pin is `digitalWrite(13, HIGH)` instead of a cryptic bit operation on a hardware register.
+
+The genius was bundling all three. Before Arduino, getting "hello world" onto a microcontroller could take a beginner days. After Arduino, it took minutes — and that drop in friction is what opened embedded electronics to artists, students, and hobbyists, not just engineers.
+
+## The sketch model: setup() and loop()
+
+An Arduino program is called a **sketch**, and every sketch is built from exactly two functions:
+
+- **`setup()`** runs **once** when the board powers on or resets. You use it to get things ready — configure pins, start a sensor, open a serial connection.
+- **`loop()`** runs **over and over, forever**, the instant `setup()` finishes. This is the main job, repeated endlessly until power is cut.
+
+That shape isn't arbitrary — it mirrors how a microcontroller genuinely behaves. With no operating system to return to, the chip must keep doing *something* forever, so "set up once, then repeat" is the natural rhythm of bare-metal code. Here's the canonical first sketch, which blinks the board's built-in LED:
+
+```cpp
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);   // run once: set the LED pin as an output
+}
+
+void loop() {
+  digitalWrite(LED_BUILTIN, HIGH); // turn the LED on
+  delay(1000);                     // wait 1000 ms (one second)
+  digitalWrite(LED_BUILTIN, LOW);  // turn the LED off
+  delay(1000);                     // wait another second, then loop repeats
+}
+```
+
+That's a complete, working program. The "Blink" sketch is the embedded world's equivalent of "Hello, world" — once an LED blinks, you know your code compiled, uploaded, and is actually running on the metal.
+
+## The ecosystem that grew around it
+
+Arduino's lasting impact is as much social as technical. A massive **ecosystem** formed around the boards:
+
+- **Shields** — add-on boards that stack onto an Uno's pins to add a feature (a motor driver, a screen, a GPS, an Ethernet port) with no wiring.
+- **Sensors and modules** — cheap breakout boards for temperature, motion, light, distance, and more, nearly all with ready-made Arduino libraries.
+- **Libraries** — community-written code that lets you drive a complex part in a few lines instead of reading its datasheet.
+- **Community** — countless tutorials, forum threads, and project write-ups, so almost any beginner problem has already been solved and posted somewhere.
+
+This is the real reason Arduino became *the* on-ramp. The hardware abstraction got you started, and the ecosystem meant you were never stuck for long. Typical projects: prototyping a product idea, classroom and university teaching, hobby electronics and art installations, and simple home automation.
+
+## Strengths and drawbacks
+
+Arduino is brilliant at what it's for, and it's worth being clear-eyed about where it stops.
+
+| | Arduino (classic AVR boards) |
+|---|---|
+| **Strengths** | Easy to learn; very cheap; enormous community and library support; hardware details abstracted away; quick from idea to blinking LED |
+| **Drawbacks** | Classic boards are slow 8-bit chips with little memory (Uno: 16 MHz, 2 KB RAM); the single `loop()` runs one thing at a time; no built-in networking on basic boards; not for heavy compute, video, or big data |
+
+The drawbacks aren't flaws so much as the cost of simplicity. The 8-bit Uno is wonderful for learning and for small control jobs, but it can't stream video or talk to the internet on its own. When a project needs wireless or more horsepower, you reach for a more capable chip that *keeps the same friendly tooling* — which is exactly the ESP32, the subject of the next lesson. (And to be clear, these chips are far too small to run something like GopherTrunk; an MCU is a teaching contrast to the SBCs and PCs that do.)
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — setup() runs once at power-on, and loop() repeats forever afterward." markdown="0">
+  <p class="knowledge-check__q">Quick check: In an Arduino sketch, what is the role of the two standard functions?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Both `setup()` and `loop()` run once and then the board stops</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">`setup()` runs once at power-on; `loop()` then repeats forever</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">`loop()` runs first to load the operating system, then `setup()` takes over</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Three things in one** — Arduino is open-source boards, a simple IDE, and a friendly C++ library bundled to make microcontrollers approachable.
+- **The sketch model** — `setup()` runs once at power-on; `loop()` repeats forever, mirroring how a bare-metal chip really works.
+- **Blink is hello-world** — a few lines turn an LED on and off and prove your code is running on the metal.
+- **A rich ecosystem** — shields, sensors, libraries, and a huge community made Arduino the standard beginner on-ramp.
+- **Know the limits** — classic 8-bit boards are slow with little memory and no networking; step up when you need wireless or compute.
+
+Next up: a microcontroller with Wi-Fi and Bluetooth built in, for the price of a coffee. See [ESP32 & wireless microcontrollers](/learn/intro-hardware/esp32/).

--- a/docs/learn/intro-hardware/building-blocks.md
+++ b/docs/learn/intro-hardware/building-blocks.md
@@ -1,0 +1,100 @@
+---
+slug: building-blocks
+title: CPU, memory, storage & I/O
+description: Every computer is built from four parts — a processor, working memory, long-term storage, and ways to talk to the world. Learn what each does and how they scale from servers to chips.
+keywords: cpu memory storage io, what is a cpu, ram vs storage, what is volatile memory, gpio and io, ssd vs flash vs eeprom, computer building blocks, cores and clock speed
+level: beginner
+status: full
+faq:
+  - q: "What is the difference between memory and storage?"
+    a: "**Memory (RAM)** is fast, volatile working space — it holds whatever the computer is actively using right now and is wiped when the power goes off. **Storage** is slower but non-volatile — it keeps files, programs, and data when the machine is unplugged. A rough analogy: memory is your desk (what you're working on now), storage is the filing cabinet (everything kept for later)."
+  - q: "What do cores and clock speed actually mean?"
+    a: "A **core** is an independent processing unit inside a CPU; more cores let the chip work on more things at once. **Clock speed** (measured in GHz) is roughly how many basic steps each core takes per second. A 4-core, 3 GHz chip can do four streams of work, each taking about three billion simple steps a second — but real-world speed depends on far more than these two numbers."
+  - q: "What is I/O on a small device like a microcontroller?"
+    a: "On a microcontroller, **I/O** usually means **GPIO** — general-purpose input/output pins you wire directly to sensors, buttons, LEDs, and motors. Larger machines do I/O through USB ports, network cards, and displays instead. It is the same idea at every scale: the channels a computer uses to read from and act on the outside world."
+  - q: "Why does a microcontroller have so little memory?"
+    a: "Because it is built for one small job at low cost and low power. A microcontroller might have a few kilobytes of RAM where a server has hundreds of gigabytes — a difference of millions of times. It does not need more: blinking an LED or reading a sensor takes almost nothing, and shrinking memory keeps the chip cheap and power-thrifty."
+---
+# CPU, memory, storage & I/O
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Four parts, every machine** — a CPU executes instructions, memory holds active work, storage keeps data when powered off, and I/O connects to the world. **Memory is volatile, storage is not** — RAM is fast and forgetful; storage is slower but permanent. **Scale is the only difference** — a server and a microcontroller have the same four parts, separated by a factor of millions in size and speed.
+</div>
+
+In the last lesson we said every computer is anything that fetches instructions and runs them. This lesson opens the box. Whether you're looking at a data-center server or a chip the size of a fingernail, you'll find the same four building blocks doing the same four jobs. Once you can name them and know what each one limits, the whole rest of this path — every platform, every trade-off — becomes much easier to reason about.
+
+## The CPU: where instructions run
+
+The **CPU** (central processing unit, or just "the processor") is the part that actually does the work. Its entire job is the fetch-execute loop: pull the next instruction from memory, carry it out, repeat — billions of times a second. Each instruction is tiny: add two numbers, compare them, move data, jump somewhere else. Everything your computer does is composed from these primitive steps.
+
+Two numbers usually describe a CPU. **Clock speed**, measured in gigahertz (GHz), is roughly how many basic steps a core takes per second — 3 GHz means about three billion. **Cores** are independent processing units on the chip; a four-core CPU can run four streams of work at the same time. More cores and a higher clock generally mean more capacity, but they're far from the whole story: cache size, instruction design, and memory speed all matter, which is why you can't compare two chips on GHz alone.
+
+The range is staggering. A server CPU might have 64 cores running at high speed; a microcontroller often has a single core at a few hundred megahertz or less. Both run the same kind of loop — one just does vastly more of it.
+
+## Memory: fast, volatile working space
+
+**Memory** — almost always meaning **RAM** (random-access memory) — is the CPU's working space. It holds the program currently running and the data it's actively using, because RAM is far faster to read and write than storage. When you open an app, it's loaded from storage into memory so the CPU can work with it quickly.
+
+The defining trait of RAM is that it's **volatile**: cut the power and everything in it vanishes. That's fine, because it's only ever holding work-in-progress. Think of it as a desk — large enough to spread out what you're using now, but cleared off every night.
+
+Memory is often the real ceiling on what a machine can do. If a program needs more RAM than the device has, it either runs painfully slowly or won't run at all. A server with 256 GB of RAM can juggle thousands of tasks; a microcontroller with 2 KB can hold only a few hundred variables. The job has to fit in the space available.
+
+## Storage: keeping data when the power is off
+
+**Storage** is the **non-volatile** counterpart to memory: it keeps its contents with the power off. This is where your operating system, programs, files, and saved data actually live. It's slower than RAM but vastly larger and permanent. Storage comes in several forms depending on the machine:
+
+| Type | Where you find it | Notes |
+|------|-------------------|-------|
+| **SSD** (solid-state drive) | Laptops, desktops, servers | Fast flash-based storage, no moving parts |
+| **HDD** (hard disk drive) | Servers, older PCs, bulk archives | Spinning magnetic platters; cheap per gigabyte, slower |
+| **Flash / eMMC** | Phones, tablets, single-board computers | Compact flash storage soldered onto the board |
+| **SD / microSD card** | Raspberry Pi, cameras, many SBCs | Removable flash; convenient but wears out over time |
+| **EEPROM / on-chip flash** | Microcontrollers | A small amount of storage built into the chip for the program itself |
+
+The pattern is the same everywhere: a slower, permanent place to keep things, sized to the machine. A microcontroller might store its entire program in a few hundred kilobytes of on-chip flash; a server may hold dozens of terabytes across many drives.
+
+## I/O: how a computer touches the world
+
+A processor with memory and storage but no way to communicate would be useless. **I/O** (input/output) is everything that lets a computer take in information and act on it. The forms it takes depend heavily on the machine:
+
+- **Networking** — Ethernet and Wi-Fi, how a machine reaches the internet and other devices. Essential for a server, optional for a sensor.
+- **USB and peripherals** — keyboards, mice, drives, and the SDR dongles GopherTrunk uses to pull in radio signals.
+- **Displays** — screens, from a phone's touchscreen to a server's complete absence of one (servers are usually "headless").
+- **GPIO** — general-purpose input/output pins on single-board computers and microcontrollers, wired directly to buttons, LEDs, motors, and sensors. This is how a tiny device senses and controls the physical world.
+
+I/O is often what actually decides which machine fits a job. A Raspberry Pi running GopherTrunk right at an antenna needs a USB port for the SDR dongle and a network connection to send data back; a microcontroller monitoring a temperature sensor needs GPIO and almost nothing else. Same four building blocks, very different I/O.
+
+## Putting it together across the spectrum
+
+Each block scales independently, but they tend to move together: powerful machines have lots of everything, tiny ones have little of anything. Here's the rough shape of it, from largest to smallest:
+
+| Platform | Typical RAM | Typical storage | Typical I/O |
+|----------|-------------|-----------------|-------------|
+| **Data-center server** | 64 GB – 1 TB+ | Terabytes (SSD/HDD) | Fast networking, no display |
+| **Laptop / desktop** | 8 – 64 GB | 256 GB – 2 TB SSD | USB, Wi-Fi, display, keyboard |
+| **Smartphone** | 4 – 16 GB | 64 GB – 1 TB flash | Touchscreen, cellular, Wi-Fi |
+| **Single-board computer (e.g. Raspberry Pi)** | 1 – 8 GB | microSD or eMMC | USB, Ethernet/Wi-Fi, GPIO |
+| **Microcontroller** | 2 KB – 512 KB | a few KB – a few MB flash | GPIO, simple serial buses |
+
+Read down the columns and the scale of the difference is clear: a server can have a million times the memory of a microcontroller. Yet every row has the same four parts. Knowing how much of each a machine has tells you most of what it can — and can't — do, which is exactly the map the next lesson draws.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — RAM is fast, volatile working space; storage is the slower, permanent place data lives when the power is off." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the key difference between memory (RAM) and storage?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Memory keeps data permanently; storage is wiped when the power is off</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Memory is fast, volatile working space; storage keeps data permanently when powered off</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">They are two names for the same thing</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **The CPU runs instructions** — its fetch-execute loop is the heartbeat of every computer; cores and clock speed describe its capacity, but only roughly.
+- **Memory is volatile working space** — RAM holds what's running now and is wiped on power-off; it's often the real ceiling on what a machine can do.
+- **Storage is permanent** — SSDs, HDDs, flash, SD cards, and on-chip EEPROM all keep data with the power off, sized to the machine.
+- **I/O connects to the world** — networking, USB, displays, and GPIO are how a computer senses and acts, and often the deciding factor in fit.
+- **Same parts, different scale** — a server and a microcontroller share all four blocks, separated by a factor of millions.
+
+Next up: with the parts named, we can lay every platform out on one map, ordered by power, cost, and control. See [The hardware spectrum — cloud to microcontroller](/learn/intro-hardware/hardware-spectrum/).

--- a/docs/learn/intro-hardware/choosing-a-dev-machine.md
+++ b/docs/learn/intro-hardware/choosing-a-dev-machine.md
@@ -1,0 +1,99 @@
+---
+slug: choosing-a-dev-machine
+title: Choosing your development machine
+description: Pick a desktop, laptop, or both by matching it to how you work — and learn which specs (RAM, SSD, CPU, screen, GPU) actually matter for writing software.
+keywords: choosing a development machine, developer laptop vs desktop, dev machine specs, how much RAM for development, remote development, thin client, WSL, SSD for coding
+level: intermediate
+status: full
+faq:
+  - q: "What spec matters most for a development machine?"
+    a: "**Memory first.** Editors, browsers, containers, and virtual machines all eat RAM, and running out of it slows everything to a crawl in a way more processor speed can't fix. After RAM, a fast SSD and a solid multi-core CPU round out the essentials. A powerful GPU only matters for specific work like machine learning or game development."
+  - q: "Should I get a desktop or a laptop for coding?"
+    a: "Match it to how you work. If you code in one place and want the most power for the money, a **desktop** wins. If your work moves with you, a **laptop** is the default. Many developers end up with both — a portable laptop for daily use and a desktop or remote server for the heavy lifting."
+  - q: "Can I develop on a cheap laptop and run heavy work elsewhere?"
+    a: "Yes, and it's a popular pattern. You edit on a light, inexpensive laptop while the demanding work — builds, tests, large services — runs on a remote **server or VPS** you connect to. The laptop becomes a comfortable window onto a much more powerful machine, so you don't pay for raw power you only need occasionally."
+---
+# Choosing your development machine
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Match the machine to how you work** — mobility, budget, and workload decide between a desktop, a laptop, or both. **RAM matters most** — then a fast SSD and a decent multi-core CPU; a strong GPU only for specific jobs. **You don't have to own all the power** — a light laptop plus a remote server or VPS lets you develop anywhere and run heavy work elsewhere.
+</div>
+
+You've now seen both personal machines: the desktop's raw value and the laptop's portability. This lesson turns that into a decision. Choosing a development machine isn't about chasing the biggest numbers — it's about matching a machine to the way you actually work and spending your budget where it helps your code. By the end you'll have a framework for picking desktop, laptop, or both, and you'll know which specs are worth paying for.
+
+## Start with how you work
+
+Before any spec sheet, answer three questions about yourself:
+
+- **Mobility** — do you work in one place, or does your work travel? If it moves, you need a laptop. If it never leaves the desk, a desktop gives you more for the money.
+- **Budget** — for a fixed budget, a desktop buys more performance; a laptop spends part of that budget on portability.
+- **Workload** — light editing and web work run on almost anything. Heavy compiling, virtual machines, video, or machine learning reward more memory, a faster CPU, and sometimes a GPU.
+
+Those three usually point at one of three answers:
+
+| Your situation | Best fit |
+|----------------|----------|
+| Work in one place, want maximum value | **Desktop** |
+| Work moves with you, "good enough" power | **Laptop** |
+| Want mobility *and* serious power | **Both** — a laptop plus a desktop or remote server |
+
+This is the same matching exercise the whole path builds toward in Module 7's [decision framework](/learn/intro-hardware/decision-framework/) — here, scaled down to one practical choice.
+
+## The specs that actually matter
+
+It's easy to over-index on processor speed. For most development, these matter more, roughly in order:
+
+- **Memory (RAM) — first priority.** Code editors, browsers with many tabs, containers, databases, and virtual machines all consume RAM at once. Run out and the machine slows to a crawl no faster CPU can rescue. 16 GB is a comfortable floor for development in 2026; 32 GB gives real breathing room.
+- **A fast SSD.** Solid-state storage makes the whole machine feel quick — opening projects, building code, searching files. Avoid old-style spinning hard drives for your main disk, and favor capacity you won't outgrow.
+- **A decent multi-core CPU.** Compiling and running tests benefit from several cores. You rarely need the absolute top chip; a solid mid-range modern CPU is plenty.
+- **A good screen.** You stare at it all day. Enough resolution and size to keep code and a browser side by side is worth more to your comfort than most benchmark wins.
+- **A GPU — only sometimes.** A powerful graphics card matters for machine learning, game development, or 3D, and barely at all for ordinary web or backend work. Don't pay for one you won't use.
+
+Spend on memory and storage before raw processor speed, and you'll feel the difference every day.
+
+## Choosing an operating system
+
+The machine is only half the choice; the system on it shapes your daily work. All three are practical for development:
+
+- **Linux** — free, scriptable, and the same family of system most servers run, so what you build locally behaves like production. A strong default for backend and systems work.
+- **macOS** — a polished Unix-based system on Apple hardware, popular for general software and the only supported way to build iOS apps.
+- **Windows + WSL** — Windows with the **Windows Subsystem for Linux** gives you a real Linux environment alongside everything Windows runs, a comfortable middle path for many.
+
+There's no single right answer. Pick the one that fits your tools and your target platforms; the languages and editors you'll use are available on all three.
+
+## Develop light, run heavy: the remote pattern
+
+Here's the option that breaks the "buy all the power you need" assumption. You don't have to run demanding work *on* your everyday machine at all. In the **thin client + remote server** pattern, you:
+
+- Work on a **light, inexpensive laptop** — comfortable to carry, cheap to replace.
+- Run the heavy work on a **remote server or VPS** you connect to over the network — long builds, big test suites, always-on services, or model training.
+
+Your laptop becomes a window onto a far more powerful machine. The benefits are real: you carry less, the heavy machine can be sized exactly for the job and shared across devices, and you stop paying a portability premium for raw power you only need occasionally. The trade is that you need a network connection and a little setup. This leans directly on the hosting tier you met earlier — a [VPS](/learn/intro-hardware/vps/) for a modest rented machine, or a [dedicated server](/learn/intro-hardware/dedicated-servers/) when you want the whole box.
+
+## A wrinkle for hardware work like SDR
+
+The remote pattern has one important limit, and **GopherTrunk** illustrates it nicely. Software-defined radio needs a physical SDR dongle plugged into a **USB** port, and that hardware has to be on the machine actually processing the signal. You can't easily move a real-time USB radio stream to a distant server.
+
+So your dev machine and your radio host may sensibly be *different computers*. You might write and test GopherTrunk on a laptop wherever you are, then deploy it to a desktop or small always-on machine sitting right at the antenna with the SDR plugged in. The lesson generalizes: whenever a project depends on local hardware, that hardware pins part of the job to a specific machine, no matter how you arrange the rest. Module 7's [combining tiers](/learn/intro-hardware/combining-tiers/) lesson explores splitting a project across machines like this.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — RAM is the first thing to get right; running out of it slows everything down." markdown="0">
+  <p class="knowledge-check__q">Quick check: Which spec should you prioritize first on a development machine?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The most powerful GPU you can afford</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Enough memory (RAM), then a fast SSD and a solid multi-core CPU</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The highest single-core clock speed available</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Match the machine to how you work** — mobility, budget, and workload decide desktop, laptop, or both.
+- **RAM first** — then a fast SSD and a decent multi-core CPU; a GPU only for ML, games, or 3D.
+- **A good screen counts** — daily comfort often beats marginal benchmark gains.
+- **Any of the three operating systems works** — Linux, macOS, or Windows with WSL; pick by tools and target platform.
+- **Develop light, run heavy** — a thin laptop plus a remote server or VPS gives you mobility and power without buying both in one box.
+- **Local hardware pins the job** — SDR's USB dongle means your dev machine and your radio host may differ.
+
+Next up: we leave the desk entirely for the computer almost everyone already owns — the one in your pocket. See [Smartphones](/learn/intro-hardware/smartphones/).

--- a/docs/learn/intro-hardware/combining-tiers.md
+++ b/docs/learn/intro-hardware/combining-tiers.md
@@ -1,0 +1,88 @@
+---
+slug: combining-tiers
+title: "Combining tiers: device, server & cloud"
+description: Real systems span tiers — tiny edge devices, a local server, and the cloud. Learn how they divide the work and how to decide what runs where.
+keywords: edge vs cloud, multi-tier architecture, edge computing, IoT gateway, device server cloud, where to run code, latency and bandwidth, edge aggregation
+level: intermediate
+status: full
+faq:
+  - q: "What does \"edge vs cloud\" mean?"
+    a: "The **edge** is hardware near where the action happens — a sensor, a gateway in the building, a Pi at the antenna. The **cloud** is shared servers in a data center far away. Edge wins on latency, bandwidth, and working offline; cloud wins on storage, heavy compute, and being reachable from anywhere. Most real systems use both, pushing each piece of work to the tier that fits it best."
+  - q: "Why not just put everything in the cloud?"
+    a: "Because some work can't move. Anything touching physical hardware — a [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) reading a sensor, a USB radio dongle — must run on a device that's physically there. And pushing raw high-rate data to the cloud can be slow, expensive, or impossible on a flaky link. You keep that work at the edge and send only the distilled results up."
+  - q: "What's the job of the middle tier — a local server or gateway?"
+    a: "It aggregates. Edge devices are cheap and dumb on purpose; a [home server](/learn/intro-hardware/home-servers/) or [SBC](/learn/intro-hardware/what-is-an-sbc/) gateway collects their data, stores it locally, runs the logic that ties them together, and decides what's worth forwarding to the cloud. It also keeps the system working when the internet is down."
+  - q: "How do I decide what runs where?"
+    a: "Push each task to the cheapest tier that can do it well. Time-critical or physical work goes to the **edge**; coordination and local storage go to a **local server**; durable storage, heavy compute, and remote access go to the **cloud**. Latency, bandwidth, power, cost, and offline resilience are the levers that decide each one."
+---
+# Combining tiers: device, server & cloud
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Real systems span tiers** — tiny edge devices, a local server or gateway, and the cloud each do part of the job. **Push work to where it fits** — physical and time-critical tasks stay at the edge; storage, heavy compute, and remote access go to the cloud. **The middle tier aggregates** — a local server collects from cheap devices, keeps working offline, and forwards only what matters.
+</div>
+
+The previous lessons treated each project as landing on one platform. Reality is messier and more interesting: most non-trivial systems are *layered*, with different tiers of hardware cooperating. A swarm of cheap microcontrollers, a local server that gathers their output, and a cloud account for storage and remote access is an extremely common shape. This lesson is about that shape — why it exists, and how to decide which tier does what.
+
+## The three tiers
+
+Think of hardware in a real system as three rough tiers, from the physical world inward:
+
+- **Edge devices** sit where the action is. They're cheap, low-power, and often single-purpose — an [ESP32](/learn/intro-hardware/esp32/) reading a sensor, a [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) driving a motor, a [Raspberry Pi](/learn/intro-hardware/raspberry-pi-and-family/) with a camera. Their defining trait is *physical presence*: they touch the world directly.
+- **A local server or gateway** sits in the same building or site. Usually a [home server](/learn/intro-hardware/home-servers/) or [SBC](/learn/intro-hardware/what-is-an-sbc/), it aggregates data from the edge devices, runs the logic that connects them, stores recent history locally, and decides what to send onward. It keeps the system alive when the internet drops.
+- **The cloud** is shared servers far away — a [VPS](/learn/intro-hardware/vps/) or managed service. It's the home for durable long-term storage, heavy compute that the edge can't do, and the public-facing parts that let you reach the system from anywhere.
+
+Not every system needs all three. A single sensor reporting to a phone is one tier and a half. But once a project has several devices, or needs both local responsiveness and remote access, the layering pays off.
+
+## Edge vs cloud: why work moves
+
+The central decision in a layered system is *where each piece of work runs*. Five forces pull the answer one way or the other:
+
+- **Latency** — a control loop that must react in milliseconds can't wait for a round trip to a data center. It stays at the edge.
+- **Bandwidth** — raw high-rate data (audio, video, radio samples) is expensive or impossible to ship upstream continuously. Process it locally and send only the summary.
+- **Power** — battery devices can't afford to keep a radio transmitting constantly; they do the minimum locally and sleep.
+- **Cost** — cloud compute and egress are metered. Doing work on hardware you already own at the edge is often far cheaper.
+- **Offline resilience** — if the link goes down, edge and local tiers must keep functioning. Anything that *must* keep working can't depend on the cloud.
+
+The rule of thumb: **push each task to the cheapest tier that can do it well.** Physical and time-critical work to the edge, coordination and local storage to the middle, durable storage and remote reach to the cloud.
+
+## What runs where
+
+| Task | Best tier | Why |
+|------|-----------|-----|
+| Reading a sensor / driving an actuator | **Edge device** | Must be physically attached; needs tight timing |
+| Reacting in real time (control loop) | **Edge device** | A cloud round trip is too slow |
+| Heavy local data reduction (e.g. decode a stream) | **Edge / local server** | Saves bandwidth by shipping results, not raw data |
+| Aggregating several devices, local logic | **Local server / gateway** | One place to coordinate; works offline |
+| Recent history, local dashboard | **Local server** | Fast, private, no internet dependency |
+| Durable long-term storage, backups | **Cloud** | Reliable, off-site, scales without buying disks |
+| Remote access from anywhere | **Cloud** | A public, always-reachable endpoint |
+| Occasional heavy compute (ML, reports) | **Cloud** | Rent burst power instead of owning it |
+
+## A worked architecture: home sensor network
+
+Picture a home environment monitor. A handful of **ESP32** nodes around the house each read temperature and humidity and, every few minutes, wake, send a reading over Wi-Fi, and sleep — that's the edge, sipping battery. A **Raspberry Pi** in a closet runs all the time as the gateway: it receives every reading, stores months of history on a local disk, serves a dashboard on the home network, and runs the automation rules ("if the basement gets damp, turn on the fan"). A small **cloud VPS** holds off-site backups and exposes a single secure endpoint so you can check the house from your phone while traveling. Three tiers, each doing what it's best at — and the house keeps regulating itself even if the internet is down, because the logic lives on the Pi, not in the cloud.
+
+## GopherTrunk across tiers
+
+GopherTrunk fits this model almost perfectly. The **edge** is a [Raspberry Pi](/learn/intro-hardware/raspberry-pi-and-family/) (or a PC) sitting right at the antenna with the **SDR dongle plugged into its USB port** — it has to be physically there, and it does the bandwidth-heavy work of capturing and decoding the radio stream locally, because shipping raw radio samples to a data center would be absurd. A **server** — that same Pi, a beefier [home server](/learn/intro-hardware/home-servers/), or a [VPS](/learn/intro-hardware/vps/) — stores the decoded recordings and serves them up. Your **phone** is the dashboard client, a browser pointed at that server from anywhere. This is also exactly *why* a cloud-only setup can't work: the cloud can store and serve recordings happily, but it can never be the capture tier, because you cannot plug a USB dongle into a machine you don't physically touch. The physical-world requirement pins the edge tier in place, and everything else layers around it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — physical, time-critical work belongs at the edge; the cloud handles storage and remote access." markdown="0">
+  <p class="knowledge-check__q">Quick check: In a layered system, which tier should handle reading a sensor and reacting to it in real time?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The cloud, so all the logic lives in one place</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The edge device, which is physically attached and avoids the cloud round trip</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Whichever tier is cheapest, regardless of latency</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Systems span tiers** — edge devices, a local server or gateway, and the cloud divide the work between them.
+- **Push work to where it fits** — physical and time-critical tasks to the edge, coordination and local storage to the middle, durable storage and remote access to the cloud.
+- **Five forces decide placement** — latency, bandwidth, power, cost, and offline resilience.
+- **The middle tier aggregates** — a local server collects from cheap devices and keeps working when the internet is down.
+- **GopherTrunk is layered by necessity** — the Pi at the antenna captures and decodes, a server stores and serves, a phone is the client — and the cloud can never be the capture tier.
+
+Next up: turn all of this into a repeatable method you can run every time. See [A practical decision framework](/learn/intro-hardware/decision-framework/).

--- a/docs/learn/intro-hardware/cost-power-performance.md
+++ b/docs/learn/intro-hardware/cost-power-performance.md
@@ -1,0 +1,89 @@
+---
+slug: cost-power-performance
+title: Cost, power & performance trade-offs
+description: Money, electricity, speed, control, and effort — five tensions that pull against each other in every hardware choice. Learn the axes so later decisions become deliberate, not guesswork.
+keywords: hardware trade-offs, cost power performance, upfront vs ongoing cost, power draw battery vs always-on, control vs convenience, hardware maintenance effort, choosing hardware
+level: beginner
+status: full
+faq:
+  - q: "What are the main trade-offs in choosing hardware?"
+    a: "Five recur in almost every decision: **cost** (upfront versus ongoing), **power draw** (battery, wall, or always-on), **performance**, **control** (how much is yours to manage versus handled for you), and **effort** to set up and maintain. They pull against each other — gaining on one axis usually costs you on another, which is why there's rarely a single best answer."
+  - q: "What's the difference between upfront and ongoing cost?"
+    a: "**Upfront cost** is what you pay once to acquire the hardware — buying a server or a Raspberry Pi. **Ongoing cost** is what it costs to keep running — monthly hosting fees, electricity, or replacement parts. A cheap-to-buy option can be expensive to run, and vice versa, so you have to weigh both against how long you'll use it."
+  - q: "Why does power draw matter so much?"
+    a: "It decides where and how a device can live. A microcontroller drawing milliwatts can run for years on a battery in a remote location; an always-on home server draws steady wall power and adds to your electricity bill 24/7. Power draw shapes battery life, running cost, and whether a device even needs cooling."
+  - q: "Does more control always mean more work?"
+    a: "Usually, yes. Renting cloud hosting gives you little control but almost no maintenance — the provider handles the hardware. Owning a home server gives you total control but makes every update, failure, and backup your responsibility. More control means more effort; more convenience means trusting someone else's choices."
+---
+# Cost, power & performance trade-offs
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Five recurring axes** — cost, power draw, performance, control, and effort show up in nearly every hardware decision. **They trade against each other** — gaining on one axis almost always costs you on another, so there's rarely a free win. **Knowing the axes makes choices deliberate** — once you can name the tensions, picking hardware becomes reasoning instead of guessing.
+</div>
+
+Across the last three lessons the same handful of tensions kept surfacing: things cost money, draw power, run fast or slow, hand you control or take it away, and demand more or less work. This lesson pulls those tensions out and names them directly. They're the axes every hardware decision turns on, and getting comfortable with them now is what lets Module 7 turn them into an actual method for choosing.
+
+## Upfront vs ongoing cost
+
+Cost has two faces, and confusing them leads to bad decisions. **Upfront cost** is what you pay once to get the hardware — buying a desktop, a server, or a Raspberry Pi. **Ongoing cost** is what it takes to keep it running — monthly hosting bills, electricity, replacement drives, your own time.
+
+The two often trade against each other. Cloud hosting is near-free to start but bills you every month forever. A microcontroller costs a few dollars once and almost nothing to run. A home server is the opposite of the cloud: you pay real money upfront, then a smaller but constant electricity cost. The right balance depends on how long you'll use the thing — a few months favors low upfront cost; years of always-on use can favor owning hardware outright.
+
+## Power draw: battery, wall, or always-on
+
+How much electricity a device uses decides where it can live and what it costs to run. There are three rough regimes:
+
+- **Battery** — phones, tablets, and low-power microcontrollers. Here every milliwatt matters, because power runs out. A microcontroller can run for years on a coin cell; a laptop lasts hours.
+- **Wall power, on demand** — desktops and laptops plugged in when used. Power draw matters for the electricity bill but isn't a hard limit.
+- **Always-on** — servers and home servers running 24/7. Even modest draw adds up over a year, and high draw means heat, fans, and cooling to manage.
+
+Power draw and performance are linked: more capability generally means more watts. A microcontroller's tiny power budget is exactly what makes it suitable for a sensor left in a field for a year — and exactly what makes it useless for anything heavy.
+
+## Performance: enough vs overkill
+
+Performance is the obvious axis — how fast and how much the machine can do — but the useful question is rarely "what's fastest?" It's "what's *enough*?" A platform far more powerful than the job needs wastes money and electricity for nothing.
+
+Reading a temperature once a minute needs almost no performance; a microcontroller does it perfectly. Serving a busy website needs a great deal, and a server delivers it. Matching performance to the job — neither starving it nor drowning it in overkill — is most of the skill. Buying the most powerful option "to be safe" is one of the most common and expensive mistakes.
+
+## Control vs effort
+
+The last two axes are tightly coupled, so it's worth taking them together. **Control** is how much of the machine is yours to decide; **effort** is how much work it takes to set up and keep running. They almost always move together: more control means more effort, and more convenience means handing both away.
+
+Rent cloud hosting and you control little — but the provider handles the hardware, cooling, and failures, so your effort is minimal. Own a home server and you control everything — but every update, failed drive, and backup is now your job. Neither is better in the abstract. A beginner who just wants a website online wants the cloud's low effort; a tinkerer who enjoys the machine wants the home server's control. The question is which side of that trade you actually want.
+
+## How the axes pull against each other
+
+The reason hardware choice is interesting — and why there's no universal best answer — is that these axes fight one another. You rarely improve one without giving ground on another:
+
+| Axis | Cheap end | Expensive / demanding end | The tension |
+|------|-----------|----------------------------|-------------|
+| **Cost** | Low upfront (cloud, MCU) | High upfront (owned server) | Pay now or pay forever |
+| **Power draw** | Milliwatts (battery MCU) | Always-on watts (server) | Frugal and limited, or capable and hungry |
+| **Performance** | Just enough (SBC, MCU) | Abundant (server, desktop) | Save money or buy headroom |
+| **Control** | Managed for you (cloud) | All yours (home server) | Convenience or autonomy |
+| **Effort** | Low (managed hosting) | High (self-hosted) | Let go or do it yourself |
+
+GopherTrunk shows every one of these at once. Run it on a dedicated server and you get maximum performance and always-on uptime, at high cost, power draw, and effort. Run it on a laptop and you trade some of that for convenience and portability. Run it on a Raspberry Pi at the antenna and you get a cheap, low-power, set-and-forget node — giving up raw performance for it. Same software, three points on every axis, and no single "right" choice — just the one that fits your constraints.
+
+That's the whole point of naming these axes. Once you can see a decision in terms of cost, power, performance, control, and effort, you stop guessing and start weighing. Module 7 builds directly on this, turning these five tensions into a repeatable way to match hardware to a project.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the axes trade against each other, so gaining on one (like control) usually costs you on another (like effort)." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the key thing to understand about these five trade-off axes?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">One platform can max out all five at once if you spend enough</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">They pull against each other — gaining on one axis usually costs you on another, so there's rarely a free win</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only cost and performance actually matter; the rest are minor</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Cost has two faces** — upfront (paid once) and ongoing (paid forever); a cheap-to-buy option can be expensive to run, so weigh both against how long you'll use it.
+- **Power draw sets where a device can live** — battery, on-demand wall power, or always-on, and it climbs with performance.
+- **Performance is about "enough," not "most"** — overkill wastes money and electricity; match the machine to the job.
+- **Control and effort move together** — more control means more maintenance; more convenience means trusting someone else's choices.
+- **The axes trade against each other** — there's rarely a free win, which is exactly why naming them turns hardware choice into reasoning.
+
+Next up: the spectrum's high end in detail — renting space on someone else's machine to put something on the web. See [Web & shared hosting](/learn/intro-hardware/web-hosting/).

--- a/docs/learn/intro-hardware/decision-framework.md
+++ b/docs/learn/intro-hardware/decision-framework.md
@@ -1,0 +1,90 @@
+---
+slug: decision-framework
+title: A practical decision framework
+description: A repeatable five-step method for turning requirements into a hardware choice — state needs, eliminate on hard constraints, weigh trade-offs, pick the simplest fit, then plan to scale.
+keywords: hardware decision framework, choosing hardware method, hard constraints, hardware trade-offs, simplest thing that works, scaling hardware, eliminate platforms, hardware checklist
+level: advanced
+status: full
+faq:
+  - q: "What's the single most useful step in choosing hardware?"
+    a: "Applying **hard constraints** to eliminate options. A few pass/fail facts — needs attached USB hardware, must run on a battery, must be a public 24/7 service — cut the field from everything down to two or three before you weigh anything. It's the cheapest, highest-leverage move, because elimination is faster and more certain than comparison."
+  - q: "How do hard constraints differ from trade-offs?"
+    a: "A **hard constraint** is pass/fail: a platform either can do the thing or it can't, so it's in or out (a cloud VPS *cannot* have a USB dongle attached, full stop). A **trade-off** is a matter of degree — cost, power, performance, effort — where every surviving option is viable and you're weighing which balance you prefer. Eliminate on the first, then weigh the second."
+  - q: "Why prefer the simplest thing that meets the needs?"
+    a: "Because every bit of extra capability is cost, power draw, and complexity you pay for forever, usually for nothing. The discipline is to **buy or rent the smallest thing that does the job** — it's cheaper, more reliable, and easier to maintain. You can always step up later; you rarely regret starting small."
+  - q: "Should I plan for scale from the start?"
+    a: "Plan for it, don't build for it prematurely. Know your likely growth path — a [VPS](/learn/intro-hardware/vps/) you can resize, a design that moves from one unit to many — so a change isn't a rewrite. But don't pay today for capacity you may never need; pick the simple option now and keep the upgrade path open."
+---
+# A practical decision framework
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Eliminate, then weigh, then keep it simple** — hard constraints cut the field, trade-offs rank what's left, and you pick the smallest thing that does the job. **Hard constraints do the heavy lifting** — a few pass/fail facts often decide the choice on their own. **Plan to change** — choose with an upgrade path in mind, but don't pay today for scale you may never need.
+</div>
+
+You've collected requirements, learned which project types reach for which platforms, and seen how tiers combine. This lesson assembles all of it into a method you can run the same way every time — five steps that move from facts (what's even possible?) to judgement (what's the best fit?). It's deliberately simple, because a method you'll actually use beats a perfect one you won't.
+
+## The five steps
+
+1. **State the requirements.** Write them down using the checklist from [Start with your requirements](/learn/intro-hardware/start-with-requirements/) — compute, connectivity, physical-world contact, power, budget, quantity, location, maintenance. You can't choose well against needs you haven't named.
+2. **Apply hard constraints to eliminate.** These are pass/fail. Walk each requirement and strike out every platform that simply can't satisfy it. This is the cheapest, highest-leverage step — it usually cuts the field from "everything" to two or three before you compare anything.
+3. **Weigh the soft trade-offs.** For what survives, balance the recurring four — cost, power, performance, and effort to build and maintain. The [cost, power & performance](/learn/intro-hardware/cost-power-performance/) lesson is the toolkit here; the point is that every survivor is *viable*, so now you're choosing a balance, not a winner.
+4. **Prefer the simplest thing that meets the needs.** Among the viable options, pick the smallest, cheapest, lowest-power one that clears the bar. Extra capability you don't need is cost and complexity you pay for forever.
+5. **Plan to scale or change.** Choose with an upgrade path in mind — a [VPS](/learn/intro-hardware/vps/) you can resize, a design that survives going from one unit to a hundred — but don't over-build today for a future that may not arrive.
+
+```text
+requirements → eliminate (hard constraints) → weigh trade-offs → pick simplest → plan to scale
+   (facts)                                                                        (judgement)
+```
+
+## Hard constraints eliminate fast
+
+Step two deserves its own focus, because it does most of the work. A hard constraint is a fact that makes a platform impossible, not merely worse. Internalize a few and most decisions collapse:
+
+| If the project... | ...then rule out | ...and lean toward |
+|-------------------|------------------|--------------------|
+| Needs attached physical/USB hardware | Any remote cloud VPS or shared host | A device on-site: [SBC](/learn/intro-hardware/what-is-an-sbc/), PC, or [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) |
+| Must run for months on a battery | Full computers and SBCs | A [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) (e.g. [ESP32](/learn/intro-hardware/esp32/)) with deep sleep |
+| Needs a full operating system & general software | Microcontrollers | An [SBC](/learn/intro-hardware/what-is-an-sbc/), [desktop](/learn/intro-hardware/desktop-computers/), or server |
+| Must be a public, always-on internet service | Battery devices, home machines on a flaky link | A [VPS](/learn/intro-hardware/vps/) or [dedicated server](/learn/intro-hardware/dedicated-servers/) |
+| Ships in the thousands at low unit cost | Expensive boards bought one at a time | The cheapest part that meets the spec at volume |
+| Needs serious GPU compute | Tiny and low-power platforms | A strong [desktop](/learn/intro-hardware/desktop-computers/) or rented cloud GPU |
+
+Notice these are *in-or-out* decisions. You're not comparing a VPS against an SBC on price when the project needs a USB dongle attached — the VPS is simply impossible, and saying so out loud ends the debate. Elimination is faster and more certain than comparison, which is exactly why it goes first.
+
+## Weighing what survives
+
+Once hard constraints have trimmed the list, every remaining option *can* do the job — so the decision shifts to trade-offs of degree. Lay them side by side on the four dimensions that recur throughout this path:
+
+- **Cost** — to buy and to keep running, at the quantity you actually need.
+- **Power** — draw matters most for battery devices and anything always-on, where electricity adds up over a year.
+- **Performance** — only as much as the job needs; headroom beyond that is waste.
+- **Effort** — to set up, program, and maintain, including who has to look after it.
+
+There's rarely a clean winner, and that's fine. The goal is to make the trade-offs *visible* so the choice is deliberate. If two options are genuinely close, the next principle breaks the tie.
+
+## Prefer the simplest fit, then plan to change
+
+Among viable options, **buy or rent the smallest thing that does the job.** A $35 Pi over a $1,000 server when both work; a single resizable VPS over a dedicated machine until traffic demands more; a $4 microcontroller over an SBC when all you need is a sensor. Simpler means cheaper, more reliable, lower-power, and easier to maintain — and you can almost always step up later.
+
+That last clause is step five. Pick simple *now*, but with eyes open about how you'd grow: a VPS you can scale up with a click, a sensor design that moves from one to many without a redesign, a home server you could later mirror to the cloud. Planning the path is cheap; building it before you need it is not. The mistake to avoid is paying today for scale that may never arrive — over-provisioning is just a slower way to over-buy.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — applying hard, pass/fail constraints eliminates impossible options and cheaply cuts the field before you weigh anything." markdown="0">
+  <p class="knowledge-check__q">Quick check: What's the highest-leverage step after stating your requirements?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Score every platform on cost and performance in detail</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Apply hard, pass/fail constraints to eliminate platforms that simply can't do the job</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Buy the most powerful option so you never hit a limit</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Five steps** — state requirements, eliminate on hard constraints, weigh the trade-offs, prefer the simplest fit, plan to scale.
+- **Hard constraints do the heavy lifting** — pass/fail facts cut the field to a handful before any comparison.
+- **Constraints rule out, trade-offs rank** — a platform is in or out on a constraint; among survivors you weigh cost, power, performance, and effort.
+- **Smallest thing that works** — buy or rent the least capability that meets the need; headroom is cost you pay forever.
+- **Plan the path, don't pre-build it** — choose with an upgrade route in mind, but don't pay today for scale you may never reach.
+
+Next up: run this framework end to end on four real projects to make it concrete. See [Worked examples: picking hardware for real projects](/learn/intro-hardware/worked-examples/).

--- a/docs/learn/intro-hardware/dedicated-servers.md
+++ b/docs/learn/intro-hardware/dedicated-servers.md
@@ -1,0 +1,95 @@
+---
+slug: dedicated-servers
+title: Dedicated servers
+description: A dedicated server is a whole physical machine that's yours alone — no virtualization, no neighbors. Learn when uncontended performance is worth the price.
+keywords: dedicated server, bare metal server, physical server, no virtualization, uncontended performance, high traffic hosting, GPU server, dedicated vs VPS, server hardware
+level: intermediate
+status: full
+faq:
+  - q: "What is a dedicated server?"
+    a: "A **dedicated server** is an entire physical machine reserved for one customer — no hypervisor splitting it, no other tenants sharing its CPU, memory, or disk. You rent (or own) the whole box and get all of its hardware, all the time. It sits one step beyond a VPS: instead of a virtual slice of a machine, you have the machine itself, sometimes called **bare metal**."
+  - q: "When is a dedicated server worth it over a VPS?"
+    a: "When you need **consistent, uncontended performance** or direct hardware access. High-traffic sites, large databases, busy game servers, heavy compute, and GPU or machine-learning workloads all benefit because no noisy neighbor can steal cycles. It's also chosen for predictable performance and certain compliance needs. The cost is real money and less elasticity, so it's overkill until your workload actually demands it."
+  - q: "What are the downsides of a dedicated server?"
+    a: "It's **expensive** compared to a VPS, **slower to provision** (a physical box may take hours instead of minutes), and **less elastic** — you can't resize it with a click. If hardware fails you either handle it yourself or pay for a managed plan where the provider does. You're paying for raw, reserved performance, and you give up the cloud's instant flexibility to get it."
+---
+# Dedicated servers
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A dedicated server is a whole physical machine, yours alone** — no virtualization, no neighbors. **You get maximum, consistent performance** and full hardware access. **It costs more and flexes less** — expensive, slower to provision, and not elastic like the cloud. **Choose it when uncontended performance is the requirement**, not before.
+</div>
+
+A VPS shares its physical hardware with other tenants, and most of the time that's fine. But some workloads can't tolerate sharing — they need every cycle, every gigabyte, and predictable performance that no neighbor can disturb. That's where a dedicated server comes in: a complete physical machine reserved for you. This lesson covers what changes when nothing is shared, the jobs that justify the price, and how it stacks up against a VPS.
+
+## What a dedicated server is
+
+A **dedicated server** is an entire physical machine devoted to a single customer. There's no hypervisor carving it into slices and no other tenants competing for its resources. When you rent one, you get the whole box — every CPU core, all the memory, the full disk, the network card — and it's all yours, all the time. This is why it's often called **bare metal**: you're running directly on the hardware, with no virtualization layer skimming a share for someone else.
+
+You can rent dedicated servers from hosting providers month to month, or — for an on-premises setup — own the physical machine outright. Either way, the defining feature is exclusivity: one machine, one tenant.
+
+## What it's for
+
+A dedicated server earns its keep wherever performance must be high *and* consistent:
+
+- **High-traffic websites** — sites whose load would crowd a shared machine.
+- **Large or busy databases** — where steady disk and memory performance matters.
+- **Game servers** — latency-sensitive workloads that hate jitter from noisy neighbors.
+- **Heavy compute** — video encoding, simulations, large builds, batch processing.
+- **GPU and machine-learning workloads** — training and inference that need specific, powerful hardware you can't get from a generic VPS.
+- **Predictable performance and compliance** — when you must guarantee resources or keep data on an isolated, known machine.
+
+The common thread is that *sharing is the problem*. If a VPS's variable performance or lack of direct hardware access is hurting you, a dedicated server removes that ceiling.
+
+## The languages and stacks it runs
+
+As with a VPS, the answer is **anything**. You control the whole operating system and the whole machine, so any language, runtime, database, or specialized framework is available — including GPU stacks like CUDA for machine learning, which a generic VPS often can't offer. The difference from a VPS isn't *what* you can run but *how much* and *how consistently* it runs, because the hardware underneath is yours alone.
+
+## Dedicated server vs VPS
+
+Most of the decision comes down to a few trade-offs against a VPS:
+
+| Aspect | VPS | Dedicated server |
+|--------|-----|------------------|
+| **Hardware** | Shared via a hypervisor | An entire physical machine, yours alone |
+| **Performance** | Good, but can vary with neighbors | Maximum and consistent |
+| **Cost** | Cheap to moderate | Expensive |
+| **Provisioning** | Ready in minutes | Slower — often hours for a physical box |
+| **Elasticity** | Resize and scale on demand | Fixed; hard to scale quickly |
+| **Hardware access** | None (virtual) | Full — GPUs, specific cards, raw disks |
+| **Hardware failures** | Provider's problem | Yours, or pay for a managed plan |
+
+The pattern is clear: a dedicated server buys you raw, reserved, predictable power, and the price is money and flexibility. A VPS is the right default; a dedicated server is what you reach for when the VPS can no longer keep up or can't give you the hardware you need.
+
+## Strengths and drawbacks
+
+To put the same balance plainly:
+
+| Strengths | Drawbacks |
+|-----------|-----------|
+| **Maximum performance** — all the hardware, all the time | **Expensive** — you pay for the whole machine |
+| **Consistent** — no noisy neighbors, no contention | **Less elastic** — can't resize with a click |
+| **Full hardware access** — GPUs, custom configurations | **Slower to provision** — physical setup takes time |
+| **Isolation** — useful for compliance and security | **Hardware failures** — your problem unless managed |
+
+For something like **GopherTrunk**, a dedicated server is usually more machine than the job needs — the radio's data stream is modest. But if you were running a large multi-receiver decoding operation crunching many streams at once, the steady, uncontended compute of a dedicated box could be exactly the right fit.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a dedicated server is a whole physical machine with no virtualization and no shared tenants." markdown="0">
+  <p class="knowledge-check__q">Quick check: What most distinguishes a dedicated server from a VPS?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's cheaper and can be resized instantly</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It's an entire physical machine with no virtualization and no other tenants sharing it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's fully managed, so you never handle the operating system</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A whole physical machine, yours alone** — no hypervisor, no shared tenants, often called bare metal.
+- **Built for uncontended performance** — high-traffic sites, big databases, game servers, heavy compute, GPU/ML.
+- **Runs anything** — full control of the OS and direct hardware access, including specialized cards.
+- **More power, less flexibility** — maximum consistent performance, but expensive, slow to provision, and not elastic.
+- **VPS first, dedicated when needed** — reach for bare metal only when sharing becomes the bottleneck.
+
+Next up: bringing the server home — running your own machine on your own internet, with all the freedom and hidden costs that come with it. See [Home servers & self-hosting](/learn/intro-hardware/home-servers/).

--- a/docs/learn/intro-hardware/desktop-computers.md
+++ b/docs/learn/intro-hardware/desktop-computers.md
@@ -1,0 +1,101 @@
+---
+slug: desktop-computers
+title: Desktop computers
+description: A desktop computer trades portability for raw value — the most performance per dollar, easy upgrades, and steady cooling that make it a developer's workhorse.
+keywords: desktop computer, desktop vs laptop, performance per dollar, upgradable PC, mini PC, all-in-one computer, developer workstation, always-on home machine
+level: beginner
+status: full
+faq:
+  - q: "Why would a developer choose a desktop over a laptop?"
+    a: "**Value and headroom.** For the same money a desktop gives you a faster processor, more memory, and better cooling, so it holds its top speed during long compiles or renders. It's also easy to upgrade and repair. The trade is that it stays on your desk — you give up portability to get more machine."
+  - q: "What is a mini PC, and does it count as a desktop?"
+    a: "Yes. A **mini PC** is a small mains-powered box with no built-in screen — think of a compact desktop without the tower. It gives up some upgrade room and top-end power for a tiny footprint, but it runs the same desktop operating systems and is a great quiet, always-on machine for something like a home server."
+  - q: "Can a desktop run my software-defined radio setup?"
+    a: "Very well. A desktop's USB ports connect straight to an **SDR** dongle, and its sustained processing power handles the heavy real-time math of demodulating and decoding signals. Because it can stay on around the clock, a desktop also makes a fine always-on host for **GopherTrunk** sitting near the antenna."
+---
+# Desktop computers
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Best performance per dollar** — a fixed, mains-powered machine spends your money on speed instead of miniaturization. **Upgradable and repairable** — swap the memory, storage, or graphics card instead of buying a whole new computer. **Sustained performance** — roomy cases cool better, so a desktop holds its top speed through long jobs. The cost is that it doesn't move and it draws wall power.
+</div>
+
+This module is about the computers you sit in front of. We start with the desktop because it's the most capable of the personal machines and the easiest to reason about: it stays put, it plugs into the wall, and almost every part inside it can be replaced. By the end of this lesson you'll know what counts as a desktop, what people actually do with one, what it runs, and where it beats every other kind of machine for a developer.
+
+## What a desktop is
+
+A **desktop computer** is a personal computer designed to live in one place and run on mains power rather than a battery. The classic form is the **tower**: a rectangular case holding the processor, memory, storage, and expansion slots, with a separate monitor, keyboard, and mouse plugged in. But "desktop" really describes a category, and it comes in a few shapes:
+
+- **Tower** — the traditional box, with the most room to cool and upgrade.
+- **All-in-one** — the computer built into the back of the monitor (an iMac is the familiar example), tidier but harder to expand.
+- **Mini PC** — a small box the size of a paperback, low-power and quiet, with little or no room inside for upgrades.
+
+What unites them is the trade they make: because a desktop never has to fit in a bag or run off a battery, its designers can prioritize raw capability, cooling, and serviceability over size and weight. That single decision is the source of every strength below.
+
+## What desktops are for
+
+A desktop suits any job where you stay in one place and want as much computer as your budget allows. Common use cases:
+
+- **Heavy development** — compiling large projects, running several services or virtual machines at once, and keeping dozens of browser tabs and tools open without slowing down.
+- **Gaming** — where a powerful, well-cooled graphics card matters most.
+- **Video editing, 3D, and rendering** — workloads that run for minutes or hours and reward sustained speed.
+- **Machine learning** — training and running models that lean hard on a fast GPU and plenty of memory.
+- **Multi-monitor work** — desktops drive several large screens easily, which suits coding, trading, and design.
+- **An always-on home machine** — a desktop or mini PC left running can act as a home server, file store, or — relevant here — a radio host.
+
+If your work never needs to leave the desk, a desktop gives you the most for your money. If it does need to travel, that's the next lesson, [Laptops](/learn/intro-hardware/laptops/).
+
+## What desktops run
+
+A desktop is a general-purpose computer, so it runs essentially **anything**. The main choice you make is the operating system, and all three major options are first-class development platforms:
+
+- **Windows** — the widest hardware and game support; pairs with WSL (Windows Subsystem for Linux) to give developers a real Linux environment alongside it.
+- **macOS** — Apple's desktops only, but a polished Unix-based system popular for software and mobile development.
+- **Linux** — free, highly customizable, and the same system most servers run, which makes it a natural choice for backend and systems work.
+
+On top of whichever you pick, every programming language and tool is available: editors and IDEs, compilers and interpreters, containers, databases, and version control. There's no language a desktop can't handle — its job is to be the comfortable, powerful place where you write and test software, including the **GopherTrunk** SDR software these docs describe. You'd typically install GopherTrunk on a desktop, plug an SDR dongle into a USB port, and have plenty of processing headroom to spare.
+
+## Where desktops shine
+
+The desktop's advantages all flow from being a fixed, mains-powered box with room inside:
+
+| Strength | Why it holds | What it means for you |
+|----------|--------------|------------------------|
+| **Performance per dollar** | No battery or miniaturization tax on the parts | More speed and memory for the same budget |
+| **Upgradable and repairable** | Standard parts in standard slots | Add memory or a new GPU instead of replacing the machine |
+| **Sustained performance** | Big cases and fans keep parts cool | Holds full speed through long compiles and renders |
+| **Connectivity** | Plenty of ports, including many USB | Connect SDR hardware, drives, and several monitors at once |
+| **Always-on duty** | Built to run on wall power indefinitely | Doubles as a quiet home server or radio host |
+
+That last point is worth dwelling on for this site. Because a desktop is happy running around the clock and has USB ports right there, it makes an excellent always-on **GopherTrunk** host — left near the antenna, processing signals continuously, while you connect to it from elsewhere.
+
+## The drawbacks
+
+A desktop's strengths come with real costs, and they're the reason laptops exist:
+
+- **Not portable.** It stays where you put it. If you need to work in different places, a desktop simply can't follow you.
+- **It takes a desk.** A tower, monitor, and peripherals occupy permanent space and add cable clutter.
+- **It needs mains power.** No battery means a power cut stops it dead, and it draws steadily from the wall — a consideration for an always-on machine you'll meet again in [Cost, power & performance trade-offs](/learn/intro-hardware/cost-power-performance/).
+
+None of these are flaws so much as the flip side of the trade. A desktop chose capability over mobility; if mobility is what you need, you look elsewhere.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a fixed, mains-powered box with room to cool and upgrade gives the most performance per dollar." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the desktop's biggest advantage over a laptop?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It runs software no laptop can run</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It offers more performance per dollar, plus easier upgrades and better sustained speed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses far less electricity than a laptop</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A desktop is a fixed, mains-powered PC** — tower, all-in-one, or mini PC, designed to stay in one place.
+- **It runs anything** — Windows, macOS, or Linux, and every language and tool on top.
+- **Best performance per dollar** — no battery or size tax means more machine for the money.
+- **Upgradable and well-cooled** — swap parts to extend its life, and keep full speed through long jobs.
+- **A natural always-on host** — plenty of USB ports and happy to run continuously, which suits an SDR setup like GopherTrunk.
+- **The cost is mobility** — it doesn't move, takes desk space, and needs wall power.
+
+Next up: the computer you can carry, and the trade it makes to fit in a bag. See [Laptops](/learn/intro-hardware/laptops/).

--- a/docs/learn/intro-hardware/developing-for-mobile.md
+++ b/docs/learn/intro-hardware/developing-for-mobile.md
@@ -1,0 +1,100 @@
+---
+slug: developing-for-mobile
+title: Developing for mobile devices
+description: There are three ways to build a mobile app — native, cross-platform, and web. Learn the languages and toolchains each uses, the trade-offs, and why you build on a desktop and deploy to the phone.
+keywords: mobile app development, native app development, cross-platform mobile, Flutter, React Native, .NET MAUI, progressive web app, PWA, Swift Xcode, Kotlin Android Studio, deploy to phone
+level: intermediate
+status: full
+faq:
+  - q: "What are the three main ways to build a mobile app?"
+    a: "**Native** — written in each platform's own language and tools (Swift/Xcode for iOS, Kotlin/Android Studio for Android) for the best performance and platform feel. **Cross-platform** — one codebase that targets both stores, using Flutter (Dart), React Native (JavaScript), or .NET MAUI. **Web/PWA** — an ordinary web app built with HTML, CSS, and JavaScript that runs in the browser and can be installed to the home screen. Each trades polish, effort, and reach differently."
+  - q: "Do I develop the app on the phone itself?"
+    a: "No. You write, build, and test mobile apps on a **desktop or laptop** using the platform's toolchain, then deploy the finished app to the phone or to an emulator. iOS development in particular requires a Mac running Xcode. This is exactly why choosing a good development machine matters — the phone is the target, not the workshop."
+  - q: "When should I choose a web app or PWA over a native app?"
+    a: "Choose **web/PWA** when reach and zero-install matter more than deep device access — anyone with a browser can use it instantly, with no app store. Choose **native or cross-platform** when you need the best performance, smooth animations, or full access to sensors and platform features. Many products start as a web app for reach and add a native app later."
+---
+# Developing for mobile devices
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Three approaches** — native (Swift/Kotlin), cross-platform (Flutter, React Native, .NET MAUI), and web/PWA (HTML/CSS/JS). **The trade-off is performance and platform feel vs. one shared codebase vs. instant reach with no install.** **You build on a desktop and deploy to the phone** — the device is the target, the development happens on a real computer, often through an app store.
+</div>
+
+You've seen that phones and tablets are deployment targets, not workstations. This lesson is about the deployment itself: the concrete ways to turn an idea into an installable mobile app. There are three broad routes, each with its own languages, toolchains, and trade-offs — and one rule that applies to all of them: you do the work on a desktop or laptop and ship the result to the device.
+
+## Approach 1: native
+
+A **native** app is written in the language and tools that a platform was designed around. You build twice — once per platform — but you get the deepest access and the most authentic feel.
+
+- **iOS** — written in **Swift** (older code in Objective-C) using **Xcode** on a Mac. Xcode handles building, the simulator, signing, and submission to the App Store.
+- **Android** — written in **Kotlin** (or Java) using **Android Studio**, which runs on Windows, macOS, or Linux and includes an emulator and build tools.
+
+Native gives you the best performance, the smoothest animations, and immediate access to every new platform feature and sensor the day it ships. The cost is duplication: two codebases, two languages, and two teams' worth of effort if you want both platforms.
+
+## Approach 2: cross-platform
+
+A **cross-platform** framework lets you write one codebase that runs on both iOS and Android. You trade a little native fidelity for a large saving in effort.
+
+- **Flutter** — Google's framework, written in **Dart**. It draws its own UI, giving consistent results across platforms.
+- **React Native** — written in **JavaScript/TypeScript**, popular with web developers because it reuses React concepts.
+- **.NET MAUI** — Microsoft's framework, using **C#**, attractive for teams already in the .NET world.
+
+These frameworks still build native app packages under the hood and can reach down to platform features when needed, often through plugins. The trade-off is that the very newest platform capabilities may lag, and squeezing out the last bit of native polish can take extra work. For most apps, the single shared codebase is well worth it.
+
+## Approach 3: web and PWA
+
+The third route skips the app stores almost entirely. A **web app** is built with the standard web stack — **HTML, CSS, and JavaScript** — and runs in the phone's browser. A **Progressive Web App (PWA)** is a web app enhanced so it can be installed to the home screen, work offline, and feel app-like, while still being just a website.
+
+The appeal is reach with no friction: anyone with a browser can use it instantly, on any platform, with no download and no store review. The limits are real too — web apps have more restricted access to device sensors and platform features, and can't always match native performance or look-and-feel. But for content, dashboards, and tools that don't need deep hardware access, web is often the fastest way to everyone at once.
+
+This is also the lightest way to put a screen on server-hosted software. A GopherTrunk dashboard served from the machine running the scanner can simply be opened in a phone or tablet browser — the device becomes a thin client, with all the real work staying on the server.
+
+## Comparing the three approaches
+
+| | Native | Cross-platform | Web / PWA |
+|---|--------|----------------|-----------|
+| **Languages** | Swift, Kotlin | Dart, JS/TS, C# | HTML, CSS, JS |
+| **Codebases** | One per platform | One shared | One shared |
+| **Performance & feel** | Best | Very good | Good enough for many apps |
+| **Device & sensor access** | Full | Most (via plugins) | Limited |
+| **Distribution** | App stores | App stores | A URL — no install needed |
+| **Best when** | Polish and depth matter | Reaching both stores efficiently | Reach and zero-install matter |
+
+There's no universally correct choice — it's the same "match the tool to the constraints" thinking the whole path teaches. Need maximum polish and a single platform? Go native. Want both stores from one team? Go cross-platform. Need everyone, instantly, with no install? Go web.
+
+## You build on a desktop, not on the phone
+
+Whatever route you pick, the development happens on a real computer. Xcode needs a Mac; Android Studio, Flutter, and the web toolchains run on a proper desktop or laptop with a keyboard, a big screen, and the freedom to install whatever you need. You write code, build it, run it in an emulator or on a tethered device, and only then deploy.
+
+This is precisely why earlier lessons treated the phone as a target and stressed picking the right *development* machine — see [Choosing a development machine](/learn/intro-hardware/choosing-a-dev-machine/). The phone is where your software lives; the laptop is where it's made.
+
+## App store realities
+
+Distribution shapes mobile development as much as code does. Native and cross-platform apps generally ship through the **App Store** and **Google Play**, which means:
+
+- **Review and approval.** Apple and Google inspect submissions; an app can be delayed or rejected.
+- **Fees and revenue cuts.** Store accounts cost money, and the stores take a percentage of in-app sales.
+- **Signing and identity.** Apps must be cryptographically signed and tied to a developer account.
+
+Web apps and PWAs sidestep most of this — there's no review and no cut, just a URL — which is part of why "ship it on the web" is such a common starting point. Knowing the distribution rules before you start often steers the technical choice as much as performance does.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — native, cross-platform, and web/PWA are the three routes, trading platform feel, shared effort, and reach." markdown="0">
+  <p class="knowledge-check__q">Quick check: What are the three broad approaches to building a mobile app?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Compiled, interpreted, and scripted</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Native, cross-platform, and web/PWA</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">iOS-only, Android-only, and Windows-only</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Native** — Swift/Xcode for iOS and Kotlin/Android Studio for Android; best performance and feel, but a codebase per platform.
+- **Cross-platform** — Flutter (Dart), React Native (JS), or .NET MAUI (C#); one shared codebase across both stores.
+- **Web / PWA** — HTML, CSS, and JavaScript in the browser, installable to the home screen; maximum reach, no install, but limited device access.
+- **The trade-off** — polish and depth vs. shared effort vs. reach; choose by which constraint matters most.
+- **Build on a desktop, deploy to the phone** — development happens on a real machine, and the device is the target.
+- **App stores set rules** — review, fees, and signing shape native distribution, while web sidesteps all of it.
+
+Next up: we leave handheld devices for the world of tiny, cheap, full computers you can build into anything. See [What is a single-board computer?](/learn/intro-hardware/what-is-an-sbc/).

--- a/docs/learn/intro-hardware/esp32.md
+++ b/docs/learn/intro-hardware/esp32.md
@@ -1,0 +1,84 @@
+---
+slug: esp32
+title: ESP32 & wireless microcontrollers
+description: The ESP32 is a microcontroller with Wi-Fi and Bluetooth built in for a couple of dollars. Learn why it powers most DIY smart-home gadgets and the IoT.
+keywords: esp32, wireless microcontroller, esp8266, esp32-s3, esp32-c3, wifi microcontroller, IoT, ESPHome, Tasmota, MicroPython, ESP-IDF
+level: intermediate
+status: full
+faq:
+  - q: "What is the ESP32?"
+    a: "The ESP32 is a low-cost microcontroller from Espressif with **Wi-Fi and Bluetooth built right into the chip**. It's typically dual-core, runs faster and with far more memory than a classic 8-bit Arduino, and costs only a few dollars on a small dev board. That combination of cheap, capable, and wireless is why it became the default chip for hobbyist Internet-of-Things projects."
+  - q: "How is the ESP32 different from an Arduino Uno?"
+    a: "The Uno is an 8-bit chip at 16 MHz with 2 KB of RAM and **no networking**. The ESP32 is a 32-bit, usually dual-core chip running at up to 240 MHz with hundreds of kilobytes of RAM and **built-in Wi-Fi and Bluetooth**. Crucially, you can program the ESP32 with the same friendly Arduino tooling, so it feels familiar while being far more powerful and wireless."
+  - q: "What can you build with an ESP32?"
+    a: "Mostly connected gadgets: smart-home sensors and switches, environmental monitors that post data to the cloud, Bluetooth peripherals, and DIY IoT devices of every kind. Ready-made firmware like **ESPHome** and **Tasmota** runs on ESP chips, letting you build smart-home devices without writing much code at all. It's still a microcontroller, though — for video or a full Linux app you'd want a single-board computer instead."
+---
+# ESP32 & wireless microcontrollers
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Wireless built in** — the ESP32 packs Wi-Fi and Bluetooth onto a cheap microcontroller, which is the game-changer for IoT. **Powerful for an MCU** — dual-core, up to 240 MHz, far more memory than a classic Arduino, for a couple of dollars. **Same friendly tooling** — program it with the Arduino core, ESP-IDF in C, or MicroPython, backed by a huge community.
+</div>
+
+The classic Arduino gave you a cheap brain but no way to talk to the network. The ESP32 fixes exactly that. It's a microcontroller with Wi-Fi and Bluetooth radios baked onto the same chip, for the price of a coffee — and that single feature is why it sits inside most DIY smart-home gadgets and hobbyist IoT projects today. This lesson covers what the ESP32 is, why built-in wireless matters so much, how you program it, and where its limits are.
+
+## What the ESP32 is
+
+The **ESP32** is a family of microcontrollers from **Espressif**. A typical ESP32 is a 32-bit, **dual-core** chip running at up to 240 MHz with several hundred kilobytes of RAM and, most importantly, **Wi-Fi and Bluetooth radios integrated onto the chip itself**. On a small development board with USB and a voltage regulator, it costs just a few dollars.
+
+It has a lineage worth knowing. Its predecessor, the **ESP8266**, was the chip that first made cheap Wi-Fi microcontrollers mainstream — it's still around and still cheap, but single-core and more limited. The ESP32 superseded it, and Espressif has since shipped a range of **variants**: the **S3** with extra power and AI-friendly features, and the smaller, cheaper single-core **C3** built on a RISC-V core. They share tooling, so what you learn on one transfers to the others.
+
+Compared with a classic 8-bit Arduino, the ESP32 is in a different league for raw capability — more cores, more speed, much more memory — while staying just as cheap. The headline difference, though, isn't the compute. It's the radio.
+
+## Why built-in wireless changes everything
+
+For the **Internet of Things (IoT)** — the idea of small devices that sense or control the physical world and report over a network — connectivity is the whole point. A temperature sensor that can't tell anyone the temperature isn't very useful. A light switch you can't reach from your phone is just a light switch.
+
+Before the ESP chips, adding network access to a microcontroller meant bolting on a separate Wi-Fi or Ethernet shield — more cost, more wiring, more power, more complexity. The ESP32 collapses all of that into the main chip. For a couple of dollars you get a computer that can read a sensor *and* publish the reading to a server, host a little configuration web page, or pair with your phone over Bluetooth — all from one tiny part.
+
+That economics is why the ESP32 became the backbone of the maker IoT world. When the radio is free and the chip is cheap, building a connected gadget stops being a project and starts being a weekend.
+
+## How you program an ESP32
+
+You have three well-trodden options, from easiest to most low-level:
+
+| Option | Language | Best for |
+|--------|----------|----------|
+| **Arduino core for ESP32** | C++ (Arduino style) | Beginners and anyone already comfortable with Arduino sketches |
+| **ESP-IDF** | C | Espressif's official SDK — full control, all features, production work |
+| **MicroPython** | Python | Quick experiments and scripting on-device with a familiar language |
+
+The **Arduino core for ESP32** is the common starting point: the same `setup()`/`loop()` model and libraries you saw in the last lesson, now with Wi-Fi and Bluetooth functions available. When you outgrow it, **ESP-IDF** gives you Espressif's full C SDK with access to every feature and finer control over power and timing. And **MicroPython** lets you write Python that runs right on the chip, which is great for tinkering. Most people start with the Arduino core and only drop down when they need to.
+
+There's also a no-code-needed path. Off-the-shelf firmware like **ESPHome** and **Tasmota** runs on ESP chips and turns them into smart-home devices configured through simple text files or a web UI — a huge shortcut for home automation.
+
+## Strengths and drawbacks
+
+The ESP32's appeal is easy to state, and so are the trade-offs that come with cramming a radio onto a microcontroller.
+
+| | ESP32 |
+|---|---|
+| **Strengths** | Built-in Wi-Fi and Bluetooth; very cheap; powerful for an MCU (dual-core, lots of RAM); reuses Arduino tooling; large, active community |
+| **Drawbacks** | Wireless draws real current, so battery life needs careful **deep-sleep** design; RF and antenna layout add complexity; still far more constrained than an SBC; the chip runs warm under heavy radio use |
+
+The biggest practical gotcha is **power**. A tiny sensor MCU can run for years on a coin cell, but an ESP32 actively using Wi-Fi can draw a few hundred milliamps in bursts — enough to flatten a small battery fast. The standard fix is **deep sleep**: the chip wakes briefly, takes a reading, sends it, then powers almost everything down for minutes or hours. Designed that way, an ESP32 sensor can still last a long time; designed naively, it won't. And remember the bigger picture — capable as it is, the ESP32 is still a microcontroller, not a Linux computer. For displays, heavy compute, or running full applications like GopherTrunk, you'd reach back up the spectrum to a single-board computer.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the ESP32's built-in Wi-Fi and Bluetooth are what make it the default chip for connected IoT projects." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the ESP32's defining advantage over a classic Arduino?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It can run desktop Linux and full applications</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It has Wi-Fi and Bluetooth built into the chip, making it ideal for IoT</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It uses an entirely different language that Arduino tooling can't touch</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Wireless on-chip** — the ESP32 integrates Wi-Fi and Bluetooth onto a cheap microcontroller, the feature that defines it.
+- **Powerful and cheap** — dual-core, up to 240 MHz, hundreds of KB of RAM, for a couple of dollars; the ESP8266 came before it and the S3/C3 are variants.
+- **Built for IoT** — free connectivity turns building a connected sensor or switch into a weekend project.
+- **Several ways in** — program it with the Arduino core, ESP-IDF in C, or MicroPython, or flash ready-made ESPHome/Tasmota firmware.
+- **Mind the power** — active Wi-Fi draws real current, so battery projects lean hard on deep sleep; it's still an MCU, not an SBC.
+
+Next up: the languages, workflow, and hard limits that apply across every microcontroller. See [Programming microcontrollers: languages, use cases & limits](/learn/intro-hardware/mcu-programming-and-tradeoffs/).

--- a/docs/learn/intro-hardware/glossary.md
+++ b/docs/learn/intro-hardware/glossary.md
@@ -1,0 +1,153 @@
+---
+slug: glossary
+title: Glossary of hardware terms
+description: Plain-language definitions for every key hardware term in the Intro to Hardware learning path, cross-linked to the lessons that explain them.
+keywords: hardware glossary, computer hardware terms, server hosting terms, single board computer glossary, microcontroller terms
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of hardware terms
+
+This is a plain-language reference for the key terms used across the Intro to Hardware path. Definitions are short on purpose; each links to the lesson that explains the idea in full. Terms are grouped by theme and roughly ordered from foundational to advanced within each group, following the shape of the path itself.
+
+## Foundations
+
+**Hardware** — The physical parts of a computing device you can touch: chips, boards, memory, drives, and the case around them. See [What is computer hardware?](/learn/intro-hardware/what-is-hardware/)
+
+**Software** — The instructions that run on hardware. Unlike hardware, it can be changed without replacing the machine. See [What is computer hardware?](/learn/intro-hardware/what-is-hardware/)
+
+**Computer** — Any machine that takes input, processes it by following instructions, and produces output, from a data-centre server down to a tiny chip in a sensor. See [What is computer hardware?](/learn/intro-hardware/what-is-hardware/)
+
+**CPU (central processing unit)** — The chip that carries out a program's instructions; the part most people call the "brain" of a computer. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**Core** — A self-contained processing unit inside a CPU; a multi-core chip can work on several tasks at once. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**Clock speed** — How many cycles per second a CPU runs, measured in gigahertz (GHz); a rough, not absolute, guide to how fast it works. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**RAM (memory)** — Fast, temporary working storage that holds the data and programs a computer is actively using; it is cleared when power is lost. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**Storage** — Where data is kept long-term so it survives a power cycle, such as a hard drive or solid-state drive. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**SSD (solid-state drive)** — Storage that keeps data on flash memory chips with no moving parts, far faster and more rugged than a spinning hard drive. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**Flash memory** — Non-volatile storage that holds data without power, used in SSDs, memory cards, and the on-board storage of small devices. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**I/O (input/output)** — The channels through which a computer takes in and sends out data, from keyboards and screens to network ports and sensors. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**Operating system (OS)** — The software that manages a device's hardware and resources and gives other programs a consistent way to run. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/)
+
+**Hardware spectrum** — The full range of computing hardware, from distant cloud servers through personal devices down to tiny microcontrollers, each suited to different jobs. See [The hardware spectrum — cloud to microcontroller](/learn/intro-hardware/hardware-spectrum/)
+
+**General-purpose computer** — A machine designed to run many different programs and adapt to many tasks, like a laptop or server. See [The hardware spectrum — cloud to microcontroller](/learn/intro-hardware/hardware-spectrum/)
+
+**Embedded computer** — A computer built into a larger device to do one specific job, rather than serving as a general-purpose machine. See [The hardware spectrum — cloud to microcontroller](/learn/intro-hardware/hardware-spectrum/)
+
+**Compiled language** — A language whose programs are translated to machine code ahead of time, common where performance and small footprints matter. See [Programming languages & where they run](/learn/intro-hardware/languages-and-hardware/)
+
+**Interpreted language** — A language whose programs are read and run on the fly, convenient on capable hardware but heavier on resources. See [Programming languages & where they run](/learn/intro-hardware/languages-and-hardware/)
+
+**Cost, power & performance** — The three competing pressures behind almost every hardware choice: what it costs, how much energy it draws, and how much work it can do. See [Cost, power & performance trade-offs](/learn/intro-hardware/cost-power-performance/)
+
+**Trade-off** — A choice where gaining one quality means giving up another, such as more performance for higher cost or power draw. See [Cost, power & performance trade-offs](/learn/intro-hardware/cost-power-performance/)
+
+## Servers and hosting
+
+**Server** — A computer that provides services or data to other machines over a network, such as serving web pages or running an application. See [Web & shared hosting](/learn/intro-hardware/web-hosting/)
+
+**Web hosting** — A service that runs your website on someone else's servers so it is reachable on the internet. See [Web & shared hosting](/learn/intro-hardware/web-hosting/)
+
+**Shared hosting** — The cheapest kind of web hosting, where many customers' sites run together on one server and share its resources. See [Web & shared hosting](/learn/intro-hardware/web-hosting/)
+
+**VPS (virtual private server)** — A slice of a physical server that acts like your own machine, giving more control than shared hosting at lower cost than a whole server. See [Virtual private servers (VPS)](/learn/intro-hardware/vps/)
+
+**Virtualization** — Splitting one physical computer into several isolated virtual machines, each behaving like a separate computer. See [Virtual private servers (VPS)](/learn/intro-hardware/vps/)
+
+**Hypervisor** — The software layer that creates and runs virtual machines on a physical host, dividing its resources between them. See [Virtual private servers (VPS)](/learn/intro-hardware/vps/)
+
+**Root access** — Full administrative control over a server, letting you install software and change any setting. See [Virtual private servers (VPS)](/learn/intro-hardware/vps/)
+
+**Dedicated server** — A whole physical server rented for your exclusive use, with no other customers sharing its hardware. See [Dedicated servers](/learn/intro-hardware/dedicated-servers/)
+
+**Home server** — A computer you run at home to host services for yourself, from file storage to a personal website. See [Home servers & self-hosting](/learn/intro-hardware/home-servers/)
+
+**Self-hosting** — Running services on hardware you own and control instead of paying a provider to run them for you. See [Home servers & self-hosting](/learn/intro-hardware/home-servers/)
+
+**NAS (network-attached storage)** — A dedicated device that stores files and shares them with other machines over a home or office network. See [Home servers & self-hosting](/learn/intro-hardware/home-servers/)
+
+**Port forwarding** — A router setting that lets traffic from the internet reach a specific device on your home network, needed to expose a self-hosted service. See [Home servers & self-hosting](/learn/intro-hardware/home-servers/)
+
+## Personal and mobile devices
+
+**Desktop** — A stationary personal computer, typically more powerful, expandable, and cheaper per unit of performance than a laptop. See [Desktop computers](/learn/intro-hardware/desktop-computers/)
+
+**Laptop** — A portable personal computer with screen, keyboard, and battery built in, trading some performance and expandability for mobility. See [Laptops](/learn/intro-hardware/laptops/)
+
+**Thermal throttling** — When a chip deliberately slows itself to avoid overheating, a common limit on sustained performance in thin laptops and small devices. See [Laptops](/learn/intro-hardware/laptops/)
+
+**Development machine** — The computer you write and test code on; choosing one means balancing power, portability, and budget against how you work. See [Choosing your development machine](/learn/intro-hardware/choosing-a-dev-machine/)
+
+**Smartphone** — A pocket-sized, touchscreen computer with a cellular connection, sensors, and a battery, running apps as well as making calls. See [Smartphones](/learn/intro-hardware/smartphones/)
+
+**Tablet** — A larger touchscreen device that sits between a phone and a laptop, good for media and light work and sometimes paired with a keyboard. See [Tablets](/learn/intro-hardware/tablets/)
+
+**Native app** — An application built specifically for one platform's hardware and operating system, giving full access to its features and best performance. See [Developing for mobile devices](/learn/intro-hardware/developing-for-mobile/)
+
+**Cross-platform** — Building software that runs on more than one kind of device or operating system from largely shared code. See [Developing for mobile devices](/learn/intro-hardware/developing-for-mobile/)
+
+**PWA (progressive web app)** — A website built to behave like an installed app, working offline and launching from the home screen without an app store. See [Developing for mobile devices](/learn/intro-hardware/developing-for-mobile/)
+
+## Single-board computers and microcontrollers
+
+**Single-board computer (SBC)** — A complete computer built on one small circuit board, with CPU, memory, storage, and ports, capable of running a full operating system. See [What is a single-board computer?](/learn/intro-hardware/what-is-an-sbc/)
+
+**GPIO (general-purpose input/output)** — Pins on an SBC or microcontroller that your code can read or switch on and off to talk to sensors, lights, motors, and other electronics. See [What is a single-board computer?](/learn/intro-hardware/what-is-an-sbc/)
+
+**Raspberry Pi** — A popular, low-cost single-board computer widely used for learning, hobby projects, and small servers. See [The Raspberry Pi & its alternatives](/learn/intro-hardware/raspberry-pi-and-family/)
+
+**HAT (hardware attached on top)** — An add-on board that stacks onto a Raspberry Pi's pins to give it extra features like displays, sensors, or power options. See [The Raspberry Pi & its alternatives](/learn/intro-hardware/raspberry-pi-and-family/)
+
+**Programming an SBC** — Writing software for a single-board computer much as you would for a desktop, using its operating system and ordinary languages and tools. See [Programming & running software on an SBC](/learn/intro-hardware/programming-an-sbc/)
+
+**Edge computing** — Running computation close to where data is produced, on devices or local hardware like an SBC, rather than sending everything to a distant data centre. See [SBC use cases, strengths & drawbacks](/learn/intro-hardware/sbc-use-cases-and-limits/)
+
+**Microcontroller (MCU)** — A tiny, low-power computer on a single chip that combines processor, memory, and I/O, dedicated to controlling one device or task. See [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/)
+
+**Bare metal** — Running code directly on a chip with no operating system in between, common on microcontrollers for tight control and predictability. See [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/)
+
+**Firmware** — Low-level software loaded onto a device's chip to control its hardware directly, sitting between pure hardware and ordinary programs. See [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/)
+
+**Arduino** — A widely used family of beginner-friendly microcontroller boards and the open-source ecosystem of tools and code around them. See [Arduino & the maker ecosystem](/learn/intro-hardware/arduino/)
+
+**Sketch** — The name Arduino gives to a program written for its boards. See [Arduino & the maker ecosystem](/learn/intro-hardware/arduino/)
+
+**ESP32** — A low-cost microcontroller with built-in Wi-Fi and Bluetooth, popular for connected and wireless projects. See [ESP32 & wireless microcontrollers](/learn/intro-hardware/esp32/)
+
+**MicroPython** — A compact version of the Python language made to run directly on microcontrollers. See [Programming microcontrollers: languages, use cases & limits](/learn/intro-hardware/mcu-programming-and-tradeoffs/)
+
+**Real-time** — A requirement that a device respond within strict, guaranteed time limits, where being late is itself a failure; common in microcontroller work. See [Programming microcontrollers: languages, use cases & limits](/learn/intro-hardware/mcu-programming-and-tradeoffs/)
+
+**Deep sleep** — A very low-power mode a microcontroller drops into between tasks to stretch battery life, waking only when needed. See [Programming microcontrollers: languages, use cases & limits](/learn/intro-hardware/mcu-programming-and-tradeoffs/)
+
+## Choosing hardware
+
+**Requirements** — What your project must actually do and the conditions it must meet, worked out before deciding what hardware to buy. See [Start with your requirements](/learn/intro-hardware/start-with-requirements/)
+
+**Constraint** — A fixed limit your choice must respect, such as budget, size, power supply, or response time. See [Start with your requirements](/learn/intro-hardware/start-with-requirements/)
+
+**Project type** — The broad category of what you are building (a website, a mobile app, a sensor, a home server), which steers you toward fitting hardware. See [Matching hardware to the project type](/learn/intro-hardware/matching-hardware-to-project/)
+
+**Combining tiers** — Using device, server, and cloud hardware together in one system, with each tier handling the part of the job it suits best. See [Combining tiers: device, server & cloud](/learn/intro-hardware/combining-tiers/)
+
+**Cloud** — Computing power and storage provided over the internet on demand, instead of from machines you own and run yourself. See [Combining tiers: device, server & cloud](/learn/intro-hardware/combining-tiers/)
+
+**Latency** — The delay between asking for something and getting a response; keeping it low is a common reason to move work closer to the user. See [Combining tiers: device, server & cloud](/learn/intro-hardware/combining-tiers/)
+
+**Scaling** — Handling more work by adding capacity, whether by upgrading a machine or by adding more machines. See [Combining tiers: device, server & cloud](/learn/intro-hardware/combining-tiers/)
+
+**Decision framework** — A structured way to weigh hardware options against your needs so the choice is reasoned rather than arbitrary. See [A practical decision framework](/learn/intro-hardware/decision-framework/)
+
+**Total cost of ownership** — The full cost of a hardware choice over time, including power, maintenance, and replacement, not just the sticker price. See [A practical decision framework](/learn/intro-hardware/decision-framework/)
+
+**Worked example** — A realistic scenario walked through end to end to show how the decision framework picks hardware for a real project. See [Worked examples: picking hardware for real projects](/learn/intro-hardware/worked-examples/)

--- a/docs/learn/intro-hardware/hardware-spectrum.md
+++ b/docs/learn/intro-hardware/hardware-spectrum.md
@@ -1,0 +1,109 @@
+---
+slug: hardware-spectrum
+title: The hardware spectrum — cloud to microcontroller
+description: From rented cloud servers down to two-dollar chips, every computing platform sits on one spectrum. See them ordered by power, cost, and how much of the machine you actually control.
+keywords: hardware spectrum, cloud to microcontroller, computing platforms compared, server vs sbc vs microcontroller, who manages the hardware, choosing a computing platform, hardware tiers
+level: beginner
+status: full
+faq:
+  - q: "What is the hardware spectrum?"
+    a: "It's a way of laying every computing platform on a single line, from the most powerful and abstract (rented cloud servers) down to the smallest and most direct (microcontrollers). Ordering them by **power**, **cost**, and **how much you control** makes it clear that there's no single best machine — only the one that fits a given job's constraints."
+  - q: "Is a more powerful platform always better?"
+    a: "No, and this is the central idea of the whole path. A cloud server is wildly overpowered for blinking an LED, and a microcontroller can't host a website. **The right tool depends on your constraints** — cost, power draw, performance, control, and effort. More power usually means more cost, more electricity, and sometimes less direct control."
+  - q: "What does \"control vs managed\" mean on this spectrum?"
+    a: "At the cloud end, someone else owns and maintains the physical machine — you just rent capacity and they handle hardware, cooling, and replacement. At the microcontroller end, you own and control everything down to the individual pins. Moving down the spectrum trades convenience for control: less is managed for you, but more is yours to decide and maintain."
+  - q: "Where does GopherTrunk fit on this spectrum?"
+    a: "Almost anywhere. Because **GopherTrunk** is software-defined-radio software, it can run on a dedicated server, a desktop, a laptop, or a Raspberry Pi sitting right at the antenna. The same job lands at very different points on the spectrum depending on whether you want raw power, portability, or a cheap node out in the field."
+---
+# The hardware spectrum — cloud to microcontroller
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**One spectrum, many platforms** — cloud, VPS, dedicated server, home server, desktop, laptop, tablet, phone, single-board computer, and microcontroller all sit on one line. **Three axes order it** — raw power, cost, and how much of the machine you control versus someone else manages. **The right tool depends on constraints** — there's no best platform, only the best fit for a job.
+</div>
+
+You now know the four building blocks every computer shares. This lesson zooms back out and lays every platform this path covers onto a single map. It's the frame the rest of the course hangs on: each later module takes one stretch of this spectrum and explores it in depth. Get this map in your head now and every lesson afterward will have a place to sit.
+
+## The spectrum, end to end
+
+Here is the full range, ordered from the most powerful and abstract down to the smallest and most direct:
+
+**Cloud / web hosting → VPS → dedicated server → home server → desktop → laptop → tablet / phone → single-board computer → microcontroller**
+
+At the top, you don't own a machine at all — you rent a slice of someone else's, and they handle the physical hardware. In the middle sit the personal computers most people picture. Toward the bottom, the machines get small, cheap, and physical: boards you hold in your hand and wire to the world. Nothing about this is a quality ranking. It's a map of trade-offs, and which end you reach for depends entirely on what you're building.
+
+## Ordering by raw power
+
+The most obvious way to read the spectrum is by capability — CPU, memory, storage, and how much work the machine can do at once. This tracks closely with the building blocks from the last lesson.
+
+| Platform | Relative power | What that buys you |
+|----------|----------------|---------------------|
+| **Cloud / web hosting** | Effectively unlimited (scales on demand) | Serve millions of users; grow instantly |
+| **Dedicated / home server** | Very high | Heavy always-on workloads, lots of storage |
+| **Desktop** | High | Demanding local work — video, compiling, simulation |
+| **Laptop** | High, with limits | Most development and daily work, on the move |
+| **Tablet / phone** | Moderate, battery-bound | Apps, sensors, communication in your pocket |
+| **Single-board computer** | Low but real | A full Linux machine for tens of dollars |
+| **Microcontroller** | Tiny | One small job, sipping power |
+
+Power falls off by orders of magnitude from top to bottom — but so does what you need to pay for and carry.
+
+## Ordering by cost and power draw
+
+The same spectrum looks different through the lens of money and electricity, and the two often move together. Cloud platforms cost little upfront but charge ongoing for what you use. A microcontroller costs a few dollars once and draws almost no power. In between, machines vary in both upfront price and the running cost of keeping them powered.
+
+| Platform | Upfront cost | Ongoing cost / power draw |
+|----------|--------------|----------------------------|
+| **Cloud / web hosting** | Near zero | Monthly fees; scales with use |
+| **VPS** | Near zero | Modest fixed monthly fee |
+| **Dedicated server** | Low (rented) to high (owned) | Significant, always-on |
+| **Home server** | One-time hardware | Your electricity bill, 24/7 |
+| **Desktop** | Moderate to high | Wall power when in use |
+| **Laptop** | Moderate to high | Battery, then wall |
+| **Phone / tablet** | Moderate to high | Battery, frugal |
+| **Single-board computer** | Tens of dollars | A few watts |
+| **Microcontroller** | A few dollars | Milliwatts — can run for years on a battery |
+
+This is why a job that's "free" to prototype on a microcontroller can be expensive to run as an always-on home server — the cost shifts from upfront to ongoing. We'll dig into exactly these tensions in the next lesson.
+
+## Ordering by control vs management
+
+The third axis is the least obvious and often the most important: **how much of the machine is yours to control, versus managed for you by someone else.**
+
+At the cloud end, you control almost nothing physical. A hosting provider owns the hardware, cools it, replaces failed drives, and keeps it online — you just deploy software onto it. That's enormously convenient, but you can't touch the metal, and you're trusting someone else's decisions. As you move down the spectrum, more is handed to you: a home server is yours to maintain entirely, and a microcontroller is yours down to the last pin. You decide everything — and you're responsible for everything.
+
+| Platform | Who manages the hardware | What you control |
+|----------|--------------------------|-------------------|
+| **Cloud / web hosting** | Provider, fully | Just your code and config |
+| **VPS** | Provider owns metal; you run the OS | The whole software stack |
+| **Dedicated server** | Provider (rented) or you (owned) | The full machine |
+| **Home server / desktop / laptop** | You | Everything |
+| **SBC / microcontroller** | You | Everything, down to the pins |
+
+Convenience and control sit at opposite ends. Neither is "better" — a beginner shipping a website wants the cloud's convenience; a tinkerer reading sensors wants the microcontroller's directness.
+
+## The right tool depends on constraints
+
+Put the three readings together and the theme of the whole path appears: **there is no best platform, only the best fit.** A platform that's perfect for one job is absurd for another. GopherTrunk makes this concrete — the same software-defined-radio software can run on a dedicated server (maximum power, always on), a laptop (portable, good for experimenting), or a Raspberry Pi bolted next to the antenna (cheap, low-power, out in the field). All three are legitimate; the right one depends on your constraints.
+
+The modules ahead each take one region of this spectrum: servers and hosting, personal computers, mobile devices, single-board computers, and microcontrollers — then Module 7 turns the whole map into a method for choosing deliberately. Keep this spectrum in mind as you go; everything else is a closer look at one stretch of it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — moving down the spectrum trades convenience for control: less is managed for you, but more is yours to decide." markdown="0">
+  <p class="knowledge-check__q">Quick check: As you move from the cloud end toward the microcontroller end of the spectrum, what generally happens?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The machine becomes more powerful and more expensive to buy</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">More of the machine becomes yours to control, and more is your responsibility to manage</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">You give up control to the hosting provider</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **One spectrum** — cloud, VPS, dedicated and home servers, desktops, laptops, tablets, phones, SBCs, and microcontrollers all sit on a single line from most powerful to smallest.
+- **Power axis** — capability falls off by orders of magnitude from top to bottom, and so does what you must pay for and carry.
+- **Cost and power axis** — the cloud trades near-zero upfront cost for ongoing fees; a microcontroller is cheap once and sips electricity.
+- **Control axis** — the cloud manages everything for you; the microcontroller hands you everything, convenience traded for control.
+- **The right tool depends on constraints** — there's no best platform, and GopherTrunk can run almost anywhere on this map depending on the job.
+
+Next up: why a web host runs PHP and a microcontroller runs C — how the hardware you've just mapped shapes which languages are even practical. See [Programming languages & where they run](/learn/intro-hardware/languages-and-hardware/).

--- a/docs/learn/intro-hardware/home-servers.md
+++ b/docs/learn/intro-hardware/home-servers.md
@@ -1,0 +1,90 @@
+---
+slug: home-servers
+title: Home servers & self-hosting
+description: A home server runs your own services on your own internet — an old PC, NAS, or Raspberry Pi. Learn the freedom, the hidden costs, and why it's a great first server.
+keywords: home server, self-hosting, Raspberry Pi server, NAS, Plex Jellyfin, home automation, port forwarding, dynamic IP, residential internet, local hardware access
+level: intermediate
+status: full
+faq:
+  - q: "What is a home server?"
+    a: "A **home server** is a computer you run in your own home to provide services — anything from an old desktop or a mini PC to a NAS box or a **Raspberry Pi**. Instead of renting space in a data center, you host your own apps, files, or media on hardware you own, connected through your home internet. The practice of running your own services this way is called **self-hosting**."
+  - q: "What can I self-host at home?"
+    a: "A lot. Common uses are a media server (**Plex** or **Jellyfin**), file storage and backups (a **NAS**), home automation, a dev/test environment, and self-hosted versions of apps you'd otherwise pay for. A home server is also ideal for an SDR setup like **GopherTrunk**, because the radio hardware plugs in locally — something a cloud VPS, with no USB ports, simply can't do."
+  - q: "Why is a Raspberry Pi a good first home server?"
+    a: "It's cheap, tiny, and sips power, so you can leave it running all day for pennies. It runs full Linux, so it teaches you real server skills, and it has **USB and GPIO ports** for attaching hardware locally. That makes it a forgiving, low-stakes way to learn self-hosting — and a natural home for a [single-board computer](/learn/intro-hardware/what-is-an-sbc/) project like a GopherTrunk box."
+---
+# Home servers & self-hosting
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A home server is a machine in your home** — an old PC, a NAS, a mini PC, or a Raspberry Pi — running your own services. **Self-hosting buys ownership, privacy, and local hardware access** with no monthly fees. **The hidden costs are real** — your electricity, your uptime, residential internet quirks, and you as the entire IT department. **A Raspberry Pi is a great first server.**
+</div>
+
+So far the server has lived somewhere else — a shared host, a VPS, a dedicated box in a data center. But you can also run a server right at home, on hardware you own and internet you already pay for. It's how a lot of developers first truly *get* servers, and it unlocks things the cloud can't do. This lesson covers what self-hosting is, what people run, the freedom it gives you, and the costs nobody mentions until you hit them.
+
+## What a home server is
+
+A **home server** is simply a computer in your home that's left running to provide services to you and your devices. It doesn't have to be special hardware. Common choices are:
+
+- **An old PC or laptop** — repurposed instead of recycled.
+- **A NAS** (network-attached storage) — a dedicated box for files and backups.
+- **A mini PC** — small, quiet, low-power, always on.
+- **A Raspberry Pi** — credit-card-sized, cheap, and perfect for learning.
+
+The practice of running your own apps and services on it — rather than renting them or relying on cloud providers — is called **self-hosting**. You own the machine, you own the data, and you decide what runs.
+
+## What it's for
+
+Home servers shine at jobs where ownership, privacy, or *local hardware* matter:
+
+- **Media server** — stream your own library with **Plex** or **Jellyfin**.
+- **File storage and backups** — a NAS that keeps your data at home, not in someone's cloud.
+- **Home automation** — a hub coordinating lights, sensors, and switches locally.
+- **Dev and test environment** — a sandbox to break things safely.
+- **Self-hosted apps** — replacements for paid services you'd rather own.
+- **An SDR / GopherTrunk box** — and this one is special. SDR hardware has to be *physically plugged in*, and a cloud VPS has no USB ports. A home server sits right where the antenna is, so you can attach the SDR dongle locally and run GopherTrunk's recorder and dashboard on the same machine. The radio's data enters through real hardware you can touch.
+
+That last case captures the whole reason home servers exist alongside the cloud: some jobs need the machine to be *here*.
+
+## The languages and stacks it runs
+
+Like a VPS or a dedicated server, a home server runs **anything** — you control the operating system, usually Linux. Most self-hosted software is distributed as ready-to-run packages or **Docker containers**, so you spend less time writing code and more time configuring services. When you do build your own, Python, Node.js, Go, and shell scripts are common choices, and on a Raspberry Pi you can also reach the **GPIO pins** to talk to attached electronics — a capability no rented server has.
+
+## Strengths and drawbacks
+
+Self-hosting is genuinely empowering and genuinely more work. The honest balance:
+
+| Strengths | Drawbacks |
+|-----------|-----------|
+| **Full ownership** — your hardware, your data | **Your electricity and uptime** — it's down when your power is |
+| **No monthly fees** — pay once for the hardware | **Residential internet** — dynamic IPs, NAT, port forwarding, ISP terms |
+| **Privacy** — data never leaves your home | **You are all of IT** — setup, updates, backups, repairs |
+| **Learning** — real server skills, low stakes | **Security exposure** — anything you open to the internet is a target |
+| **Local hardware access** — USB, GPIO, SDR dongles | **Reliability** — no data center's redundant power or cooling |
+
+A few drawbacks deserve a closer look. **Residential internet** isn't built for serving: your IP address may change (a **dynamic IP**), your router hides you behind **NAT**, and reaching a service from outside usually means **port forwarding** — and some ISP terms of service frown on running public servers from home. And once you expose anything to the internet, *you* are responsible for keeping it secure. None of this is a dealbreaker for learning; it's just the reality the cloud was quietly handling for you.
+
+## Why a Raspberry Pi is a great first server
+
+If you want to try self-hosting, a **Raspberry Pi** is hard to beat as a starting point. It's inexpensive, it draws so little power you can leave it on around the clock for pennies, and it runs full Linux so the skills transfer directly to bigger servers. Crucially, it has USB and GPIO ports for attaching hardware locally — which is exactly what an SDR-based GopherTrunk box needs. It's a forgiving, low-cost way to learn, and it leads straight into the next module on single-board computers, which we'll explore starting with [what an SBC is](/learn/intro-hardware/what-is-an-sbc/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a home server lets you plug in local hardware like an SDR dongle, which a cloud VPS can't do." markdown="0">
+  <p class="knowledge-check__q">Quick check: What can a home server do that a cloud VPS cannot?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Run Linux and host websites</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Have physical hardware like an SDR dongle plugged directly into it via USB</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Provide redundant power and cooling for guaranteed uptime</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A server in your home** — an old PC, NAS, mini PC, or Raspberry Pi running your own services.
+- **Self-hosting buys ownership** — your hardware, your data, no monthly fees, real privacy.
+- **Great for media, backups, automation, and SDR** — including a GopherTrunk box, because the radio plugs in locally.
+- **Runs anything** — full OS control, often via Docker, plus GPIO for attached electronics.
+- **The hidden costs are real** — electricity, uptime, dynamic IP/NAT/port forwarding, ISP terms, security, and being all of IT.
+- **A Raspberry Pi is the ideal starter** — cheap, low-power, full Linux, and local hardware ports.
+
+Next up: stepping away from servers to the machine you sit in front of every day, starting with the most capable of them. See [Desktop computers](/learn/intro-hardware/desktop-computers/).

--- a/docs/learn/intro-hardware/index.md
+++ b/docs/learn/intro-hardware/index.md
@@ -1,0 +1,33 @@
+---
+layout: learn-hub
+learn_path: intro-hardware
+permalink: /learn/intro-hardware/
+title: Intro to Hardware — from the cloud to the microcontroller
+description: A free, structured learning path covering the hardware a developer chooses between — web hosting, VPSes, dedicated and home servers, desktops, laptops, smartphones, tablets, single-board computers like the Raspberry Pi, and microcontrollers like the Arduino and ESP32 — with the use cases, programming languages, and trade-offs of each, plus how to pick the right platform for your project.
+keywords: learn computer hardware, hardware for developers, web hosting vs vps vs dedicated server, home server, desktop vs laptop, single board computer, raspberry pi, microcontroller, arduino, esp32, choosing hardware for a project
+---
+
+Every program runs on something — and "something" covers an enormous range, from
+a few dollars of shared web hosting to a chip the size of a fingernail soldered
+into a sensor. This path is a guided tour of that range. For each kind of
+hardware a developer is likely to use, you'll learn what it's *for*, the
+programming languages that run on it, and its honest strengths and drawbacks —
+then how to weigh all of that to pick the right platform for a project.
+
+**Who this is for.** Complete newcomers are welcome — no electronics or
+sysadmin background required. If you already write code, use the module list to
+jump to the parts you're missing: servers and hosting, single-board computers,
+microcontrollers, or the decision framework at the end. Every lesson is
+self-contained and cross-linked, so you can read straight through or hop around.
+
+**How the path works.** Seven modules move from *foundations* to *decision*. We
+start with the ideas every later module leans on — what hardware is, the parts
+inside every computer, and the trade-offs that drive every choice. Then we walk
+the whole spectrum: servers and hosting, personal computers, mobile devices,
+single-board computers like the Raspberry Pi, and microcontrollers like the
+Arduino and ESP32. The final module turns it all into a practical, repeatable
+way to choose — usually a *combination* of platforms — for a real project.
+Examples lean on **GopherTrunk**, software-defined-radio software that can live
+on anything from a laptop to a Raspberry Pi by the antenna, so abstract
+trade-offs stay concrete. Mark lessons complete as you go; your progress is saved
+in your browser. New here? **[Start with lesson 1: What is computer hardware?](what-is-hardware/)**

--- a/docs/learn/intro-hardware/languages-and-hardware.md
+++ b/docs/learn/intro-hardware/languages-and-hardware.md
@@ -1,0 +1,101 @@
+---
+slug: languages-and-hardware
+title: Programming languages & where they run
+description: Servers run almost any language while a tiny chip runs C — and hardware is the reason. Learn what "runs on" really means and why constrained devices and powerful machines differ.
+keywords: programming languages and hardware, what does runs on mean, compiled vs interpreted, microcontroller programming languages, c c++ rust micropython, languages by platform, bare metal vs runtime
+level: beginner
+status: full
+faq:
+  - q: "What does it mean for a language to \"run on\" a device?"
+    a: "It means there's a way to turn that language into instructions the device's CPU can execute. Sometimes that's a **compiler** producing a machine-code binary ahead of time; sometimes it's an **interpreter or runtime** installed on the device that reads the code as it goes. A device can only run a language if that translation path exists for its processor and fits in its memory."
+  - q: "Why do microcontrollers favor C and C++?"
+    a: "Because they're tiny and have no operating system to lean on. **C** and **C++** compile straight to compact, fast machine code with no heavy runtime, so they fit in a few kilobytes and run close to the metal. **Rust** is increasingly used for the same reasons with more safety, and **MicroPython** offers an easier path where a bit more memory is available."
+  - q: "Why can a server run almost any language but a microcontroller can't?"
+    a: "A server has gigabytes of memory and a full operating system, so it can host the heavy interpreters and runtimes that languages like Python, JavaScript, and Java need. A microcontroller has kilobytes and no OS, so those runtimes simply don't fit. The hardware sets the ceiling on which languages are practical."
+  - q: "Do I pick the language or does the hardware pick it for me?"
+    a: "Both. On powerful machines you have wide freedom and choose based on the job and your preference. On constrained devices the hardware narrows the field sharply — you'll often be choosing among **C, C++, Rust, or MicroPython** because little else fits. The smaller the device, the more the hardware decides for you."
+---
+# Programming languages & where they run
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**"Runs on" means a translation path exists** — a compiler or an installed runtime turns code into instructions a given CPU can execute. **Hardware narrows the field** — powerful machines with an OS run almost any language; tiny chips with kilobytes run mostly C, C++, Rust, or MicroPython. **The operating system does heavy lifting** — much of a language's convenience depends on the OS underneath it.
+</div>
+
+A web host happily runs PHP and Python; a two-dollar microcontroller almost always runs C. That's not fashion or accident — it's the hardware from the last few lessons making itself felt. This lesson explains what "a language runs on a device" actually means, and why the machine you choose quietly decides which languages are even on the table. (For a proper tour of the languages themselves, the [Intro to Software Development](/learn/intro-software-dev/) path is the place to go; here we focus on the hardware angle.)
+
+## What "runs on X" really means
+
+A CPU only understands machine code — raw numbers specific to its kind of chip. Every programming language needs some way to get there. There are two broad routes:
+
+- **Compiled ahead of time.** A **compiler** translates your source code into a machine-code **binary** before it runs. The binary is built for one kind of processor and runs directly on it, fast and self-contained. C, C++, Rust, and Go work this way.
+- **Interpreted or run by a runtime.** Instead of producing a standalone binary, the code is read and executed by another program — an **interpreter** or **runtime** that must already be installed on the device. Python, JavaScript (via Node), and Java work this way (Java compiles to bytecode that its runtime then executes).
+
+So "Python runs on this server" really means "the Python interpreter is installed here, and it can read your script and execute it." That's the catch for small devices: if there isn't room for the interpreter, the language can't run there at all. A compiled binary, by contrast, needs only itself — which is one reason tiny machines lean on compiled languages.
+
+There's also a third, lowest level: **bare-metal** code that runs with no operating system at all, talking straight to the hardware. That's the world of microcontrollers, and it shapes everything about how you program them.
+
+## Why constrained devices favor a short list
+
+A microcontroller has kilobytes of RAM, no operating system, and a slow processor. That rules out the heavy interpreters and runtimes immediately — there's simply nowhere to put them. What's left are languages that compile to small, efficient machine code:
+
+- **C** — the classic choice. Compact, fast, and close to the hardware, with decades of tooling. Most microcontroller code is C.
+- **C++** — C with more structure; common on slightly larger embedded projects and the Arduino ecosystem.
+- **Rust** — increasingly popular for embedded work: the same low-level control as C, with stronger safety guarantees.
+- **MicroPython / CircuitPython** — a trimmed-down Python that fits on more capable microcontrollers (those with tens of kilobytes to spare). Much easier to write, at the cost of speed and memory.
+
+The pattern is clear: the smaller and cheaper the device, the shorter the menu, and the closer to the metal you work. On the very smallest chips, you're essentially choosing between C, C++, and Rust.
+
+## Why big machines run almost anything
+
+Move up the spectrum and the constraint vanishes. A server, desktop, or laptop has gigabytes of memory and a full operating system (Linux, Windows, macOS) that manages the hardware for every program. That OS is what makes hosting big runtimes practical, so these machines run essentially the whole language landscape:
+
+- **Python** — data, scripting, web backends, automation.
+- **JavaScript / Node** — web front and back ends.
+- **Go** — networked services and command-line tools (GopherTrunk's own world).
+- **Java, C#** — large applications and enterprise systems.
+- **C, C++, Rust** — performance-critical work, the same languages the small devices use.
+
+Here the hardware barely limits you, so the choice comes down to the job and your preference rather than what fits. GopherTrunk is a good example: it's software-defined-radio software that can run on a server, desktop, or laptop, where there's ample room for whatever runtime and libraries it needs — a freedom that simply doesn't exist on a microcontroller.
+
+## Mobile and the role of the operating system
+
+Phones and tablets sit in between, and they show how much the **operating system** shapes the picture. They're powerful enough to run many languages, but their platforms steer you toward specific ones for building real apps:
+
+- **Swift** — Apple's language for iOS and iPadOS apps.
+- **Kotlin** (and Java) — the standard for Android apps.
+- Cross-platform frameworks let you use other languages, but the native pair above are the defaults.
+
+The deeper point is that the OS does enormous heavy lifting. On a server or phone, the operating system manages memory, files, networking, and lets many programs share the machine — so your language can lean on all of that. On a bare-metal microcontroller there's no OS, so the language (usually C) has to deal with the hardware directly. Much of what makes a language feel "easy" is really the operating system underneath it doing the hard parts.
+
+## Platform to language at a glance
+
+| Platform | Typical languages | Why |
+|----------|-------------------|-----|
+| **Cloud / server / VPS** | Python, JavaScript/Node, Go, Java, C#, PHP, Rust | Full OS and ample memory host any runtime |
+| **Desktop / laptop** | Same as servers, plus native app languages | Powerful, OS-managed, few limits |
+| **Single-board computer (Linux)** | Python, JavaScript, Go, C/C++ | A real OS on small hardware — most server languages work |
+| **Phone / tablet** | Swift (iOS), Kotlin/Java (Android) | Platform-defined native toolchains |
+| **Microcontroller** | C, C++, Rust, MicroPython | No OS, kilobytes of RAM — only compact, compiled (or tiny interpreted) languages fit |
+
+Read top to bottom and the menu shrinks as the hardware shrinks. A single-board computer like a Raspberry Pi sits at an interesting crossover: it's small and cheap, but it runs a full Linux OS, so it can use the same easygoing languages as a server — which is part of why it's such a useful bridge between the two worlds.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a microcontroller has no OS and only kilobytes of memory, so it can't host the heavy runtimes that languages like Python need." markdown="0">
+  <p class="knowledge-check__q">Quick check: Why does a microcontroller typically run C rather than Python?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Python hasn't been invented for small devices yet</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It has no operating system and only kilobytes of memory, so it can't host Python's heavy runtime — but it can run compact compiled C</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">C is the only programming language that exists for hardware</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **"Runs on" means a path to machine code** — either a compiler builds a self-contained binary, or an installed interpreter/runtime executes the code as it goes.
+- **Compiled binaries travel light** — they need only themselves, which is why tiny devices favor compiled C, C++, and Rust.
+- **Constrained devices have a short menu** — kilobytes of RAM and no OS limit microcontrollers to C, C++, Rust, or MicroPython.
+- **Powerful machines run almost anything** — a full OS and gigabytes of memory let servers and PCs host any runtime, so choice comes down to the job.
+- **The OS does the heavy lifting** — much of a language's convenience comes from the operating system beneath it, which bare-metal devices lack.
+
+Next up: cost, electricity, performance, control, and effort — the handful of trade-offs that recur in every hardware decision you'll make. See [Cost, power & performance trade-offs](/learn/intro-hardware/cost-power-performance/).

--- a/docs/learn/intro-hardware/laptops.md
+++ b/docs/learn/intro-hardware/laptops.md
@@ -1,0 +1,98 @@
+---
+slug: laptops
+title: Laptops
+description: A laptop is a whole computer you can carry — learn the portability-for-power trade, its battery and thermal limits, and why it's most developers' default machine.
+keywords: laptop computer, laptop vs desktop, portable computer, developer laptop, Apple Silicon, ARM laptop, thermal throttling, battery life
+level: beginner
+status: full
+faq:
+  - q: "Is a laptop powerful enough for software development?"
+    a: "For most work, easily. A modern laptop runs the same operating systems, languages, and tools as a desktop, and today's chips are fast enough that the vast majority of developers work on one full time. The limits show up only under heavy sustained loads — long compiles, video rendering, or model training — where a desktop's better cooling pulls ahead."
+  - q: "Why are Apple Silicon and other ARM laptops a big deal?"
+    a: "**Efficiency.** Apple's M-series chips and other ARM-based designs deliver strong performance while drawing little power, which means long battery life and quiet, cool operation. For a portable machine that's the ideal combination — you get desktop-class speed for everyday development without the heat and short battery life that used to come with it."
+  - q: "What is thermal throttling, and should I worry about it?"
+    a: "**Thermal throttling** is when a laptop slows its processor down to avoid overheating, because its thin case can't shed heat as fast as a desktop's. For short bursts you'll never notice. It only matters if you run the machine flat out for long stretches — a sign that a desktop or a remote server might suit that particular workload better."
+---
+# Laptops
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A whole computer you can carry** — processor, screen, keyboard, and battery in one portable package. **Good enough for most development** — modern chips, especially efficient Apple Silicon and other ARM designs, handle everyday coding with ease. **The trade is power-per-dollar and headroom** — you pay more for less raw speed, limited upgrades, fewer ports, and slowdowns under sustained heavy load.
+</div>
+
+The desktop wins on raw value, but most developers don't work on one — they work on a laptop. This lesson explains why. A laptop folds an entire computer into something you can carry, and that single fact reshapes every trade-off from the last lesson. By the end you'll understand what you gain, what you give up, and why "good enough and everywhere" usually beats "fastest but stuck on a desk."
+
+## What a laptop is
+
+A **laptop** is a personal computer with the screen, keyboard, trackpad, processor, memory, storage, and a **battery** all integrated into one foldable unit. Unlike a desktop, it doesn't need a separate monitor or a wall socket to work — you open the lid and it runs.
+
+That integration is the whole point, and it's also the whole constraint. Everything has to fit in a thin case, sip enough power to last on a battery, and stay cool without big fans. So laptop parts are chosen for efficiency and size as much as for speed, and most of them are soldered in place rather than slotted. A laptop is a desktop's mirror image: where the desktop optimizes for capability, the laptop optimizes for being able to come with you.
+
+## What laptops are for
+
+A laptop suits anyone whose work isn't tied to one spot — which, increasingly, is almost everyone:
+
+- **The default developer machine.** For most programmers a laptop is the primary computer, capable of nearly all day-to-day work.
+- **Working anywhere** — at a desk, on a couch, in a café, on a train, or at a client's office. Many laptops also dock to a big monitor and keyboard at home, giving you a near-desktop setup that still unplugs and travels.
+- **Students and learners** — one affordable machine that goes to class, the library, and home.
+
+If your work moves with you, a laptop's portability outweighs the raw value of a desktop. If you need maximum sustained power and never leave the desk, the last lesson, [Desktop computers](/learn/intro-hardware/desktop-computers/), made the other case.
+
+## What laptops run
+
+A laptop runs **the same things a desktop does** — it's a general-purpose computer with the same operating-system choices:
+
+- **Windows** — broadest selection of laptops, with WSL for a Linux environment.
+- **macOS** — Apple's laptops (MacBook Air and Pro), a popular choice for software and mobile work.
+- **Linux** — runs well on most laptops and matches the systems you'll deploy to.
+
+Every language, editor, compiler, and container you'd use on a desktop is available, and for ordinary development the experience is identical. You can absolutely install and develop **GopherTrunk** on a laptop, plug an SDR dongle into a USB port, and run it on the go. The differences from a desktop aren't about *what* you can run — they're about how much, how fast, and for how long, which the next two sections cover.
+
+## Where laptops shine, and where they don't
+
+The cleanest way to understand a laptop is straight against a desktop. Same software, different physics:
+
+| Dimension | Desktop | Laptop |
+|-----------|---------|--------|
+| **Portability** | None — stays on the desk | Goes anywhere, runs on battery |
+| **Performance per dollar** | Best | Lower — you pay for miniaturization |
+| **Upgradability** | High — swap most parts | Limited — memory and storage often soldered |
+| **Sustained performance** | Holds full speed | May throttle under long heavy loads |
+| **Ports** | Many, including lots of USB | Fewer; sometimes needs adapters |
+| **All-in-one convenience** | Needs monitor, keyboard, mouse | Screen and keyboard built in |
+
+Read that table as the **portability-for-power trade**. A laptop's strengths — it's portable, it's complete out of the box, and modern ones are genuinely fast enough — are bought with lower value-per-dollar, less room to upgrade, and slowdowns when you push it hard for a long time.
+
+One development worth calling out: **Apple Silicon** (the M-series chips) and other efficient **ARM**-based designs have narrowed the gap dramatically. They deliver strong performance with low power draw, so a modern laptop can be quiet, cool, and last all day on battery while still handling serious work. The trade is real but smaller than it used to be.
+
+## The drawbacks in practice
+
+The limits are the flip side of integration, and they show up in specific situations:
+
+- **Less power per dollar.** Fitting everything into a thin case and a power budget costs money; the same spend buys a faster desktop.
+- **Limited upgradeability.** Memory and storage are frequently soldered in, so you choose your specs at purchase and live with them. Plan for the future when you buy.
+- **Thermal throttling.** Under sustained heavy load — long compiles, video rendering, ML training — a laptop slows itself to avoid overheating. Fine for bursts, frustrating for marathons.
+- **Fewer ports.** Slim machines carry fewer connectors, so you may need a dock or adapters to attach several drives, monitors, or SDR devices at once.
+
+For most developers none of these is a dealbreaker. They simply point at the cases — heavy, sustained, multi-device workloads — where a desktop or a remote server earns its keep. That balancing act is the whole subject of the next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a laptop trades some power-per-dollar, upgrade room, and sustained speed for the ability to go anywhere." markdown="0">
+  <p class="knowledge-check__q">Quick check: What does a laptop mainly give up compared with a desktop?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The ability to run common programming languages and tools</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Some performance per dollar, upgrade room, and sustained speed — in exchange for portability</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Compatibility with Windows, macOS, and Linux</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A laptop is a portable, all-in-one computer** — screen, keyboard, and battery integrated so it runs anywhere.
+- **It runs the same software as a desktop** — same operating systems, languages, and tools, including GopherTrunk.
+- **Modern chips make it good enough** — efficient Apple Silicon and other ARM designs deliver strong performance with long battery life.
+- **The trade is power-per-dollar and headroom** — you pay more for less raw speed and fewer upgrade options.
+- **Watch for thermal throttling and ports** — sustained heavy loads slow it down, and thin cases carry fewer connectors.
+- **Portability usually wins** — for most developers, "fast enough and everywhere" beats "fastest but fixed."
+
+Next up: how to weigh desktop, laptop, or both against the way you actually work, and which specs really matter for writing software. See [Choosing your development machine](/learn/intro-hardware/choosing-a-dev-machine/).

--- a/docs/learn/intro-hardware/matching-hardware-to-project.md
+++ b/docs/learn/intro-hardware/matching-hardware-to-project.md
@@ -1,0 +1,84 @@
+---
+slug: matching-hardware-to-project
+title: Matching hardware to the project type
+description: Websites, mobile apps, data crunching, home automation, sensors, and robots each tend toward a different platform. A practical map from project type to the hardware that fits.
+keywords: hardware for web app, hardware for mobile app, hardware for machine learning, home automation hardware, sensor hardware, robotics hardware, project to platform mapping, choosing a platform
+level: intermediate
+status: full
+faq:
+  - q: "What hardware should I use to host a website?"
+    a: "Start at the smallest rung that meets the load. A static or low-traffic site is happy on [shared web hosting](/learn/intro-hardware/web-hosting/); a real app with a database wants a [VPS](/learn/intro-hardware/vps/); only heavy, sustained traffic justifies a [dedicated server](/learn/intro-hardware/dedicated-servers/). Most projects never need to leave the first two rungs."
+  - q: "Where do I run a machine-learning or data-crunching workload?"
+    a: "On something with real muscle, often a GPU. A powerful [desktop](/learn/intro-hardware/desktop-computers/) is the cheapest fast option you own outright; a [dedicated server](/learn/intro-hardware/dedicated-servers/) or rented cloud GPU is right when you need more than one machine's worth, or only burst usage. The job is compute-bound, so this is the one place raw performance genuinely dominates the choice."
+  - q: "What's the right platform for a battery-powered sensor?"
+    a: "A [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/), almost always — typically an [ESP32](/learn/intro-hardware/esp32/) if it needs Wi-Fi. It sips power, costs a few dollars, wakes to take a reading, and sleeps. A full computer would drain the battery and waste capability the job never uses."
+  - q: "Why not just use the most powerful platform for everything?"
+    a: "Because power you don't need is cost, complexity, and wasted electricity you pay for forever. The skill is matching the platform to the *type* of work — a microcontroller for a sensor, a VPS for a web app, a GPU box for ML — so each project runs on the smallest thing that does the job well."
+---
+# Matching hardware to the project type
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Project type strongly predicts platform** — websites reach for hosting and servers, sensors reach for microcontrollers, ML reaches for GPUs. **The mapping isn't rigid but it's a fast first cut** — start where your kind of project usually lands, then adjust for your specifics. **Smallest thing that does the job** — match the platform to the work, don't over-buy capability you'll never use.
+</div>
+
+In the last lesson you turned a project into a list of requirements. This lesson shortcuts the next step: most projects fall into a handful of familiar *types*, and each type tends to reach for the same region of the [hardware spectrum](/learn/intro-hardware/hardware-spectrum/). Knowing those patterns gets you to a strong default fast, which you can then refine. Let's walk the common types and where they land.
+
+## Websites and web apps
+
+A website's hardware is a question of traffic and dynamism. A static site or a small blog needs almost nothing — [shared web hosting](/learn/intro-hardware/web-hosting/) serves it for a few dollars a month, with someone else handling the machine entirely. Add a database, user accounts, and server-side logic and you've outgrown shared hosting; a [VPS](/learn/intro-hardware/vps/) gives you a real, isolated Linux box you control, which is where the large majority of web apps live comfortably for years. Only sustained heavy traffic, or a need for raw single-tenant performance, justifies stepping up to a [dedicated server](/learn/intro-hardware/dedicated-servers/). The discipline here is resisting the jump: people routinely rent far more than their traffic warrants.
+
+## Mobile apps
+
+A mobile app splits cleanly across two machines. You *develop* it on a capable [laptop](/learn/intro-hardware/laptops/) or [desktop](/learn/intro-hardware/desktop-computers/) — the build tools, simulators, and IDEs are demanding, and an iOS app specifically requires a Mac (see [choosing a dev machine](/learn/intro-hardware/choosing-a-dev-machine/) and [developing for mobile](/learn/intro-hardware/developing-for-mobile/)). The app then *runs* on the user's [phone](/learn/intro-hardware/smartphones/) or [tablet](/learn/intro-hardware/tablets/), which you don't choose — your users bring their own. If the app has a backend, that's a separate web-app decision: hosting, VPS, or server as above.
+
+## Data crunching and machine learning
+
+This is the one project type where raw performance honestly dominates. Training models, processing large datasets, or rendering all want maximum throughput, and increasingly a GPU. A well-specced [desktop](/learn/intro-hardware/desktop-computers/) with a strong GPU is the cheapest fast option you own outright, ideal for steady local work. When you need more than one machine, only occasional bursts, or hardware you'd rather rent than buy, a [dedicated server](/learn/intro-hardware/dedicated-servers/) or a cloud GPU instance fits. Here, more compute really does buy more — the opposite of most projects, where it's just waste.
+
+## Home automation and always-on services
+
+Automation hubs, media servers, network storage, and personal dashboards share a profile: modest compute, but they must run quietly, cheaply, and *constantly*. That's the sweet spot for a [home server](/learn/intro-hardware/home-servers/) — a [single-board computer](/learn/intro-hardware/what-is-an-sbc/) like a [Raspberry Pi](/learn/intro-hardware/raspberry-pi-and-family/), or a repurposed mini-PC. Low power draw matters because the thing never turns off, so a 5-watt board beats a 200-watt tower over a year of electricity bills. A cloud VPS can host the *software* parts, but anything touching local devices needs a box in the house.
+
+## Physical sensors and gadgets
+
+A device that senses or controls the physical world — temperature, soil moisture, a button, a relay — and especially one on a battery, is a [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) job. An [Arduino](/learn/intro-hardware/arduino/) suits simple offline control; an [ESP32](/learn/intro-hardware/esp32/) is the default when you want built-in Wi-Fi to report readings. These parts cost a few dollars, run for months on a battery, and do exactly one job reliably. A full computer would be overkill that drains the battery and adds failure points.
+
+## Robots and edge-AI vision
+
+Robotics and on-device vision sit one rung up from sensors: they need real compute *and* physical-world contact at once. A [single-board computer](/learn/intro-hardware/what-is-an-sbc/) is the natural fit — a Raspberry Pi for general robotics, or a board like an NVIDIA Jetson when the job involves running vision or ML models locally at the edge. Often these pair a capable SBC for the "brain" with microcontrollers for low-level motor and sensor timing, a combination the next lesson explores.
+
+## The mapping at a glance
+
+| Project type | Typical platform | Why it fits |
+|--------------|------------------|-------------|
+| **Static site / blog** | [Shared web hosting](/learn/intro-hardware/web-hosting/) | Cheap, zero machine management, plenty for low traffic |
+| **Web app with a database** | [VPS](/learn/intro-hardware/vps/) | Full control of a real Linux box; scales to most apps |
+| **High-traffic / heavy web service** | [Dedicated server](/learn/intro-hardware/dedicated-servers/) | Single-tenant performance, no noisy neighbors |
+| **Mobile app** | [Dev machine](/learn/intro-hardware/choosing-a-dev-machine/) → user's [phone](/learn/intro-hardware/smartphones/) | Build on a capable PC/Mac; runs on user devices |
+| **Data crunching / ML** | Powerful [desktop](/learn/intro-hardware/desktop-computers/) or cloud GPU | Compute-bound — raw throughput and a GPU pay off |
+| **Home automation / always-on** | [Home server](/learn/intro-hardware/home-servers/) / [SBC](/learn/intro-hardware/what-is-an-sbc/) | Low power, runs 24/7, sits near local devices |
+| **Battery sensor / gadget** | [ESP32](/learn/intro-hardware/esp32/) / [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) | Tiny, cheap, ultra-low power, touches the physical world |
+| **Robot / edge-AI vision** | [SBC](/learn/intro-hardware/what-is-an-sbc/) (Pi, Jetson) | Real compute plus on-site sensing and control |
+
+GopherTrunk is a useful edge case to keep in mind: it's web-app-*like* (it serves a dashboard you view from a browser) but it also has a hard physical-world requirement — the SDR dongle plugged in at the antenna. That mix is exactly why it doesn't sit cleanly in one row, and why the next lesson on combining tiers matters.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a battery-powered sensor is a classic microcontroller job, typically an ESP32 when it needs Wi-Fi." markdown="0">
+  <p class="knowledge-check__q">Quick check: What platform best fits a battery-powered soil-moisture sensor that reports over Wi-Fi?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A cloud VPS</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A microcontroller such as an ESP32</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A high-end desktop with a GPU</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Project type predicts platform** — each common kind of project tends toward the same region of the spectrum, giving you a fast, strong default.
+- **Websites climb a ladder** — shared hosting, then VPS, then dedicated, only as traffic and complexity demand.
+- **ML is the exception that loves power** — data crunching is compute-bound, so a strong desktop or cloud GPU genuinely pays off.
+- **Always-on and physical jobs stay home** — home servers, SBCs, and microcontrollers sit near the devices they serve.
+- **Match the work, don't over-buy** — pick the smallest platform that does the job type well; the mapping table is your shortcut.
+
+Next up: real systems rarely live on one platform — see how a device, a server, and the cloud work together in [Combining tiers: device, server & cloud](/learn/intro-hardware/combining-tiers/).

--- a/docs/learn/intro-hardware/mcu-programming-and-tradeoffs.md
+++ b/docs/learn/intro-hardware/mcu-programming-and-tradeoffs.md
@@ -1,0 +1,98 @@
+---
+slug: mcu-programming-and-tradeoffs
+title: "Programming microcontrollers: languages, use cases & limits"
+description: C/C++, MicroPython, and Rust on bare metal — the workflow for flashing a chip, the jobs microcontrollers own, and the tight limits you design around.
+keywords: microcontroller programming, embedded C, MicroPython, CircuitPython, embedded Rust, flashing firmware, cross compiling, real-time control, low power embedded
+level: intermediate
+status: full
+faq:
+  - q: "What languages do you use to program a microcontroller?"
+    a: "**C and C++** dominate embedded work because they compile to fast, compact code with tight control over memory and hardware. **MicroPython** and **CircuitPython** trade some speed for ease, letting you script the chip in Python. **Embedded Rust** is an emerging option that brings memory safety to bare metal. Raw assembly is used rarely, only for the most timing-critical fragments."
+  - q: "How do you get your program onto a microcontroller?"
+    a: "You **cross-compile** on your PC — turning your code into machine code for the chip's processor, not your computer's — and then **flash** it over USB into the chip's memory. There's no terminal or editor on the device itself. To see what's happening you usually print messages over a **serial** connection back to your PC, or for deeper work use a hardware debugger over JTAG/SWD."
+  - q: "When should I move up from a microcontroller to a single-board computer?"
+    a: "Step up to an SBC when you need an operating system, a file system, a network stack with real software, a display and desktop, lots of memory, or general-purpose compute. If your job is real-time control, ultra-low power, or fitting into a tiny cheap product, stay on the microcontroller. Many projects use both: an MCU at the sensor and an SBC doing the heavier work."
+---
+# Programming microcontrollers: languages, use cases & limits
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**C/C++ dominate** — with MicroPython for ease and embedded Rust emerging for safety. **A compile-flash-run workflow** — you cross-compile on your PC, flash over USB, and debug over a serial link, because there's no terminal on the chip. **Tight limits by design** — kilobytes of RAM, a strict power budget, and no OS conveniences are the constraints microcontrollers trade for owning real-time, ultra-low-power jobs.
+</div>
+
+You've met the microcontroller, the Arduino, and the wireless ESP32. This lesson ties the module together by looking at *how you actually program these chips* — the languages, the workflow, the jobs they're uniquely good at, and the hard limits you design around. It also draws the line for when to stop fighting an MCU and step up to a single-board computer.
+
+## The languages of embedded
+
+A handful of languages cover almost all microcontroller work, each with a clear trade-off between control and convenience:
+
+| Language | Style | Strengths | Trade-off |
+|----------|-------|-----------|-----------|
+| **C** | Low-level, compiled | Fast, compact, total control over memory and hardware; the industry default | Manual memory management; easy to make subtle mistakes |
+| **C++** | Compiled, higher-level | C's speed plus classes and libraries; what Arduino uses | Can pull in overhead if you're not careful |
+| **MicroPython / CircuitPython** | Interpreted Python | Very easy; fast to experiment; no compile step | Slower and uses more memory; not for tight timing |
+| **Embedded Rust** | Compiled, modern | Memory safety without a garbage collector; growing ecosystem | Steeper learning curve; fewer libraries than C |
+| **Assembly** | Lowest level | Exact control of every instruction | Painful to write; used only for tiny critical fragments |
+
+**C and C++** dominate for good reason: they compile to fast, small machine code and give you precise control over the chip's memory and peripherals, which matters when you only have a few kilobytes to work with. **MicroPython** and **CircuitPython** flip the priority toward ease, letting you script a chip in Python — wonderful for learning and quick projects. **Embedded Rust** is the rising newcomer, offering memory safety on bare metal. And raw **assembly** survives only for the rare, ultra-timing-critical fragment.
+
+## The compile, flash, run workflow
+
+Programming an MCU feels different from writing a normal app because the chip is too small to develop *on*. There's no editor, no compiler, and no terminal living on the device. So the workflow splits across two machines:
+
+1. **Write** your code on your PC in an editor or IDE.
+2. **Cross-compile** it — your PC's compiler produces machine code for the *chip's* processor (an ARM Cortex-M or RISC-V core), not for your computer.
+3. **Flash** the resulting binary over USB into the microcontroller's flash memory.
+4. **Run** — the chip resets and immediately starts executing your program bare-metal.
+
+Because nothing on the device talks back to you, **debugging** works differently too. The everyday tool is **serial printing**: your code sends text messages over a USB serial link to your PC, the embedded equivalent of `print()` debugging. For harder problems you connect a hardware debugger over **JTAG** or **SWD**, which lets you pause the chip, step through code, and inspect memory directly. There's no log file to open later — you watch it live or you instrument the code.
+
+## The jobs microcontrollers own
+
+There are whole categories of work where a microcontroller isn't just adequate — it's the *right* tool, better than any bigger computer:
+
+- **Real-time control.** With no OS to introduce unpredictable delays, an MCU can guarantee a pin flips or a pulse fires within microseconds, every time. Motor control, power electronics, and precise timing live here.
+- **Ultra-low-power sensing.** An MCU can sleep on microamps and wake only to take a reading, so a battery or small solar cell can run it for months or years — impossible for a power-hungry SBC.
+- **Motor and robotics control.** Driving servos, reading encoders, and balancing a robot hundreds of times a second is exactly the tight, repetitive loop an MCU excels at.
+- **Anything tiny and embedded.** When the computer must disappear inside a cheap product in a small space, the MCU's size, price, and simplicity win outright.
+
+The common thread is *focused, deterministic, low-power control of the physical world*. That's the microcontroller's home turf, and nothing else competes there.
+
+## The limits you design around
+
+The flip side of that focus is a set of hard constraints. Good embedded work is largely the discipline of designing *within* them:
+
+- **Kilobytes of RAM.** You count bytes, not gigabytes. Big data structures simply won't fit, so you stream and process in small pieces.
+- **No OS conveniences.** No file system, no processes, no shell, no rich standard library you can lean on. You often build small pieces yourself.
+- **Avoid dynamic memory.** Allocating and freeing memory at runtime risks fragmentation in a tiny space, so careful embedded code prefers fixed, pre-allocated buffers.
+- **A power budget.** Especially on battery, every milliamp and every awake millisecond counts, which shapes the whole design around sleeping as much as possible.
+- **Harder debugging.** No log files, limited visibility — you lean on serial output and hardware debuggers, and you think carefully before you flash.
+
+These aren't bugs in the platform; they're the price of being tiny, cheap, and deterministic. Embedded engineering is the skill of turning those limits into reliable products.
+
+## When to step up to an SBC
+
+The clearest sign you've outgrown a microcontroller is that you start *wishing it had an operating system*. The moment you want a real file system, a full network stack, a display and desktop, generous memory, or general-purpose compute, you've crossed into single-board-computer territory — go back to [What is a single-board computer?](/learn/intro-hardware/what-is-an-sbc/) for that tier. A full app like GopherTrunk needs that world; an MCU is far too small to host it.
+
+Often the best answer is **both**, a pattern the next module explores in [Combining tiers](/learn/intro-hardware/combining-tiers/): a microcontroller out at the sensor doing the precise, low-power, real-time work, reporting to an SBC or server that handles storage, dashboards, and the heavy lifting. Each does what it's best at.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — you cross-compile on your PC, flash the binary over USB, and there's no terminal on the chip itself." markdown="0">
+  <p class="knowledge-check__q">Quick check: How do you typically get a program running on a microcontroller?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Open a terminal on the chip and compile the code there</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Cross-compile on your PC, then flash the binary over USB into the chip</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Install it from an app store onto the device's operating system</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **C/C++ dominate** — for speed and tight memory control; MicroPython adds ease, embedded Rust adds safety, and assembly is rare.
+- **Compile, flash, run** — you cross-compile on your PC and flash over USB; there's no editor or terminal on the chip.
+- **Debug over serial** — serial printing is the everyday tool, with JTAG/SWD hardware debuggers for harder problems.
+- **MCUs own their niche** — real-time control, ultra-low-power sensing, motor/robotics control, and anything tiny and embedded.
+- **Design around the limits** — kilobytes of RAM, no OS, a power budget, and harder debugging are the constraints you build within.
+- **Step up when needed** — reach for an SBC when you want an OS, networking, a display, or real compute; often the best design uses both tiers.
+
+Next up: the start of the final module, where you turn all of this into a method for choosing hardware. See [Start with your requirements](/learn/intro-hardware/start-with-requirements/).

--- a/docs/learn/intro-hardware/programming-an-sbc.md
+++ b/docs/learn/intro-hardware/programming-an-sbc.md
@@ -1,0 +1,91 @@
+---
+slug: programming-an-sbc
+title: Programming & running software on an SBC
+description: An SBC is just a Linux box, so you use the same tools as a PC — Python, C, Go, git, Docker, SSH — plus GPIO libraries to talk to sensors and hardware.
+keywords: programming a Raspberry Pi, SBC programming, Python on Raspberry Pi, GPIO programming, gpiozero, libgpiod, flash Raspberry Pi OS, headless Raspberry Pi, SSH, Docker on Pi
+level: intermediate
+status: full
+faq:
+  - q: "What programming languages can I use on a single-board computer?"
+    a: "Because an SBC runs full Linux, you can use almost any language: **Python** (the most popular for beginners and GPIO), **C/C++** for performance, **Go** for self-contained services, plus **Node.js**, **Rust**, **Java**, and more. The same compilers, interpreters, and package managers you'd use on a Linux PC work here."
+  - q: "How do I set up a Raspberry Pi for the first time?"
+    a: "You **flash an operating system** (such as Raspberry Pi OS) onto a microSD card using a tool like the Raspberry Pi Imager, insert the card, and power on. The Imager can pre-configure Wi-Fi and SSH so the board comes up **headless** — no monitor needed — and you connect to it over the network."
+  - q: "How does a program control GPIO pins?"
+    a: "Through a **library**. On Raspberry Pi, **gpiozero** offers a friendly high-level API, while **RPi.GPIO** and the modern **libgpiod** give lower-level control. For sensors you'll often use **I2C, SPI, or UART** libraries. Your code reads pin states as inputs or drives them as outputs, just like any other function call."
+---
+# Programming & running software on an SBC
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**It's just Linux** — so you use ordinary tools: Python, C, Go, git, Docker, and SSH, exactly as on a PC. **You boot from a flashed SD card** and usually run it *headless* over SSH, with no monitor. **GPIO is what's extra** — libraries like gpiozero and libgpiod, plus I2C/SPI/UART, let your code read sensors and drive hardware. **It runs services 24/7**, which is why it's perfect for an always-on job like a GopherTrunk scanner.
+</div>
+
+The intimidating part of an SBC turns out not to be intimidating at all. People expect special embedded tooling, but the truth is simpler: a single-board computer is a normal Linux computer, and you program it with the same skills and tools you'd use on any Linux machine. This lesson covers the one big idea, how to get an OS onto the board, how you typically work with it day to day, and the one genuinely new skill — talking to the physical world through GPIO.
+
+## The big idea: it's a normal Linux box
+
+Everything else in this lesson follows from one fact: an SBC runs a full operating system, almost always **Linux**. That means there's very little new to learn about the *software* side.
+
+You write code in the same languages you'd use on a PC. **Python** is the most popular on SBCs — easy to learn and the best supported for GPIO work — but **C and C++** are there when you need speed, **Go** is excellent for compiling a single self-contained binary you can drop onto the board, and **Node.js**, **Rust**, and **Java** all run fine too. Whatever you'd reach for on a Linux desktop, you can reach for here.
+
+The tooling is identical as well. You install software with the system **package manager** (`apt` on Raspberry Pi OS), pull your code with **git**, isolate and ship apps with **Docker**, and connect remotely with **SSH**. There's no special "SBC SDK" standing between you and the machine. If you can work on a Linux server, you can work on a Pi.
+
+This is the deepest practical difference from the next module's microcontrollers: there, you cross-compile a single program and flash it onto bare metal. Here, you just... use a computer.
+
+## Getting an OS onto the board
+
+An SBC has no built-in disk in the PC sense — it boots from a **microSD card** (or, increasingly, an NVMe SSD on a Pi 5). So the first step is putting an operating system onto that card, a process called **flashing**.
+
+The standard route on a Raspberry Pi is the official **Raspberry Pi Imager**: you pick an OS image (Raspberry Pi OS is the default; many people run plain Debian or Ubuntu), point it at the SD card, and write. Crucially, the Imager lets you pre-configure settings *before* first boot — your Wi-Fi network, a username and password, and **SSH enabled**. Set those, and the board will join your network and accept remote logins the moment it powers up.
+
+After flashing, you insert the card, connect power, and wait a few seconds for it to boot. From there it behaves like any Linux machine on your network.
+
+## Headless vs desktop use
+
+There are two ways to actually use an SBC, and which you choose shapes your whole workflow:
+
+- **Desktop use** — plug in an HDMI monitor, keyboard, and mouse, and use the graphical desktop directly, like a small PC. Good for learning and for projects where someone interacts with the screen.
+- **Headless use** — no monitor at all. You connect from your main computer over **SSH** and work entirely on the command line (and copy files with `scp` or `rsync`). This is how most real SBC projects run, because the board is usually tucked away doing a job, not sitting on a desk.
+
+For an embedded job, headless is the norm. The board lives wherever it needs to be — in a robot, in a closet, at the base of an antenna — and you reach it over the network when you need to.
+
+## Talking to the physical world with GPIO
+
+The one genuinely new skill compared to PC programming is driving the **GPIO** header — the pins that let your code touch real hardware. On Linux this is done through libraries rather than raw register pokes:
+
+| Tool / interface | What it's for | Notes |
+|------------------|---------------|-------|
+| **gpiozero** | Simple on/off GPIO in Python | Friendly, beginner-first; great for LEDs, buttons, motors |
+| **RPi.GPIO** | Lower-level Python GPIO | Older, more manual; widely used in tutorials |
+| **libgpiod** | Modern Linux GPIO interface | The current standard; usable from C and Python |
+| **I2C** | Talk to chips over 2 wires | Many sensors, displays, real-time clocks |
+| **SPI** | Faster 4-wire bus | Screens, ADCs, some radio front ends |
+| **UART** | Serial (TX/RX) link | GPS modules, debug consoles, other boards |
+
+A first program is usually blinking an LED with gpiozero — set a pin as an output, turn it on, wait, turn it off. From there you read a button (an input), then a sensor over I2C or SPI, then build up to a real device. The mental model is comforting: a pin is just something your code reads from or writes to, like a variable that happens to be wired to the outside world.
+
+## Running services 24/7
+
+The reason an SBC is so well suited to embedded work is that, being a real Linux box, it can run a program **continuously and unattended** for months. You set your software up as a system service (typically with `systemd`) so it starts automatically on boot and restarts if it crashes — no one has to log in to kick it off.
+
+This is exactly the **GopherTrunk** workflow. Picture a Raspberry Pi sitting at the antenna with a USB SDR dongle plugged in. You flash an SD card, bring the Pi up headless, and SSH in from your laptop. You install GopherTrunk and its dependencies with the package manager and git, attach the dongle, and configure the scanner to run as a service. From then on the Pi quietly scans around the clock, while you check on it remotely whenever you like. The board is small, quiet, and low-power — and it's a *real computer*, so it does the job a PC would, without tying up a PC.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an SBC runs full Linux, so you use the same languages and tools as on a PC, plus GPIO libraries for hardware." markdown="0">
+  <p class="knowledge-check__q">Quick check: How do you typically program a single-board computer?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">With a special embedded SDK that replaces normal Linux tools</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">With ordinary Linux tools and languages (Python, C, Go, git, Docker), plus GPIO libraries for hardware</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">By flashing a single bare-metal program with no operating system</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **It's just Linux** — write in Python, C/C++, Go, Node, or Rust, and use apt, git, Docker, and SSH exactly as on a PC.
+- **You boot from a flashed card** — write an OS image to a microSD (or NVMe), pre-configure Wi-Fi and SSH, then power on.
+- **Headless is the norm** — most projects run with no monitor, accessed over SSH, with the board tucked away doing its job.
+- **GPIO is the new skill** — gpiozero, RPi.GPIO, and libgpiod drive pins; I2C/SPI/UART talk to sensors and chips.
+- **It runs services 24/7** — set software up with systemd to run unattended, which is why an SBC suits an always-on GopherTrunk scanner.
+
+Next up: where SBCs shine, and the limits that tell you when to choose something else. See [SBC use cases, strengths & drawbacks](/learn/intro-hardware/sbc-use-cases-and-limits/).

--- a/docs/learn/intro-hardware/raspberry-pi-and-family.md
+++ b/docs/learn/intro-hardware/raspberry-pi-and-family.md
@@ -1,0 +1,94 @@
+---
+slug: raspberry-pi-and-family
+title: The Raspberry Pi & its alternatives
+description: The Raspberry Pi defined the SBC category, but Jetson, Rock, Orange Pi, BeagleBone, and Odroid all compete. Learn the Pi lineup and how to pick a board.
+keywords: Raspberry Pi, Raspberry Pi 5, Raspberry Pi alternatives, NVIDIA Jetson, Rock SBC, Orange Pi, BeagleBone, Odroid, Raspberry Pi Pico, single-board computer comparison
+level: beginner
+status: full
+faq:
+  - q: "Which Raspberry Pi should I buy?"
+    a: "For most projects in 2026 the **Raspberry Pi 5** is the default — it's fast, has plenty of RAM options, and runs almost anything. If you need something tiny or ultra-cheap for a single light job, the **Pi Zero 2 W** is a great pick. The **Pi 4** is still perfectly capable and often cheaper. Match the board to the work rather than always buying the newest."
+  - q: "Is the Raspberry Pi Pico a single-board computer?"
+    a: "No — despite the Raspberry Pi name, the **Pico** is a *microcontroller* board, not an SBC. It runs bare-metal code with no operating system, like an Arduino, and costs only a few dollars. The confusion is common because it shares a brand. We cover boards like it in [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/)."
+  - q: "What is the best alternative to a Raspberry Pi?"
+    a: "It depends on the job. For AI and computer vision, **NVIDIA Jetson** boards add a real GPU. For raw price-to-performance, **Radxa Rock**, **Orange Pi**, and **Odroid** boards often beat the Pi on paper. **BeagleBone** shines for industrial I/O. The Pi usually wins on *software support and community*, which often matters more than specs."
+---
+# The Raspberry Pi & its alternatives
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The Raspberry Pi created and still anchors the SBC category** — a family from the tiny Pi Zero 2 W up to the powerful Pi 5. **Its real strength is the ecosystem** — documentation, community, and add-on HATs, not just the hardware. **Strong alternatives exist** — Jetson for AI, Rock and Orange Pi for value, BeagleBone for industrial I/O — chosen by RAM, price, I/O, and community.
+</div>
+
+Once you know what a single-board computer is, the next question is which one to buy. The honest answer for most people starts with the Raspberry Pi — the board that defined this whole category — but it's far from the only option. This lesson walks the Pi lineup, explains why its community matters more than its spec sheet, and introduces the rivals worth knowing so you can choose deliberately rather than by default.
+
+## The Raspberry Pi lineup
+
+The **Raspberry Pi** is the board that made SBCs mainstream. Launched in 2012 as an educational tool, it became the reference point everyone else is measured against. Today it's a family, not a single product:
+
+- **Pi Zero / Zero 2 W** — the tiny, cheap members, about the size of a stick of gum. The Zero 2 W adds a faster quad-core chip and built-in Wi-Fi. Ideal when you need a small always-on computer for one light job and want to spend very little.
+- **Pi 4** — the workhorse of the previous generation, still widely used and supported, with RAM options up to 8 GB. Often the value pick when you don't need the latest speed.
+- **Pi 5** — the current flagship as of 2026. Noticeably faster than the Pi 4, with better I/O and a PCIe connector that allows fast NVMe SSDs via an add-on board. The sensible default for new projects that need real performance.
+- **Compute Module (CM)** — the same Pi brains in a stripped-down form meant to be slotted into your own custom carrier board. This is what companies use to build Pi-based products.
+
+One important footnote: the **Raspberry Pi Pico** carries the brand but is *not* an SBC. It's a microcontroller board — bare metal, no operating system — and belongs to the next module, [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/). Keep the distinction clear: a Pi 5 runs Linux; a Pico runs a single program.
+
+## The ecosystem is the real product
+
+It's tempting to compare SBCs purely on numbers — cores, gigahertz, gigabytes. But the Raspberry Pi's biggest advantage isn't on the spec sheet. It's the **ecosystem** around it.
+
+Because so many people use the Pi, almost every problem you'll hit has already been solved and written up somewhere. The official Raspberry Pi OS is well maintained, drivers tend to just work, and there are thousands of tutorials, forum threads, and projects to copy from. When a sensor or camera says "works with Raspberry Pi," that's a real, tested guarantee.
+
+The hardware ecosystem matters too. **HATs** (Hardware Attached on Top) are add-on boards that snap onto the Pi's GPIO header — adding things like screens, motor drivers, real-time clocks, or SDR front ends. A rival board may have faster silicon, but if a HAT or driver you need only exists for the Pi, the Pi is the right choice. For something like a **GopherTrunk** scanner sitting at the antenna, the Pi's broad support for USB SDR dongles and its huge troubleshooting community make it the path of least resistance.
+
+## The alternatives worth knowing
+
+The Pi isn't always the best fit. Several families compete hard, often beating it on raw specs or a particular strength:
+
+- **NVIDIA Jetson** (Nano, Orin Nano, etc.) — the go-to when you need real **AI and GPU** power. Jetson boards include a capable GPU for running computer-vision and machine-learning models locally, far beyond what a plain Pi can do — at a higher price.
+- **Radxa Rock** — a popular line that often offers more CPU and RAM per dollar than the equivalent Pi, with similar form factors.
+- **Orange Pi** — a broad range of inexpensive boards, frequently undercutting the Pi on price, though with less polished software support.
+- **BeagleBone** — long favored for **industrial and real-time I/O**, with many more GPIO pins and onboard real-time microcontrollers for precise timing.
+- **Odroid** — known for higher-performance boards and good build quality, popular for home servers and emulation.
+
+| Board | Rough price | Typical RAM | Standout strength |
+|-------|-------------|-------------|-------------------|
+| **Pi Zero 2 W** | ~$15 | 512 MB | Tiny, cheap, low power |
+| **Raspberry Pi 5** | ~$60–80 | 4–16 GB | Ecosystem + solid performance |
+| **NVIDIA Jetson Orin Nano** | ~$250+ | 8 GB | On-board GPU for AI / vision |
+| **Radxa Rock 5** | ~$100+ | 4–32 GB | Performance per dollar |
+| **BeagleBone Black** | ~$60 | 512 MB | Lots of I/O, real-time pins |
+
+Prices and exact models shift over time; treat these as a feel for the landscape, not a current price list.
+
+## How to choose among them
+
+With so many options, a short checklist keeps you honest. Weigh these against what your project actually needs:
+
+- **Community and software support** — how easy will it be to find help and working drivers? This is where the Pi usually wins, and it often matters more than specs.
+- **Price** — what fits your budget, especially if you'll build more than one?
+- **RAM** — enough headroom for your software and any future growth.
+- **I/O** — does it have the pins, ports, camera connectors, or PCIe you need?
+- **AI acceleration** — only relevant if you're running vision or ML models; if so, lean Jetson.
+
+A useful rule: pick the Raspberry Pi unless a clear, specific need pushes you elsewhere. If you need a local GPU, go Jetson. If you need maximum CPU per dollar, look at Rock or Odroid. If you need heavy industrial I/O, consider BeagleBone. Otherwise, the Pi's support will save you more hours than a rival's spec advantage will gain you.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the Pico is a microcontroller board, not a single-board computer, despite the Raspberry Pi brand." markdown="0">
+  <p class="knowledge-check__q">Quick check: Which of these is NOT a single-board computer?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Raspberry Pi 5</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Raspberry Pi Pico</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">NVIDIA Jetson Orin Nano</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **The Raspberry Pi defined the category** — a family from the tiny Pi Zero 2 W through the Pi 4 to the flagship Pi 5, plus the Compute Module for custom products.
+- **The Pico is a microcontroller, not an SBC** — same brand, different kind of device, covered in the next module.
+- **The ecosystem is the real strength** — documentation, community, drivers, and HATs often outweigh raw specs.
+- **Strong alternatives exist** — Jetson for AI/GPU, Rock and Orange Pi for value, BeagleBone for industrial I/O, Odroid for performance.
+- **Choose by need** — weigh community, price, RAM, I/O, and AI acceleration; default to the Pi unless a specific requirement points elsewhere.
+
+Next up: how you actually write and run software on one of these boards. See [Programming & running software on an SBC](/learn/intro-hardware/programming-an-sbc/).

--- a/docs/learn/intro-hardware/sbc-use-cases-and-limits.md
+++ b/docs/learn/intro-hardware/sbc-use-cases-and-limits.md
@@ -1,0 +1,102 @@
+---
+slug: sbc-use-cases-and-limits
+title: SBC use cases, strengths & drawbacks
+description: Single-board computers excel at home labs, media servers, robots, and edge sensors. Learn where SBCs win and the heat, power, storage, and CPU limits that don't.
+keywords: SBC use cases, Raspberry Pi projects, SBC strengths and weaknesses, SD card wear, thermal throttling Raspberry Pi, home server, edge AI, SBC vs mini PC, when to use a microcontroller
+level: intermediate
+status: full
+faq:
+  - q: "What are single-board computers good for?"
+    a: "SBCs shine at small, always-on jobs: home servers and NAS-lite storage, media centers, retro gaming, robotics, edge AI and vision, IoT gateways, SDR scanners, and learning Linux. They suit anything that needs a real computer with hardware I/O but doesn't need a full PC's power, size, or electricity bill."
+  - q: "Why do Raspberry Pis sometimes become unreliable?"
+    a: "The most common culprit is the **microSD card**. SD cards wear out with repeated writes and can corrupt, especially under heavy logging or sudden power loss. Other causes are an **underpowered power supply** and **thermal throttling** when the chip overheats. A good supply, a heatsink or fan, and booting from an SSD fix most reliability problems."
+  - q: "When should I use a mini-PC or a microcontroller instead of an SBC?"
+    a: "Step **up** to a mini-PC or server when you need heavy, sustained compute — lots of RAM, fast storage, or serious CPU/GPU. Step **down** to a [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) when the job is simple, must run on a battery for a long time, or needs to start instantly. The SBC is the middle ground, not the universal answer."
+---
+# SBC use cases, strengths & drawbacks
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**SBCs win at small, always-on jobs** — home servers, media centers, robotics, edge AI, IoT gateways, and SDR scanners. **Their strengths are cheap, low-power, full-OS, and GPIO** in a small, quiet package. **Their drawbacks are real** — SD-card wear, limited CPU/RAM, thermal throttling, and fussy power supplies. **Know when to step up or down** — a mini-PC for heavy compute, a microcontroller for simple, battery, instant-on jobs.
+</div>
+
+By now you know what an SBC is, which boards to consider, and how to program one. This final lesson of the module is about judgment: where an SBC is the right tool, where it quietly disappoints, and how to recognize the moment you should reach for something bigger or smaller instead. Getting this right is the difference between a project that runs happily for years and one that mysteriously falls over every few weeks.
+
+## What SBCs are great for
+
+An SBC's sweet spot is a job that needs a *real computer with hardware access*, but not a full PC's power or footprint. That covers a remarkable range:
+
+- **Home server / NAS-lite** — file sharing, backups, a personal cloud, ad-blocking DNS, or a small website for the house.
+- **Media center** — running media software on a TV, cheaply and silently.
+- **Retro gaming** — emulating old consoles, a hugely popular hobby use.
+- **Robotics** — the brain of a robot, using GPIO to drive motors and read sensors while running higher-level logic in Python.
+- **Edge AI and vision** — running a camera and a model locally (especially on a GPU-equipped board like a Jetson) so decisions happen on-device.
+- **IoT gateway** — collecting data from many small sensors and microcontrollers, then forwarding it to the network.
+- **SDR scanner** — a **GopherTrunk** node at the antenna with a USB SDR dongle, scanning around the clock.
+- **Learning Linux** — a cheap, disposable machine to experiment on without risking your main computer.
+
+The thread connecting these is *always-on, low-stakes, hardware-adjacent* work. None of them needs a fast desktop; all of them benefit from a small, quiet, inexpensive box that can sit somewhere and just run. For more on picking the right tier for a given project, the final module starts at [Start with requirements](/learn/intro-hardware/start-with-requirements/).
+
+## The strengths that make them shine
+
+It's worth naming exactly *why* SBCs fit those jobs so well. Five strengths do most of the work:
+
+- **Cheap** — a capable board costs less than a video game, so experimenting (and replacing one) is painless.
+- **Low power** — a few watts means you can leave it on permanently for pennies, and even run it from a battery or solar in the field.
+- **Full operating system** — real Linux brings the whole software world: any language, networking, Docker, services. (See [Programming & running software on an SBC](/learn/intro-hardware/programming-an-sbc/).)
+- **GPIO** — the pins that let it touch the physical world, the thing a laptop can't easily do.
+- **Small and quiet** — credit-card-sized and usually fanless, it tucks into places a PC never could.
+
+Put together, those traits explain the SBC's whole reason for existing: it's the cheapest, smallest way to get a *complete computer* into a project.
+
+## The drawbacks that decide the limits
+
+The same smallness that's a strength is also where the limits live. An SBC is not a small PC, and treating it like one leads to grief:
+
+- **SD-card wear and reliability** — the microSD card is the weakest link. Cards wear out under heavy writes and can corrupt on sudden power loss. Heavy logging, databases, and swap all shorten their life. Booting from an SSD and minimizing writes helps a lot.
+- **Limited CPU and RAM** — even a Pi 5 is far slower and has far less memory than a modern desktop. Demanding workloads will crawl or simply won't fit.
+- **Thermal throttling** — under sustained load the chip heats up and deliberately slows itself to avoid damage. Without a heatsink or fan, you lose the performance you paid for.
+- **Power-supply pickiness** — SBCs are surprisingly fussy about power. An underpowered or low-quality supply causes random crashes, corruption, and "undervoltage" warnings that look like software bugs but aren't.
+- **Not for heavy compute** — video transcoding at scale, large databases, big ML training, or anything needing serious sustained horsepower belongs on a bigger machine.
+
+| | Strengths | Drawbacks |
+|---|-----------|-----------|
+| **Cost** | Very cheap to buy and run | — |
+| **Power** | A few watts; battery/solar capable | Fussy supplies cause crashes |
+| **Software** | Full Linux, all the usual tools | — |
+| **Hardware I/O** | GPIO, I2C, SPI, UART | — |
+| **Performance** | Plenty for light always-on jobs | Limited CPU/RAM; thermal throttling |
+| **Storage** | microSD is cheap and simple | SD wear and corruption risk |
+| **Size** | Small, quiet, fanless | Cramped for heavy workloads |
+
+Most of these are manageable — a good power supply, a heatsink, an SSD, and modest expectations turn a flaky Pi into a rock-solid one. The mistake is ignoring them and then blaming your code.
+
+## When to step up or down
+
+The deepest skill is knowing when an SBC *isn't* the answer. The decision usually goes one of two ways:
+
+**Step up to a mini-PC or server** when you need heavy, sustained compute — lots of RAM, fast storage, real CPU or GPU horsepower. If your "home server" is transcoding several video streams at once or running a big database, a small x86 mini-PC will be far happier than a Pi, often without much more power draw.
+
+**Step down to a microcontroller** when the job is simple, must sip power for a very long time, or needs to start instantly and never crash. A microcontroller running one program on bare metal can live on a coin cell for months, boot in milliseconds, and never suffer SD-card corruption — because there's no SD card and no OS to corrupt. If all you need is "read a sensor and blink a light," an SBC is overkill. That's the subject of the next module, beginning with [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/).
+
+The SBC is a brilliant middle ground, not a universal tool. Reaching for it deliberately — and knowing the two neighbors it sits between — is exactly the kind of choice this path is training you to make.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the microSD card is the usual reliability weak point, worn down by writes and vulnerable to power loss." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the most common reliability weakness of a typical SBC like a Raspberry Pi?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It has no operating system, so it crashes constantly</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The microSD card wears out with writes and can corrupt on power loss</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It cannot connect to a network or run services</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **SBCs win at small, always-on jobs** — home servers, media centers, retro gaming, robotics, edge AI, IoT gateways, SDR scanners, and learning Linux.
+- **Their strengths** — cheap, low-power, a full OS, GPIO, and small and quiet, all at once.
+- **Their drawbacks** — SD-card wear, limited CPU/RAM, thermal throttling, fussy power supplies, and no head for heavy compute.
+- **Most drawbacks are manageable** — a good supply, cooling, an SSD, and realistic expectations make an SBC reliable.
+- **Know your neighbors** — step up to a mini-PC for heavy compute, step down to a microcontroller for simple, battery, instant-on jobs.
+
+Next up: the smaller, simpler sibling of the SBC — the chip that runs one program on bare metal. See [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/).

--- a/docs/learn/intro-hardware/smartphones.md
+++ b/docs/learn/intro-hardware/smartphones.md
@@ -1,0 +1,100 @@
+---
+slug: smartphones
+title: Smartphones
+description: A smartphone is a powerful ARM computer packed with sensors. Learn what it can do, the platforms and languages behind apps, and why it's a deployment target rather than a dev machine.
+keywords: what is a smartphone, smartphone hardware, ARM SoC, iOS development, Android development, Swift, Kotlin, React Native, Flutter, mobile sensors, smartphone as a computer
+level: beginner
+status: full
+faq:
+  - q: "Is a smartphone a real computer?"
+    a: "Yes, and a remarkably capable one. A modern phone has a multi-core **ARM system-on-chip**, several gigabytes of RAM, fast storage, and more raw performance than a desktop from a decade ago. What sets it apart is the package around the chip: a touch screen, a battery, and a dense cluster of sensors and radios. It is a full general-purpose computer that happens to fit in a pocket."
+  - q: "What languages are used to build smartphone apps?"
+    a: "It depends on the platform. **iOS** apps are written mainly in **Swift** (with SwiftUI) and older code in Objective-C. **Android** apps are written in **Kotlin** or Java. If you want one codebase for both, cross-platform frameworks like **Flutter** (Dart) and **React Native** (JavaScript) let you target iOS and Android together, trading a little native polish for shared effort."
+  - q: "Can I use a smartphone as my development machine?"
+    a: "Not really, and not for long. Phones are locked down by design — you can't freely install compilers, system tools, or arbitrary software, and the small screen and on-screen keyboard make sustained coding painful. Phones are something you **build for**, not something you build **on**. You write code on a laptop or desktop and deploy it to the phone."
+---
+# Smartphones
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A smartphone is a powerful ARM computer with rich sensors** — GPS, cameras, an accelerometer, and several radios, all behind a touch screen and a battery. **It's the dominant computing platform on earth**, which makes it a deployment target you reach millions of people through. **You build for a phone, not on it** — phones are locked down and awkward to develop on, so the work happens on a desktop and ships to the device.
+</div>
+
+This lesson opens Module 4, on the computers most people actually carry. The smartphone is the most widespread computer ever made, and for a developer it plays a very particular role: it is somewhere your software *runs*, not somewhere you *write* software. By the end you'll understand what the hardware can do, which platforms and languages produce apps for it, and why "target, not workstation" is the right mental model.
+
+## What a smartphone actually is
+
+Underneath the glass, a smartphone is a small, dense computer built around an **ARM system-on-chip (SoC)** — a single piece of silicon that combines the CPU, graphics, memory controllers, and specialized accelerators. That efficiency-first ARM design is what lets a phone deliver serious performance while running on a battery.
+
+What makes a phone distinct from other computers is everything bolted around that chip:
+
+- A **touch screen** as the primary input and output, with no keyboard or mouse.
+- A **battery** that forces every part of the system to care about power.
+- A cluster of **sensors**: GPS for location, one or more **cameras**, an **accelerometer** and gyroscope for motion and orientation, plus a microphone, ambient light, and often more.
+- A stack of **radios**: cellular, Wi-Fi, Bluetooth, NFC, and GPS receivers.
+
+That last two points are the magic. A laptop can compute, but a phone *senses the world and stays connected to it* wherever you go. Apps that know where you are, what you're pointing the camera at, and how the device is moving are built directly on this sensor hardware.
+
+## What smartphones are for
+
+The obvious answer is consumer apps — messaging, maps, banking, media, games — and that alone makes the phone the dominant computing platform for most of humanity. For many people it is their *only* computer. But the same hardware serves quieter, more technical roles too:
+
+- **IoT controllers.** A phone app is the standard way to set up and control a smart bulb, a thermostat, or a drone, talking over Bluetooth or Wi-Fi.
+- **Field data capture.** GPS plus camera plus a form makes the phone an excellent tool for inspections, surveys, and logging readings where a laptop would be clumsy.
+- **Thin clients and dashboards.** Because phones are always connected, they make great windows onto software running elsewhere. With GopherTrunk, for instance, a scanner can run on a Raspberry Pi at the antenna while you watch and steer it from a phone on the same network — the heavy work stays on the server, the phone is just the remote screen.
+
+The thread through all of these: the phone's value comes from its sensors, its screen, and its constant connection, not from raw compute alone.
+
+## Platforms, languages, and toolchains
+
+Building for phones means picking a platform and its toolchain. There are two native ecosystems plus a cross-platform option that spans both.
+
+| Platform | Primary languages | Toolchain | Notes |
+|----------|-------------------|-----------|-------|
+| **iOS** (Apple) | Swift (with SwiftUI), Objective-C | Xcode on a Mac | Native development requires a Mac; distribution goes through the App Store |
+| **Android** (Google) | Kotlin (preferred), Java | Android Studio | Runs on Windows, macOS, or Linux; more open distribution |
+| **Cross-platform** | Dart (Flutter), JavaScript/TypeScript (React Native) | Flutter / RN tooling | One codebase targeting both iOS and Android |
+
+Native code gives you the fullest access to the device and the most polished platform feel. Cross-platform frameworks let a single team ship to both stores from one codebase, trading a little native fidelity for a lot of shared effort. We compare these approaches in depth in [Developing for mobile devices](/learn/intro-hardware/developing-for-mobile/). The key point for now: in every case you write the code on a real computer and the toolchain *builds and signs* an app that gets installed on the phone.
+
+## Strengths
+
+The smartphone's advantages are hard to overstate:
+
+- **Ubiquity.** Billions of people carry one. No other platform offers comparable reach.
+- **Sensors.** GPS, cameras, motion sensors, and radios come built in, ready for apps that perceive and respond to the physical world.
+- **Always connected.** Cellular and Wi-Fi mean an app can assume a network most of the time, which makes the phone an ideal client for cloud and server software.
+- **Reach with good UX.** App stores, push notifications, and a mature design language let a small team put a polished, personal experience directly in someone's pocket.
+
+For getting software in front of ordinary people, nothing else competes.
+
+## Drawbacks
+
+The same traits that make phones great products make them frustrating as machines you control:
+
+- **Locked down.** You don't fully own the software environment. Installing apps means going through a vetted store, and the operating system tightly limits what apps may touch.
+- **App-store gatekeeping.** Apple and Google review submissions, take a cut, and can reject or remove apps. Your access to users runs through their rules.
+- **Poor as a dev machine.** No real compilers, a tiny screen, and an on-screen keyboard make sustained development impractical. Phones are built to *consume and run*, not to *build*.
+- **Battery and thermal limits.** Sustained heavy compute drains the battery and triggers throttling. The phone is powerful in bursts, not as a tireless workhorse.
+
+None of these are flaws exactly — they're the price of a sealed, secure, pocket-sized appliance. They just explain why the phone sits on the *deployment* side of the line.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a phone is something you build for; the actual development happens on a desktop or laptop." markdown="0">
+  <p class="knowledge-check__q">Quick check: In a typical workflow, what role does a smartphone play for a developer?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's the main machine you write and compile code on</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It's a deployment target — you build for it on a desktop and install the app onto it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It can't run real software and is only useful for phone calls</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A phone is a powerful ARM computer** — a capable SoC, lots of RAM and storage, wrapped in a touch screen and battery.
+- **Its edge is sensors and connectivity** — GPS, cameras, motion, and radios make it perceive the world and stay online.
+- **It's the dominant platform** — consumer apps, IoT control, field capture, and thin-client dashboards all run on it.
+- **Two native stacks plus cross-platform** — iOS (Swift), Android (Kotlin), and Flutter/React Native for both at once.
+- **Target, not workstation** — locked down, store-gated, and awkward to code on, so you build for the phone elsewhere.
+
+Next up: the phone's bigger-screened cousin, and where that extra size actually pays off. See [Tablets](/learn/intro-hardware/tablets/).

--- a/docs/learn/intro-hardware/start-with-requirements.md
+++ b/docs/learn/intro-hardware/start-with-requirements.md
@@ -1,0 +1,85 @@
+---
+slug: start-with-requirements
+title: Start with your requirements
+description: Good hardware choices begin with a clear list of requirements — compute, connectivity, power, budget, and where the device must physically live — not with a favorite board.
+keywords: hardware requirements, project requirements checklist, choosing hardware, compute and memory needs, power source, connectivity needs, hardware budget, where hardware lives
+level: beginner
+status: full
+faq:
+  - q: "Why write requirements before choosing hardware?"
+    a: "Because the hardware should fall out of the needs, not the other way around. If you pick a board first and then bend the project to fit it, you'll either overpay for capacity you never use or hit a wall the part can't clear. Writing the **requirements** down — compute, connectivity, power, budget, location — turns a guess into a short list of platforms that can actually do the job."
+  - q: "What are the most important questions to answer first?"
+    a: "Five carry most of the weight: **what does it do** (how much compute and memory), **does it need networking or the internet**, **does it touch the physical world** (sensors, motors, a radio dongle), **how is it powered** (battery, wall, always-on), and **where does it physically live**. Each answer rules large parts of the [hardware spectrum](/learn/intro-hardware/hardware-spectrum/) in or out before you ever compare prices."
+  - q: "Does it matter whether I'm building one unit or thousands?"
+    a: "Hugely. A $35 board is trivial for a one-off but ruinous at ten thousand units, where a $3 microcontroller wins. Scale flips which platform is sensible, so **how many units** belongs in your requirements from the start — it changes the answer as much as performance does."
+  - q: "Who maintains it — why does that belong in requirements?"
+    a: "Because a machine someone has to babysit costs more than its price tag. If it lives somewhere awkward, runs 24/7, or will be updated by a non-developer, that pushes you toward simpler, more reliable, more remotely-manageable options. Maintenance is a real constraint, not an afterthought."
+---
+# Start with your requirements
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Requirements first, hardware second** — write down what the project needs before you fall in love with a board. **A handful of questions decide most of it** — compute, connectivity, physical-world contact, power, budget, and location each rule parts of the spectrum in or out. **Scale and maintenance count too** — one unit versus thousands, and who looks after it, can flip the answer entirely.
+</div>
+
+This is the first lesson of Module 7 — the payoff module, where everything from the platform tour comes together into a single skill: choosing well. And good choosing starts long before you compare boards or hosting plans. It starts with writing down what the project actually needs. This lesson is about that discipline: the short list of questions that, once answered honestly, point you straight at the right part of the [hardware spectrum](/learn/intro-hardware/hardware-spectrum/).
+
+## Why requirements come before parts
+
+It's tempting to start from a part you already like — a Raspberry Pi you have in a drawer, a cloud provider you've used before — and shape the project around it. That's backwards. The hardware should fall out of the requirements, not drive them.
+
+When you choose the part first, one of two things happens. Either you over-buy, paying for performance, power draw, and complexity you never use; or you under-buy and slam into a limit the part simply can't clear — no amount of clever code gives a cloud server a USB port in your living room. Writing requirements down first is the cheapest insurance against both. It also makes the decision *defensible*: when someone asks why you chose what you did, you can point at the need, not a hunch.
+
+The good news is that requirements for a hardware project are short. A page is usually plenty. The art is asking the right questions.
+
+## The questions that decide it
+
+Work through these in order. Each answer eliminates options, which is exactly what you want — a smaller field is an easier decision (the [decision framework](/learn/intro-hardware/decision-framework/) later turns this into a repeatable method).
+
+- **What does it do — and how much compute and memory does that take?** Blinking an LED and editing 4K video sit at opposite ends of the [spectrum](/learn/intro-hardware/hardware-spectrum/). Be concrete: a web dashboard for a handful of users is light; training a machine-learning model is not.
+- **Does it need networking or the internet?** A public service needs to be reachable; an offline data logger needs none. Connectivity requirements pull you toward servers and away from isolated microcontrollers, or vice versa.
+- **Does it touch the physical world?** Sensors, motors, buttons, a radio dongle — anything that must be *physically attached* rules out remote cloud machines immediately, and pulls you toward a [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) or a [single-board computer](/learn/intro-hardware/what-is-an-sbc/) sitting where the hardware is.
+- **How is it powered?** Battery, wall outlet, or always-on mains changes everything. A device that must run for months on a coin cell is a microcontroller job; one that's fine drawing 60 watts around the clock opens up servers and desktops.
+- **What's the budget — and at what quantity?** One unit or ten thousand? Cost that's trivial once can be fatal at scale. This is where a $3 part beats a $35 one even though the $35 one is "better."
+- **Where does it physically live?** A clean office, a rack in a data center, a damp garden, the base of an antenna on a roof. Location dictates ruggedness, connectivity, and power, and often eliminates whole categories on its own.
+- **Who maintains it?** A developer at a keyboard, or a non-technical person who just wants it to work? Hard-to-reach or 24/7 devices favor simple, reliable, remotely-managed options.
+
+## A requirements checklist you can reuse
+
+Capture the answers in a small table like this one. Filling it in *before* you shop is the whole point — the right column will already be hinting at platforms by the time you're done.
+
+| Requirement | The question to answer | Which way it points |
+|-------------|------------------------|---------------------|
+| **Compute & memory** | How heavy is the work — trivial, moderate, or demanding? | Light → MCU/SBC; heavy → desktop/server/cloud |
+| **Connectivity** | Offline, local network, or public internet? | Public → [VPS](/learn/intro-hardware/vps/)/server; offline → standalone device |
+| **Physical world** | Does it need sensors, actuators, or attached hardware? | Yes → device on-site, never a remote cloud box |
+| **Power** | Battery, wall, or always-on mains? | Battery → microcontroller; always-on → SBC/server |
+| **Budget & quantity** | Cost ceiling, and one unit or many? | Many → cheapest part that works; one → convenience wins |
+| **Location** | Clean indoors, harsh outdoors, data center, remote? | Harsh/remote → rugged, low-maintenance, remotely managed |
+| **Maintenance** | Who updates and fixes it, how easily? | Non-technical/hard to reach → simplest reliable option |
+
+## A worked read: where would GopherTrunk run?
+
+Run the questions against **GopherTrunk**, the SDR scanner these docs are about, and watch the field narrow. *What does it do?* Captures and decodes radio — moderately demanding signal processing. *Networking?* Useful, so you can view recordings from elsewhere. *Physical world?* Yes — and this is decisive: the SDR dongle is a **USB device that must be physically plugged into the machine**. *Power and location?* It needs to sit near the antenna, often a roof or attic, ideally always-on. *Budget?* A hobby build, one unit.
+
+Those answers eliminate a cloud [VPS](/learn/intro-hardware/vps/) outright — you can't plug a USB dongle into a server in someone else's data center. They point instead at a machine that lives *at the antenna*: a [Raspberry Pi](/learn/intro-hardware/raspberry-pi-and-family/) bolted up near the feedline, or a [laptop](/learn/intro-hardware/laptops/)/desktop with the dongle attached. We didn't compare specs to get there. We just wrote down the requirements, and the physical-world answer did most of the work.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — pin down the requirements first, and the suitable platforms fall out of them." markdown="0">
+  <p class="knowledge-check__q">Quick check: What should you do before picking a board or a host?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Pick the most powerful platform you can afford, to be safe</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Write down what the project needs — compute, connectivity, physical contact, power, budget, location — and let that narrow the field</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Start with the part you already own and bend the project to fit it</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Requirements before hardware** — let the needs choose the part, not the other way around, to avoid over-buying or hitting a wall.
+- **A short list of questions decides most of it** — compute and memory, connectivity, physical-world contact, power, budget, location, and maintenance.
+- **Physical-world contact is decisive** — anything that must be plugged in or sensed rules out remote cloud machines immediately.
+- **Scale flips the answer** — one unit versus thousands changes which platform is sensible as much as performance does.
+- **Capture it in a checklist** — a one-page table filled in before you shop already points at the right region of the spectrum.
+
+Next up: take those requirements and map common kinds of projects to the platforms they tend to reach for. See [Matching hardware to the project type](/learn/intro-hardware/matching-hardware-to-project/).

--- a/docs/learn/intro-hardware/tablets.md
+++ b/docs/learn/intro-hardware/tablets.md
@@ -1,0 +1,98 @@
+---
+slug: tablets
+title: Tablets
+description: A tablet is a big-screen touch computer sitting between phone and laptop. Learn where the extra size pays off, what runs on tablets, and their limits as a primary dev machine.
+keywords: what is a tablet, tablet computer, iPad Pro, iPadOS, Android tablet, tablet vs laptop, tablet vs phone, kiosk hardware, point of sale tablet, tablet for development
+level: beginner
+status: full
+faq:
+  - q: "How is a tablet different from a phone?"
+    a: "Mostly size. A tablet runs the same kind of operating system as a phone — **iPadOS** or **Android** — on a much larger touch screen. That bigger canvas changes what it's good at: reading, drawing, side-by-side apps, and kiosk displays all benefit from the room. High-end tablets like the iPad Pro even use laptop-class **M-series** chips, blurring the line further."
+  - q: "Can a tablet replace my laptop?"
+    a: "For some people, for some tasks — but rarely fully. Tablets handle media, reading, note-taking, and light productivity well, and an iPad can now run a few genuine development tools. But they remain fairly **locked down**, lean on touch over keyboard and mouse, and lack the freedom of a real desktop OS. As a primary development machine, a tablet is a compromise."
+  - q: "What languages do you use to build tablet apps?"
+    a: "The same ones as phones. iPad apps are built in **Swift** with Xcode; Android tablet apps in **Kotlin** with Android Studio; and cross-platform frameworks like **Flutter** and **React Native** cover both. A well-built mobile app usually adapts its layout to the larger screen rather than being a separate product."
+---
+# Tablets
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A tablet is essentially a large-screen phone** — same iPadOS or Android lineage, sometimes laptop-class silicon like the iPad Pro's M-series chips. **The extra size pays off** for media, reading, drawing, kiosks, point-of-sale, and field tools where a phone is too small and a laptop too bulky. **It sits between phone and laptop** — more capable than one, less open than the other, and a compromise as a primary dev machine.
+</div>
+
+A tablet is the phone's big-screened cousin. Architecturally it's almost the same animal — an ARM-based touch computer running a mobile operating system — but the larger display shifts what it's good for. This lesson looks at where that extra size earns its keep, what runs on tablets, and why "between phone and laptop" cuts both ways.
+
+## What a tablet is
+
+At its core, a tablet is a large phone. It runs the same family of operating systems — **iPadOS** on Apple's iPads, **Android** on most others — built around touch, apps, and a battery, with no built-in keyboard. Everything you learned about phone hardware applies: ARM SoC, sensors, radios, sealed design.
+
+The interesting wrinkle is at the high end. Apple's iPad Pro and iPad Air now run the same **M-series** chips found in MacBooks — genuinely laptop-class processors. That gives a top-tier tablet the raw horsepower of a real computer, even while the software around it stays closer to a phone than a desktop. So a tablet can range from a cheap media-consumption slab to a machine more powerful than many laptops, all in the same form factor.
+
+## Where the extra size pays off
+
+A bigger screen isn't a minor upgrade — it unlocks whole categories of use that a phone handles poorly:
+
+- **Media and reading.** Movies, magazines, comics, and documents are far more comfortable on a tablet-sized display.
+- **Drawing and creative work.** With a stylus, tablets are first-class tools for illustration, sketching, photo editing, and note-taking.
+- **Point-of-sale and kiosks.** The flat, durable, single-app tablet is the default hardware for cash registers, check-in screens, menus, and self-service kiosks.
+- **Field tools.** Inspectors, clinicians, and technicians use tablets for forms, diagrams, and reference material where a phone is cramped and a laptop is awkward to hold.
+- **Light productivity.** Email, browsing, documents, and video calls all work well, especially with a clip-on keyboard.
+
+This is also where a tablet earns a place in a setup like GopherTrunk's: propped on a desk, a tablet makes a roomy, glanceable dashboard for a scanner running on a server elsewhere — more screen than a phone, less commitment than a laptop.
+
+## Phone vs tablet vs laptop
+
+The clearest way to place a tablet is between its neighbors. Each device wins at something the others don't:
+
+| Trait | Phone | Tablet | Laptop |
+|-------|-------|--------|--------|
+| **Screen size** | Small, pocketable | Large touch screen | Large, plus keyboard |
+| **Portability** | Always with you | Carried, not pocketed | Bag-sized |
+| **Primary input** | Touch | Touch (+ stylus / keyboard) | Keyboard & trackpad |
+| **Battery life** | All day | Often very long | Half to full day |
+| **Openness** | Locked down | Fairly locked down | Fully open OS |
+| **Best at** | On-the-go, sensors | Media, drawing, kiosks | Real work & development |
+| **Dev machine?** | No | Limited | Yes |
+
+The pattern is plain: the phone wins on portability and sensors, the laptop wins on openness and real work, and the tablet sits in the middle — bigger and nicer to look at than a phone, but more constrained than a laptop. For choosing the laptop end of that spectrum deliberately, see [Choosing a development machine](/learn/intro-hardware/choosing-a-dev-machine/).
+
+## Strengths
+
+Tablets do several things better than anything else:
+
+- **Big, comfortable touch screen.** The best surface for reading, watching, drawing, and showing things to other people.
+- **Portable and quiet.** Lighter than a laptop, instant-on, fanless, and easy to hand around or mount on a wall.
+- **Long battery life.** Mobile-class efficiency plus a large body usually means excellent endurance.
+- **Great for content and kiosks.** Durable, lockable to a single app, and cheap enough to deploy in numbers — ideal for displays, registers, and field use.
+
+If the job is consuming, presenting, drawing, or showing, a tablet is often the most pleasant tool available.
+
+## Drawbacks
+
+The same in-between position creates real limits:
+
+- **Jack of both, master of neither.** A tablet is less portable than a phone and less capable than a laptop, so for many people it's a third device rather than a replacement for either.
+- **Still fairly locked down.** Like phones, tablets run a sealed mobile OS with store-gated apps and limited access to the system. iPadOS has opened up somewhat, but it's not a free desktop.
+- **Limited as a primary dev machine.** Even with laptop-class chips, the software environment, touch-first input, and restricted tooling make a tablet a compromise for serious development. An iPad can now run *some* real dev tools, but most coding still happens on a desktop or laptop.
+
+A tablet is a wonderful companion device and an excellent appliance. It just rarely wants to be the one machine you do everything on.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a tablet sits between phone and laptop: bigger and nicer than a phone, but more locked down and less capable than a laptop." markdown="0">
+  <p class="knowledge-check__q">Quick check: Where does a tablet sit relative to a phone and a laptop?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's identical to a laptop, just without a keyboard</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Between them — bigger and more comfortable than a phone, but more locked down and limited than a laptop</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's weaker than a phone in every way</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A tablet is a large phone** — same iPadOS or Android lineage, sometimes with laptop-class M-series chips.
+- **Size unlocks new uses** — media, reading, drawing, kiosks, point-of-sale, and field tools all benefit from the room.
+- **It sits between phone and laptop** — more comfortable than one, more open than the other, master of neither.
+- **Same app stacks as phones** — Swift, Kotlin, and cross-platform frameworks, with layouts that adapt to the bigger screen.
+- **A compromise as a dev machine** — still fairly locked down and touch-first, so serious development stays on a real computer.
+
+Next up: the three ways to actually build a mobile app, the toolchains behind each, and how to choose. See [Developing for mobile devices](/learn/intro-hardware/developing-for-mobile/).

--- a/docs/learn/intro-hardware/vps.md
+++ b/docs/learn/intro-hardware/vps.md
@@ -1,0 +1,86 @@
+---
+slug: vps
+title: Virtual private servers (VPS)
+description: A VPS is your own root-access slice of a server, carved out by virtualization. Learn what it runs, how hypervisors split a machine, and the sysadmin duty it brings.
+keywords: VPS, virtual private server, virtualization, hypervisor, root access, cloud server, DigitalOcean Linode Hetzner, self-managed server, sysadmin responsibility
+level: intermediate
+status: full
+faq:
+  - q: "What is a VPS?"
+    a: "A **virtual private server** is an isolated virtual machine running on shared physical hardware, with its own operating system and full **root access**. Virtualization software splits one powerful physical server into several independent virtual ones, each behaving like a standalone computer. You get the freedom of your own machine — install anything, run anything — without paying for a whole physical box."
+  - q: "How is a VPS different from shared hosting?"
+    a: "Shared hosting hands you a managed slot on a server you can't control. A VPS hands you **root** on your own virtual machine — you choose the operating system, install any software, and run long-lived processes. The catch is that everything the shared host used to do for you (security, updates, backups, configuration) is now *your* job. You trade convenience for control."
+  - q: "Can I run a GopherTrunk recorder on a VPS?"
+    a: "You can run the *software* — the dashboard, the processing, the storage — but not the radio. A cloud VPS is a virtual machine in a data center with **no USB ports**, so you can't plug in an SDR dongle. The signal has to enter somewhere physical. This is a clean illustration that some workloads need hardware physically attached, which points toward a **[home server](/learn/intro-hardware/home-servers/)** for the radio end."
+---
+# Virtual private servers (VPS)
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A VPS is your own virtual machine** carved out of shared physical hardware by virtualization, with full root access. **You can run anything** because you control the operating system. **The responsibility is yours too** — security, updates, and backups are now your job. **Performance can vary** because the underlying hardware is still shared with other tenants.
+</div>
+
+When shared hosting runs out of room, the natural next step is a VPS — a machine that *behaves* like it's all yours, even though it's a slice of a bigger one. It's the workhorse of the modern internet: most web apps, APIs, and small services you use are running on something like it. This lesson explains how virtualization carves one physical machine into many, what a VPS lets you do, and the new duty that arrives the moment you get root.
+
+## What a VPS is and how virtualization works
+
+A **virtual private server** is an isolated, self-contained virtual computer running on a physical server it shares with others. To you it looks and behaves like a dedicated machine: it boots its own operating system, has its own memory and disk, and gives you **root access** to do whatever you like.
+
+The trick that makes this possible is **virtualization**. A layer of software called a **hypervisor** runs on the physical server and divides its resources — CPU cores, memory, storage — into several walled-off virtual machines. Each VPS thinks it has its own hardware; the hypervisor keeps them isolated so one tenant can't see or disturb another. (A lighter-weight cousin, **containers**, share the host's kernel instead of emulating whole machines, but the idea is the same: slice one box into many isolated environments.)
+
+The result is the best of both worlds for the price: the independence of your own server without the cost of buying and housing a physical one.
+
+## Who provides them and what they're for
+
+Plenty of providers rent VPS instances by the hour or month — **DigitalOcean**, **Linode**, **Hetzner**, and the bigger clouds like **AWS EC2** among them. At a generic level they all offer the same thing: pick a size, pick an operating system, and a virtual machine appears in minutes.
+
+What people run on them covers most of the internet's day-to-day work:
+
+- **Web applications and APIs** — the back end behind a site or a mobile app.
+- **Bots and small services** — chat bots, schedulers, scrapers, webhooks.
+- **Databases** — a PostgreSQL or MySQL instance for your own apps.
+- **Dashboards and internal tools** — anything that needs to run continuously and be reachable.
+
+If a job needs to *stay running* and *be online*, and doesn't need physical hardware attached, a VPS is usually the right home for it.
+
+## The languages and stacks it runs
+
+Here the answer is simple: **anything**. Because you control the operating system, the question isn't "what does the host allow?" but "what do you want to install?" Python, Node.js, Go, Rust, Java, Ruby, PHP, a database, a message queue, your own compiled binaries — if it runs on Linux (or Windows, if you choose that), it runs on a VPS. This is the whole point of getting root: the environment is yours to shape.
+
+## Strengths, drawbacks, and the GopherTrunk catch
+
+The freedom of a VPS comes bundled with the duties of running a server. The balance looks like this:
+
+| Strengths | Drawbacks |
+|-----------|-----------|
+| **Full control** — root access, any OS, any software | **You're the sysadmin** — security, patching, backups are on you |
+| **Affordable** — far cheaper than a physical server | **Shared hardware** — performance can vary with neighbors |
+| **Scalable** — resize or add instances on demand | **Easy to misconfigure** — an open port can mean a breach |
+| **Snapshots** — save and restore the whole machine | **No physical access** — no USB, no plugging in hardware |
+
+That last drawback is worth dwelling on. You *could* run the **GopherTrunk** dashboard, processing, and storage on a VPS — it's just software. But a cloud VPS is a virtual machine in a data center with **no USB ports**, so there's nowhere to plug in an SDR dongle. The radio signal has to enter the system through physical hardware, and a VPS has none. It's a perfect teaching point: control over the *software* environment doesn't give you the *physical* I/O some jobs need. For the radio end of GopherTrunk, you want a machine you can physically touch — which is where home servers come in.
+
+## With control comes responsibility
+
+The single biggest difference from shared hosting isn't technical, it's a shift in who's accountable. On shared hosting the provider keeps the machine patched, watched, and backed up. On a VPS, *you* do. An unpatched service, a weak password, or an exposed database is now your problem to prevent and your problem to clean up. None of this is hard to learn, but it's real work, and underrating it is the classic beginner mistake when moving up from shared hosting.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a VPS gives you root on a virtual machine, but security, updates, and backups become your responsibility." markdown="0">
+  <p class="knowledge-check__q">Quick check: What do you gain — and take on — when you move from shared hosting to a VPS?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A fully managed server where the host still handles all maintenance</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Root access to run anything, plus the responsibility for security, updates, and backups</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A whole physical machine with no other tenants sharing the hardware</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A VPS is your own virtual machine** — an isolated slice of a physical server with full root access.
+- **Virtualization makes it work** — a hypervisor splits one machine into many walled-off virtual ones; containers do a lighter version.
+- **Providers are plentiful** — DigitalOcean, Linode, Hetzner, AWS EC2, and others rent them by the hour or month.
+- **It runs anything** — you control the OS, so any language or stack is fair game.
+- **Control brings responsibility** — security, patching, and backups become your job.
+- **No physical I/O** — a cloud VPS has no USB ports, so it can host GopherTrunk's software but not its SDR hardware.
+
+Next up: when shared hardware isn't enough and you want an entire physical machine to yourself. See [Dedicated servers](/learn/intro-hardware/dedicated-servers/).

--- a/docs/learn/intro-hardware/web-hosting.md
+++ b/docs/learn/intro-hardware/web-hosting.md
@@ -1,0 +1,93 @@
+---
+slug: web-hosting
+title: Web & shared hosting
+description: Shared web hosting is the cheapest way online — many sites on one managed server. Learn what it runs, what it hides, and when you outgrow it.
+keywords: web hosting, shared hosting, managed hosting, cPanel, WordPress hosting, static site hosting, JAMstack, PHP MySQL hosting, when to upgrade from shared hosting
+level: beginner
+status: full
+faq:
+  - q: "What is shared web hosting?"
+    a: "It's a service where many customers' websites live on a single physical server, and the hosting company manages everything underneath — the operating system, the web server, security updates, and backups. You upload your files (often through a control panel like **cPanel**) and your site is online. You don't get root access or a machine of your own; you rent a slice of a shared one for a few dollars a month."
+  - q: "What can I run on shared hosting?"
+    a: "Mostly websites built from **static HTML**, or **PHP with a MySQL database** — which is why WordPress is everywhere on shared hosting. Some managed platforms also support Python, Node.js, or Ruby in a controlled way. What you generally *cannot* run is arbitrary software, background daemons, or long-running processes, because those need control over the machine that shared hosting deliberately withholds."
+  - q: "When should I move off shared hosting?"
+    a: "When you hit its walls: you need to run a custom background service, install system packages, get root access, handle real traffic, or stop competing with noisy neighbors for resources. At that point a **[VPS](/learn/intro-hardware/vps/)** gives you your own slice of a server with full control, for a modest step up in price and responsibility."
+---
+# Web & shared hosting
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Shared hosting puts many sites on one managed server** — the host runs everything, you just upload files. **It's the cheapest, simplest way online** and perfect for blogs, small sites, and WordPress. **You give up control in exchange** — no root, no arbitrary software, no long-running processes. **You outgrow it** the moment you need real control or steady performance.
+</div>
+
+Now that we know what a computer is, the first place most software actually lands is the web — and the cheapest door into the web is shared hosting. It's where countless blogs, small business sites, and first projects begin, precisely because it asks almost nothing of you. This lesson covers what shared and managed web hosting really gives you, the kinds of sites it suits, the languages it runs, and the point where its convenience turns into a ceiling.
+
+## What shared hosting actually is
+
+**Shared hosting** is the arrangement where a hosting company packs many customers' websites onto a single physical server and manages that server for all of them. You don't see the machine. You get an account, a control panel, and somewhere to put your files.
+
+The defining trait is that *the host manages everything underneath you*: the operating system, the web server (usually Apache or Nginx), the database engine, security patches, and often backups. Your job shrinks to uploading content and maybe clicking through a one-button WordPress installer. Most accounts come with a control panel — **cPanel** is the classic — that turns tasks like adding an email address, setting up a database, or installing an SSL certificate into point-and-click operations.
+
+**Managed hosting** is the same idea taken further: platforms tuned for one job, like managed WordPress hosts or static-site and JAMstack platforms (think Netlify-style services), that handle even more for you in exchange for staying inside their lane.
+
+## What it's for
+
+Shared hosting fits any site where the content matters more than the machine:
+
+- **Blogs and personal sites** — often WordPress, often a few visitors at a time.
+- **Small business and brochure sites** — a handful of pages that rarely change.
+- **Static sites** — plain HTML, CSS, and images with no server-side code at all, which are fast and cheap to host anywhere.
+- **JAMstack sites** — static front-ends that pull dynamic data from external APIs, a popular pattern on platforms like Netlify or similar static hosts.
+
+If your project is "get this site in front of people without becoming a system administrator," shared hosting is built for exactly that.
+
+## The languages and stacks it runs
+
+Shared hosting grew up around a specific, durable stack:
+
+- **Static HTML/CSS/JS** — the simplest case, just files served as-is.
+- **PHP + MySQL** — the workhorse of shared hosting and the foundation of WordPress, Joomla, and most classic content systems. Most cheap plans assume this combination.
+- **Python, Node.js, or Ruby** — supported on *some* managed platforms, but usually in a constrained way rather than the free-for-all you'd get on your own server.
+
+The pattern to notice: shared hosting is excellent at the stacks it was designed for and awkward or impossible for anything outside them.
+
+## Strengths and drawbacks
+
+The trade is straightforward — you swap control for simplicity. Here is the balance:
+
+| Strengths | Drawbacks |
+|-----------|-----------|
+| **Cheap** — often a few dollars a month | **No root access** — you can't install system software |
+| **Zero sysadmin** — host handles OS, updates, backups | **Limited control** — you live inside the host's rules |
+| **Easy** — control panel, one-click installers | **Noisy neighbors** — other sites on the box can hog resources |
+| **Fast to start** — online in minutes | **No long-running processes** — no custom daemons, bots, or services |
+| **Predictable** — flat monthly price | **Hard limits** — caps on CPU, memory, and processes you can't lift |
+
+The strengths are real and the drawbacks are not flaws so much as the *deal*: the host keeps control so you don't have to manage anything, and that same control is exactly what you can't have.
+
+## Where you outgrow it
+
+The ceiling shows up the moment your project wants something the host won't allow. You want to run a background worker, install a system package, schedule a long-lived process, or simply stop sharing a crowded machine with strangers' traffic spikes.
+
+Consider **GopherTrunk**: it isn't a website, it's a long-running program that processes a stream of radio data and exposes a dashboard. Shared hosting flatly can't run that — there's no place for a persistent custom process and no control over the environment. That kind of workload is the signal that you've outgrown shared hosting and want your own slice of a server instead.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — shared hosting runs many managed sites on one server, trading control for simplicity." markdown="0">
+  <p class="knowledge-check__q">Quick check: What is the defining trade-off of shared hosting?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">You get full root control but must manage the whole machine yourself</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">You give up control and arbitrary software in exchange for a cheap, fully managed place to put a site</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">You get a dedicated physical machine that no one else can use</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Many sites, one managed server** — shared hosting packs customers onto a shared machine the host runs for everyone.
+- **The host manages everything** — OS, web server, updates, and backups, usually through a control panel like cPanel.
+- **Built for content sites** — blogs, small sites, static pages, WordPress, and JAMstack platforms.
+- **PHP/MySQL and static files** — the native stack, with some managed support for Python or Node.
+- **Cheap and effortless, but capped** — no root, no arbitrary software, no long-running processes, and noisy neighbors.
+- **You outgrow it** when you need real control or to run something like a persistent GopherTrunk process.
+
+Next up: your own slice of a server, with root access and the freedom (and responsibility) that comes with it. See [Virtual private servers (VPS)](/learn/intro-hardware/vps/).

--- a/docs/learn/intro-hardware/what-is-a-microcontroller.md
+++ b/docs/learn/intro-hardware/what-is-a-microcontroller.md
@@ -1,0 +1,91 @@
+---
+slug: what-is-a-microcontroller
+title: What is a microcontroller?
+description: A microcontroller is a whole computer on one cheap, low-power chip with no operating system. Learn how an MCU differs from an SBC and why it boots instantly.
+keywords: what is a microcontroller, microcontroller vs single-board computer, MCU, bare metal programming, ATmega, ARM Cortex-M, RP2040, embedded systems
+level: beginner
+status: full
+faq:
+  - q: "What is the difference between a microcontroller and a single-board computer?"
+    a: "A **microcontroller (MCU)** is a single chip with a CPU, a little RAM, flash storage, and hardware pins all in one — it runs your one program directly on the metal with no operating system. A **single-board computer (SBC)** like a Raspberry Pi is a small Linux computer with gigabytes of RAM that boots an OS and runs many programs. The MCU is smaller, cheaper, and sips power; the SBC is far more capable but draws watts and boots in seconds, not milliseconds."
+  - q: "Does a microcontroller run an operating system?"
+    a: "Usually no. Your code runs **bare-metal** — compiled to machine code and flashed straight into the chip, where it is the only thing running. Some larger MCUs run a tiny real-time operating system (an RTOS) to juggle a few tasks, but there is no Linux, no desktop, and no shell. The benefit is that the chip boots in milliseconds and behaves the same way every single time."
+  - q: "What are microcontrollers actually used for?"
+    a: "Embedded control, almost everywhere. The chip inside a microwave, a thermostat, a car's window switch, a drone's flight controller, a fitness band, and a smart light bulb is a microcontroller. They are the invisible computers that read sensors and drive motors, lights, and displays — billions ship every year, far more than PCs and phones combined."
+---
+# What is a microcontroller?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A microcontroller is a whole computer on one chip** — CPU, RAM, flash, and hardware pins together. **No operating system** — your code runs bare-metal directly on the hardware, so it boots in milliseconds and runs one program forever. **Tiny by design** — kilobytes of RAM and microamps of power, the opposite end of the spectrum from an SBC.
+</div>
+
+This module zooms all the way down to the smallest computers in the path. After single-board computers like the Raspberry Pi, the microcontroller is the next step down — and it is a genuinely different kind of machine, not just a slower one. By the end of this lesson you'll know what a microcontroller is, why it has no operating system, and how it compares to the SBC you met in [What is a single-board computer?](/learn/intro-hardware/what-is-an-sbc/).
+
+## A whole computer on one chip
+
+A **microcontroller**, or **MCU**, packs everything a computer needs onto a single piece of silicon: a processor to do the work, a small amount of RAM for working data, flash memory to hold the program, and a set of built-in **peripherals** — the hardware blocks that read sensors, drive pins, talk to other chips, and keep time. Plug in power and it runs.
+
+That integration is the whole point. A desktop CPU needs separate memory sticks, a storage drive, and a motherboard full of support chips. An MCU folds all of that into one part you can buy for a dollar or two. Common families you'll meet are Microchip's 8-bit **ATmega** (the classic Arduino brain), the huge range of 32-bit **ARM Cortex-M** chips, the Raspberry Pi Foundation's **RP2040**, and Espressif's Wi-Fi-capable **ESP** chips.
+
+Because the chip *is* the computer, you measure it in units that would be rounding errors on a laptop: kilobytes of RAM rather than gigabytes, megahertz rather than gigahertz, and milliwatts or even microwatts rather than watts. That smallness is a feature, not a limitation — it's what lets the same chip live inside a coin-cell-powered sensor for years.
+
+## No operating system: your code runs bare-metal
+
+Here's the biggest conceptual jump from everything earlier in this path. A microcontroller normally has **no operating system**. There's no Linux, no Windows, no desktop, no file system, and no terminal on the device. Instead, your program is compiled to machine code, flashed into the chip's memory, and run directly on the hardware — what people call **bare-metal** programming.
+
+When the MCU powers on, it doesn't boot an OS and wait at a login prompt. It jumps straight to the start of your code and begins executing. Your program is the only thing running, and it owns every byte of memory and every peripheral. There's no operating system underneath managing things for you — and nothing competing with you either.
+
+This is why an MCU is **deterministic** and great at **real-time** work. With no OS deciding when other tasks get to run, you can guarantee that a pin flips or a motor pulse fires within microseconds, every time. A general-purpose computer running a full OS can't make that promise — something else might grab the processor at the wrong moment. For controlling physical things on a strict schedule, having no OS is exactly what you want.
+
+## Microcontroller versus single-board computer
+
+The clearest way to understand an MCU is to put it next to an SBC. They look like neighbors on the hardware spectrum, but they live in different worlds.
+
+| Trait | Microcontroller (e.g. Arduino, ESP32) | Single-board computer (e.g. Raspberry Pi) |
+|-------|---------------------------------------|-------------------------------------------|
+| **Brain** | One chip: CPU + RAM + flash + peripherals | A full SoC with separate storage card |
+| **Operating system** | None (bare-metal) or a tiny RTOS | A full OS, usually Linux |
+| **RAM** | Kilobytes (often 2 KB–512 KB) | Gigabytes |
+| **Clock speed** | Single to a few hundred MHz | Over 1 GHz, multi-core |
+| **Power draw** | Microamps to tens of milliamps | Hundreds of milliamps to several watts |
+| **Boot time** | Milliseconds | Seconds (loads an OS) |
+| **Runs** | One program, forever | Many programs at once |
+| **Cost** | $1–$10 | $15–$80+ |
+| **Best at** | Real-time control, ultra-low power | General computing, networking, displays |
+
+The headline contrasts: an MCU has *kilobytes* of RAM where an SBC has *gigabytes*; it draws *microamps* where an SBC draws *watts*; it boots *instantly* and runs *one program forever*, where an SBC starts an operating system and juggles many. Neither is better in the abstract — they're tools for different jobs, and a single project sometimes uses both.
+
+## What microcontrollers are for
+
+Microcontrollers are the most common computers on Earth, and almost all of them are invisible. They do **embedded control**: reading inputs from the physical world and driving outputs back into it, on a tight loop, reliably, for years.
+
+Look around and you're surrounded by them:
+
+- The chip in a **microwave** or **washing machine** running the timer and motor.
+- A **thermostat** reading temperature and switching the heater.
+- A car's dozens of small controllers for windows, lights, and the engine.
+- A **drone's** flight controller balancing motors hundreds of times a second.
+- A **fitness band**, a **smart bulb**, a **keyboard**, a **toy**, a **3D printer**.
+
+What unites them is that the computer isn't the product — it's a tiny part *inside* the product, doing one focused job cheaply, in a small space, on very little power. That's the niche an MCU owns completely.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an MCU runs your program bare-metal with no operating system, which makes it boot instantly and behave deterministically." markdown="0">
+  <p class="knowledge-check__q">Quick check: What most sets a microcontroller apart from a single-board computer?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It runs a faster version of Linux</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It usually has no operating system — your one program runs bare-metal on the chip</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It has more memory and storage than an SBC</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **One chip, whole computer** — an MCU integrates CPU, RAM, flash, and peripherals onto a single cheap, low-power part.
+- **No operating system** — your code runs bare-metal directly on the hardware, owning every byte and every pin.
+- **Deterministic and real-time** — with no OS in the way, an MCU can guarantee precise, repeatable timing for controlling physical things.
+- **Tiny by design** — kilobytes of RAM, microamps of power, and millisecond boot times, the opposite end of the spectrum from an SBC.
+- **Embedded control everywhere** — microwaves, thermostats, drones, and smart bulbs all hide a microcontroller doing one focused job.
+
+Next up: the board and language that made microcontrollers approachable to everyone. See [Arduino & the maker ecosystem](/learn/intro-hardware/arduino/).

--- a/docs/learn/intro-hardware/what-is-an-sbc.md
+++ b/docs/learn/intro-hardware/what-is-an-sbc.md
@@ -1,0 +1,87 @@
+---
+slug: what-is-an-sbc
+title: What is a single-board computer?
+description: A single-board computer puts a full Linux machine on one credit-card board. Learn how an SBC sits between a PC and a microcontroller, and what its GPIO pins unlock.
+keywords: what is a single-board computer, SBC, Raspberry Pi, SBC vs microcontroller, SBC vs PC, GPIO pins, Linux on a small board, embedded Linux computer
+level: beginner
+status: full
+faq:
+  - q: "What is a single-board computer?"
+    a: "A **single-board computer (SBC)** is a complete, working computer built onto one small circuit board — processor, memory, storage interface, and input/output all in one place. Unlike a PC, you don't assemble it from parts; unlike a microcontroller, it runs a full operating system, almost always Linux. A Raspberry Pi is the best-known example."
+  - q: "Is a single-board computer the same as a microcontroller?"
+    a: "No. An **SBC** runs a real operating system (usually Linux) and behaves like a small PC, while a **microcontroller** runs a single program directly on bare metal with no OS. The SBC is far more capable; the microcontroller is far cheaper, simpler, and lower-power. We cover the contrast in depth in [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/)."
+  - q: "What are GPIO pins for on an SBC?"
+    a: "**GPIO (general-purpose input/output)** pins are the row of metal pins on the board's edge that let it sense and control the physical world — read a sensor, switch a relay, drive a light, or talk to other chips. They are the main thing that separates an SBC from an ordinary laptop, which has no easy way to touch raw electronics."
+---
+# What is a single-board computer?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**An SBC is a complete computer on one small board** — CPU, RAM, and I/O together, running a full OS (usually Linux). **It sits between a PC and a microcontroller** — a real operating system like a PC, plus GPIO pins to touch the physical world. **GPIO is the difference that matters** — those pins let it read sensors and control hardware directly, which a laptop can't.
+</div>
+
+This module is about a class of machine that has quietly become one of the most useful tools a maker or developer can own: the single-board computer. It's small enough to lose in a drawer, cheap enough to buy on a whim, and powerful enough to run real software for years. By the end of this lesson you'll know exactly what an SBC is, where it fits between the machines you already know, and why one specific feature — a row of pins along the edge — changes what you can build.
+
+## A whole computer on one board
+
+A **single-board computer (SBC)** is exactly what the name says: every part needed to make a working computer, soldered onto a single circuit board. The processor (CPU), the memory (RAM), the connections for storage, the networking, the USB ports, the video output — all of it lives on one piece of fiberglass roughly the size of a credit card.
+
+This is different from a desktop PC, which is a collection of separate parts — motherboard, CPU, RAM sticks, graphics card, drives — that you slot together inside a case. With an SBC there's nothing to assemble. You add power and storage (usually a microSD card), and it boots.
+
+And boot it does — into a real **operating system**. This is the headline feature. An SBC almost always runs Linux, the same kind of operating system that powers most of the world's servers. That means it has a file system, a network stack, a package manager, users, and processes. If you've used a Linux PC, you already know how to use an SBC. We'll meet the four parts every computer shares — CPU, memory, storage, and I/O — in more detail back in [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/).
+
+## Between a PC and a microcontroller
+
+The best way to understand an SBC is by where it sits on the [hardware spectrum](/learn/intro-hardware/hardware-spectrum/). It lives in the gap between two machines you may already know: the full PC above it and the microcontroller below it.
+
+- A **PC or server** has lots of power, lots of memory, and a full OS — but it's large, draws real electricity, and has no easy way to wire into raw electronics.
+- A **microcontroller** is tiny, cheap, and sips power — but it runs a single bare-metal program with no operating system, and has very little memory.
+
+An SBC takes the most useful traits of each: it has a *real operating system* like the PC, **and** it has pins to *touch the physical world* like the microcontroller. That combination is rare and powerful. You get the comfort of Linux — Python, networking, a web server, Docker — together with the ability to read a temperature sensor or flick a switch.
+
+| Trait | Microcontroller | Single-board computer | Desktop PC / server |
+|-------|-----------------|------------------------|---------------------|
+| **Operating system** | None (bare metal) | Full OS, usually Linux | Full OS |
+| **Typical RAM** | Kilobytes | 512 MB – 16 GB | 8 GB – 100s of GB |
+| **Power draw** | Milliwatts | A few watts | Tens to hundreds of watts |
+| **Physical I/O (GPIO)** | Yes, lots | Yes | Rarely, not built in |
+| **Rough cost** | $1 – $20 | $15 – $150 | $400 and up |
+| **Best at** | One simple, low-power job | Small always-on Linux jobs | Heavy, fast compute |
+
+## Why GPIO changes everything
+
+The feature that truly sets an SBC apart from a laptop is the row of metal pins along its edge: the **GPIO header**. GPIO stands for *general-purpose input/output*, and those pins are how the computer reaches out and touches the physical world.
+
+Each pin can be set up as an **input** (the SBC reads whether the pin is high or low — a button pressed, a sensor triggered) or an **output** (the SBC drives the pin high or low — turning on a light, switching a relay, spinning a motor through a driver). Beyond simple on/off, groups of pins speak standard hardware protocols — **I2C**, **SPI**, and **UART** — which let the board talk to sensors, displays, and other chips using just a couple of wires.
+
+A normal laptop has no equivalent. To make a laptop read a temperature sensor you'd need extra USB hardware; an SBC just wires the sensor straight to its pins. That's why SBCs dominate robotics, home automation, and sensor projects. The computer isn't behind a screen — it's *in* the project, wired into the world.
+
+This is also where **GopherTrunk** fits naturally. An SDR scanner is software, and an SBC runs that software while sitting right at the antenna with a USB SDR dongle plugged in — a small, quiet, always-on computer doing a real job in the field. We'll return to that example throughout the module.
+
+## How an SBC differs from a microcontroller
+
+It's worth drawing the SBC-versus-microcontroller line clearly now, because the rest of this path leans on it. The short version: an SBC is a *computer*, and a microcontroller is a *chip that runs one program*.
+
+An SBC boots an operating system, so it multitasks, connects to networks, stores gigabytes of data, and runs the same languages and tools you'd use on a PC. That power costs something: it needs a few watts of steady power, takes seconds to boot, and a sudden loss of power can corrupt its storage if you're unlucky.
+
+A microcontroller skips all of that. It has no OS — your program *is* the only thing running, directly on the silicon. That makes it astonishingly cheap, able to run on a coin battery for months, and instant to start. But it can't run Linux, can't easily host a website, and has memory measured in kilobytes. We give microcontrollers a full module of their own, starting with [What is a microcontroller?](/learn/intro-hardware/what-is-a-microcontroller/) — for now, just hold onto the contrast: *OS and power versus bare-metal and frugality*.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — an SBC pairs a full operating system with GPIO pins, sitting between a PC and a microcontroller." markdown="0">
+  <p class="knowledge-check__q">Quick check: What most clearly distinguishes a single-board computer from a microcontroller?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">An SBC is always physically larger and heavier</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">An SBC runs a full operating system (usually Linux); a microcontroller runs one bare-metal program with no OS</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only an SBC can read sensors or control hardware</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **An SBC is a complete computer on one board** — CPU, RAM, storage interface, and I/O together, with no assembly required.
+- **It runs a real operating system** — almost always Linux, so it behaves like a small, familiar PC.
+- **It sits between a PC and a microcontroller** — the OS and power of one, the physical I/O of the other.
+- **GPIO is the defining feature** — pins that read sensors and control hardware, plus I2C/SPI/UART to talk to other chips.
+- **Versus a microcontroller** — an SBC trades higher power draw and slower boot for the full capability of an operating system.
+
+Next up: the board that created this whole category, and the rivals worth knowing. See [The Raspberry Pi & its alternatives](/learn/intro-hardware/raspberry-pi-and-family/).

--- a/docs/learn/intro-hardware/what-is-hardware.md
+++ b/docs/learn/intro-hardware/what-is-hardware.md
@@ -1,0 +1,98 @@
+---
+slug: what-is-hardware
+title: What is computer hardware?
+description: Computer hardware is the physical machine that runs software. Learn the hardware/software split, what actually counts as a computer, and why the same job can run on a server, a laptop, or a chip the size of a stamp.
+keywords: what is computer hardware, hardware vs software, what is a computer, types of computer hardware, embedded computer, general purpose computer, hardware for developers
+level: beginner
+status: full
+faq:
+  - q: "What is the difference between hardware and software?"
+    a: "**Hardware** is the physical machine — the chips, boards, wires, and screens you can touch. **Software** is the set of instructions that tells that hardware what to do. The same hardware can run completely different software, and the same software can often run on very different hardware, which is exactly why this whole path is about choosing the right physical machine for a job."
+  - q: "Is a smartphone or a microcontroller really a computer?"
+    a: "Yes. Anything with a processor, memory, and the ability to run instructions is a computer. A data-center server, a laptop, a phone, a Raspberry Pi, and a two-dollar microcontroller are all computers — they differ in scale, not in kind. They all fetch instructions and data from memory and execute them, just at wildly different sizes, speeds, and prices."
+  - q: "Why does the hardware I choose matter if my code is the same?"
+    a: "Because hardware sets the limits your code lives inside: how fast it runs, how much memory and storage it has, whether it can reach the internet, how much power it draws, and what it costs to run. The same program can be trivial on a server and impossible on a microcontroller. Choosing hardware well is choosing the constraints you'll build within."
+---
+# What is computer hardware?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Hardware is the physical machine; software is the instructions that drive it.** **A computer is anything with a processor, memory, and the ability to run instructions** — a server, a laptop, a phone, and a microcontroller are all computers, differing in scale, not in kind. **The hardware you choose sets the limits** your software lives inside: speed, memory, connectivity, power, and cost.
+</div>
+
+This is lesson 1 of the path. Before we tour servers, laptops, phones, and tiny chips, it's worth being precise about the word that ties them all together: hardware. Every program you've ever used was running on some physical machine — and the range of machines that can run software is far wider than most people realize. By the end of this lesson you'll have a clear definition of hardware, a working idea of what counts as a "computer," and a feel for why the machine you pick shapes everything you build on top of it.
+
+## Hardware you can touch, software you can't
+
+Start with the fundamental split. **Hardware** is everything physical: the processor that does the calculating, the memory chips that hold data, the storage that keeps it when the power is off, the board that wires them together, and the ports, screens, and sensors bolted on around them. If you can drop it and crack it, it's hardware.
+
+**Software** is the set of instructions that tells that hardware what to do. It has no mass and no shape — you can copy it infinitely and send it around the world in seconds, and the same software can often run on millions of different machines.
+
+The relationship between them is the key idea: *the hardware is general, the software is specific*. A processor doesn't "know" how to be a web server or a thermostat or a radio scanner. It only knows how to do a small set of simple operations — add two numbers, compare them, move data, jump to another instruction. Software is what arranges billions of those tiny steps into something useful. (If you want the software side of this story in depth, the [Intro to Software Development](/learn/intro-software-dev/) path picks it up there; here we stay focused on the machine.)
+
+That generality is why this path exists. Because the same software can run on radically different hardware, you get a *choice* — and that choice has real consequences for cost, speed, and what's even possible.
+
+## What actually counts as a computer?
+
+People hear "computer" and picture a laptop or a desktop tower. But the honest definition is much broader:
+
+> A computer is any device with a processor and memory that can fetch instructions and data and execute them.
+
+By that definition, all of these are computers:
+
+- The rack-mounted **server** in a data center serving a website to thousands of people at once.
+- The **laptop** you might be reading this on.
+- The **smartphone** in your pocket.
+- A **Raspberry Pi** the size of a credit card running a home media server.
+- A two-dollar **microcontroller** inside a smart light bulb, with less memory than a single photo from your phone.
+
+They differ enormously in scale — a big server can have a *million* times the memory of a small microcontroller — but not in kind. Every one of them follows the same basic loop: pull instructions from memory and carry them out, over and over, very fast. We'll meet the parts that make up that loop in the next lesson, [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/).
+
+It's useful to split that range into two loose families:
+
+- **General-purpose computers** are built to run whatever software you load onto them — servers, PCs, phones, and single-board computers all qualify. You install new programs without changing the machine.
+- **Embedded computers** are built into a product to do one job — the chip in a microwave, a car's engine controller, or a sensor node. Microcontrollers are the classic example. They still run software, but it's usually a single program baked in at the factory.
+
+The line between these blurs (a Raspberry Pi can do either), but it's a helpful first cut, and it maps neatly onto the modules ahead.
+
+## The same job, very different machines
+
+Here's what makes hardware choice interesting: a surprising number of jobs can run on almost *any* of these machines — the question is which one fits best.
+
+Take a simple example: reading a temperature every minute and logging it. You could do that on a $1,000 server, a $35 Raspberry Pi, or a $4 microcontroller. All three can do the job. But the server is absurd overkill and wastes electricity around the clock; the microcontroller sips power and costs pocket change but can't easily store years of history or show you a web dashboard; the Pi sits comfortably in between. None is "right" in the abstract — the right answer depends on your constraints.
+
+This is the theme the whole path returns to. **GopherTrunk**, the software-defined-radio software these docs are about, is a good illustration: it's just software, so it can run on a beefy desktop, a laptop, or a Raspberry Pi sitting right at the antenna. Each of those is a legitimate choice with different trade-offs in cost, performance, and convenience — exactly the kind of decision Module 7 will teach you to make deliberately.
+
+## Why the hardware sets the limits
+
+If software is general and portable, why does the hardware matter so much? Because the physical machine defines the box your software has to live inside. A few dimensions recur so often that we'll spend a whole lesson on them later ([Cost, power & performance trade-offs](/learn/intro-hardware/cost-power-performance/)), but here they are in brief:
+
+| Dimension | What it means | Why it matters |
+|-----------|---------------|----------------|
+| **Performance** | How fast the processor is and how many things it can do at once | Sets what's feasible — video editing needs far more than blinking an LED |
+| **Memory & storage** | How much data the machine can hold while working, and keep long-term | Some programs simply won't fit on a small device |
+| **Connectivity** | Whether and how it reaches networks and other devices | A web server is useless offline; a sensor may need Wi-Fi or none at all |
+| **Power** | How much electricity it draws | Decides whether it runs on a battery for years or needs the wall and a fan |
+| **Cost** | Price to buy and to keep running | A choice you can afford once may be ruinous at a thousand units |
+
+The same program can be trivial on one machine and impossible on another. Choosing hardware well is really choosing *which constraints you want to build within* — and that's a skill, not a guess.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — anything with a processor and memory that runs instructions is a computer, from a server to a microcontroller." markdown="0">
+  <p class="knowledge-check__q">Quick check: Which of these counts as a "computer" in the sense this path uses?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only desktop PCs and servers</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only devices with a keyboard and screen</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Anything with a processor and memory that fetches and runs instructions — including phones and microcontrollers</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Hardware vs software** — hardware is the physical, general-purpose machine; software is the specific instructions that drive it.
+- **A computer is anything that runs instructions** — servers, PCs, phones, single-board computers, and microcontrollers are all computers, differing in scale, not in kind.
+- **General-purpose vs embedded** — some machines run whatever you load; others are built into a product to do one job.
+- **The same job fits many machines** — the interesting question is which one fits *best* for your constraints.
+- **Hardware sets the limits** — performance, memory, connectivity, power, and cost define the box your software lives in.
+
+Next up: a look inside every one of these machines at the four parts they all share. See [CPU, memory, storage & I/O](/learn/intro-hardware/building-blocks/).

--- a/docs/learn/intro-hardware/worked-examples.md
+++ b/docs/learn/intro-hardware/worked-examples.md
@@ -1,0 +1,88 @@
+---
+slug: worked-examples
+title: "Worked examples: picking hardware for real projects"
+description: The decision framework run end to end on four real projects — a blog, a battery sensor, a home media server, and a GopherTrunk scanner — from requirements to a justified choice.
+keywords: hardware worked examples, choosing hardware examples, blog hosting choice, ESP32 sensor project, home media server hardware, GopherTrunk hardware, SDR scanner hardware, decision framework example
+level: advanced
+status: full
+faq:
+  - q: "What hardware should I use for a personal blog?"
+    a: "The smallest thing that serves the pages. A static blog is happy on [shared web hosting](/learn/intro-hardware/web-hosting/) or a static host for a few dollars a month; only if you need server-side features or full control do you step up to a small [VPS](/learn/intro-hardware/vps/). A blog almost never justifies more than that."
+  - q: "Why an ESP32 for a battery temperature sensor instead of a Raspberry Pi?"
+    a: "Because a Pi is a full computer that would flatten a battery in a day, while an [ESP32](/learn/intro-hardware/esp32/) wakes, takes a reading, sends it over Wi-Fi, and drops into deep sleep drawing microamps — running for months on a small battery. The job is tiny and physical; the [microcontroller](/learn/intro-hardware/what-is-a-microcontroller/) is the right scale, and the Pi is overkill."
+  - q: "Why can't GopherTrunk run on a cloud VPS?"
+    a: "Because the SDR dongle is a **USB device that must be physically plugged into the machine doing the capture**, and you can't plug hardware into a server in someone else's data center. The capture tier has to be a machine you physically touch — a [Raspberry Pi](/learn/intro-hardware/raspberry-pi-and-family/) at the antenna or a local PC. The cloud can store and serve recordings, but it can never capture."
+  - q: "Is a repurposed mini-PC a good home server?"
+    a: "Often, yes. For a media-and-backup [home server](/learn/intro-hardware/home-servers/), a [Raspberry Pi](/learn/intro-hardware/raspberry-pi-and-family/) handles light duty cheaply, while a repurposed mini-PC or NAS gives you more storage, transcoding muscle, and headroom. The choice turns on how much you store and how heavy the workload is."
+---
+# Worked examples: picking hardware for real projects
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The framework in action** — four projects taken from requirements through hard constraints to a justified choice. **Hard constraints decide fast** — a USB dongle, a battery, a public service each collapse the field on their own. **Smallest thing that works wins** — a static host for a blog, an ESP32 for a sensor, a Pi at the antenna for a scanner.
+</div>
+
+This is the final lesson of the path, and the most practical. We take the [decision framework](/learn/intro-hardware/decision-framework/) and run it end to end on four real projects, each laid out the same way — requirements, then the hard constraints that eliminate options, then the choice and why. Watch how often a single pass/fail fact does most of the work, and how the answer is almost always the *simplest* thing that clears the bar.
+
+## Example 1: a personal blog
+
+**Requirements.** Serve a handful of articles to modest traffic; cheap; near-zero maintenance; no physical hardware; reachable publicly 24/7.
+
+**Hard constraints.** It must be a public, always-on service — so a home machine on a flaky connection is out, and so is anything battery-powered or device-bound. Beyond that, the constraints are loose: almost any host qualifies, which tells you the choice will be decided by simplicity and cost, not capability.
+
+**The choice.** A static site on [shared web hosting](/learn/intro-hardware/web-hosting/) (or a static host), a few dollars a month, with the provider managing the machine entirely. **Why:** the job is tiny and read-only, so paying for a server you administer yourself buys nothing. Only if you later need server-side features or full control would you step up to a small [VPS](/learn/intro-hardware/vps/). The lesson: when nothing is at an extreme, the *smallest, simplest* option wins — exactly as the framework predicts.
+
+## Example 2: a battery-powered temperature/soil sensor
+
+**Requirements.** Read temperature and soil moisture in a garden bed; report readings over Wi-Fi every few minutes; run for months on a small battery; cost a few dollars; live outdoors, unattended.
+
+**Hard constraints.** Two are decisive. It must touch the physical world (sensors), which rules out any remote cloud machine. And it must run for *months on a battery*, which rules out full computers and even an [SBC](/learn/intro-hardware/what-is-an-sbc/) — a Raspberry Pi would drain the battery in a day. Together these collapse the field to one region: [microcontrollers](/learn/intro-hardware/what-is-a-microcontroller/).
+
+**The choice.** An [ESP32](/learn/intro-hardware/esp32/) running a deep-sleep cycle. **Why:** it has Wi-Fi built in for the reporting requirement, and its deep-sleep mode draws microamps between readings — wake, sample, transmit, sleep — which is what makes months on a battery possible. An [Arduino](/learn/intro-hardware/arduino/) would suit a purely offline version, but the Wi-Fi requirement makes the ESP32 the natural pick. The hard constraints did all the work; by the time we weighed anything, the field was already one part.
+
+## Example 3: a home media + backup server
+
+**Requirements.** Store and stream a media library across the house; hold automatic backups of family devices; run quietly 24/7; modest budget; live in a closet; minimal fuss.
+
+**Hard constraints.** It must run always-on and serve local devices, which favors a low-power machine in the house and rules out a battery device or microcontroller (no full OS, no real storage). It needs a full operating system and real disks. None of this forces a single answer, so this one is decided more on trade-offs than elimination.
+
+**The choice.** A [home server](/learn/intro-hardware/home-servers/) — either a [Raspberry Pi](/learn/intro-hardware/raspberry-pi-and-family/) for light duty, or a repurposed mini-PC/NAS for heavier use. **Why:** weigh the trade-offs from [cost, power & performance](/learn/intro-hardware/cost-power-performance/). A Pi sips power and costs little, perfect if you mostly stream to one device at a time and store a modest library. If you need lots of storage or on-the-fly transcoding for several streams, a mini-PC or NAS earns its slightly higher power draw and price. Both are far cheaper to run over a year than leaving a full [desktop](/learn/intro-hardware/desktop-computers/) on around the clock. Pick the smaller one and step up only if it can't keep up.
+
+## Example 4: a GopherTrunk SDR scanner
+
+**Requirements.** Capture and decode trunked radio from an antenna; the **SDR dongle plugs into the machine over USB**; sit near the antenna (often a roof or attic); run continuously; let you view recordings remotely; hobby budget, one unit.
+
+**Hard constraints.** The decisive one is physical: the USB dongle must be attached to the machine doing the capture. That single fact **eliminates any cloud [VPS](/learn/intro-hardware/vps/) or shared host outright** — you cannot plug a USB device into a server you don't physically touch. The capture machine must be on-site, near the antenna, running a full OS to host GopherTrunk.
+
+**The choice.** A [Raspberry Pi](/learn/intro-hardware/raspberry-pi-and-family/) mounted at the antenna with the dongle attached, or a [laptop](/learn/intro-hardware/laptops/)/[desktop](/learn/intro-hardware/desktop-computers/) with the dongle plugged in locally. **Why:** the Pi is low-power, cheap, and small enough to live up by the feedline running 24/7 — ideal for a permanent install. A PC suits an occasional bench setup where you don't mind the dongle on your desk. As [combining tiers](/learn/intro-hardware/combining-tiers/) showed, you can layer a server (the same Pi, a home server, or a VPS) behind it to *store and serve* recordings, and view them from your phone anywhere — the cloud just can't be the *capture* tier. This is the path's recurring lesson in one project: a hard physical constraint pins the choice, and everything else layers around it.
+
+## The pattern across all four
+
+| Project | Decisive constraint | Choice | Tier |
+|---------|--------------------|--------|------|
+| Personal blog | Public 24/7, no physical hw | [Shared/static hosting](/learn/intro-hardware/web-hosting/) (or small [VPS](/learn/intro-hardware/vps/)) | Cloud |
+| Battery sensor | Battery life + physical sensing | [ESP32](/learn/intro-hardware/esp32/) with deep sleep | Edge device |
+| Home media server | Always-on, full OS, local serving | [Pi](/learn/intro-hardware/raspberry-pi-and-family/) or mini-PC [home server](/learn/intro-hardware/home-servers/) | Local server |
+| GopherTrunk scanner | USB dongle must be attached | [Pi](/learn/intro-hardware/raspberry-pi-and-family/) at antenna / local PC | Edge + local server |
+
+In every case the same shape holds: a hard constraint narrowed the field, the trade-offs broke any remaining tie, and the winner was the simplest thing that did the job. That's the whole skill.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the USB dongle must be physically attached, so a remote cloud VPS can never be the capture machine." markdown="0">
+  <p class="knowledge-check__q">Quick check: Why is a cloud VPS ruled out for the GopherTrunk capture machine?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Cloud VPSes are always too slow for radio decoding</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The SDR dongle must be physically plugged in, and you can't attach USB hardware to a remote server</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A VPS can't run a full operating system</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Run the framework every time** — requirements, then hard constraints, then trade-offs, then the simplest fit; it works on any project.
+- **A blog wants the least** — static or shared hosting beats a server you don't need to manage.
+- **A battery sensor is a microcontroller job** — the ESP32's deep sleep is what makes months on a battery possible.
+- **A home server balances trade-offs** — a Pi for light duty, a mini-PC or NAS when storage and transcoding demand it.
+- **GopherTrunk is pinned by physics** — the USB dongle forces an on-site capture machine; the cloud can store and serve but never capture.
+
+That's the path. Keep the [glossary](/learn/intro-hardware/glossary/) handy as a reference, and revisit any [module from the hub](/learn/intro-hardware/) as your projects evolve.


### PR DESCRIPTION
Add a new guided learning path covering the hardware a developer chooses
between — web hosting, VPSes, dedicated and home servers, desktops,
laptops, smartphones, tablets, single-board computers, and microcontrollers
(Arduino & ESP32). For each platform the lessons cover its use cases, the
programming languages used on it, and its strengths and drawbacks, and the
final module turns it all into a practical framework for picking the right
hardware (often a combination) for a project.

The path follows the existing learning-path conventions: a new `paths:`
entry in docs/_data/learn.yml drives the chooser, hub, sidebar nav, schema,
and llms.txt export automatically; a scope block in docs/_config.yml applies
the lesson layout. 7 modules, 28 full lessons, and a glossary.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DMB8kLogPr6tJpqBpAPoBP