### PR TITLE
cryptolab: add randomness battery, classifier, period detection, keystream-reuse

### DIFF
--- a/cmd/gophertrunk/cryptolab_enabled.go
+++ b/cmd/gophertrunk/cryptolab_enabled.go
@@ -203,6 +203,11 @@ EXAMPLES:
   gophertrunk cryptolab -resume ./out/cells/checkpoint.json alias cells -csv more.csv
   gophertrunk cryptolab brute xor -in cipher.bin -crib "UNIT "
   gophertrunk cryptolab stats scan -in payload.bin
+  gophertrunk cryptolab stats period -in payload.bin
+  gophertrunk cryptolab classify auto -in unknown.bin
+  gophertrunk cryptolab randomness battery -in keystream.bin
+  gophertrunk cryptolab ks reuse -in frames.jsonl
+  gophertrunk cryptolab ks mtp -in frames.jsonl -known-label call-12 -known-pt known.bin
   gophertrunk cryptolab lfsr bm -in keystream.bin
   gophertrunk cryptolab crc recover -in frames.txt -widths 16,8
   gophertrunk cryptolab descramble invert -in scrambled.s16 -out clear.s16

--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -3,15 +3,19 @@
 `cryptolab` is a byte-oriented cryptographic-research toolkit that ships
 *inside* the `gophertrunk` binary but is **excluded from the default
 install**. It collects the kinds of analysis you reach for when staring at
-unfamiliar RF payloads — statistical triage, keyspace brute force, LFSR /
-keystream analysis, CRC parameter recovery, analog voice descrambling — plus
-a pluggable "subject" framework for studying specific byte-oriented
+unfamiliar RF payloads — statistical triage, autocorrelation period
+detection, a NIST SP 800-22 randomness battery, an obfuscation-class
+classifier, keyspace brute force, LFSR / keystream analysis, keystream-reuse /
+many-time-pad recovery, CRC parameter recovery, analog voice descrambling —
+plus a pluggable "subject" framework for studying specific byte-oriented
 obfuscators.
 
 These are research tools: they recover obfuscation and weak/keyless
 constructions and triage whether a captured payload is even breakable. They
 make no claim to break strong keyed encryption; for that, the toolkit offers
-known-plaintext keystream extraction and breakability triage only.
+known-plaintext keystream extraction and breakability triage only. The
+keystream-reuse tool exploits operator misuse (a repeated IV/MI) and known
+plaintext — never the cipher key itself.
 
 ## Opting in at build time
 
@@ -72,18 +76,37 @@ Global flags precede the tool name (`-out`, `-resume`, `-format`,
 
 | Tool | Modes | What it does |
 |------|-------|--------------|
+| `classify` | `auto` | triage an unknown payload and recommend the next tool |
+| `stats` | `scan`, `period` | entropy / IC / chi-square / XOR key-length triage; autocorrelation period + repeated-n-gram detection |
+| `randomness` | `battery`, `quick` | NIST SP 800-22 randomness tests on a keystream / payload bitstream |
 | `brute` | `xor`, `caesar`, `vigenere`, `substitution` | classical-cipher recovery with English/crib scoring |
 | `lfsr` | `bm`, `keystream` | Berlekamp–Massey LFSR recovery; keystream = pt⊕ct |
+| `ks` | `reuse`, `mtp`, `extract` | keystream-reuse detection, many-time-pad recovery, keystream extraction |
 | `crc` | `recover`, `compute` | recover / compute CRC parameters from sample frames |
-| `stats` | `scan` | entropy / IC / chi-square / XOR key-length triage |
 | `descramble` | `invert`, `splitband`, `rolling` | analog spectral / split-band / rolling-code voice inversion |
 | `alias` | `gauge`, `structure`, `cells`, `fromseed` | length-seeded byte-obfuscator recovery |
 
 ### Examples
 
 ```
+# Triage an unknown payload and get a recommended next command.
+gophertrunk cryptolab classify auto -in unknown.bin
+
 # Statistical triage of an unknown payload.
 gophertrunk cryptolab stats scan -in payload.bin
+
+# Find the period of a repeating-key cipher or periodic scrambler.
+gophertrunk cryptolab stats period -in payload.bin -max-lag 256
+
+# Is a recovered keystream strong (random) or an exploitable generator?
+gophertrunk cryptolab randomness battery -in keystream.bin
+
+# Find frames that reuse an IV/MI (P25 OFB/ADP keystream reuse) ...
+gophertrunk cryptolab ks reuse -in frames.jsonl
+# ... then recover a whole reuse group from one known plaintext.
+gophertrunk cryptolab ks mtp -in frames.jsonl -known-label call-12 -known-pt known.bin
+# ... or crib-drag the group with no known plaintext.
+gophertrunk cryptolab ks mtp -in frames.jsonl -crib " the "
 
 # Recover a repeating-XOR key with a known crib.
 gophertrunk cryptolab brute xor -in cipher.bin -crib "UNIT "
@@ -157,9 +180,57 @@ which the Z3 script consumes directly.
   schedule; `-schedule auto` detects each frame's inversion from its
   spectral energy balance, while a CSV schedule replays a known hop sequence.
 
+## Randomness, classification, and keystream-reuse
+
+These three tools turn the "what am I looking at, and can I break it?" workflow
+into explicit, RF-framed steps:
+
+- **`classify auto`** runs the cheap measurements the other tools depend on
+  (entropy, index of coincidence, repeating-XOR key length, autocorrelation
+  period, and the randomness battery) and emits a ranked verdict —
+  `plaintext`, `substitution-or-shift`, `repeating-xor`, `periodic-scrambler`,
+  `lfsr-or-keyless-scrambler`, or `strong-encrypted` — each with the exact next
+  command to run. It is the front door for an unknown byte payload.
+- **`randomness battery`** runs a NIST SP 800-22 subset (monobit, block
+  frequency, runs, longest run, binary-matrix rank, spectral DFT, approximate
+  entropy, serial, cumulative sums, and **linear complexity**) on a bitstream.
+  The decisive RF question is whether a recovered keystream is statistically
+  random (strong keyed encryption — nothing to exploit) or carries structure (a
+  keyless scrambler or short LFSR). A failing linear-complexity or spectral
+  test is the signature of an LFSR-based scrambler. `randomness quick` runs the
+  fast, low-data subset for short captures. Input is packed bytes, MSB-first
+  (the same convention as `lfsr bm`).
+- **`ks`** exploits **keystream reuse**. Additive stream ciphers (P25 DES-OFB
+  and ADP/RC4, TETRA AIE) produce an identical keystream whenever the same key
+  and IV recur, so two frames sharing an IV satisfy `c1 ⊕ c2 = p1 ⊕ p2` — a
+  running-key system recoverable with crib-dragging or one known plaintext, **no
+  key recovery required**. For P25 the IV is the 72-bit Message Indicator the
+  decoders already extract. `ks reuse` reports IV/MI collisions; `ks mtp`
+  recovers content from a reuse group (from a known plaintext via
+  `-known-label`/`-known-pt`, or by crib-drag via `-crib`); `ks extract`
+  computes a keystream from a known plaintext/ciphertext pair so you can feed it
+  straight to `randomness battery` or `lfsr bm`.
+
+### Frames file format (`ks reuse` / `ks mtp`)
+
+Each non-empty line is either a JSON object or a CSV triple. The JSON form is
+what a future decoder→cryptolab export bridge would emit, one record per
+encrypted frame:
+
+```
+{"label":"call-12","iv":"a1b2c3d4e5f60708090a","ct":"deadbeef…"}
+call-12,a1b2c3d4e5f60708090a,deadbeef…
+```
+
+`label` identifies the source (call id / timestamp), `iv` is the hex IV / P25
+Message Indicator, and `ct` is the hex ciphertext. Frames with an empty IV are
+ignored. Lines beginning with `#` are comments.
+
 ## Scope note
 
 The toolkit does not claim to break strong keyed RF crypto (P25 DES-OFB/AES,
-ADP/RC4). For those it offers known-plaintext keystream extraction (`lfsr`),
-weak/short-key brute force (`brute`), and breakability triage (`stats`); each
-report ends with what additional data would close the remaining gap.
+ADP/RC4). For those it offers known-plaintext keystream extraction (`lfsr`,
+`ks extract`), keystream-reuse / many-time-pad recovery when a transmitter
+repeats an IV/MI (`ks`), weak/short-key brute force (`brute`), and breakability
+triage (`stats`, `randomness`, `classify`); each report ends with what
+additional data would close the remaining gap.

--- a/internal/cryptolab/doc.go
+++ b/internal/cryptolab/doc.go
@@ -1,9 +1,12 @@
 // Package cryptolab is GopherTrunk's optional cryptographic-research
 // toolkit: a set of byte-oriented analysis and brute-force tools for the
 // kinds of obfuscation and weak/keyless ciphers found in RF traffic. It
-// ships statistical triage, keyspace brute force, LFSR/keystream analysis,
-// CRC parameter recovery, analog voice descrambling, and a pluggable
-// "subject" framework for studying specific byte-oriented obfuscators.
+// ships statistical triage (entropy/IC plus autocorrelation period
+// detection), a NIST SP 800-22 randomness battery, an obfuscation-class
+// classifier, keyspace brute force, LFSR/keystream analysis,
+// keystream-reuse / many-time-pad recovery, CRC parameter recovery, analog
+// voice descrambling, and a pluggable "subject" framework for studying
+// specific byte-oriented obfuscators.
 //
 // # Optional at install
 //
@@ -23,7 +26,10 @@
 // constructions and triage whether a captured payload is even breakable;
 // they make no claim to break strong keyed encryption (e.g. DES/AES,
 // RC4-based schemes). For those, the toolkit offers known-plaintext
-// keystream extraction and breakability triage only.
+// keystream extraction and breakability triage only. The keystream-reuse /
+// many-time-pad tool likewise exploits operator misuse (a repeated IV/MI
+// reusing a keystream) and known plaintext — it does not attack the cipher
+// key itself.
 package cryptolab
 
 // SubcommandName is the gophertrunk subcommand under which the toolkit is

