### PR TITLE
p25: decode RFSS/Site from LOC_REG_RSP, hex IDs, sane autotune

### DIFF
--- a/cmd/gophertrunk/runtime.go
+++ b/cmd/gophertrunk/runtime.go
@@ -82,6 +82,7 @@ func (r *runtimeSnapshot) Runtime() api.RuntimeDTO {
 		MetricsEnabled: r.metrics,
 		VocoderMap:     vocoderProtocolMap,
 		HiddenTabs:     cfg.Web.HiddenTabs(),
+		IDBase:         cfg.Web.IDBaseOrDefault(),
 	}
 	if cfg.Recordings.Equalizer.StepSize != 0 {
 		dto.RecordingEQStepSize = formatFloat(float64(cfg.Recordings.Equalizer.StepSize))

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1187,4 +1187,11 @@ broadcast:
 #     dsc: false
 #     adsb: false
 #     mdc1200: false
+#
+#   # How identity numbers (WACN, System ID, NAC, RFSS, Site) are rendered in
+#   # the web UI: "hex" (default — the P25 field convention, shown with the
+#   # decimal in parentheses) or "dec" for plain decimal. The JSON API and
+#   # event payloads always carry the raw decimal values plus *_hex strings
+#   # regardless of this setting; it only changes the bundled web SPA's display.
+#   id_base: hex
 

--- a/docs/specs/p25-tsbk-opcodes.md
+++ b/docs/specs/p25-tsbk-opcodes.md
@@ -48,7 +48,7 @@ walk-throughs (e.g. UU_V_REQ → UU_ANS_REQ → UU_ANS_RSP call setup).
 | 0x28 | `GRP_AFF_RSP` | Group Affiliation Response | ✅ affiliation |
 | 0x29 | `SCCB_EXP` | Secondary Control Channel Broadcast — Explicit | ✅ topology |
 | 0x2A | `GRP_AFF_Q` | Group Affiliation Query | — |
-| 0x2B | `LOC_REG_RSP` | Location Registration Response | — |
+| 0x2B | `LOC_REG_RSP` | Location Registration Response | ✅ topology (RFSS/Site) |
 | 0x2C | `U_REG_RSP` | Unit Registration Response | ✅ registration |
 | 0x2D | `U_REG_CMD` | Unit Registration Command | — |
 | 0x2E | `AUTH_CMD` | Authentication Command | — |

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -119,6 +119,7 @@ func (s *Server) handleListSystems(w http.ResponseWriter, _ *http.Request) {
 	for _, sys := range s.systems {
 		dto := systemToDTO(sys)
 		overlayLiveIdentity(&dto, live)
+		dto.fillIdentityHex()
 		out = append(out, dto)
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"systems": out})
@@ -132,6 +133,7 @@ func (s *Server) handleGetSystem(w http.ResponseWriter, r *http.Request) {
 			if s.sites != nil {
 				overlayLiveIdentity(&dto, s.sites.Sites())
 			}
+			dto.fillIdentityHex()
 			writeJSON(w, http.StatusOK, dto)
 			return
 		}

--- a/internal/api/handlers_runtime.go
+++ b/internal/api/handlers_runtime.go
@@ -89,6 +89,12 @@ type RuntimeDTO struct {
 	// off via web.tabs in config. Both the web SPA and the TUI filter
 	// these out of their nav. Empty/omitted means every tab is shown.
 	HiddenTabs []string `json:"hidden_tabs,omitempty"`
+
+	// IDBase selects how identity numbers (WACN, System ID, NAC, RFSS,
+	// Site) are rendered in the UIs: "hex" (default) or "dec". Sourced
+	// from web.id_base config; the raw decimal values are always present
+	// in the API/event payloads regardless.
+	IDBase string `json:"id_base,omitempty"`
 }
 
 // ToneProfileDTO is the minimal projection of a tone-out profile —

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -55,6 +55,7 @@ func (s *Server) handleListSites(w http.ResponseWriter, _ *http.Request) {
 
 	out := make([]SiteDTO, 0, len(byKey))
 	for _, dto := range byKey {
+		dto.fillIdentityHex()
 		out = append(out, *dto)
 	}
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -88,6 +88,12 @@ type SystemDTO struct {
 	SystemID        uint16   `json:"system_id,omitempty"`
 	RFSS            uint8    `json:"rfss,omitempty"`
 	Site            uint8    `json:"site,omitempty"`
+	// Hex renderings of the identity numbers (P25 field convention),
+	// alongside the decimal fields above. Empty when the value is unknown.
+	WACNHex     string `json:"wacn_hex,omitempty"`
+	SystemIDHex string `json:"system_id_hex,omitempty"`
+	RFSSHex     string `json:"rfss_hex,omitempty"`
+	SiteHex     string `json:"site_hex,omitempty"`
 
 	// Per-protocol FEC opt-out surface. Empty strings indicate the
 	// new spec-correct default is active (channel coding / FEC on
@@ -362,6 +368,28 @@ type SiteDTO struct {
 	Name             string `json:"name"`
 	WACN             uint32 `json:"wacn,omitempty"`
 	SystemID         uint16 `json:"system_id,omitempty"`
+	// Hex renderings of the identity numbers, alongside the decimal fields.
+	WACNHex     string `json:"wacn_hex,omitempty"`
+	SystemIDHex string `json:"system_id_hex,omitempty"`
+	RFSSIDHex   string `json:"rfss_id_hex,omitempty"`
+	SiteIDHex   string `json:"site_id_hex,omitempty"`
+}
+
+// fillIdentityHex derives the *_hex fields from the decimal identity fields.
+// Call after any overlay that mutates the numeric fields so the two agree.
+func (d *SystemDTO) fillIdentityHex() {
+	d.WACNHex = trunking.IDHex(uint64(d.WACN))
+	d.SystemIDHex = trunking.IDHex(uint64(d.SystemID))
+	d.RFSSHex = trunking.IDHex(uint64(d.RFSS))
+	d.SiteHex = trunking.IDHex(uint64(d.Site))
+}
+
+// fillIdentityHex derives the *_hex fields from the decimal identity fields.
+func (d *SiteDTO) fillIdentityHex() {
+	d.WACNHex = trunking.IDHex(uint64(d.WACN))
+	d.SystemIDHex = trunking.IDHex(uint64(d.SystemID))
+	d.RFSSIDHex = trunking.IDHex(uint64(d.RFSSID))
+	d.SiteIDHex = trunking.IDHex(uint64(d.SiteID))
 }
 
 // CallEncryptionDTO mirrors trunking.CallEncryption for SSE / REST

--- a/internal/autotune/autotune.go
+++ b/internal/autotune/autotune.go
@@ -36,6 +36,21 @@ const (
 	// SuggestedErrorRounding rounds the suggested config value to the
 	// nearest N Hz. Matches trunk-recorder's SUGGESTED_ERROR_ROUNDING.
 	SuggestedErrorRounding = 10
+	// WarmupSamples is how many measurements must accumulate before the
+	// running average is trusted enough to apply. Until then Ready() is
+	// false and callers apply no correction, so a single noisy first
+	// measurement can't yank tuning by hundreds of Hz before the average
+	// has had a chance to settle.
+	WarmupSamples = 3
+	// MaxAbsErrorHz bounds a single measurement's plausible magnitude when
+	// the channel centre is unknown (the voice path passes centre 0). A
+	// real crystal error is a few PPM — single-digit Hz on a disciplined
+	// USRP, low hundreds on a loose RTL crystal at VHF/UHF. A per-call AFC
+	// residual far beyond that is a measurement glitch (an unconverged loop,
+	// a data-dependent bias snapshot at end-of-call), not drift, and folding
+	// it in produces the runaway kHz corrections this guard prevents. ~1.5 kHz
+	// is ≈3.3 PPM at 450 MHz — comfortably above any correction worth making.
+	MaxAbsErrorHz = 1500
 )
 
 // Manager accumulates carrier-error measurements for one SDR source and serves
@@ -48,6 +63,7 @@ type Manager struct {
 	mu      sync.Mutex
 	history []int // most-recent-first; capped at MaxHistory
 	avg     int   // cached running average, in Hz
+	samples int   // count of accepted measurements (for warm-up gating)
 }
 
 // NewManager returns a Manager labelled with the dongle serial for logging. A
@@ -70,12 +86,26 @@ func (m *Manager) AddErrorMeasurement(observedHz, currentOffsetHz int, centerFre
 	defer m.mu.Unlock()
 
 	total := observedHz + currentOffsetHz
+
+	// Reject implausible measurements before they can poison the average.
+	// A real crystal error is bounded by a few PPM of the channel centre;
+	// anything beyond that is a measurement glitch, not drift. Drop it (and
+	// say so at Debug) rather than averaging in a value that would drag the
+	// applied correction into the kHz.
+	if bound := m.rejectBoundHz(centerFreqHz); abs(total) > bound {
+		m.log.Debug("autotune: measurement rejected (implausible, treated as glitch)",
+			"serial", m.serial, "observed_hz", observedHz, "applied_hz", currentOffsetHz,
+			"total_hz", total, "bound_hz", bound)
+		return
+	}
+
 	// Prepend, then trim the oldest past MaxHistory (deque push_front /
 	// pop_back).
 	m.history = append([]int{total}, m.history...)
 	if len(m.history) > MaxHistory {
 		m.history = m.history[:MaxHistory]
 	}
+	m.samples++
 
 	sum := 0
 	for _, e := range m.history {
@@ -85,7 +115,8 @@ func (m *Manager) AddErrorMeasurement(observedHz, currentOffsetHz int, centerFre
 
 	m.log.Debug("autotune: measurement", "serial", m.serial,
 		"observed_hz", observedHz, "applied_hz", currentOffsetHz,
-		"total_hz", total, "avg_hz", m.avg, "samples", len(m.history))
+		"total_hz", total, "avg_hz", m.avg, "samples", len(m.history),
+		"warm", m.samples >= WarmupSamples)
 
 	if centerFreqHz != 0 {
 		ppm := float64(m.avg) / (float64(centerFreqHz) / 1e6)
@@ -99,10 +130,55 @@ func (m *Manager) AddErrorMeasurement(observedHz, currentOffsetHz int, centerFre
 
 // AverageError returns the cached running-average correction in Hz. Callers
 // apply it digitally as targetHz - AverageError(). Port of get_average_error.
+// This is the raw average regardless of warm-up; callers that drive tuning
+// should gate on Ready() so an unsettled early average is not applied.
 func (m *Manager) AverageError() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.avg
+}
+
+// Ready reports whether enough measurements have accumulated (>= WarmupSamples)
+// for the running average to be trusted as an applied tuning correction.
+// Before that, callers should apply no correction.
+func (m *Manager) Ready() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.samples >= WarmupSamples
+}
+
+// Correction returns the average correction to apply, or 0 until warm-up
+// completes. It is the value tuning call sites should use.
+func (m *Manager) Correction() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.samples < WarmupSamples {
+		return 0
+	}
+	return m.avg
+}
+
+// rejectBoundHz is the largest plausible single-measurement magnitude. With a
+// known channel centre it is the PPM-threshold equivalent (a measurement worse
+// than a misconfigured-dongle warning is not a fine correction to chase); with
+// an unknown centre (the voice path) it falls back to the absolute cap.
+func (m *Manager) rejectBoundHz(centerFreqHz uint32) int {
+	if centerFreqHz == 0 {
+		return MaxAbsErrorHz
+	}
+	bound := int(math.Round(PPMThreshold * float64(centerFreqHz) / 1e6))
+	if bound < MaxAbsErrorHz {
+		bound = MaxAbsErrorHz
+	}
+	return bound
+}
+
+// abs returns the absolute value of an int.
+func abs(v int) int {
+	if v < 0 {
+		return -v
+	}
+	return v
 }
 
 // StatusString renders the live correction and a suggested config value, given

--- a/internal/autotune/autotune_test.go
+++ b/internal/autotune/autotune_test.go
@@ -44,6 +44,57 @@ func TestHistoryCappedAtMax(t *testing.T) {
 	}
 }
 
+func TestRejectsImplausibleMeasurement(t *testing.T) {
+	m := NewManager("test", nil)
+	// A glitch far beyond plausible crystal drift must not enter the history
+	// or move the average (centre 0 -> absolute MaxAbsErrorHz bound).
+	m.AddErrorMeasurement(MaxAbsErrorHz+500, 0, 0)
+	if got := m.AverageError(); got != 0 {
+		t.Fatalf("avg after rejected glitch: got %d want 0", got)
+	}
+	if len(m.history) != 0 {
+		t.Fatalf("rejected measurement entered history: %v", m.history)
+	}
+	// The runaway feedback case from the field report: a +2300 Hz total on
+	// the voice path (centre unknown) is rejected, so the average can't be
+	// dragged into the kHz.
+	m.AddErrorMeasurement(2300, 0, 0)
+	if got := m.AverageError(); got != 0 {
+		t.Fatalf("avg after rejected 2300 Hz: got %d want 0", got)
+	}
+	// A sane measurement is still accepted.
+	m.AddErrorMeasurement(40, 0, 0)
+	if got := m.AverageError(); got != 40 {
+		t.Fatalf("avg after sane measurement: got %d want 40", got)
+	}
+}
+
+func TestWarmupGatesCorrection(t *testing.T) {
+	m := NewManager("test", nil)
+	// Below WarmupSamples, Correction() applies nothing even though the raw
+	// average is non-zero, so a noisy first measurement can't yank tuning.
+	for i := 0; i < WarmupSamples-1; i++ {
+		m.AddErrorMeasurement(100, 0, 0)
+		if m.Ready() {
+			t.Fatalf("Ready() true after %d samples, want warm-up >= %d", i+1, WarmupSamples)
+		}
+		if got := m.Correction(); got != 0 {
+			t.Fatalf("Correction() = %d before warm-up, want 0", got)
+		}
+		if got := m.AverageError(); got == 0 {
+			t.Fatalf("AverageError() should report the raw average during warm-up")
+		}
+	}
+	// The WarmupSamples-th measurement crosses the threshold.
+	m.AddErrorMeasurement(100, 0, 0)
+	if !m.Ready() {
+		t.Fatalf("Ready() false after %d samples", WarmupSamples)
+	}
+	if got := m.Correction(); got != 100 {
+		t.Fatalf("Correction() after warm-up: got %d want 100", got)
+	}
+}
+
 func TestReset(t *testing.T) {
 	m := NewManager("test", nil)
 	m.AddErrorMeasurement(500, 0, 0)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -99,6 +99,22 @@ type DiagnosticsConfig struct {
 // reachable directly.
 type WebConfig struct {
 	Tabs map[string]bool `yaml:"tabs"`
+	// IDBase selects how P25/identity numbers (WACN, System ID, NAC, RFSS,
+	// Site) are shown in the bundled web SPA: "hex" (the P25 field
+	// convention, default) or "dec". The raw decimal values are always
+	// present in the JSON API and event payloads (with *_hex strings
+	// alongside); this only changes the web display. Empty/unset means "hex".
+	IDBase string `yaml:"id_base"`
+}
+
+// IDBaseOrDefault returns the configured identity number base ("hex" or
+// "dec"), defaulting to "hex" when unset or unrecognised. Feeds
+// /api/v1/runtime so both UIs render identity numbers from one source.
+func (w WebConfig) IDBaseOrDefault() string {
+	if w.IDBase == "dec" {
+		return "dec"
+	}
+	return "hex"
 }
 
 // KnownUITabs is the canonical set of navigation tab keys both UIs
@@ -2204,6 +2220,11 @@ func (c Config) validateWeb() []error {
 			sort.Strings(valid)
 			return []error{fmt.Errorf("web.tabs: unknown tab %q (valid: %s)", key, strings.Join(valid, ", "))}
 		}
+	}
+	switch c.Web.IDBase {
+	case "", "hex", "dec":
+	default:
+		return []error{fmt.Errorf("web.id_base: must be hex or dec, got %q", c.Web.IDBase)}
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -463,6 +463,28 @@ func TestWebConfigHiddenTabs(t *testing.T) {
 	}
 }
 
+func TestWebConfigIDBase(t *testing.T) {
+	// Default (unset) and any unrecognised value fall back to hex.
+	for _, in := range []string{"", "hex", "HEX", "bogus"} {
+		if got := (WebConfig{IDBase: in}).IDBaseOrDefault(); got != "hex" {
+			t.Errorf("IDBaseOrDefault(%q) = %q, want hex", in, got)
+		}
+	}
+	if got := (WebConfig{IDBase: "dec"}).IDBaseOrDefault(); got != "dec" {
+		t.Errorf("IDBaseOrDefault(dec) = %q, want dec", got)
+	}
+
+	// validateWeb accepts hex/dec/empty and rejects anything else.
+	for _, ok := range []string{"", "hex", "dec"} {
+		if errs := (Config{Web: WebConfig{IDBase: ok}}).validateWeb(); len(errs) != 0 {
+			t.Errorf("validateWeb id_base=%q errored: %v", ok, errs)
+		}
+	}
+	if errs := (Config{Web: WebConfig{IDBase: "octal"}}).validateWeb(); len(errs) == 0 {
+		t.Error("validateWeb id_base=octal: want error, got none")
+	}
+}
+
 func writeFile(path, data string) error {
 	return writeFileImpl(path, []byte(data))
 }

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -227,7 +227,8 @@ var fieldMetas = map[string]FieldMeta{
 	"APIAuthConfig.TokenFile":       {Help: "Path to a file holding the bearer token (re-read per request, so rotation needs no restart)."},
 	"APIAuthConfig.TrustedNetworks": {Help: "CIDRs whose source addresses bypass the token under auto mode. Loopback is always trusted."},
 
-	"WebConfig.Tabs": {Help: "Show/hide navigation tabs in the operator console. Hidden tabs stay reachable by URL."},
+	"WebConfig.Tabs":   {Help: "Show/hide navigation tabs in the operator console. Hidden tabs stay reachable by URL."},
+	"WebConfig.IDBase": {Help: "Render identity numbers (WACN, System ID, NAC, RFSS, Site) in the web UI as hex (default) or dec. The JSON API always carries decimal plus *_hex values."},
 
 	// ---- Storage -----------------------------------------------------------
 	"StorageConfig.Path":        {Help: "SQLite call-log database file. Empty disables call history (the daemon still runs)."},

--- a/internal/hunt/decode.go
+++ b/internal/hunt/decode.go
@@ -173,9 +173,9 @@ func identityNote(res *siglab.Result) string {
 		// won't help if the system simply doesn't emit the NSB.
 		return fmt.Sprintf("System ID resolved from adjacent-site broadcasts, but WACN is "+
 			"unavailable: the Network Status Broadcast (NSB, 0x3B) that carries it was never "+
-			"decoded (saw NSB×%d, RFSS×%d, adjacent×%d, TSBK×%d) — if the system never emits "+
-			"the NSB, the WACN cannot be recovered",
-			cc.NetStatusSeen, cc.RFSSStatusSeen, cc.AdjacentSeen, cc.TSBKDecoded)
+			"decoded (saw NSB×%d, RFSS×%d, adjacent×%d, loc-reg×%d, TSBK×%d) — if the system never "+
+			"emits the NSB, the WACN cannot be recovered",
+			cc.NetStatusSeen, cc.RFSSStatusSeen, cc.AdjacentSeen, cc.LocRegSeen, cc.TSBKDecoded)
 	}
 	if cc.NetStatusSeen > 0 {
 		// NSB decoded but yielded no WACN — a parse problem, not a capture gap.

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -178,6 +178,11 @@ type CCStats struct {
 	NetStatusSeen     int64
 	RFSSStatusSeen    int64
 	AdjacentSeen      int64
+	// LocRegSeen counts accepted Location Registration Responses (0x2B):
+	// the high-rate RFSS/Site source. A non-zero LocRegSeen with RFSS/Site
+	// resolved but NetStatusSeen == 0 is the normal shape of a system that
+	// names its site via registrations but withholds the WACN-bearing NSB.
+	LocRegSeen int64
 }
 
 // NetworkSnapshot returns the system topology accumulated from the
@@ -277,6 +282,7 @@ func (c *ControlChannel) Stats() CCStats {
 		NetStatusSeen:     atomic.LoadInt64(&c.stats.NetStatusSeen),
 		RFSSStatusSeen:    atomic.LoadInt64(&c.stats.RFSSStatusSeen),
 		AdjacentSeen:      atomic.LoadInt64(&c.stats.AdjacentSeen),
+		LocRegSeen:        atomic.LoadInt64(&c.stats.LocRegSeen),
 	}
 }
 
@@ -1131,6 +1137,10 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 	case OpNetworkStatusBroadcast:
 		atomic.AddInt64(&c.stats.NetStatusSeen, 1)
 		c.netModel.ApplyNetworkStatus(ParseNetworkStatusBroadcast(t.Payload))
+		// 0x3B is the sole carrier of WACN — publish immediately so it
+		// reaches the SiteTracker/API the instant it lands, rather than
+		// waiting for a later RFSS/adjacent broadcast to flush the model.
+		c.publishSiteUpdate()
 	case OpRFSSStatusBroadcast:
 		atomic.AddInt64(&c.stats.RFSSStatusSeen, 1)
 		c.netModel.ApplyRFSSStatus(ParseRFSSStatusBroadcast(t.Payload))
@@ -1149,6 +1159,13 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		c.publishAffiliation(ParseGroupAffiliationResponse(t.Payload), nac)
 	case OpUnitRegistrationResponse:
 		c.publishUnitRegistration(ParseUnitRegistrationResponse(t.Payload), nac)
+	case OpLocationRegistrationResponse:
+		// The location registration response names the camped site's
+		// RFSS/Site and is emitted far more often than the RFSS Status
+		// Broadcast (0x3A) — frequently the only practical RFSS/Site source.
+		atomic.AddInt64(&c.stats.LocRegSeen, 1)
+		c.netModel.ApplyLocationRegistration(ParseLocationRegistrationResponse(t.Payload))
+		c.publishSiteUpdate()
 	default:
 		// Census + raw-payload sample — a standard opcode we don't
 		// dispatch could be (or carry) the alias transport a given site
@@ -1495,6 +1512,10 @@ func (c *ControlChannel) publishSiteUpdate() {
 			ControlChannelHz: c.freqHz,
 			WACN:             net.WACN,
 			SystemID:         net.SystemID,
+			WACNHex:          trunking.IDHex(uint64(net.WACN)),
+			SystemIDHex:      trunking.IDHex(uint64(net.SystemID)),
+			RFSSIDHex:        trunking.IDHex(uint64(net.RFSS)),
+			SiteIDHex:        trunking.IDHex(uint64(net.Site)),
 			Topology:         c.TopologySnapshot(),
 			At:               c.now(),
 		},

--- a/internal/radio/p25/phase1/network.go
+++ b/internal/radio/p25/phase1/network.go
@@ -135,6 +135,25 @@ func (m *NetworkModel) ApplyRFSSStatus(r RFSSStatusBroadcast) {
 	m.votePrimary(r.ChannelID, r.ChannelNumber)
 }
 
+// ApplyLocationRegistration folds a Location Registration Response (0x2B) in.
+// The response names the RFSS/Site the radio registered on — the camped site —
+// so its RFSS/Site are voted into the identity tally exactly like the RFSS
+// Status Broadcast. It carries neither WACN nor System ID, so neither is
+// touched here. Only an accepted response (RV 0) is trusted: a refused/denied
+// registration may name a different/last-known site.
+func (m *NetworkModel) ApplyLocationRegistration(r LocationRegistrationResponse) {
+	if r.Response != 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ensure()
+	// RFSS and Site of zero are valid (RFSS 0 is a real, common value), so
+	// they are always counted — matching ApplyRFSSStatus.
+	m.rfssVotes[r.RFSS]++
+	m.siteVotes[r.Site]++
+}
+
 // votePrimary records a primary-control-channel observation. A zero
 // (id, number) carries no information (channel 0-0 is the "no channel"
 // sentinel used across these broadcasts), so it never gets a vote and

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -192,6 +192,52 @@ func TestControlChannelAccumulatesTopology(t *testing.T) {
 	}
 }
 
+// TestControlChannelRFSSFromLocationRegistration checks that an accepted
+// Location Registration Response (0x2B) backfills the camped site's RFSS/Site
+// on a system that emits no RFSS Status Broadcast (0x3A) — the real-world
+// shape captured from Main_Site_1. Uses an on-air payload (RFSS 1, Site 1) and
+// asserts a SiteUpdate is published with those values.
+func TestControlChannelRFSSFromLocationRegistration(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+	cc := New(Options{Bus: bus, SystemName: "S"})
+
+	// Real on-air LOC_REG_RSP payload: response accept, group 0x0579,
+	// RFSS 1, Site 1, registering unit 0x024501.
+	locReg := TSBK{Opcode: OpLocationRegistrationResponse,
+		Payload: [8]byte{0x00, 0x05, 0x79, 0x01, 0x01, 0x02, 0x45, 0x01}}
+	cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, locReg), 0)
+
+	if cfg := cc.NetworkSnapshot(); cfg.RFSS != 1 || cfg.Site != 1 {
+		t.Errorf("snapshot RFSS/Site = %d/%d, want 1/1", cfg.RFSS, cfg.Site)
+	}
+
+	var gotSite bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindSiteUpdate {
+				continue
+			}
+			su, ok := ev.Payload.(trunking.SiteUpdate)
+			if !ok {
+				t.Fatalf("site update payload type = %T", ev.Payload)
+			}
+			if su.RFSSID != 1 || su.SiteID != 1 {
+				t.Errorf("SiteUpdate RFSS/Site = %d/%d, want 1/1", su.RFSSID, su.SiteID)
+			}
+			gotSite = true
+		case <-time.After(time.Second):
+			if !gotSite {
+				t.Fatal("no site.update published from LOC_REG_RSP")
+			}
+			return
+		}
+	}
+}
+
 // TestControlChannelDecodesBroadcastUnderVendorMFID drives the network/site
 // broadcasts with the Motorola vendor MFID (0x90) — the form a real VHF site
 // was seen emitting — and checks the standard broadcast opcodes are still
