### PR TITLE
Add "Solution Postmortem" blog category

### DIFF
--- a/docs/_data/blog_categories.yml
+++ b/docs/_data/blog_categories.yml
@@ -20,3 +20,6 @@
 - slug: tutorials
   label: Tutorials
   description: Step-by-step user-facing guides.
+- slug: solution-postmortem
+  label: Solution Postmortem
+  description: Post-incident write-ups — what broke, how it was diagnosed, and the fix.

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -109,6 +109,8 @@ groups:
         url: /blog/series/rf-front-end/
       - title: Tutorials
         url: /blog/category/tutorials/
+      - title: Solution Postmortem
+        url: /blog/category/solution-postmortem/
   - label: Install
     items:
       - title: Downloads

--- a/docs/blog/category/solution-postmortem.md
+++ b/docs/blog/category/solution-postmortem.md
@@ -1,0 +1,35 @@
+---
+layout: page
+title: "Blog: Solution Postmortem"
+description: Post-incident write-ups — what broke, how it was diagnosed, and the fix.
+nav_group: Blog
+permalink: /blog/category/solution-postmortem/
+category: solution-postmortem
+---
+
+{% assign posts = site.categories[page.category] %}
+{% if posts and posts.size > 0 %}
+<ul class="post-list">
+  {% for post in posts %}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+      </p>
+      {% if post.description %}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {% elsif post.excerpt %}
+        <p class="post-card__desc">{{ post.excerpt | strip_html | truncate: 200 }}</p>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p class="post-list__empty">No posts in this category yet.</p>
+{% endif %}
+
+<p class="blog-feed-link">
+  See <a href="{{ '/blog/' | relative_url }}">all posts</a> or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>


### PR DESCRIPTION
Append the category to blog_categories.yml, add its archive page under
docs/blog/category/, and link it in the Blog nav group — the three steps
documented in blog_categories.yml for adding a category.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018m2VueFCRRCgHsxragMThS