### PR TITLE
widebandt2: warn + document gain:auto for multi-tap wideband devices (#749)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -182,6 +182,35 @@ func warnLowGain(log *slog.Logger, serial string, role sdr.Role, raw string, ten
 		"hint", "manual P25/C4FM gains typically run 150-496 tenths (15-49.6 dB). gain: is in TENTHS of a dB; a reference 'gain 49' means ~49 dB -> gain: \"490\". Use 'gain: auto' or run 'gophertrunk sdr list' for the supported ladder. NOTE: this assumes the front end is not overloaded — if the iq_clip_ratio metric is non-zero (or iq_power_dbfs sits near 0), the radio is clipping and gain is already too HIGH for this site; reduce it or add attenuation instead of raising it (issue #402).")
 }
 
+// fixedGainOnSharedWideband reports whether a device is a multi-tap wideband
+// front end pinned to a single MANUAL gain. Every tap on a `role: wideband`
+// dongle shares one antenna, one centre and one gain, so a single fixed value
+// cannot serve co-tenant sites of differing strength: a gain chosen so the
+// strongest site doesn't clip leaves weaker sites under-amplified near the
+// ADC's usable floor (dead and flat regardless of the receiver's
+// post-discriminator AGC, which can't recover SNR lost at the converter).
+// `gain: auto` lets the front end run the band hotter so weak sites clear the
+// floor (issue #749). tenthDB >= 0 is a manual gain; auto parses to -1.
+func fixedGainOnSharedWideband(role sdr.Role, numChannels, tenthDB int) bool {
+	return role == sdr.RoleWideband && numChannels > 1 && tenthDB >= 0
+}
+
+// warnFixedGainOnSharedWideband emits a WARN when a multi-tap wideband dongle
+// is pinned to a manual gain (see fixedGainOnSharedWideband). No-op for auto,
+// single-tap, or non-wideband devices, so it is safe to call unconditionally
+// after every successful parseGain.
+func warnFixedGainOnSharedWideband(log *slog.Logger, serial string, role sdr.Role, raw string, tenthDB, numChannels int) {
+	if !fixedGainOnSharedWideband(role, numChannels, tenthDB) {
+		return
+	}
+	log.Warn("daemon: multi-tap wideband dongle pinned to a fixed gain — a single gain can't serve sites of differing strength on one shared front end; weaker co-tenant sites may sit dead at the noise floor while the strongest decodes",
+		"serial", serial,
+		"channels", numChannels,
+		"configured", raw,
+		"applied_db", float64(tenthDB)/10.0,
+		"hint", "prefer 'gain: auto' (AGC) for a wideband device hosting more than one site — it lets the front end run the band hot enough for weak sites to clear the ADC floor. Watch each tap on the gophertrunk_sdr_iq_power_dbfs metric to confirm; a genuinely weak/distant site may still need its own dedicated dongle (issue #749).")
+}
+
 // effectiveStreamRate returns the IQ sample rate a down-converter should be
 // built from. The RTL2832U quantizes a requested rate to its resampler divisor,
 // so a requested rate that isn't an exact divisor of the crystal streams at a
@@ -830,6 +859,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			} else {
 				warnGainUnits(log, dev.Serial, dev.Gain, gain)
 				warnLowGain(log, dev.Serial, h.Role, dev.Gain, gain)
+				warnFixedGainOnSharedWideband(log, dev.Serial, h.Role, dev.Gain, gain, len(dev.Channels))
 				h = h.WithGain(gain)
 			}
 			hints = append(hints, h)

