### PR TITLE
siglab: add spectral-occupancy metrics (occupied BW, channel power, ACPR, flatness)

### DIFF
--- a/docs/siglab.md
+++ b/docs/siglab.md
@@ -46,6 +46,19 @@ standard and Config Builder consoles (see the
   PSD, spectrogram/waterfall, [eye diagram](eye-diagram.html),
   [symbol scope](symbol-scope.html), sync-landscape heatmap, receiver-state
   series, grants, and an event timeline.
+- **Measure** lab-grade modulation quality (VSA): carrier-frequency error,
+  RMS/peak EVM split into magnitude and phase error, IQ gain imbalance and
+  quadrature skew, origin offset, an EVM-vs-symbol trace, and an error-vector
+  spectrum — plus spectral occupancy off the PSD (99% occupied bandwidth,
+  channel power, adjacent-channel power ratio, spectral flatness).
+- **Name the unknown**: when a capture or a surveyed carrier does not decode,
+  a blind symbol-rate / modulation estimate is ranked against an offline
+  signal-ID reference database, so an undecodable carrier is still named a
+  best guess rather than dropped.
+- **Dissect the data**: with `collect_pdus`, every P25 TSBK signaling block
+  (decoded and CRC-failed alike) is surfaced as a field-level dissection —
+  opcode, source/destination/talkgroup, FEC/CRC status, and raw payload —
+  filterable in the console and exportable as `csv-pdus`.
 - **Compare** several analyzed captures — overlay their power spectra and diff
   their metrics — against each other or against a synthesized ideal.
 - **Export** the structured result (JSON / JSONL / YAML / CSV) from the engine's

--- a/internal/api/handlers_siglab.go
+++ b/internal/api/handlers_siglab.go
@@ -31,6 +31,7 @@ type siglabRunConfig struct {
 	CollectIQDiag      bool    `json:"collect_iq_diag"`
 	CaptureIQ          bool    `json:"capture_iq"`
 	CaptureIQMaxPoints int     `json:"capture_iq_max_points"`
+	CollectPDUs        bool    `json:"collect_pdus"`
 
 	// P25 Phase 1 deep knobs.
 	DemodMode            string `json:"demod_mode"`
@@ -78,6 +79,7 @@ func (rc siglabRunConfig) config(cap *siglabCapture) (siglab.Config, error) {
 		CollectIQDiag:        rc.CollectIQDiag,
 		CaptureIQ:            rc.CaptureIQ,
 		CaptureIQMaxPoints:   rc.CaptureIQMaxPoints,
+		CollectPDUs:          rc.CollectPDUs,
 		DemodMode:            rc.DemodMode,
 		NIDSearchSpan:        rc.NIDSearchSpan,
 		EnableDDA:            rc.EnableDDA,
@@ -355,7 +357,7 @@ func (s *Server) handleSiglabExport(w http.ResponseWriter, r *http.Request) {
 	switch formatStr {
 	case "yaml", "yml":
 		ct, ext = "application/yaml", "yaml"
-	case "csv", "csv-summary", "csv-events":
+	case "csv", "csv-summary", "csv-events", "csv-pdus":
 		ct, ext = "text/csv", "csv"
 	case "jsonl":
 		ct, ext = "application/x-ndjson", "jsonl"

--- a/internal/api/handlers_siglab_spectrum.go
+++ b/internal/api/handlers_siglab_spectrum.go
@@ -28,6 +28,16 @@ func queryPow2(r *http.Request, key string, def int) int {
 	return def
 }
 
+// queryFloat returns a positive float query value, or def when absent/invalid.
+func queryFloat(r *http.Request, key string, def float64) float64 {
+	if s := r.URL.Query().Get(key); s != "" {
+		if v, err := strconv.ParseFloat(s, 64); err == nil && v > 0 {
+			return v
+		}
+	}
+	return def
+}
+
 // handleSiglabJobPSD answers GET /api/v1/siglab/jobs/{id}/psd with the
 // Welch-averaged power spectrum (dBFS, FFT-shifted: bin 0 = -rate/2) of the
 // job's decimated IQ. Computed server-side via spectrum.AverageDB so the web UI
@@ -43,6 +53,34 @@ func (s *Server) handleSiglabJobPSD(w http.ResponseWriter, r *http.Request) {
 		"sample_rate_hz": taps.DecimatedRateHz,
 		"fft_size":       fftSize,
 		"bins":           frame.Bins,
+	})
+}
+
+// handleSiglabJobOccupancy answers GET /api/v1/siglab/jobs/{id}/occupancy with
+// the spectral-occupancy metrics (99% occupied bandwidth, channel power, ACPR
+// upper/lower, spectral flatness) of the job's decimated IQ. It reuses the same
+// Welch-averaged spectrum as the PSD endpoint so the chart and the metric strip
+// share one computation. The channel/adjacent geometry is overridable via the
+// channel_bw_hz, adj_offset_hz and adj_bw_hz query params; defaults assume a
+// 12.5 kHz channel with 12.5 kHz adjacent spacing.
+func (s *Server) handleSiglabJobOccupancy(w http.ResponseWriter, r *http.Request) {
+	taps, ok := s.siglabJobTaps(w, r)
+	if !ok {
+		return
+	}
+	fftSize := queryPow2(r, "fft", 1024)
+	channelBW := queryFloat(r, "channel_bw_hz", 12500)
+	adjOffset := queryFloat(r, "adj_offset_hz", 12500)
+	adjBW := queryFloat(r, "adj_bw_hz", 12500)
+	frame := spectrum.AverageDB(iqPointsToComplex(taps.DecimatedIQ), 0, taps.DecimatedRateHz, fftSize)
+	occ := spectrum.ComputeOccupancy(frame.Bins, taps.DecimatedRateHz, channelBW, adjOffset, adjBW)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"sample_rate_hz": taps.DecimatedRateHz,
+		"fft_size":       fftSize,
+		"channel_bw_hz":  channelBW,
+		"adj_offset_hz":  adjOffset,
+		"adj_bw_hz":      adjBW,
+		"occupancy":      occ,
 	})
 }
 

--- a/internal/api/handlers_siglab_test.go
+++ b/internal/api/handlers_siglab_test.go
@@ -249,6 +249,32 @@ func TestSiglabJobPSDAndSpectrogram(t *testing.T) {
 			return 0
 		}())
 	}
+
+	// Occupancy: lab-grade spectral metrics off the same averaged spectrum.
+	occResp, err := http.Get(ts.URL + "/api/v1/siglab/jobs/" + run.JobID + "/occupancy?fft=512")
+	if err != nil {
+		t.Fatalf("occupancy: %v", err)
+	}
+	defer occResp.Body.Close()
+	if occResp.StatusCode != http.StatusOK {
+		t.Fatalf("occupancy status = %d, want 200", occResp.StatusCode)
+	}
+	var occ struct {
+		Occupancy struct {
+			OccupiedBandwidthHz float64 `json:"occupied_bandwidth_hz"`
+			ChannelPowerDBFS    float64 `json:"channel_power_dbfs"`
+			SpectralFlatness    float64 `json:"spectral_flatness"`
+		} `json:"occupancy"`
+	}
+	if err := json.NewDecoder(occResp.Body).Decode(&occ); err != nil {
+		t.Fatalf("decode occupancy: %v", err)
+	}
+	if occ.Occupancy.OccupiedBandwidthHz <= 0 {
+		t.Errorf("occupancy occupied_bandwidth_hz = %v, want > 0", occ.Occupancy.OccupiedBandwidthHz)
+	}
+	if math.IsNaN(occ.Occupancy.ChannelPowerDBFS) || math.IsInf(occ.Occupancy.ChannelPowerDBFS, 0) {
+		t.Errorf("occupancy channel_power_dbfs = %v, want finite", occ.Occupancy.ChannelPowerDBFS)
+	}
 }
 
 func TestSiglabRunMissingCapture(t *testing.T) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1129,6 +1129,7 @@ func (s *Server) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/siglab/jobs/{id}/iq", s.handleSiglabJobIQ)
 		mux.HandleFunc("GET /api/v1/siglab/jobs/{id}/psd", s.handleSiglabJobPSD)
 		mux.HandleFunc("GET /api/v1/siglab/jobs/{id}/spectrogram", s.handleSiglabJobSpectrogram)
+		mux.HandleFunc("GET /api/v1/siglab/jobs/{id}/occupancy", s.handleSiglabJobOccupancy)
 		mux.HandleFunc("GET /api/v1/siglab/jobs/{id}/export", s.handleSiglabExport)
 		mux.HandleFunc("POST /api/v1/siglab/identify", s.gate(s.handleSiglabIdentify))
 		mux.HandleFunc("POST /api/v1/siglab/wideband", s.gate(s.handleSiglabWideband))

--- a/internal/dsp/blind/blind.go
+++ b/internal/dsp/blind/blind.go
@@ -1,0 +1,297 @@
+// Package blind estimates the symbol/baud rate and a coarse modulation class of
+// an unknown carrier directly from its channelized IQ, with no protocol
+// decoder. It is the "what is this?" front-end for SigLab's identify/wideband
+// fallback: when nothing decodes, the blind estimate feeds a reference-database
+// ranking (internal/siglab/sigref).
+//
+// The symbol-rate estimate is the reliable part — two independent methods
+// (autocorrelation of the symbol-transition energy and the spectral line that
+// same nonlinearity regenerates) must agree for high confidence. The
+// modulation-class guess is deliberately coarse and reports "unknown" rather
+// than risk a confidently-wrong label, because a wrong class hurts ranking more
+// than a missing one.
+package blind
+
+import (
+	"math"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/stats"
+)
+
+// Modulation-class labels. These mirror the coarse families the reference DB
+// keys on; "unknown" is emitted whenever the features are inconclusive.
+const (
+	ModUnknown = "unknown"
+	ModFSK2    = "fsk2" // 2-level FSK / GFSK / GMSK family
+	ModFSK4    = "fsk4" // 4-level FSK / C4FM family
+	ModPSK     = "psk"  // constant-envelope phase modulation (incl. π/4-DQPSK)
+	ModQAM     = "qam"  // amplitude-bearing (non-constant-envelope) modulation
+)
+
+// BlindEstimate is the result of a blind analysis of one carrier.
+type BlindEstimate struct {
+	// SymbolRateHz is the best symbol-rate estimate; 0 when indeterminate.
+	SymbolRateHz float64 `json:"symbol_rate_hz"`
+	// SymbolRateConf is 0..1: high when the two methods agree, low otherwise.
+	SymbolRateConf float64 `json:"symbol_rate_conf"`
+	// SymbolRateCands carries both method estimates when they disagree.
+	SymbolRateCands []float64 `json:"symbol_rate_cands,omitempty"`
+	// ModClass is one of the Mod* labels; Levels is the detected symbol-level
+	// count (2 or 4) or 0 when unknown.
+	ModClass string `json:"mod_class"`
+	Levels   int    `json:"levels"`
+	// OccupiedBWHz is the 99% occupied bandwidth of the carrier.
+	OccupiedBWHz float64 `json:"occupied_bw_hz"`
+	// Method names the estimators that ran.
+	Method string `json:"method"`
+}
+
+const (
+	maxSamples  = 16384 // cap the work per carrier
+	acMaxLen    = 4096  // O(n²) autocorrelation input cap
+	minBaudHz   = 200.0 // search-band floor
+	constEnvCV  = 0.35  // |x| coefficient-of-variation below this ⇒ constant envelope
+	//            (loose enough to keep a channelized FSK carrier — whose filtered
+	//            transitions ripple the envelope — out of the amplitude/QAM class)
+	agreeRelTol = 0.10  // method agreement threshold
+)
+
+// Estimate analyses a channelized carrier (complex baseband at rateHz) and
+// returns its blind symbol-rate / modulation estimate. Returns a zero value for
+// too-short input or a non-positive rate.
+func Estimate(iq []complex64, rateHz float64) BlindEstimate {
+	if len(iq) < 256 || rateHz <= 0 {
+		return BlindEstimate{}
+	}
+	s := iq
+	if len(s) > maxSamples {
+		s = s[:maxSamples]
+	}
+
+	// Instantaneous frequency (rad/sample) and its symbol-transition energy:
+	// the FM-discriminator output spikes at every symbol boundary, so its
+	// first difference squared is a near-impulse train at the symbol rate.
+	d := make([]float64, len(s)-1)
+	for i := 1; i < len(s); i++ {
+		d[i-1] = phaseDiff(s[i], s[i-1])
+	}
+	tr := make([]float64, len(d)-1)
+	for i := 1; i < len(d); i++ {
+		x := d[i] - d[i-1]
+		tr[i-1] = x * x
+	}
+
+	maxBaud := rateHz / 4
+	baudA, okA := autocorrBaud(tr, rateHz, maxBaud)
+	baudB, okB := spectralLineBaud(tr, rateHz, maxBaud)
+
+	out := BlindEstimate{Method: "autocorr+spectral", ModClass: ModUnknown}
+	switch {
+	case okA && okB:
+		if math.Abs(baudA-baudB)/baudB < agreeRelTol {
+			out.SymbolRateHz = (baudA + baudB) / 2
+			out.SymbolRateConf = 0.9
+		} else {
+			// Disagreement: trust the autocorrelation's smallest-strong-lag — it
+			// pins the fundamental symbol period, whereas a lone spectral line can
+			// latch a sub-harmonic from symbol run-length structure.
+			out.SymbolRateHz = baudA
+			out.SymbolRateConf = 0.4
+			out.SymbolRateCands = []float64{baudA, baudB}
+		}
+	case okA:
+		out.SymbolRateHz, out.SymbolRateConf = baudA, 0.5
+	case okB:
+		out.SymbolRateHz, out.SymbolRateConf = baudB, 0.5
+	}
+
+	out.ModClass, out.Levels = classify(s, d)
+	out.OccupiedBWHz = occupiedBW(s, rateHz)
+	return out
+}
+
+// phaseDiff returns the angle of a·conj(b) — the per-sample instantaneous
+// frequency in radians/sample.
+func phaseDiff(a, b complex64) float64 {
+	ar, ai := float64(real(a)), float64(imag(a))
+	br, bi := float64(real(b)), float64(imag(b))
+	// a·conj(b) = (ar+jai)(br-jbi)
+	re := ar*br + ai*bi
+	im := ai*br - ar*bi
+	return math.Atan2(im, re)
+}
+
+// autocorrBaud finds the symbol period as the strongest autocorrelation lag of
+// the transition-energy signal within the baud search band, and converts it to
+// a rate. Returns ok=false when no lag in the band stands out.
+func autocorrBaud(tr []float64, rateHz, maxBaud float64) (float64, bool) {
+	m := tr
+	if len(m) > acMaxLen {
+		m = m[:acMaxLen]
+	}
+	if len(m) < 8 {
+		return 0, false
+	}
+	m = demean(m)
+	corr, _ := stats.Correlate(m, m)
+	center := len(m) - 1 // lag 0
+	lagLo := int(rateHz / maxBaud)
+	if lagLo < 2 {
+		lagLo = 2
+	}
+	lagHi := int(rateHz / minBaudHz)
+	if lagHi >= len(m) {
+		lagHi = len(m) - 1
+	}
+	if lagHi <= lagLo {
+		return 0, false
+	}
+	// Peak autocorrelation in the band, then take the SMALLEST lag that is a
+	// local maximum near that peak — the fundamental symbol period, not one of
+	// its (equally strong, for an impulse train) harmonics at 2×/3× the lag.
+	var maxVal float64
+	for lag := lagLo; lag <= lagHi; lag++ {
+		if v := corr[center+lag]; v > maxVal {
+			maxVal = v
+		}
+	}
+	if maxVal < 0.05 {
+		return 0, false
+	}
+	thresh := 0.5 * maxVal
+	for lag := lagLo + 1; lag < lagHi; lag++ {
+		v := corr[center+lag]
+		if v >= thresh && v > corr[center+lag-1] && v >= corr[center+lag+1] {
+			return rateHz / float64(lag), true
+		}
+	}
+	return 0, false
+}
+
+// spectralLineBaud finds the symbol rate as the dominant non-DC spectral line of
+// the transition-energy signal. Returns ok=false when no line stands out.
+func spectralLineBaud(tr []float64, rateHz, maxBaud float64) (float64, bool) {
+	n := pow2Floor(len(tr))
+	if n < 64 {
+		return 0, false
+	}
+	x := demean(tr[:n])
+	in := make([]complex128, n)
+	for i, v := range x {
+		in[i] = complex(v, 0)
+	}
+	out := fft.New(n).Forward(make([]complex128, n), in)
+	binHz := rateHz / float64(n)
+	loBin := int(minBaudHz / binHz)
+	if loBin < 1 {
+		loBin = 1
+	}
+	hiBin := int(maxBaud / binHz)
+	if hiBin >= n/2 {
+		hiBin = n/2 - 1
+	}
+	if hiBin <= loBin {
+		return 0, false
+	}
+	mag := make([]float64, hiBin+2)
+	var meanMag float64
+	for k := loBin; k <= hiBin; k++ {
+		mag[k] = math.Hypot(real(out[k]), imag(out[k]))
+		meanMag += mag[k]
+	}
+	meanMag /= float64(hiBin - loBin + 1)
+	if meanMag <= 0 {
+		return 0, false
+	}
+	// Take the LOWEST-frequency line that clears the band floor — the
+	// fundamental, not a harmonic (an ideal symbol-clock impulse train has
+	// equally strong lines at every multiple of the baud).
+	thresh := 3 * meanMag
+	for k := loBin + 1; k < hiBin; k++ {
+		if mag[k] >= thresh && mag[k] > mag[k-1] && mag[k] >= mag[k+1] {
+			return float64(k) * binHz, true
+		}
+	}
+	return 0, false
+}
+
+// classify returns a coarse modulation class + level count from amplitude and
+// instantaneous-frequency statistics. Conservative: returns ModUnknown when the
+// features do not clearly fit a family.
+func classify(s []complex64, d []float64) (string, int) {
+	// Amplitude coefficient of variation: low ⇒ constant envelope.
+	amp := make([]float64, len(s))
+	for i, c := range s {
+		amp[i] = math.Hypot(float64(real(c)), float64(imag(c)))
+	}
+	mean := stats.Mean(amp)
+	if mean <= 0 {
+		return ModUnknown, 0
+	}
+	cv := math.Sqrt(stats.Variance(amp, true)) / mean
+	if cv >= constEnvCV {
+		return ModQAM, 0 // amplitude carries information
+	}
+	// Constant envelope: count instantaneous-frequency clusters (FSK rails).
+	modes := freqModes(d)
+	switch modes {
+	case 4:
+		return ModFSK4, 4
+	case 2:
+		return ModFSK2, 2
+	default:
+		// Constant-envelope but no clean FSK rail structure ⇒ likely PSK.
+		return ModPSK, 0
+	}
+}
+
+// freqModes counts the dominant clusters in the instantaneous-frequency
+// histogram — the FSK rail count (2 or 4) for an FSK signal.
+func freqModes(d []float64) int {
+	counts, _ := stats.Histogram(d, 41)
+	y := make([]float64, len(counts))
+	for i, c := range counts {
+		y[i] = float64(c)
+	}
+	// IncludeEnds so the outer FSK rails — which land in the first/last
+	// histogram bins — are counted, not silently dropped.
+	peaks := stats.FindPeaks(y, stats.PeakOpts{RelHeight: 0.25, MinDistance: 4, IncludeEnds: true})
+	return len(peaks)
+}
+
+// occupiedBW returns the 99% occupied bandwidth of s, reusing the spectrum
+// package's occupancy math on a Welch-averaged spectrum.
+func occupiedBW(s []complex64, rateHz float64) float64 {
+	n := pow2Floor(len(s))
+	if n < 256 {
+		return 0
+	}
+	if n > 4096 {
+		n = 4096
+	}
+	frame := spectrum.AverageDB(s, 0, rateHz, n)
+	occ := spectrum.ComputeOccupancy(frame.Bins, rateHz, rateHz, 0, 0)
+	return occ.OccupiedBandwidthHz
+}
+
+func demean(x []float64) []float64 {
+	m := stats.Mean(x)
+	out := make([]float64, len(x))
+	for i, v := range x {
+		out[i] = v - m
+	}
+	return out
+}
+
+func pow2Floor(n int) int {
+	if n < 1 {
+		return 0
+	}
+	p := 1
+	for p<<1 <= n {
+		p <<= 1
+	}
+	return p
+}

