### PR TITLE
rfscope: emitter clustering + conversation graph (Tier 1)

### DIFF
--- a/internal/rfscope/export.go
+++ b/internal/rfscope/export.go
@@ -212,6 +212,18 @@ func writeSummary(w io.Writer, sc *Scene) error {
 		}
 	}
 
+	if len(sc.Conversations) > 0 {
+		fmt.Fprintf(bw, "\nConversations:\n")
+		for _, c := range sc.Conversations {
+			ids := make([]string, len(c.EmitterIDs))
+			for i, id := range c.EmitterIDs {
+				ids[i] = fmt.Sprintf("#%d", id)
+			}
+			fmt.Fprintf(bw, "  %-16s %s  (corr %.2f, %d exchanges)\n",
+				c.Kind, strings.Join(ids, "↔"), c.Correlation, c.Exchanges)
+		}
+	}
+
 	if len(sc.Anomalies) > 0 {
 		fmt.Fprintf(bw, "\nExpert info:\n")
 		for _, a := range sc.Anomalies {

--- a/internal/rfscope/topology.go
+++ b/internal/rfscope/topology.go
@@ -1,12 +1,23 @@
 package rfscope
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sort"
 
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/stats"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 	"github.com/MattCheramie/GopherTrunk/internal/survey"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// Trunking-deferral bounds: a burst must be at least this long to be worth a
+// full decode, and at most this many emitters are decoded per scene.
+const (
+	minTrunkDecodeSec = 0.5
+	maxTrunkDecode    = 8
 )
 
 func init() { Register(topologyAnalyzer{}) }
@@ -36,7 +47,92 @@ func (topologyAnalyzer) Analyze(ctx context.Context, sc *Scene, in *Input) error
 		return err
 	}
 	detectConversations(sc)
+	deferToTrunkingTopology(sc, in)
 	return nil
+}
+
+// deferToTrunkingTopology is the authoritative-topology bridge: when an emitter's
+// representative burst decodes as a trunking control channel, GopherTrunk's own
+// hunt accumulator is the authority on its WACN/SysID/RFSS/Site/neighbors/band
+// plan. We decode such bursts with siglab, fold them into hunt.DiscoveredSystems,
+// and attach the result under AnalyzerOutputs["topology"] — so hunt's
+// trunking-specific map becomes one specialization of the generic emitter graph.
+func deferToTrunkingTopology(sc *Scene, in *Input) {
+	if in == nil || in.BurstIQ == nil {
+		return
+	}
+	systems := map[string]*hunt.DiscoveredSystem{}
+	var order []string
+	decoded := 0
+
+	for _, e := range sc.Emitters {
+		if decoded >= maxTrunkDecode {
+			break
+		}
+		if e.Fingerprint.ClassFamily != "digital" || e.Fingerprint.MedianBurstLenSec < minTrunkDecodeSec {
+			continue
+		}
+		bestID := longestBurstID(sc, e)
+		if bestID == 0 {
+			continue
+		}
+		iq, rate, err := in.BurstIQ(sc.Bursts[burstIndexByID(sc, bestID)])
+		if err != nil || len(iq) == 0 || rate <= 0 {
+			continue
+		}
+		ident, err := siglab.IdentifyIQ(iq, "rfscope-burst", siglab.IdentifyConfig{SampleRateHz: rate, Format: siglab.FormatF32, Log: in.Log})
+		if err != nil || ident == nil || ident.Inconclusive || ident.Winner == "" {
+			continue
+		}
+		proto, err := trunking.ParseProtocol(ident.Winner)
+		if err != nil {
+			continue
+		}
+		decoded++
+		res, err := siglab.RunReader(bytes.NewReader(siglab.EncodeCapture(iq, siglab.FormatF32)), "rfscope-burst",
+			siglab.Config{Protocol: proto, SampleRateHz: rate, Format: siglab.FormatF32})
+		if err != nil || res == nil || !res.Locked || res.Topology == nil {
+			continue
+		}
+		key := ident.Winner
+		sys, ok := systems[key]
+		if !ok {
+			sys = &hunt.DiscoveredSystem{}
+			systems[key] = sys
+			order = append(order, key)
+		}
+		hunt.Accumulate(sys, hunt.Observation{
+			Protocol:       ident.Winner,
+			Confidence:     ident.Confidence,
+			Result:         res,
+			FallbackFreqHz: e.Fingerprint.CenterHz,
+		})
+	}
+
+	if len(order) == 0 {
+		return
+	}
+	out := make([]*hunt.DiscoveredSystem, 0, len(order))
+	for _, k := range order {
+		out = append(out, systems[k])
+	}
+	if sc.AnalyzerOutputs == nil {
+		sc.AnalyzerOutputs = map[string]any{}
+	}
+	sc.AnalyzerOutputs["topology"] = out
+}
+
+// longestBurstID returns the ID of the emitter's longest burst.
+func longestBurstID(sc *Scene, e Emitter) uint64 {
+	var best uint64
+	var bestDur float64
+	for _, bid := range e.BurstIDs {
+		b := sc.Bursts[burstIndexByID(sc, bid)]
+		if b.DurationSec() >= bestDur {
+			bestDur, best = b.DurationSec(), bid
+		}
+	}
+	return best
 }
 
 // Conversation-detection tuning.