--- a/internal/cryptolab/engine/keystream/keystream.go
+++ b/internal/cryptolab/engine/keystream/keystream.go
@@ -1,0 +1,175 @@
+// Package keystream implements keystream-reuse / many-time-pad analysis — the
+// real-world break against additive stream ciphers (P25 DES-OFB and ADP/RC4,
+// TETRA AIE) when a transmitter reuses an initialisation vector. Under OFB and
+// raw stream ciphers the keystream is a deterministic function of (key, IV);
+// two frames sent under the same key and the same IV therefore share an
+// identical keystream, and XORing their ciphertexts cancels it:
+//
+//	c1 ^ c2 = (p1 ^ ks) ^ (p2 ^ ks) = p1 ^ p2
+//
+// leaving a classic running-key system that crib-dragging and a language
+// model can peel apart — no key recovery required. For P25 the IV is the
+// 72-bit Message Indicator the decoder already extracts, so this is the bridge
+// from "encrypted, opaque" to "recoverable" whenever a radio's MI repeats.
+//
+// This package only exploits operator misuse (IV reuse) and known plaintext;
+// it does not attack the cipher's key, in keeping with the toolkit's scope.
+package keystream
+
+import (
+	"encoding/hex"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lang"
+)
+
+// Frame is one captured encrypted unit: an IV (e.g. a P25 Message Indicator)
+// and the ciphertext under that IV. Label identifies the source (call id,
+// timestamp) for reporting.
+type Frame struct {
+	Label string
+	IV    []byte
+	CT    []byte
+}
+
+// ReuseGroup is a set of frames that share an identical IV and therefore an
+// identical keystream.
+type ReuseGroup struct {
+	IV     []byte
+	Frames []Frame
+}
+
+// XOR returns a^b over the common prefix (min length). It is the additive
+// stream-cipher primitive: keystream = pt^ct, and ct1^ct2 = pt1^pt2.
+func XOR(a, b []byte) []byte {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		out[i] = a[i] ^ b[i]
+	}
+	return out
+}
+
+// FindReuse groups frames sharing an identical IV, returning only groups with
+// at least two frames (the exploitable ones), largest group first. Frames
+// with an empty IV are ignored — without an IV there is nothing to collide.
+func FindReuse(frames []Frame) []ReuseGroup {
+	byIV := make(map[string][]Frame)
+	var order []string
+	for _, f := range frames {
+		if len(f.IV) == 0 {
+			continue
+		}
+		k := string(f.IV)
+		if _, seen := byIV[k]; !seen {
+			order = append(order, k)
+		}
+		byIV[k] = append(byIV[k], f)
+	}
+	var out []ReuseGroup
+	for _, k := range order {
+		if len(byIV[k]) >= 2 {
+			out = append(out, ReuseGroup{IV: []byte(k), Frames: byIV[k]})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if len(out[i].Frames) != len(out[j].Frames) {
+			return len(out[i].Frames) > len(out[j].Frames)
+		}
+		return hex.EncodeToString(out[i].IV) < hex.EncodeToString(out[j].IV)
+	})
+	return out
+}
+
+// Decoded is one frame recovered by RecoverWithKnown.
+type Decoded struct {
+	Label     string
+	Plaintext []byte
+}
+
+// RecoverWithKnown turns one known plaintext within a reuse group into the
+// group's keystream (ks = knownPT ^ knownCT) and uses it to decrypt every
+// other frame in the group. This is the decisive step once any single frame's
+// content is known (a standard tone, a known data payload, a confirmed
+// transcript). It returns the recovered keystream and the decrypted frames.
+func RecoverWithKnown(group ReuseGroup, knownLabel string, knownPT []byte) (ks []byte, out []Decoded, ok bool) {
+	var known *Frame
+	for i := range group.Frames {
+		if group.Frames[i].Label == knownLabel {
+			known = &group.Frames[i]
+			break
+		}
+	}
+	if known == nil {
+		return nil, nil, false
+	}
+	ks = XOR(knownPT, known.CT)
+	for _, f := range group.Frames {
+		out = append(out, Decoded{Label: f.Label, Plaintext: XOR(f.CT, ks)})
+	}
+	return ks, out, true
+}
+
+// DragHit is one crib-drag placement: positioning crib at Offset in one
+// ciphertext reveals Revealed in the partner, scored by a language model.
+type DragHit struct {
+	CribLabel    string
+	PartnerLabel string
+	Offset       int
+	Revealed     []byte
+	Score        float64
+}
+
+// CribDragGroup slides crib across every ordered ciphertext pair in the group
+// (c_i ^ c_j ^ crib) and returns the placements whose revealed partner bytes
+// are fully printable, ranked by English trigram score — the highest are the
+// likely true positions. With the right crib this peels plaintext out of a
+// reuse group with no key and no known plaintext.
+func CribDragGroup(group ReuseGroup, crib []byte, topN int) []DragHit {
+	if len(crib) == 0 {
+		return nil
+	}
+	model := lang.EnglishTrigram()
+	var hits []DragHit
+	for i := range group.Frames {
+		for j := range group.Frames {
+			if i == j {
+				continue
+			}
+			a, b := group.Frames[i].CT, group.Frames[j].CT
+			n := len(a)
+			if len(b) < n {
+				n = len(b)
+			}
+			for off := 0; off+len(crib) <= n; off++ {
+				rev := make([]byte, len(crib))
+				printable := true
+				for k := range crib {
+					rev[k] = a[off+k] ^ b[off+k] ^ crib[k]
+					if rev[k] < 0x20 || rev[k] > 0x7e {
+						printable = false
+						break
+					}
+				}
+				if !printable {
+					continue
+				}
+				hits = append(hits, DragHit{
+					CribLabel:    group.Frames[i].Label,
+					PartnerLabel: group.Frames[j].Label,
+					Offset:       off,
+					Revealed:     rev,
+					Score:        model.Score(rev),
+				})
+			}
+		}
+	}
+	sort.SliceStable(hits, func(i, j int) bool { return hits[i].Score > hits[j].Score })
+	if topN > 0 && len(hits) > topN {
+		hits = hits[:topN]
+	}
+	return hits
+}

--- a/internal/cryptolab/engine/keystream/keystream_test.go
+++ b/internal/cryptolab/engine/keystream/keystream_test.go
@@ -1,0 +1,77 @@
+package keystream
+
+import (
+	"bytes"
+	"testing"
+)
+
+// synth builds a frame: ct = pt ^ ks (ks truncated/cycled to len(pt)).
+func synth(label string, iv, ks, pt []byte) Frame {
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] ^ ks[i%len(ks)]
+	}
+	return Frame{Label: label, IV: iv, CT: ct}
+}
+
+func TestFindReuseGroupsByIV(t *testing.T) {
+	t.Parallel()
+	ksA := []byte{0x9e, 0x21, 0x55, 0x7c, 0x03, 0xaa, 0x11, 0x42}
+	ksB := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+	frames := []Frame{
+		synth("a1", []byte{1, 2, 3}, ksA, []byte("ATTACK AT DAWN")),
+		synth("a2", []byte{1, 2, 3}, ksA, []byte("RETREAT BY SEA")),
+		synth("b1", []byte{9, 9, 9}, ksB, []byte("UNRELATED FRAME")),
+	}
+	groups := FindReuse(frames)
+	if len(groups) != 1 {
+		t.Fatalf("want 1 reuse group, got %d", len(groups))
+	}
+	if len(groups[0].Frames) != 2 {
+		t.Fatalf("want 2 frames in the reused group, got %d", len(groups[0].Frames))
+	}
+}
+
+func TestRecoverWithKnownDecryptsGroup(t *testing.T) {
+	t.Parallel()
+	ks := []byte{0x9e, 0x21, 0x55, 0x7c, 0x03, 0xaa, 0x11, 0x42, 0xfe, 0x10, 0x77, 0x33, 0x88, 0x29}
+	pt1 := []byte("ATTACK AT DAWN")
+	pt2 := []byte("RETREAT BY SEA")
+	iv := []byte{1, 2, 3}
+	g := ReuseGroup{IV: iv, Frames: []Frame{
+		synth("a1", iv, ks, pt1),
+		synth("a2", iv, ks, pt2),
+	}}
+	recoveredKS, decoded, ok := RecoverWithKnown(g, "a1", pt1)
+	if !ok {
+		t.Fatal("known frame not found")
+	}
+	if !bytes.Equal(recoveredKS, ks[:len(pt1)]) {
+		t.Fatalf("recovered keystream wrong:\n got %x\nwant %x", recoveredKS, ks[:len(pt1)])
+	}
+	want := map[string][]byte{"a1": pt1, "a2": pt2}
+	for _, d := range decoded {
+		if !bytes.Equal(d.Plaintext, want[d.Label]) {
+			t.Fatalf("frame %s decrypted to %q, want %q", d.Label, d.Plaintext, want[d.Label])
+		}
+	}
+}
+
+func TestCribDragGroupFindsKnownWord(t *testing.T) {
+	t.Parallel()
+	ks := bytes.Repeat([]byte{0x5a, 0xc3, 0x07, 0x91, 0x2e, 0x6b}, 16)
+	iv := []byte{0x10, 0x20}
+	g := ReuseGroup{IV: iv, Frames: []Frame{
+		synth("m1", iv, ks, []byte("the dispatch unit is on the way now")),
+		synth("m2", iv, ks, []byte("please send the bridge to the depot")),
+	}}
+	hits := CribDragGroup(g, []byte("the "), 20)
+	if len(hits) == 0 {
+		t.Fatal("crib-drag found nothing")
+	}
+	// The top-scoring hit should reveal real English in the partner frame.
+	top := hits[0]
+	if len(top.Revealed) == 0 {
+		t.Fatal("empty revealed fragment")
+	}
+}

