### PR TITLE
Investigate #771 replay AGC + guard premature issue closes

### DIFF
--- a/.claude/hooks/guard-issue-close.py
+++ b/.claude/hooks/guard-issue-close.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""PreToolUse guard for GitHub issue closes.
+
+Stops Claude from closing a GitHub issue as *completed* ("fixed") without a
+human in the loop. This exists because issue #764 was closed twice with a
+comment that merely repeated the fix description while the reported symptom
+was still live — see issue #771 and CLAUDE.md "Issue-closing policy".
+
+It only gates closes-as-completed. Closing as not_planned or duplicate, and
+every non-close issue write (create, comment, label, reopen), pass straight
+through. On a close-as-completed it returns an "ask" decision so the close
+still happens once a human confirms the fix is genuinely verified.
+
+Reads the PreToolUse hook payload on stdin; writes a hook decision on stdout.
+Always exits 0 — a guard must never become a hard failure that blocks work.
+"""
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        data = json.load(sys.stdin)
+    except Exception:
+        return 0  # never block on a malformed/empty payload
+
+    ti = data.get("tool_input", {}) or {}
+    is_close_completed = (
+        ti.get("method") == "update"
+        and ti.get("state") == "closed"
+        and ti.get("state_reason") in (None, "", "completed")
+    )
+    if not is_close_completed:
+        return 0  # allow: not a close-as-completed
+
+    num = ti.get("issue_number", "?")
+    reason = (
+        f"About to close issue #{num} as completed. Confirm the fix is VERIFIED first: "
+        "a failing-first regression test now passes AND the reporter has confirmed the fix "
+        "(or you reproduced the original symptom and this change resolves it). If it is not "
+        "yet verified, cancel this close and post a status comment instead, leaving the issue "
+        "open. Do not re-post the original fix description as the close justification — address "
+        "the latest follow-up. See CLAUDE.md \"Issue-closing policy\"."
+    )
+    print(json.dumps({
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": reason,
+        }
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "mcp__github__issue_write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard-issue-close.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# GopherTrunk — guidance for Claude
+
+GopherTrunk is a Go SDR trunking scanner/decoder (P25, DMR, NXDN, TETRA, …).
+This file is standing guidance for AI-assisted work in this repo. Keep it short.
+
+## Build & test
+
+- `make vet test` — vet + unit tests; must be green before any commit.
+- `make integration` — daemon/replay integration tests; run when the daemon,
+  DSP, or replay path changed.
+- Single package while iterating, e.g. `go test ./internal/scanner/ccdecoder/...`.
+
+## Change scope (mirrors CONTRIBUTING.md)
+
+- **Bug fix**: one narrow commit plus a regression test that **fails without the
+  fix and passes with it**. If you can't write a test that fails first, you have
+  not yet reproduced the bug — keep digging or ask for a reproduction, don't
+  guess at a fix.
+- **Feature / refactor**: design first; keep refactors out of behaviour-change PRs.
+
+## Issue-closing policy
+
+Closing an issue is a claim that the reported problem is gone. Do not make that
+claim until it is verified. This policy exists because issue #764 was closed
+twice on an unverified fix while the symptom was still live (see #771); a
+PreToolUse hook (`.claude/hooks/guard-issue-close.py`) now asks for human
+confirmation before any close-as-completed.
+
+- **Never close an issue as completed until the fix is verified**: a failing-first
+  regression test now passes **and** the reporter has confirmed it, or you have
+  reproduced the original symptom and shown this change resolves it.
+- **When you can't verify, leave it open.** Post a concise status comment saying
+  what you found and what's blocking (e.g. needs the reporter's capture files),
+  rather than closing.
+- **Address the latest follow-up, not the original report.** Never re-post the
+  initial fix description as a close justification — respond to the most recent
+  comment specifically.
+- **In PRs, prefer `Refs #N` over `Closes #N`** until the fix is verified, so a
+  merge doesn't auto-close an unverified issue.
+- Closing as `not_planned` or `duplicate` is fine and is not gated.
+
+## DSP / replay notes (so the next investigation starts ahead)
+
+- `gophertrunk replay -tune-hz` uses the single-channel
+  `ccdecoder.Downconverter` (`internal/scanner/ccdecoder/ddc.go`), **not** the
+  multi-tap wideband `DDCBank` (`internal/dsp/tuner/ddc.go`). They are separate
+  paths — a fix to one does not touch the other. (This is what made the #764
+  "fix" miss the #771 replay symptom.)
+- Both down-converters normalise to the per-protocol channel rate (48 kHz for
+  the 4800-baud C4FM family, 144 kHz for TETRA) and the receiver/AGC are sized
+  from that output rate, so the decode path is **rate-invariant** to the capture
+  rate. A symptom that only appears at a higher capture rate but reproduces in
+  offline replay points at the *captured data* (front-end overload / intermod /
+  gain staging), not the steady-state DSP — get the raw `.cfile` to reproduce.
+  See `internal/scanner/ccdecoder/ddc_highrate_test.go`.

--- a/internal/scanner/ccdecoder/ddc_highrate_test.go
+++ b/internal/scanner/ccdecoder/ddc_highrate_test.go
@@ -1,0 +1,163 @@
+package ccdecoder
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Regression harness for issue #771. The reporter sees a P25 control channel
+// at −812.5 kHz lock cleanly when replayed from a 2.5 MS/s capture but fail to
+// lock (AGC stuck ~10–20× above target, never converging) when replayed from a
+// 10 MS/s capture of the same site — in pure offline replay, with no live
+// daemon or USB in the loop. `gophertrunk replay -tune-hz` runs through this
+// package's Downconverter (NewDownconverterWithOffset), so any rate-dependent
+// level/alias defect would live here. These tests drive the same path at both
+// rates and assert the extracted channel is equivalent, so a real defect fails
+// first and a fix keeps them green.
+
+// c4fmSymbols returns n deterministic P25 C4FM symbols drawn from the 4-level
+// alphabet {−3,−1,+1,+3}. A fixed seed keeps the two-rate comparison apples to
+// apples: both rates modulate the identical symbol stream.
+func c4fmSymbols(n int, seed int64) []int {
+	r := rand.New(rand.NewSource(seed))
+	levels := []int{-3, -1, 1, 3}
+	out := make([]int, n)
+	for i := range out {
+		out[i] = levels[r.Intn(len(levels))]
+	}
+	return out
+}
+
+// c4fmChannel synthesises a continuous-phase 4800-baud C4FM carrier at
+// carrierHz offset, sampled at rateHz, from the supplied symbol stream. The
+// instantaneous deviation is sym·600 Hz, i.e. the standard P25 ±1800 / ±600 Hz.
+// Symbol boundaries are placed in absolute time so the same symbols line up
+// across sample rates.
+func c4fmChannel(symbols []int, carrierHz, rateHz, amp float64) []complex64 {
+	const baud = 4800.0
+	nSamp := int(float64(len(symbols)) / baud * rateHz)
+	out := make([]complex64, nSamp)
+	fmPhase := 0.0
+	carrierW := 2 * math.Pi * carrierHz / rateHz
+	for i := 0; i < nSamp; i++ {
+		symIdx := int(float64(i) * baud / rateHz)
+		if symIdx >= len(symbols) {
+			symIdx = len(symbols) - 1
+		}
+		fmPhase += 2 * math.Pi * float64(symbols[symIdx]) * 600.0 / rateHz
+		ph := fmPhase + carrierW*float64(i)
+		out[i] = complex(float32(amp*math.Cos(ph)), float32(amp*math.Sin(ph)))
+	}
+	return out
+}
+
+// fmDiscRMS returns the RMS of an amplitude-normalised FM discriminator
+// (angle of x[n]·conj(x[n−1])). For a C4FM channel this is the symbol-domain
+// signal the receiver's matched filter and AGC operate on, so it is the level
+// the AGC tries to drive to its target. A skip drops the filter startup
+// transient.
+func fmDiscRMS(x []complex64, skip int) float64 {
+	if len(x) <= skip+1 {
+		return 0
+	}
+	var sum float64
+	cnt := 0
+	for i := skip + 1; i < len(x); i++ {
+		d := complex128(x[i]) * cmplxConj(complex128(x[i-1]))
+		a := math.Atan2(imag(d), real(d))
+		sum += a * a
+		cnt++
+	}
+	if cnt == 0 {
+		return 0
+	}
+	return math.Sqrt(sum / float64(cnt))
+}
+
+func cmplxConj(c complex128) complex128 { return complex(real(c), -imag(c)) }
+
+// TestDownconverterC4FMLevelRateInvariant is the core #771 check: the same
+// C4FM control channel, replayed through the production down-converter at
+// 2.5 MS/s vs 10 MS/s, must reach the receiver at the same symbol-domain level.
+// The AGC target is fixed for the 48 kHz channel rate, so a level that differs
+// by an order of magnitude between rates is exactly the reported failure.
+func TestDownconverterC4FMLevelRateInvariant(t *testing.T) {
+	const (
+		offsetHz = -812_500.0 // Mt Anakie, the reporter's strong tap
+		amp      = 0.3        // well below full-scale; no clipping
+	)
+	symbols := c4fmSymbols(4800, 0x771) // ~1 s of symbols
+
+	// 2.5 MS/s: no shared decimation; the proven-good path.
+	lo := NewDownconverterWithOffset(2_500_000, DDCTargetRateHz, offsetHz).
+		Process(nil, c4fmChannel(symbols, offsetHz, 2_500_000, amp))
+	loLvl := fmDiscRMS(lo, 64)
+
+	// 10 MS/s: the reported-failing path. Identical symbols, identical carrier.
+	hi := NewDownconverterWithOffset(10_000_000, DDCTargetRateHz, offsetHz).
+		Process(nil, c4fmChannel(symbols, offsetHz, 10_000_000, amp))
+	hiLvl := fmDiscRMS(hi, 64)
+
+	if loLvl == 0 || hiLvl == 0 {
+		t.Fatalf("empty discriminator output (lo=%v hi=%v)", loLvl, hiLvl)
+	}
+	ratio := hiLvl / loLvl
+	if ratio < 0.8 || ratio > 1.25 {
+		t.Errorf("C4FM symbol level not rate-invariant: 2.5 MS/s=%.5f 10 MS/s=%.5f (ratio %.2f, want ~1.0). "+
+			"A ratio near the reported 10–20× points at a level/gain defect in the high-rate replay path.",
+			loLvl, hiLvl, ratio)
+	}
+}
+
+// TestDownconverterRejectsWidebandNeighbours stresses the 10 MS/s path the way
+// a real wideband capture does: the −812.5 kHz channel of interest plus strong
+// off-channel carriers (a neighbour site, an adjacent service) and a center
+// DC/LO spike, all of which the analog front end admits at 10 MS/s but not at
+// 2.5 MS/s. None of that out-of-band energy may fold into the ±24 kHz output
+// and inflate the level the AGC sees. The channel of interest must still arrive
+// at essentially the same level as when it is alone.
+func TestDownconverterRejectsWidebandNeighbours(t *testing.T) {
+	const (
+		rate     = 10_000_000.0
+		offsetHz = -812_500.0
+		amp      = 0.3
+	)
+	symbols := c4fmSymbols(4800, 0x771)
+
+	clean := c4fmChannel(symbols, offsetHz, rate, amp)
+
+	// Add wideband neighbours far stronger than the target, plus a DC spike.
+	withNeighbours := append([]complex64(nil), clean...)
+	addTone(withNeighbours, +937_500, rate, 1.0) // Mt Blackwood neighbour
+	addTone(withNeighbours, +200_000, rate, 1.0) // close-in interferer
+	addTone(withNeighbours, -1_500_000, rate, 1.0)
+	addTone(withNeighbours, +3_000_000, rate, 1.0)
+	addTone(withNeighbours, 0, rate, 1.5) // center DC/LO spike
+
+	cleanLvl := fmDiscRMS(
+		NewDownconverterWithOffset(rate, DDCTargetRateHz, offsetHz).Process(nil, clean), 64)
+	stressLvl := fmDiscRMS(
+		NewDownconverterWithOffset(rate, DDCTargetRateHz, offsetHz).Process(nil, withNeighbours), 64)
+
+	if cleanLvl == 0 {
+		t.Fatalf("empty discriminator output for clean channel")
+	}
+	ratio := stressLvl / cleanLvl
+	if ratio < 0.8 || ratio > 1.25 {
+		t.Errorf("wideband neighbours leaked into the channel: clean=%.5f with-neighbours=%.5f (ratio %.2f, want ~1.0). "+
+			"Inadequate anti-alias rejection at high M would raise the level/noise the AGC sees.",
+			cleanLvl, stressLvl, ratio)
+	}
+}
+
+// addTone superimposes a complex exponential at freqHz onto buf in place.
+func addTone(buf []complex64, freqHz, rateHz, amp float64) {
+	w := 2 * math.Pi * freqHz / rateHz
+	for i := range buf {
+		buf[i] += complex(
+			float32(amp*math.Cos(w*float64(i))),
+			float32(amp*math.Sin(w*float64(i))),
+		)
+	}
+}


### PR DESCRIPTION
Issue #771 reports a P25 control channel that locks when replayed from a
2.5 MS/s capture but fails (AGC ~10-20x above target, never converging) from a
10 MS/s capture of the same site, in pure offline replay. The merged #764 fix
(e5cf5ac) only changed the multi-tap wideband DDCBank; gophertrunk replay
-tune-hz runs through the separate single-channel ccdecoder.Downconverter,
which that fix never touched.

Add a reproduction harness (ddc_highrate_test.go) that drives the actual replay
down-converter at 2.5 and 10 MS/s with an identical synthesized C4FM channel,
plus strong wideband neighbours and a DC spike at 10 MS/s. Both pass: the
extracted symbol level is rate-invariant and out-of-band energy is rejected.
Combined with the receiver/AGC being sized from the fixed 48 kHz channel rate
in both cases, the replay pipeline has no rate-dependent gain path - so the
reported failure lives in the captured data (front-end overload / intermod at
the higher rate), not the steady-state DSP. The harness locks in that
invariance and is ready to take the reporter's raw .cfile captures.

Also add a guardrail so an issue is not closed as completed on an unverified
fix (the mistake that produced this thread):
- .claude/hooks/guard-issue-close.py + .claude/settings.json: a PreToolUse hook
  that asks for human confirmation before closing an issue as completed; closes
  as not_planned/duplicate and all non-close writes pass through.
- CLAUDE.md: issue-closing policy (verify with a failing-first regression test
  and reporter confirmation before closing; otherwise post status and leave
  open; prefer Refs over Closes until verified), plus build/test and replay-path
  notes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EPkeK4ZMj2EM42Qr8YFTVq