### PR TITLE
docs: post-release v0.5.3 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.3] — 2026-06-25
+
+Headlined by **neighbor (adjacent) sites in the live views** — the P25 Adjacent
+Site Status Broadcasts (opcode 0x3C) GopherTrunk already decoded now surface in
+the always-on monitoring surfaces (decoded-message log, the TUI and web Systems
+panels, and the `/api/v1/systems` responses), not just the drill-in report. It
+also lands a **configurable display timezone** (`display.timezone`) that renders
+every human- and machine-facing timestamp in the host's local time by default
+(overridable to UTC or any IANA zone), and an **opt-in voice enhancement chain**
+(`recordings.enhance`) that trades a little faithfulness for the cleaner, louder
+"sound-good" audio the rival decoders produce — band-limiting + uniform loudness,
+shaping both recordings and live audio from a single point. Rounded out by a
+power-complementary unvoiced-synthesis window that removes a buzzy ~7 dB tremolo
+from the IMBE/AMBE+2 vocoders (#644).
+
 ### Added
 - **Neighbor (adjacent) sites in the live views.** GopherTrunk already decoded
   P25 Adjacent Site Status Broadcasts (opcode 0x3C) but only surfaced them in the

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.2
+VERSION=v0.5.3
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.2" -%}
+  {%- assign ver = "v0.5.3" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.3.md
+++ b/docs/announcements/v0.5.3.md
@@ -1,0 +1,49 @@
+# GopherTrunk v0.5.3 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.3 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.3
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.3 — neighbor (adjacent) sites now show up in the live views, every timestamp renders in your local time by default, an opt-in "sound-good" voice enhancement chain for cleaner/louder decoded audio, and a vocoder fix that removes a buzzy tremolo from noisy speech
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.3 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.5.2:**
+
+* **Neighbor (adjacent) sites in the live views.** GopherTrunk already decoded P25 Adjacent Site Status Broadcasts (opcode 0x3C) but only surfaced them in the system drill-in report. They now show up in the always-on monitoring surfaces: an SDRtrunk-style "Neighbor Sites" block in the decoded-message log, a neighbour count column + list in the TUI and web Systems panels, and a `neighbors` array (RFSS/Site with band-plan-resolved downlink/uplink frequencies) on `GET /api/v1/systems` and `/api/v1/systems/{name}`.
+* **Configurable display timezone** (`display.timezone`). Timestamps now render in the host's **local time by default** across every human- and machine-facing surface — decoded-message/power logs, TUI panels, the JSON/gRPC API, webhook payloads, and rdioscanner uploads. Set it to "UTC" or any IANA zone (e.g. "America/New_York"). API/webhook timestamps stay RFC3339 but now carry an explicit numeric offset, so they remain an unambiguous parseable instant.
+* **Opt-in voice enhancement chain** (`recordings.enhance`). A "sound-good" post-vocoder chain — rumble high-pass, warmth shelf, telephone-band low-pass (like OP25), a louder AGC target, and an optional soft-knee compressor. It trades a little faithfulness for the cleaner/louder sound the rival decoders produce (uniform loudness + band-limiting, not exotic EQ). Because the recorder decodes each call once, the chain shapes **both** recordings and live audio from one point. Off by default; live-applies via `PATCH /api/v1/settings`.
+* **Unvoiced-synthesis tremolo fixed in the MBE vocoders** (#644). The §6.4 unvoiced overlap-add used a Hann window that isn't power-complementary at the 160-sample hop, modulating the synthesized noise floor ~7 dB at the frame rate — a buzzy artifact, most audible on noisy/fricative speech. Replaced with a power-complementary tapered-cosine window. Shared by the IMBE (P25) and AMBE+2 (DMR/NXDN/dPMR) paths.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.3
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.3 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.5.2:**
+- **Neighbor (adjacent) sites in the live views** — P25 Adjacent Site Status Broadcasts now show up in the decoded-message log, the TUI/web Systems panels, and the `/api/v1/systems` responses, not just the drill-in report.
+- **Configurable display timezone** (`display.timezone`) — timestamps render in your local time by default across logs, TUI, the API, webhooks and rdioscanner uploads; override to UTC or any IANA zone.
+- **Opt-in voice enhancement chain** (`recordings.enhance`) — a "sound-good" post-vocoder chain (band-limit + uniform loudness, like OP25 / Trunk Recorder) for cleaner, louder decoded audio; shapes both recordings and live monitoring. Off by default.
+- **Unvoiced-synthesis tremolo fixed** (#644) — a power-complementary window removes a buzzy ~7 dB noise-floor modulation from the IMBE/AMBE+2 vocoders, most audible on noisy speech.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.3>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
Promote the new [v0.5.3] — 2026-06-25 CHANGELOG section covering the
v0.5.3 contents: P25 neighbor (adjacent) sites surfaced in the live
views (decoded-message log, TUI/web Systems panels, /api/v1/systems),
the configurable display timezone that renders timestamps in local time
by default (#644 neighbours/timezone work), the opt-in voice enhancement
chain (recordings.enhance), and the power-complementary unvoiced-synthesis
window that removes the MBE vocoder tremolo (#644). Bump the README
quick-start VERSION and the latest-version.html fallback tag to v0.5.3,
and add the v0.5.3 social-announcement drafts.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JdKPojT7hxj4MWBhZFh5dt