### PR TITLE
p25: gate unverified Motorola talker-alias cipher; correct false provenance (#773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,17 @@ reassembly, and new raw-broadcast / event-log field diagnostics.
   nibble and concatenated whole bytes, shifting the cipher region by 4 bits so
   the alias decoded to garbage and failed safe to empty. Reassembly is now
   nibble-aligned (the end-to-end decoded string remains air-unverified).
+- **P25 Motorola talker-alias cipher gated as unverified** (#773). A clean-room
+  attempt to derive the per-byte cipher from the one partial capture available
+  (RID 200062) showed it is mathematically underdetermined — dozens of distinct
+  constant-sets reproduce the known bytes while disagreeing on the unknown ones,
+  and one alias character is unrecoverable from that sample — so the substitution
+  table and constants cannot be pinned without ground truth (and SDRTrunk's GPLv3
+  implementation cannot be ported into Apache-2.0 GT). The decode now carries a
+  `CipherVerified` flag (false) and `DecodeMessage` never reports an alias as
+  reliable while it is false, so a possibly-wrong table can never surface a
+  fabricated name as a confirmed alias. Misleading "reverse-engineered fact"
+  comments on the table were corrected to state the true unverified provenance.
 - **P25 autotune no longer over-corrects** (#774). Implausible single AFC
   measurements are rejected, a warm-up of several samples is required before any
   correction is applied, and only cleanly-decoded voice calls feed the estimate,

--- a/internal/radio/p25/motorola/alias.go
+++ b/internal/radio/p25/motorola/alias.go
@@ -13,15 +13,41 @@
 //	last 16 bits    : CRC-16/GSM over the preceding bits
 //
 // Keeping the cipher, the framing, and the CRC in one package lets each
-// carrier own only its fragment transport and share the decode. The
-// algorithm and 256-byte substitution table are reverse-engineered
-// facts about Motorola's wire protocol (public, identical across every
-// open-source decoder); the Go expression here is original.
+// carrier own only its fragment transport and share the decode.
+//
+// Provenance and verification status (important — see #773): the SUID
+// framing above is verified. The reassembly fix in #778 reproduces
+// SDRTrunk's FRAGMENT byte stream exactly, which is why the WACN /
+// System / Radio ID fall out correctly on real traffic. The per-byte
+// CIPHER below is NOT verified. Its algorithm *structure* is inferred
+// from the public protocol description in #773 (a length-seeded 16-bit
+// accumulator, a per-byte LUT lookup, an odd-multiplier — i.e. a
+// modular inverse mod 256 — step, a multiply, then UTF-16BE), but the
+// 256-byte substitution table and the accumulator constants are
+// unconfirmed: no committed capture maps a real RID to its plaintext
+// alias, and the cipher decodes nothing on live traffic. The single
+// partial capture available (RID 200062, #376) is mathematically
+// underdetermined — dozens of distinct constant-sets reproduce its
+// known bytes while disagreeing on the unknown ones, and one alias
+// character is not recoverable from that sample at all — so it cannot
+// pin the table. SDRTrunk has a working implementation but is GPLv3;
+// GopherTrunk is Apache-2.0, so its table/decode must not be ported
+// here. Until the cipher is validated against ground truth the decode
+// is gated (see CipherVerified) so a possibly-wrong table can never
+// surface a fabricated name as a confirmed alias.
 package motorola
 
 // motorolaAliasLUT is the 256-byte substitution table the per-byte
 // cipher indexes into. Values are stored as signed bytes to match the
 // algorithm's intermediate signed arithmetic.
+//
+// UNVERIFIED. This table is a placeholder of unconfirmed provenance: it
+// is a valid 0..255 permutation but has never been validated against a
+// real RID -> plaintext capture, and it does not decode live traffic
+// (#773). Its output must never be presented as a confirmed alias; the
+// CipherVerified gate enforces this. Replacing it with a verified table
+// requires ground-truth captures (see CipherVerified) or a licensing
+// path for an existing implementation.
 var motorolaAliasLUT = [256]int8{
 	-14, 46, 102, -112, 116, -118, 111, 120, -69, 83,
 	3, 17, 104, -51, 68, 23, 40, 95, 30, -124,
@@ -51,10 +77,31 @@ var motorolaAliasLUT = [256]int8{
 	22, 26, 32, -114, 69, 62,
 }
 
+// CipherVerified reports whether the per-byte alias cipher (the
+// motorolaAliasLUT table plus the accumulator constants in
+// DecodeAliasBytes) has been validated against ground truth — a
+// captured frame whose decoded alias matches a known plaintext for the
+// same RID.
+//
+// It is false. The cipher is currently unverified and almost certainly
+// incorrect: it decodes no live traffic (#773), and the single partial
+// capture available (RID 200062) is underdetermined — many constant-sets
+// fit its known bytes, so it cannot pin the table. While this is false,
+// DecodeMessage never reports an alias as reliable and callers must not
+// surface it as a confirmed name. Flip it to true ONLY together with a
+// committed regression fixture mapping real encoded bytes to the correct
+// plaintext alias (and update motorolaAliasLUT / the constants to the
+// verified values). Do not flip it on inference alone.
+const CipherVerified = false
+
 // DecodeAliasBytes runs the per-byte cipher across the encoded alias
 // bytes and returns the decoded byte stream. The decoded bytes are
 // intended to be read as a UTF-16 BE character sequence; callers that
 // want a printable string should run the result through CleanAlias.
+//
+// The multiplier/increment constants and the LUT are UNVERIFIED (see
+// CipherVerified): this routine is deterministic, but its output is not
+// known to be correct plaintext.
 //
 //	accum = (accum × 293 + 0x72E9) mod 65536
 //	lut   = motorolaAliasLUT[encoded_byte + 128]   (signed)
@@ -146,10 +193,13 @@ type Message struct {
 	SystemID uint16
 	RadioID  uint32
 	Alias    string
-	// AliasReliable reports whether the decoded alias is all printable
-	// ASCII. When false the decode contains non-ASCII-printable
-	// characters — a hallmark of bit-error corruption that survived the
-	// CRC — and callers should surface the alias as suspect (#711).
+	// AliasReliable reports whether the decoded alias can be trusted as a
+	// confirmed name. It is true only when the decode is all printable
+	// ASCII (no bit-error corruption hallmarks, #711) AND the cipher
+	// itself is verified (CipherVerified). While the cipher is unverified
+	// it is always false, so a possibly-wrong table never surfaces a
+	// fabricated name as a confirmed alias (#773). Callers should surface
+	// an unreliable alias as suspect rather than as a confirmed name.
 	AliasReliable bool
 	// CRCOK reports whether the trailing CRC-16/GSM matched. It is
 	// advisory: the CRC parameters are inferred from open-source
@@ -182,7 +232,11 @@ func DecodeMessage(msg []byte) (Message, bool) {
 
 	wacn, sysID, rid := decodeSUID(msg)
 	encoded := msg[encStart : encStart+encByteLen]
-	alias, aliasReliable := DecodeAlias(DecodeAliasBytes(encoded))
+	alias, aliasClean := DecodeAlias(DecodeAliasBytes(encoded))
+	// Gate on CipherVerified: an unverified cipher may decode to
+	// coincidentally-clean ASCII, so clean-ness alone is not enough to
+	// call the alias reliable (#773).
+	aliasReliable := aliasClean && CipherVerified
 
 	// CRC-16/GSM over everything before the trailing 16-bit CRC field.
 	crcBytes := CRCBits / 8

--- a/internal/radio/p25/motorola/alias_test.go
+++ b/internal/radio/p25/motorola/alias_test.go
@@ -132,12 +132,63 @@ func TestDecodeMessagePopulatesAliasReliable(t *testing.T) {
 	if !ok {
 		t.Fatal("DecodeMessage returned ok=false")
 	}
-	wantAlias, wantReliable := DecodeAlias(DecodeAliasBytes(encoded))
+	wantAlias, clean := DecodeAlias(DecodeAliasBytes(encoded))
+	// AliasReliable is gated on CipherVerified: clean ASCII alone is not
+	// enough while the cipher is unverified (#773).
+	wantReliable := clean && CipherVerified
 	if msg.Alias != wantAlias {
 		t.Errorf("Alias = %q, want %q", msg.Alias, wantAlias)
 	}
 	if msg.AliasReliable != wantReliable {
 		t.Errorf("AliasReliable = %v, want %v", msg.AliasReliable, wantReliable)
+	}
+}
+
+// TestUnverifiedCipherNeverReportedReliable pins the safety gate: while
+// the per-byte cipher is unverified (CipherVerified == false),
+// DecodeMessage must never report an alias as reliable — not even for
+// inputs whose decoded bytes happen to be clean printable ASCII. This is
+// what stops a possibly-wrong substitution table from surfacing a
+// fabricated name as a confirmed alias (#773).
+func TestUnverifiedCipherNeverReportedReliable(t *testing.T) {
+	if CipherVerified {
+		t.Skip("cipher marked verified — reliability gate intentionally lifted")
+	}
+	suid := []byte{0xBE, 0xE0, 0x01, 0x64, 0x03, 0x0D, 0x7E}
+	for n := 0; n < 4096; n++ {
+		enc := []byte{byte(n), byte(n >> 4), byte(n >> 8), byte(n >> 2)}
+		msg := append(append(append([]byte{}, suid...), enc...), 0x00, 0x00)
+		m, ok := DecodeMessage(msg)
+		if ok && m.AliasReliable {
+			t.Fatalf("AliasReliable=true for enc=% X while cipher unverified", enc)
+		}
+	}
+}
+
+// TestRealSampleYieldsRIDButNoConfidentAlias feeds the real reassembled
+// Phase-2 FACCH-S stream for RID 200062 (the #376 SDRTrunk FRAGMENT
+// dump, pinned byte-for-byte in
+// phase2.TestMotorolaAliasReassemblesSDRTrunkFragmentStream) through the
+// shared decode. GT must recover the verified RID but make NO confident
+// alias claim while the cipher is unverified — the exact state reported
+// on #773.
+func TestRealSampleYieldsRIDButNoConfidentAlias(t *testing.T) {
+	msg := []byte{
+		0xBE, 0xE0, 0x01, 0x64, 0x03, 0x0D, 0x7E, // SUID (RID 200062)
+		0x24, 0x44, 0xF6, 0xFF, 0x2F, 0xA9, 0xAC, 0x3E, 0xC3, 0x44,
+		0x32, 0xFA, 0x63, 0xCC, 0x81, 0xC3, 0xC5, 0xD9, 0x6A, 0x96, // encoded alias
+		0x00, 0x00, 0x00, 0x00, // cipher tail
+		0x00, 0x00, // CRC-16
+	}
+	m, ok := DecodeMessage(msg)
+	if !ok {
+		t.Fatal("DecodeMessage returned ok=false")
+	}
+	if m.RadioID != 200062 {
+		t.Errorf("RadioID = %d, want 200062 (verified from reassembly)", m.RadioID)
+	}
+	if !CipherVerified && m.AliasReliable {
+		t.Errorf("AliasReliable = true; an unverified cipher must not yield a confident alias (#773)")
 	}
 }
 

--- a/internal/radio/p25/phase1/motorola_alias_cipher.go
+++ b/internal/radio/p25/phase1/motorola_alias_cipher.go
@@ -17,5 +17,8 @@ func decodeAliasBytes(encoded []byte) []byte {
 // ASCII). A thin package-local alias over motorola.DecodeAlias, kept
 // alongside decodeAliasBytes so phase1 call sites stay package-local.
 func decodeAlias(raw []byte) (string, bool) {
-	return motorola.DecodeAlias(raw)
+	alias, reliable := motorola.DecodeAlias(raw)
+	// The shared per-byte cipher is unverified (#773); never report a
+	// phase 1 alias as reliable until motorola.CipherVerified is set.
+	return alias, reliable && motorola.CipherVerified
 }


### PR DESCRIPTION
The #773 follow-up confirmed that post-#778 (nibble-aligned reassembly)
RIDs resolve on live Phase 2 traffic but no talker-alias *text* ever
decodes. Root cause: the per-byte cipher in the shared motorola package
(the 256-byte substitution table + accumulator constants) is unverified.
It was AI-authored in #376 yet its comments claimed it was a
"reverse-engineered fact ... identical across every open-source decoder."

A clean-room attempt to derive the cipher from the one partial capture
available (RID 200062) showed the problem is mathematically
underdetermined: under the faithful structural model, dozens of distinct
constant-sets reproduce the 22 known crib bytes while disagreeing on the
unknowns, and one alias character's ciphertext byte never recurs at a
known position so it is unrecoverable from that sample at all. With no
ground-truth RID->plaintext pair (the reporter cannot supply one) and
SDRTrunk's GPLv3 table off-limits to Apache-2.0 GT, the table cannot be
pinned or verified. Guessing values would only ship more fake confidence.

Instead of fabricating a "fix":
- Correct the misleading provenance comments to state the truth — the
  algorithm structure is inferred from the public #773 protocol
  description, but the LUT and constants are unverified and decode no
  live traffic.
- Add motorola.CipherVerified (false). DecodeMessage now reports an
  alias as reliable only when the decode is clean ASCII AND the cipher
  is verified; the phase 1 wrapper applies the same gate. So a
  possibly-wrong table can never surface a fabricated name as a
  confirmed alias.
- Pin the honest behavior with regression tests: the real 200062 sample
  yields the verified RID but no confident alias, and an unverified
  cipher is never reported reliable.

Refs #773 (left open — unverified until a real alias decodes on air).