### PR TITLE
docs: sync release docs to v0.5.5 — promote CHANGELOG, bump refs, announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,82 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.5] — 2026-06-27
+
+A wideband-reliability release. The big wins are for dense, high-rate captures
+that were dropping samples and garbling audio: the SoapyRemote host buffer is
+now sized for jitter so a P25 control channel stops flooding framing errors, the
+polyphase channelizer's per-tap loop is parallelised across CPU cores so a
+71-channel DMR plan keeps up in real time, and outer wideband voice grants
+(±1.9 MHz of centre) finally tune through a span-aware per-call DDC instead of
+producing no audio. Also fixes **DMR Tier II conventional** voice that decoded as
+"DJ scratch" — the single-slot decoder was slicing alternating TDMA timeslots
+into each superframe; it now defaults to 2-slot interleaved cadence (#644).
+Rounded out by startup guidance to lower an oversampled capture rate, and
+research docs that push the #773 Motorola talker-alias cryptanalysis forward
+(no decoder shipped — the cipher stays gated).
+
+### Added
+- **SDR overrun visibility for network SDRs.** The SoapyRemote source now
+  surfaces device + host-side sample drops at a rate-limited WARN with running
+  counts and an actionable hint (lower `sdr.sample_rate` / reduce channel
+  count), instead of burying them in a per-datagram DEBUG line.
+- **Talker-alias cryptanalysis research** (#773). A chosen-plaintext capture
+  procedure for collecting controlled plaintext/ciphertext pairs from a
+  programmed Motorola P25 radio, plus a clean-room cryptanalysis findings doc
+  from the 3,607-pair ground truth. The cipher remains gated
+  (`CipherVerified=false`) — no decoder ships — but the framing/structure is now
+  documented for the next attempt.
+
+### Changed
+- **Parallel wideband channelizer.** The polyphase channelizer's per-tap
+  fine-tune loop (NCO mix + resampler + narrowband receiver) now runs across up
+  to one worker per CPU core via a persistent pool, so a dense plan (e.g. 71 DMR
+  channels at 10 MS/s) no longer backs up the SDR reader, stalls flow-control
+  ACKs, and overflows the radio. Below a tap-count threshold it stays on the
+  byte-identical serial path; each receiver still sees its chunks in order.
+- **Oversampled-rate startup advice.** The wideband engine now emits a startup
+  WARN when `sample_rate` is ≥1.5× the plan's minimum required rate (the rate
+  whose usable half-band just covers the widest channel offset), naming the span
+  and a suggested floor — capturing well above it only burdens the host with no
+  decode benefit.
+
+### Fixed
+- **Outer wideband voice grants now tune.** On a wideband plan whose voice
+  grants sit out to ±1.9 MHz of centre, the per-call DDC was built with the
+  no-span path (reduced rate floored at 2.5 MS/s, rejecting any offset beyond
+  ±1.1 MHz), so the outer carriers produced no audio at all. `StreamIQ` now sizes
+  the per-call bank span-aware from the grant offset — the gap left by the #764
+  shared-decimator work on the control-channel path.
+- **DMR Tier II conventional voice decoded as "DJ scratch"** (#644). A DMR
+  repeater carrier is 2-slot TDMA, but the single-slot voice decoder sliced
+  straight through it and pulled alternating timeslots into each superframe —
+  garbled, encrypted-sounding audio with the embedded LC never reassembling.
+  Tier II conventional (`proto=dmr-tier2`) now defaults to 2-slot interleaved
+  voice. Being a slot-cadence mismatch it was rate-independent, matching the
+  field report at both 10 MS/s and 6.25 MS/s.
+- **SoapyRemote host buffer dropped IQ under jitter.** The never-block read loop
+  (correct — a blocked reader stalls socket draining and makes the device
+  overflow) was paired with a fixed 8-deep stream channel, only a few
+  milliseconds of buffer at multi-MS/s. Ordinary consumer jitter (GC pauses,
+  scheduling, bursty delivery) filled it and shed ~2% of chunks — silent IQ
+  discontinuities that broke the P25 symbol clock and flooded nid-bch / tsbk-crc
+  errors even though the device never overflowed. The buffer is now sized for
+  jitter, and a full channel sheds the oldest chunk (freshest data, low latency)
+  as one counted local drop rather than stalling the radio.
+
+## [v0.5.4] — 2026-06-26
+
+Focused on **wideband front-end guidance and honesty**. A 70-channel DMR plan on
+a single 10 MS/s capture used to kill daemon init ("two tap offsets fall in the
+same channelizer bin"); the channelizer now lets multiple carriers share a bin
+and hosts dense plans instead of crashing. The release also stops the Motorola
+P25 talker-alias decoder from surfacing fabricated names — the per-byte cipher
+was AI-authored and unverified, so it is now gated behind `CipherVerified`
+(#773) — adds a `capture` sample-rate hint and `gain:auto` guidance for shared
+wideband front ends, and learns talkgroups straight off live control-channel
+grants.
+
 ### Added
 - **Capture sample-rate guidance** (#771). `gophertrunk capture` now prints a
   one-line hint when a high native rate (>4 MS/s) is chosen for a narrowband
@@ -16,6 +92,46 @@ for tagged releases.
   root cause of the #771 no-lock report. A new "Choosing a sample rate" section
   in `docs/hardware.md` documents the finding and recommends ~2.4–2.5 MS/s for
   control-channel roles.
+- **Auto-discover talkgroups from control-channel grants.** Each talkgroup is
+  catalogued the first time it is granted on the control channel, so
+  Database → Talkgroups fills in from live traffic instead of staying bare for an
+  operator who starts with an empty CSV. Discovered entries are tagged
+  "Discovered", skip individual (unit-to-unit) grants, and never silently widen a
+  curated scan list — the operator opts them in from the UI. In-memory for now.
+
+### Changed
+- **`gain:auto` guidance for multi-tap wideband devices** (#749). A single fixed
+  gain on a shared front end can't serve sites of differing strength — a gain set
+  so the strongest site doesn't clip leaves weaker co-tenants at the ADC noise
+  floor, and the post-discriminator AGC can't recover SNR lost at the converter.
+  A startup WARN now flags a `role: wideband` dongle with >1 channel pinned to a
+  manual gain (and the per-tap low-power WARN suggests `gain: "auto"`);
+  `config.example.yaml` and `docs/hardware.md` document the AGC recommendation.
+- **Unverified Motorola talker-alias cipher gated** (#773). The shared per-byte
+  cipher (256-byte substitution table + accumulator constants) was AI-authored in
+  #376 with comments falsely claiming it was a reverse-engineered fact identical
+  across open-source decoders. A clean-room derivation showed it is
+  mathematically underdetermined from the available capture. The provenance
+  comments are corrected and `motorola.CipherVerified` (false) now gates alias
+  reporting — an alias is reported reliable only when the decode is clean ASCII
+  **and** the cipher is verified — so a possibly-wrong table can never surface a
+  fabricated name as a confirmed alias.
+
+### Fixed
+- **Dense wideband plans no longer crash daemon init.** A 70-channel DMR plan on
+  a 10 MS/s capture (several 12.5 kHz carriers per 156 kHz bin) died at init
+  because the channelizer hard-rejected a second tap in a claimed bin. Multiple
+  taps may now share a bin — each already runs its own fine-tune NCO + resampler
+  and narrowband receiver, so they decode independently — and the engine hosts
+  the dense plan on the channelizer (the per-tap DDC benchmarked ~5.6× heavier
+  and would blow the real-time budget at that scale).
+- **Plots panels follow the voice channel on wideband SDRs.** The Plots panels
+  (Mixer, Symbol Scope, Tuning, Constellation, Eye Diagram, Histogram) match the
+  active call's `device_serial` to the selected SDR, but a wideband call runs on
+  a virtual voice tap (`wb:<parent>:tap-N`) while the selector lists the parent —
+  so the view stayed pinned to the control channel and "Hold" appeared to do
+  nothing. Tap serials now resolve back to their parent in every panel's follow
+  filter.
 
 ## [v0.5.3] — 2026-06-25
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.3
+VERSION=v0.5.5
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.3" -%}
+  {%- assign ver = "v0.5.5" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.4.md
+++ b/docs/announcements/v0.5.4.md
@@ -1,0 +1,51 @@
+# GopherTrunk v0.5.4 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.4 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.4
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.4 — dense wideband DMR plans (70+ channels on one SDR) no longer crash daemon init, the unverified Motorola talker-alias cipher is now gated so it can't surface fabricated names, plus capture sample-rate hints and gain:auto guidance for shared wideband front ends
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.4 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.5.3:**
+
+* **Dense wideband plans no longer crash daemon init.** A 70-channel DMR plan on a single 10 MS/s capture used to die at init ("two tap offsets fall in the same channelizer bin"). The polyphase channelizer now lets multiple 12.5 kHz carriers share a 156 kHz bin — each tap already runs its own fine-tune NCO + resampler and narrowband receiver, so they decode independently — and the engine hosts the whole dense plan instead of crashing.
+* **Unverified Motorola talker-alias cipher gated** (#773). The shared per-byte cipher was AI-authored with comments falsely claiming it was a reverse-engineered fact. A clean-room derivation showed it's mathematically underdetermined from the available capture, so it's now gated behind `CipherVerified` (false): an alias is reported reliable only when the decode is clean ASCII **and** the cipher is verified. A possibly-wrong table can no longer surface a fabricated name as a confirmed alias.
+* **Capture sample-rate guidance** (#771). `gophertrunk capture` now hints when a high native rate (>4 MS/s) is chosen for a narrowband trunking capture — the down-converter normalises to 48 kHz, and the top native clock on wideband front-ends (e.g. Airspy R2 at 10 MS/s) can degrade in-channel SNR via phase noise / reciprocal mixing. A new "Choosing a sample rate" section in the hardware docs recommends ~2.4–2.5 MS/s for control-channel roles.
+* **`gain:auto` guidance for shared wideband front ends** (#749). A single fixed gain can't serve sites of differing strength; a startup WARN now flags a `role: wideband` dongle with >1 channel pinned to a manual gain and recommends AGC, with the same advice in `config.example.yaml` and the hardware docs.
+* **Auto-discover talkgroups from control-channel grants.** Each talkgroup is catalogued the first time it's granted on the control channel, so Database → Talkgroups fills in from live traffic instead of staying bare for an empty CSV. Discovered entries are tagged, skip unit-to-unit grants, and never silently widen a curated scan list.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.4
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.4 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.5.3:**
+- **Dense wideband DMR plans no longer crash daemon init** — the polyphase channelizer now hosts multiple 12.5 kHz carriers per bin, so a 70-channel plan on one 10 MS/s SDR decodes instead of dying at startup.
+- **Unverified Motorola talker-alias cipher gated** (#773) — the AI-authored, unverified cipher is now behind `CipherVerified`, so it can't surface fabricated names; provenance comments corrected.
+- **Capture sample-rate hint** (#771) — `gophertrunk capture` warns when a high native rate is chosen for a narrowband decode; docs recommend ~2.4–2.5 MS/s for control channels.
+- **`gain:auto` guidance for shared wideband front ends** (#749) — startup WARN when a multi-channel wideband dongle is pinned to a manual gain.
+- **Auto-discover talkgroups from control-channel grants** — Database → Talkgroups fills in from live traffic, trunk-recorder style.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.4>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/announcements/v0.5.5.md
+++ b/docs/announcements/v0.5.5.md
@@ -1,0 +1,51 @@
+# GopherTrunk v0.5.5 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.5 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.5
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.5 — wideband reliability: the SoapyRemote host buffer is sized for jitter so P25 stops flooding framing errors, the channelizer runs across all your CPU cores so a 71-channel DMR plan keeps up in real time, outer wideband voice grants finally tune, and DMR Tier II conventional voice that decoded as "DJ scratch" is fixed
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.5 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.5.4:**
+
+* **SoapyRemote host buffer dropped IQ under jitter — fixed.** A never-block read loop paired with a fixed 8-deep stream channel held only a few milliseconds of buffer at multi-MS/s; ordinary consumer jitter (GC pauses, scheduling, bursty delivery) shed ~2% of chunks — silent IQ discontinuities that broke the P25 symbol clock and flooded nid-bch / tsbk-crc errors even though the device never overflowed. The buffer is now sized for jitter, and a full channel sheds the oldest chunk as one counted local drop instead of stalling the radio.
+* **Parallel wideband channelizer.** The per-tap fine-tune loop (NCO + resampler + narrowband receiver) now runs across up to one worker per CPU core, so a dense plan (71 DMR channels at 10 MS/s) no longer backs up the SDR reader, stalls flow-control ACKs, and overflows the radio. Below a tap-count threshold it stays on the byte-identical serial path.
+* **Outer wideband voice grants now tune.** On a plan whose voice grants sit out to ±1.9 MHz of centre, the per-call DDC was floored at 2.5 MS/s and rejected any offset beyond ±1.1 MHz, so the outer carriers produced no audio. `StreamIQ` now sizes the per-call bank span-aware from the grant offset — closing the gap the #764 shared-decimator work left on the voice path.
+* **DMR Tier II conventional "DJ scratch" voice — fixed** (#644). A DMR repeater carrier is 2-slot TDMA, but the single-slot decoder sliced straight through it and pulled alternating timeslots into each superframe — garbled, encrypted-sounding audio. `proto=dmr-tier2` now defaults to 2-slot interleaved voice. Being a slot-cadence mismatch it was rate-independent, matching the field report at both 10 MS/s and 6.25 MS/s.
+* **Oversampled-rate startup advice + overrun visibility.** A startup WARN fires when `sample_rate` is ≥1.5× the rate the plan's span actually needs (capturing higher just burdens the host), and SoapyRemote now surfaces device + host sample drops at a rate-limited WARN with running counts and a fix-it hint instead of a buried DEBUG line.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.5
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.5 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.5.4:**
+- **SoapyRemote host buffer dropped IQ under jitter — fixed** — the stream buffer is now sized for jitter, so a P25 control channel stops flooding nid-bch / tsbk-crc framing errors on a remote SDR.
+- **Parallel wideband channelizer** — the per-tap loop runs across all CPU cores, so a 71-channel DMR plan at 10 MS/s keeps up in real time instead of overflowing the radio.
+- **Outer wideband voice grants now tune** — a span-aware per-call DDC means grants out to ±1.9 MHz of centre produce audio instead of silence.
+- **DMR Tier II conventional "DJ scratch" voice fixed** (#644) — `proto=dmr-tier2` defaults to 2-slot interleaved voice; the single-slot decoder was chopping alternating TDMA timeslots together.
+- **Oversampled-rate startup advice + SDR overrun WARNs** — guidance to lower a needlessly high capture rate, and visible, counted sample-drop warnings.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.5>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow tagged v0.5.4 (2026-06-26) and v0.5.5
(2026-06-27) but the docs were still pinned to v0.5.3, so catch them up
in one pass:

- CHANGELOG.md: promote the [Unreleased] capture sample-rate entry into a
  new [v0.5.4] section and add the rest of v0.5.4 (dense wideband plans no
  longer crash daemon init, gated Motorola talker-alias cipher #773,
  gain:auto guidance #749, control-channel talkgroup auto-discovery, Plots
  voice-channel follow). Add a [v0.5.5] section (SoapyRemote jitter buffer
  fix, parallel channelizer, span-aware outer voice grants, DMR Tier II
  2-slot voice default #644, oversampled-rate startup advice + overrun
  WARNs). [Unreleased] is now empty.
- README.md quick-start VERSION and docs/_includes/latest-version.html
  fallback tag bumped v0.5.3 -> v0.5.5.
- Add the v0.5.4 and v0.5.5 social-announcement drafts.

Docs-only; no Go sources touched.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AQCtL26fQbVGQXpYqVyH4U