### PR TITLE
docs: post-release v0.5.1 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.1] — 2026-06-23
+
+A maintenance release headlined by a new **ka9q-radio network SDR source** —
+mount a channel from a remote `radiod` instance over IP multicast as a virtual
+tuner, so one well-sited front end can feed many GopherTrunk decoders across a
+LAN — and a fix that restores **wideband decode at sample rates above
+2.5 MS/s** (#764), where a `role: wideband` dongle run at 10 MS/s went deaf
+across every tap. The rest is P25 control-channel work: System ID recovered
+from adjacent-site broadcasts, RFSS/Site from the Location Registration
+Response, hex ID rendering, a corrected Phase 2 Motorola talker-alias
+reassembly, and new raw-broadcast / event-log field diagnostics.
+
 ### Added
 - **ka9q-radio network SDR source** (`sdr.ka9q_radio`, #765). Consume a channel
   from a remote ka9q-radio `radiod` instance over IP multicast, in pure Go.
@@ -18,6 +30,53 @@ for tagged releases.
   instance names via mDNS, retunes via RADIO_FREQUENCY commands, and decodes
   s16/f32 (either byte order) IQ payloads. Configure under `sdr.ka9q_radio`
   with the status group `addr` and channel `ssrc`; see `config.example.yaml`.
+- **P25 raw status-broadcast dump + live event log** (#779). Two additive field
+  diagnostics, no decode-behaviour change. A per-opcode sampled raw-payload +
+  decoded-field dump for the handled adjacent (0x3C), network (0x3B) and RFSS
+  (0x3A) status broadcasts captures the bytes behind a reported neighbour /
+  identity mismatch when there is no IQ to replay. An optional live event
+  JSONL/NDJSON sink (`log.event_log`) records every bus event as one JSON line
+  in the same envelope the SSE/WS streams emit, with size-capped rotation;
+  surfaced in the web Config Builder.
+
+### Changed
+- **P25 identity recovered from more control-channel opcodes** (#766, #774).
+  Systems that never transmit Network/RFSS Status Broadcasts (0x3B/0x3A) used
+  to leave the web "Network identity" panel stuck on "Awaiting status
+  broadcasts". The System ID is now voted in from Adjacent Site Status
+  Broadcasts (0x3C), and RFSS/Site from the Location Registration Response
+  (LOC_REG_RSP, 0x2B) — the practical identity source on such systems. WACN
+  publishes the instant the Network Status Broadcast lands, and a new
+  per-opcode seen-counter lets the hunt/siglab layers distinguish a genuinely
+  unavailable WACN (NSB never transmitted) from a decode gap.
+- **P25 IDs render in hex** (#774). Site-update events and the systems/sites
+  REST DTOs gain `*_hex` fields (decimal values unchanged); the web "Network
+  identity" card and the TUI render WACN/System ID/RFSS/Site in the configured
+  base (`web.id_base`, hex default).
+
+### Fixed
+- **Wideband DDC/channelizer decode at sample rates above 2.5 MS/s** (#764). A
+  `role: wideband` dongle run above 2.5 MS/s went deaf across every tap. The
+  DDC path now runs a single shared decimate-by-D stage over the wideband
+  stream to bring it into [2.5, 5) MS/s before the per-tap mixers, pinning
+  per-tap cost to the proven ~2.5 MS/s regime so the pump goroutine keeps real
+  time (below 5 MS/s the 2.4 MS/s path is unchanged). The channelizer bin count
+  now scales with the sample rate to hold ~150 kHz bins (64 bins at 10 MS/s)
+  instead of colliding adjacent carriers into one bin.
+- **P25 Phase 2 Motorola talker-alias reassembly** (#773). The Motorola FACCH-S
+  alias data fragments begin on the low nibble of their sequence octet and must
+  be concatenated as a nibble stream; the previous code dropped that leading
+  nibble and concatenated whole bytes, shifting the cipher region by 4 bits so
+  the alias decoded to garbage and failed safe to empty. Reassembly is now
+  nibble-aligned (the end-to-end decoded string remains air-unverified).
+- **P25 autotune no longer over-corrects** (#774). Implausible single AFC
+  measurements are rejected, a warm-up of several samples is required before any
+  correction is applied, and only cleanly-decoded voice calls feed the estimate,
+  so convergence stays in the low-Hz range instead of drifting into the kHz.
+- **Web CC Activity table freezes synchronously on pause** (#772). The pause
+  snapshot is now captured during render the first time pause is seen rather
+  than in a post-paint effect, closing the window where an SSE batch could leak
+  live rows through after the click. The web vitest suite is also wired into CI.
 
 ## [v0.5.0] — 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.0
+VERSION=v0.5.1
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.0" -%}
+  {%- assign ver = "v0.5.1" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.1.md
+++ b/docs/announcements/v0.5.1.md
@@ -1,0 +1,55 @@
+# GopherTrunk v0.5.1 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.1 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.1
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.1 — a new ka9q-radio network SDR source (mount a remote radiod channel over IP multicast as a virtual tuner, the way one well-sited front end can feed many decoders across a LAN), a fix that restores wideband decode above 2.5 MS/s, and a batch of P25 control-channel identity recovery
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.1 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+This is a maintenance release headlined by a new network SDR source and a wideband decode fix.
+
+**What's new since v0.5.0:**
+
+* **ka9q-radio network SDR source** (`sdr.ka9q_radio`, #765). Consume a channel from a remote ka9q-radio `radiod` instance over IP multicast, in pure Go. radiod runs fast-convolution downconverters on a front end and multicasts each channel as RTP; a channel in raw "linear" IQ mode is mounted as a virtual tuner, so one well-sited radiod can feed many GopherTrunk decoders across a LAN. The driver discovers the channel's IQ group, sample rate and encoding from radiod's status group, resolves `.local` names via mDNS, and retunes via RADIO_FREQUENCY commands. Configure with the status group `addr` and channel `ssrc`.
+* **Wideband decode above 2.5 MS/s fixed** (#764). A `role: wideband` dongle run above 2.5 MS/s (e.g. an Airspy at 10 MS/s) went deaf across every tap. The DDC path now runs a shared decimate-by-D stage before the per-tap mixers so per-tap cost stays in the proven ~2.5 MS/s regime, and the channelizer bin count scales with the sample rate to hold ~150 kHz bins instead of colliding adjacent carriers.
+* **P25 identity from more control-channel opcodes** (#766, #774). Systems that never transmit Network/RFSS Status Broadcasts no longer leave the "Network identity" panel blank: System ID is recovered from Adjacent Site Status Broadcasts (0x3C) and RFSS/Site from the Location Registration Response. IDs now render in hex, and autotune was tightened so it no longer over-corrects into the kHz.
+* **P25 Phase 2 Motorola talker-alias reassembly fixed** (#773). The FACCH-S alias fragments are now reassembled as a nibble-aligned stream, fixing the 4-bit shift that decoded the alias to garbage.
+* **Field diagnostics** (#779) — raw status-broadcast byte dumps and an optional live event JSONL log (`log.event_log`) for offline inspection when there's no IQ to replay.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.1
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.1 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+A maintenance release headlined by a new network SDR source and a wideband decode fix.
+
+**What's new since v0.5.0:**
+- **ka9q-radio network SDR source** (`sdr.ka9q_radio`, #765) — mount a channel from a remote `radiod` instance over IP multicast as a virtual tuner, so one well-sited front end can feed many decoders across a LAN.
+- **Wideband decode above 2.5 MS/s fixed** (#764) — a `role: wideband` dongle at 10 MS/s no longer goes deaf across every tap; a shared decimate stage keeps per-tap cost in the proven regime and channelizer bins scale with the rate.
+- **P25 identity recovery** (#766, #774) — System ID from adjacent-site broadcasts, RFSS/Site from the Location Registration Response, hex ID rendering, and autotune that no longer over-corrects.
+- **P25 Phase 2 Motorola talker-alias reassembly fixed** (#773) — nibble-aligned reassembly fixes the 4-bit shift that decoded the alias to garbage.
+- **Field diagnostics** (#779) — raw status-broadcast dumps + optional live event JSONL log (`log.event_log`).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.1>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
Promote the [Unreleased] entries into a dated [v0.5.1] — 2026-06-23
section with a release summary and Added/Changed/Fixed entries covering
the v0.5.1 contents (ka9q-radio network SDR source #765, the wideband
high-rate decode fix #764, P25 identity recovery from adjacent-site and
LOC_REG_RSP opcodes + hex IDs #766/#774, the Phase 2 Motorola
talker-alias reassembly fix #773, the CC Activity pause-freeze fix #772,
and the raw-broadcast / event-log diagnostics #779). Bump the README
quick-start VERSION and the latest-version.html fallback tag to v0.5.1,
and add the v0.5.1 social-announcement drafts.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014RmentCkMQS9Zm14dSMV87