### PR TITLE
docs: post-release v0.5.2 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,66 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.2] — 2026-06-24
+
+A maintenance release headlined by a **generic JSON webhook call sink** —
+POST one stable-schema JSON object per completed call to any HTTP endpoint, so
+GopherTrunk feeds custom dashboards and automations alongside the existing
+OpenMHz / Broadcastify Calls / RdioScanner / Icecast backends. The rest is
+voice-path robustness: DMR 2-slot cadence is now picked by AMBE FEC instead of
+the unvalidated embedded Link Control (fixing garbled "sounds-encrypted" audio
+on 288-cadence carriers, #644), calls that never deliver a single voice frame
+end at a bounded 7 s window instead of hanging on the 30 s watchdog (#788), and
+siglab now names *why* a control channel did not lock with an opt-in soft-sync
+fallback for marginal captures (#771).
+
+### Added
+- **Generic JSON webhook call sink** (`broadcast.webhook`, #404, #268). A new
+  outbound call-streaming backend that POSTs one `application/json` object per
+  completed call with a documented, stable schema: system, protocol, talkgroup
+  (+label), source RID, frequency, P25 site identity (channel/RFSS/site/NAC),
+  timeslot, encryption + emergency flags, patched groups, and RFC3339
+  start/stop timestamps. An optional `Authorization` header is sent verbatim and
+  `include_audio` opt-in embeds the base64 MP3 (default off keeps it a
+  lightweight metadata feed). Reuses the existing Manager fan-out (system
+  filter, min-duration gate, bounded exponential-backoff retry); configure under
+  `broadcast.webhook[]` and in the web Config Builder. See `config.example.yaml`.
+
+### Changed
+- **siglab names the no-lock reason + opt-in soft-sync fallback** (#771). The
+  scan verdict now classifies *why* a control channel did not lock —
+  SNR/EVM-limited, frame-sync-not-aligned, not-the-control-channel, or
+  no-signal — from the demod and frame-decode metrics already gathered, rendered
+  after the "did NOT lock" line and serialized into the CSV/JSON/YAML summaries.
+  A `replay -soft-sync` flag (off by default; the daemon is unchanged) widens the
+  P25 FSW correlator so sync words carrying 5–8 symbol errors decode, but admits
+  those looser hits only through the existing TSBK-CRC-corroborated marginal NID
+  tier, so a looser sync extends reach into marginal-SNR captures without
+  manufacturing a false lock.
+
+### Fixed
+- **DMR 2-slot cadence detected by AMBE FEC, not the embedded LC** (#644). The
+  interleaved DMR voice decoder picked its same-slot TDMA cadence solely by which
+  candidate stride reassembled a CRC-valid embedded Link Control — a decode that
+  frequently never validates on a real outbound carrier, so it fell back to the
+  264-dibit cadence. On a 288-cadence carrier that sliced every burst 24 dibits
+  off, splicing the other timeslot's / the CACH's bits into each AMBE frame and
+  rendering audio as structured noise that "sounds encrypted" (the reopened
+  symptom of #644). Cadence is now scored by AMBE Golay(23,12) corrected-bit
+  count when no candidate yields an authoritative LC: a correct slice decodes
+  with ~0 corrected bits, a wrong slice scores far higher, and a ceiling-and-
+  margin gate keeps genuinely garbled data from locking a cadence. The LC
+  remains authoritative when it does decode.
+- **Silent-from-start calls end at a bounded window, not the 30 s watchdog**
+  (#788). A voice grant whose channel never delivered a single matching voice
+  frame (carrier already dropped, a stale CC grant re-announcement, or a
+  mis-tuned / under-gained tap) was held by the boundary tracker for the engine's
+  full call-timeout watchdog — 30 s by default — showing as an "active" call with
+  a climbing ELAPSED and no audio. A tracker that has never seen a matching voice
+  frame now ends the call (reason `timeout`) once it has run for 2× hangtime
+  (7 s by default); if voice resumes, the CC re-announces the grant and a fresh
+  call starts.
+
 ## [v0.5.1] — 2026-06-23
 
 A maintenance release headlined by a new **ka9q-radio network SDR source** —

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.1
+VERSION=v0.5.2
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.1" -%}
+  {%- assign ver = "v0.5.2" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.2.md
+++ b/docs/announcements/v0.5.2.md
@@ -1,0 +1,53 @@
+# GopherTrunk v0.5.2 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.2 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.2
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.2 — a generic JSON webhook call sink (POST every completed call to your own endpoint on a stable schema), a DMR fix that clears garbled "sounds-encrypted" audio on 288-cadence carriers, calls that never deliver voice now end in 7s instead of hanging 30s, and siglab that names exactly why a control channel didn't lock
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.2 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+This is a maintenance release headlined by a new outbound integration and a couple of voice-path fixes.
+
+**What's new since v0.5.1:**
+
+* **Generic JSON webhook call sink** (`broadcast.webhook`, #404, #268). A new outbound call-streaming backend that POSTs one `application/json` object per completed call on a documented, stable schema — system, protocol, talkgroup (+label), source RID, frequency, P25 site identity (channel/RFSS/site/NAC), timeslot, encryption + emergency flags, patched groups, and RFC3339 start/stop timestamps. An optional `Authorization` header is sent verbatim, and `include_audio` opt-in embeds the base64 MP3 (default off keeps it a lightweight metadata feed). It rides the same fan-out as the OpenMHz / Broadcastify Calls / RdioScanner / Icecast backends, so custom dashboards and automations are just another feed.
+* **DMR garbled "sounds-encrypted" audio fixed** (#644). 2-slot TDMA cadence is now picked by AMBE Golay FEC instead of the often-unvalidated embedded Link Control, so 288-cadence carriers no longer slice every burst 24 dibits off and render clear voice as structured noise.
+* **No more phantom 30-second "active" calls** (#788). A voice grant whose channel never delivers a single voice frame (dropped carrier, stale grant re-announcement, mis-tuned tap) now ends at a bounded 7 s window instead of being held by the full call-timeout watchdog with a climbing ELAPSED and no audio.
+* **siglab names *why* a control channel didn't lock** (#771) — SNR/EVM-limited, frame-sync-not-aligned, not-the-control-channel, or no-signal — rendered after the "did NOT lock" line and serialized into the CSV/JSON/YAML summaries, plus an opt-in `replay -soft-sync` fallback that extends reach into marginal-SNR captures without manufacturing a false lock.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.2
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.2 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+A maintenance release headlined by a new outbound integration and a couple of voice-path fixes.
+
+**What's new since v0.5.1:**
+- **Generic JSON webhook call sink** (`broadcast.webhook`, #404, #268) — POST one stable-schema JSON object per completed call to any HTTP endpoint, alongside the existing OpenMHz / Broadcastify Calls / RdioScanner / Icecast backends.
+- **DMR garbled "sounds-encrypted" audio fixed** (#644) — 2-slot cadence is now picked by AMBE FEC, not the unvalidated embedded LC, so 288-cadence carriers decode clean instead of as structured noise.
+- **No more phantom 30s "active" calls** (#788) — a grant that never delivers voice ends at a bounded 7 s window instead of hanging on the call-timeout watchdog.
+- **siglab names the no-lock reason** (#771) — SNR/EVM-limited vs frame-sync vs wrong-channel vs no-signal, plus an opt-in `replay -soft-sync` fallback for marginal captures.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.2>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
Promote the new [v0.5.2] — 2026-06-24 CHANGELOG section covering the
v0.5.2 contents: the generic JSON webhook call sink (#404, #268), the DMR
2-slot cadence-by-AMBE-FEC fix for garbled "sounds-encrypted" audio on
288-cadence carriers (#644), the bounded no-voice startup window that ends
silent-from-start calls in 7s instead of the 30s watchdog (#788), and the
siglab no-lock-reason classifier plus opt-in soft-sync fallback (#771).
Bump the README quick-start VERSION and the latest-version.html fallback
tag to v0.5.2, and add the v0.5.2 social-announcement drafts.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ue1GPMXhYSmk5hc7LXSBQt