### PR TITLE
dmr: default 2-slot interleaved voice for Tier II conventional (#644)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -661,14 +661,18 @@ func NewDaemon(cfg config.Config, version string, log *slog.Logger) (*Daemon, er
 // resolveDMRInterleavedVoice turns the tri-state config.SystemConfig.
 // DMRInterleavedVoice override into the concrete bool the trunking layer
 // carries. nil (unset) takes the per-protocol default — interleaved ON for
-// DMR Tier III (ProtocolDMR), where the 2-slot TDMA carrier otherwise
-// decodes as garbled audio (issue #644); single-slot for everything else.
-// An explicit value forces it on or off.
+// DMR Tier III trunked (ProtocolDMR) AND Tier II conventional
+// (ProtocolDMRTier2), which are both 2-slot TDMA repeater carriers whose
+// outbound stream interleaves the two timeslots' bursts; the single-slot
+// decoder slices straight through them and produces garbled, encrypted-
+// sounding audio (issue #644). Tier I (ProtocolDMRTier1) is direct-mode
+// simplex — genuinely single-slot — so it stays single-slot, as does every
+// non-DMR protocol. An explicit value forces it on or off.
 func resolveDMRInterleavedVoice(proto trunking.Protocol, override *bool) bool {
 	if override != nil {
 		return *override
 	}
-	return proto == trunking.ProtocolDMR
+	return proto == trunking.ProtocolDMR || proto == trunking.ProtocolDMRTier2
 }
 
 func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *slog.Logger) (*Daemon, error) {

--- a/cmd/gophertrunk/daemon_test.go
+++ b/cmd/gophertrunk/daemon_test.go
@@ -123,3 +123,37 @@ func TestMinControlDDCTarget(t *testing.T) {
 		t.Errorf("minControlDDCTarget(TETRA) = %v, want 144000", got)
 	}
 }
