### PR TITLE
web: keep spectrum panels' follow state live; park Hold on the control channel

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1195,6 +1195,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			WriteRaw:           cfg.Recordings.WriteRaw,
 			SkipEncrypted:      cfg.Recordings.SkipEncrypted,
 			VocoderForProtocol: vocoderMap,
+			// Same display timezone the logs/TUI/API use, so WAV filenames
+			// carry the local wall-clock rather than UTC. Resolved here
+			// directly (d.displayLoc is assigned a few lines below, after
+			// this block) via the idempotent Location() helper.
+			DisplayLoc: cfg.Display.Location(),
 			Normalize: voice.NormalizeConfig{
 				Enabled:      cfg.Recordings.Normalize.AppliesToRecording(),
 				TargetLUFS:   cfg.Recordings.Normalize.TargetLUFS,

--- a/internal/radio/p25/phase1/ldu_e2e_test.go
+++ b/internal/radio/p25/phase1/ldu_e2e_test.go
@@ -146,15 +146,19 @@ func TestLDUEndToEndIntoRecorder(t *testing.T) {
 		t.Fatalf("read wav: %v", err)
 	}
 	const wavHeaderSize = 44
-	// 9 frames × 160 samples × 2 bytes per sample.
-	wantData := uint32(phase1.LDUVoiceSubframeCount * 160 * 2)
+	// 9 frames × 160 samples × 2 bytes per sample of voice, plus the
+	// recorder's optional end-of-call fade (≤10 ms = 80 samples) appended
+	// when the last decoded sample is non-zero.
+	voiceData := uint32(phase1.LDUVoiceSubframeCount * 160 * 2)
+	const maxTailBytes = uint32(80 * 2)
 	dataSize := binary.LittleEndian.Uint32(wavBytes[40:44])
-	if dataSize != wantData {
-		t.Errorf("WAV data chunk size = %d, want %d", dataSize, wantData)
+	if dataSize < voiceData || dataSize > voiceData+maxTailBytes {
+		t.Errorf("WAV data chunk size = %d, want %d..%d",
+			dataSize, voiceData, voiceData+maxTailBytes)
 	}
-	if uint32(len(wavBytes)) != wavHeaderSize+wantData {
+	if uint32(len(wavBytes)) != wavHeaderSize+dataSize {
 		t.Errorf("wav file size = %d, want %d",
-			len(wavBytes), wavHeaderSize+wantData)
+			len(wavBytes), wavHeaderSize+dataSize)
 	}
 	// Confirm at least one sample is non-zero — synthesis ran end-to-end.
 	var nonZero bool

--- a/internal/voice/imbe/recorder_integration_test.go
+++ b/internal/voice/imbe/recorder_integration_test.go
@@ -94,15 +94,19 @@ func TestRecorderDecodesP25IntoWav(t *testing.T) {
 		t.Fatalf("read wav: %v", err)
 	}
 
-	// Each IMBE frame decodes to 160 16-bit samples; with N frames
-	// the data chunk is N·160·2 bytes.
-	wantData := uint32(n * 160 * 2)
+	// Each IMBE frame decodes to 160 16-bit samples; with N frames the
+	// voice data is N·160·2 bytes. The recorder appends a short end-of-call
+	// fade (≤10 ms = 80 samples) when the last decoded sample is non-zero,
+	// so the data chunk is the voice bytes plus an optional tail.
+	voiceData := uint32(n * 160 * 2)
+	const maxTailBytes = uint32(80 * 2)
 	dataSize := binary.LittleEndian.Uint32(wavBytes[40:44])
-	if dataSize != wantData {
-		t.Errorf("WAV data chunk size = %d, want %d", dataSize, wantData)
+	if dataSize < voiceData || dataSize > voiceData+maxTailBytes {
+		t.Errorf("WAV data chunk size = %d, want %d..%d",
+			dataSize, voiceData, voiceData+maxTailBytes)
 	}
-	if uint32(len(wavBytes)) != 44+wantData {
-		t.Errorf("wav file size = %d, want %d", len(wavBytes), 44+wantData)
+	if uint32(len(wavBytes)) != 44+dataSize {
+		t.Errorf("wav file size = %d, want %d", len(wavBytes), 44+dataSize)
 	}
 
 	// Confirm at least one sample is non-zero — the IMBE pipeline

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -113,6 +113,12 @@ type Recorder struct {
 	// the head of a call isn't lost when the operator flips the
 	// switch mid-conversation.
 	recordDisabled atomic.Bool
+
+	// displayLoc is the timezone the recording-filename timestamp renders
+	// in, matching the location the rest of the app uses for human-facing
+	// timestamps (display.timezone). Never nil after NewRecorder; defaults
+	// to time.UTC when the caller leaves it unset (the prior behaviour).
+	displayLoc *time.Location
 }
 
 // DecodedPCMSink receives PCM the recorder decodes from digital
@@ -219,6 +225,13 @@ type RecorderOptions struct {
 	// composer's FM chain feeds WritePCM directly, and ProVoice
 	// where no in-binary decoder is available.
 	VocoderForProtocol map[string]string
+
+	// DisplayLoc is the timezone the recording-filename timestamp renders
+	// in (display.timezone, via config.DisplayConfig.Location()). nil falls
+	// back to time.UTC (the prior behaviour). Threaded so WAV filenames
+	// match the local wall-clock the rest of the UI/logs already show,
+	// instead of always UTC.
+	DisplayLoc *time.Location
 }
 
 // DefaultVocoderForProtocol returns the Protocol → vocoder-name
@@ -285,6 +298,10 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 	if opts.Enhance.Enabled {
 		opts.Enhance = opts.Enhance.WithDefaults()
 	}
+	loc := opts.DisplayLoc
+	if loc == nil {
+		loc = time.UTC
+	}
 	r := &Recorder{
 		bus:                opts.Bus,
 		log:                opts.Log,
@@ -295,6 +312,7 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 		normalize:          opts.Normalize,
 		enhance:            opts.Enhance,
 		vocoderForProtocol: vocoderMap,
+		displayLoc:         loc,
 		sessions:           make(map[string]*recordingSession),
 		runDone:            make(chan struct{}),
 	}
@@ -983,11 +1001,20 @@ func (r *Recorder) directoryFor(cs trunking.CallStart) string {
 }
 
 func (r *Recorder) basenameFor(cs trunking.CallStart) string {
-	t := cs.StartedAt.UTC()
-	if t.IsZero() {
-		t = time.Now().UTC()
+	loc := r.displayLoc
+	if loc == nil {
+		loc = time.UTC
 	}
-	stamp := t.Format("20060102T150405Z")
+	t := cs.StartedAt
+	if t.IsZero() {
+		t = time.Now()
+	}
+	// Render in the configured display timezone so the filename matches the
+	// local wall-clock the rest of the app shows, rather than always UTC.
+	// The Z0700 zone token keeps the stamp self-documenting and
+	// filename-safe (no colon): UTC still formats as a literal "Z", other
+	// zones as a numeric offset like "+1000".
+	stamp := t.In(loc).Format("20060102T150405Z0700")
 	// Tag the RF voice-channel frequency (Hz) into the name. Voice
 	// frequencies are shared across talkgroups on a trunked system, so
 	// having the frequency on each file makes it easy to tell which

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -570,6 +570,9 @@ func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byt
 				"device", deviceSerial, "vocoder", s.vocoder.Name(), "err", err)
 			return nil
 		}
+		if n := len(samples); n > 0 {
+			s.lastSample = samples[n-1]
+		}
 		if err := s.wav.WriteSamples(samples); err != nil {
 			return err
 		}
@@ -838,6 +841,33 @@ func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt ti
 	dataBytes := s.wav.DataBytes()
 	vs, haveStats := r.voiceStatsFor(s)
 	r.logVoiceStats(serial, s)
+	// Smooth an abrupt end-of-call cut on decoded digital voice. A short
+	// transmission that stops mid-waveform leaves a non-zero final sample
+	// that clicks/scratches on playback — the "trailing" artifact most
+	// audible on short overs, where the tail is a big fraction of the call.
+	// Ramp the last decoded sample down to zero on both the WAV and the live
+	// decoded fan-out, mirroring the analog FM chain's squelch-tail fade.
+	// Digital only (s.vocoder != nil): analog already faded in the composer,
+	// and a silent/dead-key call has lastSample == 0 so fadeTail is a no-op.
+	if s.vocoder != nil && s.wav != nil && dataBytes > 0 {
+		n := int(s.sampleRate) / 100 // ~10 ms
+		if n < 8 {
+			n = 8
+		}
+		if tail := fadeTail(s.lastSample, n); tail != nil {
+			if err := s.wav.WriteSamples(tail); err != nil {
+				r.log.Warn("recorder: writing call-tail fade failed",
+					"device", serial, "err", err)
+			}
+			if r.decodedTap != nil {
+				if cs, ok := r.decodedTap.(DecodedPCMCallSink); ok {
+					_ = cs.WritePCMForCall(serial, s.callID, tail)
+				} else {
+					_ = r.decodedTap.WritePCM(serial, tail)
+				}
+			}
+		}
+	}
 	if err := s.close(); err != nil {
 		r.log.Error("recorder: close session", "err", err)
 	}
@@ -1035,6 +1065,24 @@ func (r *Recorder) basenameFor(cs trunking.CallStart) string {
 	return base
 }
 
+// fadeTail returns an n-sample linear ramp from `from` down toward zero,
+// used to smooth an abrupt end-of-call cut on decoded digital voice (the
+// digital counterpart of the analog composer's squelch-tail fade). The
+// first sample equals `from` so the ramp continues seamlessly from the
+// last decoded sample. Returns nil when there is nothing to ramp (already
+// at silence, or a non-positive length).
+func fadeTail(from int16, n int) []int16 {
+	if from == 0 || n <= 0 {
+		return nil
+	}
+	out := make([]int16, n)
+	start := float64(from)
+	for i := range out {
+		out[i] = int16(start * (1.0 - float64(i)/float64(n)))
+	}
+	return out
+}
+
 // sanitize strips characters that are awkward in file paths across OSes.
 func sanitize(s string) string {
 	s = strings.TrimSpace(s)
@@ -1066,6 +1114,12 @@ type recordingSession struct {
 	vocoder     Vocoder
 	vocoderName string
 	sampleRate  uint32
+	// lastSample is the most recent decoded PCM sample written for this
+	// session. On close a short fade from it down to zero is appended to
+	// smooth an abrupt end-of-call cut (finalizeLocked) — the digital
+	// equivalent of the analog composer's squelch-tail fade. Zero (the
+	// default / trailing silence) means no fade is needed.
+	lastSample int16
 	// rawWanted records whether this call should get a .raw sidecar once
 	// its files are opened. The decision is made when the session is
 	// prepared (buildSession) but the file itself is created lazily on the

--- a/internal/voice/recorder_tail_test.go
+++ b/internal/voice/recorder_tail_test.go
@@ -1,0 +1,154 @@
+package voice
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// loudVocoder decodes every frame to a constant, full-level tone so a call
+// that ends mid-frame leaves a non-zero final sample — the abrupt cut that
+// the end-of-call fade is meant to smooth.
+type loudVocoder struct{}
+
+func (loudVocoder) Name() string   { return "loud" }
+func (loudVocoder) FrameSize() int { return 11 }
+func (loudVocoder) Reset()         {}
+func (loudVocoder) Close() error   { return nil }
+func (loudVocoder) Decode([]byte) ([]int16, error) {
+	s := make([]int16, 160)
+	for i := range s {
+		s[i] = 12000
+	}
+	return s, nil
+}
+
+func absI16(v int16) int16 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func readWAVSamples(t *testing.T, path string) []int16 {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read wav %s: %v", path, err)
+	}
+	if len(raw) < wavHeaderSize {
+		t.Fatalf("wav %s shorter than header (%d bytes)", path, len(raw))
+	}
+	body := raw[wavHeaderSize:]
+	out := make([]int16, len(body)/2)
+	for i := range out {
+		out[i] = int16(binary.LittleEndian.Uint16(body[i*2:]))
+	}
+	return out
+}
+
+// TestRecorderFadesDigitalTailToZero is the regression for the "trailing
+// DJ" scratch on short digital transmissions: a call that stops at a
+// non-zero decoded level must not end abruptly. finalizeLocked appends a
+// short fade from the last decoded sample down toward zero. Fails before
+// the fade is added (the WAV ends at the full 12000 level).
+func TestRecorderFadesDigitalTailToZero(t *testing.T) {
+	DefaultRegistry.Register("loud-voc", func() (Vocoder, error) { return loudVocoder{}, nil })
+
+	bus := events.NewBus(8)
+	dir := t.TempDir()
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             dir,
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"test-loud": "loud-voc"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-loud", GroupID: 1, SourceID: 3},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && !r.HasSession("VOICE-1") {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := r.WriteRawFrame("VOICE-1", make([]byte, 11)); err != nil {
+			t.Fatalf("WriteRawFrame: %v", err)
+		}
+	}
+
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: cs.Grant, DeviceSerial: "VOICE-1",
+		StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(time.Second),
+		Reason: trunking.EndReasonNormal,
+	}})
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && r.HasSession("VOICE-1") {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	samples := readWAVSamples(t, filepath.Join(dir, "S", "1", "20260505T000000Z_src3.wav"))
+	if len(samples) < 200 {
+		t.Fatalf("too few samples decoded: %d", len(samples))
+	}
+	// Body holds the constant decoded level.
+	if got := samples[100]; got != 12000 {
+		t.Fatalf("body sample = %d, want 12000", got)
+	}
+	// The recording must not end abruptly at the decoded level.
+	if last := samples[len(samples)-1]; absI16(last) > 1000 {
+		t.Fatalf("final sample = %d, want a faded value near 0 (no abrupt cut)", last)
+	}
+	// The appended tail descends monotonically from the body level.
+	tail := samples[len(samples)-80:]
+	for i := 1; i < len(tail); i++ {
+		if absI16(tail[i]) > absI16(tail[i-1]) {
+			t.Fatalf("tail not monotonically decreasing at %d: %d then %d",
+				i, tail[i-1], tail[i])
+		}
+	}
+}
+
+// TestFadeTail covers the pure ramp helper directly.
+func TestFadeTail(t *testing.T) {
+	if fadeTail(0, 80) != nil {
+		t.Error("fadeTail(0, …) should be nil — silence needs no fade")
+	}
+	if fadeTail(1000, 0) != nil {
+		t.Error("fadeTail(…, 0) should be nil")
+	}
+	tail := fadeTail(8000, 80)
+	if len(tail) != 80 {
+		t.Fatalf("len = %d, want 80", len(tail))
+	}
+	if tail[0] != 8000 {
+		t.Errorf("tail[0] = %d, want 8000 (continues from last sample)", tail[0])
+	}
+	for i := 1; i < len(tail); i++ {
+		if absI16(tail[i]) > absI16(tail[i-1]) {
+			t.Fatalf("not monotonically decreasing at %d", i)
+		}
+	}
+	if absI16(tail[len(tail)-1]) > 200 {
+		t.Errorf("tail end = %d, want near 0", tail[len(tail)-1])
+	}
+}

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -95,6 +95,49 @@ func TestRecorderWritesPerCallWav(t *testing.T) {
 	}
 }
 
