### PR TITLE
soapyremote: size the stream buffer for jitter so it stops dropping IQ

### DIFF
--- a/internal/sdr/soapyremote/driver.go
+++ b/internal/sdr/soapyremote/driver.go
@@ -404,6 +404,55 @@ func (d *device) nativeStreamFormat() (string, bool) {
 	return name, true
 }
 
+// streamBufferLatency is how much IQ the stream channel is sized to hold. The
+// read loop never blocks on the DSP consumer (see sendOrDrop) — that property is
+// what keeps the socket drained and flow-control ACKs flowing so the device does
+// not overflow. The flip side is that this bounded channel is the *only* cushion
+// for normal consumer jitter (GC pauses, goroutine scheduling, bursty network
+// delivery). When it is too shallow, sub-millisecond jitter overflows it and
+// sendOrDrop sheds a chunk — a silent IQ discontinuity that breaks every channel's
+// symbol framing — even while the device itself keeps up (device_overflows=0). The
+// pre-fix depth was a fixed 8 chunks (~a few ms at a multi-MS/s remote rate), which
+// shed ~2% of chunks on ordinary jitter and shredded P25 decode. ~400 ms is
+// comfortably above realistic jitter while bounding added latency and memory;
+// sendOrDrop still sheds the oldest chunk once this fills, so genuine *sustained*
+// over-capacity is handled and surfaced rather than stalling the reader.
+const streamBufferLatency = 400 * time.Millisecond
+
+const (
+	// minStreamBufferChunks floors the computed depth so even a low-rate or
+	// large-MTU stream keeps a healthy jitter cushion (well above the depth-8
+	// regression).
+	minStreamBufferChunks = 64
+	// maxStreamBufferChunks ceilings the depth so a very high rate can't size a
+	// pathologically large channel; at a few thousand samples per chunk this
+	// caps the channel's backing memory in the low tens of MB.
+	maxStreamBufferChunks = 2048
+	// defaultStreamBufferChunks is used when the delivered rate is unknown (the
+	// ActualSampleRate probe failed). Generous enough to absorb jitter at the
+	// rates these remote wideband streams run.
+	defaultStreamBufferChunks = 512
+)
+
+// streamBufferDepth sizes the stream channel to hold ~streamBufferLatency of IQ at
+// the delivered rate, given how many complex samples arrive per datagram chunk.
+// The result is clamped to [minStreamBufferChunks, maxStreamBufferChunks]; a
+// zero/unknown rate or chunk size falls back to defaultStreamBufferChunks.
+func streamBufferDepth(rateHz uint32, samplesPerChunk int) int {
+	if rateHz == 0 || samplesPerChunk <= 0 {
+		return defaultStreamBufferChunks
+	}
+	chunksPerSec := float64(rateHz) / float64(samplesPerChunk)
+	depth := int(math.Ceil(streamBufferLatency.Seconds() * chunksPerSec))
+	if depth < minStreamBufferChunks {
+		return minStreamBufferChunks
+	}
+	if depth > maxStreamBufferChunks {
+		return maxStreamBufferChunks
+	}
+	return depth
+}
+
 // StreamIQ sets up and activates an RX stream, then emits complex64 chunks from
 // the TCP stream socket. The channel closes when the context cancels or the
 // socket closes.
@@ -438,7 +487,15 @@ func (d *device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	}
 
 	go d.drainStatus(statusConn)
-	out := make(chan []complex64, 8)
+	// Size the stream buffer to ride out consumer jitter without dropping IQ.
+	// The read loop never blocks (sendOrDrop), so this bounded channel is the only
+	// jitter cushion; a fixed depth of 8 (~a few ms at these rates) shed ~2% of
+	// chunks on ordinary scheduling jitter and shredded decode even with
+	// device_overflows=0. Size from the delivered rate (best-effort probe; 0 on
+	// failure → default depth) and the samples-per-datagram the MTU/format imply.
+	rate, _ := d.ActualSampleRate()
+	samplesPerChunk := (d.mtu - streamHeaderSize) / d.format.bytesPerSample()
+	out := make(chan []complex64, streamBufferDepth(rate, samplesPerChunk))
 	go d.streamLoop(ctx, dataConn, streamID, out)
 	return out, nil
 }

