### PR TITLE
voice/recorder: don't create empty talkgroup folders for no-audio calls

### DIFF
--- a/cmd/gophertrunk/hunt_acquire.go
+++ b/cmd/gophertrunk/hunt_acquire.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/widebandt2"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 )
 
@@ -56,6 +57,15 @@ func chooseHuntSDR(requestedSerial, controlSerial string, voiceSerials, poolSeri
 	return "", false, fmt.Errorf("hunt: no SDR with an IQ broker available for a live hunt")
 }
 
+// huntBorrowBlocked reports whether a hunt borrow must be refused until the
+// operator confirms it: true only when the borrow would suspend live wideband
+// decode (liveEngines > 0 on the borrowed SDR) and confirmed is false. A
+// dedicated/spare SDR (borrow == false) or an SDR with no running engine is
+// never blocked. Pure so the policy is unit-testable without a real daemon.
+func huntBorrowBlocked(borrow bool, liveEngines int, confirmed bool) bool {
+	return borrow && liveEngines > 0 && !confirmed
+}
+
 // buildHuntAcquirer returns the hunt.Acquirer the daemon's hunt Manager uses to
 // obtain an IQ source per run. It auto-selects a spare SDR when available and
 // otherwise borrows the control SDR — pausing the cchunt supervisor for the
@@ -79,8 +89,23 @@ func (d *Daemon) buildHuntAcquirer() hunt.Acquirer {
 		if err != nil {
 			return nil, nil, err
 		}
+		// Borrowing retunes this SDR. Any widebandt2 engine decoding live
+		// traffic on it (the control-channel + voice path for a wideband-CC
+		// system) would otherwise keep decoding the off-frequency IQ: flooding
+		// the log with "channel iq power very low" WARNs and emitting spurious
+		// grants whose voice taps capture no audio (empty TG folders). Suspend
+		// those engines for the borrow — but only with the operator's explicit
+		// confirmation, since it knocks the live system offline for the run.
+		var borrowedEngines []*widebandt2.Engine
+		if borrow {
+			borrowedEngines = d.widebandEnginesForSerial(serial)
+			if huntBorrowBlocked(borrow, len(borrowedEngines), opts.ConfirmBorrow) {
+				return nil, nil, fmt.Errorf("hunt: borrowing SDR %q would suspend live wideband decode (control channel + voice) for the duration of the run; re-run with confirmation to proceed", serial)
+			}
+		}
+
 		broker := d.iqBrokers[serial]
-		src, sub := newBrokerIQSource(broker)
+		src, sub := newBrokerIQSource(broker, d.log)
 		// Gain control is only safe when the hunt holds the SDR exclusively (a
 		// dedicated spare). On the borrowed control SDR, changing gain would
 		// disrupt the daemon's other consumers, so auto-gain stays unavailable.
@@ -88,15 +113,41 @@ func (d *Daemon) buildHuntAcquirer() hunt.Acquirer {
 			src.setGain = broker.SetGain
 		}
 
-		if borrow && d.cchuntSup != nil {
-			d.cchuntSup.PauseAll()
+		if borrow {
+			if d.cchuntSup != nil {
+				d.cchuntSup.PauseAll()
+			}
+			// Pause wideband engines on the borrowed SDR: cchunt manages only
+			// single-channel systems, so a wideband-CC system is decoded by an
+			// Engine that PauseAll() above does not touch.
+			for _, eng := range borrowedEngines {
+				eng.Suspend()
+			}
 		}
 		release := func() {
 			sub.Close()
-			if borrow && d.cchuntSup != nil {
-				d.cchuntSup.ResumeAll()
+			if borrow {
+				for _, eng := range borrowedEngines {
+					eng.Resume()
+				}
+				if d.cchuntSup != nil {
+					d.cchuntSup.ResumeAll()
+				}
 			}
 		}
 		return src, release, nil
 	}
+}
+
+// widebandEnginesForSerial returns the running widebandt2 engines decoding on
+// the given dongle serial. A hunt that borrows that SDR suspends them so they
+// don't decode the retuned, off-frequency IQ.
+func (d *Daemon) widebandEnginesForSerial(serial string) []*widebandt2.Engine {
+	var out []*widebandt2.Engine
+	for _, eng := range d.widebandT2 {
+		if eng != nil && eng.Serial() == serial {
+			out = append(out, eng)
+		}
+	}
+	return out
 }

--- a/cmd/gophertrunk/hunt_acquire_test.go
+++ b/cmd/gophertrunk/hunt_acquire_test.go
@@ -90,3 +90,28 @@ func TestChooseHuntSDR(t *testing.T) {
 		})
 	}
 }
