### PR TITLE
Make control_channels optional for conventional DMR; add multi-repeater sample

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -722,10 +722,25 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		for _, sc := range sys.Sites {
 			sites = append(sites, trunking.ConfiguredSite{RFSS: sc.RFSS, Site: sc.Site, Name: sc.Name})
 		}
+		// Conventional DMR (Tier II / Tier I) has no real control channel —
+		// the operator lists each repeater/simplex carrier in the
+		// `role: wideband` device's `channels:` list, which is what the
+		// widebandt2 engine actually decodes. trunking.System.Validate still
+		// requires a non-empty ControlChannels list, so rather than forcing
+		// the operator to repeat every frequency under `control_channels`,
+		// derive it from the wideband channels assigned to this system. Each
+		// carrier is then listed exactly once. Trunked protocols (dmr Tier III,
+		// p25, …) keep requiring an explicit control_channels list. A non-empty
+		// list is always honoured verbatim.
+		ctrlChannels := sys.ControlChannels
+		if len(ctrlChannels) == 0 &&
+			(proto == trunking.ProtocolDMRTier2 || proto == trunking.ProtocolDMRTier1) {
+			ctrlChannels = widebandChannelsForSystem(cfg.SDR.Devices, sys.Name)
+		}
 		s := trunking.System{
 			Name:                    sys.Name,
 			Protocol:                proto,
-			ControlChannels:         sys.ControlChannels,
+			ControlChannels:         ctrlChannels,
 			Sites:                   sites,
 			P25BandPlan:             p25BandPlan,
 			DMRBandPlan:             dmrBandPlan,
@@ -3531,6 +3546,30 @@ func isControlChannel(sys trunking.System, freqHz uint32) bool {
 		}
 	}
 	return false
+}
+
+// widebandChannelsForSystem returns the de-duplicated, config-order union of
+// every `role: wideband` channel frequency assigned to the named system across
+// all devices. It backfills ControlChannels for conventional DMR (Tier II /
+// Tier I) systems that omit `control_channels`, so each repeater carrier is
+// listed exactly once (in sdr.devices[].channels). The returned slice is freshly
+// allocated and never aliases the config's backing arrays.
+func widebandChannelsForSystem(devices []config.DeviceConfig, system string) []uint32 {
+	var out []uint32
+	seen := make(map[uint32]bool)
+	for _, dev := range devices {
+		if dev.Role != "wideband" {
+			continue
+		}
+		for _, ch := range dev.Channels {
+			if ch.System != system || seen[ch.FrequencyHz] {
+				continue
+			}
+			seen[ch.FrequencyHz] = true
+			out = append(out, ch.FrequencyHz)
+		}
+	}
+	return out
 }
 
 // cchuntSystems returns the systems the sequential cchunt supervisor should

