### PR TITLE
cryptolab: web Recipe Builder + DMR active decryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **cryptolab web Recipe Builder.** The cryptolab console gains a *Recipe
+  Builder* tab that drives the `recipe` pipeline interactively (config-builder
+  style): pick an input, assemble an ordered operation list from a palette with
+  per-step parameters and move/duplicate/remove, run it server-side, and read
+  the per-step report plus the final bytes (with download). Backed by new
+  `GET /api/v1/cryptolab/recipe/ops` and `POST /api/v1/cryptolab/recipe`
+  endpoints.
+- **cryptolab DMR decryption + generic RC4.** `assess crypto -protocol dmr`
+  now actively attempts DMR privacy with the real cipher cores (RC4 "Enhanced
+  Privacy", DES/3DES/AES-OFB) keyed with operator-supplied material, and the
+  recipe pipeline gains a generic `rc4-decrypt` op. DMR's vendor key/IV
+  derivation is the analyst's to supply; the cipher cores are bundled.
 - **cryptolab security-test suite** (`-tags cryptolab`). New analysis and
   active-attack tools, ported from the industry crypto-tool landscape and
   optimized for RF:

--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -162,10 +162,25 @@ with a `steps:` list. Each step is `{op, …params}`:
 
 Operations (run `recipe run -list` for the live set): transforms `xor`, `not`,
 `reverse-bits`, `hex-decode`, `hex-encode`, `base64-decode`, `slice`,
-`adp-decrypt`, `des-ofb-decrypt`, `tdes-ofb-decrypt`, `aes-ofb-decrypt`,
-`descramble-invert`; analyses `stats`, `randomness`. The cipher ops reuse the
-same `p25crypto` keystream constructions the `assess` harness uses, so a recipe
-can decrypt a known-key capture and immediately measure the result.
+`rc4-decrypt` (raw RC4 with a caller-supplied key — DMR Enhanced Privacy /
+generic), `adp-decrypt`, `des-ofb-decrypt`, `tdes-ofb-decrypt`,
+`aes-ofb-decrypt`, `descramble-invert`; analyses `stats`, `randomness`. The
+cipher ops reuse the same `p25crypto` keystream constructions the `assess`
+harness uses, so a recipe can decrypt a known-key capture and immediately
+measure the result.
+
+### Web recipe builder
+
+The cryptolab web console (`cryptolab serve`, or the daemon mount at
+`/cryptolab/`) has a **Recipe Builder** tab that drives this pipeline
+interactively, the same way the Config Builder edits a config: pick an input
+file, assemble an ordered list of operations from a palette (with move /
+duplicate / remove and per-op parameter fields), run it, and read the per-step
+report plus the final bytes (with a download). It is backed by two endpoints —
+`GET /api/v1/cryptolab/recipe/ops` (the operation catalogue with parameters)
+and `POST /api/v1/cryptolab/recipe` (run a structured recipe over an uploaded
+file) — and is fully integrated into the existing console (shared theme,
+styling, and upload flow).
 
 ## Subject framework: byte-obfuscator recovery (`alias`)
 
@@ -331,11 +346,14 @@ Flags:
   feasibility); `-base-key` fixes the remaining high bits.
 
 **Cipher coverage.** The active methods (`weak-key`, `key-brute`) carry the
-real P25 keystream constructions — ADP (RC4), DES-OFB, two-/three-key
-Triple-DES, and AES-128/256-OFB — so a default or small-keyspace key is
-actually recovered, not just flagged. Proprietary ciphers whose keystream
-function isn't bundled (TETRA TEA1–4, Motorola DES-XL, vendor DMR privacy) are
-covered by the `known-weakness` advisory instead: for TEA1 it reports the
+real keystream constructions for both P25 (`-protocol p25`: ADP/RC4, DES-OFB,
+two-/three-key Triple-DES, AES-128/256-OFB) and DMR (`-protocol dmr`: RC4
+"Enhanced Privacy", DES/3DES/AES-OFB), so a default or small-keyspace key is
+actually recovered, not just flagged. DMR's vendor key/IV *derivation* is
+proprietary, so the cipher cores are keyed with the material the analyst
+supplies (the reconstructed key; the frame IV used directly). Proprietary
+ciphers whose keystream function isn't bundled at all (TETRA TEA1–4, Motorola
+DES-XL) are covered by the `known-weakness` advisory instead: for TEA1 it reports the
 80→32-bit backdoor (CVE-2022-24402) and that a 2³² brute would recover the key
 given a TEA1 implementation — an actionable finding without fabricating an
 unverified cipher.

--- a/internal/cryptolab/engine/assess/assess.go
+++ b/internal/cryptolab/engine/assess/assess.go
@@ -28,8 +28,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/cipherinfo"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/dmrcrypto"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/keystream"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
@@ -249,6 +251,45 @@ func methodKnownWeakness(in Input) (MethodResult, bool) {
 	return m, floor
 }
 
+// cipherSuite abstracts the per-protocol keystream constructions so the active
+// methods (weak-key, key-brute) work for P25 and DMR alike. p25crypto seeds
+// from the Message Indicator; dmrcrypto seeds from the frame IV.
+type cipherSuite interface {
+	Supported(algid uint8) bool
+	KeySize(algid uint8) int
+	AlgName(algid uint8) string
+	Keystream(algid uint8, key, iv []byte, n int) ([]byte, error)
+	DefaultKeys(algid uint8) [][]byte
+}
+
+type p25Suite struct{}
+
+func (p25Suite) Supported(a uint8) bool { return p25crypto.Supported(a) }
+func (p25Suite) KeySize(a uint8) int    { return p25crypto.KeySize(a) }
+func (p25Suite) AlgName(a uint8) string { return p25crypto.AlgName(a) }
+func (p25Suite) Keystream(a uint8, key, iv []byte, n int) ([]byte, error) {
+	return p25crypto.Keystream(a, key, iv, n)
+}
+func (p25Suite) DefaultKeys(a uint8) [][]byte { return p25crypto.DefaultKeys(a) }
+
+type dmrSuite struct{}
+
+func (dmrSuite) Supported(a uint8) bool { return dmrcrypto.Supported(a) }
+func (dmrSuite) KeySize(a uint8) int    { return dmrcrypto.KeySize(a) }
+func (dmrSuite) AlgName(a uint8) string { return dmrcrypto.AlgName(a) }
+func (dmrSuite) Keystream(a uint8, key, iv []byte, n int) ([]byte, error) {
+	return dmrcrypto.Keystream(a, key, iv, n)
+}
+func (dmrSuite) DefaultKeys(a uint8) [][]byte { return dmrcrypto.DefaultKeys(a) }
+
+// suiteFor selects the cipher suite for a protocol (default P25).
+func suiteFor(protocol string) cipherSuite {
+	if strings.Contains(strings.ToLower(protocol), "dmr") {
+		return dmrSuite{}
+	}
+	return p25Suite{}
+}
+
 // methodKeyBrute: reduced-keyspace brute force (the hashcat-analog, and the
 // shape of the TETRA TEA1 backdoor attack). With a known-plaintext oracle it
 // searches the low BruteBits of the key for the bundled cipher, verified by an
