### PR TITLE
feat(broadcast): add generic JSON webhook call sink (#404, #268)

### DIFF
--- a/cmd/gophertrunk/broadcast.go
+++ b/cmd/gophertrunk/broadcast.go
@@ -66,6 +66,22 @@ func buildBroadcastManager(cfg config.BroadcastConfig, normCfg config.NormalizeC
 		}
 		backends = append(backends, b)
 	}
+	for _, f := range cfg.Webhook {
+		if !f.Enabled {
+			continue
+		}
+		b, err := broadcast.NewWebhook(broadcast.WebhookConfig{
+			Name:         f.Name,
+			URL:          f.URL,
+			AuthHeader:   f.AuthHeader,
+			IncludeAudio: f.IncludeAudio,
+			Systems:      f.Systems,
+		}, nil)
+		if err != nil {
+			return nil, err
+		}
+		backends = append(backends, b)
+	}
 	for _, f := range cfg.Icecast {
 		if !f.Enabled {
 			continue

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1153,6 +1153,20 @@ broadcast:
   #     password: "YOUR_ICECAST_SOURCE_PASSWORD"
   #     stream_name: "GopherTrunk Live"
 
+  # Generic JSON webhook: POST one JSON object per completed call to your
+  # own endpoint (analytics DB, Grafana pipeline, Discord/Slack relay,
+  # custom uploader). The payload carries the call metadata — system,
+  # talkgroup, source RID, frequency, P25 site identity (rfss_id/site_id/
+  # nac/channel_id), encryption + emergency flags, patched groups, and
+  # start/stop timestamps. Set include_audio to also embed the base64 MP3.
+  # webhook:
+  #   - enabled: true
+  #     name: "analytics"
+  #     url: "https://example.org/gophertrunk/calls"
+  #     auth_header: "Bearer YOUR_TOKEN"   # sent verbatim as Authorization; omit to disable
+  #     include_audio: false               # true embeds the base64 MP3 in each POST
+  #     systems: ["Metro P25"]             # empty = every system
+
 # Wideband baseband (IQ) recording and offline replay. `record` taps a
 # live tuner and writes its raw IQ to a two-channel 16-bit WAV (the
 # same layout SDRtrunk uses). `replay` mounts recorded WAVs as virtual

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -41,7 +41,18 @@ type Call struct {
 	TalkgroupLabel string
 	Source         uint32
 	FrequencyHz    uint32
-	Encrypted      bool
+	// ChannelID / RFSS / Site / NAC / Timeslot carry the P25 site
+	// identity decoded off the control channel (issue #698). They let a
+	// metadata sink (the webhook) label a call by site for downstream
+	// dashboards instead of resolving an opaque channel ID by hand. All
+	// stay zero on non-P25 calls and until the site's status TSBKs land;
+	// audio-upload backends ignore them.
+	ChannelID uint8
+	RFSS      uint8
+	Site      uint8
+	NAC       uint16
+	Timeslot  uint8
+	Encrypted bool
 	// AlgorithmID / KeyID surface the P25 encryption parameters when
 	// the in-call signalling has revealed them. Zero on clear calls
 	// and on encrypted calls whose Encryption Sync never arrived
@@ -130,6 +141,11 @@ func callFromEvent(cc trunking.CallComplete) *Call {
 		Talkgroup:     cc.Grant.GroupID,
 		Source:        cc.Grant.SourceID,
 		FrequencyHz:   cc.Grant.FrequencyHz,
+		ChannelID:     cc.Grant.ChannelID,
+		RFSS:          cc.Grant.RFSSID,
+		Site:          cc.Grant.SiteID,
+		NAC:           cc.Grant.NAC,
+		Timeslot:      cc.Grant.Timeslot,
 		Encrypted:     cc.Grant.Encrypted,
 		AlgorithmID:   cc.Grant.AlgorithmID,
 		KeyID:         cc.Grant.KeyID,

--- a/internal/broadcast/webhook.go
+++ b/internal/broadcast/webhook.go
@@ -1,0 +1,161 @@
+package broadcast
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// WebhookConfig configures one generic JSON-webhook call sink.
+type WebhookConfig struct {
+	// Name is an optional log label; defaults to "webhook".
+	Name string
+	// URL is the endpoint the call payload is POSTed to (required).
+	URL string
+	// AuthHeader, when set, is sent verbatim as the Authorization header
+	// (e.g. "Bearer <token>"). Empty omits the header.
+	AuthHeader string
+	// IncludeAudio, when true, embeds the MP3-encoded call audio as a
+	// base64 string in the payload (audio_base64 / audio_format). Off by
+	// default so the webhook stays a lightweight metadata feed; consumers
+	// that want audio can opt in.
+	IncludeAudio bool
+	// Systems restricts the feed to these trunking-system names. Empty
+	// streams every system.
+	Systems []string
+}
+
+type webhookBackend struct {
+	systemFilter
+	name         string
+	endpoint     string
+	authHeader   string
+	includeAudio bool
+	http         *http.Client
+}
+
+// NewWebhook builds a generic JSON-webhook backend that POSTs one JSON
+// object per completed call (issue #404 / #268). The payload is a stable,
+// documented schema (see webhookPayload) carrying the call metadata and,
+// when IncludeAudio is set, the base64 MP3.
+func NewWebhook(cfg WebhookConfig, hc *http.Client) (Backend, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("broadcast/webhook: url is required")
+	}
+	name := cfg.Name
+	if name == "" {
+		name = "webhook"
+	}
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	return &webhookBackend{
+		systemFilter: newSystemFilter(cfg.Systems),
+		name:         name,
+		endpoint:     cfg.URL,
+		authHeader:   cfg.AuthHeader,
+		includeAudio: cfg.IncludeAudio,
+		http:         hc,
+	}, nil
+}
+
+func (b *webhookBackend) Name() string { return b.name }
+
+// webhookPayload is the stable JSON schema POSTed for each call. Fields
+// that don't apply to a given call (site identity on non-P25, encryption
+// params on clear calls, audio when not requested) are omitted via
+// omitempty so a consumer can rely on presence meaning "known".
+type webhookPayload struct {
+	Event         string   `json:"event"` // always "call"
+	System        string   `json:"system"`
+	Protocol      string   `json:"protocol"`
+	Talkgroup     uint32   `json:"talkgroup"`
+	TalkgroupID   string   `json:"talkgroup_label,omitempty"`
+	Source        uint32   `json:"source,omitempty"`
+	FrequencyHz   uint32   `json:"frequency_hz"`
+	ChannelID     uint8    `json:"channel_id,omitempty"`
+	RFSSID        uint8    `json:"rfss_id,omitempty"`
+	SiteID        uint8    `json:"site_id,omitempty"`
+	NAC           uint16   `json:"nac,omitempty"`
+	Timeslot      uint8    `json:"timeslot,omitempty"`
+	Encrypted     bool     `json:"encrypted"`
+	AlgorithmID   uint8    `json:"algorithm_id,omitempty"`
+	KeyID         uint16   `json:"key_id,omitempty"`
+	Emergency     bool     `json:"emergency"`
+	PatchedGroups []uint32 `json:"patched_groups,omitempty"`
+	StartedAt     string   `json:"started_at"` // RFC3339 UTC
+	EndedAt       string   `json:"ended_at"`   // RFC3339 UTC
+	DurationMs    int64    `json:"duration_ms"`
+	AudioFilename string   `json:"audio_filename,omitempty"`
+	AudioFormat   string   `json:"audio_format,omitempty"`
+	AudioBase64   string   `json:"audio_base64,omitempty"`
+}
+
+// Send POSTs the call as a single application/json object. The audio is
+// only MP3-encoded when IncludeAudio is set, so a metadata-only webhook
+// never pays the encode cost.
+func (b *webhookBackend) Send(ctx context.Context, c *Call) error {
+	p := webhookPayload{
+		Event:         "call",
+		System:        c.System,
+		Protocol:      c.Protocol,
+		Talkgroup:     c.Talkgroup,
+		TalkgroupID:   c.TalkgroupLabel,
+		Source:        c.Source,
+		FrequencyHz:   c.FrequencyHz,
+		ChannelID:     c.ChannelID,
+		RFSSID:        c.RFSS,
+		SiteID:        c.Site,
+		NAC:           c.NAC,
+		Timeslot:      c.Timeslot,
+		Encrypted:     c.Encrypted,
+		AlgorithmID:   c.AlgorithmID,
+		KeyID:         c.KeyID,
+		Emergency:     c.Emergency,
+		PatchedGroups: c.PatchedGroups,
+		StartedAt:     c.StartedAt.UTC().Format(time.RFC3339),
+		EndedAt:       c.EndedAt.UTC().Format(time.RFC3339),
+		DurationMs:    c.Duration().Milliseconds(),
+		AudioFilename: audioFilename(c, "mp3"),
+	}
+	if b.includeAudio {
+		audio, err := c.MP3()
+		if err != nil {
+			return fmt.Errorf("%s: encode mp3: %w", b.name, err)
+		}
+		p.AudioFormat = "mp3"
+		p.AudioBase64 = base64.StdEncoding.EncodeToString(audio)
+	}
+
+	body, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("%s: marshal: %w", b.name, err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, b.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if b.authHeader != "" {
+		req.Header.Set("Authorization", b.authHeader)
+	}
+
+	resp, err := b.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s: post: %w", b.name, err)
+	}
+	defer resp.Body.Close()
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("%s: HTTP %d: %s", b.name, resp.StatusCode,
+			strings.TrimSpace(string(msg)))
+	}
+	return nil
+}

--- a/internal/broadcast/webhook_test.go
+++ b/internal/broadcast/webhook_test.go
@@ -1,0 +1,141 @@
+package broadcast
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// p25SiteCall is testCall enriched with the P25 site identity the webhook
+// payload surfaces (issue #698).
+func p25SiteCall(t *testing.T) *Call {
+	t.Helper()
+	c := testCall(t)
+	c.ChannelID = 1
+	c.RFSS = 1
+	c.Site = 9
+	c.NAC = 359
+	c.Emergency = true
+	c.PatchedGroups = []uint32{201, 212}
+	return c
+}
+
+func TestWebhookPostsJSONMetadata(t *testing.T) {
+	var got webhookPayload
+	var gotAuth, gotCT string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		gotCT = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	be, err := NewWebhook(WebhookConfig{
+		URL:        srv.URL,
+		AuthHeader: "Bearer t0ken",
+	}, srv.Client())
+	if err != nil {
+		t.Fatalf("NewWebhook: %v", err)
+	}
+	if err := be.Send(context.Background(), p25SiteCall(t)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if gotCT != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotCT)
+	}
+	if gotAuth != "Bearer t0ken" {
+		t.Errorf("Authorization = %q, want Bearer t0ken", gotAuth)
+	}
+	if got.Event != "call" {
+		t.Errorf("event = %q, want call", got.Event)
+	}
+	if got.System != "Metro" || got.Talkgroup != 4321 || got.Source != 9001 {
+		t.Errorf("core fields wrong: %+v", got)
+	}
+	if got.RFSSID != 1 || got.SiteID != 9 || got.ChannelID != 1 || got.NAC != 359 {
+		t.Errorf("site identity not surfaced: rfss=%d site=%d ch=%d nac=%d",
+			got.RFSSID, got.SiteID, got.ChannelID, got.NAC)
+	}
+	if !got.Emergency {
+		t.Error("emergency flag not surfaced")
+	}
+	if len(got.PatchedGroups) != 2 || got.PatchedGroups[0] != 201 {
+		t.Errorf("patched_groups = %v, want [201 212]", got.PatchedGroups)
+	}
+	if got.StartedAt == "" || got.EndedAt == "" || got.DurationMs <= 0 {
+		t.Errorf("timing fields wrong: start=%q end=%q dur=%d", got.StartedAt, got.EndedAt, got.DurationMs)
+	}
+	// Metadata-only by default: no audio embedded.
+	if got.AudioBase64 != "" || got.AudioFormat != "" {
+		t.Errorf("audio embedded without include_audio: fmt=%q len=%d", got.AudioFormat, len(got.AudioBase64))
+	}
+}
+
+func TestWebhookIncludeAudioEmbedsMP3(t *testing.T) {
+	var got webhookPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	be, _ := NewWebhook(WebhookConfig{URL: srv.URL, IncludeAudio: true}, srv.Client())
+	if err := be.Send(context.Background(), testCall(t)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got.AudioFormat != "mp3" || got.AudioBase64 == "" {
+		t.Fatalf("audio not embedded: fmt=%q len=%d", got.AudioFormat, len(got.AudioBase64))
+	}
+}
+
+func TestWebhookReportsHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	be, _ := NewWebhook(WebhookConfig{URL: srv.URL}, srv.Client())
+	if err := be.Send(context.Background(), testCall(t)); err == nil {
+		t.Fatal("Send should fail on HTTP 500")
+	}
+}
+
+func TestWebhookOmitsAuthHeaderWhenUnset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := r.Header["Authorization"]; ok {
+			t.Errorf("Authorization header sent when unset")
+		}
+		io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	be, _ := NewWebhook(WebhookConfig{URL: srv.URL}, srv.Client())
+	if err := be.Send(context.Background(), testCall(t)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+}
+
+func TestWebhookRequiresURL(t *testing.T) {
+	if _, err := NewWebhook(WebhookConfig{}, nil); err == nil {
+		t.Error("Webhook without url should error")
+	}
+}
+
+func TestWebhookSystemFilter(t *testing.T) {
+	be, _ := NewWebhook(WebhookConfig{URL: "http://x", Systems: []string{"OnlyThis"}}, nil)
+	if be.Accepts("Metro") {
+		t.Error("filter should reject unlisted system")
+	}
+	if !be.Accepts("OnlyThis") {
+		t.Error("filter should accept listed system")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -465,12 +465,13 @@ type BroadcastConfig struct {
 	// Workers is the number of concurrent upload goroutines. 0 uses
 	// the broadcast package default.
 	Workers int `yaml:"workers"`
-	// Broadcastify, RdioScanner, OpenMHz and Icecast each list zero
-	// or more feeds. A feed with enabled=false is parsed but skipped.
+	// Broadcastify, RdioScanner, OpenMHz, Icecast and Webhook each list
+	// zero or more feeds. A feed with enabled=false is parsed but skipped.
 	Broadcastify []BroadcastifyFeedConfig `yaml:"broadcastify"`
 	RdioScanner  []RdioScannerFeedConfig  `yaml:"rdioscanner"`
 	OpenMHz      []OpenMHzFeedConfig      `yaml:"openmhz"`
 	Icecast      []IcecastFeedConfig      `yaml:"icecast"`
+	Webhook      []WebhookFeedConfig      `yaml:"webhook"`
 }
 
 // BroadcastifyFeedConfig is one Broadcastify Calls upload feed.
@@ -499,6 +500,21 @@ type OpenMHzFeedConfig struct {
 	APIKey    string   `yaml:"api_key"`
 	ShortName string   `yaml:"short_name"`
 	Systems   []string `yaml:"systems"`
+}
+
+// WebhookFeedConfig is one generic JSON-webhook call sink: each
+// completed call is POSTed as one JSON object to URL (issue #404 / #268).
+type WebhookFeedConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Name    string `yaml:"name"`
+	URL     string `yaml:"url"`
+	// AuthHeader is sent verbatim as the Authorization header (e.g.
+	// "Bearer <token>"). Empty omits the header.
+	AuthHeader string `yaml:"auth_header"`
+	// IncludeAudio embeds the base64 MP3 in the payload. Off by default
+	// keeps the webhook a lightweight metadata feed.
+	IncludeAudio bool     `yaml:"include_audio"`
+	Systems      []string `yaml:"systems"`
 }
 
 // IcecastFeedConfig is one live Icecast/ShoutCast feed.
@@ -2373,6 +2389,14 @@ func (b BroadcastConfig) validate() error {
 		}
 		if f.Password == "" {
 			return fmt.Errorf("broadcast.icecast[%d]: password required", i)
+		}
+	}
+	for i, f := range b.Webhook {
+		if !f.Enabled {
+			continue
+		}
+		if f.URL == "" {
+			return fmt.Errorf("broadcast.webhook[%d]: url required", i)
 		}
 	}
 	return nil

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -311,6 +311,7 @@ var fieldMetas = map[string]FieldMeta{
 	"BroadcastConfig.RdioScanner":     {Help: "RdioScanner call-upload feeds."},
 	"BroadcastConfig.OpenMHz":         {Label: "OpenMHz", Help: "OpenMHz upload feeds."},
 	"BroadcastConfig.Icecast":         {Help: "Live Icecast/ShoutCast mountpoint feeds."},
+	"BroadcastConfig.Webhook":         {Help: "Generic JSON-webhook call sinks: POST one JSON object per completed call."},
 	"BroadcastifyFeedConfig.Enabled":  {Help: "Enable this feed. false keeps it configured but skipped."},
 	"BroadcastifyFeedConfig.Name":     {Help: "Feed label for logs/metrics."},
 	"BroadcastifyFeedConfig.APIKey":   {Label: "API key", Help: "Broadcastify Calls API key."},
@@ -336,6 +337,12 @@ var fieldMetas = map[string]FieldMeta{
 	"IcecastFeedConfig.Password":      {Help: "Source password for the mountpoint."},
 	"IcecastFeedConfig.StreamName":    {Help: "Public stream name listeners see."},
 	"IcecastFeedConfig.Systems":       {Help: "GopherTrunk system names to stream. Empty = every system."},
+	"WebhookFeedConfig.Enabled":       {Help: "Enable this feed. false keeps it configured but skipped."},
+	"WebhookFeedConfig.Name":          {Help: "Feed label for logs/metrics."},
+	"WebhookFeedConfig.URL":           {Label: "URL", Help: "Endpoint each completed call is POSTed to as JSON."},
+	"WebhookFeedConfig.AuthHeader":    {Label: "Auth header", Help: "Sent verbatim as the Authorization header (e.g. 'Bearer <token>'). Empty omits it."},
+	"WebhookFeedConfig.IncludeAudio":  {Help: "Embed the base64 MP3 in the payload. Off keeps the webhook a lightweight metadata feed."},
+	"WebhookFeedConfig.Systems":       {Help: "GopherTrunk system names to stream. Empty = every system."},
 
 	// ---- Baseband ----------------------------------------------------------
 	"BasebandConfig.Record":       {Help: "Tap live tuners and write their wideband IQ to WAV."},

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -326,6 +326,14 @@ export interface IcecastFeed {
   StreamName: string;
   Systems: string[] | null;
 }
+export interface WebhookFeed {
+  Enabled: boolean;
+  Name: string;
+  URL: string;
+  AuthHeader: string;
+  IncludeAudio: boolean;
+  Systems: string[] | null;
+}
 export interface BroadcastConfig {
   MinDurationMs: number;
   Workers: number;
@@ -333,6 +341,7 @@ export interface BroadcastConfig {
   RdioScanner: RdioScannerFeed[] | null;
   OpenMHz: OpenMHzFeed[] | null;
   Icecast: IcecastFeed[] | null;
+  Webhook: WebhookFeed[] | null;
 }
 
 export interface BasebandRecordConfig {

--- a/web/configbuilder/src/sections/Broadcast.tsx
+++ b/web/configbuilder/src/sections/Broadcast.tsx
@@ -9,6 +9,7 @@ import type {
   IcecastFeed,
   OpenMHzFeed,
   RdioScannerFeed,
+  WebhookFeed,
 } from "../api/types";
 
 const SYSTEMS_HELP = "Comma-separated system names to include; leave empty for every system.";
@@ -17,7 +18,7 @@ export function BroadcastSection() {
   const [cfg, set] = useSection("Broadcast");
   const c =
     (cfg as BroadcastConfig) ??
-    ({ MinDurationMs: 0, Workers: 0, Broadcastify: null, RdioScanner: null, OpenMHz: null, Icecast: null } as BroadcastConfig);
+    ({ MinDurationMs: 0, Workers: 0, Broadcastify: null, RdioScanner: null, OpenMHz: null, Icecast: null, Webhook: null } as BroadcastConfig);
   return (
     <Section
       sectionKey="broadcast"
@@ -124,6 +125,29 @@ export function BroadcastSection() {
                 <TextField label="Username" value={f.Username} onChange={(v) => setF({ ...f, Username: v })} />
                 <TextField label="Password" value={f.Password} onChange={(v) => setF({ ...f, Password: v })} />
                 <TextField label="Stream name" value={f.StreamName} onChange={(v) => setF({ ...f, StreamName: v })} />
+                <TextField label="Systems" value={formatCommaList(f.Systems)} onChange={(v) => setF({ ...f, Systems: parseCommaList(v) })} help={SYSTEMS_HELP} />
+              </div>
+            </div>
+          )}
+        />
+      </Fieldset>
+
+      <Fieldset legend="Webhook (JSON POST)">
+        <ListEditor<WebhookFeed>
+          label="Feeds"
+          items={c.Webhook}
+          onChange={(x) => set({ ...c, Webhook: x })}
+          makeNew={() => ({ Enabled: true, Name: "", URL: "", AuthHeader: "", IncludeAudio: false, Systems: null })}
+          itemTitle={(f) => f.Name || "feed"}
+          emptyHint="No webhook feeds."
+          renderItem={(f, setF) => (
+            <div className="space-y-3">
+              <BoolField label="Enabled" value={f.Enabled} onChange={(v) => setF({ ...f, Enabled: v })} />
+              <div className="grid gap-3 sm:grid-cols-2">
+                <TextField label="Name" value={f.Name} onChange={(v) => setF({ ...f, Name: v })} />
+                <TextField label="URL" value={f.URL} onChange={(v) => setF({ ...f, URL: v })} placeholder="https://example/hook" />
+                <TextField label="Auth header" value={f.AuthHeader} onChange={(v) => setF({ ...f, AuthHeader: v })} placeholder="Bearer …" help="Sent verbatim as the Authorization header. Empty omits it." />
+                <BoolField label="Include audio" value={f.IncludeAudio} onChange={(v) => setF({ ...f, IncludeAudio: v })} />
                 <TextField label="Systems" value={formatCommaList(f.Systems)} onChange={(v) => setF({ ...f, Systems: parseCommaList(v) })} help={SYSTEMS_HELP} />
               </div>
             </div>

--- a/web/configbuilder/src/sections/sections.smoke.test.tsx
+++ b/web/configbuilder/src/sections/sections.smoke.test.tsx
@@ -26,7 +26,7 @@ describe("section editors patch the draft with capitalized Go keys", () => {
 
   it("Broadcast add Broadcastify feed writes config.Broadcast.Broadcastify", () => {
     seed({
-      Broadcast: { MinDurationMs: 0, Workers: 0, Broadcastify: null, RdioScanner: null, OpenMHz: null, Icecast: null },
+      Broadcast: { MinDurationMs: 0, Workers: 0, Broadcastify: null, RdioScanner: null, OpenMHz: null, Icecast: null, Webhook: null },
     });
     render(<BroadcastSection />);
     // The first "+ Add" button belongs to the Broadcastify list.


### PR DESCRIPTION
## What & why

The outbound call-streaming subsystem (`internal/broadcast`) already ships **OpenMHz**, **Broadcastify Calls**, **RdioScanner** and **Icecast** backends — so most of #404 is already done. The remaining piece #404 asked for was a generic **"webhook / JSON POST sink"**, and #268 separately asked for **webhook delivery against a stable JSON schema**. This PR adds exactly that, reusing the existing `Manager` machinery (subscribes to `KindCallComplete`, system filter, min-duration gate, bounded exponential-backoff retry, concurrent workers).

## The sink

A new `broadcast.Backend` that POSTs **one `application/json` object per completed call** to a configured URL. The payload is a documented, stable schema:

```json
{
  "event": "call",
  "system": "MMR", "protocol": "p25",
  "talkgroup": 20003, "talkgroup_label": "Metro EMS Disp",
  "source": 203061, "frequency_hz": 422012500,
  "channel_id": 1, "rfss_id": 1, "site_id": 9, "nac": 359, "timeslot": 0,
  "encrypted": false, "emergency": false,
  "patched_groups": [201, 212],
  "started_at": "2026-06-23T...Z", "ended_at": "2026-06-23T...Z", "duration_ms": 3520
}
```

- **Site identity** (`channel_id` / `rfss_id` / `site_id` / `nac`) is the data from #698, surfaced here so consumers can build **site-level dashboards** — the exact downstream-analytics use case the issue describes.
- Optional `auth_header` is sent verbatim as the `Authorization` header.
- `include_audio` (default **off**) opt-in embeds the base64 MP3; off keeps it a lightweight metadata feed (no MP3 encode cost).

## Config

```yaml
broadcast:
  webhook:
    - enabled: true
      name: "analytics"
      url: "https://example.org/gophertrunk/calls"
      auth_header: "Bearer YOUR_TOKEN"   # optional
      include_audio: false               # optional
      systems: ["Metro P25"]             # empty = every system
```

## Changes
- `internal/broadcast/webhook.go` — `webhookBackend` + stable `webhookPayload`.
- `internal/broadcast/broadcast.go` — carry site identity (`ChannelID`/`RFSS`/`Site`/`NAC`/`Timeslot`) on `Call`, populated from the grant. Other backends ignore the new fields.
- `internal/config/config.go` — `broadcast.webhook[]` feeds (`url` required) + validation.
- `cmd/gophertrunk/broadcast.go` — wire feeds into the `Manager`.
- Config builder: `FieldMeta` help, web `types.ts` + `Broadcast.tsx` editor (+ smoke-test fixture).
- `config.example.yaml` — documented example.

## Testing
- `internal/broadcast/webhook_test.go` — httptest coverage: payload shape, **site identity surfaced**, Authorization header set/omitted, `include_audio` embeds MP3, HTTP-error → retry, URL validation, system filter.
- `go build ./...`, `go vet`, `gofmt`, and `go test ./internal/broadcast/ ./internal/config/ ./internal/configbuilder/ ./cmd/gophertrunk/` all pass.
- Config-builder web: `tsc --noEmit` clean, all 44 vitest tests pass.

Closes #404. Substantially addresses #268 (webhook transport + stable JSON schema); the SSE/WebSocket stream it also tracks already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QEguueQP5BNjeF3bJT5uB9)_