### PR TITLE
cryptolab: substitution solver, split-band/rolling descramble, daemon mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ for tagged releases.
   `siglab`/`configbuilder` consoles — a schema-driven form exposes every tool,
   mode, and setting, streams the live run log, and renders the structured
   result with downloadable artifacts. See `docs/cryptolab.md`.
+- **`cryptolab` toolkit expansion**. The `brute` tool gains a **monoalphabetic
+  substitution** solver (frequency-seeded hill-climbing with random restarts,
+  scored by an embedded English trigram model). The `descramble` tool gains
+  **split-band** inversion (independent low/high sub-band inversion about a
+  configurable split) and **rolling-code** inversion (per-frame split schedule,
+  with `auto` detection of each frame's inversion). The web console is now also
+  **mounted inside the main daemon at `/cryptolab/`** when `gophertrunk` is
+  built with `-tags cryptolab`, so it is reachable from the running daemon
+  without a separate `cryptolab serve`; the default daemon build is unaffected.
 - **Capture sample-rate guidance** (#771). `gophertrunk capture` now prints a
   one-line hint when a high native rate (>4 MS/s) is chosen for a narrowband
   trunking capture, explaining that the down-converter normalises to 48 kHz and

--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,10 @@ test-dvsi:
 # toolkit's engine and subject packages carry no build tag (they always
 # compile and are covered by `make test`); only the gophertrunk binary's
 # cryptolab subcommand is gated, so the default install excludes it. Opt the
-# toolkit into a build with `make build TAGS=cryptolab`.
+# toolkit into a build with `make build TAGS=cryptolab`. internal/api is
+# included so the tagged daemon-mounted console (/cryptolab/) is exercised.
 test-cryptolab:
-	$(GO) test -tags "cryptolab $(TAGS)" -race -count=1 ./internal/cryptolab/... ./cmd/gophertrunk/
+	$(GO) test -tags "cryptolab $(TAGS)" -race -count=1 ./internal/cryptolab/... ./cmd/gophertrunk/ ./internal/api/
 
 # test-airspy-real runs an opt-in real-hardware probe against an attached
 # Airspy R2/Mini. The test package skips unless GOPHERTRUNK_AIRSPY_REAL=1 is

--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -50,6 +50,13 @@ structured result — summary, fields, ranked findings, notes, and downloadable
 artifacts (survivor logs, checkpoints, descrambled output). It runs entirely
 offline against uploaded files; no SDR or daemon required.
 
+When the main `gophertrunk` daemon is built with `-tags cryptolab`, the same
+console is also mounted inside it at `/cryptolab/` (its API lives under
+`/api/v1/cryptolab/`, alongside the siglab routes), so you can reach it from
+the running daemon without launching a separate `cryptolab serve`. Mutating
+routes share the daemon's mutation gate. The default daemon build links a
+no-op mount, so the toolkit stays out of the standard binary.
+
 ## Usage (CLI)
 
 ```
@@ -65,11 +72,11 @@ Global flags precede the tool name (`-out`, `-resume`, `-format`,
 
 | Tool | Modes | What it does |
 |------|-------|--------------|
-| `brute` | `xor`, `caesar`, `vigenere` | classical-cipher recovery with English/crib scoring |
+| `brute` | `xor`, `caesar`, `vigenere`, `substitution` | classical-cipher recovery with English/crib scoring |
 | `lfsr` | `bm`, `keystream` | Berlekamp–Massey LFSR recovery; keystream = pt⊕ct |
 | `crc` | `recover`, `compute` | recover / compute CRC parameters from sample frames |
 | `stats` | `scan` | entropy / IC / chi-square / XOR key-length triage |
-| `descramble` | `invert` | full-band analog spectral inversion (self-inverse) |
+| `descramble` | `invert`, `splitband`, `rolling` | analog spectral / split-band / rolling-code voice inversion |
 | `alias` | `gauge`, `structure`, `cells`, `fromseed` | length-seeded byte-obfuscator recovery |
 
 ### Examples
@@ -84,8 +91,17 @@ gophertrunk cryptolab brute xor -in cipher.bin -crib "UNIT "
 # Identify the CRC on a protocol from captured (data,crc) frames.
 gophertrunk cryptolab crc recover -in frames.txt -widths 16,8
 
+# Recover a monoalphabetic substitution cipher (English plaintext assumed).
+gophertrunk cryptolab brute substitution -in cipher.txt -restarts 40
+
 # Descramble a frequency-inverted analog voice clip (run twice to undo).
 gophertrunk cryptolab descramble invert -in scrambled.s16 -out clear.s16
+
+# Undo a split-band inversion (low/high sub-bands inverted about a split point).
+gophertrunk cryptolab descramble splitband -in scrambled.s16 -out clear.s16 -split 0.5
+
+# Undo a rolling/hopping inversion, auto-detecting the per-frame split.
+gophertrunk cryptolab descramble rolling -in scrambled.s16 -out clear.s16 -frame 1024 -schedule auto
 ```
 
 ## Subject framework: byte-obfuscator recovery (`alias`)
@@ -127,20 +143,23 @@ richer multi-round / two-table update forms than the in-binary propagator. The
 `alias structure` mode writes `high-transitions.csv` to the `-out` directory,
 which the Z3 script consumes directly.
 
-## Not yet implemented
+## Substitution and voice-descramble internals
 
-These are deliberately out of the current scope; each is a sizeable addition
-on its own and is noted here so the gap is explicit rather than silent:
+- **Monoalphabetic substitution** (`brute substitution`) auto-solves a general
+  substitution cipher by frequency-seeded hill-climbing with random restarts,
+  scored against an embedded English trigram language model
+  (`internal/cryptolab/engine/lang`, `…/engine/subst`). It assumes English
+  plaintext; `-restarts` trades runtime for recovery on short ciphertexts.
+- **Split-band inversion** (`descramble splitband`) inverts the low and high
+  sub-bands independently about a `-split` point (fraction of Nyquist) using a
+  disjoint-bin FFT so the operation stays self-inverse.
+- **Rolling-code inversion** (`descramble rolling`) applies a per-frame split
+  schedule; `-schedule auto` detects each frame's inversion from its
+  spectral energy balance, while a CSV schedule replays a known hop sequence.
 
-- **Monoalphabetic substitution solver** in `brute` — auto-solving a general
-  substitution cipher needs n-gram hill-climbing / simulated annealing over a
-  26!-key space and an embedded language model, which is a different class of
-  work from the linear-keyspace solvers shipped here.
-- **Split-band and rolling-code voice descrambling** — `descramble` currently
-  does exact full-band spectral inversion (the dominant analog scrambler);
-  split-band inverters need a band-splitting filter bank, and rolling/hopping
-  schemes need sync recovery.
-- **Daemon-mounted console** — the web console runs as the standalone
-  `cryptolab serve`; mounting it inside the main `gophertrunk` daemon at a
-  `/cryptolab/` route (alongside the siglab API) would require wiring the
-  subsystem through `internal/api` behind the build tag.
+## Scope note
+
+The toolkit does not claim to break strong keyed RF crypto (P25 DES-OFB/AES,
+ADP/RC4). For those it offers known-plaintext keystream extraction (`lfsr`),
+weak/short-key brute force (`brute`), and breakability triage (`stats`); each
+report ends with what additional data would close the remaining gap.

--- a/internal/api/cryptolab_disabled.go
+++ b/internal/api/cryptolab_disabled.go
@@ -1,0 +1,11 @@
+//go:build !cryptolab
+
+package api
+
+import "net/http"
+
+// mountCryptolab is a no-op in the default build: the cryptolab research
+// console is an opt-in subsystem, linked only with -tags cryptolab (see
+// cryptolab_enabled.go). This keeps the cryptolab packages out of the default
+// daemon binary.
+func (s *Server) mountCryptolab(_ *http.ServeMux) {}

--- a/internal/api/cryptolab_enabled.go
+++ b/internal/api/cryptolab_enabled.go
@@ -1,0 +1,71 @@
+//go:build cryptolab
+
+package api
+
+import (
+	"io/fs"
+	"net/http"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/webserver"
+	cryptolabweb "github.com/MattCheramie/GopherTrunk/web/cryptolab"
+
+	// Register the cryptolab tools and subjects so the daemon-mounted console
+	// (like the standalone `cryptolab serve`) sees the full tool schema.
+	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/subjects/motorola"
+	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/tools"
+)
+
+// mountCryptolab registers the cryptolab research console on the daemon mux:
+// the /api/v1/cryptolab/* routes (mutations gated like every other daemon
+// write route) and, when the SPA is bundled, the console at /cryptolab/. It is
+// linked only in builds tagged `cryptolab`, so the default daemon binary is
+// unaffected. The webserver service owns a temp dir that shutdown() reclaims
+// via cryptolabCloser.
+func (s *Server) mountCryptolab(mux *http.ServeMux) {
+	svc, _ := s.cryptolabCloser.(*webserver.Server)
+	if svc == nil {
+		var err error
+		svc, err = webserver.New(webserver.Options{Logger: s.log})
+		if err != nil {
+			if s.log != nil {
+				s.log.Warn("cryptolab console disabled", "err", err)
+			}
+			return
+		}
+		s.cryptolabCloser = svc
+	}
+	svc.RegisterAPI(mux, s.gate)
+
+	// Secondary SPA at /cryptolab/ (daemon path); the standalone `cryptolab
+	// serve` serves it at / instead. The /cryptolab/ matcher is more specific
+	// than the GET / catch-all, so both trees coexist.
+	if cryptolabweb.HasAssets() {
+		mux.Handle("GET /cryptolab/", s.cryptolabSpaHandler())
+		mux.HandleFunc("GET /cryptolab", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/cryptolab/", http.StatusMovedPermanently)
+		})
+	}
+}
+
+// cryptolabSpaHandler serves the cryptolab SPA mounted under /cryptolab/,
+// stripping the prefix and falling back to index.html for client-side routes
+// (mirrors configSpaHandler).
+func (s *Server) cryptolabSpaHandler() http.Handler {
+	assets := cryptolabweb.Assets()
+	fileSrv := http.FileServerFS(assets)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/cryptolab/"), "/")
+		if rel != "" {
+			if _, err := fs.Stat(assets, rel); err == nil {
+				r2 := r.Clone(r.Context())
+				r2.URL.Path = "/" + rel
+				fileSrv.ServeHTTP(w, r2)
+				return
+			}
+		}
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/"
+		fileSrv.ServeHTTP(w, r2)
+	})
+}

