### PR TITLE
wbvoice: span-aware voice-tap DDC so outer wideband grants tune

### DIFF
--- a/internal/dsp/tuner/channelizerbank.go
+++ b/internal/dsp/tuner/channelizerbank.go
@@ -40,6 +40,14 @@ type ChannelizerBank struct {
 	bins [][]complex64 // reused channelizer output buffer
 
 	taps []*channelizerTap
+
+	// pool, when non-nil, runs the per-tap fine-tune loop across worker
+	// goroutines. Each tap owns its NCO / resampler / scratch buffers and reads
+	// the shared bins read-only, so taps within one Process call are
+	// independent; the pool barriers before Process returns so the caller's
+	// post-Process reads (and the next chunk) never overlap a running tap. Nil
+	// ⇒ the serial loop, byte-identical to the pre-pool path. See EnableWorkers.
+	pool *tapPool
 }
 
 type channelizerTap struct {
@@ -141,8 +149,48 @@ func (b *ChannelizerBank) binCenterHz(binIdx int) float64 {
 	return float64(binIdx-b.channels) * b.binRateHz
 }
 
+// EnableWorkers parallelizes the per-tap fine-tune loop across up to workers
+// goroutines. It is a no-op (leaving the serial path) when workers <= 1 or the
+// tap count is below parallelTapThreshold, where the barrier overhead would
+// outweigh the work. Call once after all AddTap calls and before the first
+// Process; the tap set is fixed afterwards (the Bank contract forbids dynamic
+// add/remove), so the shard layout is computed once. Call Close to stop the
+// workers when the bank is retired.
+func (b *ChannelizerBank) EnableWorkers(workers int) {
+	if workers <= 1 || len(b.taps) < parallelTapThreshold {
+		return
+	}
+	b.pool = newTapPool(len(b.taps), workers)
+}
+
+// Close stops the worker pool, if any. Safe to call on a bank that never
+// enabled workers, and idempotent.
+func (b *ChannelizerBank) Close() {
+	if b.pool != nil {
+		b.pool.close()
+	}
+}
+
+// processTap runs one tap's fine-tune chain over its channelizer bin: NCO mix to
+// remove the residual offset, rational resample to the output rate, then sink.
+// It touches only this tap's own NCO / resampler / scratch buffers and reads
+// b.bins read-only, so distinct taps may run concurrently (see EnableWorkers).
+func (b *ChannelizerBank) processTap(t *channelizerTap) {
+	bin := b.bins[t.binIdx]
+	if cap(t.mixBuf) < len(bin) {
+		t.mixBuf = make([]complex64, len(bin))
+	} else {
+		t.mixBuf = t.mixBuf[:len(bin)]
+	}
+	mixInto(t.mixBuf, bin, t.nco)
+	t.outBuf = t.resampler.Process(t.outBuf, t.mixBuf)
+	t.sink(t.outBuf)
+}
+
 // Process drives the shared channelizer once and dispatches each tap's
-// bin into its fine-tune chain.
+// bin into its fine-tune chain. With a worker pool enabled the per-tap loop
+// fans out across goroutines and barriers before returning; otherwise it runs
+// serially, byte-identical to the pre-pool path.
 func (b *ChannelizerBank) Process(src []complex64) {
 	if len(src) == 0 {
 		for _, t := range b.taps {
@@ -151,16 +199,12 @@ func (b *ChannelizerBank) Process(src []complex64) {
 		return
 	}
 	b.bins = b.ch.Process(b.bins, src)
+	if b.pool != nil {
+		b.pool.run(func(i int) { b.processTap(b.taps[i]) })
+		return
+	}
 	for _, t := range b.taps {
-		bin := b.bins[t.binIdx]
-		if cap(t.mixBuf) < len(bin) {
-			t.mixBuf = make([]complex64, len(bin))
-		} else {
-			t.mixBuf = t.mixBuf[:len(bin)]
-		}
-		mixInto(t.mixBuf, bin, t.nco)
-		t.outBuf = t.resampler.Process(t.outBuf, t.mixBuf)
-		t.sink(t.outBuf)
+		b.processTap(t)
 	}
 }
 

--- a/internal/dsp/tuner/pool.go
+++ b/internal/dsp/tuner/pool.go
@@ -1,0 +1,105 @@
+package tuner
+
+import (
+	"runtime"
+	"sync"
+)
+
+// parallelTapThreshold is the smallest tap count worth parallelizing. Below it
+// the barrier + scheduling overhead outweighs the per-tap fine-tune work and the
+// serial loop is faster, so small plans stay serial and byte-identical to the
+// pre-pool path. Dense wideband plans (the 70-DMR case) sit well above it.
+const parallelTapThreshold = 16
+
+// DefaultTapWorkers sizes the per-tap worker pool from the host CPU count,
+// leaving headroom for the SDR read loop, the wideband pump goroutine, and the
+// downstream decoders. It is capped because the shared channelizer FFT runs
+// serially before the parallel region, so past a point more workers only add
+// barrier contention without shortening the critical path.
+func DefaultTapWorkers() int {
+	switch n := runtime.NumCPU() - 2; {
+	case n < 1:
+		return 1
+	case n > 8:
+		return 8
+	default:
+		return n
+	}
+}
+
+// tapPool runs a per-tap function over a fixed set of taps across persistent
+// worker goroutines, with a reusable barrier so there is no per-chunk goroutine
+// spawn. The taps are sharded into contiguous static ranges once at
+// construction (the tap set is fixed after AddTap — dynamic add/remove is out of
+// scope per the Bank contract); each round publishes the work function and
+// releases every worker, then waits for all shards before returning, so the
+// caller's post-Process reads see a fully-settled result and the next round's
+// function write can't race a still-running worker.
+type tapPool struct {
+	fn       func(i int)
+	starts   []chan struct{}
+	bounds   [][2]int
+	wg       sync.WaitGroup
+	quit     chan struct{}
+	quitOnce sync.Once
+}
+
+// newTapPool spawns workers goroutines sharding [0,total). workers is clamped to
+// total so no shard is empty; callers gate creation on total >= a threshold.
+func newTapPool(total, workers int) *tapPool {
+	if workers > total {
+		workers = total
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	p := &tapPool{
+		starts: make([]chan struct{}, workers),
+		bounds: make([][2]int, workers),
+		quit:   make(chan struct{}),
+	}
+	// Even contiguous split: the first `rem` shards take one extra tap.
+	base, rem := total/workers, total%workers
+	lo := 0
+	for w := 0; w < workers; w++ {
+		sz := base
+		if w < rem {
+			sz++
+		}
+		p.bounds[w] = [2]int{lo, lo + sz}
+		lo += sz
+		p.starts[w] = make(chan struct{}, 1)
+		go p.worker(w)
+	}
+	return p
+}
+
+func (p *tapPool) worker(w int) {
+	lo, hi := p.bounds[w][0], p.bounds[w][1]
+	for {
+		select {
+		case <-p.quit:
+			return
+		case <-p.starts[w]:
+			for i := lo; i < hi; i++ {
+				p.fn(i)
+			}
+			p.wg.Done()
+		}
+	}
+}
+
+// run executes fn(i) for every tap index across the workers and blocks until all
+// have finished. The channel send/receive on each worker's start channel
+// publishes the fn write (happens-before), and wg.Wait pairs with every Done.
+func (p *tapPool) run(fn func(i int)) {
+	p.fn = fn
+	p.wg.Add(len(p.starts))
+	for _, s := range p.starts {
+		s <- struct{}{}
+	}
+	p.wg.Wait()
+}
+
+// close stops the workers. Idempotent.
+func (p *tapPool) close() { p.quitOnce.Do(func() { close(p.quit) }) }

--- a/internal/dsp/tuner/pool_test.go
+++ b/internal/dsp/tuner/pool_test.go
@@ -1,0 +1,152 @@
+package tuner
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// buildDenseChannelizer returns a ChannelizerBank with the 70-DMR stress-test
+// plan's taps registered, each sink appending its output to a per-tap capture
+// slice. Returns the bank and the capture slices (indexed by tap order).
+func buildDenseChannelizer() (*ChannelizerBank, [][]complex64) {
+	offs := benchDenseOffsets()
+	bank := NewChannelizerBank(10_000_000, 48_000, 0.05, 64, 16, 9.0)
+	caps := make([][]complex64, len(offs))
+	for i, o := range offs {
+		i := i
+		if err := bank.AddTap(o, func(out []complex64) {
+			caps[i] = append(caps[i], out...)
+		}); err != nil {
+			panic(err)
+		}
+	}
+	return bank, caps
+}
+
+// TestChannelizerWorkersDeterministic is the Fix-C correctness regression: the
+// parallel per-tap path must produce bit-identical output to the serial path.
+// Taps are independent (each owns its NCO/resampler/buffers, reads bins
+// read-only), so the result must not depend on whether they run on one
+// goroutine or many.
+func TestChannelizerWorkersDeterministic(t *testing.T) {
+	serial, serialOut := buildDenseChannelizer()
+	parallel, parallelOut := buildDenseChannelizer()
+	parallel.EnableWorkers(8)
+	defer parallel.Close()
+	if parallel.pool == nil {
+		t.Fatalf("EnableWorkers(8) left the bank serial; want a pool for %d taps", len(parallel.taps))
+	}
+
+	// Feed both banks the identical wideband stream, several chunks so the
+	// resamplers settle and accumulate plenty of output.
+	gen1 := newToneGen(10_000_000, 0.2, benchDenseOffsets()...)
+	gen2 := newToneGen(10_000_000, 0.2, benchDenseOffsets()...)
+	for c := 0; c < 20; c++ {
+		chunk1 := gen1.Next(8192)
+		chunk2 := gen2.Next(8192)
+		serial.Process(chunk1)
+		parallel.Process(chunk2)
+	}
+
+	if len(serialOut) != len(parallelOut) {
+		t.Fatalf("tap count mismatch: serial %d, parallel %d", len(serialOut), len(parallelOut))
+	}
+	for i := range serialOut {
+		s, p := serialOut[i], parallelOut[i]
+		if len(s) != len(p) {
+			t.Fatalf("tap %d output length: serial %d, parallel %d", i, len(s), len(p))
+		}
+		for j := range s {
+			if s[j] != p[j] {
+				t.Fatalf("tap %d sample %d differs: serial %v, parallel %v", i, j, s[j], p[j])
+			}
+		}
+	}
+}
+
+// TestEnableWorkersBelowThresholdStaysSerial confirms a small plan keeps the
+// byte-identical serial path (no pool created).
+func TestEnableWorkersBelowThresholdStaysSerial(t *testing.T) {
+	bank := NewChannelizerBank(2_400_000, 48_000, 0.05, 16, 16, 9.0)
+	for _, o := range []float64{-200_000, 0, 200_000} {
+		if err := bank.AddTap(o, func([]complex64) {}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	bank.EnableWorkers(8)
+	if bank.pool != nil {
+		t.Errorf("EnableWorkers created a pool for %d taps (< threshold %d)", len(bank.taps), parallelTapThreshold)
+	}
+	// Close must be safe with no pool.
+	bank.Close()
+}
+
+// TestTapPoolRunsEveryIndexOnce checks the pool's shard layout covers [0,total)
+// exactly once across an uneven split, with concurrent workers.
+func TestTapPoolRunsEveryIndexOnce(t *testing.T) {
+	const total = 71
+	p := newTapPool(total, 8)
+	defer p.close()
+
+	var mu sync.Mutex
+	counts := make([]int, total)
+	p.run(func(i int) {
+		mu.Lock()
+		counts[i]++
+		mu.Unlock()
+	})
+	for i, c := range counts {
+		if c != 1 {
+			t.Errorf("index %d ran %d times, want 1", i, c)
+		}
+	}
+
+	// A second round must rerun every index (reusable barrier, no re-spawn).
+	for i := range counts {
+		counts[i] = 0
+	}
+	p.run(func(i int) {
+		mu.Lock()
+		counts[i]++
+		mu.Unlock()
+	})
+	for i, c := range counts {
+		if c != 1 {
+			t.Errorf("round 2 index %d ran %d times, want 1", i, c)
+		}
+	}
+}
+
+func TestDefaultTapWorkers(t *testing.T) {
+	got := DefaultTapWorkers()
+	if got < 1 {
+		t.Errorf("DefaultTapWorkers = %d, want >= 1", got)
+	}
+	if got > 8 {
+		t.Errorf("DefaultTapWorkers = %d, want <= 8 (cap)", got)
+	}
+	if want := runtime.NumCPU() - 2; want >= 1 && want <= 8 && got != want {
+		t.Errorf("DefaultTapWorkers = %d, want %d (NumCPU-2)", got, want)
+	}
+}
+
+// BenchmarkDense71PolyphaseWorkers measures the parallel per-tap path against
+// the serial BenchmarkDense71Polyphase so the speedup on the 70-DMR plan is
+// visible. Same 8192-sample chunk and ~819 µs real-time budget.
+func BenchmarkDense71PolyphaseWorkers(b *testing.B) {
+	offs := benchDenseOffsets()
+	bank := NewChannelizerBank(10_000_000, 48_000, 0.05, 64, 16, 9.0)
+	for _, o := range offs {
+		if err := bank.AddTap(o, func([]complex64) {}); err != nil {
+			b.Fatalf("AddTap(%.0f): %v", o, err)
+		}
+	}
+	bank.EnableWorkers(DefaultTapWorkers())
+	defer bank.Close()
+	chunk := newToneGen(10_000_000, 0.2, offs...).Next(8192)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		bank.Process(chunk)
+	}
+}

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -105,6 +105,11 @@ const (
 // the config validator uses to reject out-of-band channels.
 const guardFrac = 0.05
 
+// sampleRateAdvisoryFactor is how far above the plan's minimum required rate the
+// capture rate must sit before New advises lowering it. 1.5× leaves comfortable
+// headroom (front-end roll-off, retune slack) before flagging genuine waste.
+const sampleRateAdvisoryFactor = 1.5
+
 // strategyAutoThreshold is the channel-count cutoff for the "auto"
 // tuner strategy: at or below it, DDCBank wins on simplicity;
 // above it, ChannelizerBank's shared wide-band filter pays off.
@@ -415,6 +420,27 @@ func New(opts Options) (*Engine, error) {
 		offsets[i] = float64(ch.FrequencyHz) - float64(opts.CenterFreqHz)
 		if a := math.Abs(offsets[i]); a > maxAbsOffset {
 			maxAbsOffset = a
+		}
+	}
+
+	// Advise when the capture is materially oversampled for the plan. The DSP
+	// and network cost scale with the capture rate, but the only rate the plan
+	// needs is the one whose usable half-band (rate·(0.5−guard)) covers the
+	// widest channel offset: minRate = maxAbsOffset/(0.5−guard). Running well
+	// above that buys nothing and is a leading cause of the host failing to keep
+	// up (overruns → dropped samples → glitchy audio). Reported config: 71 DMR
+	// carriers spanning ±1.95 MHz captured at 10 MS/s, ~2.4× the ~4.3 MS/s the
+	// span needs. maxAbsOffset==0 (a single centred channel) has no meaningful
+	// minimum, so skip it.
+	if maxAbsOffset > 0 {
+		minRateHz := maxAbsOffset / (0.5 - guardFrac)
+		if float64(opts.SampleRateHz) >= minRateHz*sampleRateAdvisoryFactor {
+			log.Warn("widebandt2: capture is oversampled for the channel plan — the carriers span less than half the captured band, so a lower sdr.sample_rate would cut DSP + network load (and overrun pressure) for no loss of coverage",
+				"serial", opts.Serial,
+				"sample_rate_hz", opts.SampleRateHz,
+				"channel_span_hz", uint64(2*maxAbsOffset),
+				"min_sample_rate_hz", uint64(math.Ceil(minRateHz)),
+			)
 		}
 	}
 

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -516,6 +516,14 @@ func New(opts Options) (*Engine, error) {
 				"serial", opts.Serial, "worst_residual_frac", fmt.Sprintf("%.2f", frac),
 				"clean_threshold", channelizerCleanResidualFrac)
 		}
+		// Fan the per-tap fine-tune loop out across CPU cores. A dense plan's
+		// 71 NCO+resampler+receiver chains are the bulk of the per-chunk cost
+		// and are independent (each tap owns its state, reads the shared bins
+		// read-only), so parallelizing them is what lets the host keep up with
+		// the live pump at high sample rates instead of back-pressuring the SDR
+		// into overruns. No-op below parallelTapThreshold taps. Run's defer
+		// closes the pool on teardown.
+		cb.EnableWorkers(tuner.DefaultTapWorkers())
 	}
 	return engine, nil
 }
@@ -756,10 +764,12 @@ func (e *Engine) DMRTier3ControlChannel(freqHz uint32) *tier3.ControlChannel {
 }
 
 // Run programs the dongle's centre frequency, opens its IQ stream,
-// and pumps chunks through the tuner bank until ctx cancels. The
-// per-tap fan-out and per-channel receivers / state machines run
-// inline on this goroutine — they are not concurrent with each
-// other, so chunk ordering is preserved.
+// and pumps chunks through the tuner bank until ctx cancels. Within a
+// chunk the per-tap fine-tune chains may run concurrently across worker
+// goroutines (see ChannelizerBank.EnableWorkers), but bank.Process
+// barriers before returning, so successive chunks — and the post-Process
+// diagnostics below — never overlap a running tap and each receiver still
+// sees its chunks in order.
 func (e *Engine) Run(ctx context.Context) error {
 	if err := e.device.SetCenterFreq(e.centerHz); err != nil {
 		return fmt.Errorf("widebandt2: SetCenterFreq %d Hz: %w", e.centerHz, err)
@@ -778,6 +788,11 @@ func (e *Engine) Run(ctx context.Context) error {
 	// don't linger in Prometheus after the engine stops (issue #749).
 	if e.metrics != nil {
 		defer e.metrics.ClearWidebandInput(e.serial)
+	}
+	// Stop the bank's tap worker pool (if any) on teardown so its goroutines
+	// don't outlive the engine when an SDR is retuned/recreated.
+	if c, ok := e.bank.(interface{ Close() }); ok {
+		defer c.Close()
 	}
 	for {
 		select {

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -167,6 +168,75 @@ func TestEngineNewRejectsOutOfBandChannel(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error for out-of-band channel")
 	}
+}
+
+// warnCapture records WARN-level log messages so tests can assert on the
+// operator-facing advisories New emits.
+type warnCapture struct{ msgs []string }
+
+func (h *warnCapture) Enabled(context.Context, slog.Level) bool { return true }
+func (h *warnCapture) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h *warnCapture) WithGroup(string) slog.Handler            { return h }
+func (h *warnCapture) Handle(_ context.Context, r slog.Record) error {
+	if r.Level == slog.LevelWarn {
+		h.msgs = append(h.msgs, r.Message)
+	}
+	return nil
+}
+func (h *warnCapture) sawAdvisory() bool {
+	for _, m := range h.msgs {
+		if strings.Contains(m, "oversampled for the channel plan") {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEngineNewAdvisesOversampledCapture is the Fix-D regression: a plan whose
+// carriers span far less than half the captured band should draw a startup WARN
+// suggesting a lower sdr.sample_rate (the durable cure for the host-can't-keep-up
+// overruns), and a right-sized capture should stay silent. Mirrors the reported
+// config: 71 DMR carriers spanning ±1.95 MHz captured at 10 MS/s.
+func TestEngineNewAdvisesOversampledCapture(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	// Two outer carriers of the reported plan span ≈ ±1.9 MHz of centre, so the
+	// span needs ≈ 4.25 MS/s; everything above ~6.4 MS/s is flagged.
+	const center = 441_700_000
+	channels := []ChannelConfig{
+		{FrequencyHz: 439_787_500, SystemName: "x"}, // −1.9125 MHz
+		{FrequencyHz: 443_600_000, SystemName: "x"}, // +1.9000 MHz
+	}
+
+	t.Run("oversampled warns", func(t *testing.T) {
+		h := &warnCapture{}
+		_, err := New(Options{
+			Log: slog.New(h), Device: newMockDevice(nil), Bus: bus,
+			SampleRateHz: 10_000_000, CenterFreqHz: center, TunerStrategy: "polyphase",
+			Channels: channels, Systems: []trunking.System{t2System("x")},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !h.sawAdvisory() {
+			t.Errorf("no oversampled-capture advisory at 10 MS/s for a ±1.9 MHz plan; got WARNs %q", h.msgs)
+		}
+	})
+
+	t.Run("right-sized is silent", func(t *testing.T) {
+		h := &warnCapture{}
+		_, err := New(Options{
+			Log: slog.New(h), Device: newMockDevice(nil), Bus: bus,
+			SampleRateHz: 5_000_000, CenterFreqHz: center, TunerStrategy: "polyphase",
+			Channels: channels, Systems: []trunking.System{t2System("x")},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if h.sawAdvisory() {
+			t.Errorf("advised lowering rate for a right-sized 5 MS/s capture; got WARNs %q", h.msgs)
+		}
+	})
 }
 
 func TestEngineStrategyAuto(t *testing.T) {

--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -584,9 +584,96 @@ func (d *device) clearStreamConns() {
 	}
 }
 
-func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int32, out chan<- []complex64) {
+// soapyStatusOverflow is SoapySDR's SOAPY_SDR_OVERFLOW code, carried in a stream
+// datagram's elems field when the device dropped samples because the host wasn't
+// draining the stream fast enough. The other negative codes (timeout, stream
+// error, corruption…) are not the operator-actionable "host too slow" signal, so
+// they stay at DEBUG.
+const soapyStatusOverflow = -4
+
+// overrunWarnInterval throttles the operator-facing overrun WARN so a sustained
+// overrun storm logs a periodic summary with counts instead of flooding one line
+// per dropped datagram. Matches the 5 s cadence the wideband diagnostics use.
+const overrunWarnInterval = 5 * time.Second
+
+// overrunThrottle surfaces SDR sample loss to the operator at WARN, rate-limited.
+// It folds two sources into one summary: device-side SOAPY_SDR_OVERFLOW datagrams
+// (the radio dropped samples) and host-side local drops (streamLoop shed a chunk
+// because the DSP consumer fell behind, see sendOrDrop). Both mean the same thing
+// operationally — the host can't keep up with the configured rate — and both used
+// to be invisible (overflow logged only at DEBUG; local back-pressure stalled the
+// reader instead). It is not safe for concurrent use; streamLoop owns one.
+type overrunThrottle struct {
+	log      *slog.Logger
+	addr     string
+	interval time.Duration
+	now      func() time.Time
+
+	lastWarn     time.Time
+	devOverflows uint64 // SOAPY_SDR_OVERFLOW datagrams since the last summary
+	hostDrops    uint64 // chunks dropped locally since the last summary
+}
+
+func newOverrunThrottle(log *slog.Logger, addr string) *overrunThrottle {
+	return &overrunThrottle{log: log, addr: addr, interval: overrunWarnInterval, now: time.Now}
+}
+
+func (t *overrunThrottle) deviceOverflow() { t.devOverflows++; t.maybeWarn(false) }
+func (t *overrunThrottle) hostDrop()       { t.hostDrops++; t.maybeWarn(false) }
+
+// maybeWarn emits the summary WARN when the throttle interval has elapsed (or
+// immediately on the first event), then clears the running counts. force ignores
+// the interval — used on teardown to flush a trailing batch that would otherwise
+// never be reported.
+func (t *overrunThrottle) maybeWarn(force bool) {
+	if t.devOverflows == 0 && t.hostDrops == 0 {
+		return
+	}
+	now := t.now()
+	if !force && !t.lastWarn.IsZero() && now.Sub(t.lastWarn) < t.interval {
+		return
+	}
+	t.log.Warn("soapyremote: SDR overruns — the host can't keep up with the configured sample rate, so samples are being dropped and decoded audio will glitch. Lower sdr.sample_rate or reduce the channel/tap count.",
+		"addr", t.addr,
+		"device_overflows", t.devOverflows,
+		"host_drops", t.hostDrops,
+	)
+	t.lastWarn = now
+	t.devOverflows = 0
+	t.hostDrops = 0
+}
+
+// sendOrDrop hands samples to the DSP consumer without ever blocking the read
+// loop. A blocked send stalls socket reads and flow-control ACKs, which makes the
+// radio overflow and drop samples in a way that shreds every channel's framing at
+// once. When the bounded out-channel is full instead, we drop the oldest queued
+// chunk (keeping latency low and the data freshest) and count it — one clean local
+// glitch rather than a device-side overrun storm. Returns false only on ctx cancel.
+func (d *device) sendOrDrop(ctx context.Context, out chan []complex64, samples []complex64, t *overrunThrottle) bool {
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case out <- samples:
+			return true
+		default:
+		}
+		// Full: shed the oldest buffered chunk to make room. streamLoop is the
+		// sole producer, so one drop frees a slot and the next send succeeds.
+		select {
+		case <-out:
+			t.hostDrop()
+		default:
+		}
+	}
+}
+
+func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int32, out chan []complex64) {
 	defer close(out)
 	defer d.teardownStream(streamID)
+
+	throttle := newOverrunThrottle(d.log, d.addr)
+	defer throttle.maybeWarn(true) // flush any trailing counts on teardown
 
 	hdr := make([]byte, streamHeaderSize)
 	// Flow-control state: lastRecv tracks the next sequence we expect; lastAck
@@ -636,7 +723,14 @@ func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int
 		}
 		if h.elems < 0 {
 			// Negative elems is a SoapySDR status/error code, not samples.
-			d.log.Debug("soapyremote: stream status code", "addr", d.addr, "code", h.elems)
+			// OVERFLOW means the device dropped samples because we read too
+			// slowly — surface it to the operator (rate-limited); other codes
+			// stay at DEBUG.
+			if h.elems == soapyStatusOverflow {
+				throttle.deviceOverflow()
+			} else {
+				d.log.Debug("soapyremote: stream status code", "addr", d.addr, "code", h.elems)
+			}
 			continue
 		}
 		if payloadLen == 0 {
@@ -646,10 +740,8 @@ func (d *device) streamLoop(ctx context.Context, dataConn net.Conn, streamID int
 		if len(samples) == 0 {
 			continue
 		}
-		select {
-		case <-ctx.Done():
+		if !d.sendOrDrop(ctx, out, samples, throttle) {
 			return
-		case out <- samples:
 		}
 	}
 }

--- a/internal/sdr/soapyremote/overrun_test.go
+++ b/internal/sdr/soapyremote/overrun_test.go
@@ -1,0 +1,205 @@
+package soapyremote
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// capHandler is a minimal slog.Handler that records WARN+ messages and the
+// integer attributes we assert on, so the overrun throttle's rate-limited
+// summaries can be inspected without a real socket.
+type capHandler struct {
+	records []capRecord
+}
+
+type capRecord struct {
+	level    slog.Level
+	msg      string
+	devOver  int64
+	hostDrop int64
+}
+
+func (h *capHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *capHandler) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h *capHandler) WithGroup(string) slog.Handler            { return h }
+func (h *capHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := capRecord{level: r.Level, msg: r.Message}
+	asInt := func(v slog.Value) int64 {
+		if v.Kind() == slog.KindUint64 {
+			return int64(v.Uint64())
+		}
+		return v.Int64()
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "device_overflows":
+			rec.devOver = asInt(a.Value)
+		case "host_drops":
+			rec.hostDrop = asInt(a.Value)
+		}
+		return true
+	})
+	h.records = append(h.records, rec)
+	return nil
+}
+
+func (h *capHandler) warns() []capRecord {
+	var w []capRecord
+	for _, r := range h.records {
+		if r.level == slog.LevelWarn {
+			w = append(w, r)
+		}
+	}
+	return w
+}
+
+// TestOverrunThrottleRateLimits is the visibility regression: a sustained
+// overrun storm must surface as a periodic WARN with running counts (it used to
+// be a silent per-datagram DEBUG line), and it must NOT log one line per drop.
+func TestOverrunThrottleRateLimits(t *testing.T) {
+	h := &capHandler{}
+	now := time.Unix(0, 0)
+	tr := &overrunThrottle{
+		log:      slog.New(h),
+		addr:     "test",
+		interval: 5 * time.Second,
+		now:      func() time.Time { return now },
+	}
+
+	// First overflow logs immediately so the operator sees it without delay.
+	tr.deviceOverflow()
+	if got := len(h.warns()); got != 1 {
+		t.Fatalf("after first overflow: %d WARNs, want 1", got)
+	}
+	if w := h.warns()[0]; w.devOver != 1 {
+		t.Errorf("first WARN device_overflows = %d, want 1", w.devOver)
+	}
+
+	// A burst within the interval accumulates silently (no new WARNs).
+	for i := 0; i < 50; i++ {
+		tr.deviceOverflow()
+	}
+	for i := 0; i < 10; i++ {
+		tr.hostDrop()
+	}
+	if got := len(h.warns()); got != 1 {
+		t.Fatalf("during interval: %d WARNs, want 1 (throttled)", got)
+	}
+
+	// After the interval elapses the next event flushes the accumulated batch.
+	now = now.Add(6 * time.Second)
+	tr.deviceOverflow()
+	w := h.warns()
+	if len(w) != 2 {
+		t.Fatalf("after interval: %d WARNs, want 2", len(w))
+	}
+	// 50 mid-interval + 1 that triggered the flush = 51 overflows, 10 host drops.
+	if w[1].devOver != 51 || w[1].hostDrop != 10 {
+		t.Errorf("second WARN counts = (overflows %d, drops %d), want (51, 10)", w[1].devOver, w[1].hostDrop)
+	}
+}
+
+// TestOverrunThrottleFlush verifies a trailing batch that never reaches the
+// interval is still reported on teardown (maybeWarn(true)).
+func TestOverrunThrottleFlush(t *testing.T) {
+	h := &capHandler{}
+	now := time.Unix(100, 0)
+	tr := &overrunThrottle{
+		log:      slog.New(h),
+		addr:     "test",
+		interval: 5 * time.Second,
+		now:      func() time.Time { return now },
+	}
+	tr.deviceOverflow()  // logs immediately (count reset)
+	tr.deviceOverflow()  // within interval, accumulates silently
+	tr.hostDrop()        // ditto
+	if got := len(h.warns()); got != 1 {
+		t.Fatalf("before flush: %d WARNs, want 1", got)
+	}
+	tr.maybeWarn(true) // teardown flush ignores the interval
+	w := h.warns()
+	if len(w) != 2 {
+		t.Fatalf("after flush: %d WARNs, want 2", len(w))
+	}
+	if w[1].devOver != 1 || w[1].hostDrop != 1 {
+		t.Errorf("flush WARN counts = (overflows %d, drops %d), want (1, 1)", w[1].devOver, w[1].hostDrop)
+	}
+
+	// A flush with nothing pending is a no-op (no spurious teardown WARN).
+	tr.maybeWarn(true)
+	if got := len(h.warns()); got != 2 {
+		t.Errorf("empty flush logged: %d WARNs, want 2", got)
+	}
+}
+
+// TestSendOrDropNeverBlocks is the drop-oldest regression: when the DSP consumer
+// stalls and the bounded channel fills, the read loop must NOT block (a blocked
+// reader stalls ACKs and drives device-side overruns). sendOrDrop must shed the
+// oldest chunk, count it, and keep the freshest data — returning promptly.
+func TestSendOrDropNeverBlocks(t *testing.T) {
+	d := &device{addr: "test"}
+	h := &capHandler{}
+	tr := &overrunThrottle{log: slog.New(h), addr: "test", interval: time.Hour, now: time.Now}
+	out := make(chan []complex64, 2) // tiny bounded channel, never drained
+
+	chunk := func(tag float32) []complex64 { return []complex64{complex(tag, 0)} }
+
+	// Fill the channel to capacity, then push two more with no consumer.
+	done := make(chan bool, 1)
+	go func() {
+		ok := d.sendOrDrop(context.Background(), out, chunk(0), tr) &&
+			d.sendOrDrop(context.Background(), out, chunk(1), tr) &&
+			d.sendOrDrop(context.Background(), out, chunk(2), tr) && // channel now full
+			d.sendOrDrop(context.Background(), out, chunk(3), tr) && // drops oldest (0)
+			d.sendOrDrop(context.Background(), out, chunk(4), tr) //   drops oldest (1)
+		done <- ok
+	}()
+
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Fatal("sendOrDrop returned false without ctx cancel")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendOrDrop blocked with a full channel — the read loop would stall the radio")
+	}
+
+	if tr.hostDrops != 2 {
+		t.Errorf("host_drops = %d, want 2 (two oldest chunks shed)", tr.hostDrops)
+	}
+	// The channel retains exactly its capacity, holding the two freshest chunks
+	// (3 then 4) in FIFO order — the stale 0 and 1 were the ones shed.
+	if len(out) != cap(out) {
+		t.Fatalf("channel holds %d, want %d (full)", len(out), cap(out))
+	}
+	if v := real((<-out)[0]); v != 3 {
+		t.Errorf("oldest retained chunk = %v, want 3 (chunks 0 and 1 should have been dropped)", v)
+	}
+	if v := real((<-out)[0]); v != 4 {
+		t.Errorf("newest retained chunk = %v, want 4", v)
+	}
+}
+
+// TestSendOrDropCtxCancelUnblocks confirms a cancelled context lets the loop
+// unwind even when the channel is full (no consumer will ever drain it).
+func TestSendOrDropCtxCancelUnblocks(t *testing.T) {
+	d := &device{addr: "test"}
+	tr := &overrunThrottle{log: slog.New(&capHandler{}), addr: "test", interval: time.Hour, now: time.Now}
+	out := make(chan []complex64) // unbuffered, no consumer ⇒ send never ready
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan bool, 1)
+	go func() { done <- d.sendOrDrop(ctx, out, []complex64{0}, tr) }()
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("sendOrDrop returned true on a cancelled ctx with no consumer")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendOrDrop did not unwind on ctx cancel")
+	}
+}

--- a/internal/sdr/soapyremote/overrun_test.go
+++ b/internal/sdr/soapyremote/overrun_test.go
@@ -112,9 +112,9 @@ func TestOverrunThrottleFlush(t *testing.T) {
 		interval: 5 * time.Second,
 		now:      func() time.Time { return now },
 	}
-	tr.deviceOverflow()  // logs immediately (count reset)
-	tr.deviceOverflow()  // within interval, accumulates silently
-	tr.hostDrop()        // ditto
+	tr.deviceOverflow() // logs immediately (count reset)
+	tr.deviceOverflow() // within interval, accumulates silently
+	tr.hostDrop()       // ditto
 	if got := len(h.warns()); got != 1 {
 		t.Fatalf("before flush: %d WARNs, want 1", got)
 	}

--- a/internal/sdr/wbvoice/tuner.go
+++ b/internal/sdr/wbvoice/tuner.go
@@ -69,18 +69,24 @@ type VirtualTuner struct {
 	widebandHz uint32
 	inRateHz   uint32
 
-	// actualOutHz is the per-tap rate the DDC *actually* emits for this
-	// input rate, which is not always exactly NarrowbandRateHz: the
+	// actualOutHz is the per-tap rate the DDC *actually* emits for the
+	// current target, which is not always exactly NarrowbandRateHz: the
 	// rational resampler can only hit the nearest representable L/M ratio,
-	// so e.g. an input rate whose 48000/in ratio trips the resampler's
+	// so e.g. a reduced rate whose 48000/red ratio trips the resampler's
 	// L≤64 / M≤8192 caps lands a fraction of a percent off 48 kHz (issue
-	// #550). Computed once in New from inRateHz alone — the DDC's output
-	// rate is independent of the tap offset — and reported via
-	// SampleRateExactHz so the composer clocks the voice symbol-recovery
-	// loop at the true rate instead of the nominal target. A nominal-rate
-	// symbol clock drifts off the true symbol phase and periodically slips,
-	// which surfaces as voice spikes/glitches.
-	actualOutHz float64
+	// #550). It is reported via SampleRateExactHz so the composer clocks the
+	// voice symbol-recovery loop at the true rate instead of the nominal
+	// target; a nominal-rate symbol clock drifts off the true symbol phase
+	// and periodically slips, which surfaces as voice spikes/glitches.
+	//
+	// The exact rate depends on how far the shared decimator halves the
+	// stream, which the span-aware bank sizes from the tap offset (a far
+	// tap keeps the band wider, so it decimates less and lands a different
+	// fractional rate). The offset isn't known until SetCenterFreq, so this
+	// is (re)computed there from the same NewDDCBankForSpan args StreamIQ
+	// builds the live bank with, and guarded by tunerMu. New seeds it with
+	// the no-offset default for the pre-SetCenterFreq window.
+	actualOutHz float64 // guarded by tunerMu
 
 	tunerMu  sync.Mutex
 	targetHz uint32 // 0 ⇒ no SetCenterFreq yet
@@ -130,12 +136,12 @@ func New(opts Options) (*VirtualTuner, error) {
 	if log == nil {
 		log = slog.Default()
 	}
-	// Pre-compute the rate the DDC will actually emit for this input rate.
-	// A no-tap DDCBank only reduces the L/M ratio and stores it; the
-	// expensive Kaiser FIR prototype is built per-tap in AddTap, which we
-	// don't call here — so this is cheap and allocation-light, and it
-	// matches the args StreamIQ uses to build the live bank, so the rate
-	// reported here is exactly the rate the stream is clocked at.
+	// Seed the reported rate with the no-offset default for the window
+	// before SetCenterFreq lands. SetCenterFreq recomputes it from the tap
+	// offset (the span-aware bank decimates by an amount that depends on the
+	// offset, see actualOutHz). A no-tap DDCBank only reduces the L/M ratio
+	// and stores it; the expensive Kaiser FIR prototype is built per-tap in
+	// AddTap, which we don't call here — so this is cheap and allocation-light.
 	actualOutHz := tuner.NewDDCBank(
 		float64(opts.SDRSampleRateHz), float64(NarrowbandRateHz), GuardFrac,
 	).OutputRateHz()
@@ -162,7 +168,11 @@ func (v *VirtualTuner) Serial() string { return v.serial }
 // off when the resampler can't hit the target exactly (see actualOutHz);
 // callers that clock a symbol-recovery loop should use SampleRateExactHz
 // instead so they don't drift on the fractional part.
-func (v *VirtualTuner) SampleRateHz() uint32 { return uint32(math.Round(v.actualOutHz)) }
+func (v *VirtualTuner) SampleRateHz() uint32 {
+	v.tunerMu.Lock()
+	defer v.tunerMu.Unlock()
+	return uint32(math.Round(v.actualOutHz))
+}
 
 // SampleRateExactHz reports the per-tap rate this source actually emits,
 // with the fractional part preserved. This is the rate the DDC's rational
@@ -171,7 +181,25 @@ func (v *VirtualTuner) SampleRateHz() uint32 { return uint32(math.Round(v.actual
 // from this so the loop tracks the true symbol phase instead of drifting
 // off a rounded nominal — the parity fix the control-channel path already
 // has (issue #550; widebandt2 builds its receivers from OutputRateHz).
-func (v *VirtualTuner) SampleRateExactHz() float64 { return v.actualOutHz }
+func (v *VirtualTuner) SampleRateExactHz() float64 {
+	v.tunerMu.Lock()
+	defer v.tunerMu.Unlock()
+	return v.actualOutHz
+}
+
+// ddcBankFor builds the span-aware single-tap DDC arguments for a target
+// offset. SetCenterFreq (to report the exact rate) and StreamIQ (to build the
+// live stream) both call this so the reported rate is exactly the rate the
+// stream is clocked at. requiredHalf = |offset| keeps the shared decimator
+// from halving past the point where this tap would fall out of band — the same
+// span-awareness the wideband control-channel path uses (widebandt2 sizes its
+// bank from the widest channel offset). Without it the default ±1.1 MHz floor
+// rejects voice grants on the outer carriers of a wideband plan.
+func (v *VirtualTuner) ddcBankFor(offsetHz float64) *tuner.DDCBank {
+	return tuner.NewDDCBankForSpan(
+		float64(v.inRateHz), float64(NarrowbandRateHz), GuardFrac, math.Abs(offsetHz),
+	)
+}
 
 // CanTune reports whether hz lies inside the wideband dongle's usable
 // IQ window. The trunking pool consults this before calling
@@ -199,8 +227,15 @@ func (v *VirtualTuner) SetCenterFreq(hz uint32) error {
 	if !v.CanTune(hz) {
 		return ErrOutOfBand
 	}
+	offset := float64(hz) - float64(v.widebandHz)
+	// Recompute the exact emitted rate for this offset from the same
+	// span-aware bank StreamIQ will build, so the composer clocks symbol
+	// recovery at the true rate (issue #550). The bank build is cheap
+	// (no per-tap Kaiser prototype until AddTap, which we skip here).
+	outHz := v.ddcBankFor(offset).OutputRateHz()
 	v.tunerMu.Lock()
 	v.targetHz = hz
+	v.actualOutHz = outHz
 	v.tunerMu.Unlock()
 	return nil
 }
@@ -228,7 +263,7 @@ func (v *VirtualTuner) StreamIQ(ctx context.Context) (<-chan []complex64, error)
 
 	out := make(chan []complex64, 16)
 
-	bank := tuner.NewDDCBank(float64(v.inRateHz), float64(NarrowbandRateHz), GuardFrac)
+	bank := v.ddcBankFor(offset)
 	if err := bank.AddTap(offset, func(narrow []complex64) {
 		if len(narrow) == 0 {
 			return

--- a/internal/sdr/wbvoice/tuner_test.go
+++ b/internal/sdr/wbvoice/tuner_test.go
@@ -157,6 +157,59 @@ func TestSampleRateExactHzMatchesDDCBank(t *testing.T) {
 	}
 }
 
+// TestStreamIQAcceptsWidebandSpanGrant is the regression for the field report
+// (heavy-overrun DMR archive, 26 Jun): a 71-channel wideband DMR plan on a
+// 10 MS/s capture has voice grants out to ±1.9 MHz of centre. CanTune already
+// advertises the full ±4.5 MHz IQ window, so the trunking engine binds those
+// grants — but StreamIQ used to build its per-call DDC with the no-span
+// NewDDCBank, whose shared decimator floors the reduced rate at 2.5 MS/s and so
+// rejects any offset beyond ±1.1 MHz with ErrOffsetOutOfBand. The outer
+// carriers then produced no audio at all ("composer: StreamIQ failed ... offset
+// is outside the usable IQ band"). The span-aware bank (mirroring widebandt2's
+// maxAbsOffset sizing) must accept the grant, and the reported exact rate must
+// match the bank the live stream is actually clocked at.
+func TestStreamIQAcceptsWidebandSpanGrant(t *testing.T) {
+	const sdrRate = 10_000_000.0
+	const widebandHz = 441_700_000
+	const targetHz = 443_600_000 // +1.9 MHz, an outer carrier of the reported plan
+	const offsetHz = targetHz - widebandHz
+
+	fake := newFakeDevice()
+	broker := iqtap.New(fake, 64, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	v, err := New(Options{
+		Serial: "tap-0", Broker: broker,
+		WidebandCenterHz: widebandHz, SDRSampleRateHz: sdrRate,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// CanTune / SetCenterFreq accept it (advertised ±4.5 MHz window).
+	if !v.CanTune(targetHz) {
+		t.Fatalf("CanTune(%d) = false, want true (offset %.0f Hz inside ±%.0f Hz)",
+			targetHz, float64(offsetHz), sdrRate*(0.5-GuardFrac))
+	}
+	if err := v.SetCenterFreq(targetHz); err != nil {
+		t.Fatalf("SetCenterFreq(%d) = %v, want nil", targetHz, err)
+	}
+
+	// The crux: StreamIQ must build a DDC that keeps this offset in band.
+	// Before the fix it returned a wrapped ErrOffsetOutOfBand here.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := v.StreamIQ(ctx); err != nil {
+		t.Fatalf("StreamIQ at offset %.0f Hz = %v, want nil (outer wideband grant must tune)", float64(offsetHz), err)
+	}
+
+	// The reported exact rate must equal the span-aware bank's output rate —
+	// the rate the live stream is clocked at — so symbol recovery doesn't slip
+	// (issue #550).
+	want := tuner.NewDDCBankForSpan(sdrRate, float64(NarrowbandRateHz), GuardFrac, math.Abs(offsetHz)).OutputRateHz()
+	if got := v.SampleRateExactHz(); got != want {
+		t.Errorf("SampleRateExactHz = %v, want %v (span-aware DDCBank.OutputRateHz)", got, want)
+	}
+}
+
 // TestStreamIQShiftsCarrierToBaseband injects a complex sinusoid at the
 // target offset through a fake broker; the virtual tuner should
 // down-convert it to a near-DC tone after its DDC. Verifies that the


### PR DESCRIPTION
A 71-channel wideband DMR plan on a 10 MS/s capture has voice grants out
to ±1.9 MHz of centre. VirtualTuner.CanTune advertises the full
±inRate·(0.5−guard) IQ window (±4.5 MHz here), so the trunking engine
binds those grants — but StreamIQ built its per-call DDC with the no-span
NewDDCBank, whose shared decimator floors the reduced rate at 2.5 MS/s and
rejects any offset beyond ±1.1 MHz with ErrOffsetOutOfBand. The outer
carriers then produced no audio at all ("composer: StreamIQ failed ...
offset is outside the usable IQ band").

This is the gap left by the #764 shared-decimator work: the wideband
control-channel path was made span-aware (widebandt2 sizes its bank from
the widest channel offset via NewDDCBankForSpan), but the voice-grant path
was not. Build the per-call bank with NewDDCBankForSpan(..., |offset|) so a
grant anywhere inside the band CanTune already advertises actually tunes.

The reduced rate — and thus the exact emitted rate the composer clocks
symbol recovery from (issue #550) — now depends on the tap offset, which
isn't known until SetCenterFreq. Recompute actualOutHz there from the same
span-aware args StreamIQ uses, guard it under tunerMu, and keep New's
no-offset seed for the pre-SetCenterFreq window.

Regression test: a +1.9 MHz grant on a 10 MS/s wideband now passes
StreamIQ (it returned the wrapped ErrOffsetOutOfBand before) and reports
the span-aware bank's exact output rate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qq7mQhghEJyHy1T8L4ZVSP