### PR TITLE
docs(learn): make /learn/ a progress dashboard and goal explainer

### DIFF
--- a/docs/_layouts/learn-index.html
+++ b/docs/_layouts/learn-index.html
@@ -2,11 +2,22 @@
 layout: default
 ---
 {%- comment -%}
-  The /learn/ chooser. Lists every learning path in _data/learn.yml as a card
-  (label, tagline, lesson count, level spread) linking to that path's hub.
-  Emits an ItemList of the available courses for SEO.
+  The /learn/ chooser. The hub's front door: it explains the overall goal
+  (work from first principles up to shipping a real project like GopherTrunk),
+  shows the visitor's progress across every path, and lets them resume or reset
+  any path. Every path in _data/learn.yml becomes a card linking to its hub.
+
+  Progressive enhancement: the page is fully usable with JS off — every card
+  links to its hub, the journey stepper is a static numbered list, and the
+  mission copy and ItemList schema are server-rendered. The progress dashboard,
+  per-card rings, "continue" targets and reset buttons are populated by
+  assets/js/learn.js from localStorage, and stay hidden/empty without it.
 {%- endcomment -%}
 {%- assign paths = site.data.learn.paths -%}
+{%- assign grand_total = 0 -%}
+{%- for p in paths -%}
+  {%- for mod in p.modules -%}{%- assign grand_total = grand_total | plus: mod.lessons.size -%}{%- endfor -%}
+{%- endfor -%}
 
 <main id="content" class="page" role="main">
   <div class="container" data-cta-host>
@@ -26,24 +37,106 @@ layout: default
       {{ content }}
     </article>
 
+    {%- comment -%} ---- Journey stepper: the 6 paths leading to "ship it" ---- {%- endcomment -%}
+    <section class="learn-journey" aria-labelledby="journey-h">
+      <h2 id="journey-h" class="learn-journey__title">Your journey to shipping a project</h2>
+      <p class="learn-journey__lede">
+        Six paths take you from first principles to a real, shipping application
+        like GopherTrunk — an SDR trunking scanner. Follow them in order, or jump
+        straight to what you need. Your progress fills in as you go.
+      </p>
+      <ol class="journey" role="list">
+        {%- for p in paths -%}
+          <li class="journey__step" data-journey-path="{{ p.id }}">
+            <a class="journey__link" href="{{ '/learn/' | append: p.id | append: '/' | relative_url }}">
+              <span class="journey__marker">
+                <svg class="journey__ring" viewBox="0 0 44 44" focusable="false" aria-hidden="true">
+                  <circle class="journey__ring-track" cx="22" cy="22" r="19" />
+                  <circle class="journey__ring-fill" cx="22" cy="22" r="19"
+                          data-journey-ring stroke-dasharray="119.38" stroke-dashoffset="119.38"
+                          transform="rotate(-90 22 22)" />
+                  <text class="journey__num" x="22" y="27" text-anchor="middle">{{ forloop.index }}</text>
+                </svg>
+              </span>
+              <span class="journey__label">{{ p.label }}</span>
+              <span class="journey__pct" data-journey-pct hidden></span>
+            </a>
+          </li>
+        {%- endfor -%}
+        <li class="journey__step journey__step--goal" aria-label="Ship a project like GopherTrunk">
+          <span class="journey__marker journey__marker--goal" aria-hidden="true">★</span>
+          <span class="journey__label">Ship a project like GopherTrunk</span>
+        </li>
+      </ol>
+    </section>
+
+    {%- comment -%} ---- Progress dashboard (hidden until learn.js runs) ---- {%- endcomment -%}
+    <section class="learn-dashboard" aria-labelledby="dash-h" hidden data-learn-dashboard>
+      <h2 id="dash-h" class="learn-dashboard__title">Your progress</h2>
+      <div class="learn-dashboard__grid">
+        <figure class="learn-donut" role="img" aria-label="Overall progress across all learning paths" data-donut-figure>
+          <svg class="learn-donut__svg" viewBox="0 0 120 120" focusable="false" aria-hidden="true">
+            <circle class="learn-donut__track" cx="60" cy="60" r="52" />
+            <circle class="learn-donut__fill" cx="60" cy="60" r="52"
+                    data-donut-fill stroke-dasharray="326.726" stroke-dashoffset="326.726"
+                    transform="rotate(-90 60 60)" />
+            <text class="learn-donut__pct" x="60" y="67" text-anchor="middle" data-donut-pct>0%</text>
+          </svg>
+          <figcaption class="learn-donut__caption" data-donut-caption>0 of {{ grand_total }} lessons complete</figcaption>
+        </figure>
+
+        <ul class="learn-stats" data-learn-stats>
+          <li><span class="learn-stats__num" data-stat-lessons>0</span><span class="learn-stats__lbl">lessons done</span></li>
+          <li><span class="learn-stats__num" data-stat-started>0</span><span class="learn-stats__lbl">of {{ paths.size }} paths started</span></li>
+          <li><span class="learn-stats__num" data-stat-completed>0</span><span class="learn-stats__lbl">paths completed</span></li>
+        </ul>
+
+        <ul class="learn-cluster" data-learn-cluster aria-label="Progress by path">
+          {%- for p in paths -%}
+            {%- assign t = 0 -%}
+            {%- for mod in p.modules -%}{%- assign t = t | plus: mod.lessons.size -%}{%- endfor -%}
+            <li class="learn-cluster__row" data-cluster-path="{{ p.id }}" data-cluster-total="{{ t }}">
+              <span class="learn-cluster__name">{{ p.label }}</span>
+              <span class="learn-cluster__track"><span class="learn-cluster__bar" data-cluster-bar></span></span>
+              <span class="learn-cluster__val" data-cluster-val>0%</span>
+            </li>
+          {%- endfor -%}
+        </ul>
+      </div>
+    </section>
+
+    {%- comment -%} ---- Enhanced path cards ---- {%- endcomment -%}
     <div class="learn-modules">
       <section class="learn-module">
