### PR TITLE
cryptolab: close out deferred follow-up items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ for tagged releases.
 - **`cryptolab` — optional RF cryptographic-research toolkit**. A new,
   opt-in `gophertrunk cryptolab` subcommand collects byte-oriented research
   tools — statistical triage (entropy / index-of-coincidence / chi-square /
-  XOR key-length), keyspace brute force (single/repeating XOR with English and
-  crib scoring), LFSR/keystream analysis (Berlekamp–Massey, keystream
+  XOR key-length), classical-cipher brute force (single/repeating XOR, Caesar,
+  and Vigenère with English and crib scoring), LFSR/keystream analysis (Berlekamp–Massey, keystream
   extraction), CRC parameter recovery, and analog voice spectral
   descrambling — plus a pluggable subject framework for studying byte-oriented
   obfuscators, with an initial length-seeded-obfuscator recovery suite (gauge

--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -65,7 +65,7 @@ Global flags precede the tool name (`-out`, `-resume`, `-format`,
 
 | Tool | Modes | What it does |
 |------|-------|--------------|
-| `brute` | `xor` | single / repeating-key XOR recovery with English/crib scoring |
+| `brute` | `xor`, `caesar`, `vigenere` | classical-cipher recovery with English/crib scoring |
 | `lfsr` | `bm`, `keystream` | Berlekamp–Massey LFSR recovery; keystream = pt⊕ct |
 | `crc` | `recover`, `compute` | recover / compute CRC parameters from sample frames |
 | `stats` | `scan` | entropy / IC / chi-square / XOR key-length triage |
@@ -123,4 +123,24 @@ additional data would close the remaining gap — the effort is always directed,
 logged, and resumable.
 
 The optional Z3 structural search under `internal/cryptolab/smt/` explores
-richer multi-round / two-table update forms than the in-binary propagator.
+richer multi-round / two-table update forms than the in-binary propagator. The
+`alias structure` mode writes `high-transitions.csv` to the `-out` directory,
+which the Z3 script consumes directly.
+
+## Not yet implemented
+
+These are deliberately out of the current scope; each is a sizeable addition
+on its own and is noted here so the gap is explicit rather than silent:
+
+- **Monoalphabetic substitution solver** in `brute` — auto-solving a general
+  substitution cipher needs n-gram hill-climbing / simulated annealing over a
+  26!-key space and an embedded language model, which is a different class of
+  work from the linear-keyspace solvers shipped here.
+- **Split-band and rolling-code voice descrambling** — `descramble` currently
+  does exact full-band spectral inversion (the dominant analog scrambler);
+  split-band inverters need a band-splitting filter bank, and rolling/hopping
+  schemes need sync recovery.
+- **Daemon-mounted console** — the web console runs as the standalone
+  `cryptolab serve`; mounting it inside the main `gophertrunk` daemon at a
+  `/cryptolab/` route (alongside the siglab API) would require wiring the
+  subsystem through `internal/api` behind the build tag.

--- a/internal/cryptolab/engine/brute/brute.go
+++ b/internal/cryptolab/engine/brute/brute.go
@@ -133,6 +133,21 @@ func (Caesar) Decrypt(key, ct []byte) []byte {
 	return out
 }
 
+// Vigenere subtracts a repeating additive key (mod 256) — the additive
+// counterpart of repeating-key XOR.
+type Vigenere struct{}
+
+func (Vigenere) Decrypt(key, ct []byte) []byte {
+	if len(key) == 0 {
+		return append([]byte(nil), ct...)
+	}
+	out := make([]byte, len(ct))
+	for i := range ct {
+		out[i] = ct[i] - key[i%len(key)]
+	}
+	return out
+}
+
 // ---- Built-in keyspace ----
 
 // ByteKeySpace enumerates all keys of a fixed byte length as a big-endian
@@ -179,6 +194,36 @@ func SolveSingleByteXOR(ct []byte, sc Scorer) Candidate {
 		return Candidate{}
 	}
 	return res[0]
+}
+
+// SolveCaesar finds the single-byte additive (Caesar) shift best explaining ct.
+func SolveCaesar(ct []byte, sc Scorer) Candidate {
+	res := Run(context.Background(), Caesar{}, &ByteKeySpace{Len: 1}, sc, ct, Options{TopN: 1})
+	if len(res) == 0 {
+		return Candidate{}
+	}
+	return res[0]
+}
+
+// SolveVigenere recovers a repeating additive (Vigenère) key of the given
+// length by solving each column independently as a Caesar shift.
+func SolveVigenere(ct []byte, keyLen int, sc Scorer) Candidate {
+	if keyLen <= 0 {
+		return Candidate{}
+	}
+	key := make([]byte, keyLen)
+	for col := 0; col < keyLen; col++ {
+		var column []byte
+		for i := col; i < len(ct); i += keyLen {
+			column = append(column, ct[i])
+		}
+		best := SolveCaesar(column, sc)
+		if len(best.Key) == 1 {
+			key[col] = best.Key[0]
+		}
+	}
+	pt := Vigenere{}.Decrypt(key, ct)
+	return Candidate{Key: key, Plaintext: pt, Score: sc.Score(pt)}
 }
 
 // SolveRepeatingXOR recovers a repeating-key XOR key of the given length by

--- a/internal/cryptolab/engine/brute/brute_test.go
+++ b/internal/cryptolab/engine/brute/brute_test.go
@@ -36,6 +36,40 @@ func TestSolveRepeatingXOR(t *testing.T) {
 	}
 }
 
