### PR TITLE
Surface decoded P25 IDEN_UP frequency-band table via systems API/UI

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -120,7 +120,7 @@ func (s *Server) handleListSystems(w http.ResponseWriter, _ *http.Request) {
 	for _, sys := range s.systems {
 		dto := systemToDTO(sys)
 		overlayLiveIdentity(&dto, live)
-		s.overlayNeighbors(&dto)
+		s.overlayTopology(&dto)
 		dto.fillIdentityHex()
 		out = append(out, dto)
 	}
@@ -135,7 +135,7 @@ func (s *Server) handleGetSystem(w http.ResponseWriter, r *http.Request) {
 			if s.sites != nil {
 				overlayLiveIdentity(&dto, s.sites.Sites())
 			}
-			s.overlayNeighbors(&dto)
+			s.overlayTopology(&dto)
 			dto.fillIdentityHex()
 			writeJSON(w, http.StatusOK, dto)
 			return
@@ -203,17 +203,20 @@ func overlayLiveIdentity(dto *SystemDTO, sites []trunking.SiteInfo) {
 	}
 }
 
-// overlayNeighbors fills dto.Neighbors from the live topology snapshot for the
-// system, when the wired SitesProvider exposes one (the SiteTracker does). The
-// adjacent sites are decoded from P25 status broadcasts over the air, so a
-// configured-but-quiet system simply leaves the list empty.
-func (s *Server) overlayNeighbors(dto *SystemDTO) {
+// overlayTopology fills dto.Neighbors and dto.FrequencyBands from the live
+// topology snapshot for the system, when the wired SitesProvider exposes one
+// (the SiteTracker does). Both the adjacent sites and the P25 IDEN_UP band plan
+// are decoded from control-channel broadcasts over the air, so a
+// configured-but-quiet system simply leaves them empty. One snapshot lookup
+// feeds both.
+func (s *Server) overlayTopology(dto *SystemDTO) {
 	tp, ok := s.sites.(NetworkTopologyProvider)
 	if !ok {
 		return
 	}
 	if snap, ok := tp.Topology(dto.Name); ok {
 		dto.Neighbors = neighborsFromTopology(snap)
+		dto.FrequencyBands = bandPlanFromTopology(snap)
 	}
 }
 

--- a/internal/api/handlers_systems_bandplan_test.go
+++ b/internal/api/handlers_systems_bandplan_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestGetSystemBandPlan checks that the live topology's decoded P25 IDEN_UP
+// frequency-band table is overlaid onto SystemDTO.FrequencyBands for both the
+// detail and list endpoints, sorted by channel ID and carrying the TDMA flag
+// and transmit offset (issue #814).
+func TestGetSystemBandPlan(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	snap := &trunking.TopologySnapshot{
+		WACN:     0xBEE00,
+		SystemID: 0x2C2,
+		RFSS:     1,
+		Site:     1,
+		BandPlan: []trunking.TopoBandPlanSlot{
+			// Band 1 first in the slice; expect it sorted after band 0.
+			{ChannelID: 1, BaseHz: 421_262_500, SpacingHz: 6_250, BandwidthHz: 12_500, TxOffsetHz: 5_500_000, AccessTDMA: true},
+			{ChannelID: 0, BaseHz: 418_100_000, SpacingHz: 6_250, BandwidthHz: 12_500, TxOffsetHz: -9_450_000, AccessTDMA: true},
+		},
+	}
+	prov := fakeTopoProvider{system: "MMR", snap: snap}
+	systems := []trunking.System{{Name: "MMR"}}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: systems, Sites: prov})
+	defer teardown()
+
+	// Detail endpoint.
+	resp := mustGet(t, base+"/api/v1/systems/MMR")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var dto SystemDTO
+	if err := json.NewDecoder(resp.Body).Decode(&dto); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(dto.FrequencyBands) != 2 {
+		t.Fatalf("FrequencyBands = %d, want 2: %+v", len(dto.FrequencyBands), dto.FrequencyBands)
+	}
+	// Sorted by channel ID: band 0 before band 1.
+	if dto.FrequencyBands[0].ChannelID != 0 || dto.FrequencyBands[1].ChannelID != 1 {
+		t.Errorf("bands not sorted by channel id: %+v", dto.FrequencyBands)
+	}
+	b := dto.FrequencyBands[0]
+	if b.BaseHz != 418_100_000 {
+		t.Errorf("base = %d, want 418100000", b.BaseHz)
+	}
+	if b.SpacingHz != 6_250 {
+		t.Errorf("spacing = %d, want 6250", b.SpacingHz)
+	}
+	if b.BandwidthHz != 12_500 {
+		t.Errorf("bandwidth = %d, want 12500", b.BandwidthHz)
+	}
+	if b.TxOffsetHz != -9_450_000 {
+		t.Errorf("tx offset = %d, want -9450000", b.TxOffsetHz)
+	}
+	if !b.AccessTDMA {
+		t.Errorf("access_tdma = false, want true")
+	}
+
+	// List endpoint surfaces the same band plan.
+	listResp := mustGet(t, base+"/api/v1/systems")
+	defer listResp.Body.Close()
+	var list struct {
+		Systems []SystemDTO `json:"systems"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list.Systems) != 1 || len(list.Systems[0].FrequencyBands) != 2 {
+		t.Fatalf("list frequency bands missing: %+v", list.Systems)
+	}
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -133,6 +133,14 @@ type SystemDTO struct {
 	// panels can show them the way SDRtrunk's "Neighbor Sites" view does,
 	// instead of only the system drill-in report.
 	Neighbors []NeighborDTO `json:"neighbors,omitempty"`
+
+	// FrequencyBands is the decoded P25 IDEN_UP frequency-band table (channel
+	// ID → base/spacing/offset), overlaid live from the same topology snapshot
+	// as Neighbors. Surfaced so the Systems panel can show the band plan the way
+	// SDRtrunk's "Details" tab does, and so a neighbour's channel_id/
+	// channel_number can be mapped back to an absolute frequency. Empty until an
+	// IDEN_UP has been heard. (#814)
+	FrequencyBands []BandPlanSlotDTO `json:"frequency_bands,omitempty"`
 }
 
 // NeighborDTO is one adjacent site advertised by a system's control channel,
@@ -181,6 +189,47 @@ func neighborsFromTopology(snap *trunking.TopologySnapshot) []NeighborDTO {
 		}
 		return out[i].Site < out[j].Site
 	})
+	return out
+}
+
+// BandPlanSlotDTO is one P25 IDEN_UP frequency-band entry, mirroring
+// trunking.TopoBandPlanSlot / trunking.ReportBand. It maps a channel ID to a
+// downlink base frequency, channel spacing, and (signed) transmit offset — the
+// table SDRtrunk surfaces in its "Details" tab and the data needed to map a
+// neighbour's channel_id/channel_number back to an absolute frequency.
+type BandPlanSlotDTO struct {
+	ChannelID   uint8  `json:"channel_id"`
+	BaseHz      uint64 `json:"base_hz"`
+	SpacingHz   uint32 `json:"spacing_hz"`
+	BandwidthHz uint32 `json:"bandwidth_hz,omitempty"`
+	TxOffsetHz  int64  `json:"tx_offset_hz,omitempty"`
+	AccessTDMA  bool   `json:"access_tdma,omitempty"`
+}
+
+// bandPlanFromTopology converts a live topology snapshot's band plan into DTOs,
+// reusing trunking.ReportFromTopology so the values match the
+// network-configuration report and the decoded-message log exactly. Sorted by
+// channel ID for stable output. Returns nil when there are none.
+func bandPlanFromTopology(snap *trunking.TopologySnapshot) []BandPlanSlotDTO {
+	if snap == nil {
+		return nil
+	}
+	r := trunking.ReportFromTopology(snap)
+	if len(r.Bands) == 0 {
+		return nil
+	}
+	out := make([]BandPlanSlotDTO, 0, len(r.Bands))
+	for _, b := range r.Bands {
+		out = append(out, BandPlanSlotDTO{
+			ChannelID:   b.ChannelID,
+			BaseHz:      b.BaseHz,
+			SpacingHz:   b.SpacingHz,
+			BandwidthHz: b.BandwidthHz,
+			TxOffsetHz:  b.TxOffsetHz,
+			AccessTDMA:  b.AccessTDMA,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ChannelID < out[j].ChannelID })
 	return out
 }
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -33,6 +33,10 @@ export interface SystemDTO {
   // Live adjacent (neighbour) sites decoded from the control channel (P25
   // Adjacent Site Status Broadcast). Empty/absent until one is heard.
   neighbors?: NeighborDTO[];
+  // Decoded P25 IDEN_UP frequency-band table (channel id → base/spacing/offset),
+  // overlaid live from the same topology snapshot as neighbors. Empty/absent
+  // until an IDEN_UP is heard. (#814)
+  frequency_bands?: BandPlanSlotDTO[];
 }
 
 // NeighborDTO mirrors api.NeighborDTO — one adjacent site with resolved
@@ -46,6 +50,17 @@ export interface NeighborDTO {
   uplink_hz?: number;
   rfss_hex?: string;
   site_hex?: string;
+}
+
+// BandPlanSlotDTO mirrors api.BandPlanSlotDTO — one P25 IDEN_UP frequency-band
+// entry (channel id → downlink base, spacing, and signed transmit offset).
+export interface BandPlanSlotDTO {
+  channel_id: number;
+  base_hz: number;
+  spacing_hz: number;
+  bandwidth_hz?: number;
+  tx_offset_hz?: number;
+  access_tdma?: boolean;
 }
 
 // DMRBandPlanDTO mirrors api.DMRBandPlanDTO — exactly one of linear/table.

--- a/web/src/panels/Systems.tsx
+++ b/web/src/panels/Systems.tsx
@@ -7,6 +7,7 @@ import { StaleIndicator } from "../components/ui/StaleIndicator";
 import { useDataPoll } from "../hooks/useDataPoll";
 import { formatIdNumber } from "../lib/idFormat";
 import type {
+  BandPlanSlotDTO,
   DMRBandPlanDTO,
   DMRBandPlanLearnedDTO,
   EventDTO,
@@ -42,6 +43,19 @@ function formatNeighbor(n: NeighborDTO, idBase: "hex" | "dec"): string {
   const site = formatIdNumber(n.site, idBase) ?? String(n.site);
   let s = `RFSS ${rfss} / Site ${site}`;
   if (n.downlink_hz) s += ` → ${(n.downlink_hz / 1e6).toFixed(6)} MHz`;
+  return s;
+}
+
+// formatBand renders one decoded IDEN_UP slot the way SDRtrunk's "Details" tab
+// shows the band plan: base downlink frequency, channel spacing, and the signed
+// transmit offset, tagging TDMA bands. Offset is omitted when zero/unknown.
+function formatBand(b: BandPlanSlotDTO): string {
+  let s = `BAND ${b.channel_id}`;
+  if (b.access_tdma) s += " TDMA";
+  s += ` · BASE ${(b.base_hz / 1e6).toFixed(6)} MHz`;
+  s += ` · SPACING ${b.spacing_hz} Hz`;
+  if (b.tx_offset_hz)
+    s += ` · OFFSET ${(b.tx_offset_hz / 1e6).toFixed(6)} MHz`;
   return s;
 }
 
@@ -319,6 +333,20 @@ export function Systems() {
                 mono
                 value={selected.neighbors
                   .map((n) => formatNeighbor(n, idBase))
+                  .join("\n")}
+              />
+            </div>
+          ) : null}
+          {selected.frequency_bands && selected.frequency_bands.length > 0 ? (
+            <div>
+              <p className="text-xs uppercase tracking-wider text-muted mb-2">
+                Frequency bands ({selected.frequency_bands.length})
+              </p>
+              <DetailField
+                label="Band → base / spacing / offset"
+                mono
+                value={selected.frequency_bands
+                  .map((b) => formatBand(b))
                   .join("\n")}
               />
             </div>


### PR DESCRIPTION
The full P25 IDEN_UP / identifier-update band table is already decoded and
accumulated into TopologySnapshot.BandPlan (and rendered in the network
report), but it was not surfaced on GET /api/v1/systems nor in the web
Systems panel — only the sibling neighbor-site list (#698) was.

Overlay the band plan onto SystemDTO from the same live topology snapshot
as neighbors, and render a "Frequency bands (N)" section in the Systems
detail modal next to "Neighbor sites (N)". This lets operators read the
band plan SDRtrunk-style and map a neighbour's channel_id/channel_number
back to an absolute frequency without doing it by hand.

- api: add BandPlanSlotDTO + bandPlanFromTopology (reuses
  trunking.ReportFromTopology so values match the report/log exactly);
  rename overlayNeighbors -> overlayTopology to fill both from one snapshot.
- web: add BandPlanSlotDTO type, frequency_bands on SystemDTO, formatBand
  helper, and the new detail-modal section.
- test: handlers_systems_bandplan_test.go asserts both list and detail
  endpoints surface the table, sorted by channel id, with TDMA flag and
  transmit offset (fails before the wiring, passes after).

Refs #814

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EonG3FtR4mADEsW8nZjzk3