### PR TITLE
dmr/voice: detect 2-slot cadence by AMBE FEC, not the embedded LC (#644)

### DIFF
--- a/internal/radio/dmr/voice/superframe.go
+++ b/internal/radio/dmr/voice/superframe.go
@@ -1,6 +1,10 @@
 package voice
 
-import "github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr"
+)
 
 // VoiceSuperframe is one decoded DMR voice superframe: the 18 on-air
 // AMBE+2 frames carried by bursts A–F. Each frame is 72 bits, one bit
@@ -203,24 +207,74 @@ func (d *Decoder) Process(dibits []uint8, baseIdx int) []VoiceSuperframe {
 	return out
 }
 
+// ambeCadenceLockCeiling and ambeCadenceLockMargin gate locking a cadence by
+// AMBE FEC quality (see resolveAndSlice). A superframe sliced at the correct
+// same-slot stride decodes its 18 AMBE frames with very few Golay-corrected
+// bits; the wrong stride pulls bits from the other timeslot / the inter-burst
+// CACH and scores far higher (18 frames × up to 6 corrected bits = 108 max).
+//   - ceiling caps the winner's total corrected bits: ~24 ≈ 1.3 bits/frame, a
+//     generous weak-signal allowance still well under the ~4–5/frame a random
+//     (wrong-cadence) slice averages.
+//   - margin requires the runner-up to exceed 2×winner by this floor, so two
+//     similarly-bad (both-garbled) candidates never lock the wrong one.
+const (
+	ambeCadenceLockCeiling = 24
+	ambeCadenceLockMargin  = 6
+)
+
+// ambeErrorScore sums the Golay(23,12) corrected-bit count across a
+// superframe's 18 AMBE frames. It is the cadence-quality metric that lets the
+// interleaved decoder detect the same-slot stride WITHOUT the embedded Link
+// Control, whose FEC/CRC constants are still unvalidated against live air — the
+// coupling that left a 288-cadence (CACH) carrier sounding garbled when its LC
+// never decoded (issue #644).
+func ambeErrorScore(sf VoiceSuperframe) int {
+	score := 0
+	for i := range sf.Frames {
+		// DecodeAMBEFrame only errors on a wrong-length frame; here every
+		// frame is a full 72 bits, so err is always nil and we score the
+		// corrected-bit count.
+		if _, errs, err := DecodeAMBEFrame(sf.Frames[i]); err == nil {
+			score += errs
+		}
+	}
+	return score
+}
+
 // resolveAndSlice produces the superframe anchored at start. A decoder with
 // a locked cadence slices at it directly; an undetected interleaved decoder