+func TestSolveCaesar(t *testing.T) {
+	t.Parallel()
+	pt := []byte("The quick brown fox jumps over the lazy dog repeatedly today.")
+	const shift = 19
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] + shift
+	}
+	got := SolveCaesar(ct, English{})
+	if len(got.Key) != 1 || got.Key[0] != shift {
+		t.Fatalf("recovered shift = %v, want %d", got.Key, shift)
+	}
+	if !bytes.Equal(got.Plaintext, pt) {
+		t.Fatalf("plaintext = %q", got.Plaintext)
+	}
+}
+
+func TestSolveVigenere(t *testing.T) {
+	t.Parallel()
+	pt := []byte("WHEN IN THE COURSE OF HUMAN EVENTS IT BECOMES NECESSARY FOR ONE PEOPLE TO DISSOLVE")
+	key := []byte{3, 14, 7, 22, 1}
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] + key[i%len(key)]
+	}
+	got := SolveVigenere(ct, len(key), English{})
+	if !bytes.Equal(got.Key, key) {
+		t.Fatalf("recovered key = %v, want %v", got.Key, key)
+	}
+	if !bytes.Equal(got.Plaintext, pt) {
+		t.Fatalf("plaintext mismatch:\n got %q\nwant %q", got.Plaintext, pt)
+	}
+}
+
 func TestCribScorer(t *testing.T) {
 	t.Parallel()
 	withCrib := Crib{Crib: []byte("RADIO"), Base: Printable{}}

--- a/internal/cryptolab/schema.go
+++ b/internal/cryptolab/schema.go
@@ -38,6 +38,15 @@ var modeParams = map[string][]Param{
 		{Name: "keylen", Label: "Key length (0 = auto)", Kind: "int", Default: "0"},
 		{Name: "crib", Label: "Known-plaintext crib", Kind: "string", Help: "optional substring to boost scoring"},
 	},
+	"brute/caesar": {
+		{Name: "in", Label: "Ciphertext file", Kind: "file", Required: true},
+		{Name: "crib", Label: "Known-plaintext crib", Kind: "string", Help: "optional substring to boost scoring"},
+	},
+	"brute/vigenere": {
+		{Name: "in", Label: "Ciphertext file", Kind: "file", Required: true},
+		{Name: "keylen", Label: "Key length (0 = auto)", Kind: "int", Default: "0"},
+		{Name: "crib", Label: "Known-plaintext crib", Kind: "string", Help: "optional substring to boost scoring"},
+	},
 	"lfsr/bm": {
 		{Name: "in", Label: "Keystream file", Kind: "file", Required: true, Help: "packed bytes, MSB-first"},
 	},

--- a/internal/cryptolab/smt/README.md
+++ b/internal/cryptolab/smt/README.md
@@ -23,7 +23,7 @@ Export the dense high-byte transitions from the Go side, then point the
 solver at them:
 
 ```
-# (planned) export helper writes one "Hprev,Hcur,eo,Hnext" line per transition
+# the structure mode writes high-transitions.csv (one Hprev,Hcur,eo,Hnext per line)
 gophertrunk cryptolab -out ./out alias structure -csv ground_truth.csv
 python solve_structure.py --transitions ./out/high-transitions.csv
 ```

--- a/internal/cryptolab/subjects/motorola/modes.go
+++ b/internal/cryptolab/subjects/motorola/modes.go
@@ -1,9 +1,12 @@
 package motorola
 
 import (
+	"bufio"
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
@@ -11,6 +14,25 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/propagate"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/progress"
 )
+
+// exportTransitions writes the dense high-byte recurrence as a
+// Hprev,Hcur,eo,Hnext CSV for the optional Z3 structural search.
+func exportTransitions(dir string, cons []propagate.Constraint) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(filepath.Join(dir, "high-transitions.csv"))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	bw := bufio.NewWriter(f)
+	fmt.Fprintln(bw, "Hprev,Hcur,eo,Hnext")
+	for _, c := range cons {
+		fmt.Fprintf(bw, "%d,%d,%d,%d\n", c.HPrev, c.HCur, c.Eo, c.HNext)
+	}
+	return bw.Flush()
+}
 
 // loadFlags parses the shared -csv flag (and returns the remaining FlagSet
 // so a mode can add its own knobs first). The corpus path is required.
