### PR TITLE
docs: post-release v0.5.4 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.4] — 2026-06-26
+
+Headlined by **dense wideband plans that used to crash now host cleanly** — a
+70-channel DMR config on a single 10 MS/s wideband SDR previously killed daemon
+init ("two tap offsets fall in the same channelizer bin"); the polyphase
+channelizer now lets several 12.5 kHz carriers share a 156 kHz bin and decode
+independently. Rounded out by **auto-discovery of talkgroups from
+control-channel grants** (the roster fills in from live traffic instead of
+needing a hand-maintained CSV), the verified **capture sample-rate guidance**
+for narrowband decode (#771), **`gain: "auto"` guidance for multi-tap wideband
+front ends** (#749), a P25 web-plots fix that follows the voice channel on
+wideband SDRs, and an honest **gate on the unverified Motorola talker-alias
+cipher** so a possibly-wrong table can never surface a fabricated name (#773).
+
 ### Added
+- **Auto-discover talkgroups from control-channel grants.** The Talkgroups
+  database previously only loaded from a hand-maintained CSV, so an operator
+  starting with an empty file saw bare numbers and no roster. GopherTrunk now
+  catalogues each talkgroup the first time it is granted on the control channel
+  (the trunk-recorder behaviour operators asked for), so Database → Talkgroups
+  fills in from live traffic. Discovery runs on a lookup miss and skips
+  individual (unit-to-unit / interconnect) grants, whose 24-bit destination is a
+  subscriber address rather than a talkgroup. Placeholders are tagged
+  "Discovered" and inherit Stream/Record on, but never silently widen a curated
+  scan list — you opt a learned talkgroup into scanning from the UI. In-memory
+  only for now (cleared on restart, like the rest of the talkgroup DB);
+  persistence is a follow-up.
 - **Capture sample-rate guidance** (#771). `gophertrunk capture` now prints a
   one-line hint when a high native rate (>4 MS/s) is chosen for a narrowband
   trunking capture, explaining that the down-converter normalises to 48 kHz and
@@ -16,6 +42,49 @@ for tagged releases.
   root cause of the #771 no-lock report. A new "Choosing a sample rate" section
   in `docs/hardware.md` documents the finding and recommends ~2.4–2.5 MS/s for
   control-channel roles.
+
+### Changed
+- **`gain: "auto"` recommended for multi-tap wideband devices** (#749). A single
+  fixed gain on a shared front end can't serve sites of differing strength: a
+  gain set so the strongest site doesn't clip leaves weaker co-tenants pinned at
+  the ADC noise floor, and the post-discriminator AGC can't recover SNR lost at
+  the converter. GopherTrunk now WARNs at startup when a `role: wideband` dongle
+  hosting more than one channel is pinned to a manual gain, the per-tap low-power
+  WARN suggests `gain: "auto"` when the shared capture is healthy but a co-tenant
+  tap sits at the floor, and `config.example.yaml` / `docs/hardware.md` document
+  the AGC recommendation. (Operational guidance, not a fix for the shared-front-
+  end dynamic-range limit — a genuinely weak/distant site may still need its own
+  dongle.)
+- **Unverified Motorola talker-alias cipher is now gated** (#773). On live P25
+  Phase 2 traffic, RIDs resolve but no talker-alias *text* decodes, because the
+  per-byte Motorola cipher (substitution table + accumulator constants) is
+  unverified — and with no ground-truth RID→plaintext pair it is mathematically
+  underdetermined, so it can't be pinned without guessing. Rather than ship fake
+  confidence, the misleading "reverse-engineered fact" provenance comments are
+  corrected to the truth, and a `CipherVerified` flag (currently false) gates
+  reporting: an alias is surfaced as reliable only when the decode is clean ASCII
+  **and** the cipher is verified, so a possibly-wrong table can never present a
+  fabricated name as a confirmed alias.
+
+### Fixed
+- **Dense wideband plans (70-DMR) no longer crash daemon init.** A 70-channel
+  DMR config on a single 10 MS/s wideband SDR used to kill init with "two tap
+  offsets fall in the same channelizer bin", because a DMR repeater plan on a
+  12.5 kHz grid packs several carriers into one 156 kHz channelizer bin and the
+  polyphase bank hard-rejected any second tap per bin. The channelizer now lets
+  taps share a bin — each already runs its own fine-tune NCO + resampler off its
+  residual offset, so they decode independently and their narrow receivers reject
+  in-band neighbours. The auto strategy keeps high tap counts on the channelizer
+  (benchmarked ~5.6× lighter than a per-tap DDC at this scale) and a new
+  span-aware DDC path stays available for explicit small-fleet wide-span layouts.
+- **Web Plots follow the voice channel on wideband SDRs.** With Hold off, the
+  Plots panels (Mixer, Symbol Scope, Tuning, Constellation, Eye Diagram,
+  Histogram) follow the active call by matching its `device_serial` to the
+  selected SDR. On a wideband SDR the call runs on a virtual voice tap
+  (`wb:<parent>:tap-N`) while the selector lists the parent device, so the match
+  never fired and the view stayed pinned to the control channel. The follow
+  filter now resolves a tap serial back to its parent; direct-dongle serials pass
+  through unchanged.
 
 ## [v0.5.3] — 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.3
+VERSION=v0.5.4
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.3" -%}
+  {%- assign ver = "v0.5.4" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.4.md
+++ b/docs/announcements/v0.5.4.md
@@ -1,0 +1,49 @@
+# GopherTrunk v0.5.4 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.4 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.4
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.4 — dense wideband plans (70-channel DMR on one SDR) now host instead of crashing, talkgroups auto-discover from control-channel grants, gain:auto guidance for multi-tap wideband front ends, and an honest gate on the unverified Motorola talker-alias cipher
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.4 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.5.3:**
+
+* **Dense wideband plans no longer crash at init.** A 70-channel DMR config on a single 10 MS/s wideband SDR used to kill daemon init with "two tap offsets fall in the same channelizer bin" — a DMR repeater plan on a 12.5 kHz grid packs several carriers into one 156 kHz channelizer bin. The polyphase channelizer now lets taps share a bin and decode independently (each runs its own fine-tune NCO + resampler), so a dense multi-repeater plan hosts cleanly.
+* **Talkgroups auto-discover from control-channel grants.** Start with an empty CSV and the roster fills in from live traffic: each talkgroup is catalogued the first time it's granted on the control channel (the trunk-recorder behaviour folks asked for). Discovered entries are tagged and never silently widen a curated scan list — you opt them into scanning from the UI.
+* **`gain: "auto"` guidance for multi-tap wideband front ends** (#749). A single fixed gain on a shared front end can't serve sites of differing strength — GopherTrunk now WARNs when a `role: wideband` dongle hosting multiple channels is pinned to a manual gain, and the docs/config recommend AGC so weak co-tenant sites clear the ADC floor. Plus a verified capture sample-rate hint (#771): >4 MS/s on a narrowband decode can degrade in-channel SNR via front-end phase noise — aim for ~2.4–2.5 MS/s on control-channel roles.
+* **Web Plots follow the voice channel on wideband SDRs**, and the **unverified Motorola talker-alias cipher is now gated** (#773) — with no ground-truth to verify the table, an alias is reported reliable only when the cipher is verified, so a possibly-wrong table can never surface a fabricated name.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.4
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.4 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.5.3:**
+- **Dense wideband plans no longer crash at init** — a 70-channel DMR config on one 10 MS/s SDR used to die on a channelizer-bin collision; the polyphase channelizer now lets several 12.5 kHz carriers share a bin and decode independently.
+- **Talkgroups auto-discover from control-channel grants** — start with an empty CSV and the roster fills in from live traffic; discovered entries never silently widen a curated scan list.
+- **`gain: "auto"` guidance for multi-tap wideband front ends** (#749) — a shared front end can't serve sites of differing strength on one fixed gain; GT now WARNs and the docs recommend AGC. Plus a capture sample-rate hint (#771): keep narrowband control-channel captures around ~2.4–2.5 MS/s.
+- **Web Plots follow the voice channel on wideband SDRs**, and the **unverified Motorola talker-alias cipher is gated** (#773) so a possibly-wrong table can't surface a fabricated name.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.4>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
Promote the new [v0.5.4] — 2026-06-26 CHANGELOG section covering the
v0.5.4 contents: dense wideband plans (70-channel DMR on a single
10 MS/s SDR) now host on the polyphase channelizer instead of crashing
init on a bin collision; talkgroups auto-discover from control-channel
grants; the verified capture sample-rate guidance for narrowband decode
(#771); gain: "auto" guidance for multi-tap wideband front ends (#749);
a P25 web-plots fix that follows the voice channel on wideband SDRs; and
an honest gate on the unverified Motorola talker-alias cipher (#773).

Bump the README quick-start VERSION and the latest-version.html fallback
tag to v0.5.4, and add the v0.5.4 social-announcement drafts.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FzApJg6AHP5GpCicXgeUD3