+        <h2 class="learn-module__title">Pick a path</h2>
         <ol class="learn-grid">
           {%- for p in paths -%}
             {%- assign count = 0 -%}
             {%- for mod in p.modules -%}{%- assign count = count | plus: mod.lessons.size -%}{%- endfor -%}
             {%- assign base = '/learn/' | append: p.id | append: '/' -%}
-            <li class="learn-card learn-card--path">
+            <li class="learn-card learn-card--path" data-path-card="{{ p.id }}" data-path-total="{{ count }}">
               <a class="learn-card__link" href="{{ base | relative_url }}">
+                <span class="learn-card__ring" aria-hidden="true">
+                  <svg viewBox="0 0 44 44" focusable="false">
+                    <circle class="learn-card__ring-track" cx="22" cy="22" r="19" />
+                    <circle class="learn-card__ring-fill" cx="22" cy="22" r="19"
+                            data-card-ring stroke-dasharray="119.38" stroke-dashoffset="119.38"
+                            transform="rotate(-90 22 22)" />
+                  </svg>
+                </span>
                 <span class="learn-card__body">
                   <span class="learn-card__title">{{ p.label }}</span>
                   <span class="learn-card__summary">{{ p.tagline }}</span>
                   <span class="learn-card__meta">
-                    <span class="learn-card__time">{{ count }} lessons</span>
+                    <span class="learn-card__time" data-card-count>{{ count }} lessons</span>
                     <span class="learn-card__tag">{{ p.modules.size }} modules</span>
                   </span>
                 </span>
               </a>
+              <div class="learn-card__actions" data-card-actions hidden>
+                <a class="btn btn--secondary learn-card__continue" data-card-continue href="{{ base | append: p.start_slug | append: '/' | relative_url }}">Start lesson 1 &rarr;</a>
+                <button type="button" class="learn-card__reset" data-card-reset hidden>reset</button>
+              </div>
             </li>
           {%- endfor -%}
         </ol>
@@ -53,6 +146,35 @@ layout: default
     {%- include page-ctas.html -%}
   </div>
 </main>
