### PR TITLE
feat(p25): dump raw status-broadcast bytes + add live JSONL event log

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -366,6 +367,7 @@ type Daemon struct {
 	mdc1200Log   *storage.MDC1200Log
 	messageLog   *gtlog.MessageLog
 	powerLog     *gtlog.PowerLog
+	eventLog     *gtlog.EventLog
 	retention    *storage.Retention
 	ccCache      *trunking.Cache
 	cchuntSup    *cchunt.Supervisor
@@ -1186,6 +1188,26 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			return nil, fmt.Errorf("daemon: power log: %w", err)
 		}
 		d.powerLog = pl
+	}
+
+	// Event log — optional. Subscribes to the bus and writes every event as
+	// one JSON line (JSONL/NDJSON), using the same wire envelope as the SSE/WS
+	// streams so a recorded session matches what the web UI consumes. Captures
+	// ALL event kinds, so it's the artifact to hand to support when a decode
+	// looks wrong but there's no raw IQ to replay.
+	if cfg.Log.EventLog.Enabled && cfg.Log.EventLog.Path != "" {
+		el, err := gtlog.NewEventLog(gtlog.EventLogOptions{
+			Bus:       d.bus,
+			Path:      cfg.Log.EventLog.Path,
+			MaxSizeMB: cfg.Log.EventLog.MaxSizeMB,
+			Encode: func(ev events.Event) ([]byte, error) {
+				return json.Marshal(api.EventToDTO(ev))
+			},
+		})
+		if err != nil {
+			return nil, fmt.Errorf("daemon: event log: %w", err)
+		}
+		d.eventLog = el
 	}
 
 	// Affiliation tracker — always on. Subscribes to the bus and
@@ -2443,6 +2465,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.powerLog.Run(ctx)
 		})
 	}