--- a/internal/api/cryptolab_test.go
+++ b/internal/api/cryptolab_test.go
@@ -1,0 +1,50 @@
+//go:build cryptolab
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestCryptolabMountedOnDaemon verifies that, in a build tagged `cryptolab`,
+// the daemon mux mounts the cryptolab research console: the tool-schema route
+// answers and the closer it owns is registered for shutdown cleanup. The
+// default (untagged) build links the no-op mountCryptolab instead, so this
+// test only exists behind the tag.
+func TestCryptolabMountedOnDaemon(t *testing.T) {
+	bus := events.NewBus(4)
+	defer bus.Close()
+	s := &Server{
+		bus:        bus,
+		systems:    []trunking.System{{Name: "X", Protocol: trunking.ProtocolP25, ControlChannels: []uint32{1_000_000}}},
+		talkgroups: trunking.NewTalkgroupDB(),
+		log:        nopLogger(),
+		version:    "test",
+	}
+	mux := s.routes()
+	t.Cleanup(func() {
+		if s.cryptolabCloser != nil {
+			_ = s.cryptolabCloser.Close()
+		}
+	})
+	if s.cryptolabCloser == nil {
+		t.Fatal("cryptolab subsystem not registered for shutdown cleanup")
+	}
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/cryptolab/tools")
+	if err != nil {
+		t.Fatalf("GET cryptolab tools: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("cryptolab tools status = %d, want 200", resp.StatusCode)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -382,6 +382,13 @@ type Server struct {
 	// siglabStop signals the siglab TTL sweeper to exit on shutdown.
 	siglabStop chan struct{}
 
+	// cryptolabCloser holds the optional cryptolab web subsystem (the
+	// /cryptolab/ console + /api/v1/cryptolab/* routes). It is only
+	// constructed in builds tagged `cryptolab` (see cryptolab_enabled.go);
+	// the default build leaves it nil. Typed as a minimal closer so the
+	// non-tagged server.go does not import the cryptolab packages.
+	cryptolabCloser interface{ Close() error }
+
 	// configBuilder backs the standalone web Config Builder/Editor:
 	// the /api/v1/config/* routes (browse / load / validate / save /
 	// RadioReference browse) and, when assets are wired, the builder SPA
@@ -959,6 +966,11 @@ func (s *Server) shutdown(ctx context.Context) error {
 		}
 		s.siglab.close()
 	}
+	// Tear down the optional cryptolab subsystem (removes its temp dir).
+	if s.cryptolabCloser != nil {
+		_ = s.cryptolabCloser.Close()
+		s.cryptolabCloser = nil
+	}
 	// 30 s shutdown window: SSE / WebSocket / audio-stream subscribers
 	// get up to 30 s to drain rather than the 5 s the old bound gave
 	// them. Cuts user-visible connection drops on a clean restart.
@@ -1164,6 +1176,11 @@ func (s *Server) routes() *http.ServeMux {
 			}
 		}
 	}
+
+	// Optional cryptolab console (/cryptolab/ SPA + /api/v1/cryptolab/*).
+	// A no-op in the default build; the cryptolab-tagged build registers the
+	// routes here (see cryptolab_enabled.go).
+	s.mountCryptolab(mux)
 
 	// Pager log — recent POCSAG (and eventually FLEX) messages.
 	// Read-only; the decoder writes via the events bus → PagerLog.