--- a/internal/dsp/blind/blind.go
+++ b/internal/dsp/blind/blind.go
@@ -49,13 +49,13 @@ type BlindEstimate struct {
 }
 
 const (
-	maxSamples  = 16384 // cap the work per carrier
-	acMaxLen    = 4096  // O(n²) autocorrelation input cap
-	minBaudHz   = 200.0 // search-band floor
-	constEnvCV  = 0.35  // |x| coefficient-of-variation below this ⇒ constant envelope
+	maxSamples = 16384 // cap the work per carrier
+	acMaxLen   = 4096  // O(n²) autocorrelation input cap
+	minBaudHz  = 200.0 // search-band floor
+	constEnvCV = 0.35  // |x| coefficient-of-variation below this ⇒ constant envelope
 	//            (loose enough to keep a channelized FSK carrier — whose filtered
 	//            transitions ripple the envelope — out of the amplitude/QAM class)
-	agreeRelTol = 0.10  // method agreement threshold
+	agreeRelTol = 0.10 // method agreement threshold
 )
 
 // Estimate analyses a channelized carrier (complex baseband at rateHz) and

--- a/internal/dsp/blind/blind_test.go
+++ b/internal/dsp/blind/blind_test.go
@@ -1,0 +1,80 @@
+package blind
+
+import (
+	"math"
+	"testing"
+)
+
+// genFSK synthesizes a clean M-level FSK carrier: nSym symbols at baudHz over a
+// rateHz stream, each symbol a frequency from a deterministic level pattern,
+// integrated into a unit-amplitude complex phasor. This exercises the estimator
+// without pulling in the siglab synthesizer (which would import this package).
+func genFSK(rateHz, baudHz, devHz float64, levels, nSym int) []complex64 {
+	sps := int(math.Round(rateHz / baudHz))
+	out := make([]complex64, 0, sps*nSym)
+	phase := 0.0
+	// Level pattern: a fixed pseudo-random-ish walk over the M levels so the
+	// transition density is realistic but reproducible.
+	lvlVals := make([]float64, levels)
+	for i := range lvlVals {
+		lvlVals[i] = float64(2*i-(levels-1)) / float64(levels-1) // ±1, ±1/3 for M=4
+	}
+	seed := 12345
+	for sym := 0; sym < nSym; sym++ {
+		seed = (seed*1103515245 + 12345) & 0x7fffffff
+		// Use the high bits: an LCG's low-order bits have very short periods
+		// (seed%4 cycles every 4), which would plant a false sub-harmonic.
+		lvl := lvlVals[(seed>>16)%levels]
+		dphi := 2 * math.Pi * (lvl * devHz) / rateHz
+		for k := 0; k < sps; k++ {
+			phase += dphi
+			out = append(out, complex64(complex(math.Cos(phase), math.Sin(phase))))
+		}
+	}
+	return out
+}
+
+func TestEstimateSymbolRate(t *testing.T) {
+	cases := []struct {
+		name            string
+		rate, baud, dev float64
+		levels          int
+	}{
+		{"p25-c4fm-4800", 48000, 4800, 1800, 4},
+		{"dpmr-2400", 48000, 2400, 1800, 4},
+		{"tetra-ish-18000", 144000, 18000, 4000, 4},
+		{"gfsk-4800-2lvl", 48000, 4800, 2400, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			iq := genFSK(tc.rate, tc.baud, tc.dev, tc.levels, 3000)
+			est := Estimate(iq, tc.rate)
+			t.Logf("baud=%.0f conf=%.2f class=%s levels=%d obw=%.0f",
+				est.SymbolRateHz, est.SymbolRateConf, est.ModClass, est.Levels, est.OccupiedBWHz)
+			if est.SymbolRateHz <= 0 {
+				t.Fatalf("no symbol-rate estimate")
+			}
+			if rel := math.Abs(est.SymbolRateHz-tc.baud) / tc.baud; rel > 0.05 {
+				t.Errorf("symbol rate = %.0f Hz, want ≈ %.0f Hz (%.1f%% off)", est.SymbolRateHz, tc.baud, rel*100)
+			}
+		})
+	}
+}
+
+func TestEstimateLevelClass(t *testing.T) {
+	// A clean 4-FSK should classify as the FSK4 family with 4 levels.
+	iq := genFSK(48000, 4800, 1800, 4, 3000)
+	est := Estimate(iq, 48000)
+	if est.ModClass != ModFSK4 || est.Levels != 4 {
+		t.Errorf("4-FSK classified as %s/%d, want %s/4", est.ModClass, est.Levels, ModFSK4)
+	}
+}
+
+func TestEstimateRejectsShortOrInvalid(t *testing.T) {
+	if got := Estimate(nil, 48000); got.SymbolRateHz != 0 {
+		t.Errorf("nil input: got %+v, want zero", got)
+	}
+	if got := Estimate(make([]complex64, 1024), 0); got.SymbolRateHz != 0 {
+		t.Errorf("zero rate: got %+v, want zero", got)
+	}
+}

--- a/internal/dsp/spectrum/occupancy.go
+++ b/internal/dsp/spectrum/occupancy.go
@@ -1,0 +1,133 @@
+package spectrum
+
+import "math"
+
+// Occupancy holds the spectral-occupancy measurements derived from a single
+// FFT-shifted dBFS spectrum (a Frame's Bins). These are the lab-grade channel
+// figures a vector-signal analyzer reports alongside the constellation: how
+// wide the signal really is, how much power sits in the channel, how much leaks
+// into the neighbours, and how tone-like vs noise-like the channel is.
+type Occupancy struct {
+	// OccupiedBandwidthHz is the ITU 99% occupied bandwidth: the span between
+	// the points where the cumulative power crosses 0.5% and 99.5% of the
+	// total, i.e. the band holding 99% of the power with 0.5% in each tail.
+	OccupiedBandwidthHz float64 `json:"occupied_bandwidth_hz"`
+	// ChannelPowerDBFS is the integrated power within ±channelBW/2 of DC,
+	// in dBFS (10·log10 of the summed linear bin power).
+	ChannelPowerDBFS float64 `json:"channel_power_dbfs"`
+	// ACPRUpperDB / ACPRLowerDB are the adjacent-channel power ratios for the
+	// upper/lower adjacent channels relative to the main channel, in dB
+	// (negative for a clean signal that does not splatter into its neighbours).
+	ACPRUpperDB float64 `json:"acpr_upper_db"`
+	ACPRLowerDB float64 `json:"acpr_lower_db"`
+	// SpectralFlatness is the Wiener entropy (geometric-mean / arithmetic-mean
+	// of the in-channel linear power), 0..1: ~1 for white noise, ≪1 for a tone
+	// or a narrow carrier.
+	SpectralFlatness float64 `json:"spectral_flatness"`
+}
+
+// powerFloor clamps linear power away from zero so log/geomean math stays
+// finite, matching the package's small-value clamp convention.
+const powerFloor = 1e-30
+
+// ComputeOccupancy derives the spectral-occupancy metrics from FFT-shifted dBFS
+// bins (bin 0 = -sampleRate/2, DC at len/2, the order spectrum.AverageDB
+// produces with centerHz=0). channelBWHz is the main channel width; adjOffsetHz
+// is the centre spacing to each adjacent channel and adjBWHz its width — pass
+// the protocol channel spacing for both to measure ACPR into the neighbouring
+// channels. Non-positive widths fall back to sensible spans so a caller can ask
+// for occupied bandwidth alone.
+func ComputeOccupancy(binsDB []float32, sampleRateHz, channelBWHz, adjOffsetHz, adjBWHz float64) Occupancy {
+	n := len(binsDB)
+	if n == 0 || sampleRateHz <= 0 {
+		return Occupancy{}
+	}
+	binHz := sampleRateHz / float64(n)
+	baseHz := -sampleRateHz / 2 // frequency of bin 0
+
+	// Linear power per bin (floored).
+	lin := make([]float64, n)
+	var total float64
+	for i, db := range binsDB {
+		p := dbToLinearPower(float64(db))
+		if p < powerFloor {
+			p = powerFloor
+		}
+		lin[i] = p
+		total += p
+	}
+
+	freqOf := func(i int) float64 { return baseHz + float64(i)*binHz }
+
+	// bandPower sums the linear power of bins whose centre frequency falls in
+	// [loHz, hiHz], also returning the bin count for flatness.
+	bandPower := func(loHz, hiHz float64) (sum float64, count int) {
+		for i := 0; i < n; i++ {
+			f := freqOf(i)
+			if f >= loHz && f <= hiHz {
+				sum += lin[i]
+				count++
+			}
+		}
+		return sum, count
+	}
+
+	out := Occupancy{}
+
+	// 99% occupied bandwidth: cumulative power, 0.5% tail on each side.
+	if total > 0 {
+		loTarget := 0.005 * total
+		hiTarget := 0.995 * total
+		var cum float64
+		loBin, hiBin := 0, n-1
+		loSet := false
+		for i := 0; i < n; i++ {
+			cum += lin[i]
+			if !loSet && cum >= loTarget {
+				loBin = i
+				loSet = true
+			}
+			if cum >= hiTarget {
+				hiBin = i
+				break
+			}
+		}
+		out.OccupiedBandwidthHz = float64(hiBin-loBin) * binHz
+	}
+
+	// Main channel power.
+	chBW := channelBWHz
+	if chBW <= 0 {
+		chBW = sampleRateHz // whole span
+	}
+	mainPow, mainCount := bandPower(-chBW/2, chBW/2)
+	out.ChannelPowerDBFS = 10 * math.Log10(math.Max(mainPow, powerFloor))
+
+	// ACPR into the upper/lower adjacent channels.
+	if adjOffsetHz > 0 && adjBWHz > 0 && mainPow > 0 {
+		upPow, _ := bandPower(adjOffsetHz-adjBWHz/2, adjOffsetHz+adjBWHz/2)
+		loPow, _ := bandPower(-adjOffsetHz-adjBWHz/2, -adjOffsetHz+adjBWHz/2)
+		out.ACPRUpperDB = 10 * math.Log10(math.Max(upPow, powerFloor)/mainPow)
+		out.ACPRLowerDB = 10 * math.Log10(math.Max(loPow, powerFloor)/mainPow)
+	}
+
+	// Spectral flatness (Wiener entropy) over the in-channel bins.
+	if mainCount > 0 {
+		var lnSum, arithSum float64
+		for i := 0; i < n; i++ {
+			f := freqOf(i)
+			if f < -chBW/2 || f > chBW/2 {
+				continue
+			}
+			lnSum += math.Log(lin[i])
+			arithSum += lin[i]
+		}
+		geoMean := math.Exp(lnSum / float64(mainCount))
+		arithMean := arithSum / float64(mainCount)
+		if arithMean > 0 {
+			out.SpectralFlatness = geoMean / arithMean
+		}
+	}
+
+	return out
+}

