### PR TITLE
p25/phase2: extract ALGID/KID from MAC_PTT slot + hex MAC census (#813)

### DIFF
--- a/internal/radio/p25/phase2/encode.go
+++ b/internal/radio/p25/phase2/encode.go
@@ -91,6 +91,21 @@ func EncodeEncryptionSync(es EncryptionSync) MACPDU {
 	return MACPDU{Opcode: OpEncryptionSync, Payload: payload}
 }
 
+// EncodePushToTalk builds the MAC PDU form of a MAC_PTT message carrying
+// an Encryption Sync — the inverse of MACPDU.AsPushToTalk. The opcode
+// octet is left OpUnknown because real Phase 2 PTT is routed by slot
+// type (SlotTypeMACPTT), not by the opcode byte; a non-manufacturer
+// opcode keeps the payload free of an MFID octet so the offsets line up.
+// The source / group address tail the real message carries is omitted
+// (AsPushToTalk only reads the 12-byte MI/ALGID/KID prefix).
+func EncodePushToTalk(es EncryptionSync) MACPDU {
+	payload := make([]byte, 12)
+	copy(payload[0:9], es.MessageIndicator[:])
+	payload[9] = es.AlgorithmID
+	binary.BigEndian.PutUint16(payload[10:12], es.KeyID)
+	return MACPDU{Opcode: OpUnknown, Payload: payload}
+}
+
 // EncodeGroupAffiliationResponse builds the MAC PDU form of a Group
 // Affiliation Response — the inverse of AsGroupAffiliationResponse.
 func EncodeGroupAffiliationResponse(g GroupAffiliationResponse) MACPDU {

--- a/internal/radio/p25/phase2/encryption_test.go
+++ b/internal/radio/p25/phase2/encryption_test.go
@@ -55,6 +55,36 @@ func TestEncryptionSyncRoundTrip(t *testing.T) {
 	}
 }
 
+// TestPushToTalkRoundTrip pins the working-model MAC_PTT layout: an
+// EncryptionSync encoded as a PTT message round-trips through
+// AsPushToTalk. Synthetic — it cannot prove the on-air byte offsets are
+// right (that needs the issue #813 capture), only that the encode /
+// decode pair agree.
+func TestPushToTalkRoundTrip(t *testing.T) {
+	in := EncryptionSync{
+		AlgorithmID:      0x84, // AES-256 in the P25 algorithm registry
+		KeyID:            0xBEEF,
+		MessageIndicator: [9]byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+	pdu := EncodePushToTalk(in)
+	got, ok := pdu.AsPushToTalk()
+	if !ok {
+		t.Fatal("AsPushToTalk returned !ok")
+	}
+	if got != in {
+		t.Errorf("round-trip = %+v, want %+v", got, in)
+	}
+
+	// Survives an AssembleMACPDU → ParseMACPDU trip (the wire form).
+	reparsed, err := ParseMACPDU(AssembleMACPDU(pdu))
+	if err != nil {
+		t.Fatalf("ParseMACPDU: %v", err)
+	}
+	if got2, ok := reparsed.AsPushToTalk(); !ok || got2 != in {
+		t.Errorf("wire round-trip = %+v ok=%v, want %+v", got2, ok, in)
+	}
+}
+
 func TestControlChannelFlagsEncryptedGrant(t *testing.T) {
 	bus := events.NewBus(8)
 	defer bus.Close()

--- a/internal/radio/p25/phase2/mac_standard.go
+++ b/internal/radio/p25/phase2/mac_standard.go
@@ -201,3 +201,39 @@ func (p MACPDU) AsEncryptionSync() (EncryptionSync, bool) {
 	copy(es.MessageIndicator[:], p.Payload[3:12])
 	return es, true
 }
+
+// AsPushToTalk extracts the Encryption Sync (ALGID/KID/MI) that a P25
+// Phase 2 MAC_PTT message carries at key-up. On real systems this — not
+// the standalone OpEncryptionSync PDU AsEncryptionSync parses — is where
+// ALGID/KID/MI actually ride (issue #813): the PTT message is identified
+// by its slot type (SlotTypeMACPTT), not by a MAC opcode, so unlike
+// AsEncryptionSync this does NOT gate on the opcode byte. Callers must
+// only invoke it for a PTT-slot PDU (see DecodeSuperframeMACPDUsWithSlot
+// / the dispatcher), otherwise a long enough non-PTT payload would parse
+// as garbage.
+//
+// Layout note: field offsets follow SDRtrunk's PushToTalk MacStructure —
+// MESSAGE_INDICATOR at message bits 8-79 (72 bits), ALGORITHM_ID at
+// 80-87, KEY_ID at 88-103. Relative to the MACPDU payload, which starts
+// after the 1-octet opcode (message bits 0-7), that is:
+//
+//	bytes 0-8  : 72-bit Message Indicator
+//	byte 9     : Algorithm ID
+//	bytes 10-11: Key ID
+//
+// This is the project's working model pending issue #813 on-air
+// confirmation (the repo has no TIA-102.BBAC PDF). It is confined here
+// so a correction is a one-file change, and the grant's ServiceOptions
+// "protected" bit flags encryption independently, so a wrong layout
+// degrades gracefully to today's behaviour (Encrypted true, alg/key 0).
+func (p MACPDU) AsPushToTalk() (EncryptionSync, bool) {
+	if len(p.Payload) < 12 {
+		return EncryptionSync{}, false
+	}
+	es := EncryptionSync{
+		AlgorithmID: p.Payload[9],
+		KeyID:       binary.BigEndian.Uint16(p.Payload[10:12]),
+	}
+	copy(es.MessageIndicator[:], p.Payload[0:9])
+	return es, true
+}

--- a/internal/radio/p25/phase2/superframe_ingest.go
+++ b/internal/radio/p25/phase2/superframe_ingest.go
@@ -22,23 +22,33 @@ type MACDecodeConfig struct {
 	Seed       uint64
 }
 
-// DecodeSuperframeMACPDUs returns every successfully decoded MAC PDU
-// found in sf's MAC-typed sub-frames, in sub-frame order. Voice
-// sub-frames are skipped. Both the control-channel ingest path and the
-// voice-channel composer call this — Phase 2 voice traffic channels
-// interleave MAC sub-frames (signalling, talker alias, encryption
-// sync, …) with voice sub-frames, and the composer needs the same MAC
-// dispatch the CC runs.
+// DecodedMACPDU pairs a decoded MAC PDU with the SlotType of the
+// sub-frame it rode in. Phase 2 carries the encryption sync
+// (ALGID/KID/MI) in the MAC_PTT message (SlotTypeMACPTT) that begins a
+// transmission, not in a distinct MAC opcode, so a caller that needs to
+// tell PTT signalling from ordinary FACCH/SACCH signalling must see the
+// slot type — DecodeSuperframeMACPDUs alone discards it. Issue #813.
+type DecodedMACPDU struct {
+	SlotType SlotType
+	PDU      MACPDU
+}
+
+// DecodeSuperframeMACPDUsWithSlot returns every successfully decoded MAC
+// PDU found in sf's MAC-typed sub-frames, in sub-frame order, each
+// tagged with the SlotType of the sub-frame it came from. Voice
+// sub-frames are skipped. It is the slot-aware form of
+// DecodeSuperframeMACPDUs; callers that route on the PTT slot
+// (encryption sync) use this one.
 //
 // The PN44 descrambler is handed the spec's per-slot offset
 // (slotPN44Offset) because superframe sync pins which of the 12 TDMA
 // slots each sub-frame occupies.
-func DecodeSuperframeMACPDUs(sf Superframe, cfg MACDecodeConfig) []MACPDU {
+func DecodeSuperframeMACPDUsWithSlot(sf Superframe, cfg MACDecodeConfig) []DecodedMACPDU {
 	macLen := macPDUDibits
 	if cfg.Trellis == TrellisOn {
 		macLen = macPDUDibitsTrellis
 	}
-	var out []MACPDU
+	var out []DecodedMACPDU
 	for _, sub := range sf.Subframes {
 		if !sub.SlotType.IsMAC() {
 			continue
@@ -50,8 +60,28 @@ func DecodeSuperframeMACPDUs(sf Superframe, cfg MACDecodeConfig) []MACPDU {
 		offset := slotPN44Offset(sub.Index)
 		if pdu, ok := decodeMACPDUDibits(macDibits, cfg.Trellis, cfg.RS,
 			cfg.Interleave, cfg.Scrambler, cfg.Seed, offset); ok {
-			out = append(out, pdu)
+			out = append(out, DecodedMACPDU{SlotType: sub.SlotType, PDU: pdu})
 		}
+	}
+	return out
+}
+
+// DecodeSuperframeMACPDUs returns every successfully decoded MAC PDU
+// found in sf's MAC-typed sub-frames, in sub-frame order. Voice
+// sub-frames are skipped. Both the control-channel ingest path and the
+// voice-channel composer call this — Phase 2 voice traffic channels
+// interleave MAC sub-frames (signalling, talker alias, encryption
+// sync, …) with voice sub-frames, and the composer needs the same MAC
+// dispatch the CC runs. Callers that need each PDU's originating slot
+// type use DecodeSuperframeMACPDUsWithSlot.
+func DecodeSuperframeMACPDUs(sf Superframe, cfg MACDecodeConfig) []MACPDU {
+	decoded := DecodeSuperframeMACPDUsWithSlot(sf, cfg)
+	if len(decoded) == 0 {
+		return nil
+	}
+	out := make([]MACPDU, len(decoded))
+	for i, d := range decoded {
+		out[i] = d.PDU
 	}
 	return out
 }

--- a/internal/radio/p25/phase2/superframe_ingest_test.go
+++ b/internal/radio/p25/phase2/superframe_ingest_test.go
@@ -113,6 +113,47 @@ func TestDecodeSuperframeMACPDUsReturnsAllMACSubframes(t *testing.T) {
 	}
 }
 
+// TestDecodeSuperframeMACPDUsWithSlotTagsPTT confirms the slot-aware
+// decode surfaces each PDU's originating SlotType — specifically that a
+// MAC_PTT sub-frame is tagged SlotTypeMACPTT so the dispatcher can route
+// the encryption sync it carries by slot type (issue #813).
+func TestDecodeSuperframeMACPDUsWithSlotTagsPTT(t *testing.T) {
+	es := EncryptionSync{AlgorithmID: 0x84, KeyID: 0x1234,
+		MessageIndicator: [9]byte{9, 8, 7, 6, 5, 4, 3, 2, 1}}
+	ptt := EncodePushToTalk(es)
+	// Pad to the 18-byte MAC PDU width so the round-trip is bit-exact.
+	if b := AssembleMACPDU(ptt); len(b) < 18 {
+		ptt.Payload = append(ptt.Payload, make([]byte, 18-len(b))...)
+	}
+
+	var subs [SubframesPerSuperframe][]uint8
+	for i := range subs {
+		if i == 0 {
+			subs[i] = EncodeMACSubframe(SlotTypeMACPTT, uint8(i), ptt,
+				TrellisOn, InterleaveOff)
+		} else {
+			subs[i] = EncodeVoiceSubframe(SlotTypeVoice4V, uint8(i),
+				voicePayloads(Voice4VFrameCount))
+		}
+	}
+
+	cfg := MACDecodeConfig{Trellis: TrellisOn}
+	got := DecodeSuperframeMACPDUsWithSlot(decodeOneSuperframe(t, subs), cfg)
+	if len(got) != 1 {
+		t.Fatalf("DecodeSuperframeMACPDUsWithSlot returned %d PDUs, want 1", len(got))
+	}
+	if got[0].SlotType != SlotTypeMACPTT {
+		t.Errorf("SlotType = %v, want SlotTypeMACPTT", got[0].SlotType)
+	}
+	es2, ok := got[0].PDU.AsPushToTalk()
+	if !ok {
+		t.Fatal("AsPushToTalk on PTT-slot PDU returned !ok")
+	}
+	if es2.AlgorithmID != 0x84 || es2.KeyID != 0x1234 {
+		t.Errorf("PTT alg/key = %#x/%#x, want 0x84/0x1234", es2.AlgorithmID, es2.KeyID)
+	}
+}
+
 // TestIngestSuperframeAllVoicePublishesNothing confirms an all-voice
 // superframe drives no control-channel events — the composer owns voice.
 func TestIngestSuperframeAllVoicePublishesNothing(t *testing.T) {

--- a/internal/sigfollow/dispatcher.go
+++ b/internal/sigfollow/dispatcher.go
@@ -17,6 +17,7 @@
 package sigfollow
 
 import (
+	"encoding/hex"
 	"log/slog"
 	"time"
 
@@ -49,7 +50,7 @@ type MACDispatcher struct {
 
 	aliasAsm         *p25p2.TalkerAliasAssembler
 	motorolaAliasAsm *p25p2.MotorolaAliasAssembler
-	macSeen          map[uint16]struct{}
+	macSeen          map[uint32]struct{}
 
 	onCallSource     func(p25p2.GroupVoiceChannelUser)
 	onCallEncryption func(p25p2.EncryptionSync)
@@ -97,7 +98,7 @@ func NewMACDispatcher(opts MACDispatcherOptions) *MACDispatcher {
 		serial:           opts.Serial,
 		aliasAsm:         p25p2.NewTalkerAliasAssembler(nil),
 		motorolaAliasAsm: p25p2.NewMotorolaAliasAssembler(nil),
-		macSeen:          make(map[uint16]struct{}),
+		macSeen:          make(map[uint32]struct{}),
 		onCallSource:     opts.OnCallSource,
 		onCallEncryption: opts.OnCallEncryption,
 	}
@@ -109,18 +110,33 @@ func NewMACDispatcher(opts MACDispatcherOptions) *MACDispatcher {
 // activity watchdog off signalling presence (0 means the superframe
 // carried only voice / idle).
 func (d *MACDispatcher) Dispatch(sf p25p2.Superframe, macCfg p25p2.MACDecodeConfig) int {
-	pdus := p25p2.DecodeSuperframeMACPDUs(sf, macCfg)
-	for _, pdu := range pdus {
-		// Log the first PDU seen per (opcode, MFID) on this channel. If a
-		// real on-air system emits an opcode we don't dispatch, the line
-		// tells the next field tester exactly what we saw (issue #376).
-		key := uint16(pdu.Opcode)<<8 | uint16(pdu.MFID)
+	decoded := p25p2.DecodeSuperframeMACPDUsWithSlot(sf, macCfg)
+	for _, dec := range decoded {
+		pdu := dec.PDU
+		// Log the first PDU seen per (slot, opcode, MFID) on this channel,
+		// with the payload bytes. If a real on-air system rides the
+		// encryption sync on a slot/opcode we don't dispatch, the hex tells
+		// the next field tester exactly what we saw — the bytes needed to
+		// confirm or correct the MAC_PTT layout (issues #376, #813).
+		key := uint32(dec.SlotType)<<16 | uint32(pdu.Opcode)<<8 | uint32(pdu.MFID)
 		if _, seen := d.macSeen[key]; !seen {
 			d.macSeen[key] = struct{}{}
 			d.log.Info(d.logPrefix+": p25p2 mac pdu",
 				"system", d.system, "serial", d.serial,
-				"opcode", pdu.Opcode, "mfid", pdu.MFID,
-				"payload_len", len(pdu.Payload))
+				"slot", dec.SlotType, "opcode", pdu.Opcode, "mfid", pdu.MFID,
+				"payload_len", len(pdu.Payload),
+				"payload_hex", hex.EncodeToString(pdu.Payload))
+		}
+		// MAC_PTT slot: the key-up message that carries the encryption sync
+		// (ALGID/KID/MI) on real Phase 2 systems. Routed by slot type, not
+		// opcode, because the PTT message has no normal MAC opcode (#813).
+		if dec.SlotType == p25p2.SlotTypeMACPTT {
+			if es, ok := pdu.AsPushToTalk(); ok {
+				if d.onCallEncryption != nil {
+					d.onCallEncryption(es)
+				}
+				continue
+			}
 		}
 		if u, ok := pdu.AsGroupVoiceChannelUser(); ok {
 			if d.onCallSource != nil {
@@ -160,7 +176,7 @@ func (d *MACDispatcher) Dispatch(sf p25p2.Superframe, macCfg p25p2.MACDecodeConf
 			continue
 		}
 	}
-	return len(pdus)
+	return len(decoded)
 }
 
 // publishTalkerAlias mirrors phase2.ControlChannel.publishTalkerAlias: a

--- a/internal/sigfollow/dispatcher_test.go
+++ b/internal/sigfollow/dispatcher_test.go
@@ -106,6 +106,58 @@ func TestDispatcherPublishesTalkerAlias(t *testing.T) {
 	}
 }
 
+// TestDispatcherPTTSlotDrivesEncryptionHook builds a superframe whose
+// MAC_PTT sub-frame carries an Encryption Sync and asserts the dispatcher
+// routes its ALGID/KID to the OnCallEncryption hook (the voice composer
+// wires this to its engine-backfill publisher). Routing is by slot type,
+// not opcode, since the PTT message has no normal MAC opcode (#813).
+func TestDispatcherPTTSlotDrivesEncryptionHook(t *testing.T) {
+	es := p25p2.EncryptionSync{
+		AlgorithmID:      0x84,
+		KeyID:            0x1234,
+		MessageIndicator: [9]byte{1, 2, 3, 4, 5, 6, 7, 8, 9},
+	}
+	ptt := p25p2.EncodePushToTalk(es)
+
+	dibits := make([]uint8, 50)
+	var subs [p25p2.SubframesPerSuperframe][]uint8
+	for i := range subs {
+		if i == 0 {
+			subs[i] = p25p2.EncodeMACSubframe(p25p2.SlotTypeMACPTT, uint8(i),
+				ptt, p25p2.TrellisOn, p25p2.InterleaveOff)
+			continue
+		}
+		payloads := make([][]byte, p25p2.Voice4VFrameCount)
+		for j := range payloads {
+			payloads[j] = make([]byte, p25p2.VoiceFrameBytes)
+		}
+		subs[i] = p25p2.EncodeVoiceSubframe(p25p2.SlotTypeVoice4V, uint8(i), payloads)
+	}
+	dibits = append(dibits, p25p2.EncodeSuperframe(subs)...)
+	sfs := p25p2.NewSuperframeDecoder().Process(dibits, 0)
+	if len(sfs) == 0 {
+		t.Fatal("no superframes decoded")
+	}
+
+	var got p25p2.EncryptionSync
+	var called int
+	d := NewMACDispatcher(MACDispatcherOptions{
+		Log: quietLog(), System: "TestSys", Serial: "tap-0",
+		OnCallEncryption: func(e p25p2.EncryptionSync) { got = e; called++ },
+	})
+	macCfg := p25p2.MACDecodeConfig{Trellis: p25p2.TrellisOn}
+	for _, sf := range sfs {
+		d.Dispatch(sf, macCfg)
+	}
+	if called == 0 {
+		t.Fatal("OnCallEncryption never invoked for PTT-slot encryption sync")
+	}
+	if got.AlgorithmID != 0x84 || got.KeyID != 0x1234 {
+		t.Errorf("OnCallEncryption alg/key = %#x/%#x, want 0x84/0x1234",
+			got.AlgorithmID, got.KeyID)
+	}
+}
+
 // TestDispatcherSourceCallback verifies the in-call GROUP_VOICE_CHANNEL_USER
 // PDU routes to the OnCallSource hook (the voice composer wires this to its
 // engine-backfill publisher; the follower leaves it nil).


### PR DESCRIPTION
On real P25 Phase 2 systems encrypted calls flag encrypted:true (from the
grant ServiceOptions bit) but algorithm_id/key_id never populate. The
end-to-end ALGID/KID plumbing is present and unit-tested, but it only
fires on a synthesized standalone OpEncryptionSync (0x70) PDU — an
unverified working model. Real Phase 2 carries the encryption sync
(ALGID/KID/MI) in the MAC_PTT message that begins each transmission,
keyed by slot type (SlotTypeMACPTT), not by a MAC opcode, so the existing
accessor never matches on air.

- Add DecodeSuperframeMACPDUsWithSlot, surfacing each PDU's originating
  SlotType (DecodeSuperframeMACPDUs kept as a thin wrapper).
- Add MACPDU.AsPushToTalk extracting MI/ALGID/KID at the offsets
  SDRtrunk's PushToTalk MacStructure documents (MI bytes 0-8, ALGID byte
  9, KID bytes 10-11 of the payload). Confined to mac_standard.go and
  flagged a working model pending on-air confirmation; degrades
  gracefully (Encrypted stays true, alg/key 0) if the layout is wrong.
- Route PTT-slot PDUs through the dispatcher's existing onCallEncryption
  hook (reuses the KindCallEncryption → engine backfill path).
- Extend the per-channel MAC census key with SlotType and log the PDU
  payload hex, so a field tester can read the actual encryption-sync
  bytes off the log and confirm/correct the layout.

Synthetic tests cover the PTT round-trip, slot-tagged decode, and
dispatch hook; they cannot prove the on-air offsets — that needs the
reporter's capture, so #813 stays open.

Refs #813

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K6nN7bgcVEc7hBP1izpS8U