### PR TITLE
composer: add unconditional per-call MAC census for P25 Phase 2 (#813)

### DIFF
--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -25,6 +25,12 @@ const p25p2VoiceIntermediateHz = 48_000
 // because H-DQPSK slips differently than C4FM).
 const p25p2VoiceGardnerGain = 0.005
 
+// slotHistLen sizes the per-call SlotType histogram in the chain census.
+// It spans SlotTypeUnknown (0x0) .. SlotTypeMACEndCont (0x9); an
+// out-of-range slot value (a future enum addition) is dropped by the
+// bounds guard at the increment site rather than panicking.
+const slotHistLen = 0xA
+
 // runP25Phase2VoiceChain consumes IQ for one P25 Phase 2 voice call. It
 // decimates the wideband IQ to an H-DQPSK-friendly rate, recovers the
 // dibit stream with the Phase 2 receiver, assembles 360 ms superframes,
@@ -133,13 +139,38 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 		uncorrectableSubframes atomic.Uint64
 		corrErrBits            atomic.Uint64
 	)
+	// MAC-pipeline census (issue #813). A field test on real Phase 2
+	// traffic saw the per-PDU "composer: p25p2 mac pdu" line — which fires
+	// only on a *successful* MAC decode — never appear at all, which is
+	// ambiguous: it can't tell superframe-sync failure from ISCH
+	// mis-classification from MAC-FEC failure. These counters feed the
+	// unconditional end-of-call census (logCallCensus) that disambiguates
+	// the three. They are read from the for-select goroutine below, so they
+	// are atomic like the decode-quality counters above.
+	var (
+		superframesSeen  atomic.Uint64
+		macSubframesSeen atomic.Uint64
+		macPDUsDecoded   atomic.Uint64
+		slotHist         [slotHistLen]atomic.Uint64
+	)
 	rx := p25p2rx.New(p25p2rx.Options{
 		SampleRateHz: symbolHz,
 		ClockMode:    p25p2rx.ClockGardner,
 		GardnerGain:  p25p2VoiceGardnerGain,
 		DibitSink: func(dibits []uint8, baseIdx int) {
 			for _, sf := range sfDec.Process(dibits, baseIdx) {
+				superframesSeen.Add(1)
 				for _, sub := range sf.Subframes {
+					// Census every sub-frame's slot type — including
+					// SlotTypeUnknown and MAC types — before the voice gate,
+					// so the end-of-call census can show whether ISCH ever
+					// classified a MAC slot (#813).
+					if int(sub.SlotType) < slotHistLen {
+						slotHist[sub.SlotType].Add(1)
+					}
+					if sub.SlotType.IsMAC() {
+						macSubframesSeen.Add(1)
+					}
 					if !sub.SlotType.IsVoice() {
 						continue
 					}
@@ -171,7 +202,7 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 				// MAC PDUs that interleave with voice are decoded by the
 				// shared dispatcher (same path the signalling follower
 				// runs off the traffic channel, #376).
-				dispatcher.Dispatch(sf, macCfg)
+				macPDUsDecoded.Add(uint64(dispatcher.Dispatch(sf, macCfg)))
 			}
 		},
 	})
@@ -194,11 +225,37 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 			"voice_subframes", n, "uncorrectable_subframes", uncorrectableSubframes.Load(),
 			"corrected_bit_errs", corrErrBits.Load())
 	}
+	// logCallCensus emits exactly one line at chain end, unconditionally —
+	// even when zero superframes ever locked. It is the field diagnostic
+	// that disambiguates the three #813 failure modes when no "composer:
+	// p25p2 mac pdu" line ever appears:
+	//   - superframes=0                  → superframe sync never locked
+	//   - superframes>0, mac_subframes=0 → ISCH never classified a MAC slot
+	//                                       (inspect the slot_* histogram)
+	//   - mac_subframes>0, mac_pdus=0    → MAC FEC chain failed every slot
+	// The slot_<type> buckets reuse SlotType.String() so the line is
+	// self-describing.
+	logCallCensus := func() {
+		attrs := []any{
+			"serial", serial, "system", system,
+			"superframes", superframesSeen.Load(),
+			"voice_subframes", voiceSubframes.Load(),
+			"mac_subframes", macSubframesSeen.Load(),
+			"mac_pdus", macPDUsDecoded.Load(),
+		}
+		for st := 0; st < slotHistLen; st++ {
+			if cnt := slotHist[st].Load(); cnt > 0 {
+				attrs = append(attrs, "slot_"+p25p2.SlotType(st).String(), cnt)
+			}
+		}
+		c.log.Info("composer: p25p2 call census", attrs...)
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			logDecodeQuality(true)
+			logCallCensus()
 			return
 		case <-touchTicker.C:
 			// Touch + hangtime end-of-call handled by the shared boundary
@@ -207,6 +264,7 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 		case iq, ok := <-iqCh:
 			if !ok {
 				logDecodeQuality(true)
+				logCallCensus()
 				return
 			}
 			rx.Process(fe.Process(nil, iq))

--- a/internal/voice/composer/p25p2_voice_test.go
+++ b/internal/voice/composer/p25p2_voice_test.go
@@ -517,3 +517,104 @@ func TestComposerP25Phase2VoiceChainWarnsTrellisOff(t *testing.T) {
 		t.Fatalf("expected trellis-off warning, got:\n%s", out)
 	}
 }