--- a/internal/cryptolab/engine/lang/corpus.txt
+++ b/internal/cryptolab/engine/lang/corpus.txt
@@ -1,0 +1,59 @@
+Four score and seven years ago our fathers brought forth on this continent a
+new nation, conceived in liberty, and dedicated to the proposition that all
+men are created equal. Now we are engaged in a great civil war, testing
+whether that nation, or any nation so conceived and so dedicated, can long
+endure. We are met on a great battlefield of that war. We have come to
+dedicate a portion of that field as a final resting place for those who here
+gave their lives that that nation might live. It is altogether fitting and
+proper that we should do this. But in a larger sense we cannot dedicate, we
+cannot consecrate, we cannot hallow this ground. The brave men, living and
+dead, who struggled here have consecrated it far above our poor power to add
+or detract. The world will little note nor long remember what we say here, but
+it can never forget what they did here. It is for us the living rather to be
+dedicated here to the unfinished work which they who fought here have thus far
+so nobly advanced. It is rather for us to be here dedicated to the great task
+remaining before us, that from these honored dead we take increased devotion
+to that cause for which they gave the last full measure of devotion, that we
+here highly resolve that these dead shall not have died in vain, that this
+nation under God shall have a new birth of freedom, and that government of the
+people, by the people, for the people, shall not perish from the earth.
+
+When in the course of human events it becomes necessary for one people to
+dissolve the political bands which have connected them with another, and to
+assume among the powers of the earth the separate and equal station to which
+the laws of nature and of nature's God entitle them, a decent respect to the
+opinions of mankind requires that they should declare the causes which impel
+them to the separation. We hold these truths to be self evident, that all men
+are created equal, that they are endowed by their creator with certain
+unalienable rights, that among these are life, liberty, and the pursuit of
+happiness. That to secure these rights, governments are instituted among men,
+deriving their just powers from the consent of the governed.
+
+The quick brown fox jumps over the lazy dog while a jovial wizard vexed by
+quaint zephyrs quietly fixed the broken jukebox in the back of the old quay.
+Amazingly few discotheques provide jukeboxes, yet every able citizen enjoys
+music. The morning sun rose above the quiet valley as travelers journeyed
+across the wide plains toward distant mountains, carrying letters, maps, and
+provisions for the long expedition ahead. Doctors, lawyers, merchants, and
+sailors gathered in the harbor town to exchange news, trade goods, and discuss
+the changing weather, the price of grain, and the prospects of the coming
+season. Children played near the river while their mothers prepared supper and
+their fathers mended nets and sharpened tools for the next day of honest work.
+
+Knowledge grows when curious minds ask difficult questions and patiently seek
+honest answers through careful observation and repeated experiment. A good
+engineer measures twice and cuts once, checking every joint and weld before
+trusting the structure with a heavy load. Scientists record their findings in
+exact detail so that others may verify the results, repeat the procedure, and
+build upon the work that came before. History teaches that progress depends on
+the steady accumulation of small improvements, each one tested against reality
+and kept only if it proves useful, reliable, and worthy of the effort spent.
+
+Music, mathematics, and language share a common foundation in pattern and
+structure, yet each rewards a different kind of attention and practice. A
+skilled musician hears the silence between the notes; a careful writer weighs
+the rhythm of every sentence; a patient mathematician savors the elegance of a
+short and surprising proof. To master any craft requires both discipline and
+joy, both the willingness to fail many times and the quiet confidence that the
+next attempt will be better than the last. Keep working, keep questioning, and
+the answers will eventually arrive, often when you least expect them to.

