### PR TITLE
p25/phase2: publish WACN/System ID the instant the NSB lands

### DIFF
--- a/internal/radio/p25/phase2/control.go
+++ b/internal/radio/p25/phase2/control.go
@@ -488,6 +488,12 @@ func (c *ControlChannel) Ingest(p MACPDU) {
 		c.netSysID = nsb.SystemID
 		c.nac = nsb.ColorCode
 		c.mu.Unlock()
+		// The NSB is the sole carrier of WACN + System ID on Phase 2 —
+		// publish immediately so they reach the SiteTracker/API the instant
+		// they land, rather than waiting for an RFSS Status Broadcast to
+		// flush them (mirrors the Phase 1 NSB handler). Called outside the
+		// lock: publishSiteUpdate takes c.mu itself.
+		c.publishSiteUpdate()
 	}
 	if r, ok := p.AsRFSSStatusBroadcast(); ok {
 		c.mu.Lock()
@@ -627,7 +633,10 @@ func (c *ControlChannel) publishSiteUpdate() {
 	c.mu.Lock()
 	rfss, site, wacn, sysid := c.siteRFSS, c.siteSite, c.netWACN, c.netSysID
 	c.mu.Unlock()
-	if rfss == 0 && site == 0 {
+	// Publish once any identity scalar is known. WACN/System ID come only
+	// from the NSB and RFSS/Site only from the RFSS Status Broadcast, so an
+	// NSB-only or RFSS-only site must still surface (mirrors Phase 1's gate).
+	if rfss == 0 && site == 0 && wacn == 0 && sysid == 0 {
 		return
 	}
 	c.bus.Publish(events.Event{

--- a/internal/radio/p25/phase2/mac_coverage_test.go
+++ b/internal/radio/p25/phase2/mac_coverage_test.go
@@ -181,6 +181,46 @@ func TestControlChannelStampsSiteIdentity(t *testing.T) {
 	}
 }
 
+// TestControlChannelPublishesNSBOnlySiteUpdate confirms that a Network
+// Status Broadcast alone — with no RFSS Status Broadcast — publishes a
+// KindSiteUpdate carrying the decoded WACN / System ID. On Phase 2 the
+// WACN and System ID come ONLY from the NSB, so a system that emits the
+// NSB but seldom/never emits an RFSS Status Broadcast must still surface
+// its identity the instant the NSB lands (mirroring Phase 1). Regression
+// for the propagation defect where the NSB branch stored netWACN/netSysID
+// but never published, and publishSiteUpdate gated on RFSS/Site != 0.
+func TestControlChannelPublishesNSBOnlySiteUpdate(t *testing.T) {
+	bus := events.NewBus(32)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := New(Options{Bus: bus, SystemName: "p2", FrequencyHz: 851_000_000})
+
+	// NSB only — WACN=0xABCDE, SystemID=0x123, ColorCode=0x293. No RFSS_STS.
+	cc.Ingest(MACPDU{Opcode: OpNetworkStatusBroadcastUpdate,
+		Payload: []byte{0x07, 0xAB, 0xCD, 0xE1, 0x23, 0x29, 0x30, 0x00, 0x00}})
+
+	var sawWACN bool
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind == events.KindSiteUpdate {
+				s := ev.Payload.(trunking.SiteUpdate)
+				if s.WACN == 0xABCDE && s.SystemID == 0x123 &&
+					s.ControlChannelHz == 851_000_000 {
+					sawWACN = true
+				}
+			}
+		default:
+			if !sawWACN {
+				t.Fatal("NSB-only ingest published no KindSiteUpdate carrying WACN/SystemID")
+			}
+			return
+		}
+	}
+}
+
 func TestControlChannelPatchDelete(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -61,6 +61,27 @@ function identityEmptyHint(hunt: SystemHuntStatusDTO | undefined): string {
   return "Awaiting status broadcasts";
 }
 
+// wacnEmptyHint explains a blank WACN specifically. The WACN is carried only
+// by the P25 Network Status Broadcast (NSB) — System ID / RFSS / Site have
+// other sources (RFSS Status 0x3A, Adjacent Site 0x3C, Location Registration
+// 0x2B). So once the site is otherwise identified, a blank WACN is not "still
+// acquiring": it means the NSB specifically hasn't decoded yet, and some
+// systems emit it rarely or not at all on a given control channel. Saying so
+// is more honest than the generic "Awaiting status broadcasts", which implies
+// it's imminent. Falls back to the generic hint when nothing has decoded yet.
+function wacnEmptyHint(
+  sys: SystemDTO,
+  hunt: SystemHuntStatusDTO | undefined,
+): string {
+  if (hunt?.state === "hunting") return "Hunting control channel";
+  const identified =
+    (sys.system_id ?? 0) !== 0 ||
+    (sys.rfss ?? 0) !== 0 ||
+    (sys.site ?? 0) !== 0;
+  if (identified) return "No Network Status Broadcast yet";
+  return "Awaiting status broadcasts";
+}
+
 export function Systems() {
   const cfg = useShared(selectClientConfig);
   const systems = useShared((s) => s.systems);
@@ -207,7 +228,7 @@ export function Systems() {
                     label="WACN"
                     mono
                     value={formatIdNumber(selected.wacn ?? null, idBase)}
-                    emptyHint={hint}
+                    emptyHint={wacnEmptyHint(selected, hunt)}
                   />
                   <DetailField
                     label="System ID"


### PR DESCRIPTION
On a Phase 2 (TDMA) control channel the WACN and System ID are carried
ONLY by the Network Status Broadcast (NSB); RFSS/Site come only from the
RFSS Status Broadcast. Ingest stored the NSB's netWACN/netSysID but never
called publishSiteUpdate — only the RFSS branch did — and publishSiteUpdate
gated on `rfss == 0 && site == 0`. So a system that emits the NSB but
seldom/never emits an RFSS Status Broadcast decoded its WACN yet
permanently suppressed it from the SiteTracker/API: the web "Network
Identity" panel showed a blank WACN forever.

Mirror the Phase 1 handler: publish from the NSB branch immediately, and
widen the gate to fire when any identity scalar (WACN/System ID as well as
RFSS/Site) is known. An NSB-only update keys a SiteInfo under (system,0,0),
distinct from the eventual (system,rfss,site); overlayLiveIdentity already
picks WACN from any non-zero site of the system, so it surfaces correctly.
The only side effect is a cosmetic zero-RFSS/Site row in GET /api/v1/sites,
which the Phase 1 path already produces.

Regression test ingests an NSB with no RFSS broadcast and asserts a
KindSiteUpdate carrying the WACN — fails before the fix, passes after.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XLe33tCVpPGYqKZVqWkJXh