+// TestRecorderBasenameTimezone confirms the recording filename timestamp
+// renders in the configured display timezone (not always UTC), matching
+// the rest of the app. The Z0700 zone token keeps UTC as a literal "Z"
+// (the prior behaviour, so existing names are unchanged) while a
+// non-UTC zone gets a filename-safe numeric offset.
+func TestRecorderBasenameTimezone(t *testing.T) {
+	bus := events.NewBus(1)
+	defer bus.Close()
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", GroupID: 1, SourceID: 7},
+		DeviceSerial: "VOICE-1",
+		StartedAt:    time.Date(2026, 5, 5, 12, 30, 45, 0, time.UTC),
+	}
+
+	// A configured +05:00 zone shifts the wall-clock and tags the offset.
+	r, err := NewRecorder(RecorderOptions{
+		Bus:        bus,
+		OutDir:     t.TempDir(),
+		SampleRate: 8000,
+		DisplayLoc: time.FixedZone("UTC+5", 5*3600),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := r.basenameFor(cs), "20260505T173045+0500_src7"; got != want {
+		t.Fatalf("basenameFor with +5h zone = %q, want %q", got, want)
+	}
+
+	// No DisplayLoc keeps the prior UTC + literal "Z" form.
+	rDef, err := NewRecorder(RecorderOptions{
+		Bus:        bus,
+		OutDir:     t.TempDir(),
+		SampleRate: 8000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := rDef.basenameFor(cs), "20260505T123045Z_src7"; got != want {
+		t.Fatalf("default basenameFor = %q, want %q", got, want)
+	}
+}
+
 // TestRecorderTimeslotInWavName confirms a DMR Tier III carrier's two
 // concurrent calls (same system + talkgroup, one per TDMA slot, served
 // by two voice devices) land in the same directory as distinct WAVs

--- a/web/src/components/AudioPlayer.test.tsx
+++ b/web/src/components/AudioPlayer.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+// Capture every stream the player opens so we can assert the URL it
+// filtered to. start/stop/setVolume/setMuted are inert.
+const opened: string[] = [];
+vi.mock("../audio/streamPlayer", () => ({
+  createStreamPlayer: (opts: { url: string }) => {
+    opened.push(opts.url);
+    return {
+      start: vi.fn(),
+      stop: vi.fn(),
+      setVolume: vi.fn(),
+      setMuted: vi.fn(),
+    };
+  },
+}));
+
+import { AudioPlayer } from "./AudioPlayer";
+import { useShared } from "../store/shared";
+import type { ActiveCallDTO } from "../api/types";
+
+function call(serial: string, startedAt: string): ActiveCallDTO {
+  return {
+    grant: { group_id: 1, system: "Sys", protocol: "p25", frequency_hz: 1 },
+    device_serial: serial,
+    started_at: startedAt,
+  } as ActiveCallDTO;
+}
+
+describe("AudioPlayer live-audio follow", () => {
+  beforeEach(() => {
+    opened.length = 0;
+    useShared.setState({
+      serverURL: "http://localhost:8080",
+      token: null,
+      activeCalls: [],
+    });
+  });
+
+  it("opens the stream filtered to the primary call and follows the newest", async () => {
+    useShared.setState({ activeCalls: [call("VOICE-1", "2026-01-01T00:00:00Z")] });
+
+    render(<AudioPlayer />);
+
+    // Tap to enable → stream opens filtered to the active call's device.
+    fireEvent.click(screen.getByLabelText("Enable audio"));
+    await waitFor(() => expect(opened).toHaveLength(1));
+    expect(opened[0]).toContain("device=VOICE-1");
+
+    // A newer call on a different device → follow it (one call at a time).
+    act(() => {
+      useShared.setState({
+        activeCalls: [
+          call("VOICE-1", "2026-01-01T00:00:00Z"),
+          call("VOICE-2", "2026-01-01T00:00:05Z"),
+        ],
+      });
+    });
+    await waitFor(() => expect(opened).toHaveLength(2));
+    expect(opened[1]).toContain("device=VOICE-2");
+  });
+
+  it("opens unfiltered when no call is active", async () => {
+    render(<AudioPlayer />);
+    fireEvent.click(screen.getByLabelText("Enable audio"));
+    await waitFor(() => expect(opened).toHaveLength(1));
+    expect(opened[0]).not.toContain("device=");
+  });
+});

--- a/web/src/components/AudioPlayer.tsx
+++ b/web/src/components/AudioPlayer.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { audioStreamURL } from "../api/client";
 import { createStreamPlayer, type StreamPlayer } from "../audio/streamPlayer";
 import { writes } from "../api/write";
 import { selectClientConfig, useShared } from "../store/shared";
+import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
 import { prefs } from "../store/prefs";
 
 // AudioPlayer is a floating, dismissable mini-player that streams
@@ -24,12 +25,39 @@ import { prefs } from "../store/prefs";
 export function AudioPlayer() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
+  // AudioPlayer is always mounted but, unlike Active/Dashboard, didn't
+  // refresh activeCalls — so its Media Session metadata and (below) the
+  // call it follows went stale on every other route. Poll here so the
+  // follow logic stays live wherever the operator is.
+  useActiveCallsPoll();
   const [enabled, setEnabled] = useState(false);
   const [muted, setMuted] = useState(false);
   const [volume, setVolume] = useState(prefs.audioVolume());
   const [recording, setRecording] = useState<boolean | null>(null);
   const [error, setError] = useState<string | null>(null);
   const playerRef = useRef<StreamPlayer | null>(null);
+  // Device serial the running stream is filtered to (null = unfiltered).
+  const playerSerialRef = useRef<string | null>(null);
+  // Read inside startPlayer without re-creating it (and thus restarting
+  // the stream) every time the volume slider moves.
+  const volumeRef = useRef(volume);
+  volumeRef.current = volume;
+  const mutedRef = useRef(muted);
+  mutedRef.current = muted;
+
+  // The single call live audio follows: the most recently started active
+  // call. Playing one call at a time (standard scanner behaviour) is what
+  // stops concurrent talkgroups from overlapping into one garbled stream —
+  // the daemon's /audio/stream supports a ?device= filter, the WebUI just
+  // never used it. null when nothing is up (stream stays unfiltered so the
+  // first call is still audible before the poll narrows onto it).
+  const primarySerial = useMemo(() => {
+    if (activeCalls.length === 0) return null;
+    const newest = activeCalls.reduce((a, b) =>
+      b.started_at > a.started_at ? b : a,
+    );
+    return newest.device_serial;
+  }, [activeCalls]);
 
   // Reflect the daemon's current audio state into the local toggles.
   const daemonAudio = useShared((s) => s.audio);
@@ -62,39 +90,66 @@ export function AudioPlayer() {
     return () => {
       playerRef.current?.stop();
       playerRef.current = null;
+      playerSerialRef.current = null;
     };
   }, [cfg]);
 
+  // startPlayer (re)opens the stream filtered to one call's device serial.
+  // Stable across volume/mute changes (those read refs) so following a new
+  // call is the only thing that tears down and reopens the stream.
+  const startPlayer = useCallback(
+    (serial: string | null) => {
+      if (!cfg.baseURL) return;
+      setError(null);
+      playerRef.current?.stop();
+      const player = createStreamPlayer({
+        url: audioStreamURL(cfg, serial ? { device: serial } : {}),
+        token: cfg.token,
+        onError: (msg) => {
+          setError(msg);
+          setEnabled(false);
+        },
+        onStateChange: (state) => {
+          setEnabled(state === "playing" || state === "connecting");
+        },
+      });
+      playerRef.current = player;
+      playerSerialRef.current = serial;
+      player.setVolume(volumeRef.current);
+      player.setMuted(mutedRef.current);
+      player.start();
+    },
+    [cfg],
+  );
+
   // enable must stay synchronous: createStreamPlayer().start() resumes
   // the AudioContext inside this gesture so the autoplay policy doesn't
-  // reject playback.
+  // reject playback. Open onto the current primary call straight away.
   const enable = () => {
     if (!cfg.baseURL) return;
-    setError(null);
-    playerRef.current?.stop();
-    const player = createStreamPlayer({
-      url: audioStreamURL(cfg),
-      token: cfg.token,
-      onError: (msg) => {
-        setError(msg);
-        setEnabled(false);
-      },
-      onStateChange: (state) => {
-        setEnabled(state === "playing" || state === "connecting");
-      },
-    });
-    playerRef.current = player;
-    player.setVolume(volume);
-    player.setMuted(muted);
-    player.start();
+    startPlayer(primarySerial);
     setEnabled(true);
   };
 
   const disable = () => {
     playerRef.current?.stop();
     playerRef.current = null;
+    playerSerialRef.current = null;
     setEnabled(false);
   };
+
+  // Follow the primary call: when it changes, re-point the running stream
+  // at the new device so audio switches cleanly instead of overlapping.
+  // Only acts on a real call (non-null) and only when a stream is already
+  // running — the initial open happens in enable() inside the user
+  // gesture, and a call simply ending lets the current filter fall silent
+  // rather than dropping back to the (overlap-prone) unfiltered stream.
+  useEffect(() => {
+    if (!playerRef.current) return;
+    if (!primarySerial) return;
+    if (primarySerial === playerSerialRef.current) return;
+    startPlayer(primarySerial);
+  }, [primarySerial, startPlayer]);
 
   const onVolume = (v: number) => {
     setVolume(v);

--- a/web/src/hooks/useActiveCallsPoll.test.tsx
+++ b/web/src/hooks/useActiveCallsPoll.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+vi.mock("../api/client", () => ({
+  api: { activeCalls: vi.fn() },
+}));
+
+import { api } from "../api/client";
+import { useShared } from "../store/shared";
+import { useActiveCallsPoll } from "./useActiveCallsPoll";
+import type { ActiveCallDTO } from "../api/types";
+
+function Probe() {
+  useActiveCallsPoll();
+  return null;
+}
+
+function call(serial: string, freqHz: number): ActiveCallDTO {
+  return {
+    grant: { group_id: 1, system: "Sys", protocol: "p25", frequency_hz: freqHz },
+    device_serial: serial,
+    started_at: "2026-01-01T00:00:00Z",
+  } as ActiveCallDTO;
+}
+
+describe("useActiveCallsPoll", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useShared.setState({
+      serverURL: "http://localhost:8080",
+      token: null,
+      activeCalls: [],
+    });
+  });
+
+  // Regression for the frozen-spectrum-panel bug: a panel that follows
+  // live calls must refresh activeCalls itself, since the Active/Dashboard
+  // pollers only tick on their own routes. Without the poll the store
+  // keeps a stale snapshot and the view freezes on a single freq.
+  it("refreshes the shared-store activeCalls from the API on mount", async () => {
+    vi.mocked(api.activeCalls).mockResolvedValue([call("rtl-1", 851_000_000)]);
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      expect(useShared.getState().activeCalls).toHaveLength(1);
+    });
+    expect(api.activeCalls).toHaveBeenCalled();
+  });
+
+  it("clears a stale active call once the daemon reports none", async () => {
+    // Store starts holding a call that has since ended on the daemon.
+    useShared.setState({ activeCalls: [call("rtl-1", 851_000_000)] });
+    vi.mocked(api.activeCalls).mockResolvedValue([]);
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      expect(useShared.getState().activeCalls).toEqual([]);
+    });
+  });
+});

