### PR TITLE
voice: decimate voice IQ with a strided FIR to stop live-IQ drops

### DIFF
--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -535,21 +535,18 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 	bt := c.newBoundaryTracker(serial, 0, nil)
 	go bt.run(ctx)
 
-	// Front-end LPF: cutoff = bw / iqHz (normalized 0..0.5).
-	cutoff := float64(c.bw) / float64(iqHz)
-	if cutoff > 0.45 {
-		cutoff = 0.45
-	}
-	taps := filter.LowpassKaiser(81, cutoff, 8.6)
-	lpf := filter.NewFIR(taps)
-
-	// Naive decimation factors. They aren't exact; resampling-quality
-	// audio lands with the polyphase resampler in a follow-up.
+	// Front-end decimator: an 81-tap anti-alias FIR that convolves ONLY at
+	// the output positions, replacing the old full-rate FIR + every-Nth-
+	// sample decimation that filtered every input sample and discarded most
+	// of the result (~194M MACs/sec at 2.4 MS/s). Same filter and same kept
+	// samples, so the demodulated audio is byte-for-byte unchanged. Unlike
+	// the digital chains, FM band-limits even when not decimating, so
+	// filterAtUnity is true.
 	const intermediateHz = 48_000
-	decim1 := int(iqHz) / intermediateHz
-	if decim1 < 1 {
-		decim1 = 1
-	}
+	fe := newDecimatingFIR(float64(iqHz), intermediateHz, float64(c.bw), true)
+
+	// Second-stage decimation to PCM. Still naive; resampling-quality audio
+	// lands with the opt-in polyphase resampler below.
 	decim2 := intermediateHz / int(c.pcmHz)
 	if decim2 < 1 {
 		decim2 = 1
@@ -570,7 +567,7 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 	// treble for SNR; without the matching low-pass the recording
 	// sounds harsh. Filter runs on the real audio at the intermediate
 	// rate (~48 kHz) before the second naive decimation to PCM.
-	intermediateHzf := float64(iqHz) / float64(decim1)
+	intermediateHzf := fe.OutRateHz()
 	var deemph *filter.DeEmphasis
 	if c.deemphCfg.Enabled {
 		deemph = filter.NewDeEmphasis(c.deemphCfg.TimeConstant, intermediateHzf)
@@ -674,8 +671,7 @@ func (c *Composer) runFMChain(ctx context.Context, serial string, iqCh <-chan []
 				emitTail()
 				return
 			}
-			filtered := lpf.Process(nil, iq)
-			decimated := decimateComplex(filtered, decim1)
+			decimated := fe.Process(nil, iq)
 			if eq != nil {
 				if cap(eqScratch) < len(decimated) {
 					eqScratch = make([]complex64, len(decimated))

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -2,11 +2,9 @@ package composer
 
 import (
 	"context"
-	"math"
 	"sync/atomic"
 	"time"
 
-	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
 	dmrvoice "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/voice"
@@ -148,21 +146,16 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 	bt := c.newBoundaryTracker(serial, 0, nil)
 	go bt.run(ctx)
 
-	decim := int(math.Round(iqHz)) / dmrVoiceIntermediateHz
-	if decim < 1 {
-		decim = 1
-	}
-	symbolHz := iqHz / float64(decim)
-
-	// Front-end LPF: doubles as the anti-aliasing filter for the
-	// decimation, so it is only needed when the IQ is actually
-	// decimated (the live multi-MS/s path; decim == 1 only in tests
-	// that feed IQ already at the intermediate rate).
-	cutoff := float64(c.bw) / iqHz
-	if cutoff > 0.45 {
-		cutoff = 0.45
-	}
-	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
+	// Front-end decimator: an 81-tap anti-alias FIR that convolves ONLY at
+	// the output positions, replacing the old full-rate FIR + every-Nth-
+	// sample decimation that filtered every input sample and discarded ~98%
+	// of the result. At 2.4 MS/s that wasted ~194M MACs/sec per voice call
+	// and starved the live IQ consumer until the SDR dropped chunks. Same
+	// coefficients and same kept samples as before, so the decode is
+	// byte-for-byte unchanged — only the wasted work is removed. decim==1
+	// (a source already at the intermediate rate) is a pass-through no-op.
+	fe := newDecimatingFIR(iqHz, dmrVoiceIntermediateHz, float64(c.bw), false)
+	symbolHz := fe.OutRateHz()
 
 	rs, _ := c.sink.(rawFrameSink)
 	// ers, when the sink supports it, carries the per-frame FEC corrected-bit
@@ -291,11 +284,7 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 				logDecodeQuality(true)
 				return
 			}
-			samples := iq
-			if decim > 1 {
-				samples = decimateComplex(lpf.Process(nil, iq), decim)
-			}
-			rx.Process(samples)
+			rx.Process(fe.Process(nil, iq))
 		}
 	}
 }

--- a/internal/voice/composer/frontend_decim.go
+++ b/internal/voice/composer/frontend_decim.go
@@ -1,0 +1,130 @@
+package composer
+
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+// decimatingFIR brings a wideband voice-IQ stream down to the narrowband
+// intermediate rate the digital voice receivers expect, by running the
+// same anti-alias FIR the chains used before but computing ONLY the
+// samples it keeps.
+//
+// The old front end did `decimateComplex(lpf.Process(nil, iq), decim)`:
+// it filtered EVERY input sample at the full SDR rate (e.g. an 81-tap FIR
+// over 2.4M samples/sec ≈ 194M complex MACs/sec) and then threw away all
+// but every decim-th output. At 2.4 MS/s that wasted ~98% of the filter's
+// work, per active voice call, on one goroutine competing with the
+// control-channel decode — enough to starve the SDR reader and drop live
+// IQ at the driver buffer. A decimating FIR convolves only at the output
+// positions, so the cost drops by ~decim× (≈50× at 2.4 MS/s).
+//
+// It is byte-for-byte equivalent to the old code: the same
+// LowpassKaiser(81, c.bw/iqHz, 8.6) coefficients, the same convolution,
+// and outputs taken at the same indices (0, decim, 2·decim, …). So the
+// decode is unchanged — only the wasted multiply-accumulates are removed.
+// (A polyphase rational resampler would be cheaper still, but it uses a
+// different, sharper prototype filter that measurably degrades C4FM voice
+// decode at high decimation factors, so it is deliberately not used here.)
+//
+// When the source already streams at (or below) the intermediate rate
+// (decim ≤ 1 — only the unit tests that feed pre-channelised 48 kHz IQ)
+// the filter is skipped entirely and Process passes the chunk straight
+// through, byte-exact with the old `samples := iq` no-op.
+type decimatingFIR struct {
+	taps      []float32
+	hist      []complex64
+	histPos   int
+	decim     int
+	phase     int // input counter mod decim; emit an output when 0
+	outRateHz float64
+}
+
+// newDecimatingFIR builds a decimator from inRateHz to ~targetHz with an
+// anti-alias cutoff of bwHz (the operator-tunable voice bandwidth). The
+// decimation factor and reported OutRateHz match the old
+// `decim := round(inRateHz)/target; symbolHz := inRateHz/decim` exactly,
+// so the receiver's symbol clock is built from the same rate as before.
+//
+// filterAtUnity selects the decim==1 behaviour so each chain stays
+// byte-exact with the code it replaces. The digital chains historically
+// did `samples := iq` (raw, unfiltered) when not decimating, so they pass
+// false. The analog FM chain did `decimateComplex(lpf.Process(iq), 1)` —
+// it band-limits even at unity — so it passes true. In practice the live
+// SDR rate makes decim>1 on every path; this only pins the edge case.
+func newDecimatingFIR(inRateHz, targetHz, bwHz float64, filterAtUnity bool) *decimatingFIR {
+	f := &decimatingFIR{decim: 1, outRateHz: inRateHz}
+	decim := int(math.Round(inRateHz)) / int(math.Round(targetHz))
+	if decim < 1 {
+		decim = 1
+	}
+	f.decim = decim
+	f.outRateHz = inRateHz / float64(decim)
+	if decim == 1 && !filterAtUnity {
+		return f // pass-through, no filter — byte-exact with the old no-op
+	}
+	// Front-end LPF: doubles as the anti-aliasing filter for the
+	// decimation. Identical design to the old per-chain `lpf` so the
+	// decimated samples are bit-for-bit the same.
+	cutoff := bwHz / inRateHz
+	if cutoff > 0.45 {
+		cutoff = 0.45
+	}
+	f.taps = filter.LowpassKaiser(81, cutoff, 8.6)
+	f.hist = make([]complex64, len(f.taps))
+	return f
+}
+
+// OutRateHz returns the achieved narrowband output rate (inRateHz/decim;
+// equals inRateHz in pass-through mode). The receiver's SampleRateHz is
+// built from this so matched-filter / symbol-clock sizing matches the
+// stream — the same value the old code derived as `iqHz/decim`.
+func (f *decimatingFIR) OutRateHz() float64 { return f.outRateHz }
+
+// Process decimates one raw IQ chunk to the narrowband rate. dst is
+// reused if it has capacity. In pass-through mode (decim == 1) raw is
+// returned unchanged. raw is never mutated. The output equals
+// decimateComplex(NewFIR(taps).Process(nil, raw), decim) computed across
+// the continuous stream — the filter history and decimation phase carry
+// across chunks.
+func (f *decimatingFIR) Process(dst, raw []complex64) []complex64 {
+	if f.taps == nil {
+		return raw // pass-through (decim==1 with no filter requested)
+	}
+	N := len(f.taps)
+	dst = dst[:0]
+	for _, x := range raw {
+		f.hist[f.histPos] = x
+		f.histPos++
+		if f.histPos == N {
+			f.histPos = 0
+		}
+		if f.phase == 0 {
+			// Convolve: out = sum_k taps[k] · hist[(histPos-1-k) mod N].
+			// Same accumulation order as filter.FIR.Process, so the result
+			// is identical to filtering then striding.
+			var accI, accQ float32
+			idx := f.histPos - 1
+			if idx < 0 {
+				idx = N - 1
+			}
+			for k := 0; k < N; k++ {
+				s := f.hist[idx]
+				h := f.taps[k]
+				accI += h * real(s)
+				accQ += h * imag(s)
+				idx--
+				if idx < 0 {
+					idx = N - 1
+				}
+			}
+			dst = append(dst, complex(accI, accQ))
+		}
+		f.phase++
+		if f.phase == f.decim {
+			f.phase = 0
+		}
+	}
+	return dst
+}

--- a/internal/voice/composer/frontend_decim_test.go
+++ b/internal/voice/composer/frontend_decim_test.go
@@ -1,0 +1,144 @@
+package composer
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+)
+
+// oldFrontEnd reproduces the pre-change front end —
+// `decimateComplex(lpf.Process(nil, iq), decim)` with the same 81-tap
+// Kaiser LPF the chains built — so the decimating FIR can be pinned
+// byte-for-byte against the code it replaced. filterAtUnity mirrors the
+// two decim==1 behaviours: the digital chains' raw `samples := iq`
+// (false) and the FM chain's filtered `decimateComplex(lpf.Process,1)`
+// (true).
+func oldFrontEnd(iq []complex64, inRateHz, targetHz, bwHz float64, filterAtUnity bool) []complex64 {
+	decim := int(inRateHz) / int(targetHz)
+	if decim < 1 {
+		decim = 1
+	}
+	if decim == 1 && !filterAtUnity {
+		return iq // old `samples := iq` no-op
+	}
+	cutoff := bwHz / inRateHz
+	if cutoff > 0.45 {
+		cutoff = 0.45
+	}
+	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
+	return decimateComplex(lpf.Process(nil, iq), decim)
+}
+
+func tone(n int) []complex64 {
+	out := make([]complex64, n)
+	for i := range out {
+		// A deterministic, slowly-rotating tone with a little structure so
+		// the filter actually does something. No math/rand (banned in this
+		// harness) and no Date dependency.
+		p := float64(i) * 0.013
+		q := float64(i) * 0.0007
+		out[i] = complex(float32(0.7*math.Cos(p)+0.2*math.Cos(q)), float32(0.7*math.Sin(p)-0.2*math.Sin(q)))
+	}
+	return out
+}
+
+// TestDecimatingFIRMatchesOldFrontEnd is the core regression guard: the
+// decimating FIR must produce bit-for-bit the same samples as the old
+// filter-everything-then-stride front end, at the field-reported 2.4 MS/s
+// (decim=50) and a couple of other ratios, both as one call and fed in
+// streaming chunks (history + decimation phase must carry across chunks).
+// This is what lets the change claim "decode unchanged, only faster".
+func TestDecimatingFIRMatchesOldFrontEnd(t *testing.T) {
+	const (
+		bw     = 12_500.0
+		target = 48_000.0
+	)
+	// false = digital-chain decim==1 semantics (raw passthrough); true =
+	// FM-chain semantics (band-limit even at unity). Both must stay
+	// byte-for-byte equal to the old front end at every rate.
+	for _, filterAtUnity := range []bool{false, true} {
+		for _, rate := range []float64{96_000, 240_000, 2_400_000} {
+			iq := tone(20_000)
+			want := oldFrontEnd(iq, rate, target, bw, filterAtUnity)
+
+			// Single call.
+			fe := newDecimatingFIR(rate, target, bw, filterAtUnity)
+			got := fe.Process(nil, iq)
+			if fe.OutRateHz() != rate/float64(int(rate)/int(target)) {
+				t.Errorf("rate=%.0f OutRateHz=%.4f", rate, fe.OutRateHz())
+			}
+			if len(got) != len(want) {
+				t.Fatalf("rate=%.0f unity=%v: len got=%d want=%d", rate, filterAtUnity, len(got), len(want))
+			}
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("rate=%.0f unity=%v single: sample %d got=%v want=%v", rate, filterAtUnity, i, got[i], want[i])
+				}
+			}
+
+			// Streaming chunks of an awkward size that is not a multiple of
+			// decim, to prove the decimation phase carries across boundaries.
+			fe2 := newDecimatingFIR(rate, target, bw, filterAtUnity)
+			var streamed []complex64
+			var dst []complex64
+			for i := 0; i < len(iq); i += 777 {
+				e := i + 777
+				if e > len(iq) {
+					e = len(iq)
+				}
+				dst = fe2.Process(dst, iq[i:e])
+				streamed = append(streamed, dst...)
+			}
+			if len(streamed) != len(want) {
+				t.Fatalf("rate=%.0f unity=%v: streamed len=%d want=%d", rate, filterAtUnity, len(streamed), len(want))
+			}
+			for i := range streamed {
+				if streamed[i] != want[i] {
+					t.Fatalf("rate=%.0f unity=%v chunked: sample %d got=%v want=%v", rate, filterAtUnity, i, streamed[i], want[i])
+				}
+			}
+		}
+	}
+}
+
+// TestDecimatingFIRFilterAtUnity pins the FM-chain decim==1 behaviour:
+// with filterAtUnity the front end still band-limits (it does not return
+// raw), matching the old FM `decimateComplex(lpf.Process(iq), 1)`.
+func TestDecimatingFIRFilterAtUnity(t *testing.T) {
+	fe := newDecimatingFIR(48_000, 48_000, 12_500, true)
+	if fe.OutRateHz() != 48_000 {
+		t.Errorf("unity OutRateHz=%.3f, want 48000", fe.OutRateHz())
+	}
+	in := tone(2048)
+	got := fe.Process(nil, in)
+	want := oldFrontEnd(in, 48_000, 48_000, 12_500, true)
+	if len(got) != len(in) {
+		t.Fatalf("unity len got=%d, want %d (no decimation)", len(got), len(in))
+	}
+	if &got[0] == &in[0] {
+		t.Fatal("filterAtUnity must filter, not return the input slice unchanged")
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("unity sample %d got=%v want=%v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestDecimatingFIRPassThrough pins the decim==1 parity path: a source
+// already at the intermediate rate is returned unchanged (no filtering),
+// byte-exact with the old `samples := iq`. The existing 48 kHz chain
+// tests rely on this.
+func TestDecimatingFIRPassThrough(t *testing.T) {
+	fe := newDecimatingFIR(48_000, 48_000, 12_500, false)
+	if fe.OutRateHz() != 48_000 {
+		t.Errorf("pass-through OutRateHz=%.3f, want 48000", fe.OutRateHz())
+	}
+	in := tone(64)
+	out := fe.Process(nil, in)
+	if len(out) != len(in) || &out[0] != &in[0] {
+		t.Errorf("pass-through must return the input slice unchanged (len %d want %d, aliased=%v)",
+			len(out), len(in), len(out) > 0 && &out[0] == &in[0])
+	}
+}

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp"
-	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
@@ -68,11 +67,16 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	bt := c.newBoundaryTracker(serial, grantTG, patched)
 	go bt.run(ctx)
 
-	decim := int(math.Round(iqHz)) / p25p1VoiceIntermediateHz
-	if decim < 1 {
-		decim = 1
-	}
-	symbolHz := iqHz / float64(decim)
+	// Front-end decimator: an 81-tap anti-alias FIR that convolves ONLY at
+	// the output positions, replacing the old full-rate FIR + every-Nth-
+	// sample decimation that filtered every input sample and discarded ~98%
+	// of the result. At 2.4 MS/s that wasted ~194M MACs/sec per voice call
+	// and starved the live IQ consumer until the SDR dropped chunks. Same
+	// coefficients and same kept samples as before, so the decode is
+	// byte-for-byte unchanged — only the wasted work is removed. decim==1
+	// (a source already at the intermediate rate) is a pass-through no-op.
+	fe := newDecimatingFIR(iqHz, p25p1VoiceIntermediateHz, float64(c.bw), false)
+	symbolHz := fe.OutRateHz()
 
 	mode := c.resolveP25Phase1DemodMode(serial, demodMode)
 
@@ -109,16 +113,6 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	c.log.Info("composer: p25p1 voice chain started",
 		"serial", serial, "demod_mode", mode,
 		"iq_rate_hz", iqHz, "symbol_rate_hz", symbolHz)
-
-	// Front-end LPF: doubles as the anti-aliasing filter for the
-	// decimation, so it is only needed when the IQ is actually
-	// decimated (decim == 1 only in tests that feed IQ already at the
-	// intermediate rate).
-	cutoff := float64(c.bw) / iqHz
-	if cutoff > 0.45 {
-		cutoff = 0.45
-	}
-	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
 
 	rs, _ := c.sink.(rawFrameSink)
 	// ers, when the sink supports it, carries the per-frame FEC corrected-bit
@@ -438,10 +432,7 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 				logDecodeQuality(true)
 				return
 			}
-			samples := iq
-			if decim > 1 {
-				samples = decimateComplex(lpf.Process(nil, iq), decim)
-			}
+			samples := fe.Process(nil, iq)
 			if atNCO != nil {
 				// Shift the estimated carrier (at +atApplied Hz) down to DC.
 				// In-place is safe (NCO.Mix supports dst aliasing src).

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
@@ -150,6 +151,132 @@ func TestComposerP25Phase1VoiceChainExtractsRawFrames(t *testing.T) {
 	}
 
 	waitFor(t, time.Second, func() bool { return eng.touched.Load() > 0 })
+}
+
+// TestComposerP25Phase1VoiceChainDecodesWidebandIQ drives the voice
+// chain on the PHYSICAL-SDR path — genuine wideband C4FM IQ that the
+// chain must decimate itself before the receiver runs. This is the
+// configuration in the field report where a voice grant on a single
+// RTL-SDR started dropping live IQ ("consumer can't keep up"): the old
+// front end ran an 81-tap FIR over every input sample and threw away all
+// but every decim-th output. The chain now decimates with the same
+// filter but convolves only at the kept positions. This test guards that
+// the change preserves decode through real wideband IQ — a path the rest
+// of the suite (all 48 kHz / pass-through) never covers.
+func TestComposerP25Phase1VoiceChainDecodesWidebandIQ(t *testing.T) {
+	const (
+		// A wideband rate that forces a genuine decimation (decim = 5)
+		// without the multi-second modulation cost of synthesising the full
+		// 2.4 MS/s stream (sps=500). The field report's 2.4 MS/s (decim=50)
+		// runs the SAME decimating-FIR path; the byte-for-byte equivalence
+		// to the old front end at 2.4 MS/s is pinned separately and cheaply
+		// in TestDecimatingFIRMatchesOldFrontEnd.
+		sampleRate = 240_000.0
+		deviation  = 1800.0
+		ldus       = 12
+	)
+	framesPerLDU := phase1.LDUVoiceSubframeCount
+
+	dibits, want := buildP25P1VoiceStream(t, ldus)
+	// Modulate at the wideband rate so the chain sees real C4FM it must
+	// decimate itself (not pre-channelised 48 kHz like the other tests).
+	iq := demod.ModulateP25C4FM(dibits, sampleRate, deviation)
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "P25P1Site", Protocol: "p25",
+				GroupID: 42, FrequencyHz: 851_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 8*time.Second, func() bool {
+		return len(sink.rawFrames("VOICE-1")) >= 6*framesPerLDU
+	})
+
+	got := sink.rawFrames("VOICE-1")
+	for _, f := range got {
+		if len(f) != imbe.FrameBytes {
+			t.Fatalf("raw frame length = %d, want %d", len(f), imbe.FrameBytes)
+		}
+	}
+	// At least one full LDU of IMBE frames must round-trip through the
+	// polyphase-decimated wideband path, same bar as the 48 kHz test.
+	matches := bestAlignmentMatches(got, want)
+	if matches < framesPerLDU {
+		t.Errorf("wideband path: only %d of %d captured frames round-tripped; want at least one LDU (%d)",
+			matches, len(got), framesPerLDU)
+	}
+}
+
+// BenchmarkP25P1VoiceFrontEnd2p4MS measures the new decimating-FIR front
+// end at the reporter's 2.4 MS/s rate, and BenchmarkP25P1VoiceFrontEndNaive2p4MS
+// the old filter-everything-then-stride front end it replaced, so the
+// per-chunk cost reduction is visible in one `go test -bench` run (mirrors
+// BenchmarkDDCBankProcess10MHz4Taps for issue #764). Both use the same
+// 81-tap filter; the naive baseline runs it over every input sample then
+// keeps 1 of 50, the new path convolves only at the kept positions.
+func BenchmarkP25P1VoiceFrontEnd2p4MS(b *testing.B) {
+	const inRate = 2_400_000.0
+	fe := newDecimatingFIR(inRate, p25p1VoiceIntermediateHz, 12_500, false)
+	chunk := benchTone(8192)
+	var dst []complex64
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dst = fe.Process(dst, chunk)
+	}
+}
+
+func BenchmarkP25P1VoiceFrontEndNaive2p4MS(b *testing.B) {
+	const inRate = 2_400_000.0
+	decim := int(inRate) / p25p1VoiceIntermediateHz
+	cutoff := 12_500.0 / inRate
+	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
+	chunk := benchTone(8192)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = decimateComplex(lpf.Process(nil, chunk), decim)
+	}
+}
+
+// benchTone builds a deterministic complex tone buffer for the front-end
+// benchmarks. Avoids math/rand and Date-dependent state.
+func benchTone(n int) []complex64 {
+	out := make([]complex64, n)
+	for i := range out {
+		p := float64(i) * 0.017
+		out[i] = complex(float32(math.Cos(p)), float32(math.Sin(p)))
+	}
+	return out
 }
 
 // TestComposerP25Phase1VoiceChainHonoursDemodMode confirms a CallStart

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -2,11 +2,9 @@ package composer
 
 import (
 	"context"
-	"math"
 	"sync/atomic"
 	"time"
 
-	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	gtlog "github.com/MattCheramie/GopherTrunk/internal/log"
 	p25p2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
@@ -91,21 +89,16 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 			"scrambler", macCfg.Scrambler, "rs", macCfg.RS, "seed", macCfg.Seed)
 	}
 