+
+func TestHuntBorrowBlocked(t *testing.T) {
+	cases := []struct {
+		name        string
+		borrow      bool
+		liveEngines int
+		confirmed   bool
+		want        bool
+	}{
+		{"dedicated spare never blocks", false, 1, false, false},
+		{"borrow, no live engine, never blocks", true, 0, false, false},
+		{"borrow with live engine, unconfirmed, blocks", true, 1, false, true},
+		{"borrow with live engine, confirmed, proceeds", true, 1, true, false},
+		{"borrow with multiple engines, unconfirmed, blocks", true, 2, false, true},
+		{"confirm without borrow is irrelevant", false, 2, true, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := huntBorrowBlocked(c.borrow, c.liveEngines, c.confirmed); got != c.want {
+				t.Errorf("huntBorrowBlocked(%v,%d,%v) = %v, want %v",
+					c.borrow, c.liveEngines, c.confirmed, got, c.want)
+			}
+		})
+	}
+}

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -121,6 +121,7 @@ func (c huntCockpit) Start(req api.HuntStartRequest) (int, error) {
 		MaxDwellSeconds: req.MaxDwellSeconds,
 		MonitorSeconds:  req.MonitorSeconds,
 		Serial:          req.Serial,
+		ConfirmBorrow:   req.ConfirmBorrow,
 		FFTSize:         req.FFTSize,
 		DwellSeconds:    req.DwellSeconds,
 		MinConfidence:   req.MinConfidence,

--- a/cmd/gophertrunk/hunt_iqsource.go
+++ b/cmd/gophertrunk/hunt_iqsource.go
@@ -37,6 +37,18 @@ type streamIQSource struct {
 	bufCh   chan []complex64 // slack queue: forwarder → Capture
 	pending []complex64      // Capture-side leftover (< n) carried between calls
 	dropped atomic.Uint64    // chunks dropped at bufCh when decode falls behind real time
+	log     *slog.Logger     // nil ⇒ slog.Default(); see logger()
+}
+
+// logger returns the configured structured logger, falling back to the slog
+// default. The forwarder's "falling behind" WARN must route through this rather
+// than slog.Default() directly so it honours the daemon's log level and format
+// instead of being dumped via the bare std-log default handler.
+func (s *streamIQSource) logger() *slog.Logger {
+	if s.log != nil {
+		return s.log
+	}
+	return slog.Default()
 }
 
 func (s *streamIQSource) SampleRateHz() uint32 { return s.rate() }
@@ -77,7 +89,7 @@ func (s *streamIQSource) forward(ctx context.Context) {
 				// never blocks. Rate-limit the warning to once per second.
 				n := s.dropped.Add(1)
 				if now := time.Now(); now.Sub(lastLogAt) >= time.Second {
-					slog.Default().Warn("hunt: decode falling behind real time; dropping buffered IQ (the SDR is still drained, so this is a CPU/throughput limit, not an RF overrun)",
+					s.logger().Warn("hunt: decode falling behind real time; dropping buffered IQ (the SDR is still drained, so this is a CPU/throughput limit, not an RF overrun)",
 						"dropped_total", n)
 					lastLogAt = now
 				}
@@ -128,7 +140,7 @@ func (s *streamIQSource) Capture(ctx context.Context, n int) ([]complex64, error
 // newDeviceIQSource opens a continuous IQ stream on a raw SDR device (standalone
 // CLI live hunt). The caller's ctx governs both the stream and the forwarder
 // goroutine lifetime.
-func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*streamIQSource, error) {
+func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32, log *slog.Logger) (*streamIQSource, error) {
 	ch, err := dev.StreamIQ(ctx)
 	if err != nil {
 		return nil, err
@@ -140,6 +152,7 @@ func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*strea
 		setGain: dev.SetGain,
 		settle:  50 * time.Millisecond,
 		bufCh:   make(chan []complex64, iqSlackDepth),
+		log:     log,
 	}
 	go s.forward(ctx)
 	return s, nil
@@ -150,7 +163,7 @@ func newDeviceIQSource(ctx context.Context, dev sdr.Device, rate uint32) (*strea
 // routes through the broker so its cached center stays consistent with the
 // spectrum/rigctld views. Close the returned subscriber when the run ends — that
 // closes the broker's delivery channel, which stops the forwarder goroutine.
-func newBrokerIQSource(broker *iqtap.Broker) (*streamIQSource, *iqtap.Subscriber) {
+func newBrokerIQSource(broker *iqtap.Broker, log *slog.Logger) (*streamIQSource, *iqtap.Subscriber) {
 	sub := broker.Subscribe()
 	s := &streamIQSource{
 		ch:     sub.C,
@@ -158,6 +171,7 @@ func newBrokerIQSource(broker *iqtap.Broker) (*streamIQSource, *iqtap.Subscriber
 		rate:   broker.SampleRateHz,
 		settle: 50 * time.Millisecond,
 		bufCh:  make(chan []complex64, iqSlackDepth),
+		log:    log,
 	}
 	// Teardown is driven by sub.Close() closing sub.C; the forwarder returns
 	// when the channel closes, so context.Background is sufficient here.

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -94,7 +94,7 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	src, err := newDeviceIQSource(ctx, dev, uint32(p.sampleRateHz))
+	src, err := newDeviceIQSource(ctx, dev, uint32(p.sampleRateHz), nil)
 	if err != nil {
 		rep.Fatal(1, fmt.Errorf("start IQ stream: %w", err))
 	}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -48,6 +48,7 @@ type HuntStartRequest struct {
 	Bands           []string  `json:"bands,omitempty"`      // "low:high" MHz
 	Candidates      []float64 `json:"candidates,omitempty"` // MHz
 	NoSweep         bool      `json:"no_sweep,omitempty"`
+	ConfirmBorrow   bool      `json:"confirm_borrow,omitempty"` // authorize borrowing an SDR with live wideband decode (suspends it for the run)
 	Survey          bool      `json:"survey,omitempty"`         // classify+decode every carrier, not just trunking CCs
 	ClassifyOnly    bool      `json:"classify_only,omitempty"`  // survey: classify, skip decoding
 	PersistSurvey   bool      `json:"persist_survey,omitempty"` // survey: stream carriers to NDJSON (crash-safe, resumable)

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -87,6 +87,14 @@ type LiveHuntOptions struct {
 	// daemon Acquirer; RunLiveHunt itself ignores it (the IQSource is already
 	// resolved by the time RunLiveHunt runs).
 	Serial string
+	// ConfirmBorrow authorizes a hunt that would borrow an SDR currently
+	// decoding live wideband traffic (a widebandt2 engine). Borrowing retunes
+	// that SDR, so the live control-channel + voice decode is suspended for the
+	// hunt's duration. The daemon Acquirer refuses such a borrow unless this is
+	// set, so the operator is prompted before knocking the live system offline
+	// rather than having it happen silently. Consumed by the daemon Acquirer;
+	// RunLiveHunt itself ignores it.
+	ConfirmBorrow bool
 
 	FFTSize    int
 	SweepDwell time.Duration

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -49,6 +49,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/iqpower"
@@ -242,6 +243,48 @@ type Engine struct {
 	wbClipSamples int
 	// wbClipLogAt throttles the overload WARN. Owned by the Run pump.
 	wbClipLogAt time.Time
+
+	// suspended, when set, makes the Run pump drain its IQ stream without
+	// processing it: no channelization, no per-channel decode, no grants, no
+	// diagnostics. It exists so a live hunt that borrows this engine's SDR can
+	// retune it away without the engine decoding the off-frequency IQ — which
+	// otherwise floods the log with "channel iq power very low" WARNs and emits
+	// spurious grants whose voice taps capture no audio (empty TG folders).
+	// Read on the pump goroutine; set via Suspend/Resume from another goroutine.
+	suspended atomic.Bool
+}
+
+// Serial returns the dongle serial this engine decodes on (the value passed as
+// Options.Serial). It lets a coordinator — e.g. the daemon's hunt acquirer —
+// match a running engine to the SDR a hunt is about to borrow.
+func (e *Engine) Serial() string { return e.serial }
+
+// Suspend pauses decoding: the Run pump keeps draining the IQ stream (so the
+// SDR/broker never blocks) but processes nothing until Resume. Idempotent and
+// safe to call from any goroutine. Used while a hunt borrows this engine's SDR.
+func (e *Engine) Suspend() {
+	if e.suspended.Swap(true) {
+		return
+	}
+	e.log.Info("widebandt2: decode suspended (SDR borrowed by hunt)", "serial", e.serial)
+}
+
+// Resume re-enables decoding after a Suspend. Because the borrower retuned the
+// shared SDR, Resume first reprograms it back to this engine's centre frequency
+// so the next chunk is on-channel again; it then clears the suspend flag.
+// Idempotent and safe to call from any goroutine.
+func (e *Engine) Resume() {
+	if !e.suspended.Load() {
+		return
+	}
+	if err := e.device.SetCenterFreq(e.centerHz); err != nil {
+		// Log and clear anyway: leaving the engine suspended on a retune error
+		// would strand it decoding nothing, which is strictly worse.
+		e.log.Warn("widebandt2: resume retune failed; resuming anyway",
+			"serial", e.serial, "center_freq_hz", e.centerHz, "err", err)
+	}
+	e.suspended.Store(false)
+	e.log.Info("widebandt2: decode resumed (SDR returned by hunt)", "serial", e.serial)
 }
 
 // iqClipThreshold is the normalized magnitude at or above which an I or Q
@@ -674,6 +717,11 @@ func (e *Engine) Run(ctx context.Context) error {
 		case chunk, ok := <-stream:
 			if !ok {
 				return nil
+			}
+			if e.suspended.Load() {
+				// SDR borrowed by a hunt and retuned: drop the off-frequency
+				// chunk (keeping the stream drained) without decoding it.
+				continue
 			}
 			e.widebandPwr.Add(chunk)
 			e.foldInputClip(chunk)

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/iqpower"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -539,5 +540,106 @@ func TestEngineRunPropagatesStreamError(t *testing.T) {
 	defer cancel()
 	if err := e.Run(ctx); err == nil {
 		t.Errorf("expected error from StreamIQ propagated, got nil")
+	}
+}
+
+// countingIQObserver counts RecordWidebandInputPowerDbFS calls so a test can
+// tell whether the Run pump processed any chunks (it records once per
+// diagnostics window) or merely drained them while suspended.
+type countingIQObserver struct{ wbPower atomic.Int64 }
+
+func (c *countingIQObserver) RecordIQPowerDbFS(string, float64) {}
+func (c *countingIQObserver) ClearIQPowerDbFS(string)           {}
+func (c *countingIQObserver) RecordWidebandInputPowerDbFS(string, float64) {
+	c.wbPower.Add(1)
+}
+func (c *countingIQObserver) RecordWidebandInputClipRatio(string, float64) {}
+func (c *countingIQObserver) ClearWidebandInput(string)                    {}
+
+// engineWithChunks builds a P25 engine fed `n` silence chunks, with a now()
+// that jumps a full diagnostics window per chunk so every PROCESSED chunk
+// flushes maybeLogDiagnostics (and thus records wideband power).
+func engineWithChunks(t *testing.T, obs IQPowerObserver, serial string, n int) (*Engine, *mockDevice) {
+	t.Helper()
+	bus := events.NewBus(64)
+	t.Cleanup(bus.Close)
+	const chunkLen = 4800
+	chunks := make([][]complex64, n)
+	for i := range chunks {
+		chunks[i] = make([]complex64, chunkLen)
+	}
+	dev := newMockDevice(chunks)
+	var tick atomic.Int64
+	e, err := New(Options{
+		Log:          slog.Default(),
+		Device:       dev,
+		Bus:          bus,
+		Metrics:      obs,
+		Serial:       serial,
+		SampleRateHz: 2_400_000,
+		CenterFreqHz: 453_500_000,
+		Channels:     []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "wbsys"}},
+		Systems:      []trunking.System{t2System("wbsys")},
+		Now: func() time.Time {
+			// Each call advances two windows so a processed chunk always
+			// crosses the diagnostics-window boundary.
+			n := tick.Add(int64(2 * iqpower.Window))
+			return time.Unix(0, 0).Add(time.Duration(n))
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e, dev
+}
+
+// TestEngineSuspendDrainsWithoutDecoding: a suspended engine consumes its IQ
+// stream (so the SDR/broker never blocks) but processes nothing — no per-window
+// diagnostics are recorded. Resume restores the dongle's centre frequency.
+func TestEngineSuspendDrainsWithoutDecoding(t *testing.T) {
+	obs := &countingIQObserver{}
+	e, dev := engineWithChunks(t, obs, "WB-SUSP", 6)
+
+	if got := e.Serial(); got != "WB-SUSP" {
+		t.Errorf("Serial() = %q, want WB-SUSP", got)
+	}
+
+	// Suspend before Run consumes any chunk; the pump must drain all 6 and exit
+	// cleanly on stream close without recording a single diagnostics window.
+	e.Suspend()
+	// A borrowing hunt would have retuned the SDR; emulate that so Resume's
+	// retune-back is observable.
+	_ = dev.SetCenterFreq(440_000_000)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := e.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := obs.wbPower.Load(); got != 0 {
+		t.Errorf("suspended engine recorded %d diagnostics windows; want 0 (must not decode)", got)
+	}
+
+	// Resume must reprogram the dongle back to the engine's centre frequency.
+	e.Resume()
+	if got := dev.centerFreqHz.Load(); got != 453_500_000 {
+		t.Errorf("after Resume, centre freq = %d, want 453_500_000 (retune-back)", got)
+	}
+}
+
+// TestEngineProcessesWhenNotSuspended is the control: the same fixture, not
+// suspended, DOES record diagnostics windows — proving the suspend guard, not
+// the test setup, is what suppresses processing above.
+func TestEngineProcessesWhenNotSuspended(t *testing.T) {
+	obs := &countingIQObserver{}
+	e, _ := engineWithChunks(t, obs, "WB-RUN", 6)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := e.Run(ctx); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := obs.wbPower.Load(); got == 0 {
+		t.Error("running engine recorded 0 diagnostics windows; want > 0 (fixture should process)")
 	}
 }

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -674,11 +674,12 @@ func (r *Recorder) handleEncryptionUpdate(deviceSerial string, encrypted bool) {
 // Returns nil on a fatal error (already logged). The caller holds r.mu and
 // registers the returned session.
 func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *recordingSession {
+	// The talkgroup directory is NOT created here — it is made lazily in
+	// openSessionFiles, just before the first file is opened. A grant that is
+	// followed but never yields audio (a dead-key, an immediately-aborted
+	// encrypted call, or a voice tap left off-frequency while a hunt borrows
+	// the SDR) therefore leaves no empty <system>/<talkgroup> folder behind.
 	dir := r.directoryFor(cs)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		r.log.Error("recorder: mkdir", "dir", dir, "err", err)
-		return nil
-	}
 	nameCS := cs
 	nameCS.StartedAt = startedAt
 	base := r.basenameFor(nameCS)
@@ -746,6 +747,14 @@ func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *rec
 func (r *Recorder) openSessionFiles(s *recordingSession) error {
 	if s.wav != nil {
 		return nil
+	}
+	// Create the talkgroup directory lazily, on the first write, so a call
+	// that never yields audio leaves no empty folder (see buildSession).
+	if dir := filepath.Dir(s.wavPath); dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			r.log.Error("recorder: mkdir", "dir", dir, "err", err)
+			return err
+		}
 	}
 	wav, err := NewWavFile(s.wavPath, s.sampleRate)
 	if err != nil {

--- a/internal/voice/recorder_idle_test.go
+++ b/internal/voice/recorder_idle_test.go
@@ -276,3 +276,53 @@ func TestRecorderCallIDFenceDropsStaleFrames(t *testing.T) {
 		t.Errorf("vocoder decoded %d frames; want 1 (stale frame must be fenced)", got)
 	}
 }
+
+// TestRecorderNoAudioLeavesNoDir: a call that starts and ends without a single
+// frame must not even create its talkgroup directory. The empty <system>/<tg>
+// folder is otherwise left behind when a grant is followed but the voice tap
+// never yields audio (e.g. the SDR is off-frequency during a borrowed hunt),
+// littering the recordings tree with empty TG folders.
+func TestRecorderNoAudioLeavesNoDir(t *testing.T) {
+	DefaultRegistry.Register("stat-stub-nodir", func() (Vocoder, error) {
+		return &statStubVocoder{voicedPerFrame: true}, nil
+	})
+
+	bus := events.NewBus(16)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		WriteRaw:           true,
+		VocoderForProtocol: map[string]string{"test-nodir": "stat-stub-nodir"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-nodir", GroupID: 1421, SourceID: 0},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	waitSession(t, r, "VOICE-1", true)
+
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: cs.Grant, DeviceSerial: "VOICE-1",
+		StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+		Reason: trunking.EndReasonNormal,
+	}})
+	waitSession(t, r, "VOICE-1", false)
+
+	tgDir := filepath.Join(dir, "S", "1421")
+	if _, err := os.Stat(tgDir); !os.IsNotExist(err) {
+		t.Errorf("no-audio call must not create talkgroup dir %s; stat err = %v", tgDir, err)
+	}
+}


### PR DESCRIPTION
buildSession created the <system>/<talkgroup> directory eagerly at call
start via MkdirAll, before any audio was known to exist. The capture files
themselves are opened lazily (openSessionFiles) so a grant that never
yields audio already left no .wav/.raw behind — but the directory was still
created, littering the recordings tree with empty TG folders.

This shows up in practice when a grant is followed but the voice tap never
captures audio: e.g. a dead-key, an aborted encrypted call, or (as seen in
the 25-Jun P25 capture) grants decoded while a borrowed hunt has retuned the
shared wideband SDR off the voice channel — TGs 1421/1422/1423/1451/1493/1641
were all granted inside the hunt window and left empty folders.

Move the MkdirAll into openSessionFiles, on the first write, so a no-audio
call touches the filesystem zero times. Adds TestRecorderNoAudioLeavesNoDir,
which fails before this change (the empty TG dir is created) and passes after.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014WbpnXNptxmo5MhQerThFk