--- a/internal/sdr/soapyremote/stream_buffer_test.go
+++ b/internal/sdr/soapyremote/stream_buffer_test.go
@@ -1,0 +1,146 @@
+package soapyremote
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// The stream channel is the only cushion for consumer jitter because the read
+// loop never blocks (sendOrDrop). These tests pin the regression where the buffer
+// was a fixed 8 chunks: at a multi-MS/s remote rate that is only a few ms of IQ,
+// so ordinary scheduling jitter overflowed it and sendOrDrop shed ~2% of chunks —
+// silent IQ discontinuities that shredded P25 symbol framing even while the device
+// itself kept up (device_overflows=0). The fix sizes the buffer from the delivered
+// rate so a realistic jitter burst is absorbed losslessly.
+
+// fieldSamplesPerChunk mirrors the reported config: remote:mtu=8000 with the
+// default CS16 wire format → (8000-24)/4 ≈ 1994 complex samples per datagram.
+const fieldSamplesPerChunk = (8000 - streamHeaderSize) / 4
+
+// TestStreamBufferDepthAbsorbsRealisticJitter is the regression: at the reported
+// 6.25 MS/s the buffer must hold far more than the old fixed 8 chunks — enough to
+// ride out a realistic (~100 ms) consumer stall without dropping a single chunk.
+func TestStreamBufferDepthAbsorbsRealisticJitter(t *testing.T) {
+	const rateHz = 6_250_000
+
+	depth := streamBufferDepth(rateHz, fieldSamplesPerChunk)
+
+	// A 100 ms stall at this rate/chunk size delivers this many chunks; the
+	// buffer must hold all of them so none are shed while the consumer catches up.
+	chunksPerSec := float64(rateHz) / float64(fieldSamplesPerChunk)
+	jitter100ms := int(0.100 * chunksPerSec)
+	if depth < jitter100ms {
+		t.Fatalf("depth %d cannot absorb a 100 ms stall (%d chunks) at %d Hz — the old depth-8 regression",
+			depth, jitter100ms, rateHz)
+	}
+	if depth <= 8 {
+		t.Fatalf("depth %d is not materially deeper than the pre-fix fixed 8", depth)
+	}
+	if depth > maxStreamBufferChunks {
+		t.Fatalf("depth %d exceeds the ceiling %d", depth, maxStreamBufferChunks)
+	}
+}
+
+func TestStreamBufferDepthClampsAndFallback(t *testing.T) {
+	if got := streamBufferDepth(0, fieldSamplesPerChunk); got != defaultStreamBufferChunks {
+		t.Errorf("unknown rate: depth = %d, want fallback %d", got, defaultStreamBufferChunks)
+	}
+	if got := streamBufferDepth(6_250_000, 0); got != defaultStreamBufferChunks {
+		t.Errorf("unknown chunk size: depth = %d, want fallback %d", got, defaultStreamBufferChunks)
+	}
+	// A tiny rate floors at the minimum cushion (never back to the depth-8 regime).
+	if got := streamBufferDepth(1, fieldSamplesPerChunk); got != minStreamBufferChunks {
+		t.Errorf("tiny rate: depth = %d, want floor %d", got, minStreamBufferChunks)
+	}
+	// A very high rate is capped so the channel can't grow without bound.
+	if got := streamBufferDepth(100_000_000, 64); got != maxStreamBufferChunks {
+		t.Errorf("huge rate: depth = %d, want ceiling %d", got, maxStreamBufferChunks)
+	}
+}
+
+// nonWarningThrottle returns an overrunThrottle whose counters accumulate without
+// being reset by the periodic WARN, so a test can read total drops afterwards.
+func nonWarningThrottle() *overrunThrottle {
+	now := time.Unix(100, 0)
+	return &overrunThrottle{
+		log:      slog.New(&capHandler{}),
+		addr:     "test",
+		interval: time.Hour,
+		now:      func() time.Time { return now },
+		lastWarn: now, // already "warned" at now ⇒ maybeWarn early-returns, counts persist
+	}
+}
+
+// TestSendOrDropLosslessWithinBuffer feeds a realistic jitter burst through
+// sendOrDrop into a rate-sized buffer with no consumer draining (a stalled
+// consumer), then drains. Every chunk must survive in order with zero host drops.
+// With the pre-fix depth of 8 this burst sheds all but the last 8 chunks.
+func TestSendOrDropLosslessWithinBuffer(t *testing.T) {
+	const rateHz = 6_250_000
+	depth := streamBufferDepth(rateHz, fieldSamplesPerChunk)
+	out := make(chan []complex64, depth)
+	tr := nonWarningThrottle()
+	d := &device{}
+
+	// A realistic ~100 ms consumer stall's worth of chunks. The rate-sized buffer
+	// holds it losslessly; the pre-fix depth of 8 would shed all but the last 8.
+	r := float64(rateHz)
+	burst := int(0.100 * r / float64(fieldSamplesPerChunk))
+	if burst > depth {
+		t.Fatalf("test setup: burst %d exceeds buffer depth %d", burst, depth)
+	}
+	for i := 0; i < burst; i++ {
+		if !d.sendOrDrop(context.Background(), out, []complex64{complex(float32(i), 0)}, tr) {
+			t.Fatalf("sendOrDrop returned false (ctx not cancelled) at chunk %d", i)
+		}
+	}
+	if tr.hostDrops != 0 {
+		t.Fatalf("dropped %d chunks of a %d-chunk burst that fits the buffer", tr.hostDrops, burst)
+	}
+	close(out)
+	got := 0
+	for chunk := range out {
+		if int(real(chunk[0])) != got {
+			t.Fatalf("out-of-order: chunk %d carried %v", got, real(chunk[0]))
+		}
+		got++
+	}
+	if got != burst {
+		t.Fatalf("drained %d chunks, want %d (lossless)", got, burst)
+	}
+}
+
+// TestSendOrDropShedsUnderSustainedOverload guards efb284f's intent: when the
+// buffer is genuinely full and the consumer never catches up, sendOrDrop must keep
+// shedding the oldest chunk (never blocking the read loop) and counting the drops,
+// leaving the freshest chunks in order.
+func TestSendOrDropShedsUnderSustainedOverload(t *testing.T) {
+	const bufCap = 4
+	const burst = 20
+	out := make(chan []complex64, bufCap)
+	tr := nonWarningThrottle()
+	d := &device{}
+
+	for i := 0; i < burst; i++ {
+		if !d.sendOrDrop(context.Background(), out, []complex64{complex(float32(i), 0)}, tr) {
+			t.Fatalf("sendOrDrop returned false at chunk %d", i)
+		}
+	}
+	if want := uint64(burst - bufCap); tr.hostDrops != want {
+		t.Fatalf("hostDrops = %d, want %d (oldest shed under sustained overload)", tr.hostDrops, want)
+	}
+	// The bufCap freshest chunks remain, in order.
+	close(out)
+	want := burst - bufCap
+	for chunk := range out {
+		if int(real(chunk[0])) != want {
+			t.Fatalf("remaining chunk = %v, want freshest %d", real(chunk[0]), want)
+		}
+		want++
+	}
+	if want != burst {
+		t.Fatalf("buffer held up to chunk %d, want %d", want, burst)
+	}
+}


