### PR TITLE
docs(field-guide): add Hardware (computers & devices) domain

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -79,6 +79,16 @@ groups:
         url: /reference/#hw-sbc
       - title: Microcontrollers
         url: /reference/#hw-microcontrollers
+      - title: Networking & connectivity
+        url: /reference/#hw-networking
+      - title: Storage & memory
+        url: /reference/#hw-storage
+      - title: GPUs, FPGAs & accelerators
+        url: /reference/#hw-accelerators
+      - title: People
+        url: /reference/#hw-people
+      - title: Organizations & makers
+        url: /reference/#hw-organizations
   - label: About
     items:
       - title: The Story of GopherTrunk

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -65,6 +65,20 @@ groups:
         url: /reference/#principles-quality
       - title: Testing, tooling & delivery
         url: /reference/#testing-delivery
+      - title: "Hardware (computers & devices)"
+        url: /reference/#domain-hardware-devices
+      - title: Hardware foundations
+        url: /reference/#hw-foundations
+      - title: Servers & hosting
+        url: /reference/#hw-servers
+      - title: Personal computers
+        url: /reference/#hw-personal-computers
+      - title: Mobile devices
+        url: /reference/#hw-mobile
+      - title: Single-board computers
+        url: /reference/#hw-sbc
+      - title: Microcontrollers
+        url: /reference/#hw-microcontrollers
   - label: About
     items:
       - title: The Story of GopherTrunk

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -367,3 +367,67 @@ domains:
           - { slug: semantic-versioning, title: Semantic versioning, type: concept }
           - { slug: rest, title: REST, type: concept }
           - { slug: version-control, title: Version control, type: concept }
+
+  - id: hardware-devices
+    label: "Hardware (computers & devices)"
+    blurb: The computing hardware a developer chooses between — from cloud servers down to the microcontroller — what each is for, what runs on it, and its trade-offs.
+    categories:
+      - id: hw-foundations
+        label: Hardware foundations
+        blurb: The parts inside every computer and the ideas that span the whole spectrum from cloud to chip.
+        entries:
+          - { slug: computer-hardware, title: Computer hardware, type: concept }
+          - { slug: central-processing-unit, title: Central processing unit (CPU), type: hardware }
+          - { slug: random-access-memory, title: Random-access memory (RAM), type: hardware }
+          - { slug: data-storage, title: Storage (SSD, HDD, flash), type: hardware }
+          - { slug: input-output, title: Input/output (I/O), type: concept }
+          - { slug: operating-system, title: Operating system, type: concept }
+          - { slug: hardware-spectrum, title: The hardware spectrum, type: concept }
+
+      - id: hw-servers
+        label: Servers & hosting
+        blurb: Where software runs for other people — shared hosting, VPSes, dedicated and home servers, and the cloud behind them.
+        entries:
+          - { slug: server, title: Server, type: hardware }
+          - { slug: web-hosting, title: Web & shared hosting, type: concept }
+          - { slug: virtual-private-server, title: Virtual private server (VPS), type: concept }
+          - { slug: dedicated-server, title: Dedicated server, type: hardware }
+          - { slug: home-server, title: Home server & self-hosting, type: concept }
+          - { slug: cloud-computing, title: Cloud computing, type: concept }
+          - { slug: virtualization, title: Virtualization, type: concept }
+
+      - id: hw-personal-computers
+        label: Personal computers
+        blurb: The machines you build software on — the desktop-vs-laptop trade and what each is for.
+        entries:
+          - { slug: personal-computer, title: Personal computer, type: hardware }
+          - { slug: desktop-computer, title: Desktop computer, type: hardware }
+          - { slug: laptop, title: Laptop, type: hardware }
+
+      - id: hw-mobile
+        label: Mobile devices
+        blurb: The computers in everyone's pocket and bag, and what it takes to build software for them.
+        entries:
+          - { slug: smartphone, title: Smartphone, type: hardware }
+          - { slug: tablet, title: Tablet, type: hardware }
+          - { slug: mobile-app-development, title: Mobile app development, type: concept }
+
+      - id: hw-sbc
+        label: Single-board computers
+        blurb: A complete Linux computer on one small board — the Raspberry Pi and its rivals, and the GPIO header that touches the physical world.
+        entries:
+          - { slug: single-board-computer, title: Single-board computer (SBC), type: hardware }
+          - { slug: raspberry-pi, title: Raspberry Pi, type: hardware }
+          - { slug: nvidia-jetson, title: NVIDIA Jetson, type: hardware }
+          - { slug: beaglebone, title: BeagleBone, type: hardware }
+          - { slug: gpio, title: GPIO, type: hardware }
+
+      - id: hw-microcontrollers
+        label: Microcontrollers
+        blurb: The tiny, cheap, low-power chips that run the physical world — no OS, the Arduino, and the wireless ESP32.
+        entries:
+          - { slug: microcontroller, title: Microcontroller (MCU), type: hardware }
+          - { slug: arduino, title: Arduino, type: hardware }
+          - { slug: esp32, title: ESP32, type: hardware }
+          - { slug: firmware, title: Firmware, type: concept }
+          - { slug: internet-of-things, title: Internet of Things (IoT), type: concept }

--- a/docs/_data/reference.yml
+++ b/docs/_data/reference.yml
@@ -383,6 +383,28 @@ domains:
           - { slug: input-output, title: Input/output (I/O), type: concept }
           - { slug: operating-system, title: Operating system, type: concept }
           - { slug: hardware-spectrum, title: The hardware spectrum, type: concept }
+          - { slug: motherboard, title: Motherboard, type: hardware }
+          - { slug: graphics-processing-unit, title: Graphics processing unit (GPU), type: hardware }
+          - { slug: power-supply-unit, title: Power supply unit (PSU), type: hardware }
+          - { slug: cooling-and-thermals, title: Cooling & thermals, type: concept }
+          - { slug: system-bus, title: System bus, type: concept }
+          - { slug: pci-express, title: PCI Express (PCIe), type: hardware }
+          - { slug: usb, title: USB, type: hardware }
+          - { slug: cache-memory, title: Cache memory, type: hardware }
+          - { slug: instruction-set-architecture, title: Instruction set architecture (ISA), type: concept }
+          - { slug: x86, title: x86, type: concept }
+          - { slug: arm-architecture, title: ARM architecture, type: concept }
+          - { slug: risc-v, title: RISC-V, type: concept }
+          - { slug: transistor, title: Transistor, type: hardware }
+          - { slug: integrated-circuit, title: Integrated circuit, type: hardware }
+          - { slug: semiconductor, title: Semiconductor, type: concept }
+          - { slug: logic-gate, title: Logic gate, type: concept }
+          - { slug: von-neumann-architecture, title: Von Neumann architecture, type: concept }
+          - { slug: moores-law, title: Moore's law, type: concept }
+          - { slug: bits-and-bytes, title: Bits & bytes, type: concept }
+          - { slug: clock-speed, title: Clock speed, type: concept }
+          - { slug: bios-uefi, title: BIOS & UEFI, type: concept }
+          - { slug: chipset, title: Chipset, type: hardware }
 
       - id: hw-servers
         label: Servers & hosting
@@ -395,6 +417,28 @@ domains:
           - { slug: home-server, title: Home server & self-hosting, type: concept }
           - { slug: cloud-computing, title: Cloud computing, type: concept }
           - { slug: virtualization, title: Virtualization, type: concept }
+          - { slug: data-center, title: Data center, type: concept }
+          - { slug: rack-server, title: Rack server, type: hardware }
+          - { slug: blade-server, title: Blade server, type: hardware }
+          - { slug: bare-metal-server, title: Bare-metal server, type: hardware }
+          - { slug: colocation, title: Colocation, type: concept }
+          - { slug: managed-hosting, title: Managed hosting, type: concept }
+          - { slug: platform-as-a-service, title: Platform as a service (PaaS), type: concept }
+          - { slug: infrastructure-as-a-service, title: Infrastructure as a service (IaaS), type: concept }
+          - { slug: software-as-a-service, title: Software as a service (SaaS), type: concept }
+          - { slug: serverless-computing, title: Serverless computing, type: concept }
+          - { slug: container, title: Container, type: concept }
+          - { slug: docker, title: Docker, type: concept }
+          - { slug: kubernetes, title: Kubernetes, type: concept }
+          - { slug: hypervisor, title: Hypervisor, type: concept }
+          - { slug: load-balancer, title: Load balancer, type: concept }
+          - { slug: reverse-proxy, title: Reverse proxy, type: concept }
+          - { slug: content-delivery-network, title: Content delivery network (CDN), type: concept }
+          - { slug: network-attached-storage, title: Network-attached storage (NAS), type: hardware }
+          - { slug: raid, title: RAID, type: concept }
+          - { slug: edge-computing, title: Edge computing, type: concept }
+          - { slug: high-availability, title: High availability, type: concept }
+          - { slug: scalability, title: Scalability, type: concept }
 
       - id: hw-personal-computers
         label: Personal computers
@@ -403,6 +447,21 @@ domains:
           - { slug: personal-computer, title: Personal computer, type: hardware }
           - { slug: desktop-computer, title: Desktop computer, type: hardware }
           - { slug: laptop, title: Laptop, type: hardware }
+          - { slug: workstation, title: Workstation, type: hardware }
+          - { slug: all-in-one-computer, title: All-in-one computer, type: hardware }
+          - { slug: mini-pc, title: Mini PC, type: hardware }
+          - { slug: gaming-pc, title: Gaming PC, type: hardware }
+          - { slug: chromebook, title: Chromebook, type: hardware }
+          - { slug: thin-client, title: Thin client, type: hardware }
+          - { slug: computer-monitor, title: Computer monitor, type: hardware }
+          - { slug: keyboard, title: Keyboard, type: hardware }
+          - { slug: mouse, title: Mouse, type: hardware }
+          - { slug: peripheral, title: Peripheral, type: concept }
+          - { slug: computer-case, title: Computer case, type: hardware }
+          - { slug: webcam, title: Webcam, type: hardware }
+          - { slug: printer, title: Printer, type: hardware }
+          - { slug: motherboard-form-factor, title: Motherboard form factor, type: concept }
+          - { slug: build-vs-buy, title: Build vs buy a PC, type: concept }
 
       - id: hw-mobile
         label: Mobile devices
@@ -411,6 +470,20 @@ domains:
           - { slug: smartphone, title: Smartphone, type: hardware }
           - { slug: tablet, title: Tablet, type: hardware }
           - { slug: mobile-app-development, title: Mobile app development, type: concept }
+          - { slug: system-on-a-chip, title: System on a chip (SoC), type: hardware }
+          - { slug: mobile-operating-system, title: Mobile operating system, type: concept }
+          - { slug: android, title: Android, type: concept }
+          - { slug: ios, title: iOS, type: concept }
+          - { slug: battery-technology, title: Battery technology, type: concept }
+          - { slug: touchscreen, title: Touchscreen, type: hardware }
+          - { slug: e-reader, title: E-reader, type: hardware }
+          - { slug: smartwatch, title: Smartwatch, type: hardware }
+          - { slug: wearable-computer, title: Wearable computer, type: hardware }
+          - { slug: cellular-modem, title: Cellular modem, type: hardware }
+          - { slug: gps-receiver, title: GPS receiver, type: hardware }
+          - { slug: esim, title: eSIM, type: hardware }
+          - { slug: near-field-communication, title: Near-field communication (NFC), type: concept }
+          - { slug: foldable-phone, title: Foldable phone, type: hardware }
 
       - id: hw-sbc
         label: Single-board computers
@@ -421,6 +494,17 @@ domains:
           - { slug: nvidia-jetson, title: NVIDIA Jetson, type: hardware }
           - { slug: beaglebone, title: BeagleBone, type: hardware }
           - { slug: gpio, title: GPIO, type: hardware }
+          - { slug: compute-module, title: Compute Module, type: hardware }
+          - { slug: orange-pi, title: Orange Pi, type: hardware }
+          - { slug: odroid, title: ODROID, type: hardware }
+          - { slug: rock-pi, title: Rock Pi (Radxa), type: hardware }
+          - { slug: banana-pi, title: Banana Pi, type: hardware }
+          - { slug: google-coral, title: Google Coral, type: hardware }
+          - { slug: libre-computer, title: Libre Computer, type: hardware }
+          - { slug: hat-add-on-board, title: HAT add-on board, type: hardware }
+          - { slug: edge-ai, title: Edge AI, type: concept }
+          - { slug: home-automation, title: Home automation, type: concept }
+          - { slug: sbc-cluster, title: SBC cluster, type: concept }
 
       - id: hw-microcontrollers
         label: Microcontrollers
@@ -431,3 +515,108 @@ domains:
           - { slug: esp32, title: ESP32, type: hardware }
           - { slug: firmware, title: Firmware, type: concept }
           - { slug: internet-of-things, title: Internet of Things (IoT), type: concept }
+          - { slug: stm32, title: STM32, type: hardware }
+          - { slug: pic-microcontroller, title: PIC microcontroller, type: hardware }
+          - { slug: avr-atmega, title: AVR / ATmega, type: hardware }
+          - { slug: rp2040, title: RP2040, type: hardware }
+          - { slug: raspberry-pi-pico, title: Raspberry Pi Pico, type: hardware }
+          - { slug: teensy, title: Teensy, type: hardware }
+          - { slug: arm-cortex-m, title: ARM Cortex-M, type: concept }
+          - { slug: real-time-operating-system, title: Real-time operating system (RTOS), type: concept }
+          - { slug: bootloader, title: Bootloader, type: concept }
+          - { slug: in-system-programming, title: In-system programming, type: concept }
+          - { slug: pulse-width-modulation, title: Pulse-width modulation (PWM), type: concept }
+          - { slug: digital-to-analog-converter, title: Digital-to-analog converter (DAC), type: hardware }
+          - { slug: i2c, title: "I²C", type: concept }
+          - { slug: spi, title: SPI, type: concept }
+          - { slug: uart, title: UART, type: concept }
+          - { slug: interrupt, title: Interrupt, type: concept }
+          - { slug: embedded-system, title: Embedded system, type: concept }
+          - { slug: bare-metal-programming, title: Bare-metal programming, type: concept }
+          - { slug: watchdog-timer, title: Watchdog timer, type: concept }
+          - { slug: sensor, title: Sensor, type: hardware }
+
+      - id: hw-networking
+        label: Networking & connectivity
+        blurb: How computers reach each other and the internet — the cards, boxes, links, and addresses that move bytes between machines.
+        entries:
+          - { slug: network-interface-card, title: Network interface card (NIC), type: hardware }
+          - { slug: router, title: Router, type: hardware }
+          - { slug: network-switch, title: Network switch, type: hardware }
+          - { slug: ethernet, title: Ethernet, type: concept }
+          - { slug: wi-fi, title: Wi-Fi, type: concept }
+          - { slug: bluetooth, title: Bluetooth, type: concept }
+          - { slug: modem, title: Modem, type: hardware }
+          - { slug: wireless-access-point, title: Wireless access point, type: hardware }
+          - { slug: fiber-optic, title: Fiber-optic, type: concept }
+          - { slug: power-over-ethernet, title: Power over Ethernet (PoE), type: concept }
+          - { slug: thunderbolt, title: Thunderbolt, type: hardware }
+          - { slug: gateway, title: Gateway, type: concept }
+          - { slug: lan-and-wan, title: LAN & WAN, type: concept }
+          - { slug: ip-address, title: IP address, type: concept }
+
+      - id: hw-storage
+        label: Storage & memory
+        blurb: Where bytes live — the drives, chips, and cards that hold data, and the memory hierarchy that ranks them by speed and cost.
+        entries:
+          - { slug: hard-disk-drive, title: Hard disk drive (HDD), type: hardware }
+          - { slug: solid-state-drive, title: Solid-state drive (SSD), type: hardware }
+          - { slug: nvme, title: NVMe, type: concept }
+          - { slug: flash-memory, title: Flash memory, type: hardware }
+          - { slug: sd-card, title: SD card, type: hardware }
+          - { slug: emmc, title: eMMC, type: hardware }
+          - { slug: optical-disc, title: Optical disc, type: hardware }
+          - { slug: magnetic-tape, title: Magnetic tape, type: hardware }
+          - { slug: read-only-memory, title: Read-only memory (ROM), type: hardware }
+          - { slug: volatile-memory, title: Volatile vs non-volatile memory, type: concept }
+          - { slug: memory-hierarchy, title: Memory hierarchy, type: concept }
+          - { slug: file-system, title: File system, type: concept }
+
+      - id: hw-accelerators
+        label: GPUs, FPGAs & accelerators
+        blurb: Chips that do specialized work faster than a general CPU — graphics, AI, signal processing, and reconfigurable logic.
+        entries:
+          - { slug: cuda, title: CUDA, type: concept }
+          - { slug: gpgpu, title: GPGPU, type: concept }
+          - { slug: tensor-processing-unit, title: Tensor processing unit (TPU), type: hardware }
+          - { slug: neural-processing-unit, title: Neural processing unit (NPU), type: hardware }
+          - { slug: field-programmable-gate-array, title: Field-programmable gate array (FPGA), type: hardware }
+          - { slug: application-specific-integrated-circuit, title: Application-specific integrated circuit (ASIC), type: hardware }
+          - { slug: ai-accelerator, title: AI accelerator, type: hardware }
+          - { slug: vector-processor, title: Vector processor, type: concept }
+          - { slug: hardware-acceleration, title: Hardware acceleration, type: concept }
+          - { slug: soc-vs-discrete, title: SoC vs discrete, type: concept }
+
+      - id: hw-people
+        label: People
+        blurb: The engineers and founders who built the computing-hardware world — from the first transistors and CPUs to the boards and chips developers use today.
+        entries:
+          - { slug: alan-turing, title: Alan Turing, type: person }
+          - { slug: john-von-neumann, title: John von Neumann, type: person }
+          - { slug: gordon-moore, title: Gordon Moore, type: person }
+          - { slug: robert-noyce, title: Robert Noyce, type: person }
+          - { slug: jack-kilby, title: Jack Kilby, type: person }
+          - { slug: federico-faggin, title: Federico Faggin, type: person }
+          - { slug: steve-wozniak, title: Steve Wozniak, type: person }
+          - { slug: linus-torvalds, title: Linus Torvalds, type: person }
+          - { slug: eben-upton, title: Eben Upton, type: person }
+          - { slug: massimo-banzi, title: Massimo Banzi, type: person }
+          - { slug: sophie-wilson, title: Sophie Wilson, type: person }
+          - { slug: jensen-huang, title: Jensen Huang, type: person }
+
+      - id: hw-organizations
+        label: Organizations & makers
+        blurb: The companies and bodies that design and make computing hardware — chip makers, board vendors, foundries, and the standards groups behind them.
+        entries:
+          - { slug: intel, title: Intel, type: organization }
+          - { slug: amd, title: AMD, type: organization }
+          - { slug: arm-holdings, title: Arm Holdings, type: organization }
+          - { slug: nvidia, title: NVIDIA, type: organization }
+          - { slug: qualcomm, title: Qualcomm, type: organization }
+          - { slug: raspberry-pi-foundation, title: Raspberry Pi Foundation, type: organization }
+          - { slug: arduino-company, title: Arduino (company), type: organization }
+          - { slug: espressif, title: Espressif Systems, type: organization }
+          - { slug: broadcom, title: Broadcom, type: organization }
+          - { slug: tsmc, title: TSMC, type: organization }
+          - { slug: ieee, title: IEEE, type: organization }
+          - { slug: jedec, title: JEDEC, type: organization }

--- a/docs/reference/ai-accelerator.md
+++ b/docs/reference/ai-accelerator.md
@@ -1,0 +1,31 @@
+---
+slug: ai-accelerator
+title: AI accelerator
+entry_type: hardware
+category: hw-accelerators
+description: An AI accelerator is specialized hardware designed to speed up machine-learning workloads, especially the matrix math of neural networks, far more efficiently than a general-purpose CPU.
+keywords: AI accelerator, machine learning hardware, neural network chip, TPU, NPU, GPU, inference, training, deep learning
+infobox:
+  - { label: Type, value: Specialized compute hardware }
+  - { label: Job, value: Neural-network training / inference }
+  - { label: Forms, value: "GPU, TPU, NPU, FPGA, ASIC" }
+  - { label: Optimized for, value: Parallel matrix math }
+  - { label: Metric, value: Throughput per watt }
+see_also: [tensor-processing-unit, neural-processing-unit, graphics-processing-unit, hardware-acceleration, application-specific-integrated-circuit, edge-ai]
+cite_urls:
+  - https://en.wikipedia.org/wiki/AI_accelerator
+---
+
+An **AI accelerator** is specialized hardware designed to run machine-learning workloads — above all the dense matrix multiplications of neural networks — far faster and more efficiently than a general-purpose [CPU](/reference/central-processing-unit/).[^wiki]
+
+## Overview
+
+"AI accelerator" is an umbrella term, not a single chip. It covers the [GPU](/reference/graphics-processing-unit/) (the workhorse of deep-learning training), Google's [TPU](/reference/tensor-processing-unit/), the on-device [NPU](/reference/neural-processing-unit/) found in phones and laptops, and custom [ASIC](/reference/application-specific-integrated-circuit/) and [FPGA](/reference/field-programmable-gate-array/) designs. What they share is an architecture built for *throughput on parallel, reduced-precision arithmetic* — many multiply-accumulate units fed by high-bandwidth memory — rather than the low-latency, branch-heavy execution a CPU optimizes for.
+
+## Where it fits
+
+Accelerators split roughly by role: large, power-hungry parts (GPUs, TPUs) train and serve big models in the data center, while compact NPUs run inference on the [edge](/reference/edge-ai/) at low power. The performance metric that matters is throughput per watt. For a scanner like GopherTrunk the relevant case is the edge: an accelerator near the antenna could classify or transcribe decoded traffic locally, though the radio's own DSP is conventional [hardware acceleration](/reference/hardware-acceleration/), not neural-network work.
+
+## Sources
+
+[^wiki]: [AI accelerator](https://en.wikipedia.org/wiki/AI_accelerator) — Wikipedia, on the class of hardware built to speed up machine learning.

--- a/docs/reference/alan-turing.md
+++ b/docs/reference/alan-turing.md
@@ -1,0 +1,49 @@
+---
+slug: alan-turing
+title: Alan Turing
+entry_type: person
+category: hw-people
+description: Alan Turing (1912–1954) was a British mathematician and logician whose 1936 model of computation defined what a general-purpose computer is and laid the theoretical foundation for the modern stored-program machine.
+keywords: Alan Turing, Turing machine, computability, Bletchley Park, theoretical computer science, stored-program computer
+aka: [Alan Turing, Turing]
+autolink: true
+infobox:
+  - { label: Lived, value: "1912–1954" }
+  - { label: Field, value: Mathematics / logic / computing }
+  - { label: Known for, value: Turing machine, computability }
+see_also: [john-von-neumann, von-neumann-architecture, central-processing-unit, computer-hardware]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Alan_Turing
+---
+
+**Alan Turing** (1912–1954) was a British mathematician and logician whose abstract
+**Turing machine** defined what it means for a problem to be computable and framed the idea
+of a single machine that can run any program.[^wiki]
+
+## Life and work
+
+In his 1936 paper "On Computable Numbers," Turing described a simple abstract device — a tape,
+a read/write head, and a table of rules — and proved that one universal version of it could
+simulate any other. That universal machine is the theoretical ancestor of every
+programmable computer.[^wiki] During the Second World War he led code-breaking work at
+Bletchley Park, helping build electromechanical machines that broke the German Enigma
+cipher. After the war he contributed to early stored-program computer designs and to the
+foundations of artificial intelligence, proposing the test that bears his name.[^wiki]
+
+## Why they matter
+
+Turing's universal machine is the reason a [CPU](/reference/central-processing-unit/) can run
+word processors, web servers, and an SDR decoder without being rewired for each — software,
+not hardware, defines the task. His computability results sit alongside the practical
+[von Neumann architecture](/reference/von-neumann-architecture/) that
+[John von Neumann](/reference/john-von-neumann/) formalised a decade later, and together they
+underpin all general-purpose [computer hardware](/reference/computer-hardware/).[^wiki]
+
+## Legacy
+
+The Turing Award, computing's highest honour, is named after him, and his model remains the
+standard reference for what computers can and cannot, in principle, do.
+
+## Sources
+
+[^wiki]: [Alan Turing](https://en.wikipedia.org/wiki/Alan_Turing) — Wikipedia, for biography, the Turing machine, and Bletchley Park.

--- a/docs/reference/all-in-one-computer.md
+++ b/docs/reference/all-in-one-computer.md
@@ -1,0 +1,33 @@
+---
+slug: all-in-one-computer
+title: All-in-one computer
+entry_type: hardware
+category: hw-personal-computers
+description: An all-in-one computer integrates the whole PC — CPU, memory, storage, and components — into the same enclosure as the display, leaving only a keyboard, mouse, and power cable on the desk.
+keywords: all-in-one, AIO computer, iMac, integrated PC, desktop replacement
+aka: [AIO, All-in-one PC]
+infobox:
+  - { label: Type, value: Personal computer }
+  - { label: Form, value: PC built into the monitor }
+  - { label: Internals, value: Often laptop-class parts }
+  - { label: Examples, value: Apple iMac, many vendor AIOs }
+see_also: [personal-computer, desktop-computer, computer-monitor, laptop, mini-pc]
+related_lessons:
+  - { title: "Desktop computers", url: /learn/intro-hardware/desktop-computers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/All-in-one_computer
+---
+
+An **all-in-one computer** (AIO) integrates the whole computer — processor, memory, storage, and other components — into the same enclosure as the [display](/reference/computer-monitor/), so the only things on the desk are a [keyboard](/reference/keyboard/), a [mouse](/reference/mouse/), and a power cable.[^wiki]
+
+## Overview
+
+An AIO is a [personal computer](/reference/personal-computer/) that trades the modular tower of a [desktop computer](/reference/desktop-computer/) for a single tidy unit. To fit behind the screen it usually borrows laptop-class parts: low-power [CPUs](/reference/central-processing-unit/), soldered or limited [RAM](/reference/random-access-memory/), and integrated graphics. The best-known example is Apple's iMac, but most major PC makers ship AIO models. The upside is a clean desk and easy setup; the downside is limited upgrades and the fact that a screen failure can take the whole computer with it.
+
+## Where it fits
+
+An all-in-one suits reception desks, kiosks, classrooms, and homes where appearance and simplicity matter more than expandability or raw performance. If you want to upgrade parts later, a desktop tower or even a small [mini PC](/reference/mini-pc/) paired with a separate monitor gives more freedom. For a portable machine, a [laptop](/reference/laptop/) is the natural choice.
+
+## Sources
+
+[^wiki]: [All-in-one computer](https://en.wikipedia.org/wiki/All-in-one_computer) — Wikipedia, on PCs that integrate the system into the display enclosure.

--- a/docs/reference/amd.md
+++ b/docs/reference/amd.md
@@ -1,0 +1,47 @@
+---
+slug: amd
+title: AMD
+entry_type: organization
+category: hw-organizations
+description: AMD (Advanced Micro Devices) is an American semiconductor company that designs x86 CPUs and, through its Radeon line, GPUs, competing directly with Intel and NVIDIA.
+keywords: AMD, Advanced Micro Devices, Ryzen, EPYC, Radeon, x86, CPU, GPU
+aka: [Advanced Micro Devices]
+autolink: true
+infobox:
+  - { label: Type, value: Public semiconductor company }
+  - { label: Founded, value: "1969" }
+  - { label: HQ, value: Santa Clara, California, USA }
+  - { label: Makes, value: x86 CPUs, GPUs }
+see_also: [central-processing-unit, graphics-processing-unit, intel, x86]
+cite_urls:
+  - https://www.amd.com/
+  - https://en.wikipedia.org/wiki/AMD
+---
+
+**AMD** (Advanced Micro Devices) is an American semiconductor company founded in 1969 that
+designs [x86](/reference/x86/) [CPUs](/reference/central-processing-unit/) and, through its
+Radeon brand, [GPUs](/reference/graphics-processing-unit/).[^wiki]
+
+## Overview
+
+AMD began as a second source for chips compatible with Intel's designs and grew into a
+full competitor. Its modern Ryzen processors target desktops and laptops, while EPYC
+serves data centers and servers; its Radeon line competes in graphics. AMD acquired the
+graphics company ATI in 2006 and the FPGA maker Xilinx in 2022, broadening its reach into
+accelerators and programmable logic.[^home]
+
+Unlike a traditional integrated manufacturer, AMD is "fabless" — it designs chips but
+contracts their fabrication to foundries such as [TSMC](/reference/tsmc/), letting it focus
+investment on design rather than building plants.
+
+## Why it matters
+
+AMD keeps the x86 market competitive with [Intel](/reference/intel/), and its EPYC server
+chips and Radeon GPUs are common in workstations and data centers. For compute-heavy SDR
+work — running many decode channels or DSP on a single host — a high-core-count AMD CPU is
+a frequent choice.
+
+## Sources
+
+[^home]: [AMD](https://www.amd.com/) — the company's official site, for product lines.
+[^wiki]: [AMD](https://en.wikipedia.org/wiki/AMD) — Wikipedia, for the company's history and role.

--- a/docs/reference/android.md
+++ b/docs/reference/android.md
@@ -1,0 +1,35 @@
+---
+slug: android
+title: Android
+entry_type: concept
+category: hw-mobile
+description: Android is the Linux-based, open-source mobile operating system developed by Google, running on the majority of the world's smartphones and tablets as well as watches, TVs, and embedded devices.
+keywords: Android, Google, AOSP, Linux mobile, smartphone OS, ART runtime, Kotlin, Java, app store
+autolink: true
+infobox:
+  - { label: Type, value: Mobile operating system }
+  - { label: Developer, value: Google (AOSP) }
+  - { label: Kernel, value: Linux }
+  - { label: First release, value: 2008 }
+  - { label: Apps in, value: Kotlin, Java }
+see_also: [mobile-operating-system, ios, smartphone, tablet, mobile-app-development, system-on-a-chip]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+  - { title: "Developing for mobile", url: /learn/intro-hardware/developing-for-mobile/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Android_(operating_system)
+---
+
+**Android** is the Linux-based, open-source [mobile operating system](/reference/mobile-operating-system/) developed by Google, running on most of the world's smartphones and tablets.[^wiki]
+
+## Overview
+
+Android is built on the Linux kernel with a managed runtime (ART) on top; apps are written mainly in Kotlin or Java against Google's SDK. The core platform is released as open source (the Android Open Source Project, AOSP), which lets handset makers ship their own variants, while Google layers proprietary services and the Play Store on top. Beyond phones it powers watches (Wear OS), TVs, cars, and embedded gear. It runs largely on [Arm](/reference/arm-architecture/)-based [SoCs](/reference/system-on-a-chip/).
+
+## Where it fits
+
+Android is the open counterweight to Apple's [iOS](/reference/ios/): more device variety and more openness, at the cost of fragmentation across versions and vendors. Its Linux foundation and sideloading make it the more hackable of the two — it is at least conceivable to drive an SDR dongle and a [mobile app](/reference/mobile-app-development/) front end from a rooted Android phone, though GopherTrunk's heavy decode pipeline still prefers a dedicated capture node.
+
+## Sources
+
+[^wiki]: [Android (operating system)](https://en.wikipedia.org/wiki/Android_(operating_system)) — Wikipedia, on Android's design, history, and ecosystem.

--- a/docs/reference/application-specific-integrated-circuit.md
+++ b/docs/reference/application-specific-integrated-circuit.md
@@ -1,0 +1,33 @@
+---
+slug: application-specific-integrated-circuit
+title: Application-specific integrated circuit (ASIC)
+entry_type: hardware
+category: hw-accelerators
+description: An application-specific integrated circuit (ASIC) is a chip custom-designed for one fixed task, trading flexibility for the best possible speed, power, and cost at high volume.
+keywords: ASIC, application-specific integrated circuit, custom chip, fixed-function, fabrication, mask, tape-out, hardware acceleration
+aka: [ASIC]
+autolink: true
+infobox:
+  - { label: Type, value: Fixed-function custom chip }
+  - { label: Designed for, value: One specific application }
+  - { label: Strength, value: Best speed / power / unit cost }
+  - { label: Weakness, value: "Not reprogrammable; high NRE" }
+  - { label: Built by, value: "Foundry (e.g. TSMC)" }
+see_also: [field-programmable-gate-array, integrated-circuit, tensor-processing-unit, hardware-acceleration, soc-vs-discrete, semiconductor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Application-specific_integrated_circuit
+---
+
+An **application-specific integrated circuit** (**ASIC**) is an [integrated circuit](/reference/integrated-circuit/) custom-designed for a single, fixed task — trading away general-purpose flexibility for the best achievable speed, power efficiency, and per-unit cost.[^wiki]
+
+## Overview
+
+Where a CPU or [FPGA](/reference/field-programmable-gate-array/) is built to run many possible workloads, an ASIC's circuit is etched permanently into silicon to do exactly one job — a network switch chip, a Bitcoin miner, a phone's modem, a [TPU](/reference/tensor-processing-unit/). The design is fabricated at a foundry such as [TSMC](/reference/tsmc/) from a set of photomasks; this *non-recurring engineering* cost is large and a finished ASIC cannot be changed, so the economics only work at high volume or where nothing else meets the performance target.
+
+## Trade-offs
+
+The classic spectrum runs CPU → GPU → FPGA → ASIC, with flexibility falling and efficiency rising at each step. An ASIC wins decisively on performance-per-watt and cost-at-scale but is inflexible and slow to bring to market; an FPGA is the hedge when volumes are low or the design may still change. Many specialized [hardware accelerators](/reference/hardware-acceleration/) are ASICs. For a project like GopherTrunk, ASICs already appear *inside* the radio — the [RTL-SDR](/reference/rtl-sdr/)'s tuner and demodulator are fixed-function chips — even though the decoding itself is done in software.
+
+## Sources
+
+[^wiki]: [Application-specific integrated circuit](https://en.wikipedia.org/wiki/Application-specific_integrated_circuit) — Wikipedia, on custom fixed-function chips and their trade-offs.

--- a/docs/reference/arduino-company.md
+++ b/docs/reference/arduino-company.md
@@ -1,0 +1,50 @@
+---
+slug: arduino-company
+title: Arduino (company)
+entry_type: organization
+category: hw-organizations
+description: Arduino is an open-source hardware company that makes the Arduino microcontroller boards and development environment, popularising electronics for makers and beginners.
+keywords: Arduino, open-source hardware, microcontroller board, maker, Massimo Banzi, IDE
+aka: [Arduino LLC, Arduino SA]
+autolink: false
+infobox:
+  - { label: Type, value: Open-source hardware company }
+  - { label: Founded, value: "2005" }
+  - { label: HQ, value: Italy }
+  - { label: Makes, value: Arduino microcontroller boards and IDE }
+see_also: [arduino, massimo-banzi, microcontroller]
+related_lessons:
+  - { title: "Arduino", url: /learn/intro-hardware/arduino/ }
+cite_urls:
+  - https://www.arduino.cc/
+  - https://en.wikipedia.org/wiki/Arduino
+---
+
+**Arduino** is an open-source hardware company that makes the
+[Arduino](/reference/arduino/) [microcontroller](/reference/microcontroller/) boards and the
+accompanying development environment.[^wiki]
+
+## Overview
+
+Arduino began around 2005 at a design school in Ivrea, Italy, from a project led by
+[Massimo Banzi](/reference/massimo-banzi/) and collaborators who wanted an easy, cheap way
+for artists and students to build interactive electronics. The result paired a simple
+microcontroller board with a friendly programming environment, and released both the board
+designs and software as open source.[^home]
+
+That openness let others freely study, copy, and extend the platform, fueling a huge maker
+ecosystem of compatible boards, shields, and tutorials. The company designs and sells
+official boards and maintains the Arduino IDE and libraries.
+
+## Why it matters
+
+Arduino made microcontroller programming approachable for people without an electronics
+background, and its boards are a common starting point for sensors, automation, and small
+embedded projects. In an SDR context, an Arduino is a natural choice for the simple control
+glue around a receiver — switching an antenna relay, reading a sensor, or driving status
+LEDs.
+
+## Sources
+
+[^home]: [Arduino](https://www.arduino.cc/) — the company's official site.
+[^wiki]: [Arduino](https://en.wikipedia.org/wiki/Arduino) — Wikipedia, for the project's origin and ecosystem.

--- a/docs/reference/arduino.md
+++ b/docs/reference/arduino.md
@@ -1,0 +1,35 @@
+---
+slug: arduino
+title: Arduino
+entry_type: hardware
+category: hw-microcontrollers
+description: Arduino is a widely used family of beginner-friendly microcontroller boards and the open-source ecosystem of tools and code built around them.
+keywords: Arduino, sketch, Arduino IDE, shield, 8-bit microcontroller, open source hardware, AVR
+aka: [Arduino]
+autolink: true
+infobox:
+  - { label: Type, value: Microcontroller boards }
+  - { label: Core, value: Classic boards 8-bit AVR }
+  - { label: Memory, value: Kilobytes of RAM and flash }
+  - { label: Software, value: Arduino IDE (sketches) }
+  - { label: License, value: Open source }
+see_also: [microcontroller, esp32, gpio, single-board-computer, firmware]
+related_lessons:
+  - { title: "Arduino", url: /learn/intro-hardware/arduino/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Arduino
+---
+
+**Arduino** is a widely used family of beginner-friendly [microcontroller](/reference/microcontroller/) boards and the open-source ecosystem of tools and code built around them.[^wiki]
+
+## Overview
+
+An Arduino program is called a *sketch*. The simple Arduino IDE, plus a huge library and "shield" ecosystem of plug-in add-on boards, is what made microcontrollers approachable to hobbyists and students. Classic Arduino boards are 8-bit and modest in speed and memory, but that is enough for sensors, motors, and small projects.
+
+## Where it fits
+
+Arduino sits at the gentle end of embedded computing: you wire components to its [GPIO](/reference/gpio/) pins, write a sketch, and flash it onto the board. The ecosystem's tooling has spread well beyond the original boards — many other microcontrollers, including the [ESP32](/reference/esp32/), can be programmed with the Arduino IDE too. These tiny boards drive the kinds of small radios that fill the airwaves GopherTrunk listens to.
+
+## Sources
+
+[^wiki]: [Arduino](https://en.wikipedia.org/wiki/Arduino) — Wikipedia, on the boards, sketches, and open-source ecosystem.

--- a/docs/reference/arm-architecture.md
+++ b/docs/reference/arm-architecture.md
@@ -1,0 +1,32 @@
+---
+slug: arm-architecture
+title: ARM architecture
+entry_type: concept
+category: hw-foundations
+description: ARM is a family of RISC instruction set architectures licensed by Arm Holdings, prized for power efficiency and dominant in phones, tablets, and embedded devices.
+keywords: ARM architecture, RISC, Arm Holdings, AArch64, low power, mobile, embedded, Apple Silicon
+aka: [ARM, AArch64]
+autolink: true
+infobox:
+  - { label: Type, value: ISA (RISC) }
+  - { label: Licensed by, value: Arm Holdings }
+  - { label: Known for, value: Power efficiency }
+  - { label: Dominates, value: Mobile & embedded }
+see_also: [instruction-set-architecture, x86, risc-v, central-processing-unit, raspberry-pi, semiconductor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/ARM_architecture_family
+---
+
+**ARM** is a family of RISC [instruction set architectures](/reference/instruction-set-architecture/) licensed by Arm Holdings, known above all for power efficiency.[^wiki]
+
+## Overview
+
+ARM follows the RISC philosophy of a small set of simple, fixed-length instructions, which keeps chips lean and power-thrifty. Arm Holdings designs the architecture and core blueprints but does not make chips itself; instead it *licenses* them to companies that build their own [SoCs](/reference/system-on-a-chip/) around ARM cores. The 64-bit variant is AArch64. This licensing model put ARM cores in nearly every smartphone, in countless embedded devices, and increasingly in laptops and servers.
+
+## Where it fits
+
+ARM's efficiency made it the default for battery-powered and embedded computing, the opposite end of the spectrum from where [x86](/reference/x86/) grew up; [RISC-V](/reference/risc-v/) is a newer open RISC rival. The [Raspberry Pi](/reference/raspberry-pi/) and most single-board computers use ARM [CPUs](/reference/central-processing-unit/), which is exactly why a low-power GopherTrunk capture node by the antenna usually runs on ARM rather than x86.
+
+## Sources
+
+[^wiki]: [ARM architecture family](https://en.wikipedia.org/wiki/ARM_architecture_family) — Wikipedia, on ARM, its RISC design, and licensing model.

--- a/docs/reference/arm-cortex-m.md
+++ b/docs/reference/arm-cortex-m.md
@@ -1,0 +1,36 @@
+---
+slug: arm-cortex-m
+title: ARM Cortex-M
+entry_type: concept
+category: hw-microcontrollers
+description: ARM Cortex-M is a family of 32-bit processor cores designed for microcontrollers, prioritizing low power, deterministic interrupt handling, and small silicon area over raw throughput.
+keywords: ARM Cortex-M, Cortex-M0, Cortex-M4, Cortex-M7, Thumb, NVIC, microcontroller core, embedded processor
+aka: [Cortex-M]
+autolink: true
+infobox:
+  - { label: Type, value: Processor core family }
+  - { label: Width, value: 32-bit }
+  - { label: Designer, value: Arm Holdings }
+  - { label: Members, value: M0, M0+, M3, M4, M7, M23, M33 }
+  - { label: For, value: Microcontrollers }
+see_also: [microcontroller, stm32, rp2040, teensy, real-time-operating-system, interrupt]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/ARM_Cortex-M
+---
+
+**ARM Cortex-M** is a family of 32-bit processor cores from Arm Holdings designed specifically for [microcontrollers](/reference/microcontroller/).[^wiki]
+
+## Overview
+
+Rather than chasing raw throughput, Cortex-M cores prioritize low power, small silicon area, and predictable real-time behavior. They execute the compact Thumb instruction set and include a built-in nested vectored [interrupt](/reference/interrupt/) controller (NVIC) that makes response latency deterministic. The lineup ranges from the minimal Cortex-M0/M0+ through the DSP-capable M4 and high-performance M7, plus the security-focused M23/M33. Arm licenses the core; chip vendors wrap it in their own memory and peripherals.
+
+## Where it fits
+
+Because the core is licensed rather than sold as a chip, the same Cortex-M architecture underlies products from many vendors: [STM32](/reference/stm32/) from STMicroelectronics, the [RP2040](/reference/rp2040/) from Raspberry Pi, [Teensy](/reference/teensy/) boards, and NXP, Nordic, and Microchip parts. This shared architecture means tooling, debuggers, and [RTOS](/reference/real-time-operating-system/) ports are broadly portable across the ecosystem — a major reason Cortex-M dominates 32-bit embedded design.
+
+## Sources
+
+[^wiki]: [ARM Cortex-M](https://en.wikipedia.org/wiki/ARM_Cortex-M) — Wikipedia, on the Cortex-M core family.

--- a/docs/reference/arm-holdings.md
+++ b/docs/reference/arm-holdings.md
@@ -1,0 +1,47 @@
+---
+slug: arm-holdings
+title: Arm Holdings
+entry_type: organization
+category: hw-organizations
+description: Arm Holdings is a British company that designs the Arm processor architecture and licenses it to chipmakers, making it the dominant CPU design in phones and embedded devices.
+keywords: Arm, Arm Holdings, ARM architecture, processor IP, licensing, Cortex, RISC
+aka: [Arm, ARM Ltd, Advanced RISC Machines]
+autolink: true
+infobox:
+  - { label: Type, value: Public semiconductor IP company }
+  - { label: Founded, value: "1990" }
+  - { label: HQ, value: Cambridge, England, UK }
+  - { label: Makes, value: Processor architecture and core designs (IP) }
+see_also: [arm-architecture, sophie-wilson, central-processing-unit, qualcomm]
+cite_urls:
+  - https://www.arm.com/
+  - https://en.wikipedia.org/wiki/Arm_Holdings
+---
+
+**Arm Holdings** is a British company that designs the
+[Arm processor architecture](/reference/arm-architecture/) and licenses it to other
+chipmakers rather than manufacturing chips itself.[^wiki]
+
+## Overview
+
+Arm grew out of Acorn Computers, where the original ARM (Acorn RISC Machine) design was
+created in the 1980s by a team including [Sophie Wilson](/reference/sophie-wilson/). The
+company spun out in 1990 and adopted a pure licensing model: it sells the right to use its
+architecture and its ready-made Cortex core designs, and partners such as Apple,
+[Qualcomm](/reference/qualcomm/), and Samsung build the actual silicon.[^home]
+
+Because Arm cores are energy-efficient, they dominate battery-powered devices. The vast
+majority of smartphones, tablets, and microcontrollers — and a growing share of laptops and
+servers — run Arm-based processors.
+
+## Why it matters
+
+Arm's licensing model spread one CPU architecture across nearly the entire mobile and
+embedded world. The single-board computers and microcontrollers used as GopherTrunk capture
+nodes — Raspberry Pis and many MCU boards — are built around Arm cores, so the same
+instruction set runs from the antenna node up to phones in your pocket.
+
+## Sources
+
+[^home]: [Arm](https://www.arm.com/) — the company's official site, for its architecture and licensing.
+[^wiki]: [Arm Holdings](https://en.wikipedia.org/wiki/Arm_Holdings) — Wikipedia, for the company's history and business model.

--- a/docs/reference/avr-atmega.md
+++ b/docs/reference/avr-atmega.md
@@ -1,0 +1,35 @@
+---
+slug: avr-atmega
+title: AVR / ATmega
+entry_type: hardware
+category: hw-microcontrollers
+description: AVR is an 8-bit RISC microcontroller architecture from Atmel (now Microchip); its ATmega line, especially the ATmega328P, powers the classic Arduino Uno and countless hobby projects.
+keywords: AVR, ATmega, ATmega328P, ATtiny, Atmel, Microchip, Arduino Uno, 8-bit RISC, AVR-GCC
+aka: [AVR, ATmega]
+infobox:
+  - { label: Type, value: 8-bit microcontroller architecture }
+  - { label: Core, value: AVR RISC }
+  - { label: Vendor, value: Atmel (now Microchip) }
+  - { label: Famous part, value: ATmega328P (Arduino Uno) }
+  - { label: Language, value: C, C++, assembly }
+see_also: [arduino, microcontroller, pic-microcontroller, stm32, firmware, in-system-programming]
+related_lessons:
+  - { title: "Arduino", url: /learn/intro-hardware/arduino/ }
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/AVR_microcontrollers
+---
+
+**AVR** is an 8-bit RISC [microcontroller](/reference/microcontroller/) architecture created by Atmel and now owned by Microchip; **ATmega** is its best-known product line.[^wiki]
+
+## Overview
+
+The AVR design pairs a simple, fast 8-bit core with on-chip flash, SRAM, and EEPROM, plus [GPIO](/reference/gpio/), timers with [PWM](/reference/pulse-width-modulation/), an [ADC](/reference/analog-to-digital-converter/), and [UART](/reference/uart/)/[SPI](/reference/spi/)/[I²C](/reference/i2c/) peripherals. Sibling lines include the tiny ATtiny and the larger ATmega. The ATmega328P is iconic because it is the chip on the original [Arduino](/reference/arduino/) Uno, which made AVR the gateway architecture for a generation of makers.
+
+## Where it fits
+
+AVR shines where 8 bits are plenty: low cost, low power, and a friendly toolchain (AVR-GCC, the Arduino IDE). Code is written in [C](/reference/c-language/) or [C++](/reference/cpp-language/) and flashed via [in-system programming](/reference/in-system-programming/) over SPI. When a project needs 32-bit performance, more memory, or built-in radios, designers step up to an [STM32](/reference/stm32/) or [ESP32](/reference/esp32/); the rival 8-bit family is the [PIC](/reference/pic-microcontroller/).
+
+## Sources
+
+[^wiki]: [AVR microcontrollers](https://en.wikipedia.org/wiki/AVR_microcontrollers) — Wikipedia, on the AVR architecture and ATmega line.

--- a/docs/reference/banana-pi.md
+++ b/docs/reference/banana-pi.md
@@ -1,0 +1,33 @@
+---
+slug: banana-pi
+title: Banana Pi
+entry_type: hardware
+category: hw-sbc
+description: Banana Pi is a brand of single-board computers in the Raspberry Pi mould, notable early on for onboard SATA and gigabit Ethernet, and later for a wide range of ARM and RISC-V boards.
+keywords: Banana Pi, SATA SBC, Allwinner, gigabit Ethernet, Raspberry Pi alternative, RISC-V board, ARM single-board computer
+infobox:
+  - { label: Type, value: Single-board computer }
+  - { label: CPU, value: ARM (Allwinner / others), some RISC-V }
+  - { label: Runs, value: Linux / Android }
+  - { label: Noted for, value: Onboard SATA, gigabit Ethernet }
+  - { label: Typical price, value: ~$25 – $100 }
+see_also: [raspberry-pi, single-board-computer, orange-pi, odroid, rock-pi, risc-v]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Banana_Pi
+---
+
+**Banana Pi** is a brand of [single-board computers](/reference/single-board-computer/) in the [Raspberry Pi](/reference/raspberry-pi/) mould, an early Pi alternative that stood out for onboard SATA and gigabit Ethernet.[^wiki]
+
+## Overview
+
+The first Banana Pi boards matched the Pi's size and 40-pin [GPIO](/reference/gpio/) header but added a SATA port and gigabit networking, making them attractive for small file servers. The range has since grown to cover many ARM SoCs and, more recently, [RISC-V](/reference/risc-v/) boards. As with other clones, Linux support varies by model and is generally less polished than the Raspberry Pi's.
+
+## Where it fits
+
+Banana Pi sits among the Pi alternatives — [Orange Pi](/reference/orange-pi/), [ODROID](/reference/odroid/), [Rock Pi](/reference/rock-pi/) — and is worth a look when you want a disk and wired networking on one cheap board. For a GopherTrunk setup that both captures and serves decoded data, the built-in SATA can host the storage without a USB adapter hanging off the board.
+
+## Sources
+
+[^wiki]: [Banana Pi](https://en.wikipedia.org/wiki/Banana_Pi) — Wikipedia, on the Banana Pi single-board computers.

--- a/docs/reference/bare-metal-programming.md
+++ b/docs/reference/bare-metal-programming.md
@@ -1,0 +1,33 @@
+---
+slug: bare-metal-programming
+title: Bare-metal programming
+entry_type: concept
+category: hw-microcontrollers
+description: Bare-metal programming means writing software that runs directly on hardware with no operating system underneath, giving full control of the chip's registers, memory, and timing.
+keywords: bare metal, bare-metal programming, no OS, registers, super loop, embedded, firmware, direct hardware
+infobox:
+  - { label: Type, value: Programming approach }
+  - { label: OS, value: None }
+  - { label: Structure, value: Main loop + interrupts }
+  - { label: Control, value: Direct register access }
+see_also: [firmware, microcontroller, interrupt, real-time-operating-system, embedded-system, in-system-programming]
+related_lessons:
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bare_machine
+---
+
+**Bare-metal programming** means writing software that runs directly on the hardware with no operating system underneath it.[^wiki]
+
+## Overview
+
+On a [microcontroller](/reference/microcontroller/), bare-metal code is the [firmware](/reference/firmware/) itself: it configures the chip's peripheral registers by hand, manages its own memory, and typically runs as a "super loop" — an endless main loop that does work, with [interrupts](/reference/interrupt/) handling time-critical events. There is no scheduler, no driver model, and no abstraction between your code and the silicon, which means total control and minimal overhead, but also total responsibility for timing and correctness.
+
+## Trade-offs
+
+Bare metal is the right choice for the simplest, smallest, or most timing-sensitive [embedded systems](/reference/embedded-system/), where an OS would only add size and unpredictability. It boots instantly and wastes no resources. The cost shows up as a project grows: juggling many concurrent jobs by hand becomes error-prone, which is the point at which developers adopt a [real-time operating system](/reference/real-time-operating-system/). New firmware is loaded by [in-system programming](/reference/in-system-programming/) or a bootloader.
+
+## Sources
+
+[^wiki]: [Bare machine](https://en.wikipedia.org/wiki/Bare_machine) — Wikipedia, on running software directly on hardware.

--- a/docs/reference/bare-metal-server.md
+++ b/docs/reference/bare-metal-server.md
@@ -1,0 +1,33 @@
+---
+slug: bare-metal-server
+title: Bare-metal server
+entry_type: hardware
+category: hw-servers
+description: A bare-metal server is a single physical machine rented or owned entirely by one tenant, with no hypervisor or shared virtualization layer between the user and the hardware.
+keywords: bare-metal server, single-tenant, no hypervisor, dedicated hardware, bare metal cloud
+aka: [Bare metal]
+infobox:
+  - { label: Type, value: Single-tenant physical server }
+  - { label: Virtualization, value: None imposed }
+  - { label: Tenancy, value: One customer }
+  - { label: Contrast, value: VPS / cloud instance }
+see_also: [dedicated-server, virtual-private-server, hypervisor, server, infrastructure-as-a-service, virtualization]
+related_lessons:
+  - { title: "Dedicated servers", url: /learn/intro-hardware/dedicated-servers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bare-metal_server
+---
+
+A **bare-metal server** is a single physical machine used entirely by one tenant, with no [hypervisor](/reference/hypervisor/) or shared virtualization layer sitting between the user and the hardware.[^wiki]
+
+## Overview
+
+The term contrasts with virtualized cloud instances, where many tenants share one physical box through a hypervisor. On bare metal there is no virtualization overhead and no "noisy neighbor" competing for the same CPU and disk — you get the whole machine's performance and direct access to hardware features. Modern "bare-metal cloud" offerings rent such machines by the hour with cloud-style provisioning, blending dedicated hardware with on-demand billing.
+
+## Trade-offs
+
+Bare metal is the right call when you need predictable performance, full control of the hardware, or you intend to run your own [virtualization](/reference/virtualization/) on top. A [dedicated server](/reference/dedicated-server/) is essentially a long-lease bare-metal box; a [virtual private server](/reference/virtual-private-server/) is the shared, cheaper alternative. Within [infrastructure as a service](/reference/infrastructure-as-a-service/), bare metal is the lowest-abstraction rung. GopherTrunk runs the same on bare metal as on a VPS; the deciding factor is whether you also need a real radio front end attached, which favors local hardware.
+
+## Sources
+
+[^wiki]: [Bare-metal server](https://en.wikipedia.org/wiki/Bare-metal_server) — Wikipedia, on single-tenant physical servers.

--- a/docs/reference/battery-technology.md
+++ b/docs/reference/battery-technology.md
@@ -1,0 +1,32 @@
+---
+slug: battery-technology
+title: Battery technology
+entry_type: concept
+category: hw-mobile
+description: Battery technology covers the rechargeable chemistries — chiefly lithium-ion and lithium-polymer — that store the energy powering phones, wearables, and portable devices, defined by capacity, energy density, and cycle life.
+keywords: battery, lithium-ion, lithium-polymer, energy density, mAh, charge cycles, rechargeable, capacity, fast charging
+infobox:
+  - { label: Type, value: Energy storage }
+  - { label: Common chemistry, value: Lithium-ion / Li-polymer }
+  - { label: Rated in, value: mAh / Wh }
+  - { label: Key metrics, value: Energy density, cycle life }
+see_also: [smartphone, smartwatch, wearable-computer, mobile-operating-system, e-reader, system-on-a-chip]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Lithium-ion_battery
+---
+
+**Battery technology** is the set of rechargeable chemistries — most often lithium-ion and lithium-polymer — that store the electrical energy powering phones, wearables, and other portable devices.[^wiki]
+
+## Overview
+
+A battery is rated by capacity (milliamp-hours, mAh, or watt-hours, Wh) and judged on *energy density* — how much energy fits in a given size and weight — and *cycle life*, how many charge/discharge cycles it survives before fading. Lithium-ion dominates because it packs high energy density into a light, rechargeable cell. Lithium-polymer variants trade in a flexible pouch that can be shaped to fit thin phones and curved wearables. Charging is managed by control circuitry to balance speed, heat, and long-term wear.
+
+## Where it fits
+
+The battery is the hard constraint that shapes mobile design. A [mobile operating system](/reference/mobile-operating-system/) spends much of its effort stretching a charge; a [smartwatch](/reference/smartwatch/) or [wearable](/reference/wearable-computer/) lives or dies by how little its [SoC](/reference/system-on-a-chip/) and screen draw. The same power budget explains why a [smartphone](/reference/smartphone/) is a poor host for a continuous SDR decode load like GopherTrunk — sustained CPU and radio use drains a phone fast, where a mains-powered capture node runs indefinitely.
+
+## Sources
+
+[^wiki]: [Lithium-ion battery](https://en.wikipedia.org/wiki/Lithium-ion_battery) — Wikipedia, on the chemistry and metrics of modern rechargeable batteries.

--- a/docs/reference/beaglebone.md
+++ b/docs/reference/beaglebone.md
@@ -1,0 +1,35 @@
+---
+slug: beaglebone
+title: BeagleBone
+entry_type: hardware
+category: hw-sbc
+description: BeagleBone is an open-source single-board computer known for strong real-time I/O, with many GPIO pins and onboard programmable real-time units, favored for industrial control.
+keywords: BeagleBone, BeagleBone Black, PRU, programmable real-time unit, real-time I/O, industrial control, open-source SBC, GPIO
+autolink: true
+infobox:
+  - { label: Type, value: Single-board computer }
+  - { label: CPU, value: ARM (TI SoC) + PRUs }
+  - { label: RAM, value: ~512 MB – 4 GB }
+  - { label: Runs, value: Linux }
+  - { label: Typical price, value: ~$50 – $150 }
+see_also: [single-board-computer, gpio, raspberry-pi, nvidia-jetson, input-output, microcontroller]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+  - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/BeagleBoard#BeagleBone
+---
+
+**BeagleBone** is an open-source [single-board computer](/reference/single-board-computer/) known for strong real-time I/O — many [GPIO](/reference/gpio/) pins and onboard programmable real-time units (PRUs).[^wiki]
+
+## Overview
+
+The PRUs are small, deterministic processors alongside the main ARM CPU, which lets a BeagleBone handle precise, timing-critical signalling that a general-purpose Linux board struggles with. Combined with its generous pin count, this makes it a favourite for industrial control and electronics-heavy projects. It runs Linux like other SBCs.
+
+## Where it fits
+
+The BeagleBone is the SBC alternative to the [Raspberry Pi](/reference/raspberry-pi/) when [I/O](/reference/input-output/) and determinism matter more than raw cost or community size. For general-purpose use a Pi is simpler; for GPU work at the edge see the [NVIDIA Jetson](/reference/nvidia-jetson/).
+
+## Sources
+
+[^wiki]: [BeagleBone](https://en.wikipedia.org/wiki/BeagleBoard#BeagleBone) — Wikipedia, on the BeagleBoard family and its real-time I/O.

--- a/docs/reference/bios-uefi.md
+++ b/docs/reference/bios-uefi.md
@@ -1,0 +1,34 @@
+---
+slug: bios-uefi
+title: BIOS & UEFI
+entry_type: concept
+category: hw-foundations
+description: BIOS and its modern successor UEFI are the firmware that initializes a computer's hardware at power-on and hands control to the operating system's bootloader.
+keywords: BIOS, UEFI, firmware, boot, POST, bootloader, secure boot, motherboard firmware
+aka: [BIOS, UEFI]
+autolink: true
+infobox:
+  - { label: Type, value: Platform firmware }
+  - { label: Runs, value: At power-on, before OS }
+  - { label: Does, value: Init hardware, start boot }
+  - { label: Successor, value: UEFI replaces legacy BIOS }
+see_also: [motherboard, operating-system, chipset, central-processing-unit, firmware, data-storage]
+cite_urls:
+  - https://en.wikipedia.org/wiki/BIOS
+  - https://en.wikipedia.org/wiki/UEFI
+---
+
+**BIOS** (Basic Input/Output System) and its modern successor **UEFI** (Unified Extensible Firmware Interface) are the [firmware](/reference/firmware/) that brings a computer's hardware up at power-on and hands control to the operating system.[^bios][^uefi]
+
+## Overview
+
+Stored in a chip on the [motherboard](/reference/motherboard/), this firmware is the first code a [CPU](/reference/central-processing-unit/) runs when power is applied. It performs the power-on self-test (POST), initializes the [chipset](/reference/chipset/), memory, and basic devices, then locates a bootable [storage](/reference/data-storage/) device and starts its *bootloader*, which in turn loads the [operating system](/reference/operating-system/). Legacy BIOS dates to the early PC; UEFI replaced it with a more capable design supporting large disks, faster boot, and features like Secure Boot.
+
+## Where it fits
+
+BIOS/UEFI is the layer between bare hardware and software — without it the machine would not know how to start. It is configurable (boot order, clocks, virtualization toggles) through a setup screen, and it can be updated as *flashing* firmware. On small SDR capture boards the role is filled by an equivalent bootloader baked into the platform; conceptually the job is the same: wake the hardware, then start the OS that runs GopherTrunk.
+
+## Sources
+
+[^bios]: [BIOS](https://en.wikipedia.org/wiki/BIOS) — Wikipedia, on legacy PC firmware and POST.
+[^uefi]: [UEFI](https://en.wikipedia.org/wiki/UEFI) — Wikipedia, on the modern UEFI firmware interface.

--- a/docs/reference/bits-and-bytes.md
+++ b/docs/reference/bits-and-bytes.md
@@ -1,0 +1,33 @@
+---
+slug: bits-and-bytes
+title: Bits & bytes
+entry_type: concept
+category: hw-foundations
+description: A bit is the smallest unit of digital information, a single 0 or 1; a byte is a group of eight bits. Together they are the units in which computers store and move all data.
+keywords: bit, byte, binary, kilobyte, megabyte, gigabyte, base-2, data units, octet
+aka: [Bit, Byte]
+infobox:
+  - { label: Bit, value: One binary digit (0 or 1) }
+  - { label: Byte, value: 8 bits }
+  - { label: Byte range, value: 0–255 (256 values) }
+  - { label: Larger units, value: "KB, MB, GB, TB" }
+see_also: [logic-gate, random-access-memory, data-storage, bandwidth, central-processing-unit, transistor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bit
+  - https://en.wikipedia.org/wiki/Byte
+---
+
+A **bit** is the smallest unit of digital information — a single binary digit, either 0 or 1 — and a **byte** is a group of eight bits.[^bit][^byte]
+
+## Overview
+
+Everything a computer stores or moves is encoded in bits, physically realized as a [transistor](/reference/transistor/) switched on or off, a charge present or absent, a voltage high or low. Eight bits make a byte, which can represent 256 distinct values (0–255) — enough for one character of basic text. Larger quantities are counted in kilobytes, megabytes, gigabytes, and terabytes. Data *rates* are usually measured in **bits** per second (the unit of [bandwidth](/reference/bandwidth/)), while storage sizes are usually in **bytes** — a common source of confusion.
+
+## Where it fits
+
+Bits and bytes are the common currency of every other hardware idea: [memory](/reference/random-access-memory/) and [storage](/reference/data-storage/) are sized in bytes, [logic gates](/reference/logic-gate/) operate on bits, and a [CPU's](/reference/central-processing-unit/) word width is a bit count. In SDR terms, the IQ samples GopherTrunk ingests are streams of bytes, and a decoded voice frame is ultimately a precise pattern of bits pulled out of the noise.
+
+## Sources
+
+[^bit]: [Bit](https://en.wikipedia.org/wiki/Bit) — Wikipedia, on the bit as the basic unit of information.
+[^byte]: [Byte](https://en.wikipedia.org/wiki/Byte) — Wikipedia, on the byte as a group of (usually eight) bits.

--- a/docs/reference/blade-server.md
+++ b/docs/reference/blade-server.md
@@ -1,0 +1,31 @@
+---
+slug: blade-server
+title: Blade server
+entry_type: hardware
+category: hw-servers
+description: A blade server is a stripped-down server module that slides into a shared enclosure, which supplies power, cooling, and networking to many blades at once for high density.
+keywords: blade server, blade enclosure, blade chassis, server density, modular server
+aka: [Server blade]
+infobox:
+  - { label: Type, value: Server form factor }
+  - { label: Slots into, value: Blade enclosure }
+  - { label: Shares, value: Power, cooling, networking }
+  - { label: Optimized for, value: Density }
+see_also: [rack-server, server, data-center, dedicated-server, virtualization, high-availability]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Blade_server
+---
+
+A **blade server** is a stripped-down [server](/reference/server/) module that slides into a shared enclosure; the enclosure supplies power, cooling, and networking to many blades at once.[^wiki]
+
+## Overview
+
+Where a [rack server](/reference/rack-server/) is a complete, self-contained machine, a blade keeps only the essentials — CPU, memory, and often local storage — and offloads power supplies, fans, and switching to the chassis. A single enclosure can hold a dozen or more blades, cutting cabling and power overhead and packing more compute into each [data center](/reference/data-center/) cabinet. The trade-off is vendor lock-in to that enclosure and a larger up-front cost, so blades pay off mainly at scale.
+
+## Trade-offs
+
+Blades shine when you need many similar servers in a small footprint — for example as the compute pool behind heavy [virtualization](/reference/virtualization/) or a [high-availability](/reference/high-availability/) cluster. For a handful of machines, plain rack servers are simpler and cheaper. A GopherTrunk deployment almost never needs blade density; its bottleneck is RF capture at the antenna, not raw server compute.
+
+## Sources
+
+[^wiki]: [Blade server](https://en.wikipedia.org/wiki/Blade_server) — Wikipedia, on blade form factors and enclosures.

--- a/docs/reference/bluetooth.md
+++ b/docs/reference/bluetooth.md
@@ -1,0 +1,31 @@
+---
+slug: bluetooth
+title: Bluetooth
+entry_type: concept
+category: hw-networking
+description: Bluetooth is a short-range wireless standard for connecting devices over the 2.4 GHz band, used for audio, peripherals, and low-power sensor links between nearby gadgets.
+keywords: Bluetooth, Bluetooth Low Energy, BLE, 2.4 GHz, wireless, PAN, pairing
+aka: [BT, Bluetooth Low Energy, BLE]
+infobox:
+  - { label: Type, value: Short-range wireless }
+  - { label: Band, value: 2.4 GHz ISM }
+  - { label: Range, value: ~1–100 m (class-dependent) }
+  - { label: Variants, value: Classic, Low Energy (BLE) }
+see_also: [wi-fi, near-field-communication, wireless-access-point, electromagnetic-spectrum, internet-of-things, ethernet]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bluetooth
+---
+
+**Bluetooth** is a short-range wireless standard for connecting devices over the 2.4 GHz band, used for audio, peripherals, and low-power links between nearby gadgets.[^wiki]
+
+## Overview
+
+Bluetooth forms small *personal-area networks* between paired devices — headphones to a phone, a keyboard to a laptop, a sensor to a hub — hopping rapidly across the crowded 2.4 GHz ISM band to dodge interference. **Bluetooth Low Energy** (BLE) is a separate, power-frugal profile aimed at battery devices that wake, send a short burst, and sleep, which has made it the backbone of many [IoT](/reference/internet-of-things/) sensors and wearables. Unlike [Wi-Fi](/reference/wi-fi/), it targets close-range, low-bandwidth links rather than network access; for touch-range pairing, [NFC](/reference/near-field-communication/) is closer still.
+
+## What it's for
+
+Bluetooth is built for convenience over short distances at low power, not throughput. It is rarely part of a GopherTrunk data path, but its dense 2.4 GHz traffic — alongside Wi-Fi — is exactly the kind of noisy [spectrum](/reference/electromagnetic-spectrum/) an SDR user learns to recognize and avoid when siting an antenna.
+
+## Sources
+
+[^wiki]: [Bluetooth](https://en.wikipedia.org/wiki/Bluetooth) — Wikipedia, on the short-range wireless standard.

--- a/docs/reference/bootloader.md
+++ b/docs/reference/bootloader.md
@@ -1,0 +1,32 @@
+---
+slug: bootloader
+title: Bootloader
+entry_type: concept
+category: hw-microcontrollers
+description: A bootloader is a small program that runs first at power-on and loads the main firmware or operating system; on microcontrollers it also enables reflashing without external hardware.
+keywords: bootloader, boot, DFU, firmware update, reflash, USB bootloader, second stage, OTA
+infobox:
+  - { label: Type, value: Startup program }
+  - { label: Runs, value: First, at power-on/reset }
+  - { label: Job, value: Load and start firmware }
+  - { label: Bonus, value: Field reprogramming }
+see_also: [firmware, in-system-programming, microcontroller, embedded-system, bare-metal-programming, watchdog-timer]
+related_lessons:
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bootloader
+---
+
+**A bootloader** is a small program that runs first when a device powers on or resets, then loads and starts the main [firmware](/reference/firmware/) or operating system.[^wiki]
+
+## Overview
+
+On a desktop the bootloader chain hands off to an OS; on a [microcontroller](/reference/microcontroller/) the bootloader is often the only thing between reset and your application. Many MCUs ship with a factory bootloader in ROM that speaks USB DFU, [UART](/reference/uart/), or [SPI](/reference/spi/)/[I²C](/reference/i2c/), so new code can be loaded without a dedicated programmer. Custom bootloaders add over-the-air (OTA) updates, integrity checks, and fallback to a known-good image if an update fails.
+
+## Where it fits
+
+A bootloader is what lets you reflash a board over USB instead of always using [in-system programming](/reference/in-system-programming/) with an external debugger — the Arduino "press reset, upload sketch" flow is exactly this. In a fielded [embedded system](/reference/embedded-system/) it is the safe path for firmware updates, often paired with a [watchdog timer](/reference/watchdog-timer/) so a hung update cannot brick the device.
+
+## Sources
+
+[^wiki]: [Bootloader](https://en.wikipedia.org/wiki/Bootloader) — Wikipedia, on bootloaders and their role at startup.

--- a/docs/reference/broadcom.md
+++ b/docs/reference/broadcom.md
@@ -1,0 +1,46 @@
+---
+slug: broadcom
+title: Broadcom
+entry_type: organization
+category: hw-organizations
+description: Broadcom is an American semiconductor and software company that makes networking, broadband, and wireless chips, including the SoCs at the heart of the Raspberry Pi.
+keywords: Broadcom, SoC, networking chips, wireless, broadband, semiconductor
+aka: [Broadcom Inc, Broadcom Corporation]
+autolink: true
+infobox:
+  - { label: Type, value: Public semiconductor and software company }
+  - { label: Founded, value: "1991" }
+  - { label: HQ, value: Palo Alto, California, USA }
+  - { label: Makes, value: Networking, wireless, and broadband chips; SoCs }
+see_also: [raspberry-pi, system-on-a-chip, semiconductor]
+cite_urls:
+  - https://www.broadcom.com/
+  - https://en.wikipedia.org/wiki/Broadcom
+---
+
+**Broadcom** is an American semiconductor and infrastructure-software company that makes
+networking, broadband, and wireless chips, including the systems-on-chip used in the
+[Raspberry Pi](/reference/raspberry-pi/).[^wiki]
+
+## Overview
+
+The modern Broadcom traces back to a 1991 chip company and grew through a long series of
+mergers — most notably with Avago Technologies in 2016, after which the combined firm took
+the Broadcom name. Its products span Ethernet switch silicon, Wi-Fi and Bluetooth chips,
+set-top-box and broadband processors, and storage controllers.[^home]
+
+Broadcom designs the BCM-series [SoCs](/reference/system-on-a-chip/) that power Raspberry Pi
+boards, pairing an Arm CPU with a graphics core on one chip. In recent years the company has
+also expanded heavily into enterprise software through large acquisitions.
+
+## Why it matters
+
+Broadcom's networking and wireless chips are inside a vast amount of consumer and data-center
+equipment, often unseen. For the maker world its most visible role is the Raspberry Pi SoC —
+which means a GopherTrunk capture node running on a Pi is, at its core, running on Broadcom
+silicon.
+
+## Sources
+
+[^home]: [Broadcom](https://www.broadcom.com/) — the company's official site, for its product portfolio.
+[^wiki]: [Broadcom](https://en.wikipedia.org/wiki/Broadcom) — Wikipedia, for the company's history and acquisitions.

--- a/docs/reference/build-vs-buy.md
+++ b/docs/reference/build-vs-buy.md
@@ -1,0 +1,32 @@
+---
+slug: build-vs-buy
+title: Build vs buy a PC
+entry_type: concept
+category: hw-personal-computers
+description: Build vs buy is the decision between assembling a desktop computer from individual components and purchasing a ready-made pre-built system, trading cost, control, and effort against convenience and warranty.
+keywords: build vs buy, custom PC, pre-built PC, DIY computer, PC building, component selection
+infobox:
+  - { label: Type, value: Decision / trade-off }
+  - { label: Build, value: Cheaper, custom, more effort }
+  - { label: Buy, value: Convenient, warrantied, turnkey }
+  - { label: Applies to, value: Desktop PCs }
+see_also: [desktop-computer, gaming-pc, motherboard, computer-case, personal-computer]
+related_lessons:
+  - { title: "Choosing a dev machine", url: /learn/intro-hardware/choosing-a-dev-machine/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Custom-built_computer
+---
+
+**Build vs buy** is the decision, when getting a [desktop computer](/reference/desktop-computer/), between assembling it yourself from separate components and purchasing a ready-made pre-built system.[^wiki]
+
+## Overview
+
+Building means choosing each part — [CPU](/reference/central-processing-unit/), [motherboard](/reference/motherboard/), [RAM](/reference/random-access-memory/), [GPU](/reference/graphics-processing-unit/), [storage](/reference/solid-state-drive/), [power supply](/reference/power-supply-unit/), and [case](/reference/computer-case/) — and fitting them together yourself. Buying means a vendor delivers a complete, tested machine under a single warranty. The parts must still be compatible either way: the [motherboard form factor](/reference/motherboard-form-factor/) has to match the case, the CPU has to match the board's socket, and the power supply has to be sized for the load.
+
+## Trade-offs
+
+Building usually costs less for the same performance, lets you pick exactly the parts you want, and makes future upgrades easy — at the price of your time, the learning curve, and the fact that you troubleshoot any problems yourself. Buying is faster and lower-risk, with one company on the hook for support, but you pay a premium and accept whatever components and limited upgradeability the vendor chose. Building shines for [gaming PCs](/reference/gaming-pc/) and enthusiast [workstations](/reference/workstation/); buying suits anyone who just wants a working machine. For a GopherTrunk bench either works — the radio front end is a USB dongle regardless of how the host PC was put together.
+
+## Sources
+
+[^wiki]: [Custom-built computer](https://en.wikipedia.org/wiki/Custom-built_computer) — Wikipedia, on building versus buying a PC.

--- a/docs/reference/cache-memory.md
+++ b/docs/reference/cache-memory.md
@@ -1,0 +1,31 @@
+---
+slug: cache-memory
+title: Cache memory
+entry_type: hardware
+category: hw-foundations
+description: Cache memory is a small, very fast store close to the CPU that holds recently used data and instructions, bridging the speed gap between the processor and main memory.
+keywords: cache memory, CPU cache, L1, L2, L3, cache hit, cache miss, locality, SRAM
+aka: [CPU cache]
+infobox:
+  - { label: Type, value: Fast on-chip memory (SRAM) }
+  - { label: Levels, value: "L1, L2, L3" }
+  - { label: Goal, value: Hide main-memory latency }
+  - { label: Exploits, value: Locality of reference }
+see_also: [central-processing-unit, random-access-memory, clock-speed, system-bus, integrated-circuit, von-neumann-architecture]
+cite_urls:
+  - https://en.wikipedia.org/wiki/CPU_cache
+---
+
+**Cache memory** is a small, very fast memory close to the [CPU](/reference/central-processing-unit/) that keeps recently and frequently used data and instructions on hand, hiding the latency of slower [main memory](/reference/random-access-memory/).[^wiki]
+
+## Overview
+
+Caches are usually built from fast SRAM on the processor die and arranged in *levels*: a tiny, fastest L1 per core, a larger L2, and a big shared L3. When the CPU needs data, a *cache hit* serves it immediately; a *cache miss* forces a slow trip to RAM over the [system bus](/reference/system-bus/). Caches work because programs show *locality of reference* — they tend to reuse the same data and access nearby addresses — so a small store captures most accesses.
+
+## Where it fits
+
+Cache exists because main memory cannot keep up with [clock speed](/reference/clock-speed/): without it, a fast CPU would stall waiting on RAM. It sits between the registers and main memory in the broader [memory hierarchy](/reference/memory-hierarchy/). For throughput-heavy code like GopherTrunk's streaming DSP, keeping the hot working set — filter taps, buffers — inside cache is what lets the processor sustain its rate instead of stalling on memory.
+
+## Sources
+
+[^wiki]: [CPU cache](https://en.wikipedia.org/wiki/CPU_cache) — Wikipedia, on cache levels, hits and misses, and locality.

--- a/docs/reference/cellular-modem.md
+++ b/docs/reference/cellular-modem.md
@@ -1,0 +1,30 @@
+---
+slug: cellular-modem
+title: Cellular modem
+entry_type: hardware
+category: hw-mobile
+description: A cellular modem is the radio subsystem that connects a device to mobile networks (4G LTE, 5G), handling the RF, modulation, and protocols needed to carry data and calls over licensed cellular bands.
+keywords: cellular modem, baseband, LTE, 5G, 4G, mobile broadband, baseband processor, modem chip, SIM, eSIM
+infobox:
+  - { label: Type, value: Wireless radio modem }
+  - { label: Connects to, value: 4G/5G cellular networks }
+  - { label: Also called, value: Baseband processor }
+  - { label: Pairs with, value: SIM / eSIM }
+see_also: [system-on-a-chip, esim, gps-receiver, smartphone, mobile-operating-system, modulation]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Baseband_processor
+---
+
+A **cellular modem** is the radio subsystem that connects a device to mobile networks — 4G LTE, 5G, and their predecessors — handling the RF, [modulation](/reference/modulation/), and protocols that carry calls and data over licensed cellular bands.[^wiki]
+
+## Overview
+
+Often called the *baseband processor*, a cellular modem runs its own real-time firmware and manages the complex dance of attaching to a tower, negotiating bandwidth, and hopping between cells. It is paired with a subscriber identity from a SIM or an [eSIM](/reference/esim/). In a phone the modem is usually a block inside the main [SoC](/reference/system-on-a-chip/) (or a companion chip), wired to its own antennas separate from Wi-Fi and [GPS](/reference/gps-receiver/).
+
+## Where it fits
+
+The cellular modem is what makes a [smartphone](/reference/smartphone/) "mobile" in the connectivity sense — always-on data anywhere there is coverage. For a remote GopherTrunk capture node out of Wi-Fi range, a cellular modem (as a USB stick or HAT) is the practical backhaul, letting the node upload decoded calls over the mobile network. The modem speaks the carrier's protocols; it is not a general SDR and does not expose raw RF the way an [RTL-SDR](/reference/rtl-sdr/) does.
+
+## Sources
+
+[^wiki]: [Baseband processor](https://en.wikipedia.org/wiki/Baseband_processor) — Wikipedia, on the modem subsystem in mobile devices.

--- a/docs/reference/central-processing-unit.md
+++ b/docs/reference/central-processing-unit.md
@@ -1,0 +1,32 @@
+---
+slug: central-processing-unit
+title: Central processing unit (CPU)
+entry_type: hardware
+category: hw-foundations
+description: A central processing unit (CPU) is the chip that carries out a program's instructions — the part of a computer most often called its brain.
+keywords: CPU, central processing unit, processor, cores, multi-core, clock speed, GHz
+aka: [CPU, central processing unit, processor]
+infobox:
+  - { label: Type, value: Processor chip }
+  - { label: Role, value: Executes instructions }
+  - { label: Measured by, value: Cores, clock speed (GHz) }
+  - { label: Range, value: One tiny core to dozens }
+see_also: [computer-hardware, random-access-memory, data-storage, microcontroller, server]
+related_lessons:
+  - { title: "The building blocks", url: /learn/intro-hardware/building-blocks/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Central_processing_unit
+---
+
+**The central processing unit (CPU)** is the chip that carries out a program's instructions — the part of [computer hardware](/reference/computer-hardware/) most often called the "brain."[^wiki]
+
+## Overview
+A CPU fetches instructions, decodes them, and executes them one after another, very fast. Modern CPUs contain several **cores**: each core is a self-contained processing unit, so a multi-core CPU can genuinely work on several tasks at the same time. This is what makes [concurrency](/reference/concurrency/) and parallel work practical.
+
+**Clock speed**, measured in gigahertz (GHz), counts how many cycles a core runs per second. It is a rough guide to speed, not an absolute one — a newer 3 GHz core can outpace an older 4 GHz core because it does more useful work per cycle.
+
+## Where it fits
+The CPU scales across the whole [hardware spectrum](/reference/hardware-spectrum/). A [microcontroller](/reference/microcontroller/) has a single tiny, low-power core; a desktop has a handful; a [server](/reference/server/) may carry dozens. The CPU works hand in hand with [RAM](/reference/random-access-memory/), which holds the data and instructions it is actively using.
+
+## Sources
+[^wiki]: [Central processing unit](https://en.wikipedia.org/wiki/Central_processing_unit) — Wikipedia, on CPU function, cores, and clock speed.

--- a/docs/reference/chipset.md
+++ b/docs/reference/chipset.md
@@ -1,0 +1,30 @@
+---
+slug: chipset
+title: Chipset
+entry_type: hardware
+category: hw-foundations
+description: A chipset is the set of chips on a motherboard that manages data flow between the CPU, memory, and peripherals, defining much of a platform's connectivity and features.
+keywords: chipset, northbridge, southbridge, PCH, platform, motherboard, I/O hub
+infobox:
+  - { label: Type, value: Support chips on the board }
+  - { label: Manages, value: CPU–memory–I/O data flow }
+  - { label: Sets, value: Ports, lanes, features }
+  - { label: Modern form, value: Single hub (PCH) }
+see_also: [motherboard, central-processing-unit, pci-express, usb, system-bus, bios-uefi]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Chipset
+---
+
+A **chipset** is the set of support chips on a [motherboard](/reference/motherboard/) that manages the flow of data between the [CPU](/reference/central-processing-unit/), memory, and peripherals.[^wiki]
+
+## Overview
+
+Historically a PC chipset split into a *northbridge* (fast links to memory and graphics) and a *southbridge* (slower I/O like storage, USB, and audio). As CPUs absorbed the memory controller and graphics link onto the die, the northbridge's job moved into the processor, leaving a single I/O hub — Intel calls it the Platform Controller Hub (PCH). Today the chipset mainly provides the extra [PCIe](/reference/pci-express/) lanes, [USB](/reference/usb/) ports, SATA connectors, and other I/O that a platform exposes.
+
+## Where it fits
+
+The chipset, paired with a given CPU socket, defines much of what a board can do: how many devices it supports, which features are enabled, and how peripherals reach the processor over the [system bus](/reference/system-bus/). It works alongside the board's [BIOS/UEFI](/reference/bios-uefi/) firmware at startup. On a single-board computer the chipset's functions are folded into the [system-on-a-chip](/reference/system-on-a-chip/), so a GopherTrunk capture node has no separate chipset — but the connectivity it provides is the same idea.
+
+## Sources
+
+[^wiki]: [Chipset](https://en.wikipedia.org/wiki/Chipset) — Wikipedia, on motherboard chipsets, northbridge/southbridge, and the modern PCH.

--- a/docs/reference/chromebook.md
+++ b/docs/reference/chromebook.md
@@ -1,0 +1,35 @@
+---
+slug: chromebook
+title: Chromebook
+entry_type: hardware
+category: hw-personal-computers
+description: A Chromebook is a laptop or tablet running Google's ChromeOS, a lightweight operating system built around the Chrome browser and web apps, with most data stored in the cloud.
+keywords: Chromebook, ChromeOS, Chrome browser, web apps, education laptop, cloud computing
+aka: [ChromeOS device]
+autolink: true
+infobox:
+  - { label: Type, value: Laptop / tablet }
+  - { label: OS, value: ChromeOS (Google) }
+  - { label: Apps, value: Web, Android, some Linux }
+  - { label: Storage, value: Small local + cloud }
+  - { label: Common in, value: Education }
+see_also: [laptop, operating-system, personal-computer, thin-client, cloud-computing]
+related_lessons:
+  - { title: "Laptops", url: /learn/intro-hardware/laptops/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Chromebook
+---
+
+A **Chromebook** is a [laptop](/reference/laptop/) or tablet that runs Google's ChromeOS, a lightweight [operating system](/reference/operating-system/) built around the Chrome web browser and cloud services.[^wiki]
+
+## Overview
+
+Where a traditional [personal computer](/reference/personal-computer/) installs heavyweight desktop applications, a Chromebook leans on web apps that run inside the browser, with most documents and settings synced to the cloud. Hardware is modest by design — a low-power [CPU](/reference/central-processing-unit/), modest [RAM](/reference/random-access-memory/), and a small [SSD](/reference/solid-state-drive/) or [eMMC](/reference/emmc/) — which keeps Chromebooks cheap, fast to boot, and long on battery life. Modern models also run Android apps and an optional Linux container for development.
+
+## Where it fits
+
+Chromebooks dominate classrooms and suit anyone whose work lives in a browser: email, documents, video calls, and SaaS tools. They behave somewhat like a self-contained [thin client](/reference/thin-client/), leaning on remote services rather than local power. The trade-off is limited offline software and weak local compute — heavy native workloads, including most SDR DSP, want a full laptop or desktop instead.
+
+## Sources
+
+[^wiki]: [Chromebook](https://en.wikipedia.org/wiki/Chromebook) — Wikipedia, on Chromebooks and ChromeOS.

--- a/docs/reference/clock-speed.md
+++ b/docs/reference/clock-speed.md
@@ -1,0 +1,31 @@
+---
+slug: clock-speed
+title: Clock speed
+entry_type: concept
+category: hw-foundations
+description: Clock speed is the rate at which a processor's internal clock ticks, measured in hertz, setting the pace at which it steps through instructions — though it is only one factor in real performance.
+keywords: clock speed, clock rate, gigahertz, GHz, frequency, throttling, overclocking, IPC
+aka: [Clock rate]
+infobox:
+  - { label: Type, value: Processor timing metric }
+  - { label: Unit, value: Hertz (MHz, GHz) }
+  - { label: Sets, value: Instruction pacing }
+  - { label: Limited by, value: Heat & power }
+see_also: [central-processing-unit, cooling-and-thermals, cache-memory, moores-law, transistor, instruction-set-architecture]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Clock_rate
+---
+
+**Clock speed** (or clock rate) is the frequency at which a processor's internal clock ticks, measured in hertz, setting the basic pace at which the chip steps through its work.[^wiki]
+
+## Overview
+
+A digital chip advances in time with a clock signal; each tick, or *cycle*, lets the logic settle and move to its next state. A 3 GHz [CPU](/reference/central-processing-unit/) ticks three billion times a second. But clock speed alone does not equal performance — *how much work per cycle* (instructions per cycle, dependent on the [microarchitecture](/reference/instruction-set-architecture/), [cache](/reference/cache-memory/) behavior, and parallelism) matters just as much. Comparing clock speeds across different designs is therefore unreliable.
+
+## Where it fits
+
+For years rising clock speeds delivered most of computing's gains, but heat and power put a hard ceiling on how fast a chip can tick — push too far and it overheats, so [cooling](/reference/cooling-and-thermals/) and *throttling* govern the real sustained rate. With the end of easy clock scaling (part of the Dennard-scaling breakdown noted under [Moore's law](/reference/moores-law/)), designers turned to more cores instead. For steady SDR decoding, sustained clock under thermal load matters more than a high peak boost a node cannot hold.
+
+## Sources
+
+[^wiki]: [Clock rate](https://en.wikipedia.org/wiki/Clock_rate) — Wikipedia, on processor clock frequency and its limits.

--- a/docs/reference/cloud-computing.md
+++ b/docs/reference/cloud-computing.md
@@ -1,0 +1,34 @@
+---
+slug: cloud-computing
+title: Cloud computing
+entry_type: concept
+category: hw-servers
+description: Cloud computing is computing power and storage provided over the internet on demand, scaling up and down with near-zero upfront cost and ongoing fees.
+keywords: cloud computing, on demand, data center, IaaS, scalable, pay as you go
+aka: [Cloud computing, The cloud]
+infobox:
+  - { label: Type, value: On-demand computing }
+  - { label: Cost model, value: Pay as you go }
+  - { label: Scales, value: Up and down }
+  - { label: Built on, value: Virtualization }
+see_also: [virtualization, virtual-private-server, server, dedicated-server, home-server]
+related_lessons:
+  - { title: "Combining tiers", url: /learn/intro-hardware/combining-tiers/ }
+  - { title: "Virtual private server (VPS)", url: /learn/intro-hardware/vps/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Cloud_computing
+---
+
+**Cloud computing** is computing power and storage provided over the internet on demand, instead of from machines you own and run.[^wiki]
+
+## Overview
+
+The defining trait is elasticity: you can scale resources up when traffic spikes and back down when it fades, with near-zero upfront cost and ongoing fees for what you use. Under the hood it is [virtualization](/reference/virtualization/) at scale, run across large data centers — the same technology behind a single [virtual private server](/reference/virtual-private-server/), multiplied.
+
+## Trade-offs
+
+The cloud trades capital cost for recurring fees and adds network latency compared with a local device, so it is not always the right home for low-latency or always-on tasks. It often pairs with on-site hardware in combined-tier systems: a [home server](/reference/home-server/) captures and pre-processes locally while the cloud stores and serves the results — the model GopherTrunk fits, since the cloud cannot touch RF directly.
+
+## Sources
+
+[^wiki]: [Cloud computing](https://en.wikipedia.org/wiki/Cloud_computing) — Wikipedia, on on-demand computing over the internet.

--- a/docs/reference/colocation.md
+++ b/docs/reference/colocation.md
@@ -1,0 +1,33 @@
+---
+slug: colocation
+title: Colocation
+entry_type: concept
+category: hw-servers
+description: Colocation is renting space, power, cooling, and network connectivity in a data center for hardware you own, so you keep your own servers while outsourcing the facility.
+keywords: colocation, colo, data center space, rack space, hosting your own hardware
+aka: [Colo]
+infobox:
+  - { label: Type, value: Hosting model }
+  - { label: You provide, value: The hardware }
+  - { label: Facility provides, value: Space, power, cooling, network }
+  - { label: Sold by, value: Rack, cabinet, or cage }
+see_also: [data-center, dedicated-server, rack-server, managed-hosting, cloud-computing, server]
+related_lessons:
+  - { title: "Dedicated servers", url: /learn/intro-hardware/dedicated-servers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Colocation_centre
+---
+
+**Colocation** (colo) is renting space, power, cooling, and network connectivity in a [data center](/reference/data-center/) for hardware you own — you keep your own [servers](/reference/server/) while outsourcing the building around them.[^wiki]
+
+## Overview
+
+A colocation provider sells you a slice of the facility — a few [rack-server](/reference/rack-server/) units, a full cabinet, or a locked cage — plus metered power, cooling, and uplink bandwidth. You buy, install, and maintain the machines; they guarantee the environment and uptime. This sits between running a [home server](/reference/home-server/) (you own everything, including the room) and renting compute outright.
+
+## Where it fits
+
+Colocation suits organizations that have already invested in hardware, need physical control of their machines, or have compliance reasons to keep ownership, but lack a reliable facility of their own. The alternatives are a fully provider-owned [dedicated server](/reference/dedicated-server/), a [managed hosting](/reference/managed-hosting/) arrangement where the provider also runs the software, or [cloud computing](/reference/cloud-computing/) where you rent capacity with no hardware at all.
+
+## Sources
+
+[^wiki]: [Colocation centre](https://en.wikipedia.org/wiki/Colocation_centre) — Wikipedia, on renting data center space for customer-owned equipment.

--- a/docs/reference/compute-module.md
+++ b/docs/reference/compute-module.md
@@ -1,0 +1,34 @@
+---
+slug: compute-module
+title: Compute Module
+entry_type: hardware
+category: hw-sbc
+description: A Compute Module is a single-board computer stripped to a small module without ports, designed to be soldered or socketed into a custom carrier board for embedded products.
+keywords: Raspberry Pi Compute Module, CM4, CM5, SO-DIMM module, carrier board, system on module, embedded SBC
+aka: [Raspberry Pi Compute Module, CM4]
+infobox:
+  - { label: Type, value: Embeddable SBC module }
+  - { label: Form, value: SO-DIMM or board-to-board }
+  - { label: Needs, value: A custom carrier board }
+  - { label: Runs, value: Linux }
+  - { label: Best-known, value: Raspberry Pi CM4 / CM5 }
+see_also: [raspberry-pi, single-board-computer, system-on-a-chip, hat-add-on-board, gpio, embedded-system]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Raspberry_Pi#Compute_Module
+---
+
+**A Compute Module** is a [single-board computer](/reference/single-board-computer/) stripped down to a small module — the processor, memory, and storage — without the usual ports, meant to plug into a custom carrier board.[^wiki]
+
+## Overview
+
+The best-known example is the Raspberry Pi Compute Module (CM4, CM5), but the idea is general: take the [system on a chip](/reference/system-on-a-chip/) and memory of a board like the [Raspberry Pi](/reference/raspberry-pi/) and put it on a compact, breakable-out module. A product designer then lays out a *carrier board* that routes the [GPIO](/reference/gpio/), USB, Ethernet, and power exactly as the product needs, rather than working around a fixed consumer layout.
+
+## Where it fits
+
+A Compute Module is the choice when an [embedded system](/reference/embedded-system/) needs the brains of an SBC but its own enclosure, connectors, and shape — a step beyond bolting a [HAT](/reference/hat-add-on-board/) onto a stock board. In a GopherTrunk-style product, a Compute Module on a custom carrier could host the SDR front end and storage in a sealed, antenna-mounted capture node. The trade-off is engineering effort: you design and manufacture the carrier yourself.
+
+## Sources
+
+[^wiki]: [Raspberry Pi Compute Module](https://en.wikipedia.org/wiki/Raspberry_Pi#Compute_Module) — Wikipedia, on the modular, carrier-board form of the Raspberry Pi.

--- a/docs/reference/computer-case.md
+++ b/docs/reference/computer-case.md
@@ -1,0 +1,33 @@
+---
+slug: computer-case
+title: Computer case
+entry_type: hardware
+category: hw-personal-computers
+description: A computer case is the enclosure that houses and protects a desktop PC's components, providing mounting points, airflow, and cable routing for the motherboard, power supply, drives, and cards.
+keywords: computer case, PC case, chassis, tower, ATX case, airflow, form factor
+aka: [PC case, Chassis, Tower]
+infobox:
+  - { label: Type, value: PC enclosure }
+  - { label: Houses, value: Motherboard, PSU, drives, cards }
+  - { label: Sizes, value: Full / mid / mini tower, SFF }
+  - { label: Matches, value: Motherboard form factor }
+see_also: [desktop-computer, motherboard, motherboard-form-factor, power-supply-unit, cooling-and-thermals]
+related_lessons:
+  - { title: "Desktop computers", url: /learn/intro-hardware/desktop-computers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_case
+---
+
+A **computer case** is the enclosure that houses and protects a [desktop computer](/reference/desktop-computer/)'s components, giving each part a place to mount and a path for air and cables.[^wiki]
+
+## Overview
+
+The case holds the [motherboard](/reference/motherboard/), the [power supply unit](/reference/power-supply-unit/), drives, and expansion cards, with standoffs and brackets sized to standard layouts. Its job beyond mounting is *thermal*: fans and vents move air across the hot parts so [cooling](/reference/cooling-and-thermals/) keeps the CPU and GPU from throttling. Cases come in sizes — full, mid, and mini towers down to small-form-factor boxes — and each is built to accept a particular [motherboard form factor](/reference/motherboard-form-factor/) such as ATX or Mini-ITX.
+
+## Where it fits
+
+The case is the one part that does no computing yet shapes the whole build: it decides which boards fit, how many drives and cards you can add, how quiet the machine runs, and how it looks on the desk. A roomy tower eases upgrades and airflow; a small case saves space at the cost of expansion and cooling headroom. A pre-built [all-in-one computer](/reference/all-in-one-computer/) or [mini PC](/reference/mini-pc/) hides this choice inside a fixed enclosure.
+
+## Sources
+
+[^wiki]: [Computer case](https://en.wikipedia.org/wiki/Computer_case) — Wikipedia, on PC cases and their role.

--- a/docs/reference/computer-hardware.md
+++ b/docs/reference/computer-hardware.md
@@ -1,0 +1,33 @@
+---
+slug: computer-hardware
+title: Computer hardware
+entry_type: concept
+category: hw-foundations
+description: Computer hardware is the physical, touchable part of a computing device — the chips, boards, memory, and drives — as distinct from the software that runs on it.
+keywords: computer hardware, physical components, input process output, CPU memory storage I/O, hardware vs software
+aka: [computer hardware, hardware]
+infobox:
+  - { label: Type, value: Physical computing parts }
+  - { label: Opposite of, value: Software }
+  - { label: Building blocks, value: CPU, memory, storage, I/O }
+  - { label: Range, value: Sensor chip to data-center server }
+see_also: [central-processing-unit, random-access-memory, data-storage, input-output, hardware-spectrum]
+related_lessons:
+  - { title: "What is hardware?", url: /learn/intro-hardware/what-is-hardware/ }
+  - { title: "The building blocks", url: /learn/intro-hardware/building-blocks/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_hardware
+---
+
+**Computer hardware** is the set of physical parts you can touch — the chips, circuit boards, memory modules, drives, and case — as opposed to the [software](/reference/operating-system/) that tells them what to do.[^wiki]
+
+## Overview
+A computer is anything that takes **input**, follows instructions to **process** it, and produces **output**. That definition spans an enormous range: a warehouse [server](/reference/server/), the [laptop](/reference/laptop/) on your desk, and the tiny chip inside a sensor are all computers by the same rule.
+
+Nearly every one of them is built from the same four building blocks: a [central processing unit](/reference/central-processing-unit/) to run instructions, [random-access memory](/reference/random-access-memory/) for active working data, [storage](/reference/data-storage/) for data that must survive a power cycle, and [input/output](/reference/input-output/) to move data in and out.
+
+## Why it matters
+Knowing which physical resources a device has — how fast its CPU is, how much memory and storage it carries, what it can connect to — tells you what software it can realistically run. Software-defined-radio software like GopherTrunk runs across this whole range, from a full desktop down to a [single-board computer](/reference/single-board-computer/) by the antenna; the hardware sets the ceiling.
+
+## Sources
+[^wiki]: [Computer hardware](https://en.wikipedia.org/wiki/Computer_hardware) — Wikipedia, on the physical components of a computer and the hardware/software distinction.

--- a/docs/reference/computer-monitor.md
+++ b/docs/reference/computer-monitor.md
@@ -1,0 +1,30 @@
+---
+slug: computer-monitor
+title: Computer monitor
+entry_type: hardware
+category: hw-personal-computers
+description: A computer monitor is the display that shows a computer's visual output, characterized by its panel technology, size, resolution, and refresh rate, connected over HDMI, DisplayPort, or USB-C.
+keywords: monitor, display, LCD, LED, IPS, OLED, resolution, refresh rate, HDMI, DisplayPort
+infobox:
+  - { label: Type, value: Display / output device }
+  - { label: Panel, value: LCD (IPS/VA/TN), OLED }
+  - { label: Key specs, value: Size, resolution, refresh rate }
+  - { label: Connects via, value: HDMI, DisplayPort, USB-C }
+see_also: [peripheral, personal-computer, desktop-computer, all-in-one-computer, graphics-processing-unit]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_monitor
+---
+
+A **computer monitor** is the display that shows a computer's visual output — the screen you read and interact with, as opposed to the box that does the computing.[^wiki]
+
+## Overview
+
+Most monitors are flat-panel displays built on LCD technology (with IPS, VA, or TN variants) lit by LEDs, while higher-end models use OLED for deeper contrast. The main specifications are *size* (measured diagonally), *resolution* (the pixel count, such as 1920×1080 or 3840×2160), and *refresh rate* (how many times per second the image updates, in hertz). A monitor is an output [peripheral](/reference/peripheral/): it receives a video signal from the computer's [GPU](/reference/graphics-processing-unit/) over HDMI, DisplayPort, or USB-C and turns it into light.
+
+## Where it fits
+
+A monitor pairs with any [desktop computer](/reference/desktop-computer/), [mini PC](/reference/mini-pc/), or laptop, while an [all-in-one computer](/reference/all-in-one-computer/) builds the same panel into the system. Picking one is a trade-off: office and coding work reward resolution and screen area, gaming rewards high refresh rate and low latency, and photo or video work rewards color accuracy. For a GopherTrunk bench, screen area pays off — a wide or tall monitor keeps a waterfall, constellation plot, and call log all visible at once.
+
+## Sources
+
+[^wiki]: [Computer monitor](https://en.wikipedia.org/wiki/Computer_monitor) — Wikipedia, on display devices for computers.

--- a/docs/reference/container.md
+++ b/docs/reference/container.md
@@ -1,0 +1,30 @@
+---
+slug: container
+title: Container
+entry_type: concept
+category: hw-servers
+description: A container is a lightweight, isolated package that bundles an application with its dependencies and runs as an ordinary process on a shared operating-system kernel, making software portable and reproducible.
+keywords: container, containerization, OS-level virtualization, image, namespaces, cgroups, portable app
+infobox:
+  - { label: Type, value: OS-level isolation }
+  - { label: Shares, value: Host kernel }
+  - { label: Packages, value: App + dependencies }
+  - { label: Contrast, value: Virtual machine }
+see_also: [docker, kubernetes, virtualization, hypervisor, operating-system, serverless-computing]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Containerization_(computing)
+---
+
+A **container** is a lightweight, isolated package that bundles an application with its dependencies and runs as an ordinary process on a shared [operating-system](/reference/operating-system/) kernel — making software portable and reproducible across machines.[^wiki]
+
+## Overview
+
+Containers are a form of OS-level [virtualization](/reference/virtualization/). Unlike a virtual machine, a container does not carry its own kernel or boot an operating system; it shares the host's kernel and is isolated using kernel features such as namespaces (separate views of processes, files, and networking) and cgroups (resource limits). A container starts from an *image* — a layered, read-only template — so the same image runs identically on a laptop, a server, or the cloud. The result is fast startup, low overhead, and "it works the same everywhere" packaging.
+
+## Where it fits
+
+Containers are usually built and run with [Docker](/reference/docker/) and orchestrated at scale by [Kubernetes](/reference/kubernetes/). They are lighter than full virtualization under a [hypervisor](/reference/hypervisor/) but offer weaker isolation, since all containers share one kernel. Packaging GopherTrunk in a container makes the decoder easy to deploy reproducibly, though USB radio access (the SDR dongle) must be passed through from the host.
+
+## Sources
+
+[^wiki]: [Containerization (computing)](https://en.wikipedia.org/wiki/Containerization_(computing)) — Wikipedia, on OS-level containers.

--- a/docs/reference/content-delivery-network.md
+++ b/docs/reference/content-delivery-network.md
@@ -1,0 +1,31 @@
+---
+slug: content-delivery-network
+title: Content delivery network (CDN)
+entry_type: concept
+category: hw-servers
+description: A content delivery network (CDN) is a geographically distributed group of servers that cache and serve web content from locations close to users, cutting latency and offloading origin servers.
+keywords: CDN, content delivery network, edge cache, points of presence, latency, origin server, caching
+aka: [CDN]
+infobox:
+  - { label: Type, value: Distributed caching network }
+  - { label: Caches, value: Web content near users }
+  - { label: Nodes, value: Edge / points of presence }
+  - { label: Improves, value: Latency & origin load }
+see_also: [edge-computing, reverse-proxy, load-balancer, web-hosting, scalability, data-center]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Content_delivery_network
+---
+
+A **content delivery network** (**CDN**) is a geographically distributed group of servers that cache and serve web content from locations close to users, cutting latency and offloading the origin servers.[^wiki]
+
+## Overview
+
+A CDN places caching nodes — *points of presence* — in many [data centers](/reference/data-center/) around the world. When a user requests a file, they are routed to the nearest node, which serves a cached copy if it has one or fetches it from the origin and keeps it for the next request. Because most of the traffic (images, video, scripts, static pages) is served from the edge, the origin sees far less load and distant users get content over a short network hop instead of a transcontinental one. CDNs also commonly absorb traffic spikes and blunt denial-of-service attacks.
+
+## Where it fits
+
+A CDN is closely related to a [reverse proxy](/reference/reverse-proxy/) and a [load balancer](/reference/load-balancer/) — it is essentially a global, caching reverse proxy — and it is a form of [edge computing](/reference/edge-computing/) for content. It is a standard tool for [scalability](/reference/scalability/) in [web hosting](/reference/web-hosting/). A small GopherTrunk dashboard rarely needs one, but a public site distributing decoded archives could front them with a CDN.
+
+## Sources
+
+[^wiki]: [Content delivery network](https://en.wikipedia.org/wiki/Content_delivery_network) — Wikipedia, on CDN architecture and benefits.

--- a/docs/reference/cooling-and-thermals.md
+++ b/docs/reference/cooling-and-thermals.md
@@ -1,0 +1,30 @@
+---
+slug: cooling-and-thermals
+title: Cooling & thermals
+entry_type: concept
+category: hw-foundations
+description: Cooling is how a computer moves heat away from its chips to keep them within safe temperatures; thermal limits cap sustained performance through throttling when heat builds up.
+keywords: cooling, thermals, heat sink, thermal throttling, TDP, fan, liquid cooling, heat dissipation
+infobox:
+  - { label: Goal, value: Keep chips in safe range }
+  - { label: Methods, value: Heat sink, fan, liquid }
+  - { label: Limit, value: TDP / thermal throttling }
+  - { label: Heat source, value: Switching transistors }
+see_also: [central-processing-unit, graphics-processing-unit, power-supply-unit, clock-speed, transistor, moores-law]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_cooling
+---
+
+**Cooling** is how a computer carries heat away from its chips, and **thermals** are the temperature limits that ultimately cap how hard those chips can run.[^wiki]
+
+## Overview
+
+Every switching [transistor](/reference/transistor/) dissipates a little energy as heat, and a modern processor has billions of them. That heat is moved off the die by a *heat sink* (a finned metal block), often with a fan forcing air across it, or by liquid loops in high-end systems. A chip's *thermal design power* (TDP) states how much heat the cooling must remove. When a part gets too hot, it *throttles* — lowering [clock speed](/reference/clock-speed/) to cut heat and stay safe.
+
+## Where it fits
+
+Cooling sets the ceiling on sustained performance: a [CPU](/reference/central-processing-unit/) or [GPU](/reference/graphics-processing-unit/) can boost briefly but must back off once heat accumulates. Most of the power a [PSU](/reference/power-supply-unit/) delivers ends up as heat the cooling system has to shed. For an unattended GopherTrunk capture node baking in the sun by an antenna, passive heat sinks and good airflow keep a fanless [Raspberry Pi](/reference/raspberry-pi/) from throttling mid-decode — thermals are a real-world constraint, not an afterthought.
+
+## Sources
+
+[^wiki]: [Computer cooling](https://en.wikipedia.org/wiki/Computer_cooling) — Wikipedia, on heat sinks, fans, liquid cooling, and thermal limits.

--- a/docs/reference/cuda.md
+++ b/docs/reference/cuda.md
@@ -1,0 +1,35 @@
+---
+slug: cuda
+title: CUDA
+entry_type: concept
+category: hw-accelerators
+description: CUDA is NVIDIA's parallel computing platform and programming model that lets general-purpose code run on the GPU, exposing thousands of cores through C, C++, and other languages.
+keywords: CUDA, NVIDIA, GPGPU, GPU computing, parallel computing, kernels, cuDNN, GPU programming
+aka: [Compute Unified Device Architecture]
+autolink: true
+infobox:
+  - { label: Type, value: Parallel computing platform / API }
+  - { label: Vendor, value: NVIDIA }
+  - { label: Introduced, value: "2007" }
+  - { label: Runs on, value: NVIDIA GPUs }
+  - { label: Languages, value: "C, C++, Fortran, Python bindings" }
+see_also: [gpgpu, graphics-processing-unit, nvidia, hardware-acceleration, vector-processor, ai-accelerator]
+cite_urls:
+  - https://en.wikipedia.org/wiki/CUDA
+  - https://developer.nvidia.com/cuda-zone
+---
+
+**CUDA** is [NVIDIA](/reference/nvidia/)'s parallel computing platform and programming model that lets ordinary, general-purpose code run on the [GPU](/reference/graphics-processing-unit/) instead of only the CPU.[^wiki]
+
+## Overview
+
+A CUDA program splits work into a *kernel* — a small function executed in parallel by thousands of lightweight threads, each handling one element of the data. The platform exposes the GPU through extensions to C and C++ (and bindings for [Python](/reference/python-language/), Fortran, and others), plus tuned libraries such as cuBLAS for linear algebra and cuDNN for neural networks. Because it is proprietary to NVIDIA hardware, CUDA competes with the cross-vendor OpenCL and with newer portable frameworks, but its mature tooling made it the de facto standard for GPU computing.[^cuda]
+
+## Where it fits
+
+CUDA is the bridge that turned the GPU from a graphics device into a general accelerator (see [GPGPU](/reference/gpgpu/)), and it underpins most modern [AI accelerator](/reference/ai-accelerator/) workloads on NVIDIA hardware. For a signal-processing pipeline like GopherTrunk, a CUDA kernel can run massively parallel work — large FFTs across many channels, or batched filtering — far faster than a CPU, though for a handful of narrowband channels the data-transfer overhead to the GPU often outweighs the gain.
+
+## Sources
+
+[^wiki]: [CUDA](https://en.wikipedia.org/wiki/CUDA) — Wikipedia, on NVIDIA's parallel computing platform and programming model.
+[^cuda]: [CUDA Zone](https://developer.nvidia.com/cuda-zone) — NVIDIA's developer site for the CUDA toolkit and libraries.

--- a/docs/reference/data-center.md
+++ b/docs/reference/data-center.md
@@ -1,0 +1,31 @@
+---
+slug: data-center
+title: Data center
+entry_type: concept
+category: hw-servers
+description: A data center is a purpose-built facility that houses computing, storage, and networking equipment with the power, cooling, and connectivity needed to run it reliably around the clock.
+keywords: data center, datacenter, server farm, colocation, power and cooling, uptime, hyperscale
+aka: [Datacenter, Server farm]
+infobox:
+  - { label: Type, value: Computing facility }
+  - { label: Houses, value: Servers, storage, networking }
+  - { label: Provides, value: Power, cooling, connectivity }
+  - { label: Measured by, value: Uptime tier, PUE }
+see_also: [server, rack-server, colocation, cloud-computing, high-availability, data-storage]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Data_center
+---
+
+A **data center** is a purpose-built facility that houses computing, storage, and networking equipment together with the power, cooling, and connectivity needed to keep it running reliably around the clock.[^wiki]
+
+## Overview
+
+At its core a data center is a building full of [rack servers](/reference/rack-server/) and the supporting systems that keep them alive: redundant utility feeds and backup generators, uninterruptible power supplies, air or liquid cooling, fire suppression, and high-capacity network links to the outside world. Facilities are graded by uptime *tiers* (Tier I–IV) and by energy efficiency, often reported as **PUE** (power usage effectiveness — total facility power divided by IT power). Scale ranges from a single room to *hyperscale* campuses run by cloud providers.
+
+## Where it fits
+
+A data center is where most [servers](/reference/server/) actually live. You can put your own hardware in one through [colocation](/reference/colocation/), rent capacity inside one as [cloud computing](/reference/cloud-computing/), or rely on one indirectly every time you use a web service. The facility's redundancy is the foundation of [high availability](/reference/high-availability/). In GopherTrunk terms a data center is fine for storing and serving decoded calls, but the RF capture still happens at the antenna — the radio front end cannot move into the building.
+
+## Sources
+
+[^wiki]: [Data center](https://en.wikipedia.org/wiki/Data_center) — Wikipedia, on data center facilities, tiers, and infrastructure.

--- a/docs/reference/data-storage.md
+++ b/docs/reference/data-storage.md
@@ -1,0 +1,36 @@
+---
+slug: data-storage
+title: Storage (SSD, HDD, flash)
+entry_type: hardware
+category: hw-foundations
+description: Storage is where a computer keeps data long-term so it survives a power cycle, using technologies such as hard drives, solid-state drives, and flash memory.
+keywords: storage, SSD, HDD, hard drive, flash memory, SD card, non-volatile, permanent storage
+aka: [storage, data storage]
+infobox:
+  - { label: Type, value: Long-term storage }
+  - { label: Survives power loss, value: Yes (non-volatile) }
+  - { label: Forms, value: HDD, SSD, flash }
+  - { label: Speed, value: Slower than RAM }
+see_also: [computer-hardware, random-access-memory, central-processing-unit, single-board-computer, microcontroller]
+related_lessons:
+  - { title: "The building blocks", url: /learn/intro-hardware/building-blocks/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_data_storage
+---
+
+**Storage** is where a computer keeps data long-term, so that files and programs survive a power cycle.[^wiki] It is the permanent counterpart to [RAM](/reference/random-access-memory/).
+
+## Overview
+Storage comes in a few common forms:
+
+- **HDD** (hard disk drive): data on spinning magnetic platters — cheap and high-capacity, but slower and mechanically fragile.
+- **SSD** (solid-state drive): flash memory with no moving parts — faster, quieter, and more rugged.
+- **Flash memory**: the non-volatile technology inside SSDs, SD cards, and the on-board storage of small devices.
+
+All of these are **non-volatile** — they hold their contents with the power off, unlike RAM. The trade-off is speed: even fast storage is much slower than RAM, which is why the [CPU](/reference/central-processing-unit/) does its active work in memory and reads from or writes to storage only when it must.
+
+## Where it fits
+Storage is one of the four building blocks of [computer hardware](/reference/computer-hardware/). On a [single-board computer](/reference/single-board-computer/) it is often a microSD card; on a [microcontroller](/reference/microcontroller/) it may be a small block of on-chip flash; on a [server](/reference/server/) it can be racks of SSDs.
+
+## Sources
+[^wiki]: [Computer data storage](https://en.wikipedia.org/wiki/Computer_data_storage) — Wikipedia, on non-volatile storage and HDD/SSD/flash technologies.

--- a/docs/reference/dedicated-server.md
+++ b/docs/reference/dedicated-server.md
@@ -1,0 +1,34 @@
+---
+slug: dedicated-server
+title: Dedicated server
+entry_type: hardware
+category: hw-servers
+description: A dedicated server is a whole physical server rented for your exclusive use, with no other customers sharing the hardware.
+keywords: dedicated server, bare metal, exclusive hardware, single tenant, uncontended
+aka: [Dedicated server, Bare metal server]
+infobox:
+  - { label: Type, value: Physical server }
+  - { label: Tenancy, value: Single (exclusive) }
+  - { label: Performance, value: Uncontended }
+  - { label: You manage, value: The whole machine }
+see_also: [server, virtual-private-server, web-hosting, cloud-computing, home-server]
+related_lessons:
+  - { title: "Dedicated servers", url: /learn/intro-hardware/dedicated-servers/ }
+  - { title: "Virtual private server (VPS)", url: /learn/intro-hardware/vps/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Dedicated_hosting_service
+---
+
+A **dedicated server** is a whole physical [server](/reference/server/) rented for your exclusive use — no other customers share the hardware.[^wiki]
+
+## Overview
+
+Unlike a [virtual private server](/reference/virtual-private-server/), which carves one machine into many tenants, a dedicated server is yours alone. That means raw, uncontended performance: no neighbors competing for CPU, memory, or disk. You (or the provider, under a managed plan) handle the metal — the operating system, patching, and recovery.
+
+## When to choose it
+
+Pick a dedicated server when predictable, full-machine performance is worth the higher price compared with a VPS — sustained heavy workloads, strict latency budgets, or licensing that demands a single tenant. For lighter or bursty needs, a VPS or [cloud computing](/reference/cloud-computing/) is usually the better value.
+
+## Sources
+
+[^wiki]: [Dedicated hosting service](https://en.wikipedia.org/wiki/Dedicated_hosting_service) — Wikipedia, on single-tenant dedicated servers.

--- a/docs/reference/desktop-computer.md
+++ b/docs/reference/desktop-computer.md
@@ -1,0 +1,43 @@
+---
+slug: desktop-computer
+title: Desktop computer
+entry_type: hardware
+category: hw-personal-computers
+description: A desktop computer is a stationary personal computer that delivers the most performance per dollar and is the easiest to upgrade and expand.
+keywords: desktop computer, desktop PC, tower, workstation, upgradeable computer, stationary computer
+aka: [Desktop computer, Desktop PC, Desktop]
+infobox:
+  - { label: Type, value: Stationary personal computer }
+  - { label: Strength, value: Most power per dollar }
+  - { label: Upgradeable, value: Yes, easily }
+  - { label: Portability, value: None }
+  - { label: Best for, value: Sustained heavy work }
+see_also: [personal-computer, laptop, central-processing-unit, random-access-memory, computer-hardware, data-storage]
+related_lessons:
+  - { title: "Desktop computers", url: /learn/intro-hardware/desktop-computers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Desktop_computer
+---
+
+**A desktop computer** is a stationary [personal computer](/reference/personal-computer/)
+that trades portability for the most performance per dollar.[^wiki]
+
+## Overview
+
+Because the case is roomy and runs on wall power, a desktop fits larger, faster
+[CPUs](/reference/central-processing-unit/), more
+[RAM](/reference/random-access-memory/), and bigger
+[storage](/reference/data-storage/) than a comparable laptop — and it stays
+cool enough to run them flat out. The same roominess makes it the easiest form to
+upgrade and expand: parts swap out individually rather than being soldered down.
+
+## Trade-offs
+
+The catch is in the name: it stays on the desk. For sustained heavy work —
+compiling large projects, crunching data, running long SDR captures — a desktop's
+thermal headroom and upgrade path are hard to beat. When the work needs to travel,
+that argument flips and the [laptop](/reference/laptop/) wins.
+
+## Sources
+
+[^wiki]: [Desktop computer](https://en.wikipedia.org/wiki/Desktop_computer) — Wikipedia, on the stationary personal computer and its expandability.

--- a/docs/reference/digital-to-analog-converter.md
+++ b/docs/reference/digital-to-analog-converter.md
@@ -1,0 +1,33 @@
+---
+slug: digital-to-analog-converter
+title: Digital-to-analog converter (DAC)
+entry_type: hardware
+category: hw-microcontrollers
+description: A digital-to-analog converter turns a stream of numbers into a continuous analog voltage, the inverse of an ADC; it lets a microcontroller output audio, control voltages, or waveform signals.
+keywords: DAC, digital to analog converter, analog output, resolution, audio, waveform, reconstruction, R-2R
+aka: [DAC]
+infobox:
+  - { label: Type, value: Conversion device }
+  - { label: Does, value: Numbers to analog voltage }
+  - { label: Inverse of, value: ADC }
+  - { label: Key spec, value: Resolution (bits), rate }
+see_also: [analog-to-digital-converter, pulse-width-modulation, microcontroller, sensor, gpio, stm32]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Digital-to-analog_converter
+---
+
+**A digital-to-analog converter (DAC)** turns a sequence of digital numbers into a continuous analog voltage — the inverse of an [analog-to-digital converter](/reference/analog-to-digital-converter/).[^wiki]
+
+## Overview
+
+A DAC takes a binary value and produces a proportional voltage on its output; feeding it a stream of values at a fixed rate reconstructs a waveform. Its two headline specs mirror the ADC's: **resolution** (bits, which sets how finely the output is quantized) and **update rate** (how fast new samples are accepted). Some [microcontrollers](/reference/microcontroller/) — such as parts of the [STM32](/reference/stm32/) line — include a true on-chip DAC; others approximate one by low-pass filtering [PWM](/reference/pulse-width-modulation/).
+
+## What it's for
+
+A DAC lets an MCU output genuinely analog signals: audio, control voltages for analog circuits, programmable reference levels, or arbitrary waveforms. It pairs naturally with [sensors](/reference/sensor/) and actuators that expect an analog input. Where only a rough analog level is needed, filtered PWM on an ordinary [GPIO](/reference/gpio/) pin is the cheaper substitute; a dedicated DAC wins on clean, fast, high-resolution output.
+
+## Sources
+
+[^wiki]: [Digital-to-analog converter](https://en.wikipedia.org/wiki/Digital-to-analog_converter) — Wikipedia, on DAC operation and specifications.

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -1,0 +1,33 @@
+---
+slug: docker
+title: Docker
+entry_type: concept
+category: hw-servers
+description: Docker is a popular platform and toolset for building, sharing, and running containers, which packaged container images and a simple command line and made containerization mainstream.
+keywords: Docker, container, Dockerfile, container image, Docker Hub, containerization
+autolink: true
+infobox:
+  - { label: Type, value: Container platform }
+  - { label: Introduced, value: "2013" }
+  - { label: Builds from, value: Dockerfile }
+  - { label: Shares via, value: Image registry }
+see_also: [container, kubernetes, virtualization, operating-system, hypervisor, serverless-computing]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Docker_(software)
+  - https://www.docker.com/
+---
+
+**Docker** is a popular platform and toolset for building, sharing, and running [containers](/reference/container/). Introduced in 2013, it standardized container images and a simple command line and brought containerization into the mainstream.[^wiki]
+
+## Overview
+
+A developer describes an image in a *Dockerfile* — a recipe listing a base image, dependencies, and the application — and Docker builds it into a layered, portable image. That image can be pushed to a registry such as Docker Hub and pulled to run identically anywhere Docker is installed. Docker did not invent the underlying kernel features (namespaces and cgroups), but its tooling and image format made them easy enough that containers became the default way to ship server software.[^home]
+
+## Where it fits
+
+Docker handles single containers on one host; when you need to run many containers across many machines, [Kubernetes](/reference/kubernetes/) orchestrates them. Containers are lighter than the full [virtualization](/reference/virtualization/) a [hypervisor](/reference/hypervisor/) provides. A Docker image of GopherTrunk gives a clean, reproducible decoder build; on a capture node you pass the SDR device through from the host into the container.
+
+## Sources
+
+[^wiki]: [Docker (software)](https://en.wikipedia.org/wiki/Docker_(software)) — Wikipedia, on Docker's history and design.
+[^home]: [Docker](https://www.docker.com/) — the project's official site.

--- a/docs/reference/e-reader.md
+++ b/docs/reference/e-reader.md
@@ -1,0 +1,33 @@
+---
+slug: e-reader
+title: E-reader
+entry_type: hardware
+category: hw-mobile
+description: An e-reader is a portable device optimized for reading digital books, typically using a low-power electronic-paper display that mimics ink on paper and runs for weeks on a single charge.
+keywords: e-reader, e-ink, electronic paper, e-paper, Kindle, Kobo, ereader, reflective display, e-book
+aka: [eReader, e-book reader]
+infobox:
+  - { label: Type, value: Portable reading device }
+  - { label: Display, value: Electronic paper (E Ink) }
+  - { label: Battery life, value: Weeks per charge }
+  - { label: Examples, value: Kindle, Kobo }
+see_also: [tablet, touchscreen, battery-technology, smartphone, mobile-operating-system, system-on-a-chip]
+related_lessons:
+  - { title: "Tablets", url: /learn/intro-hardware/tablets/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/E-reader
+---
+
+An **e-reader** is a portable device built for reading digital books, using a low-power electronic-paper display that looks like ink on paper.[^wiki]
+
+## Overview
+
+The defining part is the *electronic-paper* (E Ink) display: a reflective screen of microcapsules that hold their image with no power once set, so the device only draws energy when the page changes. The result is paper-like readability in sunlight and [battery](/reference/battery-technology/) life measured in weeks rather than hours. E-readers run a stripped-down [mobile operating system](/reference/mobile-operating-system/) on a modest [SoC](/reference/system-on-a-chip/), often with a [touchscreen](/reference/touchscreen/) and a front light. Familiar examples include Amazon's Kindle and Rakuten's Kobo.
+
+## Where it fits
+
+An e-reader trades the bright, fast color of a [tablet](/reference/tablet/) for outstanding battery life and eye comfort at one task — reading. The same E Ink technology shows up on shelf labels and low-power status panels, where a display that needs power only to update is exactly the right tool for a device that mostly sits idle.
+
+## Sources
+
+[^wiki]: [E-reader](https://en.wikipedia.org/wiki/E-reader) — Wikipedia, on e-readers and electronic-paper displays.

--- a/docs/reference/eben-upton.md
+++ b/docs/reference/eben-upton.md
@@ -1,0 +1,52 @@
+---
+slug: eben-upton
+title: Eben Upton
+entry_type: person
+category: hw-people
+description: Eben Upton (born 1978) is a British engineer who created the Raspberry Pi single-board computer and co-founded the Raspberry Pi Foundation to make affordable computing widely accessible.
+keywords: Eben Upton, Raspberry Pi, Raspberry Pi Foundation, single-board computer, Broadcom, computing education
+aka: [Eben Upton]
+autolink: true
+infobox:
+  - { label: Born, value: "1978" }
+  - { label: Field, value: Computer engineering }
+  - { label: Known for, value: Raspberry Pi }
+see_also: [raspberry-pi, raspberry-pi-foundation, single-board-computer, broadcom]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Eben_Upton
+---
+
+**Eben Upton** (born 1978) is a British engineer who created the
+[Raspberry Pi](/reference/raspberry-pi/) and co-founded the
+[Raspberry Pi Foundation](/reference/raspberry-pi-foundation/), aiming to give students an
+affordable, hackable computer.[^wiki]
+
+## Life and work
+
+Concerned that applicants to study computing arrived with less hands-on experience than
+earlier generations, Upton set out to build a cheap, approachable machine for learning to
+program. Working with colleagues and drawing on his chip background at
+[Broadcom](/reference/broadcom/), he led the design of the first
+[Raspberry Pi](/reference/raspberry-pi/), a credit-card-sized
+[single-board computer](/reference/single-board-computer/) launched in 2012.[^wiki] It sold far
+beyond the educational market, becoming one of the best-selling computers ever and a staple of
+the maker and embedded-electronics world.[^wiki]
+
+## Why they matter
+
+The [Raspberry Pi](/reference/raspberry-pi/) made a complete Linux computer with
+[GPIO](/reference/gpio/) pins available for the price of a textbook, putting real computing into
+classrooms, hobby projects, and field deployments. It is a natural host for SDR work: a Pi by
+the antenna can run a capture node, feeding samples to a decoder like GopherTrunk. Upton
+continues as a leader of Raspberry Pi's commercial and foundation arms.[^wiki]
+
+## Legacy
+
+Tens of millions of Raspberry Pi boards have shipped, and the platform reshaped how people
+learn hardware, prototype devices, and build low-cost embedded systems.
+
+## Sources
+
+[^wiki]: [Eben Upton](https://en.wikipedia.org/wiki/Eben_Upton) — Wikipedia, for biography and the Raspberry Pi.

--- a/docs/reference/edge-ai.md
+++ b/docs/reference/edge-ai.md
@@ -1,0 +1,34 @@
+---
+slug: edge-ai
+title: Edge AI
+entry_type: concept
+category: hw-sbc
+description: Edge AI is the practice of running machine-learning models directly on local devices such as single-board computers, cameras, and sensors, rather than sending data to the cloud for inference.
+keywords: edge AI, on-device inference, edge inference, machine learning at the edge, AI accelerator, Edge TPU, low latency AI, privacy
+aka: [on-device AI, edge inference]
+infobox:
+  - { label: Type, value: Computing approach }
+  - { label: Where, value: On local devices }
+  - { label: Versus, value: Cloud inference }
+  - { label: Wins, value: Latency, privacy, offline use }
+  - { label: Needs, value: Efficient models / accelerators }
+see_also: [google-coral, nvidia-jetson, single-board-computer, ai-accelerator, edge-computing, home-automation]
+related_lessons:
+  - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Edge_computing
+---
+
+**Edge AI** is the practice of running machine-learning models directly on local devices — [single-board computers](/reference/single-board-computer/), cameras, sensors — instead of sending data to the cloud for inference.[^wiki]
+
+## Overview
+
+The appeal is concrete: inference next to the data is lower-latency, keeps private data on the device, and keeps working without a network. The cost is that small devices have limited compute, so edge AI leans on efficient, quantised models and on dedicated [AI accelerators](/reference/ai-accelerator/) such as [Google Coral](/reference/google-coral/)'s Edge TPU or the GPU on an [NVIDIA Jetson](/reference/nvidia-jetson/). It is a specific case of the broader move toward [edge computing](/reference/edge-computing/).
+
+## Where it fits
+
+Edge AI shows up wherever round-tripping to a server is too slow, too costly, or impossible: factory cameras, doorbells, robots, and [home automation](/reference/home-automation/). In a GopherTrunk-style deployment, edge AI could classify or flag activity in decoded data on the same node that does the radio work, sending up only the results rather than every sample.
+
+## Sources
+
+[^wiki]: [Edge computing](https://en.wikipedia.org/wiki/Edge_computing) — Wikipedia, on processing data near its source, including on-device inference.

--- a/docs/reference/edge-computing.md
+++ b/docs/reference/edge-computing.md
@@ -1,0 +1,32 @@
+---
+slug: edge-computing
+title: Edge computing
+entry_type: concept
+category: hw-servers
+description: Edge computing processes data near where it is produced — at or close to the device or sensor — instead of sending everything to a distant data center, reducing latency and bandwidth use.
+keywords: edge computing, edge, latency, bandwidth, local processing, IoT, near the source
+infobox:
+  - { label: Type, value: Computing model }
+  - { label: Runs, value: Near the data source }
+  - { label: Reduces, value: Latency & bandwidth }
+  - { label: Contrast, value: Centralized cloud }
+see_also: [cloud-computing, content-delivery-network, internet-of-things, raspberry-pi, data-center, scalability]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Edge_computing
+---
+
+**Edge computing** processes data near where it is produced — at or close to the device or sensor — instead of shipping everything to a distant [data center](/reference/data-center/), reducing latency and bandwidth use.[^wiki]
+
+## Overview
+
+In a purely centralized model, devices send raw data to the [cloud](/reference/cloud-computing/) and wait for a response. Edge computing moves some of that work outward: a small computer near the source filters, aggregates, or acts on data locally, sending only summaries or alerts upstream. This cuts round-trip latency, saves bandwidth, and keeps working when the network link is slow or down. It is closely tied to the [internet of things](/reference/internet-of-things/), where many sensors generate more data than is practical to forward whole.
+
+## Where it fits
+
+Edge computing complements the cloud rather than replacing it — heavy storage and analytics stay central while time-sensitive or high-volume processing happens locally. A [content delivery network](/reference/content-delivery-network/) is edge computing for content. GopherTrunk is naturally an edge workload: a [Raspberry Pi](/reference/raspberry-pi/) by the antenna decodes RF on the spot and forwards only the decoded calls, rather than streaming raw IQ across the network.
+
+## Sources
+
+[^wiki]: [Edge computing](https://en.wikipedia.org/wiki/Edge_computing) — Wikipedia, on the edge computing model.

--- a/docs/reference/embedded-system.md
+++ b/docs/reference/embedded-system.md
@@ -1,0 +1,33 @@
+---
+slug: embedded-system
+title: Embedded system
+entry_type: concept
+category: hw-microcontrollers
+description: An embedded system is a computer built into a larger product to perform a dedicated function, usually around a microcontroller with fixed firmware rather than a general-purpose operating system.
+keywords: embedded system, dedicated function, firmware, real-time, microcontroller, appliance, deeply embedded
+infobox:
+  - { label: Type, value: Dedicated-purpose computer }
+  - { label: Built around, value: Microcontroller or SoC }
+  - { label: Software, value: Firmware, often real-time }
+  - { label: Found in, value: Appliances, vehicles, radios }
+see_also: [microcontroller, firmware, real-time-operating-system, bare-metal-programming, internet-of-things, sensor]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Embedded_system
+---
+
+**An embedded system** is a computer built into a larger product to carry out a dedicated function, rather than a general-purpose machine you load arbitrary programs onto.[^wiki]
+
+## Overview
+
+Most embedded systems are built around a [microcontroller](/reference/microcontroller/) or system-on-chip running fixed [firmware](/reference/firmware/). They are everywhere — in appliances, cars, medical devices, industrial controllers, and radios — usually invisible to the user. Many have hard real-time constraints, met with [interrupts](/reference/interrupt/) and a [real-time operating system](/reference/real-time-operating-system/), while simpler ones run [bare metal](/reference/bare-metal-programming/). They read the physical world through [sensors](/reference/sensor/) and act on it through actuators.
+
+## Where it fits
+
+The defining trade-off is specialization: an embedded system does one job extremely well, cheaply, and reliably, at the cost of flexibility. When a device also needs network connectivity it becomes part of the [Internet of Things](/reference/internet-of-things/). In radio terms, the small transmitters that fill the airwaves GopherTrunk listens to are embedded systems — far too small to run GopherTrunk itself, which lives on a general-purpose computer with an SDR front end.
+
+## Sources
+
+[^wiki]: [Embedded system](https://en.wikipedia.org/wiki/Embedded_system) — Wikipedia, on dedicated-function computers.

--- a/docs/reference/emmc.md
+++ b/docs/reference/emmc.md
@@ -1,0 +1,33 @@
+---
+slug: emmc
+title: eMMC
+entry_type: hardware
+category: hw-storage
+description: eMMC is flash storage with a controller in a single chip soldered onto a board, giving embedded devices and cheaper computers built-in storage without a removable card.
+keywords: eMMC, embedded MultiMediaCard, embedded flash, soldered storage, NAND, MMC, JEDEC
+aka: [embedded MultiMediaCard]
+autolink: true
+infobox:
+  - { label: Type, value: Embedded flash storage }
+  - { label: Medium, value: NAND flash + controller }
+  - { label: Mounting, value: Soldered to board (BGA) }
+  - { label: Standard, value: JEDEC eMMC }
+  - { label: Common use, value: Phones, tablets, SBCs }
+see_also: [flash-memory, sd-card, solid-state-drive, jedec, nvme, data-storage]
+cite_urls:
+  - https://en.wikipedia.org/wiki/MultiMediaCard#eMMC
+---
+
+**eMMC (embedded MultiMediaCard)** is a single package that combines [flash memory](/reference/flash-memory/) and its controller, soldered directly onto a device's board as built-in storage.[^wiki]
+
+## Overview
+
+Like an [SD card](/reference/sd-card/), eMMC bundles NAND flash with a controller that handles wear leveling and presents a simple block device — but the package is permanently mounted rather than removable. The interface and command set are standardised by [JEDEC](/reference/jedec/). Because it is fixed in place, eMMC is reliable and compact, but capacities are modest and throughput sits below a modern [NVMe](/reference/nvme/) [SSD](/reference/solid-state-drive/). It is common in phones, tablets, and the cheaper tiers of single-board computers.
+
+## Where it fits
+
+eMMC is the middle ground between a removable SD card and a full SSD: faster and more durable than a typical card, cheaper and smaller than a discrete drive. Some single-board computers offer an eMMC module as a sturdier alternative to booting from microSD. For a GopherTrunk node that runs unattended near an antenna, soldered or socketed eMMC avoids the wear and connection issues that plague constantly written SD cards.
+
+## Sources
+
+[^wiki]: [MultiMediaCard — eMMC](https://en.wikipedia.org/wiki/MultiMediaCard#eMMC) — Wikipedia, on embedded MMC flash storage and its JEDEC standardisation.

--- a/docs/reference/esim.md
+++ b/docs/reference/esim.md
@@ -1,0 +1,32 @@
+---
+slug: esim
+title: eSIM
+entry_type: hardware
+category: hw-mobile
+description: An eSIM is a SIM card built directly into a device as a reprogrammable chip, letting users download and switch carrier profiles over the air instead of inserting a physical card.
+keywords: eSIM, embedded SIM, eUICC, SIM card, carrier profile, remote provisioning, virtual SIM, dual SIM
+autolink: true
+aka: [embedded SIM, eUICC]
+infobox:
+  - { label: Type, value: Embedded SIM chip }
+  - { label: Replaces, value: Physical SIM card }
+  - { label: Provisioning, value: Over the air }
+  - { label: Standard, value: GSMA eUICC }
+see_also: [cellular-modem, system-on-a-chip, smartphone, smartwatch, mobile-operating-system, near-field-communication]
+cite_urls:
+  - https://en.wikipedia.org/wiki/ESIM
+---
+
+An **eSIM** is a SIM built directly into a device as a small, reprogrammable chip, letting a user download and switch carrier profiles over the air instead of swapping a physical card.[^wiki]
+
+## Overview
+
+Technically an *eUICC* (embedded Universal Integrated Circuit Card) standardized by the GSMA, an eSIM solders the SIM function onto the board and holds one or more downloadable *profiles*. Activating a plan means scanning a QR code or following a carrier flow; switching networks or running a second line no longer requires opening a tray. Freeing a device from a card slot saves space and improves water resistance, and lets tiny products — [smartwatches](/reference/smartwatch/), trackers — carry cellular service at all.
+
+## Where it fits
+
+The eSIM is the connectivity counterpart to a device's [cellular modem](/reference/cellular-modem/): the modem provides the radio, the eSIM the identity. For a fleet of remote GopherTrunk capture nodes on cellular backhaul, eSIM provisioning means carriers and data plans can be assigned and changed remotely, without anyone visiting each node to insert a card.
+
+## Sources
+
+[^wiki]: [eSIM](https://en.wikipedia.org/wiki/ESIM) — Wikipedia, on embedded SIM technology and remote provisioning.

--- a/docs/reference/esp32.md
+++ b/docs/reference/esp32.md
@@ -1,0 +1,35 @@
+---
+slug: esp32
+title: ESP32
+entry_type: hardware
+category: hw-microcontrollers
+description: The ESP32 is a low-cost dual-core microcontroller with built-in Wi-Fi and Bluetooth, the workhorse of DIY smart-home gadgets and Internet of Things devices.
+keywords: ESP32, ESP8266, ESP-IDF, Wi-Fi, Bluetooth, dual core, IoT microcontroller, MicroPython
+aka: [ESP32]
+autolink: true
+infobox:
+  - { label: Type, value: Wireless microcontroller }
+  - { label: Core, value: Dual-core }
+  - { label: Wireless, value: Wi-Fi + Bluetooth }
+  - { label: Typical price, value: ~$2–5 }
+  - { label: Language, value: C/C++ (ESP-IDF, Arduino), MicroPython }
+see_also: [microcontroller, internet-of-things, arduino, gpio, firmware]
+related_lessons:
+  - { title: "ESP32", url: /learn/intro-hardware/esp32/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/ESP32
+---
+
+**The ESP32** is a low-cost, dual-core [microcontroller](/reference/microcontroller/) with built-in Wi-Fi and Bluetooth, often around a couple of dollars.[^wiki]
+
+## Overview
+
+That combination of price and wireless connectivity makes the ESP32 the workhorse of DIY smart-home gadgets and the [Internet of Things](/reference/internet-of-things/). Common variants include the S3 and C3, alongside the older and simpler ESP8266 that preceded it.
+
+## Where it fits
+
+You can program an ESP32 in C/C++ — using either Espressif's ESP-IDF or the [Arduino](/reference/arduino/) toolchain — or in MicroPython. Wired to sensors over its [GPIO](/reference/gpio/) pins and talking over Wi-Fi, it is exactly the kind of cheap wireless node that crowds the airwaves GopherTrunk listens to, even though it is far too small to run GopherTrunk itself.
+
+## Sources
+
+[^wiki]: [ESP32](https://en.wikipedia.org/wiki/ESP32) — Wikipedia, on the dual-core design, wireless features, and variants.

--- a/docs/reference/espressif.md
+++ b/docs/reference/espressif.md
@@ -1,0 +1,48 @@
+---
+slug: espressif
+title: Espressif Systems
+entry_type: organization
+category: hw-organizations
+description: Espressif Systems is a Chinese semiconductor company best known for its low-cost ESP8266 and ESP32 Wi-Fi and Bluetooth microcontrollers used widely in IoT projects.
+keywords: Espressif, ESP32, ESP8266, Wi-Fi microcontroller, IoT, Bluetooth
+aka: [Espressif]
+autolink: true
+infobox:
+  - { label: Type, value: Public semiconductor company }
+  - { label: Founded, value: "2008" }
+  - { label: HQ, value: Shanghai, China }
+  - { label: Makes, value: Wi-Fi/Bluetooth microcontrollers (ESP series) }
+see_also: [esp32, microcontroller, internet-of-things]
+related_lessons:
+  - { title: "ESP32", url: /learn/intro-hardware/esp32/ }
+cite_urls:
+  - https://www.espressif.com/
+  - https://en.wikipedia.org/wiki/Espressif_Systems
+---
+
+**Espressif Systems** is a Chinese semiconductor company, founded in 2008, best known for
+its low-cost [ESP32](/reference/esp32/) family of Wi-Fi and Bluetooth
+[microcontrollers](/reference/microcontroller/).[^wiki]
+
+## Overview
+
+Espressif first drew wide attention with the ESP8266, a cheap chip that put Wi-Fi within
+reach of hobbyist projects. Its successor, the ESP32, added Bluetooth, more processing
+power, and a richer set of peripherals while staying inexpensive.[^home]
+
+The chips integrate a microcontroller, radio, and memory in one package, and Espressif
+backs them with open development frameworks and broad community support. That combination
+made the ESP series a default choice for connected sensors and devices across the
+[Internet of Things](/reference/internet-of-things/).
+
+## Why it matters
+
+By making a wireless-capable microcontroller cheap and easy to program, Espressif helped
+make networked embedded projects routine. An ESP32 makes a tidy little wireless sensor or
+telemetry node — for example, reporting status or environmental data from a remote
+GopherTrunk antenna site back over Wi-Fi.
+
+## Sources
+
+[^home]: [Espressif](https://www.espressif.com/) — the company's official site, for its chips and SDKs.
+[^wiki]: [Espressif Systems](https://en.wikipedia.org/wiki/Espressif_Systems) — Wikipedia, for the company's history and products.

--- a/docs/reference/ethernet.md
+++ b/docs/reference/ethernet.md
@@ -1,0 +1,31 @@
+---
+slug: ethernet
+title: Ethernet
+entry_type: concept
+category: hw-networking
+description: Ethernet is the dominant family of wired local-area networking standards, defining the cables, connectors, and frame format that carry data between computers on a LAN.
+keywords: Ethernet, IEEE 802.3, twisted pair, RJ45, Gigabit Ethernet, frame, wired networking
+aka: [IEEE 802.3]
+infobox:
+  - { label: Type, value: Wired LAN standard }
+  - { label: Standard, value: IEEE 802.3 }
+  - { label: Common cabling, value: Twisted pair (RJ45), fiber }
+  - { label: Speeds, value: 10 Mb/s – 400 Gb/s }
+see_also: [network-switch, network-interface-card, fiber-optic, power-over-ethernet, wi-fi, lan-and-wan]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Ethernet
+---
+
+**Ethernet** is the dominant family of wired local-area networking standards, defining the cabling, signaling, and frame format that carry data between computers on a [LAN](/reference/lan-and-wan/).[^wiki]
+
+## Overview
+
+Standardized as **IEEE 802.3**, Ethernet packages data into *frames* tagged with source and destination MAC addresses and sends them over twisted-pair copper (terminated in the familiar 8-pin RJ45 plug) or over [fiber-optic](/reference/fiber-optic/) cable for longer runs and higher speeds. Speeds have climbed from the original 10 Mb/s through Fast and Gigabit Ethernet to 10, 100, and 400 Gb/s. Devices attach through a [NIC](/reference/network-interface-card/) and connect to a [switch](/reference/network-switch/); the same cabling can also carry power via [Power over Ethernet](/reference/power-over-ethernet/).
+
+## What it's for
+
+Ethernet is the default for fixed, performance-sensitive connections where a cable is practical — servers, desktops, and infrastructure — while [Wi-Fi](/reference/wi-fi/) handles mobility. A wired Ethernet link gives a GopherTrunk capture node a stable, low-jitter path to stream decoded calls to a [server](/reference/server/), avoiding the contention and interference of a shared radio channel.
+
+## Sources
+
+[^wiki]: [Ethernet](https://en.wikipedia.org/wiki/Ethernet) — Wikipedia, on the wired LAN standard family.

--- a/docs/reference/federico-faggin.md
+++ b/docs/reference/federico-faggin.md
@@ -1,0 +1,47 @@
+---
+slug: federico-faggin
+title: Federico Faggin
+entry_type: person
+category: hw-people
+description: Federico Faggin (born 1941) is an Italian-American physicist who led the design of the Intel 4004, the first commercial microprocessor, and pioneered the silicon-gate technology behind modern chips.
+keywords: Federico Faggin, Intel 4004, microprocessor, silicon gate, Zilog Z80, central processing unit
+aka: [Federico Faggin]
+autolink: true
+infobox:
+  - { label: Born, value: "1941" }
+  - { label: Field, value: Physics / chip design }
+  - { label: Known for, value: "Intel 4004, silicon-gate process" }
+see_also: [central-processing-unit, intel, integrated-circuit, semiconductor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Federico_Faggin
+---
+
+**Federico Faggin** (born 1941) is an Italian-American physicist and engineer who led the
+design of the **Intel 4004**, the first commercially available microprocessor, putting a whole
+[CPU](/reference/central-processing-unit/) on a single chip.[^wiki]
+
+## Life and work
+
+Faggin developed the silicon-gate process for [integrated circuits](/reference/integrated-circuit/)
+at Fairchild, a technique that made faster, denser chips practical. At
+[Intel](/reference/intel/) from 1970, he led the design and methodology that turned the 4004
+project into a working microprocessor in 1971, and he later worked on the 8080.[^wiki] He then
+co-founded Zilog, where he created the influential Z80 microprocessor, and went on to found
+Synaptics, an early developer of touchpad and touchscreen technology.[^wiki]
+
+## Why they matter
+
+The 4004 collapsed a computer's processing unit onto one piece of
+[silicon](/reference/semiconductor/), launching the microprocessor era that made every later
+personal computer, microcontroller, and embedded SDR node possible. Faggin's silicon-gate
+method became standard across the chip industry, and his hand-drawn signature even appears in
+the 4004's layout.[^wiki]
+
+## Legacy
+
+He received the U.S. National Medal of Technology and Innovation for his role in inventing the
+microprocessor, a device now embedded in nearly every electronic product.
+
+## Sources
+
+[^wiki]: [Federico Faggin](https://en.wikipedia.org/wiki/Federico_Faggin) — Wikipedia, for biography, the Intel 4004, and silicon-gate technology.

--- a/docs/reference/fiber-optic.md
+++ b/docs/reference/fiber-optic.md
@@ -1,0 +1,31 @@
+---
+slug: fiber-optic
+title: Fiber-optic
+entry_type: concept
+category: hw-networking
+description: Fiber-optic communication sends data as pulses of light through thin glass strands, offering very high bandwidth over long distances with low loss and immunity to electrical interference.
+keywords: fiber-optic, optical fiber, fibre, single-mode, multimode, light, photonics, SFP
+aka: [optical fiber, fibre]
+infobox:
+  - { label: Type, value: Optical transmission medium }
+  - { label: Carries, value: Data as light pulses }
+  - { label: Strengths, value: High bandwidth, low loss, long reach }
+  - { label: Kinds, value: Single-mode, multimode }
+see_also: [ethernet, modem, network-switch, coaxial-cable, lan-and-wan, electromagnetic-spectrum]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Optical_fiber
+---
+
+**Fiber-optic** communication sends data as pulses of light through thin strands of glass, delivering very high bandwidth over long distances with low loss.[^wiki]
+
+## Overview
+
+A fiber carries a modulated beam of light by total internal reflection, so the signal travels for kilometres with little attenuation and — being optical — is immune to the electromagnetic interference that affects copper. *Single-mode* fiber uses a tiny core for long-haul, high-rate links; *multimode* fiber has a wider core for shorter runs. Fiber underpins long-distance internet backbones, data-center interconnects, and high-speed [Ethernet](/reference/ethernet/), where pluggable transceivers (SFP modules) terminate the light into a [switch](/reference/network-switch/). Compared with [coaxial cable](/reference/coaxial-cable/), it offers far more capacity and reach.
+
+## Trade-offs
+
+Fiber's bandwidth and noise immunity come at the cost of more delicate cabling and transceivers that cost more than copper ports. For most short LAN runs, copper [Ethernet](/reference/ethernet/) is simpler; fiber earns its place over distance or in electrically noisy environments. The same physics — modulating light instead of an RF carrier — is a cousin of the modulation an SDR like GopherTrunk performs on radio waves.
+
+## Sources
+
+[^wiki]: [Optical fiber](https://en.wikipedia.org/wiki/Optical_fiber) — Wikipedia, on fiber-optic transmission.

--- a/docs/reference/field-programmable-gate-array.md
+++ b/docs/reference/field-programmable-gate-array.md
@@ -1,0 +1,33 @@
+---
+slug: field-programmable-gate-array
+title: Field-programmable gate array (FPGA)
+entry_type: hardware
+category: hw-accelerators
+description: A field-programmable gate array (FPGA) is a chip whose digital logic can be reconfigured after manufacture, letting designers build custom hardware circuits in software for DSP, prototyping, and acceleration.
+keywords: FPGA, field-programmable gate array, reconfigurable logic, HDL, VHDL, Verilog, lookup table, DSP, hardware acceleration
+aka: [FPGA]
+autolink: true
+infobox:
+  - { label: Type, value: Reconfigurable logic chip }
+  - { label: Configured with, value: "HDL (VHDL / Verilog)" }
+  - { label: Built from, value: "LUTs, flip-flops, DSP & RAM blocks" }
+  - { label: Strength, value: Custom parallel digital hardware }
+  - { label: Vendors, value: "AMD (Xilinx), Intel (Altera), Lattice" }
+see_also: [application-specific-integrated-circuit, hardware-acceleration, software-defined-radio, integrated-circuit, digital-filter, fast-fourier-transform]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Field-programmable_gate_array
+---
+
+A **field-programmable gate array** (**FPGA**) is an [integrated circuit](/reference/integrated-circuit/) whose internal digital logic can be reconfigured *after* manufacture — letting an engineer describe a custom hardware circuit in software and load it onto the chip.[^wiki]
+
+## Overview
+
+An FPGA is a fabric of programmable logic blocks — lookup tables (LUTs) and flip-flops — wired together by a configurable interconnect, plus dedicated blocks for arithmetic (DSP slices) and memory. A designer writes the circuit in a hardware description language (VHDL or Verilog); a toolchain *synthesizes* and *places-and-routes* it into a bitstream that configures the chip. Unlike a CPU running instructions, an FPGA *becomes* the circuit, executing many operations truly in parallel and on every clock cycle.
+
+## Where it fits
+
+FPGAs sit between general-purpose processors and fixed-function [ASICs](/reference/application-specific-integrated-circuit/): more flexible than an ASIC (you can re-flash the logic) but lower performance-per-watt and higher unit cost, making them ideal for prototyping, low-to-medium volume products, and latency-critical [hardware acceleration](/reference/hardware-acceleration/). They are a natural fit for [software-defined radio](/reference/software-defined-radio/): an FPGA in the radio front end can do the high-rate DSP — [digital filtering](/reference/digital-filter/), decimation, channelization, and [FFTs](/reference/fast-fourier-transform/) — at sample rates a CPU could never keep up with, handing GopherTrunk a stream that is already down-converted to manageable channels.
+
+## Sources
+
+[^wiki]: [Field-programmable gate array](https://en.wikipedia.org/wiki/Field-programmable_gate_array) — Wikipedia, on reconfigurable logic chips and their uses.

--- a/docs/reference/file-system.md
+++ b/docs/reference/file-system.md
@@ -1,0 +1,33 @@
+---
+slug: file-system
+title: File system
+entry_type: concept
+category: hw-storage
+description: A file system is the structure an operating system uses to organise data on storage into named files and directories, tracking where each file's blocks live on the device.
+keywords: file system, filesystem, ext4, NTFS, FAT, directory, inode, block, journaling, mount
+infobox:
+  - { label: Type, value: Storage organisation layer }
+  - { label: Provides, value: Files and directories }
+  - { label: Managed by, value: Operating system }
+  - { label: Examples, value: ext4, NTFS, FAT32, APFS }
+  - { label: Tracks, value: Blocks, metadata, free space }
+see_also: [data-storage, operating-system, solid-state-drive, hard-disk-drive, sd-card, flash-memory]
+related_lessons:
+  - { title: "Building blocks", url: /learn/intro-hardware/building-blocks/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/File_system
+---
+
+A **file system** is the structure an [operating system](/reference/operating-system/) uses to organise raw storage into named files and directories, and to track where each file's data physically lives.[^wiki]
+
+## Overview
+
+A storage device on its own offers only a flat array of numbered blocks. The file system imposes order on that array: it groups blocks into files, arranges files into a directory tree, records metadata such as names, sizes, timestamps, and permissions, and keeps track of which blocks are free. Common file systems include ext4 on Linux, NTFS on Windows, APFS on macOS, and the simple FAT family used on most [SD cards](/reference/sd-card/) and USB sticks. Many modern file systems are *journaling*, logging intended changes first so the volume can recover cleanly after a crash or power loss.
+
+## Where it fits
+
+The file system is the bridge between bare [data storage](/reference/data-storage/) hardware — an [SSD](/reference/solid-state-drive/), [HDD](/reference/hard-disk-drive/), or [flash](/reference/flash-memory/) card — and the files programs actually read and write. Before storage can be used it is *formatted* with a file system and *mounted* into the OS. GopherTrunk relies on it transparently: every decoded-call recording and IQ capture it writes becomes a file, and a journaling file system helps those logs survive an unexpected power cut at an unattended capture node.
+
+## Sources
+
+[^wiki]: [File system](https://en.wikipedia.org/wiki/File_system) — Wikipedia, on how operating systems organise storage into files and directories.

--- a/docs/reference/firmware.md
+++ b/docs/reference/firmware.md
@@ -1,0 +1,33 @@
+---
+slug: firmware
+title: Firmware
+entry_type: concept
+category: hw-microcontrollers
+description: Firmware is low-level software loaded onto a device's chip to control its hardware directly, sitting between pure hardware and ordinary application programs.
+keywords: firmware, bare metal, flash memory, reflashing, embedded software, non-volatile
+aka: [firmware]
+infobox:
+  - { label: Type, value: Low-level embedded software }
+  - { label: Stored in, value: Non-volatile flash }
+  - { label: Updated by, value: Reflashing }
+  - { label: On an MCU, value: The whole program (no OS) }
+see_also: [microcontroller, esp32, arduino, operating-system]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Firmware
+---
+
+**Firmware** is low-level software loaded onto a device's chip to control its hardware directly, sitting between the pure hardware and ordinary application programs.[^wiki]
+
+## Overview
+
+On a [microcontroller](/reference/microcontroller/) there is no operating system, so the firmware *is* the whole program: it runs bare metal, owning the chip from the moment it powers on. Firmware is stored in non-volatile flash memory so it survives a power cycle, and it is changed by reflashing the chip rather than by installing software the usual way.
+
+## Where it fits
+
+Almost every embedded device runs firmware of some kind — from a thermostat to a Wi-Fi radio. Updating it means writing a new image to flash, which is why "firmware update" and "reflashing" describe the same act. The tiny radios whose signals fill the airwaves GopherTrunk listens to are all driven by firmware of this sort.
+
+## Sources
+
+[^wiki]: [Firmware](https://en.wikipedia.org/wiki/Firmware) — Wikipedia, on firmware's role between hardware and software and its storage in flash.

--- a/docs/reference/flash-memory.md
+++ b/docs/reference/flash-memory.md
@@ -1,0 +1,31 @@
+---
+slug: flash-memory
+title: Flash memory
+entry_type: hardware
+category: hw-storage
+description: Flash memory is non-volatile solid-state storage that holds data without power by trapping charge in transistor cells, erasable and rewritable in blocks.
+keywords: flash memory, NAND, NOR, floating gate, non-volatile, erase block, wear leveling, SLC, MLC, TLC
+infobox:
+  - { label: Type, value: Non-volatile solid-state memory }
+  - { label: Cell, value: Floating-gate transistor }
+  - { label: Variants, value: NAND, NOR }
+  - { label: Erased in, value: Blocks }
+  - { label: Wears out, value: Limited erase cycles }
+see_also: [solid-state-drive, sd-card, emmc, read-only-memory, volatile-memory, nvme]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Flash_memory
+---
+
+**Flash memory** is non-volatile solid-state storage that retains data without power by trapping electric charge in floating-gate transistor cells.[^wiki]
+
+## Overview
+
+Each cell holds one or more bits as the presence or absence of trapped charge; reading senses that charge, while writing and erasing move it through the insulating layer. Flash comes in two main families: **NOR**, which allows fast random reads and is used to store firmware, and **NAND**, which is denser and cheaper per bit and underlies most mass storage. Cells can be erased only a block at a time and endure a finite number of erase cycles, so controllers use *wear leveling* to spread writes evenly. Packing more bits per cell (SLC, MLC, TLC, QLC) raises capacity at the cost of endurance and speed.
+
+## Where it fits
+
+Flash is the medium behind nearly all modern removable and embedded storage: the [SSD](/reference/solid-state-drive/), the [SD card](/reference/sd-card/), [eMMC](/reference/emmc/) chips on single-board computers, and USB sticks. Unlike [volatile](/reference/volatile-memory/) [RAM](/reference/random-access-memory/), it keeps its contents when powered off, and unlike masked [ROM](/reference/read-only-memory/) it can be rewritten in the field — which is how firmware updates work. A GopherTrunk capture node on a [Raspberry Pi](/reference/raspberry-pi/) typically boots and logs to flash-based storage.
+
+## Sources
+
+[^wiki]: [Flash memory](https://en.wikipedia.org/wiki/Flash_memory) — Wikipedia, on NAND/NOR flash, floating-gate cells, and wear leveling.

--- a/docs/reference/foldable-phone.md
+++ b/docs/reference/foldable-phone.md
@@ -1,0 +1,32 @@
+---
+slug: foldable-phone
+title: Foldable phone
+entry_type: hardware
+category: hw-mobile
+description: A foldable phone is a smartphone with a flexible display and hinge that folds, opening from a pocketable size into a larger tablet-like screen or shrinking a full phone into a compact form.
+keywords: foldable phone, folding phone, flexible display, hinge, foldable OLED, book fold, clamshell, dual screen
+infobox:
+  - { label: Type, value: Smartphone }
+  - { label: Display, value: Flexible OLED }
+  - { label: Mechanism, value: Hinge }
+  - { label: Forms, value: Book-fold, clamshell }
+see_also: [smartphone, tablet, touchscreen, mobile-operating-system, battery-technology, system-on-a-chip]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Foldable_smartphone
+---
+
+A **foldable phone** is a [smartphone](/reference/smartphone/) with a flexible display and a hinge, letting it fold from a pocketable size into a larger screen and back.[^wiki]
+
+## Overview
+
+The enabling part is a flexible OLED [touchscreen](/reference/touchscreen/) that bends around a precision hinge without cracking. Two broad styles have emerged: *book-fold* designs that open from phone size into a small [tablet](/reference/tablet/), and *clamshell* (flip) designs that fold a full-size phone down to a compact square. Inside, the device is a normal phone — an [SoC](/reference/system-on-a-chip/), radios, and a [battery](/reference/battery-technology/) split across the two halves — running an ordinary [mobile OS](/reference/mobile-operating-system/) adapted to switch layouts as the screen folds.
+
+## Where it fits
+
+The foldable tries to collapse the phone-versus-tablet trade-off into one device: pocket portability when closed, more screen when open. The costs are mechanical complexity, a visible crease, added thickness, and a higher price — engineering challenges centered on durability of the hinge and the flexible panel over thousands of folds.
+
+## Sources
+
+[^wiki]: [Foldable smartphone](https://en.wikipedia.org/wiki/Foldable_smartphone) — Wikipedia, on foldable phone designs and flexible displays.

--- a/docs/reference/gaming-pc.md
+++ b/docs/reference/gaming-pc.md
@@ -1,0 +1,33 @@
+---
+slug: gaming-pc
+title: Gaming PC
+entry_type: hardware
+category: hw-personal-computers
+description: A gaming PC is a personal computer built and tuned to run video games well, centered on a powerful graphics card, a fast multi-core CPU, ample fast memory, and cooling to sustain high frame rates.
+keywords: gaming PC, gaming rig, GPU, graphics card, high refresh, overclocking, RGB build
+aka: [Gaming rig]
+infobox:
+  - { label: Type, value: Personal computer }
+  - { label: Built for, value: Running games well }
+  - { label: Centerpiece, value: Discrete GPU }
+  - { label: Also wants, value: Fast CPU, RAM, SSD, cooling }
+see_also: [personal-computer, desktop-computer, workstation, graphics-processing-unit, central-processing-unit, build-vs-buy]
+related_lessons:
+  - { title: "Choosing a dev machine", url: /learn/intro-hardware/choosing-a-dev-machine/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Gaming_computer
+---
+
+A **gaming PC** is a [personal computer](/reference/personal-computer/) built and tuned to run video games well — usually a [desktop computer](/reference/desktop-computer/) centered on a powerful graphics card and a fast processor.[^wiki]
+
+## Overview
+
+The defining part is the discrete [GPU](/reference/graphics-processing-unit/), which renders the game's 3D scenes at high frame rates and resolutions. Around it a gaming PC pairs a fast multi-core [CPU](/reference/central-processing-unit/), plenty of quick [RAM](/reference/random-access-memory/), a [solid-state drive](/reference/solid-state-drive/) for fast loading, and enough [cooling](/reference/cooling-and-thermals/) to hold those parts at full speed without throttling. Enthusiasts often overclock the CPU or GPU and choose a [case](/reference/computer-case/) with strong airflow.
+
+## Where it fits
+
+A gaming PC overlaps heavily with the enthusiast desktop and is a common first machine for people who [build their own](/reference/build-vs-buy/). The same GPU-heavy hardware also handles GPU compute, machine learning, and video work, which blurs the line with a [workstation](/reference/workstation/) — the difference is mostly tuning, ECC memory, and certification rather than raw parts. For GopherTrunk a gaming PC's GPU and CPU headroom make it a capable bench for replaying captures and crunching many channels of DSP at once.
+
+## Sources
+
+[^wiki]: [Gaming computer](https://en.wikipedia.org/wiki/Gaming_computer) — Wikipedia, on PCs built and optimized for gaming.

--- a/docs/reference/gateway.md
+++ b/docs/reference/gateway.md
@@ -1,0 +1,30 @@
+---
+slug: gateway
+title: Gateway
+entry_type: concept
+category: hw-networking
+description: A gateway is a network node that joins two networks, acting as the entry and exit point through which traffic leaves a local network for another, such as the wider internet.
+keywords: gateway, default gateway, network gateway, edge, protocol translation, egress
+infobox:
+  - { label: Type, value: Network entry/exit node }
+  - { label: Job, value: Join one network to another }
+  - { label: Common form, value: Router as default gateway }
+  - { label: May also do, value: Protocol translation }
+see_also: [router, lan-and-wan, ip-address, modem, network-switch, edge-computing]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Gateway_(telecommunications)
+---
+
+A **gateway** is a network node that joins two networks, acting as the entry and exit point through which traffic leaves a local network for another — most commonly the wider internet.[^wiki]
+
+## Overview
+
+On a home or office network the *default gateway* is usually the [router](/reference/router/): the address a host sends packets to when their destination is not on the local [LAN](/reference/lan-and-wan/). More broadly, a gateway can translate between dissimilar networks or protocols — bridging an IoT radio network onto IP, for instance — doing more than a router that merely forwards [IP](/reference/ip-address/) packets. The term describes a *role* at a network boundary rather than one specific box.
+
+## Where it fits
+
+A gateway marks the edge of a network, which is also where [edge computing](/reference/edge-computing/) and protocol bridging often live. In a distributed GopherTrunk setup a small box can act as a gateway, gathering decoded data from several capture nodes on a private LAN and forwarding it out through one egress point to a remote [server](/reference/server/).
+
+## Sources
+
+[^wiki]: [Gateway (telecommunications)](https://en.wikipedia.org/wiki/Gateway_(telecommunications)) — Wikipedia, on the node that joins two networks.

--- a/docs/reference/google-coral.md
+++ b/docs/reference/google-coral.md
@@ -1,0 +1,37 @@
+---
+slug: google-coral
+title: Google Coral
+entry_type: hardware
+category: hw-sbc
+description: Google Coral is a hardware platform built around the Edge TPU, an AI accelerator that runs TensorFlow Lite models locally, sold as a single-board computer, a plug-in module, and a USB stick.
+keywords: Google Coral, Edge TPU, Coral Dev Board, Coral USB Accelerator, TensorFlow Lite, edge AI, machine learning accelerator
+aka: [Coral, Edge TPU]
+autolink: true
+infobox:
+  - { label: Type, value: Edge-AI platform (SBC + accelerators) }
+  - { label: Maker, value: Google }
+  - { label: Core, value: Edge TPU }
+  - { label: Runs, value: TensorFlow Lite models }
+  - { label: Forms, value: Dev Board, module, USB stick }
+see_also: [edge-ai, single-board-computer, ai-accelerator, tensor-processing-unit, raspberry-pi, neural-processing-unit]
+related_lessons:
+  - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Tensor_Processing_Unit#Edge_TPU
+  - https://coral.ai/
+---
+
+**Google Coral** is a hardware platform built around the *Edge TPU*, a small [AI accelerator](/reference/ai-accelerator/) that runs machine-learning models locally rather than in the cloud.[^wiki]
+
+## Overview
+
+The Edge TPU is a cut-down [tensor processing unit](/reference/tensor-processing-unit/) that executes TensorFlow Lite models very efficiently at low power. Coral ships in several forms: a full [single-board computer](/reference/single-board-computer/) (the Coral Dev Board), a solder-down module, and a USB Accelerator stick that adds the TPU to an existing host such as a [Raspberry Pi](/reference/raspberry-pi/).[^coral]
+
+## What it's for
+
+Coral targets [edge AI](/reference/edge-ai/): on-device vision, audio, and sensor inference where sending data to a server is too slow, too costly, or impossible. It is a more specialised choice than an [NVIDIA Jetson](/reference/nvidia-jetson/) — the Edge TPU runs supported quantised models fast and cheap, but it is not a general GPU. In a signal-processing project, a Coral could classify or flag patterns in decoded data at the edge while a Pi handles the radio.
+
+## Sources
+
+[^wiki]: [Edge TPU](https://en.wikipedia.org/wiki/Tensor_Processing_Unit#Edge_TPU) — Wikipedia, on the Edge TPU at the heart of Coral.
+[^coral]: [Coral](https://coral.ai/) — Google's Coral product site, on the Dev Board, modules, and USB Accelerator.

--- a/docs/reference/gordon-moore.md
+++ b/docs/reference/gordon-moore.md
@@ -1,0 +1,47 @@
+---
+slug: gordon-moore
+title: Gordon Moore
+entry_type: person
+category: hw-people
+description: Gordon Moore (1929–2023) was an American chemist and engineer who co-founded Intel and observed the doubling trend in transistor density that became known as Moore's law.
+keywords: Gordon Moore, Moore's law, Intel, Fairchild Semiconductor, transistor density, integrated circuit
+aka: [Gordon Moore, Gordon E. Moore]
+autolink: true
+infobox:
+  - { label: Lived, value: "1929–2023" }
+  - { label: Field, value: Chemistry / semiconductors }
+  - { label: Known for, value: "Moore's law, co-founding Intel" }
+see_also: [moores-law, intel, robert-noyce, integrated-circuit, transistor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Gordon_Moore
+---
+
+**Gordon Moore** (1929–2023) was an American chemist and engineer who co-founded
+[Intel](/reference/intel/) and gave his name to [Moore's law](/reference/moores-law/), the
+observation that the number of transistors on a chip doubles at a steady cadence.[^wiki]
+
+## Life and work
+
+Moore began at Fairchild Semiconductor, where he worked on early silicon
+[integrated circuits](/reference/integrated-circuit/). In a 1965 article he noted that the
+[transistor](/reference/transistor/) count on a chip had been doubling roughly every year (later
+revised to about every two years) and projected the trend forward — a forecast that became the
+semiconductor industry's guiding expectation.[^wiki] In 1968 he co-founded Intel with
+[Robert Noyce](/reference/robert-noyce/), where he served as a long-time executive and chairman.[^wiki]
+
+## Why they matter
+
+[Moore's law](/reference/moores-law/) framed decades of planning: chipmakers, software writers,
+and product designers all assumed compute and memory would get cheaper and denser on schedule.
+That steady cheapening is why a fingernail-sized SDR dongle or a small board near an antenna can
+now do DSP that once needed a rack of equipment. Moore's leadership at [Intel](/reference/intel/)
+helped make the microprocessor a mass-market product.[^wiki]
+
+## Legacy
+
+Though the literal doubling has slowed, "Moore's law" remains shorthand for the relentless
+improvement in computing per dollar that shaped the digital age.
+
+## Sources
+
+[^wiki]: [Gordon Moore](https://en.wikipedia.org/wiki/Gordon_Moore) — Wikipedia, for biography, Moore's law, and Intel.

--- a/docs/reference/gpgpu.md
+++ b/docs/reference/gpgpu.md
@@ -1,0 +1,32 @@
+---
+slug: gpgpu
+title: GPGPU
+entry_type: concept
+category: hw-accelerators
+description: GPGPU is the practice of using a graphics processing unit for general-purpose computation, exploiting its thousands of parallel cores for non-graphics workloads such as math, simulation, and machine learning.
+keywords: GPGPU, general-purpose GPU, GPU computing, parallel computing, CUDA, OpenCL, compute shader
+aka: [General-purpose computing on graphics processing units]
+autolink: true
+infobox:
+  - { label: Type, value: Computing technique }
+  - { label: Hardware, value: Graphics processing unit }
+  - { label: Strength, value: Massively parallel data }
+  - { label: APIs, value: "CUDA, OpenCL, compute shaders" }
+see_also: [graphics-processing-unit, cuda, hardware-acceleration, vector-processor, central-processing-unit, ai-accelerator]
+cite_urls:
+  - https://en.wikipedia.org/wiki/General-purpose_computing_on_graphics_processing_units
+---
+
+**GPGPU** (general-purpose computing on graphics processing units) is the practice of using a [GPU](/reference/graphics-processing-unit/) to run ordinary computation rather than only rendering images.[^wiki]
+
+## Overview
+
+A GPU contains thousands of small cores built to shade pixels in parallel. When a problem can be expressed as the *same operation applied to many data elements at once* — the same SIMD/data-parallel pattern a [vector processor](/reference/vector-processor/) exploits — those cores can be redirected at it. Early GPGPU work smuggled math through the graphics pipeline; dedicated APIs like [CUDA](/reference/cuda/) and the cross-vendor OpenCL later exposed the hardware directly, making GPGPU mainstream for scientific computing, cryptography, and machine learning.
+
+## What it's for
+
+GPGPU shines on large, regular, parallel workloads and is the foundation of modern deep learning, where it long preceded purpose-built [AI accelerators](/reference/ai-accelerator/). It is poor at branch-heavy, sequential work, which still belongs on the [CPU](/reference/central-processing-unit/). In a software-defined radio context, GPGPU can accelerate wideband DSP — large FFTs, polyphase channelizers splitting one capture into many channels — but the cost of moving samples to and from the GPU only pays off when the channel count is high.
+
+## Sources
+
+[^wiki]: [General-purpose computing on graphics processing units](https://en.wikipedia.org/wiki/General-purpose_computing_on_graphics_processing_units) — Wikipedia, on using GPUs for non-graphics computation.

--- a/docs/reference/gpio.md
+++ b/docs/reference/gpio.md
@@ -1,0 +1,35 @@
+---
+slug: gpio
+title: GPIO
+entry_type: hardware
+category: hw-sbc
+description: GPIO (general-purpose input/output) are pins on an SBC or microcontroller that code can read or switch on and off to talk to sensors, lights, motors, and other electronics.
+keywords: GPIO, general-purpose input output, pins, sensors, microcontroller, Raspberry Pi GPIO, hardware interface
+aka: [GPIO]
+autolink: true
+infobox:
+  - { label: Type, value: Digital I/O pins }
+  - { label: Found on, value: SBCs, microcontrollers }
+  - { label: Controls, value: Sensors, lights, motors }
+  - { label: Driven from, value: Code (Python, C, Go) }
+see_also: [single-board-computer, microcontroller, input-output, raspberry-pi, beaglebone, arduino]
+related_lessons:
+  - { title: "What is an SBC?", url: /learn/intro-hardware/what-is-an-sbc/ }
+  - { title: "Programming an SBC", url: /learn/intro-hardware/programming-an-sbc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/General-purpose_input/output
+---
+
+**GPIO** (general-purpose input/output) are pins on a [single-board computer](/reference/single-board-computer/) or [microcontroller](/reference/microcontroller/) that your code can read or switch on and off to talk to sensors, lights, motors, and other electronics.[^wiki]
+
+## Overview
+
+A GPIO pin can be configured as an input (read a button or sensor) or an output (drive an LED, relay, or motor). It is the most basic form of [input/output](/reference/input-output/) a board offers, and richer interfaces are often layered on top of the same header. Code reads and writes pins through simple library calls.
+
+## Where it fits
+
+GPIO is the bridge between software and the physical world — it is what sets an SBC or MCU apart from a sealed PC or phone. The [Raspberry Pi](/reference/raspberry-pi/) header and the extensive pinout of the [BeagleBone](/reference/beaglebone/) are common examples; on the microcontroller side, boards like the [Arduino](/reference/arduino/) expose the same idea.
+
+## Sources
+
+[^wiki]: [General-purpose input/output](https://en.wikipedia.org/wiki/General-purpose_input/output) — Wikipedia, on what GPIO pins are and how they are used.

--- a/docs/reference/gps-receiver.md
+++ b/docs/reference/gps-receiver.md
@@ -1,0 +1,33 @@
+---
+slug: gps-receiver
+title: GPS receiver
+entry_type: hardware
+category: hw-mobile
+description: A GPS receiver determines a device's position by timing signals from a constellation of navigation satellites, providing location, speed, and precise time to phones, wearables, and embedded systems.
+keywords: GPS receiver, GNSS, satellite navigation, GLONASS, Galileo, positioning, location, GPS chip, PPS, timing
+aka: [GNSS receiver]
+infobox:
+  - { label: Type, value: Satellite navigation receiver }
+  - { label: Provides, value: Position, speed, time }
+  - { label: Systems, value: GPS, GLONASS, Galileo, BeiDou }
+  - { label: Needs, value: Sky view, ≥4 satellites }
+see_also: [cellular-modem, system-on-a-chip, smartphone, smartwatch, wearable-computer, antenna]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Satellite_navigation
+  - https://en.wikipedia.org/wiki/Global_Positioning_System
+---
+
+A **GPS receiver** determines a device's position by timing radio signals from a constellation of navigation satellites, yielding location, speed, and a very precise time reference.[^gnss]
+
+## Overview
+
+The receiver listens for the faint signals of satellites overhead and, from the time each took to arrive, solves for its own position — needing a clear sky view and signals from at least four satellites for a 3D fix. Modern chips are *GNSS* receivers, combining the US GPS system with GLONASS, Galileo, and BeiDou for faster, more reliable fixes.[^gps] In a phone the GPS block sits in or beside the [SoC](/reference/system-on-a-chip/), with its own [antenna](/reference/antenna/), and often takes hints from the [cellular modem](/reference/cellular-modem/) (assisted GPS) to lock faster.
+
+## Where it fits
+
+Location is the killer feature GPS adds to phones, [smartwatches](/reference/smartwatch/), and [wearables](/reference/wearable-computer/) — maps, fitness routes, geotagging. Its precise one-pulse-per-second timing is also valuable beyond navigation: a GPS-disciplined clock can give an SDR setup like GopherTrunk an accurate frequency and time reference, useful for stable tuning and for timestamping decoded calls across distributed capture nodes.
+
+## Sources
+
+[^gnss]: [Satellite navigation](https://en.wikipedia.org/wiki/Satellite_navigation) — Wikipedia, on GNSS positioning.
+[^gps]: [Global Positioning System](https://en.wikipedia.org/wiki/Global_Positioning_System) — Wikipedia, on the GPS system specifically.

--- a/docs/reference/graphics-processing-unit.md
+++ b/docs/reference/graphics-processing-unit.md
@@ -1,0 +1,31 @@
+---
+slug: graphics-processing-unit
+title: Graphics processing unit (GPU)
+entry_type: hardware
+category: hw-foundations
+description: A GPU is a processor with thousands of small cores optimized for the parallel math behind graphics, and now widely used for general-purpose compute such as AI and DSP.
+keywords: GPU, graphics processing unit, parallel computing, CUDA, shaders, GPGPU, AI accelerator
+aka: [GPU, Graphics card]
+infobox:
+  - { label: Type, value: Parallel processor }
+  - { label: Cores, value: Hundreds to thousands }
+  - { label: Good at, value: Parallel math (SIMD) }
+  - { label: Uses, value: Graphics, AI, DSP, simulation }
+see_also: [central-processing-unit, integrated-circuit, pci-express, instruction-set-architecture, moores-law, system-bus]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Graphics_processing_unit
+---
+
+A **graphics processing unit** (**GPU**) is a processor built from many small cores that run the same operation across large blocks of data in parallel — originally for rendering graphics, now also for general computation.[^wiki]
+
+## Overview
+
+Where a [CPU](/reference/central-processing-unit/) has a few powerful cores tuned for sequential work, a GPU has hundreds or thousands of simpler cores that excel at *data-parallel* math: the same calculation applied to many pixels, vertices, or array elements at once. A discrete GPU is a card that plugs into a [PCIe](/reference/pci-express/) slot with its own high-bandwidth memory; integrated GPUs share the CPU's memory. Modern GPUs are large [integrated circuits](/reference/integrated-circuit/) whose transistor counts have ridden [Moore's law](/reference/moores-law/) upward for decades.
+
+## What it's for
+
+Beyond 3D graphics, GPUs power AI training and inference, scientific simulation, and signal processing — any workload that maps onto wide parallel arithmetic. In SDR work a GPU can accelerate FFTs and filtering across many channels at once, complementing the streaming DSP GopherTrunk runs on the CPU. The trade-off is latency and complexity: GPUs shine on big batched workloads, less so on small, branchy, latency-sensitive tasks where the CPU wins.
+
+## Sources
+
+[^wiki]: [Graphics processing unit](https://en.wikipedia.org/wiki/Graphics_processing_unit) — Wikipedia, on GPUs and parallel computation.

--- a/docs/reference/hard-disk-drive.md
+++ b/docs/reference/hard-disk-drive.md
@@ -1,0 +1,32 @@
+---
+slug: hard-disk-drive
+title: Hard disk drive (HDD)
+entry_type: hardware
+category: hw-storage
+description: A hard disk drive stores data on spinning magnetic platters read by moving heads, offering large capacity at low cost per byte but slower access than solid-state storage.
+keywords: hard disk drive, HDD, magnetic storage, platter, spindle, read/write head, RPM, mechanical drive
+aka: [HDD, hard drive, hard disk]
+infobox:
+  - { label: Type, value: Magnetic non-volatile storage }
+  - { label: Medium, value: Spinning platters }
+  - { label: Capacity, value: ~1 – 30 TB }
+  - { label: Speed, value: 5400 – 7200 RPM (typical) }
+  - { label: Strength, value: Low cost per terabyte }
+see_also: [solid-state-drive, data-storage, magnetic-tape, optical-disc, memory-hierarchy, file-system]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Hard_disk_drive
+---
+
+A **hard disk drive (HDD)** is a non-volatile storage device that records data on rapidly spinning magnetic platters, read and written by heads on a moving arm.[^wiki]
+
+## Overview
+
+Inside the sealed enclosure, one or more rigid platters spin on a spindle at a fixed rate — commonly 5400 or 7200 RPM. A read/write head floats nanometres above each surface, magnetising tiny regions to store bits. Because the head must physically seek to the right track and wait for the platter to rotate into position, access has mechanical latency that an [SSD](/reference/solid-state-drive/) avoids. HDDs are still the cheapest way to hold large amounts of data per terabyte, which keeps them in servers, archives, and bulk storage.
+
+## Where it fits
+
+HDDs sit near the slow, high-capacity end of the [memory hierarchy](/reference/memory-hierarchy/), below RAM and below flash-based storage. They are a common form of [data storage](/reference/data-storage/), often combined in a [RAID](/reference/raid/) array or a [network-attached storage](/reference/network-attached-storage/) box for capacity and redundancy. A GopherTrunk logging server can keep months of decoded calls and raw IQ captures cheaply on spinning disks, reserving faster [SSD](/reference/solid-state-drive/) storage for the active working set. The drive's contents are organised by a [file system](/reference/file-system/).
+
+## Sources
+
+[^wiki]: [Hard disk drive](https://en.wikipedia.org/wiki/Hard_disk_drive) — Wikipedia, on the construction and operation of magnetic hard drives.

--- a/docs/reference/hardware-acceleration.md
+++ b/docs/reference/hardware-acceleration.md
@@ -1,0 +1,31 @@
+---
+slug: hardware-acceleration
+title: Hardware acceleration
+entry_type: concept
+category: hw-accelerators
+description: Hardware acceleration is offloading a task from the general-purpose CPU to specialized hardware built to do it faster or more efficiently, such as a GPU, FPGA, or fixed-function ASIC.
+keywords: hardware acceleration, offload, GPU, FPGA, ASIC, fixed-function, accelerator, throughput, efficiency
+infobox:
+  - { label: Type, value: Computing technique }
+  - { label: Idea, value: Offload work from the CPU }
+  - { label: Done by, value: "GPU, FPGA, ASIC, DSP, NPU" }
+  - { label: Wins, value: Speed and power efficiency }
+  - { label: Cost, value: Less flexibility }
+see_also: [graphics-processing-unit, field-programmable-gate-array, application-specific-integrated-circuit, vector-processor, ai-accelerator, soc-vs-discrete]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Hardware_acceleration
+---
+
+**Hardware acceleration** is the practice of offloading a task from the general-purpose [CPU](/reference/central-processing-unit/) onto specialized hardware built to do it faster, more efficiently, or both.[^wiki]
+
+## Overview
+
+A CPU is a generalist: it can run any code, but it pays for that flexibility in speed and power. When a task is performed constantly and has a regular structure — graphics, video encoding, neural-network math, signal processing — it is often worth building hardware that does *only* that. Accelerators span a spectrum: the programmable [GPU](/reference/graphics-processing-unit/) and [vector](/reference/vector-processor/) units, the reconfigurable [FPGA](/reference/field-programmable-gate-array/), and the fixed-function [ASIC](/reference/application-specific-integrated-circuit/), with flexibility falling and efficiency rising along the way.
+
+## Where it fits
+
+The engineering question is always *what to offload*: moving work to an accelerator adds complexity and data-transfer overhead, so it pays only when the speedup is large or the CPU genuinely cannot keep up. This is a live trade-off in software-defined radio. GopherTrunk does its DSP and protocol decoding in software on the CPU, deliberately keeping the radio a simple front end; an [FPGA](/reference/field-programmable-gate-array/) doing the channelization in hardware would accelerate wideband, many-channel capture, at the cost of flexibility and a much harder development path.
+
+## Sources
+
+[^wiki]: [Hardware acceleration](https://en.wikipedia.org/wiki/Hardware_acceleration) — Wikipedia, on offloading tasks from the CPU to specialized hardware.

--- a/docs/reference/hardware-spectrum.md
+++ b/docs/reference/hardware-spectrum.md
@@ -1,0 +1,41 @@
+---
+slug: hardware-spectrum
+title: The hardware spectrum
+entry_type: concept
+category: hw-foundations
+description: The hardware spectrum is the full range of computing hardware ordered by power, cost, and control, from cloud servers down to tiny microcontrollers.
+keywords: hardware spectrum, computing tiers, server to microcontroller, general-purpose vs embedded, power cost control
+aka: [hardware spectrum]
+infobox:
+  - { label: Type, value: Conceptual range }
+  - { label: Ordered by, value: Power, cost, control }
+  - { label: Top end, value: Cloud and servers }
+  - { label: Bottom end, value: Microcontrollers }
+see_also: [server, personal-computer, single-board-computer, microcontroller, cloud-computing]
+related_lessons:
+  - { title: "The hardware spectrum", url: /learn/intro-hardware/hardware-spectrum/ }
+  - { title: "What is hardware?", url: /learn/intro-hardware/what-is-hardware/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Classes_of_computers
+---
+
+**The hardware spectrum** is the full range of computing hardware, ordered by how much power, cost, and direct control each tier gives you.[^wiki]
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 90" role="img" aria-label="A bar showing the hardware spectrum from cloud and servers at the high-power end to microcontrollers at the low-power end." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="60" x2="430" y2="60" stroke="currentColor" stroke-opacity="0.4"/>
+  <rect x="32" y="36" width="396" height="18" rx="3" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/>
+  <g font-size="8" fill="currentColor"><text x="32" y="74">cloud / server</text><text x="430" y="74" text-anchor="end">microcontroller</text></g>
+  <text x="230" y="24" text-anchor="middle" font-size="10" fill="currentColor">more power, cost, scale ←→ smaller, cheaper, closer to the world</text>
+</svg>
+<figcaption>From a rented slice of a data center down to a chip running one job.</figcaption>
+</figure>
+
+## Overview
+Running from the high-power end down, the tiers are roughly: [cloud computing](/reference/cloud-computing/) and [web hosting](/reference/web-hosting/) → [VPS](/reference/virtual-private-server/) → [dedicated server](/reference/dedicated-server/) → [home server](/reference/home-server/) → [desktop](/reference/desktop-computer/) → [laptop](/reference/laptop/) → [tablet](/reference/tablet/) and [smartphone](/reference/smartphone/) → [single-board computer](/reference/single-board-computer/) → [microcontroller](/reference/microcontroller/).
+
+## Why it matters
+A useful split cuts across the spectrum: **general-purpose** computers run many different programs and usually carry an [operating system](/reference/operating-system/), while **embedded** computers do one fixed job, often with no OS at all. Choosing a tier is a trade between power and cost on one side and size, efficiency, and physical closeness to the world on the other. GopherTrunk runs across most of it — from a full [server](/reference/server/) down to a [single-board computer](/reference/single-board-computer/) sitting by the antenna.
+
+## Sources
+[^wiki]: [Classes of computers](https://en.wikipedia.org/wiki/Classes_of_computers) — Wikipedia, on the range of computer sizes and roles.

--- a/docs/reference/hat-add-on-board.md
+++ b/docs/reference/hat-add-on-board.md
@@ -1,0 +1,34 @@
+---
+slug: hat-add-on-board
+title: HAT add-on board
+entry_type: hardware
+category: hw-sbc
+description: A HAT is an add-on board that stacks onto a Raspberry Pi's GPIO header to add hardware such as displays, sensors, real-time clocks, or radios, following a standard mechanical and electrical specification.
+keywords: HAT, Hardware Attached on Top, Raspberry Pi HAT, GPIO add-on, daughterboard, expansion board, EEPROM ID
+aka: [HAT, Hardware Attached on Top]
+infobox:
+  - { label: Type, value: SBC add-on board }
+  - { label: Connects via, value: 40-pin GPIO header }
+  - { label: Standard, value: Raspberry Pi HAT spec }
+  - { label: Adds, value: Displays, sensors, radios, I/O }
+  - { label: Stands for, value: Hardware Attached on Top }
+see_also: [raspberry-pi, gpio, single-board-computer, compute-module, sensor, i2c]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Raspberry_Pi#HATs
+---
+
+**A HAT** (Hardware Attached on Top) is an add-on board that stacks onto a [Raspberry Pi](/reference/raspberry-pi/)'s [GPIO](/reference/gpio/) header to add hardware.[^wiki]
+
+## Overview
+
+The HAT specification fixes the board size, mounting holes, and 40-pin connector so add-ons fit predictably, and a small EEPROM on the HAT can identify itself so the Pi auto-configures the right pins. Typical HATs add displays, [sensors](/reference/sensor/), real-time clocks, motor drivers, power management, or radios — often talking to the Pi over [I2C](/reference/i2c/) or SPI. Other SBCs use similar stackable add-ons under different names.
+
+## Where it fits
+
+A HAT is the quickest way to extend a board without designing your own electronics — a middle ground before committing to a custom carrier for a [Compute Module](/reference/compute-module/). For GopherTrunk, a HAT can supply the parts a bare Pi lacks at the antenna: a real-time clock for accurate timestamps, a fan and power controller, or a GPS HAT for precise timing on a capture node.
+
+## Sources
+
+[^wiki]: [Raspberry Pi HATs](https://en.wikipedia.org/wiki/Raspberry_Pi#HATs) — Wikipedia, on the HAT add-on board standard.

--- a/docs/reference/high-availability.md
+++ b/docs/reference/high-availability.md
@@ -1,0 +1,31 @@
+---
+slug: high-availability
+title: High availability
+entry_type: concept
+category: hw-servers
+description: High availability is the design of systems to keep running with minimal downtime by removing single points of failure through redundancy, failover, and health monitoring.
+keywords: high availability, HA, uptime, redundancy, failover, single point of failure, nines
+aka: [HA]
+infobox:
+  - { label: Type, value: System design goal }
+  - { label: Achieved by, value: Redundancy & failover }
+  - { label: Measured in, value: "Uptime (nines)" }
+  - { label: Enemy, value: Single point of failure }
+see_also: [scalability, load-balancer, raid, data-center, kubernetes, server]
+cite_urls:
+  - https://en.wikipedia.org/wiki/High_availability
+---
+
+**High availability** (HA) is the practice of designing systems to keep running with minimal downtime, by removing single points of failure through redundancy, failover, and health monitoring.[^wiki]
+
+## Overview
+
+Availability is often expressed in "nines": 99.9% uptime allows about nine hours of downtime a year, while 99.999% ("five nines") allows about five minutes. Reaching high numbers means that no single component — server, disk, network link, power feed — can take the whole system down. The toolkit includes redundant hardware, [load balancers](/reference/load-balancer/) that route around dead servers, [RAID](/reference/raid/) for disks, replicated databases, and automatic *failover* to a standby when the primary fails. The [data center](/reference/data-center/) itself contributes with redundant power and cooling.
+
+## Where it fits
+
+High availability is about staying *up*, while [scalability](/reference/scalability/) is about handling *more load*; the two are related but distinct, and many techniques (replication, multiple servers) serve both. Orchestrators like [Kubernetes](/reference/kubernetes/) automate failover for containerized apps. A hobby GopherTrunk node rarely justifies HA, but a monitoring site that must never miss a call would replicate capture nodes and back-end servers so any one can fail without an outage.
+
+## Sources
+
+[^wiki]: [High availability](https://en.wikipedia.org/wiki/High_availability) — Wikipedia, on availability, redundancy, and failover.

--- a/docs/reference/home-automation.md
+++ b/docs/reference/home-automation.md
@@ -1,0 +1,34 @@
+---
+slug: home-automation
+title: Home automation
+entry_type: concept
+category: hw-sbc
+description: Home automation is the control and coordination of household devices such as lights, locks, thermostats, and sensors, often run on a small always-on single-board computer acting as a local hub.
+keywords: home automation, smart home, Home Assistant, IoT hub, single-board computer, sensors, Raspberry Pi smart home, local hub
+aka: [smart home]
+infobox:
+  - { label: Type, value: Application area }
+  - { label: Controls, value: Lights, locks, climate, sensors }
+  - { label: Often runs on, value: An always-on SBC }
+  - { label: Relies on, value: IoT devices and sensors }
+  - { label: Goal, value: Local, scheduled, reactive control }
+see_also: [single-board-computer, raspberry-pi, internet-of-things, sensor, edge-ai, home-server]
+related_lessons:
+  - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Home_automation
+---
+
+**Home automation** is the control and coordination of household devices — lights, locks, thermostats, [sensors](/reference/sensor/) — so they run on schedules or react to conditions instead of being operated by hand.[^wiki]
+
+## Overview
+
+A typical setup ties together many [Internet of Things](/reference/internet-of-things/) devices through a central hub that holds the rules and state. That hub is often a small, always-on [single-board computer](/reference/single-board-computer/) such as a [Raspberry Pi](/reference/raspberry-pi/) running software like Home Assistant — cheap, low-power, and able to keep everything working locally even when the internet is down.
+
+## Where it fits
+
+Home automation is one of the most common reasons people pick up their first SBC, because the workload — talking to sensors and devices over [GPIO](/reference/gpio/), Wi-Fi, and other links, around the clock — fits the board's strengths. The same always-on, low-power profile makes such a board a natural host for other field roles, like running GopherTrunk as a quiet capture node beside the antenna.
+
+## Sources
+
+[^wiki]: [Home automation](https://en.wikipedia.org/wiki/Home_automation) — Wikipedia, on automating and coordinating household devices.

--- a/docs/reference/home-server.md
+++ b/docs/reference/home-server.md
@@ -1,0 +1,34 @@
+---
+slug: home-server
+title: Home server & self-hosting
+entry_type: concept
+category: hw-servers
+description: A home server is a computer you run at home to host services for yourself, such as file storage, a personal site, or media — the heart of self-hosting.
+keywords: home server, self-hosting, NAS, self host, port forwarding, home lab
+aka: [Home server, Self-hosting]
+infobox:
+  - { label: Type, value: Home-run server }
+  - { label: Common uses, value: NAS, media, personal site }
+  - { label: Hidden costs, value: Power, uptime, backups }
+  - { label: Good first box, value: Raspberry Pi or old PC }
+see_also: [server, raspberry-pi, single-board-computer, dedicated-server, cloud-computing]
+related_lessons:
+  - { title: "Home servers", url: /learn/intro-hardware/home-servers/ }
+  - { title: "Combining tiers", url: /learn/intro-hardware/combining-tiers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Self-hosting_(web_services)
+---
+
+A **home server** is a computer you run at home to host services for yourself — file storage (a NAS), a personal site, or media you stream around the house.[^wiki]
+
+## Overview
+
+Self-hosting means running those services on hardware you own instead of paying a provider. The appeal is control and privacy; the costs nobody mentions up front are electricity, keeping the box online 24/7, and a real backup plan. To reach it from outside your house you typically set up port forwarding on your router so requests find the [server](/reference/server/).
+
+## Where it fits
+
+A [Raspberry Pi](/reference/raspberry-pi/) or other [single-board computer](/reference/single-board-computer/) — or an old PC gathering dust — makes a great first server: cheap, low-power, and enough for file shares and small sites. In GopherTrunk terms a home machine can do both jobs at once: capture RF from an attached dongle *and* store and serve the decoded data, which a remote VPS cannot.
+
+## Sources
+
+[^wiki]: [Self-hosting (web services)](https://en.wikipedia.org/wiki/Self-hosting_(web_services)) — Wikipedia, on running services on hardware you own.

--- a/docs/reference/hypervisor.md
+++ b/docs/reference/hypervisor.md
@@ -1,0 +1,31 @@
+---
+slug: hypervisor
+title: Hypervisor
+entry_type: concept
+category: hw-servers
+description: A hypervisor is software or firmware that creates and runs virtual machines, dividing one physical computer's resources among several isolated guest operating systems.
+keywords: hypervisor, virtual machine monitor, VMM, type 1, type 2, bare metal, guest OS
+aka: [Virtual machine monitor, VMM]
+infobox:
+  - { label: Type, value: Virtualization layer }
+  - { label: Creates, value: Virtual machines }
+  - { label: "Type 1", value: Runs on bare metal }
+  - { label: "Type 2", value: Runs on a host OS }
+see_also: [virtualization, virtual-private-server, container, bare-metal-server, infrastructure-as-a-service, server]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Hypervisor
+---
+
+A **hypervisor** is software or firmware that creates and runs virtual machines, dividing one physical computer's CPU, memory, and I/O among several isolated guest operating systems.[^wiki]
+
+## Overview
+
+Each virtual machine believes it has its own hardware; the hypervisor mediates access to the real resources and keeps the guests separated. There are two broad kinds. A *Type 1* (bare-metal) hypervisor runs directly on the hardware and is what data centers and cloud platforms use for performance and density. A *Type 2* (hosted) hypervisor runs as an application on top of an ordinary [operating system](/reference/operating-system/), which is convenient for desktops and testing. Either way, the hypervisor is the engine that makes [virtualization](/reference/virtualization/) possible.
+
+## Where it fits
+
+The hypervisor is what lets one [server](/reference/server/) be sliced into many [virtual private servers](/reference/virtual-private-server/) and underpins [infrastructure as a service](/reference/infrastructure-as-a-service/). It provides stronger isolation than a [container](/reference/container/), at the cost of running a full guest OS per machine; a [bare-metal server](/reference/bare-metal-server/) deliberately omits it. Running GopherTrunk inside a VM works, though passing a USB SDR through the hypervisor to the guest takes extra configuration.
+
+## Sources
+
+[^wiki]: [Hypervisor](https://en.wikipedia.org/wiki/Hypervisor) — Wikipedia, on Type 1 and Type 2 hypervisors.

--- a/docs/reference/i2c.md
+++ b/docs/reference/i2c.md
@@ -1,0 +1,33 @@
+---
+slug: i2c
+title: I²C
+entry_type: concept
+category: hw-microcontrollers
+description: I²C is a two-wire serial bus that lets a controller talk to many peripheral chips over a shared clock and data line, each addressed by number, widely used to connect sensors to microcontrollers.
+keywords: I2C, I²C, IIC, two-wire, SDA, SCL, serial bus, sensor bus, TWI, address
+aka: [I2C, IIC, TWI]
+infobox:
+  - { label: Type, value: Serial bus }
+  - { label: Wires, value: Two (SDA, SCL) }
+  - { label: Topology, value: Multi-drop, addressed }
+  - { label: Speed, value: ~100 kHz – 3.4 MHz }
+see_also: [spi, uart, microcontroller, sensor, gpio, embedded-system]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/I%C2%B2C
+---
+
+**I²C** (Inter-Integrated Circuit) is a two-wire serial bus that lets one controller communicate with many peripheral chips over a shared clock and data line.[^wiki]
+
+## Overview
+
+I²C needs just two signals: a clock (SCL) and a bidirectional data line (SDA), both open-drain with pull-up resistors. Every peripheral has a numeric address, so a single pair of wires can fan out to dozens of devices on the same bus. It is slower than [SPI](/reference/spi/) — typically 100 kHz to a few MHz — but its low pin count and addressing make it ideal for connecting many small chips. A [microcontroller's](/reference/microcontroller/) I²C peripheral handles the bit-level timing in hardware.
+
+## Where it fits
+
+I²C is the standard way to wire up [sensors](/reference/sensor/) — temperature, accelerometers, real-time clocks, small displays — to an MCU, because each adds no extra pins beyond the shared bus. It trades speed for simplicity versus SPI, and addressing versus a point-to-point link like [UART](/reference/uart/). It is one of the core peripheral buses in nearly every [embedded system](/reference/embedded-system/), exposed alongside the chip's [GPIO](/reference/gpio/).
+
+## Sources
+
+[^wiki]: [I²C](https://en.wikipedia.org/wiki/I%C2%B2C) — Wikipedia, on the two-wire bus and its addressing.

--- a/docs/reference/ieee.md
+++ b/docs/reference/ieee.md
@@ -1,0 +1,47 @@
+---
+slug: ieee
+title: IEEE
+entry_type: organization
+category: hw-organizations
+description: The IEEE is a global professional association for electrical and electronics engineering that publishes widely used technical standards, including those behind Ethernet and Wi-Fi.
+keywords: IEEE, Institute of Electrical and Electronics Engineers, standards, 802.11, 802.3, engineering
+aka: [Institute of Electrical and Electronics Engineers]
+autolink: true
+infobox:
+  - { label: Type, value: Professional association and standards body }
+  - { label: Founded, value: "1963" }
+  - { label: HQ, value: New York / Piscataway, New Jersey, USA }
+  - { label: Makes, value: Technical standards, publications }
+see_also: [ethernet, wi-fi, jedec, itu]
+cite_urls:
+  - https://www.ieee.org/
+  - https://en.wikipedia.org/wiki/IEEE
+---
+
+**The IEEE** (Institute of Electrical and Electronics Engineers) is a global professional
+association for electrical, electronics, and computing engineering that publishes many of
+the technical standards the industry relies on.[^wiki]
+
+## Overview
+
+The IEEE was formed in 1963 by the merger of two older engineering societies. It is the
+world's largest technical professional organization, with members across academia and
+industry, and it runs conferences, journals, and education programs in addition to standards
+work.[^home]
+
+Its standards arm, the IEEE Standards Association, produces specifications used everywhere.
+The IEEE 802 family is the best known: 802.3 defines [Ethernet](/reference/ethernet/) and
+802.11 defines [Wi-Fi](/reference/wi-fi/). The IEEE 754 standard for floating-point
+arithmetic governs how computers represent decimal numbers.
+
+## Why it matters
+
+IEEE standards let equipment from different vendors interoperate — the reason an Ethernet
+cable or Wi-Fi connection works between any two compliant devices. The networking that ties
+a fleet of GopherTrunk capture nodes back to a server runs on IEEE-standardized links, and
+IEEE 754 arithmetic underlies the DSP math itself.
+
+## Sources
+
+[^home]: [IEEE](https://www.ieee.org/) — the association's official site.
+[^wiki]: [IEEE](https://en.wikipedia.org/wiki/IEEE) — Wikipedia, for the organization's history and standards work.

--- a/docs/reference/in-system-programming.md
+++ b/docs/reference/in-system-programming.md
@@ -1,0 +1,33 @@
+---
+slug: in-system-programming
+title: In-system programming
+entry_type: concept
+category: hw-microcontrollers
+description: In-system programming (ISP) flashes a microcontroller's firmware while the chip stays soldered in its circuit, using a debug interface such as SWD, JTAG, or SPI instead of a chip programmer.
+keywords: in-system programming, ISP, ICSP, SWD, JTAG, debug interface, flash, programmer, ST-LINK
+aka: [ISP, ICSP]
+infobox:
+  - { label: Type, value: Programming method }
+  - { label: Means, value: Flash chip in-place }
+  - { label: Interfaces, value: SWD, JTAG, SPI }
+  - { label: Tools, value: ST-LINK, PICkit, J-Link }
+see_also: [bootloader, firmware, microcontroller, spi, avr-atmega, stm32]
+related_lessons:
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/In-system_programming
+---
+
+**In-system programming (ISP)** is the practice of writing a [microcontroller's](/reference/microcontroller/) [firmware](/reference/firmware/) while the chip remains soldered into its circuit board.[^wiki]
+
+## Overview
+
+Before ISP, a chip had to be removed and placed in a dedicated programmer. ISP instead uses a small debug interface on the board — SWD or JTAG on [ARM Cortex-M](/reference/arm-cortex-m/) parts, an [SPI](/reference/spi/)-based ICSP header on [AVR/ATmega](/reference/avr-atmega/), or vendor schemes on [PIC](/reference/pic-microcontroller/) — so a programmer like ST-LINK, J-Link, or PICkit can flash and debug the device in place. The same interface usually allows single-step debugging and reading back memory.
+
+## Where it fits
+
+ISP is the lowest-level way to get code onto a chip and is how a brand-new, blank MCU is first programmed — including installing a [bootloader](/reference/bootloader/), after which routine updates can happen over USB instead. On an [STM32](/reference/stm32/) board, the SWD pins broken out next to the MCU are the ISP interface. It is the standard production and bring-up workflow for [embedded systems](/reference/embedded-system/).
+
+## Sources
+
+[^wiki]: [In-system programming](https://en.wikipedia.org/wiki/In-system_programming) — Wikipedia, on programming chips in place.

--- a/docs/reference/infrastructure-as-a-service.md
+++ b/docs/reference/infrastructure-as-a-service.md
@@ -1,0 +1,33 @@
+---
+slug: infrastructure-as-a-service
+title: Infrastructure as a service (IaaS)
+entry_type: concept
+category: hw-servers
+description: Infrastructure as a service (IaaS) is a cloud model where the provider rents out raw compute, storage, and networking — typically as virtual machines — and the customer manages everything above the hardware.
+keywords: IaaS, infrastructure as a service, cloud VM, virtual machine, compute storage networking, self-managed cloud
+aka: [IaaS]
+infobox:
+  - { label: Type, value: Cloud service model }
+  - { label: Provider runs, value: Physical hardware, virtualization }
+  - { label: You run, value: OS and everything above }
+  - { label: Typical unit, value: Virtual machine }
+see_also: [platform-as-a-service, software-as-a-service, cloud-computing, virtualization, bare-metal-server, virtual-private-server]
+related_lessons:
+  - { title: "Virtual private servers", url: /learn/intro-hardware/vps/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Infrastructure_as_a_service
+---
+
+**Infrastructure as a service** (**IaaS**) is a [cloud computing](/reference/cloud-computing/) model in which the provider rents out raw compute, storage, and networking — usually as virtual machines — and you manage everything above the bare hardware.[^wiki]
+
+## Overview
+
+With IaaS the provider owns the [data center](/reference/data-center/), the physical servers, and the [virtualization](/reference/virtualization/) layer; you receive a virtual machine and are responsible for the [operating system](/reference/operating-system/), patching, services, and your application. It is the most flexible cloud tier and the closest to running your own server, billed on demand by the hour or second. A [virtual private server](/reference/virtual-private-server/) is essentially a small, fixed slice of IaaS.
+
+## Where it fits
+
+IaaS is the bottom rung of the cloud stack, beneath [platform as a service](/reference/platform-as-a-service/) (which also runs the OS and runtime) and [software as a service](/reference/software-as-a-service/) (a finished application). Choose IaaS when you need full control of the environment but not physical hardware; choose a [bare-metal server](/reference/bare-metal-server/) when virtualization overhead or multi-tenancy is unacceptable. A GopherTrunk back end fits IaaS well for storage and serving, though capture still lives at the antenna.
+
+## Sources
+
+[^wiki]: [Infrastructure as a service](https://en.wikipedia.org/wiki/Infrastructure_as_a_service) — Wikipedia, on the IaaS cloud model.

--- a/docs/reference/input-output.md
+++ b/docs/reference/input-output.md
@@ -1,0 +1,32 @@
+---
+slug: input-output
+title: Input/output (I/O)
+entry_type: concept
+category: hw-foundations
+description: Input/output (I/O) is the set of channels through which a computer takes in and sends out data, from keyboards and screens to network ports and GPIO pins.
+keywords: input output, I/O, peripherals, USB, network ports, GPIO, keyboard screen
+aka: [I/O, input/output, input output]
+infobox:
+  - { label: Type, value: Data channels }
+  - { label: Input, value: Keyboard, sensors, network }
+  - { label: Output, value: Screen, actuators, network }
+  - { label: On small devices, value: GPIO pins }
+see_also: [computer-hardware, gpio, central-processing-unit, single-board-computer, microcontroller]
+related_lessons:
+  - { title: "The building blocks", url: /learn/intro-hardware/building-blocks/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Input/output
+---
+
+**Input/output (I/O)** is the set of channels through which a computer takes in and sends out data — everything that connects the [CPU](/reference/central-processing-unit/) to the world beyond the chip.[^wiki]
+
+## Overview
+**Input** brings data in: a keyboard, a mouse, a microphone, a sensor reading, a packet arriving on the network. **Output** sends data back out: pixels to a screen, sound to a speaker, a packet onto the network, a signal to an actuator. Many channels are bidirectional — USB and network ports carry data both ways.
+
+A computer with no I/O is sealed off and useless; I/O is what lets it observe and act.
+
+## Where it fits
+I/O is one of the four building blocks of [computer hardware](/reference/computer-hardware/). On a desktop the channels are mostly USB, video, and network. On small devices like a [single-board computer](/reference/single-board-computer/) or a [microcontroller](/reference/microcontroller/), the most direct form of I/O is [GPIO](/reference/gpio/) — general-purpose pins wired straight to sensors and actuators.
+
+## Sources
+[^wiki]: [Input/output](https://en.wikipedia.org/wiki/Input/output) — Wikipedia, on the channels a computer uses to communicate with the outside world.

--- a/docs/reference/instruction-set-architecture.md
+++ b/docs/reference/instruction-set-architecture.md
@@ -1,0 +1,31 @@
+---
+slug: instruction-set-architecture
+title: Instruction set architecture (ISA)
+entry_type: concept
+category: hw-foundations
+description: An instruction set architecture is the contract between hardware and software, defining the instructions, registers, and data types a processor understands, independent of how it is built.
+keywords: instruction set architecture, ISA, machine code, registers, RISC, CISC, opcode, microarchitecture
+aka: [ISA]
+infobox:
+  - { label: Type, value: Hardware/software contract }
+  - { label: Defines, value: Instructions, registers }
+  - { label: Styles, value: "RISC, CISC" }
+  - { label: Examples, value: "x86, ARM, RISC-V" }
+see_also: [central-processing-unit, x86, arm-architecture, risc-v, von-neumann-architecture, compiler]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Instruction_set_architecture
+---
+
+An **instruction set architecture** (**ISA**) is the contract between hardware and software: the set of instructions, registers, and data types a [processor](/reference/central-processing-unit/) understands, separate from how any particular chip implements it.[^wiki]
+
+## Overview
+
+The ISA defines what a program *can ask the CPU to do* — the opcodes, the registers, how memory is addressed — so that machine code written for an ISA runs on any chip that implements it. The *microarchitecture* is the separate question of how a given chip carries those instructions out (pipelines, caches, execution units). ISAs split loosely into **RISC** (few, simple, fixed-length instructions) and **CISC** (more, richer instructions); the major families today are [x86](/reference/x86/), [ARM](/reference/arm-architecture/), and the open [RISC-V](/reference/risc-v/).
+
+## Where it fits
+
+The ISA is why a [compiler](/reference/compiler/) must *target* a specific architecture, and why a binary built for x86 will not run on an ARM chip without recompilation or emulation. It builds on the [von Neumann](/reference/von-neumann-architecture/) idea of a stored program the processor fetches and executes. For GopherTrunk this is a daily reality: Go cross-compiles the same source to x86 servers and to the ARM CPU in a [Raspberry Pi](/reference/raspberry-pi/) capture node.
+
+## Sources
+
+[^wiki]: [Instruction set architecture](https://en.wikipedia.org/wiki/Instruction_set_architecture) — Wikipedia, on the ISA as the hardware/software interface.

--- a/docs/reference/integrated-circuit.md
+++ b/docs/reference/integrated-circuit.md
@@ -1,0 +1,31 @@
+---
+slug: integrated-circuit
+title: Integrated circuit
+entry_type: hardware
+category: hw-foundations
+description: An integrated circuit is a set of electronic circuits fabricated together on a single small piece of semiconductor, packing millions or billions of transistors into one chip.
+keywords: integrated circuit, IC, chip, microchip, silicon, transistor, fabrication, die
+aka: [IC, Microchip, Chip]
+infobox:
+  - { label: Type, value: Semiconductor chip }
+  - { label: Made of, value: Silicon (mostly) }
+  - { label: Contains, value: Up to billions of transistors }
+  - { label: Invented, value: "1958–1959" }
+see_also: [transistor, semiconductor, logic-gate, moores-law, central-processing-unit, system-on-a-chip]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Integrated_circuit
+---
+
+An **integrated circuit** (**IC**, or chip) is a set of electronic circuits fabricated together on a single small piece of [semiconductor](/reference/semiconductor/) material, usually silicon.[^wiki]
+
+## Overview
+
+Instead of wiring individual [transistors](/reference/transistor/), resistors, and other parts by hand, an IC etches them and their connections onto one *die* in a single manufacturing process. Independently invented by Jack Kilby and Robert Noyce around 1958–1959, this packed whole circuits into a tiny, reliable, cheap chip. Successive process generations shrank the features and multiplied the transistor count — the trend captured by [Moore's law](/reference/moores-law/) — until a single chip could hold billions of switches.
+
+## Where it fits
+
+The integrated circuit is what made computers small and affordable: a [CPU](/reference/central-processing-unit/), memory, or an entire [system-on-a-chip](/reference/system-on-a-chip/) is one IC. The [logic gates](/reference/logic-gate/) of digital design are built from the transistors inside it. In SDR hardware, ICs do everything from the analog-to-digital conversion in a dongle to the dedicated chips that handle wideband sampling before GopherTrunk's software takes over.
+
+## Sources
+
+[^wiki]: [Integrated circuit](https://en.wikipedia.org/wiki/Integrated_circuit) — Wikipedia, on ICs, their invention, and fabrication.

--- a/docs/reference/intel.md
+++ b/docs/reference/intel.md
@@ -1,0 +1,50 @@
+---
+slug: intel
+title: Intel
+entry_type: organization
+category: hw-organizations
+description: Intel is an American semiconductor company, the inventor of the commercial microprocessor and long the dominant maker of x86 CPUs for PCs, servers, and data centers.
+keywords: Intel, x86, microprocessor, CPU, semiconductor, Core, Xeon, fab
+aka: [Intel Corporation]
+autolink: true
+infobox:
+  - { label: Type, value: Public semiconductor company }
+  - { label: Founded, value: "1968" }
+  - { label: HQ, value: Santa Clara, California, USA }
+  - { label: Makes, value: x86 CPUs, chipsets, FPGAs }
+see_also: [central-processing-unit, x86, gordon-moore, robert-noyce, amd]
+cite_urls:
+  - https://www.intel.com/
+  - https://en.wikipedia.org/wiki/Intel
+---
+
+**Intel** is an American semiconductor company founded in 1968 that produced the first
+commercial microprocessor and became the dominant supplier of
+[x86](/reference/x86/) [CPUs](/reference/central-processing-unit/).[^wiki]
+
+## Overview
+
+Intel was founded by [Robert Noyce](/reference/robert-noyce/) and
+[Gordon Moore](/reference/gordon-moore/), two veterans of the early silicon industry. Its
+1971 Intel 4004 was the first commercially available microprocessor on a single chip, and
+the 1978 8086 launched the x86 instruction set that still underpins most desktop, laptop,
+and server processors today.[^wiki]
+
+For decades Intel built both the chip designs and the fabrication plants ("fabs") that
+made them, a vertically integrated model summarised by Moore's prediction that transistor
+counts would roughly double every two years. Its modern lines include Core processors for
+PCs and Xeon processors for servers and data centers; it has also produced chipsets,
+network controllers, and FPGAs.[^home]
+
+## Why it matters
+
+The PC era was largely built on Intel x86 CPUs running Windows and Linux, and most
+general-purpose servers — including the machines that host an SDR decoder pipeline or a
+fleet of GopherTrunk capture nodes — still use x86 processors from Intel or its rival
+[AMD](/reference/amd/). The architecture's longevity means software compiled for x86
+decades ago often still runs on current hardware.
+
+## Sources
+
+[^home]: [Intel](https://www.intel.com/) — the company's official site, for current product lines.
+[^wiki]: [Intel](https://en.wikipedia.org/wiki/Intel) — Wikipedia, for the company's history and significance.

--- a/docs/reference/internet-of-things.md
+++ b/docs/reference/internet-of-things.md
@@ -1,0 +1,34 @@
+---
+slug: internet-of-things
+title: Internet of Things (IoT)
+entry_type: concept
+category: hw-microcontrollers
+description: The Internet of Things is the network of everyday physical objects with embedded computing and connectivity that send and receive data, often over cheap wireless microcontrollers.
+keywords: Internet of Things, IoT, smart home, embedded, wireless sensors, ESP32, connected devices
+aka: [IoT, Internet of Things]
+autolink: true
+infobox:
+  - { label: Type, value: Networked embedded devices }
+  - { label: Typical node, value: Cheap wireless microcontroller }
+  - { label: Connectivity, value: Wi-Fi, Bluetooth, cellular }
+  - { label: Reports to, value: Server or cloud }
+see_also: [esp32, microcontroller, cloud-computing, firmware, server]
+related_lessons:
+  - { title: "ESP32", url: /learn/intro-hardware/esp32/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Internet_of_things
+---
+
+**The Internet of Things (IoT)** is the network of everyday physical objects — sensors, appliances, wearables — with embedded computing and connectivity that lets them send and receive data.[^wiki]
+
+## Overview
+
+IoT devices are typically built on cheap wireless [microcontrollers](/reference/microcontroller/) like the [ESP32](/reference/esp32/), each reporting its readings to a [server](/reference/server/) or the [cloud](/reference/cloud-computing/). Individually each node is tiny; collectively they number in the billions.
+
+## Where it fits
+
+The appeal of IoT is putting just enough computing into ordinary objects to make them measurable and controllable from afar. Those same low-power wireless nodes are part of the radio landscape: their transmissions are among the signals filling the airwaves GopherTrunk listens to, though the devices themselves are far too small to run it.
+
+## Sources
+
+[^wiki]: [Internet of things](https://en.wikipedia.org/wiki/Internet_of_things) — Wikipedia, on networked physical objects with embedded computing and connectivity.

--- a/docs/reference/interrupt.md
+++ b/docs/reference/interrupt.md
@@ -1,0 +1,33 @@
+---
+slug: interrupt
+title: Interrupt
+entry_type: concept
+category: hw-microcontrollers
+description: An interrupt is a hardware signal that pauses a processor's normal flow to run a short handler in response to an event, letting a microcontroller react instantly without constantly polling.
+keywords: interrupt, ISR, interrupt service routine, IRQ, NVIC, polling, event, latency, vector table
+infobox:
+  - { label: Type, value: Hardware event mechanism }
+  - { label: Triggers, value: Timers, I/O, pins, peripherals }
+  - { label: Runs, value: An interrupt service routine (ISR) }
+  - { label: Benefit, value: React without polling }
+see_also: [microcontroller, real-time-operating-system, arm-cortex-m, bare-metal-programming, gpio, watchdog-timer]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Interrupt
+---
+
+**An interrupt** is a hardware signal that pauses a processor's normal program flow to run a short handler in response to an event, then resumes where it left off.[^wiki]
+
+## Overview
+
+When a peripheral needs attention — a timer expires, a byte arrives on a [UART](/reference/uart/), a [GPIO](/reference/gpio/) pin changes — it raises an interrupt. The processor jumps to the matching **interrupt service routine (ISR)** via a vector table, runs it, and returns. On [ARM Cortex-M](/reference/arm-cortex-m/) parts a nested vectored interrupt controller (NVIC) prioritizes and arbitrates these requests with deterministic latency. The alternative, polling, wastes cycles repeatedly checking; interrupts let a [microcontroller](/reference/microcontroller/) sleep until something actually happens.
+
+## Where it fits
+
+Interrupts are the foundation of responsive, low-power embedded code: an MCU can idle in a low-power mode and wake only on an event, which is how battery devices run for years. ISRs are kept short, often just setting a flag for the main loop. In [bare-metal](/reference/bare-metal-programming/) firmware interrupts plus a main loop are the whole architecture; an [RTOS](/reference/real-time-operating-system/) builds its scheduler on top of them.
+
+## Sources
+
+[^wiki]: [Interrupt](https://en.wikipedia.org/wiki/Interrupt) — Wikipedia, on interrupts and service routines.

--- a/docs/reference/ios.md
+++ b/docs/reference/ios.md
@@ -1,0 +1,35 @@
+---
+slug: ios
+title: iOS
+entry_type: concept
+category: hw-mobile
+description: iOS is Apple's mobile operating system, running on the iPhone and underpinning iPadOS and watchOS, known for tight hardware-software integration, a curated app store, and a strong security model.
+keywords: iOS, Apple, iPhone, iPadOS, Swift, App Store, Apple Silicon, mobile OS, walled garden
+autolink: true
+infobox:
+  - { label: Type, value: Mobile operating system }
+  - { label: Developer, value: Apple }
+  - { label: Runs on, value: iPhone (iPad, Watch kin) }
+  - { label: First release, value: 2007 }
+  - { label: Apps in, value: Swift, Objective-C }
+see_also: [mobile-operating-system, android, smartphone, tablet, mobile-app-development, system-on-a-chip]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+  - { title: "Developing for mobile", url: /learn/intro-hardware/developing-for-mobile/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/IOS
+---
+
+**iOS** is Apple's [mobile operating system](/reference/mobile-operating-system/), introduced with the first iPhone in 2007 and known for tight integration between Apple's hardware and software.[^wiki]
+
+## Overview
+
+iOS runs only on Apple's own devices, atop Apple Silicon [SoCs](/reference/system-on-a-chip/) descended from the [Arm architecture](/reference/arm-architecture/). Apps are written in Swift or Objective-C and distributed through a curated App Store, with a strong sandbox and hardware-backed security (Secure Enclave, code signing). The same foundation underpins iPadOS and watchOS. Because Apple controls both silicon and software, it can tune power and performance closely — a "walled garden" that trades openness for consistency.
+
+## Where it fits
+
+iOS and [Android](/reference/android/) together define the modern [smartphone](/reference/smartphone/) landscape. iOS leans toward control and polish; Android toward openness and variety. iOS's locked-down model and lack of general USB host support make it a poor host for an SDR decode pipeline like GopherTrunk — it is far better suited as a thin client viewing data served by a capture node elsewhere.
+
+## Sources
+
+[^wiki]: [iOS](https://en.wikipedia.org/wiki/IOS) — Wikipedia, on Apple's mobile operating system.

--- a/docs/reference/ip-address.md
+++ b/docs/reference/ip-address.md
@@ -1,0 +1,31 @@
+---
+slug: ip-address
+title: IP address
+entry_type: concept
+category: hw-networking
+description: An IP address is a numeric label assigned to each device on a network running the Internet Protocol, identifying the host and letting packets be routed to it.
+keywords: IP address, IPv4, IPv6, Internet Protocol, subnet, DHCP, NAT, host address
+aka: [Internet Protocol address]
+infobox:
+  - { label: Type, value: Network address }
+  - { label: Identifies, value: A host on an IP network }
+  - { label: Versions, value: IPv4 (32-bit), IPv6 (128-bit) }
+  - { label: Assigned by, value: DHCP or statically }
+see_also: [router, gateway, lan-and-wan, network-interface-card, network-switch, ethernet]
+cite_urls:
+  - https://en.wikipedia.org/wiki/IP_address
+---
+
+An **IP address** is a numeric label assigned to each device on a network that uses the Internet Protocol, identifying the host so that packets can be routed to it.[^wiki]
+
+## Overview
+
+IP addresses come in two versions: **IPv4**, a 32-bit value written as four dotted numbers (like `192.168.1.10`), and **IPv6**, a 128-bit form created because IPv4 addresses ran short. An address is bound to a device's [NIC](/reference/network-interface-card/) and is paired with a *subnet mask* that says which part identifies the network and which the host. Addresses are usually handed out automatically by DHCP, and on home networks private addresses are shared to the internet through a [router](/reference/router/) performing address translation (NAT).
+
+## Where it fits
+
+The IP address is how a [router](/reference/router/) and [gateway](/reference/gateway/) decide where a packet should go, both within a [LAN and across a WAN](/reference/lan-and-wan/). To reach a GopherTrunk capture node — to stream its decoded calls or open its web view — you connect to its IP address on the local network, so giving such nodes stable, known addresses makes a multi-node site far easier to manage.
+
+## Sources
+
+[^wiki]: [IP address](https://en.wikipedia.org/wiki/IP_address) — Wikipedia, on the numeric label that identifies a host on an IP network.

--- a/docs/reference/jack-kilby.md
+++ b/docs/reference/jack-kilby.md
@@ -1,0 +1,48 @@
+---
+slug: jack-kilby
+title: Jack Kilby
+entry_type: person
+category: hw-people
+description: Jack Kilby (1923–2005) was an American electrical engineer at Texas Instruments who built the first working integrated circuit in 1958, later sharing the Nobel Prize in Physics for the achievement.
+keywords: Jack Kilby, integrated circuit, Texas Instruments, microchip, Nobel Prize, semiconductor
+aka: [Jack Kilby, Jack St. Clair Kilby]
+autolink: true
+infobox:
+  - { label: Lived, value: "1923–2005" }
+  - { label: Field, value: Electrical engineering }
+  - { label: Known for, value: First integrated circuit }
+see_also: [integrated-circuit, robert-noyce, semiconductor, transistor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Jack_Kilby
+---
+
+**Jack Kilby** (1923–2005) was an American electrical engineer who built the first working
+[integrated circuit](/reference/integrated-circuit/) at Texas Instruments in 1958, a
+breakthrough that earned him a share of the 2000 Nobel Prize in Physics.[^wiki]
+
+## Life and work
+
+In the summer of 1958, newly hired and with no vacation yet earned, Kilby stayed in a quiet
+lab and demonstrated that a complete electronic circuit — transistors, resistors, and their
+connections — could be fabricated on a single slab of [semiconductor](/reference/semiconductor/)
+material rather than wired together from discrete parts.[^wiki] Months later
+[Robert Noyce](/reference/robert-noyce/) developed the planar silicon version that became the
+manufacturable standard; the two are recognised as independent co-inventors of the
+integrated circuit.[^wiki]
+
+## Why they matter
+
+Before the [integrated circuit](/reference/integrated-circuit/), every
+[transistor](/reference/transistor/) and resistor was a separate soldered component, which
+capped how complex and small electronics could get. Putting the whole circuit on one chip is
+what made microprocessors, memory, and dense radio front-ends possible — the entire premise of
+a compact SDR scanner. Kilby also co-invented the handheld electronic calculator.[^wiki]
+
+## Legacy
+
+The Nobel committee cited his "part in the invention of the integrated circuit," recognising it
+as a foundation of modern information technology.
+
+## Sources
+
+[^wiki]: [Jack Kilby](https://en.wikipedia.org/wiki/Jack_Kilby) — Wikipedia, for biography, the first integrated circuit, and the Nobel Prize.

--- a/docs/reference/jedec.md
+++ b/docs/reference/jedec.md
@@ -1,0 +1,46 @@
+---
+slug: jedec
+title: JEDEC
+entry_type: organization
+category: hw-organizations
+description: JEDEC is the semiconductor industry's standards body, best known for defining the memory standards such as the DDR and LPDDR specifications used in computer RAM.
+keywords: JEDEC, memory standards, DDR, LPDDR, DRAM, semiconductor standards, RAM
+aka: [JEDEC Solid State Technology Association]
+autolink: true
+infobox:
+  - { label: Type, value: Industry standards organization }
+  - { label: Founded, value: "1958" }
+  - { label: HQ, value: Arlington, Virginia, USA }
+  - { label: Makes, value: Semiconductor and memory standards }
+see_also: [random-access-memory, semiconductor, ieee]
+cite_urls:
+  - https://www.jedec.org/
+  - https://en.wikipedia.org/wiki/JEDEC
+---
+
+**JEDEC** (the JEDEC Solid State Technology Association) is the semiconductor industry's
+standards body, best known for defining the memory standards used in computer
+[RAM](/reference/random-access-memory/).[^wiki]
+
+## Overview
+
+JEDEC began in 1958 as a joint standards effort within the electronics industry and is now
+an independent member association of [semiconductor](/reference/semiconductor/) companies. It
+develops open standards through committees of competing manufacturers, ensuring that parts
+from different vendors are compatible.[^home]
+
+Its most visible work is the DDR (Double Data Rate) and LPDDR memory specifications that
+define the DRAM modules in PCs, servers, and phones. JEDEC also standardizes flash memory
+interfaces, packaging, and reliability test methods used across the industry.
+
+## Why it matters
+
+Because JEDEC sets the memory standards, a DDR module from one maker works in a board
+designed for that standard, regardless of brand. Every computer that runs a GopherTrunk
+decoder — from a server holding hours of IQ data in RAM to a single-board capture node —
+depends on JEDEC-standardized memory to do it.
+
+## Sources
+
+[^home]: [JEDEC](https://www.jedec.org/) — the association's official site, for its standards.
+[^wiki]: [JEDEC](https://en.wikipedia.org/wiki/JEDEC) — Wikipedia, for the organization's history and memory standards.

--- a/docs/reference/jensen-huang.md
+++ b/docs/reference/jensen-huang.md
@@ -1,0 +1,47 @@
+---
+slug: jensen-huang
+title: Jensen Huang
+entry_type: person
+category: hw-people
+description: Jensen Huang (born 1963) is a Taiwanese-American engineer who co-founded NVIDIA and led its transformation from a graphics-chip maker into the dominant supplier of GPUs for gaming, AI, and high-performance computing.
+keywords: Jensen Huang, NVIDIA, GPU, graphics processing unit, CUDA, AI accelerator
+aka: [Jensen Huang, Jen-Hsun Huang]
+autolink: true
+infobox:
+  - { label: Born, value: "1963" }
+  - { label: Field, value: Engineering / business }
+  - { label: Known for, value: Co-founding NVIDIA }
+see_also: [nvidia, graphics-processing-unit, cuda, ai-accelerator]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Jensen_Huang
+---
+
+**Jensen Huang** (born 1963) is a Taiwanese-American electrical engineer who co-founded
+[NVIDIA](/reference/nvidia/) in 1993 and built it into the leading maker of the
+[graphics processing unit](/reference/graphics-processing-unit/), or GPU.[^wiki]
+
+## Life and work
+
+Huang trained as an electrical engineer and worked in the chip industry before co-founding
+NVIDIA to accelerate 3-D graphics for personal computers. Under his long tenure as chief
+executive, the company popularised the term "GPU" and steadily widened the chip's role beyond
+gaming.[^wiki] With the [CUDA](/reference/cuda/) platform, NVIDIA made the GPU's massive
+parallelism usable for general computation, positioning the company at the centre of the
+deep-learning boom and the rise of [AI accelerators](/reference/ai-accelerator/).[^wiki]
+
+## Why they matter
+
+The [GPU](/reference/graphics-processing-unit/) turned out to be ideal for the dense,
+repetitive math behind both graphics and neural networks — and behind heavy signal processing.
+The same parallel-throughput hardware that [NVIDIA](/reference/nvidia/) sells for AI can chew
+through the FFTs and filtering that wideband SDR demands. Huang's bet on
+[CUDA](/reference/cuda/) years before the AI wave made NVIDIA a defining company of the era.[^wiki]
+
+## Legacy
+
+Under Huang, NVIDIA grew from a graphics-card startup into one of the most valuable technology
+companies in the world, with its GPUs underpinning much of modern AI infrastructure.
+
+## Sources
+
+[^wiki]: [Jensen Huang](https://en.wikipedia.org/wiki/Jensen_Huang) — Wikipedia, for biography and NVIDIA.

--- a/docs/reference/john-von-neumann.md
+++ b/docs/reference/john-von-neumann.md
@@ -1,0 +1,51 @@
+---
+slug: john-von-neumann
+title: John von Neumann
+entry_type: person
+category: hw-people
+description: John von Neumann (1903–1957) was a Hungarian-American mathematician who described the stored-program computer architecture that bears his name and still organizes nearly every general-purpose computer.
+keywords: John von Neumann, von Neumann architecture, stored-program computer, EDVAC, computer science, mathematics
+aka: [John von Neumann, von Neumann]
+autolink: true
+infobox:
+  - { label: Lived, value: "1903–1957" }
+  - { label: Field, value: Mathematics / computing }
+  - { label: Known for, value: Von Neumann architecture }
+see_also: [von-neumann-architecture, central-processing-unit, alan-turing, computer-hardware]
+cite_urls:
+  - https://en.wikipedia.org/wiki/John_von_Neumann
+---
+
+**John von Neumann** (1903–1957) was a Hungarian-American mathematician and polymath who
+described the stored-program computer design — the
+[von Neumann architecture](/reference/von-neumann-architecture/) — that still organises
+nearly every general-purpose machine.[^wiki]
+
+## Life and work
+
+Von Neumann made foundational contributions across mathematics, physics, game theory, and
+the design of the atomic bomb before turning to computing. His 1945 "First Draft of a Report
+on the EDVAC" set out a machine in which program instructions and data share the same memory,
+fetched and executed by a single processing unit. That single insight — that a computer
+should store its own program — separated software from wiring and made the
+programmable computer practical.[^wiki]
+
+## Why they matter
+
+In the [von Neumann architecture](/reference/von-neumann-architecture/), a
+[CPU](/reference/central-processing-unit/) repeatedly fetches an instruction from memory,
+decodes it, and acts — the fetch-decode-execute cycle at the heart of essentially all of
+today's [computer hardware](/reference/computer-hardware/). It built on the universal-machine
+idea of [Alan Turing](/reference/alan-turing/) and turned it into a buildable blueprint. When
+GopherTrunk runs a decode pipeline, it runs as instructions in shared memory on exactly this
+kind of machine.[^wiki]
+
+## Legacy
+
+The shared instruction/data memory is sometimes called the "von Neumann bottleneck," and
+modern caches and Harvard-style splits are responses to it — but the basic model he named is
+still the default mental picture of how a computer works.
+
+## Sources
+
+[^wiki]: [John von Neumann](https://en.wikipedia.org/wiki/John_von_Neumann) — Wikipedia, for biography and the EDVAC report.

--- a/docs/reference/keyboard.md
+++ b/docs/reference/keyboard.md
@@ -1,0 +1,30 @@
+---
+slug: keyboard
+title: Keyboard
+entry_type: hardware
+category: hw-personal-computers
+description: A keyboard is the primary text-input peripheral for a computer, a grid of keys that send character and command codes, available in membrane and mechanical types and many layouts.
+keywords: keyboard, mechanical keyboard, membrane keyboard, QWERTY, key switch, input device
+infobox:
+  - { label: Type, value: Input peripheral }
+  - { label: Switches, value: Membrane or mechanical }
+  - { label: Layouts, value: QWERTY, AZERTY, Dvorak, … }
+  - { label: Connects via, value: USB, Bluetooth }
+see_also: [peripheral, mouse, personal-computer, desktop-computer, usb]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_keyboard
+---
+
+A **keyboard** is the primary text-input device for a computer: a grid of keys that, when pressed, send character and command codes to the machine.[^wiki]
+
+## Overview
+
+A keyboard is an input [peripheral](/reference/peripheral/). Each keypress is detected and translated into a code the [operating system](/reference/operating-system/) interprets as a letter, number, or command. Two switch technologies dominate: cheap, quiet *membrane* keyboards that press a contact through a rubber dome, and *mechanical* keyboards with an individual spring-loaded switch under each key that many typists prefer for feel and durability. Layouts vary by language and preference — QWERTY is most common, with AZERTY, Dvorak, and others in use. Keyboards connect over [USB](/reference/usb/) or wirelessly via Bluetooth.
+
+## Where it fits
+
+A keyboard is half of the basic input pair, alongside the [mouse](/reference/mouse/), that every [desktop computer](/reference/desktop-computer/) needs and that laptops build in. The choice is mostly ergonomic: switch feel, key spacing, and whether you want a numeric pad or a compact board. For long sessions at a GopherTrunk bench, a comfortable keyboard matters more than any spec.
+
+## Sources
+
+[^wiki]: [Computer keyboard](https://en.wikipedia.org/wiki/Computer_keyboard) — Wikipedia, on keyboards as text-entry input devices.

--- a/docs/reference/kubernetes.md
+++ b/docs/reference/kubernetes.md
@@ -1,0 +1,34 @@
+---
+slug: kubernetes
+title: Kubernetes
+entry_type: concept
+category: hw-servers
+description: Kubernetes is an open-source system for automating the deployment, scaling, and management of containerized applications across a cluster of machines, originally developed at Google.
+keywords: Kubernetes, k8s, container orchestration, cluster, pods, scaling, Google, CNCF
+autolink: true
+aka: [K8s]
+infobox:
+  - { label: Type, value: Container orchestrator }
+  - { label: Origin, value: Google, 2014 }
+  - { label: Manages, value: Containers across a cluster }
+  - { label: Unit, value: Pod }
+see_also: [container, docker, load-balancer, high-availability, scalability, virtualization]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Kubernetes
+  - https://kubernetes.io/
+---
+
+**Kubernetes** (often "K8s") is an open-source system for automating the deployment, scaling, and management of containerized applications across a cluster of machines.[^wiki] It was created at Google and released in 2014, and is now stewarded by the Cloud Native Computing Foundation.[^home]
+
+## Overview
+
+Kubernetes groups [containers](/reference/container/) into *pods*, schedules them onto a pool of worker nodes, and continuously reconciles the cluster toward a desired state you declare. If a node dies, it reschedules the affected pods elsewhere; if load rises, it can add replicas. It also wires up service discovery and internal [load balancing](/reference/load-balancer/), rolling updates, and self-healing restarts. The containers themselves are usually built with [Docker](/reference/docker/) or another compatible runtime.
+
+## Where it fits
+
+Kubernetes is the standard answer to running many containers reliably at scale, providing [high availability](/reference/high-availability/) and elastic [scalability](/reference/scalability/) on top of plain virtualization. It is powerful but operationally heavy — overkill for a single service. A lone GopherTrunk capture node needs nothing like it, but a fleet of nodes feeding a shared back end could be coordinated by Kubernetes.
+
+## Sources
+
+[^wiki]: [Kubernetes](https://en.wikipedia.org/wiki/Kubernetes) — Wikipedia, on Kubernetes' design and history.
+[^home]: [Kubernetes](https://kubernetes.io/) — the project's official site.

--- a/docs/reference/lan-and-wan.md
+++ b/docs/reference/lan-and-wan.md
@@ -1,0 +1,33 @@
+---
+slug: lan-and-wan
+title: LAN & WAN
+entry_type: concept
+category: hw-networking
+description: A LAN is a network covering a small area such as a home or office, while a WAN spans long distances connecting many networks; the internet is the largest WAN.
+keywords: LAN, WAN, local area network, wide area network, internet, network scope, subnet
+aka: [local area network, wide area network]
+infobox:
+  - { label: LAN, value: Local area network (one site) }
+  - { label: WAN, value: Wide area network (many sites) }
+  - { label: Joined by, value: Router / gateway }
+  - { label: Largest WAN, value: The internet }
+see_also: [router, gateway, network-switch, ip-address, ethernet, wi-fi]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Local_area_network
+  - https://en.wikipedia.org/wiki/Wide_area_network
+---
+
+A **LAN** (local area network) covers a small area such as a home, office, or building, while a **WAN** (wide area network) spans long distances and ties many networks together — the internet being the largest WAN of all.[^lan][^wan]
+
+## Overview
+
+A LAN connects nearby devices over [Ethernet](/reference/ethernet/) and [Wi-Fi](/reference/wi-fi/), usually through a [switch](/reference/network-switch/) and a single [IP](/reference/ip-address/) subnet, giving high speed and low latency within one site. A WAN links such sites across cities or continents over leased lines, fiber, or the public internet, at greater distance but typically lower speed and higher latency. The boundary between them is a [router](/reference/router/) acting as the [gateway](/reference/gateway/): the LAN side faces inward, the WAN side faces out.
+
+## Where it fits
+
+The LAN-versus-WAN distinction is mostly about *scope*, and it shapes how a distributed system is laid out. A GopherTrunk site keeps its capture nodes and storage [server](/reference/server/) on a fast local LAN, then reaches across the WAN only to publish results or pull in remote feeds — keeping the bandwidth-heavy raw data local and sending just the decoded output over the slower wide-area link.
+
+## Sources
+
+[^lan]: [Local area network](https://en.wikipedia.org/wiki/Local_area_network) — Wikipedia, on networks covering a small area.
+[^wan]: [Wide area network](https://en.wikipedia.org/wiki/Wide_area_network) — Wikipedia, on networks spanning long distances.

--- a/docs/reference/laptop.md
+++ b/docs/reference/laptop.md
@@ -1,0 +1,45 @@
+---
+slug: laptop
+title: Laptop
+entry_type: hardware
+category: hw-personal-computers
+description: A laptop is a complete portable personal computer with screen, keyboard, and battery built in, trading some performance and expandability for mobility.
+keywords: laptop, notebook computer, portable computer, ultrabook, thermal throttling, mobile development machine
+aka: [Laptop, Notebook, Notebook computer]
+infobox:
+  - { label: Type, value: Portable personal computer }
+  - { label: Built in, value: Screen, keyboard, battery }
+  - { label: Strength, value: Mobility }
+  - { label: Limit, value: Thermal throttling }
+  - { label: Best for, value: Working anywhere }
+see_also: [personal-computer, desktop-computer, central-processing-unit, random-access-memory, computer-hardware, operating-system]
+related_lessons:
+  - { title: "Laptops", url: /learn/intro-hardware/laptops/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Laptop
+---
+
+**A laptop** is a complete, portable [personal computer](/reference/personal-computer/)
+with screen, keyboard, and battery built into one folding shell.[^wiki]
+
+## Overview
+
+A laptop runs the same full [operating system](/reference/operating-system/) and
+the same [CPU](/reference/central-processing-unit/),
+[RAM](/reference/random-access-memory/), and
+[storage](/reference/data-storage/) building blocks as a desktop, just packed into
+a thin, battery-powered case. The packaging costs something: less room to expand,
+and in thin models the cooling can't keep up, so the CPU slows itself down under
+load — thermal throttling — capping sustained performance.
+
+## Trade-offs
+
+Against the [desktop](/reference/desktop-computer/)'s power and upgrade path, the
+laptop offers one decisive thing: it goes where you go. For most developers that
+mobility outweighs the lost headroom, which is why the laptop is the default
+development machine. SDR capture work still runs fine on one; phones and tablets,
+by contrast, are screens to view the data on rather than machines to capture it.
+
+## Sources
+
+[^wiki]: [Laptop](https://en.wikipedia.org/wiki/Laptop) — Wikipedia, on the portable all-in-one personal computer and its trade-offs.

--- a/docs/reference/libre-computer.md
+++ b/docs/reference/libre-computer.md
@@ -1,0 +1,35 @@
+---
+slug: libre-computer
+title: Libre Computer
+entry_type: hardware
+category: hw-sbc
+description: Libre Computer is a maker of single-board computers that emphasise open, mainline software support and Raspberry Pi compatibility, with boards such as Le Potato and Renegade built on Amlogic and Rockchip chips.
+keywords: Libre Computer, Le Potato, AML-S905X-CC, Renegade, open source SBC, mainline Linux, Raspberry Pi compatible, ARM single-board computer
+infobox:
+  - { label: Type, value: Single-board computer }
+  - { label: Emphasis, value: Open, mainline software }
+  - { label: CPU, value: ARM (Amlogic / Rockchip) }
+  - { label: Runs, value: Mainline Linux, Android }
+  - { label: Boards, value: Le Potato, Renegade, others }
+see_also: [raspberry-pi, single-board-computer, orange-pi, odroid, rock-pi, gpio]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Libre_Computer_Project
+  - https://libre.computer/
+---
+
+**Libre Computer** is a maker of [single-board computers](/reference/single-board-computer/) that emphasise open, mainline software support and broad [Raspberry Pi](/reference/raspberry-pi/) compatibility.[^wiki]
+
+## Overview
+
+Boards such as Le Potato (AML-S905X-CC) and the Renegade use Amlogic and Rockchip ARM chips and copy the Pi's footprint and 40-pin [GPIO](/reference/gpio/) header. The project's distinguishing goal is upstream support: getting drivers into the mainline Linux kernel and standard bootloaders so the hardware keeps working with ordinary, current software rather than a vendor's frozen image.[^libre]
+
+## Where it fits
+
+Among Pi alternatives like [Orange Pi](/reference/orange-pi/), [ODROID](/reference/odroid/), and [Rock Pi](/reference/rock-pi/), Libre Computer's pitch is longevity and trust in the software stack rather than raw specs. For an always-on GopherTrunk capture node you intend to leave in place for years, mainline support means OS updates are less likely to strand the board.
+
+## Sources
+
+[^wiki]: [Libre Computer Project](https://en.wikipedia.org/wiki/Libre_Computer_Project) — Wikipedia, on the project and its boards.
+[^libre]: [Libre Computer](https://libre.computer/) — vendor site, on the boards and their open-software focus.

--- a/docs/reference/linus-torvalds.md
+++ b/docs/reference/linus-torvalds.md
@@ -1,0 +1,48 @@
+---
+slug: linus-torvalds
+title: Linus Torvalds
+entry_type: person
+category: hw-people
+description: Linus Torvalds (born 1969) is a Finnish-American software engineer who created the Linux kernel and the Git version-control system, two pillars of modern computing infrastructure.
+keywords: Linus Torvalds, Linux, kernel, Git, open source, operating system
+aka: [Linus Torvalds]
+autolink: true
+infobox:
+  - { label: Born, value: "1969" }
+  - { label: Field, value: Software engineering }
+  - { label: Known for, value: "Linux kernel, Git" }
+see_also: [operating-system, version-control, central-processing-unit, computer-hardware]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Linus_Torvalds
+---
+
+**Linus Torvalds** (born 1969) is a Finnish-American software engineer who created the Linux
+kernel — the core of an [operating system](/reference/operating-system/) now running on
+everything from supercomputers to phones — and later the Git
+[version-control](/reference/version-control/) system.[^wiki]
+
+## Life and work
+
+In 1991, as a student in Helsinki, Torvalds announced a free Unix-like kernel he was writing
+"just as a hobby." Released under an open licence, Linux drew contributors worldwide and grew
+into a full [operating system](/reference/operating-system/) that today powers most servers,
+Android phones, and embedded devices.[^wiki] In 2005 he wrote Git to manage the kernel's own
+development, and it became the dominant tool for tracking source code.[^wiki] He continues to
+coordinate Linux kernel development.
+
+## Why they matter
+
+Linux is the [operating system](/reference/operating-system/) that ties hardware to software
+across the computing world: it schedules the [CPU](/reference/central-processing-unit/),
+manages memory, and drives devices on countless machines. A capture node sitting by an antenna
+— say a small board running a decoder like GopherTrunk — almost certainly runs Linux, and its
+source lives in a Git repository descended from Torvalds' tools.[^wiki]
+
+## Legacy
+
+Linux and Git underpin a large share of the internet and of open-source software, making
+Torvalds one of the most influential figures in modern computing infrastructure.
+
+## Sources
+
+[^wiki]: [Linus Torvalds](https://en.wikipedia.org/wiki/Linus_Torvalds) — Wikipedia, for biography, Linux, and Git.

--- a/docs/reference/load-balancer.md
+++ b/docs/reference/load-balancer.md
@@ -1,0 +1,30 @@
+---
+slug: load-balancer
+title: Load balancer
+entry_type: concept
+category: hw-servers
+description: A load balancer distributes incoming network traffic across multiple servers so that no single machine is overwhelmed, improving capacity, responsiveness, and availability.
+keywords: load balancer, load balancing, traffic distribution, health check, round robin, L4, L7
+infobox:
+  - { label: Type, value: Traffic distributor }
+  - { label: Spreads, value: Requests across servers }
+  - { label: Layers, value: "L4 (transport), L7 (application)" }
+  - { label: Improves, value: Capacity & availability }
+see_also: [reverse-proxy, high-availability, scalability, server, content-delivery-network, kubernetes]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Load_balancing_(computing)
+---
+
+A **load balancer** distributes incoming network traffic across multiple [servers](/reference/server/) so that no single machine is overwhelmed, improving capacity, responsiveness, and availability.[^wiki]
+
+## Overview
+
+A load balancer sits in front of a pool of identical backends and spreads requests among them using rules such as round-robin, least-connections, or hashing on the client. It also runs *health checks*, automatically removing a server that stops responding so users are not routed to a dead machine. Balancers operate at the transport layer (L4, forwarding TCP/UDP) or the application layer (L7, inspecting HTTP to route by path or host). They may be dedicated hardware appliances or software running on commodity servers.
+
+## Where it fits
+
+Load balancing is fundamental to [scalability](/reference/scalability/) — adding servers behind a balancer increases throughput — and to [high availability](/reference/high-availability/), since the pool survives the loss of any one member. It overlaps with a [reverse proxy](/reference/reverse-proxy/), which also fronts backends, and with a [content delivery network](/reference/content-delivery-network/) for global traffic. Orchestrators like [Kubernetes](/reference/kubernetes/) provide built-in balancing across pods.
+
+## Sources
+
+[^wiki]: [Load balancing (computing)](https://en.wikipedia.org/wiki/Load_balancing_(computing)) — Wikipedia, on load balancing techniques.

--- a/docs/reference/logic-gate.md
+++ b/docs/reference/logic-gate.md
@@ -1,0 +1,30 @@
+---
+slug: logic-gate
+title: Logic gate
+entry_type: concept
+category: hw-foundations
+description: A logic gate is a basic building block of digital circuits that computes a Boolean function such as AND, OR, or NOT; combinations of gates implement all digital computation.
+keywords: logic gate, Boolean logic, AND, OR, NOT, NAND, XOR, digital circuit, truth table
+infobox:
+  - { label: Type, value: Digital circuit element }
+  - { label: Computes, value: Boolean functions }
+  - { label: Basic gates, value: "AND, OR, NOT" }
+  - { label: Built from, value: Transistors }
+see_also: [transistor, integrated-circuit, semiconductor, central-processing-unit, bits-and-bytes, von-neumann-architecture]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Logic_gate
+---
+
+A **logic gate** is a basic building block of digital circuits that computes a simple Boolean function — such as AND, OR, or NOT — on one or more binary inputs.[^wiki]
+
+## Overview
+
+Each gate takes inputs that are either 0 or 1 and produces an output defined by a *truth table*: an AND gate outputs 1 only when all inputs are 1, an OR when any is 1, a NOT inverts its input. Physically, gates are built from a handful of [transistors](/reference/transistor/) acting as switches. From these primitives — especially the universal NAND and NOR — you can construct adders, memory cells, and ultimately every part of a processor.
+
+## Where it fits
+
+Logic gates are the bridge from raw [bits](/reference/bits-and-bytes/) to computation: arrange enough of them and you get the arithmetic and control circuits inside a [CPU](/reference/central-processing-unit/), all fabricated together on an [integrated circuit](/reference/integrated-circuit/). The whole [von Neumann](/reference/von-neumann-architecture/) machine — fetch, decode, execute — reduces, at the bottom, to networks of gates switching in step with the clock.
+
+## Sources
+
+[^wiki]: [Logic gate](https://en.wikipedia.org/wiki/Logic_gate) — Wikipedia, on logic gates, Boolean functions, and truth tables.

--- a/docs/reference/magnetic-tape.md
+++ b/docs/reference/magnetic-tape.md
@@ -1,0 +1,32 @@
+---
+slug: magnetic-tape
+title: Magnetic tape
+entry_type: hardware
+category: hw-storage
+description: Magnetic tape stores data sequentially on a long ribbon of magnetic film, offering very low cost per terabyte and long shelf life, making it the workhorse of large-scale archival.
+keywords: magnetic tape, LTO, tape drive, sequential storage, backup, archival, cold storage, data tape
+aka: [tape, LTO]
+infobox:
+  - { label: Type, value: Magnetic sequential storage }
+  - { label: Medium, value: Coated tape ribbon }
+  - { label: Common format, value: LTO (Linear Tape-Open) }
+  - { label: Access, value: Sequential (no random seek) }
+  - { label: Strength, value: Cheapest per terabyte, durable }
+see_also: [hard-disk-drive, optical-disc, data-storage, memory-hierarchy, solid-state-drive, file-system]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Magnetic_tape_data_storage
+---
+
+**Magnetic tape** stores data on a long, thin ribbon of magnetic film wound on reels, written and read sequentially by a tape drive.[^wiki]
+
+## Overview
+
+A drive pulls the tape past a head that magnetises regions to record bits, much like a [hard disk drive](/reference/hard-disk-drive/) but on flexible media that must be streamed end to end rather than seeked. The dominant modern format is LTO (Linear Tape-Open), whose cartridges now hold many terabytes each and improve with every generation. Because there are no fast random-access mechanics, the medium itself is extremely cheap, and a tape sitting on a shelf consumes no power and keeps data for decades.
+
+## Where it fits
+
+Tape lives at the coldest, deepest end of the [memory hierarchy](/reference/memory-hierarchy/): the slowest access but the lowest cost per terabyte and the longest shelf life, which is exactly what large-scale backup and archival want. Data centres still move petabytes onto LTO for "cold storage." Its sequential nature suits write-once-read-rarely archives — a fitting place to retire years of GopherTrunk IQ captures that you want to keep but rarely touch, while live decoding stays on [SSD](/reference/solid-state-drive/) or disk.
+
+## Sources
+
+[^wiki]: [Magnetic tape data storage](https://en.wikipedia.org/wiki/Magnetic_tape_data_storage) — Wikipedia, on tape storage, LTO, and its role in archival.

--- a/docs/reference/managed-hosting.md
+++ b/docs/reference/managed-hosting.md
@@ -1,0 +1,33 @@
+---
+slug: managed-hosting
+title: Managed hosting
+entry_type: concept
+category: hw-servers
+description: Managed hosting is a service where the provider not only supplies the server but also handles its operating system, updates, security, and monitoring, so the customer manages only their application.
+keywords: managed hosting, fully managed, server administration, patching, monitoring, unmanaged hosting
+aka: [Fully managed hosting]
+infobox:
+  - { label: Type, value: Hosting model }
+  - { label: Provider runs, value: OS, patching, security, monitoring }
+  - { label: You run, value: Your application }
+  - { label: Contrast, value: Unmanaged / self-managed }
+see_also: [web-hosting, dedicated-server, colocation, cloud-computing, software-as-a-service, server]
+related_lessons:
+  - { title: "Web & shared hosting", url: /learn/intro-hardware/web-hosting/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Internet_hosting_service
+---
+
+**Managed hosting** is a service in which the provider supplies the [server](/reference/server/) and also runs it for you — handling the operating system, updates, security, backups, and monitoring — so you manage only your own application.[^wiki]
+
+## Overview
+
+The line between *managed* and *unmanaged* hosting is who keeps the machine healthy. With unmanaged hosting (the typical [dedicated server](/reference/dedicated-server/) or plain [VPS](/reference/virtual-private-server/)), the provider hands you a server and you are responsible for patching the [operating system](/reference/operating-system/), configuring services, and responding to incidents. With managed hosting, the provider does that operational work — often with guaranteed response times — and you pay a premium for it.
+
+## Where it fits
+
+Managed hosting suits teams without dedicated system administrators, or those who would rather spend effort on their product than on server upkeep. It is more hands-off than [colocation](/reference/colocation/) but less abstract than [software as a service](/reference/software-as-a-service/), where even the application is run for you. For a hobbyist running GopherTrunk, managed hosting is rarely needed — the capture node is yours to tend — but it can simplify a back end that stores and serves decoded data.
+
+## Sources
+
+[^wiki]: [Internet hosting service](https://en.wikipedia.org/wiki/Internet_hosting_service) — Wikipedia, on managed versus unmanaged hosting models.

--- a/docs/reference/massimo-banzi.md
+++ b/docs/reference/massimo-banzi.md
@@ -1,0 +1,50 @@
+---
+slug: massimo-banzi
+title: Massimo Banzi
+entry_type: person
+category: hw-people
+description: Massimo Banzi (born 1968) is an Italian engineer and designer who co-founded Arduino, the open-source electronics platform that made microcontroller programming accessible to artists, students, and makers.
+keywords: Massimo Banzi, Arduino, microcontroller, open-source hardware, physical computing, electronics prototyping
+aka: [Massimo Banzi]
+autolink: true
+infobox:
+  - { label: Born, value: "1968" }
+  - { label: Field, value: Interaction design / electronics }
+  - { label: Known for, value: Co-founding Arduino }
+see_also: [arduino, arduino-company, microcontroller, gpio]
+related_lessons:
+  - { title: "Arduino", url: /learn/intro-hardware/arduino/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Massimo_Banzi
+---
+
+**Massimo Banzi** (born 1968) is an Italian engineer, designer, and educator who co-founded
+[Arduino](/reference/arduino/), the open-source platform that made
+[microcontroller](/reference/microcontroller/) programming approachable for people without an
+electronics background.[^wiki]
+
+## Life and work
+
+While teaching interaction design in Italy in the mid-2000s, Banzi and collaborators wanted a
+cheap, simple board their students could use for physical-computing projects. The result was
+[Arduino](/reference/arduino/): an inexpensive microcontroller board paired with a friendly
+programming environment, released as open-source hardware so anyone could copy, modify, or
+build on it.[^wiki] He went on to help lead the [Arduino company](/reference/arduino-company/)
+that grew around the platform and to champion open hardware broadly.[^wiki]
+
+## Why they matter
+
+[Arduino](/reference/arduino/) turned the [microcontroller](/reference/microcontroller/) from a
+specialist's tool into something a beginner could wire to a sensor and program in an afternoon
+over its [GPIO](/reference/gpio/) pins. That accessibility seeded a global maker movement and a
+flood of low-cost connected devices — the same hands-on ethos that surrounds hobbyist SDR and
+embedded radio projects.[^wiki]
+
+## Legacy
+
+The open-source approach Banzi promoted made Arduino a de facto standard for electronics
+education and rapid prototyping, spawning countless compatible boards and shields.
+
+## Sources
+
+[^wiki]: [Massimo Banzi](https://en.wikipedia.org/wiki/Massimo_Banzi) — Wikipedia, for biography and the founding of Arduino.

--- a/docs/reference/memory-hierarchy.md
+++ b/docs/reference/memory-hierarchy.md
@@ -1,0 +1,33 @@
+---
+slug: memory-hierarchy
+title: Memory hierarchy
+entry_type: concept
+category: hw-storage
+description: The memory hierarchy arranges a computer's storage in layers trading speed against capacity and cost, from fast registers and cache down to RAM, flash, disk, and tape.
+keywords: memory hierarchy, cache, RAM, registers, storage tiers, latency, locality, speed vs capacity
+infobox:
+  - { label: Type, value: Storage organisation principle }
+  - { label: Top (fast/small), value: Registers, cache }
+  - { label: Middle, value: RAM, SSD }
+  - { label: Bottom (slow/large), value: HDD, tape }
+  - { label: Trade-off, value: Speed vs capacity vs cost }
+see_also: [cache-memory, random-access-memory, solid-state-drive, hard-disk-drive, volatile-memory, data-storage]
+related_lessons:
+  - { title: "Building blocks", url: /learn/intro-hardware/building-blocks/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Memory_hierarchy
+---
+
+The **memory hierarchy** is the layered arrangement of a computer's storage, ordered so that each level trades speed for capacity and cost against the one below it.[^wiki]
+
+## Overview
+
+At the top sit the [CPU](/reference/central-processing-unit/) registers and [cache memory](/reference/cache-memory/): tiny, blisteringly fast, and expensive per byte. Below them is main memory, [RAM](/reference/random-access-memory/), which is larger but slower. Further down comes persistent storage — a [solid-state drive](/reference/solid-state-drive/), then a [hard disk drive](/reference/hard-disk-drive/), and finally archival [magnetic tape](/reference/magnetic-tape/) — each step larger and cheaper but slower to reach. The hierarchy works because programs exhibit *locality*: they tend to reuse the same data and nearby data, so keeping hot items in the fast upper levels gives most of the speed of fast memory at most of the cost of slow storage.
+
+## Where it fits
+
+The hierarchy is the unifying framework for the whole storage-and-memory category: every device here is really a point on this speed-versus-capacity curve, with the [volatile/non-volatile](/reference/volatile-memory/) split cutting across it. The [operating system](/reference/operating-system/) and hardware constantly shuttle data between levels — caching disk blocks in RAM, paging RAM to disk. GopherTrunk benefits the same way: hot decode state stays in RAM and cache, the working call database lives on fast [SSD](/reference/solid-state-drive/), and bulk captures sink to cheap disk or tape.
+
+## Sources
+
+[^wiki]: [Memory hierarchy](https://en.wikipedia.org/wiki/Memory_hierarchy) — Wikipedia, on the layered organisation of computer storage by speed and cost.

--- a/docs/reference/microcontroller.md
+++ b/docs/reference/microcontroller.md
@@ -1,0 +1,35 @@
+---
+slug: microcontroller
+title: Microcontroller (MCU)
+entry_type: hardware
+category: hw-microcontrollers
+description: A microcontroller is a tiny, low-power computer on a single chip that combines a processor, memory, and I/O to control one device or task without an operating system.
+keywords: microcontroller, MCU, embedded, bare metal, flash memory, single chip computer, low power
+aka: [MCU, microcontroller]
+autolink: true
+infobox:
+  - { label: Type, value: Single-chip computer }
+  - { label: Core, value: 8/16/32-bit, often single-core }
+  - { label: Memory, value: Kilobytes of RAM, on-chip flash }
+  - { label: OS, value: None (bare metal) }
+  - { label: Language, value: C, C++, Rust, MicroPython }
+see_also: [arduino, esp32, gpio, firmware, single-board-computer, internet-of-things]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Microcontroller
+---
+
+**A microcontroller (MCU)** is a tiny, low-power computer on a single chip that combines a processor, memory, and input/output, dedicated to controlling one device or task.[^wiki]
+
+## Overview
+
+Unlike a full computer, a microcontroller has no operating system: your code runs bare metal as the device's [firmware](/reference/firmware/). It boots in milliseconds and can run for years on a small battery, working with only kilobytes of RAM and a modest amount of on-chip flash. That frugality is the point — an MCU does one job reliably and cheaply.
+
+## How it differs from a single-board computer
+
+A [single-board computer](/reference/single-board-computer/) like a Raspberry Pi runs a real OS and behaves like a small PC; a microcontroller does not. MCUs are programmed in [C](/reference/c-language/), [C++](/reference/cpp-language/), and sometimes [Rust](/reference/rust-language/) or MicroPython, then flashed onto the chip. Popular families include [Arduino](/reference/arduino/) boards and the Wi-Fi-equipped [ESP32](/reference/esp32/), and most expose their pins as [GPIO](/reference/gpio/) for wiring up sensors and radios. These are the small radios that populate the airwaves GopherTrunk listens to, even though they are far too small to run GopherTrunk itself.
+
+## Sources
+
+[^wiki]: [Microcontroller](https://en.wikipedia.org/wiki/Microcontroller) — Wikipedia, on the single-chip design and embedded role of MCUs.

--- a/docs/reference/mini-pc.md
+++ b/docs/reference/mini-pc.md
@@ -1,0 +1,33 @@
+---
+slug: mini-pc
+title: Mini PC
+entry_type: hardware
+category: hw-personal-computers
+description: A mini PC is a small-form-factor desktop computer, often the size of a paperback, that uses low-power laptop-class parts to deliver a full PC in a fraction of the space and power of a tower.
+keywords: mini PC, small form factor, NUC, SFF PC, low-power desktop, fanless PC
+aka: [Mini PC, SFF PC, NUC]
+infobox:
+  - { label: Type, value: Small-form-factor PC }
+  - { label: Size, value: Paperback to lunchbox }
+  - { label: Internals, value: Laptop-class CPU/RAM }
+  - { label: Power, value: Low (often 10–65 W) }
+see_also: [personal-computer, desktop-computer, all-in-one-computer, thin-client, single-board-computer]
+related_lessons:
+  - { title: "Desktop computers", url: /learn/intro-hardware/desktop-computers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Nettop
+---
+
+A **mini PC** is a small-form-factor [desktop computer](/reference/desktop-computer/) — often about the size of a paperback book — that packs a full PC into a fraction of the volume and power of a conventional tower.[^wiki]
+
+## Overview
+
+To shrink the box, a mini PC uses low-power laptop-class parts: an efficient [CPU](/reference/central-processing-unit/) with integrated graphics, soldered or compact [RAM](/reference/random-access-memory/), and an M.2 [SSD](/reference/solid-state-drive/). It still runs a full desktop [operating system](/reference/operating-system/) and connects to an external [monitor](/reference/computer-monitor/), [keyboard](/reference/keyboard/), and [mouse](/reference/mouse/). Intel's NUC line popularized the format; many vendors now ship similar units, some fanless and silent.
+
+## Where it fits
+
+A mini PC suits anywhere a tower is too big or loud: media boxes, digital signage, small offices, and always-on home services. It sits between a richer [single-board computer](/reference/single-board-computer/) and a full desktop — more powerful and more standard than a Pi, smaller and quieter than a tower. A small fanless mini PC makes a tidy GopherTrunk node: it can sit by the antenna running a capture daemon around the clock and sip power doing it.
+
+## Sources
+
+[^wiki]: [Nettop](https://en.wikipedia.org/wiki/Nettop) — Wikipedia, on small-form-factor desktop PCs.

--- a/docs/reference/mobile-app-development.md
+++ b/docs/reference/mobile-app-development.md
@@ -1,0 +1,48 @@
+---
+slug: mobile-app-development
+title: Mobile app development
+entry_type: concept
+category: hw-mobile
+description: Mobile app development is building software for phones and tablets through three broad approaches — native, cross-platform, and progressive web apps — each with different trade-offs.
+keywords: mobile app development, native app, cross-platform, PWA, progressive web app, Flutter, React Native, iOS, Android
+aka: [Mobile app development, Mobile development, App development]
+infobox:
+  - { label: Type, value: Software development concept }
+  - { label: Targets, value: Phones, tablets }
+  - { label: Native, value: Swift, Kotlin/Java }
+  - { label: Cross-platform, value: Flutter, React Native }
+  - { label: Web, value: PWA }
+see_also: [smartphone, tablet, swift-language, kotlin-language, java-language, javascript-language]
+related_lessons:
+  - { title: "Developing for mobile", url: /learn/intro-hardware/developing-for-mobile/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Mobile_app_development
+---
+
+**Mobile app development** is building software for
+[smartphones](/reference/smartphone/) and [tablets](/reference/tablet/), and it
+comes in three broad flavors.[^wiki]
+
+## Overview
+
+The first is **native**: code written for one platform alone, with full hardware
+access and the best performance — [Swift](/reference/swift-language/) for iOS,
+[Kotlin](/reference/kotlin-language/) or [Java](/reference/java-language/) for
+Android. The second is **cross-platform**: a shared codebase that runs on both,
+such as Flutter or React Native (the latter built on
+[JavaScript](/reference/javascript-language/)). The third is the **PWA**, or
+progressive web app — a website that behaves like an installed app.
+
+## Trade-offs
+
+The three trade off reach against depth. Native gives the deepest hardware access
+and smoothest performance but doubles the work to cover both platforms.
+Cross-platform writes once and ships everywhere at some cost in polish and
+native-feature access. A PWA is the lightest to build and needs no app store, but
+runs inside the browser's limits. The build work itself happens on a
+[personal computer](/reference/personal-computer/); the phone or tablet is the
+target.
+
+## Sources
+
+[^wiki]: [Mobile app development](https://en.wikipedia.org/wiki/Mobile_app_development) — Wikipedia, on native, cross-platform, and web approaches.

--- a/docs/reference/mobile-operating-system.md
+++ b/docs/reference/mobile-operating-system.md
@@ -1,0 +1,32 @@
+---
+slug: mobile-operating-system
+title: Mobile operating system
+entry_type: concept
+category: hw-mobile
+description: A mobile operating system is the system software that runs phones and tablets, managing the touchscreen, radios, apps, and power on hardware that is battery-powered and always connected.
+keywords: mobile operating system, mobile OS, Android, iOS, smartphone OS, tablet OS, app sandbox, power management
+infobox:
+  - { label: Type, value: Operating system }
+  - { label: Runs on, value: Phones & tablets }
+  - { label: Leading examples, value: Android, iOS }
+  - { label: Key concerns, value: Touch UI, power, security }
+see_also: [android, ios, operating-system, smartphone, tablet, mobile-app-development]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Mobile_operating_system
+---
+
+A **mobile operating system** is the system software that runs a phone or tablet — managing the touchscreen, radios, applications, and battery on hardware that is portable, always connected, and tightly power-constrained.[^wiki]
+
+## Overview
+
+Like any [operating system](/reference/operating-system/), a mobile OS schedules processes, manages memory, and brokers access to hardware. What distinguishes it is the emphasis: a [touchscreen](/reference/touchscreen/)-first interface, aggressive power management to stretch [battery](/reference/battery-technology/) life, and a strict per-app sandbox so untrusted code from an app store cannot reach the rest of the device. Two platforms dominate: [Android](/reference/android/) and [iOS](/reference/ios/). Apps are built with [mobile app development](/reference/mobile-app-development/) tools specific to each.
+
+## Where it fits
+
+The mobile OS is the layer between the [SoC](/reference/system-on-a-chip/) and the apps a user sees. It decides which background work runs, when the cellular and Wi-Fi radios wake, and how quickly the screen sleeps — choices that directly govern how long a charge lasts. Running a full SDR decode pipeline like GopherTrunk on such a device is unusual: the power budget and locked-down background limits favor a small Linux board near the antenna instead.
+
+## Sources
+
+[^wiki]: [Mobile operating system](https://en.wikipedia.org/wiki/Mobile_operating_system) — Wikipedia, on mobile OS design and examples.

--- a/docs/reference/modem.md
+++ b/docs/reference/modem.md
@@ -1,0 +1,31 @@
+---
+slug: modem
+title: Modem
+entry_type: hardware
+category: hw-networking
+description: A modem is a device that modulates and demodulates signals so digital data can travel over a medium not designed for it, such as a phone line, cable, or radio link.
+keywords: modem, modulator demodulator, cable modem, DSL, fiber modem, broadband
+aka: [modulator-demodulator]
+infobox:
+  - { label: Type, value: Networking device }
+  - { label: Job, value: Modulate / demodulate data }
+  - { label: Bridges, value: Carrier medium to digital network }
+  - { label: Kinds, value: Cable, DSL, fiber, cellular }
+see_also: [router, cellular-modem, gateway, fiber-optic, ethernet, network-interface-card]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Modem
+---
+
+A **modem** (modulator–demodulator) is a device that encodes digital data onto a carrier signal for transmission over a medium not built for it, and decodes it again at the far end.[^wiki]
+
+## Overview
+
+The name describes the job: *modulate* outgoing data onto a carrier — a tone on a phone line, an RF channel on a coax cable, light on a [fiber](/reference/fiber-optic/) strand — and *demodulate* the incoming signal back into bits. A modem is what terminates the link from an internet provider and hands clean [Ethernet](/reference/ethernet/) to a [router](/reference/router/). Variants include cable, DSL, fiber (ONT), and [cellular modems](/reference/cellular-modem/) that ride a mobile network. In consumer gear the modem and router are often combined in one box.
+
+## Where it fits
+
+The modem is the boundary between a private network and the provider's carrier medium; downstream of it the [router](/reference/router/) acts as the [gateway](/reference/gateway/) to the local [LAN](/reference/lan-and-wan/). The modulation/demodulation idea is the same one at the heart of an SDR — a GopherTrunk decoder demodulates an RF carrier into symbols, just as a modem recovers bits from a line signal.
+
+## Sources
+
+[^wiki]: [Modem](https://en.wikipedia.org/wiki/Modem) — Wikipedia, on the modulator-demodulator and its variants.

--- a/docs/reference/moores-law.md
+++ b/docs/reference/moores-law.md
@@ -1,0 +1,32 @@
+---
+slug: moores-law
+title: Moore's law
+entry_type: concept
+category: hw-foundations
+description: Moore's law is the observation that the number of transistors on an integrated circuit roughly doubles about every two years, driving decades of exponential gains in computing.
+keywords: Moore's law, transistor density, Gordon Moore, exponential, scaling, integrated circuit, semiconductor
+aka: [Moore's Law]
+autolink: true
+infobox:
+  - { label: Type, value: Empirical observation }
+  - { label: Stated by, value: "Gordon Moore, 1965" }
+  - { label: Claim, value: Transistor count doubles ~2 yrs }
+  - { label: Status, value: Slowing }
+see_also: [transistor, integrated-circuit, semiconductor, central-processing-unit, clock-speed, graphics-processing-unit]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Moore%27s_law
+---
+
+**Moore's law** is the observation, made by Intel co-founder Gordon Moore in 1965, that the number of [transistors](/reference/transistor/) on an [integrated circuit](/reference/integrated-circuit/) roughly doubles about every two years.[^wiki]
+
+## Overview
+
+It is not a law of physics but an empirical trend that held for decades as [semiconductor](/reference/semiconductor/) makers steadily shrank feature sizes, packing ever more switches onto a chip at falling cost per transistor. That exponential scaling is what turned room-sized computers into pocket-sized ones and made each generation of [CPUs](/reference/central-processing-unit/) and [GPUs](/reference/graphics-processing-unit/) dramatically more capable. A related trend, Dennard scaling, once let [clock speeds](/reference/clock-speed/) rise as transistors shrank — but that broke down in the mid-2000s, pushing designers toward multiple cores.
+
+## Where it fits
+
+Moore's law explains why computing got cheap and abundant enough that a hobbyist can run real DSP — like GopherTrunk decoding multiple trunked channels — on a board costing a few tens of dollars. The doubling has slowed as features approach atomic scale, so progress now leans more on parallelism, specialized accelerators, and packaging than on raw shrinking.
+
+## Sources
+
+[^wiki]: [Moore's law](https://en.wikipedia.org/wiki/Moore%27s_law) — Wikipedia, on the transistor-doubling trend and its slowdown.

--- a/docs/reference/motherboard-form-factor.md
+++ b/docs/reference/motherboard-form-factor.md
@@ -1,0 +1,33 @@
+---
+slug: motherboard-form-factor
+title: Motherboard form factor
+entry_type: concept
+category: hw-personal-computers
+description: A motherboard form factor is a standardized specification for a motherboard's size, shape, mounting holes, and connector placement, so boards, cases, and power supplies from different makers fit together.
+keywords: form factor, ATX, Micro-ATX, Mini-ITX, E-ATX, motherboard size, mounting holes, expansion slots
+aka: [Form factor]
+infobox:
+  - { label: Type, value: Hardware standard }
+  - { label: Defines, value: Size, mounts, port layout }
+  - { label: Common, value: ATX, Micro-ATX, Mini-ITX }
+  - { label: Ensures, value: Case / PSU / board fit }
+see_also: [motherboard, computer-case, desktop-computer, power-supply-unit, pci-express]
+related_lessons:
+  - { title: "Desktop computers", url: /learn/intro-hardware/desktop-computers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_form_factor
+---
+
+A **motherboard form factor** is a standardized specification for a [motherboard](/reference/motherboard/)'s physical size, shape, mounting-hole positions, and connector placement, so that boards, cases, and power supplies from different makers fit and work together.[^wiki]
+
+## Overview
+
+By fixing dimensions and the location of mounting holes, the rear I/O panel, expansion slots, and the power connector, a form factor turns PC parts into interchangeable building blocks. The common desktop standards descend from Intel's ATX: full-size **ATX** (~305 × 244 mm) with the most slots and ports, smaller **Micro-ATX** for compact builds, and tiny **Mini-ITX** (170 × 170 mm) for small-form-factor machines. Larger **E-ATX** boards serve high-end [workstations](/reference/workstation/). A given [computer case](/reference/computer-case/) lists which form factors it accepts, and a [power supply unit](/reference/power-supply-unit/) follows matching standards.
+
+## Where it fits
+
+The form factor is the first decision in a desktop build because it caps everything downstream: how many [PCI Express](/reference/pci-express/) and [RAM](/reference/random-access-memory/) slots you get, how much room there is for cooling, and how small the case can be. Bigger boards mean more expansion and easier airflow; smaller ones save space at the cost of slots. Pre-built [all-in-one computers](/reference/all-in-one-computer/) and [mini PCs](/reference/mini-pc/) often use proprietary boards, trading this standardization for compactness.
+
+## Sources
+
+[^wiki]: [Computer form factor](https://en.wikipedia.org/wiki/Computer_form_factor) — Wikipedia, on motherboard form-factor standards.

--- a/docs/reference/motherboard.md
+++ b/docs/reference/motherboard.md
@@ -1,0 +1,31 @@
+---
+slug: motherboard
+title: Motherboard
+entry_type: hardware
+category: hw-foundations
+description: A motherboard is the main printed circuit board of a computer, holding the CPU socket, memory slots, chipset, and expansion buses that connect every component together.
+keywords: motherboard, mainboard, logic board, PCB, CPU socket, chipset, expansion slots, form factor
+aka: [Mainboard, Logic board]
+infobox:
+  - { label: Type, value: Main circuit board }
+  - { label: Holds, value: CPU, RAM, chipset, buses }
+  - { label: Key buses, value: PCIe, USB, SATA }
+  - { label: Form factors, value: ATX, microATX, Mini-ITX }
+see_also: [central-processing-unit, chipset, pci-express, system-bus, power-supply-unit, integrated-circuit]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Motherboard
+---
+
+A **motherboard** (or mainboard) is the main printed circuit board of a computer — the backbone that holds the [CPU](/reference/central-processing-unit/), memory, and [chipset](/reference/chipset/) and wires every other part together.[^wiki]
+
+## Overview
+
+The board provides a socket for the CPU, slots for [RAM](/reference/random-access-memory/), and connectors and [expansion buses](/reference/system-bus/) such as [PCIe](/reference/pci-express/), [USB](/reference/usb/), and SATA. Its [chipset](/reference/chipset/) and traces route signals between the processor, memory, [storage](/reference/data-storage/), and [I/O](/reference/input-output/). Firmware ([BIOS/UEFI](/reference/bios-uefi/)) lives in a chip on the board and brings the system up at power-on. Physical size and mounting follow a *form factor* — common ones are ATX, microATX, and Mini-ITX.
+
+## Where it fits
+
+Everything plugs into the motherboard, so it sets what a machine can hold: how many memory channels, how many PCIe lanes, which CPU generation. Power arrives from the [PSU](/reference/power-supply-unit/) through dedicated connectors. A small-form-factor board — like the one inside a [Raspberry Pi](/reference/raspberry-pi/) acting as a GopherTrunk capture node — folds the chipset and I/O onto a single tiny PCB, but the role is the same: be the board that everything else connects to.
+
+## Sources
+
+[^wiki]: [Motherboard](https://en.wikipedia.org/wiki/Motherboard) — Wikipedia, on the main board of a computer and what it carries.

--- a/docs/reference/mouse.md
+++ b/docs/reference/mouse.md
@@ -1,0 +1,30 @@
+---
+slug: mouse
+title: Mouse
+entry_type: hardware
+category: hw-personal-computers
+description: A mouse is a hand-held pointing device that tracks motion on a surface to move an on-screen cursor, with buttons and a scroll wheel for selecting and navigating.
+keywords: mouse, pointing device, optical mouse, trackball, cursor, scroll wheel, input device
+infobox:
+  - { label: Type, value: Input peripheral }
+  - { label: Sensing, value: Optical / laser }
+  - { label: Controls, value: Buttons, scroll wheel }
+  - { label: Connects via, value: USB, Bluetooth }
+see_also: [peripheral, keyboard, personal-computer, desktop-computer, touchscreen]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_mouse
+---
+
+A **mouse** is a hand-held pointing device that tracks motion across a surface to move a cursor on screen, with buttons and usually a scroll wheel for selecting and navigating.[^wiki]
+
+## Overview
+
+A mouse is an input [peripheral](/reference/peripheral/). Modern mice sense movement optically — an LED or laser plus a tiny camera reads the surface and reports how far the device has moved — replacing the old mechanical rolling ball. The position data drives the on-screen cursor, while button clicks and wheel scrolls send their own events to the [operating system](/reference/operating-system/). Variants include the trackball (a stationary ball you spin), the trackpad built into laptops, and ergonomic or high-precision gaming mice. Connection is over [USB](/reference/usb/) or Bluetooth.
+
+## Where it fits
+
+The mouse and the [keyboard](/reference/keyboard/) are the standard input pair for any [desktop computer](/reference/desktop-computer/); a [touchscreen](/reference/touchscreen/) replaces both on phones and tablets. Choice comes down to grip, sensitivity, and whether you want extra buttons. For panning a wide spectrum waterfall or zooming into a GopherTrunk plot, a smooth scroll wheel and steady tracking are the features that actually matter.
+
+## Sources
+
+[^wiki]: [Computer mouse](https://en.wikipedia.org/wiki/Computer_mouse) — Wikipedia, on the mouse as a pointing input device.

--- a/docs/reference/near-field-communication.md
+++ b/docs/reference/near-field-communication.md
@@ -1,0 +1,32 @@
+---
+slug: near-field-communication
+title: Near-field communication (NFC)
+entry_type: concept
+category: hw-mobile
+description: Near-field communication (NFC) is a short-range wireless technology that lets devices exchange small amounts of data over a few centimeters, used for contactless payments, transit cards, and tap-to-pair.
+keywords: NFC, near-field communication, contactless, tap to pay, RFID, 13.56 MHz, contactless payment, tag, tap to pair
+autolink: true
+aka: [NFC]
+infobox:
+  - { label: Type, value: Short-range wireless }
+  - { label: Range, value: ~4 cm }
+  - { label: Frequency, value: 13.56 MHz }
+  - { label: Uses, value: Payments, transit, pairing }
+see_also: [smartphone, esim, mobile-operating-system, smartwatch, wearable-computer, system-on-a-chip]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Near-field_communication
+---
+
+**Near-field communication (NFC)** is a short-range wireless technology that lets two devices exchange small amounts of data when held within a few centimeters of each other.[^wiki]
+
+## Overview
+
+NFC operates at 13.56 MHz and grew out of [RFID](/reference/radio-wave/). Its very short range is a feature: a tap is deliberate and hard to eavesdrop on. A device can act as a reader (scanning a tag or card), a tag (presenting credentials), or in peer-to-peer mode. An NFC controller in the [SoC](/reference/system-on-a-chip/), wired to a small loop antenna, can even power a passive tag through its field, so unpowered stickers and cards work. The [mobile OS](/reference/mobile-operating-system/) exposes it to apps for payments and pairing.
+
+## Where it fits
+
+NFC is the technology behind tap-to-pay on a [smartphone](/reference/smartphone/) or [smartwatch](/reference/smartwatch/), transit cards, and instant Bluetooth pairing. It complements an [eSIM](/reference/esim/) and the longer-range radios in a device: where the cellular and Wi-Fi radios reach across networks, NFC handles the intimate, intentional "touch here" interactions of everyday mobile use.
+
+## Sources
+
+[^wiki]: [Near-field communication](https://en.wikipedia.org/wiki/Near-field_communication) — Wikipedia, on NFC technology and uses.

--- a/docs/reference/network-attached-storage.md
+++ b/docs/reference/network-attached-storage.md
@@ -1,0 +1,33 @@
+---
+slug: network-attached-storage
+title: Network-attached storage (NAS)
+entry_type: hardware
+category: hw-servers
+description: Network-attached storage (NAS) is a dedicated file-storage device that connects to a network and lets multiple clients read and write shared files over standard protocols.
+keywords: NAS, network-attached storage, file server, SMB, NFS, shared storage, RAID
+aka: [NAS]
+infobox:
+  - { label: Type, value: Networked file storage }
+  - { label: Serves, value: Files to many clients }
+  - { label: Protocols, value: SMB, NFS, AFP }
+  - { label: Often uses, value: RAID arrays }
+see_also: [data-storage, raid, server, home-server, hard-disk-drive, data-center]
+related_lessons:
+  - { title: "Home servers", url: /learn/intro-hardware/home-servers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Network-attached_storage
+---
+
+**Network-attached storage** (**NAS**) is a dedicated file-storage device that connects to a network and lets multiple clients read and write shared files over standard protocols.[^wiki]
+
+## Overview
+
+A NAS is a small, specialized [server](/reference/server/) whose job is storage: a handful of drive bays, a modest CPU, and an operating system tuned for serving files over protocols such as SMB and NFS. Drives are usually combined into a [RAID](/reference/raid/) array for capacity and redundancy, so a single disk failure does not lose data. This contrasts with *storage-area network* (SAN) hardware, which serves raw block devices rather than files. Consumer NAS boxes from vendors like Synology and QNAP have made the form factor common in homes and small offices.
+
+## Where it fits
+
+A NAS is the natural shared-storage tier behind a [home server](/reference/home-server/) or in a [data center](/reference/data-center/) rack, built on ordinary [hard disk drives](/reference/hard-disk-drive/). It is a good home for GopherTrunk's bulk output — days of decoded calls and recordings can sit on a redundant NAS volume rather than the capture node's local disk, keeping the node lean.
+
+## Sources
+
+[^wiki]: [Network-attached storage](https://en.wikipedia.org/wiki/Network-attached_storage) — Wikipedia, on NAS devices and protocols.

--- a/docs/reference/network-interface-card.md
+++ b/docs/reference/network-interface-card.md
@@ -1,0 +1,31 @@
+---
+slug: network-interface-card
+title: Network interface card (NIC)
+entry_type: hardware
+category: hw-networking
+description: A network interface card is the hardware that connects a computer to a network, converting the machine's data into signals on the wire or air and carrying its hardware (MAC) address.
+keywords: network interface card, NIC, network adapter, Ethernet card, MAC address, wireless adapter
+aka: [NIC, network adapter, network card]
+infobox:
+  - { label: Type, value: Network adapter }
+  - { label: Connects, value: Computer to network }
+  - { label: Identifies, value: By MAC address }
+  - { label: Forms, value: Wired (Ethernet) or wireless }
+see_also: [ethernet, wi-fi, network-switch, router, ip-address, motherboard]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Network_interface_controller
+---
+
+A **network interface card** (**NIC**, or network adapter) is the hardware that connects a computer to a network, turning the machine's data into electrical, optical, or radio signals and back again.[^wiki]
+
+## Overview
+
+A NIC handles the lowest layers of networking: framing data into packets, putting them on the medium, and pulling incoming frames off it. Each NIC carries a globally unique **MAC address** burned in at manufacture, which identifies it on the local link. Adapters come as wired [Ethernet](/reference/ethernet/) ports, [Wi-Fi](/reference/wi-fi/) radios, or fiber interfaces, and may be a discrete card in a [PCI Express](/reference/pci-express/) slot, a [USB](/reference/usb/) dongle, or — most commonly today — circuitry integrated onto the [motherboard](/reference/motherboard/) or [system-on-a-chip](/reference/system-on-a-chip/).
+
+## Where it fits
+
+The NIC is where a host meets the rest of the network; an [IP address](/reference/ip-address/) is assigned to it, and a [switch](/reference/network-switch/) or [router](/reference/router/) sees it by its MAC address. In a GopherTrunk deployment a small capture node — say a [Raspberry Pi](/reference/raspberry-pi/) by the antenna — uses its built-in NIC (wired or Wi-Fi) to stream decoded calls back to a [server](/reference/server/) for storage.
+
+## Sources
+
+[^wiki]: [Network interface controller](https://en.wikipedia.org/wiki/Network_interface_controller) — Wikipedia, on the adapter that connects a computer to a network.

--- a/docs/reference/network-switch.md
+++ b/docs/reference/network-switch.md
@@ -1,0 +1,31 @@
+---
+slug: network-switch
+title: Network switch
+entry_type: hardware
+category: hw-networking
+description: A network switch is a device that connects machines within a single local network, forwarding each Ethernet frame only to the port leading to its destination.
+keywords: network switch, Ethernet switch, switched network, MAC address table, managed switch, ports
+aka: [Ethernet switch, switch]
+infobox:
+  - { label: Type, value: Networking device }
+  - { label: Operates at, value: Link layer (Ethernet) }
+  - { label: Job, value: Forward frames within a LAN }
+  - { label: Forwards by, value: MAC address }
+see_also: [router, ethernet, network-interface-card, power-over-ethernet, lan-and-wan, gateway]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Network_switch
+---
+
+A **network switch** is a device that connects multiple machines on the same [local network](/reference/lan-and-wan/), forwarding each [Ethernet](/reference/ethernet/) frame only out the port that leads to its destination.[^wiki]
+
+## Overview
+
+A switch learns which MAC address lives on which port and builds a forwarding table, so traffic between two hosts does not flood every other port — this is what makes a modern wired LAN fast and quiet compared with the old shared hubs. Switches range from cheap unmanaged boxes with a handful of ports to managed units offering VLANs, monitoring, and [Power over Ethernet](/reference/power-over-ethernet/). A switch works within one network; moving traffic *between* networks is the job of a [router](/reference/router/).
+
+## Where it fits
+
+The switch is the wiring hub of a wired LAN, where each device's [NIC](/reference/network-interface-card/) plugs in. For a GopherTrunk site with several wired nodes — capture boxes, a storage [server](/reference/server/), a workstation — a small switch ties them together, and a PoE switch can even power a [Raspberry Pi](/reference/raspberry-pi/) node over the same cable.
+
+## Sources
+
+[^wiki]: [Network switch](https://en.wikipedia.org/wiki/Network_switch) — Wikipedia, on the device that forwards frames within a local network.

--- a/docs/reference/neural-processing-unit.md
+++ b/docs/reference/neural-processing-unit.md
@@ -1,0 +1,33 @@
+---
+slug: neural-processing-unit
+title: Neural processing unit (NPU)
+entry_type: hardware
+category: hw-accelerators
+description: A neural processing unit (NPU) is an on-device accelerator for machine-learning inference, integrated into phones, laptops, and edge devices to run neural networks efficiently at low power.
+keywords: NPU, neural processing unit, AI accelerator, on-device AI, edge inference, machine learning chip, SoC
+aka: [NPU]
+autolink: true
+infobox:
+  - { label: Type, value: AI accelerator (on-device) }
+  - { label: Found in, value: Phones, laptops, edge SoCs }
+  - { label: Job, value: Neural-network inference }
+  - { label: Optimized for, value: Low-power, low-latency AI }
+  - { label: Measured in, value: TOPS (tera-ops/sec) }
+see_also: [ai-accelerator, tensor-processing-unit, system-on-a-chip, edge-ai, graphics-processing-unit, hardware-acceleration]
+cite_urls:
+  - https://en.wikipedia.org/wiki/AI_accelerator
+---
+
+A **neural processing unit** (**NPU**) is an on-device accelerator built to run neural-network inference efficiently — typically integrated into a phone, laptop, or edge device's main chip so AI features work without the cloud.[^wiki]
+
+## Overview
+
+An NPU is a class of [AI accelerator](/reference/ai-accelerator/) optimized for *inference at the edge*: running an already-trained model with low latency and minimal power, rather than the large-scale training that data-center [TPUs](/reference/tensor-processing-unit/) and GPUs handle. NPUs are usually one block inside a larger [system-on-a-chip](/reference/system-on-a-chip/), sitting alongside the CPU and GPU and handling tasks such as camera processing, voice recognition, and background-blur. Their headline spec is TOPS (trillions of operations per second) at a given power budget.
+
+## Where it fits
+
+The NPU is what makes [edge AI](/reference/edge-ai/) practical: instead of streaming data to a server, a device runs the model locally. For a distributed scanner like GopherTrunk, an SBC-class NPU could in principle do on-the-edge classification of decoded audio or signals near the antenna, keeping bandwidth and latency low — though GopherTrunk's core DSP is conventional [hardware acceleration](/reference/hardware-acceleration/) territory, not neural-network work.
+
+## Sources
+
+[^wiki]: [AI accelerator](https://en.wikipedia.org/wiki/AI_accelerator) — Wikipedia, on NPUs and related on-device machine-learning hardware.

--- a/docs/reference/nvidia-jetson.md
+++ b/docs/reference/nvidia-jetson.md
@@ -1,0 +1,35 @@
+---
+slug: nvidia-jetson
+title: NVIDIA Jetson
+entry_type: hardware
+category: hw-sbc
+description: NVIDIA Jetson is a family of single-board computers with a powerful onboard GPU, aimed at on-device AI and computer vision such as edge inference and robotics.
+keywords: NVIDIA Jetson, Jetson Nano, Jetson Orin, edge AI, GPU SBC, computer vision, edge inference, robotics
+autolink: true
+infobox:
+  - { label: Type, value: Single-board computer (GPU) }
+  - { label: CPU, value: ARM + NVIDIA GPU }
+  - { label: RAM, value: ~4 GB – 64 GB }
+  - { label: Runs, value: Linux (JetPack) }
+  - { label: Typical price, value: ~$100 – $2000+ }
+see_also: [single-board-computer, raspberry-pi, beaglebone, gpio, central-processing-unit, cloud-computing]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+  - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Nvidia_Jetson
+---
+
+**NVIDIA Jetson** is a family of [single-board computers](/reference/single-board-computer/) with a powerful onboard GPU, aimed at on-device AI and computer vision.[^wiki]
+
+## Overview
+
+Where a general-purpose board leans on its [CPU](/reference/central-processing-unit/), a Jetson pairs an ARM CPU with an NVIDIA GPU so that machine-learning inference can run locally — useful for robotics, cameras, and other edge devices that cannot rely on the cloud. Jetsons run Linux (NVIDIA's JetPack distribution).
+
+## Where it fits
+
+A Jetson is more expensive and more power-hungry than a [Raspberry Pi](/reference/raspberry-pi/), so it is the SBC you reach for specifically when you need GPU compute at the edge rather than a general-purpose board. For lighter, always-on roles a Pi is usually the better fit.
+
+## Sources
+
+[^wiki]: [Nvidia Jetson](https://en.wikipedia.org/wiki/Nvidia_Jetson) — Wikipedia, on the Jetson family and its edge-AI focus.

--- a/docs/reference/nvidia.md
+++ b/docs/reference/nvidia.md
@@ -1,0 +1,47 @@
+---
+slug: nvidia
+title: NVIDIA
+entry_type: organization
+category: hw-organizations
+description: NVIDIA is an American company that designs GPUs and the CUDA platform, and is the leading supplier of accelerators for graphics, AI, and high-performance computing.
+keywords: NVIDIA, GPU, CUDA, Jetson, GeForce, AI accelerator, Jensen Huang
+aka: [NVIDIA Corporation]
+autolink: true
+infobox:
+  - { label: Type, value: Public semiconductor company }
+  - { label: Founded, value: "1993" }
+  - { label: HQ, value: Santa Clara, California, USA }
+  - { label: Makes, value: GPUs, AI accelerators, SoCs }
+see_also: [graphics-processing-unit, cuda, nvidia-jetson, jensen-huang]
+cite_urls:
+  - https://www.nvidia.com/
+  - https://en.wikipedia.org/wiki/Nvidia
+---
+
+**NVIDIA** is an American company founded in 1993 that designs
+[GPUs](/reference/graphics-processing-unit/) and the
+[CUDA](/reference/cuda/) software platform for general-purpose GPU computing.[^wiki]
+
+## Overview
+
+NVIDIA was co-founded and is led by [Jensen Huang](/reference/jensen-huang/). It popularised
+the term "GPU" with its GeForce line and later turned the GPU into a general parallel
+processor by releasing CUDA in 2007. That move made NVIDIA hardware the standard platform
+for deep learning, and the company is now a leading supplier of AI and high-performance
+computing accelerators.[^home]
+
+Beyond add-in cards, NVIDIA designs Tegra systems-on-chip and the
+[Jetson](/reference/nvidia-jetson/) line of embedded AI modules, bringing GPU-accelerated
+computing to robotics, cameras, and edge devices.
+
+## Why it matters
+
+GPUs excel at the massively parallel arithmetic that DSP and machine learning both demand.
+An NVIDIA card can accelerate heavy SDR signal processing or run on-device classification,
+and a Jetson module can do GPU-accelerated work at the edge — for example, near an antenna
+where sending raw IQ back to a server would be impractical.
+
+## Sources
+
+[^home]: [NVIDIA](https://www.nvidia.com/) — the company's official site, for products and CUDA.
+[^wiki]: [Nvidia](https://en.wikipedia.org/wiki/Nvidia) — Wikipedia, for the company's history and significance.

--- a/docs/reference/nvme.md
+++ b/docs/reference/nvme.md
@@ -1,0 +1,33 @@
+---
+slug: nvme
+title: NVMe
+entry_type: concept
+category: hw-storage
+description: NVMe is a high-speed protocol for accessing solid-state storage directly over a PCI Express link, replacing older disk interfaces designed for slow mechanical drives.
+keywords: NVMe, Non-Volatile Memory Express, PCIe storage, M.2, NVMe SSD, queue depth, storage protocol
+aka: [Non-Volatile Memory Express]
+autolink: true
+infobox:
+  - { label: Type, value: Storage interface protocol }
+  - { label: Runs over, value: PCI Express }
+  - { label: Replaces, value: AHCI / SATA for SSDs }
+  - { label: Form factors, value: M.2, U.2, add-in card }
+  - { label: Strength, value: Low latency, deep parallelism }
+see_also: [solid-state-drive, flash-memory, pci-express, hard-disk-drive, data-storage, memory-hierarchy]
+cite_urls:
+  - https://en.wikipedia.org/wiki/NVM_Express
+---
+
+**NVMe (Non-Volatile Memory Express)** is a protocol for talking to fast solid-state storage directly over a [PCI Express](/reference/pci-express/) link, designed from the start for flash rather than spinning disks.[^wiki]
+
+## Overview
+
+Older interfaces such as SATA used the AHCI command set, which assumed the slow seek times of a [hard disk drive](/reference/hard-disk-drive/) and offered a single shallow command queue. NVMe instead exposes many deep queues that a [flash](/reference/flash-memory/)-based [SSD](/reference/solid-state-drive/) can service in parallel, with far lower per-command overhead. Drives commonly appear as an M.2 stick plugged straight into the board's PCIe lanes, so the [CPU](/reference/central-processing-unit/) reaches the flash without a legacy disk controller in the path.
+
+## What it's for
+
+NVMe exists to stop the interface from being the bottleneck once the medium is flash. A SATA SSD tops out around 550 MB/s; an NVMe drive on a few PCIe lanes runs several times that, with much lower latency under load. For a GopherTrunk node decoding many talkgroups at once, an NVMe SSD ensures that writing decoded frames and IQ snapshots never stalls the pipeline — though for a simple capture node a plain SD card or SATA SSD is usually plenty.
+
+## Sources
+
+[^wiki]: [NVM Express](https://en.wikipedia.org/wiki/NVM_Express) — Wikipedia, on the NVMe storage protocol and its advantages over AHCI/SATA.

--- a/docs/reference/odroid.md
+++ b/docs/reference/odroid.md
@@ -1,0 +1,34 @@
+---
+slug: odroid
+title: ODROID
+entry_type: hardware
+category: hw-sbc
+description: ODROID is a line of single-board computers from Hardkernel of South Korea, known for higher performance than the Raspberry Pi and unusual models such as big.LITTLE and x86 boards.
+keywords: ODROID, Hardkernel, ODROID-N2, ODROID-XU4, Amlogic, big.LITTLE, high-performance SBC, Raspberry Pi alternative
+infobox:
+  - { label: Type, value: Single-board computer }
+  - { label: Maker, value: Hardkernel (South Korea) }
+  - { label: CPU, value: ARM (Amlogic) or x86 }
+  - { label: Runs, value: Linux / Android }
+  - { label: Known for, value: Performance per board }
+see_also: [raspberry-pi, single-board-computer, rock-pi, orange-pi, banana-pi, gpio]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+  - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/ODROID
+---
+
+**ODROID** is a line of [single-board computers](/reference/single-board-computer/) from Hardkernel of South Korea, known for offering more performance than the [Raspberry Pi](/reference/raspberry-pi/) and for some unusual designs.[^wiki]
+
+## Overview
+
+ODROID boards mostly use Amlogic ARM chips, and over the years the line has included big.LITTLE designs (the ODROID-XU4), strong general-purpose boards (the ODROID-N2+), and even x86 models. Most run Linux or Android and expose [GPIO](/reference/gpio/) headers, though pinouts and accessories differ from the Pi's, so cases and add-ons are less universally compatible.
+
+## Where it fits
+
+ODROID is the alternative you reach for when a [Raspberry Pi](/reference/raspberry-pi/) is not fast enough but a [Jetson](/reference/nvidia-jetson/) is overkill — more CPU and memory bandwidth without a price jump into GPU territory. It competes with [Rock Pi](/reference/rock-pi/) and [Orange Pi](/reference/orange-pi/). For a GopherTrunk node decoding several busy trunked systems at once, an ODROID's extra cores can keep the demodulators fed where a smaller board would fall behind.
+
+## Sources
+
+[^wiki]: [ODROID](https://en.wikipedia.org/wiki/ODROID) — Wikipedia, on Hardkernel's ODROID single-board computers.

--- a/docs/reference/operating-system.md
+++ b/docs/reference/operating-system.md
@@ -1,0 +1,30 @@
+---
+slug: operating-system
+title: Operating system
+entry_type: concept
+category: hw-foundations
+description: An operating system is the software that manages a device's hardware and resources and gives other programs a consistent way to run.
+keywords: operating system, OS, Linux, Windows, macOS, Android, iOS, bare metal, kernel
+aka: [operating system, OS]
+infobox:
+  - { label: Type, value: System software }
+  - { label: Manages, value: Hardware and resources }
+  - { label: Examples, value: Linux, Windows, macOS, Android, iOS }
+  - { label: Small devices, value: Often none (bare metal) }
+see_also: [computer-hardware, firmware, microcontroller, single-board-computer, input-output]
+related_lessons:
+  - { title: "The building blocks", url: /learn/intro-hardware/building-blocks/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Operating_system
+---
+
+**An operating system (OS)** is the software that manages a device's hardware and resources and gives other programs a consistent, shared way to run.[^wiki]
+
+## Overview
+The OS sits between [computer hardware](/reference/computer-hardware/) and the applications on top of it. It decides which program gets the [CPU](/reference/central-processing-unit/) and how much memory each one holds, handles [input/output](/reference/input-output/), and presents a uniform interface so an app need not know the exact details of the chips underneath. Common examples are Linux, Windows, and macOS on larger machines, and Android and iOS on phones.
+
+## Where it fits
+Not every device has an OS. A [microcontroller](/reference/microcontroller/) often runs **bare metal** — a single program written straight to the chip as [firmware](/reference/firmware/), with no operating system in between. The larger and more general-purpose a device is, the more it leans on an OS to juggle many programs at once. (This entry is the hardware-tier view; the software-development guide covers operating systems from the programming side.)
+
+## Sources
+[^wiki]: [Operating system](https://en.wikipedia.org/wiki/Operating_system) — Wikipedia, on OS resource management and examples.

--- a/docs/reference/optical-disc.md
+++ b/docs/reference/optical-disc.md
@@ -1,0 +1,32 @@
+---
+slug: optical-disc
+title: Optical disc
+entry_type: hardware
+category: hw-storage
+description: An optical disc stores data as pits read by a laser, in formats such as CD, DVD, and Blu-ray, once dominant for software and media distribution and still useful for archival.
+keywords: optical disc, CD, DVD, Blu-ray, laser, pits and lands, optical storage, archival
+aka: [CD, DVD, Blu-ray]
+infobox:
+  - { label: Type, value: Optical non-volatile storage }
+  - { label: Read by, value: Focused laser }
+  - { label: Formats, value: CD, DVD, Blu-ray }
+  - { label: Capacity, value: ~700 MB – 100+ GB }
+  - { label: Status, value: Niche / archival }
+see_also: [magnetic-tape, hard-disk-drive, data-storage, solid-state-drive, memory-hierarchy, file-system]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Optical_disc
+---
+
+An **optical disc** stores data as microscopic pits and flat lands on a reflective surface, read by a focused laser.[^wiki]
+
+## Overview
+
+A laser shines on the spinning disc and a photodetector senses how the reflected light changes between pits and lands, recovering the bit stream. Successive generations shortened the laser's wavelength to pack data more tightly: the infrared CD (~700 MB), the red-laser DVD (4.7 GB and up), and the blue-violet Blu-ray (25 GB per layer and beyond). Discs come as read-only pressed media, write-once recordable, and rewritable types. Data is laid out under standard file systems so any drive can read it.
+
+## Where it fits
+
+Optical discs were the main way software, music, and films were distributed before broadband and [flash](/reference/flash-memory/) storage took over, and they remain useful for cheap, long-lived archival because a written disc needs no power and resists data rot if stored well. In the [memory hierarchy](/reference/memory-hierarchy/) they sit alongside [magnetic tape](/reference/magnetic-tape/) at the slow, archival end — fine for keeping a frozen snapshot of GopherTrunk logs offline, but far too slow for live capture, where an [SSD](/reference/solid-state-drive/) or [HDD](/reference/hard-disk-drive/) is required.
+
+## Sources
+
+[^wiki]: [Optical disc](https://en.wikipedia.org/wiki/Optical_disc) — Wikipedia, on CD/DVD/Blu-ray optical storage and how lasers read pits and lands.

--- a/docs/reference/orange-pi.md
+++ b/docs/reference/orange-pi.md
@@ -1,0 +1,33 @@
+---
+slug: orange-pi
+title: Orange Pi
+entry_type: hardware
+category: hw-sbc
+description: Orange Pi is a family of low-cost single-board computers from China that mimic the Raspberry Pi form factor, often offering more cores or ports per dollar with less mature software support.
+keywords: Orange Pi, Allwinner, Rockchip, Raspberry Pi alternative, low-cost SBC, ARM single-board computer
+infobox:
+  - { label: Type, value: Single-board computer }
+  - { label: Maker, value: Shenzhen Xunlong (China) }
+  - { label: CPU, value: ARM (Allwinner / Rockchip) }
+  - { label: Runs, value: Linux / Android }
+  - { label: Typical price, value: ~$15 – $90 }
+see_also: [raspberry-pi, single-board-computer, banana-pi, rock-pi, libre-computer, gpio]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Orange_Pi
+---
+
+**Orange Pi** is a family of low-cost [single-board computers](/reference/single-board-computer/) made in China that copy the [Raspberry Pi](/reference/raspberry-pi/) form factor while often packing more cores or ports per dollar.[^wiki]
+
+## Overview
+
+Orange Pi boards are built around Allwinner and Rockchip ARM chips and run Linux or Android. Many keep a Pi-style layout and a compatible 40-pin [GPIO](/reference/gpio/) header, so existing add-ons and cases often fit. The catch is software: drivers and community support are usually less mature than the Raspberry Pi's, so the same hardware can be more work to get fully running.
+
+## Where it fits
+
+Orange Pi sits alongside [Banana Pi](/reference/banana-pi/), [Rock Pi](/reference/rock-pi/), and [Libre Computer](/reference/libre-computer/) as a Raspberry Pi alternative chosen on price or specs. For a GopherTrunk capture node where you control the OS image and just need a cheap Linux box near the antenna, an Orange Pi can be a good value — provided you accept the extra setup time over a Pi.
+
+## Sources
+
+[^wiki]: [Orange Pi](https://en.wikipedia.org/wiki/Orange_Pi) — Wikipedia, on the Orange Pi line of single-board computers.

--- a/docs/reference/pci-express.md
+++ b/docs/reference/pci-express.md
@@ -1,0 +1,31 @@
+---
+slug: pci-express
+title: PCI Express (PCIe)
+entry_type: hardware
+category: hw-foundations
+description: PCI Express is the high-speed serial expansion standard that connects GPUs, SSDs, and other add-in cards to a computer over scalable point-to-point lanes.
+keywords: PCI Express, PCIe, expansion slot, lanes, serial bus, add-in card, NVMe, x16
+aka: [PCIe, PCI-E]
+infobox:
+  - { label: Type, value: Serial expansion bus }
+  - { label: Topology, value: Point-to-point lanes }
+  - { label: Widths, value: x1, x4, x8, x16 }
+  - { label: Connects, value: GPUs, SSDs, NICs }
+see_also: [system-bus, motherboard, graphics-processing-unit, usb, chipset, data-storage]
+cite_urls:
+  - https://en.wikipedia.org/wiki/PCI_Express
+---
+
+**PCI Express** (**PCIe**) is the high-speed serial expansion standard that connects add-in cards — graphics, storage, networking — to a computer's [chipset](/reference/chipset/) and CPU.[^wiki]
+
+## Overview
+
+PCIe replaced older shared parallel buses with scalable *point-to-point* links built from one or more *lanes*, each a pair of differential wires in each direction. A slot is described by its lane count — x1, x4, x8, x16 — and each new generation roughly doubles per-lane bandwidth. Unlike a classic [system bus](/reference/system-bus/), devices do not share one set of wires; each gets a dedicated link to a switch, so adding cards does not slow the others.
+
+## What it's for
+
+A [GPU](/reference/graphics-processing-unit/) typically takes a x16 slot, while NVMe [SSDs](/reference/data-storage/), network cards, and capture cards use narrower links. The slots and lanes live on the [motherboard](/reference/motherboard/), routed through the chipset. In a high-throughput SDR rig, a PCIe slot is where you would add a fast capture card or an accelerator to feed wideband samples into the decode pipeline without starving the bus.
+
+## Sources
+
+[^wiki]: [PCI Express](https://en.wikipedia.org/wiki/PCI_Express) — Wikipedia, on the PCIe serial expansion standard, lanes, and generations.

--- a/docs/reference/peripheral.md
+++ b/docs/reference/peripheral.md
@@ -1,0 +1,30 @@
+---
+slug: peripheral
+title: Peripheral
+entry_type: concept
+category: hw-personal-computers
+description: A peripheral is any device connected to a computer that extends its capabilities — input, output, or storage — sitting outside the core CPU and memory and communicating over a bus such as USB.
+keywords: peripheral, input device, output device, I/O device, USB device, external device
+infobox:
+  - { label: Type, value: Connected device class }
+  - { label: Categories, value: Input, output, storage }
+  - { label: Examples, value: Keyboard, mouse, monitor, printer }
+  - { label: Connects via, value: USB, Bluetooth, PCIe, … }
+see_also: [input-output, keyboard, mouse, computer-monitor, printer, usb]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Peripheral
+---
+
+A **peripheral** is any device connected to a computer that extends what it can do, sitting outside the core [CPU](/reference/central-processing-unit/) and memory and communicating with them over a bus.[^wiki]
+
+## Overview
+
+Peripherals are how a computer talks to the world, and they fall into three rough groups. *Input* peripherals feed data in — the [keyboard](/reference/keyboard/), [mouse](/reference/mouse/), [webcam](/reference/webcam/), and scanners. *Output* peripherals send results out — the [monitor](/reference/computer-monitor/), [printer](/reference/printer/), and speakers. *Storage* peripherals hold data, like external drives. All of them attach to the machine through an [input/output](/reference/input-output/) interface such as [USB](/reference/usb/), Bluetooth, or an expansion slot, and rely on driver software so the [operating system](/reference/operating-system/) can use them.
+
+## Where it fits
+
+The term draws the line between the computer proper and everything bolted onto it: a part inside the case on the core bus is a component, while a device hanging off an external port is a peripheral. The boundary is fuzzy — an internal drive and an external one differ mainly in where they plug in. For a software-defined radio, the [RTL-SDR](/reference/rtl-sdr/) dongle is just another USB peripheral: the computer treats the radio front end as an input device streaming [IQ data](/reference/iq-data/).
+
+## Sources
+
+[^wiki]: [Peripheral](https://en.wikipedia.org/wiki/Peripheral) — Wikipedia, on peripherals as devices that extend a computer.

--- a/docs/reference/personal-computer.md
+++ b/docs/reference/personal-computer.md
@@ -1,0 +1,46 @@
+---
+slug: personal-computer
+title: Personal computer
+entry_type: hardware
+category: hw-personal-computers
+description: A personal computer is a general-purpose computer sized and priced for a single user, built from a CPU, RAM, storage, and I/O and running a full operating system.
+keywords: personal computer, PC, development machine, desktop, laptop, general-purpose computer
+aka: [Personal computer, PC]
+infobox:
+  - { label: Type, value: General-purpose computer }
+  - { label: Users, value: One at a time }
+  - { label: Main forms, value: Desktop, laptop }
+  - { label: Building blocks, value: CPU, RAM, storage, I/O }
+  - { label: Typical role, value: Development machine }
+see_also: [desktop-computer, laptop, central-processing-unit, random-access-memory, operating-system, computer-hardware]
+related_lessons:
+  - { title: "Choosing a development machine", url: /learn/intro-hardware/choosing-a-dev-machine/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Personal_computer
+---
+
+**A personal computer** is a general-purpose computer sized and priced for one
+user, in two main forms — the [desktop](/reference/desktop-computer/) and the
+[laptop](/reference/laptop/).[^wiki]
+
+## Overview
+
+Whatever the form factor, a personal computer is built from the same four
+[building blocks](/reference/computer-hardware/): a
+[CPU](/reference/central-processing-unit/), [RAM](/reference/random-access-memory/),
+[storage](/reference/data-storage/), and [input/output](/reference/input-output/).
+What sets it apart from smaller devices is headroom: a full
+[operating system](/reference/operating-system/) and gigabytes of memory, enough
+to run essentially the whole programming-language landscape without compromise.
+
+## Where it fits
+
+The personal computer is the machine most developers write and test code on — the
+"development machine." Because it has the OS, memory, and storage to host
+compilers, editors, and full toolchains, SDR software and decoders like
+GopherTrunk run comfortably on one. This entry is the umbrella for the
+desktop-vs-laptop category; the two sub-entries cover the trade-offs.
+
+## Sources
+
+[^wiki]: [Personal computer](https://en.wikipedia.org/wiki/Personal_computer) — Wikipedia, on the general-purpose single-user computer and its forms.

--- a/docs/reference/pic-microcontroller.md
+++ b/docs/reference/pic-microcontroller.md
@@ -1,0 +1,35 @@
+---
+slug: pic-microcontroller
+title: PIC microcontroller
+entry_type: hardware
+category: hw-microcontrollers
+description: PIC is a long-running family of low-cost microcontrollers from Microchip Technology, spanning 8-, 16-, and 32-bit cores and prized for simplicity, ruggedness, and very long supply lifetimes.
+keywords: PIC, PIC microcontroller, Microchip, PIC16, PIC18, PICkit, MPLAB, 8-bit MCU
+aka: [PIC]
+infobox:
+  - { label: Type, value: Microcontroller family }
+  - { label: Cores, value: 8/16/32-bit }
+  - { label: Vendor, value: Microchip Technology }
+  - { label: Tooling, value: MPLAB X, PICkit programmer }
+  - { label: Language, value: C, assembly }
+see_also: [microcontroller, avr-atmega, stm32, firmware, in-system-programming, gpio]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/PIC_microcontrollers
+---
+
+**PIC** is a long-running family of low-cost [microcontrollers](/reference/microcontroller/) from Microchip Technology, originally introduced as "Peripheral Interface Controller" parts.[^wiki]
+
+## Overview
+
+The range stretches from simple 8-bit PIC10/PIC16/PIC18 chips through 16-bit PIC24/dsPIC up to 32-bit PIC32 parts. PICs are known for a small, regular instruction set, robust [GPIO](/reference/gpio/), and decades-long availability that makes them a staple of industrial and consumer products. They are programmed in [C](/reference/c-language/) or assembly with Microchip's MPLAB tools and flashed via [in-system programming](/reference/in-system-programming/) using a PICkit or ICD programmer.
+
+## Trade-offs
+
+PICs compete head-to-head with [AVR/ATmega](/reference/avr-atmega/) in the 8-bit space; the choice often comes down to ecosystem familiarity rather than capability. For more compute or richer peripherals, designers reach for an ARM part such as the [STM32](/reference/stm32/). Like all small [MCUs](/reference/microcontroller/), a PIC runs your code as [firmware](/reference/firmware/) with no operating system, so it boots instantly and sips power.
+
+## Sources
+
+[^wiki]: [PIC microcontrollers](https://en.wikipedia.org/wiki/PIC_microcontrollers) — Wikipedia, on the PIC families and tooling.

--- a/docs/reference/platform-as-a-service.md
+++ b/docs/reference/platform-as-a-service.md
@@ -1,0 +1,33 @@
+---
+slug: platform-as-a-service
+title: Platform as a service (PaaS)
+entry_type: concept
+category: hw-servers
+description: Platform as a service (PaaS) is a cloud model where the provider runs the servers, operating system, and runtime, and the customer just deploys application code without managing the underlying infrastructure.
+keywords: PaaS, platform as a service, cloud platform, application runtime, deploy code, managed runtime
+aka: [PaaS]
+infobox:
+  - { label: Type, value: Cloud service model }
+  - { label: Provider runs, value: Servers, OS, runtime }
+  - { label: You provide, value: Application code }
+  - { label: Sits between, value: IaaS and SaaS }
+see_also: [infrastructure-as-a-service, software-as-a-service, cloud-computing, serverless-computing, container, web-hosting]
+related_lessons:
+  - { title: "Web & shared hosting", url: /learn/intro-hardware/web-hosting/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Platform_as_a_service
+---
+
+**Platform as a service** (**PaaS**) is a [cloud computing](/reference/cloud-computing/) model in which the provider runs the servers, operating system, and application runtime, and you simply deploy code without managing the infrastructure underneath.[^wiki]
+
+## Overview
+
+PaaS is the middle tier of the cloud stack. You push an application — a web app, an API, a background worker — and the platform builds, runs, scales, and patches it for you, often using [containers](/reference/container/) behind the scenes. You do not log in to servers, install an [operating system](/reference/operating-system/), or configure load balancing; those are the platform's job. In exchange you accept its conventions about how apps are packaged and deployed.
+
+## Where it fits
+
+PaaS sits above [infrastructure as a service](/reference/infrastructure-as-a-service/) (raw VMs you must configure) and below [software as a service](/reference/software-as-a-service/) (finished applications you just use). It overlaps with [serverless computing](/reference/serverless-computing/), which pushes the abstraction further to per-request execution. For deploying a GopherTrunk web dashboard, PaaS removes server upkeep — but it cannot host the RF capture itself, which needs real radio hardware.
+
+## Sources
+
+[^wiki]: [Platform as a service](https://en.wikipedia.org/wiki/Platform_as_a_service) — Wikipedia, on the PaaS cloud model.

--- a/docs/reference/power-over-ethernet.md
+++ b/docs/reference/power-over-ethernet.md
@@ -1,0 +1,31 @@
+---
+slug: power-over-ethernet
+title: Power over Ethernet (PoE)
+entry_type: concept
+category: hw-networking
+description: Power over Ethernet delivers electrical power to a device over the same twisted-pair cable that carries its network data, removing the need for a separate power supply at the device.
+keywords: Power over Ethernet, PoE, PoE+, 802.3af, 802.3at, 802.3bt, powered device, injector
+aka: [PoE]
+infobox:
+  - { label: Type, value: Power-and-data over twisted pair }
+  - { label: Standard, value: IEEE 802.3af / at / bt }
+  - { label: Delivers, value: ~13 W up to ~90 W }
+  - { label: Source, value: PoE switch or injector }
+see_also: [ethernet, network-switch, wireless-access-point, network-interface-card, lan-and-wan, router]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Power_over_Ethernet
+---
+
+**Power over Ethernet** (**PoE**) delivers electrical power to a device over the same twisted-pair cable that carries its [Ethernet](/reference/ethernet/) data, so the device needs no separate power supply.[^wiki]
+
+## Overview
+
+Standardized in IEEE 802.3 (af, at/PoE+, and bt), PoE lets a *power sourcing equipment* device — a PoE [switch](/reference/network-switch/) or an inline injector — feed a *powered device* anywhere from about 13 W up to roughly 90 W, negotiating the level so it never over-drives a device that can't accept it. This is ideal for gear mounted where a power outlet is awkward: [wireless access points](/reference/wireless-access-point/), IP cameras, and small computers all run on a single cable.
+
+## What it's for
+
+PoE collapses two cables into one, which is exactly the appeal for an antenna-side node. A GopherTrunk capture box built on a PoE-capable [Raspberry Pi](/reference/raspberry-pi/) HAT can sit on a mast or in an attic with only a network cable run to it — data down, power up — instead of needing mains wiring at the antenna.
+
+## Sources
+
+[^wiki]: [Power over Ethernet](https://en.wikipedia.org/wiki/Power_over_Ethernet) — Wikipedia, on carrying power alongside data on Ethernet cabling.

--- a/docs/reference/power-supply-unit.md
+++ b/docs/reference/power-supply-unit.md
@@ -1,0 +1,31 @@
+---
+slug: power-supply-unit
+title: Power supply unit (PSU)
+entry_type: hardware
+category: hw-foundations
+description: A power supply unit converts AC mains electricity into the regulated low-voltage DC rails a computer's components need, and is rated by wattage and conversion efficiency.
+keywords: power supply unit, PSU, SMPS, switched-mode power supply, voltage rails, wattage, efficiency, 80 PLUS
+aka: [PSU, Power supply]
+infobox:
+  - { label: Type, value: AC-to-DC converter }
+  - { label: Outputs, value: "+12 V, +5 V, +3.3 V rails" }
+  - { label: Rated by, value: Wattage & efficiency }
+  - { label: Tech, value: Switched-mode (SMPS) }
+see_also: [motherboard, cooling-and-thermals, central-processing-unit, graphics-processing-unit, computer-hardware]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Power_supply_unit_(computer)
+---
+
+A **power supply unit** (**PSU**) converts alternating-current mains electricity into the regulated low-voltage direct current that a computer's components run on.[^wiki]
+
+## Overview
+
+Most PCs use a *switched-mode* power supply (SMPS), which is small and efficient compared with older linear designs. It delivers several DC *rails* — typically +12 V, +5 V, and +3.3 V — to the [motherboard](/reference/motherboard/), drives, and add-in cards through standardized connectors. A unit is rated by total **wattage** (how much it can deliver) and by conversion **efficiency** (how little it wastes as heat), with schemes like 80 PLUS certifying the latter.
+
+## Where it fits
+
+The PSU sizes the whole machine: a power-hungry [GPU](/reference/graphics-processing-unit/) and [CPU](/reference/central-processing-unit/) demand more headroom, and wasted power becomes heat the [cooling](/reference/cooling-and-thermals/) system must remove. Small computers skip a full PSU — a [Raspberry Pi](/reference/raspberry-pi/) running a GopherTrunk capture node takes regulated 5 V straight from a USB adapter — but the job is identical: turn wall power into the clean, steady rails the chips expect.
+
+## Sources
+
+[^wiki]: [Power supply unit (computer)](https://en.wikipedia.org/wiki/Power_supply_unit_(computer)) — Wikipedia, on PC power supplies, rails, and efficiency.

--- a/docs/reference/printer.md
+++ b/docs/reference/printer.md
@@ -1,0 +1,30 @@
+---
+slug: printer
+title: Printer
+entry_type: hardware
+category: hw-personal-computers
+description: A printer is an output peripheral that puts a computer's text and images onto paper, the two main consumer types being inkjet and laser, connected over USB, Wi-Fi, or a network.
+keywords: printer, inkjet, laser printer, all-in-one printer, output device, USB printer, network printer
+infobox:
+  - { label: Type, value: Output peripheral }
+  - { label: Common types, value: Inkjet, laser }
+  - { label: Output, value: Text and images on paper }
+  - { label: Connects via, value: USB, Wi-Fi, network }
+see_also: [peripheral, personal-computer, computer-monitor, usb, wi-fi]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Printer_(computing)
+---
+
+A **printer** is an output [peripheral](/reference/peripheral/) that puts a computer's text and images onto paper, turning a digital document into a physical page.[^wiki]
+
+## Overview
+
+Two technologies dominate the consumer and office market. *Inkjet* printers spray tiny droplets of liquid ink and excel at color and photos; *laser* printers fuse powdered toner onto the page and are faster, cheaper per page, and crisper for plain text. Many units are *all-in-one* devices that also scan and copy. A printer is a pure output device, receiving a print job from the [operating system](/reference/operating-system/) via a driver, and connects over [USB](/reference/usb/), [Wi-Fi](/reference/wi-fi/), or a wired network so it can be shared.
+
+## Where it fits
+
+For occasional documents an inkjet is cheap to buy; for steady text volume a laser saves money and frustration over time, since ink and toner costs often dwarf the price of the hardware itself. A networked printer lets every machine in a home or office print without a direct cable. In a software-centric setup like GopherTrunk a printer is incidental — useful for a paper frequency list or a printed log, but nothing the capture path needs.
+
+## Sources
+
+[^wiki]: [Printer (computing)](https://en.wikipedia.org/wiki/Printer_(computing)) — Wikipedia, on printers as output devices.

--- a/docs/reference/pulse-width-modulation.md
+++ b/docs/reference/pulse-width-modulation.md
@@ -1,0 +1,33 @@
+---
+slug: pulse-width-modulation
+title: Pulse-width modulation (PWM)
+entry_type: concept
+category: hw-microcontrollers
+description: Pulse-width modulation encodes an analog level as the on/off duty cycle of a fast digital square wave, letting a microcontroller dim LEDs, drive motors, or synthesize voltages with one pin.
+keywords: PWM, pulse-width modulation, duty cycle, motor control, LED dimming, servo, analog output, square wave
+aka: [PWM]
+infobox:
+  - { label: Type, value: Signaling technique }
+  - { label: Encodes, value: Level as duty cycle }
+  - { label: Output, value: Digital square wave }
+  - { label: Uses, value: LEDs, motors, servos, DAC }
+see_also: [microcontroller, gpio, digital-to-analog-converter, interrupt, sensor, arduino]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Pulse-width_modulation
+---
+
+**Pulse-width modulation (PWM)** encodes an analog level as the fraction of time a fast digital square wave spends switched on — its **duty cycle**.[^wiki]
+
+## Overview
+
+A pin toggled at, say, 20 kHz that is high 25% of the time delivers, on average, a quarter of the supply voltage. Because the switching is far faster than the load can respond, an LED, motor, or heater simply sees the average. A [microcontroller](/reference/microcontroller/) generates PWM in hardware timers, so it costs no CPU once configured, and the duty cycle can be changed on the fly. Servos and many [sensors](/reference/sensor/) also use PWM as their signaling format.
+
+## What it's for
+
+PWM is how an MCU produces an effectively analog output from purely digital [GPIO](/reference/gpio/): dimming LEDs, controlling motor and fan speed, positioning servos, and — with a simple low-pass filter — approximating a [digital-to-analog converter](/reference/digital-to-analog-converter/). On an [Arduino](/reference/arduino/), `analogWrite()` is PWM under the hood. Duty cycle is typically updated in the main loop or from a timer [interrupt](/reference/interrupt/).
+
+## Sources
+
+[^wiki]: [Pulse-width modulation](https://en.wikipedia.org/wiki/Pulse-width_modulation) — Wikipedia, on duty cycle and PWM applications.

--- a/docs/reference/qualcomm.md
+++ b/docs/reference/qualcomm.md
@@ -1,0 +1,47 @@
+---
+slug: qualcomm
+title: Qualcomm
+entry_type: organization
+category: hw-organizations
+description: Qualcomm is an American company known for cellular modem technology and its Snapdragon system-on-chip processors that power a large share of smartphones.
+keywords: Qualcomm, Snapdragon, modem, cellular, SoC, baseband, wireless
+aka: [Qualcomm Incorporated]
+autolink: true
+infobox:
+  - { label: Type, value: Public semiconductor company }
+  - { label: Founded, value: "1985" }
+  - { label: HQ, value: San Diego, California, USA }
+  - { label: Makes, value: Mobile SoCs, cellular modems, wireless chips }
+see_also: [system-on-a-chip, arm-holdings, arm-architecture]
+cite_urls:
+  - https://www.qualcomm.com/
+  - https://en.wikipedia.org/wiki/Qualcomm
+---
+
+**Qualcomm** is an American company founded in 1985, best known for cellular modem
+technology and its Snapdragon [systems-on-chip](/reference/system-on-a-chip/) that power a
+large share of the world's smartphones.[^wiki]
+
+## Overview
+
+Qualcomm built its early business on CDMA cellular technology and the patents around it,
+becoming a major licensor of mobile wireless intellectual property. Its Snapdragon
+SoCs combine [Arm](/reference/arm-holdings/)-based CPU cores, a GPU, an AI accelerator, and
+an integrated cellular modem on one chip, and are widely used in Android phones, tablets,
+and increasingly in laptops.[^home]
+
+The company is largely fabless, designing its chips and outsourcing manufacturing to
+foundries. It also supplies Wi-Fi, Bluetooth, and GPS components used across the mobile and
+embedded industry.
+
+## Why it matters
+
+Qualcomm's modems and SoCs sit inside a huge fraction of the mobile devices in use, making
+it central to how phones connect to networks. Its baseband and RF expertise illustrates how
+a complete radio front end and digital processor can be packed into a single power-efficient
+chip — the same integration trend that puts capable SDR-adjacent radios into small devices.
+
+## Sources
+
+[^home]: [Qualcomm](https://www.qualcomm.com/) — the company's official site, for products and technology.
+[^wiki]: [Qualcomm](https://en.wikipedia.org/wiki/Qualcomm) — Wikipedia, for the company's history and role.

--- a/docs/reference/rack-server.md
+++ b/docs/reference/rack-server.md
@@ -1,0 +1,35 @@
+---
+slug: rack-server
+title: Rack server
+entry_type: hardware
+category: hw-servers
+description: A rack server is a server built in a flat, standardized chassis that bolts into a 19-inch equipment rack, letting many machines be stacked densely in a data center.
+keywords: rack server, rack-mount, 19-inch rack, rack unit, 1U, 2U, server chassis
+aka: [Rack-mount server]
+infobox:
+  - { label: Type, value: Server form factor }
+  - { label: Mounts in, value: 19-inch rack }
+  - { label: Height unit, value: "U (1.75 in / 44.45 mm)" }
+  - { label: Common sizes, value: 1U, 2U, 4U }
+see_also: [server, blade-server, data-center, dedicated-server, network-attached-storage, colocation]
+related_lessons:
+  - { title: "Dedicated servers", url: /learn/intro-hardware/dedicated-servers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Rack_unit
+  - https://en.wikipedia.org/wiki/19-inch_rack
+---
+
+A **rack server** is a [server](/reference/server/) built in a flat, standardized chassis that bolts into a 19-inch equipment rack, so many machines can be stacked densely in a cabinet.[^rack]
+
+## Overview
+
+Height is measured in *rack units* (**U**), each 1.75 in (44.45 mm) tall.[^ru] A 1U "pizza box" is the slimmest common server; 2U and 4U chassis trade density for more drive bays, expansion slots, and cooling. The 19-inch rack standard means servers, switches, and storage from different vendors share the same rails, power distribution, and cable management. Rack servers fill the cabinets of a [data center](/reference/data-center/), where airflow runs front-to-back through cold and hot aisles.
+
+## Where it fits
+
+The rack server is the workhorse form factor for a [dedicated server](/reference/dedicated-server/) or a machine you place via [colocation](/reference/colocation/). When you need even higher density and shared power, a [blade server](/reference/blade-server/) packs more compute into the same space. Storage often rides alongside as [network-attached storage](/reference/network-attached-storage/). For most GopherTrunk users a rack server is overkill — a small box near the antenna is enough — but a rack machine is a natural home for long-term storage and serving of decoded data.
+
+## Sources
+
+[^rack]: [19-inch rack](https://en.wikipedia.org/wiki/19-inch_rack) — Wikipedia, on the rack standard and mounting.
+[^ru]: [Rack unit](https://en.wikipedia.org/wiki/Rack_unit) — Wikipedia, on the U height unit.

--- a/docs/reference/raid.md
+++ b/docs/reference/raid.md
@@ -1,0 +1,31 @@
+---
+slug: raid
+title: RAID
+entry_type: concept
+category: hw-servers
+description: RAID combines multiple physical drives into one logical unit to gain redundancy, performance, or both, so data can survive disk failures or be read and written faster.
+keywords: RAID, redundant array, mirroring, striping, parity, RAID 0, RAID 1, RAID 5, RAID 6, RAID 10
+aka: [Redundant Array of Independent Disks]
+infobox:
+  - { label: Type, value: Storage redundancy scheme }
+  - { label: Combines, value: Multiple drives }
+  - { label: Techniques, value: Striping, mirroring, parity }
+  - { label: Common levels, value: 0, 1, 5, 6, 10 }
+see_also: [data-storage, network-attached-storage, hard-disk-drive, high-availability, server, data-center]
+cite_urls:
+  - https://en.wikipedia.org/wiki/RAID
+---
+
+**RAID** (Redundant Array of Independent Disks) combines multiple physical drives into one logical unit to gain redundancy, performance, or both — so data can survive a disk failure or be read and written faster.[^wiki]
+
+## Overview
+
+RAID uses three basic techniques, mixed in different *levels*. *Striping* spreads data across drives for speed (RAID 0, no redundancy). *Mirroring* keeps identical copies so either drive can fail (RAID 1). *Parity* stores recovery information that lets the array rebuild a lost drive (RAID 5 tolerates one failure, RAID 6 tolerates two). Combined levels like RAID 10 mirror and stripe together. A key caveat: RAID protects against *drive* failure, not against deletion, corruption, or disaster — it is not a backup.
+
+## Where it fits
+
+RAID is the foundation of reliable [data storage](/reference/data-storage/) in [network-attached storage](/reference/network-attached-storage/), servers, and the [data center](/reference/data-center/), and it underpins [high availability](/reference/high-availability/) at the disk level. Built from ordinary [hard disk drives](/reference/hard-disk-drive/) or SSDs, a small mirror is a cheap way to keep a GopherTrunk archive of decoded calls alive through a single disk failure.
+
+## Sources
+
+[^wiki]: [RAID](https://en.wikipedia.org/wiki/RAID) — Wikipedia, on RAID levels and techniques.

--- a/docs/reference/random-access-memory.md
+++ b/docs/reference/random-access-memory.md
@@ -1,0 +1,32 @@
+---
+slug: random-access-memory
+title: Random-access memory (RAM)
+entry_type: hardware
+category: hw-foundations
+description: Random-access memory (RAM) is a computer's fast, temporary working storage, holding the data and programs in active use and clearing when power is lost.
+keywords: RAM, random access memory, working memory, volatile memory, memory vs storage
+aka: [RAM, random-access memory, memory]
+infobox:
+  - { label: Type, value: Working memory }
+  - { label: Speed, value: Very fast }
+  - { label: Volatile, value: Yes (cleared on power loss) }
+  - { label: Range, value: Kilobytes to terabytes }
+see_also: [computer-hardware, central-processing-unit, data-storage, input-output, server]
+related_lessons:
+  - { title: "The building blocks", url: /learn/intro-hardware/building-blocks/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Random-access_memory
+---
+
+**Random-access memory (RAM)** is a computer's fast, temporary working storage — it holds the data and programs in active use so the [CPU](/reference/central-processing-unit/) can reach them quickly.[^wiki]
+
+## Overview
+RAM is **volatile**: its contents are lost the moment power is removed. That is the key contrast with [storage](/reference/data-storage/), which is permanent. When you open a program, the device copies what it needs from storage into RAM, works there at high speed, then saves anything worth keeping back to storage before shutting down.
+
+More RAM lets a device hold more programs and larger data sets in active use at once. Run out, and the system slows to a crawl as it shuffles data back and forth with slower storage.
+
+## Where it fits
+RAM is one of the four building blocks of [computer hardware](/reference/computer-hardware/), and its size tracks the [hardware spectrum](/reference/hardware-spectrum/): a [microcontroller](/reference/microcontroller/) may have only a few kilobytes, a phone several gigabytes, and a large [server](/reference/server/) terabytes.
+
+## Sources
+[^wiki]: [Random-access memory](https://en.wikipedia.org/wiki/Random-access_memory) — Wikipedia, on RAM as fast volatile working memory.

--- a/docs/reference/raspberry-pi-foundation.md
+++ b/docs/reference/raspberry-pi-foundation.md
@@ -1,0 +1,49 @@
+---
+slug: raspberry-pi-foundation
+title: Raspberry Pi Foundation
+entry_type: organization
+category: hw-organizations
+description: The Raspberry Pi Foundation is a UK charity that created the Raspberry Pi single-board computer to make computing education affordable and accessible.
+keywords: Raspberry Pi Foundation, Raspberry Pi, single-board computer, education, charity, Eben Upton
+aka: [Raspberry Pi]
+autolink: false
+infobox:
+  - { label: Type, value: Educational charity (and trading company) }
+  - { label: Founded, value: "2009" }
+  - { label: HQ, value: Cambridge, England, UK }
+  - { label: Makes, value: Raspberry Pi single-board computers }
+see_also: [raspberry-pi, eben-upton, single-board-computer]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://www.raspberrypi.org/
+  - https://en.wikipedia.org/wiki/Raspberry_Pi_Foundation
+---
+
+**The Raspberry Pi Foundation** is a UK-based charity, founded in 2009, that created the
+[Raspberry Pi](/reference/raspberry-pi/) [single-board computer](/reference/single-board-computer/)
+to make computing affordable and accessible for education.[^wiki]
+
+## Overview
+
+The Foundation was started by a group including [Eben Upton](/reference/eben-upton/), who
+were concerned that young people were arriving at university with less hands-on computing
+experience than earlier generations. Their answer was a low-cost, credit-card-sized
+computer that could be bought for tens of dollars and freely tinkered with.[^home]
+
+The first Raspberry Pi shipped in 2012 and sold far beyond the classroom, becoming a staple
+for hobbyists, makers, and industry. Engineering and sales now run through a trading
+subsidiary (Raspberry Pi Ltd), while the charity continues educational programs and
+curriculum work.
+
+## Why it matters
+
+The Raspberry Pi turned the cheap, capable single-board computer into a mainstream tool.
+For a project like GopherTrunk, a Pi by the antenna makes a practical capture node — small,
+low-power, and inexpensive enough to deploy several — and the Foundation's mission is why
+that hardware exists at the price it does.
+
+## Sources
+
+[^home]: [Raspberry Pi](https://www.raspberrypi.org/) — the Foundation's official site.
+[^wiki]: [Raspberry Pi Foundation](https://en.wikipedia.org/wiki/Raspberry_Pi_Foundation) — Wikipedia, for the charity's history and mission.

--- a/docs/reference/raspberry-pi-pico.md
+++ b/docs/reference/raspberry-pi-pico.md
@@ -1,0 +1,36 @@
+---
+slug: raspberry-pi-pico
+title: Raspberry Pi Pico
+entry_type: hardware
+category: hw-microcontrollers
+description: The Raspberry Pi Pico is a tiny, low-cost microcontroller board built on the RP2040 chip; the Pico W variant adds Wi-Fi, making it a popular entry point for embedded and IoT projects.
+keywords: Raspberry Pi Pico, Pico W, RP2040, microcontroller board, MicroPython, Pico SDK, Wi-Fi
+aka: [Pico, Pico W]
+autolink: true
+infobox:
+  - { label: Type, value: Microcontroller board }
+  - { label: Chip, value: RP2040 (dual Cortex-M0+) }
+  - { label: Wireless, value: Wi-Fi on Pico W / 2 W }
+  - { label: Typical price, value: ~$4–6 }
+  - { label: Language, value: C/C++, MicroPython }
+see_also: [rp2040, raspberry-pi, microcontroller, esp32, gpio, internet-of-things]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Raspberry_Pi_Pico
+---
+
+**The Raspberry Pi Pico** is a tiny, low-cost [microcontroller](/reference/microcontroller/) board built around the [RP2040](/reference/rp2040/) chip.[^wiki]
+
+## Overview
+
+Unlike the Linux-running [Raspberry Pi](/reference/raspberry-pi/) single-board computers, the Pico is a bare-metal MCU board: castellated edges for soldering, a row of [GPIO](/reference/gpio/) pins, and a USB port that doubles as power and a drag-and-drop programming interface. It is written in C/C++ with the Pico SDK or in MicroPython. The **Pico W** adds Wi-Fi (and Bluetooth), turning it into a cheap connected node for the [Internet of Things](/reference/internet-of-things/); the Pico 2 and 2 W move to the newer RP2350.
+
+## Where it fits
+
+The Pico is a common first board for learning embedded programming, competing with [Arduino](/reference/arduino/) and [ESP32](/reference/esp32/) boards. It is well suited to reading [sensors](/reference/sensor/), driving displays, and bit-banging protocols via the RP2040's programmable I/O. Like any MCU it is far too small to run GopherTrunk, but it is exactly the sort of device that crowds the airwaves GopherTrunk listens to.
+
+## Sources
+
+[^wiki]: [Raspberry Pi Pico](https://en.wikipedia.org/wiki/Raspberry_Pi_Pico) — Wikipedia, on the Pico board and its variants.

--- a/docs/reference/raspberry-pi.md
+++ b/docs/reference/raspberry-pi.md
@@ -1,0 +1,35 @@
+---
+slug: raspberry-pi
+title: Raspberry Pi
+entry_type: hardware
+category: hw-sbc
+description: Raspberry Pi is a popular, low-cost single-board computer used for learning, hobby projects, home servers, and edge devices, running Linux and programmed in Python, C, or Go.
+keywords: Raspberry Pi, Pi Zero 2 W, Pi 4, Pi 5, Compute Module, HAT, Raspberry Pi OS, single-board computer
+autolink: true
+infobox:
+  - { label: Type, value: Single-board computer }
+  - { label: CPU, value: ARM (Broadcom SoC) }
+  - { label: RAM, value: ~512 MB – 16 GB }
+  - { label: Runs, value: Raspberry Pi OS / Linux }
+  - { label: Typical price, value: ~$15 – $80 }
+see_also: [single-board-computer, gpio, nvidia-jetson, beaglebone, home-server, software-defined-radio]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+  - { title: "What is an SBC?", url: /learn/intro-hardware/what-is-an-sbc/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Raspberry_Pi
+---
+
+**Raspberry Pi** is the popular, low-cost [single-board computer](/reference/single-board-computer/) that defined the category — used for learning, hobby projects, home servers, and edge devices.[^wiki]
+
+## Overview
+
+The range runs from the tiny Pi Zero 2 W through the Pi 4 and Pi 5 to the Compute Module for embedding in custom hardware. A Raspberry Pi runs Raspberry Pi OS (a Linux distribution) and is programmed in ordinary languages such as [Python](/reference/python-language/), [C](/reference/c-language/), and [Go](/reference/go-language/). A *HAT* is an add-on board that stacks onto its [GPIO](/reference/gpio/) header to add hardware.
+
+## Where it fits
+
+For most projects the Pi is the default choice: cheap, well documented, and broadly supported. A Raspberry Pi by the antenna can run GopherTrunk as a small, low-power SDR capture node. When you need GPU compute at the edge, the [NVIDIA Jetson](/reference/nvidia-jetson/) is an alternative; when you need stronger real-time I/O, look at the [BeagleBone](/reference/beaglebone/).
+
+## Sources
+
+[^wiki]: [Raspberry Pi](https://en.wikipedia.org/wiki/Raspberry_Pi) — Wikipedia, on the models and uses of the Raspberry Pi.

--- a/docs/reference/read-only-memory.md
+++ b/docs/reference/read-only-memory.md
@@ -1,0 +1,32 @@
+---
+slug: read-only-memory
+title: Read-only memory (ROM)
+entry_type: hardware
+category: hw-storage
+description: Read-only memory is non-volatile memory whose contents are fixed or rarely changed, used to hold firmware and boot code that must survive power loss.
+keywords: read-only memory, ROM, PROM, EPROM, EEPROM, firmware, mask ROM, non-volatile, boot code
+aka: [ROM]
+infobox:
+  - { label: Type, value: Non-volatile memory }
+  - { label: Holds, value: Firmware, boot code }
+  - { label: Variants, value: Mask ROM, PROM, EPROM, EEPROM }
+  - { label: Retention, value: Keeps data without power }
+  - { label: Contrast, value: vs volatile RAM }
+see_also: [random-access-memory, flash-memory, volatile-memory, firmware, memory-hierarchy, bios-uefi]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Read-only_memory
+---
+
+**Read-only memory (ROM)** is non-volatile memory whose contents are written once or rarely and retained without power, traditionally used to hold code a device needs the moment it switches on.[^wiki]
+
+## Overview
+
+Classic *mask ROM* has its data baked in during manufacture and can never be changed. Later variants made ROM progressively more editable: PROM (programmable once), EPROM (erasable with ultraviolet light), and EEPROM (electrically erasable). [Flash memory](/reference/flash-memory/) is the modern, block-erasable descendant of EEPROM and now fills most roles once handled by ROM chips. Despite the name, today's "ROM" is usually rewritable — but only deliberately, which is the point: it survives power loss and is not casually overwritten like [RAM](/reference/random-access-memory/).
+
+## Where it fits
+
+ROM's job is to store the [firmware](/reference/firmware/) and boot code that bring hardware to life, such as a [BIOS/UEFI](/reference/bios-uefi/) on a PC or the bootloader on a microcontroller. It is the [non-volatile](/reference/volatile-memory/) counterpart to volatile RAM: RAM holds the running program and is wiped at power-off, while ROM holds the unchanging instructions that start the machine. In a GopherTrunk capture node, the SDR dongle and the host both rely on firmware held in this kind of memory.
+
+## Sources
+
+[^wiki]: [Read-only memory](https://en.wikipedia.org/wiki/Read-only_memory) — Wikipedia, on ROM, its PROM/EPROM/EEPROM variants, and firmware storage.

--- a/docs/reference/real-time-operating-system.md
+++ b/docs/reference/real-time-operating-system.md
@@ -1,0 +1,34 @@
+---
+slug: real-time-operating-system
+title: Real-time operating system (RTOS)
+entry_type: concept
+category: hw-microcontrollers
+description: A real-time operating system is a small OS that schedules tasks with guaranteed, bounded timing, used on microcontrollers where responses must happen within strict deadlines.
+keywords: RTOS, real-time operating system, FreeRTOS, Zephyr, task scheduling, deadline, preemptive, deterministic
+aka: [RTOS]
+infobox:
+  - { label: Type, value: Operating system class }
+  - { label: Goal, value: Bounded, predictable timing }
+  - { label: Scheduling, value: Priority-based, preemptive }
+  - { label: Examples, value: FreeRTOS, Zephyr, ThreadX }
+  - { label: Footprint, value: Kilobytes }
+see_also: [microcontroller, bare-metal-programming, interrupt, embedded-system, arm-cortex-m, firmware]
+related_lessons:
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Real-time_operating_system
+---
+
+**A real-time operating system (RTOS)** is a small operating system that schedules tasks with guaranteed, bounded timing, so a response is delivered within a known deadline.[^wiki]
+
+## Overview
+
+What makes an OS "real-time" is not raw speed but *determinism*: the worst-case time to react to an event is predictable and small. An RTOS provides a priority-based, usually preemptive scheduler, plus primitives like tasks, queues, semaphores, and timers, all in a footprint of a few kilobytes. On a [microcontroller](/reference/microcontroller/) it sits between your application and the hardware, multiplexing several jobs onto one core while honoring deadlines. Popular examples include FreeRTOS, Zephyr, and ThreadX.
+
+## Where it fits
+
+Simple firmware often runs [bare metal](/reference/bare-metal-programming/) — a single loop plus [interrupts](/reference/interrupt/) — which is enough when there are only a couple of jobs. An RTOS earns its keep once an [embedded system](/reference/embedded-system/) juggles many concurrent tasks (reading [sensors](/reference/sensor/), driving a radio, servicing a network stack) with competing deadlines. It ports easily across [ARM Cortex-M](/reference/arm-cortex-m/) parts, so the same code runs on many chips.
+
+## Sources
+
+[^wiki]: [Real-time operating system](https://en.wikipedia.org/wiki/Real-time_operating_system) — Wikipedia, on RTOS design and determinism.

--- a/docs/reference/reverse-proxy.md
+++ b/docs/reference/reverse-proxy.md
@@ -1,0 +1,30 @@
+---
+slug: reverse-proxy
+title: Reverse proxy
+entry_type: concept
+category: hw-servers
+description: A reverse proxy is a server that sits in front of backend servers and forwards client requests to them, presenting a single front door while handling routing, TLS, caching, and security.
+keywords: reverse proxy, proxy server, TLS termination, request routing, nginx, gateway, caching
+infobox:
+  - { label: Type, value: Intermediary server }
+  - { label: Faces, value: Clients on behalf of backends }
+  - { label: Common jobs, value: TLS, routing, caching }
+  - { label: Contrast, value: Forward proxy }
+see_also: [load-balancer, content-delivery-network, web-hosting, server, high-availability, kubernetes]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Reverse_proxy
+---
+
+A **reverse proxy** is a [server](/reference/server/) that sits in front of one or more backend servers and forwards client requests to them, presenting a single front door while handling routing, encryption, caching, and security on their behalf.[^wiki]
+
+## Overview
+
+To the client, the reverse proxy *is* the website; it then decides which backend should handle each request. Along the way it commonly terminates TLS (so backends speak plain HTTP internally), routes by hostname or URL path, caches responses, compresses output, and shields backends from direct exposure. This contrasts with a *forward* proxy, which sits in front of clients to reach the wider internet. Popular reverse proxies include nginx, HAProxy, and Caddy.
+
+## Where it fits
+
+A reverse proxy overlaps heavily with a [load balancer](/reference/load-balancer/) — both front a pool of backends — and the same software often does both. It is a building block for [web hosting](/reference/web-hosting/), [high availability](/reference/high-availability/), and the edge of a [content delivery network](/reference/content-delivery-network/). For a GopherTrunk web dashboard, a reverse proxy is a tidy way to add HTTPS and a clean public address in front of the decoder's local web port.
+
+## Sources
+
+[^wiki]: [Reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy) — Wikipedia, on reverse proxies and their roles.

--- a/docs/reference/risc-v.md
+++ b/docs/reference/risc-v.md
@@ -1,0 +1,32 @@
+---
+slug: risc-v
+title: RISC-V
+entry_type: concept
+category: hw-foundations
+description: RISC-V is an open, royalty-free RISC instruction set architecture that anyone can implement freely, used in research, embedded systems, and a growing range of processors.
+keywords: RISC-V, open ISA, RISC, royalty-free, open standard, extensions, embedded
+aka: [RISC-V, RISCV]
+autolink: true
+infobox:
+  - { label: Type, value: ISA (RISC) }
+  - { label: Licensing, value: Open, royalty-free }
+  - { label: Steward, value: RISC-V International }
+  - { label: Design, value: Small base + extensions }
+see_also: [instruction-set-architecture, arm-architecture, x86, central-processing-unit, microcontroller, semiconductor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/RISC-V
+---
+
+**RISC-V** is an open, royalty-free RISC [instruction set architecture](/reference/instruction-set-architecture/) that anyone can implement without a license fee.[^wiki]
+
+## Overview
+
+Where [x86](/reference/x86/) and [ARM](/reference/arm-architecture/) are owned and licensed, RISC-V is a free and open standard stewarded by RISC-V International. It is built as a small mandatory *base* integer instruction set plus optional *extensions* (for multiplication, floating point, vectors, and more), so a designer picks only what a chip needs. This modular, open model lets universities, startups, and large vendors build compatible processors from tiny [microcontrollers](/reference/microcontroller/) up to application cores without royalties.
+
+## Where it fits
+
+RISC-V's appeal is freedom from licensing and the ability to customize the ISA, which has made it popular in research, education, and embedded designs, with broader adoption growing. It competes with ARM in efficiency-focused niches and offers an open alternative to both incumbents. For a toolchain like GopherTrunk's, supporting a new ISA is mostly a matter of the [compiler](/reference/compiler/) gaining a target — the open ISA lowers the barrier to that happening.
+
+## Sources
+
+[^wiki]: [RISC-V](https://en.wikipedia.org/wiki/RISC-V) — Wikipedia, on the open RISC-V ISA and its extension model.

--- a/docs/reference/robert-noyce.md
+++ b/docs/reference/robert-noyce.md
@@ -1,0 +1,47 @@
+---
+slug: robert-noyce
+title: Robert Noyce
+entry_type: person
+category: hw-people
+description: Robert Noyce (1927–1990) was an American physicist who co-invented the practical silicon integrated circuit and co-founded Intel, earning the nickname "the Mayor of Silicon Valley."
+keywords: Robert Noyce, integrated circuit, Intel, Fairchild Semiconductor, silicon, Silicon Valley
+aka: [Robert Noyce, Bob Noyce]
+autolink: true
+infobox:
+  - { label: Lived, value: "1927–1990" }
+  - { label: Field, value: Physics / semiconductors }
+  - { label: Known for, value: "Integrated circuit, co-founding Intel" }
+see_also: [integrated-circuit, intel, gordon-moore, jack-kilby, semiconductor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Robert_Noyce
+---
+
+**Robert Noyce** (1927–1990) was an American physicist who co-invented the practical
+silicon [integrated circuit](/reference/integrated-circuit/) and co-founded
+[Intel](/reference/intel/), becoming a central figure of Silicon Valley.[^wiki]
+
+## Life and work
+
+At Fairchild Semiconductor in 1959, Noyce devised a way to build many interconnected
+components on one piece of silicon using a planar process, with the wiring laid down on the
+chip itself — the form of [integrated circuit](/reference/integrated-circuit/) that proved
+manufacturable at scale. [Jack Kilby](/reference/jack-kilby/) had demonstrated the integrated
+circuit concept months earlier, and the two are credited as independent co-inventors.[^wiki] In
+1968 Noyce and [Gordon Moore](/reference/gordon-moore/) left Fairchild to found Intel.[^wiki]
+
+## Why they matter
+
+Noyce's planar [silicon](/reference/semiconductor/) chip is the ancestor of the modern
+microprocessor: monolithic, mass-produced, and cheap. Nearly every component in a radio
+scanner — from the tuner to the [CPU](/reference/central-processing-unit/) running the decoder
+— descends from this manufacturing breakthrough. His leadership at [Intel](/reference/intel/)
+shaped the company that brought the microprocessor to the world.[^wiki]
+
+## Legacy
+
+Known as "the Mayor of Silicon Valley," Noyce mentored a generation of entrepreneurs and
+helped define the region's culture before his death in 1990.
+
+## Sources
+
+[^wiki]: [Robert Noyce](https://en.wikipedia.org/wiki/Robert_Noyce) — Wikipedia, for biography, the integrated circuit, and Intel.

--- a/docs/reference/rock-pi.md
+++ b/docs/reference/rock-pi.md
@@ -1,0 +1,34 @@
+---
+slug: rock-pi
+title: Rock Pi (Radxa)
+entry_type: hardware
+category: hw-sbc
+description: Rock Pi is a family of single-board computers from Radxa of China, built mainly on Rockchip processors and often offering NVMe, faster networking, or more RAM than a comparably priced Raspberry Pi.
+keywords: Rock Pi, Radxa, Rockchip, RK3588, ROCK 5, NVMe SBC, Raspberry Pi alternative, ARM single-board computer
+aka: [Radxa Rock]
+infobox:
+  - { label: Type, value: Single-board computer }
+  - { label: Maker, value: Radxa (China) }
+  - { label: CPU, value: ARM (Rockchip, e.g. RK3588) }
+  - { label: Runs, value: Linux / Android }
+  - { label: Known for, value: NVMe, fast I/O, high RAM }
+see_also: [raspberry-pi, single-board-computer, odroid, orange-pi, banana-pi, nvme]
+related_lessons:
+  - { title: "Raspberry Pi and family", url: /learn/intro-hardware/raspberry-pi-and-family/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Radxa
+---
+
+**Rock Pi** is a family of [single-board computers](/reference/single-board-computer/) from Radxa of China, built mainly on Rockchip chips and often offering faster I/O than a similarly priced [Raspberry Pi](/reference/raspberry-pi/).[^wiki]
+
+## Overview
+
+The line is built around Rockchip SoCs — the powerful RK3588 powers the higher-end ROCK 5 boards — and frequently adds features the Pi lacks at the same price, such as an [NVMe](/reference/nvme/) slot, faster Ethernet, or more RAM. Boards run Linux or Android and keep a Pi-style [GPIO](/reference/gpio/) header. As with most Pi alternatives, software polish trails the Raspberry Pi.
+
+## Where it fits
+
+Rock Pi competes with [ODROID](/reference/odroid/), [Orange Pi](/reference/orange-pi/), and [Banana Pi](/reference/banana-pi/), and is a natural pick when fast local storage matters. A GopherTrunk node that records raw IQ or keeps days of decoded calls benefits from NVMe rather than an SD card, which is where a Rock Pi can edge out a stock Pi.
+
+## Sources
+
+[^wiki]: [Radxa](https://en.wikipedia.org/wiki/Radxa) — Wikipedia, on Radxa and its Rock Pi single-board computers.

--- a/docs/reference/router.md
+++ b/docs/reference/router.md
@@ -1,0 +1,30 @@
+---
+slug: router
+title: Router
+entry_type: hardware
+category: hw-networking
+description: A router is a networking device that forwards data packets between networks, choosing the path each packet takes and joining a local network to the wider internet.
+keywords: router, packet routing, default gateway, home router, NAT, routing table
+infobox:
+  - { label: Type, value: Networking device }
+  - { label: Operates at, value: Network layer (IP) }
+  - { label: Job, value: Forward packets between networks }
+  - { label: Common role, value: Home/office internet gateway }
+see_also: [network-switch, gateway, ip-address, modem, wireless-access-point, lan-and-wan]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Router_(computing)
+---
+
+A **router** is a networking device that forwards data packets between separate networks, deciding which path each packet should take toward its destination.[^wiki]
+
+## Overview
+
+A router reads the destination [IP address](/reference/ip-address/) on each packet and consults a *routing table* to choose the next hop, moving traffic between networks rather than within one — that distinguishes it from a [switch](/reference/network-switch/), which forwards frames inside a single network. The familiar home "router" is really several devices in one box: a router, a [switch](/reference/network-switch/), a [wireless access point](/reference/wireless-access-point/), and often a [modem](/reference/modem/), bridging a home [LAN](/reference/lan-and-wan/) to the internet and performing address translation (NAT).
+
+## Where it fits
+
+A router is the [gateway](/reference/gateway/) between a [local network and the wider WAN](/reference/lan-and-wan/). On a GopherTrunk network it lets a capture node, a storage [server](/reference/server/), and a viewing laptop reach each other and, where desired, the internet — while keeping the capture node addressable on the LAN.
+
+## Sources
+
+[^wiki]: [Router (computing)](https://en.wikipedia.org/wiki/Router_(computing)) — Wikipedia, on the device that forwards packets between networks.

--- a/docs/reference/rp2040.md
+++ b/docs/reference/rp2040.md
@@ -1,0 +1,36 @@
+---
+slug: rp2040
+title: RP2040
+entry_type: hardware
+category: hw-microcontrollers
+description: The RP2040 is a low-cost dual-core ARM Cortex-M0+ microcontroller designed by Raspberry Pi, notable for its programmable I/O (PIO) blocks and use in the Raspberry Pi Pico.
+keywords: RP2040, Raspberry Pi Pico, PIO, programmable IO, dual core, Cortex-M0+, MicroPython, C SDK
+aka: [RP2040]
+autolink: true
+infobox:
+  - { label: Type, value: 32-bit microcontroller }
+  - { label: Core, value: Dual ARM Cortex-M0+ }
+  - { label: Designer, value: Raspberry Pi }
+  - { label: Standout feature, value: Programmable I/O (PIO) }
+  - { label: Language, value: C/C++, MicroPython, Rust }
+see_also: [raspberry-pi-pico, arm-cortex-m, microcontroller, stm32, gpio, firmware]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/RP2040
+---
+
+**RP2040** is a low-cost, dual-core [microcontroller](/reference/microcontroller/) designed in-house by Raspberry Pi, built on two [ARM Cortex-M0+](/reference/arm-cortex-m/) cores.[^wiki]
+
+## Overview
+
+Its signature feature is **PIO** (programmable I/O): small state machines that can be programmed to bit-bang custom digital protocols at high speed, freeing the main cores from timing-critical work. The chip pairs 264 KB of on-chip SRAM with external QSPI flash and offers the usual [GPIO](/reference/gpio/), [UART](/reference/uart/), [SPI](/reference/spi/), [I²C](/reference/i2c/), [PWM](/reference/pulse-width-modulation/), and [ADC](/reference/analog-to-digital-converter/) peripherals. It is programmed in C/C++ via the Pico SDK, in MicroPython, or in Rust.
+
+## Where it fits
+
+The RP2040 first shipped on the [Raspberry Pi Pico](/reference/raspberry-pi-pico/) board, but it is sold as a bare chip and now appears in boards from many vendors and in the wireless Pico W. PIO makes it unusually good at driving LED strips, generating waveforms, or implementing odd interfaces — work that would otherwise need an [STM32](/reference/stm32/) or external logic.
+
+## Sources
+
+[^wiki]: [RP2040](https://en.wikipedia.org/wiki/RP2040) — Wikipedia, on the dual-core design and programmable I/O.

--- a/docs/reference/sbc-cluster.md
+++ b/docs/reference/sbc-cluster.md
@@ -1,0 +1,34 @@
+---
+slug: sbc-cluster
+title: SBC cluster
+entry_type: concept
+category: hw-sbc
+description: An SBC cluster is several single-board computers networked together to share work, used to learn distributed computing, build cheap low-power compute, or run lightweight container orchestration at home.
+keywords: SBC cluster, Raspberry Pi cluster, Pi cluster, Kubernetes cluster, distributed computing, parallel computing, home lab, low-power cluster
+aka: [Pi cluster]
+infobox:
+  - { label: Type, value: Computing arrangement }
+  - { label: Made of, value: Several networked SBCs }
+  - { label: Linked by, value: Ethernet / a switch }
+  - { label: Used for, value: Learning, light compute, redundancy }
+  - { label: Often runs, value: Kubernetes / container orchestration }
+see_also: [single-board-computer, raspberry-pi, odroid, rock-pi, edge-computing, home-server]
+related_lessons:
+  - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Computer_cluster
+---
+
+**An SBC cluster** is several [single-board computers](/reference/single-board-computer/) networked together so they share work — a small computer cluster built from boards like the [Raspberry Pi](/reference/raspberry-pi/).[^wiki]
+
+## Overview
+
+The boards are linked over Ethernet through a switch and coordinated by software, frequently Kubernetes or another container orchestrator, so jobs can be spread across nodes and a failed board can be replaced without taking the whole system down. People build them to learn distributed computing hands-on, to assemble cheap and low-power compute, or to run a resilient home lab.
+
+## Trade-offs
+
+A cluster of small boards rarely beats one capable machine on raw throughput per dollar or watt, so the payoff is usually learning, redundancy, or physical distribution rather than peak performance. In GopherTrunk terms, the natural reason to spread work across boards is geography, not horsepower: separate capture nodes near different antennas, each decoding locally and feeding a shared collector — closer to [edge computing](/reference/edge-computing/) than to a number-crunching cluster.
+
+## Sources
+
+[^wiki]: [Computer cluster](https://en.wikipedia.org/wiki/Computer_cluster) — Wikipedia, on networking computers to work as one system.

--- a/docs/reference/scalability.md
+++ b/docs/reference/scalability.md
@@ -1,0 +1,30 @@
+---
+slug: scalability
+title: Scalability
+entry_type: concept
+category: hw-servers
+description: Scalability is a system's ability to handle growing load by adding resources, either by using bigger machines (vertical) or by adding more machines (horizontal).
+keywords: scalability, scaling, vertical scaling, horizontal scaling, scale up, scale out, elasticity
+infobox:
+  - { label: Type, value: System property }
+  - { label: Vertical, value: Bigger machine (scale up) }
+  - { label: Horizontal, value: More machines (scale out) }
+  - { label: Related, value: Elasticity }
+see_also: [high-availability, load-balancer, cloud-computing, kubernetes, serverless-computing, server]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Scalability
+---
+
+**Scalability** is a system's ability to handle growing load by adding resources — either by using a bigger machine (vertical scaling) or by adding more machines (horizontal scaling).[^wiki]
+
+## Overview
+
+*Vertical* scaling, or scaling up, means giving one server more CPU, memory, or faster disks. It is simple but bounded by the largest machine you can buy and leaves a single point of failure. *Horizontal* scaling, or scaling out, means running many servers behind a [load balancer](/reference/load-balancer/) and dividing the work among them. Scaling out has no hard ceiling and pairs naturally with redundancy, but the software must be designed for it — stateless services and shared data stores scale out far more easily than monoliths. *Elasticity* is the related ability to add and remove capacity automatically as demand changes.
+
+## Where it fits
+
+Scalability is about handling *more*, while [high availability](/reference/high-availability/) is about staying *up*; horizontal scaling tends to deliver both. [Cloud computing](/reference/cloud-computing/), [Kubernetes](/reference/kubernetes/), and [serverless computing](/reference/serverless-computing/) all exist largely to make scaling out routine. GopherTrunk scales horizontally in a natural way: cover more sites by adding capture nodes, each decoding its own RF and feeding a shared back end.
+
+## Sources
+
+[^wiki]: [Scalability](https://en.wikipedia.org/wiki/Scalability) — Wikipedia, on vertical and horizontal scaling.

--- a/docs/reference/sd-card.md
+++ b/docs/reference/sd-card.md
@@ -1,0 +1,32 @@
+---
+slug: sd-card
+title: SD card
+entry_type: hardware
+category: hw-storage
+description: An SD card is a small removable flash-memory card used for storage in cameras, phones, and single-board computers, available in SD, microSD, and high-capacity variants.
+keywords: SD card, microSD, SDHC, SDXC, flash card, memory card, speed class, removable storage
+aka: [Secure Digital, microSD]
+infobox:
+  - { label: Type, value: Removable flash storage }
+  - { label: Medium, value: NAND flash memory }
+  - { label: Sizes, value: SD, miniSD, microSD }
+  - { label: Capacity tiers, value: SD, SDHC, SDXC, SDUC }
+  - { label: Common use, value: Cameras, phones, SBCs }
+see_also: [flash-memory, emmc, solid-state-drive, data-storage, raspberry-pi, file-system]
+cite_urls:
+  - https://en.wikipedia.org/wiki/SD_card
+---
+
+An **SD card** (Secure Digital) is a small removable storage card built around [flash memory](/reference/flash-memory/), widely used in cameras, phones, and small computers.[^wiki]
+
+## Overview
+
+The standard defines several physical sizes — full-size SD, miniSD, and the tiny microSD — and capacity tiers that grew over time: SDHC, SDXC, and SDUC. A small controller inside the card handles wear leveling and presents a simple block device, so the host just sees storage formatted with a [file system](/reference/file-system/). Speed classes (Class 10, UHS, V30, and so on) rate sustained write performance, which matters for high-bitrate recording.
+
+## Where it fits
+
+The SD card is the default boot and storage medium for many single-board computers, including the [Raspberry Pi](/reference/raspberry-pi/), which boots from a microSD card by default. It is cheap and removable, but cards vary in quality and endurance, and a low-end card can wear out under constant logging. A GopherTrunk capture node can run from an SD card, though for heavy continuous writes an [eMMC](/reference/emmc/) module or an [SSD](/reference/solid-state-drive/) lasts longer.
+
+## Sources
+
+[^wiki]: [SD card](https://en.wikipedia.org/wiki/SD_card) — Wikipedia, on Secure Digital cards, form factors, and capacity tiers.

--- a/docs/reference/semiconductor.md
+++ b/docs/reference/semiconductor.md
@@ -1,0 +1,30 @@
+---
+slug: semiconductor
+title: Semiconductor
+entry_type: concept
+category: hw-foundations
+description: A semiconductor is a material whose electrical conductivity sits between a conductor and an insulator and can be precisely controlled, making it the basis of transistors and chips.
+keywords: semiconductor, silicon, doping, conductivity, transistor, p-type, n-type, fabrication
+infobox:
+  - { label: Type, value: Material class }
+  - { label: Conductivity, value: Between conductor & insulator }
+  - { label: Key material, value: Silicon }
+  - { label: Tuned by, value: Doping }
+see_also: [transistor, integrated-circuit, logic-gate, moores-law, central-processing-unit, x86]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Semiconductor
+---
+
+A **semiconductor** is a material whose electrical conductivity falls between that of a conductor and an insulator and — crucially — can be precisely controlled.[^wiki]
+
+## Overview
+
+Silicon is the workhorse semiconductor. By *doping* it with tiny amounts of other elements, makers create regions that carry charge differently (*n-type* and *p-type*), and the junctions between them behave in controllable ways. That controllability is what makes a [transistor](/reference/transistor/) possible: a small signal can switch or modulate a larger current. Many such structures are then fabricated together on one die to form an [integrated circuit](/reference/integrated-circuit/).
+
+## Where it fits
+
+Semiconductors are the physical foundation under all of digital computing: without a material you can switch on and off reliably, there are no [logic gates](/reference/logic-gate/), no [CPUs](/reference/central-processing-unit/), no chips at all. The decades-long ability to shrink semiconductor features is what powered [Moore's law](/reference/moores-law/). The same physics serves radio too — the diodes, amplifiers, and mixers in an SDR front end are semiconductor devices handling the RF before GopherTrunk decodes it.
+
+## Sources
+
+[^wiki]: [Semiconductor](https://en.wikipedia.org/wiki/Semiconductor) — Wikipedia, on semiconductor materials, doping, and conductivity.

--- a/docs/reference/sensor.md
+++ b/docs/reference/sensor.md
@@ -1,0 +1,32 @@
+---
+slug: sensor
+title: Sensor
+entry_type: hardware
+category: hw-microcontrollers
+description: A sensor is a device that detects a physical quantity — temperature, light, motion, pressure — and converts it into an electrical signal a microcontroller can read and act on.
+keywords: sensor, transducer, temperature, accelerometer, light, pressure, analog, digital, I2C sensor
+infobox:
+  - { label: Type, value: Input transducer }
+  - { label: Senses, value: Heat, light, motion, pressure, gas }
+  - { label: Output, value: Analog or digital signal }
+  - { label: Read via, value: ADC, I²C, SPI, GPIO }
+see_also: [microcontroller, analog-to-digital-converter, i2c, spi, gpio, internet-of-things]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Sensor
+---
+
+**A sensor** is a device that detects a physical quantity — temperature, light, motion, pressure, gas — and converts it into an electrical signal a computer can read.[^wiki]
+
+## Overview
+
+Sensors are the input side of nearly every embedded device. Some output a raw analog voltage that a [microcontroller](/reference/microcontroller/) digitizes with its [ADC](/reference/analog-to-digital-converter/); many modern sensors include their own electronics and present a clean digital reading over [I²C](/reference/i2c/) or [SPI](/reference/spi/), or as a simple [GPIO](/reference/gpio/) signal. Common examples include thermistors, accelerometers and gyroscopes, photodiodes, microphones, and pressure and gas sensors.
+
+## Where it fits
+
+Sensors give an [embedded system](/reference/embedded-system/) awareness of the physical world; paired with network connectivity they are the data source behind the [Internet of Things](/reference/internet-of-things/). The microcontroller reads the sensor, decides what to do, and drives an output — closing the loop between sensing and action. A weather station node reporting temperature and humidity over a radio link is a textbook sensor-plus-MCU device.
+
+## Sources
+
+[^wiki]: [Sensor](https://en.wikipedia.org/wiki/Sensor) — Wikipedia, on sensors as transducers of physical quantities.

--- a/docs/reference/server.md
+++ b/docs/reference/server.md
@@ -1,0 +1,33 @@
+---
+slug: server
+title: Server
+entry_type: hardware
+category: hw-servers
+description: A server is a computer that provides services or data to other machines over a network, built for uptime and many simultaneous clients.
+keywords: server, network server, web server, application server, uptime, clients
+aka: [Server]
+infobox:
+  - { label: Type, value: Networked computer }
+  - { label: Role, value: Serves clients }
+  - { label: Built for, value: Uptime & concurrency }
+  - { label: Building blocks, value: CPU, RAM, storage, I/O }
+see_also: [web-hosting, virtual-private-server, dedicated-server, home-server, cloud-computing]
+related_lessons:
+  - { title: "Web & shared hosting", url: /learn/intro-hardware/web-hosting/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Server_(computing)
+---
+
+A **server** is a computer that provides services or data to other machines over a network — serving web pages, running an application, or storing files for clients to fetch.[^wiki]
+
+## Overview
+
+Under the hood a server has the same four building blocks as any computer: a [CPU](/reference/central-processing-unit/), [RAM](/reference/random-access-memory/), [storage](/reference/data-storage/), and [I/O](/reference/input-output/). What sets it apart is how it is built and run: for long uptime and to handle many simultaneous clients without falling over. A "server" can be a rack machine in a data center, a virtual slice of one, or an old box in a closet.
+
+## Where it fits
+
+This is the umbrella entry for the category. You usually do not buy a bare server so much as choose *how* you get one: [web hosting](/reference/web-hosting/) for the simplest sites, a [virtual private server](/reference/virtual-private-server/) for more control, a [dedicated server](/reference/dedicated-server/) for the whole machine, a [home server](/reference/home-server/) you run yourself, or [cloud computing](/reference/cloud-computing/) on demand. In GopherTrunk terms a server can store and serve decoded data, but it cannot capture RF — that still needs an antenna and a dongle on a machine with a radio front end.
+
+## Sources
+
+[^wiki]: [Server (computing)](https://en.wikipedia.org/wiki/Server_(computing)) — Wikipedia, on servers as machines that provide services to networked clients.

--- a/docs/reference/serverless-computing.md
+++ b/docs/reference/serverless-computing.md
@@ -1,0 +1,31 @@
+---
+slug: serverless-computing
+title: Serverless computing
+entry_type: concept
+category: hw-servers
+description: Serverless computing is a cloud model where code runs in short-lived, provider-managed containers triggered by events, scaling automatically and billing only for actual execution, with no servers to provision.
+keywords: serverless, functions as a service, FaaS, lambda, event-driven, autoscaling, pay per use
+aka: [FaaS, Functions as a service]
+infobox:
+  - { label: Type, value: Cloud execution model }
+  - { label: Unit, value: Function / event handler }
+  - { label: Scaling, value: Automatic, to zero }
+  - { label: Billing, value: Per execution }
+see_also: [platform-as-a-service, cloud-computing, container, infrastructure-as-a-service, scalability, software-as-a-service]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Serverless_computing
+---
+
+**Serverless computing** is a [cloud computing](/reference/cloud-computing/) model in which code runs in short-lived, provider-managed environments triggered by events; it scales automatically and bills only for actual execution, with no servers to provision.[^wiki]
+
+## Overview
+
+The name is a slight misnomer — servers still exist, but the developer never sees or manages them. You upload a function; the platform runs it on demand when an event fires (an HTTP request, a queue message, a timer), spins up [containers](/reference/container/) to handle load, and tears them down afterward. Because idle functions cost nothing, serverless can scale to zero between bursts. The trade-offs are cold-start latency, execution time limits, and statelessness — long-running or stateful work fits poorly.
+
+## Where it fits
+
+Serverless is the most abstract way to run your own code, sitting above [platform as a service](/reference/platform-as-a-service/) by removing even the notion of a running process you manage. Its automatic [scalability](/reference/scalability/) suits bursty, event-driven workloads. GopherTrunk's decode loop is continuous and tied to live RF, so it is a poor fit for serverless, but occasional tasks — sending an alert when a talkgroup appears — map naturally onto a function.
+
+## Sources
+
+[^wiki]: [Serverless computing](https://en.wikipedia.org/wiki/Serverless_computing) — Wikipedia, on the serverless and FaaS model.

--- a/docs/reference/single-board-computer.md
+++ b/docs/reference/single-board-computer.md
@@ -1,0 +1,36 @@
+---
+slug: single-board-computer
+title: Single-board computer (SBC)
+entry_type: hardware
+category: hw-sbc
+description: A single-board computer (SBC) is a complete computer built on one small circuit board, with CPU, memory, storage, and ports, capable of running a full operating system.
+keywords: single-board computer, SBC, Raspberry Pi, embedded Linux, GPIO, edge device, low power computer
+aka: [SBC]
+autolink: true
+infobox:
+  - { label: Type, value: Complete computer on one board }
+  - { label: CPU, value: Usually ARM (sometimes x86) }
+  - { label: RAM, value: ~512 MB – 16 GB }
+  - { label: Runs, value: Linux (full OS) }
+  - { label: Typical price, value: ~$15 – $100 }
+see_also: [raspberry-pi, nvidia-jetson, beaglebone, gpio, microcontroller, personal-computer]
+related_lessons:
+  - { title: "What is an SBC?", url: /learn/intro-hardware/what-is-an-sbc/ }
+  - { title: "SBC use cases and limits", url: /learn/intro-hardware/sbc-use-cases-and-limits/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Single-board_computer
+---
+
+**A single-board computer (SBC)** is a complete computer built on one small circuit board — [CPU](/reference/central-processing-unit/), [memory](/reference/random-access-memory/), [storage](/reference/data-storage/), and ports — capable of running a full [operating system](/reference/operating-system/), usually Linux.[^wiki]
+
+## Overview
+
+An SBC sits between a [personal computer](/reference/personal-computer/) and a [microcontroller](/reference/microcontroller/). Unlike a microcontroller, it runs a real OS and ordinary languages and tools; unlike a sealed PC or phone, it exposes [GPIO](/reference/gpio/) pins that let your code talk directly to electronics. Most are credit-card sized and draw only a few watts.
+
+## Where it fits
+
+The category is broad: the [Raspberry Pi](/reference/raspberry-pi/) is the best-known general-purpose board, the [NVIDIA Jetson](/reference/nvidia-jetson/) adds a GPU for edge AI, and the [BeagleBone](/reference/beaglebone/) emphasises real-time I/O. Their low power and small size make them well suited to always-on, embedded, and field roles — for example, a Raspberry Pi by the antenna can run GopherTrunk as a small, low-power SDR capture node.
+
+## Sources
+
+[^wiki]: [Single-board computer](https://en.wikipedia.org/wiki/Single-board_computer) — Wikipedia, on the definition and scope of SBCs.

--- a/docs/reference/smartphone.md
+++ b/docs/reference/smartphone.md
@@ -1,0 +1,47 @@
+---
+slug: smartphone
+title: Smartphone
+entry_type: hardware
+category: hw-mobile
+description: A smartphone is a pocket-sized touchscreen computer with a cellular connection, sensors, and a battery that runs apps, making it the most widespread computer on earth.
+keywords: smartphone, mobile phone, iOS, Android, app, touchscreen computer, cellular
+aka: [Smartphone, Smart phone, Mobile phone]
+infobox:
+  - { label: Type, value: Pocket touchscreen computer }
+  - { label: Connectivity, value: Cellular, Wi-Fi }
+  - { label: Platforms, value: iOS, Android }
+  - { label: Runs, value: Apps }
+  - { label: Role, value: Deployment target }
+see_also: [tablet, mobile-app-development, personal-computer, laptop, operating-system]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Smartphone
+---
+
+**A smartphone** is a pocket-sized touchscreen computer with a cellular
+connection, sensors, and a battery, running apps — the most widespread computer
+on earth.[^wiki]
+
+## Overview
+
+Inside, a smartphone has the same building blocks as any computer — a
+[CPU](/reference/central-processing-unit/), [RAM](/reference/random-access-memory/),
+and [storage](/reference/data-storage/) — paired with a touchscreen, a radio, and
+a dense cluster of sensors. It runs a mobile
+[operating system](/reference/operating-system/), almost always Apple's iOS or
+Google's Android, and the software it runs comes packaged as apps.
+
+## Where it fits
+
+For developers a smartphone is a deployment target, not a development machine:
+you write and build the software on a [laptop](/reference/laptop/) or
+[desktop](/reference/desktop-computer/), then run it on the phone. Apps are built
+with platform languages — [Swift](/reference/swift-language/) for iOS,
+[Kotlin](/reference/kotlin-language/) or [Java](/reference/java-language/) for
+Android — covered under [mobile app development](/reference/mobile-app-development/).
+In an SDR setup a phone is somewhere to view decoded data, not a capture machine.
+
+## Sources
+
+[^wiki]: [Smartphone](https://en.wikipedia.org/wiki/Smartphone) — Wikipedia, on the pocket touchscreen computer and its platforms.

--- a/docs/reference/smartwatch.md
+++ b/docs/reference/smartwatch.md
@@ -1,0 +1,32 @@
+---
+slug: smartwatch
+title: Smartwatch
+entry_type: hardware
+category: hw-mobile
+description: A smartwatch is a wrist-worn computer that pairs with or extends a smartphone, combining a small touchscreen, sensors, and radios to show notifications, track fitness, and run lightweight apps.
+keywords: smartwatch, wearable, Apple Watch, Wear OS, fitness tracker, wrist computer, heart rate sensor, smart watch
+infobox:
+  - { label: Type, value: Wrist-worn computer }
+  - { label: Display, value: Small touchscreen }
+  - { label: Sensors, value: Heart rate, GPS, accelerometer }
+  - { label: Examples, value: Apple Watch, Wear OS }
+see_also: [wearable-computer, smartphone, battery-technology, touchscreen, mobile-operating-system, gps-receiver]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Smartwatch
+---
+
+A **smartwatch** is a wrist-worn computer that pairs with or extends a [smartphone](/reference/smartphone/), packing a small [touchscreen](/reference/touchscreen/), sensors, and radios into a watch-sized case.[^wiki]
+
+## Overview
+
+A smartwatch is a tightly constrained [wearable computer](/reference/wearable-computer/): a low-power [SoC](/reference/system-on-a-chip/), a small display, Bluetooth and often Wi-Fi or cellular, and sensors such as a heart-rate monitor, accelerometer, and [GPS receiver](/reference/gps-receiver/). It runs a purpose-built [mobile OS](/reference/mobile-operating-system/) — for example watchOS or Wear OS — surfacing notifications, fitness tracking, payments, and small apps. Everything is shaped by a tiny [battery](/reference/battery-technology/), forcing aggressive power management and, on many models, a daily charge.
+
+## Where it fits
+
+The smartwatch sits at the smallest, most personal end of the mobile spectrum: not a replacement for a phone but a glanceable extension of it, and a hub for health sensors worn against the skin. Its sealed, battery-limited design makes it purely a consumer endpoint — useful as a remote notifier, not as a place to run real compute like an SDR pipeline.
+
+## Sources
+
+[^wiki]: [Smartwatch](https://en.wikipedia.org/wiki/Smartwatch) — Wikipedia, on smartwatch hardware and platforms.

--- a/docs/reference/soc-vs-discrete.md
+++ b/docs/reference/soc-vs-discrete.md
@@ -1,0 +1,31 @@
+---
+slug: soc-vs-discrete
+title: SoC vs discrete
+entry_type: concept
+category: hw-accelerators
+description: SoC vs discrete is the design trade-off between integrating processors and accelerators onto one system-on-a-chip versus using separate dedicated chips connected on a board.
+keywords: SoC, system on a chip, discrete, integrated GPU, dedicated GPU, integration, accelerator, trade-off, edge, data center
+infobox:
+  - { label: Type, value: Design trade-off }
+  - { label: SoC, value: One chip, shared memory, low power }
+  - { label: Discrete, value: Separate chips, own memory, max performance }
+  - { label: SoC wins, value: Power, size, cost, edge devices }
+  - { label: Discrete wins, value: Peak performance, upgradability }
+see_also: [system-on-a-chip, graphics-processing-unit, hardware-acceleration, ai-accelerator, neural-processing-unit, edge-ai]
+cite_urls:
+  - https://en.wikipedia.org/wiki/System_on_a_chip
+---
+
+**SoC vs discrete** is the design trade-off between integrating the processor and its accelerators onto a single [system-on-a-chip](/reference/system-on-a-chip/) versus using separate, dedicated chips wired together on a board.[^wiki]
+
+## Overview
+
+An integrated approach puts the CPU, [GPU](/reference/graphics-processing-unit/), [NPU](/reference/neural-processing-unit/), memory controller, and I/O on one die that shares a single pool of memory. A discrete approach gives an accelerator its own chip and its own high-bandwidth memory, connected over a bus such as PCI Express. Integration shortens the distance data has to travel, cutting power and latency; separation lets each part be made as large and fast as its own package allows.
+
+## Trade-offs
+
+The SoC wins on power, physical size, and cost — which is why phones, single-board computers, and edge devices use integrated [accelerators](/reference/ai-accelerator/). The discrete part wins on peak performance and upgradability, which is why data-center training rigs and gaming PCs bolt on standalone GPUs with dedicated memory. The choice mirrors the broader [hardware-acceleration](/reference/hardware-acceleration/) question of where compute should live. For a GopherTrunk capture node, an integrated SoC board by the antenna is the natural pick: low power and small, with the radio front end doing the heavy RF work.
+
+## Sources
+
+[^wiki]: [System on a chip](https://en.wikipedia.org/wiki/System_on_a_chip) — Wikipedia, on integrating components onto a single chip versus discrete designs.

--- a/docs/reference/software-as-a-service.md
+++ b/docs/reference/software-as-a-service.md
@@ -1,0 +1,33 @@
+---
+slug: software-as-a-service
+title: Software as a service (SaaS)
+entry_type: concept
+category: hw-servers
+description: Software as a service (SaaS) is a model where finished applications are hosted by a provider and accessed over the internet, usually by subscription, with no software to install or servers to run.
+keywords: SaaS, software as a service, cloud application, subscription software, web app, hosted software
+aka: [SaaS]
+infobox:
+  - { label: Type, value: Cloud service model }
+  - { label: Provider runs, value: The whole application }
+  - { label: You provide, value: Your data and use }
+  - { label: Access, value: Browser or API }
+see_also: [platform-as-a-service, infrastructure-as-a-service, cloud-computing, managed-hosting, web-hosting, serverless-computing]
+related_lessons:
+  - { title: "Web & shared hosting", url: /learn/intro-hardware/web-hosting/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Software_as_a_service
+---
+
+**Software as a service** (**SaaS**) is a model in which finished applications are hosted by a provider and accessed over the internet — usually by subscription — with no software to install and no servers for the user to run.[^wiki]
+
+## Overview
+
+SaaS is the top tier of the cloud stack: the provider runs the application, the runtime, the operating system, and the hardware, and you interact only through a browser or API. Email, document suites, chat tools, and CRM systems are common examples. Billing is typically per user or per month, and updates roll out centrally, so every customer runs the same maintained version.
+
+## Where it fits
+
+SaaS hides the most infrastructure of the three cloud tiers, above [platform as a service](/reference/platform-as-a-service/) (where you still supply code) and [infrastructure as a service](/reference/infrastructure-as-a-service/) (where you supply the OS too). It resembles [managed hosting](/reference/managed-hosting/) taken to completion — even the application is run for you. GopherTrunk is self-hosted software rather than SaaS, because it must run next to real radio hardware; only its decoded output could be pushed to a SaaS service.
+
+## Sources
+
+[^wiki]: [Software as a service](https://en.wikipedia.org/wiki/Software_as_a_service) — Wikipedia, on the SaaS cloud model.

--- a/docs/reference/solid-state-drive.md
+++ b/docs/reference/solid-state-drive.md
@@ -1,0 +1,32 @@
+---
+slug: solid-state-drive
+title: Solid-state drive (SSD)
+entry_type: hardware
+category: hw-storage
+description: A solid-state drive stores data in non-volatile flash memory with no moving parts, giving much faster access and better durability than a spinning hard disk.
+keywords: solid-state drive, SSD, flash storage, NAND, SATA SSD, NVMe SSD, wear leveling, TBW
+aka: [SSD]
+infobox:
+  - { label: Type, value: Flash non-volatile storage }
+  - { label: Medium, value: NAND flash memory }
+  - { label: Interfaces, value: SATA, NVMe (PCIe) }
+  - { label: Moving parts, value: None }
+  - { label: Strength, value: Fast random access }
+see_also: [hard-disk-drive, flash-memory, nvme, data-storage, memory-hierarchy, file-system]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Solid-state_drive
+---
+
+A **solid-state drive (SSD)** is a storage device that keeps data in non-volatile [flash memory](/reference/flash-memory/) with no moving parts, delivering far faster access than a mechanical disk.[^wiki]
+
+## Overview
+
+Where a [hard disk drive](/reference/hard-disk-drive/) seeks a head across spinning platters, an SSD reads any block electronically, so random access is orders of magnitude quicker and there is no mechanical latency or noise. A controller manages the underlying NAND, spreading writes across cells (wear leveling) because flash cells endure a limited number of erase cycles. SSDs connect over the older SATA interface or, for much higher throughput, over [NVMe](/reference/nvme/) on a [PCI Express](/reference/pci-express/) link.
+
+## Where it fits
+
+In the [memory hierarchy](/reference/memory-hierarchy/) an SSD sits between [RAM](/reference/random-access-memory/) and slow bulk disk: not as fast as memory, but vastly faster than an HDD for the random reads a [file system](/reference/file-system/) and database generate. For GopherTrunk, an SSD is the natural home for the active database of decoded calls and recent recordings — its quick random writes keep up with a busy control channel — while cheaper [HDD](/reference/hard-disk-drive/) capacity holds the long-term archive.
+
+## Sources
+
+[^wiki]: [Solid-state drive](https://en.wikipedia.org/wiki/Solid-state_drive) — Wikipedia, on flash-based drives and how they differ from mechanical disks.

--- a/docs/reference/sophie-wilson.md
+++ b/docs/reference/sophie-wilson.md
@@ -1,0 +1,47 @@
+---
+slug: sophie-wilson
+title: Sophie Wilson
+entry_type: person
+category: hw-people
+description: Sophie Wilson (born 1957) is a British computer scientist who designed the BBC Micro's BASIC and the original ARM instruction set, the architecture now found in most of the world's mobile and embedded processors.
+keywords: Sophie Wilson, ARM, ARM architecture, BBC Micro, Acorn, instruction set, RISC
+aka: [Sophie Wilson]
+autolink: true
+infobox:
+  - { label: Born, value: "1957" }
+  - { label: Field, value: Computer science / chip design }
+  - { label: Known for, value: ARM instruction set }
+see_also: [arm-architecture, arm-holdings, central-processing-unit, instruction-set-architecture]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Sophie_Wilson
+---
+
+**Sophie Wilson** (born 1957) is a British computer scientist who designed the original
+[ARM](/reference/arm-architecture/) instruction set, the processor architecture now at the
+heart of most smartphones and a vast range of embedded devices.[^wiki]
+
+## Life and work
+
+At Acorn Computers, Wilson wrote the BBC BASIC language for the BBC Micro, a hugely influential
+British educational computer of the 1980s. When Acorn set out to build its own processor, she
+designed the [instruction set](/reference/instruction-set-architecture/) for the Acorn RISC
+Machine — ARM — while colleague Steve Furber led the chip implementation. Their goal was a
+simple, efficient, low-power [CPU](/reference/central-processing-unit/), and the resulting RISC
+design was remarkably compact.[^wiki] The architecture was later spun out into what became
+[Arm Holdings](/reference/arm-holdings/).[^wiki]
+
+## Why they matter
+
+The [ARM architecture](/reference/arm-architecture/) Wilson defined emphasised doing more with
+less power, which made it ideal as battery-powered devices proliferated. ARM cores now ship in
+the tens of billions per year, powering phones, single-board computers, and embedded
+controllers — including many of the small boards used to run SDR capture and decode tasks.[^wiki]
+
+## Legacy
+
+The instruction set she created decades ago still underlies the dominant mobile and embedded
+processor family, making it one of the most widely used designs in computing history.
+
+## Sources
+
+[^wiki]: [Sophie Wilson](https://en.wikipedia.org/wiki/Sophie_Wilson) — Wikipedia, for biography, the BBC Micro, and ARM.

--- a/docs/reference/spi.md
+++ b/docs/reference/spi.md
@@ -1,0 +1,33 @@
+---
+slug: spi
+title: SPI
+entry_type: concept
+category: hw-microcontrollers
+description: SPI is a fast, full-duplex serial bus that connects a controller to peripheral chips using separate clock, data-out, data-in, and chip-select lines, common for displays, flash, and ADCs.
+keywords: SPI, serial peripheral interface, MOSI, MISO, SCLK, chip select, full duplex, flash, display
+aka: [SPI]
+infobox:
+  - { label: Type, value: Serial bus }
+  - { label: Wires, value: 4 (SCLK, MOSI, MISO, CS) }
+  - { label: Mode, value: Full-duplex }
+  - { label: Speed, value: Tens of MHz }
+see_also: [i2c, uart, microcontroller, sensor, in-system-programming, flash-memory]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Serial_Peripheral_Interface
+---
+
+**SPI** (Serial Peripheral Interface) is a fast, full-duplex serial bus that connects a controller to one or more peripheral chips.[^wiki]
+
+## Overview
+
+SPI uses four lines: a clock (SCLK), data out (MOSI), data in (MISO), and a chip-select (CS) per peripheral. Because data flows both directions on every clock edge, it is full-duplex and can run at tens of MHz — much faster than [I²C](/reference/i2c/). The cost is wiring: each additional peripheral needs its own chip-select line rather than an address. A [microcontroller's](/reference/microcontroller/) SPI peripheral shifts the bits in hardware.
+
+## Where it fits
+
+SPI is the bus of choice when speed matters: driving displays, reading high-rate [ADCs](/reference/analog-to-digital-converter/), and talking to [flash memory](/reference/flash-memory/) and SD cards. Many [sensors](/reference/sensor/) offer SPI as a faster alternative to I²C. It is also the interface behind AVR-style [in-system programming](/reference/in-system-programming/). Choosing between SPI, I²C, and [UART](/reference/uart/) is a routine design decision in any [embedded system](/reference/embedded-system/).
+
+## Sources
+
+[^wiki]: [Serial Peripheral Interface](https://en.wikipedia.org/wiki/Serial_Peripheral_Interface) — Wikipedia, on the SPI bus and its lines.

--- a/docs/reference/steve-wozniak.md
+++ b/docs/reference/steve-wozniak.md
@@ -1,0 +1,47 @@
+---
+slug: steve-wozniak
+title: Steve Wozniak
+entry_type: person
+category: hw-people
+description: Steve Wozniak (born 1950) is an American engineer who designed the Apple I and Apple II computers, single-handedly engineering machines that helped launch the personal computer industry.
+keywords: Steve Wozniak, Apple I, Apple II, personal computer, Apple Computer, hardware design
+aka: [Steve Wozniak, Woz, Stephen Wozniak]
+autolink: true
+infobox:
+  - { label: Born, value: "1950" }
+  - { label: Field, value: Electrical engineering }
+  - { label: Known for, value: "Apple I and Apple II" }
+see_also: [personal-computer, central-processing-unit, computer-hardware, integrated-circuit]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Steve_Wozniak
+---
+
+**Steve Wozniak** (born 1950) is an American engineer who designed the Apple I and Apple II,
+hardware that helped turn the [personal computer](/reference/personal-computer/) from a
+hobbyist kit into a consumer product.[^wiki]
+
+## Life and work
+
+Wozniak built the Apple I as a single-board machine and, with Steve Jobs, co-founded Apple
+Computer in 1976 to sell it. His 1977 Apple II — with colour graphics, a built-in keyboard,
+and clever economical use of [integrated circuits](/reference/integrated-circuit/) — became
+one of the first highly successful mass-produced [personal computers](/reference/personal-computer/).[^wiki]
+He was known for tight, elegant circuit designs that squeezed maximum capability from minimal
+parts, including a floppy-disk controller built from a handful of chips.[^wiki]
+
+## Why they matter
+
+The Apple II showed that an affordable [computer](/reference/computer-hardware/) built around a
+modest [CPU](/reference/central-processing-unit/) could reach ordinary homes and schools,
+seeding the software and hobbyist culture that personal computing grew from. That same culture
+— accessible hardware plus open tinkering — is the lineage behind today's SDR and
+maker projects.[^wiki]
+
+## Legacy
+
+Widely known as "Woz," he remains an icon of hands-on engineering and helped define the early
+personal-computer era before stepping back from day-to-day work at Apple.
+
+## Sources
+
+[^wiki]: [Steve Wozniak](https://en.wikipedia.org/wiki/Steve_Wozniak) — Wikipedia, for biography and the Apple I and II.

--- a/docs/reference/stm32.md
+++ b/docs/reference/stm32.md
@@ -1,0 +1,36 @@
+---
+slug: stm32
+title: STM32
+entry_type: hardware
+category: hw-microcontrollers
+description: STM32 is STMicroelectronics' broad family of 32-bit ARM Cortex-M microcontrollers, spanning ultra-low-power to high-performance parts widely used in industrial, consumer, and hobby embedded designs.
+keywords: STM32, STMicroelectronics, ARM Cortex-M, STM32F4, STM32 Nucleo, Blue Pill, HAL, STM32CubeIDE
+aka: [STM32]
+autolink: true
+infobox:
+  - { label: Type, value: 32-bit microcontroller family }
+  - { label: Core, value: ARM Cortex-M (M0 to M7/M33) }
+  - { label: Vendor, value: STMicroelectronics }
+  - { label: Tooling, value: STM32Cube, HAL, ST-LINK }
+  - { label: Language, value: C, C++, Rust }
+see_also: [arm-cortex-m, microcontroller, rp2040, avr-atmega, bare-metal-programming, firmware]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/STM32
+---
+
+**STM32** is STMicroelectronics' broad family of 32-bit [microcontrollers](/reference/microcontroller/) built around [ARM Cortex-M](/reference/arm-cortex-m/) cores.[^wiki]
+
+## Overview
+
+The line spans dozens of series, from the tiny low-power STM32L0 and value-line STM32F0 up to the high-performance STM32F7 and STM32H7. All share a common peripheral set — [UART](/reference/uart/), [SPI](/reference/spi/), [I²C](/reference/i2c/), timers with [PWM](/reference/pulse-width-modulation/), and on-chip [ADCs](/reference/analog-to-digital-converter/) — and a shared HAL (hardware abstraction layer) so code ports across the family. Parts are programmed in [C](/reference/c-language/), [C++](/reference/cpp-language/), or [Rust](/reference/rust-language/) and flashed over the ST-LINK debugger using [in-system programming](/reference/in-system-programming/).
+
+## Where it fits
+
+STM32 is the default choice when a project outgrows an 8-bit [AVR/ATmega](/reference/avr-atmega/) but does not need a full [single-board computer](/reference/single-board-computer/). The cheap "Blue Pill" board and the official Nucleo and Discovery kits make it popular with hobbyists, while its rich peripherals and long supply lifetimes keep it common in industrial and automotive products. Many designs run [bare metal](/reference/bare-metal-programming/) or under a small [RTOS](/reference/real-time-operating-system/).
+
+## Sources
+
+[^wiki]: [STM32](https://en.wikipedia.org/wiki/STM32) — Wikipedia, on the STM32 family, cores, and tooling.

--- a/docs/reference/system-bus.md
+++ b/docs/reference/system-bus.md
@@ -1,0 +1,30 @@
+---
+slug: system-bus
+title: System bus
+entry_type: concept
+category: hw-foundations
+description: A system bus is the shared set of conductors that carries data, addresses, and control signals between a computer's CPU, memory, and I/O devices.
+keywords: system bus, data bus, address bus, control bus, front-side bus, interconnect, bus width
+infobox:
+  - { label: Type, value: Shared interconnect }
+  - { label: Carries, value: Data, address, control }
+  - { label: Width, value: Bits transferred at once }
+  - { label: Modern form, value: Point-to-point links }
+see_also: [central-processing-unit, random-access-memory, pci-express, motherboard, von-neumann-architecture, input-output]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Bus_(computing)
+---
+
+A **system bus** is the shared set of electrical conductors that moves data, addresses, and control signals between a computer's [CPU](/reference/central-processing-unit/), [memory](/reference/random-access-memory/), and [I/O](/reference/input-output/) devices.[^wiki]
+
+## Overview
+
+Classically a bus has three parts: a *data bus* (the values being moved), an *address bus* (which memory location or device they go to), and a *control bus* (timing and read/write signals). The bus *width* — how many bits cross at once — and its clock set the bandwidth. This shared design comes straight from the [von Neumann architecture](/reference/von-neumann-architecture/), where one path connects the processor to a common memory and devices.
+
+## Where it fits
+
+Because the components on the [motherboard](/reference/motherboard/) cannot talk directly, the bus is the meeting point, and a shared bus can become a bottleneck when many devices compete for it. Modern systems mostly replace one wide shared bus with many fast *point-to-point* links — [PCIe](/reference/pci-express/) being the dominant example — but the concept is unchanged: a defined interconnect that lets the parts of a computer exchange data in step.
+
+## Sources
+
+[^wiki]: [Bus (computing)](https://en.wikipedia.org/wiki/Bus_(computing)) — Wikipedia, on data, address, and control buses.

--- a/docs/reference/system-on-a-chip.md
+++ b/docs/reference/system-on-a-chip.md
@@ -1,0 +1,32 @@
+---
+slug: system-on-a-chip
+title: System on a chip (SoC)
+entry_type: hardware
+category: hw-mobile
+description: A system on a chip (SoC) integrates a computer's major subsystems — CPU, GPU, memory controller, radios, and accelerators — onto a single piece of silicon, the building block of nearly every phone and small device.
+keywords: system on a chip, SoC, application processor, integrated CPU GPU, mobile chip, Snapdragon, Apple Silicon, SoC vs discrete
+aka: [SoC]
+autolink: true
+infobox:
+  - { label: Type, value: Integrated circuit }
+  - { label: Integrates, value: CPU, GPU, memory & I/O controllers }
+  - { label: Common in, value: Phones, tablets, SBCs }
+  - { label: Examples, value: Snapdragon, Apple Silicon, Broadcom }
+see_also: [mobile-operating-system, arm-architecture, central-processing-unit, soc-vs-discrete, integrated-circuit, cellular-modem]
+cite_urls:
+  - https://en.wikipedia.org/wiki/System_on_a_chip
+---
+
+A **system on a chip (SoC)** is an integrated circuit that combines a computer's major subsystems — processor cores, graphics, memory and I/O controllers, and often radios and accelerators — onto a single die.[^wiki]
+
+## Overview
+
+Where a desktop spreads its parts across a [motherboard](/reference/motherboard/), an SoC packs them into one chip: one or more [CPU](/reference/central-processing-unit/) cores, a [GPU](/reference/graphics-processing-unit/), a memory controller, and blocks such as a [cellular modem](/reference/cellular-modem/), [GPS receiver](/reference/gps-receiver/), and an [NPU](/reference/neural-processing-unit/) for on-device machine learning. Most are built on the [Arm architecture](/reference/arm-architecture/). Familiar examples include Qualcomm's Snapdragon, Apple Silicon, and the Broadcom parts inside the [Raspberry Pi](/reference/raspberry-pi/).
+
+## Where it fits
+
+Integration is what makes a [smartphone](/reference/smartphone/) small, cheap, and power-efficient: shorter traces and shared silicon cut size and energy use, at the cost of the upgradability you get from [discrete](/reference/soc-vs-discrete/) parts. The same logic puts SoCs in tablets, single-board computers, and embedded gear. A capture node running GopherTrunk on a Pi leans on its Broadcom SoC for everything but the radio front end, which still needs an external SDR dongle.
+
+## Sources
+
+[^wiki]: [System on a chip](https://en.wikipedia.org/wiki/System_on_a_chip) — Wikipedia, on SoC integration and uses.

--- a/docs/reference/tablet.md
+++ b/docs/reference/tablet.md
@@ -1,0 +1,43 @@
+---
+slug: tablet
+title: Tablet
+entry_type: hardware
+category: hw-mobile
+description: A tablet is a larger touchscreen device sitting between a phone and a laptop, sharing the phone operating system and app model and sometimes paired with a keyboard.
+keywords: tablet, iPad, Android tablet, touchscreen device, detachable keyboard, mobile device
+aka: [Tablet, Tablet computer]
+infobox:
+  - { label: Type, value: Large touchscreen device }
+  - { label: Size, value: Between phone and laptop }
+  - { label: Platforms, value: iPadOS, Android }
+  - { label: Runs, value: Apps }
+  - { label: Optional, value: Detachable keyboard }
+see_also: [smartphone, mobile-app-development, laptop, personal-computer, operating-system]
+related_lessons:
+  - { title: "Tablets", url: /learn/intro-hardware/tablets/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Tablet_computer
+---
+
+**A tablet** is a larger touchscreen device that sits between a
+[smartphone](/reference/smartphone/) and a [laptop](/reference/laptop/).[^wiki]
+
+## Overview
+
+A tablet shares the phone's mobile [operating system](/reference/operating-system/)
+and its app model, just on a bigger screen. That extra screen makes it well
+suited to media — reading, video, drawing — and to light productivity, especially
+when paired with a detachable keyboard that nudges it toward laptop territory.
+
+## Where it fits
+
+The tablet inherits the phone's role rather than the laptop's: it is a place to
+view and interact with data, not a development machine, and apps are still built
+on a [personal computer](/reference/personal-computer/) under
+[mobile app development](/reference/mobile-app-development/). The extra screen
+pays off wherever a phone feels cramped but a full laptop is more than the task
+needs — including reading decoded SDR output in the field.
+
+## Sources
+
+[^wiki]: [Tablet computer](https://en.wikipedia.org/wiki/Tablet_computer) — Wikipedia, on the touchscreen device between a phone and a laptop.

--- a/docs/reference/teensy.md
+++ b/docs/reference/teensy.md
@@ -1,0 +1,35 @@
+---
+slug: teensy
+title: Teensy
+entry_type: hardware
+category: hw-microcontrollers
+description: Teensy is a line of compact, high-performance ARM Cortex-M microcontroller boards from PJRC, Arduino-compatible and popular for audio, USB, and demanding real-time projects.
+keywords: Teensy, PJRC, Teensy 4.0, Teensy 4.1, Cortex-M7, Arduino compatible, Teensyduino, audio library
+aka: [Teensy]
+infobox:
+  - { label: Type, value: Microcontroller board }
+  - { label: Core, value: ARM Cortex-M7 (Teensy 4.x) }
+  - { label: Vendor, value: PJRC }
+  - { label: Compatible, value: Arduino (via Teensyduino) }
+  - { label: Strengths, value: USB, audio, real-time I/O }
+see_also: [arm-cortex-m, microcontroller, arduino, stm32, rp2040, firmware]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Teensy
+---
+
+**Teensy** is a line of compact, high-performance [microcontroller](/reference/microcontroller/) boards made by PJRC, built on [ARM Cortex-M](/reference/arm-cortex-m/) cores.[^wiki]
+
+## Overview
+
+The flagship Teensy 4.0 and 4.1 run a 600 MHz Cortex-M7 — far faster than a typical hobby MCU — in a board barely larger than a postage stamp. Teensy boards are [Arduino](/reference/arduino/)-compatible through the Teensyduino add-on, so they use familiar libraries and the Arduino IDE, but they also expose deep hardware features: many [GPIO](/reference/gpio/) pins, several [UART](/reference/uart/)/[SPI](/reference/spi/)/[I²C](/reference/i2c/) buses, [PWM](/reference/pulse-width-modulation/), and strong USB support.
+
+## Where it fits
+
+Teensy is the go-to when an Arduino-style workflow needs serious horsepower or precise timing. Its well-known audio library makes it a favorite for synthesizers and effects, and its fast cores suit MIDI controllers, data loggers, and other real-time work. Where a project wants the same class of compute with vendor tooling instead of the Arduino layer, an [STM32](/reference/stm32/) is the usual alternative.
+
+## Sources
+
+[^wiki]: [Teensy](https://en.wikipedia.org/wiki/Teensy) — Wikipedia, on the Teensy boards from PJRC.

--- a/docs/reference/tensor-processing-unit.md
+++ b/docs/reference/tensor-processing-unit.md
@@ -1,0 +1,35 @@
+---
+slug: tensor-processing-unit
+title: Tensor processing unit (TPU)
+entry_type: hardware
+category: hw-accelerators
+description: A tensor processing unit (TPU) is a custom chip designed by Google to accelerate machine-learning workloads, built around large matrix-multiply arrays optimized for neural-network math.
+keywords: TPU, tensor processing unit, Google, AI accelerator, machine learning chip, systolic array, matrix multiply
+aka: [TPU]
+autolink: true
+infobox:
+  - { label: Type, value: AI accelerator (ASIC) }
+  - { label: Vendor, value: Google }
+  - { label: Introduced, value: "2016" }
+  - { label: Specialty, value: Neural-network matrix math }
+  - { label: Core, value: Systolic matrix-multiply array }
+see_also: [ai-accelerator, neural-processing-unit, application-specific-integrated-circuit, graphics-processing-unit, google-coral, hardware-acceleration]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Tensor_Processing_Unit
+  - https://cloud.google.com/tpu
+---
+
+A **tensor processing unit** (**TPU**) is a custom chip designed by Google to accelerate machine-learning workloads, built around large arrays that perform the matrix multiplications at the heart of neural networks.[^wiki]
+
+## Overview
+
+A TPU is an [application-specific integrated circuit](/reference/application-specific-integrated-circuit/) (ASIC): rather than the general flexibility of a CPU or GPU, it dedicates almost all its silicon to a *systolic array* — a grid of multiply-accumulate units that streams data through to compute matrix products with very high throughput per watt. The trade-off is narrow specialization: a TPU runs tensor math (typically in reduced precision such as bfloat16) extremely well and little else. Google introduced TPUs in 2016 to power its own services and now offers them through its cloud, with the small Coral Edge TPU bringing the design to embedded devices.[^cloud]
+
+## Where it fits
+
+The TPU is the canonical example of a purpose-built [AI accelerator](/reference/ai-accelerator/), competing with the [GPU](/reference/graphics-processing-unit/) for training and inference and with the on-device [NPU](/reference/neural-processing-unit/) at the edge. Its strength is data-center scale neural-network training and serving; it is not a general DSP engine, so it has no direct role in GopherTrunk's signal chain, though the same edge-AI parts (see [Google Coral](/reference/google-coral/)) could classify decoded traffic.
+
+## Sources
+
+[^wiki]: [Tensor Processing Unit](https://en.wikipedia.org/wiki/Tensor_Processing_Unit) — Wikipedia, on Google's machine-learning accelerator.
+[^cloud]: [Cloud TPU](https://cloud.google.com/tpu) — Google's documentation for the TPU and its architecture.

--- a/docs/reference/thin-client.md
+++ b/docs/reference/thin-client.md
@@ -1,0 +1,31 @@
+---
+slug: thin-client
+title: Thin client
+entry_type: hardware
+category: hw-personal-computers
+description: A thin client is a minimal computer that does little work itself, instead connecting to a server or virtual desktop that runs the applications and stores the data centrally.
+keywords: thin client, zero client, VDI, remote desktop, virtual desktop, terminal
+aka: [Thin client, Zero client]
+infobox:
+  - { label: Type, value: Minimal networked PC }
+  - { label: Does, value: Display a remote session }
+  - { label: Relies on, value: Central server / VDI }
+  - { label: Local power, value: Very low }
+see_also: [personal-computer, server, virtualization, chromebook, mini-pc]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Thin_client
+---
+
+A **thin client** is a minimal computer that does little processing on its own, instead connecting over a network to a [server](/reference/server/) or virtual desktop that runs the applications and holds the data.[^wiki]
+
+## Overview
+
+A thin client is essentially a screen, [keyboard](/reference/keyboard/), and [mouse](/reference/mouse/) bolted to just enough hardware to draw a remote session — a low-power [CPU](/reference/central-processing-unit/), a little [RAM](/reference/random-access-memory/), and a network port, with no spinning disk and often no local [storage](/reference/data-storage/) at all. The real computing happens centrally, frequently on a [virtualized](/reference/virtualization/) desktop infrastructure (VDI), and the thin client simply streams the picture back and forth. A *zero client* takes this further, with firmware fixed to a single remote protocol.
+
+## Where it fits
+
+Thin clients suit large organizations — call centers, hospitals, schools — where central management, security, and low per-seat cost matter more than local flexibility. Because nothing important lives on the device, a failed unit is swapped in minutes and stolen hardware leaks no data. A [Chromebook](/reference/chromebook/) is a consumer cousin of the idea. The limits are the same as that idea's: take away the network or the server and a thin client can do almost nothing, so it is a poor fit for standalone or offline compute like local SDR processing.
+
+## Sources
+
+[^wiki]: [Thin client](https://en.wikipedia.org/wiki/Thin_client) — Wikipedia, on minimal client computers that rely on central servers.

--- a/docs/reference/thunderbolt.md
+++ b/docs/reference/thunderbolt.md
@@ -1,0 +1,32 @@
+---
+slug: thunderbolt
+title: Thunderbolt
+entry_type: hardware
+category: hw-networking
+description: Thunderbolt is a high-speed connection standard that carries data, video, and power over a single cable, combining PCI Express and DisplayPort and now sharing the USB-C connector.
+keywords: Thunderbolt, Thunderbolt 3, Thunderbolt 4, USB-C, PCI Express, DisplayPort, docking
+aka: [Thunderbolt 3, Thunderbolt 4]
+autolink: true
+infobox:
+  - { label: Type, value: High-speed I/O interface }
+  - { label: Carries, value: Data, video, power }
+  - { label: Connector, value: USB-C }
+  - { label: Speed, value: 40 Gb/s (TB3/4), 80 Gb/s (TB5) }
+see_also: [usb, pci-express, peripheral, network-interface-card, ethernet]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Thunderbolt_(interface)
+---
+
+**Thunderbolt** is a high-speed connection standard that carries data, video, and power over a single cable, tunnelling [PCI Express](/reference/pci-express/) and DisplayPort and sharing the [USB-C](/reference/usb/) connector.[^wiki]
+
+## Overview
+
+Developed by Intel and Apple, Thunderbolt 3 and 4 run at 40 Gb/s over a USB-C plug, with Thunderbolt 5 reaching 80 Gb/s; a single cable can drive displays, attach external SSDs and GPUs, deliver power, and even act as a peer-to-peer network link. Because it tunnels PCI Express, a Thunderbolt port behaves almost like an external expansion slot, which is why one cable to a dock can fan out to Ethernet, displays, and storage at once. Thunderbolt 3 onward is compatible with USB-C but offers far more bandwidth than plain [USB](/reference/usb/).
+
+## Where it fits
+
+Thunderbolt is the fast end of the [peripheral](/reference/peripheral/) connection spectrum, suited to bandwidth-hungry external devices on laptops and workstations. For an SDR workflow it gives a single-cable path to a dock or a fast external SSD — handy when a GopherTrunk session is recording raw I/Q at high sample rates and writing many megabytes per second to disk.
+
+## Sources
+
+[^wiki]: [Thunderbolt (interface)](https://en.wikipedia.org/wiki/Thunderbolt_(interface)) — Wikipedia, on the high-speed Thunderbolt interface.

--- a/docs/reference/touchscreen.md
+++ b/docs/reference/touchscreen.md
@@ -1,0 +1,32 @@
+---
+slug: touchscreen
+title: Touchscreen
+entry_type: hardware
+category: hw-mobile
+description: A touchscreen is a display that also serves as an input device, sensing the position of fingers or a stylus on its surface — the primary interface for phones, tablets, and many embedded devices.
+keywords: touchscreen, capacitive, resistive, multitouch, touch panel, display input, stylus, touch sensor
+infobox:
+  - { label: Type, value: Display + input device }
+  - { label: Common tech, value: Capacitive (projected) }
+  - { label: Older tech, value: Resistive }
+  - { label: Feature, value: Multitouch }
+see_also: [mobile-operating-system, smartphone, tablet, e-reader, foldable-phone, smartwatch]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Touchscreen
+---
+
+A **touchscreen** is a display that doubles as an input device, sensing where a finger or stylus touches its surface — the defining interface of modern phones and tablets.[^wiki]
+
+## Overview
+
+Most modern touchscreens are *projected capacitive*: a grid of transparent electrodes detects the tiny change in capacitance a fingertip causes, enabling fast, accurate *multitouch* (pinch, swipe, two-finger gestures). Older *resistive* panels sense pressure where two conductive layers meet — cheaper and usable with gloves or any stylus, but single-touch and less responsive. The panel is laminated over an LCD or OLED display, and a controller reports touch coordinates to the [mobile OS](/reference/mobile-operating-system/).
+
+## Where it fits
+
+The touchscreen is what let phones drop physical keyboards and become all-screen devices; it is equally central to [tablets](/reference/tablet/), [e-readers](/reference/e-reader/), [smartwatches](/reference/smartwatch/), and the inner display of a [foldable phone](/reference/foldable-phone/). For a field setup, a small touchscreen on a [Raspberry Pi](/reference/raspberry-pi/) next to the antenna can give a GopherTrunk capture node a self-contained local display without a separate keyboard or mouse.
+
+## Sources
+
+[^wiki]: [Touchscreen](https://en.wikipedia.org/wiki/Touchscreen) — Wikipedia, on capacitive and resistive touchscreen technology.

--- a/docs/reference/transistor.md
+++ b/docs/reference/transistor.md
@@ -1,0 +1,30 @@
+---
+slug: transistor
+title: Transistor
+entry_type: hardware
+category: hw-foundations
+description: A transistor is a semiconductor device that switches or amplifies electrical signals; as a tiny on/off switch it is the fundamental building block of all modern digital electronics.
+keywords: transistor, semiconductor, MOSFET, switch, amplifier, BJT, gate, solid-state
+infobox:
+  - { label: Type, value: Semiconductor device }
+  - { label: Does, value: Switches or amplifies }
+  - { label: Common type, value: MOSFET }
+  - { label: Invented, value: "Bell Labs, 1947" }
+see_also: [semiconductor, integrated-circuit, logic-gate, moores-law, central-processing-unit, clock-speed]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Transistor
+---
+
+A **transistor** is a [semiconductor](/reference/semiconductor/) device that switches or amplifies electrical signals — and as a tiny, electrically controlled on/off switch it is the fundamental building block of all modern digital electronics.[^wiki]
+
+## Overview
+
+A transistor uses a small voltage or current at one terminal to control a much larger current between two others, so it can act as an *amplifier* or as a *switch*. Invented at Bell Labs in 1947, it replaced the bulky, hot vacuum tube. The dominant type in digital chips is the **MOSFET**, billions of which are etched together on a single [integrated circuit](/reference/integrated-circuit/). Wired together, transistors form the [logic gates](/reference/logic-gate/) that implement all computation.
+
+## Where it fits
+
+Every digit a computer manipulates ultimately comes down to transistors switching on and off. Their relentless shrinking is what [Moore's law](/reference/moores-law/) describes and what lets a modern [CPU](/reference/central-processing-unit/) pack billions of switches into a fingernail-sized die. The same devices also do analog work: in an SDR front end, transistors amplify faint RF in a low-noise amplifier before the signal is digitized for GopherTrunk to decode.
+
+## Sources
+
+[^wiki]: [Transistor](https://en.wikipedia.org/wiki/Transistor) — Wikipedia, on the transistor as switch and amplifier and the basic building block of electronics.

--- a/docs/reference/tsmc.md
+++ b/docs/reference/tsmc.md
@@ -1,0 +1,47 @@
+---
+slug: tsmc
+title: TSMC
+entry_type: organization
+category: hw-organizations
+description: TSMC (Taiwan Semiconductor Manufacturing Company) is the world's largest dedicated chip foundry, manufacturing integrated circuits designed by other companies on contract.
+keywords: TSMC, foundry, semiconductor manufacturing, fab, integrated circuit, fabless
+aka: [Taiwan Semiconductor Manufacturing Company]
+autolink: true
+infobox:
+  - { label: Type, value: Public semiconductor foundry }
+  - { label: Founded, value: "1987" }
+  - { label: HQ, value: Hsinchu, Taiwan }
+  - { label: Makes, value: Integrated circuits (contract manufacturing) }
+see_also: [semiconductor, integrated-circuit, amd, nvidia]
+cite_urls:
+  - https://www.tsmc.com/
+  - https://en.wikipedia.org/wiki/TSMC
+---
+
+**TSMC** (Taiwan Semiconductor Manufacturing Company) is the world's largest dedicated chip
+foundry, manufacturing [integrated circuits](/reference/integrated-circuit/) designed by
+other companies on contract.[^wiki]
+
+## Overview
+
+Founded in 1987, TSMC pioneered the "pure-play foundry" model: it does not design or sell
+its own branded chips, but instead fabricates designs supplied by customers. That model
+enabled the rise of "fabless" companies — firms like [AMD](/reference/amd/),
+[NVIDIA](/reference/nvidia/), Apple, and Qualcomm that design chips but own no factories.[^home]
+
+TSMC operates some of the most advanced [semiconductor](/reference/semiconductor/)
+fabrication plants in the world, repeatedly leading the industry to smaller process nodes.
+Because so many top chip designs are made there, its plants are a critical link in the
+global electronics supply chain.
+
+## Why it matters
+
+Almost any modern device — a phone, a GPU, a server CPU, the SoC in a single-board computer
+running a GopherTrunk node — is likely built on silicon fabricated by TSMC. By separating
+chip design from manufacturing, TSMC reshaped the industry and concentrated a large share of
+advanced production capacity in one company.
+
+## Sources
+
+[^home]: [TSMC](https://www.tsmc.com/) — the company's official site, for its foundry services.
+[^wiki]: [TSMC](https://en.wikipedia.org/wiki/TSMC) — Wikipedia, for the company's history and the foundry model.

--- a/docs/reference/uart.md
+++ b/docs/reference/uart.md
@@ -1,0 +1,33 @@
+---
+slug: uart
+title: UART
+entry_type: concept
+category: hw-microcontrollers
+description: A UART is a hardware block that sends and receives asynchronous serial data over two wires without a shared clock, the classic way to give a microcontroller a simple point-to-point link or console.
+keywords: UART, serial, asynchronous, baud rate, TX, RX, RS-232, serial console, USB-serial
+aka: [UART, serial port]
+infobox:
+  - { label: Type, value: Serial interface }
+  - { label: Wires, value: 2 (TX, RX) }
+  - { label: Clocking, value: Asynchronous (no shared clock) }
+  - { label: Set by, value: Baud rate }
+see_also: [spi, i2c, microcontroller, bootloader, firmware, embedded-system]
+related_lessons:
+  - { title: "What is a microcontroller?", url: /learn/intro-hardware/what-is-a-microcontroller/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Universal_asynchronous_receiver-transmitter
+---
+
+**A UART** (Universal Asynchronous Receiver/Transmitter) is a hardware block that sends and receives serial data over two wires without a shared clock.[^wiki]
+
+## Overview
+
+Instead of a clock line, both ends agree on a **baud rate** and frame each byte with start and stop bits, so the receiver can recover timing from the data itself. The link uses just transmit (TX) and receive (RX), making it the simplest of the common serial interfaces. A [microcontroller](/reference/microcontroller/) usually has several UARTs; one is often wired to a USB-serial adapter to provide a console. Classic RS-232 ports are UARTs with higher voltage line drivers.
+
+## Where it fits
+
+UART is the workhorse point-to-point link: a debug/console port, a connection to a GPS or radio module, or a board-to-board serial line. Unlike the multi-drop [I²C](/reference/i2c/) and [SPI](/reference/spi/) buses, a UART connects exactly two endpoints, which keeps it dead simple. Many [bootloaders](/reference/bootloader/) accept new [firmware](/reference/firmware/) over UART, and it is a fixture of almost every [embedded system](/reference/embedded-system/).
+
+## Sources
+
+[^wiki]: [UART](https://en.wikipedia.org/wiki/Universal_asynchronous_receiver-transmitter) — Wikipedia, on asynchronous serial communication.

--- a/docs/reference/usb.md
+++ b/docs/reference/usb.md
@@ -1,0 +1,32 @@
+---
+slug: usb
+title: USB
+entry_type: hardware
+category: hw-foundations
+description: USB (Universal Serial Bus) is the dominant standard for connecting peripherals and delivering power to computers, using a tiered host-controlled bus with hot-pluggable ports.
+keywords: USB, Universal Serial Bus, peripheral, hot-plug, USB-C, USB 3, USB power delivery, host controller
+aka: [Universal Serial Bus, USB-C]
+autolink: true
+infobox:
+  - { label: Type, value: Serial peripheral bus }
+  - { label: Topology, value: Host-controlled, tiered }
+  - { label: Connectors, value: "Type-A, Type-C, micro" }
+  - { label: Also carries, value: Power (USB-PD) }
+see_also: [input-output, system-bus, pci-express, peripheral, central-processing-unit, rtl-sdr]
+cite_urls:
+  - https://en.wikipedia.org/wiki/USB
+---
+
+**USB** (Universal Serial Bus) is the most common standard for connecting peripherals to a computer and for delivering power, using a hot-pluggable, host-controlled serial bus.[^wiki]
+
+## Overview
+
+A USB system has one *host* (the computer) that controls a tree of *devices* through hubs — keyboards, mice, drives, cameras, dongles. Ports are hot-pluggable, so devices can be attached and removed while running. Successive versions (USB 2.0, 3.x, 4) raised speeds by orders of magnitude, and the reversible USB-C connector added high power delivery (USB-PD), letting one cable both run and charge a device. It is part of a machine's [I/O](/reference/input-output/), distinct from internal expansion buses like [PCIe](/reference/pci-express/).
+
+## What it's for
+
+USB is how most external hardware reaches the [CPU](/reference/central-processing-unit/): a single cable carries data and often power to a [peripheral](/reference/peripheral/). It is central to SDR — an [RTL-SDR](/reference/rtl-sdr/) dongle plugs into a USB port and streams IQ samples to the host, and many capture nodes are powered over the same USB connection. The trade-off versus internal buses is bandwidth and latency: convenient and universal, but a USB link will not match a dedicated PCIe slot for raw throughput.
+
+## Sources
+
+[^wiki]: [USB](https://en.wikipedia.org/wiki/USB) — Wikipedia, on the Universal Serial Bus standard, versions, and connectors.

--- a/docs/reference/vector-processor.md
+++ b/docs/reference/vector-processor.md
@@ -1,0 +1,31 @@
+---
+slug: vector-processor
+title: Vector processor
+entry_type: concept
+category: hw-accelerators
+description: A vector processor is a design that applies one instruction to a whole array of data elements at once, exploiting data parallelism for high throughput in numeric and signal-processing workloads.
+keywords: vector processor, SIMD, array processor, data parallelism, SSE, AVX, NEON, supercomputer, DSP
+aka: [Array processor]
+infobox:
+  - { label: Type, value: Processor architecture }
+  - { label: Model, value: "SIMD (single instruction, many data)" }
+  - { label: Strength, value: Data-parallel numeric throughput }
+  - { label: Modern form, value: "SIMD units (AVX, NEON), GPUs" }
+see_also: [central-processing-unit, graphics-processing-unit, gpgpu, hardware-acceleration, digital-filter, fast-fourier-transform]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Vector_processor
+---
+
+A **vector processor** is a processor designed to apply a single instruction to a whole array of data elements at once, rather than one element per instruction.[^wiki]
+
+## Overview
+
+The model is *SIMD* — single instruction, multiple data. Where a scalar processor adds two numbers per add instruction, a vector unit adds two arrays of numbers in one go, amortizing instruction overhead and keeping wide arithmetic pipelines full. The idea powered the early Cray supercomputers and survives today as the SIMD extensions built into ordinary CPUs (Intel's SSE/AVX, ARM's NEON) and, taken to an extreme, in the thousands-of-lanes design of the [GPU](/reference/graphics-processing-unit/).
+
+## Where it fits
+
+Vector processing is the foundation of [GPGPU](/reference/gpgpu/) and of most numeric [hardware acceleration](/reference/hardware-acceleration/): any workload that does the same math across long, regular arrays benefits. Digital signal processing is a prime example — a [FIR digital filter](/reference/digital-filter/) or an [FFT](/reference/fast-fourier-transform/) multiplies and sums across streams of samples, exactly the data-parallel shape SIMD exploits. GopherTrunk's per-sample DSP on the [CPU](/reference/central-processing-unit/) leans on these vector units to keep up with high sample rates.
+
+## Sources
+
+[^wiki]: [Vector processor](https://en.wikipedia.org/wiki/Vector_processor) — Wikipedia, on SIMD/array processor architectures.

--- a/docs/reference/virtual-private-server.md
+++ b/docs/reference/virtual-private-server.md
@@ -1,0 +1,35 @@
+---
+slug: virtual-private-server
+title: Virtual private server (VPS)
+entry_type: concept
+category: hw-servers
+description: A virtual private server is a slice of a physical server that behaves like your own machine with root access, created by virtualization via a hypervisor.
+keywords: VPS, virtual private server, hypervisor, root access, DigitalOcean, Linode, Hetzner
+aka: [VPS]
+autolink: true
+infobox:
+  - { label: Type, value: Virtual server }
+  - { label: Access, value: Root / full control }
+  - { label: Created by, value: Virtualization }
+  - { label: Providers, value: DigitalOcean, Linode, Hetzner }
+see_also: [server, web-hosting, dedicated-server, virtualization, cloud-computing]
+related_lessons:
+  - { title: "Virtual private server (VPS)", url: /learn/intro-hardware/vps/ }
+  - { title: "Web & shared hosting", url: /learn/intro-hardware/web-hosting/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Virtual_private_server
+---
+
+A **virtual private server (VPS)** is a slice of a physical [server](/reference/server/) that behaves like your own machine, complete with root access.[^wiki]
+
+## Overview
+
+A VPS sits between shared [web hosting](/reference/web-hosting/) and a whole [dedicated server](/reference/dedicated-server/): more control than the former, far cheaper than the latter. It is created by [virtualization](/reference/virtualization/) — a hypervisor divides one physical host into several isolated virtual machines, each with its own operating system. Providers like DigitalOcean, Linode, and Hetzner rent these by the month.
+
+## When to choose it
+
+Reach for a VPS when shared hosting stops being enough: you need root access, custom services, or a specific software stack. The trade-off is responsibility — you manage the operating system, security updates, and backups yourself. For GopherTrunk this is a fine place to store and serve decoded data, though it still cannot capture RF.
+
+## Sources
+
+[^wiki]: [Virtual private server](https://en.wikipedia.org/wiki/Virtual_private_server) — Wikipedia, on VPS hosting and the hypervisor model.

--- a/docs/reference/virtualization.md
+++ b/docs/reference/virtualization.md
@@ -1,0 +1,34 @@
+---
+slug: virtualization
+title: Virtualization
+entry_type: concept
+category: hw-servers
+description: Virtualization splits one physical computer into several isolated virtual machines, each behaving like a separate computer, managed by a hypervisor.
+keywords: virtualization, virtual machine, hypervisor, VM, isolation, host
+aka: [Virtualization, Virtualisation]
+infobox:
+  - { label: Type, value: Resource technology }
+  - { label: Splits, value: One host into many VMs }
+  - { label: Managed by, value: Hypervisor }
+  - { label: Underpins, value: VPS & cloud }
+see_also: [virtual-private-server, cloud-computing, server, dedicated-server, operating-system]
+related_lessons:
+  - { title: "Virtual private server (VPS)", url: /learn/intro-hardware/vps/ }
+  - { title: "Combining tiers", url: /learn/intro-hardware/combining-tiers/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Virtualization
+---
+
+**Virtualization** is splitting one physical computer into several isolated virtual machines, each behaving like a separate computer with its own operating system.[^wiki]
+
+## Overview
+
+The piece that makes this work is the *hypervisor*: a software layer that creates and runs the virtual machines and divides the host's CPU, memory, and storage between them. Each VM is walled off from its neighbors, so one tenant's crash or workload does not spill into another's.
+
+## Where it fits
+
+Virtualization is the foundation under the rest of this category. A [virtual private server](/reference/virtual-private-server/) is one such VM rented out to you, and [cloud computing](/reference/cloud-computing/) is the same idea run across whole data centers. Without it, every customer would need their own [physical server](/reference/server/) — virtualization is what makes affordable, on-demand servers possible.
+
+## Sources
+
+[^wiki]: [Virtualization](https://en.wikipedia.org/wiki/Virtualization) — Wikipedia, on virtual machines and the hypervisor model.

--- a/docs/reference/volatile-memory.md
+++ b/docs/reference/volatile-memory.md
@@ -1,0 +1,34 @@
+---
+slug: volatile-memory
+title: Volatile vs non-volatile memory
+entry_type: concept
+category: hw-storage
+description: Volatile memory loses its contents when power is removed, while non-volatile memory retains them; the distinction explains why computers separate fast working memory from persistent storage.
+keywords: volatile memory, non-volatile memory, RAM, ROM, flash, persistence, data retention, DRAM
+aka: [non-volatile memory]
+infobox:
+  - { label: Volatile, value: Loses data without power (RAM) }
+  - { label: Non-volatile, value: Retains data (flash, ROM, disk) }
+  - { label: Volatile trait, value: Fast, used as working memory }
+  - { label: Non-volatile trait, value: Persistent storage }
+  - { label: Key question, value: "Does it survive power-off?" }
+see_also: [random-access-memory, read-only-memory, flash-memory, memory-hierarchy, data-storage, cache-memory]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Volatile_memory
+  - https://en.wikipedia.org/wiki/Non-volatile_memory
+---
+
+**Volatile memory** loses its contents the moment power is removed, while **non-volatile memory** keeps them — a distinction that shapes how every computer divides fast working memory from lasting storage.[^vol][^nonvol]
+
+## Overview
+
+[RAM](/reference/random-access-memory/) is the archetypal volatile memory: it is fast and freely rewritable, which makes it ideal as the place a running program keeps its data, but everything in it vanishes at power-off. Non-volatile memory — [flash](/reference/flash-memory/), [ROM](/reference/read-only-memory/), hard disks, tape — gives up some speed or flexibility in exchange for retaining data without power. [Cache memory](/reference/cache-memory/) is also volatile. The trade-off is fundamental: the fastest memories tend to be volatile, and persistence tends to cost speed or write endurance.
+
+## Where it fits
+
+This split is why a computer cannot simply use one kind of memory for everything. Volatile RAM holds the working state of the [operating system](/reference/operating-system/) and applications; non-volatile storage holds files and programs between sessions, which is why work must be *saved* to disk to survive a reboot. The [memory hierarchy](/reference/memory-hierarchy/) arranges these layers by speed and cost. For GopherTrunk, decoded frames live briefly in volatile RAM as they are processed, then are written to non-volatile storage so the log survives a restart or power cut at the antenna site.
+
+## Sources
+
+[^vol]: [Volatile memory](https://en.wikipedia.org/wiki/Volatile_memory) — Wikipedia, on memory that requires power to retain data.
+[^nonvol]: [Non-volatile memory](https://en.wikipedia.org/wiki/Non-volatile_memory) — Wikipedia, on memory that retains data without power.

--- a/docs/reference/von-neumann-architecture.md
+++ b/docs/reference/von-neumann-architecture.md
@@ -1,0 +1,32 @@
+---
+slug: von-neumann-architecture
+title: Von Neumann architecture
+entry_type: concept
+category: hw-foundations
+description: The von Neumann architecture is the stored-program computer design in which instructions and data share one memory accessed over a common bus, the basis of nearly every modern computer.
+keywords: von Neumann architecture, stored program, von Neumann bottleneck, CPU, memory, control unit, ALU
+aka: [Stored-program architecture]
+autolink: true
+infobox:
+  - { label: Type, value: Computer architecture }
+  - { label: Key idea, value: Stored program }
+  - { label: Memory, value: Shared for code & data }
+  - { label: Named for, value: John von Neumann }
+see_also: [central-processing-unit, random-access-memory, system-bus, instruction-set-architecture, cache-memory, logic-gate]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Von_Neumann_architecture
+---
+
+The **von Neumann architecture** is the *stored-program* computer design in which both instructions and data live in the same [memory](/reference/random-access-memory/), accessed by the processor over a common [bus](/reference/system-bus/).[^wiki]
+
+## Overview
+
+In this model a computer has a [CPU](/reference/central-processing-unit/) (with a control unit and an arithmetic/logic unit), a single main memory holding both program and data, and I/O — and the processor works by repeatedly *fetching* an instruction from memory, *decoding* it, and *executing* it. Storing the program in the same memory as the data, rather than wiring it as fixed hardware, is what makes a computer general-purpose: change the program, change what the machine does.
+
+## Where it fits
+
+Almost every mainstream computer follows this design, which is why concepts like the [instruction set architecture](/reference/instruction-set-architecture/) and the fetch-execute cycle are universal. Its famous weakness is the *von Neumann bottleneck*: the shared path between CPU and memory limits throughput, which is exactly why [cache memory](/reference/cache-memory/) and wide modern buses exist. The streaming decode loop in GopherTrunk is, at heart, a von Neumann machine pulling samples and instructions from memory in lockstep.
+
+## Sources
+
+[^wiki]: [Von Neumann architecture](https://en.wikipedia.org/wiki/Von_Neumann_architecture) — Wikipedia, on the stored-program model and the von Neumann bottleneck.

--- a/docs/reference/watchdog-timer.md
+++ b/docs/reference/watchdog-timer.md
@@ -1,0 +1,33 @@
+---
+slug: watchdog-timer
+title: Watchdog timer
+entry_type: concept
+category: hw-microcontrollers
+description: A watchdog timer is a hardware counter that resets a system if software fails to periodically signal it, automatically recovering an embedded device that has hung or crashed.
+keywords: watchdog timer, WDT, kick, pet the dog, reset, hang recovery, fail-safe, embedded reliability
+aka: [watchdog, WDT]
+infobox:
+  - { label: Type, value: Hardware timer }
+  - { label: Job, value: Reset on software hang }
+  - { label: Needs, value: Periodic "kick" from firmware }
+  - { label: Benefit, value: Automatic recovery }
+see_also: [microcontroller, firmware, embedded-system, interrupt, bare-metal-programming, real-time-operating-system]
+related_lessons:
+  - { title: "MCU programming and trade-offs", url: /learn/intro-hardware/mcu-programming-and-tradeoffs/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Watchdog_timer
+---
+
+**A watchdog timer (WDT)** is a hardware counter that resets a system if the software fails to signal it within a set interval.[^wiki]
+
+## Overview
+
+The watchdog counts down continuously; healthy [firmware](/reference/firmware/) must periodically "kick" (reset) it before it reaches zero. If the code hangs in an infinite loop, deadlocks, or crashes, it stops kicking, the counter expires, and the watchdog forces a hardware reset — bringing the device back to a known state with no human intervention. Most [microcontrollers](/reference/microcontroller/) include one as a dedicated peripheral, often clocked independently so it survives even if the main clock fails.
+
+## Where it fits
+
+A watchdog is a core reliability tool for any unattended [embedded system](/reference/embedded-system/): an industrial controller, a remote [sensor](/reference/sensor/) node, or a [bootloader](/reference/bootloader/) guarding a firmware update. The trick is kicking it only when the system is genuinely making progress — kicking it blindly from an [interrupt](/reference/interrupt/) defeats the purpose. It is the safety net under both [bare-metal](/reference/bare-metal-programming/) and [RTOS](/reference/real-time-operating-system/)-based designs.
+
+## Sources
+
+[^wiki]: [Watchdog timer](https://en.wikipedia.org/wiki/Watchdog_timer) — Wikipedia, on watchdog timers and recovery.

--- a/docs/reference/wearable-computer.md
+++ b/docs/reference/wearable-computer.md
@@ -1,0 +1,33 @@
+---
+slug: wearable-computer
+title: Wearable computer
+entry_type: hardware
+category: hw-mobile
+description: A wearable computer is a small computing device worn on the body — on the wrist, head, ear, or clothing — combining sensors and radios to provide hands-free, always-available computing.
+keywords: wearable computer, wearable, smartwatch, smart glasses, hearable, fitness band, body-worn computer, AR headset
+aka: [Wearable]
+infobox:
+  - { label: Type, value: Body-worn computer }
+  - { label: Worn on, value: Wrist, head, ear, clothing }
+  - { label: Forms, value: Watches, glasses, earbuds, bands }
+  - { label: Key constraint, value: Size & battery }
+see_also: [smartwatch, smartphone, battery-technology, system-on-a-chip, near-field-communication, gps-receiver]
+related_lessons:
+  - { title: "Smartphones", url: /learn/intro-hardware/smartphones/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Wearable_computer
+---
+
+A **wearable computer** is a small computing device worn on the body — on the wrist, head, ear, or clothing — built to provide hands-free, always-available computing.[^wiki]
+
+## Overview
+
+Wearables span [smartwatches](/reference/smartwatch/) and fitness bands, smart glasses and AR headsets, and "hearables" such as smart earbuds. All share the same constraints: a tiny [SoC](/reference/system-on-a-chip/), a small or absent display, low-power radios like Bluetooth and [NFC](/reference/near-field-communication/), and a [battery](/reference/battery-technology/) measured in fractions of a phone's. Many lean on a paired [smartphone](/reference/smartphone/) for heavy lifting and connectivity, acting as a sensor-rich satellite rather than a standalone computer.
+
+## Where it fits
+
+The category is defined by being *on* the body rather than in a pocket, which favors continuous sensing — motion, heart rate, location via [GPS](/reference/gps-receiver/) — over raw performance. The extreme size and power limits make wearables the most constrained tier of personal computing, suited to capturing and relaying data, not to running compute-heavy workloads on their own.
+
+## Sources
+
+[^wiki]: [Wearable computer](https://en.wikipedia.org/wiki/Wearable_computer) — Wikipedia, on body-worn computing devices and their forms.

--- a/docs/reference/web-hosting.md
+++ b/docs/reference/web-hosting.md
@@ -1,0 +1,34 @@
+---
+slug: web-hosting
+title: Web & shared hosting
+entry_type: concept
+category: hw-servers
+description: Web hosting is a service that runs your website on someone else's servers so it is reachable on the internet, with shared hosting as the cheapest tier.
+keywords: web hosting, shared hosting, website hosting, cPanel, hosting provider
+aka: [Web hosting, Shared hosting]
+infobox:
+  - { label: Type, value: Hosting service }
+  - { label: Cheapest tier, value: Shared hosting }
+  - { label: Control, value: Limited / managed }
+  - { label: Runs, value: PHP, Python, static sites }
+see_also: [server, virtual-private-server, dedicated-server, cloud-computing, php-language]
+related_lessons:
+  - { title: "Web & shared hosting", url: /learn/intro-hardware/web-hosting/ }
+  - { title: "Virtual private server (VPS)", url: /learn/intro-hardware/vps/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Web_hosting_service
+---
+
+**Web hosting** is a service that runs your website on someone else's [servers](/reference/server/) so it is reachable on the internet.[^wiki]
+
+## Overview
+
+Shared hosting is the cheapest tier: many customers' sites live on one server, sharing its CPU, memory, and disk. It is managed for you — you upload files and the provider keeps the machine running — but you get limited control in exchange. It comfortably runs the common cases: [PHP](/reference/php-language/) apps, [Python](/reference/python-language/) sites, and plain static pages.
+
+## Where it stops being enough
+
+Shared hosting hits a wall when you need custom software, background services, or root access to the operating system. At that point you step up to a [virtual private server](/reference/virtual-private-server/), which gives you your own slice with full control, or a [dedicated server](/reference/dedicated-server/) for the whole machine.
+
+## Sources
+
+[^wiki]: [Web hosting service](https://en.wikipedia.org/wiki/Web_hosting_service) — Wikipedia, on hosting tiers including shared hosting.

--- a/docs/reference/webcam.md
+++ b/docs/reference/webcam.md
@@ -1,0 +1,30 @@
+---
+slug: webcam
+title: Webcam
+entry_type: hardware
+category: hw-personal-computers
+description: A webcam is a small camera peripheral that captures video and stills for a computer, used for video calls, streaming, and recording, connected over USB or built into a laptop or monitor.
+keywords: webcam, web camera, video conferencing, USB camera, streaming camera, image sensor
+infobox:
+  - { label: Type, value: Input peripheral (camera) }
+  - { label: Captures, value: Video and stills }
+  - { label: Key specs, value: Resolution, frame rate, FOV }
+  - { label: Connects via, value: USB; or built-in }
+see_also: [peripheral, computer-monitor, laptop, usb, sensor]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Webcam
+---
+
+A **webcam** is a small camera [peripheral](/reference/peripheral/) that captures video and still images for a computer, used for video calls, streaming, and recording.[^wiki]
+
+## Overview
+
+A webcam pairs an image [sensor](/reference/sensor/) and a lens with a small processor that encodes the picture into a video stream the computer can read. It is an input device: the [operating system](/reference/operating-system/) sees it as a camera source that applications tap into. The specs that matter are *resolution* (1080p and 4K are common), *frame rate* (frames per second), and *field of view* (how wide a scene it captures). Webcams connect over [USB](/reference/usb/) or come built into a [laptop](/reference/laptop/) bezel or a [monitor](/reference/computer-monitor/).
+
+## Where it fits
+
+The webcam became a fixture of remote work and online classes, and a step up from a built-in camera noticeably improves call quality. Beyond conferencing, the same hardware feeds streaming, security monitoring, and computer-vision projects. As a plain USB video source it slots neatly into homebrew automation — much as a software-defined radio is a USB input feeding a stream into the computer, a webcam feeds a frame stream that software can capture and process.
+
+## Sources
+
+[^wiki]: [Webcam](https://en.wikipedia.org/wiki/Webcam) — Wikipedia, on webcams as video-capture peripherals.

--- a/docs/reference/wi-fi.md
+++ b/docs/reference/wi-fi.md
@@ -1,0 +1,31 @@
+---
+slug: wi-fi
+title: Wi-Fi
+entry_type: concept
+category: hw-networking
+description: Wi-Fi is the family of wireless local-area networking standards that let devices connect to a network over radio in the 2.4, 5, and 6 GHz bands instead of a cable.
+keywords: Wi-Fi, IEEE 802.11, WLAN, wireless networking, 2.4 GHz, 5 GHz, Wi-Fi 6, access point
+aka: [WiFi, IEEE 802.11, WLAN]
+infobox:
+  - { label: Type, value: Wireless LAN standard }
+  - { label: Standard, value: IEEE 802.11 }
+  - { label: Bands, value: 2.4, 5, 6 GHz }
+  - { label: Reach, value: Tens of metres indoors }
+see_also: [wireless-access-point, ethernet, bluetooth, network-interface-card, router, electromagnetic-spectrum]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Wi-Fi
+---
+
+**Wi-Fi** is the family of wireless local-area networking standards that let devices join a network over radio, in the 2.4, 5, and 6 GHz bands, instead of a wired connection.[^wiki]
+
+## Overview
+
+Built on the **IEEE 802.11** standards, Wi-Fi connects client devices to a [wireless access point](/reference/wireless-access-point/), which bridges them onto the wired [LAN](/reference/lan-and-wan/). Successive generations — now labelled Wi-Fi 4, 5, 6, and 7 — have raised throughput and efficiency using wider channels and smarter modulation, though real-world range and speed depend on interference and walls. Because it shares unlicensed [spectrum](/reference/electromagnetic-spectrum/), Wi-Fi competes with [Bluetooth](/reference/bluetooth/), microwaves, and neighbouring networks for airtime.
+
+## What it's for
+
+Wi-Fi trades the raw stability of [Ethernet](/reference/ethernet/) for mobility and easy deployment, making it the default for laptops, phones, and IoT devices. A GopherTrunk node can report over Wi-Fi where running a cable is impractical, but the 2.4 GHz band is busy and can desensitize a nearby receiver, so a wired link or careful placement is wiser when the antenna and the radio share a roof.
+
+## Sources
+
+[^wiki]: [Wi-Fi](https://en.wikipedia.org/wiki/Wi-Fi) — Wikipedia, on the IEEE 802.11 wireless networking family.

--- a/docs/reference/wireless-access-point.md
+++ b/docs/reference/wireless-access-point.md
@@ -1,0 +1,31 @@
+---
+slug: wireless-access-point
+title: Wireless access point
+entry_type: hardware
+category: hw-networking
+description: A wireless access point is a device that lets Wi-Fi clients join a wired network, bridging radio links onto the LAN and extending wireless coverage across a site.
+keywords: wireless access point, WAP, access point, Wi-Fi AP, SSID, mesh, roaming
+aka: [WAP, access point, AP]
+infobox:
+  - { label: Type, value: Networking device }
+  - { label: Job, value: Bridge Wi-Fi clients to wired LAN }
+  - { label: Standard, value: IEEE 802.11 (Wi-Fi) }
+  - { label: Powered by, value: Mains or PoE }
+see_also: [wi-fi, network-switch, router, power-over-ethernet, ethernet, lan-and-wan]
+cite_urls:
+  - https://en.wikipedia.org/wiki/Wireless_access_point
+---
+
+A **wireless access point** (WAP, or just AP) is a device that lets [Wi-Fi](/reference/wi-fi/) clients join a wired network, bridging their radio links onto the [LAN](/reference/lan-and-wan/).[^wiki]
+
+## Overview
+
+An access point broadcasts one or more named networks (SSIDs) and relays traffic between associated wireless clients and the wired side, usually plugging into a [switch](/reference/network-switch/). Standalone APs are common in larger buildings, where several units share an SSID so devices roam seamlessly, often as a controller-managed or mesh system. Many are powered over the data cable by [Power over Ethernet](/reference/power-over-ethernet/), simplifying mounting. In a home, the AP is typically built into the same box as the [router](/reference/router/) and [modem](/reference/modem/).
+
+## Where it fits
+
+The AP is the radio edge of a wired network — the piece that actually puts Wi-Fi on the air, distinct from the routing and switching behind it. For a GopherTrunk node that must report wirelessly, a well-placed AP gives a cleaner link than a distant home router, though a wired [Ethernet](/reference/ethernet/) drop is still preferable near sensitive RF gear.
+
+## Sources
+
+[^wiki]: [Wireless access point](https://en.wikipedia.org/wiki/Wireless_access_point) — Wikipedia, on the device that bridges Wi-Fi clients onto a wired network.

--- a/docs/reference/workstation.md
+++ b/docs/reference/workstation.md
@@ -1,0 +1,34 @@
+---
+slug: workstation
+title: Workstation
+entry_type: hardware
+category: hw-personal-computers
+description: A workstation is a high-end personal computer built for demanding professional work — CAD, video, simulation, software builds — with powerful CPUs, lots of memory, and often error-correcting RAM.
+keywords: workstation, professional PC, ECC memory, Xeon, Threadripper, CAD, render workstation, ISV certified
+aka: [Pro workstation]
+infobox:
+  - { label: Type, value: High-end personal computer }
+  - { label: Built for, value: Professional / compute-heavy work }
+  - { label: CPU, value: Many-core (Xeon, Threadripper) }
+  - { label: Memory, value: Large, often ECC }
+  - { label: GPU, value: Pro / compute card common }
+see_also: [personal-computer, desktop-computer, gaming-pc, central-processing-unit, graphics-processing-unit, server]
+related_lessons:
+  - { title: "Choosing a dev machine", url: /learn/intro-hardware/choosing-a-dev-machine/ }
+cite_urls:
+  - https://en.wikipedia.org/wiki/Workstation
+---
+
+A **workstation** is a high-end [personal computer](/reference/personal-computer/) built for demanding professional work — engineering, content creation, scientific computing, and large software builds — rather than ordinary office or home use.[^wiki]
+
+## Overview
+
+A workstation looks like a [desktop computer](/reference/desktop-computer/) but is specified for sustained heavy load: a many-core [CPU](/reference/central-processing-unit/) (Intel Xeon or AMD Threadripper class), large amounts of [RAM](/reference/random-access-memory/) — frequently error-correcting (ECC) memory to catch bit errors — and a professional [GPU](/reference/graphics-processing-unit/) tuned for compute or certified rendering. Vendors often "certify" workstations against specific professional applications (ISV certification) so the hardware and drivers are validated for that software.
+
+## Where it fits
+
+Pick a workstation when the work is reliably compute-bound: CAD, finite-element simulation, 3D rendering, video editing, or compiling large codebases all day. For gaming the lighter, GPU-centric [gaming PC](/reference/gaming-pc/) is usually a better value, and a true [server](/reference/server/) wins when the job is serving many clients rather than driving one user's desktop. In GopherTrunk terms, a workstation is overkill for a single capture node but handy as the bench machine where you replay captures and run wideband DSP across many channels at once.
+
+## Sources
+
+[^wiki]: [Workstation](https://en.wikipedia.org/wiki/Workstation) — Wikipedia, on workstations as high-end computers for technical and professional work.

--- a/docs/reference/x86.md
+++ b/docs/reference/x86.md
@@ -1,0 +1,32 @@
+---
+slug: x86
+title: x86
+entry_type: concept
+category: hw-foundations
+description: x86 is the dominant CISC instruction set architecture for desktops, laptops, and servers, originated by Intel and extended to 64 bits as x86-64 by AMD.
+keywords: x86, x86-64, amd64, CISC, Intel, AMD, instruction set, IA-32
+aka: [x86-64, amd64, IA-32]
+autolink: true
+infobox:
+  - { label: Type, value: ISA (CISC) }
+  - { label: Origin, value: "Intel, 1978" }
+  - { label: 64-bit, value: "x86-64 (AMD, 2003)" }
+  - { label: Dominates, value: PCs & servers }
+see_also: [instruction-set-architecture, arm-architecture, risc-v, central-processing-unit, semiconductor, von-neumann-architecture]
+cite_urls:
+  - https://en.wikipedia.org/wiki/X86
+---
+
+**x86** is the long-dominant [instruction set architecture](/reference/instruction-set-architecture/) for desktops, laptops, and servers — a CISC design originated by Intel and extended to 64 bits as x86-64.[^wiki]
+
+## Overview
+
+The family began with Intel's 8086 in 1978 and grew by accreting new instructions while staying backward compatible, the hallmark of a CISC design with many rich, variable-length instructions. In 2003 AMD added 64-bit addressing as *x86-64* (also called amd64), which Intel adopted, and that variant is what almost every modern PC and server [CPU](/reference/central-processing-unit/) runs. Intel and AMD are the two main x86 chip makers.
+
+## Where it fits
+
+x86 owns the PC and most of the server and cloud market, so the great majority of compiled binaries and operating systems assume it. Its main challenger is [ARM](/reference/arm-architecture/), which leads in mobile and is rising in laptops and servers on efficiency, while [RISC-V](/reference/risc-v/) offers an open alternative. A GopherTrunk decode server is typically an x86-64 box; the same Go source also cross-compiles to ARM for edge capture nodes.
+
+## Sources
+
+[^wiki]: [x86](https://en.wikipedia.org/wiki/X86) — Wikipedia, on the x86 instruction set family and x86-64.


### PR DESCRIPTION
Add the final Field Guide domain — a neutral, lookup-style reference
counterpart to the Intro to Hardware learning path. It is a new top-level
domain beside "RF & SDR" and "Software Development", with six categories
mirroring the path's device tiers:

  - Hardware foundations (CPU, RAM, storage, I/O, OS, hardware spectrum)
  - Servers & hosting (server, web hosting, VPS, dedicated, home server,
    cloud, virtualization)
  - Personal computers (PC, desktop, laptop)
  - Mobile devices (smartphone, tablet, mobile app development)
  - Single-board computers (SBC, Raspberry Pi, Jetson, BeagleBone, GPIO)
  - Microcontrollers (MCU, Arduino, ESP32, firmware, IoT)

30 new articles follow the existing reference format (front matter +
Overview/role/Sources), cross-linked via see_also and linked back to the
matching intro-hardware lessons. The hub grid, A–Z index, breadcrumbs,
llms.txt, and the autolinker pick the domain up automatically from
reference.yml; nav.yml gains the domain header and category anchors.

Verified with a local jekyll build and the docs-check site-map script
(553 content pages, all in sitemap.xml and linked from /sitemap/).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RzEAa5HrFUhQt8XEXCfkfB