### PR TITLE
trunking: surface all active talkgroups, not just tuner-bound calls

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -250,9 +250,15 @@ func (s *Server) handleActiveCalls(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 	active := s.engine.ActiveCalls()
-	out := make([]ActiveCallDTO, 0, len(active))
+	observed := s.engine.ObservedCalls()
+	out := make([]ActiveCallDTO, 0, len(active)+len(observed))
 	for _, ac := range active {
-		out = append(out, activeCallToDTO(ac))
+		out = append(out, activeCallToDTO(ac, true))
+	}
+	// Control-channel-observed calls a tuner isn't following (every voice
+	// device busy) so the operator sees every talkgroup up on the system.
+	for _, ac := range observed {
+		out = append(out, activeCallToDTO(ac, false))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"calls": out})
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -24,6 +24,11 @@ import (
 // from the concrete type keeps the API testable with a fake engine.
 type EngineSnapshot interface {
 	ActiveCalls() []*trunking.ActiveCall
+	// ObservedCalls returns voice calls the control channel announced that no
+	// voice tuner is following (every device busy). The active-calls endpoint
+	// merges them with ActiveCalls so the operator sees every talkgroup up on
+	// the system, not just the ones a tuner is decoding.
+	ObservedCalls() []*trunking.ActiveCall
 }
 
 // EngineMutator is the optional write side of the engine. Daemons

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -19,10 +19,12 @@ import (
 )
 
 type fakeEngine struct {
-	calls []*trunking.ActiveCall
+	calls    []*trunking.ActiveCall
+	observed []*trunking.ActiveCall
 }
 
-func (f *fakeEngine) ActiveCalls() []*trunking.ActiveCall { return f.calls }
+func (f *fakeEngine) ActiveCalls() []*trunking.ActiveCall   { return f.calls }
+func (f *fakeEngine) ObservedCalls() []*trunking.ActiveCall { return f.observed }
 
 // mkServer wires a Server on a random localhost port and returns the
 // base URL plus a teardown function.
@@ -216,6 +218,13 @@ func TestActiveCallsReportsEngineSnapshot(t *testing.T) {
 			Talkgroup: &trunking.TalkGroup{ID: 1234, AlphaTag: "FIRE-DISP"},
 			StartedAt: time.Now().UTC(),
 		}},
+		// A second talkgroup is up on the system but no tuner is following it
+		// (control-channel-observed only, nil Device).
+		observed: []*trunking.ActiveCall{{
+			Grant:     trunking.Grant{System: "Alpha", Protocol: "p25", GroupID: 5678, FrequencyHz: 851_012_500},
+			Talkgroup: &trunking.TalkGroup{ID: 5678, AlphaTag: "PD-DISP"},
+			StartedAt: time.Now().UTC(),
+		}},
 	}
 	base, teardown := mkServer(t, ServerOptions{Bus: bus, Engine: engine})
 	defer teardown()
@@ -226,8 +235,20 @@ func TestActiveCallsReportsEngineSnapshot(t *testing.T) {
 		Calls []ActiveCallDTO `json:"calls"`
 	}
 	json.NewDecoder(resp.Body).Decode(&body)
