### PR TITLE
rfscope: add protocol-agnostic Scene data model

### DIFF
--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -67,6 +67,8 @@ func main() {
 		runSpectrum(os.Args[2:])
 	case "hunt":
 		runHunt(os.Args[2:])
+	case "rfscope":
+		runRFScope(os.Args[2:])
 	case "gen":
 		runGen(os.Args[2:])
 	case "capture":

--- a/cmd/gophertrunk/rfscope.go
+++ b/cmd/gophertrunk/rfscope.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/rfscope"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// runRFScope is the entry point for `gophertrunk rfscope` — protocol-agnostic RF
+// network analysis ("Wireshark for the RF physical layer"). It segments a
+// wideband span (a capture file or a live SDR) into bursts and runs the
+// registered analyzers (protocol hierarchy, activity timeline, burst timing, …)
+// over them, with no prior knowledge of the technology, modulation, or framing.
+func runRFScope(args []string) {
+	if len(args) > 0 {
+		switch args[0] {
+		case "analyze":
+			runRFScopeAnalyze(args[1:])
+			return
+		case "live":
+			runRFScopeLive(args[1:])
+			return
+		case "list":
+			runRFScopeList(args[1:])
+			return
+		case "help", "-h", "--help":
+			rfscopeUsage(os.Stdout)
+			return
+		}
+	}
+	rfscopeUsage(os.Stderr)
+	os.Exit(2)
+}
+
+func rfscopeUsage(w *os.File) {
+	fmt.Fprintln(w, `gophertrunk rfscope — protocol-agnostic RF network analysis.
+
+USAGE:
+  gophertrunk rfscope analyze -in <capture> [flags]   analyze a recorded IQ capture
+  gophertrunk rfscope live -serial <sdr> -freq Hz [flags]   analyze a live SDR span
+  gophertrunk rfscope list                            list registered analyzers
+
+Run a subcommand with -h for its flags.`)
+}
+
+// rfscopeAnalysisFlags are the segmentation/analysis knobs shared by analyze and
+// live. They map directly onto rfscope.SegmentConfig.
+type rfscopeAnalysisFlags struct {
+	fftSize        *int
+	channelRate    *float64
+	peakThresholdB *float64
+	minSpacing     *uint
+	analyzers      *string
+	outFormat      *string
+	out            *string
+}
+
+func registerAnalysisFlags(fs *flag.FlagSet) rfscopeAnalysisFlags {
+	return rfscopeAnalysisFlags{
+		fftSize:        fs.Int("fft", 4096, "wideband FFT size for carrier discovery (power of two)"),
+		channelRate:    fs.Float64("channel-rate", 50000, "per-channel decimated baseband rate in Hz"),
+		peakThresholdB: fs.Float64("peak-threshold-db", 10, "minimum dB above the noise floor for a carrier to count"),
+		minSpacing:     fs.Uint("min-spacing", 12500, "minimum Hz between detected carriers / channel raster"),
+		analyzers:      fs.String("analyzers", "", "comma-separated analyzers to run (default: all registered)"),
+		outFormat:      fs.String("out-format", "summary", "output format: summary | json | jsonl | yaml | csv"),
+		out:            fs.String("out", "", "write output to this file (default: stdout)"),
+	}
+}
+
+func (f rfscopeAnalysisFlags) segConfig(maxSamples int) rfscope.SegmentConfig {
+	return rfscope.SegmentConfig{
+		FFTSize:             *f.fftSize,
+		ChannelTargetRateHz: *f.channelRate,
+		PeakThresholdDb:     float32(*f.peakThresholdB),
+		MinSpacingHz:        uint32(*f.minSpacing),
+		MaxSamples:          maxSamples,
+	}
+}
+
+func (f rfscopeAnalysisFlags) selectedAnalyzers() []string {
+	if strings.TrimSpace(*f.analyzers) == "" {
+		return nil
+	}
+	var out []string
+	for _, a := range strings.Split(*f.analyzers, ",") {
+		if a = strings.TrimSpace(a); a != "" {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func runRFScopeAnalyze(args []string) {
+	fs := flag.NewFlagSet("rfscope analyze", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+	in := fs.String("in", "", "raw IQ capture file (required)")
+	format := fs.String("format", "f32", "sample format: u8 | f32")
+	sampleRate := fs.Float64("sample-rate", 2_000_000, "IQ sample rate in Hz")
+	freq := fs.Uint64("freq", 0, "capture centre frequency in Hz")
+	window := fs.Float64("window", 0, "analyze only the first N seconds (0 ⇒ whole capture)")
+	af := registerAnalysisFlags(fs)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk rfscope analyze — segment + analyze a recorded IQ capture.
+
+USAGE:
+  gophertrunk rfscope analyze -in <path> [-format u8|f32] [-sample-rate Hz] [-freq Hz]
+                             [-window sec] [-analyzers a,b] [-out-format fmt] [-out path]
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("rfscope")
+
+	if *in == "" {
+		fs.Usage()
+		rep.Fatalf(2, "-in is required")
+	}
+	if *sampleRate <= 0 {
+		rep.Fatalf(2, "-sample-rate must be > 0")
+	}
+	sampleFormat, err := siglab.ParseSampleFormat(*format)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+
+	src, err := rfscope.OpenFile(*in, sampleFormat, uint32(*freq), *sampleRate)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	defer src.Close()
+
+	maxSamples := 0
+	if *window > 0 {
+		maxSamples = int(*window * *sampleRate)
+	}
+	rfscopeRunAndExport(rep, src, af.segConfig(maxSamples), af.selectedAnalyzers(), *in, *af.outFormat, *af.out)
+}
+
+func runRFScopeLive(args []string) {
+	fs := flag.NewFlagSet("rfscope live", flag.ExitOnError)
+	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
+	serial := fs.String("serial", "", "SDR serial to capture from (default: first device)")
+	freq := fs.Uint64("freq", 0, "centre frequency to tune in Hz (required)")
+	sampleRate := fs.Uint64("sample-rate", 2_400_000, "IQ sample rate in Hz")
+	duration := fs.Float64("duration", 10, "seconds of live IQ to analyze")
+	af := registerAnalysisFlags(fs)
+	fs.Usage = func() {
+		fmt.Fprintln(fs.Output(), `gophertrunk rfscope live — segment + analyze a live SDR span.
+
+USAGE:
+  gophertrunk rfscope live -serial <sdr> -freq Hz [-sample-rate Hz] [-duration sec]
+                          [-analyzers a,b] [-out-format fmt] [-out path]
+
+FLAGS:`)
+		fs.PrintDefaults()
+	}
+	_ = fs.Parse(args)
+	resolveVerbose(*verboseFlag, false)
+	rep := newReporter("rfscope")
+
+	if *freq == 0 {
+		fs.Usage()
+		rep.Fatalf(2, "-freq is required")
+	}
+	if *sampleRate == 0 || *duration <= 0 {
+		rep.Fatalf(2, "-sample-rate and -duration must be > 0")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*duration*2)*time.Second+5*time.Second)
+	defer cancel()
+
+	dev, info, err := openCaptureDevice(*serial)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	defer dev.Close()
+	fmt.Fprintf(os.Stderr, "rfscope live: %s %s @ %.6f MHz, %.3f MS/s for %.1fs\n",
+		info.Driver, info.Serial, float64(*freq)/1e6, float64(*sampleRate)/1e6, *duration)
+
+	iqsrc, err := newDeviceIQSource(ctx, dev, uint32(*sampleRate), nil)
+	if err != nil {
+		rep.Fatal(1, fmt.Errorf("start IQ stream: %w", err))
+	}
+	src, err := rfscope.NewLiveSource(iqsrc, uint32(*freq))
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+
+	maxSamples := int(*duration * float64(*sampleRate))
+	label := fmt.Sprintf("live:%s@%.6fMHz", info.Serial, float64(*freq)/1e6)
+	rfscopeRunAndExport(rep, src, af.segConfig(maxSamples), af.selectedAnalyzers(), label, *af.outFormat, *af.out)
+}
+
+func runRFScopeList(args []string) {
+	fs := flag.NewFlagSet("rfscope list", flag.ExitOnError)
+	_ = fs.Parse(args)
+	fmt.Println("Registered rfscope analyzers:")
+	for _, a := range rfscope.Analyzers() {
+		deps := ""
+		if d := a.DependsOn(); len(d) > 0 {
+			deps = "  (after: " + strings.Join(d, ", ") + ")"
+		}
+		fmt.Printf("  %-12s %s%s\n", a.Name(), a.Synopsis(), deps)
+	}
+}
+
+// rfscopeRunAndExport segments src, runs the selected analyzers, and writes the
+// scene — the shared tail of the analyze and live subcommands.
+func rfscopeRunAndExport(rep *diag.Reporter, src rfscope.Source, cfg rfscope.SegmentConfig, analyzers []string, sourceLabel, outFormat, outPath string) {
+	ctx := context.Background()
+	scene, in, err := rfscope.Segment(ctx, src, cfg)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	scene.Source = sourceLabel
+	if err := rfscope.Run(ctx, scene, in, analyzers...); err != nil {
+		rep.Fatal(1, err)
+	}
+
+	f, err := rfscope.ParseFormat(outFormat)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+	w := os.Stdout
+	if outPath != "" {
+		file, err := os.Create(outPath)
+		if err != nil {
+			rep.Fatal(1, fmt.Errorf("create %s: %w", outPath, err))
+		}
+		defer file.Close()
+		w = file
+	}
+	if err := rfscope.Write(w, scene, f); err != nil {
+		rep.Fatal(1, err)
+	}
+}

--- a/internal/rfscope/analyzer.go
+++ b/internal/rfscope/analyzer.go
@@ -1,0 +1,192 @@
+package rfscope
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+)
+
+// Input is the read-only material an Analyzer works from. The segmented bursts
+// already live on the Scene; Input adds the run-level parameters and a lazy
+// accessor back to each burst's decimated baseband IQ, so a long capture is
+// never held whole in memory.
+type Input struct {
+	// SampleRateHz is the capture's IQ sample rate.
+	SampleRateHz float64
+	// Window is the observation window in seconds (the scene's time span).
+	Window float64
+	// Log is the run logger; never nil (Run substitutes a discard logger).
+	Log *slog.Logger
+	// BurstIQ returns the decimated baseband IQ of one burst and its rate, or an
+	// error if the source can no longer be read. Analyzers that only need the
+	// burst metadata (timeline, timing) ignore it; classifiers/identifiers call
+	// it on demand.
+	BurstIQ func(b Burst) (iq []complex64, rateHz float64, err error)
+}
+
+// Analyzer is one named analysis pass over a Scene. Analyzers register
+// themselves from init() (mirroring the cryptolab Tool registry and the
+// ccdecoder pipeline factories), so adding one is a new file plus a blank import
+// in the CLI wiring. DependsOn names analyzers that must run first; Run
+// topologically sorts on it.
+type Analyzer interface {
+	Name() string
+	Synopsis() string
+	DependsOn() []string
+	Analyze(ctx context.Context, sc *Scene, in *Input) error
+}
+
+var (
+	analyzersMu sync.RWMutex
+	analyzers   = map[string]Analyzer{}
+)
+
+// Register adds an analyzer to the global registry. It panics on a duplicate
+// name, which can only happen from a programming error at init time.
+func Register(a Analyzer) {
+	analyzersMu.Lock()
+	defer analyzersMu.Unlock()
+	name := a.Name()
+	if _, dup := analyzers[name]; dup {
+		panic(fmt.Sprintf("rfscope: analyzer %q registered twice", name))
+	}
+	analyzers[name] = a
+}
+
+// Lookup returns the analyzer registered under name.
+func Lookup(name string) (Analyzer, bool) {
+	analyzersMu.RLock()
+	defer analyzersMu.RUnlock()
+	a, ok := analyzers[name]
+	return a, ok
+}
+
+// Analyzers returns every registered analyzer sorted by name.
+func Analyzers() []Analyzer {
+	analyzersMu.RLock()
+	defer analyzersMu.RUnlock()
+	out := make([]Analyzer, 0, len(analyzers))
+	for _, a := range analyzers {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name() < out[j].Name() })
+	return out
+}
+
+// Run resolves the requested analyzers (empty names ⇒ all registered) plus their
+// transitive dependencies, orders them with a topological sort over DependsOn,
+// and runs each Analyze in turn against sc. It returns an error on an unknown
+// analyzer name, a dependency cycle, or the first Analyze failure.
+func Run(ctx context.Context, sc *Scene, in *Input, names ...string) error {
+	analyzersMu.RLock()
+	reg := make(map[string]Analyzer, len(analyzers))
+	for k, v := range analyzers {
+		reg[k] = v
+	}
+	analyzersMu.RUnlock()
+
+	order, err := topoOrder(reg, names)
+	if err != nil {
+		return err
+	}
+	if in != nil && in.Log == nil {
+		in.Log = slog.New(slog.NewTextHandler(discard{}, nil))
+	}
+	for _, a := range order {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := a.Analyze(ctx, sc, in); err != nil {
+			return fmt.Errorf("rfscope: analyzer %q: %w", a.Name(), err)
+		}
+	}
+	return nil
+}
+
+// topoOrder is the pure ordering logic, separated from the global registry so it
+// is unit-testable with a constructed map. It expands the requested set with
+// transitive DependsOn, then returns a deterministic dependency-first ordering,
+// erroring on an unknown name or a cycle.
+func topoOrder(reg map[string]Analyzer, names []string) ([]Analyzer, error) {
+	want := map[string]bool{}
+	if len(names) == 0 {
+		for n := range reg {
+			want[n] = true
+		}
+	} else {
+		for _, n := range names {
+			if _, ok := reg[n]; !ok {
+				return nil, fmt.Errorf("rfscope: unknown analyzer %q", n)
+			}
+			want[n] = true
+		}
+	}
+
+	// Pull in transitive dependencies until the set is stable.
+	for {
+		added := false
+		for n := range want {
+			for _, d := range reg[n].DependsOn() {
+				if _, ok := reg[d]; !ok {
+					return nil, fmt.Errorf("rfscope: analyzer %q depends on unknown %q", n, d)
+				}
+				if !want[d] {
+					want[d] = true
+					added = true
+				}
+			}
+		}
+		if !added {
+			break
+		}
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	state := map[string]int{}
+	var order []Analyzer
+	var visit func(n string) error
+	visit = func(n string) error {
+		switch state[n] {
+		case gray:
+			return fmt.Errorf("rfscope: dependency cycle through %q", n)
+		case black:
+			return nil
+		}
+		state[n] = gray
+		deps := append([]string(nil), reg[n].DependsOn()...)
+		sort.Strings(deps)
+		for _, d := range deps {
+			if want[d] {
+				if err := visit(d); err != nil {
+					return err
+				}
+			}
+		}
+		state[n] = black
+		order = append(order, reg[n])
+		return nil
+	}
+
+	keys := make([]string, 0, len(want))
+	for n := range want {
+		keys = append(keys, n)
+	}
+	sort.Strings(keys)
+	for _, n := range keys {
+		if err := visit(n); err != nil {
+			return nil, err
+		}
+	}
+	return order, nil
+}
+
+// discard is an io.Writer sink for the fallback logger.
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/rfscope/analyzer_test.go
+++ b/internal/rfscope/analyzer_test.go
@@ -1,0 +1,144 @@
+package rfscope
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeAnalyzer is a test double recording the order it ran in.
+type fakeAnalyzer struct {
+	name    string
+	deps    []string
+	runErr  error
+	ranInto *[]string
+}
+
+func (f fakeAnalyzer) Name() string        { return f.name }
+func (f fakeAnalyzer) Synopsis() string    { return "fake " + f.name }
+func (f fakeAnalyzer) DependsOn() []string { return f.deps }
+func (f fakeAnalyzer) Analyze(_ context.Context, _ *Scene, _ *Input) error {
+	if f.ranInto != nil {
+		*f.ranInto = append(*f.ranInto, f.name)
+	}
+	return f.runErr
+}
+
+func regOf(as ...Analyzer) map[string]Analyzer {
+	m := make(map[string]Analyzer, len(as))
+	for _, a := range as {
+		m[a.Name()] = a
+	}
+	return m
+}
+
+func names(as []Analyzer) []string {
+	out := make([]string, len(as))
+	for i, a := range as {
+		out[i] = a.Name()
+	}
+	return out
+}
+
+func TestTopoOrderDependencyFirst(t *testing.T) {
+	t.Parallel()
+	// topology depends on segment; hierarchy depends on segment.
+	reg := regOf(
+		fakeAnalyzer{name: "segment"},
+		fakeAnalyzer{name: "hierarchy", deps: []string{"segment"}},
+		fakeAnalyzer{name: "topology", deps: []string{"segment"}},
+	)
+	order, err := topoOrder(reg, nil)
+	if err != nil {
+		t.Fatalf("topoOrder: %v", err)
+	}
+	pos := map[string]int{}
+	for i, n := range names(order) {
+		pos[n] = i
+	}
+	if pos["segment"] > pos["hierarchy"] || pos["segment"] > pos["topology"] {
+		t.Fatalf("segment must precede its dependents: %v", names(order))
+	}
+	if len(order) != 3 {
+		t.Fatalf("want all 3 analyzers, got %v", names(order))
+	}
+}
+
+func TestTopoOrderPullsTransitiveDeps(t *testing.T) {
+	t.Parallel()
+	// Requesting only "conv" must still run its transitive deps.
+	reg := regOf(
+		fakeAnalyzer{name: "segment"},
+		fakeAnalyzer{name: "emitters", deps: []string{"segment"}},
+		fakeAnalyzer{name: "conv", deps: []string{"emitters"}},
+	)
+	order, err := topoOrder(reg, []string{"conv"})
+	if err != nil {
+		t.Fatalf("topoOrder: %v", err)
+	}
+	got := names(order)
+	if len(got) != 3 || got[0] != "segment" || got[1] != "emitters" || got[2] != "conv" {
+		t.Fatalf("transitive deps not pulled/ordered: %v", got)
+	}
+}
+
+func TestTopoOrderDetectsCycle(t *testing.T) {
+	t.Parallel()
+	reg := regOf(
+		fakeAnalyzer{name: "a", deps: []string{"b"}},
+		fakeAnalyzer{name: "b", deps: []string{"a"}},
+	)
+	if _, err := topoOrder(reg, nil); err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("want cycle error, got %v", err)
+	}
+}
+
+func TestTopoOrderUnknownName(t *testing.T) {
+	t.Parallel()
+	reg := regOf(fakeAnalyzer{name: "segment"})
+	if _, err := topoOrder(reg, []string{"nope"}); err == nil {
+		t.Fatalf("want unknown-analyzer error")
+	}
+	// Unknown dependency is also an error.
+	reg2 := regOf(fakeAnalyzer{name: "x", deps: []string{"ghost"}})
+	if _, err := topoOrder(reg2, nil); err == nil {
+		t.Fatalf("want unknown-dependency error")
+	}
+}
+
+func TestRunPropagatesAnalyzeError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("boom")
+	var ran []string
+	reg := regOf(
+		fakeAnalyzer{name: "ok", ranInto: &ran},
+		fakeAnalyzer{name: "bad", deps: []string{"ok"}, runErr: boom, ranInto: &ran},
+	)
+	order, err := topoOrder(reg, nil)
+	if err != nil {
+		t.Fatalf("topoOrder: %v", err)
+	}
+	// Drive Analyze directly in resolved order to mirror Run's loop.
+	var runErr error
+	for _, a := range order {
+		if runErr = a.Analyze(context.Background(), &Scene{}, &Input{}); runErr != nil {
+			break
+		}
+	}
+	if !errors.Is(runErr, boom) {
+		t.Fatalf("want boom, got %v", runErr)
+	}
+	if len(ran) != 2 || ran[0] != "ok" {
+		t.Fatalf("ok should run before bad: %v", ran)
+	}
+}
+
+func TestRegistryRoundTrip(t *testing.T) {
+	t.Parallel()
+	// Run against the real global registry: with no analyzers registered yet in
+	// this package's tests, an all-analyzers Run is a no-op and must succeed.
+	if err := Run(context.Background(), &Scene{}, &Input{}); err != nil {
+		t.Fatalf("empty Run: %v", err)
+	}
+}

--- a/internal/rfscope/export.go
+++ b/internal/rfscope/export.go
@@ -1,0 +1,224 @@
+package rfscope
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Format is an rfscope scene serialization. It mirrors the multi-format export
+// convention the siglab and hunt subcommands use.
+type Format int
+
+const (
+	// FormatJSON is one indented JSON object for the whole scene.
+	FormatJSON Format = iota
+	// FormatJSONL is one JSON record per line: a scene header, then each burst,
+	// channel, emitter, conversation, and anomaly — a stream-friendly form.
+	FormatJSONL
+	// FormatYAML is a single YAML document.
+	FormatYAML
+	// FormatCSV is the burst table (one row per burst).
+	FormatCSV
+	// FormatSummary is the human-readable hierarchy + channel table report.
+	FormatSummary
+)
+
+// ParseFormat maps a -format flag value to a Format.
+func ParseFormat(s string) (Format, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "json", "":
+		return FormatJSON, nil
+	case "jsonl", "ndjson":
+		return FormatJSONL, nil
+	case "yaml", "yml":
+		return FormatYAML, nil
+	case "csv":
+		return FormatCSV, nil
+	case "summary", "txt", "text", "report":
+		return FormatSummary, nil
+	default:
+		return FormatJSON, fmt.Errorf("rfscope: unknown format %q (want json, jsonl, yaml, csv, or summary)", s)
+	}
+}
+
+func (f Format) String() string {
+	switch f {
+	case FormatJSONL:
+		return "jsonl"
+	case FormatYAML:
+		return "yaml"
+	case FormatCSV:
+		return "csv"
+	case FormatSummary:
+		return "summary"
+	default:
+		return "json"
+	}
+}
+
+// FileExtension returns the conventional file extension for the format.
+func (f Format) FileExtension() string {
+	switch f {
+	case FormatJSONL:
+		return "jsonl"
+	case FormatYAML:
+		return "yaml"
+	case FormatCSV:
+		return "csv"
+	case FormatSummary:
+		return "txt"
+	default:
+		return "json"
+	}
+}
+
+// Write serializes sc to w in the requested format. It Sanitizes the scene first
+// so a stray NaN/Inf never reaches the encoder (or the SSE/WS wire).
+func Write(w io.Writer, sc *Scene, f Format) error {
+	sc.Sanitize()
+	switch f {
+	case FormatJSON:
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(sc)
+	case FormatYAML:
+		enc := yaml.NewEncoder(w)
+		defer enc.Close()
+		return enc.Encode(sc)
+	case FormatJSONL:
+		return writeJSONL(w, sc)
+	case FormatCSV:
+		return writeCSV(w, sc)
+	case FormatSummary:
+		return writeSummary(w, sc)
+	default:
+		return fmt.Errorf("rfscope: unsupported format %v", f)
+	}
+}
+
+type jsonlRec struct {
+	Kind string `json:"kind"`
+	Data any    `json:"data"`
+}
+
+func writeJSONL(w io.Writer, sc *Scene) error {
+	enc := json.NewEncoder(w)
+	header := *sc
+	header.Bursts, header.Channels, header.Emitters, header.Conversations, header.Anomalies = nil, nil, nil, nil, nil
+	recs := []jsonlRec{{Kind: "scene", Data: header}}
+	for i := range sc.Bursts {
+		recs = append(recs, jsonlRec{Kind: "burst", Data: sc.Bursts[i]})
+	}
+	for i := range sc.Channels {
+		recs = append(recs, jsonlRec{Kind: "channel", Data: sc.Channels[i]})
+	}
+	for i := range sc.Emitters {
+		recs = append(recs, jsonlRec{Kind: "emitter", Data: sc.Emitters[i]})
+	}
+	for i := range sc.Conversations {
+		recs = append(recs, jsonlRec{Kind: "conversation", Data: sc.Conversations[i]})
+	}
+	for i := range sc.Anomalies {
+		recs = append(recs, jsonlRec{Kind: "anomaly", Data: sc.Anomalies[i]})
+	}
+	for _, r := range recs {
+		if err := enc.Encode(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeCSV(w io.Writer, sc *Scene) error {
+	cw := csv.NewWriter(w)
+	if err := cw.Write([]string{
+		"id", "freq_hz", "start_sec", "end_sec", "duration_sec", "class",
+		"occupied_bw_hz", "channel_power_dbfs", "spectral_flatness", "snr_db", "emitter_id",
+	}); err != nil {
+		return err
+	}
+	for _, b := range sc.Bursts {
+		rec := []string{
+			strconv.FormatUint(b.ID, 10),
+			strconv.FormatUint(uint64(b.FreqHz), 10),
+			strconv.FormatFloat(b.StartSec, 'f', 4, 64),
+			strconv.FormatFloat(b.EndSec, 'f', 4, 64),
+			strconv.FormatFloat(b.DurationSec(), 'f', 4, 64),
+			string(b.Class),
+			strconv.FormatUint(uint64(b.OccupiedBwHz), 10),
+			strconv.FormatFloat(b.ChannelPowerDBFS, 'f', 2, 64),
+			strconv.FormatFloat(b.SpectralFlatness, 'f', 4, 64),
+			strconv.FormatFloat(float64(b.SNRDb), 'f', 2, 64),
+			strconv.FormatUint(b.EmitterID, 10),
+		}
+		if err := cw.Write(rec); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
+}
+
+func writeSummary(w io.Writer, sc *Scene) error {
+	bw := &strings.Builder{}
+	fmt.Fprintf(bw, "RF Scene")
+	if sc.Source != "" {
+		fmt.Fprintf(bw, " — %s", sc.Source)
+	}
+	fmt.Fprintf(bw, "\n")
+	fmt.Fprintf(bw, "  center %.6f MHz   span %.3f MHz   window %.2fs   noise floor %.1f dBFS\n",
+		float64(sc.CenterHz)/1e6, float64(sc.SpanHz)/1e6, sc.WindowSec, sc.NoiseFloorDbFS)
+	fmt.Fprintf(bw, "  %d bursts   %d channels   %d emitters   %d anomalies\n",
+		len(sc.Bursts), len(sc.Channels), len(sc.Emitters), len(sc.Anomalies))
+
+	if len(sc.Hierarchy.Nodes) > 0 {
+		fmt.Fprintf(bw, "\nProtocol hierarchy (bursts / airtime / time%% / spectrum%%):\n")
+		for _, n := range sc.Hierarchy.Nodes {
+			indent := strings.Repeat("  ", n.Depth+1)
+			fmt.Fprintf(bw, "%s%-22s %4d  %7.2fs  %5.1f%%  %5.1f%%\n",
+				indent, n.Label, n.Stats.BurstCount, n.Stats.AirtimeSec, n.Stats.TimePct, n.Stats.SpectrumPct)
+		}
+	}
+
+	if len(sc.Channels) > 0 {
+		fmt.Fprintf(bw, "\nChannels:\n")
+		fmt.Fprintf(bw, "  %-13s %-8s %6s %7s %7s %9s %8s\n",
+			"freq(MHz)", "class", "bursts", "duty%", "occ%", "rate/min", "period")
+		for _, c := range sc.Channels {
+			period := "-"
+			if c.PeriodSec > 0 {
+				period = fmt.Sprintf("%.3fs", c.PeriodSec)
+			}
+			fmt.Fprintf(bw, "  %-13.6f %-8s %6d %7.1f %7.1f %9.1f %8s\n",
+				float64(c.FreqHz)/1e6, string(c.DominantClass), c.BurstCount,
+				c.DutyCycle*100, c.OccupancyPct, c.BurstRatePerMin, period)
+		}
+	}
+
+	if len(sc.Emitters) > 0 {
+		fmt.Fprintf(bw, "\nTop talkers:\n")
+		for _, e := range sc.Emitters {
+			hop := ""
+			if len(e.HopSet) > 1 {
+				hop = fmt.Sprintf(" (hops %d)", len(e.HopSet))
+			}
+			fmt.Fprintf(bw, "  %-28s %.2fs airtime%s\n", e.Label, e.TotalAirtimeSec, hop)
+		}
+	}
+
+	if len(sc.Anomalies) > 0 {
+		fmt.Fprintf(bw, "\nExpert info:\n")
+		for _, a := range sc.Anomalies {
+			fmt.Fprintf(bw, "  [%s] %s: %s\n", a.Severity, a.Kind, a.Detail)
+		}
+	}
+
+	_, err := io.WriteString(w, bw.String())
+	return err
+}

--- a/internal/rfscope/export_test.go
+++ b/internal/rfscope/export_test.go
@@ -1,0 +1,124 @@
+package rfscope
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+	"gopkg.in/yaml.v3"
+)
+
+func exportFixture() *Scene {
+	sc := hierFixture()
+	sc.Source = "fixture.cfile"
+	sc.NoiseFloorDbFS = -92
+	sc.Channels = []Channel{
+		{FreqHz: 450_100_000, DominantClass: survey.ClassC4FM, BurstCount: 2, DutyCycle: 0.15, OccupancyPct: 15, BurstRatePerMin: 12, PeriodSec: 1.0},
+	}
+	sc.Anomalies = []Anomaly{{Severity: "warn", Kind: "intermittent", FreqHz: 450_100_000, Detail: "low duty cycle"}}
+	return sc
+}
+
+func TestParseFormatRoundTrip(t *testing.T) {
+	t.Parallel()
+	cases := map[string]Format{
+		"json": FormatJSON, "jsonl": FormatJSONL, "ndjson": FormatJSONL,
+		"yaml": FormatYAML, "yml": FormatYAML, "csv": FormatCSV,
+		"summary": FormatSummary, "txt": FormatSummary, "": FormatJSON,
+	}
+	for in, want := range cases {
+		got, err := ParseFormat(in)
+		if err != nil || got != want {
+			t.Fatalf("ParseFormat(%q) = %v,%v want %v", in, got, err, want)
+		}
+	}
+	if _, err := ParseFormat("xml"); err == nil {
+		t.Fatalf("want error for unknown format")
+	}
+}
+
+func TestWriteJSON(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := Write(&buf, exportFixture(), FormatJSON); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	var got Scene
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Source != "fixture.cfile" || len(got.Bursts) != 3 {
+		t.Fatalf("json round-trip mismatch: %+v", got)
+	}
+}
+
+func TestWriteYAML(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := Write(&buf, exportFixture(), FormatYAML); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	var got Scene
+	if err := yaml.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("yaml unmarshal: %v", err)
+	}
+	if len(got.Bursts) != 3 {
+		t.Fatalf("yaml round-trip: got %d bursts", len(got.Bursts))
+	}
+}
+
+func TestWriteJSONL(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := Write(&buf, exportFixture(), FormatJSONL); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	// 1 scene + 3 bursts + 1 channel + 1 anomaly = 6 records.
+	if len(lines) != 6 {
+		t.Fatalf("jsonl line count: got %d want 6\n%s", len(lines), buf.String())
+	}
+	var first jsonlRec
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil || first.Kind != "scene" {
+		t.Fatalf("first record kind: %q err=%v", first.Kind, err)
+	}
+}
+
+func TestWriteCSV(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	if err := Write(&buf, exportFixture(), FormatCSV); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	rows, err := csv.NewReader(&buf).ReadAll()
+	if err != nil {
+		t.Fatalf("csv read: %v", err)
+	}
+	if len(rows) != 4 { // header + 3 bursts
+		t.Fatalf("csv rows: got %d want 4", len(rows))
+	}
+	if rows[0][1] != "freq_hz" {
+		t.Fatalf("csv header: %v", rows[0])
+	}
+}
+
+func TestWriteSummary(t *testing.T) {
+	t.Parallel()
+	sc := exportFixture()
+	// Populate the hierarchy so the summary renders it.
+	_ = (hierarchyAnalyzer{}).Analyze(context.Background(), sc, nil)
+	var buf bytes.Buffer
+	if err := Write(&buf, sc, FormatSummary); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"RF Scene", "fixture.cfile", "Protocol hierarchy", "Channels:", "Expert info:", "intermittent"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("summary missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/rfscope/hierarchy.go
+++ b/internal/rfscope/hierarchy.go
@@ -1,0 +1,186 @@
+package rfscope
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func init() { Register(hierarchyAnalyzer{}) }
+
+// hierarchyAnalyzer builds the RF "protocol hierarchy" — the analog of
+// Wireshark's Protocol Hierarchy Statistics, one layer down at the physical
+// layer. It groups bursts by modulation class → occupied-bandwidth bucket →
+// identified protocol, attaching counts, airtime, spectrum/time share, and an
+// estimated symbol volume to each node.
+type hierarchyAnalyzer struct{}
+
+func (hierarchyAnalyzer) Name() string { return "hierarchy" }
+func (hierarchyAnalyzer) Synopsis() string {
+	return "RF protocol hierarchy (class → bandwidth → protocol)"
+}
+func (hierarchyAnalyzer) DependsOn() []string { return nil }
+
+func (hierarchyAnalyzer) Analyze(ctx context.Context, sc *Scene, in *Input) error {
+	if len(sc.Bursts) == 0 {
+		return nil
+	}
+
+	// class → bandwidth bucket (Hz) → burst indices.
+	byClass := map[survey.SignalClass]map[uint32][]int{}
+	for i, b := range sc.Bursts {
+		bucket := survey.SnapChannelBandwidth(b.OccupiedBwHz)
+		if byClass[b.Class] == nil {
+			byClass[b.Class] = map[uint32][]int{}
+		}
+		byClass[b.Class][bucket] = append(byClass[b.Class][bucket], i)
+	}
+
+	sc.Hierarchy.Total = aggregateStats(sc, allIndices(len(sc.Bursts)))
+
+	classes := make([]survey.SignalClass, 0, len(byClass))
+	for c := range byClass {
+		classes = append(classes, c)
+	}
+	sort.Slice(classes, func(i, j int) bool { return classes[i] < classes[j] })
+
+	var nodes []HierNode
+	for _, class := range classes {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		buckets := byClass[class]
+
+		var classIdx []int
+		for _, idxs := range buckets {
+			classIdx = append(classIdx, idxs...)
+		}
+		nodes = append(nodes, HierNode{
+			Depth: 0,
+			Label: string(class),
+			Class: class,
+			Stats: aggregateStats(sc, classIdx),
+		})
+
+		bwKeys := make([]uint32, 0, len(buckets))
+		for bw := range buckets {
+			bwKeys = append(bwKeys, bw)
+		}
+		sort.Slice(bwKeys, func(i, j int) bool { return bwKeys[i] < bwKeys[j] })
+
+		for _, bw := range bwKeys {
+			idxs := buckets[bw]
+			nodes = append(nodes, HierNode{
+				Depth: 1,
+				Label: formatBandwidth(bw),
+				Class: class,
+				Stats: aggregateStats(sc, idxs),
+			})
+
+			// Depth 2: name the protocol of a representative digital burst.
+			if !survey.IsDigital(class) {
+				continue
+			}
+			proto := identifyRepresentative(sc, in, idxs)
+			if proto == "" {
+				continue
+			}
+			st := aggregateStats(sc, idxs)
+			nodes = append(nodes, HierNode{
+				Depth:    2,
+				Label:    proto,
+				Class:    class,
+				Protocol: proto,
+				Stats:    st,
+			})
+		}
+	}
+	sc.Hierarchy.Nodes = nodes
+	return nil
+}
+
+// identifyRepresentative runs siglab.IdentifyIQ on the longest burst in the
+// bucket and returns the winning protocol, or "" when identification is
+// inconclusive or no IQ is available.
+func identifyRepresentative(sc *Scene, in *Input, idxs []int) string {
+	if in == nil || in.BurstIQ == nil || len(idxs) == 0 {
+		return ""
+	}
+	best := idxs[0]
+	for _, i := range idxs {
+		if sc.Bursts[i].DurationSec() > sc.Bursts[best].DurationSec() {
+			best = i
+		}
+	}
+	iq, rate, err := in.BurstIQ(sc.Bursts[best])
+	if err != nil || len(iq) == 0 || rate <= 0 {
+		return ""
+	}
+	res, err := siglab.IdentifyIQ(iq, "rfscope-burst", siglab.IdentifyConfig{
+		SampleRateHz: rate,
+		Format:       siglab.FormatF32,
+		Log:          in.Log,
+	})
+	if err != nil || res == nil || res.Inconclusive || res.Winner == "" {
+		return ""
+	}
+	return res.Winner
+}
+
+// aggregateStats sums the figures for a set of bursts: counts, airtime, the
+// share of spectrum (distinct channel bandwidth over the span) and time
+// (airtime over the window), distinct emitters, and an estimated symbol volume
+// (Σ duration·baud).
+func aggregateStats(sc *Scene, idxs []int) HierStats {
+	var st HierStats
+	st.BurstCount = len(idxs)
+	emitters := map[uint64]struct{}{}
+	chanBw := map[uint32]uint32{} // freq → max occupied bw on that channel
+	for _, i := range idxs {
+		b := sc.Bursts[i]
+		st.AirtimeSec += b.DurationSec()
+		st.SymbolVolume += int64(b.DurationSec() * b.Features.BaudHz)
+		if b.EmitterID != 0 {
+			emitters[b.EmitterID] = struct{}{}
+		}
+		if b.OccupiedBwHz > chanBw[b.FreqHz] {
+			chanBw[b.FreqHz] = b.OccupiedBwHz
+		}
+	}
+	st.EmitterCount = len(emitters)
+
+	var spectrumHz uint32
+	for _, bw := range chanBw {
+		spectrumHz += bw
+	}
+	if sc.SpanHz > 0 {
+		st.SpectrumPct = 100 * float64(spectrumHz) / float64(sc.SpanHz)
+	}
+	if sc.WindowSec > 0 {
+		st.TimePct = 100 * st.AirtimeSec / sc.WindowSec
+	}
+	return st
+}
+
+func allIndices(n int) []int {
+	out := make([]int, n)
+	for i := range out {
+		out[i] = i
+	}
+	return out
+}
+
+// formatBandwidth renders a channel bandwidth as a compact label (e.g. "12.5 kHz").
+func formatBandwidth(hz uint32) string {
+	switch {
+	case hz == 0:
+		return "unknown-bw"
+	case hz >= 1_000_000:
+		return fmt.Sprintf("%.3g MHz", float64(hz)/1e6)
+	default:
+		return fmt.Sprintf("%.4g kHz", float64(hz)/1e3)
+	}
+}

--- a/internal/rfscope/hierarchy_test.go
+++ b/internal/rfscope/hierarchy_test.go
@@ -1,0 +1,112 @@
+package rfscope
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func hierFixture() *Scene {
+	return &Scene{
+		CenterHz:  450_000_000,
+		SpanHz:    1_000_000,
+		WindowSec: 10,
+		Bursts: []Burst{
+			// Two C4FM bursts on the same channel.
+			{ID: 1, FreqHz: 450_100_000, StartSec: 0, EndSec: 1.0, OccupiedBwHz: 12_500,
+				Class: survey.ClassC4FM, Features: survey.ClassFeatures{BaudHz: 4800}},
+			{ID: 2, FreqHz: 450_100_000, StartSec: 2.0, EndSec: 2.5, OccupiedBwHz: 12_500,
+				Class: survey.ClassC4FM, Features: survey.ClassFeatures{BaudHz: 4800}},
+			// One analog NBFM burst on another channel.
+			{ID: 3, FreqHz: 450_300_000, StartSec: 0, EndSec: 2.0, OccupiedBwHz: 12_500,
+				Class: survey.ClassNBFM},
+		},
+	}
+}
+
+func findNode(nodes []HierNode, depth int, label string) (HierNode, bool) {
+	for _, n := range nodes {
+		if n.Depth == depth && n.Label == label {
+			return n, true
+		}
+	}
+	return HierNode{}, false
+}
+
+func TestHierarchyAggregatesAndOrders(t *testing.T) {
+	t.Parallel()
+	sc := hierFixture()
+	if err := (hierarchyAnalyzer{}).Analyze(context.Background(), sc, nil); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	if sc.Hierarchy.Total.BurstCount != 3 || sc.Hierarchy.Total.AirtimeSec != 3.5 {
+		t.Fatalf("totals wrong: %+v", sc.Hierarchy.Total)
+	}
+
+	c4fm, ok := findNode(sc.Hierarchy.Nodes, 0, "c4fm")
+	if !ok {
+		t.Fatalf("missing c4fm class node: %+v", sc.Hierarchy.Nodes)
+	}
+	if c4fm.Stats.BurstCount != 2 || c4fm.Stats.AirtimeSec != 1.5 {
+		t.Fatalf("c4fm stats: %+v", c4fm.Stats)
+	}
+	// SymbolVolume = 1.0*4800 + 0.5*4800 = 7200.
+	if c4fm.Stats.SymbolVolume != 7200 {
+		t.Fatalf("c4fm symbol volume: got %d want 7200", c4fm.Stats.SymbolVolume)
+	}
+	// One distinct channel of 12.5 kHz over a 1 MHz span = 1.25%.
+	if c4fm.Stats.SpectrumPct < 1.24 || c4fm.Stats.SpectrumPct > 1.26 {
+		t.Fatalf("c4fm spectrum pct: %v", c4fm.Stats.SpectrumPct)
+	}
+	// TimePct = 1.5 / 10 = 15%.
+	if c4fm.Stats.TimePct < 14.9 || c4fm.Stats.TimePct > 15.1 {
+		t.Fatalf("c4fm time pct: %v", c4fm.Stats.TimePct)
+	}
+
+	if _, ok := findNode(sc.Hierarchy.Nodes, 0, "nbfm"); !ok {
+		t.Fatalf("missing nbfm class node")
+	}
+
+	// Deterministic ordering: the c4fm class node precedes the nbfm class node.
+	var posC4FM, posNBFM = -1, -1
+	for i, n := range sc.Hierarchy.Nodes {
+		if n.Depth == 0 && n.Label == "c4fm" {
+			posC4FM = i
+		}
+		if n.Depth == 0 && n.Label == "nbfm" {
+			posNBFM = i
+		}
+	}
+	if posC4FM < 0 || posNBFM < 0 || posC4FM > posNBFM {
+		t.Fatalf("class ordering wrong: c4fm=%d nbfm=%d", posC4FM, posNBFM)
+	}
+
+	// A bandwidth bucket node must sit under the class node (depth 1).
+	if _, ok := findNode(sc.Hierarchy.Nodes, 1, formatBandwidth(survey.SnapChannelBandwidth(12_500))); !ok {
+		t.Fatalf("missing bandwidth bucket node: %+v", sc.Hierarchy.Nodes)
+	}
+}
+
+func TestHierarchyViaRunner(t *testing.T) {
+	t.Parallel()
+	sc := hierFixture()
+	if err := Run(context.Background(), sc, &Input{}, "hierarchy"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(sc.Hierarchy.Nodes) == 0 {
+		t.Fatalf("runner produced no hierarchy nodes")
+	}
+}
+
+func TestHierarchyEmptyScene(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{}
+	if err := (hierarchyAnalyzer{}).Analyze(context.Background(), sc, nil); err != nil {
+		t.Fatalf("Analyze empty: %v", err)
+	}
+	if len(sc.Hierarchy.Nodes) != 0 {
+		t.Fatalf("empty scene should yield no nodes")
+	}
+}

--- a/internal/rfscope/scene.go
+++ b/internal/rfscope/scene.go
@@ -1,0 +1,288 @@
+// Package rfscope is protocol-agnostic RF network analysis — "Wireshark for the
+// RF physical layer". Pointed at any band (a recorded IQ capture or a live SDR)
+// with no prior knowledge of the technology, modulation, framing, or
+// encryption, it produces a structured Scene describing what is on the air and
+// how it behaves: an RF protocol hierarchy, per-channel activity/occupancy, burst
+// timing and periodicity, an emitter/conversation graph, and an entropy/
+// encryption triage that bridges into the cryptolab toolkit.
+//
+// rfscope sits at the top of the analysis lattice and imports only downward —
+// survey, carriers, siglab, hunt, the cryptolab engines, and the dsp
+// primitives. None of those import rfscope, so there is no cycle. It adds no DSP
+// of its own; it orchestrates the existing primitives and accumulates their
+// output into one shared, JSON-exportable Scene (the protocol-agnostic peer of
+// hunt.DiscoveredSystem).
+package rfscope
+
+import (
+	"math"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// Scene is the accumulating, protocol-agnostic model of an RF environment over a
+// capture or a live window. Bursts are the raw atom; Channels, Emitters,
+// Conversations, Hierarchy and Anomalies are derived views populated by the
+// registered Analyzers. AnalyzerOutputs carries each analyzer's own structured
+// detail keyed by analyzer name (mirroring siglab.Result.Detail), so an analyzer
+// can emit more than the shared model captures.
+type Scene struct {
+	Source     string    `json:"source"`
+	StartedAt  time.Time `json:"started_at"`
+	FinishedAt time.Time `json:"finished_at"`
+	CenterHz   uint32    `json:"center_hz"`
+	SpanHz     uint32    `json:"span_hz"`
+	// WindowSec is the observation window: how much signal time the scene covers.
+	WindowSec float64 `json:"window_sec"`
+	// NoiseFloorDbFS is the scene-wide robust noise floor (spectrum.Percentile).
+	NoiseFloorDbFS float32 `json:"noise_floor_dbfs"`
+
+	Bursts        []Burst           `json:"bursts,omitempty"`
+	Channels      []Channel         `json:"channels,omitempty"`
+	Emitters      []Emitter         `json:"emitters,omitempty"`
+	Conversations []Conversation    `json:"conversations,omitempty"`
+	Hierarchy     ProtocolHierarchy `json:"hierarchy"`
+	Anomalies     []Anomaly         `json:"anomalies,omitempty"`
+
+	AnalyzerOutputs map[string]any `json:"analyzer_outputs,omitempty"`
+}
+
+// Burst is one onset→offset activity segment on one frequency — the atom every
+// downstream statistic is built from. The spectral fields (OccupiedBwHz,
+// ChannelPowerDBFS, ACPR*, SpectralFlatness) come from spectrum.ComputeOccupancy
+// (PR #831); Class/Features come from survey.Classify.
+type Burst struct {
+	ID       uint64  `json:"id"`
+	FreqHz   uint32  `json:"freq_hz"`
+	StartSec float64 `json:"start_sec"`
+	EndSec   float64 `json:"end_sec"`
+	PeakDbFS float32 `json:"peak_dbfs"`
+	SNRDb    float32 `json:"snr_db"`
+
+	OccupiedBwHz     uint32  `json:"occupied_bw_hz"`
+	ChannelPowerDBFS float64 `json:"channel_power_dbfs"`
+	ACPRUpperDB      float64 `json:"acpr_upper_db"`
+	ACPRLowerDB      float64 `json:"acpr_lower_db"`
+	// SpectralFlatness is the Wiener entropy 0..1: ≈1 noise-like/spread, ≪1 a
+	// tone or narrow carrier — a high-value protocol-agnostic discriminator.
+	SpectralFlatness float64 `json:"spectral_flatness"`
+
+	Class    survey.SignalClass   `json:"class"`
+	Features survey.ClassFeatures `json:"features"`
+
+	// EmitterID back-references the owning emitter once clustered (0 = none).
+	EmitterID uint64 `json:"emitter_id,omitempty"`
+}
+
+// DurationSec is the burst's on-air time.
+func (b Burst) DurationSec() float64 {
+	d := b.EndSec - b.StartSec
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// Channel is the per-frequency, time-aggregated view — the I/O-graph row.
+type Channel struct {
+	FreqHz          uint32             `json:"freq_hz"`
+	OccupiedBwHz    uint32             `json:"occupied_bw_hz"`
+	DominantClass   survey.SignalClass `json:"dominant_class"`
+	BurstCount      int                `json:"burst_count"`
+	AirtimeSec      float64            `json:"airtime_sec"`
+	DutyCycle       float64            `json:"duty_cycle"`
+	OccupancyPct    float64            `json:"occupancy_pct"`
+	BurstRatePerMin float64            `json:"burst_rate_per_min"`
+	MedianPowerDbFS float32            `json:"median_power_dbfs"`
+	MedianFlatness  float64            `json:"median_flatness"`
+
+	Timeline []Bin `json:"timeline,omitempty"`
+
+	BurstLenHist     Hist    `json:"burst_len_hist"`
+	InterArrivalHist Hist    `json:"inter_arrival_hist"`
+	PeriodSec        float64 `json:"period_sec"`
+	PeriodConfidence float64 `json:"period_confidence"`
+}
+
+// Bin is one time-bucket of a channel's activity timeline.
+type Bin struct {
+	TSec       float64 `json:"t_sec"`
+	PowerDbFS  float32 `json:"power_dbfs"`
+	Occupied   bool    `json:"occupied"`
+	BurstCount int     `json:"burst_count"`
+}
+
+// Hist is a simple histogram pairing bin counts with their edges, matching the
+// (counts, edges) shape dsp/stats.Histogram returns.
+type Hist struct {
+	Counts []int     `json:"counts,omitempty"`
+	Edges  []float64 `json:"edges,omitempty"`
+}
+
+// Emitter is a cluster of bursts sharing an RF fingerprint — the protocol-
+// agnostic generalization of hunt's per-site/per-unit identity.
+type Emitter struct {
+	ID              uint64      `json:"id"`
+	Label           string      `json:"label"`
+	Fingerprint     Fingerprint `json:"fingerprint"`
+	BurstIDs        []uint64    `json:"burst_ids,omitempty"`
+	FirstSec        float64     `json:"first_sec"`
+	LastSec         float64     `json:"last_sec"`
+	TotalAirtimeSec float64     `json:"total_airtime_sec"`
+	// HopSet holds >1 frequency when the emitter is a frequency hopper.
+	HopSet []uint32 `json:"hop_set,omitempty"`
+}
+
+// Fingerprint is the feature vector emitters are clustered on.
+type Fingerprint struct {
+	CenterHz          uint32  `json:"center_hz"`
+	OccupiedBwHz      uint32  `json:"occupied_bw_hz"`
+	ClassFamily       string  `json:"class_family"`
+	MedianPowerDbFS   float32 `json:"median_power_dbfs"`
+	MedianBurstLenSec float64 `json:"median_burst_len_sec"`
+	SpectralFlatness  float64 `json:"spectral_flatness"`
+	PeriodSec         float64 `json:"period_sec"`
+}
+
+// Conversation links temporally correlated emitters — the generic
+// conversation/endpoint graph (request/response, paired TDMA slots, a hop
+// sequence, or consistently co-active emitters).
+type Conversation struct {
+	ID          uint64   `json:"id"`
+	EmitterIDs  []uint64 `json:"emitter_ids"`
+	Kind        string   `json:"kind"`
+	Correlation float64  `json:"correlation"`
+	Exchanges   int      `json:"exchanges"`
+}
+
+// ProtocolHierarchy is the class→bandwidth→protocol tree, flattened depth-first
+// with a Depth field for rendering.
+type ProtocolHierarchy struct {
+	Total HierStats  `json:"total"`
+	Nodes []HierNode `json:"nodes,omitempty"`
+}
+
+// HierNode is one row of the flattened hierarchy tree.
+type HierNode struct {
+	Depth    int                `json:"depth"` // 0=class, 1=bandwidth bucket, 2=protocol candidate
+	Label    string             `json:"label"`
+	Class    survey.SignalClass `json:"class,omitempty"`
+	Protocol string             `json:"protocol,omitempty"`
+	Stats    HierStats          `json:"stats"`
+}
+
+// HierStats are the aggregate figures attached to a hierarchy node.
+type HierStats struct {
+	EmitterCount int     `json:"emitter_count"`
+	BurstCount   int     `json:"burst_count"`
+	AirtimeSec   float64 `json:"airtime_sec"`
+	SpectrumPct  float64 `json:"spectrum_pct"`
+	TimePct      float64 `json:"time_pct"`
+	SymbolVolume int64   `json:"symbol_volume"`
+	ByteVolume   int64   `json:"byte_volume"`
+}
+
+// Anomaly is one RF expert-info finding.
+type Anomaly struct {
+	Severity  string `json:"severity"` // "note" | "warn" | "alert"
+	Kind      string `json:"kind"`     // "intermittent" | "hopper" | "wide-carrier" | …
+	FreqHz    uint32 `json:"freq_hz,omitempty"`
+	EmitterID uint64 `json:"emitter_id,omitempty"`
+	Detail    string `json:"detail"`
+}
+
+// Sanitize clamps every non-finite float in the scene to a safe value so a
+// marshal (and the SSE/WS wire that carries it) never sees NaN/±Inf. Call before
+// any JSON encode or stream send.
+func (s *Scene) Sanitize() {
+	s.NoiseFloorDbFS = finite32(s.NoiseFloorDbFS)
+	s.WindowSec = finite(s.WindowSec)
+
+	for i := range s.Bursts {
+		b := &s.Bursts[i]
+		b.StartSec = finite(b.StartSec)
+		b.EndSec = finite(b.EndSec)
+		b.PeakDbFS = finite32(b.PeakDbFS)
+		b.SNRDb = finite32(b.SNRDb)
+		b.ChannelPowerDBFS = finite(b.ChannelPowerDBFS)
+		b.ACPRUpperDB = finite(b.ACPRUpperDB)
+		b.ACPRLowerDB = finite(b.ACPRLowerDB)
+		b.SpectralFlatness = finite(b.SpectralFlatness)
+		sanitizeFeatures(&b.Features)
+	}
+
+	for i := range s.Channels {
+		c := &s.Channels[i]
+		c.AirtimeSec = finite(c.AirtimeSec)
+		c.DutyCycle = finite(c.DutyCycle)
+		c.OccupancyPct = finite(c.OccupancyPct)
+		c.BurstRatePerMin = finite(c.BurstRatePerMin)
+		c.MedianPowerDbFS = finite32(c.MedianPowerDbFS)
+		c.MedianFlatness = finite(c.MedianFlatness)
+		c.PeriodSec = finite(c.PeriodSec)
+		c.PeriodConfidence = finite(c.PeriodConfidence)
+		for j := range c.Timeline {
+			c.Timeline[j].TSec = finite(c.Timeline[j].TSec)
+			c.Timeline[j].PowerDbFS = finite32(c.Timeline[j].PowerDbFS)
+		}
+		sanitizeHist(&c.BurstLenHist)
+		sanitizeHist(&c.InterArrivalHist)
+	}
+
+	for i := range s.Emitters {
+		e := &s.Emitters[i]
+		e.FirstSec = finite(e.FirstSec)
+		e.LastSec = finite(e.LastSec)
+		e.TotalAirtimeSec = finite(e.TotalAirtimeSec)
+		e.Fingerprint.MedianPowerDbFS = finite32(e.Fingerprint.MedianPowerDbFS)
+		e.Fingerprint.MedianBurstLenSec = finite(e.Fingerprint.MedianBurstLenSec)
+		e.Fingerprint.SpectralFlatness = finite(e.Fingerprint.SpectralFlatness)
+		e.Fingerprint.PeriodSec = finite(e.Fingerprint.PeriodSec)
+	}
+
+	for i := range s.Conversations {
+		s.Conversations[i].Correlation = finite(s.Conversations[i].Correlation)
+	}
+
+	sanitizeHierStats(&s.Hierarchy.Total)
+	for i := range s.Hierarchy.Nodes {
+		sanitizeHierStats(&s.Hierarchy.Nodes[i].Stats)
+	}
+}
+
+func sanitizeFeatures(f *survey.ClassFeatures) {
+	f.SNRDb = finite(f.SNRDb)
+	f.EnvelopeCV = finite(f.EnvelopeCV)
+	f.IFStd = finite(f.IFStd)
+	f.IFKurtosis = finite(f.IFKurtosis)
+	f.BaudHz = finite(f.BaudHz)
+	f.BaudProminence = finite(f.BaudProminence)
+}
+
+func sanitizeHist(h *Hist) {
+	for i := range h.Edges {
+		h.Edges[i] = finite(h.Edges[i])
+	}
+}
+
+func sanitizeHierStats(h *HierStats) {
+	h.AirtimeSec = finite(h.AirtimeSec)
+	h.SpectrumPct = finite(h.SpectrumPct)
+	h.TimePct = finite(h.TimePct)
+}
+
+// finite returns f when finite, otherwise 0.
+func finite(f float64) float64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return f
+}
+
+func finite32(f float32) float32 {
+	if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
+		return 0
+	}
+	return f
+}

--- a/internal/rfscope/scene_test.go
+++ b/internal/rfscope/scene_test.go
@@ -1,0 +1,109 @@
+package rfscope
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func TestSceneSanitizeClampsNonFinite(t *testing.T) {
+	t.Parallel()
+
+	s := &Scene{
+		NoiseFloorDbFS: float32(math.Inf(-1)),
+		WindowSec:      math.NaN(),
+		Bursts: []Burst{{
+			ID:               1,
+			ChannelPowerDBFS: math.Inf(1),
+			SpectralFlatness: math.NaN(),
+			PeakDbFS:         float32(math.NaN()),
+			Features:         survey.ClassFeatures{SNRDb: math.Inf(1), BaudHz: math.NaN()},
+		}},
+		Channels: []Channel{{
+			FreqHz:           450_000_000,
+			DutyCycle:        math.NaN(),
+			PeriodSec:        math.Inf(1),
+			MedianFlatness:   math.NaN(),
+			Timeline:         []Bin{{TSec: math.NaN(), PowerDbFS: float32(math.Inf(-1))}},
+			BurstLenHist:     Hist{Edges: []float64{math.NaN(), 1.5}},
+			InterArrivalHist: Hist{Edges: []float64{math.Inf(1)}},
+		}},
+		Emitters: []Emitter{{
+			ID:              2,
+			TotalAirtimeSec: math.NaN(),
+			Fingerprint:     Fingerprint{SpectralFlatness: math.Inf(1), MedianBurstLenSec: math.NaN()},
+		}},
+		Conversations: []Conversation{{ID: 3, Correlation: math.NaN()}},
+		Hierarchy: ProtocolHierarchy{
+			Total: HierStats{SpectrumPct: math.NaN()},
+			Nodes: []HierNode{{Stats: HierStats{TimePct: math.Inf(1)}}},
+		},
+	}
+
+	s.Sanitize()
+
+	// A successful marshal is the real assertion: encoding/json errors on NaN/Inf.
+	b, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal after Sanitize: %v", err)
+	}
+	if strings.Contains(string(b), "NaN") || strings.Contains(string(b), "Inf") {
+		t.Fatalf("sanitized JSON still contains NaN/Inf: %s", b)
+	}
+
+	// Spot-check a few clamped fields.
+	if s.WindowSec != 0 || s.Bursts[0].SpectralFlatness != 0 || s.Channels[0].PeriodSec != 0 {
+		t.Fatalf("non-finite fields not clamped to 0: %+v", s)
+	}
+	if got := s.Channels[0].BurstLenHist.Edges[0]; got != 0 {
+		t.Fatalf("hist edge not clamped: got %v", got)
+	}
+}
+
+func TestSceneJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := &Scene{
+		Source:   "fixture.cfile",
+		CenterHz: 451_000_000,
+		SpanHz:   2_400_000,
+		Bursts: []Burst{{
+			ID: 1, FreqHz: 451_012_500, StartSec: 0.5, EndSec: 1.25,
+			Class: survey.ClassC4FM, OccupiedBwHz: 12_500, SpectralFlatness: 0.3,
+		}},
+		Channels: []Channel{{FreqHz: 451_012_500, BurstCount: 1, DutyCycle: 0.2}},
+		Hierarchy: ProtocolHierarchy{
+			Total: HierStats{BurstCount: 1, AirtimeSec: 0.75},
+			Nodes: []HierNode{{Depth: 0, Label: "c4fm", Class: survey.ClassC4FM}},
+		},
+	}
+
+	b, err := json.Marshal(want)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Scene
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Source != want.Source || got.CenterHz != want.CenterHz {
+		t.Fatalf("header round-trip mismatch: %+v", got)
+	}
+	if len(got.Bursts) != 1 || got.Bursts[0].Class != survey.ClassC4FM || got.Bursts[0].DurationSec() != 0.75 {
+		t.Fatalf("burst round-trip mismatch: %+v", got.Bursts)
+	}
+	if len(got.Hierarchy.Nodes) != 1 || got.Hierarchy.Nodes[0].Label != "c4fm" {
+		t.Fatalf("hierarchy round-trip mismatch: %+v", got.Hierarchy)
+	}
+}
+
+func TestBurstDurationNeverNegative(t *testing.T) {
+	t.Parallel()
+	b := Burst{StartSec: 2.0, EndSec: 1.0}
+	if b.DurationSec() != 0 {
+		t.Fatalf("expected clamped 0 for inverted burst, got %v", b.DurationSec())
+	}
+}

--- a/internal/rfscope/segment.go
+++ b/internal/rfscope/segment.go
@@ -121,8 +121,20 @@ func Segment(ctx context.Context, src Source, cfg SegmentConfig) (*Scene, *Input
 		ThresholdDb:  cfg.PeakThresholdDb,
 		MinSpacingHz: cfg.MinSpacingHz,
 	})
-	if len(peaks) > cfg.MaxChannels {
-		peaks = peaks[:cfg.MaxChannels]
+	// DetectPeaks drops the DC bin (a front-end artifact for live SDRs), but a
+	// real carrier can sit exactly at the tuned centre — common for a
+	// single-channel capture. Always consider the band centre as a candidate; a
+	// static DC spike produces no burst (the onset floor initializes to it), so
+	// this is safe.
+	dcBin := len(avg.Bins) / 2
+	cands := []carriers.Peak{{FreqHz: center, PowerDbFS: avg.Bins[dcBin], SNRDb: avg.Bins[dcBin] - noiseFloor}}
+	for _, p := range peaks {
+		if absU32(p.FreqHz, center) >= cfg.MinSpacingHz {
+			cands = append(cands, p)
+		}
+	}
+	if len(cands) > cfg.MaxChannels {
+		cands = cands[:cfg.MaxChannels]
 	}
 
 	now := cfg.Now()
@@ -139,9 +151,16 @@ func Segment(ctx context.Context, src Source, cfg SegmentConfig) (*Scene, *Input
 	store := map[uint64]storedIQ{}
 	var nextID uint64
 
-	for _, pk := range peaks {
+	for _, pk := range cands {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
+		}
+		// Only segment confirmed carriers. DetectPeaks results clear the
+		// threshold by construction; this gates the always-added DC candidate so
+		// a dead band centre (or noise rising under an adjacent transmission)
+		// produces no phantom burst.
+		if pk.SNRDb < cfg.PeakThresholdDb {
+			continue
 		}
 		offset := float64(pk.FreqHz) - float64(center)
 		ddc := ccdecoder.NewDownconverterWithOffset(rate, cfg.ChannelTargetRateHz, offset)
@@ -151,7 +170,8 @@ func Segment(ctx context.Context, src Source, cfg SegmentConfig) (*Scene, *Input
 			continue
 		}
 
-		spans := detectBursts(base, outRate, cfg)
+		carrierConfirmed := pk.SNRDb >= cfg.PeakThresholdDb
+		spans := detectBursts(base, outRate, cfg, carrierConfirmed)
 		for _, sp := range spans {
 			slice := base[sp.startSample:sp.endSample]
 			cls := survey.Classify(slice, outRate)
@@ -220,41 +240,77 @@ type burstSpan struct {
 	endSample   int
 }
 
-// detectBursts runs the lifted onset/offset state machine over the power
-// envelope of a channel's decimated baseband and returns the burst spans.
-func detectBursts(base []complex64, outRate float64, cfg SegmentConfig) []burstSpan {
+// detectBursts slices a channel's decimated baseband into onset→offset spans.
+//
+// It applies the hysteresis + debounce logic lifted from the DMR onset detector,
+// but anchors the threshold on a fixed quiet floor (a low percentile of the
+// channel's own power envelope over the whole capture) rather than an EWMA seeded
+// from the first frame — so a transmission that is already keyed up at the start
+// of the capture is still found. When the channel has too little dynamic range to
+// segment (a continuous carrier on for the whole window, or dead air),
+// carrierConfirmed (from the wideband carrier SNR) decides between one full-span
+// burst and none.
+func detectBursts(base []complex64, outRate float64, cfg SegmentConfig, carrierConfirmed bool) []burstSpan {
 	hop := int(math.Round(outRate / cfg.EnvelopeRateHz))
 	if hop < 1 {
 		hop = 1
 	}
 	minSamples := int(math.Round(cfg.MinBurstSec * outRate))
 
-	st := channelState{}
-	var spans []burstSpan
-	curStart := -1
+	// Power envelope, one dB value per frame.
+	var env []float64
 	for i := 0; i+hop <= len(base); i += hop {
-		db := frameDb(base[i : i+hop])
-		onset, offset := st.update(db, cfg)
-		if onset {
-			// Back-date the start by the debounce latency.
-			curStart = i - (cfg.Debounce-1)*hop
-			if curStart < 0 {
-				curStart = 0
-			}
+		env = append(env, frameDb(base[i:i+hop]))
+	}
+	if len(env) == 0 {
+		return nil
+	}
+
+	floor := percentileFloat(env, 0.10)
+	peak := percentileFloat(env, 0.95)
+	// Low dynamic range ⇒ the channel is either continuously on or dead. Defer to
+	// the wideband carrier confirmation.
+	if peak-floor < cfg.OnThreshDb {
+		if carrierConfirmed && len(base) >= minSamples {
+			return []burstSpan{{startSample: 0, endSample: len(base)}}
 		}
-		if offset && curStart >= 0 {
-			end := i
-			if end > len(base) {
-				end = len(base)
+		return nil
+	}
+
+	onLevel := floor + cfg.OnThreshDb
+	offLevel := floor + cfg.OffThreshDb
+	var spans []burstSpan
+	active := false
+	above, below := 0, 0
+	curStart := -1
+	for i, db := range env {
+		switch {
+		case db >= onLevel:
+			above++
+			below = 0
+			if !active && above >= cfg.Debounce {
+				active = true
+				curStart = (i - (cfg.Debounce - 1)) * hop
+				if curStart < 0 {
+					curStart = 0
+				}
 			}
-			if end-curStart >= minSamples {
-				spans = append(spans, burstSpan{startSample: curStart, endSample: end})
+		case db <= offLevel:
+			below++
+			above = 0
+			if active && below >= cfg.Debounce {
+				active = false
+				end := i * hop
+				if end-curStart >= minSamples {
+					spans = append(spans, burstSpan{startSample: curStart, endSample: end})
+				}
+				curStart = -1
 			}
-			curStart = -1
+		default:
+			above, below = 0, 0
 		}
 	}
-	// Close an open burst at end-of-stream.
-	if curStart >= 0 && len(base)-curStart >= minSamples {
+	if active && curStart >= 0 && len(base)-curStart >= minSamples {
 		spans = append(spans, burstSpan{startSample: curStart, endSample: len(base)})
 	}
 	return spans
@@ -276,53 +332,29 @@ func frameDb(frame []complex64) float64 {
 	return 10 * math.Log10(p)
 }
 
-// channelState is the per-channel onset/offset state machine — the algorithm
-// lifted from internal/scanner/dmrlcn/onset.go's updateChannel, generalized off
-// the DMR grid to run on any channel's power envelope.
-type channelState struct {
-	floorDb   float64
-	floorInit bool
-	active    bool
-	above     int
-	below     int
+// percentileFloat returns the p-quantile (0..1) of xs without mutating it.
+func percentileFloat(xs []float64, p float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	cp := append([]float64(nil), xs...)
+	sort.Float64s(cp)
+	idx := int(p * float64(len(cp)-1))
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(cp) {
+		idx = len(cp) - 1
+	}
+	return cp[idx]
 }
 
-// update advances the machine by one envelope frame, returning whether this
-// frame triggered an onset (idle→active) or offset (active→idle).
-func (s *channelState) update(db float64, cfg SegmentConfig) (onset, offset bool) {
-	if !s.floorInit {
-		s.floorDb = db
-		s.floorInit = true
-		return
+// absU32 is the absolute difference of two unsigned frequencies.
+func absU32(a, b uint32) uint32 {
+	if a > b {
+		return a - b
 	}
-	onLevel := s.floorDb + cfg.OnThreshDb
-	offLevel := s.floorDb + cfg.OffThreshDb
-	switch {
-	case db >= onLevel:
-		s.above++
-		s.below = 0
-		if !s.active && s.above >= cfg.Debounce {
-			s.active = true
-			onset = true
-		}
-	case db <= offLevel:
-		s.below++
-		s.above = 0
-		if s.active && s.below >= cfg.Debounce {
-			s.active = false
-			offset = true
-		}
-	default:
-		s.above = 0
-		s.below = 0
-	}
-	// Track the noise floor only while idle so an active carrier can't drag the
-	// floor up and mask itself.
-	if !s.active {
-		a := cfg.NoiseAlpha
-		s.floorDb = (1-a)*s.floorDb + a*db
-	}
-	return
+	return b - a
 }
 
 // occFFTFor picks a power-of-two FFT size no larger than the slice for occupancy

--- a/internal/rfscope/segment.go
+++ b/internal/rfscope/segment.go
@@ -1,0 +1,336 @@
+package rfscope
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/carriers"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// SegmentConfig tunes the segmentation pre-pass. The zero value is valid; every
+// field falls back to a sensible default via withDefaults.
+type SegmentConfig struct {
+	// FFTSize is the wideband FFT used for carrier discovery (power of two).
+	FFTSize int
+	// ChannelTargetRateHz is the per-channel decimated baseband rate the
+	// downconverter targets. ~50 kHz comfortably holds any land-mobile / IoT
+	// narrowband channel while keeping per-burst buffers small.
+	ChannelTargetRateHz float64
+	// PeakThresholdDb / MinSpacingHz tune carrier discovery (carriers.DetectPeaks).
+	PeakThresholdDb float32
+	MinSpacingHz    uint32
+	// MaxChannels caps how many discovered carriers are analyzed (strongest first).
+	MaxChannels int
+	// EnvelopeRateHz is the per-channel power-envelope frame rate the onset state
+	// machine runs at. Higher resolves shorter bursts at more CPU.
+	EnvelopeRateHz float64
+	// OnThreshDb/OffThreshDb/Debounce/NoiseAlpha are the onset state-machine knobs,
+	// lifted from the DMR onset detector.
+	OnThreshDb  float64
+	OffThreshDb float64
+	Debounce    int
+	NoiseAlpha  float64
+	// MinBurstSec drops bursts shorter than this (debounce noise).
+	MinBurstSec float64
+	// MaxSamples caps how many wideband samples are read (0 = whole capture). The
+	// CLI sets this from a -window/-duration flag.
+	MaxSamples int
+	// Now stamps the scene; nil ⇒ time.Now.
+	Now func() time.Time
+}
+
+func (c SegmentConfig) withDefaults() SegmentConfig {
+	if c.FFTSize <= 0 || c.FFTSize&(c.FFTSize-1) != 0 {
+		c.FFTSize = 4096
+	}
+	if c.ChannelTargetRateHz <= 0 {
+		c.ChannelTargetRateHz = 50_000
+	}
+	if c.PeakThresholdDb <= 0 {
+		c.PeakThresholdDb = 10
+	}
+	if c.MinSpacingHz == 0 {
+		c.MinSpacingHz = 12_500
+	}
+	if c.MaxChannels <= 0 {
+		c.MaxChannels = 64
+	}
+	if c.EnvelopeRateHz <= 0 {
+		c.EnvelopeRateHz = 200
+	}
+	if c.OnThreshDb <= 0 {
+		c.OnThreshDb = 10
+	}
+	if c.OffThreshDb <= 0 {
+		c.OffThreshDb = 6
+	}
+	if c.Debounce <= 0 {
+		c.Debounce = 3
+	}
+	if c.NoiseAlpha <= 0 {
+		c.NoiseAlpha = 0.02
+	}
+	if c.MinBurstSec <= 0 {
+		c.MinBurstSec = 0.005
+	}
+	if c.Now == nil {
+		c.Now = time.Now
+	}
+	return c
+}
+
+// occupancyFFT is the FFT size used to measure per-burst spectral occupancy on
+// the (already narrow) decimated baseband.
+const occupancyFFT = 1024
+
+// Segment reads the wideband span from src, discovers carriers, and slices each
+// into onset→offset bursts — the protocol-agnostic atoms every analyzer
+// consumes. It returns a Scene populated with Bursts and header fields, and an
+// Input whose BurstIQ accessor serves each burst's decimated baseband. It is the
+// producer pre-pass; rfscope.Run then layers the derived views on top.
+func Segment(ctx context.Context, src Source, cfg SegmentConfig) (*Scene, *Input, error) {
+	cfg = cfg.withDefaults()
+	if src == nil {
+		return nil, nil, fmt.Errorf("rfscope: nil source")
+	}
+	rate := src.SampleRateHz()
+	center := src.CenterHz()
+	if rate <= 0 {
+		return nil, nil, fmt.Errorf("rfscope: source sample rate must be positive")
+	}
+
+	raw, err := Drain(ctx, src, 1<<18, cfg.MaxSamples)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(raw) < cfg.FFTSize {
+		return nil, nil, fmt.Errorf("rfscope: capture too short (%d samples) for FFT size %d", len(raw), cfg.FFTSize)
+	}
+
+	window := float64(len(raw)) / rate
+	avg := spectrum.AverageDB(raw, center, rate, cfg.FFTSize)
+	noiseFloor := spectrum.Percentile(avg.Bins, 0.25)
+
+	peaks := carriers.DetectPeaks(avg, carriers.PeakOptions{
+		ThresholdDb:  cfg.PeakThresholdDb,
+		MinSpacingHz: cfg.MinSpacingHz,
+	})
+	if len(peaks) > cfg.MaxChannels {
+		peaks = peaks[:cfg.MaxChannels]
+	}
+
+	now := cfg.Now()
+	scene := &Scene{
+		Source:         "",
+		StartedAt:      now,
+		FinishedAt:     now,
+		CenterHz:       center,
+		SpanHz:         uint32(math.Round(rate)),
+		WindowSec:      window,
+		NoiseFloorDbFS: noiseFloor,
+	}
+
+	store := map[uint64]storedIQ{}
+	var nextID uint64
+
+	for _, pk := range peaks {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, err
+		}
+		offset := float64(pk.FreqHz) - float64(center)
+		ddc := ccdecoder.NewDownconverterWithOffset(rate, cfg.ChannelTargetRateHz, offset)
+		base := ddc.Process(nil, raw)
+		outRate := ddc.OutRateHz()
+		if len(base) == 0 || outRate <= 0 {
+			continue
+		}
+
+		spans := detectBursts(base, outRate, cfg)
+		for _, sp := range spans {
+			slice := base[sp.startSample:sp.endSample]
+			cls := survey.Classify(slice, outRate)
+			occ := spectrum.ComputeOccupancy(
+				spectrum.AverageDB(slice, 0, outRate, occFFTFor(len(slice))).Bins,
+				outRate, float64(cfg.MinSpacingHz), float64(cfg.MinSpacingHz), float64(cfg.MinSpacingHz),
+			)
+
+			nextID++
+			id := nextID
+			b := Burst{
+				ID:               id,
+				FreqHz:           pk.FreqHz,
+				StartSec:         float64(sp.startSample) / outRate,
+				EndSec:           float64(sp.endSample) / outRate,
+				PeakDbFS:         pk.PowerDbFS,
+				SNRDb:            pk.SNRDb,
+				OccupiedBwHz:     uint32(math.Round(occ.OccupiedBandwidthHz)),
+				ChannelPowerDBFS: occ.ChannelPowerDBFS,
+				ACPRUpperDB:      occ.ACPRUpperDB,
+				ACPRLowerDB:      occ.ACPRLowerDB,
+				SpectralFlatness: occ.SpectralFlatness,
+				Class:            cls.Class,
+				Features:         cls.Features,
+			}
+			scene.Bursts = append(scene.Bursts, b)
+			// Copy the slice so a later resize of base never aliases it.
+			cp := make([]complex64, len(slice))
+			copy(cp, slice)
+			store[id] = storedIQ{iq: cp, rateHz: outRate}
+		}
+	}
+
+	// Deterministic ordering: by start time, then frequency.
+	sort.Slice(scene.Bursts, func(i, j int) bool {
+		a, b := scene.Bursts[i], scene.Bursts[j]
+		if a.StartSec != b.StartSec {
+			return a.StartSec < b.StartSec
+		}
+		return a.FreqHz < b.FreqHz
+	})
+
+	in := &Input{
+		SampleRateHz: rate,
+		Window:       window,
+		BurstIQ: func(b Burst) ([]complex64, float64, error) {
+			s, ok := store[b.ID]
+			if !ok {
+				return nil, 0, fmt.Errorf("rfscope: no stored IQ for burst %d", b.ID)
+			}
+			return s.iq, s.rateHz, nil
+		},
+	}
+	return scene, in, nil
+}
+
+type storedIQ struct {
+	iq     []complex64
+	rateHz float64
+}
+
+// burstSpan is one onset→offset run on a channel's decimated baseband, in
+// baseband-sample indices.
+type burstSpan struct {
+	startSample int
+	endSample   int
+}
+
+// detectBursts runs the lifted onset/offset state machine over the power
+// envelope of a channel's decimated baseband and returns the burst spans.
+func detectBursts(base []complex64, outRate float64, cfg SegmentConfig) []burstSpan {
+	hop := int(math.Round(outRate / cfg.EnvelopeRateHz))
+	if hop < 1 {
+		hop = 1
+	}
+	minSamples := int(math.Round(cfg.MinBurstSec * outRate))
+
+	st := channelState{}
+	var spans []burstSpan
+	curStart := -1
+	for i := 0; i+hop <= len(base); i += hop {
+		db := frameDb(base[i : i+hop])
+		onset, offset := st.update(db, cfg)
+		if onset {
+			// Back-date the start by the debounce latency.
+			curStart = i - (cfg.Debounce-1)*hop
+			if curStart < 0 {
+				curStart = 0
+			}
+		}
+		if offset && curStart >= 0 {
+			end := i
+			if end > len(base) {
+				end = len(base)
+			}
+			if end-curStart >= minSamples {
+				spans = append(spans, burstSpan{startSample: curStart, endSample: end})
+			}
+			curStart = -1
+		}
+	}
+	// Close an open burst at end-of-stream.
+	if curStart >= 0 && len(base)-curStart >= minSamples {
+		spans = append(spans, burstSpan{startSample: curStart, endSample: len(base)})
+	}
+	return spans
+}
+
+// frameDb is the mean linear power of a baseband frame, in dB (floored).
+func frameDb(frame []complex64) float64 {
+	if len(frame) == 0 {
+		return -300
+	}
+	var sum float64
+	for _, z := range frame {
+		sum += float64(real(z))*float64(real(z)) + float64(imag(z))*float64(imag(z))
+	}
+	p := sum / float64(len(frame))
+	if p < 1e-30 {
+		p = 1e-30
+	}
+	return 10 * math.Log10(p)
+}
+
+// channelState is the per-channel onset/offset state machine — the algorithm
+// lifted from internal/scanner/dmrlcn/onset.go's updateChannel, generalized off
+// the DMR grid to run on any channel's power envelope.
+type channelState struct {
+	floorDb   float64
+	floorInit bool
+	active    bool
+	above     int
+	below     int
+}
+
+// update advances the machine by one envelope frame, returning whether this
+// frame triggered an onset (idle→active) or offset (active→idle).
+func (s *channelState) update(db float64, cfg SegmentConfig) (onset, offset bool) {
+	if !s.floorInit {
+		s.floorDb = db
+		s.floorInit = true
+		return
+	}
+	onLevel := s.floorDb + cfg.OnThreshDb
+	offLevel := s.floorDb + cfg.OffThreshDb
+	switch {
+	case db >= onLevel:
+		s.above++
+		s.below = 0
+		if !s.active && s.above >= cfg.Debounce {
+			s.active = true
+			onset = true
+		}
+	case db <= offLevel:
+		s.below++
+		s.above = 0
+		if s.active && s.below >= cfg.Debounce {
+			s.active = false
+			offset = true
+		}
+	default:
+		s.above = 0
+		s.below = 0
+	}
+	// Track the noise floor only while idle so an active carrier can't drag the
+	// floor up and mask itself.
+	if !s.active {
+		a := cfg.NoiseAlpha
+		s.floorDb = (1-a)*s.floorDb + a*db
+	}
+	return
+}
+
+// occFFTFor picks a power-of-two FFT size no larger than the slice for occupancy
+// measurement, capped at occupancyFFT.
+func occFFTFor(n int) int {
+	size := occupancyFFT
+	for size > n && size > 64 {
+		size >>= 1
+	}
+	return size
+}

--- a/internal/rfscope/segment_test.go
+++ b/internal/rfscope/segment_test.go
@@ -1,0 +1,110 @@
+package rfscope
+
+import (
+	"context"
+	"math"
+	"math/cmplx"
+	"math/rand"
+	"testing"
+)
+
+// synthGatedTone builds a wideband capture with a single complex tone at
+// offsetHz from center, present only during [onSec, offSec], plus light white
+// noise everywhere so a noise floor exists for carrier discovery.
+func synthGatedTone(rate float64, durSec, onSec, offSec, offsetHz, amp float64) []complex64 {
+	n := int(rate * durSec)
+	iq := make([]complex64, n)
+	rng := rand.New(rand.NewSource(1))
+	onN, offN := int(onSec*rate), int(offSec*rate)
+	w := 2 * math.Pi * offsetHz / rate
+	for i := 0; i < n; i++ {
+		var s complex128
+		s = complex(0.01*(rng.Float64()-0.5), 0.01*(rng.Float64()-0.5))
+		if i >= onN && i < offN {
+			s += complex(amp, 0) * cmplx.Exp(complex(0, w*float64(i)))
+		}
+		iq[i] = complex64(s)
+	}
+	return iq
+}
+
+func TestSegmentGatedTone(t *testing.T) {
+	t.Parallel()
+	const (
+		rate     = 240_000.0
+		center   = 450_000_000
+		offsetHz = 30_000.0
+		onSec    = 0.10
+		offSec   = 0.30
+		durSec   = 0.50
+	)
+	iq := synthGatedTone(rate, durSec, onSec, offSec, offsetHz, 1.0)
+	src := NewMemSource(iq, center, rate)
+
+	scene, in, err := Segment(context.Background(), src, SegmentConfig{})
+	if err != nil {
+		t.Fatalf("Segment: %v", err)
+	}
+	if len(scene.Bursts) != 1 {
+		t.Fatalf("want exactly 1 burst, got %d: %+v", len(scene.Bursts), scene.Bursts)
+	}
+	b := scene.Bursts[0]
+
+	// Carrier frequency within one channel raster of center+offset.
+	wantFreq := uint32(center + offsetHz)
+	if d := absU32(b.FreqHz, wantFreq); d > 12_500 {
+		t.Fatalf("burst freq %d off from %d by %d Hz", b.FreqHz, wantFreq, d)
+	}
+	// Onset/offset within ~20 ms of the gate edges.
+	if math.Abs(b.StartSec-onSec) > 0.02 {
+		t.Fatalf("start %.3fs not near %.3fs", b.StartSec, onSec)
+	}
+	if math.Abs(b.EndSec-offSec) > 0.02 {
+		t.Fatalf("end %.3fs not near %.3fs", b.EndSec, offSec)
+	}
+	// A CW tone is tonal, not noise-like: flatness well below 1.
+	if b.SpectralFlatness >= 0.6 {
+		t.Fatalf("tone flatness %.3f should be ≪1", b.SpectralFlatness)
+	}
+	// BurstIQ serves the stored baseband.
+	bb, r, err := in.BurstIQ(b)
+	if err != nil || len(bb) == 0 || r <= 0 {
+		t.Fatalf("BurstIQ: len=%d rate=%g err=%v", len(bb), r, err)
+	}
+}
+
+func TestSegmentNoCarrier(t *testing.T) {
+	t.Parallel()
+	// Pure low-level noise: no carrier stands above the floor, so no bursts.
+	rng := rand.New(rand.NewSource(2))
+	n := int(240_000 * 0.3)
+	iq := make([]complex64, n)
+	for i := range iq {
+		iq[i] = complex64(complex(0.01*(rng.Float64()-0.5), 0.01*(rng.Float64()-0.5)))
+	}
+	scene, _, err := Segment(context.Background(), NewMemSource(iq, 450_000_000, 240_000), SegmentConfig{})
+	if err != nil {
+		t.Fatalf("Segment: %v", err)
+	}
+	if len(scene.Bursts) != 0 {
+		t.Fatalf("want no bursts from pure noise, got %d", len(scene.Bursts))
+	}
+	if scene.WindowSec <= 0 || scene.CenterHz != 450_000_000 {
+		t.Fatalf("scene header wrong: %+v", scene)
+	}
+}
+
+func TestSegmentShortCaptureErrors(t *testing.T) {
+	t.Parallel()
+	src := NewMemSource(makeIQ(100), 1000, 240_000)
+	if _, _, err := Segment(context.Background(), src, SegmentConfig{}); err == nil {
+		t.Fatalf("want error for capture shorter than FFT size")
+	}
+}
+
+func absU32(a, b uint32) uint32 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}

--- a/internal/rfscope/segment_test.go
+++ b/internal/rfscope/segment_test.go
@@ -101,10 +101,3 @@ func TestSegmentShortCaptureErrors(t *testing.T) {
 		t.Fatalf("want error for capture shorter than FFT size")
 	}
 }
-
-func absU32(a, b uint32) uint32 {
-	if a > b {
-		return a - b
-	}
-	return b - a
-}

--- a/internal/rfscope/source.go
+++ b/internal/rfscope/source.go
@@ -1,0 +1,187 @@
+package rfscope
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// Source is a sequential producer of wideband IQ chunks at one center frequency
+// and sample rate. Both an offline capture file and a bounded live SDR capture
+// implement it, so the segmentation engine and every analyzer run identically on
+// recorded and on-air IQ — "both modes equally" is satisfied at the core, not
+// bolted on. Unlike hunt.IQSource (which retunes per sweep step), a Source
+// streams a single span the scene analyzer characterizes as a whole.
+type Source interface {
+	// Next returns the next chunk of up to n complex samples. The returned slice
+	// may be shorter than n only at end-of-stream; an empty slice with io.EOF
+	// marks the end. ctx cancellation is honored.
+	Next(ctx context.Context, n int) ([]complex64, error)
+	// CenterHz is the source's absolute center frequency.
+	CenterHz() uint32
+	// SampleRateHz is the IQ sample rate.
+	SampleRateHz() float64
+}
+
+// FileSource streams an on-disk IQ capture (u8/f32) in chunks, decoding through
+// the same siglab.SampleFormat decoders the replay path uses so rfscope and
+// replay read captures identically.
+type FileSource struct {
+	f        *os.File
+	decode   siglab.SampleDecoder
+	bytesPer int
+	centerHz uint32
+	rateHz   float64
+	rbuf     []byte
+}
+
+// OpenFile opens an IQ capture for streaming. centerHz/rateHz describe the
+// capture (the segmentation engine stamps absolute frequencies from them).
+func OpenFile(path string, format siglab.SampleFormat, centerHz uint32, rateHz float64) (*FileSource, error) {
+	if rateHz <= 0 {
+		return nil, fmt.Errorf("rfscope: sample rate must be positive, got %g", rateHz)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("rfscope: open capture: %w", err)
+	}
+	decode, bytesPer := format.Decoder()
+	return &FileSource{
+		f:        f,
+		decode:   decode,
+		bytesPer: bytesPer,
+		centerHz: centerHz,
+		rateHz:   rateHz,
+	}, nil
+}
+
+func (s *FileSource) CenterHz() uint32      { return s.centerHz }
+func (s *FileSource) SampleRateHz() float64 { return s.rateHz }
+
+// Next reads up to n samples from the file. It returns io.EOF (with any final
+// partial chunk on the preceding call) once the file is exhausted.
+func (s *FileSource) Next(ctx context.Context, n int) ([]complex64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if n <= 0 {
+		return nil, nil
+	}
+	want := n * s.bytesPer
+	if cap(s.rbuf) < want {
+		s.rbuf = make([]byte, want)
+	}
+	buf := s.rbuf[:want]
+	got, err := io.ReadFull(s.f, buf)
+	switch {
+	case err == nil:
+		// full read
+	case err == io.EOF:
+		return nil, io.EOF
+	case err == io.ErrUnexpectedEOF:
+		// trailing partial — decode the whole IQ pairs we did get
+		got -= got % s.bytesPer
+		if got == 0 {
+			return nil, io.EOF
+		}
+	default:
+		return nil, fmt.Errorf("rfscope: read capture: %w", err)
+	}
+	pairs := got / s.bytesPer
+	out := make([]complex64, pairs)
+	s.decode(buf[:got], out)
+	return out, nil
+}
+
+// Close releases the underlying file.
+func (s *FileSource) Close() error { return s.f.Close() }
+
+// LiveSource adapts a hunt.IQSource (the live, broker-backed SDR provider the
+// daemon wires) to a scene Source by tuning it once to a fixed center and
+// streaming sequential captures.
+type LiveSource struct {
+	src      hunt.IQSource
+	centerHz uint32
+}
+
+// NewLiveSource tunes src to centerHz and returns it as a streaming Source.
+func NewLiveSource(src hunt.IQSource, centerHz uint32) (*LiveSource, error) {
+	if src == nil {
+		return nil, fmt.Errorf("rfscope: nil IQ source")
+	}
+	if err := src.Tune(centerHz); err != nil {
+		return nil, fmt.Errorf("rfscope: tune %d Hz: %w", centerHz, err)
+	}
+	return &LiveSource{src: src, centerHz: centerHz}, nil
+}
+
+func (s *LiveSource) CenterHz() uint32      { return s.centerHz }
+func (s *LiveSource) SampleRateHz() float64 { return float64(s.src.SampleRateHz()) }
+
+func (s *LiveSource) Next(ctx context.Context, n int) ([]complex64, error) {
+	return s.src.Capture(ctx, n)
+}
+
+// MemSource is a deterministic in-memory Source for tests: it serves a buffer
+// once, in chunks, then returns io.EOF.
+type MemSource struct {
+	iq       []complex64
+	centerHz uint32
+	rateHz   float64
+	pos      int
+}
+
+// NewMemSource builds an in-memory Source over iq.
+func NewMemSource(iq []complex64, centerHz uint32, rateHz float64) *MemSource {
+	return &MemSource{iq: iq, centerHz: centerHz, rateHz: rateHz}
+}
+
+func (s *MemSource) CenterHz() uint32      { return s.centerHz }
+func (s *MemSource) SampleRateHz() float64 { return s.rateHz }
+
+func (s *MemSource) Next(ctx context.Context, n int) ([]complex64, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if s.pos >= len(s.iq) {
+		return nil, io.EOF
+	}
+	end := s.pos + n
+	if end > len(s.iq) {
+		end = len(s.iq)
+	}
+	out := s.iq[s.pos:end]
+	s.pos = end
+	return out, nil
+}
+
+// Drain reads the whole source into one buffer, capped at maxSamples (0 = no
+// cap). It is the convenience the offline analyze path uses to materialize a
+// bounded capture; the segmentation engine can also stream Next directly for
+// live use. chunk is the per-read size.
+func Drain(ctx context.Context, src Source, chunk, maxSamples int) ([]complex64, error) {
+	if chunk <= 0 {
+		chunk = 1 << 16
+	}
+	var out []complex64
+	for {
+		if maxSamples > 0 && len(out) >= maxSamples {
+			return out[:maxSamples], nil
+		}
+		c, err := src.Next(ctx, chunk)
+		out = append(out, c...)
+		if err == io.EOF {
+			return out, nil
+		}
+		if err != nil {
+			return out, err
+		}
+		if len(c) == 0 {
+			return out, nil
+		}
+	}
+}

--- a/internal/rfscope/source_test.go
+++ b/internal/rfscope/source_test.go
@@ -1,0 +1,115 @@
+package rfscope
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+func makeIQ(n int) []complex64 {
+	iq := make([]complex64, n)
+	for i := range iq {
+		iq[i] = complex(float32(i)*1e-3, float32(-i)*1e-3)
+	}
+	return iq
+}
+
+func TestFileSourceRoundTrip(t *testing.T) {
+	t.Parallel()
+	const n = 5000
+	want := makeIQ(n)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cap.cfile")
+	if err := os.WriteFile(path, siglab.EncodeCapture(want, siglab.FormatF32), 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+
+	src, err := OpenFile(path, siglab.FormatF32, 451_000_000, 2_400_000)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer src.Close()
+
+	if src.CenterHz() != 451_000_000 || src.SampleRateHz() != 2_400_000 {
+		t.Fatalf("header mismatch: %d %g", src.CenterHz(), src.SampleRateHz())
+	}
+
+	// Read in odd-sized chunks to exercise the partial-tail path.
+	var got []complex64
+	for {
+		c, err := src.Next(context.Background(), 777)
+		got = append(got, c...)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next: %v", err)
+		}
+	}
+	if len(got) != n {
+		t.Fatalf("sample count: got %d want %d", len(got), n)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sample %d: got %v want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFileSourceUnknownFile(t *testing.T) {
+	t.Parallel()
+	if _, err := OpenFile(filepath.Join(t.TempDir(), "nope.cfile"), siglab.FormatU8, 0, 1e6); err == nil {
+		t.Fatalf("want error opening missing file")
+	}
+	if _, err := OpenFile("x", siglab.FormatU8, 0, 0); err == nil {
+		t.Fatalf("want error on non-positive rate")
+	}
+}
+
+func TestMemSourceChunksThenEOF(t *testing.T) {
+	t.Parallel()
+	iq := makeIQ(100)
+	src := NewMemSource(iq, 100_000_000, 48_000)
+
+	c, err := src.Next(context.Background(), 30)
+	if err != nil || len(c) != 30 {
+		t.Fatalf("first chunk: len=%d err=%v", len(c), err)
+	}
+	all, err := Drain(context.Background(), src, 40, 0)
+	if err != nil {
+		t.Fatalf("Drain: %v", err)
+	}
+	if len(all) != 70 { // 100 total minus the 30 already read
+		t.Fatalf("drained %d, want 70", len(all))
+	}
+	if _, err := src.Next(context.Background(), 10); err != io.EOF {
+		t.Fatalf("want EOF at end, got %v", err)
+	}
+}
+
+func TestDrainRespectsCap(t *testing.T) {
+	t.Parallel()
+	src := NewMemSource(makeIQ(1000), 0, 1e6)
+	got, err := Drain(context.Background(), src, 128, 256)
+	if err != nil {
+		t.Fatalf("Drain: %v", err)
+	}
+	if len(got) != 256 {
+		t.Fatalf("cap not respected: got %d want 256", len(got))
+	}
+}
+
+func TestSourceContextCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	src := NewMemSource(makeIQ(10), 0, 1e6)
+	if _, err := src.Next(ctx, 4); err == nil {
+		t.Fatalf("want context error")
+	}
+}

--- a/internal/rfscope/timeline.go
+++ b/internal/rfscope/timeline.go
@@ -1,0 +1,148 @@
+package rfscope
+
+import (
+	"context"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func init() { Register(timelineAnalyzer{}) }
+
+// timelineBins is the default number of time buckets in a channel's activity
+// timeline — the resolution of the I/O graph.
+const timelineBins = 100
+
+// timelineAnalyzer builds the per-channel activity view — the RF analog of
+// Wireshark's I/O Graphs. It groups bursts by frequency into Channels and fills
+// each with a time-bucketed occupancy/power series plus duty cycle, occupancy
+// percentage, and burst rate. It is also the analyzer that materializes
+// Scene.Channels, which the timing analyzer then annotates.
+type timelineAnalyzer struct{}
+
+func (timelineAnalyzer) Name() string        { return "timeline" }
+func (timelineAnalyzer) Synopsis() string    { return "per-channel activity timeline / I/O graph" }
+func (timelineAnalyzer) DependsOn() []string { return nil }
+
+func (timelineAnalyzer) Analyze(ctx context.Context, sc *Scene, in *Input) error {
+	if len(sc.Bursts) == 0 {
+		return nil
+	}
+	window := sc.WindowSec
+	if window <= 0 {
+		return nil
+	}
+
+	byFreq := map[uint32][]int{}
+	for i, b := range sc.Bursts {
+		byFreq[b.FreqHz] = append(byFreq[b.FreqHz], i)
+	}
+
+	freqs := make([]uint32, 0, len(byFreq))
+	for f := range byFreq {
+		freqs = append(freqs, f)
+	}
+	sort.Slice(freqs, func(i, j int) bool { return freqs[i] < freqs[j] })
+
+	nbins := timelineBins
+	binDur := window / float64(nbins)
+	channels := make([]Channel, 0, len(freqs))
+
+	for _, f := range freqs {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		idxs := byFreq[f]
+
+		ch := Channel{FreqHz: f, BurstCount: len(idxs)}
+		classCount := map[survey.SignalClass]int{}
+		var powers, flats []float64
+		for _, i := range idxs {
+			b := sc.Bursts[i]
+			ch.AirtimeSec += b.DurationSec()
+			classCount[b.Class]++
+			if b.OccupiedBwHz > ch.OccupiedBwHz {
+				ch.OccupiedBwHz = b.OccupiedBwHz
+			}
+			powers = append(powers, float64(b.PeakDbFS))
+			flats = append(flats, b.SpectralFlatness)
+		}
+		ch.DominantClass = mode(classCount)
+		ch.MedianPowerDbFS = float32(median(powers))
+		ch.MedianFlatness = median(flats)
+		ch.DutyCycle = clamp01(ch.AirtimeSec / window)
+		ch.BurstRatePerMin = float64(ch.BurstCount) / (window / 60)
+
+		// Time-bucketed timeline.
+		timeline := make([]Bin, nbins)
+		occupiedBins := 0
+		for k := 0; k < nbins; k++ {
+			t0 := float64(k) * binDur
+			t1 := t0 + binDur
+			bin := Bin{TSec: t0 + binDur/2, PowerDbFS: sc.NoiseFloorDbFS}
+			for _, i := range idxs {
+				b := sc.Bursts[i]
+				if b.StartSec < t1 && b.EndSec > t0 { // overlap
+					bin.Occupied = true
+					if b.PeakDbFS > bin.PowerDbFS {
+						bin.PowerDbFS = b.PeakDbFS
+					}
+				}
+				if b.StartSec >= t0 && b.StartSec < t1 { // started in this bin
+					bin.BurstCount++
+				}
+			}
+			if bin.Occupied {
+				occupiedBins++
+			}
+			timeline[k] = bin
+		}
+		ch.Timeline = timeline
+		ch.OccupancyPct = 100 * float64(occupiedBins) / float64(nbins)
+
+		channels = append(channels, ch)
+	}
+	sc.Channels = channels
+	return nil
+}
+
+// mode returns the most frequent class (ties broken by name for determinism).
+func mode(counts map[survey.SignalClass]int) survey.SignalClass {
+	best := survey.ClassUnknown
+	bestN := -1
+	keys := make([]survey.SignalClass, 0, len(counts))
+	for c := range counts {
+		keys = append(keys, c)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, c := range keys {
+		if counts[c] > bestN {
+			best, bestN = c, counts[c]
+		}
+	}
+	return best
+}
+
+// median returns the median of xs (0 for empty). xs is copied before sorting.
+func median(xs []float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	cp := append([]float64(nil), xs...)
+	sort.Float64s(cp)
+	n := len(cp)
+	if n%2 == 1 {
+		return cp[n/2]
+	}
+	return (cp[n/2-1] + cp[n/2]) / 2
+}
+
+func clamp01(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}

--- a/internal/rfscope/timeline_test.go
+++ b/internal/rfscope/timeline_test.go
@@ -1,0 +1,93 @@
+package rfscope
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func timelineFixture() *Scene {
+	return &Scene{
+		SpanHz:         1_000_000,
+		WindowSec:      10,
+		NoiseFloorDbFS: -90,
+		Bursts: []Burst{
+			{ID: 1, FreqHz: 450_100_000, StartSec: 0, EndSec: 1, PeakDbFS: -40, Class: survey.ClassC4FM, OccupiedBwHz: 12_500},
+			{ID: 2, FreqHz: 450_100_000, StartSec: 2, EndSec: 3, PeakDbFS: -42, Class: survey.ClassC4FM, OccupiedBwHz: 12_500},
+			{ID: 3, FreqHz: 450_300_000, StartSec: 0, EndSec: 5, PeakDbFS: -30, Class: survey.ClassNBFM, OccupiedBwHz: 12_500},
+		},
+	}
+}
+
+func channelAt(chs []Channel, f uint32) (Channel, bool) {
+	for _, c := range chs {
+		if c.FreqHz == f {
+			return c, true
+		}
+	}
+	return Channel{}, false
+}
+
+func TestTimelineDutyAndRate(t *testing.T) {
+	t.Parallel()
+	sc := timelineFixture()
+	if err := (timelineAnalyzer{}).Analyze(context.Background(), sc, nil); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(sc.Channels) != 2 {
+		t.Fatalf("want 2 channels, got %d", len(sc.Channels))
+	}
+	// Sorted ascending by frequency.
+	if sc.Channels[0].FreqHz > sc.Channels[1].FreqHz {
+		t.Fatalf("channels not sorted by frequency")
+	}
+
+	a, ok := channelAt(sc.Channels, 450_100_000)
+	if !ok {
+		t.Fatalf("missing channel A")
+	}
+	if a.BurstCount != 2 || a.AirtimeSec != 2 {
+		t.Fatalf("channel A counts: %+v", a)
+	}
+	if a.DutyCycle < 0.19 || a.DutyCycle > 0.21 { // 2s / 10s
+		t.Fatalf("channel A duty: %v", a.DutyCycle)
+	}
+	if a.BurstRatePerMin < 11.9 || a.BurstRatePerMin > 12.1 { // 2 bursts / (10/60) min
+		t.Fatalf("channel A burst rate: %v", a.BurstRatePerMin)
+	}
+	if a.DominantClass != survey.ClassC4FM {
+		t.Fatalf("channel A dominant class: %v", a.DominantClass)
+	}
+	if len(a.Timeline) != timelineBins {
+		t.Fatalf("timeline length: got %d want %d", len(a.Timeline), timelineBins)
+	}
+	// 2s occupied over a 10s/100-bin window ⇒ 20 occupied bins ⇒ 20%.
+	if a.OccupancyPct < 19 || a.OccupancyPct > 21 {
+		t.Fatalf("channel A occupancy pct: %v", a.OccupancyPct)
+	}
+
+	b, _ := channelAt(sc.Channels, 450_300_000)
+	if b.DutyCycle < 0.49 || b.DutyCycle > 0.51 { // 5s / 10s
+		t.Fatalf("channel B duty: %v", b.DutyCycle)
+	}
+	// An occupied bin in the first half must carry the burst peak, not the floor.
+	if b.Timeline[0].PowerDbFS != -30 || !b.Timeline[0].Occupied {
+		t.Fatalf("channel B first bin: %+v", b.Timeline[0])
+	}
+	// A bin past the burst end falls back to the noise floor.
+	if b.Timeline[len(b.Timeline)-1].PowerDbFS != sc.NoiseFloorDbFS {
+		t.Fatalf("channel B last bin should be at noise floor: %+v", b.Timeline[len(b.Timeline)-1])
+	}
+}
+
+func TestTimelineNoWindow(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{Bursts: []Burst{{ID: 1, FreqHz: 1}}}
+	if err := (timelineAnalyzer{}).Analyze(context.Background(), sc, nil); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(sc.Channels) != 0 {
+		t.Fatalf("no window ⇒ no channels")
+	}
+}

--- a/internal/rfscope/timing.go
+++ b/internal/rfscope/timing.go
@@ -1,0 +1,124 @@
+package rfscope
+
+import (
+	"context"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/stats"
+)
+
+func init() { Register(timingAnalyzer{}) }
+
+// timingHistBins is the default bucket count for the burst-length and
+// inter-arrival histograms.
+const timingHistBins = 10
+
+// minPeriodConfidence is the autocorrelation peak height (0..1) below which a
+// detected period is treated as noise and discarded.
+const minPeriodConfidence = 0.2
+
+// timingAnalyzer annotates each Channel with burst-timing statistics: the
+// burst-length and inter-arrival histograms, and the periodicity/TDMA-frame
+// period recovered by autocorrelating the channel's occupancy signal
+// (dsp/stats.Correlate + FindPeaks). It is the time-domain counterpart to the
+// byte-domain period detection cryptolab applies to recovered payloads.
+type timingAnalyzer struct{}
+
+func (timingAnalyzer) Name() string        { return "timing" }
+func (timingAnalyzer) Synopsis() string    { return "burst timing, inter-arrival, and TDMA-period stats" }
+func (timingAnalyzer) DependsOn() []string { return []string{"timeline"} }
+
+func (timingAnalyzer) Analyze(ctx context.Context, sc *Scene, in *Input) error {
+	if len(sc.Channels) == 0 {
+		return nil
+	}
+
+	byFreq := map[uint32][]int{}
+	for i, b := range sc.Bursts {
+		byFreq[b.FreqHz] = append(byFreq[b.FreqHz], i)
+	}
+
+	binDur := 0.0
+	if sc.WindowSec > 0 {
+		binDur = sc.WindowSec / float64(timelineBins)
+	}
+
+	for ci := range sc.Channels {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		ch := &sc.Channels[ci]
+		idxs := byFreq[ch.FreqHz]
+
+		// Burst-length and inter-arrival histograms.
+		starts := make([]float64, 0, len(idxs))
+		lengths := make([]float64, 0, len(idxs))
+		for _, i := range idxs {
+			starts = append(starts, sc.Bursts[i].StartSec)
+			lengths = append(lengths, sc.Bursts[i].DurationSec())
+		}
+		sort.Float64s(starts)
+		ch.BurstLenHist = histOf(lengths)
+
+		gaps := make([]float64, 0, len(starts))
+		for i := 1; i < len(starts); i++ {
+			gaps = append(gaps, starts[i]-starts[i-1])
+		}
+		ch.InterArrivalHist = histOf(gaps)
+
+		// Periodicity from the occupancy autocorrelation.
+		if binDur > 0 && len(ch.Timeline) >= 4 {
+			occ := make([]float64, len(ch.Timeline))
+			for i, b := range ch.Timeline {
+				if b.Occupied {
+					occ[i] = 1
+				}
+			}
+			ch.PeriodSec, ch.PeriodConfidence = detectPeriod(occ, binDur)
+		}
+	}
+	return nil
+}
+
+// detectPeriod autocorrelates a (binary) occupancy signal and returns the period
+// of its strongest non-zero lag, with the normalized autocorrelation height as
+// confidence. Returns (0,0) when no lag clears minPeriodConfidence.
+func detectPeriod(occ []float64, binDur float64) (periodSec, confidence float64) {
+	n := len(occ)
+	if n < 4 {
+		return 0, 0
+	}
+	mean := stats.Mean(occ)
+	sig := make([]float64, n)
+	for i, v := range occ {
+		sig[i] = v - mean
+	}
+	corr, _ := stats.Correlate(sig, sig)
+	// Positive lags start at index n-1 (lag 0, value ~1) through 2n-2 (lag n-1).
+	pos := corr[n-1:]
+	if len(pos) < 3 {
+		return 0, 0
+	}
+	peaks := stats.FindPeaks(pos[1:], stats.PeakOpts{Height: minPeriodConfidence, MinDistance: 1})
+	if len(peaks) == 0 {
+		return 0, 0
+	}
+	lag := peaks[0] + 1 // +1: pos[1:] dropped lag 0
+	if lag <= 0 || lag >= len(pos) {
+		return 0, 0
+	}
+	return float64(lag) * binDur, pos[lag]
+}
+
+// histOf builds a Hist over xs with a bucket count scaled to the sample size.
+func histOf(xs []float64) Hist {
+	if len(xs) == 0 {
+		return Hist{}
+	}
+	nbins := timingHistBins
+	if len(xs) < nbins {
+		nbins = len(xs)
+	}
+	counts, edges := stats.Histogram(xs, nbins)
+	return Hist{Counts: counts, Edges: edges}
+}

--- a/internal/rfscope/timing_test.go
+++ b/internal/rfscope/timing_test.go
@@ -1,0 +1,88 @@
+package rfscope
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// periodicScene builds one channel with a burst every periodSec across the
+// window, each of length lenSec.
+func periodicScene(window, periodSec, lenSec float64) *Scene {
+	sc := &Scene{SpanHz: 1_000_000, WindowSec: window, NoiseFloorDbFS: -90}
+	var id uint64
+	for t := 0.0; t+lenSec <= window; t += periodSec {
+		id++
+		sc.Bursts = append(sc.Bursts, Burst{
+			ID: id, FreqHz: 450_000_000, StartSec: t, EndSec: t + lenSec,
+			PeakDbFS: -40, Class: survey.ClassFSK, OccupiedBwHz: 12_500,
+		})
+	}
+	return sc
+}
+
+func TestTimingRecoversPeriod(t *testing.T) {
+	t.Parallel()
+	const (
+		window = 10.0
+		period = 1.0
+		length = 0.2
+	)
+	sc := periodicScene(window, period, length)
+
+	// Run via the registry so the timeline dependency is pulled in first.
+	if err := Run(context.Background(), sc, &Input{}, "timing"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(sc.Channels) != 1 {
+		t.Fatalf("want 1 channel, got %d", len(sc.Channels))
+	}
+	ch := sc.Channels[0]
+
+	binDur := window / float64(timelineBins) // 0.1s
+	if math.Abs(ch.PeriodSec-period) > binDur*1.5 {
+		t.Fatalf("period %.3fs not near %.3fs (binDur=%.3f)", ch.PeriodSec, period, binDur)
+	}
+	if ch.PeriodConfidence < 0.3 {
+		t.Fatalf("period confidence too low: %v", ch.PeriodConfidence)
+	}
+
+	// Inter-arrival gaps are all ~1.0s, so the histogram has entries.
+	if len(ch.InterArrivalHist.Counts) == 0 {
+		t.Fatalf("inter-arrival histogram empty")
+	}
+	total := 0
+	for _, c := range ch.InterArrivalHist.Counts {
+		total += c
+	}
+	if total != len(sc.Bursts)-1 {
+		t.Fatalf("inter-arrival count %d, want %d", total, len(sc.Bursts)-1)
+	}
+	if len(ch.BurstLenHist.Counts) == 0 {
+		t.Fatalf("burst-length histogram empty")
+	}
+}
+
+func TestTimingNonPeriodicHasNoStrongPeriod(t *testing.T) {
+	t.Parallel()
+	// A single long burst has no repeating structure.
+	sc := &Scene{
+		SpanHz: 1_000_000, WindowSec: 10, NoiseFloorDbFS: -90,
+		Bursts: []Burst{{ID: 1, FreqHz: 1_000_000, StartSec: 1, EndSec: 9, PeakDbFS: -40, Class: survey.ClassNBFM, OccupiedBwHz: 12_500}},
+	}
+	if err := Run(context.Background(), sc, &Input{}, "timing"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if sc.Channels[0].PeriodConfidence >= 0.9 {
+		t.Fatalf("single burst should not look strongly periodic: conf=%v", sc.Channels[0].PeriodConfidence)
+	}
+}
+
+func TestDetectPeriodShortSignal(t *testing.T) {
+	t.Parallel()
+	if p, c := detectPeriod([]float64{1, 0}, 0.1); p != 0 || c != 0 {
+		t.Fatalf("short signal should yield no period, got %v %v", p, c)
+	}
+}


### PR DESCRIPTION
Introduce internal/rfscope, the top-of-lattice package for protocol-agnostic
RF network analysis. This commit lands the shared data model the analyzers
populate: Scene (the peer of hunt.DiscoveredSystem) with Bursts (the atom),
and the derived Channels/Emitters/Conversations/Hierarchy/Anomalies views.

Burst and Channel carry the spectral-occupancy metrics from #831
(ChannelPowerDBFS, ACPR, SpectralFlatness) alongside survey's modulation
Class/Features; Fingerprint includes SpectralFlatness as a clustering
dimension. Scene.Sanitize() clamps every non-finite float before any JSON
marshal so the SSE/WS wire never sees NaN/Inf. Reuses survey.SignalClass and
survey.ClassFeatures rather than redefining them.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XkhQ64GwXMUX4jvYDBQEEC