### PR TITLE
voice/composer: end silent-from-start calls at a bounded window, not the 30s watchdog

### DIFF
--- a/internal/voice/composer/boundary.go
+++ b/internal/voice/composer/boundary.go
@@ -38,11 +38,13 @@ import (
 // atomics. The mutable match/segment bookkeeping is touched only by the
 // chain goroutine.
 type boundaryTracker struct {
-	c        *Composer
-	serial   string
-	grantTG  uint32
-	patches  map[uint32]bool
-	hangtime time.Duration
+	c              *Composer
+	serial         string
+	grantTG        uint32
+	patches        map[uint32]bool
+	hangtime       time.Duration
+	startNano      int64         // unixnano the tracker (≈ the call) started
+	noVoiceTimeout time.Duration // teardown window when NO voice ever decodes
 
 	lastVoiceNano atomic.Int64 // unixnano of the last MATCHING voice frame
 	sawVoice      atomic.Bool
@@ -64,6 +66,23 @@ type boundaryTracker struct {
 // one-off RS-aliased mis-decode (a garbage-but-valid LC) ending a call.
 const foreignRunToEnd = 2
 
+// noVoiceStartupFactor sets the no-initial-voice teardown window as a
+// multiple of the hangtime gap tolerance: a call that has NEVER decoded a
+// matching voice frame is ended this-many hangtimes after it started,
+// rather than holding the voice tap for the engine's much longer
+// call-timeout watchdog (the "hanging silent call").
+//
+// A live P25 voice channel delivers LDUs continuously the instant the
+// transmitter keys — even a keyed-but-silent PTT sends silence-coded IMBE
+// frames, which still drive onVoice — so producing nothing at all for two
+// full hangtimes means the carrier was already gone (a stale / late CC
+// grant), or we are mis-tuned / wrong-demod / under-gained on it. Either
+// way the right move is to free the tap promptly, not sit idle for 30 s;
+// if voice does resume the CC re-announces the grant and a fresh call
+// starts. Two hangtimes leaves ample margin for normal sync acquisition
+// (the first LDU on a healthy call lands well inside one hangtime).
+const noVoiceStartupFactor = 2
+
 func (c *Composer) newBoundaryTracker(serial string, grantTG uint32, patched []uint32) *boundaryTracker {
 	var patches map[uint32]bool
 	if len(patched) > 0 {
@@ -73,12 +92,14 @@ func (c *Composer) newBoundaryTracker(serial string, grantTG uint32, patched []u
 		}
 	}
 	return &boundaryTracker{
-		c:         c,
-		serial:    serial,
-		grantTG:   grantTG,
-		patches:   patches,
-		hangtime:  c.hangtime,
-		lastMatch: true, // write optimistically until a talkgroup proves foreign
+		c:              c,
+		serial:         serial,
+		grantTG:        grantTG,
+		patches:        patches,
+		hangtime:       c.hangtime,
+		startNano:      time.Now().UnixNano(),
+		noVoiceTimeout: c.hangtime * noVoiceStartupFactor,
+		lastMatch:      true, // write optimistically until a talkgroup proves foreign
 	}
 }
 
@@ -140,7 +161,10 @@ func (bt *boundaryTracker) onTransmissionEnd() {
 
 // run drives the hangtime timer and throttled Touch heartbeat until ctx
 // is cancelled (which the composer does when the call ends). It ends the
-// call once no matching voice has arrived for hangtime.
+// call once matching voice stops arriving for hangtime — or, when no
+// matching voice EVER arrives, once the no-voice startup window elapses,
+// so a phantom / mis-tuned grant frees its voice tap instead of hanging
+// for the engine's much longer call-timeout watchdog.
 func (bt *boundaryTracker) run(ctx context.Context) {
 	// Poll fast enough that the hangtime end + Touch heartbeat are
 	// responsive, but coarser than a frame interval so we don't spin.
@@ -156,6 +180,17 @@ func (bt *boundaryTracker) run(ctx context.Context) {
 			return
 		case <-t.C:
 			if !bt.sawVoice.Load() {
+				// No matching voice frame has EVER decoded. End the call
+				// once the no-voice startup window elapses instead of
+				// holding the tap for the full engine watchdog — this is
+				// the "hanging silent call" (carrier already dropped, stale
+				// CC grant, or a mis-tuned / wrong-demod channel). Reason
+				// timeout: not a single frame was delivered, matching the
+				// engine's silent-from-start classification.
+				if time.Since(time.Unix(0, bt.startNano)) > bt.noVoiceTimeout {
+					bt.end(trunking.EndReasonTimeout)
+					return
+				}
 				continue
 			}
 			last := bt.lastVoiceNano.Load()

--- a/internal/voice/composer/boundary_test.go
+++ b/internal/voice/composer/boundary_test.go
@@ -102,17 +102,37 @@ func TestBoundaryHangtimeEndsCall(t *testing.T) {
 	waitFor(t, time.Second, func() bool { return eng.endedCount() > 0 })
 }
 
-// TestBoundaryNoVoiceNoEnd: a tracker that never sees voice does not end
-// the call on hangtime (the engine watchdog handles silent-from-start).
-func TestBoundaryNoVoiceNoEnd(t *testing.T) {
-	c, _, eng := mkBoundaryComposer(t, true, 80*time.Millisecond)
+// TestBoundaryNoVoiceWithinStartupNoEnd: a tracker that has not yet seen
+// voice does not end the call before the no-voice startup window elapses —
+// a healthy call gets the full window to acquire sync and deliver its
+// first LDU.
+func TestBoundaryNoVoiceWithinStartupNoEnd(t *testing.T) {
+	// hangtime 1s ⇒ noVoiceTimeout 2s, so 300ms in nothing should end yet.
+	c, _, eng := mkBoundaryComposer(t, true, time.Second)
 	bt := c.newBoundaryTracker("VOICE-1", 0, nil)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go bt.run(ctx)
 	time.Sleep(300 * time.Millisecond)
 	if eng.endedCount() != 0 {
-		t.Error("tracker that never saw voice must not end the call")
+		t.Error("tracker must not end the call inside the no-voice startup window")
+	}
+}
+
+// TestBoundaryNoVoiceEndsCall is the regression for the "hanging silent
+// call": a tracker that NEVER decodes a matching voice frame must end the
+// call once the no-voice startup window elapses (reason=timeout), instead
+// of holding the voice tap for the full engine call-timeout watchdog.
+func TestBoundaryNoVoiceEndsCall(t *testing.T) {
+	// hangtime 50ms ⇒ noVoiceTimeout 100ms; never call onVoice.
+	c, _, eng := mkBoundaryComposer(t, true, 50*time.Millisecond)
+	bt := c.newBoundaryTracker("VOICE-1", 42, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go bt.run(ctx)
+	waitFor(t, time.Second, func() bool { return eng.endedCount() > 0 })
+	if got := eng.endReason("VOICE-1"); got != trunking.EndReasonTimeout {
+		t.Errorf("silent-from-start call end reason = %v, want EndReasonTimeout", got)
 	}
 }
 

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -108,14 +108,26 @@ type fakeEngine struct {
 	touched atomic.Int64
 	mu      sync.Mutex
 	ended   []string
+	reasons map[string]trunking.EndReason
 }
 
 func (e *fakeEngine) Touch(string) { e.touched.Add(1) }
-func (e *fakeEngine) EndCall(serial string, _ trunking.EndReason) bool {
+func (e *fakeEngine) EndCall(serial string, reason trunking.EndReason) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.ended = append(e.ended, serial)
+	if e.reasons == nil {
+		e.reasons = make(map[string]trunking.EndReason)
+	}
+	e.reasons[serial] = reason
 	return true
+}
+
+// endReason returns the reason the most recent EndCall(serial) carried.
+func (e *fakeEngine) endReason(serial string) trunking.EndReason {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.reasons[serial]
 }
 
 func mkComposer(t *testing.T, src *fakeSource) (*Composer, *events.Bus, *recordingSink, *fakeEngine, func()) {


### PR DESCRIPTION
A voice grant whose channel never delivers a single matching voice frame
(carrier already dropped, a stale/late CC grant re-announcement, or a
mis-tuned / wrong-demod / under-gained tap) was held by the boundary
tracker for the engine's full call-timeout watchdog — 30 s by default —
showing in the UI as an "active" call with a climbing ELAPSED and no
audio. The hangtime end-of-call only engaged *after* voice had been
decoding (the `!sawVoice` early-continue in run()), so a call that never
decoded anything skipped it entirely.

Add a no-voice startup window: a tracker that has never seen a matching
voice frame ends the call (EndReasonTimeout — not one frame was
delivered) once it has run for noVoiceStartupFactor × hangtime (2×3.5s =
7s by default) instead of waiting out the watchdog. A live P25 channel
delivers LDUs the instant the transmitter keys — even a keyed-but-silent
PTT sends silence-coded IMBE frames that drive onVoice — so producing
nothing for two full hangtimes is a phantom/failed grant; freeing the tap
promptly is correct, and if voice resumes the CC re-announces the grant
and a fresh call starts.

Regression: TestBoundaryNoVoiceEndsCall fails-first (the call hangs past
the test deadline without the fix) and asserts reason=timeout.
TestBoundaryNoVoiceNoEnd, which pinned the old "never end" behaviour, is
reworked into TestBoundaryNoVoiceWithinStartupNoEnd (no end *inside* the
startup window). fakeEngine now records EndCall reasons.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CM5saGvxzUK4xGNkic8bHy