### PR TITLE
p25/phase2: add carrier-frequency recovery to the H-DQPSK receiver (#813)

### DIFF
--- a/internal/dsp/sync/costas.go
+++ b/internal/dsp/sync/costas.go
@@ -11,14 +11,19 @@ import "math"
 // and lands every symbol in the wrong quadrant (issue #492).
 //
 // The error detector is the four-fold-symmetric differential phase: for
-// an ideal π/4-DQPSK symbol the differential product y[n]·conj(y[n−1])
-// sits at one of {±π/4, ±3π/4}, so 4× its angle is ≡ π (mod 2π)
-// regardless of the data and regardless of the π/4 constellation
-// alternation. The wrapped residual of (4·angle − π), scaled back by 4,
-// is the leftover per-symbol carrier rotation — recovered without any
-// symbol decision, so the loop converges before polarity is known and is
-// immune to the alternation that defeats a plain 4th-power-of-symbol
-// estimator on π/4-DQPSK.
+// an ideal symbol the differential product y[n]·conj(y[n−1]) sits at the
+// constellation's nominal differential phases, so 4× its angle is a
+// constant (mod 2π) regardless of the data and the constellation
+// alternation. That constant is 4× the per-symbol constellation rotation:
+// π for the π/4-DQPSK / LSM family (rotation π/4), and π/2 for P25 Phase 2
+// H-DQPSK (rotation π/8). lockPhase carries it; pass it via
+// NewQPSKCostasForRotation, or use NewQPSKCostas for the π/4 default. The
+// wrapped residual of (4·angle − lockPhase), scaled back by 4, is the
+// leftover per-symbol carrier rotation — recovered without any symbol
+// decision, so the loop converges before polarity is known and is immune
+// to the alternation that defeats a plain 4th-power-of-symbol estimator.
+// Using the wrong lockPhase leaves a constant per-symbol bias that eats
+// the differential decision margin (a π/8 bias halves it for H-DQPSK).
 //
 // It is a second-order loop: a proportional path corrects phase quickly
 // and an integrator accumulates the frequency estimate (reported in Hz
@@ -27,14 +32,15 @@ import "math"
 // the matched-filter output — must bring the residual inside that range
 // before this loop is engaged.
 type QPSKCostas struct {
-	baud    float64 // symbol rate (Hz), for the Hz <-> rad/symbol conversion
-	kp, ki  float64 // proportional / integral loop-filter gains
-	freq    float64 // integrator state: estimated offset, rad/symbol
-	phase   float64 // running de-rotation phase, rad
-	maxFreq float64 // clamp on |freq| (rad/symbol) — keeps a noisy start bounded
-	rail    int     // consecutive symbols pinned at ±maxFreq pushing further in
-	prev    complex64
-	have    bool
+	baud      float64 // symbol rate (Hz), for the Hz <-> rad/symbol conversion
+	kp, ki    float64 // proportional / integral loop-filter gains
+	freq      float64 // integrator state: estimated offset, rad/symbol
+	phase     float64 // running de-rotation phase, rad
+	maxFreq   float64 // clamp on |freq| (rad/symbol) — keeps a noisy start bounded
+	lockPhase float64 // detector lock constant = 4× constellation rotation
+	rail      int     // consecutive symbols pinned at ±maxFreq pushing further in
+	prev      complex64
+	have      bool
 }
 
 // costasRailReacquire is how many consecutive symbols the integrator may sit
@@ -53,6 +59,16 @@ const costasRailReacquire = 256
 // integral gains follow the standard second-order PLL design from the
 // normalised loop bandwidth θ = loopBWHz / baudHz.
 func NewQPSKCostas(baudHz, loopBWHz, damping float64) *QPSKCostas {
+	// Default lock phase π = 4×(π/4): the π/4-DQPSK / LSM constellation.
+	return NewQPSKCostasForRotation(baudHz, loopBWHz, damping, math.Pi/4)
+}
+
+// NewQPSKCostasForRotation is NewQPSKCostas for a constellation whose
+// per-symbol rotation is `rotation` rad (π/4 for the π/4-DQPSK / LSM
+// family, π/8 for P25 Phase 2 H-DQPSK). The detector locks to 4×rotation;
+// passing the right value keeps the loop from settling with a constant
+// per-symbol bias that would eat the differential decision margin.
+func NewQPSKCostasForRotation(baudHz, loopBWHz, damping, rotation float64) *QPSKCostas {
 	if baudHz <= 0 {
 		panic("qpskcostas: baudHz must be positive")
 	}
@@ -67,10 +83,11 @@ func NewQPSKCostas(baudHz, loopBWHz, damping float64) *QPSKCostas {
 	kp := 4 * damping * theta / denom
 	ki := 4 * theta * theta / denom
 	return &QPSKCostas{
-		baud:    baudHz,
-		kp:      kp,
-		ki:      ki,
-		maxFreq: math.Pi / 4, // the detector's unambiguous half-range
+		baud:      baudHz,
+		kp:        kp,
+		ki:        ki,
+		maxFreq:   math.Pi / 4, // the detector's unambiguous half-range
+		lockPhase: wrapPi(4 * rotation),
 	}
 }
 
@@ -93,11 +110,11 @@ func (c *QPSKCostas) Update(y complex64) complex64 {
 		pdr := yr*pr + yi*pi // Re{yd · conj(prev)}
 		pdi := yi*pr - yr*pi // Im{yd · conj(prev)}
 		ang := math.Atan2(float64(pdi), float64(pdr))
-		// Strip the four-fold data modulation (and the π/4 alternation):
-		// 4·ang ≡ π for any ideal symbol, so the wrapped residual of
-		// (4·ang − π)/4 is the leftover per-symbol carrier rotation,
-		// unambiguous over (−π/4, π/4].
-		e := wrapPi(4*ang-math.Pi) / 4
+		// Strip the four-fold data modulation (and the constellation
+		// alternation): 4·ang ≡ lockPhase for any ideal symbol, so the
+		// wrapped residual of (4·ang − lockPhase)/4 is the leftover
+		// per-symbol carrier rotation, unambiguous over (−π/4, π/4].
+		e := wrapPi(4*ang-c.lockPhase) / 4
 		c.freq += c.ki * e
 		if c.freq > c.maxFreq {
 			c.freq = c.maxFreq

--- a/internal/radio/p25/phase2/receiver/receiver.go
+++ b/internal/radio/p25/phase2/receiver/receiver.go
@@ -29,6 +29,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/sync"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
@@ -50,6 +51,53 @@ const (
 	// before quadrant classification, so a clean +π/8 phase delta
 	// lands squarely in the 0b00 quadrant.
 	Rotation = math.Pi / 8
+)
+
+// Carrier-frequency recovery for the ClockGardner path (issue #813). The
+// differential decoder removes a constant carrier *phase* but not the
+// per-symbol *rotation* (2π·Δf/SymbolRate) a real (non-TCXO) tuner's
+// residual offset Δf imposes; at 6000 baud ~750 Hz already rotates every
+// symbol a full π/4 into the wrong quadrant, so the 20-dibit outbound sync
+// never correlates and superframes never lock. This mirrors the carrier
+// recovery the Phase 1 CQPSK path gained in issue #492 (the C4FM path has
+// CoarseAFC for the same reason): a one-shot coarse seed removes the bulk
+// offset with the NCO, then a fine Costas loop tracks the residual + drift.
+//
+// On a clean, zero-offset stream the seed estimates ~0 Hz, the NCO is an
+// identity mix, the AGC is a unit scalar and Costas drives to zero — so the
+// path is a no-op and the synthesized ClockGardner fixtures are unaffected.
+const (
+	// seedMinSamples is the raw-IQ count accumulated before the one-shot
+	// coarse carrier estimate fires. Production feeds ~160-200 samples per
+	// Process call, so the estimate must accumulate across calls rather than
+	// key off one chunk; 4096 samples (~512 symbols) gives the
+	// autocorrelation estimate a low-variance average.
+	seedMinSamples = 4096
+	// seedMaxLag is the largest sub-symbol autocorrelation lag the coarse
+	// estimator fits a phase-ramp slope through. Lags must stay well below
+	// sps (8) so the pairs are within-symbol; 4 matches the CQPSK path.
+	seedMaxLag = 4
+	// seedMinCoherence is the minimum lag-1 autocorrelation coherence for the
+	// coarse estimate to be trusted; below it the stream is too weak/noisy to
+	// seed from and the NCO is left identity for the Costas loop to acquire.
+	seedMinCoherence = 0.30
+	// seedClampHz bounds the applied coarse seed to ±6 kHz of DC — the
+	// channel passband; a larger residual is a mis-tuned / un-channelised
+	// stream the upstream DDC + PPM correction should have handled.
+	seedClampHz = 6000.0
+	// agc* normalise the matched-filter output ahead of the amplitude-
+	// sensitive Gardner timing-error detector (the issue #275 lesson on the
+	// CQPSK path). Same values as the CQPSK path — gain normalisation is
+	// baud-independent.
+	agcReference = 0.95
+	agcRate      = 1e-3
+	agcMaxGain   = 1e4
+	// costas* tune the fine carrier-tracking loop. The CQPSK path used
+	// 120 Hz at 4800 baud (~2.5% of baud); 6000·0.025 = 150 Hz keeps the
+	// same normalised loop bandwidth. The loop's pull-in is only
+	// ±SymbolRate/8 = ±750 Hz, which is why the coarse seed must precede it.
+	costasLoopBWHz = 150.0
+	costasDamping  = 0.707
 )
 
 // Options configures a Receiver.
@@ -138,7 +186,20 @@ type Receiver struct {
 	clockMode ClockMode
 	gardner   *sync.Gardner
 
+	// Carrier-frequency recovery (ClockGardner only; nil under ClockNaive).
+	// nco removes the coarse seed from the raw IQ; costas tracks the residual
+	// on the symbol stream; agc normalises ahead of Gardner. See the
+	// carrier-recovery const block and issue #813.
+	nco     *dsp.NCO
+	agc     *dsp.AGC
+	costas  *sync.QPSKCostas
+	fs      float64 // IQ sample rate, for the NCO seed and Hz reporting
+	seeded  bool    // coarse carrier seed applied
+	seedHz  float64 // coarse carrier offset the NCO removes (Hz)
+	seedBuf []complex64
+
 	// Scratch buffers reused across calls.
+	rotated []complex64 // NCO-de-rotated IQ, fed to the matched filter
 	matched []complex64
 	dibits  []uint8
 	symbols []complex64
@@ -182,6 +243,13 @@ func New(opts Options) *Receiver {
 			gain = 0.03
 		}
 		r.gardner = sync.NewGardner(float64(r.sps), gain)
+		r.fs = opts.SampleRateHz
+		r.nco = dsp.NewNCO(0, opts.SampleRateHz)
+		r.agc = dsp.NewAGC(agcReference, agcRate, agcMaxGain)
+		// Rotation-aware: H-DQPSK's π/8 constellation locks the detector to
+		// 4·(π/8) = π/2, not the π/4 family's π. The wrong constant would
+		// settle a π/8 per-symbol bias that halves the decision margin.
+		r.costas = sync.NewQPSKCostasForRotation(SymbolRate, costasLoopBWHz, costasDamping, Rotation)
 	}
 	return r
 }
@@ -193,15 +261,56 @@ func (r *Receiver) Process(iq []complex64) {
 	if len(iq) == 0 {
 		return
 	}
-	r.matched = r.dq.MatchedFilter(r.matched, iq)
 	r.dibits = r.dibits[:0]
 	r.symbols = r.symbols[:0]
 
 	if r.clockMode == ClockGardner {
+		// Coarse carrier seed (issue #813): a real tuner's residual offset
+		// spins the differential constellation so the sync never correlates.
+		// Estimate it once from accumulated raw IQ and tune it out with the
+		// NCO before the matched filter; the Costas loop below then tracks the
+		// residual and drift. Production delivers ~160-200 samples per call,
+		// so the estimate accumulates across calls and fires once. Until it
+		// fires the NCO is an identity mix, so a centred/zero-offset stream is
+		// unaffected.
+		if !r.seeded {
+			r.seedBuf = append(r.seedBuf, iq...)
+			if len(r.seedBuf) >= seedMinSamples {
+				hz := estimateCarrierSeedHz(r.seedBuf, r.fs, seedMaxLag)
+				if hz > seedClampHz {
+					hz = seedClampHz
+				} else if hz < -seedClampHz {
+					hz = -seedClampHz
+				}
+				r.seedHz = hz
+				r.nco.SetOffset(hz, r.fs)
+				r.seeded = true
+				r.seedBuf = nil
+				// The pre-seed samples ran through an identity NCO, so the
+				// Costas frequency integrator wound toward the uncorrected
+				// offset; reset it to re-acquire on the now-centred signal.
+				// Gardner is left running — it re-locks within a few symbols
+				// and resetting it would discard symbol timing.
+				r.costas.Reset()
+			}
+		}
+		r.rotated = r.nco.Mix(r.rotated, iq)
+		r.matched = r.dq.MatchedFilter(r.matched, r.rotated)
+		// Normalise amplitude ahead of the gain-sensitive Gardner TED.
+		r.matched = r.agc.Process(r.matched, r.matched)
 		// Gardner manages its own cross-call tail state, so the
 		// receiver hands each matched-filter chunk straight in.
 		r.symbols = r.gardner.Process(r.symbols, r.matched)
+		// Fine carrier tracking: de-rotate each symbol so the residual
+		// per-symbol rotation the coarse seed left behind is removed before
+		// the differential decode. The Costas error detector is four-fold
+		// differential, so the π/8 constellation offset cancels in it; the
+		// downstream Decode applies the static π/8 subtraction.
+		for i, y := range r.symbols {
+			r.symbols[i] = r.costas.Update(y)
+		}
 	} else {
+		r.matched = r.dq.MatchedFilter(r.matched, iq)
 		// Naive decimation: pick every sps-th sample starting at
 		// rxOffset, preserving cross-call state in r.pending.
 		r.pending = append(r.pending, r.matched...)
@@ -245,4 +354,85 @@ func (r *Receiver) Reset() {
 	if r.gardner != nil {
 		r.gardner.Reset()
 	}
+	if r.nco != nil {
+		r.nco.Reset()
+		r.nco.SetOffset(0, r.fs) // identity until the seed re-fires
+	}
+	if r.agc != nil {
+		r.agc.Reset()
+	}
+	if r.costas != nil {
+		r.costas.Reset()
+	}
+	r.seeded = false
+	r.seedHz = 0
+	r.seedBuf = nil
+}
+
+// CarrierOffsetHz reports the carrier-recovery loop's current estimate of
+// the residual carrier-frequency offset in Hz: the coarse NCO seed plus the
+// fine Costas loop's tracked residual. Returns 0 on the ClockNaive path
+// (no carrier recovery). Field diagnostic for issue #813 — a stable small
+// value with sync still not locking points away from carrier offset (e.g.
+// spectral inversion) and toward a different root cause.
+func (r *Receiver) CarrierOffsetHz() float64 {
+	if r.costas == nil {
+		return 0
+	}
+	return r.seedHz + r.costas.OffsetHz()
+}
+
+// estimateCarrierSeedHz estimates the residual carrier offset (Hz) of an
+// oversampled H-DQPSK stream from its sub-symbol-lag autocorrelation. A pure
+// carrier offset Δf rotates the stream by a constant k·Δω at autocorrelation
+// lag k (in samples), so angle(R_k) = k·Δω is linear in k; a least-squares
+// slope through lags 1..maxLag is a lower-variance estimate than a single lag.
+// The lags are sub-symbol (< sps), so most sample pairs fall within one
+// RRC-real-pulse symbol where the only per-sample phase difference is the
+// carrier rotation: the per-symbol π/8 constellation rotation and the
+// zero-mean random data contribute only at the 1-in-sps symbol boundaries and
+// largely average out. This is the estimator the CQPSK path uses (issue #492);
+// a periodogram reads the rotation-shifted spectral centroid of a modulated
+// signal instead and mis-estimates it. Returns 0 on empty / incoherent input,
+// leaving the NCO identity for the Costas loop to acquire the in-range offset.
+func estimateCarrierSeedHz(x []complex64, fs float64, maxLag int) float64 {
+	if len(x) <= maxLag || fs <= 0 || maxLag < 1 {
+		return 0
+	}
+	var energy float64
+	for _, s := range x {
+		energy += float64(real(s))*float64(real(s)) + float64(imag(s))*float64(imag(s))
+	}
+	if energy == 0 {
+		return 0
+	}
+	ang := make([]float64, maxLag+1)
+	var coh float64
+	for k := 1; k <= maxLag; k++ {
+		var accR, accI float64
+		for n := k; n < len(x); n++ {
+			ar, ai := float64(real(x[n])), float64(imag(x[n]))
+			br, bi := float64(real(x[n-k])), float64(imag(x[n-k]))
+			accR += ar*br + ai*bi
+			accI += ai*br - ar*bi
+		}
+		if k == 1 {
+			coh = math.Hypot(accR, accI) / energy
+		}
+		ang[k] = math.Atan2(accI, accR)
+	}
+	if coh < seedMinCoherence {
+		return 0
+	}
+	// Unwrap each lag's angle around k·(lag-1 angle), then least-squares fit a
+	// slope θ (rad/sample) through (k, angle_k) constrained through the origin.
+	a1 := ang[1]
+	var num, den float64
+	for k := 1; k <= maxLag; k++ {
+		ak := float64(k)*a1 + math.Remainder(ang[k]-float64(k)*a1, 2*math.Pi)
+		num += float64(k) * ak
+		den += float64(k * k)
+	}
+	slope := num / den
+	return slope * fs / (2 * math.Pi)
 }

--- a/internal/radio/p25/phase2/receiver/receiver_test.go
+++ b/internal/radio/p25/phase2/receiver/receiver_test.go
@@ -1,8 +1,12 @@
 package receiver
 
 import (
+	"fmt"
 	"math"
 	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
 )
 
 func TestReceiverConstructsAndProcessesSilence(t *testing.T) {
@@ -68,6 +72,175 @@ func makeP2HDQPSKIQ(dibits []uint8) ([]complex64, int) {
 		}
 	}
 	return iq, sps
+}
+
+// makeP2HDQPSKIQWithOffset is makeP2HDQPSKIQ plus a constant carrier
+// rotation of offsetHz: every emitted sample n is additionally rotated
+// by e^{+j·2π·offsetHz·n/fs}, modelling the residual frequency error a
+// real (non-TCXO) RTL-SDR tuner carries. A differential decoder removes
+// constant carrier *phase* but not this per-symbol *rotation*
+// (2π·offsetHz/SymbolRate), so without carrier recovery the dibits land
+// a quadrant over and the 20-dibit outbound sync never correlates —
+// exactly the issue #813 field symptom (superframes=0). offsetHz=0 is
+// byte-identical to makeP2HDQPSKIQ.
+func makeP2HDQPSKIQWithOffset(dibits []uint8, offsetHz, fs float64) ([]complex64, int) {
+	sps := int(fs/SymbolRate + 0.5)
+	// Use the proper RRC-pulse-shaping modulator (the inverse of the
+	// receiver's RRC matched filter, Nyquist → zero ISI at symbol
+	// centres). A rectangular symbol hold would not round-trip through the
+	// matched filter and would self-corrupt fast-varying data.
+	iq := demod.ModulatePiOver4DQPSK(dibits, sps, PulseSpanSymbols, RolloffAlpha, Rotation)
+	if offsetHz != 0 {
+		w := 2 * math.Pi * offsetHz / fs
+		for n := range iq {
+			ph := w * float64(n)
+			iq[n] *= complex(float32(math.Cos(ph)), float32(math.Sin(ph)))
+		}
+	}
+	return iq, sps
+}
+
+// pseudoRandomDibits returns n deterministic pseudo-random dibits (0..3)
+// from an xorshift generator. Deterministic so the test is reproducible;
+// the varying symbol-to-symbol transitions give the Gardner timing loop
+// something to lock to (an all-idle stream is a transition-free tone).
+func pseudoRandomDibits(n int, seed uint32) []uint8 {
+	out := make([]uint8, n)
+	x := seed | 1
+	for i := range out {
+		x ^= x << 13
+		x ^= x >> 17
+		x ^= x << 5
+		out[i] = uint8(x & 0x3)
+	}
+	return out
+}
+
+// bestTailSER aligns the decoded dibit stream against the transmitted one
+// (the receiver drops the differential decoder's first symbol and the
+// Gardner warmup, so rx lags tx by a small constant) and returns the
+// minimum symbol-error rate over the settled tail (rx index >= skip). A
+// healthy decode settles to ~0; an uncorrected carrier offset throws ~3/4
+// of the symbols a quadrant over.
+func bestTailSER(tx, rx []uint8, skip int) float64 {
+	if len(rx) <= skip+100 {
+		return 1.0
+	}
+	best := 1.0
+	// The combined TX+RX RRC group delay makes the decoded stream lead tx
+	// by ~2*span symbols, so the alignment lag is negative; search a window
+	// wide enough to cover the group delay in either direction.
+	for lag := -64; lag <= 64; lag++ {
+		errs, n := 0, 0
+		for i := skip; i < len(rx); i++ {
+			j := i + lag
+			if j < 0 {
+				continue
+			}
+			if j >= len(tx) {
+				break
+			}
+			if rx[i] != tx[j] {
+				errs++
+			}
+			n++
+		}
+		if n < 100 {
+			continue
+		}
+		if r := float64(errs) / float64(n); r < best {
+			best = r
+		}
+	}
+	return best
+}
+
+// TestReceiverDecodesUnderCarrierOffset is the issue #813 failing-first
+// regression at the dibit level: a real-tuner carrier offset must not stop
+// the H-DQPSK receiver from recovering the symbols. Offsets span inside
+// (±600 Hz) and outside (±1500 Hz) the fine Costas loop's ±SymbolRate/8 =
+// ±750 Hz pull-in, so passing proves the coarse carrier seed — not just
+// the fine loop — is doing its job. Without carrier recovery the settled
+// tail SER is ~0.75; with it, ~0.
+func TestReceiverDecodesUnderCarrierOffset(t *testing.T) {
+	const fs = 48_000.0
+	tx := pseudoRandomDibits(2400, 0xC0FFEE)
+	for _, off := range []float64{600, -600, 1500, -1500} {
+		t.Run(fmt.Sprintf("offset=%gHz", off), func(t *testing.T) {
+			var rx []uint8
+			r := New(Options{
+				SampleRateHz: fs,
+				ClockMode:    ClockGardner,
+				GardnerGain:  0.005, // the value the voice/CC paths use
+				DibitSink:    func(d []uint8, _ int) { rx = append(rx, d...) },
+			})
+			iq, _ := makeP2HDQPSKIQWithOffset(tx, off, fs)
+			// Feed in production-sized chunks so the coarse seed must
+			// accumulate across calls (a single giant chunk would mask the
+			// streaming accumulate-then-fire path).
+			for i := 0; i < len(iq); i += 192 {
+				end := i + 192
+				if end > len(iq) {
+					end = len(iq)
+				}
+				r.Process(iq[i:end])
+			}
+			// skip past the coarse-seed fire (~512 symbols) + loop lock.
+			ser := bestTailSER(tx, rx, 900)
+			if ser > 0.02 {
+				t.Errorf("offset %g Hz: tail symbol-error rate = %.3f, want <= 0.02 (issue #813: no carrier recovery)", off, ser)
+			}
+		})
+	}
+}
+
+// TestReceiverLocksSuperframeUnderOffset is the symptom-level failing-first
+// regression: drive a real outbound-sync-bearing superframe stream through
+// the receiver into a SuperframeDecoder under a carrier offset and assert at
+// least one superframe locks. This reproduces the reporter's superframes=0
+// (67/67) directly. Sub-frame bodies are pseudo-random (not idle) so the
+// Gardner loop has transitions to track; only the sync lock is asserted, not
+// slot classification. The lead-in exceeds the coarse-seed sample budget so
+// the seed has fired before the first sync arrives.
+func TestReceiverLocksSuperframeUnderOffset(t *testing.T) {
+	const fs = 48_000.0
+	// Build 4 superframes of random sub-frame bodies; EncodeSuperframe
+	// injects the 20-dibit outbound sync at sub-frame 0.
+	var subs [phase2.SubframesPerSuperframe][]uint8
+	stream := make([]uint8, 0, 800+4*phase2.DibitsPerSuperframe)
+	stream = append(stream, pseudoRandomDibits(800, 0xBEEF)...) // lead-in (> seed budget)
+	for sfi := 0; sfi < 4; sfi++ {
+		for i := range subs {
+			subs[i] = pseudoRandomDibits(phase2.DibitsPerSubframe, uint32(0x1000+sfi*16+i))
+		}
+		stream = append(stream, phase2.EncodeSuperframe(subs)...)
+	}
+
+	for _, off := range []float64{0, 600, -600, 1500, -1500} {
+		t.Run(fmt.Sprintf("offset=%gHz", off), func(t *testing.T) {
+			locked := 0
+			sfDec := phase2.NewSuperframeDecoder()
+			r := New(Options{
+				SampleRateHz: fs,
+				ClockMode:    ClockGardner,
+				GardnerGain:  0.005, // the value the voice/CC paths use
+				DibitSink: func(d []uint8, baseIdx int) {
+					locked += len(sfDec.Process(d, baseIdx))
+				},
+			})
+			iq, _ := makeP2HDQPSKIQWithOffset(stream, off, fs)
+			for i := 0; i < len(iq); i += 192 {
+				end := i + 192
+				if end > len(iq) {
+					end = len(iq)
+				}
+				r.Process(iq[i:end])
+			}
+			if locked == 0 {
+				t.Errorf("offset %g Hz: superframes locked = 0, want >= 1 (issue #813)", off)
+			}
+		})
+	}
 }
 
 func TestReceiverEmitsDibitsFromHDQPSK(t *testing.T) {


### PR DESCRIPTION
On real P25 Phase 2 traffic the voice follower never locked a superframe
(reporter saw superframes=0 on 67/67 calls) even though the same RTL-SDR
records Phase 1 fine. Root cause: the Phase 2 H-DQPSK receiver had no
carrier-frequency recovery. A differential decoder removes a constant
carrier phase but not the per-symbol rotation (2pi*df/baud) a real
(non-TCXO) tuner's residual offset imposes; at 6000 baud ~750 Hz rotates
every symbol a full pi/4 into the wrong quadrant, so the 20-dibit outbound
sync never correlates. The Airspy CC (TCXO) tolerates it; the RTL-SDR
follower does not. Every Phase 2 receiver test synthesized zero-offset IQ,
so this was never caught — the same bug class already fixed for Phase 1
C4FM (CoarseAFC, #275) and Phase 1 CQPSK (NCO seed + Costas, #492).

Fix, on the ClockGardner path only (ClockNaive untouched), mirroring the
CQPSK recipe: a one-shot coarse carrier seed from the sub-symbol-lag
autocorrelation -> NCO de-rotation -> AGC -> Gardner -> Costas fine loop ->
differential decode. The seed uses autocorrelation (not a periodogram): a
periodogram reads the rotation-shifted spectral centroid of a modulated
signal and mis-estimates it. On a clean zero-offset stream the seed is ~0,
the NCO is identity and the path is a no-op, so synthesized fixtures are
unaffected. Fixing the shared receiver fixes the voice follower and the CC
path (both call receiver.New/Process).

QPSKCostas gains a rotation-aware lock phase (4x the constellation
rotation): pi for the pi/4-DQPSK/LSM family, pi/2 for H-DQPSK's pi/8.
The default keeps the CQPSK path identical; the previous hard-coded pi
would settle a pi/8 per-symbol bias that halves the H-DQPSK decision
margin (which tipped the sigfollow alias decode over through a real DDC).

Adds failing-first regression tests that synthesize properly RRC-pulse-
shaped H-DQPSK IQ with a carrier offset spanning inside and outside the
Costas +/-750 Hz pull-in: dibit-level SER and end-to-end superframe lock.
Both fail without the fix (SER ~0.72 / superframes=0) and pass with it.

Refs #813

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016LH6GSvHsUHYtLnJPRapJw