--- a/web/src/hooks/useActiveCallsPoll.ts
+++ b/web/src/hooks/useActiveCallsPoll.ts
@@ -1,0 +1,24 @@
+import { api } from "../api/client";
+import { selectClientConfig, useShared } from "../store/shared";
+import { useDataPoll } from "./useDataPoll";
+
+// useActiveCallsPoll keeps the shared-store activeCalls snapshot fresh
+// while a panel that follows live calls is mounted. The Active and
+// Dashboard panels each run their own activeCalls poll, but those only
+// tick on their own routes — so a spectrum panel opened directly (e.g.
+// #/mixer) was left reading whatever snapshot happened to be in the
+// store. A call that had already ended still looked active, freezing the
+// follow offset on a single grant frequency ("following call" forever).
+//
+// Reuses useDataPoll, which swallows fetch errors and only delivers a
+// changed snapshot, so this adds no render churn beyond a real update.
+export function useActiveCallsPoll(intervalMs = 2_000) {
+  const cfg = useShared(selectClientConfig);
+  const setActiveCalls = useShared((s) => s.setActiveCalls);
+  useDataPoll({
+    fetcher: () => api.activeCalls(cfg),
+    onData: setActiveCalls,
+    intervalMs,
+    resetKey: cfg.baseURL,
+  });
+}

