### PR TITLE
capture: hint on high sample rate for narrowband decode; doc sample-rate guidance (#771)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **Capture sample-rate guidance** (#771). `gophertrunk capture` now prints a
+  one-line hint when a high native rate (>4 MS/s) is chosen for a narrowband
+  trunking capture, explaining that the down-converter normalises to 48 kHz and
+  that the top native clock on wideband front-ends (e.g. Airspy R2 at 10 MS/s)
+  can degrade in-channel SNR via phase noise / reciprocal mixing — the verified
+  root cause of the #771 no-lock report. A new "Choosing a sample rate" section
+  in `docs/hardware.md` documents the finding and recommends ~2.4–2.5 MS/s for
+  control-channel roles.
+
 ## [v0.5.1] — 2026-06-23
 
 A maintenance release headlined by a new **ka9q-radio network SDR source** —

--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -128,6 +128,10 @@ FLAGS:`)
 	fmt.Printf("capture: %s[%s] @ %d Hz, %g MS/s → %s for %gs…\n",
 		info.Driver, info.Serial, *freq, float64(*sampleRate)/1e6, *out, *seconds)
 
+	if hint := captureSampleRateHint(uint32(*sampleRate), *protocol); hint != "" {
+		fmt.Fprintln(os.Stderr, hint)
+	}
+
 	written, capErr := captureToFile(ctx, *out, sampleFormat, stream, uint32(*sampleRate), *seconds)
 	if capErr != nil && !errors.Is(capErr, context.Canceled) {
 		rep.Fatal(1, fmt.Errorf("capture: %w (wrote %d samples to %s)", capErr, written, *out))
@@ -266,6 +270,56 @@ func captureToFile(ctx context.Context, path string, format siglab.SampleFormat,
 }
 
 // serialsOf renders the serials of the discovered devices for a friendly hint.
+// captureSampleRateHint returns a one-line front-end guidance note when the
+// requested rate is far higher than a single narrowband trunking channel needs,
+// or "" when no hint applies. Very high native rates on a wideband front-end
+// (e.g. Airspy R2 at 10 MS/s) can raise the in-channel noise floor via clock
+// phase noise / reciprocal mixing and degrade decode even without clipping
+// (issue #771). The decoder down-converts one channel to 48 kHz regardless of
+// capture rate, so a few MS/s is already generous for the narrowband
+// (P25/DMR/NXDN/dPMR/YSF/D-STAR) family.
+//
+// The hint fires when the rate is high AND the capture is for a narrowband
+// protocol (or none was declared — the common case, and the one in the #771
+// repro). An explicit non-narrowband protocol is a deliberate wide grab, so it
+// is left alone.
+func captureSampleRateHint(sampleRateHz uint32, protocol string) string {
+	// 4 MS/s sits above the 2.4 MS/s flag default and the recommended
+	// ~2.5 MS/s while staying below the common 6/10 MSPS Airspy slots that
+	// trip #771 — generous headroom for a single ~12.5 kHz channel.
+	const highRateThresholdHz = 4_000_000
+
+	if sampleRateHz <= highRateThresholdHz {
+		return ""
+	}
+	if p := strings.ToLower(strings.TrimSpace(protocol)); p != "" && !isNarrowbandTrunkingProtocol(p) {
+		return ""
+	}
+	return fmt.Sprintf(
+		"capture: note — %.1f MS/s is a high native rate for a single narrowband channel "+
+			"(the downconverter normalises to 48 kHz, so the extra bandwidth buys nothing). "+
+			"On wideband front-ends (e.g. Airspy R2) the top native clock can degrade in-channel "+
+			"SNR via phase noise / reciprocal mixing (issue #771); prefer ~2.4-2.5 MS/s for "+
+			"control-channel captures. See docs/hardware.md \"Choosing a sample rate\".",
+		float64(sampleRateHz)/1e6)
+}
+
+// isNarrowbandTrunkingProtocol reports whether p (case-insensitive, already
+// trimmed/lowered by the caller) names a trunking protocol whose channels are
+// narrow enough that a few hundred kHz of capture bandwidth is ample. Used to
+// gate captureSampleRateHint so deliberate wideband IQ grabs aren't nagged.
+func isNarrowbandTrunkingProtocol(p string) bool {
+	switch p {
+	case "p25", "p25p1", "p25-phase1", "p25p2", "p25-phase2",
+		"dmr", "dmr-tier1", "dmr-tier2", "dmr-tier3",
+		"nxdn", "nxdn48", "nxdn96", "dpmr", "dstar", "d-star", "ysf",
+		"tetra", "mpt1327", "mpt-1327", "ltr", "edacs":
+		return true
+	default:
+		return false
+	}
+}
+
 func serialsOf(infos []sdr.Info) string {
 	out := make([]string, 0, len(infos))
 	for _, in := range infos {

--- a/cmd/gophertrunk/capture_test.go
+++ b/cmd/gophertrunk/capture_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -79,6 +80,44 @@ func TestCaptureToFileContextCancel(t *testing.T) {
 	_, err := captureToFile(ctx, path, siglab.FormatF32, feedChunks(5, 300), 1_000_000, 1.0)
 	if err == nil {
 		t.Fatalf("expected ctx.Err() when the context is already cancelled")
+	}
+}
+
+func TestCaptureSampleRateHint(t *testing.T) {
+	cases := []struct {
+		name     string
+		rateHz   uint32
+		protocol string
+		wantHint bool
+	}{
+		{"default rate, p25 — silent", 2_400_000, "p25", false},
+		{"2.5 MS/s, p25 — silent (recommended R2 rate)", 2_500_000, "p25", false},
+		{"exactly at threshold — silent", 4_000_000, "p25", false},
+		{"just above threshold — fires", 4_000_001, "p25", true},
+		{"10 MS/s, p25 — fires (the #771 trap)", 10_000_000, "p25", true},
+		{"6 MS/s, dmr — fires", 6_000_000, "dmr", true},
+		{"10 MS/s, mixed-case protocol — fires", 10_000_000, "P25", true},
+		{"10 MS/s, no protocol — fires (the #771 repro command)", 10_000_000, "", true},
+		{"10 MS/s, explicit non-narrowband — silent", 10_000_000, "wfm", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := captureSampleRateHint(tc.rateHz, tc.protocol)
+			if tc.wantHint && got == "" {
+				t.Fatalf("captureSampleRateHint(%d, %q) = \"\", want a hint", tc.rateHz, tc.protocol)
+			}
+			if !tc.wantHint && got != "" {
+				t.Fatalf("captureSampleRateHint(%d, %q) = %q, want \"\"", tc.rateHz, tc.protocol, got)
+			}
+			if tc.wantHint {
+				if !strings.Contains(got, "#771") {
+					t.Errorf("hint missing issue reference: %q", got)
+				}
+				if !strings.Contains(got, "Choosing a sample rate") {
+					t.Errorf("hint missing doc pointer: %q", got)
+				}
+			}
+		})
 	}
 }
 

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -133,11 +133,13 @@ sdr:
 
 The R2 / Mini driver pins the device to `INT16_IQ` sample mode at
 open-time and reads the firmware's advertised sample-rate table —
-`SetSampleRate` then picks the closest available rate, so a `gain:
-"auto"` + `sample_rate: 10_000_000` config picks the 10 MSPS slot on
-R2 and the 6 MSPS slot on Mini without per-device overrides. The
-HF+ driver does the same; it also reads VERSION_STRING_READ to
-expose the firmware version in `TunerName`.
+`SetSampleRate` then picks the closest available rate, so a
+`sample_rate: 10_000_000` config selects the 10 MSPS slot on R2 and
+a `sample_rate: 6_000_000` config selects the 6 MSPS slot on Mini
+without per-device overrides. **For a single narrowband control
+channel, don't reach for the top native rate** — see "Choosing a
+sample rate" below. The HF+ driver does the same; it also reads
+VERSION_STRING_READ to expose the firmware version in `TunerName`.
 
 ```yaml
 sdr:
@@ -147,6 +149,44 @@ sdr:
       role: control
       gain: "auto"                 # firmware HF AGC handles the HF band well
       bias_tee: false              # set true to power an active HF antenna
+```
+
+### Choosing a sample rate
+
+A wideband front-end like the Airspy R2 advertises native rates up to
+10 MSPS, but a trunking **control channel is only ~12.5 kHz wide** and the
+down-converter normalises it to 48 kHz before decode. Capturing at the top
+native rate buys nothing for a single narrowband channel — and on some
+units it actively *hurts*.
+
+On an R2 captured at its native 10 MSPS, the same control channel — same
+antenna, gain, and centre frequency — carried roughly **16 dB worse
+in-channel SNR** than the identical signal captured at 2.5 MSPS (issue
+#771: EVM 22.5% / demod SNR 9.5 dB versus 7.4% / 19.7 dB). The penalty
+sits *inside* the channel, co-band with the signal, so no downstream
+filtering removes it, and it is independent of gain (the same deficit shows
+at 60 dB and 30 dB). The cause is front-end clock phase noise / reciprocal
+mixing at the higher native clock — not clipping, and not GopherTrunk's
+DSP, which is rate-invariant. The 2.5 MSPS capture locked; the 10 MSPS one
+did not.
+
+> **For a control-channel role, prefer a moderate native rate
+> (~2.4–2.5 MSPS).** The `gophertrunk capture` default is `2_400_000` for
+> this reason, and the tool prints a one-line hint if you ask for a high
+> rate on a narrowband capture. Reach for a high native rate only when you
+> genuinely need the wide IQ window — a wideband survey or several
+> repeaters at once — and even then verify lock, because the same
+> phase-noise penalty can still bite a narrowband channel sitting inside a
+> wide capture. (TETRA's 25 kHz channels still decode fine at a moderate
+> rate; the down-converter normalises them to 144 kHz.)
+
+```yaml
+sdr:
+  sample_rate: 2_400_000           # moderate native rate for narrowband CC decode
+  devices:
+    - serial: "..."                # whatever `gophertrunk sdr list` shows
+      role: control
+      gain: "auto"
 ```
 
 ## Linux


### PR DESCRIPTION
Issue #771 was verified as a capture-side / front-end problem, not a
GopherTrunk DSP defect: a P25 control channel captured with an Airspy R2
locks at 2.5 MS/s but not at 10 MS/s because the 10 MS/s capture carries a
~16 dB worse in-channel SNR (gain-independent), consistent with clock phase
noise / reciprocal mixing at the native 10 MS/s clock. The decode path is
rate-invariant. The remaining gap was guidance: docs recommended the
problematic 10 MS/s rate and `capture` emitted no warning.

- `gophertrunk capture` now prints a one-line hint to stderr when a high
  native rate (>4 MS/s) is selected for a narrowband trunking capture
  (protocol narrowband or unset), pointing at the down-converter's 48 kHz
  normalisation and the front-end SNR penalty. Suppressed for an explicit
  non-narrowband protocol and at/below the threshold (default 2.4 MS/s stays
  silent). Covered by a table-driven test.
- docs/hardware.md gains a "Choosing a sample rate" section recording the
  finding and recommending ~2.4-2.5 MS/s for control-channel roles; the R2
  example no longer reads as a blanket 10 MS/s recommendation.

Refs #771

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Jx6XboWEczkrU2CT1j3VEL