+	if d.eventLog != nil {
+		d.spawn(runCtx, "eventlog", false, func(ctx context.Context) error {
+			return d.eventLog.Run(ctx)
+		})
+	}
 	if d.affiliations != nil {
 		d.spawn(runCtx, "affiliations", false, func(ctx context.Context) error {
 			return d.affiliations.Run(ctx)
@@ -3122,6 +3149,9 @@ func (d *Daemon) Close() {
 		}
 		if d.powerLog != nil {
 			_ = d.powerLog.Close()
+		}
+		if d.eventLog != nil {
+			_ = d.eventLog.Close()
 		}
 		if d.affiliations != nil {
 			_ = d.affiliations.Close()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -38,6 +38,15 @@ log:
   #   path: "../logs/power.log"
   #   max_size_mb: 16          # rotates to power.log.1 past this
   #   all_windows: false       # true ⇒ log every active window, not just low-power
+  # Event log: every bus event written as one JSON line (JSONL/NDJSON), in the
+  # same envelope the web UI / SSE / WS streams consume. Unlike message_log it
+  # captures ALL event kinds, so it records a whole session for offline
+  # inspection (hand it to support when a decode looks wrong but there's no
+  # raw IQ to replay).
+  # event_log:
+  #   enabled: true
+  #   path: "../logs/events.jsonl"
+  #   max_size_mb: 16          # rotates to events.jsonl.1 past this
 
 # diagnostics — error-reporting verbosity. Every error is prefixed with
 # a diagnostics banner (version, OS, system specs, detected dongles).

--- a/internal/api/sse.go
+++ b/internal/api/sse.go
@@ -78,6 +78,12 @@ func sanitizeForHeader(s string) string {
 	return string(out)
 }
 
+// EventToDTO converts an internal events.Event to the JSON wire envelope used
+// by the SSE/WS streams. It is exported so other sinks (e.g. the event JSONL
+// file log) can serialise events in exactly the same shape clients already
+// consume, rather than inventing a divergent format.
+func EventToDTO(ev events.Event) EventDTO { return eventToDTO(ev) }
+
 // eventToDTO converts an internal events.Event to the wire envelope. The
 // payload is mapped to a JSON-friendly DTO when the kind is recognised;
 // otherwise the raw payload is passed through (useful for debugging

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -662,11 +662,24 @@ type LogConfig struct {
 	// by default, only when that level is below the low-power threshold —
 	// the "decoding but weak signal" diagnostic.
 	PowerLog PowerLogConfig `yaml:"power_log"`
+	// EventLog configures the optional full event log — every bus event
+	// written as one JSON line (JSONL/NDJSON), in the same envelope the
+	// SSE/WS streams emit. Unlike MessageLog it captures all event kinds,
+	// so a session can be recorded and replayed/inspected offline.
+	EventLog EventLogConfig `yaml:"event_log"`
 }
 
 // MessageLogConfig configures the decoded-message log. Empty Path (or
 // Enabled false) disables it.
 type MessageLogConfig struct {
+	Enabled   bool   `yaml:"enabled"`
+	Path      string `yaml:"path"`
+	MaxSizeMB int    `yaml:"max_size_mb"` // default 16
+}
+
+// EventLogConfig configures the full JSONL event log. Empty Path (or
+// Enabled false) disables it.
+type EventLogConfig struct {
 	Enabled   bool   `yaml:"enabled"`
 	Path      string `yaml:"path"`
 	MaxSizeMB int    `yaml:"max_size_mb"` // default 16
@@ -1706,6 +1719,7 @@ func (c *Config) resolvePaths(base string) {
 	c.Recordings.Dir = resolve(c.Recordings.Dir)
 	c.Log.MessageLog.Path = resolve(c.Log.MessageLog.Path)
 	c.Log.PowerLog.Path = resolve(c.Log.PowerLog.Path)
+	c.Log.EventLog.Path = resolve(c.Log.EventLog.Path)
 	c.API.Auth.TokenFile = resolve(c.API.Auth.TokenFile)
 	for i := range c.Baseband.Record {
 		c.Baseband.Record[i].Dir = resolve(c.Baseband.Record[i].Dir)

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -75,6 +75,10 @@ var fieldMetas = map[string]FieldMeta{
 	"PowerLogConfig.Path":        {Help: "File the power log is written to. Empty disables it."},
 	"PowerLogConfig.MaxSizeMB":   {Help: "Rotate the power log at this size in MB. Default 16."},
 	"PowerLogConfig.AllWindows":  {Help: "Log every decode-active window instead of only low-power windows. Off by default."},
+	"LogConfig.EventLog":         {Help: "Optional full event log: every bus event written as one JSON line (JSONL/NDJSON), in the same envelope the web UI consumes. Records a whole session for offline inspection."},
+	"EventLogConfig.Enabled":     {Help: "Turn the JSONL event log on. Needs a Path to write to."},
+	"EventLogConfig.Path":        {Help: "File the JSONL event log is written to. Empty disables it."},
+	"EventLogConfig.MaxSizeMB":   {Help: "Rotate the event log at this size in MB. Default 16."},
 
 	// ---- Diagnostics -------------------------------------------------------
 	"DiagnosticsConfig.VerboseErrors":    {Help: "Print full error chains + stack traces and expand API error envelopes (exposes host/dongle info). Enable only on trusted networks."},

--- a/internal/log/eventlog.go
+++ b/internal/log/eventlog.go
@@ -1,0 +1,171 @@
+package log
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// EventLog writes every bus event to a newline-delimited JSON (JSONL / NDJSON)
+// file — one self-contained JSON object per line — so an operator can record a
+// full session for offline inspection (and hand it to support / Claude). Unlike
+// the human-readable MessageLog it captures ALL event kinds, not just the
+// trunking subset, in the same envelope the SSE/WS streams emit. The file
+// rotates to "<path>.1" when it exceeds the configured size cap.
+type EventLog struct {
+	bus       *events.Bus
+	path      string
+	maxBytes  int64
+	encode    func(events.Event) ([]byte, error)
+	sub       *events.Subscription
+	runDone   chan struct{}
+	closeOnce sync.Once
+
+	mu   sync.Mutex
+	f    *os.File
+	size int64
+}
+
+// EventLogOptions configure an EventLog.
+type EventLogOptions struct {
+	Bus *events.Bus
+	// Path is the log file path. Required.
+	Path string
+	// MaxSizeMB caps the file size before rotation. Default 16.
+	MaxSizeMB int
+	// Encode renders one event to a single JSON line's worth of bytes (without
+	// the trailing newline). Optional: when nil a minimal {kind,timestamp,
+	// payload} envelope is used. The daemon injects the api package's wire
+	// encoder so the file matches the live SSE/WS stream byte-for-byte.
+	Encode func(events.Event) ([]byte, error)
+}
+
+// eventEnvelope is the default JSON shape when no Encode is supplied. It mirrors
+// the api.EventDTO field names so a consumer sees the same keys either way.
+type eventEnvelope struct {
+	Kind      string    `json:"kind"`
+	Timestamp time.Time `json:"timestamp"`
+	Payload   any       `json:"payload"`
+}
+
+func defaultEncode(ev events.Event) ([]byte, error) {
+	return json.Marshal(eventEnvelope{
+		Kind:      string(ev.Kind),
+		Timestamp: ev.Timestamp,
+		Payload:   ev.Payload,
+	})
+}
+
+// NewEventLog opens the log file and subscribes to the bus.
+func NewEventLog(opts EventLogOptions) (*EventLog, error) {
+	if opts.Bus == nil {
+		return nil, errors.New("log/eventlog: events.Bus is required")
+	}
+	if opts.Path == "" {
+		return nil, errors.New("log/eventlog: Path is required")
+	}
+	if opts.MaxSizeMB <= 0 {
+		opts.MaxSizeMB = 16
+	}
+	if opts.Encode == nil {
+		opts.Encode = defaultEncode
+	}
+	if err := os.MkdirAll(filepath.Dir(opts.Path), 0o755); err != nil {
+		return nil, fmt.Errorf("log/eventlog: mkdir: %w", err)
+	}
+	f, err := os.OpenFile(opts.Path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("log/eventlog: open: %w", err)
+	}
+	info, _ := f.Stat()
+	el := &EventLog{
+		bus:      opts.Bus,
+		path:     opts.Path,
+		maxBytes: int64(opts.MaxSizeMB) * 1024 * 1024,
+		encode:   opts.Encode,
+		runDone:  make(chan struct{}),
+		f:        f,
+	}
+	if info != nil {
+		el.size = info.Size()
+	}
+	el.sub = opts.Bus.Subscribe()
+	return el, nil
+}
+
+// Run drains events until ctx cancels or the bus closes.
+func (e *EventLog) Run(ctx context.Context) error {
+	defer close(e.runDone)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case ev, ok := <-e.sub.C:
+			if !ok {
+				return nil
+			}
+			b, err := e.encode(ev)
+			if err != nil {
+				// A single unencodable event must never tear down the sink;
+				// drop it and keep recording the rest of the session.
+				continue
+			}
+			b = append(b, '\n')
+			e.write(b)
+		}
+	}
+}
+
+func (e *EventLog) write(line []byte) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.f == nil {
+		return
+	}
+	if e.maxBytes > 0 && e.size+int64(len(line)) > e.maxBytes {
+		e.rotate()
+	}
+	n, err := e.f.Write(line)
+	e.size += int64(n)
+	_ = err
+}
+
+// rotate closes the current file, renames it to "<path>.1", and opens a fresh
+// one. Caller holds e.mu.
+func (e *EventLog) rotate() {
+	e.f.Close()
+	_ = os.Rename(e.path, e.path+".1")
+	f, err := os.OpenFile(e.path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		e.f = nil
+		return
+	}
+	e.f = f
+	e.size = 0
+}
+
+// Close releases the bus subscription, waits for Run to drain, and closes the
+// file.
+func (e *EventLog) Close() error {
+	e.closeOnce.Do(func() {
+		e.sub.Close()
+		select {
+		case <-e.runDone:
+		case <-time.After(time.Second):
+		}
+		e.mu.Lock()
+		if e.f != nil {
+			e.f.Close()
+			e.f = nil
+		}
+		e.mu.Unlock()
+	})
+	return nil
+}

--- a/internal/log/eventlog_test.go
+++ b/internal/log/eventlog_test.go
@@ -1,0 +1,168 @@
+package log
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// waitForLines polls path until it has at least n non-empty lines or the
+// deadline passes, returning whatever it last read.
+func waitForLines(t *testing.T, path string, n int) []string {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		data, _ := os.ReadFile(path)
+		lines := nonEmptyLines(string(data))
+		if len(lines) >= n {
+			return lines
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	data, _ := os.ReadFile(path)
+	return nonEmptyLines(string(data))
+}
+
+func nonEmptyLines(s string) []string {
+	var out []string
+	for _, l := range strings.Split(s, "\n") {
+		if strings.TrimSpace(l) != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func TestEventLogWritesOneJSONLinePerEvent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	el, err := NewEventLog(EventLogOptions{Bus: bus, Path: path})
+	if err != nil {
+		t.Fatalf("NewEventLog: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go el.Run(ctx)
+
+	bus.Publish(events.Event{
+		Kind:      events.KindGrant,
+		Timestamp: time.Unix(1700000000, 0).UTC(),
+		Payload: trunking.Grant{
+			System: "Metro", Protocol: "p25", GroupID: 1234, SourceID: 99,
+			FrequencyHz: 851_000_000,
+		},
+	})
+	bus.Publish(events.Event{
+		Kind:    events.KindAffiliation,
+		Payload: trunking.Affiliation{System: "Metro", Protocol: "dmr", SourceID: 7, GroupID: 50},
+	})
+
+	lines := waitForLines(t, path, 2)
+	cancel()
+	el.Close()
+
+	if len(lines) != 2 {
+		t.Fatalf("got %d JSON lines, want 2:\n%s", len(lines), strings.Join(lines, "\n"))
+	}
+	// Every line must be a self-contained JSON object with a non-empty kind.
+	var first struct {
+		Kind      string          `json:"kind"`
+		Timestamp time.Time       `json:"timestamp"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("line 0 is not valid JSON: %v\n%s", err, lines[0])
+	}
+	if first.Kind != string(events.KindGrant) {
+		t.Errorf("line 0 kind = %q, want %q", first.Kind, events.KindGrant)
+	}
+	if len(first.Payload) == 0 {
+		t.Errorf("line 0 has empty payload: %s", lines[0])
+	}
+	var second map[string]any
+	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {
+		t.Fatalf("line 1 is not valid JSON: %v\n%s", err, lines[1])
+	}
+	if second["kind"] != string(events.KindAffiliation) {
+		t.Errorf("line 1 kind = %v, want %q", second["kind"], events.KindAffiliation)
+	}
+}
+
+func TestEventLogUsesInjectedEncoder(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "events.jsonl")
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	el, err := NewEventLog(EventLogOptions{
+		Bus:  bus,
+		Path: path,
+		Encode: func(ev events.Event) ([]byte, error) {
+			return json.Marshal(map[string]string{"k": string(ev.Kind), "custom": "yes"})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventLog: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go el.Run(ctx)
+
+	bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{System: "X"}})
+
+	lines := waitForLines(t, path, 1)
+	cancel()
+	el.Close()
+
+	if len(lines) != 1 || !strings.Contains(lines[0], `"custom":"yes"`) {
+		t.Fatalf("injected encoder not used:\n%v", lines)
+	}
+}
+
+func TestEventLogRotatesPastSizeCap(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.jsonl")
+	bus := events.NewBus(64)
+	defer bus.Close()
+
+	// 1 MB cap via a tiny-payload encoder forces a rotation after enough events
+	// without writing a huge file. Use a fixed ~1 KB line and a cap just above
+	// it so the second batch trips the rotation.
+	el, err := NewEventLog(EventLogOptions{
+		Bus: bus, Path: path, MaxSizeMB: 1,
+		Encode: func(ev events.Event) ([]byte, error) {
+			return []byte(strings.Repeat("a", 200*1024)), nil // 200 KB per line
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEventLog: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go el.Run(ctx)
+
+	// 6 × 200 KB = 1.2 MB > 1 MB cap ⇒ at least one rotation to <path>.1.
+	for i := 0; i < 6; i++ {
+		bus.Publish(events.Event{Kind: events.KindGrant, Payload: trunking.Grant{}})
+	}
+
+	rotated := filepath.Join(dir, "events.jsonl.1")
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(rotated); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	el.Close()
+
+	if _, err := os.Stat(rotated); err != nil {
+		t.Fatalf("expected rotated file %s to exist: %v", rotated, err)
+	}
+}

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -1136,6 +1136,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		}, nac)
 	case OpNetworkStatusBroadcast:
 		atomic.AddInt64(&c.stats.NetStatusSeen, 1)
+		c.logStatusBroadcast(t, nac)
 		c.netModel.ApplyNetworkStatus(ParseNetworkStatusBroadcast(t.Payload))
 		// 0x3B is the sole carrier of WACN — publish immediately so it
 		// reaches the SiteTracker/API the instant it lands, rather than
@@ -1143,6 +1144,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		c.publishSiteUpdate()
 	case OpRFSSStatusBroadcast:
 		atomic.AddInt64(&c.stats.RFSSStatusSeen, 1)
+		c.logStatusBroadcast(t, nac)
 		c.netModel.ApplyRFSSStatus(ParseRFSSStatusBroadcast(t.Payload))
 		c.publishSiteUpdate()
 	case OpSecondaryControlChannel:
@@ -1151,6 +1153,7 @@ func (c *ControlChannel) dispatchTSBK(t TSBK, nac uint16, metric int) {
 		c.netModel.ApplySecondaryControlChannelExplicit(ParseSecondaryControlChannelBroadcastExplicit(t.Payload))
 	case OpAdjacentSiteStatusBroadcast:
 		atomic.AddInt64(&c.stats.AdjacentSeen, 1)
+		c.logStatusBroadcast(t, nac)
 		c.netModel.ApplyAdjacentSite(ParseAdjacentSiteStatusBroadcast(t.Payload))
 		// On systems that never emit 0x3B/0x3A, the adjacent broadcast is
 		// the only System ID source — publish so it reaches the SiteTracker/API.
@@ -1263,6 +1266,7 @@ const (
 	diagAliasSrc        uint32 = 2 << 24
 	diagVendorBroadcast uint32 = 3 << 24
 	diagVendorProbe     uint32 = 4 << 24
+	diagStatusBroadcast uint32 = 5 << 24
 )
 
 // isStandardBroadcastOpcode reports whether op is one of the band-plan or
@@ -1317,6 +1321,56 @@ func (c *ControlChannel) logUnhandledTSBK(t TSBK, nac uint16) {
 			"mfid", t.MFID, "opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
 			"lb", t.LB, "payload", fmt.Sprintf("%x", t.Payload[:]), "nac", nac)
 	}
+}
+
+// maxStatusBroadcastSamples caps how many raw payloads are dumped per distinct
+// status-broadcast opcode. These broadcasts (adjacent 0x3C, network 0x3B, RFSS
+// 0x3A) ARE decoded and field-decoded — but the parsed result alone can't prove
+// the on-air byte layout when a field tester reports a neighbour/identity
+// mismatch. Pinned a little higher than maxUnhandledSamples so a correlation set
+// of the first several frames (cross-checked against a reference decoder's
+// known neighbours) is enough to confirm or refute a layout theory offline.
+const maxStatusBroadcastSamples = 16
+
+// logStatusBroadcast dumps the raw payload and the fields we decoded from a
+// HANDLED status broadcast, sampled per distinct opcode. Unlike logUnhandledTSBK
+// this changes nothing about parsing or the network model — it is pure
+// instrumentation so the bytes that produced a given neighbour/identity are
+// captured in the log (and the JSONL event sink) for offline verification. The
+// CFVA nibble (byte 1 high nibble: Conventional/Failsoft/Valid/Active) is logged
+// for the adjacent broadcast because the "Valid" bit gates whether the channel
+// field is meaningful.
+func (c *ControlChannel) logStatusBroadcast(t TSBK, nac uint16) {
+	key := diagStatusBroadcast | uint32(t.Opcode)
+	n := c.diagSeen[key]
+	c.diagSeen[key] = n + 1
+	if n >= maxStatusBroadcastSamples {
+		return
+	}
+	p := t.Payload
+	// Raw payload is always logged — it is the ground truth a field tester
+	// cross-checks against a reference decoder. The decoded attrs differ by
+	// opcode: the Network Status Broadcast packs WACN across bytes 1-3 and has
+	// no RFSS/Site, whereas the adjacent (0x3C) and RFSS (0x3A) broadcasts share
+	// the LRA/SysID/RFSS/Site/channel layout.
+	attrs := []any{
+		"opcode", fmt.Sprintf("0x%02X", uint8(t.Opcode)),
+		"name", t.Opcode, "lb", t.LB,
+		"payload", fmt.Sprintf("%x", p[:]),
+		"lra", p[0],
+		"chan", fmt.Sprintf("%X.%03X", p[5]>>4, uint16(p[5]&0x0F)<<8|uint16(p[6])),
+	}
+	if t.Opcode == OpNetworkStatusBroadcast {
+		attrs = append(attrs,
+			"wacn", fmt.Sprintf("%05X", uint32(p[1])<<12|uint32(p[2])<<4|uint32(p[3])>>4),
+			"sysid", fmt.Sprintf("%03X", uint16(p[3]&0x0F)<<8|uint16(p[4])))
+	} else {
+		attrs = append(attrs,
+			"cfva", p[1]>>4, "rfss", p[3], "site", p[4],
+			"sysid", fmt.Sprintf("%03X", uint16(p[1]&0x0F)<<8|uint16(p[2])))
+	}
+	attrs = append(attrs, "nac", nac, "sample", n+1, "max", maxStatusBroadcastSamples)
+	c.log.Info("p25: status broadcast payload", attrs...)
 }
 
 // maxVendorProbeSamples bounds how many raw payloads logVendorProbe dumps per

--- a/internal/radio/p25/phase1/status_broadcast_diag_test.go
+++ b/internal/radio/p25/phase1/status_broadcast_diag_test.go
@@ -1,0 +1,62 @@
+package phase1
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestControlChannelLogsStatusBroadcastPayload confirms that the HANDLED
+// status broadcasts (adjacent 0x3C, network 0x3B, RFSS 0x3A) now dump their
+// raw payload bytes plus the decoded fields, sampled per opcode and capped at
+// maxStatusBroadcastSamples. This is pure instrumentation — added so a field
+// tester (and the JSONL event sink) captures the bytes behind a reported
+// neighbour/identity mismatch when there is no raw IQ to replay. It must not
+// change parsing: the decoded rfss/site attrs are asserted against the real
+// Mt Anakie ADJ frame to prove the spec-correct layout is what we log.
+func TestControlChannelLogsStatusBroadcastPayload(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	bus := events.NewBus(16)
+	defer bus.Close()
+	cc := New(Options{Bus: bus, Log: log, SystemName: "S"})
+
+	// Real on-air Mt Anakie ADJ_STS_BCST argument bytes: RFSS 4, Site 0x2E,
+	// channel F.065 — the same vector pinned by TestParseAdjacentSiteStatusBroadcast.
+	adj := TSBK{Opcode: OpAdjacentSiteStatusBroadcast,
+		Payload: [8]byte{0x00, 0x31, 0x64, 0x04, 0x2E, 0xF0, 0x65, 0x70}}
+	const fires = maxStatusBroadcastSamples + 4
+	for i := 0; i < fires; i++ {
+		lead := 0
+		if i == 0 {
+			lead = 10 // establish lock on the first frame
+		}
+		cc.Process(buildLockedStreamWithTSBK(lead, 0x293, DUIDTrunkingSignaling, adj), i<<20)
+	}
+
+	out := buf.String()
+	if n := strings.Count(out, `msg="p25: status broadcast payload"`); n != maxStatusBroadcastSamples {
+		t.Errorf("status-broadcast payload lines = %d, want %d (capped)", n, maxStatusBroadcastSamples)
+	}
+	if !strings.Contains(out, "payload=003164042ef06570") {
+		t.Error("status-broadcast line missing the raw payload hex")
+	}
+	// Decoded attrs must reflect the spec-correct layout (RFSS@byte3=4,
+	// Site@byte4=0x2E=46), proving instrumentation didn't alter the parse.
+	if !strings.Contains(out, "rfss=4") || !strings.Contains(out, "site=46") {
+		t.Errorf("status-broadcast line missing/incorrect decoded rfss/site:\n%s", firstLine(out))
+	}
+	if !strings.Contains(out, "opcode=0x3C") {
+		t.Error("status-broadcast line missing numeric opcode")
+	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -17,11 +17,18 @@ export interface PowerLogConfig {
   AllWindows: boolean;
 }
 
+export interface EventLogConfig {
+  Enabled: boolean;
+  Path: string;
+  MaxSizeMB: number;
+}
+
 export interface LogConfig {
   Level: string;
   Format: string;
   MessageLog: MessageLogConfig;
   PowerLog: PowerLogConfig;
+  EventLog: EventLogConfig;
 }
 
 export interface DiagnosticsConfig {

--- a/web/configbuilder/src/sections/simple.tsx
+++ b/web/configbuilder/src/sections/simple.tsx
@@ -84,6 +84,26 @@ export function LogSection() {
           placeholder="16"
         />
       </Fieldset>
+      <Fieldset legend="Event log (JSONL)">
+        <BoolField
+          label="Enabled"
+          value={!!cfg.EventLog?.Enabled}
+          onChange={(x) => set({ ...cfg, EventLog: { ...cfg.EventLog, Enabled: x } })}
+          help="Record every bus event as one JSON line (JSONL/NDJSON), in the same envelope the web UI consumes — a full session for offline inspection."
+        />
+        <TextField
+          label="Path"
+          value={cfg.EventLog?.Path ?? ""}
+          onChange={(x) => set({ ...cfg, EventLog: { ...cfg.EventLog, Path: x } })}
+          placeholder="/var/log/gophertrunk/events.jsonl"
+        />
+        <NumberField
+          label="Max size (MB)"
+          value={cfg.EventLog?.MaxSizeMB ?? 0}
+          onChange={(x) => set({ ...cfg, EventLog: { ...cfg.EventLog, MaxSizeMB: x } })}
+          placeholder="16"
+        />
+      </Fieldset>
     </Section>
   );
 }


### PR DESCRIPTION
Two field-diagnostics changes, both additive — no decode behaviour changes.

A field report (P25 site Main_Site_1) flagged a missing WACN and only one
neighbour (RFSS 1 / Site 8) resolving, and asked for a way to record the event
log to a file for offline inspection. The supplied bundle had only decoded
voice audio + logs, no control-channel IQ, and the handled status broadcasts
never dumped their bytes — so the neighbour layout couldn't be verified and
voice/WACN couldn't be reproduced.

Findings (no code change warranted):
- WACN is genuinely absent on that site: it rides only in the Network Status
  Broadcast (0x3B), which the site emits 0 times. The tool already reports this
  accurately.
- The adjacent-broadcast parser is spec-correct (TIA-102.AABF: RFSS@byte3,
  Site@byte4) and pinned by a real on-air Mt Anakie regression vector. The
  reported "dual-format 0x3C" theory would mis-decode that verified frame, so
  the parser is left untouched pending raw bytes that prove a second format.

Changes:
- Add logStatusBroadcast: per-opcode sampled raw-payload + decoded-field dump
  for the HANDLED adjacent (0x3C), network (0x3B) and RFSS (0x3A) status
  broadcasts, capped at 16/opcode via the existing diagSeen sampler. This is
  the instrument that captures the bytes behind a reported neighbour/identity
  mismatch when there is no IQ to replay.
- Add an optional live event JSONL/NDJSON sink (internal/log/eventlog.go,
  log.event_log config) that records every bus event as one JSON line in the
  same envelope the SSE/WS streams emit, with size-capped rotation. Wired into
  the daemon and surfaced in the web Config Builder.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LFBdes1DSFF3ELiUBF9Qjg