-	if len(body.Calls) != 1 || body.Calls[0].Talkgroup.AlphaTag != "FIRE-DISP" {
-		t.Errorf("calls = %+v", body.Calls)
+	if len(body.Calls) != 2 {
+		t.Fatalf("calls = %+v, want 2 (one followed, one observed)", body.Calls)
+	}
+	byTG := map[uint32]ActiveCallDTO{}
+	for _, c := range body.Calls {
+		byTG[c.Grant.GroupID] = c
+	}
+	followed, ok := byTG[1234]
+	if !ok || !followed.Following || followed.DeviceSerial != "VOICE-1" || followed.Talkgroup.AlphaTag != "FIRE-DISP" {
+		t.Errorf("followed call = %+v, want following=true on VOICE-1", followed)
+	}
+	observed, ok := byTG[5678]
+	if !ok || observed.Following || observed.DeviceSerial != "" || observed.Talkgroup.AlphaTag != "PD-DISP" {
+		t.Errorf("observed call = %+v, want following=false with empty device", observed)
 	}
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -700,15 +700,26 @@ type ActiveCallDTO struct {
 	DeviceSerial string        `json:"device_serial"`
 	StartedAt    time.Time     `json:"started_at"`
 	LastHeardAt  time.Time     `json:"last_heard_at"`
+	// Following is true when a voice tuner is actively decoding this call.
+	// False for calls the control channel has announced but no tuner is
+	// following (every voice device busy) — surfaced so the operator sees all
+	// talkgroups up on the system, not only the ones being decoded. An
+	// unfollowed call has an empty DeviceSerial.
+	Following bool `json:"following"`
 }
 
-func activeCallToDTO(ac *trunking.ActiveCall) ActiveCallDTO {
+func activeCallToDTO(ac *trunking.ActiveCall, following bool) ActiveCallDTO {
+	serial := ""
+	if ac.Device != nil {
+		serial = ac.Device.Serial
+	}
 	return ActiveCallDTO{
 		Grant:        grantToDTO(ac.Grant),
 		Talkgroup:    talkgroupToDTO(ac.Talkgroup),
-		DeviceSerial: ac.Device.Serial,
+		DeviceSerial: serial,
 		StartedAt:    ac.StartedAt,
 		LastHeardAt:  ac.LastHeardAt,
+		Following:    following,
 	}
 }
 

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -3,6 +3,7 @@ package trunking
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sync"
 	"time"
@@ -66,6 +67,23 @@ type Engine struct {
 	mu        sync.Mutex
 	calls     map[string]*ActiveCall // by device serial; mirror of pool.active for fast access
 	synthetic map[string]*ActiveCall // by device serial; calls owned by external scanners (conv FM)
+	// observed tracks every voice call the control channel has announced,
+	// keyed by observedKey (system|talkgroup|timeslot), regardless of whether
+	// a voice tuner is following it. It is the source for ObservedCalls, which
+	// lets operator UIs show ALL talkgroups currently up on a system — not just
+	// the few a tuner is decoding — so a single-voice-tuner rig no longer looks
+	// like only one talkgroup is ever active. Entries refresh on the control
+	// channel's repeated grant TSBKs and age out via runWatchdog once the call
+	// drops. Guarded by mu, like calls/synthetic.
+	observed map[string]*ActiveCall
+}
+
+// observedKey identifies a logical call for the observed-call tracker:
+// (System, talkgroup, timeslot) — the same identity HandleGrant's duplicate-
+// grant guard uses, so a DMR Tier III carrier's two per-slot calls stay
+// distinct and a band-plan re-map (same call, new frequency) updates one entry.
+func observedKey(g Grant) string {
+	return fmt.Sprintf("%s|%d|%d", g.System, g.GroupID, g.Timeslot)
 }
 
 // EngineOptions configure a new Engine.
@@ -160,6 +178,7 @@ func NewEngine(opts EngineOptions) (*Engine, error) {
 		configuredKeys: opts.ConfiguredKeys,
 		calls:          make(map[string]*ActiveCall),
 		synthetic:      make(map[string]*ActiveCall),
+		observed:       make(map[string]*ActiveCall),
 	}
 	// Subscribe at construction time so callers can publish grants
 	// before Run starts without losing them.
@@ -308,6 +327,16 @@ func (e *Engine) HandleGrant(g Grant) {
 		e.log.Debug("dropping encrypted grant (encrypted_calls mode: ignore)",
 			"grant", g.String())
 		return
+	}
+
+	// Record the call on the system-activity tracker before the tuner-
+	// allocation logic below, so a talkgroup that keys up while every voice
+	// device is busy still surfaces in ObservedCalls (the P25 "only one active
+	// talkgroup" report). Repeated grant TSBKs for a live call refresh the
+	// entry; data grants are not voice calls and are skipped. ObservedCalls
+	// filters out whichever of these a tuner ends up following.
+	if !g.DataCall {
+		e.observeCall(g, tg)
 	}
 
 	// Suppress duplicate grants. The Phase 1 CC repeats voice-grant
@@ -593,6 +622,56 @@ func (e *Engine) ActiveCalls() []*ActiveCall {
 	return out
 }
 
+// observeCall upserts the system-activity tracker entry for grant g. Called
+// for every voice grant HandleGrant accepts, whether or not a tuner follows it.
+func (e *Engine) observeCall(g Grant, tg *TalkGroup) {
+	key := observedKey(g)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if ac, ok := e.observed[key]; ok {
+		ac.Grant = g
+		ac.Talkgroup = tg
+		ac.LastHeardAt = g.At
+		return
+	}
+	e.observed[key] = &ActiveCall{
+		Grant:       g,
+		Talkgroup:   tg,
+		StartedAt:   g.At,
+		LastHeardAt: g.At,
+		// Device intentionally nil: this call is known only from the control
+		// channel, not bound to a voice tuner.
+	}
+}
+
+// ObservedCalls returns the voice calls the control channel has announced that
+// are NOT currently being followed by a voice tuner — e.g. talkgroups that
+// keyed up while every voice device was busy. They carry a nil Device. Combined
+// with ActiveCalls at the API layer, they let an operator see every talkgroup
+// up on the system (the P25 "only one active talkgroup" report), while audio
+// stays limited to the number of voice tuners. Entries age out via runWatchdog.
+func (e *Engine) ObservedCalls() []*ActiveCall {
+	// Build the set of (system|tg|timeslot) keys a tuner is actively following
+	// so they aren't double-reported as observed-only.
+	followed := make(map[string]bool)
+	for _, ac := range e.pool.Active() {
+		followed[observedKey(ac.Grant)] = true
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, ac := range e.synthetic {
+		followed[observedKey(ac.Grant)] = true
+	}
+	out := make([]*ActiveCall, 0, len(e.observed))
+	for key, ac := range e.observed {
+		if followed[key] {
+			continue
+		}
+		out = append(out, ac)
+	}
+	return out
+}
+
 func (e *Engine) startCall(d *VoiceDevice, g Grant, tg *TalkGroup) {
 	ac, err := e.pool.Bind(d, g, tg, e.now())
 	if err != nil {
@@ -743,6 +822,16 @@ func (e *Engine) runWatchdog() {
 			e.endCall(ac, reason)
 		}
 	}
+	// Age out system-activity entries the control channel has stopped
+	// repeating: once a call drops, its grant TSBKs stop, so the same grace
+	// window that reaps a followed call clears its observed-only siblings.
+	e.mu.Lock()
+	for key, ac := range e.observed {
+		if ac.LastHeardAt.Before(cutoff) {
+			delete(e.observed, key)
+		}
+	}
+	e.mu.Unlock()
 }
 
 func (e *Engine) shutdown() {

--- a/internal/trunking/observed_calls_test.go
+++ b/internal/trunking/observed_calls_test.go
@@ -1,0 +1,81 @@
+package trunking
+
+import (
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestObservedCallsSurfacesUnfollowedTalkgroups is the P25 "only one active
+// talkgroup" regression: with a single voice tuner, three distinct talkgroups
+// keying up at once must surface as three active calls — one followed (bound to
+// the tuner) and two control-channel-observed (no tuner free) — so an operator
+// sees every talkgroup up on the system, not just the one being decoded.
+func TestObservedCallsSurfacesUnfollowedTalkgroups(t *testing.T) {
+	e, _, bus, _ := mkEngine(t, 1) // ONE voice tuner
+	defer bus.Close()
+
+	// Three distinct talkgroups, all up on the same system at once.
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 100, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 200, FrequencyHz: 851_012_500})
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 300, FrequencyHz: 851_025_000})
+
+	followed := e.ActiveCalls()
+	if len(followed) != 1 {
+		t.Fatalf("followed calls = %d, want 1 (only one voice tuner)", len(followed))
+	}
+	observed := e.ObservedCalls()
+	if len(observed) != 2 {
+		t.Fatalf("observed (unfollowed) calls = %d, want 2", len(observed))
+	}
+
+	// Union of followed + observed must be exactly the three talkgroups, with
+	// no talkgroup appearing in both sets.
+	seen := map[uint32]int{}
+	for _, ac := range followed {
+		seen[ac.Grant.GroupID]++
+	}
+	for _, ac := range observed {
+		if ac.Device != nil {
+			t.Errorf("observed call should not be bound to a device, got %q", ac.Device.Serial)
+		}
+		seen[ac.Grant.GroupID]++
+	}
+	for _, tg := range []uint32{100, 200, 300} {
+		if seen[tg] != 1 {
+			t.Errorf("talkgroup %d appeared %d times across followed+observed, want exactly 1", tg, seen[tg])
+		}
+	}
+}
+
+// TestObservedCallExpiresAfterTimeout pins that a control-channel-observed call
+// ages out of ObservedCalls once the control channel stops repeating its grant,
+// reusing the engine's existing call-timeout grace window.
+func TestObservedCallExpiresAfterTimeout(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	pool, _ := mkPool(1)
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	e, err := NewEngine(EngineOptions{
+		Bus: bus, VoicePool: pool, Talkgroups: NewTalkgroupDB(),
+		CallTimeout: time.Second, Now: clk.Now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fill the single tuner, then a second talkgroup is observed-only.
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 1, FrequencyHz: 851_000_000})
+	e.HandleGrant(Grant{System: "X", Protocol: "p25", GroupID: 2, FrequencyHz: 851_012_500})
+	if got := len(e.ObservedCalls()); got != 1 {
+		t.Fatalf("observed = %d, want 1 before timeout", got)
+	}
+
+	// Past the grace window with no repeat grant, the watchdog drops it.
+	clk.t = clk.t.Add(2 * time.Second)
+	e.runWatchdog()
+	if got := len(e.ObservedCalls()); got != 0 {
+		t.Fatalf("observed = %d, want 0 after timeout", got)
+	}
+}

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -108,6 +108,9 @@ type ActiveCallDTO struct {
 	DeviceSerial string        `json:"device_serial"`
 	StartedAt    time.Time     `json:"started_at"`
 	LastHeardAt  time.Time     `json:"last_heard_at"`
+	// Following is true when a voice tuner is decoding this call; false for a
+	// call the control channel announced but no tuner is following.
+	Following bool `json:"following"`
 }
 
 // CallRow mirrors storage.CallRow — the shape returned by GET

--- a/internal/tui/panels/active.go
+++ b/internal/tui/panels/active.go
@@ -45,6 +45,11 @@ func (p *ActivePanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd)
 			if !found {
 				return p, nil
 			}
+			// Control-channel-observed calls aren't bound to a tuner, so there
+			// is nothing to end — ignore the keystroke for those rows.
+			if !ac.Following {
+				return p, nil
+			}
 			req := state.WriteRequest{
 				Confirm: fmt.Sprintf("End call on device %s (TG %d)?", ac.DeviceSerial, ac.Grant.GroupID),
 				Label:   "ended call on " + ac.DeviceSerial,
@@ -60,11 +65,11 @@ func (p *ActivePanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd)
 	// the row repaints when the engine backfills encryption metadata
 	// after an LDU2 lands (P25 Phase 1).
 	h := hashRows(s.ActiveCalls, func(ac client.ActiveCallDTO) string {
-		return fmt.Sprintf("%s|%d|%d|%s|%d|%v|%v|%d|%d",
+		return fmt.Sprintf("%s|%d|%d|%s|%d|%v|%v|%d|%d|%v",
 			ac.DeviceSerial, ac.Grant.GroupID, ac.Grant.SourceID,
 			ac.Grant.System, ac.Grant.FrequencyHz,
 			ac.Grant.Encrypted, ac.Grant.Emergency,
-			ac.Grant.AlgorithmID, ac.Grant.KeyID)
+			ac.Grant.AlgorithmID, ac.Grant.KeyID, ac.Following)
 	})
 	if h != p.lastHash {
 		p.refresh(s.ActiveCalls)
@@ -104,6 +109,12 @@ func (p *ActivePanel) refresh(calls []client.ActiveCallDTO) {
 			}
 			flags += fmt.Sprintf("TS%d", ac.Grant.Timeslot)
 		}
+		// A control-channel-observed call (no tuner following it) has no device;
+		// label it so the operator can tell it apart from a decoded call.
+		device := ac.DeviceSerial
+		if !ac.Following {
+			device = "(observed)"
+		}
 		rows = append(rows, table.Row{
 			since(ac.StartedAt),
 			fmt.Sprintf("%d", ac.Grant.GroupID),
@@ -111,7 +122,7 @@ func (p *ActivePanel) refresh(calls []client.ActiveCallDTO) {
 			fmt.Sprintf("%d", ac.Grant.SourceID),
 			ac.Grant.System,
 			client.FormatFreqMHz(ac.Grant.FrequencyHz),
-			ac.DeviceSerial,
+			device,
 			flags,
 		})
 	}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -138,6 +138,10 @@ export interface ActiveCallDTO {
   device_serial: string;
   started_at: string;
   ended_at?: string;
+  // true when a voice tuner is decoding this call; false for a call the
+  // control channel announced but no tuner is following (every voice device
+  // busy). An unfollowed call has an empty device_serial.
+  following?: boolean;
 }
 
 export interface DeviceDTO {

--- a/web/src/panels/Active.tsx
+++ b/web/src/panels/Active.tsx
@@ -112,6 +112,14 @@ export function Active() {
             )}
             {r.grant.emergency && <span className="pill-err">emerg</span>}
             {r.grant.data_call && <span className="pill">data</span>}
+            {r.following === false && (
+              <span
+                className="pill"
+                title="Announced on the control channel; no voice tuner is following it (add voice_taps or a voice SDR to decode more calls at once)"
+              >
+                observed
+              </span>
+            )}
           </div>
         ),
       },