--- a/internal/cryptolab/engine/randomness/randomness.go
+++ b/internal/cryptolab/engine/randomness/randomness.go
@@ -1,0 +1,591 @@
+// Package randomness implements a battery of statistical randomness tests
+// drawn from NIST SP 800-22 (the "STS" suite), specialised for the question
+// an RF analyst actually asks of a captured payload or a recovered keystream:
+// is this stream indistinguishable from random (strong keyed encryption — no
+// weak structure to exploit), or does it carry exploitable structure (a
+// keyless scrambler, a short LFSR, a biased generator)?
+//
+// Each test returns a p-value in [0,1]; a stream "passes" a test at
+// significance level alpha when p >= alpha. A truly random stream passes all
+// tests; a structured one fails one or more (most diagnostically the spectral
+// and linear-complexity tests for RF scramblers). The toolkit's existing
+// entropy / index-of-coincidence triage (engine/stats) answers the same
+// question coarsely; this battery answers it rigorously.
+//
+// Bit sequences are represented as a []byte holding one 0/1 value per element
+// (the same convention as engine/lfsr), so callers convert packed capture
+// bytes with lfsr.BitsFromBytes. The incomplete-gamma p-values use gonum's
+// mathext.GammaIncRegComp and the spectral test uses gonum's real FFT, so the
+// suite stays pure-Go with no new dependencies.
+package randomness
+
+import (
+	"math"
+	"math/cmplx"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
+	"gonum.org/v1/gonum/dsp/fourier"
+	"gonum.org/v1/gonum/mathext"
+)
+
+// DefaultAlpha is the conventional NIST significance level.
+const DefaultAlpha = 0.01
+
+// TestResult is the outcome of one randomness test.
+type TestResult struct {
+	Name string `json:"name"`
+	// PValue is the test statistic's p-value in [0,1]; only meaningful when
+	// Applicable is true.
+	PValue float64 `json:"p_value"`
+	// Passed reports p >= alpha. Only meaningful when Applicable is true.
+	Passed bool `json:"passed"`
+	// Applicable is false when the stream is too short for the test's
+	// preconditions; Note explains what is missing.
+	Applicable bool   `json:"applicable"`
+	Note       string `json:"note,omitempty"`
+}
+
+// Report is the full battery outcome over one bit stream.
+type Report struct {
+	Bits    int          `json:"bits"`
+	Alpha   float64      `json:"alpha"`
+	Tests   []TestResult `json:"tests"`
+	Passed  int          `json:"passed"`
+	Failed  int          `json:"failed"`
+	Skipped int          `json:"skipped"`
+}
+
+// igamc is the regularised upper incomplete gamma function Q(a,x), the
+// p-value form NIST uses for its chi-square-distributed statistics.
+func igamc(a, x float64) float64 {
+	if x < 0 || a <= 0 {
+		return 0
+	}
+	return mathext.GammaIncRegComp(a, x)
+}
+
+// normCDF is the standard normal cumulative distribution function.
+func normCDF(x float64) float64 { return 0.5 * math.Erfc(-x/math.Sqrt2) }
+
+// minus1pow returns (-1)^k without floating-point pow.
+func minus1pow(k int) float64 {
+	if k%2 == 0 {
+		return 1
+	}
+	return -1
+}
+
+func na(name, note string) TestResult {
+	return TestResult{Name: name, Applicable: false, Note: note}
+}
+
+// Monobit (frequency) test: are roughly half the bits one? The most basic
+// test; everything else assumes this passes.
+func Monobit(bits []byte) TestResult {
+	n := len(bits)
+	if n < 1 {
+		return na("monobit", "no bits")
+	}
+	s := 0
+	for _, b := range bits {
+		if b&1 == 1 {
+			s++
+		} else {
+			s--
+		}
+	}
+	sObs := math.Abs(float64(s)) / math.Sqrt(float64(n))
+	p := math.Erfc(sObs / math.Sqrt2)
+	return TestResult{Name: "monobit", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+}
+
+// BlockFrequency: is the proportion of ones uniform across M-bit blocks?
+func BlockFrequency(bits []byte, m int) TestResult {
+	n := len(bits)
+	if m < 1 {
+		m = 1
+	}
+	N := n / m
+	if N < 1 {
+		return na("block_frequency", "need at least one full block")
+	}
+	var sum float64
+	for i := 0; i < N; i++ {
+		ones := 0
+		for j := 0; j < m; j++ {
+			ones += int(bits[i*m+j] & 1)
+		}
+		pi := float64(ones)/float64(m) - 0.5
+		sum += pi * pi
+	}
+	chi := 4 * float64(m) * sum
+	p := igamc(float64(N)/2, chi/2)
+	return TestResult{Name: "block_frequency", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+}
+
+// Runs: is the number of uninterrupted runs of identical bits what a random
+// stream would produce? Detects oscillation that is too fast or too slow.
+func Runs(bits []byte) TestResult {
+	n := len(bits)
+	if n < 2 {
+		return na("runs", "need at least 2 bits")
+	}
+	ones := 0
+	for _, b := range bits {
+		ones += int(b & 1)
+	}
+	pi := float64(ones) / float64(n)
+	if math.Abs(pi-0.5) >= 2/math.Sqrt(float64(n)) {
+		return TestResult{Name: "runs", PValue: 0, Passed: false, Applicable: true,
+			Note: "fails the monobit precondition; runs p-value forced to 0"}
+	}
+	v := 1
+	for i := 1; i < n; i++ {
+		if bits[i]&1 != bits[i-1]&1 {
+			v++
+		}
+	}
+	num := math.Abs(float64(v) - 2*float64(n)*pi*(1-pi))
+	den := 2 * math.Sqrt(2*float64(n)) * pi * (1 - pi)
+	p := math.Erfc(num / den)
+	return TestResult{Name: "runs", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+}
+
+// LongestRun: is the longest run of ones within a block consistent with
+// randomness? Uses the NIST block size / category table selected by length.
+func LongestRun(bits []byte) TestResult {
+	n := len(bits)
+	var m int
+	var pi []float64
+	var bucket func(int) int
+	switch {
+	case n < 128:
+		return na("longest_run", "need >= 128 bits")
+	case n < 6272:
+		m = 8
+		pi = []float64{0.2148, 0.3672, 0.2305, 0.1875}
+		bucket = func(v int) int {
+			switch {
+			case v <= 1:
+				return 0
+			case v == 2:
+				return 1
+			case v == 3:
+				return 2
+			default:
+				return 3
+			}
+		}
+	case n < 750000:
+		m = 128
+		pi = []float64{0.1174, 0.2430, 0.2493, 0.1752, 0.1027, 0.1124}
+		bucket = func(v int) int {
+			switch {
+			case v <= 4:
+				return 0
+			case v >= 9:
+				return 5
+			default:
+				return v - 4
+			}
+		}
+	default:
+		m = 10000
+		pi = []float64{0.0882, 0.2092, 0.2483, 0.1933, 0.1208, 0.0675, 0.0727}
+		bucket = func(v int) int {
+			switch {
+			case v <= 10:
+				return 0
+			case v >= 16:
+				return 6
+			default:
+				return v - 10
+			}
+		}
+	}
+	N := n / m
+	v := make([]int, len(pi))
+	for i := 0; i < N; i++ {
+		longest, cur := 0, 0
+		for j := 0; j < m; j++ {
+			if bits[i*m+j]&1 == 1 {
+				cur++
+				if cur > longest {
+					longest = cur
+				}
+			} else {
+				cur = 0
+			}
+		}
+		v[bucket(longest)]++
+	}
+	var chi float64
+	for i := range pi {
+		e := float64(N) * pi[i]
+		d := float64(v[i]) - e
+		chi += d * d / e
+	}
+	p := igamc(float64(len(pi)-1)/2, chi/2)
+	return TestResult{Name: "longest_run", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+}
+
+// gf2Rank returns the GF(2) rank of an r×c bit matrix whose rows are packed
+// MSB-first into uint64 (c <= 64).
+func gf2Rank(rows []uint64, r, c int) int {
+	rank := 0
+	for col := 0; col < c && rank < r; col++ {
+		mask := uint64(1) << uint(c-1-col)
+		pivot := -1
+		for i := rank; i < r; i++ {
+			if rows[i]&mask != 0 {
+				pivot = i
+				break
+			}
+		}
+		if pivot < 0 {
+			continue
+		}
+		rows[rank], rows[pivot] = rows[pivot], rows[rank]
+		for i := 0; i < r; i++ {
+			if i != rank && rows[i]&mask != 0 {
+				rows[i] ^= rows[rank]
+			}
+		}
+		rank++
+	}
+	return rank
+}
+
+// BinaryMatrixRank: do the ranks of disjoint 32×32 sub-matrices follow the
+// expected distribution? Detects linear dependence among bit positions.
+func BinaryMatrixRank(bits []byte) TestResult {
+	const M, Q = 32, 32
+	n := len(bits)
+	N := n / (M * Q)
+	if N < 1 {
+		return na("binary_matrix_rank", "need >= 1024 bits")
+	}
+	var fm, fm1, rest int
+	for blk := 0; blk < N; blk++ {
+		rows := make([]uint64, M)
+		base := blk * M * Q
+		for r := 0; r < M; r++ {
+			var row uint64
+			for c := 0; c < Q; c++ {
+				if bits[base+r*Q+c]&1 == 1 {
+					row |= uint64(1) << uint(Q-1-c)
+				}
+			}
+			rows[r] = row
+		}
+		switch gf2Rank(rows, M, Q) {
+		case M:
+			fm++
+		case M - 1:
+			fm1++
+		default:
+			rest++
+		}
+	}
+	nf := float64(N)
+	chi := sq(float64(fm)-0.2888*nf)/(0.2888*nf) +
+		sq(float64(fm1)-0.5776*nf)/(0.5776*nf) +
+		sq(float64(rest)-0.1336*nf)/(0.1336*nf)
+	p := math.Exp(-chi / 2)
+	res := TestResult{Name: "binary_matrix_rank", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+	if N < 38 {
+		res.Note = "fewer than 38 matrices; p-value is approximate"
+	}
+	return res
+}
+
+// Spectral (DFT): does the discrete Fourier transform of the ±1 sequence
+// show periodic features (spikes) inconsistent with randomness? This is the
+// sharpest test for periodic RF scramblers and rolling codes.
+func Spectral(bits []byte) TestResult {
+	n := len(bits)
+	if n < 128 {
+		return na("spectral_dft", "need >= 128 bits")
+	}
+	seq := make([]float64, n)
+	for i, b := range bits {
+		if b&1 == 1 {
+			seq[i] = 1
+		} else {
+			seq[i] = -1
+		}
+	}
+	coeff := fourier.NewFFT(n).Coefficients(nil, seq)
+	half := n / 2
+	t := math.Sqrt(math.Log(1/0.05) * float64(n))
+	n0 := 0.95 * float64(n) / 2
+	n1 := 0
+	for i := 0; i < half; i++ {
+		if cmplx.Abs(coeff[i]) < t {
+			n1++
+		}
+	}
+	d := (float64(n1) - n0) / math.Sqrt(float64(n)*0.95*0.05/4.0)
+	p := math.Erfc(math.Abs(d) / math.Sqrt2)
+	return TestResult{Name: "spectral_dft", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+}
+
+// patternCounts counts occurrences of each m-bit pattern in the cyclically
+// extended sequence (NIST convention for ApEn and Serial).
+func patternCounts(bits []byte, m int) []int {
+	n := len(bits)
+	counts := make([]int, 1<<uint(m))
+	for i := 0; i < n; i++ {
+		idx := 0
+		for j := 0; j < m; j++ {
+			idx = (idx << 1) | int(bits[(i+j)%n]&1)
+		}
+		counts[idx]++
+	}
+	return counts
+}
+
+// ApproximateEntropy: compares the frequency of overlapping m- and
+// (m+1)-bit patterns; structure lowers the apparent entropy.
+func ApproximateEntropy(bits []byte, m int) TestResult {
+	n := len(bits)
+	if m < 1 || n < (1<<uint(m+5)) {
+		return na("approximate_entropy", "stream too short for the chosen block length")
+	}
+	phi := func(k int) float64 {
+		counts := patternCounts(bits, k)
+		var s float64
+		for _, c := range counts {
+			if c > 0 {
+				ci := float64(c) / float64(n)
+				s += ci * math.Log(ci)
+			}
+		}
+		return s
+	}
+	apen := phi(m) - phi(m+1)
+	chi := 2 * float64(n) * (math.Ln2 - apen)
+	p := igamc(math.Exp2(float64(m-1)), chi/2)
+	return TestResult{Name: "approximate_entropy", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+}
+
+// psi2 is the NIST serial-test statistic for block length m.
+func psi2(bits []byte, m int) float64 {
+	if m <= 0 {
+		return 0
+	}
+	n := len(bits)
+	counts := patternCounts(bits, m)
+	var s float64
+	for _, c := range counts {
+		s += float64(c) * float64(c)
+	}
+	return s*math.Exp2(float64(m))/float64(n) - float64(n)
+}
+
+// Serial: are all overlapping m-bit patterns equally likely? Returns a single
+// result that passes only when both NIST sub-p-values pass.
+func Serial(bits []byte, m int) TestResult {
+	n := len(bits)
+	if m < 3 || n < (1<<uint(m+5)) {
+		return na("serial", "stream too short for the chosen block length")
+	}
+	p0 := psi2(bits, m)
+	p1 := psi2(bits, m-1)
+	p2 := psi2(bits, m-2)
+	del1 := p0 - p1
+	del2 := p0 - 2*p1 + p2
+	pv1 := igamc(math.Exp2(float64(m-2)), del1/2)
+	pv2 := igamc(math.Exp2(float64(m-3)), del2/2)
+	pv := math.Min(pv1, pv2)
+	return TestResult{Name: "serial", PValue: pv, Passed: pv1 >= DefaultAlpha && pv2 >= DefaultAlpha, Applicable: true}
+}
+
+// CumulativeSums (forward): treats the ±1 sequence as a random walk and tests
+// whether the maximum excursion from zero is too large.
+func CumulativeSums(bits []byte) TestResult {
+	n := len(bits)
+	if n < 2 {
+		return na("cumulative_sums", "need at least 2 bits")
+	}
+	z, s := 0, 0
+	for _, b := range bits {
+		if b&1 == 1 {
+			s++
+		} else {
+			s--
+		}
+		if a := abs(s); a > z {
+			z = a
+		}
+	}
+	if z == 0 {
+		return TestResult{Name: "cumulative_sums", PValue: 1, Passed: true, Applicable: true}
+	}
+	zf, nf := float64(z), float64(n)
+	sqn := math.Sqrt(nf)
+	var sum1, sum2 float64
+	for k := int(math.Floor((-nf/zf + 1) / 4)); k <= int(math.Floor((nf/zf-1)/4)); k++ {
+		kf := float64(k)
+		sum1 += normCDF((4*kf+1)*zf/sqn) - normCDF((4*kf-1)*zf/sqn)
+	}
+	for k := int(math.Floor((-nf/zf - 3) / 4)); k <= int(math.Floor((nf/zf-1)/4)); k++ {
+		kf := float64(k)
+		sum2 += normCDF((4*kf+3)*zf/sqn) - normCDF((4*kf+1)*zf/sqn)
+	}
+	p := 1 - sum1 + sum2
+	p = clamp01(p)
+	return TestResult{Name: "cumulative_sums", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+}
+
+// LinearComplexity: blocks the stream and tests the distribution of each
+// block's shortest-LFSR length (via Berlekamp–Massey). Low linear complexity
+// is the defining weakness of an LFSR-based scrambler, so this is the most
+// RF-diagnostic test in the suite.
+func LinearComplexity(bits []byte, m int) TestResult {
+	if m <= 0 {
+		m = 500
+	}
+	n := len(bits)
+	N := n / m
+	if N < 1 {
+		return na("linear_complexity", "need at least one full block (default 500 bits)")
+	}
+	pi := []float64{0.010417, 0.03125, 0.125, 0.5, 0.25, 0.0625, 0.020833}
+	mu := float64(m)/2 + (9+minus1pow(m+1))/36 - (float64(m)/3+2.0/9.0)/math.Exp2(float64(m))
+	v := make([]int, 7)
+	for i := 0; i < N; i++ {
+		block := bits[i*m : (i+1)*m]
+		l := lfsr.BerlekampMassey(block).LinearComplexity
+		ti := minus1pow(m)*(float64(l)-mu) + 2.0/9.0
+		switch {
+		case ti <= -2.5:
+			v[0]++
+		case ti <= -1.5:
+			v[1]++
+		case ti <= -0.5:
+			v[2]++
+		case ti <= 0.5:
+			v[3]++
+		case ti <= 1.5:
+			v[4]++
+		case ti <= 2.5:
+			v[5]++
+		default:
+			v[6]++
+		}
+	}
+	var chi float64
+	for i := range pi {
+		e := float64(N) * pi[i]
+		d := float64(v[i]) - e
+		chi += d * d / e
+	}
+	p := igamc(3, chi/2) // K=6 categories -> K/2 = 3
+	res := TestResult{Name: "linear_complexity", PValue: p, Passed: p >= DefaultAlpha, Applicable: true}
+	if N < 200 {
+		res.Note = "fewer than 200 blocks; p-value is approximate"
+	}
+	return res
+}
+
+// Battery runs the full suite over the bit stream, choosing block sizes from
+// the stream length. alpha <= 0 selects DefaultAlpha.
+func Battery(bits []byte, alpha float64) Report {
+	if alpha <= 0 {
+		alpha = DefaultAlpha
+	}
+	n := len(bits)
+	blockM := n / 100
+	if blockM < 20 {
+		blockM = 20
+	}
+	if blockM > 10000 {
+		blockM = 10000
+	}
+	tests := []TestResult{
+		Monobit(bits),
+		BlockFrequency(bits, blockM),
+		Runs(bits),
+		LongestRun(bits),
+		BinaryMatrixRank(bits),
+		Spectral(bits),
+		ApproximateEntropy(bits, 2),
+		Serial(bits, 3),
+		CumulativeSums(bits),
+		LinearComplexity(bits, 0),
+	}
+	return finalize(bits, alpha, tests)
+}
+
+// Quick runs the fast, low-data subset suitable for short captures.
+func Quick(bits []byte, alpha float64) Report {
+	if alpha <= 0 {
+		alpha = DefaultAlpha
+	}
+	n := len(bits)
+	blockM := n / 50
+	if blockM < 20 {
+		blockM = 20
+	}
+	tests := []TestResult{
+		Monobit(bits),
+		BlockFrequency(bits, blockM),
+		Runs(bits),
+		CumulativeSums(bits),
+	}
+	return finalize(bits, alpha, tests)
+}
+
+func finalize(bits []byte, alpha float64, tests []TestResult) Report {
+	rep := Report{Bits: len(bits), Alpha: alpha, Tests: tests}
+	for i := range rep.Tests {
+		t := &rep.Tests[i]
+		if !t.Applicable {
+			rep.Skipped++
+			continue
+		}
+		t.Passed = t.PValue >= alpha
+		if t.Passed {
+			rep.Passed++
+		} else {
+			rep.Failed++
+		}
+	}
+	return rep
+}
+
+// WeakestTests returns the applicable tests sorted by ascending p-value (the
+// strongest evidence of non-randomness first).
+func (r Report) WeakestTests() []TestResult {
+	out := make([]TestResult, 0, len(r.Tests))
+	for _, t := range r.Tests {
+		if t.Applicable {
+			out = append(out, t)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].PValue < out[j].PValue })
+	return out
+}
+
+// LooksRandom reports whether every applicable test passed — i.e. the stream
+// is statistically indistinguishable from random at the report's alpha.
+func (r Report) LooksRandom() bool { return r.Failed == 0 && r.Passed > 0 }
+
+func sq(x float64) float64 { return x * x }
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/internal/cryptolab/engine/randomness/randomness_test.go
+++ b/internal/cryptolab/engine/randomness/randomness_test.go
@@ -1,0 +1,97 @@
+package randomness
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
+)
+
+// randomBits returns n pseudo-random 0/1 values from a seeded generator — a
+// good PRNG, so the battery should clear every applicable test.
+func randomBits(seed int64, n int) []byte {
+	r := rand.New(rand.NewSource(seed))
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = byte(r.Intn(2))
+	}
+	return out
+}
+
+func TestBatteryAcceptsRandomStream(t *testing.T) {
+	t.Parallel()
+	rep := Battery(randomBits(1, 200000), DefaultAlpha)
+	if rep.Failed > 1 {
+		t.Fatalf("random stream failed %d tests (want <=1): %+v", rep.Failed, rep.WeakestTests()[:3])
+	}
+	if rep.Passed < 8 {
+		t.Fatalf("random stream only passed %d tests: %+v", rep.Passed, rep.Tests)
+	}
+}
+
+func TestBatteryRejectsShortLFSR(t *testing.T) {
+	t.Parallel()
+	// A degree-9 LFSR has linear complexity 9 over any block, far below the
+	// ~M/2 a random stream shows — the linear-complexity and spectral tests
+	// must catch it.
+	seq, err := lfsr.Generate([]int{9, 5}, []byte{1, 0, 1, 1, 0, 0, 1, 0, 1}, 200000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep := Battery(seq, DefaultAlpha)
+	if rep.LooksRandom() {
+		t.Fatalf("short LFSR stream judged random: %+v", rep.Tests)
+	}
+	lc := find(rep, "linear_complexity")
+	if lc == nil || !lc.Applicable || lc.Passed {
+		t.Fatalf("linear_complexity should fail on a short LFSR, got %+v", lc)
+	}
+}
+
+func TestBatteryRejectsConstantStream(t *testing.T) {
+	t.Parallel()
+	bits := make([]byte, 100000) // all zeros
+	rep := Battery(bits, DefaultAlpha)
+	mb := find(rep, "monobit")
+	if mb == nil || mb.Passed {
+		t.Fatalf("monobit should fail on all-zero stream, got %+v", mb)
+	}
+	if rep.LooksRandom() {
+		t.Fatal("all-zero stream judged random")
+	}
+}
+
+func TestBatteryRejectsPeriodicStream(t *testing.T) {
+	t.Parallel()
+	// A short repeating pattern is highly periodic — the spectral test should
+	// flag it.
+	pat := []byte{1, 1, 0, 0, 1, 0, 1, 0}
+	bits := make([]byte, 0, 100000)
+	for len(bits) < 100000 {
+		bits = append(bits, pat...)
+	}
+	rep := Battery(bits[:100000], DefaultAlpha)
+	if rep.LooksRandom() {
+		t.Fatalf("periodic stream judged random: %+v", rep.Tests)
+	}
+}
+
+func TestQuickSubset(t *testing.T) {
+	t.Parallel()
+	rep := Quick(randomBits(7, 20000), DefaultAlpha)
+	if len(rep.Tests) != 4 {
+		t.Fatalf("quick should run 4 tests, ran %d", len(rep.Tests))
+	}
+	if rep.Failed > 1 {
+		t.Fatalf("quick failed %d on a random stream", rep.Failed)
+	}
+}
+
+func find(r Report, name string) *TestResult {
+	for i := range r.Tests {
+		if r.Tests[i].Name == name {
+			return &r.Tests[i]
+		}
+	}
+	return nil
+}

--- a/internal/cryptolab/engine/stats/period.go
+++ b/internal/cryptolab/engine/stats/period.go
@@ -1,0 +1,119 @@
+package stats
+
+import (
+	"math"
+	"sort"
+)
+
+// Autocorrelation returns, for each lag 1..maxLag, the coincidence rate: the
+// fraction of positions i where data[i] == data[i+lag]. For a uniform random
+// byte stream this sits near 1/256 ≈ 0.0039 at every lag; a repeating-key
+// cipher, a periodic scrambler, or a reused keystream produces sharp peaks at
+// multiples of its period. This is the byte-level analogue of CrypTool's
+// autocorrelation view, and the prerequisite measurement before choosing a
+// repeating-XOR key length or a rolling-descramble frame size.
+func Autocorrelation(data []byte, maxLag int) []float64 {
+	n := len(data)
+	if maxLag < 1 || n < 2 {
+		return nil
+	}
+	if maxLag > n-1 {
+		maxLag = n - 1
+	}
+	out := make([]float64, maxLag+1) // index by lag; out[0] unused
+	for lag := 1; lag <= maxLag; lag++ {
+		matches := 0
+		count := n - lag
+		for i := 0; i < count; i++ {
+			if data[i] == data[i+lag] {
+				matches++
+			}
+		}
+		out[lag] = float64(matches) / float64(count)
+	}
+	return out
+}
+
+// PeriodCandidate is one lag whose coincidence rate stands out, the likely
+// period (or a multiple of it) of a repeating structure.
+type PeriodCandidate struct {
+	Lag         int
+	Coincidence float64
+	// ZScore is how many baseline standard deviations the coincidence sits
+	// above the mean coincidence across all lags — a scale-free strength.
+	ZScore float64
+}
+
+// DetectPeriod ranks the lags of Autocorrelation by how far their coincidence
+// rate exceeds the across-lag baseline, returning the strongest candidates
+// first. An empty result means no lag stood out (no detectable period within
+// maxLag). topN <= 0 returns all peaks above the threshold.
+func DetectPeriod(data []byte, maxLag, topN int) []PeriodCandidate {
+	ac := Autocorrelation(data, maxLag)
+	if len(ac) == 0 {
+		return nil
+	}
+	// Baseline mean and standard deviation over lags 1..maxLag.
+	var sum, sumSq float64
+	k := 0
+	for lag := 1; lag < len(ac); lag++ {
+		sum += ac[lag]
+		sumSq += ac[lag] * ac[lag]
+		k++
+	}
+	mean := sum / float64(k)
+	variance := sumSq/float64(k) - mean*mean
+	if variance < 0 {
+		variance = 0
+	}
+	std := math.Sqrt(variance)
+	var out []PeriodCandidate
+	for lag := 1; lag < len(ac); lag++ {
+		z := 0.0
+		if std > 0 {
+			z = (ac[lag] - mean) / std
+		}
+		// Keep lags that are a real, positive excursion above baseline.
+		if z >= 3 && ac[lag] > mean {
+			out = append(out, PeriodCandidate{Lag: lag, Coincidence: ac[lag], ZScore: z})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].ZScore > out[j].ZScore })
+	if topN > 0 && len(out) > topN {
+		out = out[:topN]
+	}
+	return out
+}
+
+// NGram is one byte n-gram and how often it occurs.
+type NGram struct {
+	Bytes []byte
+	Count int
+}
+
+// TopNGrams returns the most frequent length-n byte sequences, highest count
+// first, capped at topN. It is the histogram CrypTool exposes for spotting
+// repeated blocks (ECB-style structure, repeated headers, padding).
+func TopNGrams(data []byte, n, topN int) []NGram {
+	if n < 1 || len(data) < n {
+		return nil
+	}
+	counts := make(map[string]int)
+	for i := 0; i+n <= len(data); i++ {
+		counts[string(data[i:i+n])]++
+	}
+	out := make([]NGram, 0, len(counts))
+	for k, c := range counts {
+		out = append(out, NGram{Bytes: []byte(k), Count: c})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return string(out[i].Bytes) < string(out[j].Bytes)
+	})
+	if topN > 0 && len(out) > topN {
+		out = out[:topN]
+	}
+	return out
+}

--- a/internal/cryptolab/engine/stats/period_test.go
+++ b/internal/cryptolab/engine/stats/period_test.go
@@ -1,0 +1,57 @@
+package stats
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDetectPeriodFindsRepeatingXORKeyLength(t *testing.T) {
+	t.Parallel()
+	// Repeating-key XOR with a 7-byte key over English text: the ciphertext
+	// autocorrelation should peak at lag 7 (and its multiples). Enough text is
+	// needed for the peak to clear the baseline.
+	pt := []byte(strings.Repeat("the quick brown fox jumps over the lazy dog ", 8))
+	key := []byte("SECRET!")
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] ^ key[i%len(key)]
+	}
+	cands := DetectPeriod(ct, 40, 5)
+	if len(cands) == 0 {
+		t.Fatal("no period detected")
+	}
+	found := false
+	for _, c := range cands {
+		if c.Lag%7 == 0 {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a multiple of 7 among candidates, got %+v", cands)
+	}
+}
+
+func TestDetectPeriodQuietOnRandom(t *testing.T) {
+	t.Parallel()
+	// A simple LCG byte stream has no short byte period; expect few/no peaks.
+	data := make([]byte, 4000)
+	x := uint32(12345)
+	for i := range data {
+		x = x*1664525 + 1013904223
+		data[i] = byte(x >> 24)
+	}
+	cands := DetectPeriod(data, 256, 5)
+	if len(cands) > 2 {
+		t.Fatalf("unexpected strong periodicity in pseudo-random data: %+v", cands)
+	}
+}
+
+func TestTopNGramsCountsRepeats(t *testing.T) {
+	t.Parallel()
+	data := []byte("ababab")
+	g := TopNGrams(data, 2, 3)
+	if len(g) == 0 || g[0].Count < 2 {
+		t.Fatalf("expected a repeated bigram, got %+v", g)
+	}
+}

--- a/internal/cryptolab/schema.go
+++ b/internal/cryptolab/schema.go
@@ -33,6 +33,39 @@ var modeParams = map[string][]Param{
 		{Name: "in", Label: "Payload file", Kind: "file", Required: true, Help: "binary payload to analyze"},
 		{Name: "max-keylen", Label: "Max XOR key length", Kind: "int", Default: "40"},
 	},
+	"stats/period": {
+		{Name: "in", Label: "Payload file", Kind: "file", Required: true, Help: "binary payload to analyze"},
+		{Name: "max-lag", Label: "Max autocorrelation lag (bytes)", Kind: "int", Default: "256"},
+		{Name: "ngram", Label: "N-gram length", Kind: "int", Default: "3"},
+		{Name: "top", Label: "Candidates to report", Kind: "int", Default: "8"},
+	},
+	"randomness/battery": {
+		{Name: "in", Label: "Bitstream file", Kind: "file", Required: true, Help: "packed bytes, MSB-first (e.g. a recovered keystream)"},
+		{Name: "alpha", Label: "Significance level", Kind: "string", Default: "0.01"},
+	},
+	"randomness/quick": {
+		{Name: "in", Label: "Bitstream file", Kind: "file", Required: true, Help: "packed bytes, MSB-first"},
+		{Name: "alpha", Label: "Significance level", Kind: "string", Default: "0.01"},
+	},
+	"classify/auto": {
+		{Name: "in", Label: "Payload file", Kind: "file", Required: true, Help: "unknown payload to triage"},
+		{Name: "max-keylen", Label: "Max XOR key length", Kind: "int", Default: "40"},
+	},
+	"ks/reuse": {
+		{Name: "in", Label: "Frames file", Kind: "file", Required: true, Help: "JSONL {label,iv,ct} or CSV label,iv_hex,ct_hex"},
+	},
+	"ks/mtp": {
+		{Name: "in", Label: "Frames file", Kind: "file", Required: true, Help: "JSONL/CSV frames sharing IVs"},
+		{Name: "crib", Label: "Crib", Kind: "string", Default: " the ", Help: "known substring to drag across reuse groups"},
+		{Name: "known-label", Label: "Known frame label", Kind: "string", Help: "label of a frame whose plaintext is known"},
+		{Name: "known-pt", Label: "Known plaintext file", Kind: "file", Help: "plaintext for the known frame"},
+		{Name: "top", Label: "Hits per group", Kind: "int", Default: "10"},
+	},
+	"ks/extract": {
+		{Name: "pt", Label: "Known-plaintext file", Kind: "file", Required: true},
+		{Name: "ct", Label: "Ciphertext file", Kind: "file", Required: true},
+		{Name: "out", Label: "Output keystream file", Kind: "outfile"},
+	},
 	"brute/xor": {
 		{Name: "in", Label: "Ciphertext file", Kind: "file", Required: true},
 		{Name: "keylen", Label: "Key length (0 = auto)", Kind: "int", Default: "0"},

--- a/internal/cryptolab/tools/classify.go
+++ b/internal/cryptolab/tools/classify.go
@@ -1,0 +1,189 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/randomness"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/stats"
+)
+
+// classifyTool is the "front door": it runs the cheap measurements the other
+// tools rely on (entropy / IC / XOR key-length / autocorrelation period /
+// randomness battery) and routes the operator to the right next command. It
+// is the RF-framed analogue of Ciphey's auto-detect and CrypTool's cipher
+// identifier — it knows about LFSR scramblers and reused keystreams, not just
+// book ciphers.
+type classifyTool struct{}
+
+func (classifyTool) Name() string { return "classify" }
+func (classifyTool) Synopsis() string {
+	return "identify a payload's obfuscation class and recommend the next tool"
+}
+func (classifyTool) Modes() []cryptolab.Mode {
+	return []cryptolab.Mode{classifyAuto{}}
+}
+
+type classifyAuto struct{}
+
+func (classifyAuto) Name() string { return "auto" }
+func (classifyAuto) Synopsis() string {
+	return "triage an unknown payload and recommend a next command"
+}
+
+type verdict struct {
+	class       string
+	confidence  float64
+	rationale   string
+	recommended string
+}
+
+func (classifyAuto) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("classify auto")
+	in := fs.String("in", "", "binary payload to analyze — required")
+	maxKeyLen := fs.Int("max-keylen", 40, "max repeating-XOR key length to score")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	data, err := readInput(*in)
+	if err != nil {
+		return nil, err
+	}
+
+	ent := stats.ShannonEntropy(data)
+	ic := stats.IndexOfCoincidence(data)
+	chi := stats.ChiSquareUniform(data)
+	printable, letters := charProfile(data)
+	keylens := stats.GuessXORKeyLength(data, *maxKeyLen)
+	periods := stats.DetectPeriod(data, 256, 4)
+
+	// Randomness signal: the full battery when we have enough bits, else the
+	// fast subset. The linear_complexity and spectral verdicts separate
+	// "strong encryption" from "structured scrambler".
+	bits := lfsr.BitsFromBytes(data)
+	var rep randomness.Report
+	if len(data) >= 2048 {
+		rep = randomness.Battery(bits, randomness.DefaultAlpha)
+	} else {
+		rep = randomness.Quick(bits, randomness.DefaultAlpha)
+	}
+	lcFailed := failed(rep, "linear_complexity")
+	spectralFailed := failed(rep, "spectral_dft")
+
+	var vs []verdict
+
+	if printable > 0.95 && ent < 4.8 {
+		vs = append(vs, verdict{"plaintext", 0.6 + 0.4*printable,
+			fmt.Sprintf("%.0f%% printable, entropy %.2f", printable*100, ent),
+			"already plaintext — no decryption needed"})
+	}
+	if ic > 0.045 && letters > 0.6 {
+		vs = append(vs, verdict{"substitution-or-shift", clamp01(ic / 0.066),
+			fmt.Sprintf("index of coincidence %.4f near English, %.0f%% letters", ic, letters*100),
+			"cryptolab brute substitution -in <file>   (or `brute caesar` for a single shift)"})
+	}
+	if len(keylens) > 0 && keylens[0].Length > 1 && keylens[0].Score < 3.6 {
+		conf := clamp01((3.6 - keylens[0].Score) / 3.6)
+		vs = append(vs, verdict{"repeating-xor", conf,
+			fmt.Sprintf("repeating-XOR key length ~%d (normalized Hamming %.2f)", keylens[0].Length, keylens[0].Score),
+			fmt.Sprintf("cryptolab brute xor -in <file> -keylen %d", keylens[0].Length)})
+	}
+	if len(periods) > 0 {
+		vs = append(vs, verdict{"periodic-scrambler", clamp01(periods[0].ZScore / 12),
+			fmt.Sprintf("autocorrelation peak at lag %d (z=%.1f)", periods[0].Lag, periods[0].ZScore),
+			fmt.Sprintf("cryptolab stats period -in <file>   then `descramble rolling` (frame≈%d) or `ks mtp` if frames reuse an IV", periods[0].Lag)})
+	}
+	if ent > 7.0 && (lcFailed || spectralFailed) {
+		vs = append(vs, verdict{"lfsr-or-keyless-scrambler", 0.7,
+			fmt.Sprintf("high entropy %.2f but failing %s test(s)", ent, failedNames(rep)),
+			"cryptolab lfsr bm -in <file>   (recover the shortest LFSR / linear scrambler)"})
+	}
+	if ent > 7.9 && rep.LooksRandom() {
+		vs = append(vs, verdict{"strong-encrypted", clamp01((ent - 7.9) / 0.1),
+			fmt.Sprintf("entropy %.3f and passes the randomness battery", ent),
+			"no weak structure to attack — if frames reuse an IV/MI try `cryptolab ks reuse`, else key material is required"})
+	}
+	if len(vs) == 0 {
+		vs = append(vs, verdict{"inconclusive", 0.2,
+			fmt.Sprintf("intermediate statistics (entropy %.2f, IC %.4f)", ent, ic),
+			"cryptolab stats scan -in <file>   then try the brute tool on the top key lengths"})
+	}
+
+	sort.SliceStable(vs, func(i, j int) bool { return vs[i].confidence > vs[j].confidence })
+
+	res := &cryptolab.Result{Tool: "classify", Mode: "auto",
+		Summary: fmt.Sprintf("%d bytes: likely %s (confidence %.0f%%)", len(data), vs[0].class, vs[0].confidence*100)}
+	res.AddField("bytes", len(data))
+	res.AddField("entropy_bits", ent)
+	res.AddField("index_of_coincidence", ic)
+	res.AddField("chi_square_uniform", chi)
+	res.AddField("printable_fraction", printable)
+	res.AddField("randomness_failed", rep.Failed)
+	res.AddField("recommended", vs[0].recommended)
+	for _, v := range vs {
+		res.AddFinding(v.class, v.confidence, map[string]any{
+			"rationale":   v.rationale,
+			"recommended": v.recommended,
+		})
+	}
+	res.Note("classify only triages byte payloads; analog voice scrambling (spectral inversion) operates on PCM — use the descramble tool directly for s16le audio.")
+	return res, nil
+}
+
+func charProfile(data []byte) (printable, letters float64) {
+	if len(data) == 0 {
+		return 0, 0
+	}
+	var p, l int
+	for _, b := range data {
+		if b >= 0x20 && b <= 0x7e {
+			p++
+		}
+		if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') {
+			l++
+		}
+	}
+	n := float64(len(data))
+	return float64(p) / n, float64(l) / n
+}
+
+func failed(r randomness.Report, name string) bool {
+	for _, t := range r.Tests {
+		if t.Name == name && t.Applicable && !t.Passed {
+			return true
+		}
+	}
+	return false
+}
+
+func failedNames(r randomness.Report) string {
+	var names []string
+	for _, t := range r.Tests {
+		if t.Applicable && !t.Passed {
+			names = append(names, t.Name)
+		}
+	}
+	if len(names) == 0 {
+		return "none"
+	}
+	out := names[0]
+	for _, n := range names[1:] {
+		out += ", " + n
+	}
+	return out
+}
+
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}
+
+func init() { cryptolab.Register(classifyTool{}) }