--- a/internal/rfscope/topology.go
+++ b/internal/rfscope/topology.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/stats"
 	"github.com/MattCheramie/GopherTrunk/internal/survey"
 )
 
@@ -38,10 +39,126 @@ func (topologyAnalyzer) Analyze(ctx context.Context, sc *Scene, in *Input) error
 	return nil
 }
 
-// detectConversations links temporally correlated emitters. Implemented in the
-// conversation pass (next commit); the emitter clustering above is independent
-// of it.
-func detectConversations(sc *Scene) {}
+// Conversation-detection tuning.
+const (
+	maxConvEmitters = 24  // cap pairwise comparison to the top-N talkers
+	coactiveThresh  = 0.5 // lag-0 correlation ⇒ co-active
+	rrThresh        = 0.4 // off-lag correlation peak ⇒ request/response
+)
+
+// detectConversations links temporally correlated emitters into Conversations —
+// the RF analog of a conversation/endpoint graph. A frequency hopper is its own
+// hop-sequence; a pair of emitters whose activity coincides is co-active, and a
+// pair that alternates (a correlation peak at a non-zero lag) is request/response.
+func detectConversations(sc *Scene) {
+	window := sc.WindowSec
+	if window <= 0 || len(sc.Emitters) == 0 {
+		return
+	}
+	nbins := timelineBins
+	binDur := window / float64(nbins)
+
+	byID := map[uint64]int{}
+	for i := range sc.Bursts {
+		byID[sc.Bursts[i].ID] = i
+	}
+
+	// Per-emitter binary activity signal.
+	act := make(map[uint64][]float64, len(sc.Emitters))
+	for _, e := range sc.Emitters {
+		sig := make([]float64, nbins)
+		for _, bid := range e.BurstIDs {
+			b := sc.Bursts[byID[bid]]
+			lo := int(b.StartSec / binDur)
+			hi := int(b.EndSec / binDur)
+			for k := lo; k <= hi && k < nbins; k++ {
+				if k >= 0 {
+					sig[k] = 1
+				}
+			}
+		}
+		act[e.ID] = sig
+	}
+
+	var convs []Conversation
+	var nextID uint64
+
+	// Hop sequences (intra-emitter).
+	for _, e := range sc.Emitters {
+		if len(e.HopSet) > 1 {
+			nextID++
+			convs = append(convs, Conversation{
+				ID: nextID, EmitterIDs: []uint64{e.ID}, Kind: "hop-sequence",
+				Correlation: 1, Exchanges: len(e.BurstIDs),
+			})
+		}
+	}
+
+	// Pairwise among the top talkers.
+	top := sc.Emitters
+	if len(top) > maxConvEmitters {
+		top = top[:maxConvEmitters]
+	}
+	for i := 0; i < len(top); i++ {
+		for j := i + 1; j < len(top); j++ {
+			ai, aj := act[top[i].ID], act[top[j].ID]
+			corr, _ := stats.Correlate(ai, aj)
+			if len(corr) == 0 {
+				continue
+			}
+			lag0 := corr[nbins-1]
+			bestLag, bestVal := offPeak(corr, nbins, nbins/4)
+
+			kind, score := "", 0.0
+			switch {
+			case lag0 >= coactiveThresh:
+				kind, score = "co-active", lag0
+			case bestVal >= rrThresh && bestLag != 0 && lag0 < 0.3:
+				kind, score = "request-response", bestVal
+			}
+			if kind == "" {
+				continue
+			}
+			nextID++
+			convs = append(convs, Conversation{
+				ID: nextID, EmitterIDs: []uint64{top[i].ID, top[j].ID}, Kind: kind,
+				Correlation: score, Exchanges: overlapCount(ai, aj),
+			})
+		}
+	}
+	sc.Conversations = convs
+}
+
+// offPeak returns the lag (≠0, within ±maxLag) of the largest cross-correlation
+// value and that value. corr is the full Correlate output of two length-n
+// signals (length 2n-1, lag 0 at index n-1).
+func offPeak(corr []float64, n, maxLag int) (lag int, val float64) {
+	val = -2
+	for d := -maxLag; d <= maxLag; d++ {
+		if d == 0 {
+			continue
+		}
+		idx := n - 1 + d
+		if idx < 0 || idx >= len(corr) {
+			continue
+		}
+		if corr[idx] > val {
+			val, lag = corr[idx], d
+		}
+	}
+	return lag, val
+}
+
+// overlapCount returns how many bins both signals are active.
+func overlapCount(a, b []float64) int {
+	n := 0
+	for i := range a {
+		if a[i] > 0 && b[i] > 0 {
+			n++
+		}
+	}
+	return n
+}
 
 // clusterEmitters groups bursts into emitters and sets each burst's EmitterID.
 // Stage A clusters by exact channel + class family (per-channel emitters, the