--- a/internal/dsp/spectrum/occupancy_test.go
+++ b/internal/dsp/spectrum/occupancy_test.go
@@ -1,0 +1,66 @@
+package spectrum
+
+import (
+	"math"
+	"testing"
+)
+
+// makeBins returns n dBFS bins at floorDB, with the given bin indices set to
+// peakDB — a tiny synthetic spectrum for the occupancy math.
+func makeBins(n int, floorDB, peakDB float32, peaks ...int) []float32 {
+	b := make([]float32, n)
+	for i := range b {
+		b[i] = floorDB
+	}
+	for _, p := range peaks {
+		if p >= 0 && p < n {
+			b[p] = peakDB
+		}
+	}
+	return b
+}
+
+func TestComputeOccupancyToneIsNarrowAndPeaky(t *testing.T) {
+	const n, fs = 256, 48000.0
+	// A narrow carrier hump straddling DC (bin n/2), everything else at floor.
+	bins := makeBins(n, -80, 0, 126, 127, 128, 129, 130)
+	occ := ComputeOccupancy(bins, fs, 2000, 12500, 2000)
+
+	// 99% bandwidth should be a handful of bins wide, not the whole span.
+	if occ.OccupiedBandwidthHz <= 0 || occ.OccupiedBandwidthHz > 2000 {
+		t.Errorf("tone occupied bandwidth = %.1f Hz, want narrow (0,2000]", occ.OccupiedBandwidthHz)
+	}
+	// A tone is the opposite of flat.
+	if occ.SpectralFlatness >= 0.1 {
+		t.Errorf("tone spectral flatness = %.4f, want ≪ 1", occ.SpectralFlatness)
+	}
+	// Adjacent channels hold only noise floor ⇒ strongly negative ACPR.
+	if occ.ACPRUpperDB >= -40 || occ.ACPRLowerDB >= -40 {
+		t.Errorf("tone ACPR upper=%.1f lower=%.1f dB, want both < -40", occ.ACPRUpperDB, occ.ACPRLowerDB)
+	}
+}
+
+func TestComputeOccupancyWhiteNoiseIsWideAndFlat(t *testing.T) {
+	const n, fs = 256, 48000.0
+	// Every bin equal ⇒ white noise.
+	bins := makeBins(n, -50, -50)
+	occ := ComputeOccupancy(bins, fs, 2000, 12500, 2000)
+
+	// 99% of a flat spectrum spans nearly the whole band.
+	if occ.OccupiedBandwidthHz < 0.95*fs {
+		t.Errorf("white-noise occupied bandwidth = %.1f Hz, want ≈ full span (%.0f)", occ.OccupiedBandwidthHz, fs)
+	}
+	// Equal bins ⇒ geometric mean == arithmetic mean ⇒ flatness ≈ 1.
+	if math.Abs(occ.SpectralFlatness-1) > 1e-6 {
+		t.Errorf("white-noise spectral flatness = %.6f, want ≈ 1", occ.SpectralFlatness)
+	}
+}
+
+func TestComputeOccupancyEmptyOrInvalid(t *testing.T) {
+	if got := ComputeOccupancy(nil, 48000, 2000, 12500, 2000); got != (Occupancy{}) {
+		t.Errorf("nil bins = %+v, want zero Occupancy", got)
+	}
+	if got := ComputeOccupancy(makeBins(64, -50, -50), 0, 2000, 12500, 2000); got != (Occupancy{}) {
+		t.Errorf("zero sample rate = %+v, want zero Occupancy", got)
+	}
+}

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -93,6 +93,9 @@ type ControlChannel struct {
 	// site.
 	rotations RotationSet
 
+	// pduSink mirrors Options.PDUSink — the optional data-PDU dissection feed.
+	pduSink func(SignalingBlock)
+
 	// nidSearchSpan is the per-instance grid radius used by searchNID
 	// in place of the package-level NIDSearchSpan constant — a
 	// bisect knob for issue #275 retests where the closest-miss
@@ -353,6 +356,13 @@ type Options struct {
 	// parity-valid pseudo-NID at a wrong rotation (issue #275).
 	Rotations RotationSet
 
+	// PDUSink, when non-nil, receives one SignalingBlock per TSBK the control
+	// channel decodes (including CRC/trellis-failed blocks) — the data-PDU
+	// dissection feed for SigLab's signaling inspector. It runs on the decode
+	// hot path, so it is invoked only when set; production wiring leaves it nil
+	// and pays nothing.
+	PDUSink func(SignalingBlock)
+
 	// NIDSearchSpan overrides the per-instance NID-alignment grid
 	// radius. Zero falls back to the package-level NIDSearchSpan
 	// constant — the default the ccdecoder pipeline uses in
@@ -455,6 +465,7 @@ func New(opts Options) *ControlChannel {
 		aliasAsm:            NewTalkerAliasAssembler(now),
 		diagSeen:            make(map[uint32]int),
 		rotations:           resolveRotations(opts.Rotations),
+		pduSink:             opts.PDUSink,
 		nidSearchSpan:       span,
 		p25Phase1DemodMode:  opts.P25Phase1DemodMode,
 		p25Phase2Trellis:    opts.P25Phase2Trellis,
@@ -750,6 +761,46 @@ func (c *ControlChannel) parseFrame(buf []uint8, nidStart int, fswRot uint8, req
 // pending and call again once more dibits land. Issue #402: this is what
 // lets blocks 2 and 3 decode even when the receiver hands the dibit
 // stream over in batches smaller than a frame.
+// SignalingBlock is one decoded (or attempted) TSBK signaling block, surfaced
+// to an optional PDUSink for SigLab's data-PDU inspector. It is decoder-neutral
+// and carries the raw opcode/payload plus the FEC/CRC outcome and the absolute
+// symbol offset, so the inspector can dissect, filter, and locate each PDU.
+type SignalingBlock struct {
+	Opcode     uint8
+	OpcodeName string
+	MFID       uint8
+	NAC        uint16
+	LastBlock  bool
+	Protected  bool
+	RawPayload []byte // the 8 opcode octets
+	CRCOK      bool
+	FECMetric  int // Viterbi path metric (0 = clean)
+	DibitStart int // absolute dibit index of this block
+	DibitLen   int // 98 for a TSBK block
+}
+
+// emitSignalingBlock hands one TSBK to the PDU sink when one is registered. It
+// is a no-op (and allocation-free) when the sink is nil, so the production
+// decode path is unaffected.
+func (c *ControlChannel) emitSignalingBlock(t TSBK, nac uint16, metric int, crcOK bool, dibitStart int) {
+	if c.pduSink == nil {
+		return
+	}
+	c.pduSink(SignalingBlock{
+		Opcode:     uint8(t.Opcode),
+		OpcodeName: t.Opcode.String(),
+		MFID:       t.MFID,
+		NAC:        nac,
+		LastBlock:  t.LB,
+		Protected:  t.P,
+		RawPayload: append([]byte(nil), t.Payload[:]...),
+		CRCOK:      crcOK,
+		FECMetric:  metric,
+		DibitStart: dibitStart,
+		DibitLen:   98,
+	})
+}
+
 func (c *ControlChannel) resumeTSBKBlocks(ph *pendingHit) bool {
 	for ph.blocksDone < maxTSBKBlocks {
 		start := ph.nextStart - c.bufBase
@@ -759,6 +810,7 @@ func (c *ControlChannel) resumeTSBKBlocks(ph *pendingHit) bool {
 		if start+tsbkBlockSpan > len(c.buf) {
 			return true // next block not buffered yet — resume later
 		}
+		blockStart := ph.nextStart // absolute dibit index of this TSBK block
 		fswStart := ph.fswStart - c.bufBase
 		tsbkChannel, next := gatherFrameDibits(c.buf, start, 98, fswStart, ph.strip)
 		tsbk, metric, err := DecodeTSBKChannel(rotateDibits(tsbkChannel, ph.rot))
@@ -768,6 +820,11 @@ func (c *ControlChannel) resumeTSBKBlocks(ph *pendingHit) bool {
 			} else {
 				atomic.AddInt64(&c.stats.TSBKTrellisFailed, 1)
 			}
+			// Surface the failed block too — a protocol analyzer shows the bad
+			// frames, not just the clean ones. On CRCError ParseTSBK still
+			// returns the opcode/payload; on a trellis failure they are
+			// best-effort.
+			c.emitSignalingBlock(tsbk, ph.nac, metric, false, blockStart)
 			c.log.Debug("tsbk decode failed", "err", err, "metric", metric,
 				"nac", ph.nac, "block", ph.blocksDone)
 			stage := events.StageTSBKTrellis
@@ -780,6 +837,7 @@ func (c *ControlChannel) resumeTSBKBlocks(ph *pendingHit) bool {
 			})
 			return false // a failed block leaves the next block's alignment unknown
 		}
+		c.emitSignalingBlock(tsbk, ph.nac, metric, true, blockStart)
 		c.dispatchTSBK(tsbk, ph.nac, metric)
 		ph.blocksDone++
 		ph.nextStart = next + c.bufBase

--- a/internal/radio/p25/phase1/metrics/evm.go
+++ b/internal/radio/p25/phase1/metrics/evm.go
@@ -104,10 +104,38 @@ const dqpskPhases = 8
 // 4-point QPSK stream is a subset of the eight phases, so this stays correct
 // for it too.)
 func EVMConstellation(points []complex64) float64 {
+	return VSAMetricsConstellation(points).RMSEVMPct
+}
+
+// VSAResult is the decomposed vector-signal-analyzer view of a recovered
+// constellation: the breakdown a lab VSA reports beside the scatter plot.
+// Percentages are normalized to the unit reference radius; PhaseErrDeg is the
+// RMS angular error in degrees; the per-symbol arrays carry the full time
+// series (EVM% per symbol) and the residual error vectors (measured − nearest
+// ideal, in normalized units) for an error-vector spectrum.
+type VSAResult struct {
+	RMSEVMPct       float64
+	PeakEVMPct      float64
+	MagErrPct       float64
+	PhaseErrDeg     float64
+	OriginOffsetPct float64
+	PerSymbolEVMPct []float32
+	ErrorVectors    []complex64
+}
+
+// VSAMetricsConstellation computes the decomposed VSA metrics of a π/4-DQPSK
+// constellation, reusing the same RMS normalization and 8th-power carrier-phase
+// removal as EVMConstellation (which now delegates here). Beyond the single RMS
+// EVM it returns the peak EVM, the magnitude-error and phase-error components,
+// the origin (DC) offset, and the per-symbol EVM trace + residual error vectors.
+// Returns a zero VSAResult for an empty input or a degenerate (zero-power)
+// constellation.
+func VSAMetricsConstellation(points []complex64) VSAResult {
 	if len(points) == 0 {
-		return 0
+		return VSAResult{}
 	}
 	var sumSq float64
+	var meanI, meanQ float64
 	// 8th-power phase estimator: Σ exp(j·8·θ) concentrates the eight-phase
 	// modulation onto one tone, so its argument /8 is the common carrier-phase
 	// offset the recovery loop happened to lock at. Removing it makes the EVM
@@ -118,13 +146,16 @@ func EVMConstellation(points []complex64) float64 {
 	for _, p := range points {
 		i, q := float64(real(p)), float64(imag(p))
 		sumSq += i*i + q*q
+		meanI += i
+		meanQ += q
 		ang := dqpskPhases * math.Atan2(q, i)
 		pwrReal += math.Cos(ang)
 		pwrImag += math.Sin(ang)
 	}
-	rms := math.Sqrt(sumSq / float64(len(points)))
+	n := float64(len(points))
+	rms := math.Sqrt(sumSq / n)
 	if rms <= 0 {
-		return 0
+		return VSAResult{}
 	}
 	offset := math.Atan2(pwrImag, pwrReal) / dqpskPhases
 	cosO, sinO := math.Cos(-offset), math.Sin(-offset)
@@ -135,23 +166,81 @@ func EVMConstellation(points []complex64) float64 {
 		ang := float64(k) * 2 * math.Pi / dqpskPhases
 		ideal[k] = [2]float64{math.Cos(ang), math.Sin(ang)}
 	}
-	var errSq float64
-	for _, p := range points {
+
+	out := VSAResult{
+		PerSymbolEVMPct: make([]float32, len(points)),
+		ErrorVectors:    make([]complex64, len(points)),
+	}
+	var errSq, magSq, phaseSq float64
+	for idx, p := range points {
 		// Normalize to unit reference and derotate by the recovered offset.
 		ri := float64(real(p)) / rms
 		rq := float64(imag(p)) / rms
 		i := ri*cosO - rq*sinO
 		q := ri*sinO + rq*cosO
 		best := math.Inf(1)
+		var bid [2]float64
 		for _, id := range ideal {
 			di := i - id[0]
 			dq := q - id[1]
 			d := di*di + dq*dq
 			if d < best {
 				best = d
+				bid = id
 			}
 		}
 		errSq += best
+		out.PerSymbolEVMPct[idx] = float32(100 * math.Sqrt(best))
+		out.ErrorVectors[idx] = complex(float32(i-bid[0]), float32(q-bid[1]))
+		if math.Sqrt(best)*100 > out.PeakEVMPct {
+			out.PeakEVMPct = math.Sqrt(best) * 100
+		}
+		// Magnitude error: |r̂| − |ideal| (ideal is unit). Phase error: angle
+		// between r̂ and its nearest ideal, via the signed cross/dot product.
+		magErr := math.Hypot(i, q) - 1
+		magSq += magErr * magErr
+		phaseErr := math.Atan2(bid[0]*q-bid[1]*i, i*bid[0]+q*bid[1])
+		phaseSq += phaseErr * phaseErr
 	}
-	return 100 * math.Sqrt(errSq/float64(len(points)))
+	out.RMSEVMPct = 100 * math.Sqrt(errSq/n)
+	out.MagErrPct = 100 * math.Sqrt(magSq/n)
+	out.PhaseErrDeg = math.Sqrt(phaseSq/n) * 180 / math.Pi
+	// Origin offset: residual DC (carrier leakage) as a fraction of the
+	// reference radius — the un-derotated complex mean over the RMS radius.
+	out.OriginOffsetPct = 100 * math.Hypot(meanI/n, meanQ/n) / rms
+	return out
+}
+
+// VSAMetricsC4FM is the C4FM-soft-axis analog of VSAMetricsConstellation. The
+// FM discriminator output is one-dimensional, so there is no I/Q plane: only
+// the EVM/magnitude components and the per-symbol trace are meaningful; phase,
+// quadrature, and origin offset are left zero. outer is the outer-rail
+// reference (see EVMC4FM).
+func VSAMetricsC4FM(soft []float32, outer float64) VSAResult {
+	if len(soft) == 0 || outer <= 0 {
+		return VSAResult{}
+	}
+	inner := outer * c4fmInnerRatio
+	rails := [4]float64{-outer, -inner, inner, outer}
+	out := VSAResult{PerSymbolEVMPct: make([]float32, len(soft))}
+	var sumSq float64
+	for idx, s := range soft {
+		x := float64(s)
+		best := math.Inf(1)
+		for _, r := range rails {
+			d := x - r
+			if d*d < best {
+				best = d * d
+			}
+		}
+		sumSq += best
+		ev := 100 * math.Sqrt(best) / outer
+		out.PerSymbolEVMPct[idx] = float32(ev)
+		if ev > out.PeakEVMPct {
+			out.PeakEVMPct = ev
+		}
+	}
+	out.RMSEVMPct = 100 * math.Sqrt(sumSq/float64(len(soft))) / outer
+	out.MagErrPct = out.RMSEVMPct // 1-D: the error is purely along the rail axis
+	return out
 }

--- a/internal/radio/p25/phase1/metrics/vsa_test.go
+++ b/internal/radio/p25/phase1/metrics/vsa_test.go
@@ -1,0 +1,92 @@
+package metrics
+
+import (
+	"math"
+	"math/cmplx"
+	"testing"
+)
+
+// dqpskPoints builds n π/4-DQPSK points cycling the eight ideal phases, each
+// scaled by radiusOf(i) and rotated by extraPhaseRad(i) — the knobs the tests
+// use to inject pure magnitude vs pure phase error.
+func dqpskPoints(n int, radiusOf func(int) float64, extraPhaseRad func(int) float64) []complex64 {
+	pts := make([]complex64, n)
+	for i := 0; i < n; i++ {
+		ang := float64(i%dqpskPhases)*2*math.Pi/dqpskPhases + extraPhaseRad(i)
+		pts[i] = complex64(cmplx.Rect(radiusOf(i), ang))
+	}
+	return pts
+}
+
+func TestVSAMetricsCleanConstellationIsTight(t *testing.T) {
+	pts := dqpskPoints(64, func(int) float64 { return 1 }, func(int) float64 { return 0 })
+	v := VSAMetricsConstellation(pts)
+	if v.RMSEVMPct > 1 || v.PhaseErrDeg > 1 || v.MagErrPct > 1 {
+		t.Errorf("clean: rms=%.3f phase=%.3f mag=%.3f, want all ≈0", v.RMSEVMPct, v.PhaseErrDeg, v.MagErrPct)
+	}
+	if v.PeakEVMPct < v.RMSEVMPct {
+		t.Errorf("peak EVM %.3f < rms EVM %.3f", v.PeakEVMPct, v.RMSEVMPct)
+	}
+	if len(v.PerSymbolEVMPct) != len(pts) || len(v.ErrorVectors) != len(pts) {
+		t.Errorf("per-symbol arrays len = %d/%d, want %d", len(v.PerSymbolEVMPct), len(v.ErrorVectors), len(pts))
+	}
+	// The scalar wrapper must match the decomposed RMS.
+	if got := EVMConstellation(pts); math.Abs(got-v.RMSEVMPct) > 1e-9 {
+		t.Errorf("EVMConstellation %.6f != VSA RMS %.6f", got, v.RMSEVMPct)
+	}
+}
+
+func TestVSAMetricsPhaseErrorIsolated(t *testing.T) {
+	// Alternating ±5° jitter (zero-mean, so the 8th-power carrier estimate is
+	// unaffected): raises phase error, leaves magnitude error ≈0.
+	jit := 5 * math.Pi / 180
+	pts := dqpskPoints(64, func(int) float64 { return 1 }, func(i int) float64 {
+		if i%2 == 0 {
+			return jit
+		}
+		return -jit
+	})
+	v := VSAMetricsConstellation(pts)
+	if v.PhaseErrDeg < 3 {
+		t.Errorf("phase error = %.2f°, want ≈5°", v.PhaseErrDeg)
+	}
+	if v.MagErrPct > 1 {
+		t.Errorf("magnitude error = %.2f%%, want ≈0 under pure phase jitter", v.MagErrPct)
+	}
+	if v.PhaseErrDeg <= v.MagErrPct {
+		t.Errorf("phase (%.2f) should dominate magnitude (%.2f) under phase jitter", v.PhaseErrDeg, v.MagErrPct)
+	}
+}
+
+func TestVSAMetricsMagnitudeErrorIsolated(t *testing.T) {
+	// Alternating ±10% amplitude, exact phase: raises magnitude error, leaves
+	// phase error ≈0.
+	pts := dqpskPoints(64, func(i int) float64 {
+		if i%2 == 0 {
+			return 1.1
+		}
+		return 0.9
+	}, func(int) float64 { return 0 })
+	v := VSAMetricsConstellation(pts)
+	if v.MagErrPct < 3 {
+		t.Errorf("magnitude error = %.2f%%, want ≈10%%", v.MagErrPct)
+	}
+	if v.PhaseErrDeg > 1 {
+		t.Errorf("phase error = %.2f°, want ≈0 under pure amplitude error", v.PhaseErrDeg)
+	}
+}
+
+func TestVSAMetricsC4FMTracksEVM(t *testing.T) {
+	soft := []float32{3, 1, -1, -3, 3, 1, -1, -3}
+	v := VSAMetricsC4FM(soft, 3)
+	if v.RMSEVMPct > 1 {
+		t.Errorf("clean C4FM rails: rms EVM = %.3f, want ≈0", v.RMSEVMPct)
+	}
+	if v.PeakEVMPct < v.RMSEVMPct || len(v.PerSymbolEVMPct) != len(soft) {
+		t.Errorf("peak %.3f rms %.3f trace %d", v.PeakEVMPct, v.RMSEVMPct, len(v.PerSymbolEVMPct))
+	}
+	// Phase/quadrature/origin are undefined on the 1-D soft axis.
+	if v.PhaseErrDeg != 0 || v.OriginOffsetPct != 0 {
+		t.Errorf("C4FM phase=%.3f origin=%.3f, want 0", v.PhaseErrDeg, v.OriginOffsetPct)
+	}
+}

--- a/internal/radio/p25/phase1/signaling_tap_test.go
+++ b/internal/radio/p25/phase1/signaling_tap_test.go
@@ -1,0 +1,82 @@
+package phase1
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// TestPDUSinkEmitsDecodedBlock confirms a registered PDUSink receives one
+// SignalingBlock per decoded TSBK, carrying the opcode name, MFID, NAC, raw
+// payload, CRC-OK flag and a plausible dibit offset.
+func TestPDUSinkEmitsDecodedBlock(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	var blocks []SignalingBlock
+	groupPayload := [8]byte{0x00, (1 << 4) | 0x00, 0x10, 0x00, 0xCC, 0x00, 0x04, 0xD2}
+	tsbk := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant, Payload: groupPayload}
+
+	cc := New(Options{
+		Bus:         bus,
+		FrequencyHz: 450_125_000,
+		PDUSink:     func(b SignalingBlock) { blocks = append(blocks, b) },
+	})
+	stream := buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk)
+	cc.Process(stream, 0)
+
+	if len(blocks) == 0 {
+		t.Fatal("PDUSink received no signaling blocks")
+	}
+	b := blocks[0]
+	if b.Opcode != uint8(OpGroupVoiceChannelGrant) {
+		t.Errorf("opcode = %d, want %d", b.Opcode, OpGroupVoiceChannelGrant)
+	}
+	if b.OpcodeName != OpGroupVoiceChannelGrant.String() {
+		t.Errorf("opcode name = %q, want %q", b.OpcodeName, OpGroupVoiceChannelGrant.String())
+	}
+	if b.NAC != 0x293 {
+		t.Errorf("NAC = %#x, want 0x293", b.NAC)
+	}
+	if !b.CRCOK {
+		t.Error("CRCOK = false, want true for a clean block")
+	}
+	if !b.LastBlock {
+		t.Error("LastBlock = false, want true")
+	}
+	if len(b.RawPayload) != 8 || b.RawPayload[4] != 0xCC {
+		t.Errorf("RawPayload = %v, want the 8 opcode octets with byte4=0xCC", b.RawPayload)
+	}
+	if b.DibitLen != 98 || b.DibitStart < 0 {
+		t.Errorf("DibitStart=%d DibitLen=%d, want start>=0 len=98", b.DibitStart, b.DibitLen)
+	}
+}
+
+// TestPDUSinkEmitsCorruptedBlock confirms a CRC-failed block is still surfaced
+// (with CRCOK=false) — the protocol-analyzer view includes the bad frames.
+func TestPDUSinkEmitsCorruptedBlock(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+
+	var blocks []SignalingBlock
+	tsbk := TSBK{LB: true, Opcode: OpGroupVoiceChannelGrant}
+	cc := New(Options{
+		Bus:         bus,
+		FrequencyHz: 450_125_000,
+		PDUSink:     func(b SignalingBlock) { blocks = append(blocks, b) },
+	})
+	// Corrupt the TSBK channel region of an otherwise-valid frame so the CRC
+	// fails while the NID still aligns.
+	stream := buildLockedStreamWithTSBK(10, 0x293, DUIDTrunkingSignaling, tsbk)
+	for i := len(stream) - 40; i < len(stream)-20 && i >= 0; i++ {
+		stream[i] ^= 0x3 // flip dibits inside the TSBK payload
+	}
+	cc.Process(stream, 0)
+
+	if len(blocks) == 0 {
+		t.Fatal("no signaling block emitted for the corrupted frame")
+	}
+	if blocks[0].CRCOK {
+		t.Error("CRCOK = true for a corrupted block, want false")
+	}
+}

--- a/internal/siglab/config.go
+++ b/internal/siglab/config.go
@@ -99,6 +99,11 @@ type Config struct {
 	// capture, bounding per-candidate cost regardless of capture length.
 	MaxSamples int64
 
+	// CollectPDUs retains a per-signaling-block dissection (Result.PDUs) of the
+	// data PDUs the decoder parses — the data-over-RF inspector feed. Off by
+	// default; P25 Phase 1 (TSBK) only for now. Capped at pduMaxRecords.
+	CollectPDUs bool
+
 	// Acceptance, when non-nil, is evaluated against the Result to produce a
 	// pass/fail Verdict (the `test` harness sets it).
 	Acceptance *Acceptance
@@ -152,7 +157,7 @@ func (c Config) wantP25Deep() bool {
 	if c.Protocol != trunking.ProtocolP25 {
 		return false
 	}
-	return c.CollectIQDiag || c.CollectReceiverState ||
+	return c.CollectIQDiag || c.CollectReceiverState || c.CollectPDUs ||
 		c.NIDSearchSpan > 0 || c.EnableDDA || c.EnableAdaptiveSlicer ||
 		c.EnableSoftSync || c.DemodMode != ""
 }

--- a/internal/siglab/demodmetrics_test.go
+++ b/internal/siglab/demodmetrics_test.go
@@ -54,7 +54,40 @@ func TestDemodMetricsPopulated(t *testing.T) {
 			if noisy.SNREstimateDB >= clean.SNREstimateDB {
 				t.Errorf("noise did not lower SNR estimate: clean=%.2f noisy=%.2f", clean.SNREstimateDB, noisy.SNREstimateDB)
 			}
+
+			// VSA decomposition: peak ≥ rms, the EVM trace is populated, and
+			// the worst-symbol EVM rises with noise.
+			if clean.PeakEVMPct < clean.EVMPct {
+				t.Errorf("peak EVM %.2f < rms EVM %.2f", clean.PeakEVMPct, clean.EVMPct)
+			}
+			if len(clean.EVMTrace) == 0 {
+				t.Error("EVMTrace empty, want per-symbol trace")
+			}
+			if noisy.PeakEVMPct <= clean.PeakEVMPct {
+				t.Errorf("noise did not raise peak EVM: clean=%.2f noisy=%.2f", clean.PeakEVMPct, noisy.PeakEVMPct)
+			}
 		})
+	}
+}
+
+// TestDemodVSACarrierError confirms the receiver's settled carrier-frequency
+// estimate is surfaced onto the VSA metrics: a synthesized capture with a known
+// injected frequency offset reads back ≈that offset on the CQPSK path.
+func TestDemodVSACarrierError(t *testing.T) {
+	const injectedHz = 500.0
+	synth := SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32, Modulation: "lsm"}
+	synth.Impairments = demod.Impairments{FreqOffsetHz: injectedHz, Seed: 1}
+	res, _, err := SynthesizeAndAnalyze(synth, Config{CollectIQDiag: true, DemodMode: "cqpsk"}, nil)
+	if err != nil {
+		t.Fatalf("SynthesizeAndAnalyze: %v", err)
+	}
+	if res.Signal == nil || res.Signal.Demod == nil {
+		t.Fatal("no DemodMetrics")
+	}
+	got := res.Signal.Demod.CarrierFreqErrorHz
+	t.Logf("injected %.0f Hz, reported carrier error %.1f Hz", injectedHz, got)
+	if math.Abs(got-injectedHz) > 0.5*injectedHz+150 {
+		t.Errorf("CarrierFreqErrorHz = %.1f Hz, want ≈ %.0f Hz (injected)", got, injectedHz)
 	}
 }
 

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
@@ -292,10 +293,19 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 		}
 	}
 