--- a/cmd/gophertrunk/daemon_dmr_tier2_backfill_test.go
+++ b/cmd/gophertrunk/daemon_dmr_tier2_backfill_test.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestSampleDMRTier2MultiRepeaterLoads pins the shipped many-repeater sample:
+// it must pass config validation and construct a daemon whose conventional-DMR
+// system has its control channels backfilled from the wideband channels (one
+// per repeater, across all three dongles), so the sample's "no control_channels"
+// stance stays honest.
+func TestSampleDMRTier2MultiRepeaterLoads(t *testing.T) {
+	const path = "../../samples/dmr-tier2-multi-repeater/config.yaml"
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("config.Load(%s): %v", path, err)
+	}
+	// The sample points storage / recordings at paths under its own folder;
+	// blank them so constructing the daemon here leaves no artifacts in the
+	// repo. We only care that the config validates and the system is built.
+	cfg.Storage.Path = ""
+	cfg.Storage.CCCacheFile = ""
+	cfg.Recordings.Dir = ""
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	d, err := NewDaemon(cfg, "test", logger)
+	if err != nil {
+		t.Fatalf("NewDaemon: %v", err)
+	}
+	var found bool
+	for _, s := range d.systems {
+		if s.Name != "regional-dmr" {
+			continue
+		}
+		found = true
+		// 3 dongles × 8 repeaters, all distinct frequencies.
+		if len(s.ControlChannels) != 24 {
+			t.Fatalf("regional-dmr derived ControlChannels = %d, want 24", len(s.ControlChannels))
+		}
+	}
+	if !found {
+		t.Fatal("regional-dmr system not constructed from the sample config")
+	}
+}
+
+// TestWidebandChannelsForSystem covers the pure backfill helper: it returns the
+// config-order, de-duplicated union of a system's wideband channel frequencies
+// across all devices, skipping non-wideband devices and other systems' channels.
+func TestWidebandChannelsForSystem(t *testing.T) {
+	ch := func(freq uint32, system string) config.DeviceChannelConfig {
+		return config.DeviceChannelConfig{FrequencyHz: freq, System: system}
+	}
+	devices := []config.DeviceConfig{
+		{Serial: "RTL-A", Role: "wideband", Channels: []config.DeviceChannelConfig{
+			ch(453_125_000, "regional-dmr"), ch(453_275_000, "regional-dmr"),
+		}},
+		{Serial: "RTL-B", Role: "wideband", Channels: []config.DeviceChannelConfig{
+			ch(453_275_000, "regional-dmr"), // duplicate across devices → once
+			ch(454_100_000, "regional-dmr"),
+			ch(460_000_000, "other-system"), // different system → excluded
+		}},
+		{Serial: "RTL-C", Role: "control", Channels: []config.DeviceChannelConfig{
+			ch(453_900_000, "regional-dmr"), // not a wideband device → excluded
+		}},
+	}
+
+	got := widebandChannelsForSystem(devices, "regional-dmr")
+	want := []uint32{453_125_000, 453_275_000, 454_100_000}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v (config order, deduped)", got, want)
+		}
+	}
+
+	if got := widebandChannelsForSystem(devices, "no-such-system"); len(got) != 0 {
+		t.Fatalf("unknown system: got %v, want empty", got)
+	}
+	if got := widebandChannelsForSystem(nil, "regional-dmr"); len(got) != 0 {
+		t.Fatalf("nil devices: got %v, want empty", got)
+	}
+}
+
+// TestDMRTier2ControlChannelBackfill locks the conventional-DMR ergonomics
+// change: a `dmr-tier2` / `dmr-tier1` system may omit `control_channels` and
+// have them derived from the `role: wideband` channels assigned to it, so each
+// repeater carrier is listed exactly once (in sdr.devices[].channels) instead
+// of twice. Without the backfill, trunking.System.Validate() rejects the
+// empty list with "at least one control_channel frequency is required" and
+// NewDaemon fails — that is the red state this test pins.
+func TestDMRTier2ControlChannelBackfill(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// baseCfg returns a Default() config with the API listener and storage
+	// disabled so NewDaemon constructs a hermetic, side-effect-free daemon.
+	baseCfg := func() config.Config {
+		cfg := config.Default()
+		cfg.API.HTTPAddr = ""
+		return cfg
+	}
+	wbDevice := func(serial, system string, freqs ...uint32) config.DeviceConfig {
+		d := config.DeviceConfig{Serial: serial, Role: "wideband", CenterFreqHz: 453_500_000}
+		for _, f := range freqs {
+			d.Channels = append(d.Channels, config.DeviceChannelConfig{FrequencyHz: f, System: system})
+		}
+		return d
+	}
+	findSystem := func(t *testing.T, d *Daemon, name string) trunking.System {
+		t.Helper()
+		for _, s := range d.systems {
+			if s.Name == name {
+				return s
+			}
+		}
+		t.Fatalf("system %q not found among %d constructed systems", name, len(d.systems))
+		return trunking.System{}
+	}
+	sameFreqs := func(got []uint32, want ...uint32) bool {
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	t.Run("backfill from a single wideband device", func(t *testing.T) {
+		freqs := []uint32{453_125_000, 453_275_000, 453_775_000, 454_100_000}
+		cfg := baseCfg()
+		cfg.SDR.Devices = []config.DeviceConfig{wbDevice("RTL-A", "regional-dmr", freqs...)}
+		cfg.Trunking.Systems = []config.SystemConfig{
+			{Name: "regional-dmr", Protocol: "dmr-tier2"}, // no control_channels
+		}
+		d, err := NewDaemon(cfg, "test", logger)
+		if err != nil {
+			t.Fatalf("NewDaemon: %v (control_channels should be derived from wideband channels)", err)
+		}
+		sys := findSystem(t, d, "regional-dmr")
+		if !sameFreqs(sys.ControlChannels, freqs...) {
+			t.Fatalf("derived ControlChannels = %v, want %v (config order preserved)", sys.ControlChannels, freqs)
+		}
+	})
+
+	t.Run("union across two wideband devices, deduped and ordered", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.SDR.Devices = []config.DeviceConfig{
+			wbDevice("RTL-A", "regional-dmr", 453_125_000, 453_275_000),
+			// 453_275_000 repeated across devices must appear once.
+			wbDevice("RTL-B", "regional-dmr", 453_275_000, 454_100_000),
+		}
+		cfg.Trunking.Systems = []config.SystemConfig{
+			{Name: "regional-dmr", Protocol: "dmr-tier2"},
+		}
+		d, err := NewDaemon(cfg, "test", logger)
+		if err != nil {
+			t.Fatalf("NewDaemon: %v", err)
+		}
+		sys := findSystem(t, d, "regional-dmr")
+		if !sameFreqs(sys.ControlChannels, 453_125_000, 453_275_000, 454_100_000) {
+			t.Fatalf("union ControlChannels = %v, want [453125000 453275000 454100000]", sys.ControlChannels)
+		}
+	})
+
+	t.Run("explicit control_channels are left untouched", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.SDR.Devices = []config.DeviceConfig{
+			wbDevice("RTL-A", "regional-dmr", 453_125_000, 453_275_000),
+		}
+		cfg.Trunking.Systems = []config.SystemConfig{
+			// Explicit list differs from the channel freqs: must win.
+			{Name: "regional-dmr", Protocol: "dmr-tier2", ControlChannels: []uint32{460_000_000}},
+		}
+		d, err := NewDaemon(cfg, "test", logger)
+		if err != nil {
+			t.Fatalf("NewDaemon: %v", err)
+		}
+		sys := findSystem(t, d, "regional-dmr")
+		if !sameFreqs(sys.ControlChannels, 460_000_000) {
+			t.Fatalf("ControlChannels = %v, want [460000000] (explicit list must not be overwritten)", sys.ControlChannels)
+		}
+	})
+
+	t.Run("conventional DMR with no channels and no CCs still errors", func(t *testing.T) {
+		cfg := baseCfg()
+		// Wideband channels reference a DIFFERENT system, so there is nothing
+		// to derive for regional-dmr.
+		cfg.SDR.Devices = []config.DeviceConfig{wbDevice("RTL-A", "some-other-system", 453_125_000)}
+		cfg.Trunking.Systems = []config.SystemConfig{
+			{Name: "regional-dmr", Protocol: "dmr-tier2"},
+			{Name: "some-other-system", Protocol: "dmr-tier2"},
+		}
+		if _, err := NewDaemon(cfg, "test", logger); err == nil {
+			t.Fatal("expected an error: regional-dmr has no control_channels and no wideband channels")
+		}
+	})
+
+	t.Run("dmr-tier1 direct mode is also backfilled", func(t *testing.T) {
+		cfg := baseCfg()
+		cfg.SDR.Devices = []config.DeviceConfig{wbDevice("RTL-A", "dmr-dm", 446_500_000)}
+		cfg.Trunking.Systems = []config.SystemConfig{
+			{Name: "dmr-dm", Protocol: "dmr-tier1"},
+		}
+		d, err := NewDaemon(cfg, "test", logger)
+		if err != nil {
+			t.Fatalf("NewDaemon: %v", err)
+		}
+		sys := findSystem(t, d, "dmr-dm")
+		if !sameFreqs(sys.ControlChannels, 446_500_000) {
+			t.Fatalf("derived ControlChannels = %v, want [446500000]", sys.ControlChannels)
+		}
+	})
+
+	t.Run("trunked DMR Tier III is not backfilled", func(t *testing.T) {
+		cfg := baseCfg()
+		// A wideband channel hosts the Tier III control channel, but the
+		// backfill must NOT apply to trunked protocols — they require an
+		// explicit control_channels list.
+		cfg.SDR.Devices = []config.DeviceConfig{wbDevice("RTL-A", "t3-system", 851_037_500)}
+		cfg.Trunking.Systems = []config.SystemConfig{
+			{Name: "t3-system", Protocol: "dmr"}, // Tier III, no control_channels
+		}
+		if _, err := NewDaemon(cfg, "test", logger); err == nil {
+			t.Fatal("expected an error: dmr Tier III must declare control_channels explicitly")
+		}
+	})
+}