-// tries each candidate cadence and locks onto the first whose bursts B–E
-// yield a CRC-valid embedded Link Control. If none validate (e.g. a
-// superframe carrying no clean LC) it falls back to the smallest candidate
-// without locking, so a later LC-bearing superframe can still detect the
-// true cadence. The caller has guaranteed maxSpan dibits past start are
+// tries each candidate cadence. A bursts-B–E CRC-valid embedded Link Control
+// is authoritative and locks immediately. Absent any LC, it scores each
+// candidate by AMBE FEC quality (ambeErrorScore) and locks the clearly-best
+// one — so a real carrier whose embedded LC never decodes still finds its
+// cadence (issue #644). With no clear winner it falls back to the smallest
+// candidate without locking, so a later LC-bearing or cleaner superframe can
+// still detect. The caller has guaranteed maxSpan dibits past start are
 // buffered, so every candidate is sliceable.
 func (d *Decoder) resolveAndSlice(start int, syncName string) VoiceSuperframe {
 	if d.lockedStep != 0 {
 		return d.sliceAt(start, d.lockedStep, syncName)
 	}
-	for _, step := range d.cadenceCandidates {
+	bestIdx, bestScore, secondScore := -1, math.MaxInt, math.MaxInt
+	var bestSF VoiceSuperframe
+	for i, step := range d.cadenceCandidates {
 		sf := d.sliceAt(start, step, syncName)
 		if sf.HasLC {
 			d.lockedStep = step
 			return sf
 		}
+		switch s := ambeErrorScore(sf); {
+		case s < bestScore:
+			secondScore = bestScore
+			bestScore, bestIdx, bestSF = s, i, sf
+		case s < secondScore:
+			secondScore = s
+		}
+	}
+	if bestIdx >= 0 && bestScore <= ambeCadenceLockCeiling &&
+		bestScore*2+ambeCadenceLockMargin <= secondScore {
+		d.lockedStep = d.cadenceCandidates[bestIdx]
+		return bestSF
 	}
 	return d.sliceAt(start, d.cadenceCandidates[0], syncName)
 }

--- a/internal/radio/dmr/voice/superframe_test.go
+++ b/internal/radio/dmr/voice/superframe_test.go
@@ -148,6 +148,62 @@ func buildInterleavedStream(t *testing.T, n, lead int) (stream []uint8, aFrames,
 	return stream, aFrames, bFrames
 }
 
+// mkCodewordFrame builds a deterministic, distinct 72-bit on-air AMBE frame
+// that is a VALID Golay codeword (EncodeAMBEFrame of a seeded 49-bit payload).
+// Unlike mkFrame's arbitrary bit pattern, such a frame decodes with zero
+// corrected bits at the right cadence, so a wrong-cadence slice — which mixes
+// in the other slot / CACH — scores measurably higher. This is what exercises
+// the AMBE-FEC cadence detection (see ambeErrorScore / resolveAndSlice).
+func mkCodewordFrame(t *testing.T, seed int) []byte {
+	t.Helper()
+	info := make([]byte, 49)
+	info[0] = 1 // keep payloads non-trivial so a misaligned read clearly differs
+	for i := 1; i < 49; i++ {
+		info[i] = byte((seed*7 + i*3) & 1)
+	}
+	f, err := EncodeAMBEFrame(info)
+	if err != nil {
+		t.Fatalf("EncodeAMBEFrame: %v", err)
+	}
+	return f
+}
+
+// buildInterleavedStreamNoLC weaves a 2-slot TDMA stream with NO embedded Link
+// Control (bursts B–E carry BS-Data filler, like buildInterleavedStream), cach
+// filler dibits before each woven burst (cach=12 models the 288-dibit outbound
+// cadence; cach=0 the 264 CACH-free one), and — when codewords is true — frames
+// that are valid AMBE codewords so cadence can be found by FEC quality alone.
+func buildInterleavedStreamNoLC(t *testing.T, n, lead, cach int, codewords bool) (stream []uint8, aFrames, bFrames [][]byte) {
+	t.Helper()
+	const bSeedOffset = 10000
+	mk := mkFrame
+	if codewords {
+		mk = func(seed int) []byte { return mkCodewordFrame(t, seed) }
+	}
+	stream = make([]uint8, lead)
+	total := n * FramesPerSuperframe
+	for f := 0; f < total; f++ {
+		aFrames = append(aFrames, mk(f))
+		bFrames = append(bFrames, mk(f+bSeedOffset))
+	}
+	cachFiller := make([]uint8, cach)
+	for s := 0; s < n; s++ {
+		for b := 0; b < BurstsPerSuperframe; b++ {
+			sync := dmr.BSData.Dibits
+			if b == 0 {
+				sync = dmr.BSVoice.Dibits
+			}
+			base := s*FramesPerSuperframe + b*FramesPerBurst
+			stream = append(stream, cachFiller...)
+			stream = append(stream, makeVoiceBurst(aFrames[base:base+FramesPerBurst], sync)...)
+			stream = append(stream, cachFiller...)
+			stream = append(stream, makeVoiceBurst(bFrames[base:base+FramesPerBurst], sync)...)
+		}
+	}
+	stream = append(stream, make([]uint8, interleaveTail)...)
+	return stream, aFrames, bFrames
+}
+
 func checkFrames(t *testing.T, sf VoiceSuperframe, frames [][]byte, firstFrame int) {
 	t.Helper()
 	for i := 0; i < FramesPerSuperframe; i++ {
@@ -457,6 +513,66 @@ func TestInterleavedDecoderAutoDetectsNoCACHCadence(t *testing.T) {
 	}
 	checkFrames(t, got[0], aFrames, 0)
 	checkFrames(t, got[1], bFrames, 0)
+}
+
+// TestInterleavedDecoderDetectsCACHCadenceWithoutLC is the reopened-#644 guard.
+// On a real outbound DMR carrier a 12-dibit CACH precedes each burst, so a
+// call's same-slot bursts are 288 dibits apart, not 264 — and the embedded
+// Link Control (whose FEC/CRC constants are still unvalidated against live air)
+// frequently never decodes. The old detector keyed cadence ONLY on a CRC-valid
+// LC, so it fell back to 264 and sliced every burst B–F 24 dibits off, garbling
+// the audio ("sounds encrypted"). The decoder must instead detect the 288
+// cadence from AMBE FEC quality and separate the slots cleanly.
+func TestInterleavedDecoderDetectsCACHCadenceWithoutLC(t *testing.T) {
+	stream, aFrames, bFrames := buildInterleavedStreamNoLC(t, 1, 0, cachDibits, true)
+
+	d := NewInterleavedDecoder()
+	got := d.Process(stream, 0)
+	if len(got) != 2 {
+		t.Fatalf("got %d superframes, want 2 (one per timeslot)", len(got))
+	}
+	if d.lockedStep != 2*(dmr.BurstDibits+cachDibits) {
+		t.Errorf("lockedStep = %d, want %d (288 CACH cadence detected via FEC)", d.lockedStep, 2*(dmr.BurstDibits+cachDibits))
+	}
+	for _, sf := range got {
+		if sf.HasLC {
+			t.Fatalf("unexpected HasLC on a no-LC stream — test would lock via LC, not FEC")
+		}
+	}
+	checkFrames(t, got[0], aFrames, 0)
+	checkFrames(t, got[1], bFrames, 0)
+}
+
+// TestInterleavedDecoderDetectsNoCACHCadenceWithoutLC is the symmetric case: a
+// CACH-free 264-cadence carrier with no decodable LC must lock 264 via FEC.
+func TestInterleavedDecoderDetectsNoCACHCadenceWithoutLC(t *testing.T) {
+	stream, aFrames, bFrames := buildInterleavedStreamNoLC(t, 1, 0, 0, true)
+
+	d := NewInterleavedDecoder()
+	got := d.Process(stream, 0)
+	if len(got) != 2 {
+		t.Fatalf("got %d superframes, want 2", len(got))
+	}
+	if d.lockedStep != 2*dmr.BurstDibits {
+		t.Errorf("lockedStep = %d, want %d (264 cadence detected via FEC)", d.lockedStep, 2*dmr.BurstDibits)
+	}
+	checkFrames(t, got[0], aFrames, 0)
+	checkFrames(t, got[1], bFrames, 0)
+}
+
+// TestInterleavedDecoderDoesNotLockOnGarbledFrames pins the locking margin: on
+// data that is not valid AMBE codewords at EITHER cadence (no clear FEC winner,
+// both scores above the ceiling) the decoder must NOT lock a cadence — it stays
+// open so a later clean / LC-bearing superframe can detect — rather than guess
+// and risk garbling a carrier the FEC can't actually discriminate.
+func TestInterleavedDecoderDoesNotLockOnGarbledFrames(t *testing.T) {
+	stream, _, _ := buildInterleavedStreamNoLC(t, 1, 0, cachDibits, false) // mkFrame, non-codewords
+
+	d := NewInterleavedDecoder()
+	d.Process(stream, 0)
+	if d.lockedStep != 0 {
+		t.Errorf("lockedStep = %d, want 0 (no clear FEC winner must not lock)", d.lockedStep)
+	}
 }
 
 // TestDecoderSuperframeNoLCWhenAbsent confirms a superframe whose B–E


### PR DESCRIPTION
The interleaved DMR voice decoder picked its same-slot TDMA cadence
(264-dibit CACH-free vs 288-dibit with inter-burst CACH) solely by which
candidate stride reassembled a CRC-valid embedded Link Control. That LC
decode (BPTC + Hamming + 5-bit CRC) is still unvalidated against live air
and frequently never decodes on a real outbound carrier, so detection fell
back to 264. On a 288-cadence carrier that slices every burst B-F 24 dibits
off, splicing the other timeslot's / the CACH's bits into each AMBE frame
and rendering the audio as structured noise that "sounds encrypted" — the
reopened symptom of #644.

Decouple cadence detection from the unvalidated LC: when no candidate yields
an authoritative LC, score each by AMBE Golay(23,12) corrected-bit count
(DecodeAMBEFrame) and lock the clearly-best one. A correct slice decodes its
18 frames with ~0 corrected bits; a wrong slice scores far higher. A
conservative ceiling-and-margin gate means non-codeword / genuinely garbled
data never locks a cadence (it stays open for a later clean or LC-bearing
superframe), and the LC remains authoritative when it does decode, so all
existing behaviour is preserved.

Regression test fails first: a 288-cadence stream of valid AMBE codewords
with no decodable LC garbles under the old detector and now locks 288 and
separates the slots cleanly. Symmetric 264 and no-clear-winner guards added.

Refs #644

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FkkULtKjtWdXuE6g2iVKN1