### PR DESCRIPTION
A field report ("P25 decoding looks completely broken… regressed") on a
single P25 Phase 1 control channel — role=wideband, driver=soapy_remote,
6.25 MS/s, polyphase, CC at -625 kHz offset — showed a continuous flood of
nid-bch / tsbk-crc decode errors while the system still locked and completed
calls: the signature of symbol framing repeatedly losing sync, not a dead
decoder. The capture's debug.log is conclusive: device_overflows=0 (the radio
keeps up) but host_drops holds at ~370-690 per 5 s window for the entire run —
the *host-side* stream buffer was shedding ~2% of chunks.

Root cause is efb284f's pairing of a never-block read loop (correct: a blocked
reader stalls socket draining + flow-control ACKs and makes the device
overflow) with a fixed 8-deep stream channel. At a multi-MS/s remote rate the
server delivers MTU-sized datagrams thousands of times a second, so 8 chunks is
only a few milliseconds of buffer. Ordinary consumer jitter (GC pauses,
goroutine scheduling, bursty network delivery) momentarily fills those 8 slots
and sendOrDrop sheds the oldest chunk — a silent IQ discontinuity that breaks
the P25 symbol clock/framer — even though the device never overflows. Before
efb284f the same back-pressure simply blocked for a fraction of a millisecond
(in-order, lossless), so this capture would have decoded cleanly.

This is not a channelizer regression, contrary to the report's guess: 179afa3
only touches the per-call voice DDC (internal/sdr/wbvoice); dc7060b's serial
channelizer path is byte-identical and its worker pool is a no-op below 16 taps
(this plan has one); and #764 predates the window and improves this geometry.
The one in-window change to the live IQ stream the CC reads is efb284f.

Fix: keep efb284f's never-block property but size the stream channel from the
delivered rate (ActualSampleRate, best-effort) and the samples-per-datagram the
MTU/format imply, targeting ~400 ms of buffering, clamped to [64, 2048] chunks
with a 512 fallback when the rate is unknown. Realistic jitter is now absorbed
losslessly; sendOrDrop still sheds the oldest chunk under genuine *sustained*
over-capacity (where device_overflows and the "lower sdr.sample_rate" advisory
already apply), so flow control and the overrun WARN are unchanged.

Regression test (stream_buffer_test.go): streamBufferDepth at the reported
6.25 MS/s must hold far more than a 100 ms stall (fails at the old depth of 8),
clamps/fallback are pinned, a realistic jitter burst through sendOrDrop into the
rate-sized buffer is lossless and in-order, and a sustained-overload burst still
sheds the oldest and counts host_drops.

Verified: make vet test and make integration both green. End-to-end confirmation
needs the reporter to re-run the same config and confirm host_drops collapses to
~0 and the decode-error rate falls to background.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UEavvYa4gVMUgAU55iW59X