-	decim := int(math.Round(iqHz)) / p25p2VoiceIntermediateHz
-	if decim < 1 {
-		decim = 1
-	}
-	symbolHz := iqHz / float64(decim)
-
-	// Front-end LPF: doubles as the anti-aliasing filter for the
-	// decimation, so it is only needed when the IQ is actually
-	// decimated (decim == 1 only in tests that feed IQ already at the
-	// intermediate rate).
-	cutoff := float64(c.bw) / iqHz
-	if cutoff > 0.45 {
-		cutoff = 0.45
-	}
-	lpf := filter.NewFIR(filter.LowpassKaiser(81, cutoff, 8.6))
+	// Front-end decimator: an 81-tap anti-alias FIR that convolves ONLY at
+	// the output positions, replacing the old full-rate FIR + every-Nth-
+	// sample decimation that filtered every input sample and discarded ~98%
+	// of the result. At 2.4 MS/s that wasted ~194M MACs/sec per voice call
+	// and starved the live IQ consumer until the SDR dropped chunks. Same
+	// coefficients and same kept samples as before, so the decode is
+	// byte-for-byte unchanged — only the wasted work is removed. decim==1
+	// (a source already at the intermediate rate) is a pass-through no-op.
+	fe := newDecimatingFIR(iqHz, p25p2VoiceIntermediateHz, float64(c.bw), false)
+	symbolHz := fe.OutRateHz()
 
 	rs, _ := c.sink.(rawFrameSink)
 	sfDec := p25p2.NewSuperframeDecoder()