@@ -279,13 +320,14 @@ func methodKeyBrute(in Input, total int) (MethodResult, []byte) {
 	if proto == "" {
 		proto = "p25"
 	}
-	if !p25crypto.Supported(oracle.AlgID) {
+	suite := suiteFor(proto)
+	if !suite.Supported(oracle.AlgID) {
 		// Unbundled cipher: report the brute that would apply (e.g. TEA1).
 		if info, ok := cipherinfo.Lookup(proto, oracle.AlgID); ok && info.BruteForceable {
 			m.note(fmt.Sprintf("%s has a %d-bit effective keyspace (%s) — a 2^%d brute is feasible, but its keystream function is not bundled here; supply an implementation to run it.",
 				info.Name, info.EffectiveKeyBits, info.Reference, info.EffectiveKeyBits))
 		} else {
-			m.note(fmt.Sprintf("the oracle's algorithm 0x%02X is not bundled, so its keystream cannot be brute-forced here.", oracle.AlgID))
+			m.note(fmt.Sprintf("the oracle's algorithm 0x%02X is not bundled for %s, so its keystream cannot be brute-forced here.", oracle.AlgID, proto))
 		}
 		return m, nil
 	}
@@ -294,7 +336,7 @@ func methodKeyBrute(in Input, total int) (MethodResult, []byte) {
 		in.BruteBits = 32
 	}
 	m.Applicable = true
-	sz := p25crypto.KeySize(oracle.AlgID)
+	sz := suite.KeySize(oracle.AlgID)
 	base := make([]byte, sz)
 	copy(base, in.BaseKey)
 	want := keystream.XOR(in.KnownPT, oracle.CT)
@@ -309,7 +351,7 @@ func methodKeyBrute(in Input, total int) (MethodResult, []byte) {
 	space := uint64(1) << uint(in.BruteBits)
 	for i := uint64(0); i < space; i++ {
 		key := keyWithLowBits(base, i, in.BruteBits)
-		cand, err := p25crypto.Keystream(oracle.AlgID, key, oracle.IV, prefix)
+		cand, err := suite.Keystream(oracle.AlgID, key, oracle.IV, prefix)
 		if err != nil {
 			m.note(err.Error())
 			return m, nil
@@ -317,7 +359,7 @@ func methodKeyBrute(in Input, total int) (MethodResult, []byte) {
 		if !bytesEqual(cand, want[:prefix]) {
 			continue
 		}
-		full, _ := p25crypto.Keystream(oracle.AlgID, key, oracle.IV, len(want))
+		full, _ := suite.Keystream(oracle.AlgID, key, oracle.IV, len(want))
 		if !bytesEqual(full, want) {
 			continue
 		}
@@ -326,12 +368,12 @@ func methodKeyBrute(in Input, total int) (MethodResult, []byte) {
 		m.RecoveredBytes = bytesForAlg(in.Frames, oracle.AlgID)
 		m.SampleHex = hexPreview(in.KnownPT, 32)
 		m.SampleASCII = asciiPreview(in.KnownPT, 32)
-		m.Detail = map[string]any{"algorithm": p25crypto.AlgName(oracle.AlgID), "key_hex": hex.EncodeToString(key), "searched": i + 1, "brute_bits": in.BruteBits}
-		m.note(fmt.Sprintf("COMPLETE BREAK: brute-forced %s key %s in the low %d bits after %d candidates — the keyspace is too small.", p25crypto.AlgName(oracle.AlgID), hex.EncodeToString(key), in.BruteBits, i+1))
+		m.Detail = map[string]any{"algorithm": suite.AlgName(oracle.AlgID), "key_hex": hex.EncodeToString(key), "searched": i + 1, "brute_bits": in.BruteBits}
+		m.note(fmt.Sprintf("COMPLETE BREAK: brute-forced %s key %s in the low %d bits after %d candidates — the keyspace is too small.", suite.AlgName(oracle.AlgID), hex.EncodeToString(key), in.BruteBits, i+1))
 		return m, full
 	}
-	m.Detail = map[string]any{"algorithm": p25crypto.AlgName(oracle.AlgID), "searched": space, "brute_bits": in.BruteBits}
-	m.note(fmt.Sprintf("searched all 2^%d low-bit keys for %s; none matched. The key lies outside this slice of the keyspace.", in.BruteBits, p25crypto.AlgName(oracle.AlgID)))
+	m.Detail = map[string]any{"algorithm": suite.AlgName(oracle.AlgID), "searched": space, "brute_bits": in.BruteBits}
+	m.note(fmt.Sprintf("searched all 2^%d low-bit keys for %s; none matched. The key lies outside this slice of the keyspace.", in.BruteBits, suite.AlgName(oracle.AlgID)))
 	return m, nil
 }
 
@@ -413,16 +455,17 @@ func methodKnownPlaintext(in Input, total int) (MethodResult, []byte) {
 // reported unverified.
 func methodWeakKey(in Input, total int) (MethodResult, []byte) {
 	m := MethodResult{Name: "weak-key", TotalBytes: total}
+	suite := suiteFor(in.Protocol)
 
 	// Group frames by supported algorithm.
 	algs := map[uint8]bool{}
 	for _, f := range in.Frames {
-		if p25crypto.Supported(f.AlgID) {
+		if suite.Supported(f.AlgID) {
 			algs[f.AlgID] = true
 		}
 	}
 	if len(algs) == 0 {
-		m.note("no frames carry a supported algorithm id (ADP/DES/AES), or ALGID is absent — cannot generate a keystream to test keys.")
+		m.note("no frames carry a supported algorithm id for this protocol, or ALGID is absent — cannot generate a keystream to test keys.")
 		return m, nil
 	}
 	m.Applicable = true
@@ -442,12 +485,12 @@ func methodWeakKey(in Input, total int) (MethodResult, []byte) {
 
 	tried := 0
 	for alg := range algs {
-		keys := append(p25crypto.DefaultKeys(alg), keysOfSize(in.ExtraKeys, p25crypto.KeySize(alg))...)
+		keys := append(suite.DefaultKeys(alg), keysOfSize(in.ExtraKeys, suite.KeySize(alg))...)
 		for _, key := range keys {
 			tried++
 			// Verification path: exact keystream match against the oracle.
 			if oracle != nil && oracle.AlgID == alg {
-				cand, err := p25crypto.Keystream(alg, key, oracle.IV, len(oracleKSWant))
+				cand, err := suite.Keystream(alg, key, oracle.IV, len(oracleKSWant))
 				if err != nil {
 					continue
 				}
@@ -457,8 +500,8 @@ func methodWeakKey(in Input, total int) (MethodResult, []byte) {
 					m.RecoveredBytes = bytesForAlg(in.Frames, alg)
 					m.SampleHex = hexPreview(in.KnownPT, 32)
 					m.SampleASCII = asciiPreview(in.KnownPT, 32)
-					m.Detail = map[string]any{"algorithm": p25crypto.AlgName(alg), "key_hex": hex.EncodeToString(key), "keys_tried": tried}
-					m.note(fmt.Sprintf("COMPLETE BREAK: %s key %s verified against the known plaintext — every frame under this key/algorithm is decryptable.", p25crypto.AlgName(alg), hex.EncodeToString(key)))
+					m.Detail = map[string]any{"algorithm": suite.AlgName(alg), "key_hex": hex.EncodeToString(key), "keys_tried": tried}
+					m.note(fmt.Sprintf("COMPLETE BREAK: %s key %s verified against the known plaintext — every frame under this key/algorithm is decryptable.", suite.AlgName(alg), hex.EncodeToString(key)))
 					return m, cand
 				}
 			}

--- a/internal/cryptolab/engine/assess/assess_test.go
+++ b/internal/cryptolab/engine/assess/assess_test.go
@@ -3,6 +3,7 @@ package assess
 import (
 	"testing"
 
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/dmrcrypto"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/keystream"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
 )
@@ -171,6 +172,29 @@ func TestAssessTDESWeakKey(t *testing.T) {
 	rep := Run(Input{Frames: []keystream.Frame{f}, KnownLabel: "c1", KnownPT: pt})
 	if rep.Verdict != VerdictBroken {
 		t.Fatalf("all-zero-key TDES should break, verdict = %s", rep.Verdict)
+	}
+}
+
+// TestAssessDMRWeakKey: a DMR RC4 (Enhanced Privacy) frame under the all-zero
+// default key, assessed with -protocol dmr, must break via the weak-key method
+// using the DMR cipher suite.
+func TestAssessDMRWeakKey(t *testing.T) {
+	t.Parallel()
+	key := make([]byte, dmrcrypto.KeySize(dmrcrypto.AlgRC4)) // default all-zero
+	pt := []byte("DMR PRIVACY TRAFFIC OK")
+	iv := []byte{0x10, 0x20, 0x30}
+	ks, err := dmrcrypto.Keystream(dmrcrypto.AlgRC4, key, iv, len(pt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := keystream.Frame{Label: "d1", IV: iv, CT: xorb(pt, ks), AlgID: dmrcrypto.AlgRC4}
+	rep := Run(Input{Frames: []keystream.Frame{f}, Protocol: "dmr", KnownLabel: "d1", KnownPT: pt})
+	if rep.Verdict != VerdictBroken {
+		t.Fatalf("DMR default-key RC4 should break, verdict = %s; methods: %+v", rep.Verdict, rep.Methods)
+	}
+	wk := find(rep, "weak-key")
+	if wk == nil || !wk.Verified {
+		t.Fatalf("weak-key should verify the DMR default key, got %+v", wk)
 	}
 }
 

--- a/internal/cryptolab/engine/cipherinfo/cipherinfo.go
+++ b/internal/cryptolab/engine/cipherinfo/cipherinfo.go
@@ -83,13 +83,13 @@ var table = map[string]map[uint8]Info{
 		// DMRA / vendor privacy types as surfaced by common decoders.
 		0x00: {Name: "Basic Privacy", Family: "proprietary", KeyBits: 8, EffectiveKeyBits: 8, Strength: StrengthBroken, BruteForceable: true,
 			Weakness: "DMRA 'Basic Privacy' is a short keyed scrambler with a tiny keyspace — trivially recovered; not real encryption."},
-		0x21: {Name: "RC4 (Enhanced Privacy)", Family: "RC4", KeyBits: 40, EffectiveKeyBits: 40, Strength: StrengthWeak, BruteForceable: true,
-			Weakness: "vendor 'Enhanced Privacy' RC4 with a short key; small keyspace plus RC4 biases. Keystream construction is vendor-specific (not bundled)."},
-		0x22: {Name: "DES-OFB", Family: "DES", KeyBits: 56, EffectiveKeyBits: 56, Strength: StrengthLegacy,
-			Weakness: "single DES, exhaustively searchable; vendor key construction not bundled."},
-		0x23: {Name: "Triple-DES", Family: "3DES", KeyBits: 168, EffectiveKeyBits: 112, Strength: StrengthStrong},
-		0x24: {Name: "AES-128", Family: "AES", KeyBits: 128, EffectiveKeyBits: 128, Strength: StrengthStrong},
-		0x25: {Name: "AES-256", Family: "AES", KeyBits: 256, EffectiveKeyBits: 256, Strength: StrengthStrong},
+		0x21: {Name: "RC4 (Enhanced Privacy)", Family: "RC4", KeyBits: 40, EffectiveKeyBits: 40, Strength: StrengthWeak, BruteForceable: true, Bundled: true,
+			Weakness: "vendor 'Enhanced Privacy' RC4 with a short key; small keyspace plus RC4 biases. The cipher core is bundled; the vendor key/IV derivation is the analyst's to supply."},
+		0x22: {Name: "DES-OFB", Family: "DES", KeyBits: 56, EffectiveKeyBits: 56, Strength: StrengthLegacy, Bundled: true,
+			Weakness: "single DES, exhaustively searchable; supply the reconstructed key/IV."},
+		0x23: {Name: "Triple-DES", Family: "3DES", KeyBits: 168, EffectiveKeyBits: 112, Strength: StrengthStrong, Bundled: true},
+		0x24: {Name: "AES-128", Family: "AES", KeyBits: 128, EffectiveKeyBits: 128, Strength: StrengthStrong, Bundled: true},
+		0x25: {Name: "AES-256", Family: "AES", KeyBits: 256, EffectiveKeyBits: 256, Strength: StrengthStrong, Bundled: true},
 	},
 }
 

--- a/internal/cryptolab/engine/dmrcrypto/keystream.go
+++ b/internal/cryptolab/engine/dmrcrypto/keystream.go
@@ -1,0 +1,141 @@
+// Package dmrcrypto generates the keystreams DMR's link-layer privacy
+// algorithms produce, so the assessment harness and recipe pipeline can
+// attempt DMR decryption the same way p25crypto handles P25.
+//
+// Honesty note: DMR encryption is vendor-specific. The cipher *cores* are
+// standard — Motorola "Enhanced Privacy" is RC4, and the DMRA types map to
+// DES/3DES/AES — but the key and IV *derivation* from the air interface is
+// proprietary and reverse-engineered, and differs between Motorola and Hytera.
+// This package therefore implements the standard cores keyed with the material
+// the caller supplies (the reconstructed key, and the frame's IV bytes used
+// directly): it does not fabricate a vendor key schedule. An analyst who has
+// recovered the key can decrypt; the package makes no claim to derive that key
+// from the signalling.
+package dmrcrypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/des"
+	"fmt"
+
+	"github.com/MattCheramie/GopherTrunk/internal/crypto/rc4"
+)
+
+// DMRA / vendor privacy algorithm identifiers, as surfaced by common decoders.
+const (
+	AlgRC4    = 0x21 // Motorola "Enhanced Privacy"
+	AlgDESOFB = 0x22
+	AlgTDES   = 0x23
+	AlgAES128 = 0x24
+	AlgAES256 = 0x25
+)
+
+// KeySize returns the canonical key length in bytes for algid (RC4 keys are
+// variable; 5 bytes / 40 bits is the common Enhanced-Privacy size used for the
+// default-key dictionary and brute), or 0 when unsupported.
+func KeySize(algid uint8) int {
+	switch algid {
+	case AlgRC4:
+		return 5
+	case AlgDESOFB:
+		return 8
+	case AlgTDES:
+		return 24
+	case AlgAES128:
+		return 16
+	case AlgAES256:
+		return 32
+	}
+	return 0
+}
+
+// Supported reports whether Keystream can realise this algorithm.
+func Supported(algid uint8) bool { return KeySize(algid) != 0 }
+
+// AlgName returns a short human label for algid.
+func AlgName(algid uint8) string {
+	switch algid {
+	case AlgRC4:
+		return "RC4 (Enhanced Privacy)"
+	case AlgDESOFB:
+		return "DES-OFB"
+	case AlgTDES:
+		return "Triple-DES"
+	case AlgAES128:
+		return "AES-128"
+	case AlgAES256:
+		return "AES-256"
+	}
+	return fmt.Sprintf("dmr-alg-0x%02X", algid)
+}
+
+// Keystream returns n keystream bytes for the algorithm, key, and IV. For RC4
+// the IV (if present) is appended to the key — the common Enhanced-Privacy
+// model — and no warm-up bytes are discarded (unlike P25 ADP). For the block
+// ciphers the IV seeds OFB directly. RC4 accepts a 1..256-byte key; the block
+// ciphers require the exact KeySize.
+func Keystream(algid uint8, key, iv []byte, n int) ([]byte, error) {
+	if n < 0 {
+		return nil, fmt.Errorf("dmrcrypto: negative length")
+	}
+	switch algid {
+	case AlgRC4:
+		rcKey := append(append([]byte(nil), key...), iv...)
+		c, err := rc4.NewCipher(rcKey)
+		if err != nil {
+			return nil, fmt.Errorf("dmrcrypto: rc4: %w", err)
+		}
+		return c.KeyStream(n), nil
+	case AlgDESOFB:
+		if len(key) != 8 {
+			return nil, fmt.Errorf("dmrcrypto: DES needs an 8-byte key, got %d", len(key))
+		}
+		return ofb(func(k []byte) (cipher.Block, error) { return des.NewCipher(k) }, key, ivBlock(iv, des.BlockSize), n)
+	case AlgTDES:
+		if len(key) != 24 {
+			return nil, fmt.Errorf("dmrcrypto: 3DES needs a 24-byte key, got %d", len(key))
+		}
+		return ofb(func(k []byte) (cipher.Block, error) { return des.NewTripleDESCipher(k) }, key, ivBlock(iv, des.BlockSize), n)
+	case AlgAES128, AlgAES256:
+		if want := KeySize(algid); len(key) != want {
+			return nil, fmt.Errorf("dmrcrypto: %s needs a %d-byte key, got %d", AlgName(algid), want, len(key))
+		}
+		return ofb(func(k []byte) (cipher.Block, error) { return aes.NewCipher(k) }, key, ivBlock(iv, aes.BlockSize), n)
+	}
+	return nil, fmt.Errorf("dmrcrypto: unsupported algorithm 0x%02X", algid)
+}
+
+func ofb(newBlock func([]byte) (cipher.Block, error), key, iv []byte, n int) ([]byte, error) {
+	block, err := newBlock(key)
+	if err != nil {
+		return nil, fmt.Errorf("dmrcrypto: %w", err)
+	}
+	out := make([]byte, n)
+	cipher.NewOFB(block, iv).XORKeyStream(out, out)
+	return out, nil
+}
+
+// ivBlock left-justifies the IV into a size-byte block (zero-padded/truncated).
+func ivBlock(iv []byte, size int) []byte {
+	b := make([]byte, size)
+	copy(b, iv)
+	return b
+}
+
+// DefaultKeys returns a small dictionary of weak/default/test keys to try for
+// algid (all-zero, all-FF, and an incrementing pattern), or nil if unsupported.
+func DefaultKeys(algid uint8) [][]byte {
+	sz := KeySize(algid)
+	if sz == 0 {
+		return nil
+	}
+	zero := make([]byte, sz)
+	ff := make([]byte, sz)
+	inc := make([]byte, sz)
+	for i := range ff {
+		ff[i] = 0xFF
+		inc[i] = byte(i + 1)
+	}
+	return [][]byte{zero, ff, inc}
+}

--- a/internal/cryptolab/engine/dmrcrypto/keystream_test.go
+++ b/internal/cryptolab/engine/dmrcrypto/keystream_test.go
@@ -1,0 +1,67 @@
+package dmrcrypto
+
+import (
+	"bytes"
+	"testing"
+)
+
+func xor(a, b []byte) []byte {
+	out := make([]byte, len(a))
+	for i := range a {
+		out[i] = a[i] ^ b[i]
+	}
+	return out
+}
+
+func TestKeystreamRoundTrip(t *testing.T) {
+	t.Parallel()
+	iv := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+	pt := []byte("DMR ENHANCED PRIVACY TEST TRAFFIC 0123456789")
+	cases := []struct {
+		alg uint8
+		key []byte
+	}{
+		{AlgRC4, []byte{0x11, 0x22, 0x33, 0x44, 0x55}},
+		{AlgDESOFB, []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+		{AlgTDES, bytes.Repeat([]byte{0x3C}, 24)},
+		{AlgAES128, bytes.Repeat([]byte{0xAB}, 16)},
+		{AlgAES256, bytes.Repeat([]byte{0xCD}, 32)},
+	}
+	for _, c := range cases {
+		ks, err := Keystream(c.alg, c.key, iv, len(pt))
+		if err != nil {
+			t.Fatalf("%s: %v", AlgName(c.alg), err)
+		}
+		ct := xor(pt, ks)
+		if bytes.Equal(ct, pt) {
+			t.Fatalf("%s: ciphertext equals plaintext", AlgName(c.alg))
+		}
+		ks2, _ := Keystream(c.alg, c.key, iv, len(pt))
+		if !bytes.Equal(ks, ks2) {
+			t.Fatalf("%s: keystream not deterministic", AlgName(c.alg))
+		}
+		if got := xor(ct, ks2); !bytes.Equal(got, pt) {
+			t.Fatalf("%s: decrypt mismatch: %q", AlgName(c.alg), got)
+		}
+	}
+}
+
+func TestRC4AppendsIV(t *testing.T) {
+	t.Parallel()
+	key := []byte{1, 2, 3, 4, 5}
+	a, _ := Keystream(AlgRC4, key, []byte{0xAA}, 16)
+	b, _ := Keystream(AlgRC4, key, []byte{0xBB}, 16)
+	if bytes.Equal(a, b) {
+		t.Fatal("different IVs should change the RC4 keystream (IV is appended to the key)")
+	}
+}
+
+func TestUnsupported(t *testing.T) {
+	t.Parallel()
+	if Supported(0x99) {
+		t.Fatal("0x99 should be unsupported")
+	}
+	if _, err := Keystream(0x99, []byte{1}, nil, 4); err == nil {
+		t.Fatal("expected error for unsupported algorithm")
+	}
+}

--- a/internal/cryptolab/engine/recipe/recipe.go
+++ b/internal/cryptolab/engine/recipe/recipe.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/MattCheramie/GopherTrunk/internal/crypto/rc4"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/randomness"
@@ -54,28 +55,46 @@ type Report struct {
 
 type opFunc func(buf []byte, p params) ([]byte, map[string]any, string, error)
 
+// OpParam describes one parameter of an operation, enough for the web recipe
+// builder to render an input control.
+type OpParam struct {
+	Name  string `json:"name"`
+	Label string `json:"label"`
+	Kind  string `json:"kind"` // hex | int
+	Help  string `json:"help,omitempty"`
+}
+
 type opDef struct {
 	transform bool
 	synopsis  string
+	params    []OpParam
 	fn        opFunc
 }
 
+// param spec presets shared by several ops.
+var (
+	keyParam   = OpParam{Name: "key", Label: "Key (hex)", Kind: "hex"}
+	miParam    = OpParam{Name: "mi", Label: "MI / IV (hex)", Kind: "hex"}
+	cipherKeys = []OpParam{keyParam, miParam}
+)
+
 // ops is the operation registry.
 var ops = map[string]opDef{
-	"xor":               {true, "repeating-key XOR (key=hex)", opXOR},
-	"not":               {true, "bitwise NOT of every byte", opNot},
-	"reverse-bits":      {true, "reverse the bit order within each byte (MSB↔LSB framing)", opReverseBits},
-	"hex-decode":        {true, "decode an ASCII hex string to bytes", opHexDecode},
-	"hex-encode":        {true, "encode bytes as an ASCII hex string", opHexEncode},
-	"base64-decode":     {true, "decode standard base64 to bytes", opBase64Decode},
-	"slice":             {true, "keep bytes [offset, offset+length) (length=0 → to end)", opSlice},
-	"adp-decrypt":       {true, "P25 ADP/RC4 decrypt (key=hex 5B, mi=hex)", cipherOp(p25crypto.AlgADP)},
-	"des-ofb-decrypt":   {true, "P25 DES-OFB decrypt (key=hex 8B, mi=hex)", cipherOp(p25crypto.AlgDESOFB)},
-	"tdes-ofb-decrypt":  {true, "P25 Triple-DES-OFB decrypt (key=hex 24B, mi=hex)", cipherOp(p25crypto.AlgTDES)},
-	"aes-ofb-decrypt":   {true, "P25 AES-OFB decrypt (key=hex 16/32B, mi=hex)", cipherOp(p25crypto.AlgAES256)},
-	"descramble-invert": {true, "full-band spectral inversion of s16le mono PCM (self-inverse)", opDescramble},
-	"stats":             {false, "report entropy / index-of-coincidence / chi-square", opStats},
-	"randomness":        {false, "quick NIST randomness subset (strong vs structured)", opRandomness},
+	"xor":               {transform: true, synopsis: "repeating-key XOR (key=hex)", params: []OpParam{keyParam}, fn: opXOR},
+	"not":               {transform: true, synopsis: "bitwise NOT of every byte", fn: opNot},
+	"reverse-bits":      {transform: true, synopsis: "reverse the bit order within each byte (MSB↔LSB framing)", fn: opReverseBits},
+	"hex-decode":        {transform: true, synopsis: "decode an ASCII hex string to bytes", fn: opHexDecode},
+	"hex-encode":        {transform: true, synopsis: "encode bytes as an ASCII hex string", fn: opHexEncode},
+	"base64-decode":     {transform: true, synopsis: "decode standard base64 to bytes", fn: opBase64Decode},
+	"slice":             {transform: true, synopsis: "keep bytes [offset, offset+length) (length=0 → to end)", params: []OpParam{{Name: "offset", Label: "Offset", Kind: "int"}, {Name: "length", Label: "Length", Kind: "int"}}, fn: opSlice},
+	"rc4-decrypt":       {transform: true, synopsis: "raw RC4 decrypt with a caller-supplied key (DMR Enhanced Privacy / generic)", params: []OpParam{{Name: "key", Label: "Full RC4 key (hex)", Kind: "hex", Help: "the complete RC4 key bytes, e.g. privacy key ‖ IV"}}, fn: opRC4},
+	"adp-decrypt":       {transform: true, synopsis: "P25 ADP/RC4 decrypt (key=hex 5B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgADP)},
+	"des-ofb-decrypt":   {transform: true, synopsis: "P25 DES-OFB decrypt (key=hex 8B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgDESOFB)},
+	"tdes-ofb-decrypt":  {transform: true, synopsis: "P25 Triple-DES-OFB decrypt (key=hex 24B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgTDES)},
+	"aes-ofb-decrypt":   {transform: true, synopsis: "P25 AES-OFB decrypt (key=hex 16/32B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgAES256)},
+	"descramble-invert": {transform: true, synopsis: "full-band spectral inversion of s16le mono PCM (self-inverse)", fn: opDescramble},
+	"stats":             {transform: false, synopsis: "report entropy / index-of-coincidence / chi-square", fn: opStats},
+	"randomness":        {transform: false, synopsis: "quick NIST randomness subset (strong vs structured)", fn: opRandomness},
 }
 
 // Run executes the steps over input, threading the working buffer through the
@@ -106,22 +125,41 @@ func Run(input []byte, steps []Step) (*Report, error) {
 	return rep, nil
 }
 
-// Ops returns the registered operation names and synopses, sorted.
+// OpSpec is the full, web-facing description of one operation.
+type OpSpec struct {
+	Name      string    `json:"name"`
+	Synopsis  string    `json:"synopsis"`
+	Transform bool      `json:"transform"`
+	Params    []OpParam `json:"params,omitempty"`
+}
+
+// Specs returns every operation with its parameters, sorted by name — the
+// source the web recipe builder renders its palette and step forms from.
+func Specs() []OpSpec {
+	out := make([]OpSpec, 0, len(ops))
+	for name, def := range ops {
+		out = append(out, OpSpec{Name: name, Synopsis: def.synopsis, Transform: def.transform, Params: def.params})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Ops returns the registered operation names and synopses, sorted (CLI -list).
 func Ops() []struct {
 	Name, Synopsis string
 	Transform      bool
 } {
-	var out []struct {
+	specs := Specs()
+	out := make([]struct {
 		Name, Synopsis string
 		Transform      bool
-	}
-	for name, def := range ops {
-		out = append(out, struct {
+	}, len(specs))
+	for i, s := range specs {
+		out[i] = struct {
 			Name, Synopsis string
 			Transform      bool
-		}{name, def.synopsis, def.transform})
+		}{s.Name, s.Synopsis, s.Transform}
 	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }
 
@@ -139,6 +177,23 @@ func opXOR(buf []byte, p params) ([]byte, map[string]any, string, error) {
 	for i := range buf {
 		out[i] = buf[i] ^ key[i%len(key)]
 	}
+	return out, map[string]any{"key_len": len(key)}, "", nil
+}
+
+func opRC4(buf []byte, p params) ([]byte, map[string]any, string, error) {
+	key, err := p.hex("key")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	if len(key) == 0 {
+		return nil, nil, "", fmt.Errorf("rc4-decrypt: key is required")
+	}
+	c, err := rc4.NewCipher(key)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("rc4-decrypt: %w", err)
+	}
+	out := make([]byte, len(buf))
+	c.XORKeyStream(out, buf)
 	return out, map[string]any{"key_len": len(key)}, "", nil
 }
 
@@ -283,7 +338,15 @@ func (p params) str(key string) string {
 }
 
 func (p params) hex(key string) ([]byte, error) {
-	s := strings.TrimSpace(p.str(key))
+	// Tolerate spaces and a 0x prefix so pasted keys ("11 22 aa" / "0x1122")
+	// just work — the same leniency the config builder's key field offers.
+	s := strings.Map(func(r rune) rune {
+		if r == ' ' || r == '\t' || r == '\n' || r == '\r' || r == ':' {
+			return -1
+		}
+		return r
+	}, p.str(key))
+	s = strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
 	if s == "" {
 		return nil, nil
 	}

--- a/internal/cryptolab/engine/recipe/recipe_test.go
+++ b/internal/cryptolab/engine/recipe/recipe_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	rc4lib "github.com/MattCheramie/GopherTrunk/internal/crypto/rc4"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
 )
 
@@ -57,6 +58,51 @@ func TestCipherDecryptOp(t *testing.T) {
 	}
 	if !bytes.Equal(rep.FinalBytes, pt) {
 		t.Fatalf("adp-decrypt failed:\n got %q\nwant %q", rep.FinalBytes, pt)
+	}
+}
+
+func TestRC4DecryptOp(t *testing.T) {
+	t.Parallel()
+	// Standard RC4 with a full caller-supplied key (the DMR Enhanced-Privacy
+	// model: privacy key ‖ IV concatenated by the analyst).
+	pt := []byte("DMR ENHANCED PRIVACY TRAFFIC HERE")
+	fullKey := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0xAA, 0xBB} // key ‖ iv
+	c, err := rc4lib.NewCipher(fullKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct := make([]byte, len(pt))
+	c.XORKeyStream(ct, pt)
+	rep, err := Run(ct, []Step{{Op: "rc4-decrypt", Params: map[string]any{"key": "11223344 55aabb"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(rep.FinalBytes) != string(pt) {
+		t.Fatalf("rc4-decrypt failed: %q", rep.FinalBytes)
+	}
+}
+
+func TestSpecsExposeParams(t *testing.T) {
+	t.Parallel()
+	var sawXORKey, sawCipherMI bool
+	for _, s := range Specs() {
+		if s.Name == "xor" {
+			for _, p := range s.Params {
+				if p.Name == "key" && p.Kind == "hex" {
+					sawXORKey = true
+				}
+			}
+		}
+		if s.Name == "adp-decrypt" {
+			for _, p := range s.Params {
+				if p.Name == "mi" {
+					sawCipherMI = true
+				}
+			}
+		}
+	}
+	if !sawXORKey || !sawCipherMI {
+		t.Fatal("Specs() should expose per-op params (xor.key, adp-decrypt.mi)")
 	}
 }
 

--- a/internal/cryptolab/webserver/recipe.go
+++ b/internal/cryptolab/webserver/recipe.go
@@ -1,0 +1,89 @@
+package webserver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/recipe"
+)
+
+// maxRecipeOutputB64 caps how many output bytes the recipe endpoint returns
+// inline (base64) so the builder can offer a download without a second
+// round-trip; larger outputs return the previews only.
+const maxRecipeOutputB64 = 16 << 20
+
+// handleRecipeOps returns the recipe operation catalogue (name, synopsis,
+// transform flag, and per-op parameters) the web builder renders its palette
+// and step forms from. Read-only, so it is not gated.
+func (s *Server) handleRecipeOps(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, recipe.Specs())
+}
+
+type recipeStepDTO struct {
+	Op     string         `json:"op"`
+	Params map[string]any `json:"params"`
+}
+
+type recipeRequest struct {
+	InputID string          `json:"input_id"`
+	Steps   []recipeStepDTO `json:"steps"`
+}
+
+// handleRecipe runs a structured recipe (built in the web UI) over a
+// previously-uploaded input file and returns the per-step report plus the
+// final bytes. The pipeline is pure and in-memory, so it runs synchronously —
+// no job is created. Gated like the other mutations.
+func (s *Server) handleRecipe(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 8<<20)
+	var req recipeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "recipe: "+err.Error())
+		return
+	}
+	if req.InputID == "" {
+		writeErr(w, http.StatusBadRequest, "recipe: input_id is required")
+		return
+	}
+	if len(req.Steps) == 0 {
+		writeErr(w, http.StatusBadRequest, "recipe: at least one step is required")
+		return
+	}
+
+	s.mu.Lock()
+	u, ok := s.files[req.InputID]
+	s.mu.Unlock()
+	if !ok {
+		writeErr(w, http.StatusBadRequest, "recipe: unknown input_id (upload the input first)")
+		return
+	}
+	data, err := os.ReadFile(u.Path)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "recipe: read input: "+err.Error())
+		return
+	}
+
+	steps := make([]recipe.Step, len(req.Steps))
+	for i, st := range req.Steps {
+		steps[i] = recipe.Step{Op: st.Op, Params: st.Params}
+	}
+
+	rep, runErr := recipe.Run(data, steps)
+	resp := map[string]any{
+		"input_bytes": rep.InputBytes,
+		"steps":       rep.Steps,
+		"final_hex":   rep.FinalHex,
+		"final_ascii": rep.FinalASCII,
+		"final_bytes": len(rep.FinalBytes),
+	}
+	if len(rep.FinalBytes) <= maxRecipeOutputB64 {
+		resp["output_b64"] = base64.StdEncoding.EncodeToString(rep.FinalBytes)
+	}
+	if runErr != nil {
+		// The pipeline aborts at the failing step but the partial report is
+		// still useful, so return 200 with the error surfaced in the body.
+		resp["error"] = runErr.Error()
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/cryptolab/webserver/recipe_test.go
+++ b/internal/cryptolab/webserver/recipe_test.go
@@ -1,0 +1,100 @@
+package webserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
+)
+
+func TestRecipeOpsEndpoint(t *testing.T) {
+	t.Parallel()
+	ts := newTestServer(t)
+	resp, err := http.Get(ts.URL + "/api/v1/cryptolab/recipe/ops")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var specs []struct {
+		Name      string `json:"name"`
+		Transform bool   `json:"transform"`
+		Params    []struct {
+			Name string `json:"name"`
+			Kind string `json:"kind"`
+		} `json:"params"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&specs); err != nil {
+		t.Fatal(err)
+	}
+	if len(specs) < 8 {
+		t.Fatalf("expected the op catalogue, got %d", len(specs))
+	}
+	// xor must expose a hex key param.
+	var ok bool
+	for _, s := range specs {
+		if s.Name == "xor" {
+			for _, p := range s.Params {
+				if p.Name == "key" && p.Kind == "hex" {
+					ok = true
+				}
+			}
+		}
+	}
+	if !ok {
+		t.Fatal("xor op should expose a hex `key` param")
+	}
+}
+
+func TestRecipeEndpointDecrypts(t *testing.T) {
+	t.Parallel()
+	ts := newTestServer(t)
+	pt := []byte("DISPATCH UNIT SEVEN TO MAIN STREET NOW")
+	key := []byte{0xAB, 0xCD, 0xEF, 0x01, 0x23}
+	mi := []byte{9, 8, 7, 6, 5, 4, 3, 2, 1}
+	ks, err := p25crypto.Keystream(p25crypto.AlgADP, key, mi, len(pt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] ^ ks[i]
+	}
+	id := uploadFile(t, ts.URL, "enc.bin", ct)
+
+	body, _ := json.Marshal(map[string]any{
+		"input_id": id,
+		"steps": []map[string]any{
+			{"op": "adp-decrypt", "params": map[string]any{"key": "abcdef0123", "mi": "090807060504030201"}},
+			{"op": "stats"},
+		},
+	})
+	resp, err := http.Post(ts.URL+"/api/v1/cryptolab/recipe", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("recipe status %d: %s", resp.StatusCode, b)
+	}
+	var out struct {
+		FinalASCII string `json:"final_ascii"`
+		Steps      []any  `json:"steps"`
+		Error      string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Error != "" {
+		t.Fatalf("recipe error: %s", out.Error)
+	}
+	if out.FinalASCII != string(pt) {
+		t.Fatalf("final_ascii = %q, want %q", out.FinalASCII, pt)
+	}
+	if len(out.Steps) != 2 {
+		t.Fatalf("want 2 step results, got %d", len(out.Steps))
+	}
+}

--- a/internal/cryptolab/webserver/server.go
+++ b/internal/cryptolab/webserver/server.go
@@ -131,6 +131,8 @@ func (s *Server) RegisterAPI(mux *http.ServeMux, gate func(http.HandlerFunc) htt
 	mux.HandleFunc("GET /api/v1/cryptolab/jobs/{id}", s.handleJob)
 	mux.HandleFunc("GET /api/v1/cryptolab/jobs/{id}/events", s.handleJobEvents)
 	mux.HandleFunc("GET /api/v1/cryptolab/jobs/{id}/artifacts/{name}", s.handleArtifact)
+	mux.HandleFunc("GET /api/v1/cryptolab/recipe/ops", s.handleRecipeOps)
+	mux.HandleFunc("POST /api/v1/cryptolab/recipe", gate(s.handleRecipe))
 }
 
 // Close removes the temp directory if the server created it.

--- a/web/cryptolab/src/App.tsx
+++ b/web/cryptolab/src/App.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useStore } from "./store/shared";
 import { ParamField } from "./components/ParamField";
 import { ResultView } from "./components/ResultView";
+import { RecipeBuilder } from "./components/RecipeBuilder";
 
 export function App() {
+  const [page, setPage] = useState<"tools" | "recipe">("tools");
   const loadSchema = useStore((s) => s.loadSchema);
   const schema = useStore((s) => s.schema);
   const loadingSchema = useStore((s) => s.loadingSchema);
@@ -47,9 +49,27 @@ export function App() {
             <span className="text-xs text-accent animate-pulse">working…</span>
           ) : null}
         </div>
+        <nav className="flex items-center gap-1">
+          {(["tools", "recipe"] as const).map((p) => (
+            <button
+              key={p}
+              onClick={() => setPage(p)}
+              className={`rounded px-2.5 py-1 text-sm ${
+                page === p ? "bg-accent/20 text-fg" : "text-muted hover:bg-panel"
+              }`}
+            >
+              {p === "tools" ? "Tools" : "Recipe Builder"}
+            </button>
+          ))}
+        </nav>
         <div className="ml-auto text-xs text-muted">offline cryptographic research</div>
       </header>
 
+      {page === "recipe" ? (
+        <main className="min-h-0 flex-1 overflow-y-auto p-4">
+          <RecipeBuilder />
+        </main>
+      ) : (
       <div className="flex min-h-0 flex-1">
         <nav className="w-56 shrink-0 overflow-y-auto border-r border-line p-2">
           {tools.length === 0 ? (
@@ -118,6 +138,7 @@ export function App() {
           )}
         </main>
       </div>
+      )}
     </div>
   );
 }

--- a/web/cryptolab/src/api/client.ts
+++ b/web/cryptolab/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { JobDTO, ModeSchema, UploadDTO } from "./types";
+import type { JobDTO, ModeSchema, OpSpec, RecipeResult, UploadDTO } from "./types";
 
 // Same-origin API. The standalone `cryptolab serve` binds loopback with no
 // token; a remote bind can pass one via #token=… (see main.tsx).
@@ -63,4 +63,9 @@ export const api = {
 
   artifactURL: (id: string, name: string) =>
     `/api/v1/cryptolab/jobs/${id}/artifacts/${encodeURIComponent(name)}`,
+
+  recipeOps: () => reqJSON<OpSpec[]>("GET", "/api/v1/cryptolab/recipe/ops"),
+
+  recipe: (body: { input_id: string; steps: { op: string; params: Record<string, unknown> }[] }) =>
+    reqJSON<RecipeResult>("POST", "/api/v1/cryptolab/recipe", body),
 };

--- a/web/cryptolab/src/api/types.ts
+++ b/web/cryptolab/src/api/types.ts
@@ -66,3 +66,38 @@ export interface LogEvent {
   msg: string;
   attrs?: string;
 }
+
+// --- Recipe builder ---
+
+export interface OpParam {
+  name: string;
+  label: string;
+  kind: "hex" | "int";
+  help?: string;
+}
+
+export interface OpSpec {
+  name: string;
+  synopsis: string;
+  transform: boolean;
+  params?: OpParam[];
+}
+
+export interface RecipeStepResult {
+  op: string;
+  transform: boolean;
+  bytes_in: number;
+  bytes_out: number;
+  info?: Record<string, unknown>;
+  note?: string;
+}
+
+export interface RecipeResult {
+  input_bytes: number;
+  steps: RecipeStepResult[];
+  final_hex: string;
+  final_ascii: string;
+  final_bytes: number;
+  output_b64?: string;
+  error?: string;
+}

--- a/web/cryptolab/src/components/RecipeBuilder.tsx
+++ b/web/cryptolab/src/components/RecipeBuilder.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useMemo, useState } from "react";
+import { useRecipe } from "../store/recipe";
+import type { BuilderStep } from "../store/recipe";
+import type { OpSpec, RecipeStepResult } from "../api/types";
+
+// RecipeBuilder is the interactive, config-builder-style editor for the
+// `recipe` pipeline: pick an input, assemble an ordered list of operations
+// (transforms + analyses) with their parameters, run it server-side, and read
+// the per-step report plus the final bytes. It calls the dedicated
+// /api/v1/cryptolab/recipe endpoint (no job needed — the pipeline is fast).
+export function RecipeBuilder() {
+  const ops = useRecipe((s) => s.ops);
+  const loadOps = useRecipe((s) => s.loadOps);
+  const opsError = useRecipe((s) => s.opsError);
+  const steps = useRecipe((s) => s.steps);
+  const addStep = useRecipe((s) => s.addStep);
+  const clearSteps = useRecipe((s) => s.clearSteps);
+  const input = useRecipe((s) => s.input);
+  const uploading = useRecipe((s) => s.uploading);
+  const uploadInput = useRecipe((s) => s.uploadInput);
+  const running = useRecipe((s) => s.running);
+  const result = useRecipe((s) => s.result);
+  const error = useRecipe((s) => s.error);
+  const run = useRecipe((s) => s.run);
+
+  const [pick, setPick] = useState("");
+
+  useEffect(() => {
+    void loadOps();
+  }, [loadOps]);
+
+  const grouped = useMemo(() => {
+    const transforms = ops.filter((o) => o.transform);
+    const analyses = ops.filter((o) => !o.transform);
+    return { transforms, analyses };
+  }, [ops]);
+
+  const canRun = !!input && steps.length > 0 && !running && !uploading;
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[18rem_minmax(0,1fr)]">
+      {/* Op palette */}
+      <aside className="space-y-3">
+        <div className="card space-y-2">
+          <div className="label">Operations</div>
+          {opsError ? <p className="help text-err">{opsError}</p> : null}
+          <OpPalette title="Transforms" ops={grouped.transforms} onAdd={addStep} />
+          <OpPalette title="Analyses" ops={grouped.analyses} onAdd={addStep} />
+        </div>
+      </aside>
+
+      {/* Pipeline + result */}
+      <section className="space-y-4">
+        {/* Input */}
+        <div className="card space-y-2">
+          <div className="label">Input</div>
+          <input
+            type="file"
+            className="input"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) void uploadInput(f);
+            }}
+          />
+          {uploading ? <p className="help text-accent">uploading…</p> : null}
+          {input ? (
+            <p className="help text-ok">
+              ✓ {input.name} ({input.size.toLocaleString()} bytes)
+            </p>
+          ) : (
+            <p className="help">Upload the payload to run the pipeline over.</p>
+          )}
+        </div>
+
+        {/* Pipeline */}
+        <div className="card space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="label mb-0">Pipeline ({steps.length})</div>
+            <div className="flex items-center gap-2">
+              <select className="input w-auto py-1" value={pick} onChange={(e) => setPick(e.target.value)}>
+                <option value="">add operation…</option>
+                <optgroup label="Transforms">
+                  {grouped.transforms.map((o) => (
+                    <option key={o.name} value={o.name}>
+                      {o.name}
+                    </option>
+                  ))}
+                </optgroup>
+                <optgroup label="Analyses">
+                  {grouped.analyses.map((o) => (
+                    <option key={o.name} value={o.name}>
+                      {o.name}
+                    </option>
+                  ))}
+                </optgroup>
+              </select>
+              <button
+                className="btn-ghost"
+                disabled={!pick}
+                onClick={() => {
+                  if (pick) addStep(pick);
+                }}
+              >
+                + Add
+              </button>
+              {steps.length > 0 ? (
+                <button className="btn-danger" onClick={() => clearSteps()}>
+                  Clear
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          {steps.length === 0 ? (
+            <p className="help">
+              Empty pipeline. Add operations from the palette; bytes flow from each step into the next.
+            </p>
+          ) : (
+            <ol className="space-y-2">
+              {steps.map((st, i) => (
+                <StepCard key={st.id} step={st} index={i} count={steps.length} />
+              ))}
+            </ol>
+          )}
+
+          <div className="flex items-center gap-3 pt-1">
+            <button className="btn" disabled={!canRun} onClick={() => void run()}>
+              {running ? "Running…" : "Run pipeline"}
+            </button>
+            {!input ? <span className="help">Upload an input to run.</span> : null}
+          </div>
+          {error ? (
+            <div className="rounded-md border border-err/40 bg-err/10 px-3 py-2 text-sm text-err">{error}</div>
+          ) : null}
+        </div>
+
+        {result ? <RecipeResultView /> : null}
+      </section>
+    </div>
+  );
+}
+
+function OpPalette({ title, ops, onAdd }: { title: string; ops: OpSpec[]; onAdd: (op: string) => void }) {
+  return (
+    <div>
+      <div className="mb-1 text-xs uppercase tracking-wide text-muted">{title}</div>
+      <div className="flex flex-wrap gap-1">
+        {ops.map((o) => (
+          <button
+            key={o.name}
+            title={o.synopsis}
+            onClick={() => onAdd(o.name)}
+            className="rounded border border-line px-2 py-1 text-xs hover:bg-panel"
+          >
+            {o.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StepCard({ step, index, count }: { step: BuilderStep; index: number; count: number }) {
+  const spec = useRecipe((s) => s.opSpec(step.op));
+  const moveStep = useRecipe((s) => s.moveStep);
+  const removeStep = useRecipe((s) => s.removeStep);
+  const duplicateStep = useRecipe((s) => s.duplicateStep);
+  const setStepParam = useRecipe((s) => s.setStepParam);
+
+  return (
+    <li className="rounded-md border border-line p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-xs text-muted">{index + 1}.</span>
+          <span className="font-mono text-sm">{step.op}</span>
+          <span
+            className={`rounded px-1.5 py-0.5 text-[10px] uppercase ${
+              spec?.transform ? "bg-accent/20 text-accent" : "bg-panel text-muted"
+            }`}
+          >
+            {spec?.transform ? "transform" : "analysis"}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <button className="btn-ghost px-2 py-1" disabled={index === 0} onClick={() => moveStep(step.id, -1)} title="Move up">
+            ↑
+          </button>
+          <button
+            className="btn-ghost px-2 py-1"
+            disabled={index === count - 1}
+            onClick={() => moveStep(step.id, 1)}
+            title="Move down"
+          >
+            ↓
+          </button>
+          <button className="btn-ghost px-2 py-1" onClick={() => duplicateStep(step.id)} title="Duplicate">
+            Dup
+          </button>
+          <button className="btn-danger px-2 py-1" onClick={() => removeStep(step.id)} title="Remove">
+            ✕
+          </button>
+        </div>
+      </div>
+      {spec?.synopsis ? <p className="help mt-1">{spec.synopsis}</p> : null}
+      {(spec?.params ?? []).length > 0 ? (
+        <div className="mt-2 grid gap-2 sm:grid-cols-2">
+          {(spec?.params ?? []).map((p) => (
+            <label key={p.name}>
+              <span className="label">{p.label}</span>
+              <input
+                className="input"
+                type={p.kind === "int" ? "number" : "text"}
+                value={step.params[p.name] ?? ""}
+                placeholder={p.kind === "hex" ? "hex" : ""}
+                onChange={(e) => setStepParam(step.id, p.name, e.target.value)}
+              />
+              {p.help ? <p className="help">{p.help}</p> : null}
+            </label>
+          ))}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+function RecipeResultView() {
+  const result = useRecipe((s) => s.result)!;
+
+  const download = () => {
+    if (!result.output_b64) return;
+    const bin = atob(result.output_b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    const url = URL.createObjectURL(new Blob([bytes], { type: "application/octet-stream" }));
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "recipe-output.bin";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-3">
+      {result.error ? (
+        <div className="rounded-md border border-err/40 bg-err/10 px-3 py-2 text-sm text-err">
+          Pipeline stopped: {result.error}
+        </div>
+      ) : (
+        <div className="rounded-md border border-ok/30 bg-ok/10 px-3 py-2 text-sm text-ok">
+          ✓ Ran {result.steps.length} step(s): {result.input_bytes} → {result.final_bytes} bytes
+        </div>
+      )}
+
+      <div className="card overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="text-xs uppercase text-muted">
+            <tr>
+              <th className="py-1 pr-3">#</th>
+              <th className="py-1 pr-3">op</th>
+              <th className="py-1 pr-3">bytes</th>
+              <th className="py-1">note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {result.steps.map((s, i) => (
+              <StepRow key={i} i={i} s={s} />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="card space-y-2">
+        <div className="flex items-center justify-between">
+          <div className="label mb-0">Output</div>
+          {result.output_b64 ? (
+            <button className="btn-ghost" onClick={download}>
+              Download ({result.final_bytes.toLocaleString()} bytes)
+            </button>
+          ) : null}
+        </div>
+        <div>
+          <div className="help">ASCII (first 64)</div>
+          <pre className="overflow-x-auto rounded bg-bg p-2 font-mono text-xs">{result.final_ascii || "—"}</pre>
+        </div>
+        <div>
+          <div className="help">Hex (first 64)</div>
+          <pre className="overflow-x-auto rounded bg-bg p-2 font-mono text-xs">{result.final_hex || "—"}</pre>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StepRow({ i, s }: { i: number; s: RecipeStepResult }) {
+  const info = s.info ? Object.entries(s.info).map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : String(v)}`).join(" ") : "";
+  return (
+    <tr className="border-t border-line/60 align-top">
+      <td className="py-1 pr-3 text-muted">{i + 1}</td>
+      <td className="py-1 pr-3 font-mono">
+        {s.op}
+        <span className="ml-1 text-[10px] uppercase text-muted">{s.transform ? "" : "(analysis)"}</span>
+      </td>
+      <td className="py-1 pr-3 font-mono text-xs text-muted">
+        {s.bytes_in}
+        {s.transform ? `→${s.bytes_out}` : ""}
+      </td>
+      <td className="py-1 text-xs text-muted">{s.note || info || "—"}</td>
+    </tr>
+  );
+}

--- a/web/cryptolab/src/store/recipe.ts
+++ b/web/cryptolab/src/store/recipe.ts
@@ -1,0 +1,145 @@
+import { create } from "zustand";
+import { api } from "../api/client";
+import type { OpSpec, RecipeResult, UploadDTO } from "../api/types";
+
+// BuilderStep is one step in the editable pipeline. Params are held as strings
+// (the input controls' values) and coerced to the right JSON type at run time.
+export interface BuilderStep {
+  id: number;
+  op: string;
+  params: Record<string, string>;
+}
+
+let nextStepID = 1;
+
+interface RecipeStore {
+  ops: OpSpec[];
+  loadingOps: boolean;
+  opsError?: string;
+  loadOps: () => Promise<void>;
+  opSpec: (op: string) => OpSpec | undefined;
+
+  steps: BuilderStep[];
+  addStep: (op: string) => void;
+  removeStep: (id: number) => void;
+  moveStep: (id: number, dir: -1 | 1) => void;
+  duplicateStep: (id: number) => void;
+  setStepParam: (id: number, name: string, value: string) => void;
+  clearSteps: () => void;
+
+  input?: UploadDTO;
+  uploading: boolean;
+  uploadInput: (file: File) => Promise<void>;
+
+  running: boolean;
+  result?: RecipeResult;
+  error?: string;
+  run: () => Promise<void>;
+}
+
+export const useRecipe = create<RecipeStore>((set, get) => ({
+  ops: [],
+  loadingOps: false,
+
+  async loadOps() {
+    if (get().ops.length > 0 || get().loadingOps) return;
+    set({ loadingOps: true, opsError: undefined });
+    try {
+      const ops = await api.recipeOps();
+      set({ ops, loadingOps: false });
+    } catch (e) {
+      set({ loadingOps: false, opsError: String(e) });
+    }
+  },
+
+  opSpec(op) {
+    return get().ops.find((o) => o.name === op);
+  },
+
+  steps: [],
+
+  addStep(op) {
+    set((s) => ({ steps: [...s.steps, { id: nextStepID++, op, params: {} }] }));
+  },
+
+  removeStep(id) {
+    set((s) => ({ steps: s.steps.filter((st) => st.id !== id) }));
+  },
+
+  moveStep(id, dir) {
+    set((s) => {
+      const i = s.steps.findIndex((st) => st.id === id);
+      const j = i + dir;
+      if (i < 0 || j < 0 || j >= s.steps.length) return s;
+      const steps = s.steps.slice();
+      [steps[i], steps[j]] = [steps[j], steps[i]];
+      return { steps };
+    });
+  },
+
+  duplicateStep(id) {
+    set((s) => {
+      const i = s.steps.findIndex((st) => st.id === id);
+      if (i < 0) return s;
+      const copy: BuilderStep = { id: nextStepID++, op: s.steps[i].op, params: { ...s.steps[i].params } };
+      const steps = s.steps.slice();
+      steps.splice(i + 1, 0, copy);
+      return { steps };
+    });
+  },
+
+  setStepParam(id, name, value) {
+    set((s) => ({
+      steps: s.steps.map((st) => (st.id === id ? { ...st, params: { ...st.params, [name]: value } } : st)),
+    }));
+  },
+
+  clearSteps() {
+    set({ steps: [], result: undefined, error: undefined });
+  },
+
+  uploading: false,
+
+  async uploadInput(file) {
+    set({ uploading: true });
+    try {
+      const up = await api.upload(file);
+      set({ input: up, result: undefined, error: undefined });
+    } catch (e) {
+      set({ error: String(e) });
+    } finally {
+      set({ uploading: false });
+    }
+  },
+
+  running: false,
+
+  async run() {
+    const { input, steps, opSpec } = get();
+    if (!input) {
+      set({ error: "Upload an input file first." });
+      return;
+    }
+    if (steps.length === 0) {
+      set({ error: "Add at least one operation." });
+      return;
+    }
+    set({ running: true, error: undefined, result: undefined });
+    const payload = steps.map((st) => {
+      const spec = opSpec(st.op);
+      const params: Record<string, unknown> = {};
+      for (const p of spec?.params ?? []) {
+        const v = st.params[p.name];
+        if (v == null || v === "") continue;
+        params[p.name] = p.kind === "int" ? Number(v) : v;
+      }
+      return { op: st.op, params };
+    });
+    try {
+      const result = await api.recipe({ input_id: input.id, steps: payload });
+      set({ running: false, result });
+    } catch (e) {
+      set({ running: false, error: String(e) });
+    }
+  },
+}));


### PR DESCRIPTION
## Summary

Two additions to the cryptolab security-test suite: an interactive **web Recipe Builder** (the cryptolab console's answer to the Config Builder) and **active DMR decryption**. Both stay behind the `cryptolab` build tag, so the default operator binary is unaffected.

## Changes

**1) Web Recipe Builder.** A new *Recipe Builder* tab in the cryptolab console drives the `recipe` pipeline interactively, the way the Config Builder edits a config: upload an input, assemble an ordered operation list from a palette (with per-op parameter fields and move / duplicate / remove), run it server-side, and read the per-step report plus the final bytes (with a download). Fully integrated into the existing console — shared theme, styling, upload flow, and bearer-token auth.
- **backend**: `GET /api/v1/cryptolab/recipe/ops` (operation catalogue with per-op params) and `POST /api/v1/cryptolab/recipe` (run a structured recipe over an uploaded file — synchronous, since the pipeline is pure/in-memory). Gated like the other mutations.
- **engine**: `recipe.Specs()` exposes each op's parameters for the builder; the hex param helper now tolerates spaces / a `0x` prefix.
- **frontend**: `src/store/recipe.ts` (builder state slice), `src/components/RecipeBuilder.tsx`, a `Tools | Recipe Builder` tab in `App.tsx`, and the `api/client.ts` + `api/types.ts` additions.

**2) DMR active decryption + generic RC4.** New `engine/dmrcrypto` carries the real DMR privacy cipher cores — RC4 "Enhanced Privacy" (key‖IV), DES/3DES/AES-OFB — keyed with operator-supplied material. `assess` now dispatches its `weak-key` / `key-brute` methods through a per-protocol cipher suite, so `assess crypto -protocol dmr` actively attempts DMR. The recipe pipeline gains a protocol-neutral `rc4-decrypt` op. `cipherinfo` marks the DMR entries bundled.
- **Honesty note**: DMR's *vendor key/IV derivation* is proprietary and varies by vendor, so this implements the standard cipher cores keyed with the material the analyst supplies (the reconstructed key; the frame IV used directly) — it does not fabricate a vendor key schedule. Ciphers we can't verify at all (TETRA TEA1–4, DES-XL) remain advisory-only via `known-weakness`.

## Test plan

- [x] `make vet test` is green locally (whole repo, `-race`)
- [x] `make test-cryptolab` is green locally
- [x] Added tests — `dmrcrypto` round-trip (RC4/DES/3DES/AES) + IV-appended RC4 + unsupported; `assess` DMR default-key break through the DMR suite; recipe `rc4-decrypt` op + `Specs()` params; webserver `recipe`/`recipe/ops` endpoints (ADP decrypt end-to-end). Frontend: `tsc --noEmit` + `vite build` clean and `vitest` passes.
- [x] Smoke-tested the built `-tags cryptolab` binary: it serves the Recipe Builder page and the `recipe/ops` endpoint (15 ops incl. `rc4-decrypt`); the full upload → `adp-decrypt → stats → randomness` flow recovers the plaintext (independently cross-checked).
- [ ] `make integration` not run (no daemon-path change beyond the gated cryptolab console)

No hardware smoke test — no SDR/USB/vocoder DSP changed.

## Breaking changes

None. All new code is behind the `cryptolab` build tag; no config/schema changes outside cryptolab. The web `dist/` is built at release (`make cryptolab-web-build`) and remains gitignored.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md`
- [x] Updated `docs/cryptolab.md` (recipe ops list, a web Recipe Builder section, and DMR cipher coverage in the assess section)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzEG7UxiWbbT5q76ECWWZ5)_