### PR TITLE
web: freeze CC Activity table synchronously on pause (#772)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,25 @@ jobs:
           go-version: "1.25.11"
       - run: make test-integration
 
+  # web-test runs the SPA's vitest suite (web/src/**/*.test.tsx) so a
+  # broken web panel can't land unverified — the gap that let #672's CC
+  # Activity pause "fix" ship while the symptom was still live (#772). Not
+  # yet a required check; promote it in the `Protect main` ruleset to gate
+  # merges on it.
+  web-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install deps
+        run: npm install --no-audit --no-fund
+        working-directory: web
+      - name: Test
+        run: npm test
+        working-directory: web
+
   # govulncheck enumerates known CVEs that affect the direct +
   # transitive dependency graph. Failing this job blocks merge — a
   # known-vulnerable dep means the operator has to either upgrade

--- a/web/src/panels/CCActivity.test.tsx
+++ b/web/src/panels/CCActivity.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 
@@ -291,6 +291,49 @@ describe("CCActivity panel", () => {
     expect(row!.textContent).toMatch(/12\.50 kHz spacing/);
     expect(row!.textContent).toMatch(/6 pairs/);
     expect(row!.textContent).toMatch(/conf 97%/);
+  });
+
+  // Guard test for #772 (re: #672): once paused, the displayed table must
+  // not grow as new CC events land in the store. Note: testing-library's
+  // act() flushes effects, so this passes against both the old effect-based
+  // freeze and the synchronous-ref freeze — it is a regression guard, not a
+  // fail-first reproduction (the real bug lives in the unbatched
+  // useSyncExternalStore render path that jsdom can't reproduce). Live-browser
+  // verification is the actual proof of the fix.
+  it("freezes the table on pause: new events do not add rows (#772)", async () => {
+    setEvents([
+      {
+        kind: "grant",
+        timestamp: "2026-05-26T12:00:00Z",
+        payload: { system: "Sys-A", group_id: 1 },
+      },
+    ]);
+    renderPanel();
+    expect(screen.getByText("1 matching event")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /pause/i }));
+    expect(screen.getByText(/paused/)).toBeInTheDocument();
+
+    // A new CC event arrives while paused, via the real append path.
+    act(() => {
+      useShared.getState().appendEvents([
+        {
+          kind: "grant",
+          timestamp: "2026-05-26T12:00:05Z",
+          payload: { system: "Sys-B", group_id: 2 },
+        },
+      ]);
+    });
+
+    // Frozen: still one row; Sys-B must not appear. While paused the counter
+    // carries a " (paused …)" suffix, so match the count substring.
+    expect(screen.getByText(/^1 matching event/)).toBeInTheDocument();
+    expect(screen.queryByText("Sys-B")).not.toBeInTheDocument();
+
+    // Resume re-syncs to the live store (now two rows).
+    await userEvent.click(screen.getByRole("button", { name: /resume/i }));
+    expect(screen.getByText("2 matching events")).toBeInTheDocument();
+    expect(screen.getByText("Sys-B")).toBeInTheDocument();
   });
 
   it("renders talker alias events", () => {

--- a/web/src/panels/CCActivity.tsx
+++ b/web/src/panels/CCActivity.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { useShared } from "../store/shared";
 import { groupEvents } from "../lib/groupEvents";
@@ -97,17 +97,21 @@ export function CCActivity() {
     return list.reverse();
   }, [events, talkgroups, systemFilter, kindFilter, grouped]);
 
-  // Pause must actually freeze the table so an operator can read/click a row
-  // without it churning under them: snapshot rows at the moment of pausing and
-  // render that snapshot until resumed. (Previously `paused` re-sliced the live
-  // rows, so it never froze anything.)
-  const rowsRef = useRef(rows);
-  rowsRef.current = rows;
-  const [frozen, setFrozen] = useState<Row[] | null>(null);
-  useEffect(() => {
-    setFrozen(paused ? rowsRef.current : null);
-  }, [paused]);
-  const displayRows = frozen ?? rows;
+  // Pause freezes the table so an operator can read/click a row without it
+  // churning. Snapshot synchronously during render the first time we see
+  // `paused`, so there is no effect-timing window where a live SSE batch can
+  // leak through after the click (#772). An earlier fix snapshotted in a
+  // post-paint useEffect, which left a render cycle where the live rows were
+  // still committed — and because the store is a useSyncExternalStore, an event
+  // batch arriving in that window re-rendered before the freeze engaged.
+  // Cleared on resume.
+  const frozenRef = useRef<Row[] | null>(null);
+  if (paused) {
+    if (frozenRef.current === null) frozenRef.current = rows;
+  } else {
+    frozenRef.current = null;
+  }
+  const displayRows = paused ? (frozenRef.current ?? rows) : rows;
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
The #672 fix snapshotted rows into state inside a post-paint useEffect
keyed on [paused]. On the render where the user clicks Pause, `frozen`
is still null, so the live rows are committed and painted; the snapshot
only lands one render cycle later. Because the events store is a
useSyncExternalStore, an SSE batch (~100ms) can force a synchronous
re-render in that window — outside React's event batching — so live
rows leak through after the click and the freeze lags the user's intent.

Capture the snapshot synchronously during render the first time `paused`
is seen, and clear it on resume. There is now no commit-then-effect
window for a live batch to slip through. The write is idempotent, so it
is StrictMode-safe.

Add a regression guard test for the pause-freeze invariant. Note: it
passes against both the old and new code because testing-library's act()
flushes effects and masks the unbatched useSyncExternalStore race, so it
is a guard, not a fail-first reproduction — the real proof is a live
browser, which could not be run here (egress policy blocks the Chromium
download).

Also wire the web vitest suite into CI as a `web-test` job; it ran Go
only, the gap that let the unverified #672 fix ship.

Refs #772

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018TFBCu9b2zByV5VQA1npMd