+
+// TestResolveDMRInterleavedVoice pins the per-protocol default for the 2-slot
+// interleaved voice decoder. DMR Tier II conventional and Tier III trunked are
+// both 2-slot TDMA repeater carriers, so an unset (nil) override must default
+// the interleaved decoder ON for both — the single-slot decoder slices straight
+// through a 2-slot carrier and produces the garbled, "DJ-scratch" audio a field
+// report saw on a Tier II site (issue #644, never extended to Tier II until
+// now). Tier I is direct-mode simplex (genuinely single-slot) and non-DMR
+// protocols have no DMR voice chain, so both default OFF. An explicit override
+// always wins.
+func TestResolveDMRInterleavedVoice(t *testing.T) {
+	ptr := func(b bool) *bool { return &b }
+	cases := []struct {
+		name     string
+		proto    trunking.Protocol
+		override *bool
+		want     bool
+	}{
+		{"tier2 conventional defaults on", trunking.ProtocolDMRTier2, nil, true},
+		{"tier3 trunked defaults on", trunking.ProtocolDMR, nil, true},
+		{"tier1 direct-mode defaults off", trunking.ProtocolDMRTier1, nil, false},
+		{"non-dmr defaults off", trunking.ProtocolP25, nil, false},
+		{"override false beats tier2 default", trunking.ProtocolDMRTier2, ptr(false), false},
+		{"override true beats tier1 default", trunking.ProtocolDMRTier1, ptr(true), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveDMRInterleavedVoice(tc.proto, tc.override); got != tc.want {
+				t.Errorf("resolveDMRInterleavedVoice(%v, %v) = %v, want %v",
+					tc.proto, tc.override, got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/status.md
+++ b/docs/status.md
@@ -85,9 +85,9 @@ The inner FEC layers still pending real-air validation:
   fixtures end-to-end; on-air recovery margins (Viterbi
   correction depth vs. real co-channel + adjacent-channel
   interference) need a live capture to characterise.
-- **DMR 2-slot interleaved voice — now the Tier III default
-  (issue #644).** A DMR carrier is 2-slot TDMA, so a real outbound
-  stream interleaves both timeslots' bursts. The single-slot
+- **DMR 2-slot interleaved voice — now the Tier II conventional &
+  Tier III default (issue #644).** A DMR carrier is 2-slot TDMA, so a real
+  outbound stream interleaves both timeslots' bursts. The single-slot
   `voice.NewDecoder` splices the two slots together into garbled,
   encrypted-sounding audio — the #644 report. `voice.NewInterleavedDecoder`
   decodes the carrier correctly: it locks each slot's burst A on its own
@@ -103,11 +103,15 @@ The inner FEC layers still pending real-air validation:
   identical BS-sourced burst-A sync cannot give. The chain is unit-tested
   against synthetic interleaved + embedded-LC vectors at **both** cadences
   (`TestInterleavedDecoderAutoDetects{CACH,NoCACH}Cadence`).
-  As of #644 the interleaved + LC path is the **default for DMR Tier III**:
-  the daemon tags Tier III voice grants so the composer runs
-  `NewInterleavedDecoder` and routes each call to its timeslot by the
-  embedded LC's talkgroup (a `slotRouter`). `dmr_interleaved_voice` is now
-  a tri-state override (unset = protocol default; true/false to force).
+  The interleaved + LC path is the **default for DMR Tier II conventional
+  and Tier III** (#644, extended to Tier II after a field report of garbled
+  "DJ-scratch" audio on a `dmr-tier2` site — the same single-slot/2-slot
+  mismatch): the daemon tags those systems' voice grants so the composer
+  runs `NewInterleavedDecoder` and routes each call to its timeslot by the
+  embedded LC's talkgroup (a `slotRouter`). DMR Tier I is direct-mode
+  simplex (genuinely single-slot) and stays on `NewDecoder`.
+  `dmr_interleaved_voice` is a tri-state override (unset = protocol default;
+  true/false to force).
   One piece still wants a real IQ capture to cross-check: the exact ETSI
   embedded-signalling de-interleave order, the EMB QR(16,7) FEC (read
   systematically for now), and the 5-bit CRC polynomial — currently

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -184,7 +184,7 @@ var fieldMetas = map[string]FieldMeta{
 	"SystemConfig.P25Phase2InterleaveMode": {Label: "P25 Ph2 interleave", Help: "Per-burst block deinterleave before trellis decode. off (default) or on. P25 Phase 2 only."},
 	"SystemConfig.P25Phase2ScramblerMode":  {Label: "P25 Ph2 scrambler", Help: "PN44 descrambling of the MAC PDU. on (default, all on-air) or off (unscrambled fixtures). P25 Phase 2 only."},
 	"SystemConfig.P25Phase2ClockMode":      {Label: "P25 Ph2 clock", Help: "Symbol-timing recovery: gardner (default, live SDR) or naive (fixtures). P25 Phase 2 only."},
-	"SystemConfig.DMRInterleavedVoice":     {Label: "DMR interleaved voice", Help: "Override the 2-slot interleaved DMR voice decoder. Unset = on for DMR Tier III (single-slot otherwise); set true/false to force. DMR only."},
+	"SystemConfig.DMRInterleavedVoice":     {Label: "DMR interleaved voice", Help: "Override the 2-slot interleaved DMR voice decoder. Unset = on for DMR Tier II conventional & Tier III (single-slot only for Tier I direct-mode); set true/false to force. DMR only."},
 	"SystemConfig.NXDNViterbiMode":         {Label: "NXDN Viterbi mode", Help: "K=5 Viterbi FEC on the NXDN CAC. spec (default), on (older fixtures), or off. NXDN only."},
 	"SystemConfig.NXDNDeviationHz":         {Label: "NXDN deviation", Help: "Peak FM deviation (Hz) the NXDN slicer is calibrated to. 0 = spec 1800 Hz; try 2400 for bimodal captures. NXDN only."},
 	"SystemConfig.EDACSBCHMode":            {Label: "EDACS BCH mode", Help: "BCH(40,28,2) FEC on the EDACS CCW. on (default) or off (pre-stripped fixtures). EDACS only."},


### PR DESCRIPTION
A field report on a DMR Tier II conventional system (proto=dmr-tier2)
described recorded voice as "complete DJ scratch" — garbled, encrypted-
sounding audio — at both 10 MS/s and 6.25 MS/s. The reporter suspected
encrypted data being run through the voice decoder. The supplied capture
shows otherwise:

  composer: dmr decode quality ... superframes=8 uncorrectable_frames=0 \
    corrected_bit_errs=385 lc_superframes=0

Every quality line has lc_superframes=0 (the embedded LC never reassembles)
with uncorrectable_frames=0 and ~2.7 corrected bits/frame — the frames are
real AMBE, not noise. That is the exact signature of the #644 bug: a DMR
repeater carrier is 2-slot TDMA, so the single-slot voice decoder
(voice.NewDecoder, 132-dibit contiguous cadence) slices straight through
the carrier and pulls ALTERNATING timeslots into each superframe. Two
slots' audio chopped together = the "DJ scratch" sound, and the LC
fragments (bursts B-E) are likewise scrambled across slots, so the slot
router never binds. Being a slot-cadence mismatch it is rate-independent,
matching the report at both sample rates.

#644 fixed this for Tier III by defaulting the interleaved decoder ON for
ProtocolDMR, but ProtocolDMRTier2 (conventional, same identical 2-slot
wire format) fell through to single-slot. Extend the default: Tier II
conventional and Tier III trunked are both 2-slot repeater carriers and
get the interleaved decoder; Tier I direct-mode simplex is genuinely
single-slot and stays so, as do non-DMR protocols. The explicit
dmr_interleaved_voice override still wins.

No decoder changes — voice.NewInterleavedDecoder + slotRouter already exist
and are tested (superframe_test.go: TestLegacyDecoderMixesInterleavedSlots
pins single-slot mixing, TestInterleavedDecoderSeparatesSlots pins the
fix). The bug was purely the per-protocol default, so the regression test
covers resolveDMRInterleavedVoice: the Tier II/nil row fails before this
change and passes after.

The reporter's other two observations are not this bug: the cyclical
"voice header BPTC uncorrectable" log lines are benign control-plane noise
(a data burst whose slot-type Hamming miscorrects to VoiceLCHeader is
routed to handleVoiceHeader, fails BPTC+RS, and is correctly rejected with
no grant/audio), and the large carrier-error fluctuation in the Tuning
plot is the P25 C4FM FLL pointed at a DMR channel.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0182GER8UtJjYYN5dzyZzc2L