+
+// TestComposerP25Phase2CallCensusAlwaysFires is the #813 regression guard:
+// the end-of-call MAC census must log exactly once even when the chain
+// locks zero superframes (the silent-failure case the field test hit,
+// where the success-only "composer: p25p2 mac pdu" line never appears).
+// A closed IQ channel drives that zero-superframe path.
+func TestComposerP25Phase2CallCensusAlwaysFires(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	c, err := New(Options{
+		Bus:           events.NewBus(8),
+		Devices:       &fakeDevices{src: map[string]IQSource{}},
+		Sink:          &recordingSink{},
+		Engine:        &fakeEngine{},
+		IQSampleRate:  48_000,
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+		Log:           logger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Clean live-decode config so no entry warnings pollute the buffer; the
+	// closed channel returns the chain before any IQ is processed.
+	iqCh := make(chan []complex64)
+	close(iqCh)
+	done := make(chan struct{})
+	c.runP25Phase2VoiceChain(context.Background(), "VOICE-1", "TestSys",
+		p25p2.MACDecodeConfig{
+			Trellis:    p25p2.TrellisOn,
+			RS:         p25p2.RSOn,
+			Interleave: p25p2.InterleaveOn,
+			Scrambler:  p25p2.ScramblerOn,
+			Seed:       12345,
+		}, iqCh, 48_000, done)
+	<-done
+
+	out := buf.String()
+	if !strings.Contains(out, "composer: p25p2 call census") {
+		t.Fatalf("expected unconditional call-census line, got:\n%s", out)
+	}
+	if !strings.Contains(out, "superframes=0") {
+		t.Fatalf("census must report superframes=0 for a zero-IQ call, got:\n%s", out)
+	}
+}
+
+// TestComposerP25Phase2CallCensusCountsMAC confirms the census counters
+// and slot histogram are wired correctly: when real MAC signalling rides
+// the superframes, the census reports a non-zero mac_pdus count and a
+// per-slot bucket for the MAC slot type carried (#813).
+func TestComposerP25Phase2CallCensusCountsMAC(t *testing.T) {
+	const (
+		sampleRate = 48_000.0
+		sps        = 8
+		span       = 8
+		alpha      = 0.20
+	)
+	dibits, _, _, _, _ := buildP25P2MetadataStream(6)
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	c, err := New(Options{
+		Bus:           events.NewBus(128),
+		Devices:       &fakeDevices{src: map[string]IQSource{}},
+		Sink:          &recordingSink{},
+		Engine:        &fakeEngine{},
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+		Log:           logger,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The fixture encodes MAC PDUs unscrambled + RS-uncovered (matching
+	// every Phase 2 fixture), so decode needs the same TrellisOn /
+	// ScramblerOff config. Buffer + close so the synchronous chain drains
+	// the IQ then exits via the closed-channel census path.
+	iqCh := make(chan []complex64, 1)
+	iqCh <- iq
+	close(iqCh)
+	done := make(chan struct{})
+	c.runP25Phase2VoiceChain(context.Background(), "VOICE-1", "MMR",
+		p25p2.MACDecodeConfig{Trellis: p25p2.TrellisOn}, iqCh, sampleRate, done)
+	<-done
+
+	out := buf.String()
+	if !strings.Contains(out, "composer: p25p2 call census") {
+		t.Fatalf("expected call-census line, got:\n%s", out)
+	}
+	if strings.Contains(out, "mac_pdus=0") {
+		t.Fatalf("census reported mac_pdus=0 despite MAC signalling in the stream, got:\n%s", out)
+	}
+	if !strings.Contains(out, "slot_"+p25p2.SlotTypeMACSignaling.String()+"=") {
+		t.Fatalf("census missing slot_%s bucket, got:\n%s", p25p2.SlotTypeMACSignaling, out)
+	}
+}


### PR DESCRIPTION
On real MMR Phase 2 traffic the per-PDU "composer: p25p2 mac pdu" line —
which logs only on a successful MAC decode — never fired at all, for any
slot type, across hundreds of voice chains. That silence is ambiguous: it
cannot distinguish superframe-sync failure from ISCH mis-classification
from MAC-FEC failure, and the existing "decode quality" line only fires
once voice subframes advance, so a fully-silent call yields no data.

Add an end-of-call census that logs exactly once per chain,
unconditionally (both the ctx-cancel and channel-close exits), reporting
superframes locked, a per-SlotType subframe histogram (incl. Unknown),
MAC subframes seen, and MAC PDUs decoded. The counts pin which stage of
the pipeline produces nothing on real air:

  - superframes=0                  -> sync never locked
  - superframes>0, mac_subframes=0 -> ISCH never classified a MAC slot
  - mac_subframes>0, mac_pdus=0    -> MAC FEC failed every slot

No protocol/FEC/geometry logic changes — this only surfaces telemetry so
the next field test is conclusive. Regression tests cover the always-fires
zero-superframe path and the counter/histogram wiring on a stream that
carries decodable MAC signalling.

Refs #813

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BXGxzFwXZRNpkMU3UZUUwJ