+	// Optional per-signaling-block (TSBK) dissection for the data-PDU inspector
+	// — P25 deep path only.
+	var pduColl *pduCollector
+	var pduTap func(p25phase1.SignalingBlock)
+	if cfg.CollectPDUs {
+		pduColl = newPDUCollector(expectedSymbolRate(cfg.Protocol))
+		pduTap = pduColl.observeP25
+	}
+
 	// Build the run bundle: either a generic factory pipeline (any protocol)
 	// or the P25 Phase 1 deep path (direct receiver + control channel with
 	// soft/state capture and the experimental bisect knobs).
-	bundle, err := buildBundle(cfg, bus, logger, receiverRate, symbolTap, softTap, constTap)
+	bundle, err := buildBundle(cfg, bus, logger, receiverRate, symbolTap, softTap, constTap, pduTap)
 	if err != nil {
 		sub.Close()
 		bus.Close()
@@ -471,6 +481,12 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 		res.Signal.Demod.CarrierFreqErrorHz = bundle.carrierErrHz()
 	}
 
+	// Attach the per-signaling-block dissection (data-PDU inspector feed).
+	if pduColl != nil {
+		res.PDUs = pduColl.recs
+		res.PDUsTruncated = pduColl.truncated
+	}
+
 	// Name *why* the control channel did not lock (SNR-limited / misaligned /
 	// not-control / no-signal), from the demod + frame-decode metrics now
 	// attached — so a capture-quality failure is not misread as a tuning or AGC
@@ -560,9 +576,9 @@ type runBundle struct {
 // when requested, otherwise the generic factory pipeline (any protocol). Both
 // publish lock/grant/decode-error events to bus and feed symbolTap; only the
 // deep path feeds softTap and exposes state/ccStats.
-func buildBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate float64, symbolTap func([]uint8, bool, int), softTap func([]float32), constTap func([]complex64)) (*runBundle, error) {
+func buildBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate float64, symbolTap func([]uint8, bool, int), softTap func([]float32), constTap func([]complex64), pduTap func(p25phase1.SignalingBlock)) (*runBundle, error) {
 	if cfg.wantP25Deep() {
-		return buildP25DeepBundle(cfg, bus, logger, receiverRate, symbolTap, softTap, constTap)
+		return buildP25DeepBundle(cfg, bus, logger, receiverRate, symbolTap, softTap, constTap, pduTap)
 	}
 	pipe, ok, err := ccdecoder.NewPipeline(cfg.Protocol, ccdecoder.PipelineOptions{
 		Bus:          bus,

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -465,6 +465,12 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 		}
 	}
 
+	// Surface the receiver's settled carrier-frequency error onto the VSA demod
+	// metrics (deep path only; the generic factory path exposes no AFC loop).
+	if bundle.carrierErrHz != nil && res.Signal != nil && res.Signal.Demod != nil {
+		res.Signal.Demod.CarrierFreqErrorHz = bundle.carrierErrHz()
+	}
+
 	// Name *why* the control channel did not lock (SNR-limited / misaligned /
 	// not-control / no-signal), from the demod + frame-decode metrics now
 	// attached — so a capture-quality failure is not misread as a tuning or AGC
@@ -519,7 +525,7 @@ func assembleResult(source string, cfg Config, totalSamples, symbols int64, rece
 		decodeErrTotal += int64(n)
 	}
 	if an != nil {
-		res.Signal = an.result(decodeErrTotal)
+		res.Signal = an.result(decodeErrTotal, cfg.captureIQMaxPoints())
 	}
 
 	if cfg.Acceptance != nil {
@@ -545,6 +551,9 @@ type runBundle struct {
 	stateAt  func(t float64) ReceiverState
 	ccStats  func() *CCStatsBreakdown
 	topology func() *TopologySnapshot
+	// carrierErrHz reports the receiver's settled residual carrier-frequency
+	// error (Hz) for the VSA metrics. Nil on the generic factory path.
+	carrierErrHz func() float64
 }
 
 // buildBundle constructs the run bundle for cfg: the P25 Phase 1 deep path

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -96,6 +96,12 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 			}
 		},
 		topology: func() *TopologySnapshot { return cc.TopologySnapshot() },
+		carrierErrHz: func() float64 {
+			if isCQPSK {
+				return rx.CQPSKCarrierOffsetHz()
+			}
+			return rx.AFCOffsetHz()
+		},
 	}, nil
 }
 

--- a/internal/siglab/engine_p25.go
+++ b/internal/siglab/engine_p25.go
@@ -22,7 +22,7 @@ const p25DeviationHz = 1800.0
 // the production newP25Phase1Pipeline construction so a deep replay lock still
 // implies an on-air lock, while surfacing the diagnostics the factory path
 // cannot.