--- a/cmd/gophertrunk/gain_test.go
+++ b/cmd/gophertrunk/gain_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
 
 func TestParseGain(t *testing.T) {
 	cases := []struct {
@@ -103,6 +107,40 @@ func TestGainLooksTooLow(t *testing.T) {
 		if got := gainLooksTooLow(c.raw, c.tenthDB); got != c.want {
 			t.Errorf("gainLooksTooLow(%q, %d) = %v, want %v",
 				c.raw, c.tenthDB, got, c.want)
+		}
+	}
+}
+
+func TestFixedGainOnSharedWideband(t *testing.T) {
+	cases := []struct {
+		name        string
+		role        sdr.Role
+		numChannels int
+		tenthDB     int
+		want        bool
+	}{
+		// The reported case (issue #749): a multi-tap wideband dongle pinned
+		// to a fixed gain — fires regardless of how reasonable the level is,
+		// because the problem is cross-site dynamic range, not absolute level.
+		{"wideband 2 taps, 60 dB", sdr.RoleWideband, 2, 600, true},
+		{"wideband 4 taps, 30 dB", sdr.RoleWideband, 4, 300, true},
+		{"wideband 5 taps, 49.6 dB", sdr.RoleWideband, 5, 496, true},
+		{"wideband 2 taps, gain 0", sdr.RoleWideband, 2, 0, true},
+		// auto (tenthDB == -1) is exactly the recommended remedy: never warn.
+		{"wideband 4 taps, auto", sdr.RoleWideband, 4, -1, false},
+		// A single-tap wideband device has no co-tenants to starve.
+		{"wideband 1 tap, fixed", sdr.RoleWideband, 1, 600, false},
+		{"wideband 0 taps, fixed", sdr.RoleWideband, 0, 600, false},
+		// Non-wideband roles tune their own channel with their own gain, so
+		// the shared-front-end starvation can't apply — never warn.
+		{"control, fixed", sdr.RoleControl, 4, 600, false},
+		{"voice, fixed", sdr.RoleVoice, 4, 600, false},
+		{"auto role, fixed", sdr.RoleAuto, 4, 600, false},
+	}
+	for _, c := range cases {
+		if got := fixedGainOnSharedWideband(c.role, c.numChannels, c.tenthDB); got != c.want {
+			t.Errorf("%s: fixedGainOnSharedWideband(%v, %d, %d) = %v, want %v",
+				c.name, c.role, c.numChannels, c.tenthDB, got, c.want)
 		}
 	}
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -318,9 +318,19 @@ sdr:
     #     attenuation (do NOT raise gain) — a hot site is desensitising the
     #     receiver. Set gain in TENTHS of a dB ("gain: 600" = 60 dB, which
     #     is very high for a wideband capture; try a lower value first).
+    #   - PREFER `gain: "auto"` (AGC) when one dongle hosts more than one
+    #     site of differing strength. A single FIXED gain can't serve them
+    #     all: a value chosen so the strongest site doesn't clip leaves the
+    #     weaker co-tenants under-amplified, dead and flat at the ADC floor
+    #     (the receiver's own AGC can't recover SNR lost at the converter).
+    #     AGC lets the front end run the band hot enough for weak sites to
+    #     clear the floor — the single biggest lever for a multi-site
+    #     wideband cluster (issue #749). The daemon logs a startup WARN when
+    #     a multi-tap wideband dongle is pinned to a fixed gain.
     #   - A genuinely weak distant site may simply not survive a shared
-    #     capture optimised for a stronger one — give it a dedicated dongle
-    #     (role: control or its own role: wideband) if it matters.
+    #     capture optimised for a stronger one even under AGC — give it a
+    #     dedicated dongle (role: control or its own role: wideband) if it
+    #     matters.
     #
     # Constraints (validated at load time):
     #   - serial must match a discovered dongle

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -96,6 +96,19 @@ sdr:
 > on every device (`sdr: gain set ... gain_db=...`). A decimal form like
 > `"32.0"` is taken as whole dB, so that works too.
 
+> **Multi-site `role: wideband` dongles: prefer `gain: "auto"`.** Every
+> tap on a wideband dongle shares one antenna, one centre and one gain.
+> A single *fixed* gain can't serve sites of differing strength: a value
+> chosen so the strongest site doesn't clip leaves weaker co-tenants
+> under-amplified, sitting dead and flat at the ADC noise floor — and the
+> receiver's own post-discriminator AGC can't recover SNR that was lost
+> at the converter. AGC (`gain: "auto"`) lets the front end run the band
+> hot enough for weak sites to clear the floor; in field testing it took
+> a co-tenant control channel from zero decoded TSBKs to hundreds (issue
+> #749). The daemon warns at startup when a multi-tap wideband dongle is
+> pinned to a fixed gain. A genuinely weak/distant site may still not
+> survive a shared capture even under AGC — give it its own dongle.
+
 ### HackRF tested combinations
 
 | Device | PID | Coverage | Gain chain | Bias-tee | Notes |

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -833,7 +833,13 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 					// this one (issue #749). Reduce gain, don't raise it.
 					hint = "wideband front end is overloaded (clipping) — a stronger co-channel is burying this site; reduce gain or add attenuation, do NOT raise gain"
 				case wbHealthy:
-					hint = "wideband input is healthy — this carrier is likely outside the captured passband or tuned to the wrong frequency"
+					// The shared capture is healthy and other taps may be
+					// decoding, yet this one sits at the floor. Most often the
+					// carrier is off-passband / mistuned; but on a multi-tap
+					// device a single fixed gain can also under-amplify a weaker
+					// co-tenant site below the ADC floor — try 'gain: auto' so
+					// the front end runs hot enough for it to clear (issue #749).
+					hint = "wideband input is healthy — this carrier is likely outside the captured passband or tuned to the wrong frequency; if other taps on this dongle decode, try 'gain: auto' (AGC) so a weaker co-tenant site can clear the shared ADC floor"
 				}
 				e.log.Warn("widebandt2: channel iq power very low — "+hint,
 					"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag,

--- a/internal/scanner/widebandt2/engine_lowpower_hint_test.go
+++ b/internal/scanner/widebandt2/engine_lowpower_hint_test.go
@@ -69,6 +69,12 @@ func TestLowPowerHintOffBand(t *testing.T) {
 	if !strings.Contains(r.msg, "outside the captured passband") {
 		t.Errorf("WARN msg = %q, want the off-band hint", r.msg)
 	}
+	// On a shared front end a healthy capture with a dead tap can also be a
+	// weaker co-tenant under-amplified by a fixed gain; the hint now points
+	// at 'gain: auto' (AGC) as the remedy (issue #749).
+	if !strings.Contains(r.msg, "gain: auto") {
+		t.Errorf("WARN msg = %q, want the gain: auto (AGC) hint", r.msg)
+	}
 	if _, has := r.attrs["wideband_input_dbfs"]; !has {
 		t.Errorf("WARN missing wideband_input_dbfs attr; attrs=%v", r.attrs)
 	}


### PR DESCRIPTION
The latest #749 follow-up isolated the real lever for a multi-site wideband
cluster: a single FIXED gain on a shared front end can't serve sites of
differing strength. A gain chosen so the strongest site doesn't clip leaves
weaker co-tenants under-amplified, dead and flat at the ADC noise floor; the
receiver's post-discriminator AGC can't recover SNR lost at the converter.
Switching the device to gain: "auto" (AGC) lets the front end run the band hot
enough for weak sites to clear the floor (reporter saw 0 -> 345 TSBKs).

At 2.5 MS/s the wideband DDCBank tap and the proven single-channel
ccdecoder.Downconverter are functionally identical (same filter constants and
resampler), so this is a gain-mode effect, not a DDC bug. Surface the remedy
proactively rather than letting operators foot-gun a fixed gain:

- Startup WARN when a role: wideband dongle with >1 channel is pinned to a
  manual gain, recommending gain: "auto".
- Per-tap low-power WARN now suggests gain: "auto" when the shared capture is
  healthy but a co-tenant tap sits at the floor.
- config.example.yaml and docs/hardware.md document the AGC recommendation.

A genuinely weak/distant site may still need its own dongle even under AGC;
this is operational guidance, not a fix for the shared-front-end dynamic-range
limit, so the issue stays open.

Refs #749

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013QAZEe1Aittki48ZVxT87M