@@ -90,6 +207,13 @@ func clusterEmitters(sc *Scene) {
 			sc.Bursts[burstIndexByID(sc, bid)].EmitterID = emitters[i].ID
 		}
 	}
+	// Present top talkers first (most airtime), keeping the assigned IDs.
+	sort.Slice(emitters, func(i, j int) bool {
+		if emitters[i].TotalAirtimeSec != emitters[j].TotalAirtimeSec {
+			return emitters[i].TotalAirtimeSec > emitters[j].TotalAirtimeSec
+		}
+		return emitters[i].ID < emitters[j].ID
+	})
 	sc.Emitters = emitters
 }
 

--- a/internal/rfscope/topology.go
+++ b/internal/rfscope/topology.go
@@ -1,0 +1,261 @@
+package rfscope
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func init() { Register(topologyAnalyzer{}) }
+
+// hopperPowerBucketDb groups emitters into power bands when looking for a
+// frequency hopper: candidate hop members must sit within one bucket.
+const hopperPowerBucketDb = 6.0
+
+// topologyAnalyzer builds the protocol-agnostic network topology — the
+// generalization of hunt's trunking map. It clusters bursts into Emitters by RF
+// fingerprint (so a frequency hopper's scattered bursts collapse into one
+// logical source), then links temporally correlated emitters into Conversations
+// (request/response, paired slots, hop sequences, co-active). This is the RF
+// analog of Wireshark's Conversations/Endpoints, one layer down.
+type topologyAnalyzer struct{}
+
+func (topologyAnalyzer) Name() string        { return "topology" }
+func (topologyAnalyzer) Synopsis() string    { return "emitter clustering + conversation graph" }
+func (topologyAnalyzer) DependsOn() []string { return nil }
+
+func (topologyAnalyzer) Analyze(ctx context.Context, sc *Scene, in *Input) error {
+	if len(sc.Bursts) == 0 {
+		return nil
+	}
+	clusterEmitters(sc)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	detectConversations(sc)
+	return nil
+}
+
+// detectConversations links temporally correlated emitters. Implemented in the
+// conversation pass (next commit); the emitter clustering above is independent
+// of it.
+func detectConversations(sc *Scene) {}
+
+// clusterEmitters groups bursts into emitters and sets each burst's EmitterID.
+// Stage A clusters by exact channel + class family (per-channel emitters, the
+// common case). Stage B conservatively merges several single-channel emitters
+// into one frequency-hopping emitter when they share a fingerprint and never
+// transmit at the same time.
+func clusterEmitters(sc *Scene) {
+	// Stage A: (FreqHz, classFamily) → emitter.
+	type key struct {
+		freq   uint32
+		family string
+	}
+	groups := map[key][]int{}
+	var order []key
+	for i, b := range sc.Bursts {
+		k := key{b.FreqHz, classFamily(b.Class)}
+		if _, seen := groups[k]; !seen {
+			order = append(order, k)
+		}
+		groups[k] = append(groups[k], i)
+	}
+	sort.Slice(order, func(i, j int) bool {
+		if order[i].freq != order[j].freq {
+			return order[i].freq < order[j].freq
+		}
+		return order[i].family < order[j].family
+	})
+
+	var emitters []Emitter
+	for _, k := range order {
+		emitters = append(emitters, buildEmitter(sc, groups[k]))
+	}
+
+	emitters = mergeHoppers(sc, emitters)
+
+	// Assign IDs (stable: by first-seen time, then frequency) and back-reference.
+	sort.Slice(emitters, func(i, j int) bool {
+		if emitters[i].FirstSec != emitters[j].FirstSec {
+			return emitters[i].FirstSec < emitters[j].FirstSec
+		}
+		return emitters[i].Fingerprint.CenterHz < emitters[j].Fingerprint.CenterHz
+	})
+	for i := range emitters {
+		emitters[i].ID = uint64(i + 1)
+		for _, bid := range emitters[i].BurstIDs {
+			sc.Bursts[burstIndexByID(sc, bid)].EmitterID = emitters[i].ID
+		}
+	}
+	sc.Emitters = emitters
+}
+
+// buildEmitter constructs an emitter from a set of burst indices.
+func buildEmitter(sc *Scene, idxs []int) Emitter {
+	var e Emitter
+	e.FirstSec = sc.Bursts[idxs[0]].StartSec
+	e.LastSec = sc.Bursts[idxs[0]].EndSec
+	var powers, lens, flats []float64
+	freqSet := map[uint32]struct{}{}
+	for _, i := range idxs {
+		b := sc.Bursts[i]
+		e.BurstIDs = append(e.BurstIDs, b.ID)
+		e.TotalAirtimeSec += b.DurationSec()
+		if b.StartSec < e.FirstSec {
+			e.FirstSec = b.StartSec
+		}
+		if b.EndSec > e.LastSec {
+			e.LastSec = b.EndSec
+		}
+		powers = append(powers, float64(b.PeakDbFS))
+		lens = append(lens, b.DurationSec())
+		flats = append(flats, b.SpectralFlatness)
+		freqSet[b.FreqHz] = struct{}{}
+	}
+	b0 := sc.Bursts[idxs[0]]
+	e.Fingerprint = Fingerprint{
+		CenterHz:          b0.FreqHz,
+		OccupiedBwHz:      b0.OccupiedBwHz,
+		ClassFamily:       classFamily(b0.Class),
+		MedianPowerDbFS:   float32(median(powers)),
+		MedianBurstLenSec: median(lens),
+		SpectralFlatness:  median(flats),
+	}
+	freqs := make([]uint32, 0, len(freqSet))
+	for f := range freqSet {
+		freqs = append(freqs, f)
+	}
+	sort.Slice(freqs, func(i, j int) bool { return freqs[i] < freqs[j] })
+	if len(freqs) > 1 {
+		e.HopSet = freqs
+	}
+	e.Label = emitterLabel(e)
+	return e
+}
+
+// mergeHoppers collapses several single-frequency emitters into one hopping
+// emitter when they share a class family and power band, span ≥2 frequencies,
+// and never transmit simultaneously (a single radio cannot key two channels at
+// once). It is deliberately conservative to avoid merging distinct co-channel
+// radios.
+func mergeHoppers(sc *Scene, emitters []Emitter) []Emitter {
+	type hkey struct {
+		family string
+		powB   int
+	}
+	buckets := map[hkey][]int{}
+	for i, e := range emitters {
+		if len(e.HopSet) > 1 {
+			continue // already multi-freq
+		}
+		k := hkey{e.Fingerprint.ClassFamily, int(float64(e.Fingerprint.MedianPowerDbFS) / hopperPowerBucketDb)}
+		buckets[k] = append(buckets[k], i)
+	}
+
+	merged := map[int]bool{}
+	var out []Emitter
+	// Build merged hoppers first.
+	keys := make([]hkey, 0, len(buckets))
+	for k := range buckets {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].family != keys[j].family {
+			return keys[i].family < keys[j].family
+		}
+		return keys[i].powB < keys[j].powB
+	})
+	for _, k := range keys {
+		members := buckets[k]
+		if len(members) < 2 {
+			continue
+		}
+		// Distinct frequencies and pairwise time-disjoint bursts.
+		freqs := map[uint32]struct{}{}
+		for _, mi := range members {
+			freqs[emitters[mi].Fingerprint.CenterHz] = struct{}{}
+		}
+		if len(freqs) < 2 {
+			continue
+		}
+		if !timeDisjoint(sc, emitters, members) {
+			continue
+		}
+		// Merge.
+		var idxs []int
+		for _, mi := range members {
+			merged[mi] = true
+			for _, bid := range emitters[mi].BurstIDs {
+				idxs = append(idxs, burstIndexByID(sc, bid))
+			}
+		}
+		he := buildEmitter(sc, idxs)
+		out = append(out, he)
+	}
+	// Keep unmerged emitters.
+	for i, e := range emitters {
+		if !merged[i] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// timeDisjoint reports whether the bursts of all listed emitters are pairwise
+// non-overlapping in time (a precondition for them being one hopping radio).
+func timeDisjoint(sc *Scene, emitters []Emitter, members []int) bool {
+	type iv struct{ start, end float64 }
+	var ivs []iv
+	for _, mi := range members {
+		for _, bid := range emitters[mi].BurstIDs {
+			b := sc.Bursts[burstIndexByID(sc, bid)]
+			ivs = append(ivs, iv{b.StartSec, b.EndSec})
+		}
+	}
+	sort.Slice(ivs, func(i, j int) bool { return ivs[i].start < ivs[j].start })
+	for i := 1; i < len(ivs); i++ {
+		if ivs[i].start < ivs[i-1].end {
+			return false
+		}
+	}
+	return true
+}
+
+// burstIndexByID maps a burst ID to its slice index (linear; burst counts are
+// modest, and this keeps EmitterID back-references simple).
+func burstIndexByID(sc *Scene, id uint64) int {
+	for i := range sc.Bursts {
+		if sc.Bursts[i].ID == id {
+			return i
+		}
+	}
+	return 0
+}
+
+// classFamily folds the modulation classes into the coarse families emitters are
+// clustered on, so a hopper whose hops are classified inconsistently (c4fm on
+// one, fsk on the next) still collapses to one emitter.
+func classFamily(c survey.SignalClass) string {
+	switch c {
+	case survey.ClassAM:
+		return "am"
+	case survey.ClassNBFM, survey.ClassWideFM:
+		return "analog-fm"
+	case survey.ClassFSK, survey.ClassC4FM, survey.ClassPSK, survey.ClassContinuousData,
+		survey.ClassPaging, survey.ClassTrunkControl, survey.ClassTrunkVoice:
+		return "digital"
+	default:
+		return "unknown"
+	}
+}
+
+// emitterLabel renders a short human label for an emitter.
+func emitterLabel(e Emitter) string {
+	if len(e.HopSet) > 1 {
+		return fmt.Sprintf("%s hopper (%d ch)", e.Fingerprint.ClassFamily, len(e.HopSet))
+	}
+	return fmt.Sprintf("%s@%.4fMHz", e.Fingerprint.ClassFamily, float64(e.Fingerprint.CenterHz)/1e6)
+}

--- a/internal/rfscope/topology_test.go
+++ b/internal/rfscope/topology_test.go
@@ -98,6 +98,70 @@ func TestClusterEmittersNoMergeWhenOverlapping(t *testing.T) {
 	}
 }
 