@@ -216,11 +209,7 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 				logDecodeQuality(true)
 				return
 			}
-			samples := iq
-			if decim > 1 {
-				samples = decimateComplex(lpf.Process(nil, iq), decim)
-			}
-			rx.Process(samples)
+			rx.Process(fe.Process(nil, iq))
 		}
 	}
 }


### PR DESCRIPTION
A field report on a single-RTL-SDR P25 Phase 1 site showed the SDR
dropping live IQ the moment a voice call started:

  INFO  composer: p25p1 voice chain started serial=00000502 \
        demod_mode=c4fm iq_rate_hz=2.4e+06 symbol_rate_hz=48000
  WARN  sdr: dropping live IQ chunks; consumer can't keep up \
        driver=rtlsdr serial=00000502 dropped_since_last=28

iq_rate_hz=2.4e+06 means the voice chain ran the physical-SDR path and
decimated the full stream itself. Its front end did
`decimateComplex(lpf.Process(nil, iq), decim)`: an 81-tap FIR run over
EVERY sample at 2.4 MS/s (~194M complex MACs/sec) followed by throwing
away all but every 50th output. That wasted ~98% of the filter's work,
per active voice call, on one goroutine competing with the control-
channel decode — enough to starve the SDR reader goroutine so its driver
buffer overflowed and dropped chunks. The same naive front end was
copied verbatim into every other composer voice chain.