-func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate float64, symbolTap func([]uint8, bool, int), softTap func([]float32), constTap func([]complex64)) (*runBundle, error) {
+func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiverRate float64, symbolTap func([]uint8, bool, int), softTap func([]float32), constTap func([]complex64), pduTap func(p25phase1.SignalingBlock)) (*runBundle, error) {
 	demodMode := p25phase1rx.DemodC4FM
 	if cfg.DemodMode != "" {
 		m, ok := p25phase1rx.ParseDemodMode(cfg.DemodMode)
@@ -54,6 +54,7 @@ func buildP25DeepBundle(cfg Config, bus *events.Bus, logger *slog.Logger, receiv
 		Rotations:            rotations,
 		NIDSearchSpan:        nidSpan,
 		FSWFallbackTolerance: fswFallbackTol,
+		PDUSink:              pduTap, // nil unless Config.CollectPDUs
 	})
 	rx := p25phase1rx.New(p25phase1rx.Options{
 		SampleRateHz:              receiverRate,

--- a/internal/siglab/export.go
+++ b/internal/siglab/export.go
@@ -30,6 +30,8 @@ const (
 	FormatCSVSummary
 	// FormatCSVEvents is a CSV with one row per captured event.
 	FormatCSVEvents
+	// FormatCSVPDUs is a CSV with one row per dissected signaling PDU.
+	FormatCSVPDUs
 )
 
 // ParseFormat maps a -format flag value to a Format. csv defaults to the
@@ -48,8 +50,10 @@ func ParseFormat(s string) (Format, error) {
 		return FormatCSVSummary, nil
 	case "csv-events":
 		return FormatCSVEvents, nil
+	case "csv-pdus":
+		return FormatCSVPDUs, nil
 	default:
-		return FormatTextSummary, fmt.Errorf("siglab: unknown format %q (want json|jsonl|yaml|csv|csv-events)", s)
+		return FormatTextSummary, fmt.Errorf("siglab: unknown format %q (want json|jsonl|yaml|csv|csv-events|csv-pdus)", s)
 	}
 }
 
@@ -75,6 +79,8 @@ func WriteResult(w io.Writer, r *Result, f Format) error {
 		return writeCSVSummary(w, r)
 	case FormatCSVEvents:
 		return writeCSVEvents(w, r)
+	case FormatCSVPDUs:
+		return writeCSVPDUs(w, r)
 	case FormatTextSummary:
 		return fmt.Errorf("siglab: text summary is rendered by the caller, not WriteResult")
 	default:
@@ -154,6 +160,38 @@ func writeCSVEvents(w io.Writer, r *Result) error {
 		}
 		row := []string{
 			strconv.Itoa(ev.Seq), ftoa(ev.OffsetSec), ev.Kind, string(fields),
+		}
+		if err := cw.Write(row); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+// writeCSVPDUs writes one row per dissected signaling PDU, mirroring the
+// csv-events shape: the promoted entity IDs in their own columns and the
+// opcode-specific Fields JSON-encoded into a single stable column.
+func writeCSVPDUs(w io.Writer, r *Result) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{
+		"seq", "offset_sec", "protocol", "opcode", "opcode_name", "nac",
+		"source_id", "dest_id", "talkgroup", "crc_ok", "fec_metric",
+		"dibit_start", "raw_hex", "fields_json",
+	}); err != nil {
+		return err
+	}
+	for _, p := range r.PDUs {
+		fields, err := json.Marshal(p.Fields)
+		if err != nil {
+			return err
+		}
+		row := []string{
+			strconv.Itoa(p.Seq), ftoa(p.OffsetSec), p.Protocol,
+			strconv.Itoa(int(p.Opcode)), p.OpcodeName, strconv.Itoa(int(p.NAC)),
+			strconv.Itoa(int(p.SourceID)), strconv.Itoa(int(p.DestID)), strconv.Itoa(int(p.Talkgroup)),
+			strconv.FormatBool(p.CRCOK), strconv.Itoa(p.FECMetric),
+			strconv.Itoa(p.DibitStart), p.RawHex, string(fields),
 		}
 		if err := cw.Write(row); err != nil {
 			return err

--- a/internal/siglab/identify.go
+++ b/internal/siglab/identify.go
@@ -10,7 +10,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/blind"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab/sigref"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -56,6 +58,13 @@ type IdentifyResult struct {
 	// non-dominant carrier, not the band's loudest). 0 when no shift was used.
 	TuneHz     float64          `json:"tune_hz"`
 	Candidates []CandidateScore `json:"candidates"`
+
+	// Blind / ReferenceMatches are the offline-signal-ID fallback, populated
+	// only when the decode-based identification is Inconclusive: the blind
+	// symbol-rate/modulation estimate and the reference-database candidates it
+	// ranks (so an undecodable carrier is still named a best guess).
+	Blind            *blind.BlindEstimate `json:"blind,omitempty"`
+	ReferenceMatches []sigref.Match       `json:"reference_matches,omitempty"`
 }
 
 // maxIdentifyCarrierCandidates caps how many carrier offsets the auto-tune
@@ -181,7 +190,42 @@ func IdentifyReader(r io.ReadSeeker, source string, cfg IdentifyConfig) (*Identi
 	out.Winner = bestScores[0].Protocol
 	out.Confidence = bestConf
 	out.Inconclusive = bestConf < identifyConfidenceFloor
+	if out.Inconclusive {
+		// Nothing decoded with confidence — fall back to the offline reference
+		// DB: blindly estimate the carrier's symbol rate / modulation and name
+		// the closest catalog signals. Best-effort; a read error just leaves
+		// the fallback empty.
+		attachReferenceFallback(r, cfg, out)
+	}
 	return out, nil
+}
+
+// attachReferenceFallback runs the blind estimator over a prefix of the capture
+// and ranks it against the signal-ID reference database, attaching the result to
+// out. It is invoked only for an inconclusive identification, so the
+// decode-based happy path is untouched.
+func attachReferenceFallback(r io.ReadSeeker, cfg IdentifyConfig, out *IdentifyResult) {
+	// The scan loop leaves r at EOF; rewind before reading the prefix.
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return
+	}
+	decode, bytesPerSample := cfg.Format.Decoder()
+	iq, err := readCarrierPrefix(r, decode, bytesPerSample)
+	if err != nil || len(iq) == 0 {
+		return
+	}
+	est := blind.Estimate(iq, cfg.SampleRateHz)
+	if est.SymbolRateHz <= 0 {
+		return
+	}
+	out.Blind = &est
+	out.ReferenceMatches = sigref.Rank(sigref.Observation{
+		SymbolRateHz:   est.SymbolRateHz,
+		SymbolRateConf: est.SymbolRateConf,
+		ModClass:       est.ModClass,
+		Levels:         est.Levels,
+		ChannelBWHz:    est.OccupiedBWHz,
+	}, 5)
 }
 
 // scanProtocolsAtOffset runs every candidate protocol over the capture with the

--- a/internal/siglab/identify_reference_test.go
+++ b/internal/siglab/identify_reference_test.go
@@ -1,0 +1,62 @@
+package siglab
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// gen4FSK builds a clean 4-FSK carrier with no valid protocol structure, so no
+// decoder locks — exercising the inconclusive → reference-DB fallback path.
+func gen4FSK(rateHz, baudHz, devHz float64, nSym int) []complex64 {
+	sps := int(math.Round(rateHz / baudHz))
+	lv := []float64{-1, -1.0 / 3, 1.0 / 3, 1}
+	out := make([]complex64, 0, sps*nSym)
+	phase, seed := 0.0, 987654321
+	for s := 0; s < nSym; s++ {
+		seed = (seed*1103515245 + 12345) & 0x7fffffff
+		dphi := 2 * math.Pi * (lv[(seed>>16)%4] * devHz) / rateHz
+		for k := 0; k < sps; k++ {
+			phase += dphi
+			out = append(out, complex64(complex(math.Cos(phase), math.Sin(phase))))
+		}
+	}
+	return out
+}
+
+// TestIdentifyReferenceFallback feeds a structureless 4-FSK carrier that no
+// decoder can lock and asserts the offline reference DB still names it from its
+// blind symbol-rate / modulation estimate.
+func TestIdentifyReferenceFallback(t *testing.T) {
+	iq := gen4FSK(48000, 4800, 1800, 8000)
+	res, err := IdentifyIQ(iq, "synthetic-4fsk", IdentifyConfig{
+		SampleRateHz: 48000,
+		Format:       FormatF32,
+		// Restrict to a couple of decoders that cannot lock structureless
+		// noise, guaranteeing the inconclusive fallback path.
+		Candidates: []trunking.Protocol{trunking.ProtocolP25, trunking.ProtocolDMR},
+	})
+	if err != nil {
+		t.Fatalf("IdentifyIQ: %v", err)
+	}
+	if !res.Inconclusive {
+		t.Fatalf("expected inconclusive identification, got winner=%q conf=%.2f", res.Winner, res.Confidence)
+	}
+	if res.Blind == nil {
+		t.Fatal("no blind estimate attached")
+	}
+	if rel := math.Abs(res.Blind.SymbolRateHz-4800) / 4800; rel > 0.05 {
+		t.Errorf("blind symbol rate = %.0f Hz, want ≈ 4800 Hz", res.Blind.SymbolRateHz)
+	}
+	if len(res.ReferenceMatches) == 0 {
+		t.Fatal("no reference matches for an undecodable carrier")
+	}
+	// The top match should be a 4800-baud 4FSK family protocol.
+	top := res.ReferenceMatches[0].Entry
+	if math.Abs(top.SymbolRateHz-4800) > 100 {
+		t.Errorf("top reference match = %s (%.0f sym/s), want a ~4800-baud signal; why=%q",
+			top.DisplayName, top.SymbolRateHz, res.ReferenceMatches[0].Why)
+	}
+	t.Logf("named undecodable carrier as %q (%.2f): %s", top.DisplayName, res.ReferenceMatches[0].Score, res.ReferenceMatches[0].Why)
+}

--- a/internal/siglab/pdu.go
+++ b/internal/siglab/pdu.go
@@ -1,0 +1,108 @@
+package siglab
+
+import (
+	"encoding/hex"
+
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+)
+
+// pduMaxRecords caps the per-signaling-block dissection a run retains, so a long
+// busy control-channel capture cannot grow Result.PDUs without bound. Mirrors
+// the IQ-tap cap discipline.
+const pduMaxRecords = 5000
+
+// PDURecord is one decoded (or attempted) data/signaling PDU, surfaced for
+// SigLab's data-over-RF inspector. It is a flattened, export-friendly view of a
+// decoder SignalingBlock with the common entity IDs promoted out of Fields for
+// filtering.
+type PDURecord struct {
+	Seq        int            `json:"seq" yaml:"seq"`
+	OffsetSec  float64        `json:"offset_sec" yaml:"offset_sec"`
+	Protocol   string         `json:"protocol" yaml:"protocol"`
+	Opcode     uint8          `json:"opcode" yaml:"opcode"`
+	OpcodeName string         `json:"opcode_name" yaml:"opcode_name"`
+	MFID       uint8          `json:"mfid,omitempty" yaml:"mfid,omitempty"`
+	NAC        uint16         `json:"nac,omitempty" yaml:"nac,omitempty"`
+	SourceID   uint32         `json:"source_id,omitempty" yaml:"source_id,omitempty"`
+	DestID     uint32         `json:"dest_id,omitempty" yaml:"dest_id,omitempty"`
+	Talkgroup  uint32         `json:"talkgroup,omitempty" yaml:"talkgroup,omitempty"`
+	Fields     map[string]any `json:"fields,omitempty" yaml:"fields,omitempty"`
+	RawHex     string         `json:"raw_hex" yaml:"raw_hex"`
+	CRCOK      bool           `json:"crc_ok" yaml:"crc_ok"`
+	FECMetric  int            `json:"fec_metric" yaml:"fec_metric"`
+	DibitStart int            `json:"dibit_start" yaml:"dibit_start"`
+	DibitLen   int            `json:"dibit_len" yaml:"dibit_len"`
+}
+
+// pduCollector accumulates the per-block dissection from the decoder's PDU sink.
+// It is driven from a single goroutine (the read loop), so it needs no locking.
+type pduCollector struct {
+	recs      []PDURecord
+	max       int
+	truncated bool
+	baudHz    float64 // for OffsetSec from DibitStart
+}
+
+func newPDUCollector(baudHz float64) *pduCollector {
+	return &pduCollector{max: pduMaxRecords, baudHz: baudHz}
+}
+
+// observeP25 folds one P25 Phase 1 signaling block into the collection.
+func (p *pduCollector) observeP25(b p25phase1.SignalingBlock) {
+	if len(p.recs) >= p.max {
+		p.truncated = true
+		return
+	}
+	rec := PDURecord{
+		Seq:        len(p.recs),
+		Protocol:   "p25p1",
+		Opcode:     b.Opcode,
+		OpcodeName: b.OpcodeName,
+		MFID:       b.MFID,
+		NAC:        b.NAC,
+		RawHex:     hex.EncodeToString(b.RawPayload),
+		CRCOK:      b.CRCOK,
+		FECMetric:  b.FECMetric,
+		DibitStart: b.DibitStart,
+		DibitLen:   b.DibitLen,
+	}
+	if p.baudHz > 0 {
+		rec.OffsetSec = float64(b.DibitStart) / p.baudHz
+	}
+	if b.CRCOK {
+		dissectP25TSBK(&rec, b) // only a CRC-valid payload is worth field-decoding
+	}
+	p.recs = append(p.recs, rec)
+}
+
+// dissectP25TSBK decodes the high-value P25 opcodes into promoted entity IDs
+// and a Fields map, reusing the decoder's own Parse* field decoders. Opcodes
+// not handled here still carry their name + raw hex.
+func dissectP25TSBK(rec *PDURecord, b p25phase1.SignalingBlock) {
+	var payload [8]byte
+	copy(payload[:], b.RawPayload)
+	f := map[string]any{}
+	switch p25phase1.Opcode(b.Opcode) {
+	case p25phase1.OpGroupVoiceChannelGrant:
+		g := p25phase1.ParseGroupVoiceChannelGrant(payload)
+		rec.Talkgroup, rec.SourceID = uint32(g.GroupAddress), g.SourceID
+		f["GroupAddress"], f["SourceID"] = g.GroupAddress, g.SourceID
+		f["ChannelID"], f["ChannelNumber"] = g.ChannelID, g.ChannelNumber
+	case p25phase1.OpUnitToUnitVoiceChannelGrant:
+		g := p25phase1.ParseUnitToUnitVoiceChannelGrant(payload)
+		rec.DestID, rec.SourceID = g.TargetID, g.SourceID
+		f["TargetID"], f["SourceID"] = g.TargetID, g.SourceID
+		f["ChannelID"], f["ChannelNumber"] = g.ChannelID, g.ChannelNumber
+	case p25phase1.OpGroupAffiliationResponse:
+		a := p25phase1.ParseGroupAffiliationResponse(payload)
+		rec.Talkgroup, rec.SourceID = uint32(a.GroupAddress), a.TargetID
+		f["GroupAddress"], f["TargetID"] = a.GroupAddress, a.TargetID
+	case p25phase1.OpUnitRegistrationResponse:
+		u := p25phase1.ParseUnitRegistrationResponse(payload)
+		rec.SourceID = u.SourceID
+		f["SourceID"], f["SourceAddress"] = u.SourceID, u.SourceAddress
+	}
+	if len(f) > 0 {
+		rec.Fields = f
+	}
+}

--- a/internal/siglab/pdu_test.go
+++ b/internal/siglab/pdu_test.go
@@ -1,0 +1,73 @@
+package siglab
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestCollectPDUs synthesizes a P25 Phase 1 control channel, replays it with
+// CollectPDUs set, and asserts the per-signaling-block dissection is populated
+// with named opcodes and monotonically-increasing offsets.
+func TestCollectPDUs(t *testing.T) {
+	synth := SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32, Modulation: "c4fm"}
+	res, _, err := SynthesizeAndAnalyze(synth, Config{CollectPDUs: true}, nil)
+	if err != nil {
+		t.Fatalf("SynthesizeAndAnalyze: %v", err)
+	}
+	if !res.Locked {
+		t.Fatalf("synthetic P25 CC did not lock; cannot exercise PDU dissection")
+	}
+	if len(res.PDUs) == 0 {
+		t.Fatal("CollectPDUs set but Result.PDUs is empty")
+	}
+
+	var lastOff float64 = -1
+	namedOpcodes := 0
+	for i, p := range res.PDUs {
+		if p.Seq != i {
+			t.Errorf("PDU %d: Seq = %d, want %d", i, p.Seq, i)
+		}
+		if p.Protocol != "p25p1" {
+			t.Errorf("PDU %d: protocol = %q, want p25p1", i, p.Protocol)
+		}
+		if p.OpcodeName == "" {
+			t.Errorf("PDU %d: empty opcode name", i)
+		}
+		if p.OpcodeName != "" && p.RawHex != "" {
+			namedOpcodes++
+		}
+		if p.OffsetSec < lastOff {
+			t.Errorf("PDU %d: offset %.4f went backwards from %.4f", i, p.OffsetSec, lastOff)
+		}
+		lastOff = p.OffsetSec
+	}
+	if namedOpcodes == 0 {
+		t.Error("no PDU carried an opcode name + raw payload")
+	}
+	t.Logf("dissected %d signaling blocks (e.g. %s, crc_ok=%v)", len(res.PDUs), res.PDUs[0].OpcodeName, res.PDUs[0].CRCOK)
+
+	// csv-pdus export round-trips the header + one row per PDU.
+	var buf bytes.Buffer
+	if err := WriteResult(&buf, res, FormatCSVPDUs); err != nil {
+		t.Fatalf("WriteResult csv-pdus: %v", err)
+	}
+	lines := strings.Count(strings.TrimRight(buf.String(), "\n"), "\n") + 1
+	if !strings.HasPrefix(buf.String(), "seq,offset_sec,protocol,opcode,opcode_name") {
+		t.Errorf("csv-pdus header missing; got %q", strings.SplitN(buf.String(), "\n", 2)[0])
+	}
+	if lines != len(res.PDUs)+1 {
+		t.Errorf("csv-pdus rows = %d, want %d (header + %d PDUs)", lines, len(res.PDUs)+1, len(res.PDUs))
+	}
+
+	// Without the flag, no PDUs are collected (default-off, zero hot-path cost).
+	off, _, err := SynthesizeAndAnalyze(synth, Config{}, nil)
+	if err != nil {
+		t.Fatalf("control run: %v", err)
+	}
+	if len(off.PDUs) != 0 {
+		t.Errorf("PDUs collected without CollectPDUs: %d", len(off.PDUs))
+	}
+}

--- a/internal/siglab/result.go
+++ b/internal/siglab/result.go
@@ -71,6 +71,12 @@ type Result struct {
 	// before serializing the summary or running the exporters and serves
 	// it from a dedicated endpoint instead.
 	IQTaps *IQTaps `json:"iq_taps,omitempty" yaml:"iq_taps,omitempty"`
+
+	// PDUs is the optional per-signaling-block (TSBK) dissection populated when
+	// Config.CollectPDUs is set — the data-over-RF inspector feed. Capped at
+	// pduMaxRecords; PDUsTruncated marks an overflow. P25 Phase 1 only for now.
+	PDUs          []PDURecord `json:"pdus,omitempty" yaml:"pdus,omitempty"`
+	PDUsTruncated bool        `json:"pdus_truncated,omitempty" yaml:"pdus_truncated,omitempty"`
 }
 
 // LockInfo is the flattened, protocol-agnostic view of a KindCCLocked

--- a/internal/siglab/signal.go
+++ b/internal/siglab/signal.go
@@ -4,6 +4,7 @@ import (
 	"math"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/fft"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/metrics"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 )
@@ -72,6 +73,39 @@ type DemodMetrics struct {
 	// SymbolsAnalyzed is the soft-sample count the estimate was formed over
 	// (after the warmup skip).
 	SymbolsAnalyzed int64 `json:"symbols_analyzed" yaml:"symbols_analyzed"`
+
+	// The fields below are the vector-signal-analyzer (VSA) decomposition of
+	// the same recovered symbols — the breakdown a lab VSA reports beside the
+	// constellation. PeakEVMPct, MagErrPct and the EVMTrace populate on both
+	// paths; PhaseErrDeg, IQGainImbalanceDB, QuadratureErrorDeg and
+	// OriginOffsetPct require the I/Q plane and are populated on the CQPSK
+	// (constellation) path only — on the 1-D C4FM soft axis they stay zero.
+
+	// PeakEVMPct is the worst single-symbol EVM (≥ EVMPct).
+	PeakEVMPct float64 `json:"peak_evm_pct" yaml:"peak_evm_pct"`
+	// MagErrPct / PhaseErrDeg split the error vector into its amplitude
+	// (RMS magnitude error, %) and angular (RMS phase error, degrees) parts.
+	MagErrPct   float64 `json:"mag_err_pct" yaml:"mag_err_pct"`
+	PhaseErrDeg float64 `json:"phase_err_deg" yaml:"phase_err_deg"`
+	// CarrierFreqErrorHz is the residual carrier-frequency error the receiver's
+	// AFC/CQPSK loop settled at, in Hz (surfaced from the receiver, not
+	// re-estimated). Zero when the deep receiver did not expose it.
+	CarrierFreqErrorHz float64 `json:"carrier_freq_error_hz" yaml:"carrier_freq_error_hz"`
+	// IQGainImbalanceDB / QuadratureErrorDeg are the I/Q gain imbalance and
+	// quadrature-skew measured on the *recovered* constellation — distinct from
+	// SignalQuality's pre-DDC front-end IQ figures.
+	IQGainImbalanceDB  float64 `json:"iq_gain_imbalance_db" yaml:"iq_gain_imbalance_db"`
+	QuadratureErrorDeg float64 `json:"quadrature_error_deg" yaml:"quadrature_error_deg"`
+	// OriginOffsetPct is the residual DC (carrier-leakage) offset as a percent
+	// of the reference radius.
+	OriginOffsetPct float64 `json:"origin_offset_pct" yaml:"origin_offset_pct"`
+	// EVMTrace is the per-symbol EVM% time series, stride-decimated to the IQ
+	// cap. ErrorVectorSpectrum is the FFT-shifted magnitude spectrum (dB) of
+	// the residual error vectors — a spur in it points at a periodic
+	// impairment rather than white noise. Both omitempty so the CSV/summary
+	// path is unaffected.
+	EVMTrace            []float32 `json:"evm_trace,omitempty" yaml:"evm_trace,omitempty"`
+	ErrorVectorSpectrum []float32 `json:"error_vector_spectrum,omitempty" yaml:"error_vector_spectrum,omitempty"`
 }
 
 // demodWarmupSkip drops the leading soft samples so the AGC/clock/AFC
@@ -163,8 +197,9 @@ func (a *analyzer) observeIQ(raw []complex64) {
 }
 
 // result builds the SignalQuality from the accumulated observations.
-// decodeErrors / symbols give the per-ksym error rate.
-func (a *analyzer) result(decodeErrors int64) *SignalQuality {
+// decodeErrors / symbols give the per-ksym error rate; maxTracePoints caps the
+// decimated VSA EVM trace.
+func (a *analyzer) result(decodeErrors int64, maxTracePoints int) *SignalQuality {
 	sq := &SignalQuality{
 		SymbolCardinality:  a.cardinality,
 		SymbolHistogram:    a.hist,
@@ -185,7 +220,7 @@ func (a *analyzer) result(decodeErrors int64) *SignalQuality {
 	if a.rmsN > 0 {
 		sq.RMSPowerDBFS = dsp.Mag2dB(math.Sqrt(a.rmsSqSum / float64(a.rmsN)))
 	}
-	sq.Demod = a.demodMetrics()
+	sq.Demod = a.demodMetrics(maxTracePoints)
 	return sq
 }
 
@@ -194,15 +229,29 @@ func (a *analyzer) result(decodeErrors int64) *SignalQuality {
 // constellation (CQPSK / linear path) when present, otherwise the 4-level soft
 // eye (C4FM). Returns nil when neither buffer holds enough post-warmup samples
 // to form a stable estimate.
-func (a *analyzer) demodMetrics() *DemodMetrics {
+func (a *analyzer) demodMetrics(maxTracePoints int) *DemodMetrics {
 	if len(a.constBuf) > demodWarmupSkip {
 		pts := a.constBuf[demodWarmupSkip:]
-		return &DemodMetrics{
-			Modulation:      "cqpsk",
-			EVMPct:          metrics.EVMConstellation(pts),
-			SNREstimateDB:   capSNR(metrics.SNRM2M4Constellation(pts)),
-			SymbolsAnalyzed: int64(len(pts)),
+		v := metrics.VSAMetricsConstellation(pts)
+		// I/Q gain imbalance + quadrature skew of the recovered constellation,
+		// via the same moment estimator used for the front-end figures.
+		var iqs rtlsdr.IQImbalanceStats
+		iqs.Observe(pts)
+		dm := &DemodMetrics{
+			Modulation:          "cqpsk",
+			EVMPct:              v.RMSEVMPct,
+			SNREstimateDB:       capSNR(metrics.SNRM2M4Constellation(pts)),
+			SymbolsAnalyzed:     int64(len(pts)),
+			PeakEVMPct:          v.PeakEVMPct,
+			MagErrPct:           v.MagErrPct,
+			PhaseErrDeg:         v.PhaseErrDeg,
+			OriginOffsetPct:     v.OriginOffsetPct,
+			IQGainImbalanceDB:   iqs.GainImbalanceDB(),
+			QuadratureErrorDeg:  iqs.PhaseImbalanceDeg(),
+			EVMTrace:            decimateF32(v.PerSymbolEVMPct, maxTracePoints),
+			ErrorVectorSpectrum: errorVectorSpectrum(v.ErrorVectors),
 		}
+		return dm
 	}
 	if len(a.softBuf) > demodWarmupSkip {
 		soft := a.softBuf[demodWarmupSkip:]
@@ -210,14 +259,62 @@ func (a *analyzer) demodMetrics() *DemodMetrics {
 		if outer <= 0 {
 			return nil
 		}
+		v := metrics.VSAMetricsC4FM(soft, outer)
 		return &DemodMetrics{
 			Modulation:      "c4fm",
-			EVMPct:          metrics.EVMC4FM(soft, outer),
+			EVMPct:          v.RMSEVMPct,
 			SNREstimateDB:   capSNR(metrics.SNRResidualC4FM(soft, outer)),
 			SymbolsAnalyzed: int64(len(soft)),
+			PeakEVMPct:      v.PeakEVMPct,
+			MagErrPct:       v.MagErrPct,
+			EVMTrace:        decimateF32(v.PerSymbolEVMPct, maxTracePoints),
 		}
 	}
 	return nil
+}
+
+// decimateF32 stride-decimates xs to at most maxPoints values, preserving the
+// first sample and the overall shape (the same cap discipline as the IQ taps).
+func decimateF32(xs []float32, maxPoints int) []float32 {
+	n := len(xs)
+	if n == 0 || maxPoints <= 0 {
+		return nil
+	}
+	stride := 1
+	if n > maxPoints {
+		stride = (n + maxPoints - 1) / maxPoints
+	}
+	out := make([]float32, 0, n/stride+1)
+	for i := 0; i < n; i += stride {
+		out = append(out, xs[i])
+	}
+	return out
+}
+
+// evSpectrumSize is the fixed FFT length for the error-vector spectrum: small,
+// power-of-two, enough to reveal a periodic impairment line.
+const evSpectrumSize = 256
+
+// errorVectorSpectrum returns the FFT-shifted magnitude spectrum (dB) of the
+// residual error-vector time series — a peak at a non-zero bin marks a periodic
+// impairment (a spur / residual tone), a flat floor marks white noise. Returns
+// nil when there are too few error vectors to transform.
+func errorVectorSpectrum(evs []complex64) []float32 {
+	if len(evs) < evSpectrumSize {
+		return nil
+	}
+	in := make([]complex128, evSpectrumSize)
+	fft.Cmplx64ToCmplx128(in, evs[:evSpectrumSize])
+	out := fft.New(evSpectrumSize).Forward(make([]complex128, evSpectrumSize), in)
+	// FFT-shift so bin 0 is the most-negative frequency, DC at the centre.
+	half := evSpectrumSize / 2
+	mag := make([]float32, evSpectrumSize)
+	for i := 0; i < evSpectrumSize; i++ {
+		c := out[(i+half)%evSpectrumSize]
+		m := math.Hypot(real(c), imag(c)) / float64(evSpectrumSize)
+		mag[i] = float32(dsp.Mag2dB(m))
+	}
+	return mag
 }
 
 // capSNR clamps a possibly-infinite SNR estimate (noise-free input) to a

--- a/internal/siglab/sigref/sigref.go
+++ b/internal/siglab/sigref/sigref.go
@@ -1,0 +1,242 @@
+// Package sigref is SigLab's offline signal-identification reference database —
+// a small, curated catalog (Artemis / sigidwiki in spirit) that names a carrier
+// by its band, bandwidth, modulation, and symbol rate even when no decoder
+// locks. It is the fallback namer for identify and the wideband survey: a
+// non-decoding carrier still gets ranked candidates ("looks like TETRA: 25 kHz,
+// π/4-DQPSK, 18000 sym/s") rather than vanishing.
+//
+// The rows for protocols GopherTrunk decodes derive their symbol rate directly
+// from the receiver packages' SymbolRate constants, so a constant change
+// propagates here at compile time (a drift-guard test pins the rest).
+package sigref
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/blind"
+
+	dmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dmr/receiver"
+	dpmrrx "github.com/MattCheramie/GopherTrunk/internal/radio/dpmr/receiver"
+	dstarrx "github.com/MattCheramie/GopherTrunk/internal/radio/dstar/receiver"
+	edacsrx "github.com/MattCheramie/GopherTrunk/internal/radio/edacs/receiver"
+	ltrrx "github.com/MattCheramie/GopherTrunk/internal/radio/ltr/receiver"
+	motorx "github.com/MattCheramie/GopherTrunk/internal/radio/motorola/receiver"
+	mptrx "github.com/MattCheramie/GopherTrunk/internal/radio/mpt1327/receiver"
+	nxdnrx "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn/receiver"
+	p25p1rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/receiver"
+	p25p2rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+	ysfrx "github.com/MattCheramie/GopherTrunk/internal/radio/ysf/receiver"
+)
+
+// Band is an inclusive frequency range (Hz) a signal is typically allocated in.
+type Band struct {
+	LoHz, HiHz float64
+}
+
+// Entry is one reference signal. For decodable protocols Protocol is the
+// trunking protocol string (the identify candidate name) and Decodable is true;
+// for catalog-only entries Protocol is "" and Decodable is false.
+type Entry struct {
+	Protocol     string   `json:"protocol"`
+	DisplayName  string   `json:"display_name"`
+	ModClass     string   `json:"mod_class"` // one of blind.Mod*
+	ModLabels    []string `json:"mod_labels"`
+	SymbolRateHz float64  `json:"symbol_rate_hz"`
+	ChannelBWHz  float64  `json:"channel_bw_hz"`
+	Levels       int      `json:"levels"`
+	Bands        []Band   `json:"bands,omitempty"`
+	Decodable    bool     `json:"decodable"`
+	Notes        string   `json:"notes,omitempty"`
+}
+
+// entries is the reference catalog. Decodable rows pull SymbolRateHz from the
+// receiver consts so the two cannot drift.
+var entries = []Entry{
+	{"p25", "P25 Phase 1", blind.ModFSK4, []string{"C4FM"}, p25p1rx.SymbolRate, 12500, 4, nil, true, ""},
+	{"p25-phase2", "P25 Phase 2", blind.ModPSK, []string{"H-DQPSK", "TDMA"}, p25p2rx.SymbolRate, 12500, 4, nil, true, ""},
+	{"dmr", "DMR", blind.ModFSK4, []string{"4FSK", "TDMA"}, dmrrx.SymbolRate, 12500, 4, nil, true, ""},
+	{"nxdn", "NXDN", blind.ModFSK4, []string{"4FSK"}, nxdnrx.SymbolRate, 6250, 4, nil, true, ""},
+	{"dpmr", "dPMR", blind.ModFSK4, []string{"4FSK"}, dpmrrx.SymbolRate, 6250, 4, nil, true, ""},
+	{"edacs", "EDACS", blind.ModFSK2, []string{"GFSK"}, edacsrx.SymbolRate, 12500, 2, nil, true, ""},
+	{"motorola", "Motorola Type II", blind.ModFSK2, []string{"GFSK"}, motorx.SymbolRate, 12500, 2, nil, true, ""},
+	{"ltr", "LTR", blind.ModFSK2, []string{"sub-audible FSK"}, ltrrx.SymbolRate, 12500, 2, nil, true, ""},
+	{"mpt1327", "MPT-1327", blind.ModFSK2, []string{"FFSK"}, mptrx.SymbolRate, 12500, 2, nil, true, ""},
+	{"tetra", "TETRA", blind.ModPSK, []string{"π/4-DQPSK"}, tetrarx.SymbolRate, 25000, 4, nil, true, ""},
+	{"ysf", "Yaesu System Fusion", blind.ModFSK4, []string{"C4FM"}, ysfrx.SymbolRate, 12500, 4, nil, true, ""},
+	{"dstar", "D-STAR", blind.ModFSK2, []string{"GMSK"}, dstarrx.SymbolRate, 6250, 2, nil, true, ""},
+
+	// Catalog-only reference signals (no GopherTrunk decoder). Kept small.
+	{"", "POCSAG-1200", blind.ModFSK2, []string{"2FSK paging"}, 1200, 12500, 2, nil, false, "pager"},
+	{"", "POCSAG-512", blind.ModFSK2, []string{"2FSK paging"}, 512, 12500, 2, nil, false, "pager"},
+	{"", "FLEX", blind.ModFSK4, []string{"4FSK paging"}, 1600, 25000, 4, nil, false, "pager"},
+	{"", "ACARS", blind.ModFSK2, []string{"MSK"}, 2400, 25000, 2, nil, false, "aviation data"},
+}
+
+// All returns the full catalog (decodable + reference-only).
+func All() []Entry { return entries }
+
+// Decodable returns only the entries GopherTrunk has a decoder for.
+func Decodable() []Entry {
+	out := make([]Entry, 0, len(entries))
+	for _, e := range entries {
+		if e.Decodable {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// ByProtocol returns the decodable entry for a protocol string.
+func ByProtocol(p string) (Entry, bool) {
+	for _, e := range entries {
+		if e.Decodable && e.Protocol == p {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
+// Observation is what a blind analysis knows about an unknown carrier. Missing
+// fields (zero) are simply not scored, so a sparse observation does not penalise.
+type Observation struct {
+	SymbolRateHz   float64
+	SymbolRateConf float64
+	ModClass       string
+	Levels         int
+	ChannelBWHz    float64
+	CenterFreqHz   uint32
+}
+
+// Match is a scored reference candidate.
+type Match struct {
+	Entry Entry   `json:"entry"`
+	Score float64 `json:"score"` // 0..1
+	Why   string  `json:"why"`
+}
+
+// Rank scores every catalog entry against obs and returns the top `limit`
+// matches by descending score (limit<=0 returns all). The symbol rate carries
+// the most weight; modulation class, level count and bandwidth refine it; an
+// in-band centre frequency adds a small bonus.
+func Rank(obs Observation, limit int) []Match {
+	out := make([]Match, 0, len(entries))
+	for _, e := range entries {
+		s := score(obs, e)
+		if s <= 0 {
+			continue
+		}
+		out = append(out, Match{Entry: e, Score: s, Why: why(e)})
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Score > out[j].Score })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func score(obs Observation, e Entry) float64 {
+	var acc, totalW float64
+
+	if obs.SymbolRateHz > 0 && e.SymbolRateHz > 0 {
+		tol := 0.05 * e.SymbolRateHz
+		if tol < 100 {
+			tol = 100
+		}
+		d := obs.SymbolRateHz - e.SymbolRateHz
+		if d < 0 {
+			d = -d
+		}
+		sc := 1 - d/tol
+		if sc < 0 {
+			sc = 0
+		}
+		conf := obs.SymbolRateConf
+		if conf <= 0 {
+			conf = 0.5
+		}
+		acc += 0.5 * sc * conf
+		totalW += 0.5
+	}
+
+	if obs.ModClass != "" && obs.ModClass != blind.ModUnknown {
+		acc += 0.25 * modScore(obs.ModClass, e.ModClass)
+		totalW += 0.25
+	}
+
+	if obs.Levels > 0 && e.Levels > 0 {
+		sc := 0.0
+		if obs.Levels == e.Levels {
+			sc = 1
+		}
+		acc += 0.1 * sc
+		totalW += 0.1
+	}
+
+	if obs.ChannelBWHz > 0 && e.ChannelBWHz > 0 {
+		d := obs.ChannelBWHz - e.ChannelBWHz
+		if d < 0 {
+			d = -d
+		}
+		sc := 1 - d/e.ChannelBWHz
+		if sc < 0 {
+			sc = 0
+		}
+		acc += 0.1 * sc
+		totalW += 0.1
+	}
+
+	if totalW == 0 {
+		return 0
+	}
+	s := acc / totalW
+
+	// Small bonus for a centre frequency inside one of the entry's bands.
+	if obs.CenterFreqHz > 0 {
+		f := float64(obs.CenterFreqHz)
+		for _, b := range e.Bands {
+			if f >= b.LoHz && f <= b.HiHz {
+				s += 0.05
+				break
+			}
+		}
+	}
+	if s > 1 {
+		s = 1
+	}
+	return s
+}
+
+// modScore is 1 for an exact class match, 0.5 for the same broad family
+// (any FSK vs any constant-envelope-PSK vs amplitude), else 0.
+func modScore(a, b string) float64 {
+	if a == b {
+		return 1
+	}
+	if family(a) == family(b) {
+		return 0.5
+	}
+	return 0
+}
+
+func family(m string) string {
+	switch m {
+	case blind.ModFSK2, blind.ModFSK4:
+		return "fsk"
+	case blind.ModPSK:
+		return "psk"
+	case blind.ModQAM:
+		return "qam"
+	default:
+		return m
+	}
+}
+
+func why(e Entry) string {
+	label := ""
+	if len(e.ModLabels) > 0 {
+		label = e.ModLabels[0]
+	}
+	return fmt.Sprintf("%.3g kHz, %s, %.0f sym/s", e.ChannelBWHz/1000, label, e.SymbolRateHz)
+}

--- a/internal/siglab/sigref/sigref_test.go
+++ b/internal/siglab/sigref/sigref_test.go
@@ -30,9 +30,9 @@ func TestDecodableRowsValid(t *testing.T) {
 
 func TestRankNamesSignatures(t *testing.T) {
 	cases := []struct {
-		name     string
-		obs      Observation
-		wantTop  string
+		name    string
+		obs     Observation
+		wantTop string
 	}{
 		{
 			"tetra signature",

--- a/internal/siglab/sigref/sigref_test.go
+++ b/internal/siglab/sigref/sigref_test.go
@@ -1,0 +1,75 @@
+package sigref
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/blind"
+)
+
+// TestDecodableRowsCoverProtocols is a drift guard: every decodable row must
+// carry a positive symbol rate and bandwidth, and the catalog must include the
+// core trunking protocols by name.
+func TestDecodableRowsValid(t *testing.T) {
+	want := []string{"p25", "p25-phase2", "dmr", "nxdn", "dpmr", "edacs", "motorola", "ltr", "mpt1327", "tetra", "ysf", "dstar"}
+	for _, p := range want {
+		e, ok := ByProtocol(p)
+		if !ok {
+			t.Errorf("missing decodable entry for %q", p)
+			continue
+		}
+		if e.SymbolRateHz <= 0 || e.ChannelBWHz <= 0 {
+			t.Errorf("%s: symbol rate %.0f / BW %.0f, want both > 0", p, e.SymbolRateHz, e.ChannelBWHz)
+		}
+	}
+	for _, e := range Decodable() {
+		if !e.Decodable || e.Protocol == "" {
+			t.Errorf("Decodable() returned a non-decodable/blank-protocol row: %+v", e)
+		}
+	}
+}
+
+func TestRankNamesSignatures(t *testing.T) {
+	cases := []struct {
+		name     string
+		obs      Observation
+		wantTop  string
+	}{
+		{
+			"tetra signature",
+			Observation{SymbolRateHz: 18000, SymbolRateConf: 0.9, ModClass: blind.ModPSK, Levels: 4, ChannelBWHz: 25000},
+			"tetra",
+		},
+		{
+			"p25p1 signature",
+			Observation{SymbolRateHz: 4800, SymbolRateConf: 0.9, ModClass: blind.ModFSK4, Levels: 4, ChannelBWHz: 12500},
+			"p25",
+		},
+		{
+			"dpmr signature (2400, 4FSK, narrow)",
+			Observation{SymbolRateHz: 2400, SymbolRateConf: 0.9, ModClass: blind.ModFSK4, Levels: 4, ChannelBWHz: 6250},
+			"dpmr",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Rank(tc.obs, 3)
+			if len(m) == 0 {
+				t.Fatal("no matches")
+			}
+			if m[0].Entry.Protocol != tc.wantTop {
+				t.Errorf("top match = %q (%.2f), want %q; why=%q", m[0].Entry.Protocol, m[0].Score, tc.wantTop, m[0].Why)
+			}
+			if m[0].Score <= 0 || m[0].Score > 1 {
+				t.Errorf("score %.3f out of (0,1]", m[0].Score)
+			}
+		})
+	}
+}
+
+func TestRankSparseObservation(t *testing.T) {
+	// Symbol rate alone should still rank — and not crash on missing fields.
+	m := Rank(Observation{SymbolRateHz: 18000, SymbolRateConf: 0.8}, 1)
+	if len(m) == 0 || m[0].Entry.Protocol != "tetra" {
+		t.Fatalf("symbol-rate-only TETRA: got %+v", m)
+	}
+}

--- a/internal/siglab/wideband.go
+++ b/internal/siglab/wideband.go
@@ -7,9 +7,11 @@ import (
 	"math"
 
 	"github.com/MattCheramie/GopherTrunk/internal/carriers"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/blind"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/tuner"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab/sigref"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -33,6 +35,11 @@ const (
 	// (e.g. 10 MS/s) survey gets enough bins to keep adjacent carriers in
 	// distinct bins instead of the fixed-16 collapse (issue #764).
 	wbChannelizerBinWidthHz = 150_000.0
+
+	// wbReferenceKeepFloor is the minimum reference-DB match score at which a
+	// non-decoding carrier is kept and named (rather than dropped as noise). It
+	// mirrors identifyConfidenceFloor — a best-guess threshold, not a lock.
+	wbReferenceKeepFloor = 0.40
 )
 
 // wbChannelizerBinsFor mirrors widebandt2.channelizerBinsFor: the power of
@@ -93,6 +100,12 @@ type CarrierResult struct {
 	SystemID     uint32        `json:"system_id,omitempty" yaml:"system_id,omitempty"`
 	Grants       []GrantRecord `json:"grants,omitempty" yaml:"grants,omitempty"`
 	Score        float64       `json:"score" yaml:"score"`
+
+	// Blind / ReferenceMatches name a carrier that did NOT decode, via the
+	// offline signal-ID reference DB (Protocol is blanked for such carriers and
+	// Role is RoleUnknown). Populated from the per-carrier identify fallback.
+	Blind            *blind.BlindEstimate `json:"blind,omitempty" yaml:"blind,omitempty"`
+	ReferenceMatches []sigref.Match       `json:"reference_matches,omitempty" yaml:"reference_matches,omitempty"`
 
 	identify *IdentifyResult // retained for the hunt bridge
 	result   *Result         // full Run of the winning protocol
@@ -294,14 +307,32 @@ func SurveyWidebandIQ(iq []complex64, source string, cfg WidebandConfig) (*Wideb
 			cr.Score = win.Score
 		}
 		cr.Role = roleForCarrier(cr)
-		if !keepCarrier(cr) {
+		cr.Blind = idr.Blind
+		cr.ReferenceMatches = idr.ReferenceMatches
+		if keepCarrier(cr) {
+			out.Carriers = append(out.Carriers, cr)
 			continue
 		}
-		out.Carriers = append(out.Carriers, cr)
+		// The carrier did not decode, but the reference DB names it with
+		// confidence — surface it as an unidentified-but-named carrier rather
+		// than dropping it (Artemis-style "looks like TETRA…").
+		if keepAsReference(cr) {
+			cr.Protocol = ""
+			cr.Role = RoleUnknown
+			out.Carriers = append(out.Carriers, cr)
+		}
 	}
 
 	out.Systems = clusterSystems(out.Carriers, cfg.CenterHz, cfg.SampleRateHz, chRate)
 	return out, nil
+}
+
+// keepAsReference reports whether a carrier that no decoder could lock should
+// still be kept and named from the offline reference DB — its top match must
+// clear the best-guess floor. Such carriers are surfaced with a blank Protocol
+// and RoleUnknown.
+func keepAsReference(c CarrierResult) bool {
+	return len(c.ReferenceMatches) > 0 && c.ReferenceMatches[0].Score >= wbReferenceKeepFloor
 }
 
 // keepCarrier filters the spectral detections down to genuine carriers: a DMR

--- a/internal/siglab/wideband_reference_test.go
+++ b/internal/siglab/wideband_reference_test.go
@@ -1,0 +1,39 @@
+package siglab
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab/sigref"
+)
+
+// TestKeepAsReference covers the wideband survey's decision to keep and name a
+// non-decoding carrier from the reference DB: a confident reference match is
+// kept, a weak or absent one is dropped. This is the wiring that turns the
+// per-carrier identify fallback (blind estimate → sigref.Rank, proven in the
+// identify tests) into a surfaced "looks like TETRA…" carrier.
+func TestKeepAsReference(t *testing.T) {
+	strong := CarrierResult{ReferenceMatches: []sigref.Match{
+		{Entry: sigref.Entry{DisplayName: "TETRA"}, Score: 0.72, Why: "25 kHz, π/4-DQPSK, 18000 sym/s"},
+	}}
+	weak := CarrierResult{ReferenceMatches: []sigref.Match{
+		{Entry: sigref.Entry{DisplayName: "FLEX"}, Score: 0.20},
+	}}
+	none := CarrierResult{}
+
+	if !keepAsReference(strong) {
+		t.Error("strong reference match should be kept")
+	}
+	if keepAsReference(weak) {
+		t.Error("below-floor reference match should be dropped")
+	}
+	if keepAsReference(none) {
+		t.Error("carrier with no reference matches should be dropped")
+	}
+	// A carrier that already locked is never routed here (keepCarrier handles
+	// it), but the reference predicate must not depend on lock state.
+	locked := strong
+	locked.Locked = true
+	if !keepAsReference(locked) {
+		t.Error("reference predicate must judge by score, not lock state")
+	}
+}

--- a/web/siglab/src/api/client.ts
+++ b/web/siglab/src/api/client.ts
@@ -11,6 +11,7 @@ import type {
   IQTaps,
   IdentifyResult,
   JobDTO,
+  OccupancyResult,
   ProtocolsDTO,
   PSDResult,
   RunConfig,
@@ -132,6 +133,11 @@ export const api = {
       "GET",
       `/api/v1/siglab/jobs/${id}/spectrogram?fft=${fft}&hop=${hop}`,
     ),
+
+  // jobOccupancy fetches the server-computed spectral-occupancy metrics
+  // (occupied bandwidth, channel power, ACPR, flatness) off the same spectrum.
+  jobOccupancy: (c: ClientConfig, id: string, fft = 1024) =>
+    req<OccupancyResult>(c, "GET", `/api/v1/siglab/jobs/${id}/occupancy?fft=${fft}`),
 
   identify: (
     c: ClientConfig,

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -245,6 +245,34 @@ export interface CandidateScore {
   score: number;
 }
 
+// BlindEstimate is the offline blind symbol-rate / modulation estimate
+// (mirrors blind.BlindEstimate). ReferenceMatch is one scored reference-DB
+// candidate (mirrors sigref.Match).
+export interface BlindEstimate {
+  symbol_rate_hz: number;
+  symbol_rate_conf: number;
+  symbol_rate_cands?: number[];
+  mod_class: string;
+  levels: number;
+  occupied_bw_hz: number;
+  method: string;
+}
+
+export interface ReferenceMatch {
+  entry: {
+    protocol: string;
+    display_name: string;
+    mod_class: string;
+    mod_labels: string[];
+    symbol_rate_hz: number;
+    channel_bw_hz: number;
+    levels: number;
+    decodable: boolean;
+  };
+  score: number;
+  why: string;
+}
+
 export interface IdentifyResult {
   source: string;
   sample_rate_hz: number;
@@ -252,6 +280,9 @@ export interface IdentifyResult {
   confidence: number;
   inconclusive: boolean;
   candidates: CandidateScore[];
+  // Offline-signal-ID fallback, populated only when inconclusive.
+  blind?: BlindEstimate;
+  reference_matches?: ReferenceMatch[];
 }
 
 export interface CaptureDTO {
@@ -365,6 +396,9 @@ export interface WidebandCarrier {
   system_id?: number;
   grants?: GrantRecord[];
   score: number;
+  // Reference-DB naming for a carrier that did not decode (protocol is blank).
+  blind?: BlindEstimate;
+  reference_matches?: ReferenceMatch[];
 }
 
 // WidebandSystem clusters carriers into one trunked-system verdict.

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -209,6 +209,26 @@ export interface Detail {
   [k: string]: unknown;
 }
 
+// PDURecord is one dissected data/signaling PDU (mirrors siglab.PDURecord).
+export interface PDURecord {
+  seq: number;
+  offset_sec: number;
+  protocol: string;
+  opcode: number;
+  opcode_name: string;
+  mfid?: number;
+  nac?: number;
+  source_id?: number;
+  dest_id?: number;
+  talkgroup?: number;
+  fields?: Record<string, unknown>;
+  raw_hex: string;
+  crc_ok: boolean;
+  fec_metric: number;
+  dibit_start: number;
+  dibit_len: number;
+}
+
 export interface Result {
   source: string;
   protocol: string;
@@ -232,6 +252,8 @@ export interface Result {
   detail?: Detail;
   verdict?: { pass: boolean; failures?: string[] };
   iq_taps?: IQTaps;
+  pdus?: PDURecord[];
+  pdus_truncated?: boolean;
 }
 
 export interface CandidateScore {
@@ -351,6 +373,7 @@ export interface RunConfig {
   collect_iq_diag?: boolean;
   capture_iq?: boolean;
   capture_iq_max_points?: number;
+  collect_pdus?: boolean;
   demod_mode?: string;
   nid_search_span?: number;
   enable_dda?: boolean;

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -101,6 +101,17 @@ export interface DemodMetrics {
   evm_pct: number;
   snr_estimate_db: number;
   symbols_analyzed: number;
+  // VSA decomposition (see siglab.DemodMetrics). The phase/IQ/origin fields
+  // are populated on the CQPSK path only; arrays are omitted when empty.
+  peak_evm_pct: number;
+  mag_err_pct: number;
+  phase_err_deg: number;
+  carrier_freq_error_hz: number;
+  iq_gain_imbalance_db: number;
+  quadrature_error_deg: number;
+  origin_offset_pct: number;
+  evm_trace?: number[];
+  error_vector_spectrum?: number[];
 }
 
 export interface RailStat {

--- a/web/siglab/src/api/types.ts
+++ b/web/siglab/src/api/types.ts
@@ -30,6 +30,23 @@ export interface PSDResult {
   bins: number[];
 }
 
+// OccupancyResult is the server-computed spectral-occupancy metric set from
+// GET /jobs/{id}/occupancy, derived from the same Welch spectrum as the PSD.
+export interface OccupancyResult {
+  sample_rate_hz: number;
+  fft_size: number;
+  channel_bw_hz: number;
+  adj_offset_hz: number;
+  adj_bw_hz: number;
+  occupancy: {
+    occupied_bandwidth_hz: number;
+    channel_power_dbfs: number;
+    acpr_upper_db: number;
+    acpr_lower_db: number;
+    spectral_flatness: number;
+  };
+}
+
 // SpectrogramResult is the server-computed STFT from GET /jobs/{id}/spectrogram:
 // z[frame][bin] dBFS, each row FFT-shifted (bin 0 = -sample_rate_hz/2).
 export interface SpectrogramResult {

--- a/web/siglab/src/panels/Captures.tsx
+++ b/web/siglab/src/panels/Captures.tsx
@@ -338,6 +338,7 @@ function RunForm({ capture }: { capture: CaptureDTO }) {
           v={!!cfg.collect_receiver_state}
           on={(v) => set("collect_receiver_state", v)}
         />
+        <Toggle label="collect PDUs" v={!!cfg.collect_pdus} on={(v) => set("collect_pdus", v)} />
       </div>
       <details className="text-sm">
         <summary className="cursor-pointer text-muted">P25 deep knobs</summary>

--- a/web/siglab/src/panels/Identify.tsx
+++ b/web/siglab/src/panels/Identify.tsx
@@ -97,6 +97,30 @@ export function Identify() {
               ))}
             </tbody>
           </table>
+
+          {result.inconclusive && result.reference_matches && result.reference_matches.length > 0 && (
+            <div className="mt-4 border-t border-line pt-3">
+              <p className="mb-1 text-xs font-semibold text-warn">
+                Nothing decoded — best-guess from the signal-ID reference
+                {result.blind && (
+                  <span className="ml-1 font-normal text-muted">
+                    (blind: {result.blind.symbol_rate_hz.toFixed(0)} sym/s, {result.blind.mod_class})
+                  </span>
+                )}
+              </p>
+              <ul className="text-xs">
+                {result.reference_matches.map((m) => (
+                  <li key={m.entry.display_name} className="flex justify-between gap-2 py-0.5">
+                    <span>
+                      {m.entry.display_name}
+                      <span className="ml-1 text-muted">— {m.why}</span>
+                    </span>
+                    <span className="font-mono">{(m.score * 100).toFixed(0)}%</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/web/siglab/src/panels/Results.tsx
+++ b/web/siglab/src/panels/Results.tsx
@@ -12,7 +12,7 @@ import { RotationTracker } from "../viz/RotationTracker";
 import { VSAMetrics } from "../viz/VSAMetrics";
 import { SyncLandscape } from "../viz/SyncLandscape";
 import { ReceiverStates } from "../viz/ReceiverStates";
-import { GrantsTable, EventTimeline } from "../viz/Tables";
+import { GrantsTable, EventTimeline, PDUTable } from "../viz/Tables";
 
 export function Results() {
   const { captureId = "" } = useParams();
@@ -150,6 +150,7 @@ function VizGrid({ r, iq, jobId }: { r: Result; iq?: Result["iq_taps"]; jobId?: 
       )}
       <GrantsTable grants={r.grants} />
       <EventTimeline events={r.events} />
+      {r.pdus && r.pdus.length > 0 && <PDUTable pdus={r.pdus} truncated={r.pdus_truncated} />}
     </div>
   );
 }

--- a/web/siglab/src/panels/Results.tsx
+++ b/web/siglab/src/panels/Results.tsx
@@ -9,6 +9,7 @@ import { Spectrogram } from "../viz/Spectrogram";
 import { EyeDiagram } from "../viz/EyeDiagram";
 import { SymbolScope } from "../viz/SymbolScope";
 import { RotationTracker } from "../viz/RotationTracker";
+import { VSAMetrics } from "../viz/VSAMetrics";
 import { SyncLandscape } from "../viz/SyncLandscape";
 import { ReceiverStates } from "../viz/ReceiverStates";
 import { GrantsTable, EventTimeline } from "../viz/Tables";
@@ -126,6 +127,7 @@ function VizGrid({ r, iq, jobId }: { r: Result; iq?: Result["iq_taps"]; jobId?: 
   return (
     <div className="grid gap-4 lg:grid-cols-2">
       {r.signal && <SymbolHistogram signal={r.signal} />}
+      {r.signal?.demod && <VSAMetrics demod={r.signal.demod} />}
       {hasIQ && <Constellation points={iq!.decimated_iq} />}
       {hasIQ && jobId && <PSD jobId={jobId} />}
       {hasIQ && jobId && <Spectrogram jobId={jobId} />}

--- a/web/siglab/src/viz/PSD.tsx
+++ b/web/siglab/src/viz/PSD.tsx
@@ -2,30 +2,33 @@ import { useEffect, useState } from "react";
 import { Line } from "react-chartjs-2";
 import { useStore } from "../store/shared";
 import { api } from "../api/client";
-import type { PSDResult } from "../api/types";
+import type { OccupancyResult, PSDResult } from "../api/types";
 import { ensureChart } from "./chartSetup";
 
 ensureChart();
 
 // PSD renders the Welch power-spectral-density of a job's captured IQ. The FFT
 // is computed server-side (GET /jobs/{id}/psd via internal/dsp/spectrum), so the
-// browser needs no FFT library.
+// browser needs no FFT library. Beneath the chart it shows the lab-grade
+// spectral-occupancy metrics computed off the same spectrum.
 export function PSD({ jobId }: { jobId: string }) {
   const config = useStore((s) => s.config);
   const [psd, setPsd] = useState<PSDResult | null>(null);
+  const [occ, setOcc] = useState<OccupancyResult | null>(null);
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     if (!jobId) return;
     setBusy(true);
-    api
-      .jobPSD(config, jobId, 1024)
-      .then((r) => {
-        if (!cancelled) setPsd(r);
-      })
-      .catch(() => {
-        if (!cancelled) setPsd(null);
+    Promise.all([
+      api.jobPSD(config, jobId, 1024).catch(() => null),
+      api.jobOccupancy(config, jobId, 1024).catch(() => null),
+    ])
+      .then(([p, o]) => {
+        if (cancelled) return;
+        setPsd(p);
+        setOcc(o);
       })
       .finally(() => {
         if (!cancelled) setBusy(false);
@@ -70,6 +73,24 @@ export function PSD({ jobId }: { jobId: string }) {
       ) : (
         !busy && <p className="text-xs text-muted">No IQ captured.</p>
       )}
+      {occ && (
+        <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-3">
+          <Metric label="Occupied BW" value={`${(occ.occupancy.occupied_bandwidth_hz / 1000).toFixed(2)} kHz`} />
+          <Metric label="Channel power" value={`${occ.occupancy.channel_power_dbfs.toFixed(1)} dBFS`} />
+          <Metric label="Flatness" value={occ.occupancy.spectral_flatness.toFixed(3)} />
+          <Metric label="ACPR upper" value={`${occ.occupancy.acpr_upper_db.toFixed(1)} dB`} />
+          <Metric label="ACPR lower" value={`${occ.occupancy.acpr_lower_db.toFixed(1)} dB`} />
+        </dl>
+      )}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-2">
+      <dt className="text-muted">{label}</dt>
+      <dd className="font-mono">{value}</dd>
     </div>
   );
 }

--- a/web/siglab/src/viz/Tables.test.tsx
+++ b/web/siglab/src/viz/Tables.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { EventTimeline, GrantsTable } from "./Tables";
-import type { EventRecord, GrantRecord } from "../api/types";
+import { EventTimeline, GrantsTable, PDUTable } from "./Tables";
+import type { EventRecord, GrantRecord, PDURecord } from "../api/types";
 
 describe("GrantsTable", () => {
   it("renders grant rows", () => {
@@ -27,6 +27,55 @@ describe("GrantsTable", () => {
   it("shows an empty state", () => {
     render(<GrantsTable grants={[]} />);
     expect(screen.getByText(/No traffic grants/)).toBeInTheDocument();
+  });
+});
+
+describe("PDUTable", () => {
+  const pdus: PDURecord[] = [
+    {
+      seq: 0,
+      offset_sec: 0.12,
+      protocol: "p25p1",
+      opcode: 0,
+      opcode_name: "GRP_V_CH_GRANT",
+      nac: 0x293,
+      source_id: 5005,
+      talkgroup: 101,
+      raw_hex: "0001100000cc",
+      crc_ok: true,
+      fec_metric: 0,
+      dibit_start: 100,
+      dibit_len: 98,
+    },
+    {
+      seq: 1,
+      offset_sec: 0.2,
+      protocol: "p25p1",
+      opcode: 58,
+      opcode_name: "RFSS_STS_BCST",
+      nac: 0x293,
+      raw_hex: "deadbeef",
+      crc_ok: false,
+      fec_metric: 3,
+      dibit_start: 198,
+      dibit_len: 98,
+    },
+  ];
+
+  it("renders PDU rows and filters by opcode", () => {
+    render(<PDUTable pdus={pdus} />);
+    expect(screen.getByText(/Signaling \/ data PDUs \(2\/2\)/)).toBeInTheDocument();
+    expect(screen.getByText("5005")).toBeInTheDocument(); // grant row source id
+
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "RFSS_STS_BCST" } });
+    expect(screen.getByText(/\(1\/2\)/)).toBeInTheDocument();
+    expect(screen.queryByText("5005")).not.toBeInTheDocument(); // grant row filtered out
+  });
+
+  it("filters to CRC-OK blocks", () => {
+    render(<PDUTable pdus={pdus} />);
+    fireEvent.click(screen.getByLabelText(/CRC-OK only/));
+    expect(screen.getByText(/\(1\/2\)/)).toBeInTheDocument();
   });
 });
 

--- a/web/siglab/src/viz/Tables.tsx
+++ b/web/siglab/src/viz/Tables.tsx
@@ -1,4 +1,5 @@
-import type { EventRecord, GrantRecord } from "../api/types";
+import { useMemo, useState } from "react";
+import type { EventRecord, GrantRecord, PDURecord } from "../api/types";
 
 export function GrantsTable({ grants }: { grants: GrantRecord[] }) {
   return (
@@ -34,6 +35,96 @@ export function GrantsTable({ grants }: { grants: GrantRecord[] }) {
           </tbody>
         </table>
       )}
+    </div>
+  );
+}
+
+// PDUTable renders the data-over-RF signaling dissection with client-side
+// filters: by opcode name, CRC pass/fail, and a source/talkgroup id substring.
+export function PDUTable({ pdus, truncated }: { pdus: PDURecord[]; truncated?: boolean }) {
+  const [opcode, setOpcode] = useState("");
+  const [crcOnly, setCrcOnly] = useState(false);
+  const [idFilter, setIdFilter] = useState("");
+
+  const opcodes = useMemo(
+    () => [...new Set(pdus.map((p) => p.opcode_name))].sort(),
+    [pdus],
+  );
+  const rows = useMemo(
+    () =>
+      pdus.filter((p) => {
+        if (opcode && p.opcode_name !== opcode) return false;
+        if (crcOnly && !p.crc_ok) return false;
+        if (idFilter) {
+          const hay = `${p.source_id ?? ""} ${p.dest_id ?? ""} ${p.talkgroup ?? ""}`;
+          if (!hay.includes(idFilter)) return false;
+        }
+        return true;
+      }),
+    [pdus, opcode, crcOnly, idFilter],
+  );
+
+  return (
+    <div className="card overflow-x-auto">
+      <h3 className="mb-2 text-sm font-semibold">
+        Signaling / data PDUs ({rows.length}/{pdus.length})
+        {truncated && <span className="ml-1 text-warn">· truncated</span>}
+      </h3>
+      <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
+        <select
+          className="rounded bg-panel px-1 py-0.5"
+          value={opcode}
+          onChange={(e) => setOpcode(e.target.value)}
+        >
+          <option value="">all opcodes</option>
+          {opcodes.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+        <label className="flex items-center gap-1">
+          <input type="checkbox" checked={crcOnly} onChange={(e) => setCrcOnly(e.target.checked)} />
+          CRC-OK only
+        </label>
+        <input
+          className="rounded bg-panel px-1 py-0.5"
+          placeholder="src / TG id"
+          value={idFilter}
+          onChange={(e) => setIdFilter(e.target.value)}
+        />
+      </div>
+      <table className="w-full text-left text-xs">
+        <thead className="text-muted">
+          <tr>
+            <th className="py-1 pr-3">t (s)</th>
+            <th className="pr-3">Opcode</th>
+            <th className="pr-3">NAC</th>
+            <th className="pr-3">Src</th>
+            <th className="pr-3">Dest/TG</th>
+            <th className="pr-3">CRC</th>
+            <th className="pr-3">FEC</th>
+            <th>Raw</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 500).map((p) => (
+            <tr key={p.seq} className="border-t border-line">
+              <td className="py-1 pr-3">{p.offset_sec.toFixed(2)}</td>
+              <td className="pr-3">
+                {p.opcode_name}
+                <span className="ml-1 text-muted">0x{p.opcode.toString(16)}</span>
+              </td>
+              <td className="pr-3">{p.nac ? `0x${p.nac.toString(16)}` : "—"}</td>
+              <td className="pr-3">{p.source_id || "—"}</td>
+              <td className="pr-3">{p.talkgroup || p.dest_id || "—"}</td>
+              <td className="pr-3">{p.crc_ok ? "✓" : <span className="text-err">✗</span>}</td>
+              <td className="pr-3">{p.fec_metric}</td>
+              <td className="font-mono text-muted">{p.raw_hex}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/web/siglab/src/viz/VSAMetrics.test.tsx
+++ b/web/siglab/src/viz/VSAMetrics.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { VSAMetrics } from "./VSAMetrics";
+import type { DemodMetrics } from "../api/types";
+
+const base: DemodMetrics = {
+  modulation: "cqpsk",
+  evm_pct: 4.2,
+  snr_estimate_db: 27.5,
+  symbols_analyzed: 9000,
+  peak_evm_pct: 11.3,
+  mag_err_pct: 2.1,
+  phase_err_deg: 3.4,
+  carrier_freq_error_hz: 512,
+  iq_gain_imbalance_db: 0.3,
+  quadrature_error_deg: 1.1,
+  origin_offset_pct: 0.8,
+  evm_trace: [1, 2, 3, 4, 5],
+  error_vector_spectrum: [-40, -38, -50, -42],
+};
+
+describe("VSAMetrics", () => {
+  it("renders the VSA decomposition for the CQPSK path", () => {
+    render(<VSAMetrics demod={base} />);
+    expect(screen.getByText("Modulation quality (VSA)")).toBeInTheDocument();
+    expect(screen.getByText("4.20 %")).toBeInTheDocument(); // RMS EVM
+    expect(screen.getByText("11.30 %")).toBeInTheDocument(); // peak EVM
+    expect(screen.getByText("512 Hz")).toBeInTheDocument(); // carrier error
+    expect(screen.getByText("Phase err")).toBeInTheDocument();
+  });
+
+  it("hides phase/IQ fields on the C4FM (1-D) path", () => {
+    render(<VSAMetrics demod={{ ...base, modulation: "c4fm" }} />);
+    expect(screen.queryByText("Phase err")).not.toBeInTheDocument();
+    expect(screen.queryByText("Quadrature err")).not.toBeInTheDocument();
+    expect(screen.getByText("Magnitude err")).toBeInTheDocument();
+  });
+});

--- a/web/siglab/src/viz/VSAMetrics.tsx
+++ b/web/siglab/src/viz/VSAMetrics.tsx
@@ -1,0 +1,117 @@
+import { Line } from "react-chartjs-2";
+import type { DemodMetrics } from "../api/types";
+import { ensureChart } from "./chartSetup";
+
+ensureChart();
+
+// VSAMetrics renders the vector-signal-analyzer decomposition of the recovered
+// constellation — the lab-VSA breakdown (carrier error, EVM split into
+// magnitude/phase, IQ imbalance, origin offset) plus the per-symbol EVM trace
+// and the error-vector spectrum. Mirrors siglab.DemodMetrics; phase/IQ/origin
+// fields are meaningful only on the CQPSK path.
+export function VSAMetrics({ demod }: { demod: DemodMetrics }) {
+  const cqpsk = demod.modulation === "cqpsk";
+  const evm = demod.evm_trace ?? [];
+  const evs = demod.error_vector_spectrum ?? [];
+
+  // Decimate the trace for a responsive chart.
+  const max = 4000;
+  const step = Math.max(1, Math.floor(evm.length / max));
+  const evmLabels: number[] = [];
+  const evmSeries: number[] = [];
+  for (let i = 0; i < evm.length; i += step) {
+    evmLabels.push(i);
+    evmSeries.push(evm[i]);
+  }
+
+  return (
+    <div className="card">
+      <h3 className="mb-2 text-sm font-semibold">Modulation quality (VSA)</h3>
+      <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-3">
+        <Metric label="RMS EVM" value={`${demod.evm_pct.toFixed(2)} %`} />
+        <Metric label="Peak EVM" value={`${demod.peak_evm_pct.toFixed(2)} %`} />
+        <Metric label="SNR est." value={`${demod.snr_estimate_db.toFixed(1)} dB`} />
+        <Metric label="Magnitude err" value={`${demod.mag_err_pct.toFixed(2)} %`} />
+        {cqpsk && <Metric label="Phase err" value={`${demod.phase_err_deg.toFixed(2)}°`} />}
+        <Metric label="Carrier err" value={`${demod.carrier_freq_error_hz.toFixed(0)} Hz`} />
+        {cqpsk && (
+          <Metric label="IQ gain imb." value={`${demod.iq_gain_imbalance_db.toFixed(2)} dB`} />
+        )}
+        {cqpsk && (
+          <Metric label="Quadrature err" value={`${demod.quadrature_error_deg.toFixed(2)}°`} />
+        )}
+        {cqpsk && <Metric label="Origin offset" value={`${demod.origin_offset_pct.toFixed(2)} %`} />}
+      </dl>
+
+      {evmSeries.length > 1 && (
+        <div className="mt-3">
+          <Line
+            data={{
+              labels: evmLabels,
+              datasets: [
+                {
+                  label: "EVM (%)",
+                  data: evmSeries,
+                  borderColor: "rgba(56,189,248,0.9)",
+                  pointRadius: 0,
+                  borderWidth: 1,
+                },
+              ],
+            }}
+            options={{
+              responsive: true,
+              plugins: { legend: { display: false }, title: { display: true, text: "EVM vs symbol" } },
+              scales: {
+                x: { title: { display: true, text: "symbol index" }, ticks: { maxTicksLimit: 10 } },
+                y: { title: { display: true, text: "EVM %" } },
+              },
+            }}
+          />
+        </div>
+      )}
+
+      {evs.length > 1 && (
+        <div className="mt-3">
+          <Line
+            data={{
+              labels: evs.map((_, i) => i - evs.length / 2),
+              datasets: [
+                {
+                  label: "EV spectrum (dB)",
+                  data: evs,
+                  borderColor: "rgba(244,114,182,0.9)",
+                  pointRadius: 0,
+                  borderWidth: 1,
+                },
+              ],
+            }}
+            options={{
+              responsive: true,
+              plugins: {
+                legend: { display: false },
+                title: { display: true, text: "Error-vector spectrum" },
+              },
+              scales: {
+                x: { title: { display: true, text: "bin (DC centred)" }, ticks: { maxTicksLimit: 9 } },
+                y: { title: { display: true, text: "dB" } },
+              },
+            }}
+          />
+        </div>
+      )}
+      <p className="mt-2 text-xs text-muted">
+        Error vectors split into magnitude vs phase. A peak away from centre in the
+        error-vector spectrum points at a periodic impairment; a flat floor is white noise.
+      </p>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex justify-between gap-2">
+      <dt className="text-muted">{label}</dt>
+      <dd className="font-mono">{value}</dd>
+    </div>
+  );
+}

--- a/web/siglab/src/viz/WidebandSurvey.test.tsx
+++ b/web/siglab/src/viz/WidebandSurvey.test.tsx
@@ -94,6 +94,48 @@ describe("WidebandSurvey", () => {
     expect(screen.getByText("voice")).toBeInTheDocument();
   });
 
+  it("names a non-decoding carrier from the reference DB", () => {
+    const r = sampleResult();
+    r.carriers.push({
+      offset_hz: 96_000,
+      freq_hz: 441_096_000,
+      snr_db: 14,
+      protocol: "", // did not decode
+      confidence: 0.2,
+      inconclusive: true,
+      locked: false,
+      role: "",
+      grants: [],
+      score: 0,
+      blind: {
+        symbol_rate_hz: 18000,
+        symbol_rate_conf: 0.9,
+        mod_class: "psk",
+        levels: 4,
+        occupied_bw_hz: 24000,
+        method: "autocorr+spectral",
+      },
+      reference_matches: [
+        {
+          entry: {
+            protocol: "tetra",
+            display_name: "TETRA",
+            mod_class: "psk",
+            mod_labels: ["π/4-DQPSK"],
+            symbol_rate_hz: 18000,
+            channel_bw_hz: 25000,
+            levels: 4,
+            decodable: true,
+          },
+          score: 0.71,
+          why: "25 kHz, π/4-DQPSK, 18000 sym/s",
+        },
+      ],
+    });
+    render(<WidebandSurvey result={r} />);
+    expect(screen.getByText("TETRA (71%)")).toBeInTheDocument();
+  });
+
   it("handles a survey with no carriers", () => {
     const empty: WidebandResult = {
       ...sampleResult(),

--- a/web/siglab/src/viz/WidebandSurvey.tsx
+++ b/web/siglab/src/viz/WidebandSurvey.tsx
@@ -165,7 +165,8 @@ export function WidebandSurvey({ result }: { result: WidebandResult }) {
                 <th className="pr-3">Protocol</th>
                 <th className="pr-3">SNR (dB)</th>
                 <th className="pr-3">Locked</th>
-                <th>Grants</th>
+                <th className="pr-3">Grants</th>
+                <th>Best guess</th>
               </tr>
             </thead>
             <tbody>
@@ -178,7 +179,12 @@ export function WidebandSurvey({ result }: { result: WidebandResult }) {
                   <td className="pr-3">{c.protocol || "—"}</td>
                   <td className="pr-3">{c.snr_db.toFixed(1)}</td>
                   <td className="pr-3">{c.locked ? "✓" : ""}</td>
-                  <td>{c.grants?.length ?? 0}</td>
+                  <td className="pr-3">{c.grants?.length ?? 0}</td>
+                  <td className="text-muted">
+                    {!c.protocol && c.reference_matches && c.reference_matches.length > 0
+                      ? `${c.reference_matches[0].entry.display_name} (${(c.reference_matches[0].score * 100).toFixed(0)}%)`
+                      : "—"}
+                  </td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
Adds VSA-style spectral-occupancy measurements computed off the same
Welch-averaged spectrum SigLab already produces for the PSD:

- internal/dsp/spectrum/occupancy.go: pure ComputeOccupancy() — ITU 99%
  occupied bandwidth, integrated channel power (dBFS), adjacent-channel
  power ratio (upper/lower), and spectral flatness (Wiener entropy),
  reusing the package's dbToLinearPower helper. Deterministic unit tests
  cover tone (narrow/peaky), white noise (wide/flat), and invalid input.
- internal/api/handlers_siglab_spectrum.go: GET /siglab/jobs/{id}/occupancy
  off the existing taps + spectrum.AverageDB, with channel_bw_hz /
  adj_offset_hz / adj_bw_hz query overrides. Route registered in server.go;
  API test extends the PSD/spectrogram coverage.
- web/siglab: OccupancyResult type, jobOccupancy client, and a metric strip
  rendered beneath the PSD chart.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FnP8Wkw9tEbm56AHSonzFt