+func convKind(cs []Conversation, kind string) bool {
+	for _, c := range cs {
+		if c.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func TestConversationsCoActive(t *testing.T) {
+	t.Parallel()
+	// Two distinct emitters active over the same interval ⇒ co-active.
+	sc := &Scene{
+		SpanHz: 2_000_000, WindowSec: 10,
+		Bursts: []Burst{
+			{ID: 1, FreqHz: 450_100_000, StartSec: 0, EndSec: 3, PeakDbFS: -40, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+			{ID: 2, FreqHz: 450_500_000, StartSec: 0, EndSec: 3, PeakDbFS: -55, Class: survey.ClassPSK, OccupiedBwHz: 12_500},
+		},
+	}
+	clusterEmitters(sc)
+	detectConversations(sc)
+	if len(sc.Emitters) != 2 {
+		t.Fatalf("want 2 emitters, got %d", len(sc.Emitters))
+	}
+	if !convKind(sc.Conversations, "co-active") {
+		t.Fatalf("want a co-active conversation, got %+v", sc.Conversations)
+	}
+}
+
+func TestConversationsRequestResponse(t *testing.T) {
+	t.Parallel()
+	// Two emitters alternating in 1 s slots ⇒ request/response (peak at a lag).
+	sc := &Scene{SpanHz: 2_000_000, WindowSec: 10}
+	var id uint64
+	for t0 := 0.0; t0+2 <= 8; t0 += 2 {
+		id++
+		sc.Bursts = append(sc.Bursts, Burst{ID: id, FreqHz: 450_100_000, StartSec: t0, EndSec: t0 + 1, PeakDbFS: -40, Class: survey.ClassFSK, OccupiedBwHz: 12_500})
+		id++
+		sc.Bursts = append(sc.Bursts, Burst{ID: id, FreqHz: 450_500_000, StartSec: t0 + 1, EndSec: t0 + 2, PeakDbFS: -55, Class: survey.ClassPSK, OccupiedBwHz: 12_500})
+	}
+	clusterEmitters(sc)
+	detectConversations(sc)
+	if !convKind(sc.Conversations, "request-response") {
+		t.Fatalf("want a request-response conversation, got %+v", sc.Conversations)
+	}
+}
+
+func TestConversationsHopSequence(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{
+		SpanHz: 2_000_000, WindowSec: 10,
+		Bursts: []Burst{
+			{ID: 1, FreqHz: 450_100_000, StartSec: 0.0, EndSec: 0.5, PeakDbFS: -40, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+			{ID: 2, FreqHz: 450_500_000, StartSec: 1.0, EndSec: 1.5, PeakDbFS: -41, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+			{ID: 3, FreqHz: 450_900_000, StartSec: 2.0, EndSec: 2.5, PeakDbFS: -39, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+		},
+	}
+	clusterEmitters(sc)
+	detectConversations(sc)
+	if !convKind(sc.Conversations, "hop-sequence") {
+		t.Fatalf("want a hop-sequence conversation, got %+v", sc.Conversations)
+	}
+}
+
 func TestTopologyViaRunner(t *testing.T) {
 	t.Parallel()
 	sc := &Scene{

--- a/internal/rfscope/topology_test.go
+++ b/internal/rfscope/topology_test.go
@@ -162,6 +162,21 @@ func TestConversationsHopSequence(t *testing.T) {
 	}
 }
 
+func TestTrunkingDeferralNoOpWithoutIQ(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{
+		SpanHz: 1_000_000, WindowSec: 10,
+		Bursts: []Burst{{ID: 1, FreqHz: 450_100_000, StartSec: 0, EndSec: 1, PeakDbFS: -40, Class: survey.ClassNBFM, OccupiedBwHz: 12_500}},
+	}
+	clusterEmitters(sc)
+	// nil Input and nil BurstIQ must both be safe no-ops (no panic, no output).
+	deferToTrunkingTopology(sc, nil)
+	deferToTrunkingTopology(sc, &Input{})
+	if _, ok := sc.AnalyzerOutputs["topology"]; ok {
+		t.Fatalf("analog/no-IQ scene must not attach trunking topology")
+	}
+}
+
 func TestTopologyViaRunner(t *testing.T) {
 	t.Parallel()
 	sc := &Scene{

--- a/internal/rfscope/topology_test.go
+++ b/internal/rfscope/topology_test.go
@@ -1,0 +1,113 @@
+package rfscope
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func emitterByLabelContains(es []Emitter, sub string) (Emitter, bool) {
+	for _, e := range es {
+		if containsStr(e.Label, sub) {
+			return e, true
+		}
+	}
+	return Emitter{}, false
+}
+
+func containsStr(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestClusterEmittersTwoChannels(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{
+		SpanHz: 1_000_000, WindowSec: 10,
+		Bursts: []Burst{
+			{ID: 1, FreqHz: 450_100_000, StartSec: 0, EndSec: 1, PeakDbFS: -40, Class: survey.ClassNBFM, OccupiedBwHz: 12_500},
+			{ID: 2, FreqHz: 450_100_000, StartSec: 2, EndSec: 3, PeakDbFS: -41, Class: survey.ClassNBFM, OccupiedBwHz: 12_500},
+			{ID: 3, FreqHz: 450_300_000, StartSec: 0, EndSec: 5, PeakDbFS: -30, Class: survey.ClassC4FM, OccupiedBwHz: 12_500},
+		},
+	}
+	clusterEmitters(sc)
+	if len(sc.Emitters) != 2 {
+		t.Fatalf("want 2 emitters, got %d: %+v", len(sc.Emitters), sc.Emitters)
+	}
+	// Every burst is assigned to an emitter.
+	for _, b := range sc.Bursts {
+		if b.EmitterID == 0 {
+			t.Fatalf("burst %d unassigned", b.ID)
+		}
+	}
+	// The two NBFM bursts share one emitter; the C4FM burst is its own.
+	if sc.Bursts[0].EmitterID != sc.Bursts[1].EmitterID {
+		t.Fatalf("co-channel NBFM bursts should share an emitter")
+	}
+	if sc.Bursts[2].EmitterID == sc.Bursts[0].EmitterID {
+		t.Fatalf("C4FM burst must be a distinct emitter")
+	}
+}
+
+func TestClusterEmittersMergesHopper(t *testing.T) {
+	t.Parallel()
+	// Same family/power, three distinct freqs, time-disjoint ⇒ one hopper.
+	sc := &Scene{
+		SpanHz: 2_000_000, WindowSec: 10,
+		Bursts: []Burst{
+			{ID: 1, FreqHz: 450_100_000, StartSec: 0.0, EndSec: 0.5, PeakDbFS: -40, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+			{ID: 2, FreqHz: 450_500_000, StartSec: 1.0, EndSec: 1.5, PeakDbFS: -41, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+			{ID: 3, FreqHz: 450_900_000, StartSec: 2.0, EndSec: 2.5, PeakDbFS: -39, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+		},
+	}
+	clusterEmitters(sc)
+	if len(sc.Emitters) != 1 {
+		t.Fatalf("want 1 hopper emitter, got %d: %+v", len(sc.Emitters), sc.Emitters)
+	}
+	e := sc.Emitters[0]
+	if len(e.HopSet) != 3 {
+		t.Fatalf("want HopSet of 3 freqs, got %v", e.HopSet)
+	}
+	if _, ok := emitterByLabelContains([]Emitter{e}, "hopper"); !ok {
+		t.Fatalf("hopper label expected, got %q", e.Label)
+	}
+}
+
+func TestClusterEmittersNoMergeWhenOverlapping(t *testing.T) {
+	t.Parallel()
+	// Same family/power but two freqs active at the SAME time ⇒ two radios, no merge.
+	sc := &Scene{
+		SpanHz: 2_000_000, WindowSec: 10,
+		Bursts: []Burst{
+			{ID: 1, FreqHz: 450_100_000, StartSec: 0.0, EndSec: 2.0, PeakDbFS: -40, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+			{ID: 2, FreqHz: 450_500_000, StartSec: 1.0, EndSec: 3.0, PeakDbFS: -40, Class: survey.ClassFSK, OccupiedBwHz: 12_500},
+		},
+	}
+	clusterEmitters(sc)
+	if len(sc.Emitters) != 2 {
+		t.Fatalf("overlapping co-band emitters must not merge: got %d", len(sc.Emitters))
+	}
+}
+
+func TestTopologyViaRunner(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{
+		SpanHz: 1_000_000, WindowSec: 10,
+		Bursts: []Burst{{ID: 1, FreqHz: 450_100_000, StartSec: 0, EndSec: 1, PeakDbFS: -40, Class: survey.ClassNBFM, OccupiedBwHz: 12_500}},
+	}
+	if err := Run(context.Background(), sc, &Input{}, "topology"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(sc.Emitters) != 1 || sc.Emitters[0].ID == 0 {
+		t.Fatalf("topology runner did not build emitters: %+v", sc.Emitters)
+	}
+}


### PR DESCRIPTION
## Summary

Tier 1 of the protocol-agnostic RF network analyzer (`internal/rfscope`, "Wireshark for the RF physical layer"). Tier 0 (merged) gave the source-agnostic core plus the protocol-hierarchy, activity-timeline, and burst-timing analyzers. This adds the **network topology** layer: cluster bursts into logical **emitters** by RF fingerprint, link temporally correlated emitters into **conversations**, and defer to `hunt`'s authoritative map when a trunking control channel is present. It's the RF analog of Wireshark's Conversations/Endpoints, one layer down at the physical layer.

## Changes

- **`internal/rfscope/topology.go` — new `topology` analyzer (self-registers).**
  - *Emitter clustering:* stage A groups bursts by channel + class family (per-channel emitters); stage B conservatively merges several single-channel emitters into one **frequency-hopping** emitter when they share a class family and power band, span ≥2 frequencies, and never transmit simultaneously. Each burst gets an `EmitterID`; emitters carry a fingerprint, airtime, and `HopSet`.
  - *Conversation graph:* a hopper is its own `hop-sequence`; pairs of top-talker emitters are classified from the cross-correlation of their activity signals (`dsp/stats.Correlate`) as `co-active` (lag-0) or `request-response` (peak at a non-zero lag). Emitters are presented most-airtime-first.
  - *Trunking deferral:* when an emitter's representative burst decodes as a trunking CC, fold the `siglab` decode into a `hunt.DiscoveredSystem` via `hunt.Accumulate` and attach it under `AnalyzerOutputs["topology"]` — bounded by a minimum burst length and a per-scene decode cap; a no-IQ/analog scene is a safe no-op.
- **`internal/rfscope/export.go`** — summary renderer gains a Conversations section (top-talkers section already present).
- **`internal/rfscope/topology_test.go`** — emitter separation, hopper merge, no-merge guard for overlapping co-band radios, co-active / request-response / hop-sequence detection, and the trunking-deferral no-op path.

The `rfscope` CLI runs all registered analyzers automatically, so `gophertrunk rfscope analyze` (and `-analyzers topology`) pick this up with no extra wiring.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` is green locally (if the change touches the daemon) — n/a, no daemon/DSP path touched
- [x] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware — n/a; verified end-to-end on a synthesized `gophertrunk gen` P25 capture (`rfscope analyze` reports emitters, co-active conversations, and top talkers)

## Breaking changes

None. Additive: a new analyzer in an existing package and a new section in the `rfscope` summary output.

## Docs / CHANGELOG

- [ ] CHANGELOG — deferred to the Tier roadmap's polish tier (feature is not yet operator-surfaced beyond the `rfscope` subcommand added in Tier 0)
- [ ] README/docs — n/a for this tier

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkhQ64GwXMUX4jvYDBQEEC)_