--- a/internal/cryptolab/tools/ks.go
+++ b/internal/cryptolab/tools/ks.go
@@ -1,0 +1,268 @@
+package tools
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/keystream"
+)
+
+// ksTool exploits keystream reuse: additive stream ciphers (P25 DES-OFB and
+// ADP/RC4, TETRA AIE) produce an identical keystream whenever the same key and
+// IV recur, so frames sharing an IV (a P25 Message Indicator) leak
+// plaintext^plaintext. This tool finds those collisions and recovers content
+// from them — operator-misuse exploitation, not key recovery.
+type ksTool struct{}
+
+func (ksTool) Name() string     { return "ks" }
+func (ksTool) Synopsis() string { return "keystream-reuse / many-time-pad recovery (IV/MI collisions)" }
+func (ksTool) Modes() []cryptolab.Mode {
+	return []cryptolab.Mode{ksReuse{}, ksMTP{}, ksExtract{}}
+}
+
+// frameLine parses one corpus line into a Frame. Each non-empty, non-comment
+// line is either a JSON object {"label","iv","ct"} (the format the decoder
+// bridge emits) or a CSV triple label,iv_hex,ct_hex.
+func frameLine(line string) (keystream.Frame, bool, error) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return keystream.Frame{}, false, nil
+	}
+	if strings.HasPrefix(line, "{") {
+		var rec struct {
+			Label string `json:"label"`
+			IV    string `json:"iv"`
+			CT    string `json:"ct"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			return keystream.Frame{}, false, fmt.Errorf("bad JSON frame: %w", err)
+		}
+		iv, err := hex.DecodeString(rec.IV)
+		if err != nil {
+			return keystream.Frame{}, false, fmt.Errorf("frame %q: bad iv hex: %w", rec.Label, err)
+		}
+		ct, err := hex.DecodeString(rec.CT)
+		if err != nil {
+			return keystream.Frame{}, false, fmt.Errorf("frame %q: bad ct hex: %w", rec.Label, err)
+		}
+		return keystream.Frame{Label: rec.Label, IV: iv, CT: ct}, true, nil
+	}
+	parts := strings.Split(line, ",")
+	if len(parts) != 3 {
+		return keystream.Frame{}, false, fmt.Errorf("expected `label,iv_hex,ct_hex`, got %q", line)
+	}
+	iv, err := hex.DecodeString(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return keystream.Frame{}, false, fmt.Errorf("frame %q: bad iv hex: %w", parts[0], err)
+	}
+	ct, err := hex.DecodeString(strings.TrimSpace(parts[2]))
+	if err != nil {
+		return keystream.Frame{}, false, fmt.Errorf("frame %q: bad ct hex: %w", parts[0], err)
+	}
+	return keystream.Frame{Label: strings.TrimSpace(parts[0]), IV: iv, CT: ct}, true, nil
+}
+
+func loadFrames(path string) ([]keystream.Frame, error) {
+	data, err := readInput(path)
+	if err != nil {
+		return nil, err
+	}
+	var frames []keystream.Frame
+	for i, line := range strings.Split(string(data), "\n") {
+		f, ok, err := frameLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", i+1, err)
+		}
+		if ok {
+			frames = append(frames, f)
+		}
+	}
+	if len(frames) == 0 {
+		return nil, fmt.Errorf("no frames parsed from %s", path)
+	}
+	return frames, nil
+}
+
+type ksReuse struct{}
+
+func (ksReuse) Name() string     { return "reuse" }
+func (ksReuse) Synopsis() string { return "find frames that share an IV/MI (and thus a keystream)" }
+
+func (ksReuse) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("ks reuse")
+	in := fs.String("in", "", "frames file (JSONL {label,iv,ct} or CSV label,iv_hex,ct_hex) — required")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	frames, err := loadFrames(*in)
+	if err != nil {
+		return nil, err
+	}
+	groups := keystream.FindReuse(frames)
+
+	res := &cryptolab.Result{Tool: "ks", Mode: "reuse",
+		Summary: fmt.Sprintf("%d frames: %d IV/MI reuse group(s) found", len(frames), len(groups))}
+	res.AddField("frames", len(frames))
+	res.AddField("reuse_groups", len(groups))
+	for _, g := range groups {
+		labels := make([]string, len(g.Frames))
+		for i, f := range g.Frames {
+			labels[i] = f.Label
+		}
+		res.AddFinding(fmt.Sprintf("iv=%x", g.IV), float64(len(g.Frames)),
+			map[string]any{"frames": len(g.Frames), "labels": labels})
+	}
+	if len(groups) == 0 {
+		res.Note("no IV reuse: every frame uses a distinct IV/MI, so no keystream collision to exploit. This is the secure case.")
+	} else {
+		res.Note("reused IVs leak plaintext^plaintext — run `cryptolab ks mtp` on this same file to recover content from each group.")
+	}
+	return res, nil
+}
+
+type ksMTP struct{}
+
+func (ksMTP) Name() string { return "mtp" }
+func (ksMTP) Synopsis() string {
+	return "recover plaintext from a reuse group via known-plaintext or crib-drag"
+}
+
+func (ksMTP) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("ks mtp")
+	in := fs.String("in", "", "frames file (JSONL/CSV) — required")
+	crib := fs.String("crib", " the ", "crib to drag across reuse groups")
+	knownLabel := fs.String("known-label", "", "label of a frame whose plaintext is known")
+	knownPTFile := fs.String("known-pt", "", "file with the known plaintext for -known-label")
+	top := fs.Int("top", 10, "crib-drag hits to report per group")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	frames, err := loadFrames(*in)
+	if err != nil {
+		return nil, err
+	}
+	groups := keystream.FindReuse(frames)
+	res := &cryptolab.Result{Tool: "ks", Mode: "mtp",
+		Summary: fmt.Sprintf("%d frames: %d reuse group(s)", len(frames), len(groups))}
+	res.AddField("frames", len(frames))
+	res.AddField("reuse_groups", len(groups))
+	if len(groups) == 0 {
+		res.Note("no IV reuse to exploit.")
+		return res, nil
+	}
+
+	// Known-plaintext path: the strongest recovery. Derive the keystream from
+	// the named frame and decrypt its whole group.
+	if *knownLabel != "" {
+		if *knownPTFile == "" {
+			return nil, fmt.Errorf("-known-label requires -known-pt")
+		}
+		pt, err := readInput(*knownPTFile)
+		if err != nil {
+			return nil, err
+		}
+		recovered := false
+		for _, g := range groups {
+			ks, decoded, ok := keystream.RecoverWithKnown(g, *knownLabel, pt)
+			if !ok {
+				continue
+			}
+			recovered = true
+			res.AddField("keystream_hex", hex.EncodeToString(ks))
+			for _, d := range decoded {
+				res.AddFinding(d.Label, 1.0, map[string]any{
+					"plaintext_hex":   hex.EncodeToString(d.Plaintext),
+					"plaintext_ascii": printableASCII(d.Plaintext),
+					"method":          "known-plaintext",
+				})
+			}
+		}
+		if !recovered {
+			return nil, fmt.Errorf("frame %q not found in any reuse group", *knownLabel)
+		}
+		res.Note("recovered the keystream from the known frame and decrypted its reuse group; the same keystream decrypts any future frame that reuses this IV.")
+		return res, nil
+	}
+
+	// Crib-drag path: no known plaintext, peel content with a crib.
+	var anyHit bool
+	for _, g := range groups {
+		hits := keystream.CribDragGroup(g, []byte(*crib), *top)
+		for _, h := range hits {
+			anyHit = true
+			res.AddFinding(fmt.Sprintf("iv=%x off=%d", g.IV, h.Offset), h.Score, map[string]any{
+				"crib_in":    h.CribLabel,
+				"reveals_in": h.PartnerLabel,
+				"offset":     h.Offset,
+				"revealed":   string(h.Revealed),
+				"method":     "crib-drag",
+			})
+		}
+	}
+	if !anyHit {
+		res.Note(fmt.Sprintf("crib %q produced no fully-printable placements; try a different crib (a known call sign, unit id, or common word) or supply -known-label/-known-pt.", *crib))
+	} else {
+		res.Note("each hit reveals plaintext in the partner frame at that offset; extend the highest-scoring cribs to grow the recovered text.")
+	}
+	return res, nil
+}
+
+type ksExtract struct{}
+
+func (ksExtract) Name() string     { return "extract" }
+func (ksExtract) Synopsis() string { return "keystream = plaintext XOR ciphertext (known-plaintext)" }
+
+func (ksExtract) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("ks extract")
+	ptPath := fs.String("pt", "", "known-plaintext file — required")
+	ctPath := fs.String("ct", "", "ciphertext file — required")
+	outPath := fs.String("out", "", "optional file to write the raw keystream")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if *ptPath == "" || *ctPath == "" {
+		return nil, fmt.Errorf("both -pt and -ct are required")
+	}
+	pt, err := readInput(*ptPath)
+	if err != nil {
+		return nil, err
+	}
+	ct, err := readInput(*ctPath)
+	if err != nil {
+		return nil, err
+	}
+	ks := keystream.XOR(pt, ct)
+	res := &cryptolab.Result{Tool: "ks", Mode: "extract",
+		Summary: fmt.Sprintf("recovered %d keystream bytes", len(ks))}
+	res.AddField("keystream_bytes", len(ks))
+	res.AddField("keystream_hex", hex.EncodeToString(ks))
+	if *outPath != "" {
+		if err := os.WriteFile(*outPath, ks, 0o644); err != nil {
+			return nil, fmt.Errorf("write %s: %w", *outPath, err)
+		}
+		res.AddField("written", *outPath)
+	}
+	res.Note("feed this keystream to `cryptolab randomness battery` or `cryptolab lfsr bm` to test whether it is strong (random) or an exploitable linear generator.")
+	return res, nil
+}
+
+// printableASCII renders bytes with non-printables shown as '.', for a
+// human-skimmable preview alongside the hex.
+func printableASCII(b []byte) string {
+	out := make([]byte, len(b))
+	for i, c := range b {
+		if c >= 0x20 && c <= 0x7e {
+			out[i] = c
+		} else {
+			out[i] = '.'
+		}
+	}
+	return string(out)
+}
+
+func init() { cryptolab.Register(ksTool{}) }

--- a/internal/cryptolab/tools/newtools_test.go
+++ b/internal/cryptolab/tools/newtools_test.go
@@ -1,0 +1,168 @@
+package tools
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+)
+
+func TestNewToolsRegistered(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"randomness", "classify", "ks"} {
+		if _, ok := cryptolab.Lookup(name); !ok {
+			t.Fatalf("tool %q not registered", name)
+		}
+	}
+}
+
+func TestStatsPeriodMode(t *testing.T) {
+	t.Parallel()
+	pt := []byte(strings.Repeat("the quick brown fox jumps over the lazy dog ", 8))
+	key := []byte("SECRET!")
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] ^ key[i%len(key)]
+	}
+	in := writeFile(t, "ct.bin", ct)
+	res := runMode(t, "stats", "period", []string{"-in", in, "-max-lag", "40"})
+	if res.Mode != "period" || len(res.Findings) == 0 {
+		t.Fatalf("expected period findings, got %+v", res)
+	}
+}
+
+func TestRandomnessBatteryToolFlagsStructure(t *testing.T) {
+	t.Parallel()
+	// All-zero stream is maximally structured; the battery must report
+	// failures and not "looks_random".
+	in := writeFile(t, "zeros.bin", make([]byte, 20000))
+	res := runMode(t, "randomness", "battery", []string{"-in", in})
+	looksRandom := fieldBool(t, res, "looks_random")
+	if looksRandom {
+		t.Fatal("all-zero stream reported as random")
+	}
+}
+
+func TestClassifyPlaintext(t *testing.T) {
+	t.Parallel()
+	in := writeFile(t, "pt.txt", []byte(strings.Repeat("the meeting is at noon by the river bridge today ", 40)))
+	res := runMode(t, "classify", "auto", []string{"-in", in})
+	if len(res.Findings) == 0 {
+		t.Fatalf("classify returned no verdict: %+v", res)
+	}
+	// Top verdict should be a plaintext/substitution-family class, never
+	// strong-encrypted, for clear English.
+	if res.Findings[0].Label == "strong-encrypted" {
+		t.Fatalf("English text misclassified as strong-encrypted: %+v", res.Findings)
+	}
+}
+
+func TestKsReuseAndMTPKnownPlaintext(t *testing.T) {
+	t.Parallel()
+	ks := mustHex(t, "9e21557c03aa1142fe10773388291a4b5c6d7e8f")
+	iv := "010203"
+	pt1 := []byte("ATTACK AT DAWN OK")
+	pt2 := []byte("RETREAT BY THE SE")
+	ct1 := xorBytes(pt1, ks)
+	ct2 := xorBytes(pt2, ks)
+	lines := fmt.Sprintf("a1,%s,%s\na2,%s,%s\nb1,ffff,%s\n",
+		iv, hex.EncodeToString(ct1),
+		iv, hex.EncodeToString(ct2),
+		hex.EncodeToString([]byte("solo")))
+	in := writeFile(t, "frames.csv", []byte(lines))
+
+	reuse := runMode(t, "ks", "reuse", []string{"-in", in})
+	if fieldInt(t, reuse, "reuse_groups") != 1 {
+		t.Fatalf("expected exactly one reuse group, got %+v", reuse)
+	}
+
+	ptFile := writeFile(t, "known.bin", pt1)
+	mtp := runMode(t, "ks", "mtp", []string{"-in", in, "-known-label", "a1", "-known-pt", ptFile})
+	// The recovered plaintext for a2 must match pt2.
+	found := false
+	for _, f := range mtp.Findings {
+		if f.Label == "a2" {
+			if got, _ := f.Detail["plaintext_ascii"].(string); got != string(pt2) {
+				t.Fatalf("a2 recovered as %q, want %q", got, pt2)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a2 not recovered: %+v", mtp.Findings)
+	}
+}
+
+func TestKsExtractKeystream(t *testing.T) {
+	t.Parallel()
+	pt := []byte("KNOWN PLAINTEXT FRAME")
+	ks := mustHex(t, "0102030405060708090a0b0c0d0e0f10111213141516171819")
+	ct := xorBytes(pt, ks)
+	ptFile := writeFile(t, "pt.bin", pt)
+	ctFile := writeFile(t, "ct.bin", ct)
+	res := runMode(t, "ks", "extract", []string{"-pt", ptFile, "-ct", ctFile})
+	gotHex := fieldString(t, res, "keystream_hex")
+	wantHex := hex.EncodeToString(ks[:len(pt)])
+	if gotHex != wantHex {
+		t.Fatalf("keystream %s, want %s", gotHex, wantHex)
+	}
+}
+
+// --- small local helpers ---
+
+func xorBytes(a, b []byte) []byte {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		out[i] = a[i] ^ b[i]
+	}
+	return out
+}
+
+func fieldBool(t *testing.T, r *cryptolab.Result, key string) bool {
+	t.Helper()
+	for _, f := range r.Fields {
+		if f.Key == key {
+			b, ok := f.Value.(bool)
+			if !ok {
+				t.Fatalf("field %q is not bool: %T", key, f.Value)
+			}
+			return b
+		}
+	}
+	t.Fatalf("field %q not found", key)
+	return false
+}
+
+func fieldInt(t *testing.T, r *cryptolab.Result, key string) int {
+	t.Helper()
+	for _, f := range r.Fields {
+		if f.Key == key {
+			if v, ok := f.Value.(int); ok {
+				return v
+			}
+			t.Fatalf("field %q is not int: %T", key, f.Value)
+		}
+	}
+	t.Fatalf("field %q not found", key)
+	return 0
+}
+
+func fieldString(t *testing.T, r *cryptolab.Result, key string) string {
+	t.Helper()
+	for _, f := range r.Fields {
+		if f.Key == key {
+			if v, ok := f.Value.(string); ok {
+				return v
+			}
+			t.Fatalf("field %q is not string: %T", key, f.Value)
+		}
+	}
+	t.Fatalf("field %q not found", key)
+	return ""
+}

--- a/internal/cryptolab/tools/randomness.go
+++ b/internal/cryptolab/tools/randomness.go
@@ -1,0 +1,106 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/randomness"
+)
+
+type randomnessTool struct{}
+
+func (randomnessTool) Name() string { return "randomness" }
+func (randomnessTool) Synopsis() string {
+	return "NIST SP 800-22 statistical randomness battery for keystreams / payloads"
+}
+func (randomnessTool) Modes() []cryptolab.Mode {
+	return []cryptolab.Mode{randomnessBattery{}, randomnessQuick{}}
+}
+
+// runBattery is shared by both modes; quick selects the fast subset.
+func runBattery(modeName, in string, alpha float64, quick bool) (*cryptolab.Result, error) {
+	data, err := readInput(in)
+	if err != nil {
+		return nil, err
+	}
+	bits := lfsr.BitsFromBytes(data)
+	var rep randomness.Report
+	if quick {
+		rep = randomness.Quick(bits, alpha)
+	} else {
+		rep = randomness.Battery(bits, alpha)
+	}
+
+	res := &cryptolab.Result{Tool: "randomness", Mode: modeName,
+		Summary: fmt.Sprintf("%d bits: %d/%d tests passed, %d failed, %d skipped (alpha %.3f)",
+			rep.Bits, rep.Passed, rep.Passed+rep.Failed, rep.Failed, rep.Skipped, rep.Alpha)}
+	res.AddField("bits", rep.Bits)
+	res.AddField("alpha", rep.Alpha)
+	res.AddField("passed", rep.Passed)
+	res.AddField("failed", rep.Failed)
+	res.AddField("skipped", rep.Skipped)
+	res.AddField("looks_random", rep.LooksRandom())
+
+	// Findings: one per test, weakest (most non-random) first. A failing test
+	// scores higher so it sorts to the top of the ranked findings.
+	for _, t := range rep.WeakestTests() {
+		detail := map[string]any{"p_value": t.PValue, "passed": t.Passed}
+		if t.Note != "" {
+			detail["note"] = t.Note
+		}
+		score := 0.0
+		if !t.Passed {
+			score = 1 - t.PValue
+		}
+		res.AddFinding(t.Name, score, detail)
+	}
+	for _, t := range rep.Tests {
+		if !t.Applicable {
+			res.Note(fmt.Sprintf("%s skipped: %s", t.Name, t.Note))
+		}
+	}
+
+	switch {
+	case rep.LooksRandom():
+		res.Note("indistinguishable from random at this alpha: consistent with strong keyed encryption (AES/DES-class) or good compression — no weak structure to brute-force. If you have known plaintext for a reused IV/MI, try `cryptolab ks`.")
+	case rep.Failed > 0:
+		res.Note("one or more tests failed: the stream carries exploitable structure. A failing linear_complexity or spectral test points at an LFSR / keyless scrambler — try `cryptolab lfsr bm` and `cryptolab stats period`.")
+	}
+	return res, nil
+}
+
+type randomnessBattery struct{}
+
+func (randomnessBattery) Name() string { return "battery" }
+func (randomnessBattery) Synopsis() string {
+	return "run the full NIST SP 800-22 subset (10 tests) over a bitstream"
+}
+func (randomnessBattery) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("randomness battery")
+	in := fs.String("in", "", "bitstream file (packed bytes, MSB-first) — required")
+	alpha := fs.Float64("alpha", randomness.DefaultAlpha, "significance level")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return runBattery("battery", *in, *alpha, false)
+}
+
+type randomnessQuick struct{}
+
+func (randomnessQuick) Name() string { return "quick" }
+func (randomnessQuick) Synopsis() string {
+	return "fast randomness subset (monobit / block-freq / runs / cusum) for short captures"
+}
+func (randomnessQuick) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("randomness quick")
+	in := fs.String("in", "", "bitstream file (packed bytes, MSB-first) — required")
+	alpha := fs.Float64("alpha", randomness.DefaultAlpha, "significance level")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	return runBattery("quick", *in, *alpha, true)
+}
+
+func init() { cryptolab.Register(randomnessTool{}) }

--- a/internal/cryptolab/tools/stats.go
+++ b/internal/cryptolab/tools/stats.go
@@ -14,7 +14,7 @@ func (statsTool) Name() string { return "stats" }
 func (statsTool) Synopsis() string {
 	return "entropy / IC / chi-square / XOR key-length triage of a payload"
 }
-func (statsTool) Modes() []cryptolab.Mode { return []cryptolab.Mode{statsScan{}} }
+func (statsTool) Modes() []cryptolab.Mode { return []cryptolab.Mode{statsScan{}, statsPeriod{}} }
 
 type statsScan struct{}
 
@@ -58,6 +58,60 @@ func (statsScan) Run(_ context.Context, args []string, env cryptolab.Env) (*cryp
 		res.Note("elevated index of coincidence: looks like a mono-alphabetic / shift cipher or plaintext — try the brute tool.")
 	default:
 		res.Note("intermediate statistics: possibly a polyalphabetic / repeating-key cipher — try the top key lengths above with `cryptolab brute`.")
+	}
+	return res, nil
+}
+
+// statsPeriod reports byte-autocorrelation peaks and repeated n-grams, the
+// measurements that reveal the period of a repeating-key cipher, a periodic
+// scrambler, or a reused keystream before choosing a key length / frame size.
+type statsPeriod struct{}
+
+func (statsPeriod) Name() string { return "period" }
+func (statsPeriod) Synopsis() string {
+	return "autocorrelation period detection and repeated-n-gram histogram"
+}
+
+func (statsPeriod) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("stats period")
+	in := fs.String("in", "", "binary payload to analyze — required")
+	maxLag := fs.Int("max-lag", 256, "maximum autocorrelation lag (bytes) to scan")
+	ngram := fs.Int("ngram", 3, "n-gram length for the repeated-block histogram")
+	top := fs.Int("top", 8, "number of candidates to report")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	data, err := readInput(*in)
+	if err != nil {
+		return nil, err
+	}
+
+	cands := stats.DetectPeriod(data, *maxLag, *top)
+	grams := stats.TopNGrams(data, *ngram, *top)
+
+	res := &cryptolab.Result{Tool: "stats", Mode: "period",
+		Summary: fmt.Sprintf("%d bytes: %d period candidate(s) within lag %d", len(data), len(cands), *maxLag)}
+	res.AddField("bytes", len(data))
+	res.AddField("max_lag", *maxLag)
+	res.AddField("period_candidates", len(cands))
+
+	for _, c := range cands {
+		res.AddFinding(fmt.Sprintf("period=%d", c.Lag), c.ZScore,
+			map[string]any{"coincidence": c.Coincidence, "z_score": c.ZScore})
+	}
+	for _, g := range grams {
+		if g.Count < 2 {
+			continue
+		}
+		res.AddFinding(fmt.Sprintf("ngram=%x", g.Bytes), float64(g.Count),
+			map[string]any{"count": g.Count, "kind": "repeated_ngram"})
+	}
+
+	switch {
+	case len(cands) == 0:
+		res.Note("no autocorrelation peak stood out: no short repeating period within the scanned lag — consistent with strong encryption or a long/aperiodic keystream.")
+	default:
+		res.Note(fmt.Sprintf("strongest period is %d byte(s): for a repeating-XOR cipher try `cryptolab brute xor -keylen %d`; for a periodic scrambler this is the likely frame size.", cands[0].Lag, cands[0].Lag))
 	}
 	return res, nil
 }


### PR DESCRIPTION
Port the highest-impact analysis/test features from industry crypto tools
(CrypTool, NIST STS, Ciphey, DSD-FME/OP25, TETRA:BURST) into the cryptolab
toolkit, RF-optimized and within the toolkit's existing "no key-breaking"
scope. All new tools auto-register and appear in the CLI, daemon API, and
schema-driven web console with no extra wiring.

New engines (internal/cryptolab/engine/):
- randomness: NIST SP 800-22 subset (monobit, block-frequency, runs,
  longest-run, binary-matrix-rank, spectral DFT, approximate-entropy, serial,
  cumulative-sums, linear-complexity) returning p-values via gonum's
  incomplete-gamma and real FFT. Answers the decisive RF triage question: is a
  recovered keystream strong (random) or a structured/LFSR scrambler?
- keystream: keystream-reuse / many-time-pad recovery. Groups frames that
  share an IV/MI (P25 OFB/ADP keystream reuse), recovers a whole group from
  one known plaintext, and crib-drags reuse groups with an English model.
  Exploits operator misuse, not the cipher key.
- stats/period.go: byte autocorrelation, period detection, repeated-n-gram
  histogram (the prerequisite measurement for repeating-key / scrambler period).

New tools (internal/cryptolab/tools/):
- randomness {battery,quick}
- classify auto: front-door triage that runs the cheap measurements and
  routes to the right next command (plaintext / substitution / repeating-xor /
  periodic-scrambler / lfsr-or-keyless-scrambler / strong-encrypted).
- ks {reuse,mtp,extract}: keystream-reuse workflow over a JSONL/CSV frames
  file ({label,iv,ct}) — the format a future decoder->cryptolab bridge emits.
- stats period

Tests cover each engine and tool (random vs LFSR/periodic/constant streams,
MTP recovery from known plaintext, crib-drag, period detection). Docs and CLI
help updated. make vet test and make test-cryptolab are green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JzEG7UxiWbbT5q76ECWWZ5