### PR TITLE
docs: post-release v0.5.7 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.7] — 2026-06-29
+
+Headlined by a **P25 Phase 2 voice-decode fix**: the H-DQPSK receiver now
+recovers the carrier frequency, so the Phase 2 voice follower locks
+superframes on ordinary non-TCXO tuners (e.g. RTL-SDR) instead of only on a
+TCXO-clocked Airspy. Rounded out by live-audio quality fixes — decoded voice
+fades cleanly at call end, the WebUI plays one call at a time instead of
+mixing overlapping talkgroups, and recording filenames render in the
+configured display timezone — plus a spectrum-panel follow-state fix.
+
+### Added
+- **P25 Phase 2 per-call MAC census** (#813). An end-of-call census logs once
+  per voice chain — superframes locked, a per-`SlotType` subframe histogram,
+  MAC subframes seen, and MAC PDUs decoded — so a silent decode pins exactly
+  which pipeline stage (superframe sync / ISCH classification / MAC FEC)
+  produced nothing on real air. Telemetry only; no protocol/FEC/geometry
+  logic changes.
+- **"Solution Postmortem" blog category** on the docs site (#808).
+
+### Changed
+- **Recording filenames render in the display timezone**, not always UTC. The
+  per-call WAV basename now honours `display.timezone` — a configured non-UTC
+  zone gets a filename-safe numeric offset like `+1000`, while UTC still
+  formats as a literal `Z`, so existing filenames are unchanged.
+
+### Fixed
+- **P25 Phase 2 H-DQPSK carrier-frequency recovery** (#813). The Phase 2
+  voice follower never locked a superframe on real traffic (a reporter saw
+  `superframes=0` on 67/67 calls) even though the same RTL-SDR decodes Phase 1
+  fine: the H-DQPSK receiver had no carrier-frequency recovery, so a real
+  tuner's residual offset rotated every symbol out of its quadrant and the
+  outbound sync never correlated. The receiver now does a one-shot coarse
+  carrier seed → NCO de-rotation → AGC → Gardner → Costas fine loop (on the
+  `ClockGardner` path only; clean zero-offset streams stay a no-op), and the
+  Costas lock phase is now rotation-aware for the π/8 H-DQPSK constellation.
+  Fixes both the voice follower and the control-channel path.
+- **Decoded digital voice fades to zero at call end** (P25/DMR). Short
+  transmissions ended on a hard waveform discontinuity — an audible
+  scratch/click — because digital voice, unlike the analog FM chain, had no
+  end-of-call ramp. A call now appends a short (~10 ms) linear fade to both
+  the recorded WAV and the live decoded fan-out; silent/dead-key calls are a
+  no-op.
+- **WebUI live audio plays one call at a time.** The browser player opened the
+  audio stream unfiltered, so every concurrent voice call's PCM arrived
+  interleaved into one body and talkgroups overlapped. The player now follows
+  the primary (most recently started) active call and filters the stream to
+  its device, re-pointing as the primary changes so audio switches cleanly
+  between calls — standard scanner behaviour.
+- **Spectrum panels keep their follow state live** (#810). The
+  Mixer/Tuning/Histogram/Constellation/SymbolScope panels read active calls
+  from the shared store but nothing refreshed it off the Active/Dashboard
+  routes, so opening a panel directly froze it on a stale "following call".
+  Each panel now polls active calls itself, and re-checking Hold parks the
+  view on the control channel instead of a possibly-stale call frequency.
+
+### Internal
+- End-to-end regression test for the adjacent-carrier offset WARN through the
+  real `ccdecoder.Decoder` (#815), guarding the live behaviour the reporter
+  confirmed — a control lock ~12.5 kHz off-frequency tripping the WARN —
+  which the existing stubbed tests and the `replay` path did not exercise.
+
 ## [v0.5.6] — 2026-06-28
 
 Headlined by the **`cryptolab` cryptographic-research toolkit** — a new,

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.6
+VERSION=v0.5.7
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.6" -%}
+  {%- assign ver = "v0.5.7" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.7.md
+++ b/docs/announcements/v0.5.7.md
@@ -1,0 +1,52 @@
+# GopherTrunk v0.5.7 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.7 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.7
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.7 — P25 Phase 2 voice now locks on RTL-SDR (H-DQPSK carrier-frequency recovery), decoded voice fades cleanly at call end, the WebUI plays one call at a time instead of overlapping talkgroups, and recording filenames render in your display timezone
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.7 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.5.6:**
+
+* **P25 Phase 2 voice now locks on ordinary tuners** (#813). The Phase 2 voice follower used to never lock a superframe on real traffic (a reporter saw `superframes=0` on 67/67 calls) even though the same RTL-SDR decodes Phase 1 fine — the H-DQPSK receiver had no carrier-frequency recovery, so a real tuner's residual offset rotated every symbol out of its quadrant and the outbound sync never correlated. The receiver now does a coarse carrier seed → NCO de-rotation → AGC → Gardner → Costas fine loop (rotation-aware lock for the π/8 H-DQPSK constellation), fixing both the voice follower and the control path. Clean zero-offset streams are a no-op.
+* **Decoded digital voice fades to zero at call end.** Short P25/DMR overs used to end on a hard waveform discontinuity — an audible scratch/click — because digital voice, unlike the analog FM chain, had no end-of-call ramp. Calls now append a short (~10 ms) linear fade to both the recorded WAV and the live decoded audio.
+* **WebUI live audio plays one call at a time.** The browser player opened the audio stream unfiltered, so concurrent voice calls arrived interleaved and talkgroups overlapped. It now follows the primary (most recently started) active call and filters to its device, switching cleanly between calls — standard scanner behaviour.
+* **Recording filenames render in your display timezone**, not always UTC. The per-call WAV basename now honours `display.timezone` (a non-UTC zone gets a filename-safe numeric offset like `+1000`; UTC still formats as a literal `Z`, so existing filenames are unchanged).
+* **Spectrum panels keep their follow state live** (#810). The Mixer/Tuning/Histogram/Constellation/SymbolScope panels could freeze on a stale "following call" when opened directly; they now poll active calls themselves, and re-checking Hold parks the view on the control channel instead of a possibly-stale call frequency.
+* **P25 Phase 2 per-call MAC census** (#813) — an end-of-call census logs superframes locked, a per-slot subframe histogram, and MAC subframes/PDUs decoded, so a silent decode pins exactly which pipeline stage produced nothing on real air.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.7
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.7 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.5.6:**
+- **P25 Phase 2 voice now locks on ordinary tuners** (#813) — H-DQPSK carrier-frequency recovery fixes the `superframes=0` no-lock on RTL-SDR that left Phase 2 voice silent.
+- **Decoded digital voice fades to zero at call end** — kills the trailing scratch/click on short P25/DMR overs, in both recordings and live audio.
+- **WebUI live audio plays one call at a time** — follows the primary active call instead of mixing overlapping talkgroups.
+- **Recording filenames render in your display timezone** — honours `display.timezone` instead of hard-coded UTC.
+- **Spectrum panels keep their follow state live** (#810) — no more stale "following call"; Hold parks on the control channel.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.7>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow shipped v0.5.7 (it was first misfired as a
re-publish of the old v0.4.7 tag, then re-run with the correct version),
so catch the post-release docs up to it:

- CHANGELOG: promote a dated [v0.5.7] section from what actually shipped —
  P25 Phase 2 H-DQPSK carrier-frequency recovery so the voice follower
  locks on non-TCXO tuners (#813), end-of-call digital-voice fade,
  one-call-at-a-time WebUI live audio, display-timezone recording
  filenames, the spectrum-panel follow-state fix (#810), the Phase 2
  per-call MAC census (#813), the "Solution Postmortem" blog category
  (#808), and the end-to-end adjacent-carrier offset WARN test (#815).
- README + latest-version.html: bump the quick-start VERSION and the
  Pages fallback tag from v0.5.6 to v0.5.7.
- Add the v0.5.7 social-announcement drafts.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BsLKNFiqs9WeY2L4aNGoyw