### PR TITLE
cryptolab: recipe — CyberChef-style operation pipeline (Tier 3B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ for tagged releases.
     (P25 OFB/ADP keystream reuse via a repeated Message Indicator).
   - `stats period` — autocorrelation period detection and repeated-n-gram
     histogram.
+  - `recipe run` — a CyberChef-style operation pipeline: chain byte transforms
+    (XOR, the real ADP/DES/3DES/AES cipher decrypts, bit reversal, spectral
+    inversion, hex/base64) and analyses (entropy, randomness) from a JSON/YAML
+    recipe, piping the bytes between steps.
 - **Live decoder → cryptolab crypto-frame bridge.** Setting
   `recordings.crypto_capture_path` makes the P25 Phase 1 voice composer append
   each encrypted superframe's Message Indicator + encrypted voice frames as

--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -85,6 +85,7 @@ Global flags precede the tool name (`-out`, `-resume`, `-format`,
 | `brute` | `xor`, `caesar`, `vigenere`, `substitution` | classical-cipher recovery with English/crib scoring |
 | `lfsr` | `bm`, `keystream` | Berlekamp–Massey LFSR recovery; keystream = pt⊕ct |
 | `ks` | `reuse`, `mtp`, `extract` | keystream-reuse detection, many-time-pad recovery, keystream extraction |
+| `recipe` | `run` | CyberChef-style pipeline: chain transform + analysis ops, piping bytes between steps |
 | `crc` | `recover`, `compute` | recover / compute CRC parameters from sample frames |
 | `descramble` | `invert`, `splitband`, `rolling` | analog spectral / split-band / rolling-code voice inversion |
 | `alias` | `gauge`, `structure`, `cells`, `fromseed` | length-seeded byte-obfuscator recovery |
@@ -132,6 +133,39 @@ gophertrunk cryptolab descramble splitband -in scrambled.s16 -out clear.s16 -spl
 # Undo a rolling/hopping inversion, auto-detecting the per-frame split.
 gophertrunk cryptolab descramble rolling -in scrambled.s16 -out clear.s16 -frame 1024 -schedule auto
 ```
+
+## Recipe pipeline (`recipe run`)
+
+`recipe` is a CyberChef-style operation pipeline. A recipe is an ordered list of
+steps; each step is either a **transform** (it rewrites the working buffer —
+XOR, a cipher decrypt, a bit reversal, a spectral inversion, hex/base64) or an
+**analysis** (it measures the current buffer — entropy, randomness — without
+changing it). The bytes flow from one step to the next, so the de-obfuscation
+sequence an analyst repeats by hand becomes one reusable artifact.
+
+```
+cryptolab recipe run -in payload.bin -recipe recipe.json [-out final.bin]
+cryptolab recipe run -list      # list the available operations
+```
+
+The recipe file is JSON or YAML — either a top-level list of steps or an object
+with a `steps:` list. Each step is `{op, …params}`:
+
+```json
+[
+  {"op": "hex-decode"},
+  {"op": "adp-decrypt", "key": "abcdef0123", "mi": "090807060504030201"},
+  {"op": "stats"},
+  {"op": "randomness"}
+]
+```
+
+Operations (run `recipe run -list` for the live set): transforms `xor`, `not`,
+`reverse-bits`, `hex-decode`, `hex-encode`, `base64-decode`, `slice`,
+`adp-decrypt`, `des-ofb-decrypt`, `tdes-ofb-decrypt`, `aes-ofb-decrypt`,
+`descramble-invert`; analyses `stats`, `randomness`. The cipher ops reuse the
+same `p25crypto` keystream constructions the `assess` harness uses, so a recipe
+can decrypt a known-key capture and immediately measure the result.
 
 ## Subject framework: byte-obfuscator recovery (`alias`)
 

--- a/internal/cryptolab/engine/recipe/recipe.go
+++ b/internal/cryptolab/engine/recipe/recipe.go
@@ -1,0 +1,332 @@
+// Package recipe is a CyberChef-style operation pipeline for RF payloads. A
+// recipe is an ordered list of steps; each step is either a TRANSFORM (it
+// rewrites the working buffer — XOR, a cipher decrypt, a bit reversal, a
+// spectral inversion) or an ANALYSIS (it measures the current buffer — entropy,
+// randomness — without changing it). The bytes flow from one step to the next,
+// so an analyst can encode the de-obfuscation sequence they repeat by hand
+// (e.g. hex-decode → xor → stats → randomness) as a single reusable artifact.
+//
+// The transform ops reuse the toolkit's existing engines (p25crypto for the
+// real ADP/DES/3DES/AES ciphers, voice for spectral inversion, stats and
+// randomness for the analyses), so the pipeline composes the same primitives
+// the standalone tools expose.
+package recipe
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"math/bits"
+	"sort"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/randomness"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/stats"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/voice"
+)
+
+// Step is one recipe operation: an op name plus its parameters.
+type Step struct {
+	Op     string
+	Params map[string]any
+}
+
+// StepResult records what one step did.
+type StepResult struct {
+	Op        string         `json:"op"`
+	Transform bool           `json:"transform"`
+	BytesIn   int            `json:"bytes_in"`
+	BytesOut  int            `json:"bytes_out"`
+	Info      map[string]any `json:"info,omitempty"`
+	Note      string         `json:"note,omitempty"`
+}
+
+// Report is the pipeline outcome.
+type Report struct {
+	InputBytes int          `json:"input_bytes"`
+	Steps      []StepResult `json:"steps"`
+	FinalBytes []byte       `json:"-"`
+	FinalHex   string       `json:"final_hex"`
+	FinalASCII string       `json:"final_ascii"`
+}
+
+type opFunc func(buf []byte, p params) ([]byte, map[string]any, string, error)
+
+type opDef struct {
+	transform bool
+	synopsis  string
+	fn        opFunc
+}
+
+// ops is the operation registry.
+var ops = map[string]opDef{
+	"xor":               {true, "repeating-key XOR (key=hex)", opXOR},
+	"not":               {true, "bitwise NOT of every byte", opNot},
+	"reverse-bits":      {true, "reverse the bit order within each byte (MSB↔LSB framing)", opReverseBits},
+	"hex-decode":        {true, "decode an ASCII hex string to bytes", opHexDecode},
+	"hex-encode":        {true, "encode bytes as an ASCII hex string", opHexEncode},
+	"base64-decode":     {true, "decode standard base64 to bytes", opBase64Decode},
+	"slice":             {true, "keep bytes [offset, offset+length) (length=0 → to end)", opSlice},
+	"adp-decrypt":       {true, "P25 ADP/RC4 decrypt (key=hex 5B, mi=hex)", cipherOp(p25crypto.AlgADP)},
+	"des-ofb-decrypt":   {true, "P25 DES-OFB decrypt (key=hex 8B, mi=hex)", cipherOp(p25crypto.AlgDESOFB)},
+	"tdes-ofb-decrypt":  {true, "P25 Triple-DES-OFB decrypt (key=hex 24B, mi=hex)", cipherOp(p25crypto.AlgTDES)},
+	"aes-ofb-decrypt":   {true, "P25 AES-OFB decrypt (key=hex 16/32B, mi=hex)", cipherOp(p25crypto.AlgAES256)},
+	"descramble-invert": {true, "full-band spectral inversion of s16le mono PCM (self-inverse)", opDescramble},
+	"stats":             {false, "report entropy / index-of-coincidence / chi-square", opStats},
+	"randomness":        {false, "quick NIST randomness subset (strong vs structured)", opRandomness},
+}
+
+// Run executes the steps over input, threading the working buffer through the
+// transforms. A step error aborts the pipeline and is returned with the
+// partial report.
+func Run(input []byte, steps []Step) (*Report, error) {
+	rep := &Report{InputBytes: len(input)}
+	buf := append([]byte(nil), input...)
+	for i, s := range steps {
+		def, ok := ops[s.Op]
+		if !ok {
+			return rep, fmt.Errorf("step %d: unknown op %q (see `cryptolab recipe ops`)", i+1, s.Op)
+		}
+		out, info, note, err := def.fn(buf, params(s.Params))
+		if err != nil {
+			return rep, fmt.Errorf("step %d (%s): %w", i+1, s.Op, err)
+		}
+		sr := StepResult{Op: s.Op, Transform: def.transform, BytesIn: len(buf), Info: info, Note: note}
+		if def.transform {
+			buf = out
+		}
+		sr.BytesOut = len(buf)
+		rep.Steps = append(rep.Steps, sr)
+	}
+	rep.FinalBytes = buf
+	rep.FinalHex = hexPreview(buf, 64)
+	rep.FinalASCII = asciiPreview(buf, 64)
+	return rep, nil
+}
+
+// Ops returns the registered operation names and synopses, sorted.
+func Ops() []struct {
+	Name, Synopsis string
+	Transform      bool
+} {
+	var out []struct {
+		Name, Synopsis string
+		Transform      bool
+	}
+	for name, def := range ops {
+		out = append(out, struct {
+			Name, Synopsis string
+			Transform      bool
+		}{name, def.synopsis, def.transform})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// --- transform ops ---
+
+func opXOR(buf []byte, p params) ([]byte, map[string]any, string, error) {
+	key, err := p.hex("key")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if len(key) == 0 {
+		return nil, nil, "", fmt.Errorf("xor: key is required")
+	}
+	out := make([]byte, len(buf))
+	for i := range buf {
+		out[i] = buf[i] ^ key[i%len(key)]
+	}
+	return out, map[string]any{"key_len": len(key)}, "", nil
+}
+
+func opNot(buf []byte, _ params) ([]byte, map[string]any, string, error) {
+	out := make([]byte, len(buf))
+	for i, b := range buf {
+		out[i] = ^b
+	}
+	return out, nil, "", nil
+}
+
+func opReverseBits(buf []byte, _ params) ([]byte, map[string]any, string, error) {
+	out := make([]byte, len(buf))
+	for i, b := range buf {
+		out[i] = bits.Reverse8(b)
+	}
+	return out, nil, "", nil
+}
+
+func opHexDecode(buf []byte, _ params) ([]byte, map[string]any, string, error) {
+	s := strings.Map(func(r rune) rune {
+		if r == ' ' || r == '\n' || r == '\r' || r == '\t' {
+			return -1
+		}
+		return r
+	}, string(buf))
+	out, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("hex-decode: %w", err)
+	}
+	return out, nil, "", nil
+}
+
+func opHexEncode(buf []byte, _ params) ([]byte, map[string]any, string, error) {
+	return []byte(hex.EncodeToString(buf)), nil, "", nil
+}
+
+func opBase64Decode(buf []byte, _ params) ([]byte, map[string]any, string, error) {
+	out, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(buf)))
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("base64-decode: %w", err)
+	}
+	return out, nil, "", nil
+}
+
+func opSlice(buf []byte, p params) ([]byte, map[string]any, string, error) {
+	off := p.intDefault("offset", 0)
+	length := p.intDefault("length", 0)
+	if off < 0 || off > len(buf) {
+		return nil, nil, "", fmt.Errorf("slice: offset %d out of range (len %d)", off, len(buf))
+	}
+	end := len(buf)
+	if length > 0 && off+length < end {
+		end = off + length
+	}
+	return append([]byte(nil), buf[off:end]...), map[string]any{"offset": off, "length": end - off}, "", nil
+}
+
+// cipherOp builds a decrypt transform for a P25 algorithm: keystream =
+// Keystream(alg, key, mi, len(buf)); out = buf ⊕ keystream.
+func cipherOp(alg uint8) opFunc {
+	return func(buf []byte, p params) ([]byte, map[string]any, string, error) {
+		key, err := p.hex("key")
+		if err != nil {
+			return nil, nil, "", err
+		}
+		mi, err := p.hex("mi")
+		if err != nil {
+			return nil, nil, "", err
+		}
+		ks, err := p25crypto.Keystream(alg, key, mi, len(buf))
+		if err != nil {
+			return nil, nil, "", err
+		}
+		out := make([]byte, len(buf))
+		for i := range buf {
+			out[i] = buf[i] ^ ks[i]
+		}
+		return out, map[string]any{"algorithm": p25crypto.AlgName(alg)}, "", nil
+	}
+}
+
+func opDescramble(buf []byte, _ params) ([]byte, map[string]any, string, error) {
+	if len(buf)%2 != 0 {
+		return nil, nil, "", fmt.Errorf("descramble-invert: need s16le PCM (even byte count), got %d", len(buf))
+	}
+	samples := make([]int16, len(buf)/2)
+	for i := range samples {
+		samples[i] = int16(uint16(buf[2*i]) | uint16(buf[2*i+1])<<8)
+	}
+	inv := voice.SpectralInvertInt16(samples)
+	out := make([]byte, len(inv)*2)
+	for i, s := range inv {
+		out[2*i] = byte(uint16(s))
+		out[2*i+1] = byte(uint16(s) >> 8)
+	}
+	return out, map[string]any{"samples": len(samples)}, "", nil
+}
+
+// --- analysis ops (buffer unchanged) ---
+
+func opStats(buf []byte, _ params) ([]byte, map[string]any, string, error) {
+	ent := stats.ShannonEntropy(buf)
+	info := map[string]any{
+		"entropy_bits":         ent,
+		"index_of_coincidence": stats.IndexOfCoincidence(buf),
+		"chi_square_uniform":   stats.ChiSquareUniform(buf),
+	}
+	note := "intermediate structure"
+	switch {
+	case ent > 7.5:
+		note = "high entropy — looks encrypted/compressed"
+	case ent < 4.8:
+		note = "low entropy — looks like plaintext/structured data"
+	}
+	return buf, info, note, nil
+}
+
+func opRandomness(buf []byte, _ params) ([]byte, map[string]any, string, error) {
+	rep := randomness.Quick(lfsr.BitsFromBytes(buf), randomness.DefaultAlpha)
+	note := "structured (fails randomness) — exploitable"
+	if rep.LooksRandom() {
+		note = "indistinguishable from random — strong"
+	}
+	return buf, map[string]any{"passed": rep.Passed, "failed": rep.Failed, "looks_random": rep.LooksRandom()}, note, nil
+}
+
+// --- params helpers ---
+
+type params map[string]any
+
+func (p params) str(key string) string {
+	if p == nil {
+		return ""
+	}
+	if v, ok := p[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+func (p params) hex(key string) ([]byte, error) {
+	s := strings.TrimSpace(p.str(key))
+	if s == "" {
+		return nil, nil
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("param %q: bad hex %q: %w", key, s, err)
+	}
+	return b, nil
+}
+
+func (p params) intDefault(key string, def int) int {
+	if p == nil {
+		return def
+	}
+	switch v := p[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	}
+	return def
+}
+
+func hexPreview(b []byte, n int) string {
+	if len(b) > n {
+		b = b[:n]
+	}
+	return hex.EncodeToString(b)
+}
+
+func asciiPreview(b []byte, n int) string {
+	if len(b) > n {
+		b = b[:n]
+	}
+	out := make([]byte, len(b))
+	for i, c := range b {
+		if c >= 0x20 && c <= 0x7e {
+			out[i] = c
+		} else {
+			out[i] = '.'
+		}
+	}
+	return string(out)
+}

--- a/internal/cryptolab/engine/recipe/recipe_test.go
+++ b/internal/cryptolab/engine/recipe/recipe_test.go
@@ -1,0 +1,114 @@
+package recipe
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
+)
+
+func TestXORThenAnalyses(t *testing.T) {
+	t.Parallel()
+	pt := []byte("THE QUICK BROWN FOX OVER THE LAZY DOG AGAIN AND AGAIN")
+	key := []byte{0x6b, 0x21}
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] ^ key[i%len(key)]
+	}
+	steps := []Step{
+		{Op: "xor", Params: map[string]any{"key": "6b21"}},
+		{Op: "stats"},
+		{Op: "randomness"},
+	}
+	rep, err := Run(ct, steps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(rep.FinalBytes, pt) {
+		t.Fatalf("xor did not recover plaintext: %q", rep.FinalBytes)
+	}
+	if len(rep.Steps) != 3 {
+		t.Fatalf("want 3 steps, got %d", len(rep.Steps))
+	}
+	// Analysis steps must not change the buffer length.
+	if rep.Steps[1].Transform || rep.Steps[1].BytesIn != rep.Steps[1].BytesOut {
+		t.Fatalf("stats should be a non-transform: %+v", rep.Steps[1])
+	}
+}
+
+func TestCipherDecryptOp(t *testing.T) {
+	t.Parallel()
+	pt := []byte("DISPATCH TO MAIN ST NOW PLEASE OK")
+	key := []byte{0x11, 0x22, 0x33, 0x44, 0x55}
+	mi := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	ks, err := p25crypto.Keystream(p25crypto.AlgADP, key, mi, len(pt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] ^ ks[i]
+	}
+	rep, err := Run(ct, []Step{
+		{Op: "adp-decrypt", Params: map[string]any{"key": "1122334455", "mi": "010203040506070809"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(rep.FinalBytes, pt) {
+		t.Fatalf("adp-decrypt failed:\n got %q\nwant %q", rep.FinalBytes, pt)
+	}
+}
+
+func TestNotIsSelfInverse(t *testing.T) {
+	t.Parallel()
+	in := []byte{0x00, 0xFF, 0xA5, 0x5A}
+	rep, err := Run(in, []Step{{Op: "not"}, {Op: "not"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(rep.FinalBytes, in) {
+		t.Fatalf("double NOT != identity: %x", rep.FinalBytes)
+	}
+}
+
+func TestHexDecodeThenXOR(t *testing.T) {
+	t.Parallel()
+	// "48490a" -> "HI\n"; XOR key 0x00 leaves it unchanged.
+	rep, err := Run([]byte("48 49 0a"), []Step{
+		{Op: "hex-decode"},
+		{Op: "xor", Params: map[string]any{"key": "00"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(rep.FinalBytes, []byte{0x48, 0x49, 0x0a}) {
+		t.Fatalf("hex-decode chain wrong: %x", rep.FinalBytes)
+	}
+}
+
+func TestUnknownOpErrors(t *testing.T) {
+	t.Parallel()
+	if _, err := Run([]byte("x"), []Step{{Op: "nope"}}); err == nil {
+		t.Fatal("expected an error for an unknown op")
+	}
+}
+
+func TestOpsListed(t *testing.T) {
+	t.Parallel()
+	ops := Ops()
+	if len(ops) < 8 {
+		t.Fatalf("expected the op registry to be populated, got %d", len(ops))
+	}
+	var sawTransform, sawAnalysis bool
+	for _, o := range ops {
+		if o.Transform {
+			sawTransform = true
+		} else {
+			sawAnalysis = true
+		}
+	}
+	if !sawTransform || !sawAnalysis {
+		t.Fatal("expected both transform and analysis ops")
+	}
+}

--- a/internal/cryptolab/schema.go
+++ b/internal/cryptolab/schema.go
@@ -66,6 +66,12 @@ var modeParams = map[string][]Param{
 		{Name: "ct", Label: "Ciphertext file", Kind: "file", Required: true},
 		{Name: "out", Label: "Output keystream file", Kind: "outfile"},
 	},
+	"recipe/run": {
+		{Name: "in", Label: "Input file", Kind: "file", Required: true},
+		{Name: "recipe", Label: "Recipe file (JSON/YAML)", Kind: "file", Required: true, Help: "ordered steps: a list of {op, params} or {steps: [...]}"},
+		{Name: "out", Label: "Output file", Kind: "outfile", Help: "write the final transformed bytes"},
+		{Name: "list", Label: "List operations", Kind: "bool", Help: "list available ops instead of running"},
+	},
 	"assess/crypto": {
 		{Name: "in", Label: "Frames file", Kind: "file", Required: true, Help: "JSONL {label,iv,ct,algid,…} or CSV captured encrypted frames"},
 		{Name: "protocol", Label: "Protocol", Kind: "select", Default: "p25", Options: []string{"p25", "tetra", "dmr"}, Help: "algorithm-id namespace for the known-weakness advisory"},

--- a/internal/cryptolab/tools/recipe.go
+++ b/internal/cryptolab/tools/recipe.go
@@ -1,0 +1,149 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/recipe"
+)
+
+// recipeTool is a CyberChef-style operation pipeline: chain byte transforms
+// (XOR, cipher decrypt, bit reversal, spectral inversion, hex/base64) and
+// analyses (entropy, randomness) into one reusable recipe, piping the bytes
+// from each step into the next. It encodes the de-obfuscation sequence an RF
+// analyst repeats by hand.
+type recipeTool struct{}
+
+func (recipeTool) Name() string { return "recipe" }
+func (recipeTool) Synopsis() string {
+	return "chain transform/analysis operations into a reusable pipeline"
+}
+func (recipeTool) Modes() []cryptolab.Mode {
+	return []cryptolab.Mode{recipeRun{}}
+}
+
+type recipeRun struct{}
+
+func (recipeRun) Name() string     { return "run" }
+func (recipeRun) Synopsis() string { return "run a recipe (JSON/YAML steps) over an input file" }
+
+func (recipeRun) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := newFlagSet("recipe run")
+	in := fs.String("in", "", "input file — required")
+	recipePath := fs.String("recipe", "", "recipe file (JSON or YAML) — required")
+	out := fs.String("out", "", "optional file to write the final transformed bytes")
+	list := fs.Bool("list", false, "list the available operations instead of running")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if *list {
+		res := &cryptolab.Result{Tool: "recipe", Mode: "run", Summary: "available recipe operations"}
+		for _, op := range recipe.Ops() {
+			kind := "analysis"
+			if op.Transform {
+				kind = "transform"
+			}
+			res.AddFinding(op.Name, 0, map[string]any{"kind": kind, "synopsis": op.Synopsis})
+		}
+		return res, nil
+	}
+	data, err := readInput(*in)
+	if err != nil {
+		return nil, err
+	}
+	if *recipePath == "" {
+		return nil, fmt.Errorf("-recipe is required")
+	}
+	steps, err := loadRecipe(*recipePath)
+	if err != nil {
+		return nil, err
+	}
+
+	rep, runErr := recipe.Run(data, steps)
+	// rep is non-nil even on error (partial); surface what ran before failing.
+
+	res := &cryptolab.Result{Tool: "recipe", Mode: "run"}
+	res.AddField("input_bytes", rep.InputBytes)
+	res.AddField("steps", len(rep.Steps))
+	for i, s := range rep.Steps {
+		detail := map[string]any{"transform": s.Transform, "bytes_in": s.BytesIn, "bytes_out": s.BytesOut}
+		for k, v := range s.Info {
+			detail[k] = v
+		}
+		if s.Note != "" {
+			detail["note"] = s.Note
+		}
+		res.AddFinding(fmt.Sprintf("%d. %s", i+1, s.Op), float64(i+1), detail)
+	}
+	if runErr != nil {
+		return res, runErr
+	}
+	res.Summary = fmt.Sprintf("ran %d step(s): %d → %d bytes", len(rep.Steps), rep.InputBytes, len(rep.FinalBytes))
+	res.AddField("final_bytes", len(rep.FinalBytes))
+	res.AddField("final_hex", rep.FinalHex)
+	res.AddField("final_ascii", rep.FinalASCII)
+	if *out != "" {
+		if err := os.WriteFile(*out, rep.FinalBytes, 0o644); err != nil {
+			return res, fmt.Errorf("write %s: %w", *out, err)
+		}
+		res.AddField("written", *out)
+	}
+	res.Note("transform steps rewrite the working buffer; analysis steps (stats, randomness) observe it without changing it.")
+	return res, nil
+}
+
+// loadRecipe parses a recipe file into ordered steps. The file is JSON or YAML
+// (JSON is valid YAML, so one parser handles both): either a top-level list of
+// step objects, or an object with a `steps:` list. Each step object has an
+// `op` key plus that op's parameters.
+func loadRecipe(path string) ([]recipe.Step, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read recipe %s: %w", path, err)
+	}
+	var doc any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse recipe %s: %w", path, err)
+	}
+	var list []any
+	switch d := doc.(type) {
+	case []any:
+		list = d
+	case map[string]any:
+		s, ok := d["steps"].([]any)
+		if !ok {
+			return nil, fmt.Errorf("recipe %s: object form needs a `steps:` list", path)
+		}
+		list = s
+	default:
+		return nil, fmt.Errorf("recipe %s: expected a list of steps or an object with `steps:`", path)
+	}
+	var steps []recipe.Step
+	for i, e := range list {
+		m, ok := e.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("recipe step %d: expected an object {op: ...}", i+1)
+		}
+		op, _ := m["op"].(string)
+		if op == "" {
+			return nil, fmt.Errorf("recipe step %d: missing `op`", i+1)
+		}
+		params := make(map[string]any, len(m))
+		for k, v := range m {
+			if k != "op" {
+				params[k] = v
+			}
+		}
+		steps = append(steps, recipe.Step{Op: op, Params: params})
+	}
+	if len(steps) == 0 {
+		return nil, fmt.Errorf("recipe %s: no steps", path)
+	}
+	return steps, nil
+}
+
+func init() { cryptolab.Register(recipeTool{}) }

--- a/internal/cryptolab/tools/recipe_test.go
+++ b/internal/cryptolab/tools/recipe_test.go
@@ -1,0 +1,64 @@
+package tools
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
+)
+
+func TestRecipeToolRegistered(t *testing.T) {
+	t.Parallel()
+	if _, ok := cryptolab.Lookup("recipe"); !ok {
+		t.Fatal("recipe tool not registered")
+	}
+}
+
+func TestRecipeListOps(t *testing.T) {
+	t.Parallel()
+	res := runMode(t, "recipe", "run", []string{"-list"})
+	if len(res.Findings) == 0 {
+		t.Fatalf("-list returned no ops: %+v", res)
+	}
+}
+
+// TestRecipeRunDecryptsADP drives the tool end-to-end: an ADP-encrypted input
+// plus a two-step recipe (adp-decrypt → stats) must recover the plaintext.
+func TestRecipeRunDecryptsADP(t *testing.T) {
+	t.Parallel()
+	pt := []byte("UNITS RESPOND CODE THREE NOW")
+	key := []byte{0xAB, 0xCD, 0xEF, 0x01, 0x23}
+	mi := []byte{9, 8, 7, 6, 5, 4, 3, 2, 1}
+	ks, err := p25crypto.Keystream(p25crypto.AlgADP, key, mi, len(pt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] ^ ks[i]
+	}
+	inFile := writeFile(t, "ct.bin", ct)
+	recipeJSON := fmt.Sprintf(
+		`[{"op":"adp-decrypt","key":"%s","mi":"%s"},{"op":"stats"}]`,
+		hex.EncodeToString(key), hex.EncodeToString(mi))
+	recipeFile := writeFile(t, "recipe.json", []byte(recipeJSON))
+
+	res := runMode(t, "recipe", "run", []string{"-in", inFile, "-recipe", recipeFile})
+	if got := fieldString(t, res, "final_ascii"); got != string(pt) {
+		t.Fatalf("final_ascii = %q, want %q", got, pt)
+	}
+}
+
+// TestRecipeYAMLStepsForm verifies the object-with-steps YAML form parses.
+func TestRecipeYAMLStepsForm(t *testing.T) {
+	t.Parallel()
+	inFile := writeFile(t, "in.bin", []byte{0x00, 0xFF})
+	recipeYAML := "steps:\n  - op: not\n  - op: not\n"
+	recipeFile := writeFile(t, "recipe.yaml", []byte(recipeYAML))
+	res := runMode(t, "recipe", "run", []string{"-in", inFile, "-recipe", recipeFile})
+	if got := fieldString(t, res, "final_hex"); got != "00ff" {
+		t.Fatalf("double-NOT via YAML steps form = %q, want 00ff", got)
+	}
+}


### PR DESCRIPTION
## Summary

Completes the cryptolab roadmap (Tier 3B) with a **CyberChef-style operation pipeline**, so the de-obfuscation sequence an RF analyst repeats by hand becomes one reusable artifact. A recipe is an ordered list of steps; each is a **transform** (rewrites the working buffer) or an **analysis** (measures it), with bytes flowing step to step. The cipher transforms reuse the exact `p25crypto` keystream constructions the `assess` harness uses, so a recipe can decrypt a known-key capture and measure the result in one pass.

Like the rest of cryptolab, it's behind the `cryptolab` build tag (absent from the default operator binary) and auto-registers into the CLI, daemon API, and schema-driven web console.

## Changes

- **`engine/recipe`** — operation registry + `Run`. Transforms: `xor`, `not`, `reverse-bits`, `hex-decode`/`hex-encode`, `base64-decode`, `slice`, `adp-decrypt`, `des-ofb-decrypt`, `tdes-ofb-decrypt`, `aes-ofb-decrypt` (reusing `p25crypto`), `descramble-invert` (reusing `engine/voice`). Analyses: `stats`, `randomness`.
- **`tools/recipe`** — `recipe run -in <file> -recipe <json|yaml> [-out <file>]` executes the pipeline; `-list` prints the available ops. The recipe file is JSON or YAML — a top-level step list or a `{steps: [...]}` object — each step `{op, …params}`. JSON is parsed via `yaml.v3` (JSON ⊂ YAML), so one path handles both.

Example recipe:

```json
[
  {"op": "hex-decode"},
  {"op": "adp-decrypt", "key": "abcdef0123", "mi": "090807060504030201"},
  {"op": "stats"},
  {"op": "randomness"}
]
```

## Test plan

- [x] `make vet test` is green locally (whole repo, `-race`)
- [x] `make test-cryptolab` is green locally
- [x] Added tests — engine (xor-then-analyses recovers plaintext, real ADP decrypt, NOT self-inverse, hex-decode chaining, unknown-op error, op registry populated) and tool (ADP decrypt end-to-end, the YAML `steps:` form, `-list`, registration).
- [x] Smoke-tested the built `-tags cryptolab` binary: an ADP-encrypted capture run through `adp-decrypt → stats → randomness` recovers the plaintext (independently cross-checked against a standalone RC4 ADP implementation); `recipe run -list` shows the 14 ops.
- [ ] `make integration` not run (no daemon change)

No hardware smoke test — no SDR/USB/vocoder DSP changed.

## Breaking changes

None. New tool is behind the `cryptolab` build tag; no config or schema changes outside cryptolab.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Updated `docs/cryptolab.md` (tool table + a `recipe run` section)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzEG7UxiWbbT5q76ECWWZ5)_