@@ -126,6 +148,14 @@ func (structureMode) Run(ctx context.Context, args []string, env cryptolab.Env) 
 	}
 	env.Logf("high-byte constraints", "count", len(cons))
 
+	// Export the dense transitions for the optional Z3 structural search
+	// (internal/cryptolab/smt/solve_structure.py consumes this CSV).
+	if env.OutDir != "" {
+		if err := exportTransitions(env.OutDir, cons); err != nil {
+			return nil, err
+		}
+	}
+
 	jl, _ := progress.OpenJSONL(env.OutDir, "structure-survivors.jsonl")
 	defer jl.Close()
 
@@ -198,15 +228,25 @@ func ctxKey(c Context) string { return fmt.Sprintf("%d:%d", c.HPrev, c.HCur) }
 func packState(s gauge.State) uint16 { return uint16(s.Hi)<<8 | uint16(s.Mul) }
 
 func (cellsMode) Run(ctx context.Context, args []string, env cryptolab.Env) (*cryptolab.Result, error) {
-	rows, err := parseCorpus("cells", args, env, nil)
+	// -resume is also accepted as a mode flag (the web console passes an
+	// uploaded checkpoint this way); it falls back to the CLI-global
+	// env.ResumePath when not given.
+	var resumeFlag string
+	rows, err := parseCorpus("cells", args, env, func(fs *flag.FlagSet) {
+		fs.StringVar(&resumeFlag, "resume", "", "checkpoint file to resume from")
+	})
 	if err != nil {
 		return nil, err
 	}
 	t := Recovered()
+	resumePath := resumeFlag
+	if resumePath == "" {
+		resumePath = env.ResumePath
+	}
 
 	ck := &cellCheckpoint{Version: 1, Candidates: map[string][]uint16{}}
-	if env.ResumePath != "" {
-		if found, err := progress.LoadCheckpoint(env.ResumePath, ck); err != nil {
+	if resumePath != "" {
+		if found, err := progress.LoadCheckpoint(resumePath, ck); err != nil {
 			return nil, err
 		} else if found {
 			env.Logf("resumed checkpoint", "contexts", len(ck.Candidates))
@@ -240,11 +280,17 @@ func (cellsMode) Run(ctx context.Context, args []string, env cryptolab.Env) (*cr
 	// Decode coverage: a char is decodable when its context is pinned.
 	charsDecodable, charsTotal, msgsFull := decodeCoverage(t, rows, ck)
 
-	if env.OutDir != "" {
-		ckPath := env.ResumePath
-		if ckPath == "" {
-			ckPath = env.OutDir + "/cells/checkpoint.json"
-		}
+	// Persist the (refined) checkpoint. Prefer the artifact dir so the web
+	// console can offer it as a top-level download; otherwise write back to
+	// the resume path so a CLI `-resume` run accumulates in place.
+	ckPath := ""
+	switch {
+	case env.OutDir != "":
+		ckPath = filepath.Join(env.OutDir, "checkpoint.json")
+	case resumePath != "":
+		ckPath = resumePath
+	}
+	if ckPath != "" {
 		if err := progress.SaveCheckpoint(ckPath, ck); err != nil {
 			return nil, err
 		}

--- a/internal/cryptolab/subjects/motorola/motorola_test.go
+++ b/internal/cryptolab/subjects/motorola/motorola_test.go
@@ -248,6 +248,49 @@ func TestModesRunEndToEnd(t *testing.T) {
 	}
 }
 
+func TestCellsModeResumeRoundTrip(t *testing.T) {
+	t.Parallel()
+	csv := synthCSV(t)
+	dir1 := t.TempDir()
+	env1 := cryptolab.Env{OutDir: dir1, Stdout: &bytes.Buffer{}, Format: cryptolab.FormatText}
+	if _, err := (cellsMode{}).Run(context.Background(), []string{"-csv", csv}, env1); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	ckPath := filepath.Join(dir1, "checkpoint.json")
+	if _, err := os.Stat(ckPath); err != nil {
+		t.Fatalf("checkpoint not written to top-level artifact path: %v", err)
+	}
+
+	// Resume from the written checkpoint via the -resume mode flag (the path
+	// the web console uses). Must not error and must stay monotone.
+	dir2 := t.TempDir()
+	env2 := cryptolab.Env{OutDir: dir2, Stdout: &bytes.Buffer{}, Format: cryptolab.FormatText}
+	res, err := (cellsMode{}).Run(context.Background(), []string{"-csv", csv, "-resume", ckPath}, env2)
+	if err != nil {
+		t.Fatalf("resume run: %v", err)
+	}
+	if res == nil || res.Mode != "cells" {
+		t.Fatalf("bad resume result %+v", res)
+	}
+}
+
+func TestStructureModeExportsTransitions(t *testing.T) {
+	t.Parallel()
+	csv := synthCSV(t)
+	dir := t.TempDir()
+	env := cryptolab.Env{OutDir: dir, Stdout: &bytes.Buffer{}, Format: cryptolab.FormatText}
+	if _, err := (structureMode{}).Run(context.Background(), []string{"-csv", csv}, env); err != nil {
+		t.Fatalf("structure run: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, "high-transitions.csv"))
+	if err != nil {
+		t.Fatalf("transitions CSV not written: %v", err)
+	}
+	if !bytes.HasPrefix(b, []byte("Hprev,Hcur,eo,Hnext")) {
+		t.Fatalf("transitions CSV missing header: %q", b[:min(40, len(b))])
+	}
+}
+
 func TestAliasToolRegistered(t *testing.T) {
 	t.Parallel()
 	tool, ok := cryptolab.Lookup("alias")

--- a/internal/cryptolab/tools/brute.go
+++ b/internal/cryptolab/tools/brute.go
@@ -11,9 +11,11 @@ import (
 
 type bruteTool struct{}
 
-func (bruteTool) Name() string            { return "brute" }
-func (bruteTool) Synopsis() string        { return "keyspace brute force for classical / XOR ciphers" }
-func (bruteTool) Modes() []cryptolab.Mode { return []cryptolab.Mode{bruteXOR{}} }
+func (bruteTool) Name() string     { return "brute" }
+func (bruteTool) Synopsis() string { return "keyspace brute force for classical / XOR ciphers" }
+func (bruteTool) Modes() []cryptolab.Mode {
+	return []cryptolab.Mode{bruteXOR{}, bruteCaesar{}, bruteVigenere{}}
+}
 
 type bruteXOR struct{}
 
@@ -79,6 +81,82 @@ func firstN(g []stats.KeyLenScore, n int) []stats.KeyLenScore {
 		return g[:n]
 	}
 	return g
+}
+
+// scorerFor returns an English scorer, optionally boosted by a known-plaintext crib.
+func scorerFor(crib string) brute.Scorer {
+	if crib != "" {
+		return brute.Crib{Crib: []byte(crib), Base: brute.English{}}
+	}
+	return brute.English{}
+}
+
+type bruteCaesar struct{}
+
+func (bruteCaesar) Name() string     { return "caesar" }
+func (bruteCaesar) Synopsis() string { return "recover a single additive (Caesar/ROT) shift" }
+
+func (bruteCaesar) Run(_ context.Context, args []string, env cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("brute caesar")
+	in := fs.String("in", "", "ciphertext file — required")
+	crib := fs.String("crib", "", "optional known-plaintext substring to boost scoring")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	ct, err := readInput(*in)
+	if err != nil {
+		return nil, err
+	}
+	cand := brute.SolveCaesar(ct, scorerFor(*crib))
+	res := &cryptolab.Result{Tool: "brute", Mode: "caesar"}
+	shift := byte(0)
+	if len(cand.Key) == 1 {
+		shift = cand.Key[0]
+	}
+	res.AddField("shift", shift)
+	addXORFinding(res, cand)
+	res.Summary = fmt.Sprintf("recovered Caesar shift %d", shift)
+	return res, nil
+}
+
+type bruteVigenere struct{}
+
+func (bruteVigenere) Name() string { return "vigenere" }
+func (bruteVigenere) Synopsis() string {
+	return "recover a repeating additive (Vigenère) key from ciphertext"
+}
+
+func (bruteVigenere) Run(_ context.Context, args []string, env cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("brute vigenere")
+	in := fs.String("in", "", "ciphertext file — required")
+	keyLen := fs.Int("keylen", 0, "key length (0 = auto-detect via Hamming)")
+	crib := fs.String("crib", "", "optional known-plaintext substring to boost scoring")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	ct, err := readInput(*in)
+	if err != nil {
+		return nil, err
+	}
+	scorer := scorerFor(*crib)
+	res := &cryptolab.Result{Tool: "brute", Mode: "vigenere"}
+	kl := *keyLen
+	if kl <= 0 {
+		guesses := stats.GuessXORKeyLength(ct, 40) // periodicity test is cipher-agnostic
+		res.AddField("auto_keylen_candidates", topLens(guesses, 3))
+		if len(guesses) > 0 {
+			kl = guesses[0].Length
+		}
+		if kl <= 0 {
+			kl = 1
+		}
+	}
+	cand := brute.SolveVigenere(ct, kl, scorer)
+	res.AddField("keylen", kl)
+	env.Logf("vigenere solved", "keylen", kl)
+	addXORFinding(res, cand)
+	res.Summary = fmt.Sprintf("recovered %d-byte Vigenère key", len(cand.Key))
+	return res, nil
 }
 
 func addXORFinding(res *cryptolab.Result, c brute.Candidate) {

--- a/internal/cryptolab/webserver/schema_args_test.go
+++ b/internal/cryptolab/webserver/schema_args_test.go
@@ -1,0 +1,85 @@
+package webserver
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+
+	// Register every tool and subject so the schema is complete.
+	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/subjects/motorola"
+	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/tools"
+)
+
+// TestSchemaArgsAcceptedByEveryMode is the drift guard between the web schema
+// and each mode's own flag set: it builds the CLI args the web server would
+// produce for every schema parameter and runs the mode, asserting the mode's
+// flag parser never rejects an arg with "flag provided but not defined". (A
+// content error from dummy input is fine — only a flag-wiring mismatch fails.)
+func TestSchemaArgsAcceptedByEveryMode(t *testing.T) {
+	t.Parallel()
+	s, err := New(Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	for _, ms := range cryptolab.Schema() {
+		ms := ms
+		t.Run(ms.Tool+"/"+ms.Mode, func(t *testing.T) {
+			t.Parallel()
+			// Stage a real temp file for every file/optional-file param so
+			// buildArgs has an upload id to resolve.
+			params := map[string]string{}
+			files := map[string]string{}
+			for _, p := range ms.Params {
+				switch p.Kind {
+				case "file":
+					id := randomID()
+					path := filepath.Join(t.TempDir(), id+".bin")
+					if err := os.WriteFile(path, []byte("\x00\x01\x02\x03"), 0o644); err != nil {
+						t.Fatal(err)
+					}
+					s.mu.Lock()
+					s.files[id] = &upload{ID: id, Path: path}
+					s.mu.Unlock()
+					files[p.Name] = id
+				case "outfile":
+					params[p.Name] = p.Default
+				case "bool":
+					params[p.Name] = "true"
+				default:
+					if p.Default != "" {
+						params[p.Name] = p.Default
+					} else {
+						params[p.Name] = "1"
+					}
+				}
+			}
+			jobDir := t.TempDir()
+			args, err := s.buildArgs(ms, runRequest{Tool: ms.Tool, Mode: ms.Mode, Params: params, Files: files}, jobDir)
+			if err != nil {
+				t.Fatalf("buildArgs: %v", err)
+			}
+			_, mode, err := cryptolab.LookupMode(ms.Tool, ms.Mode)
+			if err != nil {
+				t.Fatal(err)
+			}
+			env := cryptolab.Env{Logger: slog.New(slog.NewTextHandler(io.Discard, nil)), OutDir: jobDir, Stdout: io.Discard}
+			_, runErr := mode.Run(context.Background(), args, env)
+			if runErr != nil {
+				low := strings.ToLower(runErr.Error())
+				if strings.Contains(low, "not defined") || strings.Contains(low, "flag provided") {
+					t.Fatalf("schema/flag drift for %s/%s: %v (args=%v)", ms.Tool, ms.Mode, runErr, args)
+				}
+				// Any other error is an expected content/validation failure on
+				// the dummy input, not a flag-wiring problem.
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to the merged cryptolab toolkit (#819) and web console (#820). An audit of the toolkit surfaced a real bug, a deferred integration, and a couple of gaps between the plan and what shipped — this closes them. Everything stays opt-in (`make build TAGS=cryptolab`); the default install is unchanged.

## Changes

- **Bug:** the web schema sends `-resume` for `alias cells`, but the mode never defined that flag — uploading a checkpoint in the console errored with *"flag provided but not defined"*. Added a `-resume` mode flag (falling back to the CLI-global `env.ResumePath`) and made the refined checkpoint a top-level downloadable `checkpoint.json`.
- **Closed the SMT loop:** `alias structure` now exports `high-transitions.csv` (`Hprev,Hcur,eo,Hnext`) to the `-out` directory, which `internal/cryptolab/smt/solve_structure.py` consumes directly (the README's "(planned) export helper" is now real). Also `MkdirAll` the `-out` dir so the CLI path doesn't fail when it doesn't exist yet.
- **Rounded out `brute`** to the planned classical-cipher set: added `caesar` and `vigenere` modes (new Vigenère cipher + per-column additive solvers). They appear in the web console automatically (schema-driven).
- **Drift guard:** `webserver/schema_args_test.go` builds every mode's web args from the schema and asserts the mode's own flag parser accepts them — this would have caught the `-resume` bug. Plus an end-to-end cells `-resume` round-trip and a structure-mode transitions-export test, and Caesar/Vigenère solver tests.
- **Documented the intentionally out-of-scope items** (monoalphabetic substitution solver, split-band/rolling descrambling, daemon-mounted console) under a "Not yet implemented" section in `docs/cryptolab.md` so the gaps are explicit rather than silent.

## Test plan

- [x] `go build ./...` and `go vet` (default + `-tags cryptolab`) green against current `main`
- [x] `go test ./internal/cryptolab/...` and `go test -tags cryptolab ./cmd/gophertrunk/` green
- [x] New tests: schema↔flag drift guard across all modes, cells `-resume` round-trip, structure transitions export, Caesar/Vigenère solvers
- [x] Smoke-tested: SMT export → `solve_structure.py` pre-checks parse the transitions; `cryptolab serve` still serves the console with the new `brute` modes appearing automatically
- [ ] `make integration` — n/a (no daemon/DSP code touched)
- [ ] Real-hardware smoke — n/a (no SDR/USB/vocoder code touched)

## Breaking changes

None. Additive and absent from the default build.

## Docs / CHANGELOG

- [x] Updated the `## [Unreleased]` cryptolab bullet in `CHANGELOG.md` (broadened `brute` to XOR/Caesar/Vigenère)
- [x] Updated `docs/cryptolab.md` (broadened `brute` table, SMT export note, "Not yet implemented" roadmap)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxQENEPxmgVF1dQTbCBT3H)_