+
+<script type="application/json" id="learn-paths-data">
+{
+  "paths": [
+    {%- for p in paths -%}
+    {%- assign base = '/learn/' | append: p.id | append: '/' -%}
+    {%- assign t = 0 -%}
+    {%- for mod in p.modules -%}{%- assign t = t | plus: mod.lessons.size -%}{%- endfor -%}
+    {
+      "id": {{ p.id | jsonify }},
+      "label": {{ p.label | jsonify }},
+      "total": {{ t }},
+      "hubUrl": {{ base | relative_url | jsonify }},
+      "lessons": [
+        {%- assign k = 0 -%}
+        {%- for mod in p.modules -%}
+          {%- for lesson in mod.lessons -%}
+            {%- assign k = k | plus: 1 -%}
+            {"slug": {{ lesson.slug | jsonify }}, "title": {{ lesson.title | jsonify }}, "url": {{ base | append: lesson.slug | append: '/' | relative_url | jsonify }}}{%- unless k == t -%},{%- endunless -%}
+          {%- endfor -%}
+        {%- endfor -%}
+      ]{%- if p.glossary -%},
+      "glossary": {"slug": {{ p.glossary.slug | jsonify }}, "url": {{ base | append: 'glossary/' | relative_url | jsonify }}}
+      {%- endif -%}
+    }{%- unless forloop.last -%},{%- endunless -%}
+    {%- endfor -%}
+  ]
+}
+</script>
 
 <script type="application/ld+json">
 {
@@ -71,3 +193,4 @@ layout: default
   ]
 }
 </script>