--- a/web/src/panels/Constellation.tsx
+++ b/web/src/panels/Constellation.tsx
@@ -17,6 +17,7 @@ import {
 } from "../api/symbols";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
+import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
 import { TuningControls } from "../components/TuningControls";
 
 // Constellation panel — a 2D scatter of the signal in the complex
@@ -121,6 +122,10 @@ interface RenderOpts {
 export function Constellation() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
+  // Keep the follow logic live: this panel reads activeCalls but, unlike
+  // Active/Dashboard, didn't refresh it — so the view froze on a stale
+  // call ("following call" forever, single freq) when opened directly.
+  useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [conn, setConn] = useState<ConnState>("closed");
@@ -500,7 +505,13 @@ export function Constellation() {
             setOffsetKHz(khz);
           }}
           hold={hold}
-          onHoldChange={setHold}
+          onHoldChange={(next) => {
+            // Re-checking Hold parks the view on the control channel (a
+            // stable, known reference) rather than freezing on a call
+            // frequency that may already be stale.
+            if (next && controlOffsetKHz != null) setOffsetKHz(controlOffsetKHz);
+            setHold(next);
+          }}
           following={
             followOffsetKHz != null
               ? "call"

--- a/web/src/panels/Histogram.tsx
+++ b/web/src/panels/Histogram.tsx
@@ -19,6 +19,7 @@ import {
 import { openSymbolStream, type SymbolFrame } from "../api/symbols";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
+import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
 import { TuningControls } from "../components/TuningControls";
 
 ChartJS.register(
@@ -101,6 +102,10 @@ function computeQuality(dibits: number[], soft: number[]): Quality {
 export function Histogram() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
+  // Keep the follow logic live: this panel reads activeCalls but, unlike
+  // Active/Dashboard, didn't refresh it — so the view froze on a stale
+  // call ("following call" forever, single freq) when opened directly.
+  useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [conn, setConn] = useState<ConnState>("closed");
@@ -325,7 +330,13 @@ export function Histogram() {
             setOffsetKHz(khz);
           }}
           hold={hold}
-          onHoldChange={setHold}
+          onHoldChange={(next) => {
+            // Re-checking Hold parks the view on the control channel (a
+            // stable, known reference) rather than freezing on a call
+            // frequency that may already be stale.
+            if (next && controlOffsetKHz != null) setOffsetKHz(controlOffsetKHz);
+            setHold(next);
+          }}
           following={
             followOffsetKHz != null
               ? "call"

--- a/web/src/panels/Mixer.tsx
+++ b/web/src/panels/Mixer.tsx
@@ -9,6 +9,7 @@ import {
 import { openMixerStream, type MixerFrame } from "../api/mixer";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
+import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
 import { TuningControls } from "../components/TuningControls";
 
 // Mixer plot — GopherTrunk's take on OP25's Raw Mixer / Tuned Mixer tabs.
@@ -35,6 +36,10 @@ type ConnState = "connecting" | "open" | "closed";
 export function Mixer() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
+  // Keep the follow logic live: this panel reads activeCalls but, unlike
+  // Active/Dashboard, didn't refresh it — so the view froze on a stale
+  // call ("following call" forever, single freq) when opened directly.
+  useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [conn, setConn] = useState<ConnState>("closed");
@@ -219,7 +224,13 @@ export function Mixer() {
             setOffsetKHz(khz);
           }}
           hold={hold}
-          onHoldChange={setHold}
+          onHoldChange={(next) => {
+            // Re-checking Hold parks the view on the control channel (a
+            // stable, known reference) rather than freezing on a call
+            // frequency that may already be stale.
+            if (next && controlOffsetKHz != null) setOffsetKHz(controlOffsetKHz);
+            setHold(next);
+          }}
           following={
             followOffsetKHz != null
               ? "call"

--- a/web/src/panels/SymbolScope.tsx
+++ b/web/src/panels/SymbolScope.tsx
@@ -14,6 +14,7 @@ import {
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
 import { SymbolScopeChart } from "../components/SymbolScopeChart";
+import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
 import { TuningControls } from "../components/TuningControls";
 
 // Symbol scope panel — a live oscilloscope of the demodulated symbol
@@ -41,6 +42,10 @@ type ConnState = "connecting" | "open" | "closed";
 export function SymbolScope() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
+  // Keep the follow logic live: this panel reads activeCalls but, unlike
+  // Active/Dashboard, didn't refresh it — so the view froze on a stale
+  // call ("following call" forever, single freq) when opened directly.
+  useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [conn, setConn] = useState<ConnState>("closed");
@@ -255,7 +260,13 @@ export function SymbolScope() {
             setOffsetKHz(khz);
           }}
           hold={hold}
-          onHoldChange={setHold}
+          onHoldChange={(next) => {
+            // Re-checking Hold parks the view on the control channel (a
+            // stable, known reference) rather than freezing on a call
+            // frequency that may already be stale.
+            if (next && controlOffsetKHz != null) setOffsetKHz(controlOffsetKHz);
+            setHold(next);
+          }}
           following={
             followOffsetKHz != null
               ? "call"

--- a/web/src/panels/Tuning.test.tsx
+++ b/web/src/panels/Tuning.test.tsx
@@ -95,6 +95,52 @@ describe("Tuning panel", () => {
     });
   });
 
+  it("snaps the view to the control channel when Hold is re-checked", async () => {
+    // SDR centred at 851.0125 MHz with its control channel +50 kHz up.
+    const CTRL_DEVICE = [
+      {
+        serial: "rtl-1",
+        driver: "rtlsdr",
+        role: "control",
+        center_hz: 851_012_500,
+        sample_rate_hz: 2_048_000,
+        control_channel_hz: 851_062_500, // +50 kHz
+      },
+    ];
+    vi.mocked(fetchSpectrumDevices).mockResolvedValue(CTRL_DEVICE as never);
+    // A live call on this SDR sits +100 kHz from centre. With Hold off the
+    // view follows it; the poll's real fetch rejects under jsdom, so this
+    // seeded snapshot survives.
+    useShared.setState({
+      activeCalls: [
+        {
+          grant: {
+            group_id: 1,
+            system: "Sys",
+            protocol: "p25",
+            frequency_hz: 851_112_500, // +100 kHz
+          },
+          device_serial: "rtl-1",
+          started_at: "2026-01-01T00:00:00Z",
+        },
+      ] as never,
+    });
+
+    render(<Tuning />);
+
+    const offset = (await screen.findByLabelText(
+      "View offset from SDR centre in kHz (numeric)",
+    )) as HTMLInputElement;
+    // Follows the call: +100 kHz.
+    await waitFor(() => expect(offset.value).toBe("100"));
+    expect(screen.getByText(/following call/)).toBeInTheDocument();
+
+    // Tick Hold → snap to the control channel (+50 kHz), not frozen on the call.
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() => expect(offset.value).toBe("50"));
+    expect(screen.queryByText(/following call/)).not.toBeInTheDocument();
+  });
+
   it("shows the carrier-error meter once a frame arrives", async () => {
     vi.mocked(fetchSpectrumDevices).mockResolvedValue(ONE_DEVICE as never);
     vi.mocked(openSymbolStream).mockImplementation((_cfg, opts) => {

--- a/web/src/panels/Tuning.tsx
+++ b/web/src/panels/Tuning.tsx
@@ -21,6 +21,7 @@ import {
 import { openSymbolStream, type SymbolFrame } from "../api/symbols";
 import { selectClientConfig, useShared } from "../store/shared";
 import { prefs } from "../store/prefs";
+import { useActiveCallsPoll } from "../hooks/useActiveCallsPoll";
 import { TuningControls } from "../components/TuningControls";
 
 ChartJS.register(
@@ -54,6 +55,10 @@ type ConnState = "connecting" | "open" | "closed";
 export function Tuning() {
   const cfg = useShared(selectClientConfig);
   const activeCalls = useShared((s) => s.activeCalls);
+  // Keep the follow logic live: this panel reads activeCalls but, unlike
+  // Active/Dashboard, didn't refresh it — so the view froze on a stale
+  // call ("following call" forever, single freq) when opened directly.
+  useActiveCallsPoll();
   const [devices, setDevices] = useState<SpectrumDevice[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
   const [conn, setConn] = useState<ConnState>("closed");
@@ -272,7 +277,13 @@ export function Tuning() {
             setOffsetKHz(khz);
           }}
           hold={hold}
-          onHoldChange={setHold}
+          onHoldChange={(next) => {
+            // Re-checking Hold parks the view on the control channel (a
+            // stable, known reference) rather than freezing on a call
+            // frequency that may already be stale.
+            if (next && controlOffsetKHz != null) setOffsetKHz(controlOffsetKHz);
+            setHold(next);
+          }}
           following={
             followOffsetKHz != null
               ? "call"


### PR DESCRIPTION
The Mixer/Tuning/Histogram/Constellation/SymbolScope panels read
activeCalls from the shared store to follow the newest active call (and
rest on the control channel when none is up), but nothing on those routes
refreshed activeCalls — only the Active and Dashboard pollers do, and they
only run on their own routes. Opening #/mixer directly left the store
holding a stale snapshot, so a call that had already ended still looked
active: the view froze on a single grant frequency and showed "following
call" forever.

Add a small useActiveCallsPoll hook (wrapping the existing useDataPoll +
api.activeCalls) and call it in each of the five spectrum panels so their
follow logic stays live. With the snapshot fresh, Hold off correctly
follows live calls and falls back to the control channel when a call ends.

Also make re-checking Hold park the view on the control channel (when
known) instead of freezing on a possibly-stale call frequency, giving a
stable, known reference when the operator pins the view.

Regression tests cover the stale-call refresh and the Hold snap-to-CC.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FNcvREuUEajmdgoFyi1k5M