@@ -369,6 +415,13 @@ func TestControlChannelPublishesSiteUpdate(t *testing.T) {
 			if !ok {
 				t.Fatalf("KindSiteUpdate payload is %T, want trunking.SiteUpdate", ev.Payload)
 			}
+			// The NSB (0x3B) now publishes an interim update as soon as it
+			// lands (carrying WACN/SystemID but not yet RFSS/Site); the named
+			// site arrives on the following RFSS Status Broadcast. Skip the
+			// interim publish and assert on the complete one.
+			if u.RFSSID == 0 && u.SiteID == 0 {
+				continue
+			}
 			if u.System != "MMR" || u.RFSSID != 4 || u.SiteID != 7 {
 				t.Fatalf("site update identity wrong: %+v", u)
 			}
@@ -379,6 +432,11 @@ func TestControlChannelPublishesSiteUpdate(t *testing.T) {
 			// Broadcast carry SystemID 0x123 for these payloads.
 			if u.WACN != 0xABCDE || u.SystemID != 0x123 {
 				t.Fatalf("site update network ids wrong: %+v", u)
+			}
+			// Hex renderings accompany the decimal identity fields.
+			if u.WACNHex != "ABCDE" || u.SystemIDHex != "123" ||
+				u.RFSSIDHex != "4" || u.SiteIDHex != "7" {
+				t.Fatalf("site update hex fields wrong: %+v", u)
 			}
 			return
 		case <-deadline:

--- a/internal/radio/p25/phase1/opcodes.go
+++ b/internal/radio/p25/phase1/opcodes.go
@@ -437,6 +437,55 @@ func ParseUnitRegistrationResponse(p [8]byte) UnitRegistrationResponse {
 	}
 }
 
+// LocationRegistrationResponse (opcode 0x2B) confirms (or denies) a radio's
+// registration on the camped site and, unlike the Unit Registration Response,
+// names the RFSS / Site the unit registered on — which is the very site the
+// receiver is camped on. Payload layout per TIA-102.AABF, cross-checked
+// against SDRTrunk's LocationRegistrationResponse
+// (…/tsbk/standard/osp/LocationRegistrationResponse.java):
+//
+//	byte 0 bits 1-0 : Registration Response Value (RV)
+//	bytes 1-2       : Group Address (16 bits)
+//	byte 3          : RFSS ID
+//	byte 4          : Site ID
+//	bytes 5-7       : Target Address — the registering radio's unit ID
+//
+// The message carries no WACN and no System ID, so it backfills only RFSS/Site
+// — but it is emitted far more often than the RFSS Status Broadcast (0x3A),
+// making it the practical source of the camped site's RFSS/Site on systems that
+// rarely (or never) send 0x3A.
+type LocationRegistrationResponse struct {
+	Response      uint8
+	GroupAddress  uint16
+	RFSS          uint8
+	Site          uint8
+	TargetAddress uint32 // 24-bit registering radio
+}
+
+// ParseLocationRegistrationResponse decodes payload bytes for opcode 0x2B.
+func ParseLocationRegistrationResponse(p [8]byte) LocationRegistrationResponse {
+	return LocationRegistrationResponse{
+		Response:      p[0] & 0x03,
+		GroupAddress:  binary.BigEndian.Uint16(p[1:3]),
+		RFSS:          p[3],
+		Site:          p[4],
+		TargetAddress: uint32(p[5])<<16 | uint32(p[6])<<8 | uint32(p[7]),
+	}
+}
+
+// AssembleLocationRegistrationResponse is the inverse; for tests.
+func AssembleLocationRegistrationResponse(r LocationRegistrationResponse) [8]byte {
+	var p [8]byte
+	p[0] = r.Response & 0x03
+	binary.BigEndian.PutUint16(p[1:3], r.GroupAddress)
+	p[3] = r.RFSS
+	p[4] = r.Site
+	p[5] = byte(r.TargetAddress >> 16)
+	p[6] = byte(r.TargetAddress >> 8)
+	p[7] = byte(r.TargetAddress)
+	return p
+}
+
 // NetworkStatusBroadcast (opcode 0x3B) carries the system's network
 // identity. Payload layout per TIA-102.AABF — identical to the Phase 2
 // Network Status Broadcast (see phase2/mac.go AsNetworkStatusBroadcast):

--- a/internal/radio/p25/phase1/tsbk_test.go
+++ b/internal/radio/p25/phase1/tsbk_test.go
@@ -161,6 +161,47 @@ func TestParseUnitRegistrationResponse(t *testing.T) {
 	}
 }
 