+<script defer src="{{ '/assets/js/learn.js' | relative_url }}"></script>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -941,6 +941,216 @@ a.category-chip:hover {
 .learn-card--stub { opacity: 0.92; }
 .learn-card--glossary { border-style: dashed; }
 
+/* ---------- Chooser: journey stepper ---------- */
+.learn-journey { margin: 0 0 2.75rem; }
+.learn-journey__title { font-size: 1.4rem; font-weight: 600; margin: 0 0 0.3rem; }
+.learn-journey__lede { margin: 0 0 1.5rem; color: var(--fg-muted); max-width: 48rem; }
+
+.journey {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+.journey__step {
+  flex: 1 1 0;
+  min-width: 7rem;
+  position: relative;
+  text-align: center;
+}
+/* connector line from the previous marker centre to this one (steps are equal
+   width, so left:-50% / width:100% spans marker-to-marker). */
+.journey__step:not(:first-child)::before {
+  content: "";
+  position: absolute;
+  top: 22px;
+  left: -50%;
+  width: 100%;
+  height: 2px;
+  background: var(--border);
+  z-index: 0;
+}
+.journey__step.is-done::before { background: #1a7f37; }
+:root.dark .journey__step.is-done::before { background: #3fb950; }
+.journey__link {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0 0.25rem;
+  color: var(--fg);
+  text-decoration: none;
+}
+.journey__link:hover { text-decoration: none; }
+.journey__marker { position: relative; z-index: 1; width: 44px; height: 44px; }
+.journey__ring { width: 44px; height: 44px; display: block; }
+.journey__ring-track { fill: var(--bg); stroke: var(--border); stroke-width: 3; }
+.journey__ring-fill {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 3;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.4s ease;
+}
+.journey__step.is-done .journey__ring-fill { stroke: #1a7f37; }
+:root.dark .journey__step.is-done .journey__ring-fill { stroke: #3fb950; }
+.journey__num { fill: var(--fg); font-size: 0.95rem; font-weight: 700; }
+.journey__label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--fg-muted);
+  max-width: 9rem;
+  line-height: 1.3;
+}
+.journey__link:hover .journey__label { color: var(--fg); }
+.journey__pct { font-size: 0.72rem; font-family: var(--font-mono); color: var(--accent); }
+.journey__step--goal { flex: 1 1 0; min-width: 7rem; }
+.journey__marker--goal {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  border: 2px solid var(--accent);
+  font-size: 1.35rem;
+  line-height: 1;
+}
+.journey__step--goal .journey__label { display: block; margin-top: 0.4rem; color: var(--fg); }
+
+@media (max-width: 640px) {
+  .journey { flex-direction: column; align-items: stretch; }
+  .journey__step { min-width: 0; text-align: left; padding-left: 0.25rem; }
+  .journey__step:not(:first-child)::before {
+    top: -0.55rem;
+    left: 22px;
+    width: 2px;
+    height: 0.55rem;
+  }
+  .journey__link { flex-direction: row; align-items: center; gap: 0.7rem; padding: 0.45rem 0; }
+  .journey__step--goal { display: flex; align-items: center; gap: 0.7rem; padding: 0.45rem 0.25rem; }
+  .journey__step--goal .journey__label { margin-top: 0; }
+}
+
+/* ---------- Chooser: progress dashboard ---------- */
+.learn-dashboard {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  padding: 1.5rem;
+  margin: 0 0 2.75rem;
+}
+.learn-dashboard__title { font-size: 1.4rem; font-weight: 600; margin: 0 0 1.1rem; }
+.learn-dashboard__grid {
+  display: grid;
+  grid-template-columns: auto auto minmax(12rem, 1fr);
+  gap: 1.25rem 2rem;
+  align-items: center;
+}
+@media (max-width: 760px) {
+  .learn-dashboard__grid { grid-template-columns: 1fr; justify-items: center; }
+  .learn-cluster { width: 100%; }
+}
+
+.learn-donut { margin: 0; text-align: center; }
+.learn-donut__svg { width: 120px; height: 120px; }
+.learn-donut__track { fill: none; stroke: var(--border); stroke-width: 10; }
+.learn-donut__fill {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.5s ease;
+}
+.learn-donut__pct { fill: var(--fg); font-size: 1.5rem; font-weight: 700; font-family: var(--font-mono); }
+.learn-donut__caption { margin: 0.4rem 0 0; font-size: 0.85rem; color: var(--fg-muted); }
+
+.learn-stats { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+.learn-stats li { display: flex; align-items: baseline; gap: 0.5rem; }
+.learn-stats__num {
+  font-size: 1.6rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  min-width: 1.4em;
+  text-align: right;
+}
+.learn-stats__lbl { color: var(--fg-muted); font-size: 0.9rem; }
+
+.learn-cluster { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.45rem; }
+.learn-cluster__row {
+  display: grid;
+  grid-template-columns: minmax(6rem, 10rem) 1fr 2.6rem;
+  align-items: center;
+  gap: 0.65rem;
+  font-size: 0.82rem;
+}
+.learn-cluster__name { color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.learn-cluster__track {
+  height: 7px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.learn-cluster__bar {
+  display: block;
+  height: 100%;
+  width: 0;
+  background: var(--accent);
+  border-radius: 999px;
+  transition: width 0.4s ease;
+}
+.learn-cluster__val { font-family: var(--font-mono); color: var(--fg-muted); text-align: right; }
+
+/* ---------- Chooser: per-path card ring + actions ---------- */
+.learn-card--path { display: flex; flex-direction: column; }
+.learn-card--path .learn-card__link { height: auto; flex: 1 1 auto; }
+.learn-card__ring { flex-shrink: 0; width: 44px; height: 44px; }
+.learn-card__ring svg { width: 44px; height: 44px; display: block; }
+.learn-card__ring-track { fill: var(--bg); stroke: var(--border); stroke-width: 3; }
+.learn-card__ring-fill {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 3;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 0.4s ease;
+}
+.learn-card--path.is-complete .learn-card__ring-fill { stroke: #1a7f37; }
+:root.dark .learn-card--path.is-complete .learn-card__ring-fill { stroke: #3fb950; }
+.learn-card__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 1rem 0.85rem;
+  border-top: 1px solid var(--border);
+}
+.learn-card__continue { font-size: 0.85rem; padding: 0.35rem 0.7rem; }
+.learn-card--path.is-complete .learn-card__continue { color: #1a7f37; border-color: #1a7f37; }
+:root.dark .learn-card--path.is-complete .learn-card__continue { color: #3fb950; border-color: #3fb950; }
+.learn-card__reset {
+  margin-left: auto;
+  background: none;
+  border: none;
+  color: var(--link);
+  padding: 0;
+  font-size: 0.82rem;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress__bar,
+  .learn-donut__fill,
+  .journey__ring-fill,
+  .learn-card__ring-fill,
+  .learn-cluster__bar { transition: none; }
+}
+
 /* ---------- Lesson page chrome ---------- */
 .lesson__meta {
   display: flex;

--- a/docs/assets/js/learn.js
+++ b/docs/assets/js/learn.js
@@ -114,6 +114,142 @@
     paint();
   }
 
+  /* ---- Chooser page: cross-path progress dashboard ---- */
+  var RING_C = 119.38;   // 2*pi*19, matches the per-path/journey ring dasharray
+  var DONUT_C = 326.726; // 2*pi*52, matches the aggregate donut dasharray
+
+  function setRing(el, pct, circumference) {
+    if (el) el.setAttribute('stroke-dashoffset', (circumference * (1 - pct)).toFixed(2));
+  }
+
+  // Count completed lessons for a path and find its first incomplete one.
+  // Only slugs in the ordered `lessons` list count, so the glossary (stored
+  // but never listed) is ignored for both totals and the resume target.
+  function pathState(p) {
+    var done = load(p.id);
+    var n = 0, first = -1, i;
+    for (i = 0; i < p.lessons.length; i++) {
+      if (done.indexOf(p.lessons[i].slug) !== -1) n++;
+      else if (first === -1) first = i;
+    }
+    return { n: n, total: p.total, first: first };
+  }
+
+  function paintCard(p, s) {
+    var card = document.querySelector('[data-path-card="' + p.id + '"]');
+    if (!card) return;
+    var pct = s.total ? s.n / s.total : 0;
+    setRing(card.querySelector('[data-card-ring]'), pct, RING_C);
+
+    var count = card.querySelector('[data-card-count]');
+    if (count) count.textContent = s.n + ' of ' + s.total + ' lessons';
+
+    var actions = card.querySelector('[data-card-actions]');
+    if (actions) actions.hidden = false;
+
+    card.classList.toggle('is-complete', s.total > 0 && s.n >= s.total);
+
+    var cont = card.querySelector('[data-card-continue]');
+    if (cont) {
+      if (s.total > 0 && s.n >= s.total) {
+        cont.textContent = '✓ Completed';
+        cont.href = p.hubUrl;
+        cont.removeAttribute('aria-label');
+      } else if (s.n === 0) {
+        cont.textContent = 'Start lesson 1 →';
+        cont.href = p.lessons[0] ? p.lessons[0].url : p.hubUrl;
+        cont.removeAttribute('aria-label');
+      } else {
+        var next = p.lessons[s.first];
+        cont.textContent = 'Continue →';
+        cont.href = next.url;
+        cont.setAttribute('aria-label', 'Continue ' + p.label + ': ' + next.title);
+      }
+    }
+
+    var reset = card.querySelector('[data-card-reset]');
+    if (reset) reset.hidden = s.n === 0;
+  }
+
+  function paintCluster(p, s) {
+    var row = document.querySelector('[data-cluster-path="' + p.id + '"]');
+    if (!row) return;
+    var pct = s.total ? Math.round((s.n / s.total) * 100) : 0;
+    var bar = row.querySelector('[data-cluster-bar]');
+    var val = row.querySelector('[data-cluster-val]');
+    if (bar) bar.style.width = pct + '%';
+    if (val) val.textContent = pct + '%';
+  }
+
+  function paintJourney(p, s) {
+    var step = document.querySelector('[data-journey-path="' + p.id + '"]');
+    if (!step) return;
+    var pct = s.total ? s.n / s.total : 0;
+    setRing(step.querySelector('[data-journey-ring]'), pct, RING_C);
+    step.classList.toggle('is-started', s.n > 0);
+    step.classList.toggle('is-done', s.total > 0 && s.n >= s.total);
+    var pctEl = step.querySelector('[data-journey-pct]');
+    if (pctEl) {
+      pctEl.textContent = Math.round(pct * 100) + '%';
+      pctEl.hidden = s.n === 0;
+    }
+  }
+
+  function paintDashboard(done, total, started, completed) {
+    var box = document.querySelector('[data-learn-dashboard]');
+    if (!box) return;
+    box.hidden = false;
+    var pct = total ? done / total : 0;
+    setRing(box.querySelector('[data-donut-fill]'), pct, DONUT_C);
+    var pctEl = box.querySelector('[data-donut-pct]');
+    var cap = box.querySelector('[data-donut-caption]');
+    if (pctEl) pctEl.textContent = Math.round(pct * 100) + '%';
+    if (cap) cap.textContent = done + ' of ' + total + ' lessons complete';
+    var l = box.querySelector('[data-stat-lessons]');
+    var st = box.querySelector('[data-stat-started]');
+    var cp = box.querySelector('[data-stat-completed]');
+    if (l) l.textContent = done;
+    if (st) st.textContent = started;
+    if (cp) cp.textContent = completed;
+  }
+
+  function initChooserProgress() {
+    var dataEl = document.getElementById('learn-paths-data');
+    if (!dataEl) return; // not the chooser page
+    var data;
+    try { data = JSON.parse(dataEl.textContent); } catch (e) { return; }
+    if (!data || !data.paths) return;
+
+    var grandDone = 0, grandTotal = 0, started = 0, completed = 0;
+    data.paths.forEach(function (p) {
+      var s = pathState(p);
+      grandDone += s.n;
+      grandTotal += s.total;
+      if (s.n > 0) started++;
+      if (s.total > 0 && s.n >= s.total) completed++;
+      paintCard(p, s);
+      paintCluster(p, s);
+      paintJourney(p, s);
+    });
+    paintDashboard(grandDone, grandTotal, started, completed);
+
+    // Delegate reset clicks once: re-running initChooserProgress repaints
+    // everything from fresh storage, so a single bound listener is enough.
+    var grid = document.querySelector('.learn-grid');
+    if (grid && !grid.getAttribute('data-reset-bound')) {
+      grid.setAttribute('data-reset-bound', '1');
+      grid.addEventListener('click', function (ev) {
+        var btn = ev.target.closest && ev.target.closest('[data-card-reset]');
+        if (!btn) return;
+        ev.preventDefault();
+        var card = btn.closest('[data-path-card]');
+        if (!card) return;
+        save(card.getAttribute('data-path-card'), []);
+        initChooserProgress();
+      });
+    }
+  }
+
   /* ---- Calculators ---- */
   var C = 299792458; // speed of light, m/s
 
@@ -182,6 +318,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     initLessonComplete();
     initHubProgress();
+    initChooserProgress();
     document.querySelectorAll('[data-calc="freq"]').forEach(initFreqCalc);
     document.querySelectorAll('[data-calc="db"]').forEach(initDbCalc);
     document.querySelectorAll('[data-quiz]').forEach(initQuiz);

--- a/docs/learn/index.md
+++ b/docs/learn/index.md
@@ -7,7 +7,17 @@ keywords: GopherTrunk learn, SDR tutorial, learn git, github tutorial, radio fun
 permalink: /learn/
 ---
 
-Pick a path below to get started. Each one is a guided curriculum broken into
-short modules, with progress saved in your browser as you go. Lessons are
-self-contained and cross-linked, so you can read straight through or jump
-to the topics you need.
+**The goal of this hub is to take you from curious beginner to shipping a real
+project of your own** — something like [GopherTrunk]({{ '/' | relative_url }})
+itself: a software-defined-radio trunking scanner built in Go. Getting there
+touches a lot of ground — how radio works, how signals become numbers, how
+software is designed and version-controlled, the hardware it runs on, and how
+modern AI tools fit into the workflow. Each path below covers one of those
+pieces, in plain language, one short lesson at a time.
+
+You don't have to take them in order, and you don't have to finish them all to
+build something. Start where you're weakest, follow the **journey** from first
+principles to a finished application, and watch your **progress** fill in as you
+go. Everything is saved in your browser — pick up any path exactly where you
+left off, or reset one to start over. Lessons are self-contained and
+cross-linked, so you can read straight through or jump to just what you need.


### PR DESCRIPTION
Rework the learning-hub chooser page from a flat list of path cards into
an engaging, interactive front door that states the hub's mission and
tracks the visitor's progress across every path.

- Mission copy framing the hub as a guided journey from first principles
  to shipping a real project like GopherTrunk.
- A journey stepper (SVG progress rings) showing the six paths leading to
  a "ship it" goal node.
- A progress dashboard: an aggregate SVG donut, headline stats (lessons
  done, paths started/completed) and a per-path bar cluster.
- Enhanced path cards with a per-path ring, "N of T lessons", a
  "Continue where you left off" link targeting the first incomplete
  lesson, and a per-path reset control.

All new UI is progressive enhancement: rendered hidden/empty server-side
and populated by a new initChooserProgress() in learn.js from the existing
localStorage progress store (gt-learn-progress:<path-id>). With JS off the
page stays fully usable — every card still links to its hub, the stepper
is a static numbered list, and the ItemList schema and CTAs are intact.
Charts use CSS variables (dark-mode safe) and respect prefers-reduced-motion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F45viWErdiUVTrFKPwcjjE