@@ -129,7 +137,9 @@ export function Active() {
         key: "device",
         header: "Device",
         render: (r) => (
-          <span className="font-mono text-xs text-muted">{r.device_serial}</span>
+          <span className="font-mono text-xs text-muted">
+            {r.following === false ? "—" : r.device_serial}
+          </span>
         ),
         sort: (a, b) => a.device_serial.localeCompare(b.device_serial),
         className: "hidden lg:table-cell",
@@ -156,7 +166,9 @@ export function Active() {
       <DataTable
         rows={activeCalls}
         columns={columns}
-        rowKey={(r) => `${r.device_serial}-${r.started_at}`}
+        rowKey={(r) =>
+          `${r.device_serial}-${r.grant.system}-${r.grant.group_id}-${r.grant.timeslot ?? 0}-${r.started_at}`
+        }
         defaultSortKey="elapsed"
         defaultSortDirection="desc"
         searchable
@@ -268,7 +280,14 @@ export function Active() {
               <DetailField label="Mode" value={selected.talkgroup.mode} />
             </div>
           )}
-          {canMutate ? (
+          {selected.following === false ? (
+            <p className="text-xs text-muted pt-2">
+              This call is only known from the control channel — no voice tuner
+              is following it. Add <code>voice_taps</code> to a wideband device,
+              or another <code>role: voice</code> SDR, to decode more calls at
+              once.
+            </p>
+          ) : canMutate ? (
             <div className="pt-2">
               <button
                 className="btn-danger w-full"


### PR DESCRIPTION
A Discord report: monitoring a P25 trunk only ever shows one active
talkgroup at a time, even when several calls are up. The engine only
surfaced calls bound to a voice tuner (pool.Active + synthetic), so with
a single voice tuner (one role: voice SDR, or voice_taps: 1) only one
call could ever appear — distinct talkgroups otherwise allocate fine.
Audio is necessarily limited by tuner count, but the *display* of active
talkgroups should not be: every grant the control channel announces is a
talkgroup currently up on the system.

Add a control-channel activity tracker to the engine: every accepted
voice grant upserts an entry keyed by (system, talkgroup, timeslot) —
the same identity HandleGrant's duplicate-grant guard uses — refreshed by
the control channel's repeated grant TSBKs and aged out by the existing
call-timeout grace window in runWatchdog. A new ObservedCalls() returns
the entries no tuner is following; ActiveCalls() is unchanged so existing
callers and tests keep their tuner-bound semantics.

The active-calls API merges both sets with a `following` flag (true =
decoded by a tuner, false = control-channel-observed only, empty device).
The TUI and web active panels render observed calls distinctly and don't
offer to end them (there is no tuner to release), with a hint to add
voice_taps / a voice SDR to decode more calls at once.

Tests: a 1-tuner engine with three distinct-TG grants now reports one
followed + two observed (was one total); observed entries age out after
the call timeout; the active-calls handler returns both sets with correct
following flags.

Refs #356 (same duplicate-grant identity); addresses the P25 "one active
talkgroup" Discord report.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VAhAmqYxTjixHmGXhiF6zN