### PR TITLE
ccdecoder: warn + surface when the control lock sits far off frequency (#815)

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1611,6 +1611,8 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					Conjugate:    iqInvert,
 					LOOffsetHz:   loOffsetHz,
 					Autotune:     d.autotune.Get(controlEntry.Info.Serial),
+					// 0 → ccdecoder's built-in default (issue #815).
+					CarrierOffsetWarnHz: int(cfg.SDR.CarrierOffsetWarnHz),
 				}
 				d.controlSerial = controlEntry.Info.Serial
 				// The CC decoder owns StreamIQ on this dongle's broker,

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -26,12 +26,13 @@ func (s *Server) handleListSites(w http.ResponseWriter, _ *http.Request) {
 		for _, si := range s.sites.Sites() {
 			k := key{si.System, si.RFSSID, si.SiteID}
 			byKey[k] = &SiteDTO{
-				System:           si.System,
-				RFSSID:           si.RFSSID,
-				SiteID:           si.SiteID,
-				ControlChannelHz: si.ControlChannelHz,
-				WACN:             si.WACN,
-				SystemID:         si.SystemID,
+				System:                        si.System,
+				RFSSID:                        si.RFSSID,
+				SiteID:                        si.SiteID,
+				ControlChannelHz:              si.ControlChannelHz,
+				ControlChannelCarrierOffsetHz: si.ControlChannelCarrierOffsetHz,
+				WACN:                          si.WACN,
+				SystemID:                      si.SystemID,
 			}
 		}
 	}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -424,9 +424,14 @@ type SiteDTO struct {
 	RFSSID           uint8  `json:"rfss_id"`
 	SiteID           uint8  `json:"site_id"`
 	ControlChannelHz uint32 `json:"control_channel_hz,omitempty"`
-	Name             string `json:"name"`
-	WACN             uint32 `json:"wacn,omitempty"`
-	SystemID         uint16 `json:"system_id,omitempty"`
+	// ControlChannelCarrierOffsetHz is the demod's measured carrier offset (Hz)
+	// of the locked control carrier relative to the tuned centre. A large value
+	// flags a control lock sitting well off the configured frequency — e.g. an
+	// adjacent site bleeding through at 12.5 kHz spacing (issue #815).
+	ControlChannelCarrierOffsetHz int32  `json:"control_channel_carrier_offset_hz,omitempty"`
+	Name                          string `json:"name"`
+	WACN                          uint32 `json:"wacn,omitempty"`
+	SystemID                      uint16 `json:"system_id,omitempty"`
 	// Hex renderings of the identity numbers, alongside the decimal fields.
 	WACNHex     string `json:"wacn_hex,omitempty"`
 	SystemIDHex string `json:"system_id_hex,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -785,8 +785,15 @@ type SDRConfig struct {
 	// ppm — it only logs a suggested ppm/error value you can bake into the
 	// device block by hand. Off by default; harmless to leave on for
 	// TCXO-equipped units (the correction simply stays near zero).
-	Autotune bool           `yaml:"autotune"`
-	Devices  []DeviceConfig `yaml:"devices"`
+	Autotune bool `yaml:"autotune"`
+	// CarrierOffsetWarnHz is the magnitude of the locked control-channel carrier
+	// offset (Hz) above which the decoder logs a WARN that GT may be decoding an
+	// adjacent site's stronger carrier rather than the configured frequency
+	// (issue #815). Zero selects the built-in default (4000 Hz); raise it for a
+	// high-drift dongle whose legitimate crystal error would otherwise trip the
+	// warning. Advisory only — it never changes tuning or decode.
+	CarrierOffsetWarnHz uint32         `yaml:"carrier_offset_warn_hz"`
+	Devices             []DeviceConfig `yaml:"devices"`
 	// RTLTCP lists remote rtl_tcp endpoints (host:port + optional
 	// per-endpoint metadata) to mount as virtual tuners. Each entry
 	// becomes a pool device alongside any locally-attached USB

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -91,13 +91,14 @@ var fieldMetas = map[string]FieldMeta{
 	"RadioReferenceConfig.Password": {Help: "Your RadioReference.com account password (required with username for premium browse/import/verify). Can come from GOPHERTRUNK_RR_PASS instead — prefer the env var to keeping the secret in config.yaml."},
 
 	// ---- SDR ---------------------------------------------------------------
-	"SDRConfig.SampleRate":         {Label: "Sample rate", Hz: true, Help: "IQ rate every tuner is programmed to (225 kHz–20 MHz). RTL dongles cap ~3.2 MHz; higher needs a wideband soapy_remote source. Primary CPU-load lever."},
-	"SDRConfig.Devices":            {Help: "Locally-attached USB SDR dongles, selected by serial."},
-	"SDRConfig.RTLTCP":             {Label: "rtl_tcp sources", Help: "Remote rtl_tcp endpoints mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
-	"SDRConfig.SoapyRemote":        {Label: "SoapyRemote sources", Help: "Remote SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, RTL) mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
-	"SDRConfig.Ka9qRadio":          {Label: "ka9q-radio sources", Help: "Channels from remote ka9q-radio radiod instances mounted as virtual tuners over IP multicast. Plaintext — trusted LANs only."},
-	"SDRConfig.WatchdogIntervalMs": {Help: "USB-disconnect watchdog poll interval (ms). 0 = default 30 s; negative disables it."},
-	"SDRConfig.Autotune":           {Label: "Autotune", Help: "Track each dongle's carrier-frequency error on locked P25 Phase 1 control + voice and apply a digital correction so the demod's AFC starts near lock. Never rewrites hardware ppm — logs a suggested value. Off by default; safe to leave on."},
+	"SDRConfig.SampleRate":          {Label: "Sample rate", Hz: true, Help: "IQ rate every tuner is programmed to (225 kHz–20 MHz). RTL dongles cap ~3.2 MHz; higher needs a wideband soapy_remote source. Primary CPU-load lever."},
+	"SDRConfig.Devices":             {Help: "Locally-attached USB SDR dongles, selected by serial."},
+	"SDRConfig.RTLTCP":              {Label: "rtl_tcp sources", Help: "Remote rtl_tcp endpoints mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
+	"SDRConfig.SoapyRemote":         {Label: "SoapyRemote sources", Help: "Remote SoapySDRServer endpoints (USRP, Lime, bladeRF, HackRF, Airspy, RTL) mounted as virtual tuners. Plaintext — trusted networks / tunnels only."},
+	"SDRConfig.Ka9qRadio":           {Label: "ka9q-radio sources", Help: "Channels from remote ka9q-radio radiod instances mounted as virtual tuners over IP multicast. Plaintext — trusted LANs only."},
+	"SDRConfig.WatchdogIntervalMs":  {Help: "USB-disconnect watchdog poll interval (ms). 0 = default 30 s; negative disables it."},
+	"SDRConfig.Autotune":            {Label: "Autotune", Help: "Track each dongle's carrier-frequency error on locked P25 Phase 1 control + voice and apply a digital correction so the demod's AFC starts near lock. Never rewrites hardware ppm — logs a suggested value. Off by default; safe to leave on."},
+	"SDRConfig.CarrierOffsetWarnHz": {Label: "Carrier-offset warning (Hz)", Help: "Warn when the locked control carrier sits this far (Hz) from the configured frequency — a sign GT may be decoding a stronger adjacent site bleeding through, not the site you tuned. 0 = built-in default (4000 Hz); raise it for a high-drift dongle. Advisory only — never changes tuning or decode."},
 
 	"DeviceConfig.Serial":         {Help: "USB serial that selects this dongle. Run `gophertrunk sdr list` to see attached serials."},
 	"DeviceConfig.Role":           {Help: "Pool role hint. control/voice pin a P25-trunking dongle; wideband fans several channels off one stick; auto lets the pool decide.", Options: opts("", "(auto)", "control", "control", "voice", "voice", "auto", "auto", "wideband", "wideband")},

--- a/internal/configbuilder/webschema_test.go
+++ b/internal/configbuilder/webschema_test.go
@@ -24,7 +24,7 @@ var webRoundTripAllow = map[string][]string{
 	// Rarely-tuned SDR watchdog interval + the autotune enable flag; the web
 	// SDR section doesn't render a bespoke editor for either (they round-trip
 	// via the SDRConfig index signature). Editable in the TUI and raw YAML.
-	"SDRConfig": {"WatchdogIntervalMs", "Autotune"},
+	"SDRConfig": {"WatchdogIntervalMs", "Autotune", "CarrierOffsetWarnHz"},
 
 	// The LoRa section round-trips through the web Config Builder's generic
 	// index-signature editor; a bespoke typed editor in types.ts is a

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -43,8 +44,13 @@ type ControlChannel struct {
 	freqHz     uint32
 	bandPlan   *BandPlan
 	now        func() time.Time
-	locked     bool
-	lastNAC    uint16
+	// carrierOffsetHz, when non-nil, reports the demod's current locked carrier
+	// offset in Hz (Options.CarrierOffsetHz); publishSiteUpdate snapshots it onto
+	// the site-update event so a large adjacent-channel offset is visible on
+	// /api/v1/sites (issue #815). Nil leaves the published field zero.
+	carrierOffsetHz func() float64
+	locked          bool
+	lastNAC         uint16
 	// lastSiteLog dedupes the concise site-configuration log line so an
 	// established site logs once and re-logs only when its identity / primary
 	// control channel materially changes (see logSiteIdentity).
@@ -396,6 +402,16 @@ type Options struct {
 	P25Phase2RS         uint8
 	P25Phase2Interleave uint8
 	P25Phase2Scrambler  uint8
+
+	// CarrierOffsetHz, when non-nil, reports the demodulator's current carrier
+	// offset (Hz) of the locked control carrier relative to the tuned centre.
+	// publishSiteUpdate snapshots it onto SiteUpdate.ControlChannelCarrierOffsetHz
+	// so an operator can spot a control lock that sits far off the configured
+	// frequency — an adjacent site bleeding through (issue #815) — from the
+	// /api/v1/sites surface without dropping to `capture`/`spectrum`. The
+	// ccdecoder pipeline wires this to the receiver's AFCOffsetHz; nil (the
+	// default, and what the decode/replay tests pass) leaves the field zero.
+	CarrierOffsetHz func() float64
 }
 
 // New constructs a ControlChannel from Options. SystemName ends up on
@@ -434,6 +450,7 @@ func New(opts Options) *ControlChannel {
 		freqHz:              opts.FrequencyHz,
 		bandPlan:            bp,
 		now:                 now,
+		carrierOffsetHz:     opts.CarrierOffsetHz,
 		fswTol:              fswTol,
 		aliasAsm:            NewTalkerAliasAssembler(now),
 		diagSeen:            make(map[uint32]int),
@@ -1604,21 +1621,26 @@ func (c *ControlChannel) publishSiteUpdate() {
 	if net.RFSS == 0 && net.Site == 0 && net.SystemID == 0 && net.WACN == 0 {
 		return
 	}
+	var carrierOffsetHz int32
+	if c.carrierOffsetHz != nil {
+		carrierOffsetHz = int32(math.Round(c.carrierOffsetHz()))
+	}
 	c.bus.Publish(events.Event{
 		Kind: events.KindSiteUpdate,
 		Payload: trunking.SiteUpdate{
-			System:           c.systemName,
-			RFSSID:           net.RFSS,
-			SiteID:           net.Site,
-			ControlChannelHz: c.freqHz,
-			WACN:             net.WACN,
-			SystemID:         net.SystemID,
-			WACNHex:          trunking.IDHex(uint64(net.WACN)),
-			SystemIDHex:      trunking.IDHex(uint64(net.SystemID)),
-			RFSSIDHex:        trunking.IDHex(uint64(net.RFSS)),
-			SiteIDHex:        trunking.IDHex(uint64(net.Site)),
-			Topology:         c.TopologySnapshot(),
-			At:               c.now(),
+			System:                        c.systemName,
+			RFSSID:                        net.RFSS,
+			SiteID:                        net.Site,
+			ControlChannelHz:              c.freqHz,
+			ControlChannelCarrierOffsetHz: carrierOffsetHz,
+			WACN:                          net.WACN,
+			SystemID:                      net.SystemID,
+			WACNHex:                       trunking.IDHex(uint64(net.WACN)),
+			SystemIDHex:                   trunking.IDHex(uint64(net.SystemID)),
+			RFSSIDHex:                     trunking.IDHex(uint64(net.RFSS)),
+			SiteIDHex:                     trunking.IDHex(uint64(net.Site)),
+			Topology:                      c.TopologySnapshot(),
+			At:                            c.now(),
 		},
 	})
 	c.logSiteIdentity(net)

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -445,6 +445,52 @@ func TestControlChannelPublishesSiteUpdate(t *testing.T) {
 	}
 }
 
+// TestControlChannelStampsCarrierOffset drives an RFSS Status Broadcast through
+// a control channel built with a CarrierOffsetHz provider and asserts the
+// published SiteUpdate carries the rounded offset, so a control lock sitting far
+// off the configured frequency (an adjacent site bleeding through) is visible on
+// /api/v1/sites without dropping to the spectrum command (issue #815).
+func TestControlChannelStampsCarrierOffset(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	const ccHz = 420075000
+	cc := New(Options{
+		Bus: bus, SystemName: "MMR", FrequencyHz: ccHz,
+		CarrierOffsetHz: func() float64 { return 12499.6 }, // rounds to 12500
+	})
+
+	nsb := TSBK{Opcode: OpNetworkStatusBroadcast, Payload: [8]byte{0x00, 0xAB, 0xCD, 0xE1, 0x23}}
+	rfss := TSBK{Opcode: OpRFSSStatusBroadcast, Payload: [8]byte{9, 0x01, 0x23, 4, 7}}
+	base := 0
+	for _, tsbk := range []TSBK{nsb, rfss} {
+		cc.Process(buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk), base)
+		base += 1 << 20
+	}
+
+	deadline := time.After(3 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindSiteUpdate {
+				continue
+			}
+			u := ev.Payload.(trunking.SiteUpdate)
+			if u.RFSSID == 0 && u.SiteID == 0 {
+				continue // skip the interim NSB-only publish
+			}
+			if u.ControlChannelCarrierOffsetHz != 12500 {
+				t.Fatalf("control_channel_carrier_offset_hz = %d, want 12500", u.ControlChannelCarrierOffsetHz)
+			}
+			return
+		case <-deadline:
+			t.Fatal("no KindSiteUpdate published within deadline")
+		}
+	}
+}
+
 func TestControlChannelPublishesSiteUpdateFromAdjacentOnly(t *testing.T) {
 	// A system that never emits 0x3B/0x3A but does emit adjacent-site
 	// broadcasts (0x3C) must still publish a SiteUpdate carrying the System ID

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -145,6 +145,22 @@ const iqClipThreshold = 0.98
 // front-end overload — reduce gain or add attenuation (issue #402).
 const iqClipWarnRatio = 0.002
 
+// defaultCarrierOffsetWarnHz is the default magnitude of the TOTAL control-
+// channel carrier offset (autotune correction + receiver residual) above which,
+// while locked, the pump warns that GT may have locked onto an adjacent site's
+// carrier rather than the configured frequency (issue #815). Overridable via
+// Options.CarrierOffsetWarnHz.
+//
+// 4000 Hz sits in the gap between: a good front-end (Airspy/TCXO) after autotune
+// leaves a sub-kHz residual (never trips); the P25 6.25/12.5 kHz adjacent-channel
+// steps both clear it (an adjacent-site lock always trips); a reasonably-corrected
+// dongle's 1-3 kHz crystal error stays under it.
+const defaultCarrierOffsetWarnHz = 4000
+
+// carrierOffsetWarnInterval throttles a sustained large-offset WARN, matching the
+// iqClipLog / iqDCLog 30 s cadence so a stuck adjacent-channel lock logs steadily.
+const carrierOffsetWarnInterval = 30 * time.Second
+
 // decodeQueueDepth is the size of the internal queue between the
 // lightweight IQ forwarder and the decode goroutine (issue #402). The
 // SDR driver drops the instant its own small delivery channel backs up
@@ -225,6 +241,12 @@ type Options struct {
 	// average at each (re)acquisition so the demod's AFC starts near lock.
 	// Nil disables autotune at zero cost. See internal/autotune.
 	Autotune *autotune.Manager
+	// CarrierOffsetWarnHz is the magnitude of the total locked carrier offset
+	// (autotune correction + receiver residual) above which the pump emits a
+	// throttled WARN that GT may have locked onto an adjacent site's carrier
+	// (issue #815). Zero selects defaultCarrierOffsetWarnHz. Raise it for a
+	// high-drift dongle to avoid benign warnings.
+	CarrierOffsetWarnHz int
 }
 
 // Decoder is the long-lived component that converts the control
@@ -250,7 +272,15 @@ type Decoder struct {
 	autotuneApplied int
 	locked          atomic.Bool
 	lastATSampleAt  time.Time
-	systems         map[string]trunking.System
+	// carrierOffsetWarnHz is the large-offset WARN threshold (Options.
+	// CarrierOffsetWarnHz, defaulted in New). lastOffsetWarnAt throttles the
+	// WARN to one line per carrierOffsetWarnInterval while the offset stays
+	// over threshold; it resets to zero when the offset falls back under
+	// threshold so a fresh excursion re-warns at once (owned by the pump
+	// goroutine). Issue #815.
+	carrierOffsetWarnHz int
+	lastOffsetWarnAt    time.Time
+	systems             map[string]trunking.System
 
 	// ddc decimates the raw SDR IQ stream to pipelineRateHz before
 	// the active pipeline sees a chunk; ddcTarget records the
@@ -405,6 +435,10 @@ func New(opts Options) (*Decoder, error) {
 		d.iqCorrector = rtlsdr.NewIQImbalanceCorrector()
 	}
 	d.conjugate = opts.Conjugate
+	d.carrierOffsetWarnHz = opts.CarrierOffsetWarnHz
+	if d.carrierOffsetWarnHz <= 0 {
+		d.carrierOffsetWarnHz = defaultCarrierOffsetWarnHz
+	}
 	for _, s := range opts.Systems {
 		d.systems[s.Name] = s
 	}
@@ -734,6 +768,7 @@ func (d *Decoder) pump(iq []complex64) {
 	d.ddcOut = d.ddc.Process(d.ddcOut, iq)
 	d.active.Process(d.ddcOut)
 	d.sampleAutotuneLocked()
+	d.checkCarrierOffsetLocked()
 }
 
 // afcReporter is the optional capability a pipeline exposes when its
@@ -768,6 +803,45 @@ func (d *Decoder) sampleAutotuneLocked() {
 	d.log.Info("ccdecoder: "+d.autotune.StatusString(d.activeFreqHz, 0),
 		"system", d.activeAt, "freq_hz", d.activeFreqHz,
 		"observed_hz", observed, "applied_hz", d.autotuneApplied)
+}
+
+// checkCarrierOffsetLocked emits a throttled WARN when, while the CC is locked,
+// the TOTAL carrier offset from the configured control frequency exceeds
+// d.carrierOffsetWarnHz. Total = autotuneApplied + the receiver's residual
+// AFCOffsetHz: with autotune off (the default) applied is 0 and the total is the
+// raw residual; with autotune on, a large genuine offset is folded into applied,
+// so summing the two still catches an adjacent-channel lock autotune would
+// otherwise hide by chasing the wrong carrier (issue #815). Advisory only — it
+// never retunes; it tells the operator the locked carrier sits far from the
+// configured frequency, so the reported site identity may belong to a stronger
+// neighbouring site bleeding through (or the front-end oscillator is mistuned).
+// Caller holds d.mu.
+func (d *Decoder) checkCarrierOffsetLocked() {
+	if !d.locked.Load() {
+		return
+	}
+	rep, ok := d.active.(afcReporter)
+	if !ok {
+		return
+	}
+	total := d.autotuneApplied + int(math.Round(rep.AFCOffsetHz()))
+	if total < 0 {
+		total = -total
+	}
+	if total < d.carrierOffsetWarnHz {
+		d.lastOffsetWarnAt = time.Time{} // re-arm so a fresh excursion warns at once
+		return
+	}
+	now := time.Now()
+	if !d.lastOffsetWarnAt.IsZero() && now.Sub(d.lastOffsetWarnAt) < carrierOffsetWarnInterval {
+		return
+	}
+	d.lastOffsetWarnAt = now
+	d.log.Warn("ccdecoder: control carrier offset far from configured frequency — "+
+		"GT may be locked onto an adjacent site's stronger carrier (wrong site identity) "+
+		"or the receiver oscillator is badly mistuned; verify the reported site against "+
+		"the configured frequency (issue #815)",
+		"offset_hz", total, "freq_hz", d.activeFreqHz, "system", d.activeAt)
 }
 
 // observeIQPower folds one raw IQ chunk into the per-second power / DC /

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1,8 +1,10 @@
 package ccdecoder
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -1972,5 +1974,149 @@ func TestPumpNoConjugateByDefault(t *testing.T) {
 		if got != in[i] {
 			t.Errorf("sample %d = %v, want unchanged %v", i, got, in[i])
 		}
+	}
+}
+
+// fakeAFCPipeline is a ProtocolPipeline that also satisfies the unexported
+// afcReporter capability, reporting a fixed carrier offset so a test can drive
+// the pump's offset-sanity path without a real receiver (issue #815).
+type fakeAFCPipeline struct{ offsetHz float64 }
+
+func (f *fakeAFCPipeline) Process([]complex64)  {}
+func (f *fakeAFCPipeline) Reset()               {}
+func (f *fakeAFCPipeline) Close() error         { return nil }
+func (f *fakeAFCPipeline) AFCOffsetHz() float64 { return f.offsetHz }
+
+const carrierOffsetWarnMsg = "control carrier offset far from configured frequency"
+
+func newOffsetTestDecoder(t *testing.T, buf *bytes.Buffer) *Decoder {
+	t.Helper()
+	bus := events.NewBus(8)
+	t.Cleanup(bus.Close)
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000,
+		Log: slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	setActiveSystem(d, "Geelong")
+	d.activeFreqHz = 420_075_000
+	return d
+}
+
+// TestDecoderWarnsOnLargeCarrierOffset pins issue #815: while locked, a control
+// carrier sitting far from the configured frequency (an adjacent site bleeding
+// through at 12.5 kHz spacing) must produce a WARN, computed from the TOTAL
+// offset (autotuneApplied + receiver residual) so it fires whether or not
+// autotune is enabled. A small residual, and the not-locked state, must stay
+// silent.
+func TestDecoderWarnsOnLargeCarrierOffset(t *testing.T) {
+	cases := []struct {
+		name     string
+		offset   float64
+		applied  int
+		locked   bool
+		wantWarn bool
+	}{
+		{"adjacent channel 12.5kHz", 12500, 0, true, true},
+		{"small residual", 200, 0, true, false},
+		{"autotune folded adjacent lock", 100, 12400, true, true},
+		{"not locked", 12500, 0, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			d := newOffsetTestDecoder(t, &buf)
+			d.active = &fakeAFCPipeline{offsetHz: tc.offset}
+			d.autotuneApplied = tc.applied
+			d.locked.Store(tc.locked)
+
+			d.checkCarrierOffsetLocked()
+
+			got := strings.Contains(buf.String(), carrierOffsetWarnMsg)
+			if got != tc.wantWarn {
+				t.Fatalf("warn emitted = %v, want %v (log: %q)", got, tc.wantWarn, buf.String())
+			}
+			if tc.wantWarn {
+				if !strings.Contains(buf.String(), "offset_hz=12500") {
+					t.Errorf("WARN missing offset_hz=12500; log: %q", buf.String())
+				}
+				if !strings.Contains(buf.String(), "freq_hz=420075000") {
+					t.Errorf("WARN missing freq_hz=420075000; log: %q", buf.String())
+				}
+			}
+		})
+	}
+}
+
+// TestDecoderCarrierOffsetWarnThrottled pins the throttle + edge re-arm: a
+// sustained over-threshold offset warns once per interval, but dropping back
+// under threshold re-arms so the next excursion warns immediately (issue #815).
+func TestDecoderCarrierOffsetWarnThrottled(t *testing.T) {
+	var buf bytes.Buffer
+	d := newOffsetTestDecoder(t, &buf)
+	pipe := &fakeAFCPipeline{offsetHz: 12500}
+	d.active = pipe
+	d.locked.Store(true)
+
+	countWarns := func() int {
+		return strings.Count(buf.String(), carrierOffsetWarnMsg)
+	}
+
+	d.checkCarrierOffsetLocked()
+	if n := countWarns(); n != 1 {
+		t.Fatalf("after first over-threshold tick: warns = %d, want 1", n)
+	}
+	// A second immediate over-threshold tick is throttled.
+	d.checkCarrierOffsetLocked()
+	if n := countWarns(); n != 1 {
+		t.Fatalf("second immediate tick should be throttled: warns = %d, want 1", n)
+	}
+	// Offset falls back under threshold — re-arms the warn.
+	pipe.offsetHz = 200
+	d.checkCarrierOffsetLocked()
+	if n := countWarns(); n != 1 {
+		t.Fatalf("under-threshold tick should not warn: warns = %d, want 1", n)
+	}
+	// Fresh excursion warns immediately despite being within the interval.
+	pipe.offsetHz = 12500
+	d.checkCarrierOffsetLocked()
+	if n := countWarns(); n != 2 {
+		t.Fatalf("re-armed excursion should warn at once: warns = %d, want 2", n)
+	}
+}
+
+// TestDecoderCarrierOffsetWarnHzConfigurable confirms Options.CarrierOffsetWarnHz
+// overrides the default threshold, and that zero falls back to the default.
+func TestDecoderCarrierOffsetWarnHzConfigurable(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	d, err := New(Options{Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer d.Close()
+	if d.carrierOffsetWarnHz != defaultCarrierOffsetWarnHz {
+		t.Fatalf("zero Options.CarrierOffsetWarnHz = %d, want default %d", d.carrierOffsetWarnHz, defaultCarrierOffsetWarnHz)
+	}
+
+	var buf bytes.Buffer
+	d2, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{}, SampleRateHz: 48000,
+		CarrierOffsetWarnHz: 20000,
+		Log:                 slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer d2.Close()
+	setActiveSystem(d2, "Geelong")
+	d2.active = &fakeAFCPipeline{offsetHz: 12500}
+	d2.locked.Store(true)
+	d2.checkCarrierOffsetLocked()
+	if strings.Contains(buf.String(), carrierOffsetWarnMsg) {
+		t.Errorf("12.5 kHz offset under a 20 kHz threshold should not warn; log: %q", buf.String())
 	}
 }

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -283,6 +283,10 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		log.Warn("ccdecoder: unrecognised p25_phase2_scrambler_mode; falling back to on",
 			"system", opts.SystemName, "value", opts.System.P25Phase2ScramblerMode)
 	}
+	// rx is forward-declared so the control channel's CarrierOffsetHz provider
+	// can close over it; the closure is only called later, at site-update
+	// publish time, well after rx is assigned below (issue #815).
+	var rx *p25phase1rx.Receiver
 	cc := p25phase1.New(p25phase1.Options{
 		Bus:                 opts.Bus,
 		Log:                 opts.Log,
@@ -295,8 +299,9 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		P25Phase2RS:         uint8(p2RS),
 		P25Phase2Interleave: uint8(p2Interleave),
 		P25Phase2Scrambler:  uint8(p2Scrambler),
+		CarrierOffsetHz:     func() float64 { return rx.AFCOffsetHz() },
 	})
-	rx := p25phase1rx.New(p25phase1rx.Options{
+	rx = p25phase1rx.New(p25phase1rx.Options{
 		SampleRateHz: opts.SampleRateHz,
 		// P25 Phase 1 nominal peak deviation per TIA-102.BAAA-A
 		// — calibrates the slicer thresholds against the

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -330,8 +330,16 @@ type SiteUpdate struct {
 	RFSSID           uint8
 	SiteID           uint8
 	ControlChannelHz uint32
-	WACN             uint32
-	SystemID         uint16
+	// ControlChannelCarrierOffsetHz is the demodulator's measured carrier
+	// offset (signed Hz) of the locked control carrier relative to the tuned
+	// centre, as of this update. A large value means the locked carrier sits
+	// well off the configured frequency — e.g. a stronger neighbouring site
+	// bleeding through at 12.5 kHz spacing (issue #815) — so the reported site
+	// identity may not belong to the configured frequency. Zero on demod paths
+	// without an AFC stage (CQPSK) or when the offset is genuinely ~0.
+	ControlChannelCarrierOffsetHz int32 `json:"control_channel_carrier_offset_hz,omitempty"`
+	WACN                          uint32
+	SystemID                      uint16
 	// Hex renderings of the identity numbers (P25 field convention),
 	// alongside the decimal fields above so JSON consumers get both. Empty
 	// when the corresponding value is unknown (zero).

--- a/internal/trunking/site_tracker.go
+++ b/internal/trunking/site_tracker.go
@@ -16,14 +16,19 @@ import (
 // not set here; the API layer merges operator-supplied names from the
 // system config onto matching rows.
 type SiteInfo struct {
-	System           string    `json:"system"`
-	RFSSID           uint8     `json:"rfss_id"`
-	SiteID           uint8     `json:"site_id"`
-	ControlChannelHz uint32    `json:"control_channel_hz,omitempty"`
-	WACN             uint32    `json:"wacn,omitempty"`
-	SystemID         uint16    `json:"system_id,omitempty"`
-	FirstSeen        time.Time `json:"first_seen"`
-	LastSeen         time.Time `json:"last_seen"`
+	System           string `json:"system"`
+	RFSSID           uint8  `json:"rfss_id"`
+	SiteID           uint8  `json:"site_id"`
+	ControlChannelHz uint32 `json:"control_channel_hz,omitempty"`
+	// ControlChannelCarrierOffsetHz is the demod's measured carrier offset (Hz)
+	// of the locked control carrier relative to the tuned centre, as of LastSeen.
+	// A large value flags a control lock sitting well off the configured
+	// frequency — e.g. an adjacent site bleeding through (issue #815).
+	ControlChannelCarrierOffsetHz int32     `json:"control_channel_carrier_offset_hz,omitempty"`
+	WACN                          uint32    `json:"wacn,omitempty"`
+	SystemID                      uint16    `json:"system_id,omitempty"`
+	FirstSeen                     time.Time `json:"first_seen"`
+	LastSeen                      time.Time `json:"last_seen"`
 }
 
 // SiteTracker maintains a live table of the P25 sites GT has decoded
@@ -126,6 +131,10 @@ func (t *SiteTracker) observe(u SiteUpdate) {
 	if u.ControlChannelHz != 0 {
 		s.ControlChannelHz = u.ControlChannelHz
 	}
+	// Always refresh the live carrier offset (zero is a valid reading — on
+	// frequency, or a demod path with no AFC stage), so the surfaced value
+	// tracks the most recent lock (issue #815).
+	s.ControlChannelCarrierOffsetHz = u.ControlChannelCarrierOffsetHz
 	if u.WACN != 0 {
 		s.WACN = u.WACN
 	}


### PR DESCRIPTION
A strong adjacent-site P25 control carrier 12.5 kHz away can bleed through
GT's narrowband receiver: when nothing is present on the configured
frequency, the C4FM demod acquires the neighbouring carrier, locks, and
decodes that site's identity while still reporting the tuned frequency —
with no indication anything is wrong (issue #815, Geelong vs Mt Anakie).

The receiver already measures the true carrier offset (AFCOffsetHz, the
issue #402 value), but nothing inspected it unless autotune was enabled.
Add checkCarrierOffsetLocked: while locked, if the TOTAL offset
(autotuneApplied + residual) from the configured frequency exceeds a
threshold, emit a throttled, edge-re-armed WARN naming both plausible
causes (adjacent-site lock or a mistuned oscillator). Advisory only — it
never retunes. The threshold defaults to 4 kHz and is operator-configurable
via sdr.carrier_offset_warn_hz for high-drift dongles.

Also surface the live offset on the site-update event so it reaches
GET /api/v1/sites (ControlChannelCarrierOffsetHz), letting an operator spot
the mismatch without dropping to capture/spectrum: a CarrierOffsetHz
provider is injected into the P25 ControlChannel and wired in the pipeline
factory to the receiver's AFCOffsetHz.

Regression tests cover the 12.5 kHz warn, the silent small-residual and
not-locked cases, the autotune-folded total, the throttle/edge re-arm, the
configurable threshold, and the offset reaching the published SiteUpdate.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mj9BP4eYHj1EMXUS89iVpY