--- a/docs/reference/dmr-tier-2.md
+++ b/docs/reference/dmr-tier-2.md
@@ -67,8 +67,16 @@ Tier II repeaters and hotspots over the internet.
 
 ## Decoding it with GopherTrunk
 
-GopherTrunk decodes both timeslots of a Tier II channel and renders AMBE+2 audio. For
-trunked DMR, see [Tier III](/reference/dmr-tier-3/). See [Status](/status.html).
+GopherTrunk decodes both timeslots of a Tier II channel and renders AMBE+2 audio.
+Color Code, time slot, and talkgroup are read off the air per call — you only
+configure each repeater's frequency. A single dongle channelizes a cluster of
+repeaters at once; to cover many repeaters spread across a wide band, add one
+`role: wideband` dongle per ~2 MHz cluster, all pointed at the same system. The
+[`dmr-tier2-multi-repeater`](https://github.com/MattCheramie/GopherTrunk/tree/main/samples/dmr-tier2-multi-repeater)
+sample is a worked "a bunch of repeaters, different CCs and slots" config; for a
+single carrier see
+[`dmr-simplex`](https://github.com/MattCheramie/GopherTrunk/tree/main/samples/dmr-simplex).
+For trunked DMR, see [Tier III](/reference/dmr-tier-3/). See [Status](/status.html).
 
 ## Sources
 

--- a/samples/dmr-tier2-multi-repeater/README.md
+++ b/samples/dmr-tier2-multi-repeater/README.md
@@ -1,0 +1,96 @@
+# A fleet of conventional DMR repeaters across a wide band
+
+This sample monitors many conventional **DMR Tier II** repeaters — the
+"40 freqs with different Color Codes and slots, just a bunch of repeaters"
+case — spread across more RF than a single dongle can cover. It tunes one
+`role: wideband` dongle per ~2 MHz cluster of repeaters and decodes every
+repeater in parallel.
+
+If all your repeaters cluster inside a single ~2 MHz window, use the simpler
+[`dmr-tier2-multichannel`](../dmr-tier2-multichannel/) sample (one dongle). For
+a single simplex/hotspot frequency, see [`dmr-simplex`](../dmr-simplex/).
+
+## The one thing to understand first
+
+**Color Code, Time Slot (TS1/TS2), and Talkgroup are not configured.**
+GopherTrunk decodes them straight off the air and reports them per call. You
+only declare:
+
+- **where** to listen — each repeater's output frequency, and
+- **what** it is — `protocol: dmr-tier2`.
+
+So a deployment of 40 repeaters with 40 different Color Codes and both slots in
+use is, from a config standpoint, just **40 frequencies**. There is nothing
+per-Color-Code or per-slot to type in. The `talkgroups-dmr.csv` file only maps
+decoded talkgroup numbers (e.g. `8`) to friendly names.
+
+## Why you may need more than one dongle
+
+DMR is decoded by GopherTrunk's wideband channelizer
+(`internal/scanner/widebandt2`): a dongle is pinned to a center frequency and
+the daemon splits its IQ stream into one narrow-band DMR decoder per repeater.
+There is **no sequential "hop through N frequencies" DMR scanner** — every
+repeater must sit inside some dongle's IQ window simultaneously.
+
+At 2.4 MS/s a dongle sees roughly **±1.08 MHz** of usable bandwidth around its
+center (≈2.16 MHz total, after a 5% guard at each edge; out-of-band channels
+are rejected at startup). So:
+
+- Repeaters that all fall inside one ~2 MHz window → **one dongle**.
+- Repeaters spread wider → **one dongle per cluster**.
+
+  > Rule of thumb: 40 repeaters spread over ~8 MHz ≈ **4 dongles**, ~10 each.
+
+## Spanning more than one dongle
+
+Point **every** dongle's channels at the **same** `system:` name. GopherTrunk
+unions the wideband channels across all dongles into one system, so calls from
+any repeater land under one consistent system in the API, recordings, and call
+log. This sample uses three dongles (centered at 453.5 / 460.5 / 465.5 MHz),
+all feeding `system: regional-dmr`. To add another cluster, copy a `- serial:`
+block, re-center it, and list that cluster's repeaters.
+
+Because Tier II is conventional, the system needs **no `control_channels`** —
+GopherTrunk derives the carrier list from the wideband channels assigned to it,
+so each repeater frequency is listed exactly once. (An explicit
+`control_channels:` list is still accepted and honoured verbatim if you prefer
+to be explicit.)
+
+## Channelizer strategy
+
+`tuner_strategy: auto` (the default) picks a single-channel **DDC** tap for ≤ 6
+channels and a **polyphase** channelizer above that — so a dongle hosting 8–10
+repeaters automatically uses the polyphase path. Force `ddc` or `polyphase`
+only if you have a reason to override.
+
+## Tuning
+
+Edit `config.yaml`:
+
+1. **`serial`** — run `gophertrunk sdr list` and paste each dongle's serial.
+   The daemon binds each channel list to its device by serial.
+2. **`center_freq_hz`** — center each dongle so every one of its
+   `channels[].frequency_hz` sits within `center ± ~1.08 MHz`. Keep carriers a
+   little off the exact center to dodge the RTL-SDR's center-DC spike. The
+   config validator rejects out-of-band channels at startup.
+3. **`channels`** — one entry per repeater output frequency, each referencing
+   `system: regional-dmr`.
+
+## Running
+
+```sh
+go run ./cmd/gophertrunk run -config samples/dmr-tier2-multi-repeater/config.yaml
+```
+
+The startup log line `widebandt2: starting` (one per dongle) confirms the
+engine came up. `cc.locked` and `grant` events fire per repeater frequency as
+calls arrive, each carrying the Color Code and time slot decoded from the air.
+
+## If nothing decodes
+
+- Confirm the repeaters are actually keyed up (DMR is bursty — idle repeaters
+  are silent). Bump `log.level` to `debug`.
+- Check each carrier is inside its dongle's window (`center ± ~1.08 MHz`); a
+  startup error names any out-of-band channel.
+- Verify gain — `"auto"` is the safe start; a deafened front end decodes
+  nothing.

--- a/samples/dmr-tier2-multi-repeater/config.yaml
+++ b/samples/dmr-tier2-multi-repeater/config.yaml
@@ -1,0 +1,128 @@
+# Monitor a fleet of conventional DMR Tier II repeaters across a WIDE band.
+#
+# Use this when you have many DMR repeaters (a dozen, forty, …) spread over
+# more RF than a single dongle can see at once — "just a bunch of repeaters,
+# each with its own Color Code and both slots in use."
+#
+# ─── The one thing to understand first ────────────────────────────────────
+#
+# Color Code, Time Slot (TS1/TS2), and Talkgroup are NOT configured here.
+# GopherTrunk reads them straight off the air and reports them per call. You
+# only tell the daemon WHERE to listen (each repeater's output frequency) and
+# WHAT it is (DMR Tier II conventional). The talkgroups CSV just maps the
+# decoded TG numbers to friendly names. So a "40 freqs, different CC, different
+# slots" deployment is just 40 frequencies — there is nothing per-CC or
+# per-slot to type in.
+#
+# ─── Why each repeater must sit inside a dongle's window ───────────────────
+#
+# DMR is decoded by GopherTrunk's wideband channelizer (internal/scanner/
+# widebandt2): one `role: wideband` dongle is tuned to a center frequency and
+# the daemon splits its IQ stream into a separate narrow-band decoder PER
+# repeater. There is no sequential "hop through 40 frequencies" DMR scanner —
+# every repeater you list must fall inside some dongle's IQ window AT THE SAME
+# TIME.
+#
+# At 2.4 MS/s one dongle sees about ±1.08 MHz of usable bandwidth around its
+# center (≈2.16 MHz total, after a 5% guard at each edge). Repeaters that all
+# cluster inside one ~2 MHz window share one dongle. Repeaters spread wider
+# than that need MORE dongles — one per cluster. Point every dongle's channels
+# at the SAME system name (below) and GopherTrunk treats them as one system:
+# the wideband channels are unioned across all dongles.
+#
+#   40 repeaters spread over ~8 MHz  →  ≈4 dongles, ~10 repeaters each.
+#
+# This file shows three dongles, each centered on a ~2 MHz cluster. Copy a
+# `- serial:` block, re-center it, and list that cluster's repeaters to add a
+# fourth, fifth, … dongle until all your carriers are covered.
+#
+# PATHS below (talkgroup CSV, recordings) resolve RELATIVE TO THIS FILE.
+
+log:
+  level: info       # bump to "debug" if nothing decodes and you want detail
+  format: text
+
+api:
+  http_addr: "127.0.0.1:8080"   # web UI / REST / SSE
+  auth:
+    mode: auto                  # loopback is trusted; no token needed locally
+
+storage:
+  path: "data/calls.db"
+  cc_cache_file: "data/cc-cache.json"
+
+recordings:
+  dir: "recordings"
+  sample_rate: 8000
+
+sdr:
+  # 2.4 MS/s is the RTL-SDR sweet spot: ~2.16 MHz usable per dongle.
+  sample_rate: 2_400_000
+  devices:
+    # ── Dongle 1: repeaters clustered around 453.5 MHz ────────────────────
+    - serial: "REPLACE_WITH_SERIAL_1"   # run `gophertrunk sdr list` and paste yours
+      role: wideband
+      center_freq_hz: 453_500_000        # keep every channel below within ±1.08 MHz
+      tuner_strategy: auto               # auto: DDC for ≤6 channels, polyphase above 6
+      gain: "auto"
+      channels:
+        - { frequency_hz: 453_137_500, system: "regional-dmr" }
+        - { frequency_hz: 453_262_500, system: "regional-dmr" }
+        - { frequency_hz: 453_412_500, system: "regional-dmr" }
+        - { frequency_hz: 453_537_500, system: "regional-dmr" }
+        - { frequency_hz: 453_662_500, system: "regional-dmr" }
+        - { frequency_hz: 453_787_500, system: "regional-dmr" }
+        - { frequency_hz: 453_912_500, system: "regional-dmr" }
+        - { frequency_hz: 454_037_500, system: "regional-dmr" }
+
+    # ── Dongle 2: repeaters clustered around 460.5 MHz ────────────────────
+    - serial: "REPLACE_WITH_SERIAL_2"
+      role: wideband
+      center_freq_hz: 460_500_000
+      tuner_strategy: auto
+      gain: "auto"
+      channels:
+        - { frequency_hz: 460_137_500, system: "regional-dmr" }
+        - { frequency_hz: 460_262_500, system: "regional-dmr" }
+        - { frequency_hz: 460_412_500, system: "regional-dmr" }
+        - { frequency_hz: 460_537_500, system: "regional-dmr" }
+        - { frequency_hz: 460_662_500, system: "regional-dmr" }
+        - { frequency_hz: 460_787_500, system: "regional-dmr" }
+        - { frequency_hz: 460_912_500, system: "regional-dmr" }
+        - { frequency_hz: 461_037_500, system: "regional-dmr" }
+
+    # ── Dongle 3: repeaters clustered around 465.5 MHz ────────────────────
+    - serial: "REPLACE_WITH_SERIAL_3"
+      role: wideband
+      center_freq_hz: 465_500_000
+      tuner_strategy: auto
+      gain: "auto"
+      channels:
+        - { frequency_hz: 465_137_500, system: "regional-dmr" }
+        - { frequency_hz: 465_262_500, system: "regional-dmr" }
+        - { frequency_hz: 465_412_500, system: "regional-dmr" }
+        - { frequency_hz: 465_537_500, system: "regional-dmr" }
+        - { frequency_hz: 465_662_500, system: "regional-dmr" }
+        - { frequency_hz: 465_787_500, system: "regional-dmr" }
+        - { frequency_hz: 465_912_500, system: "regional-dmr" }
+        - { frequency_hz: 466_037_500, system: "regional-dmr" }
+
+    # ── Add a Dongle 4, 5, … here for further clusters, same system name ──
+    # - serial: "REPLACE_WITH_SERIAL_4"
+    #   role: wideband
+    #   center_freq_hz: 470_500_000
+    #   channels:
+    #     - { frequency_hz: 470_137_500, system: "regional-dmr" }
+    #     ...
+
+trunking:
+  systems:
+    - name: "regional-dmr"
+      protocol: dmr-tier2
+      # NOTE: no `control_channels:` here. Tier II is conventional — there is
+      # no real control channel. GopherTrunk derives the channel list for this
+      # system from every `role: wideband` channel above that references it
+      # (unioned across all dongles), so each repeater carrier is listed ONCE.
+      # (If you prefer, you may still list them explicitly under
+      # `control_channels:` — an explicit list is always honoured verbatim.)
+      talkgroup_file: "talkgroups-dmr.csv"

--- a/samples/dmr-tier2-multi-repeater/talkgroups-dmr.csv
+++ b/samples/dmr-tier2-multi-repeater/talkgroups-dmr.csv
@@ -1,0 +1,9 @@
+Decimal,Alpha Tag,Description,Mode,Tag,Group
+1,Local 1,Local Repeater 1 Wide,D,Talkgroup,Local
+2,Local 2,Local Repeater 2 Wide,D,Talkgroup,Local
+8,Regional,Regional Wide-Area,D,Talkgroup,Regional
+9,Local,Local Site Wide,D,Talkgroup,Local
+13,State,Statewide,D,Talkgroup,Regional
+99,Simplex,Simplex / Local Talkgroup,D,Talkgroup,Local
+310,TAC 310,Tactical 310,D,Talkgroup,Tactical
+3100,Bridge,Inter-repeater Bridge,D,Talkgroup,Regional


### PR DESCRIPTION
Conventional DMR (Tier II / Tier I) has no real control channel — the
operator lists each repeater carrier in a role: wideband device's
channels: list, which is what the widebandt2 engine actually decodes.
trunking.System.Validate still required a non-empty control_channels
list, forcing every frequency to be typed twice (once under sdr channels,
once under control_channels) — tedious and error-prone for a deployment
of many repeaters.

Backfill control_channels for conventional DMR from the wideband channels
assigned to the system (unioned across all devices) when the operator
omits them, so each carrier is listed exactly once. Trunked protocols are
unaffected and still require an explicit list; a non-empty list is always
honoured verbatim. The derived set equals the wideband set, so
cchuntSystems still drops the system from the sequential hunt.

Add a worked samples/dmr-tier2-multi-repeater/ config + README showing
many repeaters split across multiple dongles (one per ~2 MHz cluster, all
pointed at one system), and emphasising that Color Code, time slot, and
talkgroup are auto-detected off the air rather than configured. Link it
from docs/reference/dmr-tier-2.md.

Tests: failing-first daemon_dmr_tier2_backfill_test.go (single/union/
explicit/empty/tier1/tier3 cases), a pure unit test for the new
widebandChannelsForSystem helper, and a guard that the shipped sample
loads and backfills 24 channels.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017E7PRjaFwQowrx17pDvzvK