--- a/internal/cryptolab/engine/lang/lang.go
+++ b/internal/cryptolab/engine/lang/lang.go
@@ -1,0 +1,127 @@
+// Package lang holds a small embedded English language model used to score
+// candidate plaintexts during cipher solving (e.g. the monoalphabetic
+// substitution hill-climb). The model is built at init from an embedded
+// public-domain English corpus (corpus.txt) — no network, no external data.
+package lang
+
+import (
+	_ "embed"
+	"math"
+	"sort"
+	"sync"
+)
+
+//go:embed corpus.txt
+var corpus string
+
+// Letters maps a byte to a 0..25 letter index, or -1 for non-letters
+// (case-folded).
+func LetterIndex(b byte) int {
+	switch {
+	case b >= 'A' && b <= 'Z':
+		return int(b - 'A')
+	case b >= 'a' && b <= 'z':
+		return int(b - 'a')
+	default:
+		return -1
+	}
+}
+
+// Clean returns the A..Z letter indices of s (case-folded, non-letters dropped).
+func Clean(s []byte) []int {
+	out := make([]int, 0, len(s))
+	for _, b := range s {
+		if i := LetterIndex(b); i >= 0 {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// Model is an n-gram log-probability scorer over the 26-letter alphabet.
+type Model struct {
+	n     int
+	logp  map[uint32]float64
+	floor float64
+}
+
+func ngramKey(idx []int) uint32 {
+	var k uint32
+	for _, v := range idx {
+		k = k*26 + uint32(v)
+	}
+	return k
+}
+
+// NewModel builds an n-gram model from the embedded corpus.
+func NewModel(n int) *Model {
+	idx := Clean([]byte(corpus))
+	counts := map[uint32]int{}
+	total := 0
+	for i := 0; i+n <= len(idx); i++ {
+		counts[ngramKey(idx[i:i+n])]++
+		total++
+	}
+	m := &Model{n: n, logp: make(map[uint32]float64, len(counts))}
+	for k, c := range counts {
+		m.logp[k] = math.Log10(float64(c) / float64(total))
+	}
+	// Unseen n-grams get a small floor probability (Practical-Cryptography
+	// style): markedly worse than any observed n-gram.
+	m.floor = math.Log10(0.01 / float64(total))
+	return m
+}
+
+// Score sums the n-gram log-probabilities of text (case-folded, letters only).
+// Higher is more English-like. Texts shorter than n score 0.
+func (m *Model) Score(text []byte) float64 {
+	idx := Clean(text)
+	if len(idx) < m.n {
+		return 0
+	}
+	var s float64
+	for i := 0; i+m.n <= len(idx); i++ {
+		if lp, ok := m.logp[ngramKey(idx[i:i+m.n])]; ok {
+			s += lp
+		} else {
+			s += m.floor
+		}
+	}
+	return s
+}
+
+var (
+	triOnce sync.Once
+	triMod  *Model
+)
+
+// EnglishTrigram returns the cached trigram model.
+func EnglishTrigram() *Model {
+	triOnce.Do(func() { triMod = NewModel(3) })
+	return triMod
+}
+
+var (
+	freqOnce  sync.Once
+	freqOrder []int
+)
+
+// FreqOrder returns the 26 letter indices ordered from most to least frequent
+// in the corpus. Used to seed a frequency-matched starting key.
+func FreqOrder() []int {
+	freqOnce.Do(func() {
+		var counts [26]int
+		for _, v := range Clean([]byte(corpus)) {
+			counts[v]++
+		}
+		order := make([]int, 26)
+		for i := range order {
+			order[i] = i
+		}
+		sort.SliceStable(order, func(a, b int) bool { return counts[order[a]] > counts[order[b]] })
+		freqOrder = order
+	})
+	out := make([]int, 26)
+	copy(out, freqOrder)
+	return out
+}

--- a/internal/cryptolab/engine/lang/lang_test.go
+++ b/internal/cryptolab/engine/lang/lang_test.go
@@ -1,0 +1,44 @@
+package lang
+
+import "testing"
+
+func TestCleanDropsNonLetters(t *testing.T) {
+	t.Parallel()
+	got := Clean([]byte("Ab! 9zZ"))
+	want := []int{0, 1, 25, 25}
+	if len(got) != len(want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v want %v", got, want)
+		}
+	}
+}
+
+func TestTrigramScoresEnglishAboveGibberish(t *testing.T) {
+	t.Parallel()
+	m := EnglishTrigram()
+	eng := m.Score([]byte("the patient analyst studies the common patterns of the language"))
+	gib := m.Score([]byte("xqzj kwvbq mxptz qfxw jjkq zzxv qwxk vbmn pqrx zzqj kwxv"))
+	if eng <= gib {
+		t.Fatalf("english score %.2f should beat gibberish %.2f", eng, gib)
+	}
+}
+
+func TestFreqOrderHasCommonLettersFirst(t *testing.T) {
+	t.Parallel()
+	order := FreqOrder()
+	if len(order) != 26 {
+		t.Fatalf("FreqOrder len = %d", len(order))
+	}
+	// 'E' (index 4) and 'T' (19) are the two most common English letters and
+	// should land in the top handful of a real English corpus.
+	top := map[int]bool{}
+	for _, v := range order[:5] {
+		top[v] = true
+	}
+	if !top[4] || !top[19] {
+		t.Fatalf("expected E and T near the front, got top5 %v", order[:5])
+	}
+}

--- a/internal/cryptolab/engine/subst/subst.go
+++ b/internal/cryptolab/engine/subst/subst.go
@@ -1,0 +1,121 @@
+// Package subst solves monoalphabetic substitution ciphers by hill-climbing
+// over the 26! key space, scored by an embedded English n-gram model. It
+// seeds from a frequency match and refines with random key-swaps under random
+// restarts — the standard approach for this class of cipher.
+package subst
+
+import (
+	"math/rand"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lang"
+)
+
+// Key is a substitution key: Key[c] is the plaintext letter index (0..25) for
+// ciphertext letter index c. It is always a permutation of 0..25.
+type Key [26]byte
+
+// Decrypt applies the key, preserving case and passing non-letters through.
+func (k Key) Decrypt(ct []byte) []byte {
+	out := make([]byte, len(ct))
+	for i, b := range ct {
+		li := lang.LetterIndex(b)
+		if li < 0 {
+			out[i] = b
+			continue
+		}
+		p := k[li]
+		if b >= 'a' && b <= 'z' {
+			out[i] = 'a' + p
+		} else {
+			out[i] = 'A' + p
+		}
+	}
+	return out
+}
+
+// letterFreqOrder returns ciphertext letter indices ordered most→least frequent.
+func letterFreqOrder(ct []byte) []int {
+	var counts [26]int
+	for _, b := range ct {
+		if i := lang.LetterIndex(b); i >= 0 {
+			counts[i]++
+		}
+	}
+	order := make([]int, 26)
+	for i := range order {
+		order[i] = i
+	}
+	sort.SliceStable(order, func(a, b int) bool { return counts[order[a]] > counts[order[b]] })
+	return order
+}
+
+// freqSeedKey maps the most frequent ciphertext letters onto the most frequent
+// English letters — a strong starting point for the hill-climb.
+func freqSeedKey(ct []byte) Key {
+	ctOrder := letterFreqOrder(ct)
+	engOrder := lang.FreqOrder()
+	var k Key
+	for i := 0; i < 26; i++ {
+		k[ctOrder[i]] = byte(engOrder[i])
+	}
+	return k
+}
+
+func randKey(r *rand.Rand) Key {
+	var k Key
+	for i := range k {
+		k[i] = byte(i)
+	}
+	r.Shuffle(26, func(i, j int) { k[i], k[j] = k[j], k[i] })
+	return k
+}
+
+// Options tune the search. Zero values get sensible defaults.
+type Options struct {
+	Restarts int // independent hill-climbs (default 25)
+	MaxFails int // consecutive non-improving swaps before a restart ends (default 1500)
+}
+
+// Solve recovers the most English-like substitution key for ct using model m
+// and randomness r. It returns the best key, its decryption, and its score.
+func Solve(ct []byte, m *lang.Model, r *rand.Rand, opt Options) (Key, []byte, float64) {
+	if opt.Restarts <= 0 {
+		opt.Restarts = 25
+	}
+	if opt.MaxFails <= 0 {
+		opt.MaxFails = 1500
+	}
+
+	bestKey := freqSeedKey(ct)
+	bestScore := m.Score(bestKey.Decrypt(ct))
+
+	for restart := 0; restart < opt.Restarts; restart++ {
+		key := bestKey
+		if restart > 0 {
+			key = randKey(r) // diversify after the freq-seeded first climb
+		}
+		score := m.Score(key.Decrypt(ct))
+
+		fails := 0
+		for fails < opt.MaxFails {
+			i, j := r.Intn(26), r.Intn(26)
+			if i == j {
+				continue
+			}
+			key[i], key[j] = key[j], key[i]
+			s := m.Score(key.Decrypt(ct))
+			if s > score {
+				score = s
+				fails = 0
+			} else {
+				key[i], key[j] = key[j], key[i] // revert
+				fails++
+			}
+		}
+		if score > bestScore {
+			bestScore, bestKey = score, key
+		}
+	}
+	return bestKey, bestKey.Decrypt(ct), bestScore
+}

--- a/internal/cryptolab/engine/subst/subst_test.go
+++ b/internal/cryptolab/engine/subst/subst_test.go
@@ -1,0 +1,80 @@
+package subst
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lang"
+)
+
+// encrypt applies a substitution permutation (enc[plain]=cipher), preserving
+// case and non-letters.
+func encrypt(pt []byte, enc [26]byte) []byte {
+	out := make([]byte, len(pt))
+	for i, b := range pt {
+		li := lang.LetterIndex(b)
+		if li < 0 {
+			out[i] = b
+			continue
+		}
+		c := enc[li]
+		if b >= 'a' && b <= 'z' {
+			out[i] = 'a' + c
+		} else {
+			out[i] = 'A' + c
+		}
+	}
+	return out
+}
+
+const plaintext = `It is a truth universally acknowledged that a careful reader will recover the
+meaning of a scrambled message when enough of the text survives intact. The
+patient analyst studies the frequency of each symbol, compares the common
+patterns of the language, and slowly rebuilds the hidden alphabet one letter
+at a time. With every correct guess the surrounding words grow clearer, until
+the whole passage stands revealed and the original sentence can be read aloud
+without the slightest doubt about its honest and ordinary meaning.`
+
+func TestSolveSubstitutionRecoversPlaintext(t *testing.T) {
+	t.Parallel()
+	// A fixed random encryption permutation.
+	encR := rand.New(rand.NewSource(7))
+	var enc [26]byte
+	for i := range enc {
+		enc[i] = byte(i)
+	}
+	encR.Shuffle(26, func(i, j int) { enc[i], enc[j] = enc[j], enc[i] })
+
+	ct := encrypt([]byte(plaintext), enc)
+
+	solveR := rand.New(rand.NewSource(42))
+	_, got, _ := Solve(ct, lang.EnglishTrigram(), solveR, Options{})
+
+	match, total := 0, 0
+	for i := range plaintext {
+		if lang.LetterIndex(plaintext[i]) < 0 {
+			continue
+		}
+		total++
+		if got[i] == plaintext[i] {
+			match++
+		}
+	}
+	ratio := float64(match) / float64(total)
+	if ratio < 0.9 {
+		t.Fatalf("recovered only %.1f%% of letters:\n%s", ratio*100, got)
+	}
+}
+
+func TestDecryptPreservesNonLetters(t *testing.T) {
+	t.Parallel()
+	var k Key
+	for i := range k {
+		k[i] = byte(25 - i) // atbash-like
+	}
+	got := k.Decrypt([]byte("AB! cd."))
+	// A(0)->25=Z, B(1)->24=Y, c(2)->23=x, d(3)->22=w; punctuation/space kept.
+	if string(got) != "ZY! xw." {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/cryptolab/engine/voice/band.go
+++ b/internal/cryptolab/engine/voice/band.go
@@ -1,0 +1,209 @@
+package voice
+
+import (
+	"math"
+	"math/cmplx"
+)
+
+// This file adds frequency-domain descramblers beyond the full-band
+// SpectralInvert in voice.go: split-band inversion (invert sub-bands
+// independently) and rolling inversion (a per-frame schedule), plus a
+// best-effort detector for which frames are inverted. All operate offline on
+// a whole clip via an internal radix-2 FFT; at power-of-two lengths they are
+// exact involutions (run twice to undo), and approximately so otherwise.
+
+func nextPow2(n int) int {
+	m := 1
+	for m < n {
+		m <<= 1
+	}
+	return m
+}
+
+// fft does an in-place iterative radix-2 transform; inverse normalizes by n.
+func fft(x []complex128, inverse bool) {
+	n := len(x)
+	for i, j := 1, 0; i < n; i++ {
+		bit := n >> 1
+		for ; j&bit != 0; bit >>= 1 {
+			j ^= bit
+		}
+		j ^= bit
+		if i < j {
+			x[i], x[j] = x[j], x[i]
+		}
+	}
+	for length := 2; length <= n; length <<= 1 {
+		ang := 2 * math.Pi / float64(length)
+		if !inverse {
+			ang = -ang
+		}
+		wlen := cmplx.Exp(complex(0, ang))
+		for i := 0; i < n; i += length {
+			w := complex(1, 0)
+			half := length >> 1
+			for k := 0; k < half; k++ {
+				u := x[i+k]
+				v := x[i+k+half] * w
+				x[i+k] = u + v
+				x[i+k+half] = u - v
+				w *= wlen
+			}
+		}
+	}
+	if inverse {
+		nc := complex(float64(n), 0)
+		for i := range x {
+			x[i] /= nc
+		}
+	}
+}
+
+// invertBinBands mirrors (spectrally inverts) each given positive-half bin
+// range within itself and returns the real result. Bands are integer bin
+// ranges [lo,hi] over 1..half-1 and MUST be disjoint, which makes the
+// operation an exact involution at power-of-two lengths. DC and the Nyquist
+// bin are never moved, so the output stays real.
+func invertBinBands(samples []float64, bands [][2]int) []float64 {
+	n := len(samples)
+	if n == 0 {
+		return nil
+	}
+	m := nextPow2(n)
+	x := make([]complex128, m)
+	for i, s := range samples {
+		x[i] = complex(s, 0)
+	}
+	fft(x, false)
+
+	half := m / 2
+	y := make([]complex128, m)
+	copy(y, x)
+	for _, b := range bands {
+		lo, hi := b[0], b[1]
+		for k := lo; k <= hi; k++ {
+			y[k] = x[lo+hi-k] // mirror within the band
+		}
+	}
+	// Rebuild the negative half from conjugate symmetry so the IFFT is real.
+	for k := 1; k < half; k++ {
+		y[m-k] = cmplx.Conj(y[k])
+	}
+	fft(y, true)
+	out := make([]float64, n)
+	for i := range out {
+		out[i] = real(y[i])
+	}
+	return out
+}
+
+func clampBin(b, half int) int {
+	if b < 1 {
+		return 1
+	}
+	if b > half-1 {
+		return half - 1
+	}
+	return b
+}
+
+// BandInvert spectrally inverts a single normalized band [loFrac,hiFrac] of
+// Nyquist. BandInvert(s,0,1) is full-band inversion (cf. SpectralInvert).
+func BandInvert(samples []float64, loFrac, hiFrac float64) []float64 {
+	half := nextPow2(len(samples)) / 2
+	if half < 2 {
+		return append([]float64(nil), samples...)
+	}
+	lo := clampBin(int(math.Round(loFrac*float64(half))), half)
+	hi := clampBin(int(math.Round(hiFrac*float64(half))), half)
+	if lo > hi {
+		return append([]float64(nil), samples...)
+	}
+	return invertBinBands(samples, [][2]int{{lo, hi}})
+}
+
+// SplitBandInvert inverts the low sub-band [0,split] and the high sub-band
+// [split,1] independently — the classic split-band (variable-split) inverter.
+// The two sub-bands are disjoint by construction, so it is its own inverse.
+func SplitBandInvert(samples []float64, split float64) []float64 {
+	half := nextPow2(len(samples)) / 2
+	if half < 2 {
+		return append([]float64(nil), samples...)
+	}
+	sb := int(math.Round(split * float64(half)))
+	if sb < 1 {
+		sb = 1
+	}
+	if sb > half-1 {
+		sb = half - 1
+	}
+	var bands [][2]int
+	bands = append(bands, [2]int{1, sb}) // low sub-band [1, sb]
+	if sb+1 <= half-1 {
+		bands = append(bands, [2]int{sb + 1, half - 1}) // high sub-band, disjoint
+	}
+	return invertBinBands(samples, bands)
+}
+
+// RollingInvert applies a per-frame split-band inversion: frame i is inverted
+// with splits[i % len(splits)]. Re-applying the same schedule descrambles a
+// rolling/hopping inverter whose schedule is known. A split of 1.0 is a
+// full-band inversion of that frame.
+func RollingInvert(samples []float64, frameLen int, splits []float64) []float64 {
+	if frameLen <= 0 || len(splits) == 0 {
+		return append([]float64(nil), samples...)
+	}
+	out := make([]float64, len(samples))
+	copy(out, samples)
+	for f, start := 0, 0; start < len(samples); f, start = f+1, start+frameLen {
+		end := start + frameLen
+		if end > len(samples) {
+			end = len(samples)
+		}
+		inv := SplitBandInvert(out[start:end], splits[f%len(splits)])
+		copy(out[start:end], inv)
+	}
+	return out
+}
+
+// DetectInversion is a best-effort per-frame inversion detector for full-band
+// rolling inverters: voiced speech concentrates energy in the lower half of
+// the band, so a frame with more high-band than low-band energy is flagged as
+// inverted. It is a heuristic sync aid, not exact recovery.
+func DetectInversion(samples []float64, frameLen int) []bool {
+	if frameLen <= 0 {
+		return nil
+	}
+	var flags []bool
+	for start := 0; start < len(samples); start += frameLen {
+		end := start + frameLen
+		if end > len(samples) {
+			end = len(samples)
+		}
+		frame := samples[start:end]
+		lo := BandEnergy(frame, 0, 0.5)
+		hi := BandEnergy(frame, 0.5, 1.0)
+		flags = append(flags, hi > lo)
+	}
+	return flags
+}
+
+// RollingAuto detects full-band-inverted frames and undoes them, returning the
+// descrambled signal and the per-frame flags it acted on.
+func RollingAuto(samples []float64, frameLen int) ([]float64, []bool) {
+	flags := DetectInversion(samples, frameLen)
+	out := make([]float64, len(samples))
+	copy(out, samples)
+	for i, inv := range flags {
+		if !inv {
+			continue
+		}
+		start := i * frameLen
+		end := start + frameLen
+		if end > len(samples) {
+			end = len(samples)
+		}
+		copy(out[start:end], BandInvert(out[start:end], 0, 1))
+	}
+	return out, flags
+}

--- a/internal/cryptolab/engine/voice/band_test.go
+++ b/internal/cryptolab/engine/voice/band_test.go
@@ -1,0 +1,96 @@
+package voice
+
+import (
+	"math"
+	"testing"
+)
+
+func tone(n int, bin float64) []float64 {
+	s := make([]float64, n)
+	for i := range s {
+		s[i] = math.Sin(2 * math.Pi * bin * float64(i) / float64(n))
+	}
+	return s
+}
+
+func maxAbsDiff(a, b []float64) float64 {
+	d := 0.0
+	for i := range a {
+		if x := math.Abs(a[i] - b[i]); x > d {
+			d = x
+		}
+	}
+	return d
+}
+
+func TestSplitBandInvertSelfInverse(t *testing.T) {
+	t.Parallel()
+	in := tone(256, 10)
+	for i := range in {
+		in[i] += 0.3 * math.Sin(2*math.Pi*40*float64(i)/256) // a second component
+	}
+	got := SplitBandInvert(SplitBandInvert(in, 0.5), 0.5)
+	if d := maxAbsDiff(got, in); d > 1e-9 {
+		t.Fatalf("split-band not self-inverse: maxdiff %g", d)
+	}
+}
+
+func TestBandInvertMovesEnergyWithinLowBand(t *testing.T) {
+	t.Parallel()
+	// A tone near the bottom of the low sub-band should move toward the top of
+	// that sub-band after a split-band inversion (energy stays in the low half
+	// but flips within it).
+	const n = 256
+	in := tone(n, 8) // low-frequency tone (bin 8, well inside [0,0.5])
+	lowBottom := BandEnergy(in, 0.0, 0.1)
+	lowTop := BandEnergy(in, 0.4, 0.5)
+	if lowBottom <= lowTop {
+		t.Fatalf("setup: tone not at band bottom (bottom=%g top=%g)", lowBottom, lowTop)
+	}
+	out := SplitBandInvert(in, 0.5)
+	// Energy must remain in the low half...
+	if BandEnergy(out, 0, 0.5) <= BandEnergy(out, 0.5, 1.0) {
+		t.Fatal("split-band inversion leaked energy into the high band")
+	}
+	// ...but flipped to the top of the low sub-band.
+	if BandEnergy(out, 0.4, 0.5) <= BandEnergy(out, 0.0, 0.1) {
+		t.Fatal("low-band tone did not invert within its sub-band")
+	}
+}
+
+func TestRollingInvertRoundTrip(t *testing.T) {
+	t.Parallel()
+	in := make([]float64, 1024)
+	for i := range in {
+		in[i] = math.Sin(2*math.Pi*float64(i)*0.05) + 0.5*math.Sin(2*math.Pi*float64(i)*0.2)
+	}
+	sched := []float64{0.5, 0.7, 1.0, 0.3}
+	scrambled := RollingInvert(in, 256, sched)
+	got := RollingInvert(scrambled, 256, sched)
+	if d := maxAbsDiff(got, in); d > 1e-9 {
+		t.Fatalf("rolling invert not self-inverse with a fixed schedule: maxdiff %g", d)
+	}
+	// Scrambling actually changed the signal.
+	if maxAbsDiff(scrambled, in) < 1e-3 {
+		t.Fatal("rolling invert did not change the signal")
+	}
+}
+
+func TestDetectInversionFlagsInvertedFrames(t *testing.T) {
+	t.Parallel()
+	frame := 256
+	// Two frames of low-frequency "speech"; invert the second full-band.
+	a := tone(frame, 12)
+	b := tone(frame, 12)
+	bInv := BandInvert(b, 0, 1)
+	sig := append(append([]float64{}, a...), bInv...)
+	flags := DetectInversion(sig, frame)
+	if len(flags) != 2 || flags[0] || !flags[1] {
+		t.Fatalf("detector flags = %v, want [false true]", flags)
+	}
+	// RollingAuto should undo the inverted second frame.
+	out, _ := RollingAuto(sig, frame)
+	if BandEnergy(out[frame:], 0, 0.5) <= BandEnergy(out[frame:], 0.5, 1.0) {
+		t.Fatal("RollingAuto did not restore the inverted frame to low-band")
+	}
+}

--- a/internal/cryptolab/schema.go
+++ b/internal/cryptolab/schema.go
@@ -47,6 +47,11 @@ var modeParams = map[string][]Param{
 		{Name: "keylen", Label: "Key length (0 = auto)", Kind: "int", Default: "0"},
 		{Name: "crib", Label: "Known-plaintext crib", Kind: "string", Help: "optional substring to boost scoring"},
 	},
+	"brute/substitution": {
+		{Name: "in", Label: "Ciphertext file", Kind: "file", Required: true, Help: "English plaintext assumed"},
+		{Name: "restarts", Label: "Hill-climb restarts (0 = default)", Kind: "int", Default: "0"},
+		{Name: "seed", Label: "RNG seed", Kind: "int", Default: "1"},
+	},
 	"lfsr/bm": {
 		{Name: "in", Label: "Keystream file", Kind: "file", Required: true, Help: "packed bytes, MSB-first"},
 	},
@@ -70,6 +75,17 @@ var modeParams = map[string][]Param{
 	"descramble/invert": {
 		{Name: "in", Label: "Scrambled PCM (s16le mono)", Kind: "file", Required: true},
 		{Name: "out", Label: "Output file", Kind: "outfile", Required: true, Default: "descrambled.s16"},
+	},
+	"descramble/splitband": {
+		{Name: "in", Label: "Scrambled PCM (s16le mono)", Kind: "file", Required: true},
+		{Name: "out", Label: "Output file", Kind: "outfile", Required: true, Default: "descrambled.s16"},
+		{Name: "split", Label: "Split point (fraction of Nyquist)", Kind: "string", Default: "0.5"},
+	},
+	"descramble/rolling": {
+		{Name: "in", Label: "Scrambled PCM (s16le mono)", Kind: "file", Required: true},
+		{Name: "out", Label: "Output file", Kind: "outfile", Required: true, Default: "descrambled.s16"},
+		{Name: "frame", Label: "Frame length (samples)", Kind: "int", Default: "1024"},
+		{Name: "schedule", Label: "Split schedule (CSV) or 'auto'", Kind: "string", Default: "auto"},
 	},
 	"alias/gauge":     {{Name: "csv", Label: "Ground-truth corpus CSV", Kind: "file", Required: true}},
 	"alias/structure": {{Name: "csv", Label: "Ground-truth corpus CSV", Kind: "file", Required: true}},

--- a/internal/cryptolab/tools/brute.go
+++ b/internal/cryptolab/tools/brute.go
@@ -3,10 +3,13 @@ package tools
 import (
 	"context"
 	"fmt"
+	"math/rand"
 
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/brute"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lang"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/stats"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/subst"
 )
 
 type bruteTool struct{}
@@ -14,7 +17,7 @@ type bruteTool struct{}
 func (bruteTool) Name() string     { return "brute" }
 func (bruteTool) Synopsis() string { return "keyspace brute force for classical / XOR ciphers" }
 func (bruteTool) Modes() []cryptolab.Mode {
-	return []cryptolab.Mode{bruteXOR{}, bruteCaesar{}, bruteVigenere{}}
+	return []cryptolab.Mode{bruteXOR{}, bruteCaesar{}, bruteVigenere{}, bruteSubstitution{}}
 }
 
 type bruteXOR struct{}
@@ -156,6 +159,50 @@ func (bruteVigenere) Run(_ context.Context, args []string, env cryptolab.Env) (*
 	env.Logf("vigenere solved", "keylen", kl)
 	addXORFinding(res, cand)
 	res.Summary = fmt.Sprintf("recovered %d-byte Vigenère key", len(cand.Key))
+	return res, nil
+}
+
+type bruteSubstitution struct{}
+
+func (bruteSubstitution) Name() string { return "substitution" }
+func (bruteSubstitution) Synopsis() string {
+	return "solve a monoalphabetic substitution cipher (English n-gram hill-climb)"
+}
+
+func (bruteSubstitution) Run(_ context.Context, args []string, env cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("brute substitution")
+	in := fs.String("in", "", "ciphertext file (English plaintext assumed) — required")
+	restarts := fs.Int("restarts", 0, "hill-climb restarts (0 = default 25)")
+	seed := fs.Int64("seed", 1, "RNG seed for reproducibility")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	ct, err := readInput(*in)
+	if err != nil {
+		return nil, err
+	}
+	r := rand.New(rand.NewSource(*seed))
+	key, pt, score := subst.Solve(ct, lang.EnglishTrigram(), r, subst.Options{Restarts: *restarts})
+	env.Logf("substitution solved", "score", score)
+
+	// Render the recovered key as a ciphertext->plaintext alphabet string.
+	keyStr := make([]byte, 26)
+	for c := 0; c < 26; c++ {
+		keyStr[c] = 'A' + key[c]
+	}
+	preview := pt
+	if len(preview) > 80 {
+		preview = preview[:80]
+	}
+	res := &cryptolab.Result{Tool: "brute", Mode: "substitution",
+		Summary: fmt.Sprintf("recovered substitution key %s", keyStr)}
+	res.AddField("key", string(keyStr))
+	res.AddField("score", score)
+	res.AddFinding("plaintext", score, map[string]any{
+		"key":              string(keyStr),
+		"plaintext_prefix": string(sanitize(preview)),
+	})
+	res.Note("monoalphabetic substitution solving assumes English plaintext and enough ciphertext; very short or rare-letter-heavy messages may leave a few letters unresolved.")
 	return res, nil
 }
 

--- a/internal/cryptolab/tools/descramble.go
+++ b/internal/cryptolab/tools/descramble.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/voice"
@@ -12,9 +14,44 @@ import (
 
 type descrambleTool struct{}
 
-func (descrambleTool) Name() string            { return "descramble" }
-func (descrambleTool) Synopsis() string        { return "analog voice descramblers (spectral inversion)" }
-func (descrambleTool) Modes() []cryptolab.Mode { return []cryptolab.Mode{descrambleInvert{}} }
+func (descrambleTool) Name() string     { return "descramble" }
+func (descrambleTool) Synopsis() string { return "analog voice descramblers (spectral inversion)" }
+func (descrambleTool) Modes() []cryptolab.Mode {
+	return []cryptolab.Mode{descrambleInvert{}, descrambleSplitband{}, descrambleRolling{}}
+}
+
+// readPCM reads a raw 16-bit signed little-endian mono PCM file into float64
+// samples in [-1,1).
+func readPCM(path string) ([]float64, int, error) {
+	raw, err := readInput(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(raw)%2 != 0 {
+		return nil, 0, fmt.Errorf("descramble: input length %d is not a whole number of 16-bit samples", len(raw))
+	}
+	n := len(raw) / 2
+	s := make([]float64, n)
+	for i := 0; i < n; i++ {
+		s[i] = float64(int16(binary.LittleEndian.Uint16(raw[2*i:]))) / 32768.0
+	}
+	return s, n, nil
+}
+
+// writePCM writes float64 samples back to 16-bit signed little-endian PCM.
+func writePCM(path string, s []float64) error {
+	buf := make([]byte, len(s)*2)
+	for i, v := range s {
+		x := v * 32768.0
+		if x > 32767 {
+			x = 32767
+		} else if x < -32768 {
+			x = -32768
+		}
+		binary.LittleEndian.PutUint16(buf[2*i:], uint16(int16(x)))
+	}
+	return os.WriteFile(path, buf, 0o644)
+}
 
 type descrambleInvert struct{}
 
@@ -33,33 +70,132 @@ func (descrambleInvert) Run(_ context.Context, args []string, env cryptolab.Env)
 	if *out == "" {
 		return nil, fmt.Errorf("-out is required")
 	}
-	raw, err := readInput(*in)
+	s, n, err := readPCM(*in)
 	if err != nil {
 		return nil, err
 	}
-	if len(raw)%2 != 0 {
-		return nil, fmt.Errorf("descramble: input length %d is not a whole number of 16-bit samples", len(raw))
-	}
-	samples := make([]int16, len(raw)/2)
-	for i := range samples {
-		samples[i] = int16(binary.LittleEndian.Uint16(raw[2*i:]))
-	}
-	inv := voice.SpectralInvertInt16(samples)
-	obuf := make([]byte, len(raw))
-	for i, s := range inv {
-		binary.LittleEndian.PutUint16(obuf[2*i:], uint16(s))
-	}
-	if err := os.WriteFile(*out, obuf, 0o644); err != nil {
+	if err := writePCM(*out, voice.BandInvert(s, 0, 1)); err != nil {
 		return nil, fmt.Errorf("descramble: write %s: %w", *out, err)
 	}
-	env.Logf("inverted", "samples", len(samples), "out", *out)
-
+	env.Logf("inverted", "samples", n, "out", *out)
 	res := &cryptolab.Result{Tool: "descramble", Mode: "invert",
-		Summary: fmt.Sprintf("spectrally inverted %d samples -> %s", len(samples), *out)}
-	res.AddField("samples", len(samples))
+		Summary: fmt.Sprintf("spectrally inverted %d samples -> %s", n, *out)}
+	res.AddField("samples", n)
 	res.AddField("output", *out)
-	res.Note("spectral inversion is its own inverse: run again to undo. For split-band/rolling inverters this is only a first pass.")
+	res.Note("spectral inversion is its own inverse: run again to undo.")
 	return res, nil
+}
+
+type descrambleSplitband struct{}
+
+func (descrambleSplitband) Name() string { return "splitband" }
+func (descrambleSplitband) Synopsis() string {
+	return "split-band inversion (invert low and high sub-bands independently)"
+}
+
+func (descrambleSplitband) Run(_ context.Context, args []string, env cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("descramble splitband")
+	in := fs.String("in", "", "raw 16-bit signed little-endian mono PCM — required")
+	out := fs.String("out", "", "output PCM path — required")
+	split := fs.Float64("split", 0.5, "split point as a fraction of Nyquist (0..1)")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if *out == "" {
+		return nil, fmt.Errorf("-out is required")
+	}
+	s, n, err := readPCM(*in)
+	if err != nil {
+		return nil, err
+	}
+	if err := writePCM(*out, voice.SplitBandInvert(s, *split)); err != nil {
+		return nil, fmt.Errorf("descramble: write %s: %w", *out, err)
+	}
+	env.Logf("split-band inverted", "samples", n, "split", *split, "out", *out)
+	res := &cryptolab.Result{Tool: "descramble", Mode: "splitband",
+		Summary: fmt.Sprintf("split-band inverted %d samples at split=%.3f -> %s", n, *split, *out)}
+	res.AddField("samples", n)
+	res.AddField("split", *split)
+	res.AddField("output", *out)
+	res.Note("split-band inversion is its own inverse for a given split: re-run with the same -split to undo.")
+	return res, nil
+}
+
+type descrambleRolling struct{}
+
+func (descrambleRolling) Name() string { return "rolling" }
+func (descrambleRolling) Synopsis() string {
+	return "rolling inversion: a per-frame split schedule, or auto-detect inverted frames"
+}
+
+func (descrambleRolling) Run(_ context.Context, args []string, env cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("descramble rolling")
+	in := fs.String("in", "", "raw 16-bit signed little-endian mono PCM — required")
+	out := fs.String("out", "", "output PCM path — required")
+	frame := fs.Int("frame", 1024, "frame length in samples")
+	schedule := fs.String("schedule", "auto", "comma-separated split fractions, or 'auto' to detect inverted frames")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if *out == "" {
+		return nil, fmt.Errorf("-out is required")
+	}
+	s, n, err := readPCM(*in)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &cryptolab.Result{Tool: "descramble", Mode: "rolling"}
+	var result []float64
+	if strings.EqualFold(strings.TrimSpace(*schedule), "auto") {
+		var flags []bool
+		result, flags = voice.RollingAuto(s, *frame)
+		inverted := 0
+		for _, f := range flags {
+			if f {
+				inverted++
+			}
+		}
+		res.AddField("frames", len(flags))
+		res.AddField("frames_inverted", inverted)
+		res.Summary = fmt.Sprintf("auto-descrambled %d frames (%d inverted) -> %s", len(flags), inverted, *out)
+		res.Note("auto mode is a heuristic full-band inversion detector (energy balance); a known schedule is exact.")
+	} else {
+		splits, err := parseFloatList(*schedule)
+		if err != nil {
+			return nil, fmt.Errorf("descramble: -schedule: %w", err)
+		}
+		result = voice.RollingInvert(s, *frame, splits)
+		res.AddField("schedule", splits)
+		res.Summary = fmt.Sprintf("rolling-inverted %d samples with a %d-step schedule -> %s", n, len(splits), *out)
+		res.Note("re-run with the same -frame and -schedule to undo a known rolling inverter.")
+	}
+	if err := writePCM(*out, result); err != nil {
+		return nil, fmt.Errorf("descramble: write %s: %w", *out, err)
+	}
+	env.Logf("rolling descramble", "samples", n, "frame", *frame, "out", *out)
+	res.AddField("samples", n)
+	res.AddField("output", *out)
+	return res, nil
+}
+
+func parseFloatList(s string) ([]float64, error) {
+	var out []float64
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		v, err := strconv.ParseFloat(p, 64)
+		if err != nil {
+			return nil, fmt.Errorf("bad split %q: %w", p, err)
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("empty schedule")
+	}
+	return out, nil
 }
 
 func init() { cryptolab.Register(descrambleTool{}) }

--- a/internal/cryptolab/webserver/server.go
+++ b/internal/cryptolab/webserver/server.go
@@ -47,10 +47,14 @@ const defaultMaxUpload = 512 << 20
 // Server is the cryptolab web console HTTP handler.
 type Server struct {
 	assets    fs.FS
-	tempDir   string
-	ownTemp   bool
+	fixedDir  string // explicit temp dir from Options (empty ⇒ owned/lazy)
 	maxUpload int64
 	log       *slog.Logger
+
+	dirOnce sync.Once
+	tempDir string
+	ownTemp bool
+	dirErr  error
 
 	mu    sync.Mutex
 	files map[string]*upload
@@ -63,18 +67,10 @@ type upload struct {
 	Created        time.Time
 }
 
-// New constructs a Server, creating a temp directory if none was supplied.
+// New constructs a Server. The staging temp directory is created lazily on
+// the first upload/run (not at construction), so merely registering the
+// routes — as the daemon does for every request mux — costs nothing on disk.
 func New(opts Options) (*Server, error) {
-	dir, own := opts.TempDir, false
-	if dir == "" {
-		d, err := os.MkdirTemp("", "gophertrunk-cryptolab-")
-		if err != nil {
-			return nil, fmt.Errorf("cryptolab web: temp dir: %w", err)
-		}
-		dir, own = d, true
-	} else if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, fmt.Errorf("cryptolab web: temp dir %s: %w", dir, err)
-	}
 	max := opts.MaxUploadBytes
 	if max <= 0 {
 		max = defaultMaxUpload
@@ -85,8 +81,7 @@ func New(opts Options) (*Server, error) {
 	}
 	return &Server{
 		assets:    opts.Assets,
-		tempDir:   dir,
-		ownTemp:   own,
+		fixedDir:  opts.TempDir, // empty ⇒ create an owned temp dir lazily
 		maxUpload: max,
 		log:       log,
 		files:     map[string]*upload{},
@@ -94,17 +89,48 @@ func New(opts Options) (*Server, error) {
 	}, nil
 }
 
-// Handler returns the configured HTTP mux.
+// ensureTempDir creates the staging directory on first use and returns it.
+func (s *Server) ensureTempDir() (string, error) {
+	s.dirOnce.Do(func() {
+		if s.fixedDir != "" {
+			s.dirErr = os.MkdirAll(s.fixedDir, 0o755)
+			s.tempDir = s.fixedDir
+			return
+		}
+		d, err := os.MkdirTemp("", "gophertrunk-cryptolab-")
+		if err != nil {
+			s.dirErr = err
+			return
+		}
+		s.tempDir, s.ownTemp = d, true
+	})
+	return s.tempDir, s.dirErr
+}
+
+// Handler returns a standalone HTTP mux: the cryptolab API plus the embedded
+// SPA at /. Used by `cryptolab serve`.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
+	s.RegisterAPI(mux, nil)
+	mux.Handle("GET /", s.spaHandler())
+	return mux
+}
+
+// RegisterAPI mounts the /api/v1/cryptolab/* routes onto mux. Mutating routes
+// (file upload, run) are wrapped with gate when non-nil, so the daemon can
+// apply the same auth middleware it uses for its other write routes; the
+// standalone server passes nil. This lets the same service back both the
+// standalone `cryptolab serve` and the daemon-mounted console at /cryptolab/.
+func (s *Server) RegisterAPI(mux *http.ServeMux, gate func(http.HandlerFunc) http.HandlerFunc) {
+	if gate == nil {
+		gate = func(h http.HandlerFunc) http.HandlerFunc { return h }
+	}
 	mux.HandleFunc("GET /api/v1/cryptolab/tools", s.handleTools)
-	mux.HandleFunc("POST /api/v1/cryptolab/files", s.handleUpload)
-	mux.HandleFunc("POST /api/v1/cryptolab/run", s.handleRun)
+	mux.HandleFunc("POST /api/v1/cryptolab/files", gate(s.handleUpload))
+	mux.HandleFunc("POST /api/v1/cryptolab/run", gate(s.handleRun))
 	mux.HandleFunc("GET /api/v1/cryptolab/jobs/{id}", s.handleJob)
 	mux.HandleFunc("GET /api/v1/cryptolab/jobs/{id}/events", s.handleJobEvents)
 	mux.HandleFunc("GET /api/v1/cryptolab/jobs/{id}/artifacts/{name}", s.handleArtifact)
-	mux.Handle("GET /", s.spaHandler())
-	return mux
 }
 
 // Close removes the temp directory if the server created it.
@@ -132,8 +158,13 @@ func (s *Server) handleUpload(w http.ResponseWriter, r *http.Request) {
 	}
 	defer f.Close()
 
+	dir, err := s.ensureTempDir()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "upload: temp dir: "+err.Error())
+		return
+	}
 	id := randomID()
-	path := filepath.Join(s.tempDir, id+".bin")
+	path := filepath.Join(dir, id+".bin")
 	dst, err := os.Create(path)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, "upload: "+err.Error())
@@ -176,8 +207,13 @@ func (s *Server) handleRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	dir, err := s.ensureTempDir()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "run: temp dir: "+err.Error())
+		return
+	}
 	id := randomID()
-	jobDir := filepath.Join(s.tempDir, "job-"+id)
+	jobDir := filepath.Join(dir, "job-"+id)
 	if err := os.MkdirAll(jobDir, 0o755); err != nil {
 		writeErr(w, http.StatusInternalServerError, "run: "+err.Error())
 		return


### PR DESCRIPTION
Completes the three remaining cryptolab roadmap items.

- brute substitution: monoalphabetic substitution solver using
  frequency-seeded hill-climbing with random restarts, scored against an
  embedded English trigram language model (engine/lang, engine/subst).
- descramble splitband / rolling: split-band inversion (independent low/high
  sub-band inversion about a configurable split, disjoint-bin FFT so the
  operation stays self-inverse) and rolling-code inversion (per-frame split
  schedule with auto energy-balance detection) in engine/voice.
- Daemon-mounted console: with -tags cryptolab the main daemon now mounts the
  research console at /cryptolab/ and its API under /api/v1/cryptolab/,
  reusing the daemon's mutation gate. The default build links a no-op mount,
  so the toolkit stays out of the standard binary (verified: 0 cryptolab
  symbols in the untagged gophertrunk). The webserver temp dir is created
  lazily so mounting on every daemon start does not leak directories.

Schema, docs, CHANGELOG, and the test-cryptolab Make target updated; the
target now also exercises ./internal/api/ for the tagged mount.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GxQENEPxmgVF1dQTbCBT3H