### PR TITLE
siglab: diagnose no-lock cause + opt-in soft-sync; guard premature issue closes (#771)

### DIFF
--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -41,6 +41,7 @@ func runReplay(args []string) {
 	diag := fs.Bool("diag", false, "collect the demod-quality diagnostic report (symbol histogram + P25 FSW landscape + soft-sample eye) and print it at EOF")
 	enableDDA := fs.Bool("dda", false, "enable the experimental decision-directed AFC on the P25 C4FM path (off by default; see issue #402)")
 	enableAdaptiveSlicer := fs.Bool("adaptive-slicer", false, "enable the adaptive C4FM slicer on the P25 C4FM path (off by default; see issue #402)")
+	enableSoftSync := fs.Bool("soft-sync", false, "widen the P25 FSW correlator and admit looser sync words whose TSBK CRC corroborates the NID — extends lock reach on marginal-SNR captures without risking a false lock (off by default; see issue #771)")
 	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation (off by default; see issue #402)")
 	tuneHzFlag := fs.Float64("tune-hz", 0, "frequency-shift the capture so a channel at +tune-hz lands at 0 Hz before demod (0 = no shift)")
 	autoTune := fs.Bool("auto-tune", false, "find the control channel by trying the ranked carrier candidates and keeping the best lock — handles an off-centre / non-dominant control channel in a wideband capture (overrides -tune-hz)")
@@ -118,6 +119,7 @@ FLAGS:`)
 		NIDSearchSpan:        *nidSearchSpan,
 		EnableDDA:            *enableDDA,
 		EnableAdaptiveSlicer: *enableAdaptiveSlicer,
+		EnableSoftSync:       *enableSoftSync,
 		// P25 replay always wants the per-frame CCStats + receiver-state series
 		// (the historical EOF summary + per-second state log); -diag adds the
 		// dibit/soft-eye landscape on top.

--- a/cmd/gophertrunk/siglab_render.go
+++ b/cmd/gophertrunk/siglab_render.go
@@ -39,6 +39,9 @@ func renderResultText(w io.Writer, r *siglab.Result) {
 		fmt.Fprintln(w)
 	} else {
 		fmt.Fprintln(w, "siglab: did NOT lock the control channel")
+		if r.NoLockReason != "" {
+			fmt.Fprintf(w, "siglab:   reason: %s\n", r.NoLockReason)
+		}
 	}
 
 	if len(r.Grants) > 0 {

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -38,6 +38,7 @@ type ControlChannel struct {
 	bus        *events.Bus
 	log        *slog.Logger
 	det        *SyncDetector
+	fswTol     int // FSW correlator tolerance det was built with (≥ fswStrictTolerance)
 	systemName string
 	freqHz     uint32
 	bandPlan   *BandPlan
@@ -294,6 +295,11 @@ type pendingHit struct {
 	end int
 	rot uint8
 
+	// corroborate ⇒ this hit was found only by the wider fallback FSW
+	// tolerance (distance > fswStrictTolerance), so its NID is accepted only
+	// when the frame's TSBK CRC corroborates it (never on the trusted tier).
+	corroborate bool
+
 	cont       bool   // true ⇒ resume trailing TSBK blocks (NID already decoded)
 	blocksDone int    // TSBK blocks already dispatched for this data unit
 	nextStart  int    // absolute index of the next TSBK block to decode
@@ -301,6 +307,21 @@ type pendingHit struct {
 	strip      bool   // status-symbol stripping the alignment search chose
 	nac        uint16 // NAC the NID decoded to (for dispatch)
 }
+
+// FSWFallbackToleranceDefault is the wider frame-sync-word tolerance the
+// opt-in soft-sync fallback uses, versus the strict default of 4 of 24 dibits.
+// An FSW hit looser than the strict gate is admitted ONLY through the
+// TSBK-CRC-corroborated marginal NID tier, so the looser sync cannot
+// manufacture a false lock — it only extends reach into marginal-SNR captures
+// whose sync word carries 5–8 symbol errors but whose NID + TSBK still decode.
+// Exposed so the siglab/replay flag plumbing names one value.
+const FSWFallbackToleranceDefault = 8
+
+// fswStrictTolerance is the production FSW correlator tolerance. A hit at or
+// below this distance uses the normal trusted/marginal NID gate unchanged; a
+// hit above it (only reachable when a wider fallback tolerance is configured)
+// is forced to corroborate via the TSBK CRC.
+const fswStrictTolerance = 4
 
 // Options configure a ControlChannel.
 type Options struct {
@@ -341,6 +362,15 @@ type Options struct {
 	// existing replay / unit tests pass.
 	P25Phase1DemodMode string
 
+	// FSWFallbackTolerance opts the FSW correlator into a wider fallback
+	// tolerance (see FSWFallbackToleranceDefault). Zero (the default, and what
+	// the daemon pipelines pass) keeps the strict 4-of-24 behaviour byte-for-
+	// byte. When set above fswStrictTolerance, FSW hits in the (strict, this]
+	// band are decoded only if the frame's TSBK CRC corroborates the NID, so a
+	// looser sync extends reach into marginal captures without ever
+	// manufacturing a false lock. Surfaced by `replay -soft-sync` (issue #771).
+	FSWFallbackTolerance int
+
 	// P25Phase2Trellis / P25Phase2RS / P25Phase2Interleave /
 	// P25Phase2Scrambler hold the per-system FEC mode the voice
 	// composer's Phase 2 chain needs to decode MAC PDUs that
@@ -378,7 +408,11 @@ func New(opts Options) *ControlChannel {
 	if now == nil {
 		now = time.Now
 	}
-	det := NewSyncDetector(4)
+	fswTol := fswStrictTolerance
+	if opts.FSWFallbackTolerance > fswTol {
+		fswTol = opts.FSWFallbackTolerance
+	}
+	det := NewSyncDetector(fswTol)
 	if len(opts.Rotations) > 0 {
 		det.SetRotations(opts.Rotations)
 	}
@@ -394,6 +428,7 @@ func New(opts Options) *ControlChannel {
 		freqHz:              opts.FrequencyHz,
 		bandPlan:            bp,
 		now:                 now,
+		fswTol:              fswTol,
 		aliasAsm:            NewTalkerAliasAssembler(now),
 		diagSeen:            make(map[uint32]int),
 		rotations:           resolveRotations(opts.Rotations),
@@ -531,7 +566,7 @@ const NIDMarginalMaxErrs = 11
 // frame — so without cross-call buffering every FSW hit was discarded
 // and the control channel never locked (issue #275).
 func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
-	hits, rots, next := c.det.ProcessWithRotation(nil, nil, dibits, baseIdx)
+	hits, rots, margins, next := c.det.ProcessWithMargin(nil, nil, nil, dibits, baseIdx)
 	if len(hits) == 0 && len(dibits) > 0 && !c.locked {
 		now := c.now()
 		if now.Sub(c.lastNoHitsAt) >= noHitsThrottle {
@@ -560,7 +595,13 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 	}
 	c.buf = append(c.buf, dibits...)
 	for i, h := range hits {
-		c.pending = append(c.pending, pendingHit{end: h, rot: rots[i]})
+		// margin = fswTol+1 − bestMismatch, so bestMismatch = fswTol+1 − margin.
+		// A hit beyond the strict budget was reachable only via the wider
+		// fallback tolerance; require TSBK-CRC corroboration before it can lock.
+		bestMis := c.fswTol + 1 - margins[i]
+		c.pending = append(c.pending, pendingHit{
+			end: h, rot: rots[i], corroborate: bestMis > fswStrictTolerance,
+		})
 	}
 
 	// Parse every pending FSW hit whose first block has now been buffered,
@@ -585,7 +626,7 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 			kept = append(kept, ph) // not enough buffered yet
 			continue
 		}
-		if cont, more := c.parseFrame(c.buf, nidStart, ph.rot); more {
+		if cont, more := c.parseFrame(c.buf, nidStart, ph.rot, ph.corroborate); more {
 			kept = append(kept, cont)
 		}
 	}
@@ -615,8 +656,8 @@ func (c *ControlChannel) Process(dibits []uint8, baseIdx int) int {
 // parseFrame returns a continuation pendingHit (and more=true) when the
 // data unit's trailing TSBK blocks have not all buffered yet, so the
 // caller can resume them on a later Process call without re-searching.
-func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8) (cont pendingHit, more bool) {
-	best, found, diag := c.searchNID(buf, nidStart, fswRot)
+func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8, requireCorroboration bool) (cont pendingHit, more bool) {
+	best, found, diag := c.searchNID(buf, nidStart, fswRot, requireCorroboration)
 	if !found {
 		atomic.AddInt64(&c.stats.NIDFailed, 1)
 		c.log.Debug("nid parse failed", "system", c.systemName,
@@ -766,7 +807,12 @@ type nidGuess struct {
 // codeword — so a reporter can see where errors cluster (one end =
 // timing slip, near dibit 31 = status-phase fault, uniform = SNR
 // limited) without re-running the decode.
-func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nidGuess, bool, string) {
+// requireCorroboration forces every parity-valid NID candidate — even a clean
+// errs ≤ NIDAcceptErrs one — through the marginal tier, where the frame's TSBK
+// CRC must corroborate the alignment before it is accepted. It is set for FSW
+// hits found only by the wider fallback tolerance, so a looser sync extends
+// reach without ever bypassing the CRC-gated false-lock guard (issue #771).
+func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8, requireCorroboration bool) (nidGuess, bool, string) {
 	var best nidGuess
 	found := false
 	closestMiss := -1 // lowest BCH errs of a parity-rejected near-miss
@@ -796,11 +842,12 @@ func (c *ControlChannel) searchNID(buf []uint8, nidStart int, fswRot uint8) (nid
 				}
 				cand := nidGuess{delta: delta, strip: strip, rot: rot,
 					nid: nid, errs: errs, tsbkStart: tsbkStart, errPattern: pattern}
-				if errs > NIDAcceptErrs {
-					// Parity-valid but too far from the received word for
-					// BCH+parity to tell a noisy real NID from a bad
-					// alignment's miscorrection. Defer to the marginal
-					// tier, where the TSBK CRC decides.
+				if errs > NIDAcceptErrs || requireCorroboration {
+					// Parity-valid but either too far from the received word for
+					// BCH+parity to tell a noisy real NID from a bad alignment's
+					// miscorrection, or admitted only by the wider fallback FSW
+					// tolerance. Defer to the marginal tier, where the TSBK CRC
+					// decides.
 					marginal = append(marginal, cand)
 					continue
 				}

--- a/internal/radio/p25/phase1/control_softsync_test.go
+++ b/internal/radio/p25/phase1/control_softsync_test.go
@@ -1,0 +1,95 @@
+package phase1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestControlChannelSoftSyncFallback exercises the opt-in wider FSW-fallback
+// tolerance (issue #771). A sync word carrying 6 symbol errors — above the
+// strict 4-of-24 gate but within the fallback bound — must NOT lock the strict
+// detector, must lock the fallback detector when the NID + TSBK still decode,
+// and must NOT lock the fallback detector when the TSBK CRC is broken (the
+// false-lock guard: the looser sync is admitted only through CRC corroboration).
+func TestControlChannelSoftSyncFallback(t *testing.T) {
+	const (
+		nac    = 0x293
+		fswOff = 30 // FSW occupies dibits [fswOff, fswOff+24): status symbols
+		// start only after 35 dibits, so the 24-dibit FSW is contiguous here.
+	)
+	makeStream := func() []uint8 {
+		// Status-interleaved on-air stream, so the TSBK-CRC corroboration path
+		// sees the same status-symbol layout it does on a real capture.
+		return buildLockedStreamWithTSBK(fswOff, nac, DUIDTrunkingSignaling,
+			TSBK{LB: true, Opcode: OpRFSSStatusBroadcast})
+	}
+	// corruptFSW flips n FSW dibits (each +1 mod 4 is a guaranteed rot-0
+	// mismatch), so the best correlation distance becomes exactly n.
+	corruptFSW := func(s []uint8, n int) {
+		for i := 0; i < n; i++ {
+			s[fswOff+i] = (s[fswOff+i] + 1) & 3
+		}
+	}
+	locked := func(t *testing.T, fallbackTol int, mutate func([]uint8)) bool {
+		t.Helper()
+		// A generous buffer so nothing is dropped: a wide-tolerance hit can
+		// publish a few KindDecodeError events (from spurious near-miss FSW
+		// positions) before the genuine KindCCLocked.
+		bus := events.NewBus(256)
+		defer bus.Close()
+		sub := bus.Subscribe()
+		defer sub.Close()
+		cc := New(Options{Bus: bus, FrequencyHz: 851_000_000, FSWFallbackTolerance: fallbackTol})
+		s := makeStream()
+		if mutate != nil {
+			mutate(s)
+		}
+		cc.Process(s, 0)
+		// Scan the published events for a control-channel lock; ignore the
+		// decode-error noise a marginal capture produces.
+		for {
+			select {
+			case ev := <-sub.C:
+				if ev.Kind == events.KindCCLocked {
+					return ev.Payload.(LockState).NAC == nac
+				}
+			case <-time.After(250 * time.Millisecond):
+				// Events are published synchronously during Process, so a lock
+				// would already be buffered; a timeout here means none came.
+				return false
+			}
+		}
+	}
+
+	t.Run("clean frame locks strict", func(t *testing.T) {
+		if !locked(t, 0, nil) {
+			t.Fatal("a clean FSW+NID+TSBK frame must lock the strict detector")
+		}
+	})
+	t.Run("6-error FSW does not lock strict", func(t *testing.T) {
+		if locked(t, 0, func(s []uint8) { corruptFSW(s, 6) }) {
+			t.Fatal("a 6-error FSW (> strict tolerance 4) must not lock the strict detector")
+		}
+	})
+	t.Run("6-error FSW locks soft-sync fallback", func(t *testing.T) {
+		if !locked(t, FSWFallbackToleranceDefault, func(s []uint8) { corruptFSW(s, 6) }) {
+			t.Fatal("the fallback must lock a 6-error FSW whose NID + TSBK still corroborate")
+		}
+	})
+	t.Run("6-error FSW + broken TSBK does not false-lock", func(t *testing.T) {
+		mutate := func(s []uint8) {
+			corruptFSW(s, 6)
+			// Wreck the TSBK channel block — well past the FSW(24)+NID(32)+status
+			// region (~fswOff+57) — so the CRC cannot corroborate; the fallback
+			// must then reject the hit.
+			for i := 0; i < 40 && fswOff+62+i < len(s); i++ {
+				s[fswOff+62+i] = (s[fswOff+62+i] + 1) & 3
+			}
+		}
+		if locked(t, FSWFallbackToleranceDefault, mutate) {
+			t.Fatal("a 6-error FSW with a broken TSBK CRC must not lock (false-lock guard)")
+		}
+	})
+}

--- a/internal/siglab/config.go
+++ b/internal/siglab/config.go
@@ -65,6 +65,12 @@ type Config struct {
 	// EnableAdaptiveSlicer opts the C4FM path into the adaptive slicer
 	// (issue #402; off in production).
 	EnableAdaptiveSlicer bool
+	// EnableSoftSync opts the P25 control channel into the wider FSW-fallback
+	// tolerance: sync words carrying 5–8 symbol errors are decoded if the
+	// frame's TSBK CRC corroborates the NID, extending lock reach into
+	// marginal-SNR captures. Gated by the existing NID/CRC validation, so it
+	// cannot manufacture a false lock (issue #771; off in production).
+	EnableSoftSync bool
 	// CollectReceiverState captures a per-(stream-)second snapshot of the P25
 	// receiver's AFC/AGC/clock/slicer state into the Result (the per-second
 	// state log replay emitted to stderr, now structured + exportable).
@@ -148,7 +154,7 @@ func (c Config) wantP25Deep() bool {
 	}
 	return c.CollectIQDiag || c.CollectReceiverState ||
 		c.NIDSearchSpan > 0 || c.EnableDDA || c.EnableAdaptiveSlicer ||
-		c.DemodMode != ""
+		c.EnableSoftSync || c.DemodMode != ""
 }
 
 // ParseProtocolCLI maps a command-line protocol name to a trunking.Protocol.

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -464,6 +464,12 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 			res.IQTaps.DiffPhase = diffPhaseSeries(an.constBuf, cfg.captureIQMaxPoints())
 		}
 	}
+
+	// Name *why* the control channel did not lock (SNR-limited / misaligned /
+	// not-control / no-signal), from the demod + frame-decode metrics now
+	// attached — so a capture-quality failure is not misread as a tuning or AGC
+	// bug (issues #764 / #771). No-op when locked.
+	res.NoLockReason = classifyNoLockReason(res)
 	return res, nil
 }
 

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -42,13 +42,18 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 		nidSpan = p25phase1.NIDSearchSpan
 	}
 
+	fswFallbackTol := 0
+	if cfg.EnableSoftSync {
+		fswFallbackTol = p25phase1.FSWFallbackToleranceDefault
+	}
 	cc := p25phase1.New(p25phase1.Options{
-		Bus:           bus,
-		Log:           logger,
-		SystemName:    cfg.SystemName,
-		FrequencyHz:   cfg.FrequencyHz,
-		Rotations:     rotations,
-		NIDSearchSpan: nidSpan,
+		Bus:                  bus,
+		Log:                  logger,
+		SystemName:           cfg.SystemName,
+		FrequencyHz:          cfg.FrequencyHz,
+		Rotations:            rotations,
+		NIDSearchSpan:        nidSpan,
+		FSWFallbackTolerance: fswFallbackTol,
 	})
 	rx := p25phase1rx.New(p25phase1rx.Options{
 		SampleRateHz:              receiverRate,

--- a/internal/siglab/export.go
+++ b/internal/siglab/export.go
@@ -110,6 +110,7 @@ func writeCSVSummary(w io.Writer, r *Result) error {
 		"source", "protocol", "sample_rate_hz", "pipeline_rate_hz", "duration_sec",
 		"total_samples", "symbols", "effective_baud", "expected_baud", "baud_deviation_pct",
 		"locked", "lock_latency_sec", "lock_frequency_hz", "grants", "decode_errors", "verdict_pass",
+		"no_lock_reason",
 	}
 	if err := cw.Write(header); err != nil {
 		return err
@@ -129,6 +130,7 @@ func writeCSVSummary(w io.Writer, r *Result) error {
 		ftoa(r.EffectiveBaud), ftoa(r.ExpectedBaud), ftoa(r.BaudDeviationPct),
 		strconv.FormatBool(r.Locked), ftoa(r.LockLatencySec), lockFreq,
 		strconv.Itoa(len(r.Grants)), strconv.Itoa(sumCounts(r.DecodeErrors)), verdict,
+		r.NoLockReason,
 	}
 	if err := cw.Write(row); err != nil {
 		return err

--- a/internal/siglab/result.go
+++ b/internal/siglab/result.go
@@ -56,6 +56,14 @@ type Result struct {
 	// Verdict (nil unless Config.Acceptance supplied).
 	Verdict *Verdict `json:"verdict,omitempty" yaml:"verdict,omitempty"`
 
+	// NoLockReason is a human-readable classification of why the control
+	// channel did not lock, populated only when !Locked. It turns a bare "did
+	// not lock" into a named cause — SNR-limited capture / frame sync not
+	// aligned / not the control channel / no signal — from the demod and
+	// frame-decode metrics already gathered, so a capture-quality failure is
+	// not misread as a tuning or AGC bug (issues #764 / #771).
+	NoLockReason string `json:"no_lock_reason,omitempty" yaml:"no_lock_reason,omitempty"`
+
 	// IQTaps is the optional decimated signal capture (channelized IQ +
 	// pre-slicer soft samples) populated when Config.CaptureIQ is set. It
 	// backs the web visualization views (constellation, spectrogram, PSD,

--- a/internal/siglab/verdict.go
+++ b/internal/siglab/verdict.go
@@ -135,6 +135,73 @@ func evaluateAcceptance(r *Result, a *Acceptance) *Verdict {
 	return v
 }
 
+// lockPlausibleEVMPct / lockPlausibleSNRdB are the lock-plausibility
+// heuristics classifyNoLockReason uses to separate an SNR-limited capture from
+// a misalignment. They gate the human-readable *diagnosis* only — never the
+// real lock decision, which stays gated on NID BCH/parity + TSBK CRC in the
+// receiver. The bounds bracket the observed P25 C4FM behaviour on the #771
+// captures (a 7.4 % EVM / 19.7 dB capture locks; a 22.5 % EVM / 9.5 dB capture
+// does not).
+const (
+	lockPlausibleEVMPct = 15.0
+	lockPlausibleSNRdB  = 12.0
+)
+
+// classifyNoLockReason returns a human-readable explanation of why the control
+// channel failed to lock, or "" when it locked. It reuses metrics already on
+// the Result — the P25 frame-decode tally (CCStats), the FSW landscape, and the
+// demod EVM/SNR soft-eye estimate when -diag captured it — and degrades
+// gracefully when the richer diagnostics are absent. The point is to name a
+// capture-quality failure as such, rather than leave it to be misread as a
+// tuning or AGC fault (issues #764 / #771).
+func classifyNoLockReason(r *Result) string {
+	if r.Locked {
+		return ""
+	}
+	if r.Symbols == 0 {
+		return "no symbols were recovered — the input may be empty or not interleaved IQ; check -sample-rate and -format"
+	}
+
+	// P25 deep-path frame outcomes + FSW landscape, when present.
+	var cc *CCStatsBreakdown
+	fswHits := 0
+	if d, ok := r.Detail.(*P25P1Detail); ok && d != nil {
+		cc = d.CCStats
+		fswHits = d.WinningHits
+	}
+
+	// Demod soft-eye quality — only when -diag captured the soft samples.
+	var evm, snr float64
+	haveDemod := r.Signal != nil && r.Signal.Demod != nil
+	if haveDemod {
+		evm = r.Signal.Demod.EVMPct
+		snr = r.Signal.Demod.SNREstimateDB
+	}
+
+	nidValidated := cc != nil && cc.NIDTrusted+cc.NIDMarginal > 0
+	framesSynced := fswHits > 0 || (cc != nil && cc.NIDTrusted+cc.NIDMarginal+cc.NIDFailed > 0)
+
+	switch {
+	case nidValidated:
+		// Valid NIDs decoded but no lock → the frames are not the trunking
+		// control channel (wrong DUID — a voice / traffic carrier).
+		return "valid P25 frames decoded but no trunking-control (TSDU) frame seen — this looks like a voice/traffic channel, not the control channel"
+	case framesSynced:
+		// FSW aligned but the NID never BCH/parity-validates → degraded frames.
+		msg := "frame sync aligned but the NID never validates (BCH/parity) — the channel is too degraded to decode"
+		if haveDemod {
+			msg += fmt.Sprintf(" (EVM %.1f%% / demod SNR %.1f dB)", evm, snr)
+		}
+		return msg
+	case haveDemod && (evm > lockPlausibleEVMPct || snr < lockPlausibleSNRdB):
+		return fmt.Sprintf("a C4FM signal is present at the tune offset but EVM %.1f%% / demod SNR %.1f dB is below the lock threshold — SNR-limited capture, not a tuning or AGC issue", evm, snr)
+	case haveDemod:
+		return fmt.Sprintf("signal present and the eye looks lockable (EVM %.1f%% / demod SNR %.1f dB) but the frame sync never aligned — check -tune-hz / -conjugate, or try -auto-tune", evm, snr)
+	default:
+		return "no frame sync was found — re-run with -diag for an EVM/SNR diagnosis, or try -auto-tune if the control channel may be off-centre"
+	}
+}
+
 // lookupLockField finds a lock field by name, tolerating the snake_case the
 // metadata schema uses vs the Go field names the flattener emits (e.g.
 // "system_id" ↔ "SystemID", "frequency_hz" ↔ the dedicated FrequencyHz).

--- a/internal/siglab/verdict_test.go
+++ b/internal/siglab/verdict_test.go
@@ -1,6 +1,57 @@
 package siglab
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// TestClassifyNoLockReason pins the no-lock diagnosis classifier (issues
+// #764 / #771): a capture-quality failure must be named as such, not left to be
+// misread as a tuning or AGC fault. The SNR-limited case mirrors the verified
+// #771 10 MS/s capture (EVM 22.5 % / demod SNR 9.5 dB, no FSW sync).
+func TestClassifyNoLockReason(t *testing.T) {
+	p25 := func(cc *CCStatsBreakdown, hits int) *P25P1Detail {
+		return &P25P1Detail{CCStats: cc, WinningHits: hits}
+	}
+	demod := func(evm, snr float64) *SignalQuality {
+		return &SignalQuality{Demod: &DemodMetrics{Modulation: "c4fm", EVMPct: evm, SNREstimateDB: snr}}
+	}
+	cases := []struct {
+		name string
+		r    *Result
+		want string // expected substring ("" ⇒ must be empty)
+	}{
+		{"locked ⇒ no reason", &Result{Locked: true, Symbols: 1000}, ""},
+		{"no symbols", &Result{Symbols: 0}, "no symbols"},
+		{"SNR-limited (the #771 10 MS/s case)",
+			&Result{Symbols: 48000, Signal: demod(22.5, 9.5), Detail: p25(&CCStatsBreakdown{}, 0)},
+			"SNR-limited capture"},
+		{"clean eye but no sync ⇒ alignment",
+			&Result{Symbols: 48000, Signal: demod(6.0, 20.0), Detail: p25(&CCStatsBreakdown{}, 0)},
+			"frame sync never aligned"},
+		{"synced but NID never validates ⇒ degraded frames",
+			&Result{Symbols: 48000, Signal: demod(13.0, 13.0), Detail: p25(&CCStatsBreakdown{NIDFailed: 40}, 5)},
+			"NID never validates"},
+		{"valid NIDs but no control DUID",
+			&Result{Symbols: 48000, Detail: p25(&CCStatsBreakdown{NIDTrusted: 10}, 8)},
+			"not the control channel"},
+		{"no -diag, no frames ⇒ hint at -diag/-auto-tune",
+			&Result{Symbols: 48000, Detail: p25(&CCStatsBreakdown{}, 0)},
+			"re-run with -diag"},
+	}
+	for _, c := range cases {
+		got := classifyNoLockReason(c.r)
+		if c.want == "" {
+			if got != "" {
+				t.Errorf("%s: want empty reason, got %q", c.name, got)
+			}
+			continue
+		}
+		if !strings.Contains(got, c.want) {
+			t.Errorf("%s: got %q, want substring %q", c.name, got, c.want)
+		}
+	}
+}
 
 func TestFieldMatchesHexTolerant(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Context

`Refs #771` (follow-up to #764). #764 was closed twice on an unverified fix while the symptom was still live. With the reporter's raw captures now in hand, I reproduced both and pinned the cause.

**Verified diagnosis** (production `replay` + an independent numpy re-implementation of the down-converter):
- 2.5 MS/s **locks** (NAC 356); 10 MS/s **fails** — same site, `-tune-hz -812500`, only the sample rate differs.
- The **"AGC 10–20× high" reading is a red herring**: the *locking* 2.5 MS/s capture shows the identical `agc_level≈1.47` vs target `0.157` (that ratio is just the symbol-AGC's normal operating gain).
- Real difference is **in-channel demod quality**: EVM 7.4 % / 19.7 dB (locks) vs 22.5 % / 9.5 dB (fails); message-band (±2.4 kHz) post-discriminator SNR ~22 dB vs ~6 dB — a ~16 dB deficit **co-band with the signal**, so unfilterable.
- **Not the DSP.** Ruled out aliasing of the wideband neighbours (band-limiting the 10 MS/s input changes nothing), float32 NCO/resampler precision (bit-identical to float64), and channel-filter width (< 0.5 dB across 24 k→6.25 k). An independent channelizer reproduces the deficit → it's in the captured samples (a front-end / gain-staging / decimation difference between the two recordings).

No narrow DSP change makes a 6 dB-message-SNR / 22.5 %-EVM signal lock, so this PR does not fake one — `Refs` not `Closes`, and #771 stays open.

## What's in this PR

**1. Name the no-lock reason** (`Result.NoLockReason`). The replay output now classifies *why* the control channel didn't lock — SNR/EVM-limited, frame-sync-not-aligned, not-the-control-channel, or no-signal — from metrics already computed, rendered after the "did NOT lock" line and added to CSV / json / yaml. On the 10 MS/s capture it prints: *"a C4FM signal is present at the tune offset but EVM 22.5 % / demod SNR 9.5 dB is below the lock threshold — SNR-limited capture, not a tuning or AGC issue."*

**2. Opt-in soft-sync FSW fallback** (`replay -soft-sync`, **off by default**, daemon pipelines unchanged). Widens the P25 FSW correlator so sync words with 5–8 symbol errors are decoded, but admits those looser hits **only** through the existing TSBK-CRC + NID-BCH corroboration — so a looser sync **cannot manufacture a false lock**; it only extends reach into marginal-SNR captures. It does **not** rescue this 10 MS/s file (verified: still no lock), and 2.5 MS/s still locks with it on.

**3. Issue-close guardrail** (from the first commit). A `PreToolUse` hook (`.claude/hooks/guard-issue-close.py` + `.claude/settings.json`) that asks for confirmation before any close-as-completed, plus a `CLAUDE.md` issue-closing policy and a `ddc_highrate_test.go` rate-invariance regression harness — so the original "close on an unverified fix" mistake can't recur.

## Tests
- `TestClassifyNoLockReason` — the no-lock classifier (incl. the #771 SNR-limited case).
- `TestControlChannelSoftSyncFallback` — clean locks; strict rejects a 6-error FSW; fallback locks a 6-error FSW whose NID + TSBK corroborate; a 6-error FSW with a broken TSBK CRC does **not** false-lock.
- `make vet test` ✓ · `make integration` ✓ · verified end-to-end on the reporter's real 2.5 / 10 MS/s captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EPkeK4ZMj2EM42Qr8YFTVq)_