### PR TITLE
docs(learn): add "Software Licensing & Agreements" learning path

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -107,6 +107,14 @@ defaults:
       learn_path: ai-software-dev
       nav_group: Learn
       permalink: /learn/ai-software-dev/:basename/
+  - scope:
+      path: "learn/software-licensing"
+      type: pages
+    values:
+      layout: lesson
+      learn_path: software-licensing
+      nav_group: Learn
+      permalink: /learn/software-licensing/:basename/
   # Field Guide articles under /reference/ get the reference layout and nav
   # group automatically. The hub (reference/index.md) overrides to reference-hub.
   - scope:

--- a/docs/_data/learn.yml
+++ b/docs/_data/learn.yml
@@ -1493,3 +1493,320 @@ paths:
       minutes: 12
       level: beginner
       status: full
+
+  - id: software-licensing
+    label: "Software Licensing"
+    title: "Software Licensing & Agreements — from open source to selling your own"
+    tagline: "Every software license from open source to proprietary, using open source in what you sell, how to read any agreement, and choosing the right license and user agreements for your own software."
+    start_slug: what-is-a-software-license
+    workload: "PT7H"
+    intro: >
+      Licensing is where software meets the law, and it decides what you and your
+      users are actually allowed to do with code. This path is a plain-language,
+      end-to-end tour — start with what a license is and how copyright makes
+      software ownable, then work through every open-source license in detail
+      (MIT, BSD, Apache, the GPL family, the weak-copyleft licenses, and public
+      domain) with the real strengths, weaknesses, and trade-offs of each. From
+      there you'll learn to choose and combine open-source licenses, how
+      proprietary and commercial licensing works, how to write a custom license
+      to sell software, and how to use open-source libraries inside a product you
+      sell without breaking the rules. The back half teaches you to read any
+      software agreement and understand it before you sign, covers the other
+      agreements software needs — EULAs, terms of service, privacy policies,
+      DPAs, SLAs, and NDAs — and ends by walking you through choosing the right
+      license and the right set of agreements for your own software. Concepts are
+      taught with US law as the reference point and the major differences in other
+      jurisdictions flagged throughout, so you get the complete picture. This is
+      educational material, not legal advice. No legal background required;
+      examples lean on real software, including GopherTrunk's own Apache-2.0
+      license and dependency notices.
+    modules:
+      - id: foundations
+        label: "Module 1 — Licensing & IP Foundations"
+        blurb: "What a software license actually is, how copyright and other IP make code ownable, license versus contract, the full spectrum of license types, and how the law differs around the world."
+        lessons:
+          - slug: what-is-a-software-license
+            title: What is a software license?
+            summary: A license is permission to use code you don't own — why software defaults to "all rights reserved", what a license grants, and why every project needs one.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: copyright-and-software-ownership
+            title: Copyright & software ownership
+            summary: How copyright attaches to code automatically, what it does and doesn't protect, and who actually owns software written by employees, contractors, and you.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: other-ip-in-software
+            title: Patents, trademarks & trade secrets
+            summary: Copyright isn't the only IP in software — how patents, trademarks, and trade secrets each touch your code, your name, and your competitive edge.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: license-vs-contract
+            title: License vs contract
+            summary: A license grants permission; a contract is a deal with obligations on both sides — why the difference matters, and how click-wrap and browse-wrap agreements bind users.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: the-licensing-spectrum
+            title: The licensing spectrum
+            summary: From locked-down proprietary to source-available to open source to public domain — the full map of how software can be licensed, and where each model fits.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: licensing-across-jurisdictions
+            title: Licensing across jurisdictions
+            summary: US copyright is the reference point, but moral rights, enforceability, warranty disclaimers, and data law differ worldwide — the complete cross-border picture.
+            minutes: 11
+            level: intermediate
+            status: full
+
+      - id: open-source-in-depth
+        label: "Module 2 — Open Source Licenses in Depth"
+        blurb: "What 'open source' really means, the permissive-versus-copyleft divide, and a detailed look at every common license — MIT, BSD, Apache, GPL, AGPL, the weak-copyleft licenses, and public domain — with the real strengths and weaknesses of each."
+        lessons:
+          - slug: what-is-open-source
+            title: What open source really means
+            summary: The OSI Open Source Definition, the FSF's four freedoms, "free vs open", and why source-available is not the same as open source.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: permissive-vs-copyleft
+            title: Permissive vs copyleft
+            summary: The single divide that organizes every open-source license — do nothing back, or share alike — and what "copyleft" really obligates.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: mit-and-bsd-licenses
+            title: "MIT & BSD: minimal permissive"
+            summary: The short, do-almost-anything licenses behind most of the ecosystem — what MIT and the BSD variants say, where they shine, and their few real weaknesses.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: apache-license
+            title: "Apache 2.0: permissive with a patent grant"
+            summary: Permissive freedom plus an explicit patent grant and NOTICE requirement — why Apache 2.0 is the corporate default, and why GopherTrunk uses it.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: gpl-strong-copyleft
+            title: "The GPL: strong copyleft"
+            summary: The license that started copyleft — what triggers GPLv2/v3 obligations, the source-code requirement, and the strengths and costs of "share alike".
+            minutes: 11
+            level: intermediate
+            status: full
+          - slug: agpl-network-copyleft
+            title: "The AGPL: copyleft over the network"
+            summary: How the AGPL closes the SaaS "loophole" by triggering on network use, why it protects user freedom, and why so many companies ban it outright.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: weak-copyleft-licenses
+            title: "Weak copyleft: LGPL, MPL, EPL"
+            summary: The middle ground — file- and library-level copyleft that lets you link from proprietary code while keeping the open parts open; strengths and traps of each.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: public-domain-and-cc0
+            title: Public domain, Unlicense & CC0
+            summary: Giving up all rights — public-domain dedications, the Unlicense, CC0, and 0BSD — plus why "no license at all" is a trap, not a gift.
+            minutes: 8
+            level: beginner
+            status: full
+
+      - id: choosing-and-combining
+        label: "Module 3 — Choosing & Combining Open Source"
+        blurb: "Putting the licenses to work: how they combine and where they conflict, how to pick one for your own project, contributor agreements, dual licensing, and the long-term risks of depending on open source."
+        lessons:
+          - slug: license-compatibility
+            title: License compatibility
+            summary: When code under different licenses can legally be combined, why GPL compatibility runs one way, and a mental model for the compatibility matrix.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: choosing-an-oss-license
+            title: Choosing an open-source license
+            summary: Turning strengths and weaknesses into a decision — match your goals to a license, and the tools (choosealicense.com and friends) that help.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: contributor-agreements
+            title: "Contributor agreements: CLAs & DCO"
+            summary: How projects take in outside contributions cleanly — CLAs, the DCO, and "inbound=outbound" — and what every contributor should understand before signing.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: dual-licensing-and-relicensing
+            title: Dual licensing & relicensing
+            summary: Offering the same code as both open source and a paid license, what makes it possible (owning the copyright), and the constraints on changing a license later.
+            minutes: 9
+            level: advanced
+            status: full
+          - slug: open-source-risks
+            title: The risks of depending on open source
+            summary: License changes and "rug pulls", abandonment, supply-chain and provenance risk, and the audit and legal exposure that come with every dependency.
+            minutes: 10
+            level: intermediate
+            status: full
+
+      - id: proprietary-and-commercial
+        label: "Module 4 — Proprietary & Commercial Licensing"
+        blurb: "The paid side of the spectrum: how proprietary licensing works, the commercial pricing models, source-available licenses, and how to write and price a custom license to sell your own software — plus where to get real help."
+        lessons:
+          - slug: proprietary-licensing
+            title: Proprietary & closed-source licensing
+            summary: What a proprietary license restricts and why, from "all rights reserved" to reverse-engineering and redistribution clauses — the opposite end of open source.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: commercial-license-models
+            title: Commercial license models
+            summary: Perpetual vs subscription, per-seat, per-core, usage-based, site and enterprise licenses, and OEM — the pricing structures behind software you pay for.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: source-available-licenses
+            title: Source-available & "fair source"
+            summary: BSL, SSPL, the Elastic License and "fair source" — why companies adopt them, what they actually allow, and why they are not open source.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: writing-a-commercial-license
+            title: Writing a license to sell software
+            summary: Building a custom commercial license — the grant, scope, structure, and the decisions you must make first before any clause goes on the page.
+            minutes: 11
+            level: advanced
+            status: full
+          - slug: key-commercial-clauses
+            title: Key clauses in a commercial license
+            summary: Warranty, limitation of liability, indemnity, IP ownership, termination, governing law, and audit rights — the clauses that decide who carries the risk.
+            minutes: 11
+            level: advanced
+            status: full
+          - slug: where-to-get-licensing-help
+            title: Where to get licensing help
+            summary: When you genuinely need a lawyer, the reputable template and contract sources, the standards bodies, and the generators — where to find more information.
+            minutes: 8
+            level: beginner
+            status: full
+
+      - id: oss-in-products
+        label: "Module 5 — Using Open Source in Software You Sell"
+        blurb: "You can absolutely build a paid product on open source — if you follow the rules. Meeting permissive obligations, handling copyleft and the 'viral' question, and auditing your dependencies so compliance is continuous, not a fire drill."
+        lessons:
+          - slug: using-oss-in-products
+            title: Can you sell software built on open source?
+            summary: Yes — and here are the rules that make it legal. The obligations that come with every dependency, and the myths that scare people away from open source.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: permissive-compliance
+            title: Meeting permissive obligations
+            summary: The attribution, license-text, and NOTICE requirements behind MIT, BSD, and Apache — modeled on GopherTrunk's own THIRD_PARTY_LICENSES.md.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: copyleft-in-products
+            title: "Copyleft in products: the viral question"
+            summary: What actually triggers GPL, AGPL, and LGPL obligations in a product, where the linking and distribution boundaries fall, and the patterns that keep you safe.
+            minutes: 11
+            level: advanced
+            status: full
+          - slug: auditing-dependencies
+            title: Auditing dependencies & SBOMs
+            summary: Knowing every license you ship — dependency scanning, SBOMs, SPDX, the tooling (FOSSA, ScanCode, and friends), and building an ongoing compliance process.
+            minutes: 10
+            level: intermediate
+            status: full
+
+      - id: reading-agreements
+        label: "Module 6 — Reading Agreements & Other User Agreements"
+        blurb: "How to actually read a software agreement and understand it before you sign — the main clauses, the risk clauses, and the red flags — then a tour of the other agreements software needs: EULAs, terms of service, privacy policies, DPAs, SLAs, and NDAs."
+        lessons:
+          - slug: how-to-read-an-agreement
+            title: How to read a software agreement
+            summary: A repeatable method for reading any license or agreement — following defined terms, mapping the structure, and extracting what actually matters to you.
+            minutes: 10
+            level: beginner
+            status: full
+          - slug: main-clauses-decoded
+            title: The main clauses, decoded
+            summary: The clauses in nearly every software agreement — grant, scope, fees, term, confidentiality, IP — and what each one really means in plain language.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: risk-clauses
+            title: "The risk clauses: who pays when it breaks"
+            summary: Warranty disclaimers, limitation of liability, indemnification, and "as-is" — the quiet clauses that decide who is on the hook when software fails.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: before-you-agree
+            title: What to check before you agree
+            summary: A pre-signature checklist and the red flags — auto-renewal, price changes, data use, assignment, audit rights, and termination — to catch before you click "I agree".
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: eula-and-tos
+            title: EULAs & terms of service
+            summary: The agreements your users accept — end-user license agreements and terms of service — what they cover, how they bind users, and the terms that matter most.
+            minutes: 9
+            level: beginner
+            status: full
+          - slug: privacy-and-data-agreements
+            title: Privacy policies & data agreements
+            summary: Privacy policies, data processing agreements, GDPR and CCPA basics, and sub-processors — the data-side agreements most modern software is required to have.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: sla-and-support-agreements
+            title: SLAs & support agreements
+            summary: Service level agreements, uptime guarantees and credits, and support and maintenance terms — read from both the buyer's and the seller's side.
+            minutes: 9
+            level: intermediate
+            status: full
+          - slug: nda-and-other-agreements
+            title: NDAs & the rest of the landscape
+            summary: NDAs, master service agreements, acceptable-use policies, and beta/evaluation agreements — the remaining agreements software businesses run on.
+            minutes: 9
+            level: beginner
+            status: full
+
+      - id: putting-it-together
+        label: "Module 7 — Choosing Your License & Agreements"
+        blurb: "Everything applied: a repeatable framework that turns your goals into a license choice, a step-by-step walkthrough to pick yours, a way to determine which other agreements your software needs, and a full worked example end to end."
+        lessons:
+          - slug: the-decision-framework
+            title: A framework for choosing
+            summary: A repeatable decision framework — goals, business model, dependencies, and risk tolerance map to a license and a set of agreements, not the other way around.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: choose-your-license
+            title: Choosing your license, step by step
+            summary: A guided walkthrough to land on your license — open source, proprietary, source-available, or dual — with the questions that decide each fork.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: which-agreements-do-you-need
+            title: Which agreements does your software need?
+            summary: Determining the full set — EULA or ToS, privacy policy, DPA, SLA — from how your software is delivered, who uses it, and what data it touches.
+            minutes: 10
+            level: intermediate
+            status: full
+          - slug: putting-it-all-together
+            title: Putting it all together
+            summary: An end-to-end worked example — choosing a license and the full agreement set for a GopherTrunk-like product — plus where to go next and how to stay compliant.
+            minutes: 11
+            level: advanced
+            status: full
+
+    # Standalone reference, not part of the sequential path (no prev/next slot).
+    glossary:
+      slug: glossary
+      title: Glossary of software-licensing terms
+      summary: Plain-language definitions for every term in the path — copyright, copyleft, permissive, GPL/AGPL/LGPL, dual licensing, EULA, ToS, SLA, DPA, SBOM, SPDX, indemnity, and more — cross-linked to the lessons.
+      minutes: 12
+      level: beginner
+      status: full

--- a/docs/learn/software-licensing/agpl-network-copyleft.md
+++ b/docs/learn/software-licensing/agpl-network-copyleft.md
@@ -1,0 +1,108 @@
+---
+slug: agpl-network-copyleft
+title: "The AGPL: copyleft over the network"
+description: The GNU Affero GPL closes the "SaaS loophole" — it adds a trigger so that users who interact with the software over a network must be offered its complete source code, even when no binary is ever distributed.
+keywords: AGPL, Affero GPL, GNU AGPL, SaaS loophole, network copyleft, section 13, copyleft over network, AGPL banned, hosted software, cloud provider protection, SSPL, source-available, GPL distribution gap
+level: intermediate
+status: full
+faq:
+  - q: "What exactly is the \"SaaS loophole\" the AGPL closes?"
+    a: "The plain [GPL](/learn/software-licensing/gpl-strong-copyleft/) only triggers its source-sharing duty on **distribution**. A software-as-a-service company never distributes the binary — users just talk to it over the network — so the GPL's source obligation never fires and users never get the source. The AGPL adds a trigger for **network interaction**, so remote users must be offered the source too."
+  - q: "Why do companies like Google ban AGPL dependencies?"
+    a: "Because the network trigger is broad and the boundary of what counts as a combined work is uncertain, a company worries that linking AGPL code into an internal service could obligate it to publish source for proprietary systems. Rather than analyze every case, large firms (Google being the well-known example) often **ban AGPL outright** in their codebases as a blanket risk-avoidance policy."
+  - q: "Is the AGPL the same as a source-available license like the SSPL?"
+    a: "No. The AGPL is a true open-source license approved by the OSI; it just extends copyleft to network use. Licenses like the **SSPL** go further and impose conditions that the OSI considers to cross the line out of open source. The AGPL protects user freedom; the SSPL is mainly aimed at stopping cloud providers from reselling the software — see [source-available licenses](/learn/software-licensing/source-available-licenses/)."
+---
+# The AGPL: copyleft over the network
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**It closes the SaaS loophole** — plain GPL triggers on distribution, but SaaS never distributes a binary, so users never see source; the AGPL fixes that. **Section 13 is the heart** — it adds a trigger on *interacting with the software over a network*. **Remote users get an offer of source** — if people use your modified AGPL service, you must make its complete source available to them. **Powerful but feared** — it protects against cloud capture, which is exactly why many companies ban it.
+</div>
+
+The [GPL lesson](/learn/software-licensing/gpl-strong-copyleft/) ended on a gap: the GPL's obligations only fire on *distribution*, and a network service never distributes anything. The GNU Affero General Public License — **AGPL** — exists to close that gap. By the end of this lesson you'll understand the "SaaS loophole" precisely, what section 13 actually requires, why this matters so much in the cloud era, why a number of large companies ban AGPL code, where it's genuinely the right choice, and how it relates to the more aggressive source-available licenses that came after it.
+
+## The SaaS loophole
+
+Recall the GPL bargain: you get the four freedoms, and in exchange you must pass them on **when you distribute** the software. That worked beautifully when software was something you shipped — a binary on a disk, a download, a device. The duty to provide source was tied to the moment a copy changed hands.
+
+Then the world moved to **software as a service (SaaS)**. Instead of shipping you a program, a company runs the program on its own servers and lets you interact with it over the network — your browser, an API call, a mobile app talking to a backend. You use the software fully, but **no copy is ever handed to you**.
+
+Look at what that does to the GPL. The trigger is distribution. SaaS never distributes the binary. So a company can take a GPL program, modify it heavily, run it as a public service used by millions, and owe **no one any source code at all**. The users get all the benefit of the software and none of the freedoms the GPL was written to protect. This is the **SaaS loophole** (sometimes the "ASP loophole," from the older term "application service provider").
+
+It isn't a bug in the GPL so much as a consequence of how it was scoped. But to the people who care most about user freedom, it was a hole big enough to drive the entire cloud industry through.
+
+## Section 13: the network trigger
+
+The AGPL is, line for line, almost identical to GPLv3 — it grants the same freedoms and imposes the same distribution obligations. The difference is one added clause: **section 13**, the "Remote Network Interaction" provision.
+
+Section 13 adds a second trigger alongside distribution. In plain terms: **if you modify the program and let users interact with it remotely over a network, you must give those remote users access to the complete corresponding source** of your modified version. The license requires that the software offer remote users a way to obtain that source — typically a prominent link in the interface to download it.
+
+So the AGPL has *two* ways its source obligation can fire:
+
+| Trigger | Plain GPL | AGPL |
+|---|---|---|
+| You distribute the binary | Yes | Yes |
+| Users interact with it over a network (no binary handed over) | **No** | **Yes (section 13)** |
+
+The same scoping rules carry over from the GPL: **internal use still doesn't count**. Running AGPL software for yourself, or modifying it on a machine no one else can reach, triggers nothing. The duty arises only when *other people* interact with your modified version over the network. And as before, the obligation is to provide **complete corresponding source** — everything needed to build and run the version you're operating — under the AGPL.
+
+```text
+Plain GPL:  source duty fires only when a copy is handed over.
+AGPL:       source duty also fires when remote users use the running service.
+            -> a "Download source" link in the UI is the usual way to comply.
+```
+
+## Why this matters for hosted software
+
+The AGPL flips the economics for hosted software. Under the GPL, a SaaS provider can keep its modifications secret forever. Under the AGPL, the moment it lets the public use a modified version, it must share those modifications back. That's a strong guarantee that improvements to the software remain available to the community, even when the software is never "shipped" in the traditional sense.
+
+For an open-source project that expects to be **run as a service** — a database, a monitoring tool, a collaboration platform — the AGPL is the only mainstream license that preserves copyleft's reciprocity in that delivery model. Without it, the most common way the software gets used (hosted by someone else) would be the one way copyleft didn't reach.
+
+## Why many companies ban the AGPL
+
+Despite being a legitimate, OSI-approved open-source license, the AGPL is **banned outright in the codebases of many large companies** — Google's published open-source policy forbidding it is the famous example, and plenty of others quietly follow suit.
+
+The reason is risk, not ideology. Two worries drive it:
+
+- **Breadth of the trigger.** "Interacting over a network" is broad, and the boundary of what counts as part of the combined work — much like the [linking question for the GPL](/learn/software-licensing/gpl-strong-copyleft/) — is not crisply settled in case law. A company fears that pulling an AGPL library into one internal service could, in a worst-case reading, obligate it to publish source for adjacent proprietary systems.
+- **Cost of analysis.** Even if most uses would be fine, evaluating each one is expensive. A blanket ban is cheaper than per-case legal review across thousands of engineers.
+
+So the ban is a coarse but rational policy: it trades away access to some good AGPL software in exchange for never having to reason about the edge cases. The practical upshot for *you*: if you license your project AGPL, you should expect that a meaningful slice of corporate users won't touch it. That's a deliberate trade-off, covered more in [the risks of depending on open source](/learn/software-licensing/open-source-risks/) and in [choosing an OSS license](/learn/software-licensing/choosing-an-oss-license/).
+
+## Legitimate uses: protecting against cloud capture
+
+The AGPL isn't only a thorn — it's a genuinely good fit for some goals, especially **defending a project against cloud providers**.
+
+Imagine you build an open-source database and a large cloud company offers it as a managed service, makes valuable proprietary improvements, captures most of the revenue, and contributes nothing back. Under permissive or even GPL terms, there's little you can do. Under the **AGPL**, that provider must publish its server-side modifications under the AGPL — so its enhancements flow back to you and everyone else. The license turns "host it and keep the improvements secret" into "host it and share the improvements."
+
+This is why a number of infrastructure projects adopted the AGPL: it keeps the reciprocity promise alive against exactly the actor most able to exploit the SaaS loophole. When your worry is *cloud capture*, the AGPL is the strongest mainstream open-source tool for the job.
+
+## Strengths and weaknesses
+
+**Strengths.** The AGPL preserves copyleft's core promise in the cloud era, where the GPL alone falls short. It's a real open-source license, so the software stays free and community improvements keep coming. And it's a credible deterrent against proprietary cloud capture, protecting both the project and its users' freedoms.
+
+**Weaknesses.** Its breadth scares corporate users and triggers outright bans, shrinking adoption. The section 13 boundary is legally less-tested than one would like, so even well-intentioned users face uncertainty. And operational compliance — making sure your running service actually offers source to users — is an ongoing obligation, not a one-time packaging step.
+
+A final connection: some projects decided even the AGPL didn't go far enough to stop cloud resale, and moved to **source-available** licenses such as the **SSPL** that impose conditions the open-source community rejects as crossing the line out of open source. That's a different category — not open source at all — and we treat it in [source-available and "fair source"](/learn/software-licensing/source-available-licenses/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the AGPL's section 13 adds a trigger for network interaction, so remote users of a modified service must be offered its source." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the AGPL add that the plain GPL lacks?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">A trigger requiring you to offer source to users who interact with the software over a network</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Permission to relicense the software as proprietary after five years</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A clause that removes all source-sharing obligations for SaaS providers</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **The SaaS loophole is the problem** — plain GPL triggers only on distribution, but SaaS never distributes a binary, so users never get the source.
+- **Section 13 is the fix** — the AGPL adds a trigger for interacting with the software over a network, requiring that remote users be offered the complete corresponding source.
+- **Internal use is still safe** — like the GPL, the AGPL only fires when others use your modified version; running it for yourself triggers nothing.
+- **Many companies ban it** — the broad trigger and uncertain boundary lead firms like Google to forbid AGPL dependencies as blanket risk-avoidance, so expect reduced corporate adoption.
+- **It's the strongest defense against cloud capture** — when your concern is a provider hosting your project and keeping improvements secret, the AGPL forces those improvements back into the open.
+- **It's still real open source** — unlike source-available licenses such as the SSPL, the AGPL is OSI-approved; it extends copyleft without leaving the open-source category.
+
+Next up: the middle ground between permissive and strong copyleft — licenses that keep one component open while letting proprietary code link to it. See [Weak copyleft: LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/).

--- a/docs/learn/software-licensing/apache-license.md
+++ b/docs/learn/software-licensing/apache-license.md
@@ -1,0 +1,114 @@
+---
+slug: apache-license
+title: "Apache 2.0: permissive with a patent grant"
+description: Apache 2.0 is permissive like MIT but adds an explicit patent license, a patent-retaliation clause, a NOTICE file, and a duty to state your changes. See why it's the corporate default — using GopherTrunk, which is Apache-2.0, as the example.
+keywords: Apache License 2.0, Apache 2.0, patent grant, patent retaliation, NOTICE file, permissive license, trademark, license compatibility, GPLv3, contributor patent, open source, attribution, GopherTrunk license
+level: intermediate
+status: full
+faq:
+  - q: "Why pick Apache 2.0 over MIT if both are permissive?"
+    a: "The headline reason is **patents**. Apache 2.0 includes an explicit patent license from every contributor and a retaliation clause that revokes it if you sue over patents — protection MIT and BSD don't spell out. It also formalizes attribution via the NOTICE file and requires you to state your changes. That extra structure is why companies and foundations prefer it."
+  - q: "What is the NOTICE file and do I have to keep it?"
+    a: "The **NOTICE file** is a text file an Apache-2.0 project can ship containing required attribution notices. If a work you redistribute includes a NOTICE file, you must pass along the attribution notices it contains. It's a defined, structured way to carry credit — distinct from the license text itself, which you must also include."
+  - q: "Can I combine Apache-2.0 code with GPL code?"
+    a: "Carefully. Apache 2.0 is **one-way compatible with GPLv3** — you can include Apache-2.0 code in a GPLv3 project (the result is GPLv3), but not the reverse. It is **not compatible with GPLv2**, because of GPLv2's stance on the patent and termination terms. We cover the details in [License compatibility](/learn/software-licensing/license-compatibility/)."
+---
+# Apache 2.0: permissive with a patent grant
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Permissive, with more structure** — Apache 2.0 grants the same broad freedoms as MIT but spells out far more. **An explicit patent grant** — every contributor licenses their patents, and a retaliation clause revokes that grant if you sue. **NOTICE file and stated changes** — formal attribution plus a duty to mark what you changed. **The corporate/foundation default** — including GopherTrunk itself, which is Apache-2.0.
+</div>
+
+The **Apache License 2.0** is what you reach for when you want permissive freedom but with the legal loose ends tied up — especially around patents. It's the default for the Apache Software Foundation, the Cloud Native Computing Foundation, and a huge share of corporate open source. By the end of this lesson you'll understand what Apache 2.0 adds over MIT and BSD (an explicit patent license, a retaliation clause, a NOTICE file, a stated-changes duty, and a trademark carve-out), why those additions make it the corporate default, and how it fits with the GPL. We'll use GopherTrunk as the running example, because GopherTrunk itself is Apache-2.0.
+
+## Permissive, but with the gaps filled in
+
+At its core, Apache 2.0 is a permissive license: you may use, modify, and distribute the software, including in closed-source and commercial products, and there's no copyleft obligation to publish your changes. So far, this is MIT's bargain.
+
+The difference is everything Apache 2.0 says *around* that grant. Where MIT is three short paragraphs, Apache 2.0 is several pages — and that length buys precision on the questions MIT leaves silent: patents, attribution, what counts as a contribution, and trademarks. If MIT is a handshake, Apache 2.0 is the same handshake written down by lawyers so there's nothing to argue about later.
+
+## The explicit patent grant
+
+This is the headline feature. Section 3 of Apache 2.0 grants you a patent license from **each contributor** covering their contributions:
+
+```text
+3. Grant of Patent License. ... each Contributor hereby grants to You a
+   perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   ... patent license to make, have made, use, offer to sell, sell, import,
+   and otherwise transfer the Work ...
+```
+
+Why this matters: code can be covered by patents, and a copyright license alone doesn't give you the right to practice those patents. With MIT or BSD, a contributor could in principle hand you code and still hold a patent over the technique, leaving downstream users exposed. Apache 2.0 closes that hole — by contributing, you grant everyone a patent license to use what you contributed.
+
+### The retaliation (termination) clause
+
+Paired with the grant is a **patent-retaliation clause**: if you initiate patent litigation alleging that the software infringes a patent, your patent license under Apache 2.0 terminates. It's a defensive mechanism — you keep your patent license only as long as you don't weaponize patents against the project. This discourages "use the code, then sue everyone" behavior and is a big part of why patent-conscious organizations favor Apache 2.0.
+
+## The NOTICE file and stating changes
+
+Apache 2.0 makes attribution more structured than MIT's "keep the notice." When you redistribute the work, Section 4 requires you to:
+
+- **Include a copy of the license** and retain copyright, patent, trademark, and attribution notices.
+- **Carry the NOTICE file.** If the work ships a file called `NOTICE` with attribution text, you must include those notices in your redistribution (in the source, the docs, or a display the software produces). The NOTICE file is the defined channel for required credit.
+- **State your changes.** Modified files must carry prominent notices that you changed them. This is a duty MIT and BSD don't impose, and it helps downstream users see what diverged from upstream.
+
+These obligations are light, but they're real, and meeting them is the heart of [permissive compliance](/learn/software-licensing/permissive-compliance/).
+
+## Trademark non-grant
+
+Apache 2.0 is explicit that it does **not** grant any trademark rights (Section 6). You get copyright and patent permissions, but the project's *name and logo* are not yours to use freely. You can build on the code, but you can't pass your fork off as the original project. This separation — open code, protected name — is common and sensible; we touch on the broader topic in [Patents, trademarks & trade secrets](/learn/software-licensing/other-ip-in-software/).
+
+## GopherTrunk as the concrete example
+
+You don't have to go far for a real Apache-2.0 project: **GopherTrunk is licensed under Apache 2.0**, and the full text lives in [`/LICENSE`](/LICENSE) at the repo root. Everything above applies to it directly:
+
+- Anyone may use, modify, and ship GopherTrunk, including in a commercial product, as long as they keep the license and notices.
+- Every contributor to GopherTrunk grants the Apache 2.0 patent license over their contributions, and the retaliation clause applies.
+- A fork must state its changes and can't use the GopherTrunk name to imply endorsement.
+
+GopherTrunk also ships a [`/THIRD_PARTY_LICENSES.md`](/THIRD_PARTY_LICENSES.md) file inventorying the licenses of the code it depends on — a mix of MIT, BSD, and Apache-2.0 modules. That file is a preview of the *attribution* side of using open source: when you build on other people's code, you have to track and reproduce their notices. We'll dig into doing this properly in [Meeting permissive obligations](/learn/software-licensing/permissive-compliance/) and [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/).
+
+## Apache 2.0 vs MIT
+
+| | **MIT** | **Apache 2.0** |
+|---|---|---|
+| Permissive (no copyleft) | Yes | Yes |
+| Keep copyright/license notice | Yes | Yes |
+| Warranty disclaimer | Yes | Yes |
+| Explicit patent grant | **No** | **Yes** |
+| Patent-retaliation clause | No | **Yes** |
+| NOTICE-file attribution | No | **Yes** |
+| Must state your changes | No | **Yes** |
+| Trademark explicitly not granted | Silent | **Yes** |
+| Length / complexity | Tiny | Several pages |
+| Typical user | Small libraries, broad reuse | Companies, foundations, patent-sensitive projects |
+
+The trade is straightforward: Apache 2.0 asks a little more of you (carry the NOTICE, state changes) and gives a lot more certainty in return (patents, attribution, trademarks). For a one-file utility, MIT's brevity often wins; for anything with corporate involvement or patent exposure, Apache 2.0's structure is usually worth it.
+
+## Compatibility with the GPL
+
+One practical wrinkle to remember: Apache 2.0 is **one-way compatible with GPLv3**. You can include Apache-2.0 code in a GPLv3 project — the combined result is GPLv3 — but you can't take GPLv3 code into an Apache-2.0 project, because GPLv3's copyleft would govern the result.
+
+Apache 2.0 is **not compatible with GPLv2**. The Free Software Foundation considers Apache 2.0's patent-termination and other terms to impose conditions GPLv2 doesn't permit, so the two can't be legally combined. GPLv3 was deliberately written to be compatible with Apache 2.0, which is one reason the GPLv2-vs-GPLv3 distinction matters. This is exactly the kind of trap [License compatibility](/learn/software-licensing/license-compatibility/) exists to help you avoid — for now, just remember "Apache 2.0 → GPLv3 yes, GPLv2 no."
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the explicit patent license (plus a retaliation clause) is Apache 2.0's signature addition over MIT and BSD." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does Apache 2.0 add that MIT and BSD do not clearly provide?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A copyleft requirement to publish your modifications</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A ban on using the code in commercial products</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">An explicit patent grant from contributors plus a patent-retaliation clause</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Permissive with structure** — Apache 2.0 grants MIT-like freedoms but spells out patents, attribution, and trademarks in detail.
+- **Explicit patent grant + retaliation** — contributors license their patents, and that license ends if you sue over patents.
+- **NOTICE file and stated changes** — formal, structured attribution plus a duty to mark modified files.
+- **Trademark not granted** — open code, protected name.
+- **GopherTrunk's own license** — Apache-2.0 (`/LICENSE`), with `/THIRD_PARTY_LICENSES.md` previewing dependency attribution.
+- **GPL compatibility** — one-way compatible with GPLv3, but not compatible with GPLv2.
+
+Next up: the other side of the divide — the license that makes freedom stick. See [The GPL: strong copyleft](/learn/software-licensing/gpl-strong-copyleft/).

--- a/docs/learn/software-licensing/auditing-dependencies.md
+++ b/docs/learn/software-licensing/auditing-dependencies.md
@@ -1,0 +1,112 @@
+---
+slug: auditing-dependencies
+title: Auditing dependencies & SBOMs
+description: You can't comply with licenses you don't know you're shipping. Learn how to inventory direct and transitive dependency licenses, what an SBOM is (SPDX and CycloneDX), the scanning tools to use including go-licenses for Go projects, and how to make license auditing continuous in CI.
+keywords: auditing dependencies, SBOM, software bill of materials, SPDX, CycloneDX, transitive dependencies, license scanning, FOSSA, ScanCode, Syft, go-licenses, license policy CI, dependency inventory, license compliance automation
+level: intermediate
+status: full
+faq:
+  - q: "What is an SBOM and why do people suddenly care?"
+    a: "An **SBOM** (Software Bill of Materials) is a machine-readable inventory of every component in your software — names, versions, and licenses — like an ingredients label. Interest spiked because supply-chain attacks and government rules (notably the US Executive Order 14028) now require SBOMs for software sold to many agencies, and because they make license and vulnerability auditing tractable. The two main formats are **SPDX** and **CycloneDX**."
+  - q: "Why do I need to scan transitive dependencies — I only added a few libraries?"
+    a: "Because the few libraries you added pull in *their* dependencies, which pull in more. A handful of direct dependencies routinely expands to dozens or hundreds of **transitive** ones, each with its own license. A copyleft or AGPL license can ride in three levels deep where you'd never notice it by hand — which is exactly why automated inventory exists."
+  - q: "How do I keep license problems from sneaking back in?"
+    a: "Make the check **continuous**, not a one-time audit. Run a license scanner in CI with a policy (allowed licenses, forbidden ones like AGPL) so a pull request that introduces a banned or unknown license **fails the build**. GopherTrunk does this — its `make licenses` target and CI `licenses` job run `go-licenses` over the whole module graph."
+---
+# Auditing dependencies & SBOMs
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**You can't comply blind** — compliance starts with knowing every component you ship. **Transitive is the trap** — your few direct dependencies expand into dozens of indirect ones, each licensed separately. **An SBOM is your ingredients label** — a machine-readable inventory (SPDX or CycloneDX), now often legally required. **Make it continuous** — a license scanner with a policy in CI catches problems on every pull request, not in a yearly fire drill.
+</div>
+
+Every previous lesson in this module assumed you *know* what's in your product. This one earns that assumption. The hard truth of license compliance is simple: **you cannot comply with a license you don't know you're shipping.** Modern software is assembled from hundreds of pieces you never personally chose, and any one of them can carry an obligation — or a copyleft trigger — you'd never spot by reading code. By the end of this lesson you'll know how to inventory the licenses in your dependency tree, what an SBOM is and why governments now demand one, the tools that automate the work (including the right one for a Go project like GopherTrunk), and how to turn a one-time audit into a continuous CI gate.
+
+## The transitive dependency problem
+
+When you add a library, you don't add one thing — you add a *tree*. Your **direct dependencies** are the ones you chose. Each of those has its own dependencies, and so on, several levels deep. These indirect ones are **transitive dependencies**, and they typically outnumber the direct ones by an order of magnitude. A project with a dozen direct dependencies can easily ship two hundred transitive ones.
+
+Every node in that tree is separately licensed. So the real surface area of your compliance obligation is the whole tree, not the short list you typed into your manifest. A permissive MIT direct dependency might pull in an AGPL transitive dependency three levels down — and if you ship it, that obligation is yours whether or not you knew. Manual review doesn't scale to hundreds of components that change with every update. This is precisely why automated inventory exists.
+
+## How to inventory the licenses
+
+You don't read every LICENSE file by hand — you let the tooling do it, then review. The raw material is already there:
+
+- **Package-manager metadata.** Every ecosystem records dependency licenses. `go.mod` plus module metadata for Go, `package.json` for npm, `pom.xml`/Maven for Java, `Cargo.toml` for Rust, `requirements`/wheel metadata for Python. Tools read this graph.
+- **SPDX license identifiers.** [SPDX](https://spdx.org/licenses/) is a standardized list of short license IDs — `MIT`, `Apache-2.0`, `GPL-3.0-or-later`, `AGPL-3.0` — that make licenses machine-comparable. Most metadata and scanners speak SPDX, so you can write a policy in terms of these IDs rather than fuzzy names.
+- **Source scanning** for the cases metadata misses — vendored code, files with embedded license headers, or dependencies that didn't declare a license cleanly. Deep scanners read the actual files.
+
+The output of inventory is a list: every component, its version, and its detected license. That list is the basis for both your attribution file (the [previous lesson's](/learn/software-licensing/permissive-compliance/) `THIRD_PARTY_LICENSES`) and your SBOM.
+
+## What an SBOM is
+
+An **SBOM** — Software Bill of Materials — is a formal, machine-readable inventory of everything that goes into your software: components, versions, suppliers, and licenses. The analogy that sticks is the **ingredients label** on food: you can't make an informed choice about what you're consuming without knowing what's in it.
+
+SBOMs went from nice-to-have to near-mandatory for two reasons. First, **supply-chain security**: when a vulnerability lands in a widely-used library, organizations need to answer "are we affected?" in minutes, and that's only possible if they have an inventory. Second, **regulation**: the US Executive Order 14028 (2021) directed federal agencies to require SBOMs from software vendors, and similar expectations are spreading internationally (the EU's Cyber Resilience Act pushes the same direction). If you sell software to governments or large enterprises, an SBOM is increasingly a contractual requirement, not a courtesy.
+
+There are two dominant formats; you'll usually generate one or both:
+
+| Format | Steward | Notes |
+|--------|---------|-------|
+| **SPDX** | Linux Foundation (ISO/IEC 5962 standard) | License-focused heritage, broad tool support, an international standard |
+| **CycloneDX** | OWASP | Security-focused heritage, lightweight, strong vulnerability/VEX support |
+
+Both can express components, versions, and licenses; pick based on what your customers or tools expect, or emit both since most generators can.
+
+## License-scanning tools
+
+A healthy ecosystem of tools turns inventory and SBOM generation into a command. A representative sampling:
+
+| Tool | What it does | Notes |
+|------|--------------|-------|
+| **Syft** | Generates SBOMs (SPDX/CycloneDX) from images and source | Fast, pairs with Grype for vulnerabilities |
+| **ScanCode Toolkit** | Deep source-level license & copyright detection | Open source, very thorough, catches embedded headers |
+| **FOSSology** | License scanning + compliance workflow server | Open source, good for a review process |
+| **FOSSA** | Hosted dependency & license compliance platform | Commercial, policy + CI integration |
+| **license-checker** | Lists licenses of an npm dependency tree | Lightweight, JavaScript ecosystem |
+| **go-licenses** | Reports licenses of a Go module's full dependency graph | The natural fit for Go projects |
+
+The split worth understanding: **metadata-based tools** (license-checker, go-licenses) read the package graph and are fast and accurate when licenses are declared cleanly; **deep scanners** (ScanCode, FOSSology) read the actual files and catch what metadata misses, at the cost of speed. SBOM generators like **Syft** sit in between and produce the standardized artifact. Many teams use a fast metadata gate in CI and a deep scan periodically.
+
+### go-licenses for a Go project like GopherTrunk
+
+For a Go codebase, **`go-licenses`** (from Google) is the idiomatic choice: it walks the module graph and reports the license of every package the binary links in, transitive ones included. This isn't hypothetical for GopherTrunk — it's exactly what the project uses. The `make licenses` target runs `go-licenses` to regenerate the transitive inventory, and the **CI `licenses` job** runs the same target so a newly-introduced dependency with a non-permissive license fails the build. That machine-generated graph backstops the hand-curated [`/THIRD_PARTY_LICENSES.md`](/learn/software-licensing/permissive-compliance/), so the attribution file and the actual dependency tree can't silently drift apart.
+
+```bash
+# Inventory every package's license across the whole module graph
+go-licenses csv ./... > THIRD_PARTY_LICENSES.csv
+
+# Or fail loudly if a forbidden license type shows up
+go-licenses check ./... --disallowed_types=forbidden,restricted
+```
+
+## Setting a policy and making it continuous
+
+An inventory is only useful against a **policy** — a decision, made once, about which licenses are acceptable:
+
+- **Allowed** — typically the permissive set: MIT, BSD, Apache-2.0.
+- **Review required** — weak copyleft (LGPL, MPL) that's usable with care.
+- **Forbidden** — most commonly **AGPL** (the [SaaS trigger](/learn/software-licensing/copyleft-in-products/)), sometimes strong GPL for closed products, and anything with an **unknown or missing** license (which is the most dangerous case — no license means no permission).
+
+Writing the policy in terms of [SPDX identifiers](/learn/software-licensing/license-compatibility/) makes it enforceable by machine. And the key move is to make enforcement **continuous, not a fire drill.** A one-time audit is stale the moment someone updates a dependency. Instead, run the scanner in CI so that any pull request introducing a forbidden, unknown, or newly non-compliant license **fails the build** before it merges. That turns license compliance from an annual scramble into a property the codebase maintains automatically — which is exactly the posture GopherTrunk takes with its `licenses` CI job.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — running a license scanner with a policy in CI catches a forbidden or unknown license on the pull request that introduces it, before it ships." markdown="0">
+  <p class="knowledge-check__q">Quick check: what's the most reliable way to keep a banned license out of your product?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Audit the dependency list by hand once a year</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Run a license scanner with a policy in CI so non-compliant pull requests fail the build</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only review the direct dependencies you added yourself</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Compliance starts with knowing** — you cannot meet obligations for components you don't know you ship.
+- **Transitive dependencies dominate** — a few direct dependencies expand into dozens or hundreds of indirect ones, each separately licensed.
+- **Inventory from metadata and SPDX** — package-manager data plus SPDX identifiers let tools build a machine-readable license list, with deep scanners for what metadata misses.
+- **An SBOM is the standardized inventory** — SPDX or CycloneDX, now widely required by governments and enterprises for security and compliance.
+- **Use the right tool** — Syft, ScanCode, FOSSology, FOSSA, license-checker; for Go, `go-licenses`, which GopherTrunk runs in CI.
+- **Make it continuous** — a license policy enforced in CI fails non-compliant pull requests, turning a yearly fire drill into an automatic guardrail.
+
+Next up: licenses aren't the only agreements you'll meet — now turn to reading the contracts themselves. See [How to read a software agreement](/learn/software-licensing/how-to-read-an-agreement/).

--- a/docs/learn/software-licensing/before-you-agree.md
+++ b/docs/learn/software-licensing/before-you-agree.md
@@ -1,0 +1,102 @@
+---
+slug: before-you-agree
+title: What to check before you agree
+description: A practical pre-signature checklist and the red flags to catch before you commit — auto-renewal and notice windows, unilateral price increases, broad data and telemetry rights, IP grabs on your inputs and feedback, assignment on acquisition, mandatory arbitration, audit rights, and unilateral term changes.
+keywords: contract checklist, before you sign, software agreement red flags, auto-renewal, notice window, unilateral price increase, telemetry, data use rights, IP assignment, feedback clause, change of control, mandatory arbitration, class action waiver, audit rights, terms change anytime, export compliance
+level: intermediate
+status: full
+faq:
+  - q: "What's the single most common thing people get burned by?"
+    a: "**Auto-renewal with a long notice window.** The subscription rolls over automatically and you can only stop it by giving written notice inside a specific window (often 30–90 days before renewal). People forget, miss the window, and get billed for another full term. The fix is mechanical: the day you sign, put the cancellation deadline on your calendar."
+  - q: "Is mandatory arbitration always bad?"
+    a: "Not always, but it's worth noticing. **Mandatory arbitration** moves disputes out of court into private arbitration, and a paired **class-action waiver** means you can't band together with others harmed the same way. Arbitration can be faster and cheaper for some disputes, but it limits your remedies and is generally hard to negotiate out of consumer terms. For a meaningful B2B deal, it's a legitimate point to push back on."
+  - q: "I'm just a small user — do these red flags really matter to me?"
+    a: "Yes, proportionally. You may not negotiate a consumer terms of service, but you can still **choose not to use** a service whose data rights or auto-renewal terms you don't like, and you can calendar deadlines and read the data clauses. For anything you pay for or build a business on, every red flag here is worth a deliberate decision rather than a reflexive click."
+---
+# What to check before you agree
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Run a checklist, not a vibe** — a short, repeatable pass catches the things that matter. **Auto-renewal and notice windows** — the most common way people get locked in and billed. **Watch the data and IP grabs** — broad telemetry rights and claims on your inputs and feedback. **Spot the one-sided terms** — unilateral price hikes, "we can change these anytime," and assignment on acquisition. **Match scrutiny to stakes** — read hardest where the money and risk are real.
+</div>
+
+You now know how to read an agreement, what the main clauses mean, and where the risk lives. This final lesson of the module turns that knowledge into a tool you can use under time pressure: a **pre-signature checklist** and a list of **red flags** to scan for before you commit. The goal isn't to make you a lawyer — it's to make sure nothing important slips past you because the document was long and boring. By the end you'll have a scannable routine you can run on any agreement, and a clear sense of which findings mean "stop and think" versus "stop and get help."
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+## The pre-signature checklist
+
+Before you click "I Agree" or sign, run through this. It's ordered roughly by how often each item causes regret:
+
+1. **Term and auto-renewal** — How long is the commitment? Does it auto-renew? If so, *what's the notice window to cancel*, and in what form (email, certified mail)? Calendar the deadline now.
+2. **Price and price changes** — What's the total cost including taxes and metered usage? Can the vendor raise the price unilaterally, and with how much notice?
+3. **Your obligations** — Re-read every clause that names *your* party. Are there obligations you genuinely can't meet?
+4. **Data rights** — What can they collect, use, and share? Can they use your data to "improve products" or train models? Is your data deleted on exit? (See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/).)
+5. **IP ownership** — Do you keep your inputs and outputs? Does feedback you send become theirs?
+6. **Liability and indemnity** — What's the liability cap? Is there an IP indemnity, and is it carved out of the cap? (See [The risk clauses](/learn/software-licensing/risk-clauses/).)
+7. **Termination** — Can you exit as easily as they can? What survives? Do you get your data back, and in what format?
+8. **Assignment / change of control** — Can the agreement be handed to an acquirer without your consent?
+9. **Dispute resolution** — Mandatory arbitration? Class-action waiver? Which jurisdiction's law and courts?
+10. **Amendment** — Can they change the terms unilaterally later?
+11. **Audit and compliance** — Do they have the right to audit your usage? Any export-control or compliance obligations on you?
+
+You won't negotiate all of these in a consumer click-through — but even there, the checklist tells you what you're accepting, and for anything you pay for or build on, each item is a decision worth making on purpose.
+
+## The red flags, and what to do about them
+
+Some findings should make you pause. Here are the common ones, what they mean, and your move:
+
+| Red flag | What it means | What to do |
+|---|---|---|
+| **Auto-renewal + long notice window** | Rolls over and bills unless you cancel far in advance | Calendar the deadline the day you sign; ask to shorten the window |
+| **Unilateral price increase** | They can raise the price; you signed up for an unfixed cost | Ask for a cap on increases or price-lock for the term |
+| **Broad data / telemetry rights** | They can use your data beyond running the service | Check for "improve products"/training; restrict or decline |
+| **IP assignment of your inputs/feedback** | Your content or ideas become theirs | Narrow the feedback clause; confirm you keep your data |
+| **Assignment on acquisition** | Your contract can move to a company you didn't choose | Ask for consent-on-assignment, at least on change of control |
+| **Mandatory arbitration / class waiver** | Disputes leave court; no collective action | Notice it; push back in B2B deals; weigh it as a consumer |
+| **Audit rights** | They can inspect your usage/compliance | Bound the scope, frequency, and notice required |
+| **"We can change these terms anytime"** | The deal can shift unilaterally under you | Require signed amendments, or at least advance notice + opt-out |
+| **Revocable where you expected perpetual** | The right you're paying for can be pulled | Confirm the grant matches what you're buying |
+| **No exit for your data** | You can't extract your data on termination | Require export in a usable format before you depend on it |
+| **Export / compliance obligations** | You must meet trade-control or regulatory rules | Confirm you *can* comply, especially across borders |
+
+A red flag isn't automatically a dealbreaker — many are standard. The point is to make each one a **conscious choice**: accept it knowingly, negotiate it, or walk away. The danger is accepting it *un*knowingly because you didn't read that far.
+
+## A few that deserve extra attention
+
+**"We can change these terms anytime."** Common in consumer terms of service ("continued use constitutes acceptance"), and worth understanding: the agreement you read today may not be the one you're bound by next month. There's not much to negotiate as a consumer, but it's a reason to favor services with a track record of fair changes — and in a B2B deal, to insist on signed amendments.
+
+**Perpetual vs revocable.** If you're paying for a perpetual license, make sure the grant actually *says* perpetual and irrevocable. A "perpetual" license that's quietly revocable "for any reason" isn't the durable right you think you bought. (The [main clauses lesson](/learn/software-licensing/main-clauses-decoded/) covered grant scope.)
+
+**Export and compliance.** Some agreements push trade-control, sanctions, or regulatory obligations onto you. If you operate across borders, confirm you can actually meet them — agreeing to a compliance term you can't satisfy is its own risk.
+
+## Match scrutiny to the stakes
+
+Don't spend an hour on a free app's terms, and don't speed-click a six-figure contract. Calibrate:
+
+- **Free / low-stakes consumer service** — skim for data rights and auto-renewal; accept the rest knowingly.
+- **Paid subscription** — run the full checklist; calendar the renewal; read the data and price clauses closely.
+- **Business-critical or high-value contract** — full checklist *plus* a lawyer. As the [first lesson in this module](/learn/software-licensing/how-to-read-an-agreement/) put it, reading it yourself makes the legal help cheap and targeted; [Where to get licensing help](/learn/software-licensing/where-to-get-licensing-help/) covers where to find it.
+
+The throughline of this whole module: these documents are readable, they follow patterns, and a few minutes of deliberate attention before you agree saves a great deal of grief after.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — auto-renewal with a notice window means you must actively cancel in advance, so the fix is to calendar the cancellation deadline the day you sign." markdown="0">
+  <p class="knowledge-check__q">Quick check: you spot an auto-renewal clause with a 60-day notice window. What's the practical first move?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nothing — auto-renewal clauses are unenforceable, so you can ignore it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Cancel the agreement immediately so it can never renew</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Calendar the cancellation deadline now so you don't miss the notice window</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Run a checklist, not a vibe** — a short ordered pass over term, price, data, IP, liability, termination, and dispute terms catches what matters.
+- **Auto-renewal is the top trap** — find the notice window and calendar the cancellation deadline the day you sign.
+- **Guard your data and IP** — watch for broad telemetry and data-use rights and for clauses that grab your inputs or feedback.
+- **Spot one-sided terms** — unilateral price increases, "we can change these anytime," assignment on acquisition, and mandatory arbitration each warrant a deliberate decision.
+- **Confirm what you're actually buying** — perpetual should mean perpetual, and you should be able to get your data out on exit.
+- **Match scrutiny to stakes** — skim a free app, run the full checklist on anything paid, and bring a lawyer to anything business-critical.
+
+Next up: with the reading method in hand, the rest of this module looks at specific agreement types you'll meet — starting with the agreements behind the software you install and use. See [EULAs & terms of service](/learn/software-licensing/eula-and-tos/).

--- a/docs/learn/software-licensing/choose-your-license.md
+++ b/docs/learn/software-licensing/choose-your-license.md
@@ -1,0 +1,111 @@
+---
+slug: choose-your-license
+title: Choosing your license, step by step
+description: A guided, branching walkthrough that lands you on a specific license — open vs proprietary vs source-available vs dual, then permissive vs copyleft — with a decision table and worked mini-scenarios.
+keywords: choose a software license, which license should I use, MIT vs Apache vs GPL vs AGPL, permissive vs copyleft, source available license, dual licensing, BSL, AGPL for SaaS, proprietary EULA, license decision tree, pick a license
+level: intermediate
+status: full
+faq:
+  - q: "I just want people to use my library — which license?"
+    a: "A **permissive** license. Pick **MIT** for the shortest, simplest terms, or **Apache 2.0** if you also want an explicit patent grant (worth it for anything touching patentable techniques or aimed at corporate users). Both let companies adopt your code in closed products, which removes the biggest barrier to adoption."
+  - q: "How do I stop a cloud provider from reselling my project as a service?"
+    a: "Two paths. The **AGPL** keeps the project open source but forces anyone offering it as a network service to release their modifications. A **source-available** license like the BSL goes further by restricting commercial hosting outright, at the cost of no longer being open source. Pick based on whether staying OSI-open matters to you."
+  - q: "What if I want to sell my software?"
+    a: "Then you're past open source and into a **proprietary** license — typically a EULA for downloaded software or terms of service for a hosted product. Some teams keep an open or copyleft core and sell a proprietary edition (open core or dual licensing). Writing the actual license is its own job — see [writing a commercial license](/learn/software-licensing/writing-a-commercial-license/)."
+---
+# Choosing your license, step by step
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**One branching walkthrough** — answer a short series of questions and you land on a specific license, not a family. **First fork: open vs proprietary vs source-available vs dual** — this top-level choice determines everything downstream. **Within open: permissive vs copyleft** — MIT/Apache for reach, GPL/AGPL for sharing-back, LGPL/MPL for the middle. **Match the worry to the tool** — patent comfort → Apache; cloud resellers → AGPL or source-available; selling → proprietary.
+</div>
+
+The [decision framework](/learn/software-licensing/the-decision-framework/) gave you the inputs and a high-level profile. This lesson is the concrete follow-through: a guided walkthrough that takes you from "I have some software" to a single named license. We'll go branch by branch — the top-level fork first, then the sub-choices within open source — back it with a decision table, and finish with worked mini-scenarios so you can see the whole path in action. By the end you'll be able to name the license that fits your project and know exactly why.
+
+## Step 1 — The top-level fork
+
+Before any nuance, every project sits in one of four buckets. Answer this first; it determines which branch you walk next.
+
+- **Open source** — anyone can use, modify, and redistribute, subject to a standard [open-source license](/learn/software-licensing/what-is-open-source/). Choose this if your goal is adoption or community, and the software isn't *directly* how you make money.
+- **Proprietary** — you keep the rights and grant only limited, usually paid, permission to use. Choose this if selling the software (or restricting it) is the point.
+- **Source-available** — the source is public to read, but the license restricts use (commonly: no competing commercial hosting). Choose this when you want transparency *and* protection from cloud resellers, and you're willing to give up the "open source" label.
+- **Dual** — two licenses at once: typically a free copyleft license plus a paid proprietary one for those who can't accept copyleft. Choose this to monetize while staying open, if you own all the rights.
+
+If you picked **proprietary**, jump to [writing a commercial license](/learn/software-licensing/writing-a-commercial-license/) — that's a whole craft of its own, and the rest of this lesson is about the open branch. If you picked **dual**, you'll still choose an open license for the free side using the steps below, then pair it with a commercial license. If you picked **source-available**, see Step 4. If you picked **open**, continue to Step 2.
+
+## Step 2 — Within open source: permissive or copyleft?
+
+This is the central question of open-source licensing, and it comes straight from your goal.
+
+- **Permissive** (MIT, BSD, Apache) — "do almost anything, just keep my notice." Maximizes adoption by *allowing* closed forks. Pick this if reach matters more than forcing anyone to share back.
+- **Copyleft** (GPL, AGPL) — "you may use and modify, but derivatives must stay open under the same terms." Prevents closed forks at some cost to adoption. Pick this if you want improvements to flow back.
+- **Weak copyleft** (LGPL, MPL) — a middle path: the *file or library* stays open, but a larger work that merely links to it can remain closed. Pick this for a library you want shared back without forcing every user's whole app open.
+
+The deeper trade-off is laid out in [permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/) and the [weak-copyleft](/learn/software-licensing/weak-copyleft-licenses/) lesson. The rule of thumb: the more you value adoption, the more permissive you go; the more you value forced sharing-back, the stronger the copyleft.
+
+## Step 3 — Within permissive: MIT or Apache?
+
+If Step 2 sent you permissive, the practical choice is almost always MIT vs Apache 2.0.
+
+- **MIT** (and the similar BSD) — the shortest, most familiar permissive license. Use it when you want minimal text and maximum simplicity, and patents aren't a concern. Covered in [MIT & BSD](/learn/software-licensing/mit-and-bsd-licenses/).
+- **Apache 2.0** — permissive *plus* an explicit patent grant and patent-retaliation clause. Use it when your code might touch patentable techniques, or you want corporate users and legal teams to feel safe adopting it. Covered in [Apache 2.0](/learn/software-licensing/apache-license/).
+
+A simple way to decide: **if you want a patent grant, choose Apache; otherwise MIT is fine.** GopherTrunk itself is licensed Apache-2.0 for exactly this reason — a signal-processing project benefits from the explicit patent grant.
+
+## Step 4 — Within copyleft: GPL, AGPL, or source-available?
+
+If Step 2 sent you copyleft, the deciding factor is *how your software is delivered* — distributed or hosted.
+
+- **GPL** — strong copyleft triggered by **distribution**. If you ship binaries or source, recipients get the source and the same freedoms. But it has a famous gap: running modified code as a network service (without distributing it) doesn't trigger it. See [the GPL](/learn/software-licensing/gpl-strong-copyleft/).
+- **AGPL** — closes that gap. Copyleft extends over the **network**, so a provider offering your software as a hosted service must release their modifications to users of the service. This is the open-source answer to cloud resellers. See [the AGPL](/learn/software-licensing/agpl-network-copyleft/).
+- **Source-available (e.g., BSL)** — if the AGPL still isn't enough — you want to *prohibit* commercial hosting outright, not just require source-sharing — a [source-available license](/learn/software-licensing/source-available-licenses/) does that, but it is **not** open source and will narrow your contributor and adopter pool.
+
+## The whole walkthrough as a table
+
+Here's the branching logic collapsed into a single lookup. Find the row that matches your strongest need; the license is the answer.
+
+| Your strongest need | License | Why |
+|---|---|---|
+| Maximum adoption, simplest terms | **MIT** | Permissive, minimal, universally understood |
+| Adoption + a patent grant | **Apache 2.0** | Permissive with explicit patent protection |
+| A library shared back, app stays closed-able | **LGPL / MPL** | Weak copyleft scoped to the component |
+| Improvements to distributed software stay open | **GPL** | Strong copyleft on distribution |
+| Block closed *and* cloud-only forks, stay open source | **AGPL** | Copyleft over the network |
+| Prohibit competing commercial hosting (giving up "open") | **Source-available (BSL)** | Use restriction, not just share-back |
+| Sell the software | **Proprietary EULA** | You keep rights; users buy limited permission |
+| Monetize while staying open, you own all rights | **Dual (copyleft + commercial)** | Free copyleft side + paid proprietary side |
+
+## Worked mini-scenarios
+
+Seeing the walkthrough applied makes it stick. Four common cases:
+
+**1. A library you want everyone to adopt.** Goal: reach. Step 1 → open. Step 2 → permissive (you *want* companies to build on it). Step 3 → MIT if patents are irrelevant, **Apache 2.0** if you want the patent grant and corporate comfort. → **MIT or Apache 2.0.**
+
+**2. A SaaS backend you want to keep others from reselling.** Goal: control, specifically against cloud capture. Step 1 → open (you still want the openness benefit) or source-available (if you want a harder block). Step 2 → copyleft. Step 4 → **AGPL** to force resellers to publish modifications, or **BSL** if you'd rather forbid commercial hosting outright. → **AGPL or BSL.**
+
+**3. A paid desktop app.** Goal: revenue, downloaded delivery. Step 1 → proprietary. There's no open branch to walk; you grant limited use under a **EULA** and head to [writing a commercial license](/learn/software-licensing/writing-a-commercial-license/). → **Proprietary EULA.**
+
+**4. A copyleft tool you also want to sell to companies that can't accept copyleft.** Goal: revenue *and* openness. Step 1 → dual. You pick **GPL or AGPL** for the free side (Steps 2/4) and pair it with a **paid commercial license** for customers who need proprietary terms. This requires owning all the rights — see [dual licensing](/learn/software-licensing/dual-licensing-and-relicensing/). → **Dual: copyleft + commercial.**
+
+One closing rule that applies to every branch: **pick a standard, well-known license and don't write your own.** Custom licenses create compatibility headaches, scare off contributors and corporate legal teams, and may not even qualify as open source. Use an OSI-approved license via [choosealicense.com](https://choosealicense.com) or the [SPDX list](https://spdx.org/licenses/), then apply it correctly — a `LICENSE` file plus per-file notices — so the choice actually takes effect.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Apache 2.0 is the permissive choice when you want an explicit patent grant; MIT is the choice when you don't need one." markdown="0">
+  <p class="knowledge-check__q">Quick check: you've decided on a permissive license and you want an explicit patent grant. Which do you pick?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">MIT, because it's the shortest license</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">AGPL, because it has the strongest protections</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Apache 2.0, because it adds an explicit patent grant to permissive terms</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Start at the top fork** — open vs proprietary vs source-available vs dual decides which branch you walk.
+- **Within open, permissive vs copyleft** — reach (MIT/Apache) vs forced sharing-back (GPL/AGPL), with LGPL/MPL as the middle.
+- **Within permissive, patents decide** — Apache 2.0 if you want a patent grant, MIT if you don't.
+- **Within copyleft, delivery decides** — GPL for distribution, AGPL to also cover network hosting, source-available to block commercial hosting outright.
+- **Selling means proprietary** — a EULA or hosted terms, written as its own document.
+- **Always pick a standard license** — use an OSI-approved license and apply it correctly; never invent your own.
+
+Next up: the license covers your code, but how you deliver it decides what else you need. See [Which agreements does your software need?](/learn/software-licensing/which-agreements-do-you-need/).

--- a/docs/learn/software-licensing/choosing-an-oss-license.md
+++ b/docs/learn/software-licensing/choosing-an-oss-license.md
@@ -1,0 +1,113 @@
+---
+slug: choosing-an-oss-license
+title: Choosing an open-source license
+description: Turn what you know about license families into a decision. Learn the key questions — adoption, preventing proprietary forks, SaaS protection, patent grants — and a goal-to-license decision table for MIT, Apache, MPL, GPL, and AGPL.
+keywords: choosing an open source license, which license to pick, MIT vs Apache vs GPL, open source license decision, choosealicense, SPDX, OSI approved licenses, AGPL SaaS, patent grant license, prevent proprietary forks, license families
+level: intermediate
+status: full
+faq:
+  - q: "What license should I pick if I just want as many people as possible to use my code?"
+    a: "Reach for a **permissive** license — **MIT** if you want minimal text and maximum simplicity, or **Apache 2.0** if you also want an explicit patent grant. Permissive licenses let anyone, including companies shipping closed products, adopt your code, which removes the biggest barrier to adoption."
+  - q: "How do I stop a company from taking my open-source project, running it as a paid service, and giving nothing back?"
+    a: "That's exactly what the **AGPL** is designed for. It extends copyleft to network use, so a provider who offers your code as a hosted service must release their modified source. The MPL and GPL don't reach network-only use, so they won't close that gap."
+  - q: "Should I ever write my own custom open-source license?"
+    a: "Almost never. A custom license creates compatibility headaches, scares off contributors and corporate legal teams, and may not even qualify as open source. Pick a standard **OSI-approved** license from [choosealicense.com](https://choosealicense.com) or the [SPDX list](https://spdx.org/licenses/) — they're vetted, understood, and tooling-friendly."
+---
+# Choosing an open-source license
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Start from your goal** — adoption, preventing proprietary forks, SaaS protection, or a patent grant each point to a different license. **Map goals to families** — permissive (MIT/Apache) for reach, weak copyleft (MPL) for a middle path, strong copyleft (GPL/AGPL) for sharing-back. **Pick a standard license** — choose an OSI-approved license via choosealicense.com or SPDX; never write your own. **Apply it correctly** — add the license file and per-file notices so the choice actually takes effect.
+</div>
+
+You've toured the license families — [permissive](/learn/software-licensing/mit-and-bsd-licenses/), [Apache](/learn/software-licensing/apache-license/), [GPL](/learn/software-licensing/gpl-strong-copyleft/), [AGPL](/learn/software-licensing/agpl-network-copyleft/), and the [weak-copyleft](/learn/software-licensing/weak-copyleft-licenses/) middle — and you understand [compatibility](/learn/software-licensing/license-compatibility/). This lesson turns all of that into a single decision: which license to put on *your* project. By the end you'll have a short list of questions to ask yourself, a goal-to-license table, the tools that make the choice easy, and a clear reason to pick a standard license rather than invent one.
+
+## The decision is about your goals, not the licenses
+
+There's no "best" open-source license — there's the one that matches what you want to happen to your code. The whole choice collapses to a few honest questions about your intent. Answer these and the license almost picks itself.
+
+- **Do you want adoption above all else?** If your priority is the widest possible use — including by companies building closed products on top of you — you want the fewest possible conditions. That points permissive.
+- **Do you want to prevent proprietary forks?** If you'd be unhappy seeing someone take your code, improve it, and ship those improvements without sharing back, you want copyleft to require that they share.
+- **Do you want to protect against SaaS capture?** If your worry is specifically a cloud provider running your code as a *service* and never distributing a binary (so ordinary copyleft never triggers), you need network copyleft.
+- **Do you need an explicit patent grant?** If your code might touch patentable techniques, or you want corporate users to feel safe, you want a license that grants patent rights and includes a patent-retaliation clause.
+- **Do you care about contributor and corporate comfort?** Some licenses (notably the AGPL) make corporate legal teams nervous and can shrink your contributor pool; permissive licenses are the easiest sell.
+
+Notice these can conflict. Maximum adoption and strong sharing-back pull in opposite directions — permissive maximizes reach by *allowing* closed forks, while copyleft prevents closed forks at the cost of some adoption. Choosing a license is choosing which trade-off you want.
+
+## A goal-to-license decision table
+
+Here's the mapping from the question you answered "yes" to most strongly, to the license family that serves it.
+
+| Your main goal | License to reach for | What it gives you | The trade-off |
+|---|---|---|---|
+| Maximum adoption, minimal fuss | **MIT** | Shortest, most familiar permissive license | No patent grant; closed forks allowed |
+| Adoption **plus** patent protection | **Apache 2.0** | Permissive + explicit patent grant + notice rules | Slightly longer; incompatible with GPLv2 |
+| A middle path — share file-level changes but allow linking into closed code | **MPL 2.0** | File-level (weak) copyleft | Won't force the *whole* product open |
+| Prevent proprietary forks of a distributed app/library | **GPLv3** | Strong copyleft on distribution | Many companies avoid GPL dependencies |
+| Prevent SaaS capture — share-back even when only offered as a service | **AGPLv3** | Copyleft extended to network use | Strongest deterrent to corporate adoption |
+
+If you genuinely don't know, the safe default for most new projects that just want to be used is **MIT or Apache 2.0** — Apache if patents or corporate trust matter, MIT if you want the absolute minimum. If your project's whole point is keeping the ecosystem open, **GPLv3** (distributed software) or **AGPLv3** (network services) is the deliberate copyleft choice.
+
+## Why a standard, OSI-approved license beats a custom one
+
+It is tempting to write your own license, or to bolt a custom clause onto a standard one. Resist it. A non-standard license causes real, lasting problems:
+
+- **Compatibility unknowns.** Standard licenses have well-understood [compatibility](/learn/software-licensing/license-compatibility/) relationships. A custom license is a question mark — nobody knows if it can be combined with anything.
+- **Contributor and corporate friction.** Developers and company legal teams recognize MIT, Apache, and GPL instantly and can clear them in minutes. A bespoke license triggers an expensive, slow legal review — or an outright "no."
+- **It may not even be open source.** "Open source" has a specific definition (the OSI's Open Source Definition). A homemade license with, say, a non-commercial clause is *source-available*, not open source — a distinction we cover in [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/).
+- **Tooling won't recognize it.** License scanners, SBOM generators, and package registries key off standard SPDX identifiers. A custom license is invisible or flagged as "unknown" to all of them.
+
+The **OSI** (Open Source Initiative) maintains the canonical list of licenses that meet the Open Source Definition. **SPDX** assigns each a short standard identifier (`MIT`, `Apache-2.0`, `GPL-3.0-only`, `AGPL-3.0-only`) that tooling everywhere relies on. Sticking to that vetted set is almost always the right call.
+
+## Tools that make the choice (and the application) easy
+
+You don't have to reason from scratch:
+
+- **[choosealicense.com](https://choosealicense.com)** — GitHub's plain-language guide. Answer a couple of questions about what you want and it recommends a license, shows the full text, and even helps you add it. The best starting point for most people.
+- **The [OSI license list](https://opensource.org/licenses)** — the authoritative set of licenses that meet the Open Source Definition. If a license isn't here (or in the SPDX list), be skeptical of calling it open source.
+- **The [SPDX license list](https://spdx.org/licenses/)** — standard identifiers for every common license, the strings you put in metadata and SBOMs.
+
+Choosing isn't enough — you have to *apply* the license so it legally takes effect. In practice that means a `LICENSE` file at the repository root and, for many licenses, a short per-file header. GopherTrunk does exactly this: its [Apache-2.0](/learn/software-licensing/apache-license/) terms live in `/LICENSE`, and it ships a `/THIRD_PARTY_LICENSES.md` attribution file for its dependencies.
+
+```text
+# A typical short license header for an Apache-2.0 source file
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 The GopherTrunk Authors
+```
+
+The `SPDX-License-Identifier` line is the machine-readable way to declare a file's license — short, unambiguous, and recognized by every scanning tool.
+
+## A quick recap of the family strengths and weaknesses
+
+To consolidate the whole module so far:
+
+| Family | Strength | Weakness |
+|---|---|---|
+| **Permissive (MIT/BSD)** | Maximum adoption; trivial to comply with | Allows closed forks; no patent grant |
+| **Apache 2.0** | Permissive *and* an explicit patent grant; corporate-friendly | Patent terms make it incompatible with GPLv2 |
+| **Weak copyleft (MPL/LGPL/EPL)** | Share file/library changes, still linkable into closed code | Boundary of what must be shared can be subtle |
+| **Strong copyleft (GPL)** | Forces distributed derivatives to stay open | Many companies refuse GPL dependencies |
+| **Network copyleft (AGPL)** | Closes the SaaS loophole; strongest share-back | Biggest deterrent to corporate adoption |
+
+There's no winner in this table — only fits. The right license is the one whose strength matches your goal and whose weakness you can live with.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the AGPL extends copyleft to network use, so a provider offering your code as a hosted service must release their source." markdown="0">
+  <p class="knowledge-check__q">Quick check: which license is designed to stop a cloud provider from running your code as a paid service without sharing their changes?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">MIT, because it has the fewest conditions</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Apache 2.0, because of its patent grant</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">AGPLv3, because it extends copyleft to network use</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Start from your goal** — adoption, preventing proprietary forks, SaaS protection, or a patent grant each lead to a different license.
+- **Map goal to family** — MIT/Apache for reach, MPL for a middle path, GPL to keep distributed derivatives open, AGPL to close the SaaS loophole.
+- **Default to MIT or Apache** if you mainly want to be used; choose copyleft deliberately when keeping the ecosystem open is the point.
+- **Pick a standard license** — use an OSI-approved, SPDX-identified license; never write your own.
+- **Use the tools** — choosealicense.com, the OSI list, and SPDX make both the choice and the metadata easy.
+- **Apply it correctly** — a `LICENSE` file plus per-file SPDX headers are what make your choice actually bind.
+
+Next up: once others start contributing to your project, who owns and licenses *their* code? See [Contributor agreements: CLAs & DCO](/learn/software-licensing/contributor-agreements/).

--- a/docs/learn/software-licensing/commercial-license-models.md
+++ b/docs/learn/software-licensing/commercial-license-models.md
@@ -1,0 +1,112 @@
+---
+slug: commercial-license-models
+title: Commercial license models
+description: How paid software is structured — perpetual licenses with maintenance vs subscriptions, per-seat vs concurrent, per-core, usage-based, site licenses, freemium, open-core, and OEM. A clear comparison of who each model fits and where the traps are.
+keywords: commercial license models, perpetual license, subscription, SaaS, per-seat license, named user, concurrent license, per-core licensing, usage-based pricing, site license, enterprise license, freemium, open core, OEM license, software pricing
+level: intermediate
+status: full
+faq:
+  - q: "What's the difference between a perpetual license and a subscription?"
+    a: "A **perpetual** license is bought once and lets you use that version forever, usually with an optional yearly **maintenance** fee for updates and support. A **subscription** is a recurring payment (monthly or yearly) that grants the right to use the software *only while you keep paying* — stop paying and access ends. Perpetual front-loads the cost; subscription spreads it out but never finishes."
+  - q: "What's the difference between per-seat and concurrent licensing?"
+    a: "**Per-seat** (or named-user) ties a license to specific people or devices — if you have 50 named users, only those 50 can use it. **Concurrent** licensing caps how many people use it *at the same time* — 50 concurrent licenses can serve 200 occasional users as long as no more than 50 are active at once. Concurrent suits tools used intermittently by many people; per-seat suits daily, dedicated users."
+  - q: "Is open-core the same as open source?"
+    a: "No. **Open-core** means a company publishes a genuinely open-source core and sells proprietary add-ons (advanced features, support, hosting) on top. The core is open source; the paid layer is not. It's a business model built *around* open source, not an open-source license. See [source-available licenses](/learn/software-licensing/source-available-licenses/) for the related but distinct strategies vendors use."
+---
+# Commercial license models
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Perpetual vs subscription** — buy-once-plus-maintenance versus pay-to-keep-using. **How you're counted** — per-seat/named-user, concurrent, per-core/CPU/instance, or by usage. **Scope tiers** — site, enterprise, and unlimited deals trade per-unit price for coverage. **Hybrid models** — freemium and open-core layer free and paid; OEM/redistribution licenses let others embed your software.
+</div>
+
+Proprietary software has to be paid for somehow, and over the years the industry has settled into a handful of well-worn structures for charging. Understanding them helps whether you're buying software (so you don't overpay or get trapped) or selling it (so you pick a model that fits your product and customers). By the end of this lesson you'll be able to tell perpetual from subscription, understand the main ways vendors count usage, recognize the scope-based and hybrid models, and spot the common pitfalls of each.
+
+## Perpetual licenses vs subscriptions
+
+The most fundamental split is *how long your right to use lasts*.
+
+A **perpetual license** is a one-time purchase that grants the right to use a specific version of the software forever. Because software needs fixing and updating, perpetual licenses are almost always paired with an optional **maintenance** (or "software assurance") contract — a yearly fee, often 15–25% of the purchase price, that buys you bug fixes, updates, and support. Let the maintenance lapse and you keep the software you have, but you stop getting updates.
+
+A **subscription** flips the model: you pay a recurring fee (monthly or annual), and your right to use the software lasts *only as long as you keep paying*. Stop, and access ends. Most cloud-delivered software (**SaaS** — Software as a Service) works this way, because the vendor is also hosting and running the software for you.
+
+The industry has shifted hard toward subscriptions over the last decade. Vendors prefer the predictable recurring revenue; buyers get lower upfront cost and continuous updates but lose the "I paid once and own this version" finality.
+
+| Model | How you pay | You stop paying… | Watch out for |
+|---|---|---|---|
+| **Perpetual + maintenance** | Large one-time fee, then optional yearly maintenance | …you keep the version you have, lose updates | Maintenance creep; being stranded on an old version |
+| **Subscription / SaaS** | Recurring monthly or yearly | …access ends entirely | Lock-in; price hikes; no "owned" fallback |
+
+## How vendors count you
+
+Within either model, the vendor needs a *unit* to charge per. The unit shapes the whole deal.
+
+### Per-seat and named-user
+
+The most familiar unit is the **seat**. A **per-seat** or **named-user** license is assigned to a specific person (or sometimes a specific device). Twenty named users means twenty people may use it; a twenty-first needs another license. This is simple and predictable, and it fits software people use every day as part of their job.
+
+### Concurrent (floating)
+
+A **concurrent** or **floating** license caps the number of *simultaneous* users rather than total users. If you buy ten concurrent licenses, any of your hundred employees can use the software, but only ten at a time; the eleventh waits for a seat to free up. This is efficient for tools used intermittently by a large, rotating group — think of a specialized analysis app that each engineer needs only occasionally.
+
+### Per-core, per-CPU, per-instance
+
+For server and infrastructure software, charging per human makes no sense — the software serves machines, not individuals. These products license by **hardware or deployment unit**: per CPU socket, per **core**, per virtual machine, or per running **instance**. Databases and middleware are classic examples. The pitfall here is that modern multi-core CPUs and virtualized/cloud environments can make the count explode — a single beefy server can carry dozens of billable cores, and "do you count physical or virtual cores?" has been the source of many painful audit disputes.
+
+### Usage / consumption-based
+
+The newest common model charges for **what you actually use**: API calls, data processed, messages sent, compute-hours, gigabytes stored. It scales naturally with value and lets small users pay little — but it can be unpredictable, and a runaway job or a traffic spike can produce a shocking bill. Metered pricing is the default for most cloud platform services.
+
+## Scope-based licensing: site, enterprise, unlimited
+
+Counting per unit gets expensive and tedious at scale, so for large customers vendors offer **scope** deals that drop the per-unit math:
+
+- **Site license** — covers everyone at a particular location or facility, no per-seat counting.
+- **Enterprise license / Enterprise License Agreement (ELA)** — covers an entire organization, often across locations, usually as a negotiated lump sum.
+- **Unlimited license** — use as much as you want, typically the most expensive and most heavily negotiated.
+
+These trade a higher total price for simplicity and predictability. The pitfall is over-buying: an "unlimited" deal sold on projected growth that never materializes can cost far more than per-seat would have. Read the renewal terms — the easy first-year price sometimes resets sharply later.
+
+## Hybrid and channel models
+
+Several models mix free and paid, or license software for *others* to build on.
+
+- **Freemium** — a free tier plus paid upgrades. The free tier is real software (still proprietary — see [Proprietary & closed-source licensing](/learn/software-licensing/proprietary-licensing/)) used as a funnel; you pay to unlock capacity or features.
+- **Open-core** — a genuinely [open-source](/learn/software-licensing/what-is-open-source/) core with proprietary paid add-ons, support, or hosting on top. The core is open source; the surrounding layer is commercial. This is a business model around open source, not a license type.
+- **OEM / redistribution / embedding** — licenses that let *another company* bundle your software inside their product (an "Original Equipment Manufacturer" deal), redistribute it to their customers, or embed it in a device. These are negotiated separately and priced by volume or royalty, because the licensee is reselling your work, not just using it.
+
+## Putting it together
+
+| Model | How you pay | Fits | Main pitfall |
+|---|---|---|---|
+| **Perpetual + maintenance** | Once, plus yearly support | Buyers who want to own a version | Stranded on old versions if maintenance lapses |
+| **Subscription / SaaS** | Recurring | Continuously updated, hosted tools | Lock-in and price increases |
+| **Per-seat / named-user** | Per person/device | Daily, dedicated users | Paying for idle seats |
+| **Concurrent / floating** | Per simultaneous user | Intermittent use by many people | Bottlenecks at peak demand |
+| **Per-core / CPU / instance** | Per hardware/deployment unit | Server & infrastructure software | Core/VM counts exploding in the cloud |
+| **Usage / consumption** | Per call, GB, hour, etc. | Variable workloads, platform services | Unpredictable, spiky bills |
+| **Site / enterprise / unlimited** | Negotiated lump sum | Large organizations | Over-buying; renewal price resets |
+| **Freemium / open-core** | Free tier + paid upgrades | Bottom-up adoption | Free tier cannibalizing paid |
+| **OEM / redistribution** | Volume or royalty | Embedding in another product | Mispriced royalties at scale |
+
+No model is "best." The right one depends on the product, the buyer, and how value scales with use — which is exactly the kind of decision we work through in [A framework for choosing](/learn/software-licensing/the-decision-framework/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — concurrent licensing caps simultaneous users, so a large rotating pool can share a small number of seats." markdown="0">
+  <p class="knowledge-check__q">Quick check: a tool is used briefly and occasionally by 200 employees, rarely more than 8 at once. Which model is most cost-efficient?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Per-seat / named-user licensing for all 200 people</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A per-core license sized to the server it runs on</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A handful of concurrent (floating) licenses sized to peak simultaneous use</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Perpetual vs subscription** — own a version forever (with optional maintenance) versus pay-to-keep-using; the industry has shifted toward subscriptions and SaaS.
+- **Counting units** — per-seat/named-user (per person), concurrent (per simultaneous user), per-core/CPU/instance (per machine), and usage-based (per call/GB/hour).
+- **Scope tiers** — site, enterprise, and unlimited licenses trade per-unit price for coverage and simplicity, with over-buying as the risk.
+- **Hybrid models** — freemium and open-core layer free and paid offerings; open-core is a model around open source, not an open-source license.
+- **Channel licenses** — OEM, redistribution, and embedding licenses let another company ship your software, priced by volume or royalty.
+
+Next up: the gray zone between open source and proprietary — code you can see but not freely use, and why companies are moving there. See [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/).

--- a/docs/learn/software-licensing/contributor-agreements.md
+++ b/docs/learn/software-licensing/contributor-agreements.md
@@ -1,0 +1,108 @@
+---
+slug: contributor-agreements
+title: "Contributor agreements: CLAs & DCO"
+description: When others contribute code, who owns and licenses it? Learn the inbound=outbound default, what a CLA grants a project, how the DCO sign-off works, and what contributors should understand before signing either.
+keywords: contributor license agreement, CLA, DCO, developer certificate of origin, inbound equals outbound, copyright assignment, signed-off-by, contributor agreement, contributing to open source, relicensing rights, who owns contributions
+level: intermediate
+status: full
+faq:
+  - q: "If a project has no CLA, who owns the code I contribute?"
+    a: "You keep your copyright, and by contributing you license your work to the project under the project's own license — the **inbound=outbound** default. Your code goes in under the same terms it goes out under (e.g. Apache-2.0 in, Apache-2.0 out). No rights transfer beyond that license unless a CLA says so."
+  - q: "What's the difference between a CLA and a DCO?"
+    a: "A **CLA** is a legal agreement where you grant the project specific rights (and sometimes assign copyright) — it's heavyweight and enables things like relicensing. A **DCO** is a lightweight *certification*: you add a `Signed-off-by` line attesting you have the right to submit the code under the project's license. The DCO grants no extra rights; it just records a promise."
+  - q: "Should I worry about signing a company's CLA?"
+    a: "Read it. A broad CLA can let the company **relicense or dual-license** your contribution however it wants, including in closed commercial products — you're granting that right. That may be perfectly fine, but understand you might be handing a company broad rights to code you wrote for free before you click 'agree.'"
+---
+# Contributor agreements: CLAs & DCO
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Inbound=outbound is the default** — without any extra agreement, contributions come in under the project's own license. **A CLA grants the project rights** — sometimes broad, sometimes copyright assignment; it's what enables relicensing and dual-licensing. **A DCO is a lightweight sign-off** — a `Signed-off-by` line certifying you have the right to contribute, granting no extra rights. **Contributors should read before signing** — a CLA can hand a company broad rights to code you wrote for free.
+</div>
+
+The moment someone else sends a patch to your project, a question appears that didn't exist when you were the only author: who owns that code, and under what terms can the project use it? This lesson covers the three answers in practice — the silent default, the Contributor License Agreement (CLA), and the Developer Certificate of Origin (DCO) — from both sides of the table. By the end you'll know what each mechanism does, why a maintainer might want one, and — just as important — what you as a contributor are agreeing to when you sign.
+
+## The default: inbound=outbound
+
+Suppose your project is [Apache-2.0](/learn/software-licensing/apache-license/) and a stranger opens a pull request. If you have *no* separate agreement in place, what governs their contribution?
+
+The widely accepted default is **inbound=outbound**: contributions come *in* under the same license the project goes *out* under. Phrased by the Apache and open-source community as a norm, it means a contributor who submits code to your Apache-2.0 project is — by the act of contributing — licensing that code to the project under Apache-2.0. The contributor keeps their copyright; they simply grant the project (and everyone downstream) the same license everyone else already has.
+
+GitHub's own terms of service codify this for public repos: absent a different agreement, contributions are licensed under the repository's existing license. Many projects also state it explicitly in `CONTRIBUTING.md`. The Apache-2.0 license even has section 5, which says contributions are deemed to be under the license's terms unless stated otherwise — so an Apache project gets a clean inbound grant essentially for free.
+
+The thing to understand about inbound=outbound: it grants the project *exactly* the project's license and **no more**. That's usually all a healthy open-source project needs. But it means the project can't later relicense the code, because each contributor only granted the existing license — not the right to change it. That limitation is the reason CLAs exist.
+
+## The CLA: a Contributor License Agreement
+
+A **CLA** is a separate legal agreement a contributor signs (often once, electronically, before their first merge) that grants the project specific rights to their contributions. CLAs come in two main flavors:
+
+- **License-grant CLA.** The contributor keeps copyright but grants the project a broad, irrevocable license — including, critically, the right to *relicense* and to grant patent rights. The Apache Software Foundation's Individual CLA is the model here. This lets the project sublicense and combine contributions flexibly.
+- **Copyright-assignment CLA.** The contributor *transfers ownership* of the contribution's copyright to the project or its sponsoring entity. The strongest version — the entity now owns the code outright. The Free Software Foundation historically required this for GNU projects.
+
+Why would a maintainer or company want a CLA? A few reasons:
+
+- **Relicensing flexibility.** With broad rights from every contributor, the project can move to a new license version, or **dual-license** the code — for example, offering it as both GPL and a paid commercial license. (That model is the subject of the next lesson, [Dual licensing & relicensing](/learn/software-licensing/dual-licensing-and-relicensing/).)
+- **Legal certainty / enforcement.** A signed CLA gives the project a clear, documented chain of rights — useful if it ever has to defend the license or prove it had permission to use a contribution.
+- **Patent clarity.** Many CLAs include an explicit patent grant, so a contributor can't later claim a patent over code they donated.
+
+The cost is real friction: contributors must sign before they can help, which deters drive-by fixes, and a corporate CLA can feel — and be — like asking volunteers to sign over rights to a company.
+
+## The DCO: Developer Certificate of Origin
+
+The **DCO** is the lightweight alternative, created for the Linux kernel after the SCO lawsuits. It is **not** a rights grant — it's a *certification*. By adding a one-line `Signed-off-by` to each commit, the contributor attests to a short, fixed statement: that they wrote the code (or have the right to submit it) and that they're contributing it under the project's license.
+
+```text
+Signed-off-by: Jane Developer <jane@example.com>
+```
+
+That line, added with `git commit -s`, is the entire mechanism. It points to the published DCO text (version 1.1) and records the contributor's promise that the code is theirs to give. There's no separate document to sign, no account to register, no copyright transfer. The contribution still flows in under the project's license via inbound=outbound — the DCO just adds an auditable assertion of provenance on top.
+
+The DCO grants the project **no extra rights** — no relicensing power, no copyright assignment. That's the point. It gives a maintainer a record of who certified what, without asking contributors to give up anything beyond the normal inbound license.
+
+## CLA vs DCO: a side-by-side
+
+| Aspect | CLA | DCO |
+|---|---|---|
+| What it is | A signed legal agreement | A per-commit certification line |
+| Rights granted to project | Broad license, possibly copyright assignment | None beyond inbound=outbound |
+| Enables relicensing / dual-licensing | Yes (that's a main purpose) | No |
+| Contributor effort | Sign a document, often via a bot | `git commit -s` adds one line |
+| Friction for casual contributors | Higher — deters one-off fixes | Low |
+| Who uses it | Google, Apache (ASF projects), many corporate-backed projects | Linux kernel, GitLab, many CNCF projects |
+| Main downside | Can grant a company broad rights to volunteer work | Doesn't give the project relicensing flexibility |
+
+Neither is "better" in the abstract. A single-company project that may want to dual-license later leans CLA. A community project that values low contribution friction and doesn't plan to relicense leans DCO — or just relies on inbound=outbound with nothing extra at all.
+
+## What contributors should understand before signing
+
+Most lessons on this topic are written for maintainers. Here's the contributor's side, because it matters:
+
+- **A DCO costs you nothing extra.** You're certifying you have the right to submit the code under the project's license. If that's true, sign off freely.
+- **A CLA can grant a lot.** Read it before agreeing. A broad license-grant CLA may let the project — often a company — **relicense your contribution into closed, paid products**. A copyright-assignment CLA means you no longer own the code you wrote. That can be entirely reasonable (it's how many sustainable projects fund themselves), but go in with eyes open.
+- **Watch for asymmetry.** Some CLAs let the company do things with your code that the open-source license wouldn't let *you* do with theirs. You're contributing to a commons; under a broad CLA the company may be contributing to its own commercial product.
+- **Check what you're allowed to contribute.** If your employer owns your code (common under employment agreements), you may need their permission before you can truthfully sign either a DCO or a CLA. This intersects with [copyright and ownership](/learn/software-licensing/copyright-and-software-ownership/).
+
+None of this means "don't sign." It means *read the specific agreement*, understand whether you're merely certifying provenance (DCO) or granting broad rights (CLA), and decide knowingly.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a DCO is a per-commit certification of provenance and grants the project no rights beyond the normal inbound=outbound license." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does signing a DCO with `Signed-off-by` actually do?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Transfers the copyright of your contribution to the project</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Grants the project the right to relicense your code commercially</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Certifies that you have the right to submit the code under the project's license</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Inbound=outbound is the silent default** — without an agreement, contributions come in under the project's own license, and the contributor keeps copyright.
+- **A CLA grants the project rights** — a broad license or even copyright assignment, which is what enables relicensing and dual-licensing.
+- **A DCO is a sign-off, not a grant** — a `Signed-off-by` line certifying provenance, granting no extra rights and adding minimal friction.
+- **Maintainers choose based on intent** — CLA for relicensing flexibility and legal certainty; DCO (or nothing extra) for low-friction community contribution.
+- **Contributors should read before signing** — a DCO is cheap to grant, but a broad CLA can hand a company sweeping rights to code you wrote for free.
+- **Employment can complicate it** — if your employer owns your work, you may need permission before you can honestly sign either.
+
+Next up: the relicensing flexibility a CLA unlocks has a powerful business use — offering the same code under two licenses at once. See [Dual licensing & relicensing](/learn/software-licensing/dual-licensing-and-relicensing/).

--- a/docs/learn/software-licensing/copyleft-in-products.md
+++ b/docs/learn/software-licensing/copyleft-in-products.md
@@ -1,0 +1,100 @@
+---
+slug: copyleft-in-products
+title: "Copyleft in products: the viral question"
+description: Will the GPL infect your product? Learn what actually triggers copyleft obligations — distribution, not internal use or SaaS (except AGPL) — the contested linking boundary, and the safe architectural patterns that let you use copyleft code with discipline.
+keywords: GPL infect product, copyleft viral, GPL commercial product, copyleft trigger distribution, derivative work linking, static vs dynamic linking, LGPL relink, AGPL SaaS, mere aggregation, copyleft compliance, copyleft architecture
+level: advanced
+status: full
+faq:
+  - q: "Will using a GPL library force me to open-source my entire product?"
+    a: "Only if you **distribute** a product that is a *derivative work* of that GPL code. Using GPL code privately inside your company, or offering it as a hosted service, does **not** trigger the GPL's source-sharing obligation (the AGPL is the exception — it triggers on network use). And whether your code is a derivative work depends on how tightly it's bound to the GPL code, which is exactly what good architecture controls."
+  - q: "Is dynamic linking a safe way around the GPL?"
+    a: "It's safer than static linking, but it is **not a settled legal guarantee.** The Free Software Foundation considers most linking — static or dynamic — to create a derivative work. Many lawyers treat a clean, arm's-length boundary (separate process, stable interface) as far stronger evidence of independence than dynamic linking alone. For the **LGPL** specifically, dynamic linking plus a relink mechanism is explicitly permitted."
+  - q: "Does running GPL software on my servers (SaaS) trigger anything?"
+    a: "Under the plain **GPL**, no — making software available over a network is not 'distribution' in the GPL's sense, so there's no obligation to share source with users. The **AGPL** was written precisely to close that gap: if users interact with AGPL software over a network, you must offer them the corresponding source. So the answer is license-specific."
+---
+# Copyleft in products: the viral question
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Distribution is the trigger** — copyleft obligations fire when you *ship* a derivative to users, not from internal use. **SaaS is mostly safe — except AGPL** — the GPL doesn't trigger on network use; the AGPL does. **The linking boundary is contested** — static vs dynamic matters, but a clean separate-process boundary is the stronger defense. **Usable with discipline** — copyleft is fine in products if you architect deliberately, and dangerous only if you ignore it.
+</div>
+
+This is the lesson everyone is secretly worried about. "Copyleft" — the family of licenses led by the [GPL](/learn/software-licensing/gpl-strong-copyleft/) — has a reputation for being *viral*: the fear that touching one GPL file forces you to give away your entire commercial product. That reputation is half-true and half-myth, and the difference is worth real money. By the end of this lesson you'll know exactly what triggers copyleft obligations, why internal use and most SaaS don't, where the genuinely contested "derivative work" line sits, and the architectural patterns that let you use copyleft code in a product safely — plus when to just keep it at arm's length.
+
+## What actually triggers an obligation: distribution
+
+The single most important word in copyleft is **distribution** (the GPLv3 calls it *conveying*). Copyleft's source-sharing obligation attaches when you **convey the software to someone else** — ship a binary, hand over an installer, sell a device with the code on it. Until you distribute, you can do anything you like in private: modify GPL code, link it into your closed product, run it across your whole company. The GPL grants you those rights with **no obligation** as long as the result stays inside your walls.
+
+This is why the "viral" framing misleads. The GPL doesn't spread by contact; it attaches a condition to one specific act — distribution. No distribution, no obligation. Three consequences fall out of this:
+
+- **Internal use is free.** A company can use, modify, and deploy GPL software internally with zero source-sharing duty. Nothing is conveyed.
+- **Most SaaS is free of GPL obligations.** Letting users *interact with* software over a network is not conveying a copy to them. So a hosted product built on GPL code does not, under the plain GPL, owe users source. (This famous gap is the "ASP loophole.")
+- **The AGPL closes the SaaS gap.** The [AGPL](/learn/software-licensing/agpl-network-copyleft/) adds a clause that treats network interaction *as if* it were distribution: if users interact with AGPL software over a network, you must offer them the corresponding source. We return to this below.
+
+## "Derivative work" and the linking boundary
+
+When you *do* distribute, the next question is scope: **how much** must you release? Copyleft obligations cover the derivative work — the GPL code plus whatever is so tightly combined with it that it counts as one work. Code that is genuinely separate and independent is *not* covered, even if you ship it in the same package (more on that under "mere aggregation").
+
+The hard part is that "derivative work" is a copyright concept, not a precise technical one, and the **linking boundary is genuinely contested.** Here's the honest state of it:
+
+- The **Free Software Foundation's position** is that linking GPL code into your program — *static or dynamic* — generally creates a derivative work, so the combined program falls under the GPL.
+- **Many practitioners and some courts** focus less on the linking mechanism and more on *how intertwined* the code is: shared data structures, intimate function calls, and tight coupling point toward a derivative; communication across a clean, stable, arm's-length interface points toward independence.
+- **There is no single binding US precedent** that resolves dynamic linking cleanly. So treat dynamic linking as *safer* but not as a magic exemption.
+
+| Combination pattern | Typical risk of being a derivative |
+|---------------------|-------------------------------------|
+| Static linking (GPL compiled into your binary) | High — widely treated as derivative |
+| Dynamic linking (GPL shared library) | Contested — FSF says derivative; weaker boundary than separation |
+| LGPL dynamic linking with relink ability | Allowed — the LGPL explicitly permits this for your closed code |
+| Separate process, talking over IPC/CLI/socket | Low — strong evidence of independence |
+| Two independent programs shipped together | Mere aggregation — not derivative |
+
+### LGPL's relink allowance
+
+The [LGPL](/learn/software-licensing/weak-copyleft-licenses/) — "Lesser GPL," a weak copyleft license — was designed for exactly the linking case. It lets your proprietary program link against an LGPL library while keeping your own code closed, **on the condition** that the user can replace the library with a modified version. In practice that means dynamic linking (so the user can swap the `.so`/`.dll`), or shipping object files for relinking. The library itself stays copyleft — changes to *it* must be shared — but your application doesn't.
+
+## Safe architectural patterns
+
+Architecture is the lever. The same copyleft component can be a compliance non-event or a problem depending on how you build around it. The guiding principle: **the cleaner the boundary, the weaker the case that your code is a derivative.**
+
+- **Run it as a separate process.** Invoke the copyleft tool as its own program — a CLI you shell out to, or a service you talk to over a socket or pipe. Two programs communicating at arm's length are strong evidence of independence (this is *mere aggregation* territory).
+- **Define a clear, stable interface.** Talk through a documented protocol, file format, or standard system call, not by reaching into the copyleft code's internals. Intimacy is what creates derivation; a narrow interface limits it.
+- **For LGPL, dynamic-link and preserve relink.** Use the library as a swappable shared object and document how a user can replace it.
+- **Keep GPL *tools* at arm's length from your *product*.** Using a GPL compiler, build tool, or test harness to *produce* your software does **not** make your software GPL — the GPL covers the tool, not its output (unless the output embeds GPL code). Build-time use is generally fine.
+- **Isolate, don't intertwine.** If you need a GPL component's functionality, wrap it behind a boundary rather than weaving it through your codebase.
+
+### Mere aggregation vs derivative work
+
+The GPL itself draws this line. **Mere aggregation** — putting independent programs together on the same disk, image, or installer — does *not* make the aggregate a single work, so your independent program keeps its own license. A Linux distribution is the canonical example: it ships thousands of separately-licensed programs together, and that bundling alone doesn't relicense any of them. The test is whether the parts are genuinely independent works that merely sit together, versus components fused into one program.
+
+## AGPL in a hosted product
+
+The [AGPL](/learn/software-licensing/agpl-network-copyleft/) deserves its own caution because it defeats the usual "SaaS is safe" reasoning. If your hosted product includes AGPL code that users interact with over the network — even unmodified — you must make the **corresponding source** (including your modifications) available to those users. Many companies respond by **banning AGPL outright** in their dependency policy, precisely because it's easy to pull in accidentally and its trigger reaches the hosted model that the plain GPL doesn't. If you do use it, isolate it behind a clear network boundary and be ready to publish your changes to it.
+
+## The bottom line
+
+Copyleft is **usable with discipline and fatal if ignored.** None of these licenses forbid commercial use, and large products ship copyleft components every day. What they punish is carelessness — statically linking GPL into a closed binary you then sell, or pulling in AGPL without realizing the SaaS trigger. The defense is the same defense as for all compliance: know what you're shipping (the [next lesson](/learn/software-licensing/auditing-dependencies/)), decide deliberately how each copyleft component sits in your architecture, and keep clean boundaries. Do that, and "will it infect my product?" stops being a fear and becomes a design choice.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the plain GPL's source-sharing obligation triggers on distribution, not on internal use or network/SaaS access; the AGPL is what extends it to network use." markdown="0">
+  <p class="knowledge-check__q">Quick check: which act triggers the plain GPL's obligation to offer source?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Using the GPL software internally inside your company</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Letting users access it over a network as a hosted service</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Distributing (conveying) a derivative work to other people</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Distribution is the trigger** — copyleft obligations attach when you convey a derivative to users; private internal use carries no source-sharing duty.
+- **SaaS is mostly safe — except AGPL** — the plain GPL doesn't trigger on network access, but the AGPL was written to close that exact gap.
+- **The linking boundary is contested** — static linking is high-risk, dynamic linking is safer but not settled, and a separate-process boundary is the strongest defense.
+- **Architecture controls scope** — separate processes, clean interfaces, LGPL relinking, and keeping GPL tools at build-time arm's length all limit derivation.
+- **Mere aggregation isn't derivation** — independent programs bundled together keep their own licenses.
+- **Discipline, not fear** — copyleft is fully usable in commercial products when you choose deliberately and keep boundaries clean.
+
+Next up: you can only comply with licenses you know you're shipping. See [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/).

--- a/docs/learn/software-licensing/copyright-and-software-ownership.md
+++ b/docs/learn/software-licensing/copyright-and-software-ownership.md
@@ -1,0 +1,120 @@
+---
+slug: copyright-and-software-ownership
+title: Copyright & software ownership
+description: Copyright attaches to code automatically the moment it's written. Learn what it protects, the difference between authorship and ownership, and why contractors keep their copyright unless it's assigned in writing.
+keywords: software copyright, copyright ownership, automatic copyright, copyright registration, work made for hire, contractor copyright assignment, joint authorship, expression vs ideas, who owns code, source code copyright
+level: beginner
+status: full
+faq:
+  - q: "Do I need to register my software copyright for it to count?"
+    a: "No. Copyright attaches **automatically** on creation in essentially every country, with no registration required. In the **US specifically**, registering with the Copyright Office is optional but valuable — it's a prerequisite to suing and unlocks statutory damages and attorney's fees. Most other countries have no registration system at all, so this is a US-specific tactic, not a global requirement."
+  - q: "If I pay a freelancer to build my app, do I own the code?"
+    a: "Not automatically. By default, an independent **contractor keeps the copyright** in what they create, and you only get whatever license the contract grants. To actually *own* the code you need a written **copyright assignment** in the contract. Skipping this is one of the most common and expensive mistakes in software — fix it before work starts, in writing."
+  - q: "Can someone copyright an algorithm or an idea?"
+    a: "No. Copyright protects the specific **expression** — your actual source and binary — not the underlying **idea, algorithm, or functionality**. Someone can study what your program does and write their own independent implementation without infringing your copyright. Protecting the idea itself, if it's even possible, is the realm of patents, which we cover in the [next lesson](/learn/software-licensing/other-ip-in-software/)."
+---
+# Copyright & software ownership
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Copyright is automatic** — it attaches the instant original code is written, with no registration needed. **It protects expression, not ideas** — your source and binary are covered; the underlying algorithm and functionality are not. **Authorship and ownership can differ** — who wrote it isn't always who owns it. **Get assignments in writing** — employees' work is the employer's by default in the US, but contractors keep their copyright unless they assign it.
+</div>
+
+In the [first lesson](/learn/software-licensing/what-is-a-software-license/) we said code is owned the moment it's written and that a license grants permission from that owner. This lesson unpacks the "owned" half: where copyright comes from, what it does and doesn't cover, and — crucially — *who* the owner actually is, which is less obvious than it sounds. By the end you'll know why registration is optional, what copyright protects, and the written-assignment rule that trips up so many people who hire others to write code.
+
+## Copyright attaches automatically
+
+The foundational rule from lesson one bears repeating because so much follows from it: **copyright protection is automatic.** The instant you create an original work and fix it in a tangible medium — and saving a source file counts — copyright exists. You don't apply for it, you don't pay for it, and you don't need to add a `©` notice (though a notice is still a useful signal to others).
+
+This isn't a quirk of one country. An international treaty, the **Berne Convention**, commits its many member states to automatic, no-formalities copyright, which is why the rule looks the same across most of the world.
+
+### Registration: useful in the US, mostly absent elsewhere
+
+If copyright is automatic, what is "registering a copyright"? This is where countries diverge, so be careful.
+
+In the **United States**, registration with the Copyright Office is *optional* but carries real teeth. You generally must register before you can file an infringement lawsuit, and timely registration unlocks **statutory damages** (a fixed range of damages you can claim without proving exact financial harm) plus attorney's fees. That combination makes US registration a serious deterrent and a practical prerequisite to enforcement.
+
+Here's the part people miss: **this is largely US-specific.** Many countries have no copyright registration system at all — your rights are simply automatic and that's the end of it. So "you should register your copyright" is good advice in the US and meaningless in much of the rest of the world. The [cross-border lesson](/learn/software-licensing/licensing-across-jurisdictions/) returns to this.
+
+| | Automatic protection | Registration | Why register (where it exists) |
+|---|---|---|---|
+| **United States** | Yes, on creation | Optional, via Copyright Office | Required to sue; unlocks statutory damages + attorney's fees |
+| **Most of the world** | Yes, on creation (Berne) | Often no system at all | N/A — rights are automatic |
+
+## What copyright protects — and what it doesn't
+
+Copyright is powerful but narrow. It protects **expression**, not **ideas**. For software, the practical line looks like this:
+
+**Protected (expression):**
+
+- Your **source code** — the specific way you wrote it.
+- Your **compiled binary** — copying it bit-for-bit is copying the expression.
+- Other creative expression bundled with the software, like documentation, UI art, and original text.
+
+**Not protected by copyright (ideas and function):**
+
+- The **idea** behind the program.
+- The **algorithm** or method it uses.
+- The **functionality** — what the program does.
+- Facts and data themselves.
+
+This distinction has big consequences. A competitor is free to look at what your program does, understand the idea, and write their *own independent* implementation in their own code. As long as they didn't copy your expression, they haven't infringed your copyright — even if their product competes directly with yours. If you want to protect the underlying invention itself, that's the job of **patents**, not copyright, and it's a much harder and more limited road (covered in [the next lesson](/learn/software-licensing/other-ip-in-software/)).
+
+## Authorship is not the same as ownership
+
+It's natural to assume the person who *wrote* the code owns it. Often they do — but not always. The law distinguishes two ideas:
+
+- **Authorship** — who actually created the work.
+- **Ownership** — who holds the copyright (the exclusive rights).
+
+These usually start out together: the author is the first owner. But ownership can shift — by operation of law, by employment status, or by a written transfer — so that the author and the owner are different people or entities. The next two sections are the most important cases of exactly that.
+
+## Work made for hire: employees' code belongs to the employer
+
+In the **US**, code an employee writes *within the scope of their employment* is a **work made for hire**, and the **employer is the author and owner** from the start — not the employee. The developer who typed it never held the copyright in the first place.
+
+This is why your day-job code belongs to your company, and it's why companies can confidently build and ship products without getting an assignment from each engineer for every commit. The employment relationship does the work automatically (for code created in the scope of the job — a genuinely personal side project on your own time and equipment is a different, sometimes contested, question).
+
+A jurisdiction flag: the *result* — employer owns employee work — is common across many countries, but the legal machinery and the precise boundaries differ, and some systems (especially in Europe) keep certain **moral rights** with the human author regardless. More on that in [Licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/).
+
+## Contractors keep their copyright unless they assign it
+
+Now the rule that costs people real money. An **independent contractor** is *not* an employee, so the work-made-for-hire default does **not** automatically apply. By default, **the contractor owns the copyright in what they create**, and the client who paid for it gets only whatever rights the contract grants — sometimes just an implied license to use the deliverable.
+
+Read that again, because it's counterintuitive: *you can pay someone to build your software and not own it.* The money changing hands does not transfer the copyright. Only a written transfer does.
+
+The fix is a **copyright assignment** — an explicit clause in the contract, in writing, saying the contractor assigns all copyright in the work to the client. With it, you own the code. Without it, you're relying on a license you may not even have nailed down, and you can be blocked from things as basic as relicensing, selling the business, or stopping the contractor from reusing your code elsewhere.
+
+```text
+Contractor hereby assigns to Client all right, title, and interest,
+including all copyright, in and to the Work Product.
+```
+
+A single sentence like that, signed before work begins, is the difference between owning your product and merely being allowed to use it. Putting "make it a work made for hire" in a contract is not always enough on its own — for many works the law won't treat contractor output as work-for-hire even if you say so — which is why a belt-and-suspenders **assignment** clause is the standard, safe move. (This is a great example of where a real situation warrants a lawyer.)
+
+## Joint authorship: when two people own one work
+
+What if two developers genuinely co-create a single, merged work, each contributing copyrightable expression with the intent to combine it? They may be **joint authors**, co-owning the copyright together.
+
+Joint ownership has surprising defaults, and they vary by country. In the **US**, each joint owner can generally license the *whole* work to others without the other's permission — but typically must **account** to the co-owner for their share of any profits. In some other countries, each co-owner can *block* a license, requiring unanimous consent. Either way, ambiguous joint ownership is a recipe for disputes, which is why serious projects with multiple contributors use [contributor agreements](/learn/software-licensing/contributor-agreements/) to make ownership and licensing explicit rather than leaving it to these defaults.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — without a written copyright assignment, an independent contractor keeps the copyright, and paying them doesn't transfer ownership." markdown="0">
+  <p class="knowledge-check__q">Quick check: you hire an independent freelancer to write your app and the contract says nothing about copyright. Who owns the code?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">The contractor — they keep the copyright unless they assign it to you in writing</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">You — paying for the work automatically transfers ownership to the client</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Nobody — unregistered code has no owner until it's filed with the Copyright Office</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Copyright is automatic** — it attaches on creation everywhere under the Berne Convention, with no registration required.
+- **Registration is a US-specific tactic** — optional but it's a prerequisite to suing and unlocks statutory damages; most countries have no registration system at all.
+- **It protects expression, not ideas** — your source and binary are covered; the algorithm, functionality, and underlying idea are not (that's patent territory).
+- **Authorship ≠ ownership** — the person who wrote the code isn't always the one who holds the copyright.
+- **Employees' work is the employer's** — in the US, in-scope employee code is a work made for hire owned by the employer from the start.
+- **Contractors keep their copyright** — you only own a freelancer's work if they assign it to you in writing; this is a common, expensive mistake to avoid.
+
+Next up: copyright is only one of four kinds of intellectual property around software. See [Patents, trademarks & trade secrets](/learn/software-licensing/other-ip-in-software/).

--- a/docs/learn/software-licensing/dual-licensing-and-relicensing.md
+++ b/docs/learn/software-licensing/dual-licensing-and-relicensing.md
@@ -1,0 +1,99 @@
+---
+slug: dual-licensing-and-relicensing
+title: Dual licensing & relicensing
+description: Offering the same code under two licenses at once — GPL for the community and a paid commercial license for everyone else — is the classic open-core business model. Learn how it works, why you must own all the rights, and why relicensing an existing project is so hard.
+keywords: dual licensing, relicensing, open core, GPL commercial license, MySQL dual license, Qt dual license, copyright assignment relicensing, license proliferation, dual license business model, contributor rights relicensing, changing a project license
+level: advanced
+status: full
+faq:
+  - q: "How can the same code be GPL and also sold under a commercial license?"
+    a: "The **copyright holder** can offer their code to different people under different terms. They release it under the GPL for anyone who accepts copyleft, and sell a separate **commercial license** to companies that can't or won't comply with the GPL. Only the rights owner can do this, because only they can grant licenses other than the one already published."
+  - q: "Why do I need a CLA to dual-license my project?"
+    a: "To offer the code under a *second* license, you must hold the rights to **all** of it. The moment outside contributors add GPL'd code, you no longer own the whole work — so you can't relicense it commercially unless every contributor granted you that right, which is exactly what a broad [CLA](/learn/software-licensing/contributor-agreements/) collects."
+  - q: "Can I just change my open-source project's license whenever I want?"
+    a: "Only if you own all the copyright. If others have contributed under the old license without a CLA, you need **every** contributor's agreement to relicense — which is often impractical for a large, old project. This is why relicensing campaigns are rare, slow, and sometimes impossible."
+---
+# Dual licensing & relicensing
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Dual licensing = one codebase, two licenses** — typically GPL for the community plus a paid commercial license for those who can't accept copyleft. **It powers open core** — the classic MySQL/Qt model that funds open-source development from commercial sales. **You must own all the rights** — only the copyright holder can offer extra licenses, so you need to own the code or have CLA grants from every contributor. **Relicensing is hard** — changing an existing project's license needs every contributor's agreement, which is often impractical.
+</div>
+
+The previous lesson showed how a [CLA](/learn/software-licensing/contributor-agreements/) collects broad rights from contributors. This lesson shows the most powerful thing those rights unlock: offering the very same code under *two* licenses at once, and the related — and much harder — act of changing a project's license after the fact. By the end you'll understand the dual-licensing business model, the strict ownership requirement behind it, why relicensing an established project is so difficult, and how all of this connects to the open-core companies you've heard of.
+
+## What dual licensing is
+
+**Dual licensing** (sometimes multi-licensing) means the copyright holder releases the *same* code under more than one license, and each user picks the one that fits them. The classic pattern pairs a strong copyleft license with a commercial one:
+
+- **A copyleft license — usually the [GPL](/learn/software-licensing/gpl-strong-copyleft/) — for the community.** Anyone can use the code for free, as long as they accept the GPL's terms: derivatives they distribute must also be GPL, with source.
+- **A paid commercial license for everyone who can't accept that.** A company that wants to embed the code in a closed-source product *cannot* comply with the GPL without opening their own product. So they buy a commercial license from the copyright holder that grants the same code under proprietary-friendly terms — no copyleft obligations.
+
+The clever part is that the GPL does the selling for you. Because the GPL would force a commercial user to open their product, it creates demand for the paid escape hatch. The community gets genuinely free software; the vendor gets paying customers among those who need to stay closed. The two licenses aren't in conflict — they're offered to *different audiences* by the one party allowed to offer them.
+
+This is exactly the **open-core / commercial open-source** model behind famous examples: **MySQL** was dual-licensed (GPL plus a commercial license for embedding in closed products), and **Qt** has long offered both an open-source license and a paid commercial one. The community edition drives adoption and contributions; the commercial license funds the company.
+
+## Why you must own (or have rights to) all the code
+
+Here is the iron rule of dual licensing: **only the copyright holder can grant a license.** To offer the code under a *second*, commercial license, you must hold the rights to **every line** you're relicensing. If you don't own a part, you can't grant a non-GPL license to it — only its actual owner can.
+
+This is fine when you're the sole author. It breaks the instant outside contributors add code:
+
+- A contributor sends a GPL'd patch under plain inbound=outbound. You now have GPL'd code in your tree that *you don't own.*
+- You can still ship the combined work under the GPL — that's allowed. But you **cannot** offer that contributor's code under your commercial license, because they never granted you that right.
+- One un-owned line in a file is enough to poison your ability to commercially license that file.
+
+The solution is the [CLA](/learn/software-licensing/contributor-agreements/) from the previous lesson. A broad license-grant CLA (or a copyright-assignment CLA) collects, from every contributor, the right for you to license their contribution under *other* terms — including commercially. That's why companies running a dual-licensed project almost always require a CLA: without it, every external contribution would quietly erode the very thing the business model depends on. This is also a concrete example of the contributor-side caution from the last lesson — by signing that CLA, contributors are enabling the company to sell their volunteer work under closed terms.
+
+## Relicensing an existing project
+
+**Relicensing** is changing the license a project is released under. It's governed by the same iron rule, which makes it one of the hardest things to do in open source.
+
+To relicense, you need permission from **every copyright holder** in the codebase:
+
+- **If you own all the code** (sole author, or everyone signed a CLA/assignment), you can relicense at will — you're just choosing different terms for code you own.
+- **If contributors hold rights** under the old license with no CLA, you must get **each one** to agree to the new license. For a project with hundreds of contributors over many years — some unreachable, some deceased, some who refuse — this can be slow, expensive, or simply impossible.
+
+| Situation | Can you relicense? |
+|---|---|
+| You are the sole author | Yes — you own everything |
+| All contributors signed a broad CLA / assignment | Yes — they granted you the right |
+| Contributors used "or later" version clauses | Partially — you may move to a newer version of the same license |
+| Many contributors, plain inbound=outbound, no CLA | Only with every contributor's explicit agreement — often impractical |
+
+Real campaigns show how hard this is. Mozilla spent years and tracked down contributors to relicense Firefox's code to its tri-license. Some projects have rewritten contested code from scratch rather than chase down an unreachable contributor. The practical lesson: **decide your licensing strategy early**, because reversing it later may be off the table.
+
+A gentler form is moving between *versions* of the same license. Code released as "GPLv2 **or later**" can be used under GPLv3 by downstream users without re-collecting permission — the "or later" clause grants that flexibility up front. This is one reason license version choices matter, as we saw in [license compatibility](/learn/software-licensing/license-compatibility/).
+
+## License proliferation, the cost side
+
+Dual licensing and bespoke commercial terms feed a broader problem the open-source community calls **license proliferation**: too many slightly different licenses. Every non-standard license a project introduces adds [compatibility](/learn/software-licensing/license-compatibility/) uncertainty, more work for legal reviewers, and more confusion for users trying to combine software.
+
+This is one more argument for using **standard** licenses for the open side of a dual-licensing scheme (a well-known copyleft license like the GPL or AGPL), keeping only the *commercial* license custom — because the commercial license is a private contract between you and one buyer, not something that has to compose with the wider ecosystem. Reusing a standard copyleft license for the public edition keeps your project compatible and recognizable while the paid license does the bespoke work.
+
+## The open-core model, previewed
+
+Dual licensing is one engine of a bigger pattern: **open core**, where a company builds an open-source core and sells something extra around it — a commercial license, proprietary add-ons, hosting, or support. The dual-license version we covered here is the "sell a commercial license to the same code" flavor, but open core has several shapes, and it shades into the source-available licensing that newer companies have adopted.
+
+That whole business landscape — how companies actually make money from software they also give away, and the trade-offs of each model — is the subject of [Commercial license models](/learn/software-licensing/commercial-license-models/) in the next module. For now, hold onto the core mechanic: dual licensing works because *one party owns the rights and can therefore offer the same code on more than one set of terms.*
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — only the copyright holder can grant additional licenses, so dual licensing requires owning all the code or holding CLA rights to every contribution." markdown="0">
+  <p class="knowledge-check__q">Quick check: why can a company dual-license its project but a random fork usually can't?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Only the copyright holder can offer code under additional licenses, and the company owns or has CLA rights to all of it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The GPL specifically allows the original author to add commercial terms but forbids forks from doing anything</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Dual licensing only requires registering the project with the OSI first</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Dual licensing offers one codebase under two licenses** — typically GPL for the community plus a paid commercial license for those who can't accept copyleft.
+- **The GPL drives the sale** — because copyleft would force closed users to open their product, they buy the commercial escape hatch.
+- **It powers open core** — MySQL and Qt are the classic examples of funding open-source work through commercial licensing.
+- **You must own all the rights** — only the copyright holder can grant extra licenses, so dual licensing requires sole authorship or broad CLA grants from every contributor.
+- **Relicensing is hard** — changing an existing project's license needs every contributor's agreement, which is often impractical, so decide early.
+- **Standardize the open side** — reuse a well-known copyleft license publicly to avoid license proliferation; keep only the commercial license bespoke.
+
+Next up: depending on open source carries risks beyond price — including the relicensing moves we just saw, turned against *users*. See [The risks of depending on open source](/learn/software-licensing/open-source-risks/).

--- a/docs/learn/software-licensing/eula-and-tos.md
+++ b/docs/learn/software-licensing/eula-and-tos.md
@@ -1,0 +1,118 @@
+---
+slug: eula-and-tos
+title: EULAs & terms of service
+description: A EULA licenses software you install; terms of service set the rules for using an online service. Learn the difference, when you need which, how click-wrap acceptance works, and the key terms each one contains.
+keywords: EULA, end user license agreement, terms of service, terms of use, ToS, click-wrap, acceptable use, SaaS subscription agreement, software license grant, user accounts, account termination, user content license
+level: beginner
+status: full
+faq:
+  - q: "What's the actual difference between a EULA and terms of service?"
+    a: "A **EULA** licenses a piece of software you install or download — its heart is the license grant and the restrictions on what you may do with the copy. **Terms of service** set the rules for using an ongoing service, site, or app you access — accounts, acceptable use, your content, and when access can be cut off. One licenses a thing; the other governs a relationship."
+  - q: "Does a SaaS product need a EULA?"
+    a: "Usually not a classic one. With **software as a service**, nobody installs your code — they use it over the network — so there's little to license to the user. SaaS typically pairs **terms of service** with a **subscription agreement** (the commercial terms: fees, term, SLA). You only need a EULA-style grant when the customer actually runs your binary on their own machine."
+  - q: "Is a EULA legally binding if I just clicked 'I agree'?"
+    a: "Generally yes. **Click-wrap** — where you take an affirmative action like ticking a box or clicking \"I agree\" — is widely enforced because you clearly assented. The weak form is **browse-wrap**, where terms are merely linked and using the site supposedly means acceptance; courts treat that as much shakier. See [license vs contract](/learn/software-licensing/license-vs-contract/)."
+---
+# EULAs & terms of service
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**EULA = license for software you run** — its core is the grant of permission to use the copy, plus restrictions. **ToS = rules for using a service** — accounts, acceptable use, your content, and termination. **SaaS usually skips the EULA** — it pairs terms of service with a subscription agreement instead. **Acceptance is by click-wrap** — clicking "I agree" forms a binding agreement; merely linking terms (browse-wrap) is far weaker.
+</div>
+
+Up to now this path has mostly looked at agreements between developers — open-source licenses, contributor terms, commercial licenses. This lesson turns to the agreements your software shows ordinary users: the **End User License Agreement (EULA)** and the **terms of service**. They sound interchangeable and are often confused, but they do different jobs. By the end you'll know which one fits installed software versus an online service, how acceptance actually works, and the key clauses each document carries.
+
+## Two different jobs
+
+The cleanest way to tell them apart is to ask *what is being agreed to*.
+
+A **EULA** is a license. It is the agreement that comes with a piece of software you **install or download** — a desktop app, a mobile app, a game, a driver. Its center of gravity is the [license grant](/learn/software-licensing/what-is-a-software-license/): the publisher owns the copyright, and the EULA is how they give *you*, the end user, permission to run a copy. Around that grant sit the restrictions — what you may not do with the software.
+
+**Terms of service** (also called **terms of use**) govern an ongoing **service** you access rather than a copy you possess — a website, a web app, a social platform, an API. There may be no software for you to license at all; you're using software that runs on someone else's servers. So the document's job shifts from "here's permission to use this copy" to "here are the rules of the relationship": who may have an account, what you're allowed to do on the service, what happens to content you upload, and when your access can be ended.
+
+A rough rule of thumb: **a EULA licenses a thing; terms of service govern a relationship.**
+
+## When you need which
+
+Which document you need follows directly from how your software reaches the user.
+
+- **You ship software the user installs and runs** — a downloaded app or on-premises product. The user has a copy, so you need a **EULA** to license that copy.
+- **You run software the user accesses over the network** — software as a service (SaaS), a website, a web or mobile app backed by your servers. The user has no copy to license, so you need **terms of service** for the rules, and for a paid product a **subscription agreement** for the commercial terms.
+- **You do both** — say a desktop client that talks to your cloud backend. It's common to use *both*: a EULA (or an embedded license grant) for the installed client and terms of service for the hosted side.
+
+The SaaS case trips people up, so it's worth stating plainly: **most SaaS products do not use a classic EULA.** Because nothing is installed, the old "license to use this copy" framing barely applies. Instead you'll typically see terms of service paired with a subscription (or "master subscription") agreement that handles fees, the subscription term, renewal, and any [service-level commitments](/learn/software-licensing/sla-and-support-agreements/). The license grant that remains is small — usually a limited right to *access and use* the service during the subscription — rather than a right to possess and run a binary.
+
+| | **EULA** | **Terms of service / use** |
+|---|---|---|
+| **Governs** | A copy of installed/downloaded software | Use of an online service, site, or app |
+| **Core clause** | The software license grant + restrictions | Acceptable use, accounts, content, termination |
+| **Typical product** | Desktop app, mobile app, game, driver | Website, web app, SaaS, social platform, API |
+| **Is there a "copy"?** | Yes — the user runs it | Often no — it runs on the provider's servers |
+| **Paired with** | Sometimes a separate sales contract | Often a subscription agreement (for paid SaaS) |
+| **Main concern** | Protecting and bounding the licensed copy | Running the service and the user community safely |
+
+## How acceptance works
+
+Neither document does anything unless the user has actually **agreed** to it, and how that agreement is captured matters a great deal. This ties straight back to [license vs contract](/learn/software-licensing/license-vs-contract/): a EULA or ToS is typically a *contract*, and a contract needs assent.
+
+The reliable mechanism is **click-wrap**: the user must take an affirmative action — tick a box, click "I agree," tap "Accept" — before they can proceed. Because the user clearly signaled agreement, courts in the US (and broadly elsewhere) generally enforce click-wrap terms. The weak mechanism is **browse-wrap**, where the terms are simply linked somewhere — often a small "Terms" link in the footer — and the document claims that merely using the site means you accept them. With no affirmative click, a user may never have seen the terms, and courts frequently find browse-wrap **unenforceable**, especially against consumers.
+
+```text
+Strong (click-wrap):
+  [x] I have read and agree to the Terms of Service and EULA
+  [ Continue ]   <- blocked until the box is checked
+
+Weak (browse-wrap):
+  ...site footer... | Privacy | Terms |   <- no action required, easy to miss
+```
+
+The practical lesson for anyone publishing software: **make acceptance affirmative and conspicuous.** Put the agreement (or a clear link to it) right at the point of installation, sign-up, or first use, and require a deliberate click. Burying it in a footer and hoping is a recipe for terms that don't hold up.
+
+> Acceptance rules vary by jurisdiction, and consumer-protection law (for example in the EU and UK) adds its own requirements around clarity and unfair terms. The dedicated lesson on [licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/) goes deeper; here, just remember that *how* you obtain consent is as important as *what* the terms say.
+
+## What a EULA typically contains
+
+A EULA is organized around the licensed copy. The usual building blocks:
+
+- **License grant** — the permission itself: typically a non-exclusive, non-transferable right to install and use the software, often limited by number of devices, seats, or a personal-vs-commercial distinction.
+- **Restrictions** — the "thou shalt nots": no reverse-engineering (subject to legal limits in some places), no redistribution, no renting or sublicensing, no removing notices.
+- **Ownership / IP reservation** — a reminder that you are licensed, not sold, the software, and the publisher keeps all [intellectual-property rights](/learn/software-licensing/other-ip-in-software/).
+- **Updates and termination** — how updates are delivered and when the license ends (for example, if you breach the restrictions).
+- **Warranty disclaimer and limitation of liability** — the risk-shifting clauses we cover in the reading-agreements module; almost every EULA disclaims warranties and caps liability.
+- **Third-party / open-source notices** — attribution for bundled open-source components (GopherTrunk's own [`THIRD_PARTY_LICENSES.md`](/learn/software-licensing/permissive-compliance/) is exactly this kind of notice file).
+
+## What terms of service typically contain
+
+Terms of service are organized around the *relationship and the service*. Common building blocks:
+
+- **Eligibility and accounts** — who may use the service (age, region), and the user's duties to keep their account secure and their details accurate.
+- **Acceptable use** — what users may and may not do on the service: no illegal activity, no abuse, no scraping, no interfering with others. Larger services often split this into a separate [Acceptable Use Policy](/learn/software-licensing/nda-and-other-agreements/).
+- **Your content** — for any service where users upload or post, a clause covering ownership (usually *you* keep ownership) and the **license you grant the provider** to host, display, and process your content so the service can function.
+- **Fees and subscription** — for paid services, how billing, renewal, and cancellation work (sometimes split into the subscription agreement).
+- **Termination and suspension** — when and how either side can end the relationship, and what happens to your data and content afterward.
+- **Disclaimers, liability limits, dispute resolution** — the same risk clauses as a EULA, plus often a governing-law and arbitration clause.
+- **Changes to the terms** — how the provider may update the ToS and how you'll be notified.
+
+### A note on consumer-facing examples
+
+You agree to these constantly. The "I accept the License Agreement" screen when installing a desktop app or a game is a **EULA**. The "By creating an account you agree to our Terms" box on a social network, streaming service, or web app is **terms of service**. A paid cloud tool's "Terms" plus "Subscription Agreement" plus "Privacy Policy" trio is the SaaS pattern in the wild — terms for the rules, subscription for the money, and a [privacy policy](/learn/software-licensing/privacy-and-data-agreements/) for the data. Recognizing which is which tells you immediately where to look for the clause you care about.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — SaaS users don't install a copy, so it leans on terms of service plus a subscription agreement rather than a classic EULA." markdown="0">
+  <p class="knowledge-check__q">Quick check: a company offers a cloud-only product nobody installs. Which set of agreements fits best?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Terms of service plus a subscription agreement, rather than a classic EULA</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A classic installed-software EULA, because all software needs a EULA</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">No agreement at all, since the user never downloads anything</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A EULA licenses installed/downloaded software** — its core is the license grant to use the copy, plus the restrictions on what you may do with it.
+- **Terms of service govern an online service** — accounts, acceptable use, your uploaded content, and termination of access.
+- **SaaS usually skips the classic EULA** — because nothing is installed, it leans on terms of service plus a subscription agreement.
+- **Acceptance must be affirmative** — click-wrap ("I agree") is enforceable; browse-wrap (terms merely linked) is weak and often fails.
+- **Each document has a predictable shape** — know the standard clauses and you'll find what you need fast, whether you're agreeing or drafting.
+
+Next up: the document that governs the personal data your software touches — what it must disclose, and the rules that may legally require it. See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/).

--- a/docs/learn/software-licensing/glossary.md
+++ b/docs/learn/software-licensing/glossary.md
@@ -1,0 +1,209 @@
+---
+slug: glossary
+title: Glossary of software-licensing terms
+description: Plain-language definitions for every key term in the Software Licensing & Agreements learning path, cross-linked to the lessons that explain them.
+keywords: software licensing glossary, copyleft, permissive license, GPL, EULA, SLA, DPA, SBOM, indemnity, warranty disclaimer, dual licensing
+level: beginner
+status: full
+lesson_standalone: true
+---
+
+# Glossary of software-licensing terms
+
+This is a plain-language reference for the key terms used across the Software Licensing & Agreements path. Definitions are short on purpose; each links to the lesson that explains the idea in full. Terms are grouped by theme and roughly ordered from foundational to advanced within each group, following the shape of the path itself. This is educational material, not legal advice.
+
+## Foundations & IP
+
+**License** — Permission from a rights holder to do things with software that copyright would otherwise forbid, such as copying, modifying, or distributing it. See [What is a software license?](/learn/software-licensing/what-is-a-software-license/)
+
+**Copyright** — The automatic legal right an author has over an original work, including source code, controlling who may copy, modify, or distribute it. See [Copyright & software ownership](/learn/software-licensing/copyright-and-software-ownership/)
+
+**Copyright registration** — The optional step of recording a copyright with a government office, which in the US is required before you can sue for infringement and unlocks stronger remedies. See [Copyright & software ownership](/learn/software-licensing/copyright-and-software-ownership/)
+
+**Work made for hire** — A work whose copyright belongs to the employer or commissioning party rather than the person who created it, common for code written by employees. See [Copyright & software ownership](/learn/software-licensing/copyright-and-software-ownership/)
+
+**Patent** — A time-limited monopoly on an invention, which in software can cover a method or process and is a separate right from copyright. See [Patents, trademarks & trade secrets](/learn/software-licensing/other-ip-in-software/)
+
+**Trademark** — A name, logo, or mark that identifies the source of a product, protecting branding rather than the code itself. See [Patents, trademarks & trade secrets](/learn/software-licensing/other-ip-in-software/)
+
+**Trade secret** — Valuable information kept confidential, such as proprietary source code or algorithms, protected only as long as it stays secret. See [Patents, trademarks & trade secrets](/learn/software-licensing/other-ip-in-software/)
+
+**License grant** — The clause in a license that spells out exactly what rights you are given and under what conditions. See [License vs contract](/learn/software-licensing/license-vs-contract/)
+
+**Contract** — A legally binding agreement formed by mutual assent and consideration, which a license may or may not also be depending on how it is presented. See [License vs contract](/learn/software-licensing/license-vs-contract/)
+
+**Click-wrap** — An agreement you accept by clicking a button such as "I agree", generally enforceable because you took a clear action to consent. See [License vs contract](/learn/software-licensing/license-vs-contract/)
+
+**Browse-wrap** — An agreement that claims to bind you simply by using a site or product, which courts enforce less reliably because consent is not explicit. See [License vs contract](/learn/software-licensing/license-vs-contract/)
+
+**The licensing spectrum** — The full range of license types, from public domain through permissive and copyleft open source to source-available and fully proprietary. See [The licensing spectrum](/learn/software-licensing/the-licensing-spectrum/)
+
+**Jurisdiction** — The legal system whose rules apply to a license or dispute; copyright and contract law differ from one country to the next. See [Licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/)
+
+## Open source
+
+**Open source** — Software released under a license that grants users the freedoms to use, study, modify, and redistribute it, as defined by the Open Source Initiative. See [What open source really means](/learn/software-licensing/what-is-open-source/)
+
+**OSI (Open Source Initiative)** — The organization that maintains the Open Source Definition and reviews whether licenses qualify as open source. See [What open source really means](/learn/software-licensing/what-is-open-source/)
+
+**Free software** — Software that respects users' freedom to run, study, change, and share it, a movement and definition maintained by the Free Software Foundation. See [What open source really means](/learn/software-licensing/what-is-open-source/)
+
+**Four freedoms** — The Free Software Foundation's criteria for free software: the freedom to run, study, redistribute, and improve a program. See [What open source really means](/learn/software-licensing/what-is-open-source/)
+
+**FOSS** — A catch-all abbreviation for "free and open-source software", covering both the free-software and open-source framings. See [What open source really means](/learn/software-licensing/what-is-open-source/)
+
+**Source-available** — Software whose source code you can read but whose license withholds one or more open-source freedoms, so it is not open source. See [What open source really means](/learn/software-licensing/what-is-open-source/)
+
+## The open-source licenses
+
+**Permissive license** — An open-source license that lets you do nearly anything with the code, including using it in closed products, as long as you keep the notices. See [Permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/)
+
+**Copyleft** — A licensing approach that requires derivative works to be released under the same license, keeping the code and its descendants open. See [Permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/)
+
+**Reciprocity** — The copyleft principle that anyone who benefits from the code must share their changes back under the same terms. See [Permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/)
+
+**Strong copyleft** — Copyleft that extends to a whole combined work, so linking the licensed code into a program can pull the whole program under the license. See [Permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/)
+
+**Weak copyleft** — Copyleft scoped to the licensed files or library, so you can combine it with proprietary code while only the original component stays open. See [Weak copyleft: LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/)
+
+**MIT license** — A short, very permissive license that requires only that the copyright notice and license text be preserved. See [MIT & BSD: minimal permissive](/learn/software-licensing/mit-and-bsd-licenses/)
+
+**BSD license** — A family of minimal permissive licenses (2-clause and 3-clause) similar to MIT, with the 3-clause version adding a no-endorsement term. See [MIT & BSD: minimal permissive](/learn/software-licensing/mit-and-bsd-licenses/)
+
+**Apache License 2.0** — A permissive license that, unlike MIT or BSD, includes an explicit patent grant and rules for handling NOTICE files. See [Apache 2.0: permissive with a patent grant](/learn/software-licensing/apache-license/)
+
+**Patent grant** — A clause in which contributors license any patents that cover their contribution, protecting users from patent claims by those contributors. See [Apache 2.0: permissive with a patent grant](/learn/software-licensing/apache-license/)
+
+**NOTICE file** — A file used by Apache-2.0 projects to carry required attributions that downstream users must preserve and pass along. See [Apache 2.0: permissive with a patent grant](/learn/software-licensing/apache-license/)
+
+**GPL (GNU General Public License)** — The best-known strong-copyleft license, requiring that anyone who distributes the software also make its source available under the GPL. See [The GPL: strong copyleft](/learn/software-licensing/gpl-strong-copyleft/)
+
+**GPLv2** — The 1991 version of the GPL, still widely used (notably by the Linux kernel) and not always compatible with GPLv3. See [The GPL: strong copyleft](/learn/software-licensing/gpl-strong-copyleft/)
+
+**GPLv3** — The 2007 revision of the GPL, adding explicit patent terms, anti-tivoization rules, and clearer compatibility provisions. See [The GPL: strong copyleft](/learn/software-licensing/gpl-strong-copyleft/)
+
+**AGPL (GNU Affero General Public License)** — A GPL variant that closes the "network loophole", requiring source disclosure even when the software is offered to users over a network rather than distributed. See [The AGPL: copyleft over the network](/learn/software-licensing/agpl-network-copyleft/)
+
+**LGPL (GNU Lesser General Public License)** — A weak-copyleft license that lets you link a covered library into proprietary software while keeping the library itself open. See [Weak copyleft: LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/)
+
+**MPL (Mozilla Public License)** — A weak-copyleft license that applies copyleft at the level of individual files, so changed files stay open but new files can be proprietary. See [Weak copyleft: LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/)
+
+**EPL (Eclipse Public License)** — A weak-copyleft license common in the Java ecosystem, with file-level reciprocity and its own patent terms. See [Weak copyleft: LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/)
+
+**CDDL (Common Development and Distribution License)** — A file-level weak-copyleft license derived from the MPL, known for its incompatibility with the GPL. See [Weak copyleft: LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/)
+
+**Public domain** — Works with no copyright, which anyone may use for any purpose; software rarely falls into it automatically and usually needs a deliberate dedication. See [Public domain, Unlicense & CC0](/learn/software-licensing/public-domain-and-cc0/)
+
+**CC0** — A Creative Commons tool that waives copyright as far as the law allows, used to place a work as close to the public domain as possible. See [Public domain, Unlicense & CC0](/learn/software-licensing/public-domain-and-cc0/)
+
+**Unlicense** — A short public-domain dedication aimed at software, combining a waiver with a fallback permissive license. See [Public domain, Unlicense & CC0](/learn/software-licensing/public-domain-and-cc0/)
+
+**0BSD** — A zero-clause BSD license that grants permissive rights without even requiring attribution, behaving much like a public-domain dedication. See [Public domain, Unlicense & CC0](/learn/software-licensing/public-domain-and-cc0/)
+
+## Choosing & combining
+
+**License compatibility** — Whether two licenses can legally coexist in the same combined work; some open-source licenses cannot be merged at all. See [License compatibility](/learn/software-licensing/license-compatibility/)
+
+**Derivative work** — A new work based on or substantially incorporating an existing one, which can inherit the original's license obligations. See [License compatibility](/learn/software-licensing/license-compatibility/)
+
+**Distribution (conveying)** — Giving software to others, the act that typically triggers a license's obligations such as providing source or notices. See [License compatibility](/learn/software-licensing/license-compatibility/)
+
+**CLA (Contributor License Agreement)** — An agreement contributors sign to grant a project the rights it needs to use and relicense their contributions. See [Contributor agreements: CLAs & DCO](/learn/software-licensing/contributor-agreements/)
+
+**DCO (Developer Certificate of Origin)** — A lightweight alternative to a CLA where contributors certify, via a sign-off line, that they have the right to submit their code. See [Contributor agreements: CLAs & DCO](/learn/software-licensing/contributor-agreements/)
+
+**Inbound=outbound** — The convention that contributions come in under the same license the project ships under, avoiding the need for a separate CLA. See [Contributor agreements: CLAs & DCO](/learn/software-licensing/contributor-agreements/)
+
+**Dual licensing** — Offering the same code under two licenses at once, typically an open-source license plus a paid commercial one. See [Dual licensing & relicensing](/learn/software-licensing/dual-licensing-and-relicensing/)
+
+**Relicensing** — Releasing existing code under a different license, which generally requires holding or gathering rights from all contributors. See [Dual licensing & relicensing](/learn/software-licensing/dual-licensing-and-relicensing/)
+
+**Open-source risk** — The supply-chain and legal exposure that comes from depending on third-party open source, from abandonment to license violations. See [The risks of depending on open source](/learn/software-licensing/open-source-risks/)
+
+## Proprietary & commercial
+
+**Proprietary / closed source** — Software whose owner keeps the source code private and licenses only limited rights to use it. See [Proprietary & closed-source licensing](/learn/software-licensing/proprietary-licensing/)
+
+**Perpetual license** — A license to use software indefinitely after a one-time purchase, usually with optional paid upgrades or support. See [Commercial license models](/learn/software-licensing/commercial-license-models/)
+
+**Subscription license** — A license that grants use for as long as you keep paying a recurring fee, after which the rights lapse. See [Commercial license models](/learn/software-licensing/commercial-license-models/)
+
+**Per-seat license** — Pricing tied to the number of named users or devices that may use the software. See [Commercial license models](/learn/software-licensing/commercial-license-models/)
+
+**Usage-based license** — Pricing tied to how much you use the software, such as per API call, per transaction, or per unit of compute. See [Commercial license models](/learn/software-licensing/commercial-license-models/)
+
+**OEM license** — A license to embed or resell another company's software as part of your own product. See [Commercial license models](/learn/software-licensing/commercial-license-models/)
+
+**Open core** — A business model where a permissively or copyleft-licensed core is paired with proprietary paid add-ons. See [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/)
+
+**BSL (Business Source License)** — A source-available license that restricts production use for a period before converting to an open-source license. See [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/)
+
+**SSPL (Server Side Public License)** — A source-available license, derived from the AGPL, that imposes broad source-disclosure duties on those who offer the software as a service. See [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/)
+
+**Fair source** — A category of licenses that publish source and allow most uses while reserving commercial rights, sitting between open source and proprietary. See [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/)
+
+## Using open source in products
+
+**Permissive compliance** — Meeting the lightweight duties of permissive licenses, chiefly preserving copyright notices and license text in what you ship. See [Meeting permissive obligations](/learn/software-licensing/permissive-compliance/)
+
+**Attribution** — Crediting the authors of a component as a license requires, often by including its license text and copyright notice. See [Meeting permissive obligations](/learn/software-licensing/permissive-compliance/)
+
+**Viral licensing** — The informal name for strong copyleft's tendency to extend its terms to a whole combined work, the central worry when using copyleft in products. See [Copyleft in products: the viral question](/learn/software-licensing/copyleft-in-products/)
+
+**SBOM (Software Bill of Materials)** — A formal inventory of all the components and dependencies in a piece of software, used for license and security tracking. See [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/)
+
+**SPDX** — A standard format and identifier list for describing licenses and software components, widely used in SBOMs. See [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/)
+
+**CycloneDX** — An SBOM standard focused on security use cases, an alternative to SPDX for listing components and their licenses. See [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/)
+
+**License scanning** — Using tools to detect the licenses of your dependencies automatically and flag obligations or conflicts. See [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/)
+
+## Reading & other agreements
+
+**EULA (End User License Agreement)** — The agreement that governs an end user's right to use a piece of software, typically presented at install or first run. See [EULAs & terms of service](/learn/software-licensing/eula-and-tos/)
+
+**Terms of service (ToS)** — The rules you agree to in order to use an online service, covering acceptable use, accounts, liability, and more. See [EULAs & terms of service](/learn/software-licensing/eula-and-tos/)
+
+**Acceptable use policy** — The part of an agreement that lists what you may not do with a product or service, such as abuse, illegal use, or reverse engineering. See [EULAs & terms of service](/learn/software-licensing/eula-and-tos/)
+
+**Warranty disclaimer** — A clause stating the software is provided "as is" with no guarantees, shifting the risk of defects to the user. See [The risk clauses: who pays when it breaks](/learn/software-licensing/risk-clauses/)
+
+**Limitation of liability** — A clause that caps or excludes how much one party can be made to pay if something goes wrong. See [The risk clauses: who pays when it breaks](/learn/software-licensing/risk-clauses/)
+
+**Indemnification** — A promise by one party to cover certain losses or legal claims the other party suffers, common around IP infringement. See [The risk clauses: who pays when it breaks](/learn/software-licensing/risk-clauses/)
+
+**Governing law** — The clause that names which jurisdiction's law applies and where disputes will be heard. See [The main clauses, decoded](/learn/software-licensing/main-clauses-decoded/)
+
+**Termination** — The clause setting out when and how an agreement ends and what happens to your rights afterward. See [The main clauses, decoded](/learn/software-licensing/main-clauses-decoded/)
+
+**Privacy policy** — A document that explains what personal data a service collects, how it is used, and the rights users have over it. See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/)
+
+**GDPR** — The European Union's General Data Protection Regulation, a strict data-protection law with wide reach over how personal data is handled. See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/)
+
+**CCPA** — California's Consumer Privacy Act, a US state law granting consumers rights over their personal data. See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/)
+
+**DPA (Data Processing Agreement)** — A contract that governs how one company processes personal data on behalf of another, often required under GDPR. See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/)
+
+**Controller** — Under data-protection law, the party that decides why and how personal data is processed. See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/)
+
+**Processor** — Under data-protection law, the party that processes personal data on a controller's behalf and under its instructions. See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/)
+
+**Sub-processor** — A third party a processor brings in to help handle personal data, who must be disclosed and bound by similar terms. See [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/)
+
+**SLA (Service Level Agreement)** — A commitment about service quality, typically uptime, with remedies if the provider falls short. See [SLAs & support agreements](/learn/software-licensing/sla-and-support-agreements/)
+
+**Service credit** — Compensation, usually a billing discount, owed to a customer when a provider misses its SLA targets. See [SLAs & support agreements](/learn/software-licensing/sla-and-support-agreements/)
+
+**NDA (Non-Disclosure Agreement)** — A contract in which parties agree to keep shared confidential information secret. See [NDAs & the rest of the landscape](/learn/software-licensing/nda-and-other-agreements/)
+
+**MSA (Master Services Agreement)** — An umbrella contract setting the standing terms between two parties, under which specific work is then ordered. See [NDAs & the rest of the landscape](/learn/software-licensing/nda-and-other-agreements/)
+
+**SOW (Statement of Work)** — A document under an MSA that defines a specific project's scope, deliverables, timeline, and price. See [NDAs & the rest of the landscape](/learn/software-licensing/nda-and-other-agreements/)
+
+## Choosing & process
+
+**Decision framework** — A structured way to decide how to license your software, weighing your goals, dependencies, and business model. See [A framework for choosing](/learn/software-licensing/the-decision-framework/)
+
+**License chooser** — A step-by-step method or tool for narrowing down to the right license for your project. See [Choosing your license, step by step](/learn/software-licensing/choose-your-license/)
+
+**Agreement inventory** — The set of agreements a given piece of software actually needs, from a license to a privacy policy to an SLA, depending on how it is delivered. See [Which agreements does your software need?](/learn/software-licensing/which-agreements-do-you-need/)

--- a/docs/learn/software-licensing/gpl-strong-copyleft.md
+++ b/docs/learn/software-licensing/gpl-strong-copyleft.md
@@ -1,0 +1,133 @@
+---
+slug: gpl-strong-copyleft
+title: "The GPL: strong copyleft"
+description: The GNU General Public License is the original copyleft license — it gives users broad freedoms and requires that anyone distributing the software pass those same freedoms on, in source form, under the same license.
+keywords: GPL, GNU General Public License, strong copyleft, GPLv2, GPLv3, copyleft, derivative work, distribution trigger, corresponding source, tivoization, license compatibility, free software, viral license
+level: intermediate
+status: full
+faq:
+  - q: "If I use GPL software inside my company, do I have to publish my source code?"
+    a: "No. The GPL's obligations are triggered by **distribution** (GPLv3 calls it *conveying*), not by use. Running GPL software on your own servers, or modifying it for purely internal use, does not require you to give source to anyone. The duty to share source only arises when you hand the binary to someone outside your organization."
+  - q: "What's the practical difference between GPLv2 and GPLv3?"
+    a: "GPLv3 adds three big things: an **anti-tivoization** clause (if you ship GPLv3 code in a device, you must also provide the keys or info users need to install modified versions), an **explicit patent grant and retaliation** terms, and better **compatibility** with some other licenses (like Apache 2.0). GPLv2 has none of these and is **not** automatically upgradeable unless the project said \"v2 or later.\""
+  - q: "Does linking my proprietary program to a GPL library make my program GPL?"
+    a: "Often, yes — that's the crux of the \"derivative work\" debate. The Free Software Foundation's position is that linking (static *or* dynamic) generally creates a combined work that must be GPL when distributed. The legal boundary is genuinely contested, which is exactly why the [LGPL and other weak-copyleft licenses](/learn/software-licensing/weak-copyleft-licenses/) exist to carve out a safe path for linking."
+---
+# The GPL: strong copyleft
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The original copyleft** — the GPL uses copyright to *guarantee* freedom rather than restrict it. **The bargain is reciprocity** — you get the four freedoms, and in return you must pass them on whenever you distribute. **The trigger is distribution, not use** — internal use and modification carry no source-sharing duty; *conveying* the software does. **Same license, complete source** — recipients must get the complete corresponding source under the same GPL terms.
+</div>
+
+In the [permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/) lesson you met the two great families of open-source license. This lesson goes deep on the most influential copyleft license of all: the GNU General Public License, or **GPL**. By the end you'll understand the bargain the GPL strikes, what specifically triggers its obligations (and what does *not*), what "complete corresponding source" really means, how GPLv2 and GPLv3 differ, why "derivative work" and linking are the hardest questions in the whole field, and the honest strengths and weaknesses that make the GPL both beloved and avoided.
+
+## The idea: copyright turned inside out
+
+Most licenses use copyright to *withhold* permissions. The GPL, written by Richard Stallman and the Free Software Foundation (FSF) in 1989, does the opposite: it uses the author's copyright to **guarantee** that the software — and every version derived from it — stays free for users. This judo move is called **copyleft**.
+
+The GPL grants four freedoms: to **run** the program for any purpose, to **study and modify** it (which requires source code), to **redistribute** copies, and to **distribute your modified versions**. To keep those freedoms from being stripped away by a later distributor, the license attaches one condition: anyone who passes the software on must pass on the same freedoms, under the same license. Because the freedoms are protected even after the code changes hands, the GPL is called **strong copyleft** — its reach extends across the whole combined program, not just the original files.
+
+This is the difference from permissive licenses like [MIT and BSD](/learn/software-licensing/mit-and-bsd-licenses/). MIT lets a recipient take your code and ship it inside a closed product. The GPL forbids that closing-off: the freedoms must survive every hop.
+
+## The bargain: you get the freedoms, you pass them on
+
+It helps to think of the GPL as a deal. The author offers you something valuable — the right to use, read, change, and share working software — for free. In exchange, you accept one obligation that only matters if you choose to distribute: you must extend the same deal to whoever you give it to.
+
+If you never distribute, you owe nothing. You can run a modified GPL program for years, on a thousand machines, and never publish a line. The obligation is dormant until you **convey** the software to someone else. At that moment the bargain activates: your recipients get the four freedoms too, including the source code they'd need to exercise them.
+
+This reciprocity is the whole point. It's why the GPL is sometimes called "viral" — a loaded word we'll handle carefully in [Copyleft in products: the viral question](/learn/software-licensing/copyleft-in-products/). The freedoms spread because the license requires them to.
+
+## What triggers the obligations: distribution, not use
+
+This is the single most misunderstood part of the GPL, so be precise about it.
+
+**Internal use does not trigger anything.** Running GPL software, deploying it on your own servers, or modifying it for your own purposes are all unconditionally allowed and impose no duty to share. The GPL is not a "use" license; it is a **distribution** license.
+
+The obligation fires when you **distribute** (GPLv2's word) or **convey** (GPLv3's broader, more carefully defined word) the software to a third party. Conveying means making the software available to others in a way that lets them get copies. Handing someone a binary, shipping a device with the software inside, putting an installer on a download page — those convey. Letting users *interact* with the software over a network, without giving them a copy, generally does **not** count as conveying under the plain GPL.
+
+That last point is a famous gap. A company can run modified GPL software as a web service, never distribute the binary, and owe its users no source at all. Closing that gap is the entire reason the [AGPL](/learn/software-licensing/agpl-network-copyleft/) exists — that's the next lesson.
+
+| Activity | Triggers GPL source obligation? |
+|---|---|
+| Running the program | No |
+| Modifying it for internal use | No |
+| Offering it as a network service (plain GPL) | No — see [AGPL](/learn/software-licensing/agpl-network-copyleft/) |
+| Shipping the binary to a customer | **Yes** |
+| Embedding it in a device you sell | **Yes** |
+| Publishing it for download | **Yes** |
+
+## What you must provide: complete corresponding source
+
+When the trigger fires, the core obligation is to provide the **complete corresponding source code** under the same GPL license. "Complete corresponding source" is a deliberately demanding phrase. It means everything a recipient needs to **build, install, and run** the exact version you distributed — not just the files you happened to edit.
+
+In practice that includes the source for the whole program, the **build scripts and makefiles**, and the definitions of interfaces it uses to build. It does **not** require you to include the standard system libraries or the compiler — the so-called "system library" exception keeps you from having to ship the operating system. GPLv3 also requires the **Installation Information** (sometimes "installation scripts and keys") needed to install a modified version on the same device, when the software ships inside consumer hardware.
+
+You can deliver the source two main ways: **alongside** the binary (the simplest), or with a **written offer** valid for three years to supply the source on request. You must also keep all license and copyright notices intact and state any changes you made.
+
+```text
+A typical GPL distribution includes, at minimum:
+  - the complete source for the program as shipped
+  - the Makefile / build scripts to compile it
+  - the unmodified GPL license text (COPYING)
+  - notices of what you changed and when
+  - (GPLv3, consumer device) installation info / keys
+```
+
+## GPLv2 vs GPLv3: what changed and why it matters
+
+There are two GPL versions in wide use, and they are **not** interchangeable. Many famous projects (the Linux kernel, for one) are GPLv2-only and have deliberately not moved to v3. Choosing or combining GPL code means knowing which version you're dealing with.
+
+| Topic | GPLv2 (1991) | GPLv3 (2007) |
+|---|---|---|
+| **Anti-tivoization** | None — you can lock down hardware so users can't run modified code | Requires you to provide keys/info so users *can* install modified versions on consumer devices |
+| **Patent grant** | Implicit at best; weak | Explicit patent license from contributors, plus retaliation terms |
+| **Compatibility** | Incompatible with Apache 2.0 and several others | Compatible with Apache 2.0 and a wider set |
+| **Anti-DRM language** | None | Clarifies the software isn't part of an "effective technological measure" |
+| **Internationalization** | US-centric wording | Cleaner, more jurisdiction-neutral wording |
+| **Cure period** | A single violation can permanently terminate | Offers a way to cure a first violation and be reinstated |
+
+**Tivoization** — the headline GPLv3 concern — is named after TiVo, which shipped GPLv2 Linux but used hardware signature checks so a modified kernel wouldn't boot. Technically the source was provided; practically, the freedom to run modified versions was defeated. GPLv3 closes that loophole for consumer devices.
+
+The **patent** changes matter too: like [Apache 2.0](/learn/software-licensing/apache-license/), GPLv3 gives recipients an explicit license to the patents a contributor holds over their contribution, and it discourages patent aggression. GPLv2 predates the era when this was a pressing worry.
+
+One subtlety: a project licensed "GPLv2 **or later**" lets you choose v3, but "GPLv2 **only**" does not. Always check the exact grant.
+
+## The hard part: "derivative work" and linking
+
+The GPL's reach extends to anything that counts as a **derivative work** (or, in GPLv3 terms, a work "based on" the program) of the GPL code. Pinning down that boundary is the single thorniest question in open-source licensing.
+
+Clear cases are easy. If you edit GPL source and ship the result, that's covered. If you fork a GPL project, the fork is GPL. The hard case is **linking**: if your otherwise-proprietary program calls into a GPL library, is the combination a derivative work that must be released under the GPL?
+
+The FSF's position is that linking — whether **static** (the library is compiled into your binary) or **dynamic** (loaded at runtime) — generally creates a single combined work, so distributing it triggers the GPL on the whole thing. Many lawyers agree for static linking; the dynamic-linking case is more contested and has rarely been fully litigated, so it remains a genuine legal gray area rather than a settled rule. Communicating with a separate GPL program at arm's length — say, over a pipe, a socket, or as a separate process — is widely considered *not* to create a derivative work.
+
+Because this uncertainty scares off legitimate use, the FSF created the **Lesser GPL (LGPL)** precisely to permit linking from non-GPL programs. That, along with file-level options like the MPL, is the subject of [Weak copyleft: LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/). And the question of how all this plays out in shipping products gets its own deep treatment in [Copyleft in products](/learn/software-licensing/copyleft-in-products/).
+
+## Strengths and weaknesses, honestly
+
+The GPL's **strengths** are real and have shaped modern computing. It keeps software free in a way permissive licenses cannot: a GPL project can't be quietly absorbed into a closed product, so improvements tend to flow back to everyone. It prevents **proprietary capture**, where a company takes a community's work and gives nothing back. For projects whose authors care most about user freedom, it is the strongest tool available, and it built ecosystems (GNU, Linux, much of the toolchain you compile with) on exactly that promise.
+
+The **weaknesses** are equally real. The strong reach creates **compatibility headaches**: GPL code can't be freely combined with code under licenses whose terms conflict, and even GPLv2 and GPLv3 code can't be mixed unless the v2 side said "or later." This is the heart of [license compatibility](/learn/software-licensing/license-compatibility/). The same reach produces **commercial hesitancy**: companies wary of accidentally GPL-ing their proprietary code often ban GPL dependencies outright, which can shrink a project's adoption. And the linking ambiguity above means even careful engineers sometimes can't be sure where the line is without legal help.
+
+There's no universally "right" answer — it's a values choice. Maximize freedom-for-users and accept narrower adoption (GPL), or maximize adoption and accept proprietary forks (permissive). [Choosing an open-source license](/learn/software-licensing/choosing-an-oss-license/) walks through making that call deliberately.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the GPL's source-sharing duty is triggered by distributing (conveying) the software, not by merely using or modifying it internally." markdown="0">
+  <p class="knowledge-check__q">Quick check: what triggers the GPL's obligation to provide source code?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Running or modifying the software for your own internal use</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Distributing (conveying) the software to a third party</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Simply downloading a copy of the GPL software</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **The GPL is the original copyleft** — it uses copyright to guarantee user freedom rather than to withhold it, and its reach extends across the whole combined program (strong copyleft).
+- **The bargain is reciprocity** — you receive the four freedoms and must pass them on, in source form and under the same license, whenever you distribute.
+- **Distribution is the trigger, not use** — internal use and modification impose no source duty; conveying the software to others does. Plain GPL doesn't cover network-only access (that's the AGPL).
+- **You must provide complete corresponding source** — everything needed to build, install, and run the version you shipped, with notices intact.
+- **GPLv2 and GPLv3 differ and aren't interchangeable** — v3 adds anti-tivoization, explicit patent terms, and broader compatibility; check whether a project is "v2 only" or "v2 or later."
+- **Linking and "derivative work" are genuinely contested** — which is why weak-copyleft licenses exist and why the viral question gets its own lesson.
+
+Next up: how copyleft adapts to the cloud, where software is used over a network but never handed over. See [The AGPL: copyleft over the network](/learn/software-licensing/agpl-network-copyleft/).

--- a/docs/learn/software-licensing/how-to-read-an-agreement.md
+++ b/docs/learn/software-licensing/how-to-read-an-agreement.md
@@ -1,0 +1,134 @@
+---
+slug: how-to-read-an-agreement
+title: How to read a software agreement
+description: A repeatable method for reading any software agreement — start with the defined terms, map the structure, find which party you are, and read the obligations that fall on you. Learn the search techniques and when to stop and get help.
+keywords: how to read a software agreement, reading contracts, defined terms, contract structure, license agreement clauses, EULA reading, terms of service, auto-renewal, governing law, boilerplate, contract review checklist
+level: beginner
+status: full
+faq:
+  - q: "Do I really have to read the whole agreement?"
+    a: "You should read all of it before signing something with real money or risk attached — but you can read it *smartly*. Read the **defined terms** first so the rest makes sense, then move clause by clause, slowing down on the parts that bind **you**: payment, termination, renewal, liability, and data. For a free app's terms of service you may skim, but never skim a contract you're paying for or selling under."
+  - q: "Why are so many words Capitalized in a contract?"
+    a: "A capitalized word like **Software**, **Services**, or **Confidential Information** is almost always a **defined term** — it means exactly what the agreement's definitions say it means, no more and no less. Find the definition before you interpret the clause, because the everyday meaning and the defined meaning can differ in ways that matter."
+  - q: "When should I stop reading and get a lawyer?"
+    a: "When the dollars or the risk are large, when a clause is genuinely unclear and the stakes are high, or when you spot something that looks one-sided and you can't tell if it's normal. Reading the agreement yourself isn't a substitute for legal advice — it's how you know *which questions* to bring to an attorney so you don't pay them to explain the boilerplate."
+---
+# How to read a software agreement
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Read the defined terms first** — capitalized words mean exactly their definition, not their everyday sense. **Map the structure** — most agreements run grant → restrictions → money → risk → boilerplate, so you know where to look. **Find which party you are** — then read the obligations that fall on *you* most carefully. **Don't skip the boring parts** — auto-renewal, governing law, and assignment hide in the boilerplate. **Know when to stop** — reading well tells you which questions to take to a lawyer.
+</div>
+
+A software agreement looks like a wall of dense text designed to be skipped, and most people do skip it. But these documents are more regular than they appear: nearly every one is built from the same handful of parts in roughly the same order. This lesson gives you a repeatable method for reading any of them — a license, a EULA, a SaaS contract, a terms of service — so you can find what matters fast, understand what you're agreeing to, and know when a clause is over your head. By the end you'll have a procedure you can run on any agreement that lands in your inbox.
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+## Start with the defined terms
+
+The single most useful habit is counterintuitive: **read the definitions section before you read the body.** Most agreements have a block — often titled "Definitions" or "Interpretation," frequently near the top or the very end — that assigns precise meanings to certain words.
+
+Here's the rule that unlocks the whole document: **a capitalized word is a defined term, and it means exactly what its definition says.** When a contract says *Software*, *Services*, *Documentation*, *Authorized Users*, *Confidential Information*, or *Affiliates* with a capital letter, it is not using the everyday word — it's using a label whose meaning was nailed down elsewhere.
+
+```text
+"Software" means the GopherTrunk binaries and source code made available
+under this Agreement, together with any Updates, but excluding any
+Third-Party Components.
+```
+
+That definition changes how you read every later sentence that uses *Software*. If a warranty covers "the Software," it may quietly *not* cover the third-party components bundled with it — because the definition carved them out. Misreading a defined term is the most common way people misunderstand a contract, so resolve them first.
+
+A quick technique: when you hit a capitalized term you're unsure about, search the document (Ctrl-F / Cmd-F) for the word in quotes — definitions are usually written `"Term" means …`.
+
+## Map the structure
+
+Once the terms are clear, orient yourself with the document's shape. Most software agreements follow a predictable arc, and knowing it tells you *where* to look for any given concern.
+
+| Section | What it covers | The question it answers |
+|---|---|---|
+| **Grant** | What you're allowed to do | "What rights do I get?" |
+| **Restrictions** | What you may *not* do | "Where are the limits?" |
+| **Money** | Fees, taxes, payment, price changes | "What does it cost, and when can that change?" |
+| **Term & termination** | How long it lasts, how it ends, what survives | "How do I get out, and what sticks around?" |
+| **Risk** | Warranties, liability limits, indemnity | "Who pays when something breaks?" |
+| **Boilerplate** | Governing law, assignment, notices, amendment | "What are the background rules of the relationship?" |
+
+Not every agreement uses these exact headings, and the order varies — but if you know the five buckets, you can skim the headings and route each clause to the right one. We decode the core clauses in [The main clauses, decoded](/learn/software-licensing/main-clauses-decoded/) and the risk clauses in [The risk clauses](/learn/software-licensing/risk-clauses/).
+
+## Identify the parties — and which one you are
+
+Near the top, an agreement names its parties, often with shorthand labels: "**Licensor**" and "**Licensee**," "**Provider**" and "**Customer**," "**Company**" and "**You**." Before you read a single obligation, settle one question: **which party are you?**
+
+It sounds obvious, but it's the hinge of the whole document. A clause that says "Customer shall pay all fees within thirty (30) days" is *your* obligation if you're the Customer and someone else's if you're not. Every "shall," "must," and "agrees to" attaches to one party. Until you know which label is yours, you can't tell which promises are yours to keep.
+
+A practical move: once you know your label, search for it. Ctrl-F your party name ("Customer," "Licensee," "You") and read every clause that names you — those are the duties and rights that are actually yours.
+
+## Read the obligations that fall on you
+
+This is the heart of careful reading. An agreement spends a lot of words on what the *other* side will do — but the part that can bite you is what *you* promised. Hunt for the language that creates your obligations:
+
+- **"shall" / "must" / "will" / "agrees to"** — these create duties. Whose? Check the subject of the sentence.
+- **"shall not" / "may not"** — these are your restrictions. Breaking one can end the agreement or trigger liability.
+- **Conditions ("provided that," "so long as," "subject to")** — your rights often hinge on you doing something. Miss the condition, lose the right.
+
+Read your obligations as if you'll have to actually perform them, because you will. Can you really keep the data in-region? Notify within five business days? Restrict use to "Authorized Users" as defined? If an obligation is one you can't realistically meet, that's a problem to raise *before* you agree, not after — see [What to check before you agree](/learn/software-licensing/before-you-agree/).
+
+## Don't skip the "boring" boilerplate
+
+The most expensive surprises hide in the section everyone skips. "Boilerplate" — the miscellaneous or "General" clauses at the end — sounds like throat-clearing, but several of its clauses can reshape the entire deal.
+
+- **Governing law and venue** — which jurisdiction's law applies and where disputes are heard. This can decide whether a dispute is even practical for you to pursue. (And as the [license-vs-contract](/learn/software-licensing/license-vs-contract/) lesson noted, some clauses enforceable in one place are void in another.)
+- **Assignment / change of control** — can the other side hand your agreement to a company you'd never have signed with, say after an acquisition?
+- **Auto-renewal** — the clause that quietly renews your subscription (and its bill) unless you cancel inside a notice window. It lives in the term section but reads like boilerplate, which is exactly why it's missed.
+- **Amendment / "we may change these terms"** — can they alter the deal unilaterally later?
+- **Entire agreement (merger clause)** — only what's written counts; that promise the salesperson made over email may not.
+
+None of these are exotic. They're standard, and they're standard *because* they matter. Read them.
+
+## Techniques that make reading faster
+
+You don't have to read linearly. A few search-driven passes catch most of what matters:
+
+| Search for… | What you're hunting | Why |
+|---|---|---|
+| `terminate` | How the deal ends and what survives | Exit terms and surviving obligations |
+| `renew` / `renewal` | Auto-renewal and notice windows | So a subscription doesn't roll over silently |
+| `liable` / `liability` | Caps and exclusions on damages | Where the real money risk lives |
+| `data` / `personal` | What they can collect, use, and share | Privacy and telemetry rights |
+| `fee` / `price` / `increase` | Costs and unilateral price changes | What you'll actually pay over time |
+| `indemnif` | Who defends whom against third-party claims | Important if you embed others' code |
+| your party name | Every duty and right that is *yours* | The obligations you must actually keep |
+
+Run these first, read the hits, then read the document straight through for context. The searches tell you where to slow down.
+
+## When to stop and get help
+
+Reading the agreement yourself is the goal, but it has a ceiling. Stop and bring in a qualified attorney when:
+
+- The **money or risk is significant** — a multi-year commitment, a large contract value, or anything where a bad clause could seriously hurt you.
+- A clause is **genuinely unclear** and the stakes of getting it wrong are real.
+- You spot something **one-sided** (an uncapped liability, a broad IP grab, a perpetual obligation) and can't tell whether it's normal or a red flag.
+- You're **selling or signing under** the agreement, not just clicking through a free app.
+
+Crucially, reading it yourself isn't a *substitute* for legal advice — it's what makes that advice cheap and sharp. You walk in already knowing the structure, your obligations, and the specific clauses that worry you, so the lawyer answers *your* questions instead of explaining the boilerplate on your dime. [Where to get licensing help](/learn/software-licensing/where-to-get-licensing-help/) covers your options.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a capitalized word is a defined term that means exactly what the agreement's definitions say, so you read the definitions first." markdown="0">
+  <p class="knowledge-check__q">Quick check: in a contract, what does a Capitalized word like "Software" usually signal?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">It's a defined term that means exactly what the agreement's definitions say</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's emphasized for importance but means the ordinary everyday word</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's a typo or formatting artifact you can safely ignore</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Read the defined terms first** — capitalized words carry their precise defined meaning, and resolving them prevents the most common misreadings.
+- **Map the structure** — grant → restrictions → money → risk → boilerplate tells you where any concern lives.
+- **Find which party you are** — every "shall" attaches to one side; you can't read your duties until you know your label.
+- **Read your own obligations carefully** — search for "shall," "must," and conditions, and treat each as something you'll actually have to do.
+- **Don't skip the boilerplate** — governing law, assignment, auto-renewal, and amendment clauses can reshape the whole deal.
+- **Know when to stop** — reading well isn't a substitute for a lawyer; it's how you make their help cheap and targeted.
+
+Next up: a guided tour of the clauses you'll meet in almost every agreement, in plain English. See [The main clauses, decoded](/learn/software-licensing/main-clauses-decoded/).

--- a/docs/learn/software-licensing/index.md
+++ b/docs/learn/software-licensing/index.md
@@ -1,0 +1,48 @@
+---
+layout: learn-hub
+learn_path: software-licensing
+permalink: /learn/software-licensing/
+title: Software Licensing & Agreements — from open source to selling your own
+description: A free, structured learning path on software licensing and agreements — every license type from open source to proprietary, the open-source licenses in depth, writing a commercial license, using open source in software you sell, how to read an agreement, EULAs, terms of service, privacy and SLA terms, and choosing the right license and agreements for your own software.
+keywords: software license, open source licenses, MIT license, Apache license, GPL, copyleft, permissive license, proprietary licensing, commercial license, EULA, terms of service, software license agreement, license compatibility, choosing a license, SBOM, dual licensing
+---
+
+"Software licensing" sounds like fine print, but it's really the set of rules
+that decide who may use, copy, change, and sell a piece of code — including the
+code you write and the code you build on. Get it wrong and you can lose the
+right to ship, or hand away rights you meant to keep; get it right and you can
+share freely, sell confidently, and reuse the world's open source without
+nasty surprises. This path builds that understanding one short lesson at a
+time, starting from what a license actually is and ending with a concrete plan
+for licensing and agreements around your own software.
+
+**Who this is for.** Anyone who ships software and wants to handle the legal
+layer on purpose instead of by guesswork — developers picking a license for a
+side project, founders building a product on open-source components, and anyone
+who has to read an agreement before clicking "I agree". No legal background is
+assumed, and every term is explained the first time it appears. If you're brand
+new to building software, the
+**[Intro to Software Development](/learn/intro-software-dev/)** path pairs
+naturally with this one; every lesson here is self-contained and cross-linked,
+so you can read straight through or jump to what you need.
+
+**How the path works.** Seven modules move from *foundations* to *doing*. We
+open with the groundwork — what a license is, how copyright and the other
+intellectual-property rights work, how a license differs from a contract, and
+the full spectrum from public domain to closed source. From there we cover the
+open-source licenses in depth (MIT, BSD, Apache, the GPL family, the weak-
+copyleft licenses, and public-domain dedications), then how to choose and
+combine them safely. Module 4 turns to proprietary and commercial licensing,
+including writing a license to sell your own software; Module 5 tackles the
+question every founder asks — *can you sell software built on open source?* —
+and how to stay compliant. Module 6 teaches you to read agreements and the
+other documents users meet (EULAs, terms of service, privacy policies, SLAs,
+NDAs), and Module 7 turns all of it into a decision framework for your own
+projects. Throughout, we teach *concepts first*, use the United States as the
+reference jurisdiction while flagging how things differ elsewhere, and lean on
+real examples — including GopherTrunk's own Apache-2.0 license and dependency
+attribution — to keep things concrete. One thing to keep in mind as you read:
+this is **educational material, not legal advice**, and decisions that carry
+real risk deserve a qualified attorney. Mark lessons complete as you go; your
+progress is saved in your browser.
+**[Start with lesson 1: What is a software license?](what-is-a-software-license/)**

--- a/docs/learn/software-licensing/key-commercial-clauses.md
+++ b/docs/learn/software-licensing/key-commercial-clauses.md
@@ -1,0 +1,144 @@
+---
+slug: key-commercial-clauses
+title: Key clauses in a commercial license
+description: A clause-by-clause guide to commercial software licenses — grant, restrictions, fees, term and termination, warranty, limitation of liability, indemnification, IP, confidentiality, audit, and governing law — with what each does and what to watch for, whether you're writing or signing.
+keywords: commercial license clauses, EULA clauses, license grant, limitation of liability, indemnification, warranty disclaimer, term and termination, audit rights, governing law, confidentiality, IP ownership, consequential damages, liability cap, software contract
+level: advanced
+status: full
+faq:
+  - q: "What's the single most important clause to read in a commercial license?"
+    a: "For most buyers it's the **limitation of liability** clause, because it decides who absorbs the loss when the software causes real damage. Vendors cap their liability (often at fees paid) and exclude consequential damages, which can leave you holding far more than the cap if something goes badly wrong. For vendors, the **license grant and restrictions** matter most, since they define the product being sold. Read both carefully."
+  - q: "Why are warranty disclaimers written in ALL CAPS?"
+    a: "In the US, the Uniform Commercial Code requires that a disclaimer of implied warranties be **conspicuous** to be enforceable. All-caps (or bold) text is the traditional way to meet that bar. It's not shouting for emphasis — it's a legal formality to make sure the disclaimer can't be dismissed as buried fine print."
+  - q: "Can a vendor disclaim *all* liability?"
+    a: "Not entirely, and not everywhere. Most jurisdictions don't let you disclaim liability for things like gross negligence, willful misconduct, or death/personal injury, and **consumer-protection law (especially in the EU and UK)** limits how far you can push disclaimers against consumers. A clause that says \"we are never liable for anything\" is often partly unenforceable. The enforceable version uses a **cap** plus targeted **exclusions** — see [Licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/)."
+---
+# Key clauses in a commercial license
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Grant + restrictions define the product** — what you may do, and what you may not. **The risk clauses decide who pays** — warranty disclaimer, limitation of liability, and indemnification matter most when things go wrong. **Term, termination, and survival** — what ends the deal and what outlives it. **The operational clauses** — fees, IP, confidentiality, audit rights, and governing law round out the agreement.
+</div>
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+This is the detailed companion to [Writing a license to sell software](/learn/software-licensing/writing-a-commercial-license/). Here we go clause by clause through a commercial software license: what each clause is for, and what to watch for. It's written to be useful from *both* sides — if you're drafting a license to sell, these are the clauses you'll write; if you're a buyer being handed an agreement, these are the clauses to read before you sign. Readers focused on the *signing* side will also want the [reading-agreements module](/learn/software-licensing/how-to-read-an-agreement/), which covers this from the customer's perspective. By the end you'll recognize every major clause and know its traps.
+
+## The clauses that define the product
+
+### License grant & scope
+
+The **grant** is the heart of the license — the rights the vendor actually gives. A typical grant is "non-exclusive, non-transferable" and bounded by scope (users, devices, installs, territory, purpose). Everything not granted is reserved.
+
+*Watch for:* vague scope ("reasonable use"), and whether the grant is *perpetual* or tied to a paid term. As a buyer, make sure the grant actually covers how you intend to use it (e.g., affiliates, contractors, cloud deployment). As a vendor, make the boundaries explicit so overuse is a clear breach.
+
+### Restrictions
+
+The flip side of the grant: the explicit list of prohibitions — no redistribution, no modification, no reverse engineering (subject to law), no benchmarking/publishing performance results, no competing use.
+
+*Watch for:* the **reverse-engineering** ban, which in the EU is partly overridden by a legal right to decompile for interoperability; and "no benchmarking" clauses, which are common but controversial. Restrictions that contradict mandatory law are unenforceable to that extent.
+
+## The money and the timeline
+
+### Fees & payment
+
+What's owed, when, in what currency, and the consequences of late payment (interest, suspension, termination). For subscriptions, this is also where **auto-renewal** and **price-increase** terms live.
+
+*Watch for:* automatic renewal with a short cancellation window, and uncapped annual price increases. As a buyer, negotiate a renewal cap; as a vendor, be clear and conspicuous about renewals (some jurisdictions require it).
+
+### Term & termination — and what survives
+
+The **term** is how long the agreement lasts; **termination** covers how it ends — for convenience, for breach (often with a cure period), or automatically on non-payment. Critically, a **survival** clause lists which obligations continue *after* termination — typically confidentiality, limitation of liability, IP ownership, and accrued fees.
+
+*Watch for:* what happens to your access and **your data** on termination (especially SaaS — is there an export window?), and whether the vendor can terminate "for convenience" on short notice. The survival list is easy to overlook and very important: a license with no survival clause may let obligations evaporate at the worst moment.
+
+## The risk clauses: who pays when it breaks
+
+These three clauses, together, allocate the financial risk of the deal. They are the most negotiated part of any serious contract and the most important to read.
+
+### Warranty — and the all-caps disclaimer
+
+A **warranty** is a promise about the software (e.g., "will perform substantially per the documentation for 90 days"). Almost every commercial license then **disclaims all other warranties** — the implied warranties of *merchantability* and *fitness for a particular purpose* that the law would otherwise read in. This disclaimer is written in ALL CAPS or bold because, under the US Uniform Commercial Code, a disclaimer of implied warranties must be **conspicuous** to be enforceable.
+
+```text
+EXCEPT AS EXPRESSLY SET FORTH ABOVE, THE SOFTWARE IS PROVIDED "AS IS"
+WITHOUT WARRANTY OF ANY KIND, AND VENDOR DISCLAIMS ALL IMPLIED WARRANTIES,
+INCLUDING THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE.
+```
+
+*Watch for:* "AS IS" with essentially no express warranty at all. As a buyer of critical software, push for at least a basic performance warranty.
+
+### Limitation of liability
+
+The clause that decides **how much** a party can be made to pay if the other suffers a loss. It has two standard parts: a **cap** (often "fees paid in the prior 12 months") and an **exclusion of consequential damages** (lost profits, lost data, business interruption).
+
+*Watch for:* a cap far below your potential exposure, and remember the important limit — **some jurisdictions restrict how far you can disclaim liability**. You generally cannot exclude liability for gross negligence, willful misconduct, or death/personal injury, and **consumer and EU/UK law** further constrains disclaimers against consumers. A clause claiming zero liability for everything is often partly void. Common carve-outs sit *above* the cap: IP indemnity, breach of confidentiality, and the customer's payment obligations.
+
+### Indemnification
+
+An **indemnity** is a promise to defend and cover the other party against certain third-party claims. The classic one runs from vendor to customer: if a third party sues the customer claiming the software infringes their patent or copyright, the **vendor defends and pays**. Customers often give a narrower indemnity back (e.g., for misuse of the software).
+
+*Watch for:* whether the **IP indemnity** exists at all (some vendors omit it), its exceptions (modifications, combinations, open-source components), and the vendor's remedies if a claim succeeds (repair, replace, or refund). For software built on open source, the indemnity interacts with your dependency hygiene — see [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/).
+
+## The operational and legal clauses
+
+### IP ownership
+
+A plain statement that the vendor **retains all intellectual property** in the software; the customer gets only the license granted. For SaaS, this clause should also address ownership of **customer data** (the customer keeps it) and any **feedback** (often assigned to the vendor).
+
+*Watch for:* overbroad assignment of customer data or work product to the vendor.
+
+### Confidentiality
+
+Defines what each side must keep secret (pricing, the software's non-public details, business information), with standard carve-outs (already public, independently developed, legally compelled). Often mirrors a separate [NDA](/learn/software-licensing/nda-and-other-agreements/).
+
+*Watch for:* the duration of the obligation and whether trade secrets are protected indefinitely.
+
+### Audit rights
+
+A vendor right to **inspect** the customer's usage to confirm compliance with the license counts (seats, cores, instances). Common in enterprise software and a frequent source of friction.
+
+*Watch for:* the notice period, frequency, and who pays for the audit. As a buyer, bound it (reasonable notice, once a year, vendor pays unless material under-licensing is found).
+
+### Governing law & dispute resolution
+
+Whose law applies (the **governing law**) and how/where disputes are resolved — courts in a named jurisdiction, or **arbitration**. This clause quietly decides how expensive and how convenient any future fight will be.
+
+*Watch for:* an inconvenient forum (the other side's home turf far from you) and mandatory arbitration that waives your right to court or class actions. This is heavily jurisdiction-dependent — see [Licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/).
+
+## Quick reference
+
+| Clause | What it does | Watch for |
+|---|---|---|
+| **License grant & scope** | The rights you get | Vague scope; perpetual vs term |
+| **Restrictions** | What you may not do | Reverse-engineering / benchmarking bans vs mandatory law |
+| **Fees & payment** | What's owed and when | Auto-renewal; uncapped price hikes |
+| **Term & termination + survival** | How it ends; what continues | Data export on termination; "for convenience" exits |
+| **Warranty + disclaimer** | Promises, and the all-caps "AS IS" | No real warranty at all |
+| **Limitation of liability** | How much can be owed | Low cap; over-broad disclaimer that law won't enforce |
+| **Indemnification** | Who defends third-party claims | Missing or narrow IP indemnity; exclusions |
+| **IP ownership** | Vendor keeps the IP | Grabs on customer data/feedback |
+| **Confidentiality** | What stays secret | Duration; trade-secret handling |
+| **Audit rights** | Vendor can verify usage | Notice, frequency, who pays |
+| **Governing law & disputes** | Whose law, where, how | Inconvenient forum; forced arbitration |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — warranty disclaimers are in all caps because US law requires the disclaimer of implied warranties to be conspicuous to be enforceable." markdown="0">
+  <p class="knowledge-check__q">Quick check: why is the warranty disclaimer typically written in ALL CAPS?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's a formatting convention with no legal meaning</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It makes the clause apply in more countries automatically</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">US law requires a disclaimer of implied warranties to be conspicuous to be enforceable</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Grant & restrictions define the product** — a scoped grant plus an explicit list of prohibitions; check the scope actually fits your use.
+- **The risk clauses allocate loss** — the warranty disclaimer (all-caps for conspicuousness), the limitation of liability (cap + consequential-damages exclusion), and indemnification (who defends IP claims) are the most important to read.
+- **You can't disclaim everything** — gross negligence, willful misconduct, and consumer/EU protections limit how far liability can be excluded.
+- **Term, termination, and survival** — know what ends the deal, what happens to your data, and which obligations survive.
+- **Operational clauses round it out** — fees and renewal, IP ownership, confidentiality, audit rights, and governing law/dispute resolution.
+
+Next up: when DIY is fine, when you genuinely need a lawyer, and the reputable resources for both. See [Where to get licensing help](/learn/software-licensing/where-to-get-licensing-help/).

--- a/docs/learn/software-licensing/license-compatibility.md
+++ b/docs/learn/software-licensing/license-compatibility.md
@@ -1,0 +1,129 @@
+---
+slug: license-compatibility
+title: License compatibility
+description: License compatibility is whether code under two different licenses can be legally combined into one distributable work. Learn why permissive licenses combine freely, how copyleft constrains the result, and how to check before adding a dependency.
+keywords: license compatibility, compatible licenses, combining open source licenses, GPL compatibility, Apache GPLv3, GPLv2 GPLv3 incompatible, one-way compatibility, most restrictive license, copyleft compatibility, license of the combined work, permissive licenses
+level: intermediate
+status: full
+faq:
+  - q: "What does it mean for two licenses to be 'compatible'?"
+    a: "It means code under license A and code under license B can be legally combined into a single distributable work without violating either license. Compatibility is about *combining and shipping*, not about whether you personally like the terms. Two perfectly reasonable licenses can still be incompatible because their conditions clash."
+  - q: "Can I put a GPL library into my MIT-licensed proprietary app?"
+    a: "Not while keeping the app proprietary. The GPL is **copyleft**: combining GPL code into your work generally requires you to license the *whole* combined work under the GPL and share its source. You can pull MIT code into a GPL project, but not the other way into closed source — that's the **one-way** nature of copyleft."
+  - q: "Are GPLv2 and GPLv3 compatible with each other?"
+    a: "Generally **no**, unless the GPLv2 code says 'version 2 or later' (`GPL-2.0-or-later`). Plain GPLv2-only code and GPLv3 code cannot be combined, because each license forbids adding the other's extra conditions. This is one of the most famous incompatibilities in open source."
+---
+# License compatibility
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Compatible = combinable** — two licenses are compatible if their code can be merged into one work you can legally distribute. **Permissive combines freely** — MIT, BSD, and Apache impose few conditions, so they slot into almost anything. **Copyleft is the constraint** — the GPL family flows one way: you can pull permissive code *into* the GPL, but not GPL code into a permissive or proprietary work. **The result takes the strictest terms** — the combined work must satisfy every license at once, which usually means the most restrictive one wins.
+</div>
+
+By now you know the difference between [permissive and copyleft](/learn/software-licensing/permissive-vs-copyleft/) licenses. This lesson is about what happens when you mix them. The moment you pull a dependency into your project, you're combining your code's license with theirs — and not every pair of licenses can legally be combined. By the end you'll know exactly what "compatible" means, why the direction of the combination matters, the specific pairings that trip people up, and how to check a license before you add the dependency.
+
+## What "compatible" actually means
+
+Two licenses are **compatible** when you can take code released under one and code released under the other, combine them into a single work, and distribute that work without breaking either license's terms. That's the whole definition — and notice what it's *not* about. It is not about whether the licenses are similar, whether you approve of them, or whether they're both "open source." It's strictly about whether their conditions can all be satisfied at the same time in one shipped artifact.
+
+Conditions clash when one license *requires* something another license *forbids*. If license A says "you may add no further restrictions" and license B says "you must add this restriction," there is no way to obey both in the same combined work. They're incompatible — not because either is bad, but because their rules contradict each other.
+
+A few clarifications worth nailing down:
+
+- Compatibility matters most when you **combine and distribute** a work — linking a library, copying a file, bundling source. Merely *using* a tool, or running unmodified copies side by side, is a much lighter question.
+- "Distribute" includes shipping a binary, a container image, or a downloadable app. (Whether putting software on a *network* counts is the special twist the [AGPL](/learn/software-licensing/agpl-network-copyleft/) adds.)
+- Compatibility is asymmetric for copyleft licenses. The order you combine things in changes the answer, which is the single most counterintuitive part — so it gets its own section.
+
+## Permissive licenses combine freely
+
+[Permissive licenses](/learn/software-licensing/mit-and-bsd-licenses/) — MIT, BSD, and [Apache 2.0](/learn/software-licensing/apache-license/) — ask for very little: keep the copyright notice and license text, and (for Apache) respect the patent and trademark terms. They do **not** demand that the larger work adopt their license. Because they impose almost no conditions on the combined work, they slot into nearly anything: another permissive project, a copyleft project, or closed-source proprietary software.
+
+This is why permissive code is everywhere. You can take an MIT-licensed utility and drop it into a commercial product, a GPL application, or another MIT library, and in each case you satisfy the license simply by preserving its notice. GopherTrunk itself is [Apache-2.0](/learn/software-licensing/apache-license/) licensed and depends on a stack of permissively licensed Go modules; that breadth of compatibility is a big part of why permissive licensing dominates the dependency ecosystem.
+
+The one wrinkle inside the permissive family is Apache 2.0's explicit patent and notice clauses. Older permissive licenses (4-clause BSD, and Apache 2.0 against GPL**v2**) have specific incompatibilities — we'll get to the Apache case below — but as a rule, permissive-to-permissive combinations just work.
+
+## Copyleft is the constraint — and it flows one way
+
+[Copyleft licenses](/learn/software-licensing/gpl-strong-copyleft/) like the GPL flip the deal. They say: you may use and modify this code, but if you distribute a work built from it, that whole work must be released under the *same* copyleft license, with source available. That requirement is what creates the compatibility problem, because it imposes a condition on the *combined* work, not just on the original code.
+
+Here is the key mental model — **one-way compatibility**:
+
+- **Permissive → copyleft: allowed.** You can take MIT or BSD code and pull it *into* a GPL project. The permissive license doesn't object to the result being GPL'd, and the GPL is happy to absorb code that came with looser terms. The combined work ships as GPL.
+- **Copyleft → permissive or proprietary: not allowed.** You cannot take GPL code and fold it into an MIT-licensed library or a closed-source product while keeping that looser/closed license. The GPL would require the whole combined work to *become* GPL, which contradicts the permissive or proprietary licensing you wanted.
+
+So compatibility has a *direction*. Code flows "uphill" from permissive into copyleft, but copyleft code can't flow "downhill" into something more permissive. People get burned when they assume "it's all open source, so it must mix" — adding one GPL dependency can force your entire distributable work to become GPL, or block the combination entirely if you can't accept that.
+
+## The specific pairings that trip people up
+
+Beyond the broad rule, a handful of named incompatibilities cause most real-world headaches.
+
+### GPLv2 vs GPLv3
+
+The GPL comes in versions, and **GPLv2 and GPLv3 are generally incompatible with each other.** GPLv3 added new conditions (an explicit patent grant, anti-tivoization terms) that GPLv2 doesn't permit you to add, and GPLv2 forbids adding terms beyond its own. So plain `GPL-2.0-only` code and `GPL-3.0` code can't be combined.
+
+The escape hatch is the "or later" clause. Much GPL code is released as **"version 2 or later"** (`GPL-2.0-or-later`), which lets a downstream user choose to apply it under GPLv3 — making it compatible with other GPLv3 code. Always check whether a project is "v2 only" or "v2 or later"; the difference decides the whole question.
+
+### Apache 2.0 → GPLv3 is fine; → GPLv2 is not
+
+Apache 2.0's patent and indemnity provisions are considered *additional restrictions* under GPLv2, so **Apache-2.0 code cannot be combined into a GPLv2 work.** GPLv3, however, was deliberately written to accept Apache 2.0's patent terms, so **Apache-2.0 → GPLv3 is compatible.** This is a common surprise: the same Apache library is fine in one GPL version and forbidden in the other.
+
+### A compatibility-direction table
+
+| From (the code you're adding) | Into (the project) | Compatible? | Why |
+|---|---|---|---|
+| MIT / BSD-2/3 / Apache-2.0 | Another permissive | Yes | Few conditions; notices preserved |
+| MIT / BSD | Proprietary / closed | Yes | Permissive allows closed combination |
+| MIT / BSD / Apache-2.0 | GPLv3 | Yes | Permissive flows up into copyleft |
+| Apache-2.0 | **GPLv2-only** | **No** | Apache patent terms = added restriction |
+| GPL (any) | MIT / proprietary | **No** | Copyleft would force the whole work to be GPL |
+| GPLv2-only | GPLv3 | **No** | Each forbids the other's added terms |
+| GPLv2-**or-later** | GPLv3 | Yes | Downstream may upgrade to v3 |
+
+(Read the table as direction-sensitive: "From → Into." Reverse the arrow and the answer often changes.)
+
+## The combined work takes the most restrictive terms
+
+When compatible licenses *do* combine, what license governs the result? The practical rule: **the combined work must satisfy every component license simultaneously, which means the most restrictive set of conditions wins.**
+
+Mix a pile of MIT code with one GPL component and ship them as one program, and the *whole distributable work* must be offered under the GPL — because that's the only way to satisfy the GPL's requirement, and the MIT pieces don't object. The MIT files keep their own license notices internally (you must still preserve them), but the work as a whole is bound by the GPL's copyleft. The strictest license effectively sets the floor for the entire shipped artifact.
+
+This is why a single copyleft dependency can quietly change the license of your product. It doesn't relicense the dependency's original files, but it constrains how you may distribute the *combination*.
+
+## How to check before you add a dependency
+
+The cheapest time to catch an incompatibility is *before* `go get`, `npm install`, or copying a file. A quick routine:
+
+1. **Find the dependency's license.** Look for a `LICENSE` file, the SPDX identifier in package metadata, or the license field in `go.mod`/`package.json`. If you can't tell what license it's under, treat that as a red flag, not a green light.
+2. **Identify your project's license and your intent.** Are you shipping closed-source? Permissive? GPL? The same dependency can be fine or fatal depending on what *you* ship.
+3. **Check the direction against the table above.** Permissive-into-anything is almost always fine. Copyleft-into-permissive-or-proprietary almost never is. For GPL, check the exact version and the "or later" clause.
+4. **Mind transitive dependencies.** Your direct dependency may pull in others under different licenses. The combination is only as compatible as its strictest link.
+5. **When in doubt, use a tool.** Automated scanners (and SPDX-based tooling like GopherTrunk's `make licenses` job) inventory every license in the tree so a human can review it.
+
+```bash
+# GopherTrunk inventories every dependency license via this CI step,
+# so an incompatible license shows up before it ships.
+make licenses
+```
+
+That auditing process — scanning the whole dependency tree, producing an attribution file, and catching surprises — is a lesson of its own. We cover it in depth in [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — permissive code flows up into the GPL, but GPL code can't flow down into a permissive or proprietary work without forcing the whole thing to become GPL." markdown="0">
+  <p class="knowledge-check__q">Quick check: which combination is allowed?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Pulling MIT-licensed code into a GPLv3 project and shipping the result as GPLv3</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Folding a GPL library into your closed-source product while keeping it closed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Combining GPLv2-only code with GPLv3 code into one program</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Compatible means combinable** — two licenses are compatible if their code can be merged into one work you can legally distribute, satisfying both at once.
+- **Permissive combines freely** — MIT, BSD, and Apache impose so few conditions they slot into almost any project, open or closed.
+- **Copyleft flows one way** — you can pull permissive code into the GPL, but not GPL code into a permissive or proprietary work.
+- **Versions and patents matter** — GPLv2-only and GPLv3 are incompatible unless "or later"; Apache-2.0 works with GPLv3 but not GPLv2.
+- **The strictest license wins** — a compatible combined work must satisfy every component license, so its terms default to the most restrictive one.
+- **Check before you add** — confirm the dependency's license, your intent, the direction, and the transitive tree before pulling anything in.
+
+Next up: now that you can tell which licenses combine, how do you pick the right one for your *own* project? See [Choosing an open-source license](/learn/software-licensing/choosing-an-oss-license/).

--- a/docs/learn/software-licensing/license-vs-contract.md
+++ b/docs/learn/software-licensing/license-vs-contract.md
@@ -1,0 +1,119 @@
+---
+slug: license-vs-contract
+title: License vs contract
+description: A bare license is one-sided permission; a contract is a mutual agreement with obligations and consideration. Learn why the distinction changes your legal remedies and how click-wrap, browse-wrap, and EULAs fit in.
+keywords: license vs contract, bare license, unilateral permission, contract consideration, copyright infringement vs breach of contract, click-wrap, browse-wrap, EULA enforceability, open source license contract debate, affirmative assent
+level: intermediate
+status: full
+faq:
+  - q: "Is an open-source license a contract or just a license?"
+    a: "It's genuinely **debated**, and the answer can depend on the jurisdiction and the facts. The traditional open-source view is that these are **bare licenses** — unilateral grants of permission whose violation is copyright infringement. But courts have increasingly been willing to treat their conditions as **contract** terms too, which can give *additional* remedies. In practice a violation may be both at once."
+  - q: "What's the difference between click-wrap and browse-wrap agreements?"
+    a: "**Click-wrap** requires an affirmative action — you check a box or click \"I agree\" before proceeding — so it's generally **enforceable** because you clearly assented. **Browse-wrap** just posts terms via a link and claims that using the site means you accept them, with no click; courts treat it as **much weaker** and often unenforceable, since the user may never have seen or agreed to the terms."
+  - q: "Why does it matter whether something is a license or a contract?"
+    a: "Because the **remedies differ**. Breaking the conditions of a bare license can be **copyright infringement**, which carries copyright remedies (potentially including statutory damages in the US). Breaking a contract is **breach of contract**, with its own remedies. The same act may trigger one, the other, or both — and which applies affects what the wronged party can claim."
+---
+# License vs contract
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**A bare license is one-sided** — it's just permission the owner grants, no promises required from you. **A contract is mutual** — it needs agreement, obligations on both sides, and consideration (an exchange of value). **The distinction changes remedies** — violating a license can be copyright infringement; breaking a contract is breach of contract. **How you "agree" matters** — click-wrap (you click "I agree") is far more enforceable than browse-wrap (terms just linked).
+</div>
+
+So far we've treated a license as simply "permission granted." But many software agreements are also full-blown **contracts**, and the two are not the same legal animal. This lesson draws the line between a bare license and a contract, explains why the difference changes what happens when something goes wrong, and walks through how everyday agreements — click-wrap boxes, browse-wrap links, and EULAs — fit the picture. By the end you'll understand why the same broken term can be infringement, breach, or both.
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+## A bare license: one-sided permission
+
+A **bare license** (sometimes "naked license") is the simplest case, and it's exactly the picture from [lesson one](/learn/software-licensing/what-is-a-software-license/): the copyright owner *unilaterally grants permission*. It's one-directional. The owner says "you may do X with my code," and that's the whole transaction. You aren't required to promise anything back; you just have permission you didn't have before.
+
+A bare license typically comes with **conditions** — "you may use this *provided that* you keep the copyright notice." But those conditions are framed as the *boundaries of the permission*, not as promises you owe the owner. Stay inside the conditions and you're licensed; step outside them and you simply lose the permission, falling back to "all rights reserved."
+
+## A contract: a mutual agreement
+
+A **contract** is a different structure: a *mutual* agreement that binds both sides. To form one (in common-law systems like the US and UK), you generally need:
+
+- **Offer and acceptance** — one side proposes terms, the other agrees to them.
+- **Consideration** — each side gives or promises something of value. This is the classic "bargained-for exchange" — money for software, your data for a free service, mutual promises.
+- **Intent to be bound** — both sides mean to create legal obligations.
+
+The defining feature is **mutual obligation**. In a contract, *both* parties owe each other something, and either can be held to their promises. That's a richer relationship than a bare license's one-way grant.
+
+| | Bare license | Contract |
+|---|---|---|
+| **Direction** | One-sided (permission granted) | Two-sided (mutual obligations) |
+| **Needs your agreement?** | Not necessarily | Yes — offer, acceptance |
+| **Needs consideration?** | No | Yes (exchange of value) |
+| **Conditions are…** | Limits on the permission | Promises you've made |
+| **Violation is…** | Often copyright infringement | Breach of contract |
+
+## Why the distinction changes your remedies
+
+This isn't an academic hair-split — it determines what the wronged party can actually claim when things go wrong.
+
+If a grant is a **bare license** and you act outside its conditions, you no longer have permission, so your use is **copyright infringement**. That routes you into copyright remedies — injunctions, actual damages, and in the US potentially **statutory damages** and attorney's fees if the work was registered (see [the copyright lesson](/learn/software-licensing/copyright-and-software-ownership/)).
+
+If the same arrangement is a **contract** and you violate a term, that's **breach of contract**, which carries its own, often different, remedies — typically the damages needed to put the other side where they'd have been had you performed, and whatever the contract itself specifies.
+
+The amounts, the available remedies, and even *who can sue and where* can differ between the two paths. And critically, a single act can sometimes be **both** at once — infringement *and* breach — giving the owner a choice of theories. That's why lawyers care a great deal about which one a given clause is.
+
+## The open-source debate: license or contract?
+
+Here's where it gets genuinely unsettled. Are open-source licenses bare licenses or contracts?
+
+The **traditional open-source position** is that they're **bare licenses**: a unilateral grant whose conditions (like copyleft's "share your changes under the same terms") are conditions *on the copyright permission*. Violate them and you've lost your license, so you're infringing copyright — and infringement remedies are what enforce the license. This framing has been important historically, partly because copyright remedies can be stronger.
+
+But courts have increasingly been willing to treat those same conditions as **contractual** as well, especially as open-source agreements get used in commercial relationships. A notable line of US cases has recognized that open-source conditions can be enforced as contract terms, potentially giving licensors *both* infringement and breach remedies. The upshot for you: don't assume an open-source license is "just a license with no teeth." Depending on the jurisdiction and facts, violating one can expose you to copyright *and* contract liability.
+
+## How you agree: click-wrap vs browse-wrap
+
+For something to be a *contract*, you generally have to **assent** to it — and *how* a piece of software asks for your agreement strongly affects whether a court will enforce it.
+
+### Click-wrap: affirmative assent, generally enforceable
+
+A **click-wrap** agreement requires you to take a clear, affirmative action — check a box, click "I Agree," type "ACCEPT" — *before* you can proceed. Because you visibly and deliberately assented, courts generally find click-wrap **enforceable**: there's strong evidence you had the chance to read the terms and agreed to them.
+
+```text
+☐ I have read and agree to the Terms of Service and Privacy Policy.
+            [ Continue ]   ← disabled until the box is checked
+```
+
+That pattern — proceeding *blocked* until you act — is the gold standard for forming an enforceable agreement.
+
+### Browse-wrap: weak and often unenforceable
+
+A **browse-wrap** agreement just posts the terms somewhere (often a footer link) and *declares* that by using the site or software you accept them — with **no click, no box, no required action**. Courts treat browse-wrap as **much weaker**. If a user could plausibly never have seen the terms, there's no real assent, and the agreement may be unenforceable. The more buried the link and the less a user has to do, the worse it holds up.
+
+The lesson for builders: if you want your terms to bind, make people *act* to accept them. The lesson for users: a click-wrap "I Agree" is a real legal act — clicking it can form a binding contract, so it's worth a moment's attention ([How to read a software agreement](/learn/software-licensing/how-to-read-an-agreement/) covers what to look for).
+
+## EULAs and their enforceability
+
+A **EULA (End User License Agreement)** is the agreement presented when you install or first run software — the long text behind the "I Agree." Most EULAs are a *blend*: they grant a license (permission to use the software) *and* impose contract terms (restrictions on use, disclaimers of warranty, limits on liability). We give EULAs and terms of service their own treatment later in [EULAs & terms of service](/learn/software-licensing/eula-and-tos/).
+
+Are EULAs enforceable? Largely **yes**, especially when delivered click-wrap style with affirmative assent — courts in the US have broadly upheld them. But enforceability isn't unlimited. Specific terms can be struck down if they're unconscionable or violate other law, and *how* the EULA was presented matters (the click-wrap vs browse-wrap distinction again).
+
+### A jurisdiction note
+
+This is heavily US-flavored. Other legal systems can treat consumer agreements quite differently — many **EU** countries and the UK have **unfair contract terms** rules and strong consumer-protection law that can void one-sided clauses (for example, sweeping disclaimers of liability to consumers) no matter what the EULA says, and they regulate how terms must be presented to bind a consumer. So a clause that's routinely enforced in the US might be unenforceable against a consumer in the EU. The dedicated [cross-border lesson](/learn/software-licensing/licensing-across-jurisdictions/) digs into this.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — click-wrap requires an affirmative action ('I Agree'), giving clear evidence of assent, so it's generally enforceable; browse-wrap requires no action and is much weaker." markdown="0">
+  <p class="knowledge-check__q">Quick check: which kind of online agreement is generally the most enforceable?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Browse-wrap — a terms link in the page footer that applies just by using the site</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Click-wrap — you must check a box or click "I Agree" before proceeding</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Both are equally enforceable, since posting the terms is all that legally matters</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **A bare license is one-sided** — unilateral permission with conditions that bound the grant, requiring nothing back from you.
+- **A contract is mutual** — it needs offer, acceptance, and consideration, and binds both parties to obligations.
+- **The distinction changes remedies** — violating a bare license can be copyright infringement; breaking a contract is breach of contract, and one act can be both.
+- **Open source is debated** — traditionally bare licenses, but courts increasingly enforce their conditions as contract terms too, so they can carry both kinds of liability.
+- **How you agree matters** — click-wrap with affirmative assent is generally enforceable; browse-wrap with no required action is much weaker.
+- **EULAs are mostly enforceable, but not unlimited** — and consumer-protection regimes (notably in the EU) can void one-sided terms the US would uphold.
+
+Next up: zoom out to the full range of how software gets licensed, from fully closed to public domain. See [The licensing spectrum](/learn/software-licensing/the-licensing-spectrum/).

--- a/docs/learn/software-licensing/licensing-across-jurisdictions.md
+++ b/docs/learn/software-licensing/licensing-across-jurisdictions.md
@@ -1,0 +1,139 @@
+---
+slug: licensing-across-jurisdictions
+title: Licensing across jurisdictions
+description: Software licensing law is not uniform worldwide. Learn how moral rights, registration, warranty disclaimers, the license-vs-contract question, governing law, and data-protection regimes differ across the US, EU, and beyond.
+keywords: software licensing jurisdictions, moral rights, copyright registration international, warranty disclaimer enforceability, governing law clause, choice of law, GDPR CCPA, license vs contract international, Berne Convention, shipping software worldwide
+level: intermediate
+status: full
+faq:
+  - q: "Can I just disclaim all warranties and liability the way open-source licenses do?"
+    a: "In the US, broad **\"AS IS\" disclaimers** are widely upheld, which is why MIT, Apache, and GPL all shout them in capitals. But many consumer-protection regimes — notably in the **EU and UK** — limit how far you can disclaim warranties or liability *to consumers*, and some such clauses are void no matter what the license says. Disclaimers are strong defaults, not a guarantee everywhere."
+  - q: "What does a 'governing law' clause actually do?"
+    a: "A **governing-law** (choice-of-law) clause states which jurisdiction's law interprets the agreement, and a paired **forum** clause says where disputes are heard. They add predictability, but they're not absolute — courts can override them, especially when **mandatory consumer-protection or data-protection law** in the user's country applies regardless of what the contract picked."
+  - q: "Are moral rights a real concern for software?"
+    a: "They can be. **Moral rights** — like the right to be credited as author and to object to derogatory treatment of the work — are strong in much of the **EU** (France and Germany especially) and often **can't be fully waived**. In the **US** they're weak for software. For most code it rarely bites, but it's a reason a blanket 'you waive all rights' clause may not hold everywhere."
+---
+# Licensing across jurisdictions
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**US law is our baseline, not the world's** — core copyright is global via treaty, but the details diverge. **Moral rights differ sharply** — strong and often unwaivable in much of the EU, weak in the US. **Disclaimers aren't bulletproof** — consumer-protection regimes can limit warranty and liability waivers. **Governing-law clauses help but don't override mandatory local law** — especially data protection like GDPR and CCPA.
+</div>
+
+Throughout this path we've used the **United States as the reference jurisdiction** and flagged differences in passing. This is the lesson where we slow down and treat those differences properly, because software ships across borders by default — a license written in California binds a user in Berlin, São Paulo, or Tokyo, and not every clause survives the trip. By the end you'll know the main axes on which licensing law varies and how to ship software worldwide without nasty surprises.
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+## The shared baseline: copyright is global
+
+Start with the good news, because it's substantial. Thanks to the **Berne Convention** and related treaties, the *core* of copyright is remarkably consistent worldwide:
+
+- Copyright is **automatic on creation** in essentially every country — no registration required (the rule from [the copyright lesson](/learn/software-licensing/copyright-and-software-ownership/)).
+- Foreign works get **national treatment** — a US program is protected in France roughly as a French one would be, and vice versa.
+- The basic exclusive rights (copy, modify, distribute) exist broadly.
+
+So your copyright follows your code abroad without you doing anything special. The divergence is in the *details* of ownership, what you can disclaim, how agreements are enforced, and — increasingly the biggest axis of all — what you must do with users' data. The rest of this lesson walks those axes.
+
+## Moral rights: strong in Europe, weak in the US
+
+This is one of the sharpest divides. **Moral rights** are rights that stay with the *human author* personally, separate from the economic copyright that can be sold or licensed. The main ones are:
+
+- **Attribution** — the right to be named as the author.
+- **Integrity** — the right to object to distortion or derogatory treatment of the work.
+
+In much of the **EU — France and Germany especially** — moral rights are strong and, importantly, often **cannot be fully waived or assigned**, even by contract. In the **US**, moral rights are narrow (largely confined to certain visual art) and effectively weak for software; you can generally waive them.
+
+The practical fallout: a "you irrevocably waive all rights, including moral rights" clause that's routine in a US contributor agreement may be **partly unenforceable** in a country where moral rights can't be waived. For most software this rarely surfaces, but it's a real reason blanket waivers don't always travel, and a consideration when you take contributions or contractor work from authors in moral-rights jurisdictions.
+
+## Copyright registration: a US norm, not a global one
+
+We noted this in [lesson two](/learn/software-licensing/copyright-and-software-ownership/); it's worth restating as a jurisdiction axis. In the **US**, registration is optional but valuable — a prerequisite to suing and the gateway to **statutory damages** and attorney's fees. Many other countries have **no registration system at all**; rights are automatic and that's it.
+
+So "register your copyright" is sound US-specific advice and a non-sequitur elsewhere. If you operate internationally, treat registration as a US enforcement tactic, not a universal step.
+
+## Warranty and liability disclaimers: how far they hold
+
+Look at almost any open-source license and you'll find SHOUTING CAPITALS like:
+
+```text
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND ...
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES ...
+```
+
+These **warranty disclaimers** and **liability limitations** are central to how licensors protect themselves. In the **US**, they're broadly enforceable (the caps-lock convention exists because US commercial law historically wanted disclaimers to be "conspicuous").
+
+But their reach varies a lot:
+
+- In the **EU and UK**, **consumer-protection law** limits how far you can disclaim warranties or exclude liability *to consumers*. Some exclusions — for instance, excluding liability for death or personal injury caused by negligence, or stripping a consumer's statutory rights — are **void regardless of what the agreement says**.
+- The **business-to-business vs business-to-consumer** distinction is critical: a disclaimer fully effective between two companies may be unenforceable against an individual consumer in the same jurisdiction.
+
+So treat "AS IS" as a strong default that protects you well in the US and in B2B contexts, but *not* as an absolute shield against consumer claims everywhere.
+
+## "License vs contract" varies by country
+
+We met this question in [License vs contract](/learn/software-licensing/license-vs-contract/). Its answer is itself jurisdiction-dependent. Whether an open-source license is treated as a **bare license** (violation = copyright infringement) or as a **contract** (violation = breach), and how things like consideration and assent are evaluated, differs across legal traditions:
+
+- **Common-law systems** (US, UK) lean on doctrines like consideration and have generated the case law treating open-source conditions as enforceable, sometimes as both license and contract.
+- **Civil-law systems** (much of Europe) frame contract formation differently and may analyze the same license through a different lens.
+
+The upshot: the *enforceability mechanics* of the very same license text can differ depending on where a dispute lands — another reason the next axis matters.
+
+## Governing law and forum-selection clauses
+
+Because the same words can be read differently in different places, well-drafted agreements try to pin down *where* and *under whose law* they'll be interpreted:
+
+- A **governing-law (choice-of-law)** clause: "This agreement is governed by the laws of [State/Country]."
+- A **forum-selection (jurisdiction)** clause: "Disputes shall be resolved in the courts of [place]."
+
+These add valuable predictability. But they are **not absolute**:
+
+- Courts can **decline to enforce** them, particularly against consumers, or where the chosen forum is wildly unfair.
+- **Mandatory local law** can apply *regardless* of the clause. A consumer's home country's consumer-protection rules — and, crucially, its data-protection law — often apply no matter which law the contract picked. You can't contract your way out of GDPR by choosing US law.
+
+| Axis | United States | Much of EU / UK |
+|---|---|---|
+| **Moral rights** | Weak for software; waivable | Strong (FR, DE); often not fully waivable |
+| **Copyright registration** | Optional but unlocks statutory damages | Often no system; rights automatic |
+| **Consumer warranty/liability disclaimers** | Broadly enforceable if conspicuous | Limited by consumer-protection law; some void |
+| **Governing-law clause respected?** | Generally, with limits | Yes, but mandatory consumer/data law overrides |
+
+## Data-protection law: a separate axis entirely
+
+Here's the axis that has grown from a footnote into a headline. Even if your *licensing* is perfectly sorted, if your software **collects or processes personal data**, you face a whole separate body of law that has nothing to do with copyright:
+
+- **GDPR** (EU) — sweeping rules on processing personal data, with extraterritorial reach (it can apply to you because of *where your users are*, not where *you* are) and large fines.
+- **CCPA/CPRA** (California) and a growing patchwork of US **state** privacy laws.
+- Many others — the UK, Brazil (LGPD), Canada, and more, each with their own requirements.
+
+Two things make this dangerous to overlook. First, these laws often apply based on the **user's location**, so a small team shipping worldwide can be on the hook for GDPR. Second, they are largely **mandatory** — a governing-law clause won't opt you out. This deserves real attention of its own; we cover it in [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/).
+
+## Practical advice for shipping worldwide
+
+You don't need to master every country's law to ship responsibly. A few pragmatic habits cover most of the ground:
+
+- **Use well-known, vetted licenses.** Standard open-source licenses (MIT, Apache, GPL) were drafted with international use in mind and behave predictably across borders. A bespoke license is a bespoke problem in every country.
+- **Don't rely on a single clause to do impossible work.** Assume your most aggressive disclaimers and waivers may be trimmed for consumers in some places, and don't build your business on them holding everywhere.
+- **Include sensible governing-law and forum clauses** — they help — but know they bow to mandatory local consumer and data law.
+- **Treat data protection as a first-class, separate workstream.** If you touch personal data, scope your obligations by where your *users* are, not just where you are.
+- **Get local advice for real exposure.** When you're selling at scale into a specific country or taking on real risk, a local attorney is cheap insurance — exactly the situation the disclaimer at the top of this lesson is about.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — mandatory local law, especially consumer-protection and data-protection rules, can apply regardless of a governing-law clause." markdown="0">
+  <p class="knowledge-check__q">Quick check: your EULA says it's governed by US law. Can that clause keep EU data-protection rules from applying to your EU users?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Yes — a governing-law clause overrides any other country's law for everyone</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">No — mandatory local law like GDPR can apply based on where users are, regardless of the clause</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only if the user explicitly opts out of US law in writing first</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Copyright's core is global** — automatic protection and national treatment hold almost everywhere via the Berne Convention; the *details* diverge.
+- **Moral rights differ sharply** — strong and often unwaivable in much of the EU, weak for software in the US, so blanket waivers don't always travel.
+- **Registration is a US norm** — valuable there for statutory damages, but absent in many countries.
+- **Disclaimers aren't absolute** — broadly enforceable in the US and B2B, but consumer-protection law (EU/UK) can limit or void them.
+- **Governing-law clauses help but bow to mandatory local law** — especially consumer-protection and data-protection rules.
+- **Data protection is a separate axis** — GDPR, CCPA, and others apply by user location and can't be contracted away; treat it as its own workstream.
+
+Next up: we leave the foundations and dig into what "open source" actually requires. See [What open source really means](/learn/software-licensing/what-is-open-source/).

--- a/docs/learn/software-licensing/main-clauses-decoded.md
+++ b/docs/learn/software-licensing/main-clauses-decoded.md
@@ -1,0 +1,140 @@
+---
+slug: main-clauses-decoded
+title: The main clauses, decoded
+description: A plain-English tour of the clauses in nearly every software agreement — license grant, permitted and prohibited use, fees, term and auto-renewal, termination and survival, confidentiality, IP ownership of your data and feedback, assignment, and the entire-agreement clause.
+keywords: software contract clauses explained, license grant, permitted use, prohibited use, fees and taxes, price changes, term and renewal, auto-renewal, termination, survival clause, confidentiality, IP ownership, feedback clause, assignment, change of control, entire agreement, amendment
+level: intermediate
+status: full
+faq:
+  - q: "What's the difference between the license grant and the restrictions clause?"
+    a: "The **grant** says what you *may* do — the scope of your permission (who can use it, for what, how many seats, perpetual or for the term). The **restrictions** list what you *may not* do — reverse-engineer, resell, exceed your seat count, benchmark, and so on. Read them together: your real rights are the grant minus the restrictions, and stepping outside either can end the license."
+  - q: "Who owns the data I put into a service, or the feedback I send the vendor?"
+    a: "Usually **you keep ownership of your data**, but you grant the provider a license to process it to run the service — read that license's scope carefully. **Feedback** is different and often overlooked: many agreements say any suggestions you send become the vendor's to use freely and forever. That's common, but worth knowing you're giving away."
+  - q: "What does 'survival' mean in a termination clause?"
+    a: "**Survival** lists the clauses that stay in force *after* the agreement ends — typically confidentiality, payment of amounts already owed, liability limits, and IP ownership. Termination doesn't wipe the slate clean; the surviving clauses keep binding you, sometimes indefinitely, so always check what survives before assuming an exit is a clean break."
+---
+# The main clauses, decoded
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Grant and restrictions define your real rights** — what you may do, minus what you may not. **Money clauses change over time** — watch fees, taxes, and unilateral price increases. **Term and renewal can auto-roll** — auto-renewal plus a notice window is the classic trap. **Termination has a survival list** — some clauses outlive the agreement. **IP clauses can reach your data and feedback** — know what you keep and what you give away.
+</div>
+
+You've learned [a method for reading any agreement](/learn/software-licensing/how-to-read-an-agreement/). Now we'll walk through the actual clauses you'll meet, one by one, and translate each into plain English: what it's for, what it really means, and why you should care. These same clauses appear, in some form, in almost every software agreement — a EULA, a SaaS contract, a commercial license. Learn them once and the next contract reads far faster. This lesson takes the *buyer/user* point of view; the [key commercial clauses](/learn/software-licensing/key-commercial-clauses/) lesson covers the same ground from the seller's side.
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+## The license grant and its scope
+
+The **grant** is the heart of the agreement — it's the permission itself. A well-drafted grant spells out its *scope* along several axes, and the scope is where the real meaning lives:
+
+- **Exclusive or non-exclusive** — almost always non-exclusive (others get the same software).
+- **Perpetual or for the term** — does the right last forever, or only while you keep paying?
+- **Revocable or irrevocable** — can they pull it back?
+- **Transferable or not** — can you pass it on, or is it locked to you?
+- **The permitted users and uses** — how many seats, which entities (you, your Affiliates?), internal use only or also for serving customers.
+
+A grant that says "non-exclusive, non-transferable, revocable license for internal business use by up to ten Authorized Users for the Subscription Term" is a very different thing from "perpetual, irrevocable license." Read every adjective; each one narrows what you actually get.
+
+## Permitted and prohibited use
+
+Right after the grant, agreements list what you **may not** do. Common restrictions: no reverse engineering, no reselling or sublicensing, no removing notices, no exceeding your seat or usage limits, no using the software to build a competing product, and sometimes no publishing benchmarks. 
+
+Your real rights are **the grant minus the restrictions**. A generous-sounding grant can be hollowed out by a long restrictions list, so read them as a pair. And note: violating a restriction often doesn't just breach the contract — it can put you *outside* the license entirely, which (as the [license-vs-contract](/learn/software-licensing/license-vs-contract/) lesson explained) can make your use copyright infringement.
+
+## Fees, taxes, and price changes
+
+The money clause is more than a number. Watch for:
+
+- **What the fee covers and how it's metered** — per seat, per usage, flat. Does it scale in a way you control?
+- **Taxes** — most agreements make *you* responsible for applicable taxes on top of the listed price.
+- **Payment terms** — net 30, late fees, suspension for non-payment.
+- **Price changes** — the clause that lets the vendor raise prices, often "upon renewal" or sometimes "upon notice." A **unilateral price-increase** clause means the cost you signed up for is not the cost you're locked into.
+
+The headline price is what gets advertised; the price-change clause is what you'll actually pay over the years.
+
+## Term, renewal, and the auto-renewal trap
+
+The **term** clause sets how long the agreement lasts. The part to slow down on is **renewal** — specifically **automatic renewal**.
+
+```text
+This Agreement renews automatically for successive one-year terms unless
+either party gives written notice of non-renewal at least sixty (60) days
+before the end of the then-current term.
+```
+
+Read that carefully. It renews *by default*. To stop it, you must act, in writing, inside a **notice window** (here, 60 days before the end). Miss the window by a day and you're locked in — and billed — for another full year. Auto-renewal isn't inherently abusive; it's everywhere. But the combination of auto-renewal *and* a long notice window is a classic way to keep customers paying past the point they meant to leave. Calendar the deadline the day you sign.
+
+## Termination and survival
+
+The **termination** clause says how the agreement ends: at the end of the term, for convenience (either side, with notice), or for cause (a breach the other side didn't cure). Read it for symmetry — can *you* exit as easily as they can?
+
+Then read what **survives**. A **survival clause** lists the provisions that remain in force after termination — typically:
+
+- **Confidentiality** (often for years afterward)
+- **Payment** of amounts already owed
+- **Limitation of liability** and **disclaimers**
+- **IP ownership**
+
+Termination is not a reset button. The surviving clauses keep binding you, so "we can cancel anytime" is only half the story — check what stays alive after you do.
+
+## Confidentiality
+
+The **confidentiality** clause defines what information each side must keep secret, for how long, and the carve-outs (information already public, independently developed, or legally compelled). If the agreement is mutual, it binds both ways; sometimes it's one-sided. Note the duration — confidentiality obligations commonly survive termination for a fixed number of years, occasionally forever for trade secrets. NDAs get their own treatment in [NDAs & the rest of the landscape](/learn/software-licensing/nda-and-other-agreements/).
+
+## Intellectual-property ownership — including yours
+
+This clause settles who owns what. Three pieces matter to you:
+
+1. **The vendor's IP stays the vendor's.** Standard — you're licensed, not buying ownership.
+2. **Your data.** Usually *you* keep ownership of the data you put into a service, but you grant the provider a **license** to process it to deliver the service. Read that license's scope: does it allow only running the service, or also "improving our products," training, or analytics? (We go deeper in [Privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/).)
+3. **Feedback.** Easy to miss: many agreements say any **feedback, suggestions, or ideas** you send the vendor become *theirs* to use freely, forever, with no obligation to you. That's common and usually fine — but you should know you're handing it over.
+
+## Assignment and change of control
+
+**Assignment** governs whether either party can transfer the agreement to someone else. The clause to watch: can the vendor **assign on a change of control** — say, when they're acquired — so your contract ends up with a company you'd never have chosen? Many agreements let the vendor assign freely while restricting *you* from doing the same. Note the asymmetry.
+
+## Entire agreement and amendment
+
+Two short clauses with outsized effect:
+
+- **Entire agreement (merger clause)** — states that the written agreement is the *complete* deal and supersedes all prior discussions. Translation: that promise the salesperson made in an email **doesn't count** unless it's in the document. If a commitment matters, get it written into the agreement.
+- **Amendment** — how the terms can change. The safe version requires a signed writing from both sides. The risky version lets the vendor **change the terms unilaterally** (common in consumer terms of service: "we may update these terms; continued use is acceptance").
+
+## A clause-by-clause reference
+
+| Clause | Plain meaning | Why you care |
+|---|---|---|
+| **License grant** | What you may do, and the scope of it | Defines your core rights — read every adjective |
+| **Restrictions** | What you may not do | Hollows out the grant; breaking one can void the license |
+| **Fees & taxes** | What you pay, plus tax | Taxes and metering can exceed the headline price |
+| **Price changes** | When the vendor can raise prices | The signed price may not be the locked-in price |
+| **Term & renewal** | How long, and auto-renewal | Miss the notice window, get billed another term |
+| **Termination** | How it ends, by whom | Check whether *you* can exit as easily as they can |
+| **Survival** | Which clauses outlive the agreement | Ending the deal doesn't end every obligation |
+| **Confidentiality** | What stays secret, for how long | Can bind you for years after termination |
+| **IP ownership** | Who owns the software, your data, your feedback | You may be licensing your data and giving away feedback |
+| **Assignment** | Who can transfer the deal | You could end up bound to a company you didn't choose |
+| **Entire agreement** | Only the written terms count | Side promises don't bind unless they're in the document |
+| **Amendment** | How terms change | A unilateral-change clause means the deal can shift under you |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a survival clause lists the provisions (like confidentiality and liability limits) that stay binding even after the agreement ends." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a "survival" clause do in a software agreement?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It guarantees the software keeps running if the vendor goes out of business</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It lets you survive a price increase by locking in your original rate</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It lists the clauses that stay in force after the agreement is terminated</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Grant minus restrictions equals your real rights** — read the scope adjectives and the prohibited-use list together.
+- **Money clauses evolve** — taxes, metering, and unilateral price increases can push the cost past the headline number.
+- **Auto-renewal plus a notice window is the classic trap** — calendar the cancellation deadline the day you sign.
+- **Termination isn't a clean break** — the survival clause keeps confidentiality, payment, and liability terms alive afterward.
+- **IP clauses can reach your data and feedback** — you usually keep your data but license it, and you may be giving feedback away outright.
+- **Boilerplate bites** — the entire-agreement clause kills side promises, and an amendment clause can let terms change unilaterally.
+
+Next up: the clauses that decide who actually pays when something goes wrong — warranties, liability caps, and indemnity. See [The risk clauses](/learn/software-licensing/risk-clauses/).

--- a/docs/learn/software-licensing/mit-and-bsd-licenses.md
+++ b/docs/learn/software-licensing/mit-and-bsd-licenses.md
@@ -1,0 +1,134 @@
+---
+slug: mit-and-bsd-licenses
+title: "MIT & BSD: minimal permissive"
+description: A walkthrough of the MIT and BSD licenses — the shortest, most permissive open-source licenses. See the grant, the keep-this-notice condition, the warranty disclaimer, the BSD non-endorsement clause, and where their minimalism helps and hurts.
+keywords: MIT license, BSD license, BSD 2-clause, BSD 3-clause, permissive license, warranty disclaimer, copyright notice, non-endorsement clause, open source, patent grant, license compatibility, closed-source fork
+level: beginner
+status: full
+faq:
+  - q: "What's the actual difference between MIT and BSD?"
+    a: "They're almost identical in effect — both are short permissive licenses that ask you to keep the copyright and license notice and disclaim warranty. The **3-clause BSD** adds a non-endorsement clause (you can't use the author's name to promote your product without permission); the **2-clause BSD** drops that and is essentially equivalent to MIT. Pick by taste; all three are maximally compatible."
+  - q: "Does the MIT license give me a patent license?"
+    a: "Not explicitly, and that's its main gap. MIT and BSD grant **copyright** permissions in plain language but say nothing clear about **patents**. If patent exposure matters to you, prefer [Apache 2.0](/learn/software-licensing/apache-license/), which includes an express patent grant and a retaliation clause."
+  - q: "Can someone take my MIT-licensed code and make it closed source?"
+    a: "Yes. Permissive licenses allow closed-source forks — anyone can build a proprietary product on your MIT or BSD code, as long as they keep your notice. If you want to prevent that and require changes to stay open, you want a [copyleft license](/learn/software-licensing/permissive-vs-copyleft/) instead."
+---
+# MIT & BSD: minimal permissive
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The minimalist permissive licenses** — MIT and BSD are among the shortest licenses in wide use. **Three parts** — a broad grant, one condition (keep the notice), and a warranty disclaimer. **BSD adds clauses** — 2-clause is MIT-like; 3-clause adds a non-endorsement clause. **Maximally compatible, with gaps** — simple and business-friendly, but no patent grant and no copyleft protection.
+</div>
+
+If you've used open-source software, you've used MIT- and BSD-licensed code — they're the most common permissive licenses on the planet. Their appeal is their brevity: you can read the entire MIT license in under a minute, and once you understand its three moving parts you understand most permissive licensing. By the end of this lesson you'll be able to read the MIT and BSD texts and know exactly what they grant and require, tell the BSD 2-clause and 3-clause variants apart, and weigh their strengths (simplicity, compatibility, adoption) against their real gaps (no patent grant, no copyleft protection, closed-source forks allowed).
+
+## The MIT license, walked through
+
+The MIT license is short enough to read in full. Here it is, with the placeholder fields a project fills in:
+
+```text
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following condition:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. ...
+```
+
+It has exactly three parts:
+
+### 1. The grant
+
+The middle paragraph is the **grant** — and it's about as broad as a license can be. You may "use, copy, modify, merge, publish, distribute, sublicense, and/or sell" the software, and let others do the same. Note that **sell** is right there in the list: MIT-licensed code can be used in commercial products without restriction. "Sublicense" means you can pass the code along under different terms as part of your own work.
+
+### 2. The one condition
+
+There's a single string attached: **"The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software."** In other words — keep the notice. When you ship MIT-licensed code (or a substantial chunk of it), you must include the original copyright line and the license text. That's the entire compliance obligation. It's why a complete product can contain hundreds of MIT notices bundled in an attribution file. We cover doing this properly in [Meeting permissive obligations](/learn/software-licensing/permissive-compliance/).
+
+### 3. The warranty disclaimer
+
+The shouting all-caps paragraph at the end is the **warranty disclaimer**. It says the software is provided "AS IS," with no warranty of any kind — not of merchantability, not of fitness for a purpose, not of non-infringement. The capitals are a legal convention for "conspicuous" disclaimers. The point is to protect the author: if the code breaks something, you can't come after them. Almost every open-source license has a clause like this; we look at why in [The risk clauses](/learn/software-licensing/risk-clauses/).
+
+## The BSD licenses
+
+The **BSD** licenses (from the Berkeley Software Distribution) are the other minimalist family. They come in numbered variants for the number of clauses they carry.
+
+### BSD 2-clause
+
+The 2-clause BSD ("Simplified BSD") has the same shape as MIT: a grant, a keep-the-notice condition (it spells out that the notice must appear in both source and binary distributions), and a warranty disclaimer. For practical purposes it is equivalent to MIT.
+
+### BSD 3-clause
+
+The 3-clause BSD ("New" or "Modified" BSD) adds one extra clause — the **non-endorsement clause**:
+
+```text
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+```
+
+This says you can't use the original author's or organization's name to advertise your product. Build whatever you like on the code, but don't imply they endorse it. That's the only meaningful difference from the 2-clause version, and it's why many companies and projects prefer 3-clause BSD — it adds a touch of name protection at no cost to permissiveness. (An older "4-clause" BSD existed with an advertising requirement; it caused compatibility headaches and is effectively retired — avoid it.)
+
+## How they compare
+
+| | **MIT** | **BSD 2-clause** | **BSD 3-clause** |
+|---|---|---|---|
+| Grant breadth | Very broad (use, modify, sell, sublicense) | Very broad | Very broad |
+| Keep copyright/license notice | Yes | Yes (source and binary) | Yes (source and binary) |
+| Warranty disclaimer | Yes | Yes | Yes |
+| Non-endorsement clause | No | No | **Yes** |
+| Explicit patent grant | No | No | No |
+| Copyleft protection | No | No | No |
+| Practical equivalence | ≈ BSD 2-clause | ≈ MIT | MIT + name protection |
+
+The honest summary: all three are nearly the same license, and choosing among them is mostly a matter of taste and whether you want the non-endorsement clause.
+
+## Strengths
+
+These licenses are popular for good reasons:
+
+- **Simple and readable.** You can understand the whole thing in one sitting — no lawyer required to grasp the basics.
+- **Maximally compatible.** Because they impose so few conditions, MIT and BSD code can be combined with almost anything, including copyleft and proprietary code. This makes them the safe default for libraries meant to be widely reused. We'll see why compatibility matters in [License compatibility](/learn/software-licensing/license-compatibility/).
+- **Business-friendly.** No obligation to open your own code means companies adopt them without legal hand-wringing.
+- **Huge adoption.** A vast amount of the modern software ecosystem — front-end frameworks, utility libraries, language runtimes — is MIT or BSD, so they're familiar to everyone.
+
+## Weaknesses
+
+The same minimalism is also where they fall short:
+
+- **No patent grant.** MIT and BSD speak the language of copyright and say nothing clear about patents. A contributor could, in theory, contribute code and still assert a patent against users of it. If that risk matters to you, [Apache 2.0](/learn/software-licensing/apache-license/) was designed to close exactly this gap with an explicit patent license.
+- **No copyleft protection.** Nothing requires anyone to share their improvements. A company can take your MIT library, improve it substantially, and ship the result as closed source, giving nothing back.
+- **Closed-source forks allowed.** This follows directly — if you want to *prevent* proprietary forks and force improvements to stay open, a permissive license is the wrong tool; you want [copyleft](/learn/software-licensing/permissive-vs-copyleft/).
+
+None of these are bugs — they're the deliberate consequences of choosing "make it easy to use" over "make it stay free." Whether they're acceptable depends entirely on your goals, which is the subject of [Choosing an open-source license](/learn/software-licensing/choosing-an-oss-license/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the 3-clause BSD's extra clause is the non-endorsement clause; the rest matches the 2-clause and MIT." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does the BSD 3-clause license add over the 2-clause version?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A requirement to release your changes under the same license</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">An explicit patent grant from contributors</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A non-endorsement clause barring use of the author's name to promote your product</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Minimal permissive licenses** — MIT and BSD are among the shortest and most widely used open-source licenses.
+- **Three parts** — a broad grant (including the right to sell), one condition (keep the copyright and license notice), and a warranty disclaimer.
+- **BSD variants** — 2-clause is essentially MIT; 3-clause adds a non-endorsement clause protecting the author's name.
+- **Strengths** — simple, maximally compatible, business-friendly, and hugely adopted.
+- **Weaknesses** — no explicit patent grant, no copyleft protection, and closed-source forks are allowed.
+
+Next up: a permissive license that keeps the freedom but closes the patent gap. See [Apache 2.0: permissive with a patent grant](/learn/software-licensing/apache-license/).

--- a/docs/learn/software-licensing/nda-and-other-agreements.md
+++ b/docs/learn/software-licensing/nda-and-other-agreements.md
@@ -1,0 +1,113 @@
+---
+slug: nda-and-other-agreements
+title: NDAs & the rest of the landscape
+description: Round out the agreement landscape — NDAs and confidentiality, the MSA plus SOW structure for B2B deals, acceptable use policies, beta and trial agreements, partner/reseller terms, and developer/API terms, and how they all fit with the license.
+keywords: NDA, non-disclosure agreement, confidentiality agreement, mutual NDA, one-way NDA, MSA, master service agreement, statement of work, SOW, order form, acceptable use policy, AUP, beta agreement, evaluation agreement, reseller agreement, API terms, developer terms
+level: beginner
+status: full
+faq:
+  - q: "What's the difference between a one-way and a mutual NDA?"
+    a: "A **one-way (unilateral) NDA** protects one side's secrets — typical when only one party is sharing, like a company showing a contractor its plans. A **mutual NDA** protects both sides because both will share confidential information — common when two companies explore a partnership. Mutual is the default when the conversation is genuinely two-directional; the obligations are otherwise much the same."
+  - q: "Why split a B2B deal into an MSA plus a SOW or order form?"
+    a: "It separates the *stable legal terms* from the *deal-specific details*. The **Master Service Agreement (MSA)** is negotiated once and covers liability, IP, confidentiality, and the like; each new project or purchase is then a short **Statement of Work (SOW)** or **order form** referencing the MSA. You re-negotiate the heavy terms once, then move fast on each subsequent deal."
+  - q: "Does an NDA make information confidential just because it says so?"
+    a: "Not by itself. An NDA defines *what counts* as confidential and obliges the recipient to protect it, but it also includes **carve-outs** — information that's already public, independently developed, or rightfully obtained elsewhere isn't covered. And to keep trade-secret protection you generally must actually treat the information as secret, not just paper it. The agreement is one part of a broader practice."
+---
+# NDAs & the rest of the landscape
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**NDAs protect secrets** — one-way or mutual, with a defined scope, a term, and carve-outs. **MSA + SOW structures B2B deals** — negotiate the heavy terms once, then add short order forms. **AUPs set usage boundaries** — what users may not do on a service. **Beta, partner, and API terms** cover special relationships. **It all clips onto the license** — the license grants permission; these agreements govern the relationships around it.
+</div>
+
+This module has worked through the agreements your software shows users — [EULAs and terms of service](/learn/software-licensing/eula-and-tos/), [privacy and data agreements](/learn/software-licensing/privacy-and-data-agreements/), and [SLAs and support](/learn/software-licensing/sla-and-support-agreements/). This final lesson rounds out the landscape: the confidentiality agreements that protect what you share, the contract *structure* B2B vendors use, and the specialized terms for betas, partners, and developers. None of these replace the license — they sit *around* it. By the end you'll recognize each agreement, know what it governs, and understand when you reach for it.
+
+> **This is educational material, not legal advice.** For agreements that carry real risk, have a qualified attorney review them before you sign.
+
+## NDAs and confidentiality
+
+A **Non-Disclosure Agreement (NDA)** — also called a confidentiality agreement — is a contract where one or both parties promise to protect information the other shares. You sign them constantly: before a partnership talk, when hiring a contractor, during due diligence, or when showing pre-release plans. NDAs are also one of the main ways you protect a [trade secret](/learn/software-licensing/other-ip-in-software/), which keeps its legal status only as long as you actually keep it secret.
+
+**One-way vs mutual.** A **one-way (unilateral)** NDA protects a single side's information — appropriate when only one party is disclosing, such as a company briefing a freelancer. A **mutual (bilateral)** NDA protects both, which is the norm when two organizations will each reveal something, like two companies scoping a deal. The obligations look similar either way; the difference is *who is protected*.
+
+Whatever the direction, the substance turns on a few clauses:
+
+- **Definition of "Confidential Information."** What's actually covered — often anything marked confidential, plus anything a reasonable person would treat as such.
+- **Carve-outs (exclusions).** Information that's *not* covered: already public, already known to the recipient, independently developed, or rightfully received from a third party. These keep an NDA from absurdly locking up public facts.
+- **Permitted use and recipients.** The recipient may use the information only for the agreed purpose and may share it only with people who need it and are themselves bound.
+- **Term.** How long the duty lasts — a fixed number of years after disclosure, though genuine trade secrets are sometimes protected for as long as they stay secret.
+- **Return or destruction.** What happens to the information when the relationship ends.
+
+A common misconception is that signing an NDA *makes* information confidential. It doesn't, on its own — the carve-outs still apply, and you must back the paper with actual secrecy practices for it to mean much.
+
+## MSA + SOW: the structure of B2B deals
+
+Business-to-business software and services rarely live in one big document. The standard pattern splits the stable legal terms from the deal-specific details:
+
+- The **Master Service Agreement (MSA)** is the master contract, negotiated once. It carries the heavy, slow-to-agree terms: liability limits, indemnification, IP ownership, confidentiality, warranties, governing law, termination — the [risk clauses](/learn/software-licensing/before-you-agree/) you don't want to re-fight on every order.
+- A **Statement of Work (SOW)** or **order form** then describes a single engagement *under* the MSA: the specific scope, deliverables, timeline, and price. It's short, because it inherits all the legal terms from the MSA by reference.
+
+```text
+  Master Service Agreement (MSA)        <- the heavy terms, signed once
+    ├── SOW #1: build the data pipeline   (scope, dates, price)
+    ├── Order form: 50 seats, 12 months   (quantity, term, fees)
+    └── SOW #2: migration project         (scope, dates, price)
+```
+
+The payoff is speed without re-litigating fundamentals: agree the MSA once, then each new project or purchase is a quick SOW or order form. When you review a B2B deal, read the MSA *and* the SOW together — a friendly-looking order form may be carrying very serious MSA terms beneath it.
+
+## Acceptable Use Policy (AUP)
+
+An **Acceptable Use Policy** spells out what users may *not* do with a service — no illegal activity, no spam, no hacking or probing, no overloading the system, no infringing others' rights. It's often broken out of the [terms of service](/learn/software-licensing/eula-and-tos/) into its own document so the provider can update the rules of conduct without reopening the main contract. Violating the AUP is typically grounds for suspension or termination, which ties it back to the termination clause in the ToS.
+
+## Beta, evaluation, and trial agreements
+
+Before a product is generally available — or before a customer commits — special short-term agreements apply. **Beta (or evaluation/trial) agreements** cover pre-release or time-limited access, and they differ from normal terms in predictable ways: they grant a **limited, temporary** right to use; they disclaim warranties even more firmly ("provided as-is, may break"); they often add **feedback** and confidentiality clauses (the beta itself may be a secret); and they make clear the provider can change or pull the product at any time. If you're evaluating software, read these for what survives the trial — especially any clause about who owns feedback or what happens to your data when the trial ends.
+
+## Partner, reseller, and developer/API terms
+
+Two more relationship types round out the picture:
+
+- **Partner and reseller agreements** govern others selling or building on your product — resellers, distributors, affiliates, integration partners. They cover who may sell to whom, in what territory, at what margin or referral fee, branding rules, and how the end customer's license is granted (directly by you, or sublicensed through the partner).
+- **Developer / API terms** govern third parties that build on your **API** or platform. They set rate limits and acceptable use, restrict scraping and competing uses, address ownership of data passing through, and often reserve the right to change or deprecate the API. If your product exposes an API, these terms are what keep that ecosystem healthy and within bounds.
+
+## How it all fits together with the license
+
+Step back and the whole landscape clicks into place. The **license** is the foundation — it grants the permission to use the software at all, the subject of [what is a software license](/learn/software-licensing/what-is-a-software-license/). Everything in this module clips onto that foundation to govern a *relationship* around the licensed software: terms of service set the rules of use, the privacy policy and DPA govern data, the SLA and support agreement set service quality, the NDA protects what's shared, the MSA/SOW structures a B2B deal, and AUP, beta, partner, and API terms handle specific situations.
+
+| Agreement | What it governs | When you need it |
+|---|---|---|
+| **License / EULA** | Permission to use the software/copy | Always — it's the foundation |
+| **Terms of service** | Rules for using an online service | You run a service/site/app |
+| **Privacy policy** | What you do with personal data | You collect personal data (often legally required) |
+| **DPA** | A vendor processing data for you | A processor handles personal data on your behalf |
+| **SLA** | Availability/performance promises | You sell an ongoing service |
+| **Support agreement** | Help: tiers, response, coverage | You offer paid support |
+| **NDA** | Protecting shared confidential info | Before sharing secrets with anyone |
+| **MSA + SOW** | The legal frame + each deal's scope | Repeat B2B sales/services |
+| **AUP** | What users may not do | A multi-user service needs conduct rules |
+| **Beta / trial** | Limited pre-release/evaluation use | You offer betas, trials, or evaluations |
+| **Partner / reseller** | Others selling/distributing your product | You sell through a channel |
+| **Developer / API terms** | Third parties building on your API | You expose an API or platform |
+
+You won't need all of these — most products use a handful. The skill is recognizing which relationships your software actually creates and reaching for the matching agreement. That's exactly what the final module turns into a decision you can make for your own project.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the MSA holds the heavy legal terms negotiated once, and each new project or purchase is a short SOW or order form referencing it." markdown="0">
+  <p class="knowledge-check__q">Quick check: a vendor wants to sell you several projects over time without re-negotiating liability and IP each time. What structure fits?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A fresh standalone contract with full legal terms for every single project</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A one-way NDA that also covers pricing and deliverables</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A Master Service Agreement for the heavy terms, plus a short SOW or order form per project</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **NDAs protect confidential information** — one-way or mutual, with a defined scope, carve-outs for public/independent info, a term, and the actual-secrecy practices that back them.
+- **MSA + SOW structures repeat B2B deals** — heavy legal terms negotiated once in the MSA, deal specifics in each short SOW or order form.
+- **An AUP sets conduct rules** — what users may not do, often split out of the terms of service so it can be updated independently.
+- **Beta, partner, and developer terms cover special relationships** — temporary trials, channel sales, and third parties building on your API.
+- **Everything clips onto the license** — the license grants permission; these agreements govern the relationships built around the licensed software.
+
+Next up: with the whole agreement landscape in view, the path turns to choosing what *your* project needs. See [A framework for choosing](/learn/software-licensing/the-decision-framework/).

--- a/docs/learn/software-licensing/open-source-risks.md
+++ b/docs/learn/software-licensing/open-source-risks.md
@@ -1,0 +1,109 @@
+---
+slug: open-source-risks
+title: The risks of depending on open source
+description: Depending on open source carries real risks beyond "is it free" — license rug pulls, maintainer burnout and abandonment, supply-chain attacks, transitive license surprises, and audit exposure. Learn each risk and how to mitigate it.
+keywords: open source risks, license rug pull, Redis SSPL, HashiCorp BSL, Elastic relicensing, maintainer burnout, supply chain attack, xz backdoor, typosquatting, transitive dependencies, SBOM, dependency pinning, vendoring, open source compliance risk
+level: intermediate
+status: full
+faq:
+  - q: "What is a license 'rug pull' in open source?"
+    a: "It's when a project that built its user base as open source switches to a restrictive license, so existing users can no longer use new versions under the old terms. Redis moving to SSPL, HashiCorp's Terraform moving to the BSL, and Elastic's relicensing are the well-known examples. The old versions usually stay under the old license, but future development moves behind the new one."
+  - q: "How can a free dependency become a security risk?"
+    a: "Open-source packages are a prime **supply-chain** target. Attackers publish typosquatted package names, hijack abandoned packages, or — as in the **xz** backdoor — patiently gain maintainer trust and slip in malicious code. Because you pull dependencies automatically, a compromised package runs with your application's privileges."
+  - q: "How do I reduce open-source dependency risk without avoiding open source?"
+    a: "**Pin** exact versions so you control upgrades, consider **vendoring** critical dependencies so you're not at the mercy of a registry, generate an **SBOM** to know exactly what you ship, and audit licenses regularly. The goal isn't to avoid open source — it's to know what you depend on and stay able to comply."
+---
+# The risks of depending on open source
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The risk isn't only "is it free"** — license changes, abandonment, and security all matter as much as price. **Rug pulls happen** — vendors relicense projects to restrictive terms (Redis, HashiCorp, Elastic), stranding users. **Supply-chain risk is real** — typosquatting, hijacked packages, and the xz backdoor show how a free dependency can carry an attack. **Mitigate, don't avoid** — pin versions, vendor critical code, generate SBOMs, and audit licenses to stay in control and in compliance.
+</div>
+
+Open source is one of the best deals in software, but "free to use" is not the same as "free of risk." Depending on someone else's code means inheriting their licensing decisions, their maintenance energy, and their security. This lesson surveys the risks that actually bite teams — license rug pulls, abandonment, supply-chain attacks, transitive license surprises, and audit exposure — and the concrete habits that keep those risks manageable. By the end you'll be able to depend on open source with your eyes open rather than your fingers crossed.
+
+## License changes and "rug pulls"
+
+The first risk is the one this whole path equips you to see: the license can **change**. A project can be released under a permissive or copyleft license for years, build a huge user base, and then — usually when a company decides it needs to monetize or defend against cloud competitors — switch to far more restrictive terms.
+
+Recent, high-profile examples:
+
+- **Redis** moved from BSD to a dual SSPL/RSAL scheme (and the community forked it as Valkey).
+- **HashiCorp** moved Terraform and its other tools from the Mozilla Public License to the **Business Source License (BSL)** (the community forked Terraform as OpenTofu).
+- **Elastic** relicensed Elasticsearch from Apache-2.0 to SSPL/Elastic License (Amazon forked it as OpenSearch).
+
+These are often called **rug pulls** because users who adopted the software as open source suddenly can't use new versions under the old terms. Typically the *old* releases stay under the *old* license — copyright already granted can't be revoked — but all future development moves behind the new, restrictive license. If you depend on the project, you're stuck choosing between an aging fork, accepting the new terms, or migrating.
+
+The terms these vendors move *to* are usually **source-available** licenses — you can read the source, but you can't use it freely (often with a "no competing service" clause). That category is important enough to get its own lesson: [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/). The mitigation here is awareness: prefer projects under standard licenses with broad governance (e.g. foundation-stewarded projects are far less likely to rug-pull than single-vendor ones), and know that any single-company open-source project *can* relicense — that's the [relicensing](/learn/software-licensing/dual-licensing-and-relicensing/) power we just studied, pointed at users.
+
+## Abandonment and maintainer burnout
+
+The second risk is quieter: the project just **stops**. A huge amount of critical infrastructure is maintained by one or a few unpaid people, and burnout, life changes, or loss of interest can end maintenance with no notice. The dependency doesn't disappear — it simply stops getting bug fixes, security patches, and compatibility updates.
+
+An abandoned dependency is a slow-motion problem: it works until a security flaw is found, a platform changes underneath it, or a transitive dependency breaks — and now *you* own a fix for code you didn't write. Warning signs to check before you adopt: when was the last commit? How many maintainers? Is there a release cadence? A single-maintainer package with no activity in two years is a liability even if it works today.
+
+Mitigation is partly about choosing well-supported dependencies and partly about being ready to step in — which is much easier if you've **vendored** the code (kept a copy in your own tree) so you can patch it yourself if you must.
+
+## Supply-chain and provenance risk
+
+The third risk turns a free dependency into an attack vector. Because modern projects pull packages automatically from public registries, the registry — and every package in it — is part of your **supply chain**. Attackers exploit this in several ways:
+
+- **Typosquatting.** A malicious package is published under a name one keystroke away from a popular one (`reqeusts` for `requests`), hoping you'll fat-finger the install.
+- **Hijacked / compromised packages.** An attacker gains control of an existing trusted package — through stolen credentials or by taking over an abandoned one — and pushes a malicious update that flows straight into everyone who upgrades.
+- **The long con.** The **xz Utils backdoor** (2024) is the cautionary tale: an attacker spent *years* building maintainer trust on a widely used compression library, then slipped in a backdoor targeting SSH. It was caught almost by accident. It showed that even careful provenance can be subverted by patience.
+
+Because dependencies run with your application's privileges, a compromised one can read your secrets, exfiltrate data, or open a backdoor. **Provenance** — knowing where a package came from, who published it, and that it hasn't been tampered with — is the defense. In practice that means pinning to known-good versions, verifying checksums/signatures where available, and not blindly auto-upgrading.
+
+## Transitive dependency license surprises
+
+The fourth risk is a licensing one. You carefully choose a permissive direct dependency — but *it* depends on something else, which depends on something else. Your real license exposure is the **whole transitive tree**, and a copyleft or source-available license can hide several layers down.
+
+A classic surprise: you ship a closed-source product, your direct dependencies are all MIT/Apache, but one of them transitively pulls in a GPL library. Per [license compatibility](/learn/software-licensing/license-compatibility/), that GPL component can force obligations onto your distributable work that you never intended to take on. You can't manage what you can't see, which is the whole reason for systematic dependency auditing.
+
+## Legal and audit exposure
+
+The fifth risk is the consequence of all the above: if you ship software you can't legally comply with, you carry **audit and legal exposure.** Missing attribution, an undetected copyleft obligation, or a source-available license used outside its terms can surface during a security audit, an acquisition due-diligence review, or a customer's compliance check — exactly when it's most expensive. Acquirers routinely scan a target's dependency licenses; a single unmanaged copyleft component can reduce a company's valuation or sink a deal.
+
+This isn't hypothetical or rare; it's a standard part of corporate due diligence. The cost of getting it wrong is paid later and at a bad moment, which is why getting it right is cheap insurance.
+
+## Mitigation: stay in control of what you depend on
+
+None of this is an argument against open source — it's an argument for *managing* it. The core habits:
+
+| Practice | What it protects against |
+|---|---|
+| **Pin exact versions** | Surprise upgrades, hijacked-update supply-chain attacks |
+| **Vendor critical dependencies** | Abandonment, registry outages, rug pulls (you keep a working copy) |
+| **Generate an SBOM** (software bill of materials) | Transitive license/security surprises — you know exactly what you ship |
+| **Audit licenses regularly** | Compliance and acquisition-time legal exposure |
+| **Prefer well-governed projects** | Rug pulls and single-maintainer abandonment |
+| **Verify provenance** (checksums, signatures) | Typosquatting and tampered packages |
+
+```bash
+# GopherTrunk keeps a license inventory and attribution file so
+# transitive surprises and compliance gaps surface in CI, not in an audit.
+make licenses
+```
+
+The throughline: know what you depend on, control when it changes, and keep enough of a copy and a record that a vendor's decision can't strand you. The mechanics of doing this systematically — generating SBOMs, scanning the dependency tree, producing an attribution file like GopherTrunk's `/THIRD_PARTY_LICENSES.md` — are covered in depth in [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Redis, HashiCorp, and Elastic all relicensed established open-source projects to restrictive terms, stranding users on the old versions." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is a license "rug pull"?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A security flaw that lets an attacker revoke your license remotely</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">When a project relicenses to restrictive terms, so users can't use new versions under the old open-source license</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">A bug where a dependency silently downgrades to an older, vulnerable version</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Look past "is it free"** — license changes, abandonment, and security are as real as price.
+- **Rug pulls happen** — Redis, HashiCorp, and Elastic relicensed to restrictive terms; single-vendor projects are the ones most likely to do it.
+- **Abandonment is a slow-motion risk** — an unmaintained dependency works until a security flaw or platform change makes it your problem.
+- **Open source is a supply-chain target** — typosquatting, hijacked packages, and the xz backdoor show how a dependency can carry an attack.
+- **Your exposure is the whole transitive tree** — copyleft or source-available licenses can hide several layers down and surface at audit time.
+- **Mitigate, don't avoid** — pin versions, vendor critical code, generate SBOMs, audit licenses, and prefer well-governed projects.
+
+Next up: we shift from open source to the other side of the spectrum — how closed, commercial software is licensed. See [Proprietary & closed-source licensing](/learn/software-licensing/proprietary-licensing/).

--- a/docs/learn/software-licensing/other-ip-in-software.md
+++ b/docs/learn/software-licensing/other-ip-in-software.md
@@ -1,0 +1,110 @@
+---
+slug: other-ip-in-software
+title: Patents, trademarks & trade secrets
+description: Copyright is only one of four kinds of intellectual property around software. Learn how patents, trademarks, and trade secrets work, why license patent grants matter, and why open-source licenses don't give away trademarks.
+keywords: software intellectual property, software patents, trademarks open source, trade secrets, patent grant license, project name trademark, NDA confidentiality, IP types software, patent troll, copyright vs patent
+level: beginner
+status: full
+faq:
+  - q: "Do open-source licenses let me use the project's name and logo too?"
+    a: "Generally **no**. Open-source licenses grant copyright (and sometimes patent) rights to the *code*, but they almost always **exclude trademark rights** — the project's name and logo. You can fork and ship the code, but you usually can't call your version by the original name or use its logo in a way that implies endorsement. Apache 2.0, for instance, explicitly says it grants no trademark rights."
+  - q: "Why do some licenses include a patent grant if the code is already copyrighted?"
+    a: "Because copyright and patents are **different rights**. A copyright license lets you copy and modify the code, but a contributor could still hold a **patent** covering what the code does and sue you for using it. A patent grant — like the one in [Apache 2.0](/learn/software-licensing/apache-license/) — closes that gap by promising contributors won't assert their patents against users of the project."
+  - q: "Is keeping my source code secret a form of legal protection?"
+    a: "Yes — it's the basis of **trade secret** protection. Information that has value *because* it's secret, and that you take reasonable steps to keep secret, can be protected as a trade secret indefinitely. The catch is that protection evaporates the moment the secret leaks or is independently discovered, which is why companies pair secrecy with **NDAs** and access controls."
+---
+# Patents, trademarks & trade secrets
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Four kinds of IP surround software** — copyright, patents, trademarks, and trade secrets, each protecting something different. **Patents cover inventions, not expression** — they're why some licenses include a patent grant. **Trademarks protect names and logos** — and open-source licenses generally don't give them away. **Trade secrets protect what stays hidden** — valuable as long as it's kept secret, backstopped by NDAs.
+</div>
+
+The [last lesson](/learn/software-licensing/copyright-and-software-ownership/) showed that copyright protects the *expression* of your code but not the underlying ideas, algorithms, or functionality. So how do those get protected — and what about a project's name, or a secret algorithm you never publish? This lesson covers the other three forms of **intellectual property (IP)** that surround software, why they matter when you're reading a license, and how they stack together. By the end you'll be able to tell which kind of right is at play in any licensing situation.
+
+## The four kinds of IP around software
+
+Software is unusual in that all four major flavors of intellectual property can apply to a single product at once. They protect different things and have different rules:
+
+| IP type | Protects | How you get it | Rough lifespan |
+|---------|----------|----------------|----------------|
+| **Copyright** | The *expression* — source and binary | Automatic on creation | Decades (life + ~70 yrs, varies) |
+| **Patent** | A novel, non-obvious *invention* or method | Apply and be granted (expensive, slow) | ~20 years from filing |
+| **Trademark** | *Names, logos, brands* that identify a source | Use in commerce; registration strengthens it | Indefinite, while in use |
+| **Trade secret** | Valuable *secret* information | Keep it secret with reasonable measures | Indefinite, until it leaks |
+
+Copyright we've covered. The other three each fill a gap copyright leaves.
+
+## Patents: protecting the invention itself
+
+Where copyright protects how you *wrote* something, a **patent** can protect the *invention behind it* — a novel and non-obvious method or process, regardless of the specific code used to implement it. If copyright is "you can't copy my words," a patent is closer to "you can't use my method, even in your own words."
+
+Patents are a different beast from copyright in every practical way. They're **not automatic** — you must file an application, satisfy an examiner that the invention is new and non-obvious, and pay substantial fees, often over years. In exchange you get a strong but time-limited monopoly (roughly 20 years from filing).
+
+### Software patents are controversial
+
+Whether software *should* be patentable is genuinely contested. Critics argue many software patents are overly broad, cover "obvious" techniques, or describe abstract ideas dressed up as inventions, and that they're wielded by **patent trolls** (entities that hold patents mainly to extract licensing fees through litigation, not to build products). Different jurisdictions draw the line very differently — software patents are easier to obtain in some countries than others. You don't need to resolve the debate; you just need to know patents exist as a separate risk layer on top of copyright.
+
+### Why patents matter for licenses
+
+Here's the connection that makes patents relevant to *licensing*. Imagine you receive code under a license that grants you full copyright permission to use and modify it. You're safe on copyright — but a contributor to that project might *also* hold a **patent** covering what the code does. Nothing in a pure copyright license stops them from later suing you for patent infringement.
+
+To close that gap, some licenses include an explicit **patent grant**: contributors promise not to assert their patents against users of the project. This is one of the headline differences between the bare MIT License (no explicit patent grant) and the [Apache 2.0 license](/learn/software-licensing/apache-license/) (explicit patent grant plus a defensive termination clause). The [GPL family](/learn/software-licensing/gpl-strong-copyleft/) also addresses patents. When you see "patent grant" in a license, this is the worry it's answering.
+
+## Trademarks: protecting the name and brand
+
+A **trademark** protects the things that identify *who a product comes from* — names, logos, slogans, distinctive branding. Its purpose is consumer protection: so that when you download "Firefox" you know it really came from Mozilla and not an impostor.
+
+This creates a subtle but important rule for open source. **Open-source licenses generally do *not* grant trademark rights.** They let you copy, modify, and redistribute the *code*, but they specifically hold back the *name and logo*. The Apache 2.0 license is explicit about it:
+
+```text
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor ...
+```
+
+The practical effect: you can legally fork an open-source project and ship your own modified version, but you usually **can't keep calling it by the original name** or use its logo in a way that suggests the original maintainers endorse your fork. This is why forks get renamed (think of the projects that rebranded after forking) and why you'll see notes like "this product includes software developed by X" rather than "this *is* X." Code is shareable; brand is not. The brand stays with its owner so users aren't misled.
+
+## Trade secrets: protection through secrecy
+
+The first three rights all involve *disclosing* something — published code, a published patent, a public brand. A **trade secret** is the opposite: it protects information precisely *because it's kept secret*.
+
+To qualify, information generally must (1) derive value from not being publicly known and (2) be subject to reasonable efforts to keep it secret. A famous non-software example is the Coca-Cola formula. In software, a closed-source product's source code, an internal algorithm, or a clever optimization can all be trade secrets — protected indefinitely, for as long as they stay secret.
+
+The trade-off is fragility. Trade secret protection gives you **no monopoly** over the idea — if a competitor independently invents the same thing, or lawfully reverse-engineers it, you have no claim against them. And the protection collapses entirely the moment the secret is genuinely public. That's why secrecy is rarely relied on alone. Companies reinforce it with:
+
+- **NDAs (non-disclosure agreements)** — contracts that legally bind people who *do* see the secret to keep it confidential. (We cover NDAs in depth in [NDAs & the rest of the landscape](/learn/software-licensing/nda-and-other-agreements/).)
+- **Access controls** — limiting who can see the source, and logging who does.
+
+Keeping your source closed is itself a strategic choice on the [licensing spectrum](/learn/software-licensing/the-licensing-spectrum/): trade secret is the protection model that proprietary, closed-source software leans on most.
+
+## How they layer together
+
+The real power — and complexity — is that these rights stack on one product simultaneously. A single commercial application can be:
+
+- **Copyrighted** — its source and binary can't be copied.
+- **Patented** — a novel technique inside it is patent-protected.
+- **Trademarked** — its name and logo identify the vendor.
+- **Trade-secret-protected** — the unreleased internals stay confidential.
+
+Even an open-source project layers them. GopherTrunk's code is licensed permissively under [Apache 2.0](/learn/software-licensing/apache-license/) (copyright *and* a patent grant given away), while — like virtually all open-source projects — its **name and any logo are not** licensed to you. Understanding which right is in play tells you what you can actually do: copy the code, yes; use a contributor's patent, yes (Apache grants it); call your fork "GopherTrunk," no.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — open-source licenses grant rights to the code but generally withhold trademark rights to the project's name and logo." markdown="0">
+  <p class="knowledge-check__q">Quick check: you fork a project released under an open-source license. What does that license typically NOT give you?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The right to modify the source code</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The right to redistribute your modified version</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The right to use the project's name and logo for your fork</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Four IP types surround software** — copyright, patents, trademarks, and trade secrets, each protecting a different thing.
+- **Patents protect inventions** — the method itself, not the code's expression; they're filed, expensive, time-limited, and controversial for software.
+- **Patent grants close a gap** — a copyright license alone doesn't stop a patent claim, which is why licenses like Apache 2.0 add an explicit patent grant.
+- **Trademarks protect names and logos** — and open-source licenses generally don't grant them, so forks get renamed.
+- **Trade secrets protect secrets** — valuable while hidden, backed by NDAs and access controls, but lost the moment they leak or are independently discovered.
+- **They layer together** — a single product can be covered by all four at once; knowing which right applies tells you what you're actually allowed to do.
+
+Next up: a license grants permission, but is it also a contract? The distinction changes your remedies. See [License vs contract](/learn/software-licensing/license-vs-contract/).

--- a/docs/learn/software-licensing/permissive-compliance.md
+++ b/docs/learn/software-licensing/permissive-compliance.md
@@ -1,0 +1,111 @@
+---
+slug: permissive-compliance
+title: Meeting permissive obligations
+description: MIT, BSD, and Apache are easy to comply with — but easy is not the same as nothing. Learn exactly what permissive licenses require when you ship, Apache's extra NOTICE and state-changes terms, and where to put attributions, with GopherTrunk's own THIRD_PARTY_LICENSES as a worked example.
+keywords: permissive license compliance, MIT license attribution, BSD license notice, Apache 2.0 NOTICE file, third party licenses file, license attribution, open source notices, binary distribution attribution, THIRD_PARTY_LICENSES, software compliance
+level: intermediate
+status: full
+faq:
+  - q: "Do I really have to include the license text if I only ship a binary?"
+    a: "Yes. MIT, BSD, and Apache all require the copyright notice and license text to travel with **the software**, whether you distribute source or a compiled binary. For a binary you can't put it in a code comment, so you collect the notices into a file or screen that ships with the product — an about box, a bundled `THIRD_PARTY_LICENSES` file, or in-app credits."
+  - q: "What's the difference between Apache's NOTICE file and the LICENSE file?"
+    a: "The **LICENSE** is the Apache-2.0 license text itself. The **NOTICE** is a separate file the original authors may include with required attributions; Apache-2.0 says you must pass along the relevant parts of any NOTICE you received. So Apache compliance is: include the license text, preserve copyright notices, propagate NOTICE contents, and state if you modified files."
+  - q: "Is one big THIRD_PARTY_LICENSES file enough?"
+    a: "For most products, yes — a single, accurate file (or about-box section) that lists each dependency with its copyright line and full license text satisfies MIT, BSD, and Apache attribution. The key is that it's **complete and reachable** by the user. GopherTrunk does exactly this with its `/THIRD_PARTY_LICENSES.md`."
+---
+# Meeting permissive obligations
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Easy isn't nothing** — permissive licenses ask little, but that little is mandatory. **Ship the text and the notice** — include the full license and the copyright line for every permissive dependency. **Apache adds extras** — propagate the NOTICE file and flag files you changed. **Put it somewhere reachable** — an about box, a `THIRD_PARTY_LICENSES` file, or docs that travel with the product.
+</div>
+
+[Permissive licenses](/learn/software-licensing/mit-and-bsd-licenses/) — MIT, the BSD family, and [Apache 2.0](/learn/software-licensing/apache-license/) — are the friendliest licenses to ship in a commercial product. They let you keep your own code closed, charge what you like, and combine almost anything. But "friendly" is not "free of obligations," and the single most common compliance failure in the industry is shipping permissive code while quietly dropping its attribution. By the end of this lesson you'll know precisely what these licenses require when you distribute, the extra terms Apache adds, where to place attributions for source and binary releases, and what a correct attribution looks like — using GopherTrunk's own dependency file as a real example.
+
+## The core obligation: notices travel with the software
+
+Strip away the legalese and every mainstream permissive license boils down to one duty when you distribute: **carry the copyright notice and the license text along with the software.** That's the whole deal for MIT and BSD. You may do nearly anything else — modify, relicense your combined work, sell it, keep your additions secret — provided those notices ride along.
+
+Read the operative line from the MIT license itself:
+
+```text
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+```
+
+"All copies or substantial portions" is the key phrase. If your product contains a substantial portion of MIT-licensed code — which a linked library certainly is — the notice and license text must be included with what you ship. The BSD licenses say essentially the same thing, with the 3-clause variant adding that you can't use the authors' names to endorse your product without permission.
+
+The mistake to avoid is treating attribution as optional politeness. It is a **condition of the license.** If you don't meet it, your permission to use the code lapses, and you're now distributing someone's copyrighted code without a license — the same legal position as if you'd never had one.
+
+## Apache 2.0 adds three things
+
+[Apache 2.0](/learn/software-licensing/apache-license/) is still permissive, but it spells out more than MIT or BSD. When you ship Apache-licensed code, you owe four things:
+
+1. **Include the license.** Provide a copy of the Apache-2.0 license text.
+2. **Preserve notices.** Keep all copyright, patent, trademark, and attribution notices from the source.
+3. **Propagate the NOTICE file.** If the project shipped a `NOTICE` file, you must include the readable attribution notices it contains in your distribution (in your own NOTICE, the docs, or a displayed screen). The NOTICE is *separate* from the license — it's the authors' required-attribution text.
+4. **State your changes.** If you modified any Apache-licensed files, the modified files must carry prominent notices that you changed them.
+
+There's also the [patent grant](/learn/software-licensing/apache-license/): Apache-2.0 gives you a license to the contributors' patents that read on the code, and that grant terminates if you sue a contributor over patents in that code. You don't have to *do* anything for the patent grant — but it's a big reason Apache is preferred for commercial use.
+
+| Requirement | MIT | BSD (2/3-clause) | Apache 2.0 |
+|-------------|-----|------------------|------------|
+| Include license text | Yes | Yes | Yes |
+| Preserve copyright notice | Yes | Yes | Yes |
+| Propagate a NOTICE file | n/a | n/a | Yes, if one exists |
+| Mark modified files | No | No | Yes |
+| No-endorsement clause | No | 3-clause only | Yes (trademark) |
+| Express patent grant | No | No | Yes |
+
+## Where to put the attributions
+
+The license says the notices must accompany the software; it doesn't dictate exactly where. What matters is that the attribution is **complete** and **reachable by the person who receives your product.** Common, accepted placements:
+
+- **An "About" or "Credits" screen** in a GUI or mobile app — often an "Open Source Licenses" sub-screen listing each dependency and its license.
+- **A bundled file**, conventionally named `THIRD_PARTY_LICENSES`, `NOTICES`, or `licenses.txt`, shipped alongside the binary or inside the installer/package.
+- **Documentation or a docs page** that travels with the product (printed manual, in-app help, or a docs site you point users to).
+- **For source distributions**, the upstream `LICENSE` and `NOTICE` files preserved in the tree, which is usually automatic if you don't delete them.
+
+### Binary vs source distribution
+
+The obligation is the same either way — the *mechanics* differ:
+
+- **Source distribution:** keep each dependency's `LICENSE`/`NOTICE` where they sit. If you vendor dependencies into your tree, don't strip their license files.
+- **Binary distribution:** the source comments and license files don't ship with a compiled artifact, so you must **collect** the notices into something that does — that bundled file or about screen. A statically-linked binary still "contains" its dependencies, so their notices still must accompany it.
+
+## A worked example: GopherTrunk
+
+This is not hypothetical — GopherTrunk does exactly this. GopherTrunk is itself licensed **Apache-2.0** (see [`/LICENSE`](/learn/software-licensing/apache-license/)), and because it ships as a single statically-linked binary, every dependency it links in must have its notice carried along. GopherTrunk collects them in **`/THIRD_PARTY_LICENSES.md`** at the repository root — a single, reachable attribution file that lists each direct dependency with its version, SPDX license identifier, and a link upstream, plus the full text for in-tree code derived from other projects.
+
+A correct attribution entry is simple. For an MIT dependency it looks like this:
+
+```text
+github.com/charmbracelet/bubbletea  v1.3.10  MIT
+  Copyright (c) 2020-2023 Charmbracelet, Inc.
+
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software ... [full MIT license text]
+  ... THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND.
+```
+
+The essential parts are the **identity** (which component), the **copyright line** (who holds it), and the **full license text** (so the recipient has their own copy of the grant and the warranty disclaimer). Repeat that for every permissive dependency and you've met the obligation. The next lesson, [auditing dependencies](/learn/software-licensing/auditing-dependencies/), covers how to make sure that list is complete — including the transitive dependencies you didn't add by hand.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — Apache-2.0 additionally requires propagating the NOTICE file and marking files you modified, on top of including the license and preserving notices." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does Apache 2.0 require that MIT and BSD do not?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">That you release your own source code under Apache 2.0</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">That you pay a royalty for commercial use</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">That you propagate any NOTICE file and mark files you modified</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **The core duty is attribution** — include the full license text and the copyright notice for every permissive dependency you distribute, in source or binary form.
+- **It's mandatory, not polite** — dropping the notice voids your permission to use the code, turning use into infringement.
+- **Apache adds three extras** — propagate the NOTICE file, mark modified files, and benefit from its patent grant.
+- **Put notices somewhere reachable** — an about box, a bundled `THIRD_PARTY_LICENSES`/`NOTICES` file, or docs that ship with the product.
+- **GopherTrunk is a real example** — Apache-2.0 licensed, it collects every dependency's notice in `/THIRD_PARTY_LICENSES.md` because its single static binary carries them all.
+
+Next up: the harder case, and the one people fear most. See [Copyleft in products: the viral question](/learn/software-licensing/copyleft-in-products/).

--- a/docs/learn/software-licensing/permissive-vs-copyleft.md
+++ b/docs/learn/software-licensing/permissive-vs-copyleft.md
@@ -1,0 +1,106 @@
+---
+slug: permissive-vs-copyleft
+title: Permissive vs copyleft
+description: The single biggest divide among open-source licenses is permissive vs copyleft — whether you can keep your changes to yourself or must share them back. Learn reciprocity, strong vs weak copyleft, and what each kind asks of you.
+keywords: permissive license, copyleft, reciprocity, share alike, strong copyleft, weak copyleft, GPL, MIT, Apache, derivative works, open source obligations, license comparison, copyleft vs permissive
+level: beginner
+status: full
+faq:
+  - q: "What's the simplest way to tell permissive and copyleft apart?"
+    a: "Ask: *if I modify this and ship it, what must I give back?* A **permissive** license asks only that you keep the copyright and license notice — you can otherwise do almost anything, including keeping your changes closed. A **copyleft** license adds reciprocity: derivative works you distribute must be released under the same (or a compatible) license, so the source stays open downstream."
+  - q: "Is copyleft 'better' or 'worse' than permissive?"
+    a: "Neither — they optimize for different goals. **Permissive** maximizes adoption and lets anyone, including closed-source vendors, build on the code. **Copyleft** maximizes the guarantee that the software and its descendants stay free. The right choice depends on what you want; we cover that in [Choosing an open-source license](/learn/software-licensing/choosing-an-oss-license/)."
+  - q: "What's the difference between strong and weak copyleft?"
+    a: "It's about *how far* the share-alike obligation reaches. **Strong copyleft** (like the GPL) extends to the whole combined work that includes the licensed code. **Weak copyleft** (like the LGPL or MPL) limits the obligation to the licensed component itself — typically the files or the library — so you can link it into a larger, differently-licensed program without that program becoming copyleft."
+---
+# Permissive vs copyleft
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The biggest divide in open source** — almost every open-source license is either permissive or copyleft. **Permissive = keep the notice** — do nearly anything, just preserve the copyright and license text. **Copyleft = share alike** — derivatives you distribute must stay under the same license; this is reciprocity. **Strong vs weak** — strong copyleft covers the whole combined work; weak copyleft covers only the licensed component.
+</div>
+
+Once you know that open source is a precise term, the next thing to understand is that open-source licenses are not all alike. They split along one dominant axis — **permissive vs copyleft** — and that single distinction shapes almost everything else: what you can build, what you must publish, and which licenses you can safely combine. By the end of this lesson you'll be able to place any open-source license on this axis, explain the idea of reciprocity, and tell strong copyleft from weak copyleft. This framing sets up the next several lessons, each of which zooms in on a specific license family.
+
+## The one axis that matters most
+
+There are dozens of open-source licenses, but the practical question they answer first is always the same: **when you take this code, change it, and give it to someone else, what do you owe?**
+
+The answers cluster into two camps:
+
+- **Permissive licenses** ask for very little. Keep the original copyright and license notice, and you're free to do almost anything else — including building a closed-source product on top and never showing anyone your changes.
+- **Copyleft licenses** ask for reciprocity. If you distribute a modified or derived version, you must release it under the same kind of license, so the freedoms travel downstream with the code.
+
+Everything else — patent grants, attribution files, network clauses — is detail layered on top of this core choice. Get this axis straight and the rest of the open-source landscape becomes navigable.
+
+## Permissive: "do almost anything, just keep the notice"
+
+A **permissive** license is the minimal-strings option. The canonical examples are MIT, the BSD licenses, and Apache 2.0, which get their own lessons next. The deal is roughly: *here is the code; use it however you like — commercially, in closed products, modified or not — as long as you preserve the copyright notice and a copy of the license, and don't pretend there's a warranty.*
+
+What permissive licenses deliberately do **not** require:
+
+- They do not require you to publish your changes.
+- They do not require your larger product to be open source.
+- They do not restrict who can use the code or for what.
+
+This is why permissive licenses dominate in business settings and why they tend to get the widest adoption — a company can build on them without taking on obligations about its own proprietary code. The trade-off is that nothing stops someone from taking the code, improving it, and releasing only a closed-source fork. For the author, that's a feature or a flaw depending on what they wanted. We walk through the mechanics in [MIT & BSD](/learn/software-licensing/mit-and-bsd-licenses/) and [Apache 2.0](/learn/software-licensing/apache-license/).
+
+## Copyleft: "share alike"
+
+A **copyleft** license flips the permissive bargain. It uses copyright law not to restrict sharing but to *guarantee* it: anyone who receives the software gets the four freedoms, and — this is the key part — anyone who distributes a modified version must pass those same freedoms along. The name is a play on "copyright": instead of reserving rights, it reserves *freedoms*.
+
+The mechanism is a license condition that says, in effect, *if you distribute a derivative work, you must license that work under this same license.* The GNU General Public License (GPL) is the archetype, covered in [The GPL: strong copyleft](/learn/software-licensing/gpl-strong-copyleft/).
+
+The intuition behind copyleft is that permissive freedom can be a one-way door: a company can take freely-given code and lock its improvements away, and the next user never benefits. Copyleft closes that door by making the freedom *sticky*. The cost is that copyleft code is more constraining to combine with proprietary software, which is exactly the tension [Copyleft in products: the viral question](/learn/software-licensing/copyleft-in-products/) tackles.
+
+## Reciprocity: the idea under copyleft
+
+The concept that makes copyleft tick is **reciprocity**. The bargain is: *you may have all these freedoms with my code, on the condition that you extend the same freedoms to everyone you pass it on to.* You take freedom, you give freedom — a fair exchange that keeps the commons growing instead of being quietly drained.
+
+Reciprocity is why copyleft is sometimes loosely called "viral" — but that word is misleading and often used pejoratively. Copyleft doesn't reach out and infect unrelated code on your machine; it only applies to works that actually incorporate the copyleft-licensed code, and only when you *distribute* them. We'll unpack exactly where the boundary falls, because "what counts as a derivative work" is the whole ballgame for compliance.
+
+A useful reframing: permissive licenses optimize for **adoption** (make it as easy as possible to use), while copyleft licenses optimize for **preservation** (make sure the software and its descendants stay free). Both are legitimate goals.
+
+## Strong vs weak copyleft (a preview)
+
+Copyleft is not all-or-nothing. It comes in two strengths that differ in *how far* the share-alike obligation reaches:
+
+- **Strong copyleft** extends the obligation to the entire combined work. If you link GPL code into your program and distribute the result, the whole program generally must be GPL. This is the GPL and, for network use, the AGPL ([copyleft over the network](/learn/software-licensing/agpl-network-copyleft/)).
+- **Weak copyleft** confines the obligation to the licensed component itself — usually the specific files or the library. You can use a weak-copyleft library inside a larger proprietary program: you must share changes *to the library*, but the rest of your program can stay under whatever license you choose. The LGPL, MPL, and EPL are the main examples, covered in [Weak copyleft: LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/).
+
+Weak copyleft is the middle ground between "anything goes" permissive and "the whole thing must be free" strong copyleft.
+
+## The comparison at a glance
+
+This table is the one to keep in your head. It frames the next several lessons.
+
+| | **Permissive** | **Weak copyleft** | **Strong copyleft** |
+|---|---|---|---|
+| Examples | MIT, BSD, Apache 2.0 | LGPL, MPL, EPL | GPL, AGPL |
+| Must keep copyright/license notice | Yes | Yes | Yes |
+| Must publish your changes when you distribute | No | Yes — to the licensed **component** only | Yes — to the **whole combined work** |
+| Can you build a closed-source product on it | Yes | Yes (the larger product stays proprietary) | Generally no — the combined work must be copyleft |
+| What stays open downstream | Only the original files (if at all) | The licensed component | The entire derivative work |
+| Optimizes for | Adoption | A middle ground | Preserving freedom |
+
+Read across the rows and you can see the obligation grow from left to right: every column keeps the notice, but the *share-alike* duty starts at "none," widens to "just this component," and finally reaches "the whole thing."
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — reciprocity (share-alike) is the defining feature of copyleft; permissive licenses don't require you to publish your changes." markdown="0">
+  <p class="knowledge-check__q">Quick check: what does a copyleft license require that a permissive one does not?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">That derivative works you distribute be released under the same (or a compatible) license</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">That you pay a royalty to the original author for commercial use</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">That you keep the copyright and license notice intact</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **One dominant axis** — open-source licenses split into permissive and copyleft, and that split shapes nearly everything else.
+- **Permissive** — keep the copyright and license notice, then do almost anything, including shipping closed-source builds.
+- **Copyleft** — adds reciprocity: distributed derivatives must stay under the same kind of license, keeping the source open downstream.
+- **Reciprocity, not virality** — copyleft only applies to works that actually include the code, and only when you distribute them.
+- **Strong vs weak** — strong copyleft covers the whole combined work; weak copyleft covers only the licensed component.
+
+Next up: the simplest, most widely used permissive licenses, walked through line by line. See [MIT & BSD: minimal permissive](/learn/software-licensing/mit-and-bsd-licenses/).

--- a/docs/learn/software-licensing/privacy-and-data-agreements.md
+++ b/docs/learn/software-licensing/privacy-and-data-agreements.md
@@ -1,0 +1,124 @@
+---
+slug: privacy-and-data-agreements
+title: Privacy policies & data agreements
+description: If your software touches personal data you likely need a privacy policy and, with vendors, a data processing agreement. Learn what a privacy policy must disclose, GDPR and CCPA basics, controller vs processor, and cross-border data transfers.
+keywords: privacy policy, data processing agreement, DPA, GDPR, CCPA, CPRA, personal data, data controller, data processor, sub-processor, lawful basis, data subject rights, standard contractual clauses, data residency, cross-border data transfer
+level: intermediate
+status: full
+faq:
+  - q: "Does my software actually need a privacy policy?"
+    a: "If it collects or processes **personal data** — names, emails, IP addresses, device IDs, location, analytics tied to a person — then almost certainly yes, and often it's **legally required**. Laws like the EU's GDPR and California's CCPA/CPRA mandate disclosure, and app stores and ad networks require a policy to publish at all. A purely offline tool that touches no personal data may not need one, but that's rarer than people think."
+  - q: "What's the difference between a data controller and a data processor?"
+    a: "The **controller** decides *why and how* personal data is processed — it sets the purposes. The **processor** handles data *on the controller's behalf and instructions* — a vendor that stores or crunches data for you. If you run a service that collects user data, you're typically the **controller**; your cloud host or analytics vendor is a **processor**, which is exactly why you sign a **DPA** with them."
+  - q: "What is a DPA and when do I need one?"
+    a: "A **Data Processing Agreement** is a contract between a controller and a processor that locks down how the processor may handle personal data — purpose limits, security, breach notice, sub-processors, and deletion. Under GDPR it's **legally required** whenever a processor handles personal data for you. In practice you sign one with most data-handling vendors, and your own customers will ask you to sign one when *you* are their processor."
+---
+# Privacy policies & data agreements
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Touch personal data, need a privacy policy** — and it's often legally required, not just good manners. **A policy must disclose** what you collect, why, who you share it with, how long you keep it, and users' rights. **GDPR (EU) and CCPA/CPRA (California)** are the two reference regimes, and they differ. **Controller vs processor** decides who's responsible — and a **Data Processing Agreement (DPA)** binds the processor. **Cross-border transfers** need a legal mechanism like Standard Contractual Clauses.
+</div>
+
+The agreements in the last lesson set the rules for *using* your software. This one is about the **data your software handles about people**. If your product collects anything that can identify a user, a whole body of law and a set of standard agreements come into play. This lesson is concepts-first, using the United States (California's CCPA/CPRA) and the EU (GDPR) as the two reference points, because the cross-border angle is where this topic gets real. By the end you'll know when you need a privacy policy, what it must say, the difference between a data controller and a processor, and why you end up signing DPAs.
+
+> **This is educational material, not legal advice.** Privacy law is fast-moving and jurisdiction-specific; for real compliance decisions, consult a qualified attorney or privacy professional.
+
+## If you touch personal data, you probably need a policy
+
+**Personal data** (the GDPR term; US laws say **personal information**) is any information relating to an identifiable person — obvious things like name and email, but also IP addresses, device identifiers, location, cookies, and analytics tied to an individual. The threshold is lower than people expect: a web app with logins and analytics is already processing personal data.
+
+Once you are, a **privacy policy** is usually not optional. It's **legally required** under GDPR and the California laws (among many others), it's demanded by the Apple and Google app stores before you can publish, and ad and analytics networks require one in their terms. A privacy policy is a *disclosure* document — its job is to tell people, in plain terms, what you do with their data. It is distinct from the [terms of service](/learn/software-licensing/eula-and-tos/), which set the rules of use; the two usually travel together but do different jobs.
+
+## What a privacy policy must disclose
+
+The exact requirements vary by law, but a sound privacy policy answers a consistent set of questions:
+
+- **What you collect** — the categories of personal data (account info, usage data, device data, location, etc.).
+- **Why you collect it** — the purposes, and under GDPR the **lawful basis** for each (more below).
+- **Who you share it with** — categories of third parties: vendors/processors, partners, advertisers, and any sale or "sharing" of data.
+- **How long you keep it** — retention periods, or the criteria you use to decide them.
+- **Users' rights and how to exercise them** — access, correction, deletion, opting out, and a contact channel.
+- **Transfers** — whether data leaves the user's country/region, and the safeguard used.
+- **Cookies/tracking and contact details** — your identity as the responsible party and how to reach you (under GDPR, sometimes a Data Protection Officer).
+
+The throughline: a privacy policy should let a reasonable person understand what happens to their data *before* they hand it over. Vague boilerplate that says "we may use your data to improve our services" satisfies nobody and increasingly fails legal scrutiny.
+
+## GDPR basics (EU)
+
+The EU's **General Data Protection Regulation** is the most influential privacy law in the world; it applies to organizations in the EU and to those *outside* the EU that target or monitor people in the EU. A few core ideas:
+
+- **Lawful basis.** You can't process personal data just because you'd like to. You need one of six lawful bases — commonly **consent**, **contract** (processing needed to deliver what the user signed up for), or **legitimate interests** (a balancing test). You must pick and document the basis for each purpose.
+- **Consent has standards.** Where you rely on consent, it must be freely given, specific, informed, and unambiguous — an affirmative opt-in, not a pre-ticked box. And it must be as easy to withdraw as to give.
+- **Data subject rights.** Individuals can request access to their data, correction, **erasure** ("right to be forgotten"), portability, and can object to certain processing. You must be able to respond, usually within a set time.
+- **Accountability and breach notice.** You must be able to *demonstrate* compliance, and serious breaches generally must be reported to a regulator within 72 hours.
+
+Penalties are large — up to the greater of €20 million or 4% of global annual turnover for the most serious violations — which is why GDPR drives so much global practice. The UK has its own post-Brexit equivalent (UK GDPR) that is closely aligned.
+
+## CCPA / CPRA basics (California)
+
+The United States has **no single federal privacy law**; instead it has a growing patchwork of state laws, of which California's is the bellwether. The **California Consumer Privacy Act (CCPA)**, strengthened by the **California Privacy Rights Act (CPRA)**, gives California residents rights over their personal information.
+
+- **Rights.** To **know** what's collected, to **delete** it, to **correct** it, and to **opt out of the sale or "sharing"** of personal information (CPRA added the "sharing" concept, aimed at cross-context behavioral advertising).
+- **Opt-out, not opt-in.** This is a key contrast with GDPR. CCPA generally works on an **opt-out** model — businesses can collect and even "sell" data unless the consumer opts out (hence "Do Not Sell or Share My Personal Information" links). GDPR leans toward needing a lawful basis up front.
+- **Who it covers.** It applies to for-profit businesses that meet certain thresholds (revenue or volume of data), not to every tiny app.
+
+Other US states (Virginia, Colorado, and more) have passed similar laws, so "comply with US privacy law" increasingly means handling a set of state regimes, not one rule.
+
+| | **GDPR (EU)** | **CCPA / CPRA (California)** |
+|---|---|---|
+| **Default model** | Need a **lawful basis** to process at all | Collect unless consumer **opts out** |
+| **Consent** | Affirmative opt-in, easy to withdraw | Opt-out of sale/sharing is the headline right |
+| **Term for data** | Personal data | Personal information |
+| **Key rights** | Access, erasure, portability, object | Know, delete, correct, opt out of sale/sharing |
+| **Who's regulated** | Anyone targeting/monitoring EU people | For-profit businesses over set thresholds |
+| **Headline penalty** | Up to €20M or 4% of global turnover | Per-violation fines; private action for breaches |
+
+These two are the reference points, but they are not the whole world — Brazil's LGPD, Canada's PIPEDA, and many others exist. The [licensing-across-jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/) lesson is where this path treats cross-border issues in depth.
+
+## Controller vs processor, and the DPA
+
+When more than one organization touches the data, the law assigns roles, and the roles decide who's responsible.
+
+- A **controller** decides the *purposes and means* of processing — *why* and *how* data is handled. If you run a service that collects users' data for your own ends, you're the controller.
+- A **processor** processes data **on the controller's behalf and under its instructions** — a vendor doing a job for you. Your cloud host, your email-sending service, your analytics provider, your error-tracking tool are typically processors.
+
+Because a controller stays responsible for data even when a vendor handles it, GDPR **requires a contract** between them: the **Data Processing Agreement (DPA)**. A DPA pins down how the processor may act:
+
+- Process only on the controller's documented instructions and only for the stated purpose.
+- Keep the data secure and keep staff under confidentiality.
+- Notify the controller of breaches without undue delay.
+- Allow audits and help the controller meet data-subject requests.
+- Delete or return the data when the engagement ends.
+
+### Sub-processors
+
+A processor often uses its own vendors — a SaaS app that runs on a cloud provider, for instance. Those downstream vendors are **sub-processors**. A DPA normally requires the processor to *flow down* the same obligations to its sub-processors, to disclose who they are, and often to give the controller a chance to object to new ones. This is why mature vendors publish a sub-processor list.
+
+You will sit on **both sides** of this over time. When you use vendors, you're the controller signing DPAs with them. When your *customers* feed their users' data into your product, *you* are the processor and they'll ask you to sign a DPA — so you'll need one ready to offer.
+
+## Data residency and cross-border transfers
+
+Personal data often crosses borders — a European user's data landing on a US-based cloud server, say. GDPR restricts transferring personal data outside the EU/EEA unless there's an approved safeguard. The most common one for ordinary companies is the **Standard Contractual Clauses (SCCs)** — pre-approved contract terms the parties sign to commit to GDPR-level protection. (For the EU–US route specifically, the **Data Privacy Framework** is an additional adequacy-based mechanism for certified US companies.)
+
+**Data residency** is the related, more concrete question of *where data physically lives* — which country's data centers store it. Some customers and some laws require data to stay within a particular region, which is why cloud providers offer region selection and why enterprise contracts often specify residency. The takeaway: if your data moves across borders, you need a transfer mechanism, and if customers care where it sits, you need to be able to answer.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — you set the purposes, so you're the controller; the analytics vendor processes on your behalf, making it your processor, which is why you sign a DPA." markdown="0">
+  <p class="knowledge-check__q">Quick check: your app collects user data for your own purposes and sends some of it to a third-party analytics vendor. What are the roles?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">You're the processor and the analytics vendor is the controller</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">You're both controllers, so no agreement between you is needed</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">You're the controller, the vendor is your processor, and you sign a DPA with it</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Touch personal data, need a privacy policy** — it's commonly legally required and demanded by app stores and ad networks, not just polite.
+- **Disclose the essentials** — what you collect, why, who you share with, how long you keep it, users' rights, and any transfers.
+- **GDPR and CCPA/CPRA differ in default** — GDPR needs a lawful basis up front (opt-in for consent); CCPA leans on a consumer opt-out of sale/sharing.
+- **Roles decide responsibility** — the controller sets the purposes; the processor acts on instructions; a DPA binds the processor (and flows down to sub-processors).
+- **Cross-border data needs a mechanism** — Standard Contractual Clauses or similar for transfers, and data-residency choices when customers or law require it.
+
+Next up: the agreements that promise how *well* a service will run, and what you get when it doesn't. See [SLAs & support agreements](/learn/software-licensing/sla-and-support-agreements/).

--- a/docs/learn/software-licensing/proprietary-licensing.md
+++ b/docs/learn/software-licensing/proprietary-licensing.md
@@ -1,0 +1,119 @@
+---
+slug: proprietary-licensing
+title: Proprietary & closed-source licensing
+description: Proprietary software sits at the opposite end from open source — "all rights reserved" by default, with the license granting you a narrow, restricted right to use a copy. Learn what proprietary licenses typically forbid and why you license rather than buy software.
+keywords: proprietary software, closed source, all rights reserved, EULA, software license vs purchase, no reverse engineering, no redistribution, seat license, freeware, shareware, trialware, license not sale
+level: beginner
+status: full
+faq:
+  - q: "If I pay for proprietary software, don't I own it?"
+    a: "Almost never. You own the **copy** — the bits on your disk — but you don't own the software itself. What you buy is a **license**: a permission to use the software under the seller's terms. The copyright stays with the vendor, which is why the EULA can restrict copying, sharing, and modification even after you've paid."
+  - q: "Is closed-source the same as proprietary?"
+    a: "They overlap heavily but aren't identical. **Closed-source** describes the *delivery* — you get a binary, not the source code. **Proprietary** describes the *rights* — the vendor reserves them and licenses you a narrow set. Most proprietary software is also closed-source, but you can have proprietary licenses over visible source (that's [source-available](/learn/software-licensing/source-available-licenses/)) and closed binaries that are nonetheless freely redistributable."
+  - q: "Are freeware and shareware open source?"
+    a: "No. **Freeware** costs nothing but is still proprietary — you get a free copy under a restrictive license, not the freedoms open source grants. **Shareware** and **trialware** are the same idea with a payment or time gate. \"Free of charge\" is about price; **open source** is about freedom. They're unrelated axes."
+---
+# Proprietary & closed-source licensing
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Proprietary is the opposite end** — the vendor reserves the rights and licenses you a narrow slice of them. **"All rights reserved" by default** — copyright law gives the owner control, and a proprietary license hands back only what it explicitly says. **You license, you don't buy** — you own your copy, not the software. **Freeware, shareware, trialware** — all proprietary; "free of charge" is not "free as in freedom."
+</div>
+
+Open source defines itself by what it lets you do. Proprietary software defines itself by what it holds back. It's the far end of the [licensing spectrum](/learn/software-licensing/the-licensing-spectrum/) from the permissive licenses we've been studying: instead of granting broad freedoms, a proprietary license starts from total control and lends you a carefully limited right to use the product. By the end of this lesson you'll understand what "all rights reserved" means in practice, the restrictions a typical proprietary license imposes, the crucial idea that you license software rather than buy it, the clauses you'll see again and again, and where freeware, shareware, and trialware fit in.
+
+## "All rights reserved" is the default
+
+Here's the foundation everything else rests on, and it surprises people: under copyright law, the author of a piece of software automatically holds the exclusive rights to copy, modify, and distribute it the moment it's written. Nobody else may do those things **without permission**. You can read more about why in [Copyright & software ownership](/learn/software-licensing/copyright-and-software-ownership/), but the short version is that the default state of any code is *closed*.
+
+This is the meaning of the old phrase **"all rights reserved."** It signals that the owner is keeping every right the law grants and is not waiving any of them. Open-source and permissive licenses are *generous exceptions* to this default — the author voluntarily hands rights to everyone. Proprietary licensing is what you get when the author keeps the default and grants you only a thin, specific set of permissions in return for payment (or for agreeing to terms).
+
+So "proprietary" isn't a special legal mechanism you have to invent. It's what software *is* until someone chooses to open it up. A proprietary license is simply the document that says exactly which slivers of the reserved rights you're allowed to exercise.
+
+## What a proprietary license typically restricts
+
+Because the license starts from "you get nothing" and adds back only named permissions, the interesting content is usually the list of restrictions. The exact wording varies, but the same prohibitions show up across nearly every commercial product:
+
+| Restriction | What it means in practice |
+|---|---|
+| **No source code** | You receive a binary (closed-source). The human-readable source is a [trade secret](/learn/software-licensing/other-ip-in-software/) the vendor keeps. |
+| **No redistribution** | You may not give, sell, or share copies. The license is for *you* (or your organization), not the world. |
+| **No modification** | You may not alter, adapt, or build derivative works from the software. |
+| **No reverse engineering** | You may not decompile, disassemble, or otherwise try to recover the source or internal design. |
+| **Seat / usage limits** | Use is capped — a number of users, devices, CPUs, or installs. Exceeding the cap is a breach. |
+| **No transfer / assignment** | You often can't sell or give your license to someone else without the vendor's consent. |
+
+Each of these is a right the vendor reserved and declined to grant. The "no reverse engineering" clause is worth a special note: it's extremely common, but its enforceability varies by jurisdiction. In the **EU**, for instance, the law explicitly permits some decompilation for *interoperability* purposes regardless of what the contract says, and a few US cases have limited overbroad bans. The clause is real and you should respect it, but "the EULA says so" doesn't make every restriction airtight everywhere — a theme we return to in [Licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/).
+
+## You license software; you don't buy it
+
+This is the single idea most people get wrong, so it's worth stating bluntly: **when you "buy" proprietary software, you are not buying the software.** You are buying a **license** — a permission to use it on the vendor's terms — and a copy to run it from.
+
+The slogan to remember is *"you own a copy, not the software."* The DVD, the download, the activation key — those are yours. The underlying program, and the copyright in it, remain the vendor's property. That's why:
+
+- The vendor can dictate how you use *your* copy (one machine, no sharing, no tinkering).
+- The license can be **revoked** or **expire** even though you paid, if you breach the terms or the subscription lapses.
+- You can't legally resell a download the way you'd resell a used book — the "first sale" doctrine that lets you resell physical goods is murky and limited for licensed digital software.
+
+This is a genuine difference from owning a physical object, and it's not a trick — it's how copyright-based licensing works. We dig into *why* a license isn't the same as a sale, and when it behaves more like a contract, in [License vs contract](/learn/software-licensing/license-vs-contract/).
+
+## Typical clauses you'll meet
+
+Open up almost any proprietary **EULA** (End User License Agreement — covered in depth in [EULAs & terms of service](/learn/software-licensing/eula-and-tos/)) and you'll find a recognizable skeleton. Here, briefly, is what to expect — the full clause-by-clause tour is in [Key clauses in a commercial license](/learn/software-licensing/key-commercial-clauses/):
+
+- **Grant of license** — the narrow permission you *do* get ("a non-exclusive, non-transferable right to install and use one copy…").
+- **Restrictions** — the prohibitions from the table above, spelled out.
+- **Ownership / IP** — a reminder that the vendor owns everything and you own nothing but your copy.
+- **Term & termination** — how long the license lasts and what ends it (and what happens to your right to use when it ends).
+- **Warranty disclaimer** — usually an all-caps statement that the software is provided "AS IS."
+- **Limitation of liability** — a cap on what the vendor will pay if things go wrong.
+
+A short example of the grant-and-restriction core, the kind of language you'll see near the top of a EULA:
+
+```text
+Subject to your compliance with this Agreement, Vendor grants you a
+limited, non-exclusive, non-transferable, revocable license to install
+and use one (1) copy of the Software for your internal business use.
+
+You may NOT: (a) copy or redistribute the Software; (b) modify or create
+derivative works; (c) reverse engineer, decompile, or disassemble it;
+or (d) transfer your rights to any third party.
+```
+
+Notice the shape: a tightly bounded grant, then a list of "you may not." That contrast *is* proprietary licensing in miniature.
+
+## Freeware, shareware, and trialware
+
+A common confusion is that software which costs nothing must be open or unrestricted. It isn't. These zero- or low-cost models are all **proprietary variants** — restrictive licenses that happen to adjust the price or the trial mechanics:
+
+| Variant | Price model | Still proprietary? |
+|---|---|---|
+| **Freeware** | Free of charge, indefinitely | Yes — closed binary, restrictive license, no source |
+| **Shareware** | Free to try, pay to keep using (honor system or nag screens) | Yes |
+| **Trialware** | Free for a limited time or feature set, then locks | Yes |
+| **Freemium** | Free tier, pay to unlock more (see [commercial models](/learn/software-licensing/commercial-license-models/)) | Yes |
+
+The key insight: **"free of charge" and "free as in freedom" are different axes entirely.** Freeware can be downloaded at no cost yet forbid copying, modification, and reverse engineering just as strictly as a $500 product. You got a free *copy*; you did not get *freedom*. Plenty of well-known utilities are freeware — proprietary software the author chose not to charge for. That's a pricing decision, not a licensing philosophy.
+
+These models lead naturally into how vendors actually structure paid software, which is the subject of the next lesson.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — you buy a license (permission to use) and a copy; the software itself and its copyright stay with the vendor." markdown="0">
+  <p class="knowledge-check__q">Quick check: you pay for a copy of a closed-source app. What did you actually acquire?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">A license to use a copy under the vendor's terms — not ownership of the software</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Full ownership of the software, including the right to modify and resell it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The source code, since you paid for the product</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Proprietary is open source's opposite** — the vendor reserves the rights and grants you a narrow, named set of permissions.
+- **"All rights reserved" is the default** — copyright closes all software automatically; open licenses are the exception, not the rule.
+- **Typical restrictions** — no source, no redistribution, no modification, no reverse engineering, plus seat/usage caps and transfer limits.
+- **You license, you don't buy** — you own your copy, not the software; the license can expire or be revoked even after payment.
+- **Recognizable clauses** — grant, restrictions, ownership, term/termination, warranty disclaimer, liability cap.
+- **Freeware, shareware, trialware are proprietary** — free of charge is not the same as free as in freedom.
+
+Next up: how vendors actually package and charge for proprietary software — perpetual vs subscription, per-seat vs concurrent, and more. See [Commercial license models](/learn/software-licensing/commercial-license-models/).

--- a/docs/learn/software-licensing/public-domain-and-cc0.md
+++ b/docs/learn/software-licensing/public-domain-and-cc0.md
@@ -1,0 +1,106 @@
+---
+slug: public-domain-and-cc0
+title: "Public domain, Unlicense & CC0"
+description: Giving up all rights sounds simple, but "public domain" is legally tricky in many countries. Learn how the Unlicense, CC0, and 0BSD try to dedicate work to everyone — and why no license at all is the opposite of free.
+keywords: public domain, CC0, Unlicense, 0BSD, WTFPL, public domain dedication, moral rights, disclaim copyright, no license, all rights reserved, US federal works, fallback license, dedicate to public domain
+level: beginner
+status: full
+faq:
+  - q: "Can I just put my code in the public domain?"
+    a: "In the US you can come close, but it's surprisingly hard to do cleanly — copyright attaches automatically and several countries don't even let you disclaim it. That's why the recommended approach is a tool like **CC0**, which is a public-domain *dedication* plus a fallback license that grants the same broad permissions in places where dedication doesn't work."
+  - q: "If a repository has no license file, is it public domain?"
+    a: "No — it's the **opposite**. With no license, default copyright applies and **all rights are reserved**: nobody has permission to copy, modify, or distribute it. \"No license\" is the most restrictive state, not the freest. See [what is a software license](/learn/software-licensing/what-is-a-software-license/)."
+  - q: "What are \"moral rights\" and why do they complicate public domain?"
+    a: "Moral rights are an author's personal rights (like attribution and integrity of the work) that, in much of the EU and elsewhere, **cannot be waived or transferred** even if the author wants to. So a pure \"I give up everything\" dedication can't fully take effect in those countries, which is why good dedications like CC0 include language to waive what's waivable and license the rest."
+---
+# Public domain, Unlicense & CC0
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Public domain means no rights reserved** — anyone can use the work for anything, with no conditions. **But it's legally tricky** — copyright is automatic, and several countries won't let you disclaim it (moral rights survive). **CC0 is the recommended tool** — it's a dedication *plus* a fallback license, so it works even where pure dedication doesn't. **No license is NOT public domain** — it's the most restrictive default of all: all rights reserved.
+</div>
+
+The licenses you've seen so far all keep *some* rights and attach *some* conditions, even the gentle [MIT and BSD](/learn/software-licensing/mit-and-bsd-licenses/) ones. This lesson covers the far end of the spectrum: giving up rights entirely, putting work in the **public domain**. It sounds like the simplest possible choice, but it's one of the most legally subtle. By the end you'll know what public domain really means, why a clean disclaimer of copyright is harder than expected, which tools (CC0, the Unlicense, 0BSD) actually do the job, why "no license at all" is the opposite of free, and when public domain genuinely makes sense.
+
+## What "public domain" means
+
+A work in the **public domain** belongs to everyone and no one. There is no copyright holder controlling it, so anyone may copy, modify, distribute, sell, or build on it for any purpose, with no permission required and no conditions to satisfy — not even attribution. It is the most permissive state a creative work can be in: even more open than MIT, because MIT still requires you keep its notice.
+
+Works enter the public domain in a few ways: copyright **expires** (very old works), the law **never granted** copyright in the first place (see US federal works below), or the author deliberately **dedicates** the work to the public domain. That last route — a living author voluntarily releasing rights — is the one that concerns software, and it's where things get complicated.
+
+## Why dedicating to the public domain is tricky
+
+Here's the catch most people don't expect: **copyright is automatic and not always disposable.** The moment you write original code, copyright attaches to it whether you want it or not. To put it in the public domain you'd have to actively *give that copyright away* — and the law doesn't always provide a clean mechanism to do so.
+
+Two problems in particular:
+
+- **No clear disclaimer mechanism.** US law has no formal, reliable procedure for an author to abandon copyright. A bare statement like "I release this into the public domain" may or may not be fully effective, and its meaning is uncertain enough that careful lawyers don't rely on it alone.
+- **Moral rights that can't be waived.** In much of the EU, and in many other jurisdictions, authors hold **moral rights** — personal rights such as attribution and the integrity of the work — that are **inalienable**: they cannot be waived or sold even if the author wants to. So a pure "I give up everything" dedication simply cannot take full effect in those countries.
+
+The net result: a one-line "this is public domain" note is well-intentioned but legally shaky, especially across borders. The deep cross-border treatment lives in [licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/); for now, just hold the idea that "public domain" doesn't mean the same thing everywhere.
+
+## The tools that actually do the job
+
+Because a bare dedication is fragile, several tools were created to dedicate work to the public domain *robustly*. The good ones share a clever two-part structure: **waive every right you can, and as a fallback, grant an extremely broad permissive license for anything that can't be waived.** That fallback is what makes them work internationally.
+
+| Tool | What it is | Notes |
+|---|---|---|
+| **CC0** | Creative Commons "no rights reserved" dedication + fallback license | **Recommended.** Carefully drafted; handles moral-rights jurisdictions via the fallback. Used for data, docs, and code. |
+| **Unlicense** | A public-domain dedication aimed at software | Popular and simple, but its legal drafting is more debated than CC0's. |
+| **0BSD** ("Zero-clause BSD") | A normal *permissive license* with the attribution requirement removed | Not a dedication at all, but achieves a similar "do anything, no conditions" effect with rock-solid, familiar license mechanics. |
+| **WTFPL** | "Do What The F*** You Want To Public License" | Mentioned for completeness; **discouraged** — its joke tone and thin drafting make it a poor choice for anything serious. |
+
+A few practical points:
+
+- **CC0** is the safest pick when you genuinely want public-domain-like behavior. Its fallback license means it still grants near-total freedom even in countries where you can't actually abandon copyright. (One caveat worth knowing: CC0 explicitly does *not* grant patent rights, so it differs from licenses with an express patent grant like [Apache 2.0](/learn/software-licensing/apache-license/).)
+- **0BSD** is often the *better* choice for source code specifically. Because it's a plain permissive license rather than a dedication, it avoids the "can you really abandon copyright?" question entirely while giving users the same no-conditions experience. Many people who want "MIT but without even the attribution line" reach for 0BSD.
+- **The Unlicense** works and is widely used, but if a lawyer is in the room, CC0 or 0BSD will usually be preferred for stronger drafting.
+- **WTFPL** is a meme. Avoid it for real projects — the lack of a warranty disclaimer alone is a reason to skip it.
+
+```text
+The robust-dedication pattern (CC0, Unlicense):
+  1. Waive all copyright and related rights, worldwide, to the extent allowed.
+  2. As a fallback, grant a maximally broad license for any rights that
+     cannot be waived (e.g., moral rights in the EU).
+  -> result: "do anything," enforceable almost everywhere.
+```
+
+## The big trap: no license is NOT public domain
+
+This is the most important practical takeaway in the lesson, and it catches people constantly. **A project with no license file is not in the public domain. It is the most restrictive state possible.**
+
+Remember from [what is a software license](/learn/software-licensing/what-is-a-software-license/) that copyright is automatic and the default is **all rights reserved**. So when you find code on a public repository with no LICENSE file, the absence of a license doesn't mean "take it freely" — it means the author has granted *no permissions at all*. Legally, you may look at it, but you have no right to copy, modify, or redistribute it. Posting code publicly does not waive copyright.
+
+So the spectrum has a surprising shape at its edges. Public domain (CC0/0BSD) is the *freest* state; "no license" is the *least* free. They look superficially similar — neither has a long license text — but they are opposites. If you mean "anyone can use this," you must *say so* with an actual dedication or license; silence does the reverse of what you intend.
+
+## When public domain makes sense
+
+Given the complications, when is public-domain dedication actually the right call? A few clear cases:
+
+- **Specifications and standards.** When you want maximum, frictionless adoption of a format or protocol, you don't want attribution lines or license terms getting in the way. Dedicating the spec text to the public domain (or CC0) removes all barriers.
+- **Tiny snippets and examples.** A ten-line example in documentation isn't worth a license header. CC0 or 0BSD lets people copy it into their own code without bookkeeping. (Below a threshold, very short snippets may not even be copyrightable, but a dedication removes the doubt.)
+- **Government works.** In the United States, works created by **federal government employees** in the course of their duties are, by statute, **not subject to copyright** — they're in the public domain from creation. This is why a lot of US government software and data can be used freely. Note this is US-specific: other governments handle their works differently (the UK, for instance, uses Crown Copyright), another reason jurisdiction matters.
+- **Maximizing reuse over recognition.** If you simply don't care about credit or control and want the lowest-friction reuse imaginable, a robust dedication is the way to express that.
+
+For most ordinary software projects, a short permissive license like [MIT](/learn/software-licensing/mit-and-bsd-licenses/) is still the more common choice, because the one remaining condition — keep the notice — is trivial and the license is universally understood. But when you truly want *nothing* asked of users, reach for CC0 or 0BSD rather than a bare "public domain" note. How to weigh these options deliberately is covered in [choosing an open-source license](/learn/software-licensing/choosing-an-oss-license/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — with no license, default copyright reserves all rights, so it's the most restrictive state, not public domain." markdown="0">
+  <p class="knowledge-check__q">Quick check: a public repository has code but no LICENSE file. What does that mean?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The code is in the public domain — anyone can use it freely</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">All rights are reserved by default — you have no permission to copy, modify, or redistribute it</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's automatically licensed under MIT because it was posted publicly</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Public domain is the freest state** — no rights reserved, no conditions, not even attribution; freer than MIT.
+- **Clean dedication is legally tricky** — copyright is automatic, the US has no formal abandonment procedure, and moral rights can't be waived in many countries.
+- **Use a real tool, not a bare note** — CC0 (a dedication plus a fallback license) is recommended; 0BSD is often the best choice for source code; the Unlicense works but is less crisply drafted; WTFPL is discouraged.
+- **No license is NOT public domain** — it's the most restrictive default (all rights reserved); silence does the opposite of "use freely."
+- **Public domain fits specific cases** — specs and standards, tiny snippets, and US federal government works (US-specific — other countries differ).
+- **For most projects, permissive still wins** — a short MIT-style license is universally understood; reach for CC0/0BSD only when you want truly nothing asked of users.
+
+Next up: what happens when you try to combine code under different licenses — and why some combinations simply aren't allowed. See [License compatibility](/learn/software-licensing/license-compatibility/).

--- a/docs/learn/software-licensing/putting-it-all-together.md
+++ b/docs/learn/software-licensing/putting-it-all-together.md
@@ -1,0 +1,135 @@
+---
+slug: putting-it-all-together
+title: Putting it all together
+description: A full end-to-end worked example — turning an SDR scanner into an open-source core plus a paid hosted edition — applying the framework to choose a license, handle dependencies, and assemble the agreement set. The capstone of the path.
+keywords: software licensing worked example, open core licensing, Apache vs AGPL, third party licenses, SBOM dependency scanning, SaaS agreements, DPA SLA subscription terms, GopherTrunk Apache 2.0, putting licensing together, end to end licensing decision, staying compliant
+level: advanced
+status: full
+faq:
+  - q: "How do I license an open-source core and a paid hosted version at the same time?"
+    a: "Common pattern: license the **core** under a standard open-source license (Apache 2.0 for adoption, or AGPL to keep hosted competitors from going closed) and run the **paid hosted edition** under your own terms of service plus the commercial agreement stack. The open license governs the code; the hosted edition's agreements govern the service you sell on top of it."
+  - q: "What's the minimum agreement set for a paid hosted product?"
+    a: "At a realistic minimum: **terms of service** (the rules of the service), a **privacy policy** (what you collect and why), a **DPA** with any vendor that processes user data for you, and **subscription terms** (the commercial deal). Add an **SLA** if you promise uptime, and a **CLA/DCO** if the open core takes outside contributions."
+  - q: "What is GopherTrunk actually licensed under?"
+    a: "**Apache 2.0** — see the repository's [`/LICENSE`](https://github.com/MattCheramie/GopherTrunk/blob/main/LICENSE) file. It also ships a [`/THIRD_PARTY_LICENSES.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/THIRD_PARTY_LICENSES.md) attribution file and inventories transitive dependency licenses with `make licenses` in CI. It's a real, working example of permissive licensing done correctly, which is why this path keeps pointing at it."
+---
+# Putting it all together
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**One worked example, end to end** — we take a realistic product through the whole framework: license, dependencies, and agreements. **Open core + paid hosted** — Apache (or AGPL) for the core, a full agreement stack for the hosted edition. **Dependencies are real work** — attribution files and scanning keep you compliant as the tree changes. **You now have a process** — six inputs in, a license and an agreement set out, repeatable on any project.
+</div>
+
+This is the final lesson of the path. You've learned the foundations, the license families, how to combine open source, how proprietary and commercial licensing work, how to use open source in software you sell, how to read agreements, and how to choose your own. Now we put it all to work on one realistic product, start to finish, so the whole thing clicks into a single mental motion. Then we'll wrap up everything you can now do, note how to stay compliant as things change, and point you to where to get help. By the end you'll have seen the entire path applied at once — and be ready to do it for real.
+
+## The scenario
+
+Imagine you've built a capable SDR trunking scanner — much like [GopherTrunk](https://github.com/MattCheramie/GopherTrunk) — that decodes P25, DMR, and TETRA from raw radio captures. You want two things at once:
+
+1. An **open-source core** so the community can use, audit, and improve the decoder.
+2. A **paid hosted edition** — a web dashboard where customers point their receivers at your cloud, and you decode, store, and visualize their traffic for a subscription.
+
+This is the classic **open-core / hosted** model, and it's an ideal capstone because it exercises every part of the framework: an open-source license *and* a commercial one, real dependencies to comply with, a hosted delivery model, and personal data. Let's run the [decision framework](/learn/software-licensing/the-decision-framework/) on it.
+
+## Step 1 — Run the six inputs
+
+Walking the framework's six inputs:
+
+| Input | For this product |
+|---|---|
+| **Goal** | Both adoption (the core) *and* revenue (the hosted edition) |
+| **Business model** | Open core: free core + paid hosted service |
+| **Dependencies** | Go modules and in-tree code under various OSS licenses |
+| **Delivery model** | Downloaded (core binary) **and** hosted (the web edition) |
+| **Data handled** | Hosted edition stores user accounts, captures, locations |
+| **Risk & jurisdiction** | Paying customers + personal data → moderate-to-high; assume US + EU users |
+
+Notice the split goal. That's the signature of open core, and it means we'll produce *two* answers — a license for the core and a commercial stack for the hosted edition — rather than one.
+
+## Step 2 — Choose the license for the core
+
+Run the [license walkthrough](/learn/software-licensing/choose-your-license/). Step 1 (the top fork) is **open** for the core. Step 2 (permissive vs copyleft) is where the interesting decision lives, and it hinges on the one thing the open-core model has to worry about: a competitor taking your open core and running their *own* hosted edition against you.
+
+- **Apache 2.0** — maximizes adoption and includes a patent grant, which matters for signal-processing code. The trade-off: nothing stops a competitor from hosting your core commercially. You accept that in exchange for the widest possible community. **This is what GopherTrunk itself chose** (`/LICENSE`).
+- **AGPL** — keeps the core open but forces any competitor who hosts a modified version to publish their changes, blunting the "take it closed and resell it" move. The trade-off: AGPL makes some corporate users and contributors wary, shrinking adoption.
+
+Both are defensible; the choice is a pure expression of the [permissive-vs-copyleft](/learn/software-licensing/permissive-vs-copyleft/) trade-off you learned early. For a project whose *first* priority is community trust and reach, **Apache 2.0** is the right call — and your paid edition's moat then comes from the hosting, support, and proprietary dashboard, not from the license. If protecting the hosted edition were the higher priority, **AGPL** (or even a [source-available](/learn/software-licensing/source-available-licenses/) license, giving up the "open" label) would be the move. We'll go with **Apache 2.0 for the core**, matching the real GopherTrunk.
+
+## Step 3 — Handle the open-source dependencies
+
+Your core isn't written from scratch — it links a tree of Go modules and includes some in-tree code derived from other projects. Before you ship *anything*, open or paid, you must comply with those licenses. This is the [auditing dependencies](/learn/software-licensing/auditing-dependencies/) and [permissive compliance](/learn/software-licensing/permissive-compliance/) work made concrete.
+
+Two things to get right:
+
+- **Attribution.** Permissive licenses (MIT, BSD, Apache) require you to carry their copyright notices and license text. GopherTrunk does this with a [`/THIRD_PARTY_LICENSES.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/THIRD_PARTY_LICENSES.md) file listing every direct dependency, its version, license, and upstream — plus the in-tree derived code. Your product needs the same: one canonical attribution file.
+- **Scanning, continuously.** A dependency tree changes with every update, and a new transitive dependency can quietly introduce a license you don't want (a copyleft one that conflicts with your distribution). Automate it. GopherTrunk inventories transitive licenses with a `make licenses` target and a CI `licenses` job that fails the build on a surprise. This is the practical face of an **SBOM** (software bill of materials).
+
+```text
+# The pattern, illustrated
+$ make licenses          # regenerate the dependency license inventory
+$ git diff THIRD_PARTY_LICENSES.md   # review what changed
+# CI runs the same check and fails if an unexpected/incompatible license appears
+```
+
+The lesson here, which the whole [using-OSS-in-products](/learn/software-licensing/using-oss-in-products/) module drove home: compliance isn't a one-time chore at launch — it's a check that runs forever, because the inputs keep moving.
+
+## Step 4 — Assemble the agreement set for the hosted edition
+
+The core is just an Apache-licensed binary — it needs the license and the attribution file, nothing more. The **paid hosted edition** is where the [agreement set](/learn/software-licensing/which-agreements-do-you-need/) comes in. Run that lesson's table against this product: it's a business SaaS, it handles personal data, you'll promise some uptime, and the open core takes contributions. That unions to:
+
+| Agreement | Why this product needs it |
+|---|---|
+| **Terms of Service** | It's a hosted service users access, not a copy they install — ToS governs accounts, acceptable use, payment, termination ([EULA & ToS](/learn/software-licensing/eula-and-tos/)) |
+| **Privacy policy** | It stores user accounts, captures, and locations — personal data, with GDPR (EU) and CCPA (US/CA) duties ([privacy & data](/learn/software-licensing/privacy-and-data-agreements/)) |
+| **DPA** | Your cloud host and any analytics vendor process that personal data on your behalf ([privacy & data](/learn/software-licensing/privacy-and-data-agreements/)) |
+| **Subscription terms** | The commercial deal — pricing, renewal, refunds — for the paid tier ([commercial models](/learn/software-licensing/commercial-license-models/)) |
+| **SLA** | You promise uptime; the SLA states the level and the remedy (credits) if you miss ([SLAs & support](/learn/software-licensing/sla-and-support-agreements/)) |
+| **CLA or DCO** | The open core accepts outside contributions; you need clear rights to that code ([contributor agreements](/learn/software-licensing/contributor-agreements/)) |
+
+Note one thing worth flagging given the product: a scanner that decodes radio traffic may touch communications that are sensitive or regulated in some jurisdictions. That's a domain-specific legal question beyond licensing, and exactly the kind of thing to raise with a lawyer — your ToS should at minimum put acceptable-use responsibility on the customer.
+
+That's the complete picture: **Apache 2.0 + attribution** for the core, and **ToS + privacy policy + DPA + subscription terms + SLA + CLA/DCO** for the hosted edition. Six inputs in, a license and an agreement set out — the framework delivered exactly what it promised.
+
+## You now know how to…
+
+Step back and look at what this path has given you. You can now:
+
+- **Tell a license from a contract** and read either one — the [main clauses](/learn/software-licensing/main-clauses-decoded/), the [risk clauses](/learn/software-licensing/how-to-read-an-agreement/), and what to check [before you agree](/learn/software-licensing/before-you-agree/).
+- **Place any license on the spectrum** — from [public domain](/learn/software-licensing/public-domain-and-cc0/) through [permissive](/learn/software-licensing/mit-and-bsd-licenses/) and [Apache](/learn/software-licensing/apache-license/) to [copyleft](/learn/software-licensing/gpl-strong-copyleft/) and [network copyleft](/learn/software-licensing/agpl-network-copyleft/), with the [weak-copyleft](/learn/software-licensing/weak-copyleft-licenses/) middle.
+- **Combine open source safely** — [compatibility](/learn/software-licensing/license-compatibility/), [contributor agreements](/learn/software-licensing/contributor-agreements/), and the [risks](/learn/software-licensing/open-source-risks/) of depending on it.
+- **Build a business on it** — [proprietary](/learn/software-licensing/proprietary-licensing/) and [commercial models](/learn/software-licensing/commercial-license-models/), [source-available](/learn/software-licensing/source-available-licenses/) options, and how to [sell software built on open source](/learn/software-licensing/using-oss-in-products/) while meeting its obligations.
+- **Choose for your own project** — run the [framework](/learn/software-licensing/the-decision-framework/), pick a [license](/learn/software-licensing/choose-your-license/), and assemble the [agreement set](/learn/software-licensing/which-agreements-do-you-need/).
+
+That's a complete working literacy in software licensing — enough to make confident, defensible decisions and to know precisely when a question has grown big enough to hand to a professional.
+
+## Staying compliant as things change
+
+A license-and-agreement decision is not a monument; it's a living thing. Three habits keep it healthy:
+
+- **Re-scan dependencies on every change.** A new transitive dependency can introduce an incompatible license overnight — which is why GopherTrunk's `make licenses` check runs in CI, not once a year.
+- **Revisit when the product changes.** Add an API, start handling a new kind of data, expand into a new region, or open a paid tier, and your agreement set changes with it. Re-run the [agreements table](/learn/software-licensing/which-agreements-do-you-need/).
+- **Watch the landscape.** Licenses and data laws evolve; staying current is part of the job, and the [jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/) lesson is your starting point for the cross-border picture.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — in open core you license the code with an open license and govern the paid service with its own agreement stack; they're separate, layered decisions." markdown="0">
+  <p class="knowledge-check__q">Quick check: in an open-core product with a paid hosted edition, what governs the paid service itself?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The same open-source license as the core, with nothing added</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only a EULA, since the customer is using your software</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A separate agreement stack — terms of service, privacy policy, DPA, subscription terms, and often an SLA</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **The framework delivers two outputs** — for our scanner: Apache 2.0 (with attribution) for the core, and a full agreement stack for the paid hosted edition.
+- **License the code, then agreements layer on top** — the open license governs the core; ToS, privacy policy, DPA, subscription terms, SLA, and a CLA/DCO govern the hosted service and contributions.
+- **GopherTrunk is the real example** — Apache-2.0 (`/LICENSE`), a `/THIRD_PARTY_LICENSES.md` attribution file, and a `make licenses` CI check show permissive licensing done correctly.
+- **Compliance is continuous** — re-scan dependencies, revisit agreements when the product changes, and watch the legal landscape.
+- **You have a repeatable process** — six inputs in, a license and an agreement set out, ready to apply to any project.
+
+That's the whole path. You started not knowing what a software license *is*, and you can now take a real product end-to-end — choose its license, comply with its dependencies, and assemble its agreements — and recognize the moment a question deserves a professional's eyes. When that moment comes, [Where to get licensing help](/learn/software-licensing/where-to-get-licensing-help/) points you to the right resources.
+
+Thank you for working through it. To consolidate every term you've met along the way, head to the [glossary](/learn/software-licensing/glossary/) — and go make something, license it well, and ship it with confidence.

--- a/docs/learn/software-licensing/risk-clauses.md
+++ b/docs/learn/software-licensing/risk-clauses.md
@@ -1,0 +1,126 @@
+---
+slug: risk-clauses
+title: "The risk clauses: who pays when it breaks"
+description: The clauses that decide liability — warranties versus AS-IS disclaimers, limitation-of-liability caps, exclusion of indirect and consequential damages, indemnification, insurance, and force majeure. Where the real money risk lives and what gets negotiated.
+keywords: limitation of liability, liability cap, AS IS disclaimer, disclaimer of warranties, implied warranties, indemnification, indemnity, consequential damages, indirect damages, lost profits, force majeure, insurance clause, third-party IP claims, risk allocation
+level: intermediate
+status: full
+faq:
+  - q: "What does a liability cap actually limit?"
+    a: "It sets a **maximum total amount** one party can be made to pay the other if things go wrong. A very common cap is the **fees you paid in the prior 12 months** — so if you paid $10,000, that's roughly the most you could recover even from a serious failure. Caps are usually paired with an **exclusion of indirect damages**, which removes lost profits and consequential losses on top. Read both together to see your true exposure."
+  - q: "What's the difference between a liability cap and an indemnity?"
+    a: "A **limitation of liability** caps what the parties owe *each other* under the contract. An **indemnity** is a promise to cover a *third party's* claim — for example, the vendor agreeing to defend you if someone sues claiming the software infringes their patent. Indemnities are often **carved out of the cap**, because the whole point is to make that protection meaningful, so they can be the largest real exposure in the deal."
+  - q: "Can a vendor just disclaim all liability with an 'AS IS' clause?"
+    a: "Largely in the US for business deals, yes — courts broadly uphold conspicuous warranty disclaimers and liability limits between sophisticated parties. But not without limits: many jurisdictions **void overly broad disclaimers**, especially against consumers. EU and UK consumer law, for instance, won't let a seller disclaim core protections, and most systems won't allow you to disclaim liability for things like gross negligence, fraud, or death and personal injury."
+---
+# The risk clauses: who pays when it breaks
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Warranties vs "AS IS"** — a warranty is a promise about the software; "AS IS" disclaims those promises. **Liability caps limit the total payout** — often capped at fees paid, with indirect damages excluded entirely. **Indemnity covers third-party claims** — crucial when you embed others' code. **This is where the real money risk lives** — and why these clauses are the most negotiated in B2B deals. **Disclaimers have legal limits** — consumer and other law can void overly broad ones.
+</div>
+
+The clauses we covered last lesson define the deal; the **risk clauses** decide what happens when the deal goes wrong. They allocate who bears the cost of a bug, an outage, a security breach, or a lawsuit — and they're written, almost always, to push that cost away from the vendor and toward you. This lesson decodes the major risk-allocation clauses so you can see your real exposure, understand why these are the most fought-over terms in any serious contract, and know where the law won't let a clause go too far. By the end you'll read the back half of a contract — the part most people's eyes glaze over — as the most important part.
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+## Warranties vs "AS IS"
+
+A **warranty** is a promise about the software — that it will perform as documented, that the vendor has the right to license it, that it's free of known malware. Warranties give you something to point to when the product fails.
+
+The flip side is the **disclaimer of warranties**, usually written in shouting capitals:
+
+```text
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+```
+
+That paragraph does real work. The law would otherwise read certain **implied warranties** into the deal automatically — notably **merchantability** (the goods are fit for ordinary use) and **fitness for a particular purpose** (suitable for the use the seller knew about). The disclaimer strips those out, leaving you with only whatever *express* warranties the contract explicitly grants — often none. The all-caps formatting isn't decoration; the law in many places requires such disclaimers to be **conspicuous** to be effective.
+
+You'll recognize "AS IS" from open-source licenses too — Apache 2.0, MIT, and the GPL all disclaim warranties this way, because the code is given for free with no promises. In a paid commercial deal, by contrast, a blanket "AS IS" is something to push back on.
+
+## Limitation of liability
+
+If a warranty governs *whether* the vendor owes you anything, the **limitation of liability** governs *how much*. It has two moving parts, and you must read both:
+
+### The cap
+
+A **liability cap** sets the maximum total a party can be required to pay. The single most common formula is **the fees paid in the prior 12 months**:
+
+```text
+IN NO EVENT SHALL EITHER PARTY'S TOTAL AGGREGATE LIABILITY EXCEED THE FEES
+PAID BY CUSTOMER IN THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
+```
+
+So if you paid $10,000 last year, $10,000 is roughly the ceiling on what you could recover — even if a vendor failure cost you far more. Caps can also be a fixed dollar figure or a multiple of fees.
+
+### The exclusion of indirect damages
+
+Stacked on top of the cap is an **exclusion of consequential, indirect, and special damages** — and the big one, **lost profits**. Direct damages are the immediate, obvious losses; **consequential** damages are the knock-on losses (the revenue you lost while the service was down, the customers who churned). Excluding them is standard and often removes the *largest* real-world harm from the table.
+
+Read the cap and the exclusion together: a low cap plus a broad exclusion of indirect damages means that even a catastrophic failure may leave you recovering only a fraction of your actual loss.
+
+## Indemnification
+
+**Indemnification** is a promise by one party to **cover a third party's claim** against the other — to defend the lawsuit and pay the resulting costs or damages. The most important kind in software is the **IP indemnity**: the vendor agrees that if someone sues *you* claiming the software infringes their patent or copyright, the vendor will step in and handle it.
+
+This matters enormously when you **embed others' code** in something you ship. If you build a product on third-party components and a patent holder comes after your customers, an indemnity from your suppliers is what stands between you and the bill. (This is one reason the [Apache 2.0](/learn/software-licensing/apache-license/) patent grant is valued, and why [auditing your dependencies](/learn/software-licensing/auditing-dependencies/) matters.)
+
+Two things to check on any indemnity: **what it covers** (IP claims only, or also data breaches and personal injury?) and **whether it's carved out of the liability cap**. A good IP indemnity is usually *uncapped* or has a much higher cap — otherwise the protection is hollow.
+
+## Insurance and force majeure
+
+Two supporting risk clauses round out the picture:
+
+- **Insurance** — larger B2B contracts require each side to carry certain coverage (commercial general liability, cyber, errors-and-omissions) at stated limits. Insurance is what makes an indemnity *collectible* — a promise to pay is only as good as the payer's ability to pay.
+- **Force majeure** — excuses a party from performing when something genuinely outside its control intervenes (natural disaster, war, sometimes large-scale infrastructure failure). It pauses obligations rather than ending them. Read what it covers: a clause that sweeps in "any event beyond reasonable control" can be used to excuse more than you'd expect. Note it usually does *not* excuse paying money you already owe.
+
+## Why these clauses are the most negotiated
+
+In B2B deals, the risk clauses are where the real negotiation happens — far more than the price. The reason is simple: **this is where the money risk actually lives.** A price is a known, bounded number. An uncapped liability or a missing indemnity is an *unbounded* number, and that's what keeps lawyers up at night.
+
+Expect a serious negotiation to focus on raising the cap, narrowing the indirect-damages exclusion, getting (or giving) an uncapped IP indemnity, and adding carve-outs from the cap for the scariest scenarios (data breach, confidentiality violations, IP infringement). When you read a contract and the risk clauses are aggressively one-sided, that's not a detail — it's the heart of the deal.
+
+## Jurisdictional limits on disclaimers
+
+Risk clauses are not infinitely enforceable. The law sets floors that a contract can't disclaim below:
+
+- **Consumer protection** — the EU and UK won't let sellers disclaim core consumer warranties or unfairly limit liability to consumers; a sweeping "AS IS" that's routine in a US B2B deal can be **void** against an EU consumer.
+- **Unconscionability** — US courts can strike a liability limit that's grossly one-sided or hidden.
+- **Carve-outs the law requires** — most systems forbid disclaiming liability for **gross negligence, willful misconduct, fraud, and death or personal injury**, no matter what the contract says.
+
+So a clause that looks ironclad may not hold, especially across borders. The dedicated [cross-border lesson](/learn/software-licensing/licensing-across-jurisdictions/) goes deeper.
+
+## A risk-clause reference
+
+| Clause | What it does | Where the risk lands |
+|---|---|---|
+| **Warranty** | Promises the software performs as stated | More on vendor if granted; on you if absent |
+| **"AS IS" / disclaimer** | Strips implied warranties (merchantability, fitness) | On you — you take the product as it is |
+| **Liability cap** | Limits total payout, often to fees paid | On you, above the cap |
+| **Indirect-damages exclusion** | Removes lost profits and consequential loss | On you — often the largest real loss |
+| **Indemnification** | Covers third-party claims (esp. IP) | On the indemnifier — vital when embedding others' code |
+| **Insurance** | Requires coverage at stated limits | Makes indemnities actually collectible |
+| **Force majeure** | Excuses performance for uncontrollable events | Pauses obligations; rarely excuses paying what's owed |
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a very common limitation-of-liability cap is the total fees you paid in the previous 12 months, often paired with an exclusion of indirect damages." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is a very common way a limitation-of-liability clause caps the vendor's total liability?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">At the full amount of any losses you can prove, with no ceiling</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">At the total fees you paid in the prior 12 months</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">At a fixed statutory minimum set by federal law</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Warranties vs "AS IS"** — a warranty promises performance; an "AS IS" disclaimer strips the implied warranties the law would otherwise add.
+- **Liability caps limit the payout** — commonly to fees paid, and almost always paired with an exclusion of indirect and consequential damages.
+- **Indemnity covers third-party claims** — the IP indemnity is critical when you ship products built on others' code; check whether it's carved out of the cap.
+- **Insurance and force majeure** — insurance makes indemnities collectible; force majeure pauses (not erases) obligations and rarely excuses payment.
+- **This is where the money risk lives** — which is exactly why these are the most negotiated clauses in B2B deals.
+- **Disclaimers have legal limits** — consumer law and rules against disclaiming gross negligence, fraud, or personal injury can void overly broad clauses, especially abroad.
+
+Next up: turn all of this into a pre-signature checklist and a list of red flags to catch before you commit. See [What to check before you agree](/learn/software-licensing/before-you-agree/).

--- a/docs/learn/software-licensing/sla-and-support-agreements.md
+++ b/docs/learn/software-licensing/sla-and-support-agreements.md
@@ -1,0 +1,122 @@
+---
+slug: sla-and-support-agreements
+title: SLAs & support agreements
+description: An SLA promises how available a service will be and what you get when it falls short; a support agreement defines response times, tiers, and coverage. Learn the "nines," service credits, severity levels, and how to read both from each side.
+keywords: service level agreement, SLA, uptime, availability, the nines, service credits, maintenance window, support agreement, support tiers, response time, resolution time, severity levels, end of life, EOL, SLA exclusions
+level: intermediate
+status: full
+faq:
+  - q: "What does '99.9% uptime' actually mean in real downtime?"
+    a: "It's the fraction of time the service must be available. **99.9%** (\"three nines\") allows about **43 minutes** of downtime per month; **99.99%** (\"four nines\") allows about **4.3 minutes**. Each extra nine cuts allowed downtime roughly tenfold — and gets dramatically harder and more expensive to deliver. Always check the *measurement window* and what counts as downtime, because exclusions can make a high number mean less than it looks."
+  - q: "Are service credits real compensation if a service goes down?"
+    a: "Rarely in proportion to your loss. A **service credit** is usually a small percentage of *your fee* for the affected period, capped low, and often **the sole remedy** — meaning you can't claim your actual business losses. They're a accountability signal more than insurance. If uptime is mission-critical, negotiate higher credits, an exit right for repeated breaches, or carry your own resilience and insurance."
+  - q: "What's the difference between response time and resolution time in support?"
+    a: "**Response time** is how fast support *acknowledges* and starts working on your ticket. **Resolution time** is how fast it's actually *fixed*. Most support agreements commit firmly to response times by severity and are far vaguer about resolution — because a fix can depend on factors outside the vendor's control. Read which one the SLA actually guarantees; the gap matters."
+---
+# SLAs & support agreements
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**An SLA promises availability** — the "nines" of uptime, how it's measured, and the exclusions. **Service credits are the usual remedy** — a small, capped refund, often the *only* recourse. **A support agreement defines help** — tiers, severity levels, response vs resolution times, and hours of coverage. **Maintenance and EOL matter too** — updates, patches, and when support ends. **Read both from both sides** — as a buyer, is the promise meaningful? As a seller, can you actually keep it?
+</div>
+
+When you buy or sell a service rather than a one-off copy of software, two agreements describe the *quality* of the ongoing relationship: the **Service Level Agreement (SLA)**, which commits to how available and performant the service will be, and the **support agreement**, which defines what help you get when something goes wrong. They often sit inside a larger [subscription or service contract](/learn/software-licensing/eula-and-tos/). This lesson explains the "nines" of uptime, why service credits are weaker than they sound, how support tiers and severity levels work, and — crucially — how the same document reads very differently depending on whether you're buying or selling. By the end you'll be able to size up an SLA on either side of the table.
+
+## The SLA: a promise about availability
+
+An **SLA** is a commitment to a measurable level of service — most commonly **availability**, expressed as a percentage of uptime over a period. The famous shorthand is the **"nines."** More nines means less allowed downtime, and each nine is roughly ten times harder to achieve.
+
+| Availability | Nickname | Downtime / month | Downtime / year |
+|---|---|---|---|
+| 99% | "two nines" | ~7.3 hours | ~3.65 days |
+| 99.9% | "three nines" | ~43 minutes | ~8.8 hours |
+| 99.95% | — | ~22 minutes | ~4.4 hours |
+| 99.99% | "four nines" | ~4.3 minutes | ~52 minutes |
+| 99.999% | "five nines" | ~26 seconds | ~5.3 minutes |
+
+The headline number is the easy part. The real meaning lives in three details:
+
+- **Measurement window.** Is uptime measured monthly or annually? A monthly window resets the budget every month; an annual window lets one bad outage be averaged away. Buyers prefer monthly; sellers prefer annual.
+- **What counts as "down."** Total outage only, or also degraded performance and partial failures? A service that's technically "up" but unusably slow may not breach a narrowly written SLA.
+- **Exclusions.** Scheduled **maintenance windows**, force majeure, problems caused by the customer or by third-party networks, and beta features are commonly carved out and don't count against uptime. Generous exclusions can hollow out an impressive percentage.
+
+### Service credits: the typical remedy, and their limits
+
+When an SLA is breached, the standard remedy is a **service credit** — a partial refund applied to a future bill, scaled to how badly the target was missed (for example, 10% credit for falling below 99.9%, more for worse). Three limits make credits weaker than they first appear:
+
+1. **They're small and capped.** Credits are a fraction of *your fee* for the affected period, with an overall cap (often a month's fees). They are not tied to *your* losses from the outage.
+2. **They're often the "sole and exclusive remedy."** That phrase, common in SLAs, means the credit is *all you get* — you waive the right to claim your actual business damages.
+3. **You usually have to claim them.** Credits frequently aren't automatic; you must request them within a window, or you forfeit them.
+
+So a service credit is best understood as an **accountability signal** — skin in the game for the provider — rather than insurance against your loss. If availability is genuinely critical to you, the credit alone won't make you whole; you negotiate stronger terms (higher credits, a **termination right** if the SLA is missed repeatedly) and you build your own resilience.
+
+## The support agreement: getting help
+
+Where the SLA covers whether the service is *up*, the **support agreement** covers what happens when you need *help* — a bug, a question, an incident. Its main moving parts:
+
+- **Support tiers / packages.** Vendors usually sell levels — say Basic, Business, Premium/Enterprise — that buy faster response, more channels, and longer hours.
+- **Hours of coverage.** "Business hours" (e.g., 9–5 in one time zone) versus **24/7**. For a global or always-on system, the difference is enormous.
+- **Channels.** Email/ticket only, versus chat, phone, or a named technical contact.
+- **Response vs resolution time.** This distinction is central. **Response time** is how fast support *acknowledges and engages* your ticket; **resolution time** is how fast it's actually *fixed*. Agreements commit firmly to response, vaguely (if at all) to resolution — because fixing can depend on reproducing the issue, third parties, or a release cycle. Read which one is actually guaranteed.
+
+### Severity levels
+
+Support commitments are almost always **tiered by severity** — how badly the problem hurts you — so a production outage isn't treated like a cosmetic glitch. A typical scheme:
+
+| Severity | Meaning | Typical target response |
+|---|---|---|
+| **Sev 1 / Critical** | Production down or unusable; no workaround | Minutes to ~1 hour, 24/7 |
+| **Sev 2 / High** | Major function impaired; workaround painful | Hours, business day |
+| **Sev 3 / Medium** | Minor issue or limited impact; workaround exists | ~1 business day |
+| **Sev 4 / Low** | Cosmetic, question, or feature request | Best effort / next release |
+
+Note that *the customer often files at a severity, but the vendor may reclassify it.* Check who decides severity and whether you can escalate — a vendor that quietly downgrades your "critical" to "medium" has changed the deal.
+
+## Maintenance, updates, and end of life
+
+Both agreements interact with the **lifecycle** of the software:
+
+- **Updates and patches.** Who delivers them, how often, and whether security patches are guaranteed for a defined period. For self-hosted software this is a core part of the value.
+- **Maintenance windows.** Planned downtime for upgrades — usually excluded from the SLA, but a good agreement bounds them (advance notice, off-peak timing, a monthly cap).
+- **End of life (EOL).** When a version stops receiving support and security fixes. An EOL policy tells you how long you can safely run a given release before you *must* upgrade — vital for planning and for security (an unsupported version that stops getting patches becomes a liability, a theme in [the risks of depending on open source](/learn/software-licensing/open-source-risks/) and in [auditing dependencies](/learn/software-licensing/auditing-dependencies/)).
+
+## Reading from both sides
+
+The same SLA or support agreement should be read very differently depending on which seat you're in — this is the most useful habit in this lesson.
+
+**As a buyer, ask: is the promise meaningful?**
+
+- Does the uptime number, *after exclusions*, actually cover what I depend on?
+- Is the credit worth anything next to what an outage costs me — and is it the *only* remedy?
+- Are response times guaranteed for the severities I'll actually hit, in my time zone?
+- What's my exit if they keep missing the targets?
+
+**As a seller, ask: can I actually meet this?**
+
+- Can my infrastructure realistically sustain the nines I'm promising, every measurement window — not on a good month?
+- Have I scoped exclusions and maintenance windows so a routine upgrade doesn't breach my own SLA?
+- Can my support team meet the response times I've committed to, at the hours I've promised, including 24/7 if I sold it?
+- Are my credits capped and structured so a bad incident doesn't sink the contract — without being so stingy they look like bad faith?
+
+The discipline cuts both ways: **don't buy a number you can't verify, and don't sell a number you can't keep.** An SLA you can't meet is worse than a humbler one you can, because chronic breach erodes trust and invites the exit clauses you wrote.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a service credit is usually a small, capped refund of your own fees, and frequently the sole remedy, so it rarely covers your real losses." markdown="0">
+  <p class="knowledge-check__q">Quick check: a 99.9% SLA is breached and your business loses far more than a month of fees. What does the typical service-credit clause give you?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Full compensation for your actual business losses from the outage</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">A small, capped credit against your fees — often the sole remedy, not your real losses</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">An automatic right to terminate immediately with a full refund</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **An SLA commits to availability** — the "nines" of uptime, but the meaning lives in the measurement window, what counts as down, and the exclusions.
+- **Service credits are weak remedies** — small, capped, often the sole recourse and not automatic; treat them as accountability, not insurance.
+- **Support agreements define help** — tiers, hours of coverage, channels, and the key gap between guaranteed *response* time and looser *resolution* time.
+- **Severity levels prioritize** — and watch who gets to set or downgrade the severity of your ticket.
+- **Lifecycle matters** — updates, bounded maintenance windows, and an EOL policy that tells you how long a version stays supported.
+- **Read from both sides** — buyers ask whether the promise is meaningful; sellers ask whether they can actually keep it.
+
+Next up: the confidentiality agreements and the rest of the B2B contract landscape, and how all these documents fit together. See [NDAs & the rest of the landscape](/learn/software-licensing/nda-and-other-agreements/).

--- a/docs/learn/software-licensing/source-available-licenses.md
+++ b/docs/learn/software-licensing/source-available-licenses.md
@@ -1,0 +1,108 @@
+---
+slug: source-available-licenses
+title: Source-available & "fair source"
+description: The middle ground that is not open source — code you can read but can't freely use. Learn the Business Source License (BSL), SSPL, the Elastic License, the Fair Source movement, why companies adopt them, and why the OSI doesn't call them open source.
+keywords: source available, fair source, Business Source License, BSL, SSPL, Server Side Public License, Elastic License, MongoDB, HashiCorp, open source rug pull, cloud provider monetization, copyleft, OSI, license restrictions
+level: intermediate
+status: full
+faq:
+  - q: "Why isn't source-available code considered open source?"
+    a: "Because it fails the [Open Source Definition](/learn/software-licensing/what-is-open-source/). Open source requires that *anyone* may use, modify, and redistribute the code *for any purpose*, including commercially and including competing with the vendor. Source-available licenses keep the code visible but restrict exactly those things — most often a ban on production use, competing use, or offering it as a service — so the OSI doesn't recognize them as open source."
+  - q: "What is the Business Source License (BSL) and does it ever become open source?"
+    a: "The **BSL** lets you read, modify, and use the code with one main restriction — typically no production or competing commercial use — and then **automatically converts** to a true open-source license (often Apache 2.0 or GPL) after a set delay, commonly four years. So today's release is source-available; the same version becomes open source on a timer. It's a compromise between monetizing now and committing to openness later."
+  - q: "Why did several big projects relicense away from open source?"
+    a: "Mostly because **cloud providers were taking the open-source software, running it as a paid managed service, and capturing the revenue** without contributing much back. Companies like MongoDB, Elastic, and HashiCorp responded by moving to source-available licenses (SSPL, the Elastic License, BSL) that specifically restrict offering the software as a competing service. This is the commercial flip side of the dependency \"rug pull\" risk covered in [The risks of depending on open source](/learn/software-licensing/open-source-risks/)."
+---
+# Source-available & "fair source"
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Source-available ≠ open source** — the code is visible, but the license restricts use, so it fails the Open Source Definition. **The main licenses** — BSL (converts to open source on a timer), SSPL (copyleft aimed at cloud providers), the Elastic License. **"Fair source"** — a newer label for source-available-with-eventual-openness. **Why companies move here** — to stop cloud providers from monetizing their work without giving back.
+</div>
+
+Between fully open source and fully proprietary lies a fast-growing middle ground: software whose source code is published and readable, but whose license withholds some of the freedoms that would make it open source. This is **source-available** code, and over the last few years several major projects have moved into it — a shift worth understanding whether you're choosing a dependency or a license. By the end of this lesson you'll know the major source-available licenses, what each one restricts, what "fair source" means, why companies adopt these terms, and why the Open Source Initiative declines to call them open source.
+
+## The middle of the spectrum
+
+Recall the [licensing spectrum](/learn/software-licensing/the-licensing-spectrum/): permissive open source on one end, proprietary closed-source on the other. Source-available sits squarely in the middle. You get something proprietary software almost never gives you — the actual source code, to read, audit, and often to modify and self-host — but you *don't* get the full bundle of open-source freedoms. There's a string attached, usually one of:
+
+- **No competing use** — you can't offer the software as a service that competes with the vendor.
+- **No production use** (for a time) — you can use it for development, testing, and evaluation, but not in production, until a delay passes.
+- **No redistribution as a service** — you can't run it as a managed offering for others.
+
+The mental test from [What open source really means](/learn/software-licensing/what-is-open-source/) applies cleanly: *can anyone use this for any purpose, including commercially and including competing with the author?* If the answer is "no, not for X," it's source-available, not open source — no matter how much code is on display.
+
+## The Business Source License (BSL)
+
+The **Business Source License (BSL)**, originally from MariaDB and adopted by HashiCorp, CockroachDB, Sentry, and others, is the most influential source-available license because of one clever twist: it has an **expiration date**.
+
+Under the BSL you may freely read, copy, modify, and use the code, subject to a single **Additional Use Grant** restriction the vendor specifies — almost always *no production or competing commercial use*. Then, after a **Change Date** (commonly four years after release), each version **automatically converts** to a stated open-source license — typically Apache 2.0 or GPL.
+
+```text
+Business Source License — typical shape
+
+  Additional Use Grant: You may use the Licensed Work in production,
+  except to offer a commercial service that competes with the Licensor.
+
+  Change Date:    Four years from the date of each release.
+  Change License: Apache License, Version 2.0.
+```
+
+So a given version is source-available today and becomes genuinely open source on a timer. The BSL is best understood as a compromise: monetize the newest releases now, while guaranteeing the community gets full openness eventually. Note that "BSL" is a template — the real restriction depends on the Additional Use Grant the vendor fills in, so always read *that* line.
+
+## SSPL — copyleft turned against cloud providers
+
+The **Server Side Public License (SSPL)** was created by **MongoDB** in 2018. It looks like an aggressive form of [copyleft](/learn/software-licensing/permissive-vs-copyleft/): it builds on the AGPL idea that offering software over a network triggers source-sharing, then goes much further.
+
+The AGPL says that if you modify the software and offer it as a network service, you must share *your modifications*. The SSPL says that if you offer the software *as a service*, you must release the source code of **the entire service stack used to provide it** — the management software, automation, monitoring, the works. In practice that demand is so sweeping that no cloud provider will comply, which is precisely the point: the SSPL is designed to make it commercially impossible to offer MongoDB-as-a-service without a commercial license. It's copyleft weaponized against a specific business behavior.
+
+The OSI explicitly declined to approve the SSPL as open source. We compare it directly to the AGPL in [The AGPL: copyleft over the network](/learn/software-licensing/agpl-network-copyleft/).
+
+## The Elastic License and friends
+
+When Elastic relicensed Elasticsearch and Kibana in 2021 (it offered both the SSPL and its own license), it popularized the **Elastic License v2 (ELv2)** — a short, plain-language source-available license that grants broad rights with three carve-outs: you can't provide the software as a hosted/managed service, you can't circumvent license-key functionality, and you can't remove licensing notices. Other vendors have shipped similar bespoke "you may do anything except compete with us as a service" licenses (Confluent, Redis, and others have used variants of this idea).
+
+The common thread across BSL, SSPL, and ELv2 is the **anti-cloud-provider** clause: read it, run it, modify it, self-host it — just don't resell it as a competing managed service.
+
+## The "Fair Source" movement
+
+**Fair Source** is a newer umbrella label (with its own site, fair.io) for software that is publicly readable, allows use, modification, and redistribution with *minimal* restrictions to protect the maker's business, and — crucially — includes a **delayed open-source** provision so the code eventually becomes truly open. The BSL is the canonical Fair Source license. The movement is an attempt to give this middle ground a positive, honest name rather than letting it be confused with open source. The important word is **honest**: Fair Source advocates are clear that it is *not* open source, which is more than can be said for some vendors who blur the line.
+
+## Why companies move here — and the "rug pull"
+
+Why would a company that built its name on open source relicense away from it? The dominant reason is **cloud providers monetizing OSS**. A hyperscaler can take a popular open-source database, wrap it in a slick managed service, and earn enormous revenue from it — while contributing little back to the project that made it possible. The original company foots the development bill; the cloud provider captures the margin.
+
+Source-available licenses are the counter-move: keep the code open enough for users and self-hosters, but block competitors from running it as a service. From the vendor's side it's survival. From a *user's* side, a relicensing can feel like a **rug pull** — you adopted something as open source, built on it, and then the terms changed under you. That's the commercial face of the dependency risk we cover in [The risks of depending on open source](/learn/software-licensing/open-source-risks/): the license you depend on is only as stable as the business behind it (and as the contributor agreements that let them relicense — see [Contributor agreements](/learn/software-licensing/contributor-agreements/)).
+
+## Why the OSI says these aren't open source
+
+| License | Source visible? | Main restriction | Becomes open source? | OSI-approved? |
+|---|---|---|---|---|
+| **BSL** | Yes | No production/competing use (per Additional Use Grant) | Yes — after the Change Date | No |
+| **SSPL** | Yes | Must open-source your *entire* service stack to offer it as a service | No | No |
+| **Elastic License v2** | Yes | No hosted/managed-service offering; no key circumvention | No | No |
+| **A true OSS license (e.g. Apache 2.0)** | Yes | None on field of use | n/a — already open | Yes |
+
+The reason all the source-available licenses fail the [Open Source Definition](/learn/software-licensing/what-is-open-source/) is the same: they **discriminate against a field of endeavor** (offering a competing service) or otherwise restrict use. The OSD forbids that flatly — no "free for everything except commercial hosting." So however generous these licenses are, and however good their reasons, they are not open source, and the OSI is firm about not letting the term be stretched to cover them. Calling them "source-available" or "fair source" keeps the vocabulary honest.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the BSL restricts use now but automatically converts each version to a true open-source license after the Change Date." markdown="0">
+  <p class="knowledge-check__q">Quick check: which source-available license is designed to automatically become open source after a set delay?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">The SSPL (Server Side Public License)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">The Business Source License (BSL)</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">The Elastic License v2</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Source-available is the middle ground** — the code is visible and often modifiable and self-hostable, but the license restricts use, so it is *not* open source.
+- **BSL** — usable now with a no-production/no-competing restriction, automatically converting to a true open-source license after a Change Date (often four years).
+- **SSPL** — copyleft taken to an extreme, demanding the source of your entire service stack, designed to block cloud-provider services; OSI rejected it.
+- **Elastic License v2 and friends** — short licenses granting broad rights minus a managed-service carve-out.
+- **Fair Source** — an honest umbrella label for source-available code with a delayed-openness provision; explicitly not open source.
+- **Why companies move here** — to stop cloud providers from monetizing their OSS without giving back; for users it can feel like a rug pull.
+- **Why the OSI says no** — these licenses discriminate against a field of use, which the Open Source Definition forbids.
+
+Next up: from analyzing other people's licenses to drafting your own — what to decide before you write a license to sell software. See [Writing a license to sell software](/learn/software-licensing/writing-a-commercial-license/).

--- a/docs/learn/software-licensing/the-decision-framework.md
+++ b/docs/learn/software-licensing/the-decision-framework.md
@@ -1,0 +1,130 @@
+---
+slug: the-decision-framework
+title: A framework for choosing
+description: A repeatable framework that turns six inputs — your goal, business model, dependencies, delivery model, data handled, and risk tolerance — into a clear license and agreement decision.
+keywords: choosing a software license, license decision framework, license and agreement decision, open core, SaaS licensing, business model licensing, delivery model, license compatibility, risk tolerance, software licensing strategy, dual licensing decision
+level: intermediate
+status: full
+faq:
+  - q: "Where do I even start when picking a license and agreements?"
+    a: "Start with your **goal**, not the licenses. Decide whether you most want adoption, control, or revenue — that single answer steers everything else. Then layer in your business model, dependencies, delivery model, data, and risk tolerance. The framework in this lesson walks those six inputs in order so the answer falls out at the end."
+  - q: "Can my dependencies force my hand on which license I pick?"
+    a: "Yes. If you build on **strong-copyleft** code like the GPL and distribute the result, you generally have to license your combined work under compatible terms. So before you fall in love with a license, audit what you already depend on — see [license compatibility](/learn/software-licensing/license-compatibility/) and [auditing dependencies](/learn/software-licensing/auditing-dependencies/)."
+  - q: "Is the license the whole decision?"
+    a: "No — the license governs your **code**, but how you *deliver* the software and what *data* it touches decide which **agreements** you also need (a EULA, terms of service, a privacy policy, an SLA, and so on). This lesson produces both halves of the decision; the next two lessons turn each half into specifics."
+---
+# A framework for choosing
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Six inputs, one decision** — your goal, business model, dependencies, delivery model, data handled, and risk tolerance together determine your license and agreements. **Goal first** — adoption vs control vs revenue is the master question that orients everything else. **Constraints before preferences** — your existing dependencies and the data you touch can rule options out before you ever pick a favorite. **Two outputs** — the framework produces a *license* for your code and an *agreement set* for how you ship it.
+</div>
+
+You've spent this path learning the parts — license families, open source, proprietary models, agreements, and how to read the fine print. This lesson assembles those parts into a single repeatable process: a short, ordered set of questions that turns facts about your project into a license-and-agreement decision you can defend. By the end you'll have a framework you can run on any project — yours, your employer's, or a side project — and a summary table that maps the inputs to outcomes. The next two lessons then turn the two halves of that decision into specifics: [which license](/learn/software-licensing/choose-your-license/) and [which agreements](/learn/software-licensing/which-agreements-do-you-need/).
+
+## The six inputs
+
+The decision feels overwhelming because people try to answer it all at once. Don't. The choice is driven by six inputs, and if you gather them in order, the answer mostly assembles itself. Two of them — your goal and your business model — are *preferences* that point you toward an option. The other four — dependencies, delivery model, data, and risk — are *constraints* that can rule options out no matter what you'd prefer.
+
+| Input | The question it answers | What it drives |
+|---|---|---|
+| **Goal** | What do you want to *happen* to this software? | The broad license posture |
+| **Business model** | How (if at all) does this make money? | License + commercial agreements |
+| **Dependencies** | What licenses must you already comply with? | Hard limits on your license |
+| **Delivery model** | How does the software reach users? | Which agreements you need |
+| **Data handled** | What does it collect or process? | Privacy/data agreements |
+| **Risk & jurisdiction** | How much risk can you carry, and where? | Strength of terms, where you operate |
+
+Work top to bottom. The preferences set your direction; the constraints prune it. Let's take them one at a time as a set of questions with outcomes.
+
+## Question 1 — What is your goal: adoption, control, or revenue?
+
+This is the master question. Almost every later trade-off resolves once you know which of these three you weight most heavily.
+
+- **Adoption** — you want the widest possible use, including by companies building closed products on top of you. Fewer conditions means more reach. → *Points toward permissive open source.*
+- **Control** — you want to keep your code shared but stop others from taking it private, or from reselling it as a service. → *Points toward copyleft (or, if a cloud competitor is the worry, network copyleft or source-available).*
+- **Revenue** — the software is, directly, how you make money, and you need to charge for it or restrict it. → *Points toward proprietary or a dual/open-core model.*
+
+These aren't mutually exclusive — many projects want some of each — but ranking them honestly is the single most clarifying thing you can do. A project that says "I want maximum adoption *and* nobody can ever build a closed fork" is asking for two licenses at once, and the [permissive-vs-copyleft](/learn/software-licensing/permissive-vs-copyleft/) trade-off is exactly that tension.
+
+## Question 2 — What is your business model?
+
+Your goal is what you *want*; your business model is how the project sustains itself. The two usually agree, but naming the model sharpens the license choice and tells you whether you need *commercial* agreements at all.
+
+| Business model | Typical license posture | Commercial agreements? |
+|---|---|---|
+| **Pure open / community** | Permissive or copyleft open source | No — just the open license |
+| **Paid, downloaded product** | Proprietary EULA | Yes — a EULA, maybe support terms |
+| **SaaS / hosted** | Often AGPL or source-available for the core; proprietary backend | Yes — ToS, subscription terms |
+| **Open core** | Permissive/copyleft core + proprietary add-ons | Yes — for the paid tier only |
+| **Dual-licensed** | Copyleft for free use + a paid proprietary license | Yes — the commercial license |
+
+If you're considering open core or dual licensing, revisit [commercial license models](/learn/software-licensing/commercial-license-models/) and [dual licensing & relicensing](/learn/software-licensing/dual-licensing-and-relicensing/) — those models have real ownership prerequisites (you generally need to own or have CLA-backed rights to all the code you want to relicense).
+
+## Question 3 — What dependencies must you already comply with?
+
+Here the *constraints* begin, and this one can override your preferences entirely. You don't get a free hand: the licenses of the code you build on can dictate what license your own work may carry.
+
+The rule that bites hardest is strong copyleft. If you incorporate GPL or AGPL code and then **distribute** (or, for AGPL, **network-serve**) the result, you generally must release the whole combined work under compatible copyleft terms. That can make a proprietary or even a permissive outcome impossible without removing the dependency. Permissive dependencies (MIT, BSD, Apache) impose far lighter obligations — mostly attribution — and rarely constrain your choice.
+
+So before you commit to anything in Questions 1–2, inventory what you depend on. This is precisely the work covered in [license compatibility](/learn/software-licensing/license-compatibility/) and [auditing dependencies](/learn/software-licensing/auditing-dependencies/). If an audit turns up a copyleft dependency that conflicts with your intended outcome, you have three options: change the license you target, replace the dependency, or get a commercial license for it. Discovering this *after* you've shipped is far more expensive.
+
+## Question 4 — How is the software delivered?
+
+Delivery model is what switches the decision from "just a license" to "license **plus** agreements." How the software reaches its users determines which agreements you need on top of the license.
+
+| Delivery model | License governs | You also typically need |
+|---|---|---|
+| **Downloaded / installed** | The copy they run | A EULA |
+| **Hosted / SaaS** | (Often nothing the user holds) | Terms of service, privacy policy |
+| **Embedded / bundled** | The component you ship | Compliance with the component's license; passthrough terms |
+
+Two subtleties matter. First, for a hosted service the user never receives a copy, so a traditional EULA is the wrong instrument — a [terms of service](/learn/software-licensing/eula-and-tos/) governs the relationship instead. Second, delivery interacts with Question 3: network copyleft (AGPL) is triggered by *hosting*, not by *distributing*, which is exactly why it matters for SaaS and not for a desktop app.
+
+## Question 5 — What data does it handle?
+
+If your software touches personal data — names, emails, locations, anything tied to a person — you inherit legal obligations that exist independently of your license. At minimum you'll need a [privacy policy](/learn/software-licensing/privacy-and-data-agreements/); depending on jurisdiction you may owe GDPR or CCPA duties, and if vendors process data on your behalf you'll need a data processing agreement (DPA) with them.
+
+This input is binary in a useful way: either you handle personal data or you don't, and the answer adds a fixed block of agreements. A GopherTrunk-style scanner that decodes radio signals locally and stores nothing personal sits at the easy end; a hosted dashboard that logs user accounts and locations sits at the demanding end.
+
+## Question 6 — What is your risk tolerance and jurisdiction?
+
+The final input tunes the *strength* of your terms rather than their kind. Higher stakes — paying customers, regulated data, enterprise buyers — justify stronger warranty disclaimers, limitation-of-liability caps, and clearer indemnification, the [risk clauses](/learn/software-licensing/main-clauses-decoded/) you met earlier. Lower stakes (a hobby project) need far less.
+
+Jurisdiction matters too, but mostly as a flag: consumer-protection rules in the EU and UK limit how far you can disclaim liability, and data law varies widely. Keep it light here — the dedicated [licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/) lesson carries the cross-border depth. The framework just asks: where do your users live, and how much risk can you afford to carry?
+
+## The framework as one table
+
+Run the six questions and you'll land in one of a handful of common profiles. This summary table collapses the framework into its typical outcomes — a starting point, not a verdict.
+
+| Profile (goal + model) | Likely license | Likely agreement set |
+|---|---|---|
+| Library, want broad adoption | Permissive (MIT/Apache) | License only |
+| App, want code shared but no closed forks | GPL | License only (+ EULA if you also sell builds) |
+| SaaS, want to block cloud resellers | AGPL or source-available (BSL) | ToS, privacy policy, DPA, maybe SLA |
+| Paid desktop app | Proprietary EULA | EULA, support terms |
+| Open-core product | Permissive/copyleft core + proprietary tier | License (core) + commercial agreements (tier) |
+| Dual-licensed component | Copyleft + paid proprietary | Copyleft license + commercial license |
+
+Notice the table has two columns of output: a **license** for your code and an **agreement set** for how you deliver it. That split is the whole point of the framework, and it's why the next two lessons exist — one for each column.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — your goal (adoption vs control vs revenue) is the master input that orients the whole decision." markdown="0">
+  <p class="knowledge-check__q">Quick check: in this framework, which input is the "master question" you answer first?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">Your goal — adoption, control, or revenue</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Which programming language you wrote it in</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Whether you personally prefer MIT or GPL</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Six inputs drive the decision** — goal, business model, dependencies, delivery model, data handled, and risk/jurisdiction.
+- **Goal first** — adoption, control, or revenue is the master question that orients everything else.
+- **Constraints can override preferences** — your existing dependencies (especially copyleft) and the data you touch can rule options out before you pick a favorite.
+- **Delivery and data add agreements** — how you ship and what data you handle decide which agreements you need on top of the license.
+- **Two outputs** — the framework produces a license for your code *and* an agreement set for how you deliver it.
+- **It's a starting point** — the summary table gives a typical answer; the next lessons turn each half into specifics.
+
+Next up: turn the first output into a concrete pick with the guided, branching walkthrough in [Choosing your license, step by step](/learn/software-licensing/choose-your-license/).

--- a/docs/learn/software-licensing/the-licensing-spectrum.md
+++ b/docs/learn/software-licensing/the-licensing-spectrum.md
@@ -1,0 +1,108 @@
+---
+slug: the-licensing-spectrum
+title: The licensing spectrum
+description: Software licensing runs on a spectrum from fully proprietary to public domain. Learn the five main bands — proprietary, source-available, permissive open source, copyleft, and public domain — and what each lets you do.
+keywords: software licensing spectrum, proprietary vs open source, source-available, permissive license, copyleft, public domain, open source spectrum, license comparison, closed source, free software
+level: beginner
+status: full
+faq:
+  - q: "Is 'source-available' the same as open source?"
+    a: "No, and conflating them is a common mistake. **Source-available** means you can *see* the source, but the license still restricts what you can do — you may not be allowed to use it commercially, compete, or redistribute freely. **Open source** requires the freedoms to use, modify, and redistribute for any purpose. Visible source is necessary for open source but nowhere near sufficient."
+  - q: "If something is open source, can I sell it?"
+    a: "Yes. A core requirement of open source is that the license can't forbid selling the software or charging for it — there's no 'non-commercial only' open-source license. What [copyleft](/learn/software-licensing/permissive-vs-copyleft/) licenses *can* require is that if you distribute it, you also share your source under the same terms. Selling is fine; locking it up may not be."
+  - q: "Where does public domain sit on the spectrum?"
+    a: "At the far 'most free' end. **Public domain** means no copyright applies at all — anyone can do anything with the work, with no conditions and no need for permission. It's even more permissive than a permissive license, which still imposes small conditions like keeping a notice. Reaching public domain deliberately is trickier than it sounds, which is why tools like [CC0](/learn/software-licensing/public-domain-and-cc0/) exist."
+---
+# The licensing spectrum
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Licensing is a spectrum, not two camps** — it runs from fully proprietary to public domain, with meaningful bands in between. **Source-available ≠ open source** — visible source can still come with heavy restrictions. **Open source splits into permissive and copyleft** — both grant the core freedoms, but copyleft adds share-alike conditions. **Public domain is the free extreme** — no copyright, no conditions at all.
+</div>
+
+People tend to talk about software as either "open" or "closed," but that misses most of the picture. Licensing is better understood as a **spectrum**, running from the most restrictive (locked-down proprietary) to the most free (public domain), with several distinct bands along the way. This lesson lays out that spectrum end to end and gives you one big comparison table to anchor it. By the end you'll have a mental map that the rest of the path fills in band by band.
+
+## The spectrum, end to end
+
+From most restrictive to least, the five main bands are:
+
+1. **Proprietary / closed-source** — source hidden, rights tightly restricted.
+2. **Source-available** — source visible, but use is restricted.
+3. **Permissive open source** — full freedoms, minimal conditions.
+4. **Copyleft open source** — full freedoms, but with share-alike conditions.
+5. **Public domain** — no copyright, no conditions at all.
+
+Notice the spectrum has two axes hiding inside it: *can you see the source?* and *what may you do with it?* They don't move in lockstep — source-available shows you the code without granting the freedoms, which is exactly why "I can see it" tells you almost nothing about "I can use it." Keep the four actions from [lesson one](/learn/software-licensing/what-is-a-software-license/) in mind — use, copy, modify, distribute — because each band answers them differently.
+
+## Band 1: Proprietary / closed-source
+
+**Proprietary** software is the default-restrictive end. The source code is kept secret (protected as a [trade secret](/learn/software-licensing/other-ip-in-software/)), and the license grants you a narrow right — usually just to *use* the binary, often on specific terms, with no right to copy beyond your license, modify, or redistribute. Most commercial desktop and enterprise software lives here. This is the world of EULAs, seat licenses, and subscriptions, which we cover in [Proprietary & closed-source licensing](/learn/software-licensing/proprietary-licensing/).
+
+## Band 2: Source-available
+
+**Source-available** software lets you *read* the source — and sometimes modify it for your own use — but the license still imposes real restrictions that disqualify it from being open source. Common limits include "non-commercial use only," "you may not compete with us," or "you may not offer this as a hosted service."
+
+This band has grown fast as companies look for a middle ground: transparency and the goodwill of visible code, without giving competitors the right to take it. But it is **not open source**, and calling it that is misleading. We give this band its own lesson, [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/). The key takeaway now: *seeing the source is not the same as being free to use it.*
+
+## Band 3: Permissive open source
+
+Now we cross into genuine **open source**, which begins with **permissive** licenses. These grant the full open-source freedoms — use, copy, modify, distribute, for any purpose including commercial — with only **minimal conditions**, typically just "keep the copyright and license notice." The MIT, BSD, and [Apache 2.0](/learn/software-licensing/apache-license/) licenses are the classic examples.
+
+The defining trait: you can take permissively licensed code, modify it, and ship it inside a **closed-source** product without being required to release your own source. The permission flows out and asks very little back. GopherTrunk uses one of these — Apache 2.0 — which is why others can build on it freely. We compare these in [MIT & BSD](/learn/software-licensing/mit-and-bsd-licenses/) and [Permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/).
+
+## Band 4: Copyleft open source
+
+**Copyleft** licenses grant the same core freedoms as permissive ones — but attach a powerful condition: if you distribute the software (or a modified version), you must **release your source under the same license**. The freedoms are designed to *propagate*: everyone downstream gets the same rights you did.
+
+This is sometimes called "viral," though that word overstates it — copyleft obligations trigger on **distribution**, not merely on use, and the scope depends on the specific license. **Strong copyleft** (the [GPL](/learn/software-licensing/gpl-strong-copyleft/)) reaches broadly; **weak copyleft** ([LGPL, MPL, EPL](/learn/software-licensing/weak-copyleft-licenses/)) is more contained, typically applying only to the licensed component itself; and the [AGPL](/learn/software-licensing/agpl-network-copyleft/) extends the obligation even to software offered over a network. Copyleft is still firmly open source — you can sell it — but it constrains *how* you can combine and ship it.
+
+## Band 5: Public domain
+
+At the far end, **public domain** means **no copyright applies at all**. There's no owner exercising exclusive rights, so anyone can do anything — use, copy, modify, sell, relicense — with no conditions and no need to credit anyone. It's even freer than a permissive license, which still asks you to preserve a notice.
+
+The catch is that *getting* to public domain deliberately is harder than it sounds: in many countries you can't simply abandon your copyright, and there's no clean legal mechanism to do so. That's why dedicated tools exist — the **Unlicense** and Creative Commons **CC0** try to achieve a public-domain-like result, with a permissive license as a fallback for jurisdictions that don't allow true dedication. We cover them in [Public domain, Unlicense & CC0](/learn/software-licensing/public-domain-and-cc0/).
+
+## The whole spectrum at a glance
+
+Here is the spectrum across the questions that matter most:
+
+| | See source? | Modify? | Redistribute? | Sell it? | Main obligation |
+|---|---|---|---|---|---|
+| **Proprietary** | No | No | No | No (only the vendor sells) | Pay; obey EULA; don't reverse-engineer |
+| **Source-available** | Yes | Often, for own use | Restricted | Usually no | Obey the (non-open) restrictions |
+| **Permissive OSS** | Yes | Yes | Yes | Yes | Keep the copyright/license notice |
+| **Copyleft OSS** | Yes | Yes | Yes | Yes | Share your source under the same license when you distribute |
+| **Public domain** | Yes | Yes | Yes | Yes | None |
+
+Read down any column and the spectrum comes into focus: rights generally *expand* as you move from proprietary toward public domain, while *obligations* shift from "pay and obey" to "just keep a notice" to "nothing." The interesting wrinkle is copyleft, which grants broad freedoms yet adds an obligation back — its share-alike condition is the price of keeping those freedoms open for everyone downstream.
+
+## Using the map
+
+This spectrum is the scaffolding for the rest of the path. Most of the upcoming modules zoom into one band:
+
+- The **open-source** module dives into permissive and copyleft licenses one by one.
+- The **proprietary & commercial** module covers the closed and source-available bands and how to *sell* software.
+- The **using open source in products** module is all about combining bands safely — what happens when permissive, copyleft, and proprietary code meet in one product.
+
+Whenever you meet a new license, your first move is to place it on this spectrum. That single act — "which band is this?" — tells you most of what you need to know before you read a word of the fine print.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — source-available means you can see the code, but the license still restricts use, so it is not open source." markdown="0">
+  <p class="knowledge-check__q">Quick check: a project's license lets you view and read the source but forbids commercial use. Where does it sit on the spectrum?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's open source, because the source code is available to read</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It's source-available — visible source but restricted use, which is not open source</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It's public domain, because anyone can access the code</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Licensing is a spectrum** — from fully proprietary to public domain, with distinct bands rather than a simple open/closed split.
+- **Two hidden axes** — "can you see the source?" and "what may you do with it?" move independently.
+- **Source-available is not open source** — visible code can still carry heavy use restrictions.
+- **Open source = permissive + copyleft** — both grant the core freedoms; permissive asks little back, copyleft adds share-alike conditions on distribution.
+- **Public domain is the free extreme** — no copyright, no conditions, though reaching it deliberately needs tools like CC0.
+- **Place every license on the map first** — identifying the band is the fastest way to understand a new license.
+
+Next up: the same concepts shift across borders — moral rights, registration norms, and which clauses actually hold up. See [Licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/).

--- a/docs/learn/software-licensing/using-oss-in-products.md
+++ b/docs/learn/software-licensing/using-oss-in-products.md
@@ -1,0 +1,109 @@
+---
+slug: using-oss-in-products
+title: Can you sell software built on open source?
+description: Yes — you can absolutely build and sell commercial software on open source. The catch is obligations, not prohibition. Learn what permissive and copyleft licenses require, what "selling" open source means, and the few things you can never do.
+keywords: sell software built on open source, commercial open source, can you sell open source, open source in products, open source obligations, permissive vs copyleft selling, monetize open source, open source compliance, relicensing, attribution
+level: beginner
+status: full
+faq:
+  - q: "Is it legal to charge money for software that uses open source?"
+    a: "Yes. Open-source licenses grant the right to use, modify, and **distribute** the code, including commercially — none of the mainstream ones forbid charging money. The Open Source Definition explicitly bars any license that restricts selling. What you owe is **compliance** with the license's conditions (like attribution), not a fee or permission."
+  - q: "Can I keep my own code closed if it's built on open source?"
+    a: "It depends on the license. With **permissive** licenses (MIT, BSD, Apache) you can keep your additions closed as long as you preserve notices. With **copyleft** licenses (GPL, AGPL), distributing a derivative can require you to release your changes under the same terms. Knowing which bucket each dependency falls in is the whole game — covered in the next lessons."
+  - q: "Do I need permission from the project to use it commercially?"
+    a: "No. The license *is* the permission — it's a standing grant to everyone, so you don't need to ask or sign anything. You just have to follow its terms. The exceptions are dual-licensed projects offering a separate commercial license, and trademark use, which licenses usually don't grant."
+---
+# Can you sell software built on open source?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Yes, you can sell it** — commercial software built on open source is normal, legal, and everywhere. **The catch is obligations, not prohibition** — licenses say *what you must do* (attribution, sometimes sharing changes), not *that you can't*. **Effort is a spectrum** — permissive licenses ask for little; copyleft asks for real discipline. **A few hard lines** — never strip notices or pass off others' code as your own.
+</div>
+
+This is the first lesson of the module on shipping commercial software built on open source. There's a stubborn myth that "open source" and "selling software" are opposites — that touching an open-source library somehow forces your whole product to be free, or that you need special permission to make money. None of that is true. By the end of this lesson you'll understand why you can absolutely build a paid product on open source, what the licenses actually ask of you in return, what "selling" open source even means, and the handful of things you can never do. The next three lessons then make compliance practical.
+
+## Busting the myth: open source is built for commercial use
+
+Start with the single most important fact: **open-source licenses permit commercial use.** This isn't a loophole or a gray area — it's the design. The [Open Source Definition](/learn/software-licensing/what-is-open-source/), the criteria a license must meet to be called open source, explicitly requires that the license **not restrict anyone from selling the software** and **not discriminate against fields of endeavor**, including commercial ones. A license that said "free for hobbyists, but not for companies" would, by definition, not be open source.
+
+So the question "can I sell software built on open source?" has a clear answer: **yes.** Some of the largest software businesses in the world run on open-source foundations. Your phone, your bank's servers, and the website you bought something from this morning are all stacked on open-source code that someone is very much making money around.
+
+What trips people up is conflating two different things:
+
+| The myth | The reality |
+|----------|-------------|
+| "Using open source means my product must be free" | You can charge whatever you like; price is yours to set |
+| "I need the project's permission to use it commercially" | The license is the permission — it's already granted to everyone |
+| "Open source forbids making a profit" | It forbids *restricting others*, not *you profiting* |
+| "Any open source 'infects' my code" | Only some copyleft licenses create sharing obligations, and only on distribution |
+
+The thing that *is* real — and that the rest of this module is about — is **obligations**. Open source gives you broad rights up front, and in exchange attaches conditions. Meeting those conditions is the job.
+
+## Permission is granted; obligations are the price
+
+A useful mental model: an open-source license is a **standing offer** from the author to everyone. It says, in effect, "here are rights — to use, copy, modify, and distribute this — and here is what you must do if you accept them." You accept the offer by using the code under its terms. There's no contract to sign, no invoice, no gatekeeper. (Whether a license is technically a [license or a contract](/learn/software-licensing/license-vs-contract/) is a subtle legal question, but the practical effect is the same: rights with conditions.)
+
+Because the rights are already granted, the only way to *lose* them is to break the conditions. That reframes the whole topic. You're not asking "am I allowed?" — you are. You're asking "**what do I owe in return, and can I meet it?**" For the vast majority of dependencies, the answer is "very little, and easily."
+
+## The spectrum of effort
+
+Not all obligations are equal. They run along a spectrum from trivial to substantial, and the license family tells you roughly where a dependency sits. This is the [permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/) distinction, viewed through the lens of "how much work is this going to be?"
+
+| License family | Examples | What you typically owe | Effort |
+|----------------|----------|------------------------|--------|
+| **Permissive** | [MIT, BSD](/learn/software-licensing/mit-and-bsd-licenses/), [Apache 2.0](/learn/software-licensing/apache-license/) | Preserve copyright and license notices; Apache adds a NOTICE file and patent terms | Low — mostly bookkeeping |
+| **Weak copyleft** | LGPL, MPL, EPL | Share changes *to the open-source files themselves*; your own separate code can stay closed | Moderate — keep boundaries clean |
+| **Strong copyleft** | [GPL](/learn/software-licensing/gpl-strong-copyleft/) | Distribute the derivative work's source under the same license | High — architectural discipline |
+| **Network copyleft** | [AGPL](/learn/software-licensing/agpl-network-copyleft/) | Strong copyleft, *and* it triggers even when users only reach the software over a network | Highest — affects SaaS too |
+
+Permissive licenses are the easy case: you ship the product, include the right notices, done. Copyleft is where the real constraints live — and where the fear of "infection" comes from. The honest summary is that **copyleft is entirely usable in commercial products with discipline, and genuinely risky if ignored.** We'll dedicate a full lesson to making that practical.
+
+## What "selling" open source actually means
+
+Here's a point that confuses newcomers: if anyone can get the code for free, how can you *sell* it? The answer is that open source doesn't give you exclusivity, and selling open source is not selling exclusivity — it's selling something else:
+
+- **Copies and convenience.** You can charge for a packaged, ready-to-run build, an installer, an app-store listing, or a supported distribution. The license lets others redistribute too, but plenty of customers happily pay for the convenient version.
+- **Support, warranties, and SLAs.** Open-source code ships "as is" with no warranty. Businesses pay real money for someone to stand behind it — support contracts, [SLAs](/learn/software-licensing/sla-and-support-agreements/), security patches, and indemnity.
+- **Hosting and operations.** Running software well is a service. Selling a managed, hosted version of open-source software is a huge and legitimate business model.
+- **Proprietary additions on top.** With permissive (and carefully with weak-copyleft) dependencies, you can build closed features around an open core and sell those.
+
+What you are *not* selling is the right to be the only one who has the code. Open source trades exclusivity for reach. That's the bargain — and it's a workable, profitable one.
+
+## What you can never do
+
+The rights are broad, but a few lines are bright and absolute. Crossing them isn't a compliance slip; it's infringement.
+
+- **Never strip or hide the notices.** Practically every open-source license requires you to preserve the copyright statement and a copy of the license text when you distribute. Deleting them to make your product look wholly yours breaks the license — which means you no longer have permission to use the code at all. We cover exactly how to keep them in the [next lesson](/learn/software-licensing/permissive-compliance/).
+- **Never relicense others' code as your own.** You can't take someone's MIT-licensed library, slap your name and a proprietary license on it, and claim authorship. You may license *your* contributions, but the original code keeps its license and its [copyright](/learn/software-licensing/copyright-and-software-ownership/).
+- **Never ignore copyleft on distribution.** If you ship a product that includes GPL code as part of a derivative work, "I didn't realize" is not a defense. The obligation to offer source attaches whether or not you read the license.
+- **Never assume the license covers trademarks.** A license to the *code* is not a license to the project's *name or logo*. Using those to imply endorsement is a separate problem — see [patents, trademarks & trade secrets](/learn/software-licensing/other-ip-in-software/).
+
+Stay inside those lines and follow each dependency's conditions, and you can build and sell with confidence.
+
+## Where this module goes next
+
+This lesson set the frame: yes, you can sell, and the work is meeting obligations. The next three lessons make it concrete:
+
+- **[Permissive compliance](/learn/software-licensing/permissive-compliance/)** — the easy-but-mandatory case: exactly what MIT, BSD, and Apache require when you ship, and where to put the attributions.
+- **[Copyleft in products](/learn/software-licensing/copyleft-in-products/)** — the "will GPL infect my product?" question, answered with what actually triggers obligations and the safe architectural patterns.
+- **[Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/)** — you can't comply with licenses you don't know you're shipping, so this is how to find and track them all.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — open source grants commercial rights up front; the work is meeting the license's obligations, not asking permission." markdown="0">
+  <p class="knowledge-check__q">Quick check: what is the real catch when selling software built on open source?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="correct">You must meet the license's obligations, such as preserving notices and sometimes sharing changes</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">You must get written permission from each project before charging money</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">You are not allowed to make a profit from open-source code</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Selling is allowed** — open-source licenses permit commercial use by design; the Open Source Definition forbids restricting sale.
+- **Obligations, not prohibition** — the license is a standing grant of rights with conditions; your job is to meet the conditions, not to ask permission.
+- **Effort is a spectrum** — permissive licenses ask for little more than attribution; copyleft asks for real architectural discipline.
+- **"Selling" means copies, support, hosting, and add-ons** — you trade exclusivity for reach and monetize everything around the code.
+- **A few hard lines** — never strip notices, relicense others' code as your own, ignore copyleft on distribution, or assume you got the trademark.
+
+Next up: the easy-but-mandatory case in detail. See [Meeting permissive obligations](/learn/software-licensing/permissive-compliance/).

--- a/docs/learn/software-licensing/weak-copyleft-licenses.md
+++ b/docs/learn/software-licensing/weak-copyleft-licenses.md
@@ -1,0 +1,114 @@
+---
+slug: weak-copyleft-licenses
+title: "Weak copyleft: LGPL, MPL, EPL"
+description: Weak-copyleft licenses scope the share-alike duty to a single library or file instead of the whole program — so proprietary code can use the component as long as the component itself stays open.
+keywords: weak copyleft, LGPL, MPL 2.0, EPL, CDDL, file-level copyleft, library copyleft, dynamic linking, static linking, relink, patent grant, business-friendly license, copyleft scope
+level: intermediate
+status: full
+faq:
+  - q: "How is weak copyleft different from the GPL?"
+    a: "The [GPL is strong copyleft](/learn/software-licensing/gpl-strong-copyleft/): its share-alike duty extends to the whole combined program. Weak copyleft narrows that scope to just the licensed **component** — the library (LGPL) or the individual file (MPL). You can link or combine proprietary code with it as long as the component's own source stays open under its license."
+  - q: "What's the deal with LGPL and linking?"
+    a: "The LGPL lets a proprietary program link to an LGPL library without becoming LGPL, but it adds a condition: users must be able to **relink** your program against a modified version of the library. **Dynamic linking** satisfies this easily; **static linking** is allowed too but requires you to provide object files (or equivalent) so users can swap in a new library build."
+  - q: "Why do so many people like MPL 2.0?"
+    a: "Because its **file-level** copyleft is a clean, predictable boundary: files that were already under MPL stay open when modified, but you can add new proprietary files in the same project without them becoming MPL. It also includes an explicit **patent grant** and is written to be compatible with the GPL, which avoids many of the headaches of older copyleft licenses."
+---
+# Weak copyleft: LGPL, MPL, EPL
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The middle ground** — weak copyleft sits between permissive and strong copyleft. **Scope is the component, not the program** — only the licensed library or file must stay open; surrounding proprietary code can stay closed. **LGPL = library scope; MPL = file scope** — LGPL protects a whole library (with relink rights), MPL 2.0 protects modified files individually. **Business-friendly, but boundary-fussy** — easier to adopt commercially than the GPL, at the cost of having to track exactly where the copyleft line falls.
+</div>
+
+You've now seen the two ends of the spectrum: [permissive licenses](/learn/software-licensing/mit-and-bsd-licenses/) that ask almost nothing, and the [strong copyleft of the GPL](/learn/software-licensing/gpl-strong-copyleft/) that reaches across the whole combined program. This lesson covers the deliberate compromise in between: **weak copyleft**. By the end you'll understand the core idea — copyleft scoped to a component rather than the whole program — and the differences between the main weak-copyleft licenses: the LGPL, MPL 2.0, the EPL, and (briefly) the CDDL. You'll know when each fits and where their boundaries get tricky.
+
+## The core idea: copyleft, but scoped
+
+Strong copyleft's reach is its strength and its liability. It keeps the whole program free, but it also means proprietary software generally can't combine with GPL code without becoming GPL — which scares off a lot of legitimate use. Weak copyleft was invented to solve exactly that.
+
+The trick is to **narrow the scope of the share-alike duty**. Instead of "any work that combines with this must be open," weak copyleft says "this *component* must stay open — but code that merely uses it can stay proprietary." The reciprocity still protects the original work and improvements to it, but it stops at the component boundary instead of spreading to the whole program.
+
+There are two common ways to draw that boundary:
+
+- **Library scope (LGPL).** The unit is a whole library. You may link proprietary code to the library; only the library itself (and changes to it) must stay open.
+- **File scope (MPL, EPL, CDDL).** The unit is the individual source file. Files originally under the license stay open even after you modify them, but new files you write can be under any license you choose, including proprietary.
+
+This makes weak copyleft a **business-friendly compromise**: companies can build closed products on top of these components and still contribute improvements back to the shared part.
+
+## LGPL: copyleft for a library
+
+The **GNU Lesser General Public License (LGPL)** was created by the FSF specifically to answer the [linking question](/learn/software-licensing/gpl-strong-copyleft/) that makes the GPL so cautious. "Lesser" signals that it asks less than the full GPL. Its bargain: a proprietary program may **link to** an LGPL library without itself becoming LGPL, **provided** the library stays open and users retain the ability to **relink** the program against a modified library.
+
+That relink requirement is the heart of the LGPL, and it's where the static-vs-dynamic distinction matters:
+
+| Linking style | Allowed under LGPL? | What you must do |
+|---|---|---|
+| **Dynamic linking** (library loaded at runtime) | Yes | Easiest case — users can already swap in a new `.so`/`.dll`, satisfying the relink right |
+| **Static linking** (library compiled into your binary) | Yes | Also allowed, but you must provide object files (or source) so users can rebuild the binary against a modified library |
+
+In both cases, any changes *to the LGPL library itself* must be released under the LGPL. What stays proprietary is your own application code that merely calls the library. Dynamic linking is the path of least resistance; static linking works but adds the obligation to ship enough (object files or the like) that a user could relink. The LGPL comes in versions tied to GPLv2 and GPLv3, inheriting the corresponding patent and anti-tivoization stances.
+
+## MPL 2.0: copyleft per file
+
+The **Mozilla Public License 2.0 (MPL)** — written for the Firefox/Mozilla ecosystem and now widely used well beyond it — takes the file-level approach, and it's the one many engineers find the cleanest.
+
+The rule is simple to reason about: **any file that is under the MPL must stay under the MPL, including your modifications to it.** But files you *add* to the project can be under any license, including a proprietary one. So you can drop an MPL component into a closed-source product, modify the MPL files (those changes stay open), and write all your new code as proprietary — no relink mechanics to worry about, just "keep the MPL files open."
+
+MPL 2.0 also includes two features that earn it goodwill:
+
+- An **explicit patent grant** from contributors, similar in spirit to [Apache 2.0](/learn/software-licensing/apache-license/), with patent-retaliation terms.
+- Deliberate **GPL compatibility** (unless a file is specifically marked "Incompatible With Secondary Licenses"), which sidesteps a class of [compatibility problems](/learn/software-licensing/license-compatibility/) that plagued earlier copyleft licenses.
+
+The combination — predictable boundary, real patent protection, broad compatibility — is why MPL 2.0 is one of the best-liked copyleft licenses in modern practice.
+
+## EPL and CDDL: the file-level cousins
+
+Two more file-level weak-copyleft licenses come up often enough to know.
+
+The **Eclipse Public License (EPL)** is the license of the Eclipse Foundation and much of the Java ecosystem (the Eclipse IDE, many Jakarta EE and tooling projects). Like the MPL it is **file-level** copyleft with an explicit patent grant. Its distinctive wrinkle is a **commercial contributor** indemnity provision: a contributor who distributes the work commercially takes on some responsibility to defend others against claims related to its commercial use. EPL 2.0 also added an option to designate GPL compatibility. Practically, EPL behaves much like MPL for the question that matters most — your own files can stay proprietary, the EPL files stay open.
+
+The **Common Development and Distribution License (CDDL)**, written by Sun for projects like OpenSolaris and ZFS, is another file-level, MPL-derived license. It's worth knowing mainly for one famous friction point: the CDDL is widely considered **incompatible with the GPL**, which is the reason ZFS can't be shipped as part of the mainline GPLv2 Linux kernel. It's a clean illustration that even two reasonable open-source licenses can refuse to combine — the subject of the next module's [license-compatibility lesson](/learn/software-licensing/license-compatibility/).
+
+## Comparing the scope and trigger
+
+The single most useful way to hold these in your head is by **what the copyleft attaches to** and **what stays proprietary**:
+
+| License | Copyleft scope | Proprietary code can… | Notable feature |
+|---|---|---|---|
+| **GPL** (for contrast) | Whole combined program | …generally not combine without becoming GPL | Strong copyleft |
+| **LGPL** | The library | …link to the library if users can relink | Relink requirement; static-link conditions |
+| **MPL 2.0** | Each individual file | …live in new files alongside MPL files | Patent grant; GPL-compatible |
+| **EPL** | Each individual file | …live in new files alongside EPL files | Patent grant; commercial-contributor indemnity |
+| **CDDL** | Each individual file | …live in new files alongside CDDL files | File-level; **GPL-incompatible** |
+| **MIT/BSD** (for contrast) | Nothing (permissive) | …do almost anything | No share-alike at all |
+
+Notice the trend: as you move from GPL down toward MIT, the unit the copyleft protects shrinks from "the whole program" to "a library" to "a file" to "nothing." Weak copyleft is precisely the part of that gradient where reciprocity is preserved for the shared component but released for everything you build around it.
+
+## Strengths and weaknesses
+
+**Strengths.** Weak copyleft is the **business-friendly compromise**: it lets proprietary products use open components while still guaranteeing the components — and improvements to them — stay open. That makes these licenses far easier to adopt than the GPL, so the components see wide use, and the original projects still get changes flowed back. MPL and EPL's patent grants add real protection, and their file-level scope is easy to reason about.
+
+**Weaknesses.** The cost is **boundary complexity**. You have to actually track where the copyleft line falls — which files are MPL, what counts as "the library," whether your linking satisfies the LGPL's relink requirement. Get the boundary wrong and you can fail to meet the obligation without realizing it. Compatibility surprises also lurk (the CDDL/GPL clash being the classic), so combining weak-copyleft code with other licenses still needs care. And static linking under the LGPL, in particular, carries enough conditions that some teams avoid it.
+
+For most teams the rule of thumb is comforting: weak copyleft means **you can build a proprietary product on it — just keep the component itself open.** How that plays out when you ship is covered in [copyleft in products](/learn/software-licensing/copyleft-in-products/), and how to meet the lighter permissive duties is in [meeting permissive obligations](/learn/software-licensing/permissive-compliance/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — weak copyleft scopes the share-alike duty to the component (the library or the file), so proprietary code can use it as long as that component stays open." markdown="0">
+  <p class="knowledge-check__q">Quick check: what makes a license "weak" copyleft rather than "strong"?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">It places no obligations on anyone, exactly like the MIT license</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">It removes the copyleft duty once the software is offered over a network</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">It scopes the share-alike duty to the component (a library or a file) instead of the whole program</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Weak copyleft is the middle ground** — it preserves reciprocity for one component while letting surrounding proprietary code stay closed.
+- **Scope is the key difference from the GPL** — strong copyleft reaches the whole program; weak copyleft stops at the library (LGPL) or the file (MPL/EPL/CDDL).
+- **LGPL is library-scoped with a relink right** — proprietary code may link to it; dynamic linking satisfies the relink requirement easily, static linking adds conditions.
+- **MPL 2.0 is file-scoped and well-liked** — modified MPL files stay open, new files can be proprietary, plus a patent grant and GPL compatibility.
+- **EPL and CDDL are file-level cousins** — EPL adds a commercial-contributor indemnity; CDDL is famously GPL-incompatible (the ZFS-on-Linux problem).
+- **Strengths vs weaknesses** — business-friendly and widely adopted, but you must track the copyleft boundary carefully and watch for compatibility surprises.
+
+Next up: the other extreme — giving up rights entirely, and why "public domain" is trickier than it sounds. See [Public domain, Unlicense & CC0](/learn/software-licensing/public-domain-and-cc0/).

--- a/docs/learn/software-licensing/what-is-a-software-license.md
+++ b/docs/learn/software-licensing/what-is-a-software-license.md
@@ -1,0 +1,116 @@
+---
+slug: what-is-a-software-license
+title: What is a software license?
+description: A software license is the grant of permission that lets you use, copy, modify, or share someone else's code. Learn why code is "all rights reserved" by default and why even free projects need an explicit license.
+keywords: software license, what is a software license, all rights reserved, copyright default, permission to use software, no license means no permission, open source license, license grant, using copying modifying distributing, free software license
+level: beginner
+status: full
+faq:
+  - q: "If a project on the internet has no license at all, can I use it?"
+    a: "Legally, no — not safely. With **no license**, the code is \"all rights reserved\" by default, so you have no permission to copy, modify, or distribute it, even if the source is public. You might get away with reading it, but building on it exposes you to a copyright claim. The fix is to ask the author to add a license."
+  - q: "Isn't putting code on a public site the same as making it free to use?"
+    a: "No. Posting source publicly makes it **visible**, not **licensed**. Visibility and permission are separate things. Unless the author attached a license granting rights, the default \"all rights reserved\" still applies, and the public copy is just a copy you're allowed to look at, not one you're allowed to reuse."
+  - q: "Do I need a license for my own hobby project that nobody pays for?"
+    a: "Yes, if you want anyone to legally use it. Being free of charge is about **price**; a license is about **permission**, and the two are unrelated. Without a license your free project is still \"all rights reserved,\" which usually defeats the point of sharing it. Adding even a one-line permissive license fixes that."
+---
+# What is a software license?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Code is copyrighted the moment it's written** — the default is "all rights reserved," meaning no one else has permission to use it. **A license is the grant of permission** — it's the document that says what others may do with your code. **No license means no permission** — public source with no license is something you can look at but legally can't reuse. **Free and licensed are different things** — price and permission are separate, so even free projects need a license.
+</div>
+
+This is the first lesson of the path. Before we get into open source, copyleft, EULAs, or how to choose a license, we need the one idea the whole subject rests on: software is *owned* the instant it's created, and a license is how that owner hands out permission to everyone else. By the end of this lesson you'll understand why code defaults to "all rights reserved," what a license actually grants, why even a free personal project needs one, and why "no license" is a trap rather than a generosity.
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+## Software is owned the moment it's written
+
+Here's the part that surprises most people: you don't have to register anything, file anything, or even add a copyright notice for your code to be protected. The moment you write an original program and fix it in some tangible form — saving the file is enough — it is automatically protected by **copyright**, and you are the owner. (We'll dig into copyright itself in the [next lesson](/learn/software-licensing/copyright-and-software-ownership/).)
+
+Copyright gives the owner a set of exclusive rights: the right to copy the work, to modify it, to distribute it, and so on. "Exclusive" is the important word. By default, *only* the owner may do those things. Everyone else has no permission at all.
+
+This is the legal default for every piece of code on Earth, and it has a name people use as shorthand: **"all rights reserved."** Unless the owner says otherwise, all of those rights stay with them, and you have none of them.
+
+## "All rights reserved" is the starting point
+
+It's worth sitting with how restrictive the default really is. If a friend emails you a useful Go file with no further word, the law's default position is:
+
+- You may **read** it (you have a lawful copy in front of you).
+- You may **not** legally copy it into your own project.
+- You may **not** legally modify it and ship the result.
+- You may **not** legally redistribute it to anyone else.
+
+None of that depends on the author being unfriendly or wanting money. It's simply the off state. Copyright is "deny by default," and permission has to be *granted* — it doesn't appear on its own.
+
+## A license is permission, granted
+
+A **software license** is exactly that grant of permission. It is a statement from the copyright owner that says, in effect, "I still own this, but here is what I allow you to do with it, and on what conditions." It turns "all rights reserved" into "these specific rights, granted to you."
+
+A license can be tiny or enormous. One of the most popular licenses in the world, the MIT License, is a single short paragraph that says you can do almost anything as long as you keep the copyright notice. A commercial enterprise license can run many pages of conditions, payments, and restrictions. Both are doing the same fundamental job: defining the permission the owner is handing out.
+
+```text
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software ... to use, copy, modify, merge, publish, distribute ...
+```
+
+That snippet is the heart of the MIT License. Notice what it is: not a transfer of ownership, but a *grant of permission*. The author keeps the copyright; you get rights to use the code under the stated terms.
+
+## The four things permission usually covers
+
+When you read any license, you're really asking which of a small set of actions it allows, and under what conditions. These four come up again and again:
+
+| Action | What it means | Why it matters |
+|--------|---------------|----------------|
+| **Use** | Running the software for its purpose | Even just *running* a program can require permission, especially for commercial software |
+| **Copy** | Making additional copies of the code or binary | Installing on many machines, vendoring a dependency, forking a repo |
+| **Modify** | Changing the source to suit your needs | Fixing a bug, adding a feature, adapting it to your project |
+| **Distribute** | Giving copies to other people | Shipping a product, publishing a fork, including it in your release |
+
+A license might grant all four freely (most permissive open-source licenses), grant them with conditions attached (copyleft licenses ask you to share your changes under the same terms), or grant only a narrow slice (a typical commercial license lets you *use* the software but not modify or redistribute it). Keeping these four actions straight is the single most useful habit when reading any license, and it's the lens we'll use throughout this path.
+
+## Free of charge is not the same as licensed
+
+A common and costly confusion: people treat "free" and "open" and "public" as if they all mean "I can use it." They don't.
+
+- **Free of charge** is about *price*. You paid nothing.
+- **Licensed** is about *permission*. You were granted rights.
+
+These are independent. Expensive proprietary software is licensed (you bought permission). A free download might be fully licensed, partly licensed, or — surprisingly often — not licensed at all. The fact that something cost nothing tells you nothing about what you're allowed to do with it. We'll map this whole landscape in [The licensing spectrum](/learn/software-licensing/the-licensing-spectrum/).
+
+## Why even a personal project needs a license
+
+If you publish a hobby project to a public repository and add no license, here's the unhappy result: *nobody can legally use it.* The code is visible, but it's still "all rights reserved." A developer who wants to build on your project, a company that might adopt it, even a friend who wants to fix a typo and send it back — none of them have permission. Many of them, knowing the rules, will simply walk away rather than risk it.
+
+Posting source code in public makes it **visible**. It does not make it **usable**. Those are two different acts, and only adding a license accomplishes the second.
+
+So if your goal in sharing is for people to actually use your work, the license isn't bureaucratic overhead — it's the whole point. Choosing the right one is its own topic ([Choosing an open-source license](/learn/software-licensing/choosing-an-oss-license/)), but the decision to have *a* license is rarely the wrong one for code you want others to use.
+
+> A quick jurisdiction note: this "automatic copyright, no registration required" rule holds in essentially every country, thanks to an international treaty (the Berne Convention). The details of *enforcement* differ — the [cross-border lesson](/learn/software-licensing/licensing-across-jurisdictions/) covers those — but the core idea that code is owned by default is close to universal.
+
+## "No license" is a decision, even if you didn't mean it to be
+
+Leaving off a license feels like *not deciding*. Legally, it's a very firm decision: you've chosen the most restrictive option available. "No license" means "all rights reserved" means "no one may use this." If that's genuinely what you want — say, code you're sharing only to show, not to share — then fine. But if you wanted people to use your work, silence has the opposite effect from what you intended.
+
+The good news is the fix is trivial: add a `LICENSE` file. GopherTrunk itself does exactly this — its `/LICENSE` file is the Apache 2.0 license, which is what makes the whole project legally usable by others. One file converts "look but don't touch" into "here's what you may do."
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — with no license, code stays 'all rights reserved' by default, so you have no permission to reuse it even when the source is public." markdown="0">
+  <p class="knowledge-check__q">Quick check: a project is on a public site with no license file. What can you legally do with the code?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Anything you like, because publishing it publicly puts it in the public domain</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Use and modify it freely, since it was offered free of charge</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Essentially nothing beyond looking at it — with no license it stays "all rights reserved"</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Code is copyrighted on creation** — the moment you write original software, you own it, with no registration or notice required.
+- **The default is "all rights reserved"** — copyright is deny-by-default, so by default no one else may use, copy, modify, or distribute your code.
+- **A license is a grant of permission** — it keeps ownership with the author while spelling out what others may do, and on what conditions.
+- **Think in four actions** — use, copy, modify, distribute; reading any license is mostly asking which of these it grants and how.
+- **Free is not licensed** — price and permission are separate, so a no-cost project still needs an explicit license to be usable.
+- **"No license" blocks everyone** — public but unlicensed code is look-but-don't-touch; adding a `LICENSE` file is what makes a project usable.
+
+Next up: where that automatic protection comes from and who actually owns the code. See [Copyright & software ownership](/learn/software-licensing/copyright-and-software-ownership/).

--- a/docs/learn/software-licensing/what-is-open-source.md
+++ b/docs/learn/software-licensing/what-is-open-source.md
@@ -1,0 +1,110 @@
+---
+slug: what-is-open-source
+title: What open source really means
+description: 'Open source is a precise term defined by the OSI''s Open Source Definition, not just "the code is visible." Learn the criteria, the FSF''s four freedoms, free-as-in-freedom vs free-as-in-beer, and why source-available is not the same thing.'
+keywords: open source, Open Source Definition, OSI, free software, FSF, four freedoms, FOSS, FLOSS, free as in freedom, source available, software license, OSD criteria, copyleft, permissive
+level: beginner
+status: full
+faq:
+  - q: "Does 'open source' just mean I can see the source code?"
+    a: "No — that's the most common misconception. **Open source** is a precise term defined by the OSI's [Open Source Definition](/learn/software-licensing/what-is-open-source/): the license must also let you **use, modify, and redistribute** the code, including for any purpose and by anyone. Code that is merely visible but carries usage restrictions is **source-available**, not open source."
+  - q: "What's the difference between 'open source' and 'free software'?"
+    a: "They describe almost the same set of licenses but emphasize different things. The Free Software Foundation's **free software** frames it around four **freedoms** for the user (run, study, modify, distribute); the Open Source Initiative's **open source** frames it around a ten-point definition aimed at developers and businesses. In practice the approved license lists overlap heavily, which is why people say **FOSS** or **FLOSS** to cover both."
+  - q: "Is free software always free of charge?"
+    a: "No. **Free** here means freedom, not price — \"free as in freedom, not free as in beer.\" You are allowed to sell free or open-source software, and many companies do. What the license guarantees is the user's freedom to run, study, change, and share it, not that it costs nothing."
+---
+# What open source really means
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Open source is a precise term** — defined by the OSI's ten-point Open Source Definition, not by whether you can read the code. **Free software and the four freedoms** — the FSF's parallel idea, framed as freedoms to run, study, modify, and distribute. **Free means freedom, not price** — "free as in freedom, not free as in beer"; you can sell it. **Source-available is not open source** — visible code with usage limits fails the definition.
+</div>
+
+"Open source" is one of the most used and most misunderstood phrases in software. Plenty of people assume it just means "I can see the code," but it is actually a precise, agreed-upon term with a published definition — and a lot of code that looks open turns out not to qualify. By the end of this lesson you'll know what the Open Source Initiative's definition actually requires, how the Free Software Foundation's "four freedoms" frame the same idea, why "free" here means freedom rather than zero cost, what the FOSS and FLOSS acronyms mean, and the crucial distinction between open source and merely *source-available* code.
+
+## "Open source" is not just "the source is visible"
+
+The single biggest misconception is that open source means you can look at the code. You can read the source of plenty of programs — leaked code, code published "for reference," code with a "no commercial use" sticker on it — and none of that makes them open source.
+
+Open source is a term of art. It refers to software released under a license that meets a specific, published standard. That standard grants you far more than the ability to read: the right to **run** the program for any purpose, to **modify** it, and to **redistribute** it and your changes. Visibility is necessary but nowhere near sufficient.
+
+This matters because the word carries real expectations. When a developer says a library is open source, others assume they can build on it, ship it, and fork it if the project goes sideways. If the license quietly forbids commercial use, those expectations are wrong — and the project shouldn't be calling itself open source. We pick this thread up directly in [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/).
+
+## The Open Source Definition (OSI)
+
+The authority most of the industry points to is the **Open Source Initiative (OSI)** and its **Open Source Definition (OSD)** — a checklist of ten criteria a license must satisfy to be called open source. The OSI also maintains a list of *approved* licenses that have been reviewed against it, which is how you avoid arguing the criteria from scratch every time.
+
+You don't need all ten memorized, but the key ones are worth knowing:
+
+- **Free redistribution.** The license can't stop anyone from giving the software away or selling it as part of a larger distribution, and can't demand a royalty for that.
+- **Source code available.** The program must include source, or make it readily available at no more than a reasonable reproduction cost. Deliberately obfuscated source doesn't count.
+- **Derived works allowed.** The license must permit modifications and derived works, and allow them to be distributed under the same terms.
+- **No discrimination against persons or groups.** The license can't say "everyone except company X" or exclude any group of people.
+- **No discrimination against fields of endeavor.** It can't forbid use in a particular field — no "not for commercial use," no "not for military use," no "not for genetic research." This one trips up a lot of would-be open licenses.
+- **License must not be specific to a product, and must not restrict other software.** The rights travel with the code on their own, and the license can't, for example, require that everything on the same disk also be open source.
+
+The field-of-use rule is the one to remember, because it rules out a whole category of "almost open" licenses. A "free for non-commercial use" license is, by definition, not open source, no matter how visible the code is.
+
+## Free software and the four freedoms (FSF)
+
+Before "open source" was coined in 1998, the **Free Software Foundation (FSF)**, founded by Richard Stallman, had been promoting **free software** since the 1980s. It frames the same territory differently — as a matter of user freedom rather than a developer/business checklist. A program is free software if it grants its users **four freedoms**:
+
+| Freedom | What it means |
+|---|---|
+| **Freedom 0** | Run the program as you wish, for any purpose |
+| **Freedom 1** | Study how it works and change it (requires source access) |
+| **Freedom 2** | Redistribute copies so you can help others |
+| **Freedom 3** | Distribute copies of your modified versions |
+
+The freedoms are numbered from zero partly as a programmer's joke and partly to signal that the right to *run* the software is the most basic. Freedoms 1 and 3 both depend on having the source code, which is why source availability is built into the idea rather than tacked on.
+
+The OSD and the four freedoms were developed somewhat independently and use different language, but they describe nearly the same set of licenses. A license that satisfies the four freedoms almost always meets the OSD, and vice versa. The disagreements are at the edges and are usually about emphasis and philosophy, not about which licenses are acceptable.
+
+## "Free as in freedom," not "free as in beer"
+
+English overloads the word "free," and that overload causes endless confusion. The FSF's stock clarification is the one to internalize: **"free as in freedom, not free as in beer."**
+
+- *Free as in beer* means zero cost — someone bought it for you.
+- *Free as in freedom* means liberty — you are free to do certain things with it.
+
+Free and open-source software is about the second kind. The license guarantees your freedom to run, study, modify, and share the software. It does **not** guarantee that the software costs nothing, and it explicitly permits selling it. Red Hat built a large business selling a supported Linux distribution that is free software; that's entirely consistent with the definition. We'll return to the business side in [Commercial license models](/learn/software-licensing/commercial-license-models/) and [Can you sell software built on open source?](/learn/software-licensing/using-oss-in-products/).
+
+Because of the ambiguity, many people prefer "open source" specifically to sidestep the price confusion — "open" doesn't sound like "no charge" the way "free" does.
+
+## FOSS and FLOSS
+
+Two communities, two preferred words, one overlapping reality — so people invented neutral umbrella terms:
+
+- **FOSS** — Free and Open Source Software.
+- **FLOSS** — Free/Libre and Open Source Software. The "Libre" (the Spanish/French word for free-as-in-freedom) is added to make the freedom sense unmistakable to anyone confused by English "free."
+
+Both terms mean roughly "software that is free *and/or* open source," covering the whole family without taking sides in the philosophical debate between the FSF and the OSI. When you see FOSS or FLOSS, read it as a deliberate attempt to be inclusive of both camps.
+
+## Crucially: source-available is not open source
+
+This is the distinction that most often catches people out, so it's worth stating plainly. **Source-available** means the source code is published and readable, but the license imposes restrictions that an open-source license is not allowed to have — most commonly a ban on commercial use, a ban on competing with the vendor, or a delay before the rights kick in.
+
+Source-available code can be a perfectly reasonable choice for a business, and some well-known projects use it. But it is **not open source**, because it fails the OSD — usually on the no-discrimination-against-fields-of-endeavor or derived-works criteria. Calling it open source is inaccurate and, increasingly, a thing the community pushes back on hard.
+
+The mental test: *can anyone use, modify, and redistribute this for any purpose, including commercially?* If the answer is "no, not for X," it's source-available, not open source. We give this its own full treatment in [Source-available & "fair source"](/learn/software-licensing/source-available-licenses/) — for now, just hold the line between "I can read it" and "I'm free to use it."
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — the field-of-use rule means a 'no commercial use' license fails the Open Source Definition, so it's source-available, not open source." markdown="0">
+  <p class="knowledge-check__q">Quick check: a library's full source is on GitHub, but its license forbids commercial use. Is it open source?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Yes — the source code is publicly visible, so it's open source</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">No — banning a field of use (commercial) fails the Open Source Definition; it's source-available</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Yes, as long as the project calls itself open source in its README</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Open source is a precise term** — it means a license meeting the OSI's Open Source Definition, not simply that the code is visible.
+- **The OSD's key criteria** — free redistribution, available source, allowed modifications and derived works, and no discrimination against people or fields of use.
+- **Free software's four freedoms** — run, study, modify, and distribute; the FSF's parallel framing of nearly the same set of licenses.
+- **Free means freedom, not price** — "free as in freedom, not free as in beer"; selling open-source software is allowed.
+- **FOSS / FLOSS** — umbrella acronyms covering both the free-software and open-source camps.
+- **Source-available is not open source** — visible code with usage restrictions fails the definition.
+
+Next up: the single biggest divide within open-source licenses — whether you must share your changes back. See [Permissive vs copyleft](/learn/software-licensing/permissive-vs-copyleft/).

--- a/docs/learn/software-licensing/where-to-get-licensing-help.md
+++ b/docs/learn/software-licensing/where-to-get-licensing-help.md
@@ -1,0 +1,108 @@
+---
+slug: where-to-get-licensing-help
+title: Where to get licensing help
+description: When a template or DIY is fine versus when you genuinely need a lawyer, plus the reputable resources for software licensing — choosealicense.com, OSI, SPDX, tldrlegal, the SFC/SFLC, FSF, Creative Commons — and how to brief a lawyer efficiently.
+keywords: software licensing help, choosealicense.com, OSI, SPDX, tldrlegal, Software Freedom Conservancy, SFLC, FSF, Creative Commons, license template, EULA generator, when to hire a lawyer, briefing a lawyer, official license text
+level: beginner
+status: full
+faq:
+  - q: "When do I actually need a lawyer for licensing?"
+    a: "When real money or real risk is involved: **selling** software at scale, **raising investment** (investors will scrutinize your IP and licenses), **enterprise deals** with custom or negotiated terms, anything with **custom clauses**, and any situation where being wrong is expensive. For picking a standard open-source license for a side project, or applying a vetted template to a simple product, you can usually do it yourself with good resources."
+  - q: "Are free EULA generators safe to use?"
+    a: "Use them with caution. A generator can produce a reasonable first draft and is fine for low-stakes situations, but the output is generic, may not fit your jurisdiction, and can contain unenforceable or inappropriate clauses. Treat generator output as a **starting point to review**, never as a finished agreement for anything that carries risk. For real sales, have a lawyer check it."
+  - q: "Where do I find the official, authoritative text of a license?"
+    a: "Go to the **steward** of that license. For open-source licenses, the [OSI](https://opensource.org) hosts approved license texts, and **SPDX** (spdx.org) maintains canonical identifiers and texts. The **FSF** (gnu.org) publishes the GPL family; **Creative Commons** (creativecommons.org) publishes the CC licenses. Always copy the exact official text — don't retype or paraphrase a license."
+---
+# Where to get licensing help
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**DIY vs lawyer** — templates are fine for standard, low-risk situations; selling, fundraising, enterprise, and custom terms need a professional. **Trusted resources** — choosealicense.com, OSI, SPDX, tldrlegal, the SFC/SFLC, FSF, and Creative Commons. **Generators need caution** — useful drafts, not finished agreements. **Brief a lawyer well** — come prepared and you'll spend far less.
+</div>
+
+This is the "where to find more information" lesson for the whole path. Software licensing is a field where you can get a long way on your own with good resources — and a field where, past a certain point, trying to save money by skipping a lawyer is how you lose a lot of it. By the end of this lesson you'll know how to judge when DIY or a template is genuinely fine versus when you need professional help, which resources are reputable and what each is for, how to treat license generators, and how to brief a lawyer efficiently so the bill stays small.
+
+## DIY, template, or lawyer?
+
+The right level of help scales with the **stakes**. A useful way to think about it:
+
+| Situation | Usually fine to… |
+|---|---|
+| Picking a standard OSS license for a personal or community project | **DIY** with [choosealicense.com](https://choosealicense.com) |
+| Applying a well-known license correctly (notices, file headers) | **DIY** with OSI / SPDX references |
+| A simple product EULA, low revenue, no custom terms | **Vetted template**, ideally with a quick legal review |
+| **Selling software at scale** | **Lawyer** |
+| **Raising investment** | **Lawyer** (investors audit your IP/licenses) |
+| **Enterprise or negotiated deals** | **Lawyer** |
+| **Any custom clauses or unusual terms** | **Lawyer** |
+| Anything where being wrong is expensive | **Lawyer** |
+
+The pattern: **standard + low-risk → do it yourself; non-standard or high-risk → get a professional.** The cost of an attorney is almost always small next to the cost of an unenforceable agreement, a licensing dispute, or a deal that falls through in due diligence because your IP paperwork was a mess. This continues directly from the advice in [Writing a license to sell software](/learn/software-licensing/writing-a-commercial-license/): don't draft serious agreements from a blank page.
+
+## Reputable resources
+
+These are the places professionals actually point to. Knowing what each one is *for* saves you from bad search results.
+
+### Choosing and understanding open-source licenses
+
+- **[choosealicense.com](https://choosealicense.com)** — GitHub's friendly guide for picking a common open-source license by answering a few questions. The best starting point for a project. We use it directly in [Choosing an open-source license](/learn/software-licensing/choosing-an-oss-license/).
+- **[OSI — opensource.org](https://opensource.org)** — the Open Source Initiative: the authoritative [Open Source Definition](/learn/software-licensing/what-is-open-source/) and the list of **OSI-approved** licenses with their official texts. The reference for "is this actually open source?"
+- **[SPDX — spdx.org](https://spdx.org)** — the Software Package Data Exchange: canonical **license identifiers** (like `Apache-2.0`, `MIT`, `GPL-3.0-only`) and texts, used in SBOMs and tooling. The standard way to *name* a license unambiguously — see [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/).
+- **[tldrlegal.com](https://tldrlegal.com)** — plain-language summaries of what licenses let you do, must do, and can't do. A great quick read, but a *summary* — always confirm against the real text for decisions.
+
+### Free-software and stewardship organizations
+
+- **Software Freedom Conservancy (SFC)** and the **Software Freedom Law Center (SFLC)** — nonprofits providing legal support, education, and (for the SFC) a fiscal home for free-software projects. Good resources on compliance and enforcement.
+- **FSF — gnu.org** — the Free Software Foundation: steward and publisher of the **GPL family** (GPL, LGPL, AGPL), plus extensive license FAQs that are surprisingly practical.
+- **Creative Commons — creativecommons.org** — not for software code, but the standard for **documentation, media, and data** licenses (CC BY, CC BY-SA, CC0). Relevant when your project ships docs or assets alongside code.
+
+### Where official license text lives
+
+Always get a license's text from its **steward**, never from a random copy. The OSI and SPDX host open-source texts; the FSF publishes the GPL family; Creative Commons publishes the CC licenses. Copy the exact, official wording — a retyped or paraphrased license is a legal liability, and tools rely on byte-exact text to identify licenses.
+
+## Templates and generators — use with caution
+
+Templates and **EULA / privacy-policy generators** are everywhere, and they have a real place: they produce a reasonable first draft fast, which is fine for low-stakes situations. But treat their output carefully:
+
+- It's **generic** — written for nobody in particular, so it may not fit your product or business model.
+- It may be **jurisdiction-wrong** — a US-flavored template can be unenforceable or non-compliant in the EU/UK, and vice versa.
+- It can contain **inappropriate or unenforceable clauses** you won't recognize as problems.
+- The **provenance** may be unknown — a template from a random blog has no guarantees behind it.
+
+The rule: a generator or template gives you a **starting point to review**, not a finished agreement. For anything with real risk, a lawyer reviewing a good template is far cheaper than a lawyer drafting from scratch — which is itself a reason to bring a template *to* your lawyer.
+
+## How to brief a lawyer efficiently
+
+Legal time is expensive, and most of the cost of a licensing engagement is the lawyer figuring out *what you actually want*. You can cut that dramatically by coming prepared. Before the meeting, write down:
+
+1. **What you're licensing** — the product, in one paragraph, plain language.
+2. **The business decisions** — duration, scope, pricing model, who the customers are, what's prohibited. (Work through the list in [Writing a license to sell software](/learn/software-licensing/writing-a-commercial-license/).)
+3. **A draft or template** — even a rough one. Editing beats originating.
+4. **Your specific worries** — "we're concerned about liability if our software is used in X," not "make it safe."
+5. **The dependencies you ship** — your open-source components and their licenses (an SBOM is ideal), so the lawyer can assess obligations and indemnity risk.
+
+Walk in with those five things and you've turned an open-ended (expensive) engagement into a focused (cheap) review. The lawyer is then doing legal judgment — which is what you're paying for — instead of interviewing you about your own product.
+
+## Standards bodies and authoritative sources
+
+Finally, when you need *the* answer rather than a summary: licenses are stewarded by specific bodies, and that's where the canonical text and interpretation live — OSI and SPDX for open source identifiers and texts, the FSF for the GPL family, Creative Commons for content licenses. For commercial-contract questions, the governing body is ultimately the **law of the jurisdiction** you've chosen, which is why governing-law clauses matter and why cross-border deals get their own treatment in [Licensing across jurisdictions](/learn/software-licensing/licensing-across-jurisdictions/).
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — standard, low-risk choices can be DIY with good resources; selling, fundraising, enterprise, and custom terms warrant a lawyer." markdown="0">
+  <p class="knowledge-check__q">Quick check: which situation most clearly calls for a qualified attorney rather than a template?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Picking a standard open-source license for a personal side project</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Negotiating a custom enterprise deal while raising investment</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Looking up the official text of the Apache 2.0 license</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Match help to stakes** — DIY or templates for standard, low-risk choices; a lawyer for selling at scale, fundraising, enterprise deals, and custom terms.
+- **Know the resources** — choosealicense.com to pick, OSI and SPDX for authoritative identifiers and texts, tldrlegal for summaries, the SFC/SFLC and FSF for free-software support, Creative Commons for docs and media.
+- **Get official text from the steward** — never retype or paraphrase a license.
+- **Generators need caution** — useful first drafts, generic and possibly jurisdiction-wrong; review before use.
+- **Brief a lawyer well** — bring the product summary, business decisions, a draft, your specific worries, and your dependency list to keep the bill small.
+
+Next up: the start of Module 5 — whether you can sell software built on open source at all, and how. See [Can you sell software built on open source?](/learn/software-licensing/using-oss-in-products/).

--- a/docs/learn/software-licensing/which-agreements-do-you-need.md
+++ b/docs/learn/software-licensing/which-agreements-do-you-need.md
@@ -1,0 +1,112 @@
+---
+slug: which-agreements-do-you-need
+title: Which agreements does your software need?
+description: Beyond the license, the full set of agreements your software needs is determined by how it's delivered and what data it touches — a decision table mapping scenarios to EULA, ToS, privacy policy, DPA, SLA, CLA, NDA, and API terms.
+keywords: software agreements needed, EULA vs terms of service, privacy policy required, data processing agreement, SLA, CLA DCO, NDA, API terms of use, SaaS legal documents, which agreements does my software need, delivery model agreements
+level: intermediate
+status: full
+faq:
+  - q: "Isn't the license enough? Why do I need other agreements?"
+    a: "The license governs *who may use and copy your code*. Everything else — the terms of the service, what you do with users' data, uptime promises, contributions, confidential discussions — needs its own agreement. A downloaded app needs a EULA; a hosted service needs terms of service, a privacy policy, and often more. The license is one document in a set."
+  - q: "Do I need a privacy policy?"
+    a: "If your software collects or processes **personal data** — names, emails, locations, accounts, even IP addresses in some jurisdictions — then yes, you almost certainly do, and in the EU (GDPR) and California (CCPA) it's a legal requirement. You'll also need a [data processing agreement](/learn/software-licensing/privacy-and-data-agreements/) with any vendor that handles that data on your behalf."
+  - q: "What's the difference between a EULA and terms of service?"
+    a: "A **EULA** licenses a copy of software the user installs and runs on their own machine. **Terms of service** govern access to a hosted service the user doesn't possess. Downloaded software → EULA; web app or SaaS → ToS. Some products need both. See [EULAs & terms of service](/learn/software-licensing/eula-and-tos/)."
+---
+# Which agreements does your software need?
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**The license is only one document** — it covers your code; other agreements cover delivery, data, uptime, contributions, and confidentiality. **Delivery decides the core agreement** — downloaded → EULA; hosted → terms of service. **Data decides the privacy stack** — personal data means a privacy policy, and often a DPA with vendors and GDPR/CCPA duties. **Add-ons follow features** — uptime promises → SLA; contributions → CLA/DCO; an API → developer terms; confidential talks → NDA.
+</div>
+
+You've chosen a [license](/learn/software-licensing/choose-your-license/) — but a license only answers *who may use and copy your code*. The rest of your legal footprint is decided by two things: **how the software is delivered** and **what data it touches**. This lesson turns those into a concrete agreement set. We'll work through each agreement, give you a decision table that maps scenarios to the documents they require, and point back to the earlier lessons that cover each one in depth. By the end you'll be able to list exactly which agreements your specific product needs — no more, no less.
+
+## The two questions that drive the set
+
+Just as the [decision framework](/learn/software-licensing/the-decision-framework/) used delivery and data as constraints, the agreement set falls out of the same two questions:
+
+1. **How does the software reach users?** Downloaded and installed, hosted as a service, embedded in something else, or exposed as an API. This decides your *core* agreement.
+2. **What does it touch and promise?** Personal data, confidential information, uptime commitments, outside contributions. Each of these adds a specific document.
+
+Answer both and you have your list. Let's walk the agreements one at a time, then assemble the table.
+
+## Delivery-driven agreements
+
+These are decided by *how* the software is delivered — the core of your set.
+
+### Downloaded or installed software → EULA
+
+If users download and run a copy on their own machine, you grant them permission to use that copy through an **End-User License Agreement (EULA)**. It sets what they may and may not do (install on N machines, no reverse-engineering), disclaims warranties, and limits your liability. This is the natural fit for a paid desktop app or any installed binary. Full treatment in [EULAs & terms of service](/learn/software-licensing/eula-and-tos/).
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+### Web app or SaaS → Terms of service (+ more)
+
+If users access a hosted service they don't possess, a EULA is the wrong instrument — there's no copy to license. Instead you publish **Terms of Service (ToS)** governing acceptable use, accounts, payment, and termination of the service relationship. A hosted service almost always also needs a **privacy policy** (see below), and if you're selling to businesses, a **subscription agreement** or **Master Services Agreement (MSA)** spelling out the commercial terms.
+
+### Embedded or bundled → passthrough and component compliance
+
+If your software is embedded in a larger product or bundled with others' components, two things apply: you must comply with the licenses of the components you include (attribution, source offers — see [permissive compliance](/learn/software-licensing/permissive-compliance/)), and you often need *passthrough* terms so the obligations flow correctly to your downstream users.
+
+### An API → developer / API terms
+
+If you expose an API, you need **developer terms** (sometimes called API terms of use) covering rate limits, acceptable use, data ownership, and the right to change or deprecate endpoints. These are distinct from your end-user ToS because the audience — developers building on you — has different rights and risks.
+
+## Data- and feature-driven agreements
+
+These are decided by *what the software touches or promises*, and they stack on top of the core agreement.
+
+### Handles personal data → privacy policy (+ DPA, + GDPR/CCPA)
+
+If your software collects or processes personal data, you need a **privacy policy** that discloses what you collect, why, and who you share it with. In the EU this is mandatory under the **GDPR**; in California, under the **CCPA/CPRA**. And whenever a third-party vendor processes that data on your behalf (your cloud host, analytics, email sender), you need a **Data Processing Agreement (DPA)** with them. All of this is covered in [privacy policies & data agreements](/learn/software-licensing/privacy-and-data-agreements/).
+
+### Makes uptime promises → SLA
+
+If you commit to a level of availability or support — "99.9% uptime," "responses within 4 hours" — that promise belongs in a **Service Level Agreement (SLA)**, with the remedies (usually service credits) if you miss it. Enterprise buyers expect one; consumer products often skip it. See [SLAs & support agreements](/learn/software-licensing/sla-and-support-agreements/).
+
+### Accepts outside contributions → CLA or DCO
+
+If people contribute code to your project, you need clarity on the rights to that code. A **Contributor License Agreement (CLA)** has contributors grant you explicit rights; a lighter-weight **Developer Certificate of Origin (DCO)** has them certify they wrote it and may submit it. Either prevents nasty ownership surprises later — especially if you ever want to relicense. See [contributor agreements](/learn/software-licensing/contributor-agreements/).
+
+### Shares confidential information → NDA
+
+If you'll exchange confidential information — with a contractor, partner, or beta customer — before or alongside other agreements, a **Non-Disclosure Agreement (NDA)** protects it. NDAs sit beside the rest of your stack rather than replacing any of it. See [NDAs & the rest of the landscape](/learn/software-licensing/nda-and-other-agreements/).
+
+## The decision table
+
+Here's the whole picture as a lookup. Find the rows that describe your product and union their agreements — most real products match several rows at once.
+
+| If your software… | You need |
+|---|---|
+| Is **downloaded and installed** | EULA |
+| Is a **web app / SaaS** | Terms of service + privacy policy |
+| Is **SaaS sold to businesses** | + subscription agreement / MSA + DPA |
+| **Handles personal data** | Privacy policy (+ GDPR/CCPA duties, + DPA with vendors) |
+| **Makes uptime/support promises** | SLA |
+| **Accepts outside contributions** | CLA or DCO |
+| **Shares confidential info** | NDA |
+| **Exposes an API** | Developer / API terms |
+| Is **embedded / bundled** | Component-license compliance + passthrough terms |
+
+Two reminders as you assemble. First, these *combine*: a business SaaS that handles personal data, promises uptime, accepts contributions, and has an API needs a ToS, privacy policy, DPA, subscription/MSA, SLA, CLA/DCO, and API terms — all of it. Second, the license you chose still sits underneath the whole stack; these agreements layer *on top of* it, they don't replace it.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — a hosted service the user never installs is governed by terms of service, not a EULA, and it almost always needs a privacy policy too." markdown="0">
+  <p class="knowledge-check__q">Quick check: your product is a hosted web app users access in a browser. Which core agreement governs it?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">A EULA, the same as a downloaded desktop app</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Terms of service, because the user never installs a copy</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Only an open-source license — no other agreement is needed</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **The license is one document in a set** — it covers your code; delivery and data decide the rest.
+- **Delivery picks the core agreement** — downloaded → EULA; hosted → terms of service; embedded → component compliance; API → developer terms.
+- **Personal data triggers the privacy stack** — a privacy policy, GDPR/CCPA obligations, and a DPA with any vendor that processes data for you.
+- **Features add specific documents** — uptime promises → SLA; contributions → CLA/DCO; confidential sharing → NDA.
+- **Agreements combine** — most real products match several rows of the table at once, and the stack layers on top of the license.
+
+Next up: see the whole framework, license choice, and agreement set applied end-to-end to a realistic product in [Putting it all together](/learn/software-licensing/putting-it-all-together/).

--- a/docs/learn/software-licensing/writing-a-commercial-license.md
+++ b/docs/learn/software-licensing/writing-a-commercial-license.md
@@ -1,0 +1,126 @@
+---
+slug: writing-a-commercial-license
+title: Writing a license to sell software
+description: What to decide before you draft a commercial software license or EULA — the rights you're granting, the skeleton of the document, how a license relates to a purchase order or MSA, and why you should start from a vetted template or lawyer, not a blank page.
+keywords: writing a commercial license, software EULA, license drafting, license grant, end user license agreement, MSA, master services agreement, purchase order, license template, SaaS terms, software contract structure, sell software license
+level: advanced
+status: full
+faq:
+  - q: "Can I just write my own EULA from scratch?"
+    a: "You *can*, but for anything beyond a hobby project you shouldn't. License language has decades of case law behind specific phrasings, and a homemade clause can be unenforceable or accidentally give away more than you meant. Start from a **vetted template** or have a lawyer draft or review it — see [Where to get licensing help](/learn/software-licensing/where-to-get-licensing-help/). Writing from a blank page is where expensive mistakes get baked in."
+  - q: "What's the difference between a license, a purchase order, and an MSA?"
+    a: "The **license** (EULA) defines what the customer may *do* with the software. A **purchase order (PO)** is the commercial transaction — what's being bought, quantity, price. A **Master Services Agreement (MSA)** is an overarching contract governing an ongoing business relationship, with the license and specific deals as schedules under it. Big enterprise sales often use all three; a simple product may use only a EULA."
+  - q: "Is this lesson legal advice?"
+    a: "No. **This is educational material, not legal advice.** It explains the structure and decisions involved so you can have a productive conversation with a qualified attorney. For an actual license you intend to sell under, get professional review — the cost of a lawyer is small next to the cost of an unenforceable or overreaching agreement."
+---
+# Writing a license to sell software
+
+<div class="tldr" markdown="1">
+<span class="tldr__label">Key takeaways</span>
+**Decide before you draft** — what you're granting, to how many, whether they can modify or transfer, and what's prohibited. **Know the skeleton** — grant, definitions, restrictions, fees, term/termination, warranty, liability, IP, governing law. **License vs PO vs MSA** — the license says what they may *do*; other documents handle the *deal* and the *relationship*. **Don't start from a blank page** — use a vetted template or a lawyer.
+</div>
+
+> **This is educational material, not legal advice.** For decisions that carry real risk, consult a qualified attorney.
+
+If you're going to sell proprietary software, at some point you need a document that says what your customers are allowed to do with it. This lesson is about *preparing* to create that document — the decisions you make before any drafting, the standard structure a commercial license follows, and how the license fits alongside the other paperwork of a sale. By the end you'll know what you need to settle up front, what a EULA's skeleton looks like, how the license relates to a purchase order and an MSA, and — most importantly — why you should not write one from scratch.
+
+## Decide what you're granting before you draft
+
+The biggest mistake in license drafting is opening a blank document and starting to write clauses. The clauses are downstream. First, settle the **business decisions** that the license merely *records*. Get these wrong and even perfect legal language ships the wrong product.
+
+Work through these questions before anything else:
+
+| Decision | The question to answer |
+|---|---|
+| **Duration** | Perpetual or subscription? (See [commercial license models](/learn/software-licensing/commercial-license-models/).) |
+| **Scope of use** | How many users, devices, installs, cores, or calls? Counted how? |
+| **Modification** | May the customer modify or configure the software, or not at all? |
+| **Transfer** | Can they assign or resell the license, or is it locked to them? |
+| **Redistribution** | May they embed or redistribute it, or is it for internal use only? |
+| **Prohibited uses** | What's flatly banned — reverse engineering, benchmarking, competing use? |
+| **Support & updates** | Are these included, separate, or excluded? |
+| **Data & hosting** | For SaaS: who owns the data, where does it live, what happens at termination? |
+
+Notice that every one of these is a *product and pricing* decision, not a legal one. The license is the place you write the answers down precisely. If you can't answer them, you're not ready to draft — and no template will answer them for you. The [decision framework](/learn/software-licensing/the-decision-framework/) lesson helps work through them systematically.
+
+## The skeleton of a commercial license / EULA
+
+Commercial licenses are remarkably consistent in structure, because the same things have to be covered every time. Here's the standard skeleton, in roughly the order you'll see it:
+
+1. **Parties** — who's licensing to whom (the licensor and the licensee).
+2. **Definitions** — the precise meaning of key terms ("Software," "Documentation," "Authorized Users," "Order"). Boring but load-bearing; ambiguity here causes most disputes.
+3. **License grant** — the rights you *are* giving, with their scope and limits.
+4. **Restrictions** — what the customer may *not* do.
+5. **Fees & payment** — what's owed, when, and what happens if it isn't paid.
+6. **Term & termination** — how long it lasts, what ends it, and what survives.
+7. **Warranty / disclaimer** — any promises, and the disclaimer of everything else.
+8. **Limitation of liability** — caps and exclusions on what you'll pay if things go wrong.
+9. **Intellectual property** — a clear statement that you keep ownership.
+10. **Governing law & dispute resolution** — whose law applies and where disputes are settled.
+
+A minimal grant-and-restriction core looks like this — the heart of the document, even when everything around it grows:
+
+```text
+1. LICENSE GRANT. Subject to the terms of this Agreement and payment of
+   the applicable Fees, Licensor grants Licensee a non-exclusive,
+   non-transferable license to install and use the Software for up to the
+   number of Authorized Users specified in the applicable Order, solely
+   for Licensee's internal business purposes.
+
+2. RESTRICTIONS. Licensee shall not (a) sublicense, sell, rent, or
+   redistribute the Software; (b) modify or create derivative works;
+   (c) reverse engineer, decompile, or disassemble it except to the
+   extent that applicable law expressly permits; or (d) remove any
+   proprietary notices.
+```
+
+We walk through each of these clauses — what it does, what to put in it, and what to watch for — in [Key clauses in a commercial license](/learn/software-licensing/key-commercial-clauses/). Treat that lesson as the detailed companion to this structural overview.
+
+## How the license relates to the PO and the MSA
+
+A common source of confusion: the license is usually *not the only document* in a real sale. Three pieces of paper do three different jobs, and keeping them straight matters.
+
+- **The license / EULA** answers *"what may the customer do with the software?"* — the grant, restrictions, and the legal terms above.
+- **The purchase order (PO) or order form** answers *"what exactly is being bought?"* — which product, how many seats, the price, the dates. It's the commercial transaction.
+- **The Master Services Agreement (MSA)** answers *"what governs the overall relationship?"* — the umbrella contract for an ongoing engagement, under which individual orders and license terms hang as schedules or exhibits.
+
+For a small product sold off a website, a single EULA accepted at install or checkout may be all you have. For an enterprise deal, you'll typically have an MSA that incorporates the license terms by reference, with one or more order forms specifying the actual purchase. The key drafting principle is to avoid **conflicts** between them: state clearly which document controls if they disagree (usually the MSA, with order-specific details winning on quantity and price).
+
+| Document | Answers | When you need it |
+|---|---|---|
+| **License / EULA** | What can the customer do with the software? | Always |
+| **Purchase order / order form** | What is being bought, how much, for how long? | Any paid transaction |
+| **MSA** | What governs the ongoing relationship? | Larger / recurring B2B deals |
+
+## Start from a template or a lawyer — not a blank page
+
+This is the strongest practical advice in the whole lesson: **do not draft a commercial license from scratch.**
+
+License language is dense with terms of art whose exact wording has been tested in court. A homegrown limitation-of-liability clause might be unenforceable; a sloppy grant might accidentally be broader than you intended; a missing "survives termination" line might let a customer keep using your IP after the deal ends. These aren't hypotheticals — they're the everyday failure modes of DIY legal drafting.
+
+Two good starting points, in increasing order of safety:
+
+- **A vetted template.** Reputable, professionally prepared templates encode the standard structure and battle-tested language. They still need *your* business decisions filled in, and ideally a lawyer's once-over, but they save you from inventing clauses. Be wary of random templates of unknown provenance — see the discussion of template risks in [Where to get licensing help](/learn/software-licensing/where-to-get-licensing-help/).
+- **A qualified attorney.** For anything that carries real risk — selling at scale, enterprise deals, custom terms, raising money — have a lawyer draft or review the license. The cost is small compared to a dispute over an unenforceable agreement, and a good lawyer will also catch jurisdiction-specific issues you won't know to look for.
+
+The judgment call of *when a template is fine versus when you genuinely need a lawyer* is exactly what the next module-mate lesson, [Where to get licensing help](/learn/software-licensing/where-to-get-licensing-help/), is built to answer.
+
+<div class="knowledge-check" data-quiz data-correct-msg="Right — settle the business decisions (duration, scope, modification, transfer, prohibitions) first; the license just records them." markdown="0">
+  <p class="knowledge-check__q">Quick check: what should you do *first* when creating a license to sell your software?</p>
+  <ul class="quiz__options">
+    <li><button type="button" class="quiz__option" data-answer="wrong">Open a blank document and start writing the legal clauses</button></li>
+    <li><button type="button" class="quiz__option" data-answer="correct">Decide the business terms — duration, scope, modification, transfer, and prohibitions</button></li>
+    <li><button type="button" class="quiz__option" data-answer="wrong">Pick a governing-law jurisdiction before anything else</button></li>
+  </ul>
+  <p class="quiz__feedback" data-quiz-feedback hidden></p>
+</div>
+
+## Recap
+
+- **Decide before you draft** — duration, scope, modification, transfer, redistribution, prohibited uses, support, and data are business decisions the license merely records.
+- **Know the skeleton** — parties, definitions, grant, restrictions, fees, term/termination, warranty, liability, IP, and governing law, in roughly that order.
+- **The grant and restrictions are the core** — a tightly scoped grant followed by an explicit list of prohibitions.
+- **License vs PO vs MSA** — the license says what they may *do*, the order says what's *bought*, the MSA governs the *relationship*; state which controls in a conflict.
+- **Don't start from a blank page** — use a vetted template or a lawyer; DIY drafting is where unenforceable and overbroad clauses get baked in.
+
+Next up: the detailed companion — every major clause in a commercial license, what it does, and what to watch for. See [Key clauses in a commercial license](/learn/software-licensing/key-commercial-clauses/).


### PR DESCRIPTION
Add a seventh learning path covering software licensing and user
agreements end to end, matching the existing data-driven learn system
(learn.yml entry + _config.yml scope + per-lesson markdown).

41 lessons across 7 modules plus a glossary:
- Licensing & IP foundations (copyright, patents/trademarks/trade
  secrets, license vs contract, the licensing spectrum, jurisdictions)
- Open source licenses in depth (MIT/BSD, Apache, GPL, AGPL, weak
  copyleft, public domain) with strengths and weaknesses of each
- Choosing & combining open source (compatibility, CLAs/DCO, dual
  licensing, dependency risks)
- Proprietary & commercial licensing (models, source-available,
  writing a custom commercial license, key clauses, where to get help)
- Using open source in software you sell (compliance, copyleft "viral"
  question, dependency auditing & SBOMs)
- Reading agreements & other user agreements (how to read one, the main
  and risk clauses, EULA/ToS, privacy/DPA, SLA, NDA)
- Choosing your own license & agreement set, with an end-to-end example

Concepts are taught with US law as the reference point and major
differences in other jurisdictions flagged throughout. Content is
educational, not legal advice.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WvCScAVx1cgYkbA3LoKzpd