+// TestParseLocationRegistrationResponse pins the byte layout against four
+// real on-air LOC_REG_RSP (0x2B) payloads captured from a live Motorola P25
+// site (Main_Site_1). All four name the same camped site — RFSS 1, Site 1 —
+// with plausible group addresses and 24-bit registering-unit IDs, which is
+// how the layout (response, group, RFSS@p3, Site@p4, target) was confirmed.
+func TestParseLocationRegistrationResponse(t *testing.T) {
+	// Assemble/Parse round-trip first.
+	in := LocationRegistrationResponse{
+		Response: 0, GroupAddress: 0x0579, RFSS: 1, Site: 1, TargetAddress: 0x024501,
+	}
+	if out := ParseLocationRegistrationResponse(AssembleLocationRegistrationResponse(in)); out != in {
+		t.Errorf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+
+	vectors := []struct {
+		payload [8]byte
+		group   uint16
+		target  uint32
+	}{
+		{[8]byte{0x00, 0x05, 0x79, 0x01, 0x01, 0x02, 0x45, 0x01}, 0x0579, 0x024501},
+		{[8]byte{0x00, 0x05, 0x15, 0x01, 0x01, 0x02, 0x13, 0x4A}, 0x0515, 0x02134A},
+		{[8]byte{0x00, 0x02, 0xC1, 0x01, 0x01, 0x01, 0x1C, 0x1D}, 0x02C1, 0x011C1D},
+		{[8]byte{0x00, 0x02, 0xC1, 0x01, 0x01, 0x01, 0x1C, 0x1A}, 0x02C1, 0x011C1A},
+	}
+	for _, v := range vectors {
+		r := ParseLocationRegistrationResponse(v.payload)
+		if r.Response != 0 {
+			t.Errorf("payload %X: Response = %X, want 0 (accept)", v.payload, r.Response)
+		}
+		if r.RFSS != 1 || r.Site != 1 {
+			t.Errorf("payload %X: RFSS/Site = %d/%d, want 1/1", v.payload, r.RFSS, r.Site)
+		}
+		if r.GroupAddress != v.group {
+			t.Errorf("payload %X: GroupAddress = %04X, want %04X", v.payload, r.GroupAddress, v.group)
+		}
+		if r.TargetAddress != v.target {
+			t.Errorf("payload %X: TargetAddress = %06X, want %06X", v.payload, r.TargetAddress, v.target)
+		}
+	}
+}
+
 func TestParseNetworkStatusBroadcast(t *testing.T) {
 	// LRA = 0x07, WACN = 0xABCDE (20-bit), SystemID = 0x123 (12-bit),
 	// channel = 4.010, service class = 0x42. Layout per TIA-102.AABF:

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -686,7 +686,9 @@ func (d *Decoder) ensureDownconverterLocked(targetHz float64) {
 	offset := d.loOffsetHz
 	applied := 0
 	if d.autotune != nil {
-		applied = d.autotune.AverageError()
+		// Correction() stays 0 through warm-up, so a cold dongle doesn't get
+		// its DDC shifted by an unsettled first measurement.
+		applied = d.autotune.Correction()
 		offset += float64(applied)
 	}
 	if d.ddc != nil && d.ddcTarget == targetHz && d.ddcOffsetHz == offset {

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -87,6 +87,7 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 				NetStatusSeen:     s.NetStatusSeen,
 				RFSSStatusSeen:    s.RFSSStatusSeen,
 				AdjacentSeen:      s.AdjacentSeen,
+				LocRegSeen:        s.LocRegSeen,
 			}
 		},
 		topology: func() *TopologySnapshot { return cc.TopologySnapshot() },

--- a/internal/siglab/p25detail.go
+++ b/internal/siglab/p25detail.go
@@ -49,6 +49,11 @@ type CCStatsBreakdown struct {
 	NetStatusSeen  int64 `json:"net_status_seen" yaml:"net_status_seen"`
 	RFSSStatusSeen int64 `json:"rfss_status_seen" yaml:"rfss_status_seen"`
 	AdjacentSeen   int64 `json:"adjacent_seen" yaml:"adjacent_seen"`
+	// LocRegSeen counts accepted Location Registration Responses (0x2B), the
+	// high-rate RFSS/Site source. RFSS/Site resolved via LocRegSeen while
+	// NetStatusSeen == 0 is the normal shape of a site that names itself in
+	// registrations but withholds the WACN-bearing NSB.
+	LocRegSeen int64 `json:"loc_reg_seen" yaml:"loc_reg_seen"`
 }
 
 // ReceiverState is one snapshot of the P25 receiver's internal loops at a

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -332,6 +332,13 @@ type SiteUpdate struct {
 	ControlChannelHz uint32
 	WACN             uint32
 	SystemID         uint16
+	// Hex renderings of the identity numbers (P25 field convention),
+	// alongside the decimal fields above so JSON consumers get both. Empty
+	// when the corresponding value is unknown (zero).
+	WACNHex     string `json:"WACNHex,omitempty"`
+	SystemIDHex string `json:"SystemIDHex,omitempty"`
+	RFSSIDHex   string `json:"RFSSIDHex,omitempty"`
+	SiteIDHex   string `json:"SiteIDHex,omitempty"`
 	// Topology, when non-nil, is the full network-configuration snapshot of the
 	// camped site (identity + primary/secondary control channels + neighbours +
 	// band plan) as of this update. It is built on the decoder's Process

--- a/internal/trunking/network_report.go
+++ b/internal/trunking/network_report.go
@@ -169,6 +169,17 @@ func channelLine(prefix string, c ReportChannel) string {
 // hexDec renders a value as "HEX[decimal]" — e.g. WACN BEE00 as "BEE00[781824]".
 func hexDec(v uint64) string { return fmt.Sprintf("%X[%d]", v, v) }
 
+// IDHex renders a P25 identity number (WACN, System ID, NAC, RFSS, Site) as an
+// uppercase hex string with no "0x" prefix — the convention these are quoted in
+// the field, e.g. System ID 706 as "2C2". Returns "" for zero so it drops out
+// of omitempty JSON fields (an unknown/absent identity carries no hex).
+func IDHex(v uint64) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%X", v)
+}
+
 // mhz formats a frequency in Hz as MHz with 6 decimals (1 Hz resolution).
 func mhz(hz uint64) string { return fmt.Sprintf("%.6f MHz", float64(hz)/1e6) }
 

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -31,7 +31,8 @@ func formatSystemDetail(s client.SystemDTO) string {
 		lines = append(lines, fmt.Sprintf("SystemID: %X", s.SystemID))
 	}
 	if s.RFSS != 0 || s.Site != 0 {
-		lines = append(lines, fmt.Sprintf("RFSS/Site: %d / %d", s.RFSS, s.Site))
+		// Hex to match WACN/SystemID above (P25 field convention).
+		lines = append(lines, fmt.Sprintf("RFSS/Site: %X / %X", s.RFSS, s.Site))
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/tui/panels/systems.go
+++ b/internal/tui/panels/systems.go
@@ -67,7 +67,7 @@ func (p *SystemsPanel) refresh(sys []client.SystemDTO) {
 			ids = append(ids, fmt.Sprintf("SYS %X", s.SystemID))
 		}
 		if s.RFSS != 0 || s.Site != 0 {
-			ids = append(ids, fmt.Sprintf("RFSS %d/Site %d", s.RFSS, s.Site))
+			ids = append(ids, fmt.Sprintf("RFSS %X/Site %X", s.RFSS, s.Site))
 		}
 		rows = append(rows, table.Row{s.Name, s.Protocol, ccs, strings.Join(ids, " ")})
 	}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -89,7 +89,10 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 		atApplied int
 	)
 	if atManager != nil {
-		atApplied = atManager.AverageError()
+		// Correction() is 0 until the running average has warmed up, so the
+		// first few calls on a fresh dongle apply nothing rather than chasing
+		// a single noisy measurement.
+		atApplied = atManager.Correction()
 		if atApplied != 0 {
 			atNCO = dsp.NewNCO(float64(atApplied), symbolHz)
 		}
@@ -370,16 +373,26 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	})
 
 	// At end-of-call fold this call's residual carrier offset into the
-	// dongle's running average — but only if the receiver actually locked
-	// and decoded voice (frames > 0), so noise on a never-locked call can't
-	// poison the average. The residual (AFCOffsetHz) plus what we already
+	// dongle's running average — but only from a call that decoded *cleanly*.
+	// The AFC residual is only a meaningful carrier-error estimate when the
+	// loop actually locked and tracked; a short or error-ridden call yields a
+	// data-dependent snapshot that, folded in, drags the correction toward the
+	// kHz. So require a minimum run of LDUs and a low uncorrectable rate before
+	// trusting the measurement. The residual (AFCOffsetHz) plus what we already
 	// applied (atApplied) is the dongle's true error; the next call on this
 	// serial picks up the updated correction. centerFreq is 0 here (the
 	// chain isn't handed the grant frequency), so the PPM sanity warning is
 	// the control decoder's job; the average + suggested value still log.
 	if atManager != nil {
 		defer func() {
-			if frames.Load() == 0 {
+			n := frames.Load()
+			bad := uncorrectableLDUs.Load()
+			// minAutotuneLDUs ~= 1 s of voice (9 frames/LDU, 180 ms/LDU);
+			// drop a call with too few LDUs or >10% uncorrectable.
+			const minAutotuneLDUs = 5
+			if n < minAutotuneLDUs || bad*10 > n {
+				c.log.Debug("composer: p25p1 autotune measurement skipped (call too short or noisy)",
+					"serial", serial, "ldus", n, "uncorrectable_ldus", bad)
 				return
 			}
 			observed := int(math.Round(rx.AFCOffsetHz()))

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -211,6 +211,8 @@ export interface AudioConfig {
 
 export interface WebConfig {
   Tabs: Record<string, boolean> | null;
+  // "hex" (default) or "dec": base for rendering identity numbers in the web UI.
+  IDBase?: string;
 }
 
 export interface P25BandPlanEntry {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,6 +52,7 @@ export function App() {
   const setMutations = useShared((s) => s.setMutations);
   const setWSStatus = useShared((s) => s.setWSStatus);
   const setHiddenTabs = useShared((s) => s.setHiddenTabs);
+  const setIDBase = useShared((s) => s.setIDBase);
   const setConfigPath = useShared((s) => s.setConfigPath);
   const configPath = useShared((s) => s.configPath);
   const appendEvents = useShared((s) => s.appendEvents);
@@ -109,6 +110,7 @@ export function App() {
       .runtime(cfg)
       .then((rt) => {
         setHiddenTabs(rt.hidden_tabs ?? []);
+        setIDBase(rt.id_base === "dec" ? "dec" : "hex");
         setConfigPath(rt.config_path ?? "");
       })
       .catch(() => setHiddenTabs([]));

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -427,6 +427,9 @@ export interface RuntimeDTO {
   // HiddenTabs lists the navigation tab keys switched off via
   // web.tabs in config. The App filters them out of the nav strip.
   hidden_tabs?: string[];
+  // IDBase selects how identity numbers (WACN, System ID, NAC, RFSS,
+  // Site) are rendered: "hex" (default) or "dec". From web.id_base config.
+  id_base?: "hex" | "dec";
   // RuntimeDTO is large and changes shape as the daemon grows. Read
   // unknown fields lazily.
   [key: string]: unknown;

--- a/web/src/lib/idFormat.test.ts
+++ b/web/src/lib/idFormat.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatIdNumber } from "./idFormat";
+
+describe("formatIdNumber", () => {
+  it("renders hex with decimal in parentheses by default", () => {
+    expect(formatIdNumber(706, "hex")).toBe("0x2C2 (706)");
+    expect(formatIdNumber(781824, "hex")).toBe("0xBEE00 (781824)");
+  });
+
+  it("renders plain decimal in dec mode", () => {
+    expect(formatIdNumber(706, "dec")).toBe("706");
+  });
+
+  it("returns null for null/undefined so callers can show a hint", () => {
+    expect(formatIdNumber(null, "hex")).toBeNull();
+    expect(formatIdNumber(undefined, "dec")).toBeNull();
+  });
+
+  it("renders zero (not treated as missing)", () => {
+    expect(formatIdNumber(0, "hex")).toBe("0x0 (0)");
+    expect(formatIdNumber(0, "dec")).toBe("0");
+  });
+});

--- a/web/src/lib/idFormat.ts
+++ b/web/src/lib/idFormat.ts
@@ -1,0 +1,14 @@
+// formatIdNumber renders a P25 identity number — WACN, System ID, NAC, RFSS,
+// or Site — in the operator-selected base (web.id_base config, surfaced via
+// /api/v1/runtime). "hex" is the convention these are quoted in the field, and
+// keeps the decimal in parentheses so no information is lost; "dec" shows plain
+// decimal. Returns null for null/undefined so callers can fall back to an
+// "awaiting" hint.
+export function formatIdNumber(
+  value: number | null | undefined,
+  base: "hex" | "dec",
+): string | null {
+  if (value == null) return null;
+  if (base === "dec") return String(value);
+  return `0x${value.toString(16).toUpperCase()} (${value})`;
+}

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -5,6 +5,7 @@ import { DetailField, DetailModal } from "../components/DetailModal";
 import { PageHeader } from "../components/ui/PageHeader";
 import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
+import { formatIdNumber } from "../lib/idFormat";
 import type {
   DMRBandPlanDTO,
   DMRBandPlanLearnedDTO,
@@ -67,6 +68,7 @@ export function Systems() {
   const scanner = useShared((s) => s.scanner);
   const setScanner = useShared((s) => s.setScanner);
   const events = useShared((s) => s.events);
+  const idBase = useShared((s) => s.idBase);
   const [selected, setSelected] = useState<SystemDTO | null>(null);
 
   // Poll the scanner snapshot alongside systems so the detail modal can
@@ -204,25 +206,25 @@ export function Systems() {
                   <DetailField
                     label="WACN"
                     mono
-                    value={selected.wacn ?? null}
+                    value={formatIdNumber(selected.wacn ?? null, idBase)}
                     emptyHint={hint}
                   />
                   <DetailField
                     label="System ID"
                     mono
-                    value={selected.system_id ?? null}
+                    value={formatIdNumber(selected.system_id ?? null, idBase)}
                     emptyHint={hint}
                   />
                   <DetailField
                     label="RFSS"
                     mono
-                    value={selected.rfss ?? null}
+                    value={formatIdNumber(selected.rfss ?? null, idBase)}
                     emptyHint={hint}
                   />
                   <DetailField
                     label="Site"
                     mono
-                    value={selected.site ?? null}
+                    value={formatIdNumber(selected.site ?? null, idBase)}
                     emptyHint={hint}
                   />
                 </div>

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -66,6 +66,11 @@ interface SharedState {
    *  nav bar filters these out. Sourced from /api/v1/runtime. */
   hiddenTabs: string[];
 
+  /** Base for rendering identity numbers (WACN, System ID, NAC, RFSS,
+   *  Site): "hex" (default, P25 field convention) or "dec". Sourced from
+   *  web.id_base config via /api/v1/runtime. */
+  idBase: "hex" | "dec";
+
   /** Absolute path of the config.yaml backing the daemon, or "" when it
    *  runs on built-in defaults (no -config). null until the runtime
    *  snapshot has been fetched. Sourced from /api/v1/runtime. */
@@ -92,6 +97,7 @@ interface SharedState {
   setDevices(d: DeviceDTO[]): void;
   setScanner(s: ScannerStatusDTO | null): void;
   setHiddenTabs(tabs: string[]): void;
+  setIDBase(base: "hex" | "dec"): void;
   setConfigPath(path: string | null): void;
   appendEvents(evs: EventDTO[]): void;
   setError(msg: string | null): void;
@@ -122,6 +128,7 @@ export const useShared = create<SharedState>((set, get) => ({
   events: [],
   eventCap: 500,
   hiddenTabs: [],
+  idBase: "hex",
   configPath: null,
 
   lastError: null,
@@ -171,6 +178,9 @@ export const useShared = create<SharedState>((set, get) => ({
   },
   setHiddenTabs(tabs) {
     set({ hiddenTabs: tabs });
+  },
+  setIDBase(base) {
+    set({ idBase: base });
   },
   setConfigPath(path) {
     set({ configPath: path });
@@ -245,6 +255,7 @@ export const useShared = create<SharedState>((set, get) => ({
       events: [],
       mutations: null,
       hiddenTabs: [],
+      idBase: "hex",
       configPath: null,
       lastError: null,
       toasts: [],


### PR DESCRIPTION
Three fixes from a field report against a live Motorola P25 site where
System ID decoded but WACN/RFSS/Site stayed blank, IDs showed only in
decimal, and autotune produced impossible multi-kHz corrections.

Decode (WACN/RFSS/Site):
- Parse the Location Registration Response (LOC_REG_RSP, 0x2B) and vote
  its RFSS/Site into the network model. The site emits it constantly
  (308x in a 10-min capture) but it was unhandled; it's the practical
  RFSS/Site source on systems that rarely send the RFSS Status Broadcast.
  Layout confirmed against four real on-air payloads (all RFSS 1/Site 1).
- Publish a site update on the Network Status Broadcast (0x3B) too, so
  WACN reaches the API/log the instant it lands instead of waiting for a
  following RFSS/adjacent broadcast.
- Add a LocRegSeen counter alongside the NSB/RFSS/adjacent counters so the
  hunt/siglab layers can show whether WACN is genuinely unavailable
  (NSB never transmitted) vs a decode gap.

Hex output:
- Add *_hex string fields to the site.update event payload and the
  systems/sites REST DTOs (decimal values unchanged).
- web.id_base config (hex default, or dec) surfaced via /api/v1/runtime;
  the web Systems "Network identity" card renders WACN/System ID/RFSS/Site
  in the chosen base (hex shows decimal in parens). TUI renders RFSS/Site
  in hex to match WACN/System ID.

Autotune (gate + reject + warm-up):
- Reject implausible single measurements (beyond a few PPM / abs cap) so a
  glitchy AFC snapshot can't drag the correction into the kHz.
- Require a warm-up of several samples before applying any correction, and
  only fold measurements from cleanly-decoded voice calls (min LDUs, low
  uncorrectable rate). Convergence now stays in the low-Hz range.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012g3K8srJDMLGaEKaYpa8dR