Replace it with a decimating FIR (newDecimatingFIR) that convolves only
at the kept output positions. It uses the SAME LowpassKaiser(81,
c.bw/iqHz, 8.6) coefficients and emits the SAME samples (indices 0,
decim, 2·decim, …), so the decimated output — and therefore the decode /
demodulated audio — is byte-for-byte identical to before; only the
wasted multiply-accumulates are removed. The VoiceBandwidthHz knob is
unchanged. At 2.4 MS/s the per-chunk cost drops ~26× (954µs → 37µs) with
zero allocations, removing the CPU starvation behind the drops.

A polyphase rational resampler (the control channel's ccdecoder.Down-
converter) would be cheaper still, but its sharper prototype filter
measurably regresses C4FM voice decode at high decimation factors — on a
synthetic 2.4 MS/s C4FM capture it dropped from 10 decoded LDUs to 0 —
so it is deliberately not used here.

Applied to all composer voice chains:
  - P25 Phase 1, P25 Phase 2, and DMR (Tier 1/2/3 all run the one DMR
    chain) — the digital chains pass the IQ straight through at decim==1.
  - Analog FM — same defect; it additionally band-limits even when not
    decimating, so newDecimatingFIR takes a filterAtUnity flag to keep
    that edge byte-exact. Its byte-identical output means there is no
    audio-quality change to validate.
The remaining digital protocols (TETRA, NXDN, dPMR, YSF, D-STAR, EDACS
ProVoice) have no composer voice chain yet, so there is nothing to
optimise for them here.

Tests: TestDecimatingFIRMatchesOldFrontEnd pins byte-for-byte
equivalence to the old front end at 96k/240k/2.4 MS/s, for both
decim==1 modes, single-call and streamed in awkward chunks (history +
decimation phase carry across boundaries); TestDecimatingFIRPassThrough
and TestDecimatingFIRFilterAtUnity pin the two decim==1 edges;
TestComposerP25Phase1VoiceChainDecodesWidebandIQ exercises a genuine
wideband decimate-then-decode end to end (previously uncovered — all
other voice tests feed 48 kHz); BenchmarkP25P1VoiceFrontEnd{,Naive}2p4MS
quantify the per-chunk reduction.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SH3xK77k4cf5tCJdmZSDcL