### PR TITLE
rfscope: entropy/encryption triage + cryptolab bridge + expert info (Tier 2)

### DIFF
--- a/cmd/gophertrunk/rfscope.go
+++ b/cmd/gophertrunk/rfscope.go
@@ -242,6 +242,14 @@ func rfscopeRunAndExport(rep *diag.Reporter, src rfscope.Source, cfg rfscope.Seg
 		if groups := rfscope.DetectKeystreamReuse(scene); len(groups) > 0 {
 			fmt.Fprintf(os.Stderr, "rfscope: %d keystream-reuse group(s) detected — try `cryptolab ks reuse -in %s`\n", len(groups), framesOut)
 		}
+		// When cryptolab is linked, run the ks-reuse hand-off in-process and
+		// surface its verdict; the default binary skips this (engine triage above
+		// already ran).
+		if rfscope.CryptolabLinked {
+			if res, err := rfscope.RunCryptolabTool(ctx, "ks", "reuse", []string{"-in", framesOut}); err == nil && res != nil {
+				fmt.Fprintf(os.Stderr, "rfscope: cryptolab ks reuse → %s\n", res.Summary)
+			}
+		}
 	}
 
 	f, err := rfscope.ParseFormat(outFormat)

--- a/cmd/gophertrunk/rfscope.go
+++ b/cmd/gophertrunk/rfscope.go
@@ -60,6 +60,7 @@ type rfscopeAnalysisFlags struct {
 	analyzers      *string
 	outFormat      *string
 	out            *string
+	framesOut      *string
 }
 
 func registerAnalysisFlags(fs *flag.FlagSet) rfscopeAnalysisFlags {
@@ -71,6 +72,7 @@ func registerAnalysisFlags(fs *flag.FlagSet) rfscopeAnalysisFlags {
 		analyzers:      fs.String("analyzers", "", "comma-separated analyzers to run (default: all registered)"),
 		outFormat:      fs.String("out-format", "summary", "output format: summary | json | jsonl | yaml | csv"),
 		out:            fs.String("out", "", "write output to this file (default: stdout)"),
+		framesOut:      fs.String("frames-out", "", "write recovered payloads as a cryptolab `ks` frames file (JSONL)"),
 	}
 }
 
@@ -142,7 +144,7 @@ FLAGS:`)
 	if *window > 0 {
 		maxSamples = int(*window * *sampleRate)
 	}
-	rfscopeRunAndExport(rep, src, af.segConfig(maxSamples), af.selectedAnalyzers(), *in, *af.outFormat, *af.out)
+	rfscopeRunAndExport(rep, src, af.segConfig(maxSamples), af.selectedAnalyzers(), *in, *af.outFormat, *af.out, *af.framesOut)
 }
 
 func runRFScopeLive(args []string) {
@@ -197,7 +199,7 @@ FLAGS:`)
 
 	maxSamples := int(*duration * float64(*sampleRate))
 	label := fmt.Sprintf("live:%s@%.6fMHz", info.Serial, float64(*freq)/1e6)
-	rfscopeRunAndExport(rep, src, af.segConfig(maxSamples), af.selectedAnalyzers(), label, *af.outFormat, *af.out)
+	rfscopeRunAndExport(rep, src, af.segConfig(maxSamples), af.selectedAnalyzers(), label, *af.outFormat, *af.out, *af.framesOut)
 }
 
 func runRFScopeList(args []string) {
@@ -215,7 +217,7 @@ func runRFScopeList(args []string) {
 
 // rfscopeRunAndExport segments src, runs the selected analyzers, and writes the
 // scene — the shared tail of the analyze and live subcommands.
-func rfscopeRunAndExport(rep *diag.Reporter, src rfscope.Source, cfg rfscope.SegmentConfig, analyzers []string, sourceLabel, outFormat, outPath string) {
+func rfscopeRunAndExport(rep *diag.Reporter, src rfscope.Source, cfg rfscope.SegmentConfig, analyzers []string, sourceLabel, outFormat, outPath, framesOut string) {
 	ctx := context.Background()
 	scene, in, err := rfscope.Segment(ctx, src, cfg)
 	if err != nil {
@@ -224,6 +226,22 @@ func rfscopeRunAndExport(rep *diag.Reporter, src rfscope.Source, cfg rfscope.Seg
 	scene.Source = sourceLabel
 	if err := rfscope.Run(ctx, scene, in, analyzers...); err != nil {
 		rep.Fatal(1, err)
+	}
+
+	if framesOut != "" {
+		ff, err := os.Create(framesOut)
+		if err != nil {
+			rep.Fatal(1, fmt.Errorf("create %s: %w", framesOut, err))
+		}
+		n, werr := rfscope.EmitFrames(scene, ff)
+		ff.Close()
+		if werr != nil {
+			rep.Fatal(1, fmt.Errorf("write frames: %w", werr))
+		}
+		fmt.Fprintf(os.Stderr, "rfscope: wrote %d cryptolab frame(s) → %s\n", n, framesOut)
+		if groups := rfscope.DetectKeystreamReuse(scene); len(groups) > 0 {
+			fmt.Fprintf(os.Stderr, "rfscope: %d keystream-reuse group(s) detected — try `cryptolab ks reuse -in %s`\n", len(groups), framesOut)
+		}
 	}
 
 	f, err := rfscope.ParseFormat(outFormat)

--- a/internal/rfscope/bridge.go
+++ b/internal/rfscope/bridge.go
@@ -1,0 +1,66 @@
+package rfscope
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/keystream"
+)
+
+// frameRec is one line of the cryptolab `ks` frames file. The field names and
+// hex encoding match exactly what cryptolab/tools/ks.go's loadFrames parses —
+// the decoder→cryptolab bridge format #832 anticipates.
+type frameRec struct {
+	Label string `json:"label"`
+	IV    string `json:"iv"`
+	CT    string `json:"ct"`
+}
+
+// EmitFrames writes the entropy analyzer's recovered payloads as a cryptolab `ks`
+// frames file: one JSON object per line, {label, iv, ct} with iv/ct hex-encoded.
+// The emitted file feeds `cryptolab ks reuse|mtp|extract`, `classify auto`, and
+// `brute` directly. Returns the number of frames written. A frame with no
+// recovered IV carries an empty iv (cryptolab ignores it for reuse but still
+// accepts it for the other tools).
+func EmitFrames(sc *Scene, w io.Writer) (int, error) {
+	enc := json.NewEncoder(w)
+	n := 0
+	for _, r := range entropyResults(sc) {
+		if len(r.payload) == 0 {
+			continue
+		}
+		rec := frameRec{
+			Label: fmt.Sprintf("emitter-%d@%.4fMHz", r.EmitterID, float64(r.FreqHz)/1e6),
+			IV:    hex.EncodeToString(r.iv),
+			CT:    hex.EncodeToString(r.payload),
+		}
+		if err := enc.Encode(rec); err != nil {
+			return n, err
+		}
+		n++
+	}
+	return n, nil
+}
+
+// DetectKeystreamReuse builds keystream.Frames from the entropy payloads and
+// reports reuse groups (frames sharing an IV/MI) via keystream.FindReuse — the
+// in-binary half of the keystream-reuse workflow. Generic unknown payloads carry
+// no IV, so this fires only once IV/MI recovery is wired for a partial protocol;
+// when it does, the same frames feed `cryptolab ks reuse|mtp`.
+func DetectKeystreamReuse(sc *Scene) []keystream.ReuseGroup {
+	results := entropyResults(sc)
+	frames := make([]keystream.Frame, 0, len(results))
+	for _, r := range results {
+		if len(r.iv) == 0 {
+			continue
+		}
+		frames = append(frames, keystream.Frame{
+			Label: fmt.Sprintf("emitter-%d", r.EmitterID),
+			IV:    r.iv,
+			CT:    r.payload,
+		})
+	}
+	return keystream.FindReuse(frames)
+}

--- a/internal/rfscope/bridge_test.go
+++ b/internal/rfscope/bridge_test.go
@@ -1,0 +1,81 @@
+package rfscope
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func sceneWithEntropy(results []EntropyResult) *Scene {
+	return &Scene{AnalyzerOutputs: map[string]any{"entropy": results}}
+}
+
+func TestEmitFramesFormat(t *testing.T) {
+	t.Parallel()
+	sc := sceneWithEntropy([]EntropyResult{
+		{EmitterID: 1, FreqHz: 450_100_000, payload: []byte{0xde, 0xad, 0xbe, 0xef}},
+		{EmitterID: 2, FreqHz: 450_500_000, payload: []byte{0x01, 0x02}, iv: []byte{0xaa, 0xbb}},
+		{EmitterID: 3, FreqHz: 450_900_000, payload: nil}, // skipped (no payload)
+	})
+
+	var buf bytes.Buffer
+	n, err := EmitFrames(sc, &buf)
+	if err != nil {
+		t.Fatalf("EmitFrames: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("want 2 frames written, got %d", n)
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("want 2 JSONL lines, got %d:\n%s", len(lines), buf.String())
+	}
+
+	// Each line must parse with the exact {label,iv,ct} fields the ks loader uses,
+	// with iv/ct hex-decodable back to the originals.
+	var first frameRec
+	if err := json.Unmarshal([]byte(lines[0]), &first); err != nil {
+		t.Fatalf("frame 0 not valid JSON: %v", err)
+	}
+	ct, err := hex.DecodeString(first.CT)
+	if err != nil || !bytes.Equal(ct, []byte{0xde, 0xad, 0xbe, 0xef}) {
+		t.Fatalf("frame 0 ct round-trip failed: %q err=%v", first.CT, err)
+	}
+	if first.IV != "" {
+		t.Fatalf("frame 0 should have empty iv, got %q", first.IV)
+	}
+
+	var second frameRec
+	_ = json.Unmarshal([]byte(lines[1]), &second)
+	if second.IV != "aabb" {
+		t.Fatalf("frame 1 iv hex should be aabb, got %q", second.IV)
+	}
+}
+
+func TestDetectKeystreamReuse(t *testing.T) {
+	t.Parallel()
+	// Two payloads sharing an IV ⇒ a reuse group; the third (distinct IV) does not.
+	sc := sceneWithEntropy([]EntropyResult{
+		{EmitterID: 1, payload: []byte("aaaaaaaa"), iv: []byte{0x01, 0x02, 0x03}},
+		{EmitterID: 2, payload: []byte("bbbbbbbb"), iv: []byte{0x01, 0x02, 0x03}},
+		{EmitterID: 3, payload: []byte("cccccccc"), iv: []byte{0x09, 0x09, 0x09}},
+	})
+	groups := DetectKeystreamReuse(sc)
+	if len(groups) != 1 {
+		t.Fatalf("want 1 reuse group, got %d", len(groups))
+	}
+	if len(groups[0].Frames) != 2 {
+		t.Fatalf("reuse group should hold 2 frames, got %d", len(groups[0].Frames))
+	}
+	// No-IV payloads must never form a reuse group.
+	noIV := sceneWithEntropy([]EntropyResult{
+		{EmitterID: 1, payload: []byte("xxxxxxxx")},
+		{EmitterID: 2, payload: []byte("yyyyyyyy")},
+	})
+	if g := DetectKeystreamReuse(noIV); len(g) != 0 {
+		t.Fatalf("payloads without IV must not form reuse groups, got %d", len(g))
+	}
+}

--- a/internal/rfscope/entropy.go
+++ b/internal/rfscope/entropy.go
@@ -38,6 +38,7 @@ type EntropyResult struct {
 	Recommended        string  `json:"recommended"`
 
 	payload []byte // raw recovered bytes, for the bridge; not serialized
+	iv      []byte // recovered IV/MI when a partial protocol exposes one; nil otherwise
 }
 
 // entropyAnalyzer triages every unidentified digital emitter's payload: it

--- a/internal/rfscope/entropy.go
+++ b/internal/rfscope/entropy.go
@@ -1,0 +1,223 @@
+package rfscope
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/randomness"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/stats"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+func init() { Register(entropyAnalyzer{}) }
+
+const (
+	// minPayloadBytes is the shortest recovered payload worth triaging.
+	minPayloadBytes = 32
+	// maxEntropyEmitters caps how many emitters are triaged per scene.
+	maxEntropyEmitters = 16
+)
+
+// EntropyResult is the byte-level triage of one emitter's recovered payload. It
+// mirrors the cryptolab `classify auto` taxonomy so an operator can take the
+// recommended next command straight into the cryptolab toolkit. The raw payload
+// is carried (unserialized) for the cryptolab bridge.
+type EntropyResult struct {
+	EmitterID          uint64  `json:"emitter_id"`
+	FreqHz             uint32  `json:"freq_hz"`
+	Bytes              int     `json:"bytes"`
+	Class              string  `json:"class"`
+	Confidence         float64 `json:"confidence"`
+	EntropyBits        float64 `json:"entropy_bits"`
+	IndexOfCoincidence float64 `json:"index_of_coincidence"`
+	ChiSquareUniform   float64 `json:"chi_square_uniform"`
+	KeyLen             int     `json:"key_len,omitempty"`
+	LooksRandom        bool    `json:"looks_random"`
+	Recommended        string  `json:"recommended"`
+
+	payload []byte // raw recovered bytes, for the bridge; not serialized
+}
+
+// entropyAnalyzer triages every unidentified digital emitter's payload: it
+// blind-demodulates a representative burst, then runs the cryptolab randomness
+// battery and the same measurements `classify auto` uses to label the payload
+// plaintext / substitution / repeating-xor / periodic-scrambler /
+// lfsr-or-keyless-scrambler / strong-encrypted. It is the entropy-based
+// encryption detector — Wireshark's "is this flow encrypted?" for RF — built on
+// #832's engines rather than hand-rolled thresholds. Results land in
+// AnalyzerOutputs["entropy"]; expert.go turns the interesting ones into anomalies
+// and bridge.go hands the payloads to the cryptolab toolkit.
+type entropyAnalyzer struct{}
+
+func (entropyAnalyzer) Name() string { return "entropy" }
+func (entropyAnalyzer) Synopsis() string {
+	return "bitstream entropy / encryption triage (cryptolab bridge)"
+}
+func (entropyAnalyzer) DependsOn() []string { return []string{"topology"} }
+
+func (entropyAnalyzer) Analyze(ctx context.Context, sc *Scene, in *Input) error {
+	if in == nil || in.BurstIQ == nil || len(sc.Emitters) == 0 {
+		return nil
+	}
+	var results []EntropyResult
+	triaged := 0
+	for _, e := range sc.Emitters {
+		if triaged >= maxEntropyEmitters {
+			break
+		}
+		if e.Fingerprint.ClassFamily != "digital" {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		bid := longestBurstID(sc, e)
+		if bid == 0 {
+			continue
+		}
+		bidx := burstIndexByID(sc, bid)
+		iq, rate, err := in.BurstIQ(sc.Bursts[bidx])
+		if err != nil || len(iq) == 0 || rate <= 0 {
+			continue
+		}
+		// Skip emitters that decode as a known protocol — triage is for unknowns.
+		if ident, err := siglab.IdentifyIQ(iq, "rfscope-burst", siglab.IdentifyConfig{SampleRateHz: rate, Format: siglab.FormatF32, Log: in.Log}); err == nil && ident != nil && !ident.Inconclusive {
+			continue
+		}
+		payload := recoverPayload(iq, rate, sc.Bursts[bidx].Features)
+		if len(payload) < minPayloadBytes {
+			continue
+		}
+		triaged++
+		r := classifyPayload(payload)
+		r.EmitterID = e.ID
+		r.FreqHz = e.Fingerprint.CenterHz
+		results = append(results, r)
+	}
+	if len(results) == 0 {
+		return nil
+	}
+	if sc.AnalyzerOutputs == nil {
+		sc.AnalyzerOutputs = map[string]any{}
+	}
+	sc.AnalyzerOutputs["entropy"] = results
+	return nil
+}
+
+// classifyPayload runs the cryptolab measurements over a recovered payload and
+// returns the highest-confidence verdict, using the exact thresholds and
+// recommendations cryptolab's `classify auto` applies (so rfscope and the
+// toolkit agree). It calls the untagged engine packages directly, so it works in
+// the default binary without the cryptolab build tag.
+func classifyPayload(data []byte) EntropyResult {
+	ent := stats.ShannonEntropy(data)
+	ic := stats.IndexOfCoincidence(data)
+	chi := stats.ChiSquareUniform(data)
+	printable, letters := charProfileBytes(data)
+	keylens := stats.GuessXORKeyLength(data, 40)
+	periods := stats.DetectPeriod(data, 256, 4)
+
+	bits := lfsr.BitsFromBytes(data)
+	var rep randomness.Report
+	if len(data) >= 2048 {
+		rep = randomness.Battery(bits, randomness.DefaultAlpha)
+	} else {
+		rep = randomness.Quick(bits, randomness.DefaultAlpha)
+	}
+	lcFailed := randomnessFailed(rep, "linear_complexity")
+	spectralFailed := randomnessFailed(rep, "spectral_dft")
+
+	type verdict struct {
+		class       string
+		confidence  float64
+		recommended string
+		keyLen      int
+	}
+	var vs []verdict
+	if printable > 0.95 && ent < 4.8 {
+		vs = append(vs, verdict{"plaintext", 0.6 + 0.4*printable, "already plaintext — no decryption needed", 0})
+	}
+	if ic > 0.045 && letters > 0.6 {
+		vs = append(vs, verdict{"substitution-or-shift", clampUnit(ic / 0.066), "cryptolab brute substitution -in <file>", 0})
+	}
+	if len(keylens) > 0 && keylens[0].Length > 1 && keylens[0].Score < 3.6 {
+		vs = append(vs, verdict{"repeating-xor", clampUnit((3.6 - keylens[0].Score) / 3.6),
+			fmt.Sprintf("cryptolab brute xor -in <file> -keylen %d", keylens[0].Length), keylens[0].Length})
+	}
+	if len(periods) > 0 {
+		vs = append(vs, verdict{"periodic-scrambler", clampUnit(periods[0].ZScore / 12),
+			fmt.Sprintf("cryptolab stats period -in <file> (lag≈%d) then descramble rolling or ks mtp", periods[0].Lag), 0})
+	}
+	if ent > 7.0 && (lcFailed || spectralFailed) {
+		vs = append(vs, verdict{"lfsr-or-keyless-scrambler", 0.7, "cryptolab lfsr bm -in <file>", 0})
+	}
+	if ent > 7.9 && rep.LooksRandom() {
+		vs = append(vs, verdict{"strong-encrypted", clampUnit((ent - 7.9) / 0.1),
+			"no weak structure — if frames reuse an IV/MI try cryptolab ks reuse, else key material is required", 0})
+	}
+	if len(vs) == 0 {
+		vs = append(vs, verdict{"inconclusive", 0.2, "cryptolab stats scan -in <file>", 0})
+	}
+	sort.SliceStable(vs, func(i, j int) bool { return vs[i].confidence > vs[j].confidence })
+	top := vs[0]
+
+	return EntropyResult{
+		Bytes:              len(data),
+		Class:              top.class,
+		Confidence:         top.confidence,
+		EntropyBits:        ent,
+		IndexOfCoincidence: ic,
+		ChiSquareUniform:   chi,
+		KeyLen:             top.keyLen,
+		LooksRandom:        rep.LooksRandom(),
+		Recommended:        top.recommended,
+		payload:            data,
+	}
+}
+
+func charProfileBytes(data []byte) (printable, letters float64) {
+	if len(data) == 0 {
+		return 0, 0
+	}
+	var p, l int
+	for _, b := range data {
+		if b >= 0x20 && b <= 0x7e {
+			p++
+		}
+		if (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') {
+			l++
+		}
+	}
+	n := float64(len(data))
+	return float64(p) / n, float64(l) / n
+}
+
+func randomnessFailed(r randomness.Report, name string) bool {
+	for _, t := range r.Tests {
+		if t.Name == name && t.Applicable && !t.Passed {
+			return true
+		}
+	}
+	return false
+}
+
+func clampUnit(x float64) float64 {
+	if x < 0 {
+		return 0
+	}
+	if x > 1 {
+		return 1
+	}
+	return x
+}
+
+// entropyResults returns the triage results from a populated scene, or nil.
+func entropyResults(sc *Scene) []EntropyResult {
+	if sc.AnalyzerOutputs == nil {
+		return nil
+	}
+	r, _ := sc.AnalyzerOutputs["entropy"].([]EntropyResult)
+	return r
+}

--- a/internal/rfscope/entropy_test.go
+++ b/internal/rfscope/entropy_test.go
@@ -1,0 +1,103 @@
+package rfscope
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/stats"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func randomBytes(n int, seed int64) []byte {
+	rng := rand.New(rand.NewSource(seed))
+	b := make([]byte, n)
+	rng.Read(b)
+	return b
+}
+
+func TestClassifyPayloadStrongEncrypted(t *testing.T) {
+	t.Parallel()
+	r := classifyPayload(randomBytes(4096, 7))
+	if r.Class != "strong-encrypted" {
+		t.Fatalf("random bytes should be strong-encrypted, got %q (entropy %.3f, looksRandom %v)", r.Class, r.EntropyBits, r.LooksRandom)
+	}
+	if !r.LooksRandom {
+		t.Fatalf("random bytes should pass the randomness battery")
+	}
+}
+
+func TestClassifyPayloadRepeatingXOR(t *testing.T) {
+	t.Parallel()
+	// Non-periodic letter plaintext XOR'd with a 5-byte repeating key — the only
+	// structure is the key period, so repeating-xor must win over periodic-scrambler.
+	rng := rand.New(rand.NewSource(99))
+	const alphabet = "abcdefghijklmnopqrstuvwxyz "
+	pt := make([]byte, 3000)
+	for i := range pt {
+		pt[i] = alphabet[rng.Intn(len(alphabet))]
+	}
+	key := []byte{0x13, 0x37, 0x42, 0x99, 0x05}
+	ct := make([]byte, len(pt))
+	for i := range pt {
+		ct[i] = pt[i] ^ key[i%len(key)]
+	}
+	r := classifyPayload(ct)
+	if r.Class != "repeating-xor" {
+		t.Fatalf("repeating-XOR ciphertext misclassified as %q", r.Class)
+	}
+	if r.KeyLen == 0 || r.KeyLen%len(key) != 0 {
+		t.Fatalf("recovered key length %d not a multiple of %d", r.KeyLen, len(key))
+	}
+}
+
+func TestClassifyPayloadMatchesEngines(t *testing.T) {
+	t.Parallel()
+	data := randomBytes(2048, 11)
+	r := classifyPayload(data)
+	if r.EntropyBits != stats.ShannonEntropy(data) {
+		t.Fatalf("entropy mismatch with engine: %v vs %v", r.EntropyBits, stats.ShannonEntropy(data))
+	}
+	if r.IndexOfCoincidence != stats.IndexOfCoincidence(data) {
+		t.Fatalf("IC mismatch with engine")
+	}
+	if r.ChiSquareUniform != stats.ChiSquareUniform(data) {
+		t.Fatalf("chi-square mismatch with engine")
+	}
+}
+
+func TestEntropyAnalyzerViaRunner(t *testing.T) {
+	t.Parallel()
+	// A digital emitter carrying random bits ⇒ a strong-encrypted triage result.
+	bitsN := 4096
+	bits := make([]int, bitsN)
+	rng := rand.New(rand.NewSource(3))
+	for i := range bits {
+		bits[i] = rng.Intn(2)
+	}
+	iq := synthFSK(bits, 48000, 4800, 1200)
+	dur := float64(len(iq)) / 48000
+
+	sc := &Scene{
+		SpanHz: 1_000_000, WindowSec: 10,
+		Bursts: []Burst{{
+			ID: 1, FreqHz: 450_000_000, StartSec: 0, EndSec: dur,
+			PeakDbFS: -40, Class: survey.ClassFSK, OccupiedBwHz: 12_500,
+			Features: survey.ClassFeatures{BaudHz: 4800, IFModality: 2},
+		}},
+	}
+	in := &Input{
+		SampleRateHz: 48000, Window: 10,
+		BurstIQ: func(b Burst) ([]complex64, float64, error) { return iq, 48000, nil },
+	}
+	if err := Run(context.Background(), sc, in, "entropy"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	res := entropyResults(sc)
+	if len(res) != 1 {
+		t.Fatalf("want 1 entropy result, got %d", len(res))
+	}
+	if res[0].EmitterID == 0 || res[0].Bytes < minPayloadBytes {
+		t.Fatalf("entropy result incomplete: %+v", res[0])
+	}
+}

--- a/internal/rfscope/expert.go
+++ b/internal/rfscope/expert.go
@@ -1,0 +1,106 @@
+package rfscope
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+func init() { Register(expertAnalyzer{}) }
+
+// Expert-info thresholds.
+const (
+	intermittentDuty   = 0.05 // duty below this with several bursts ⇒ intermittent
+	intermittentBursts = 3
+	noiseLikeFlatness  = 0.80  // spectral flatness above this ⇒ noise-like/spread
+	wideCarrierHz      = 30000 // wider than the widest common narrowband channel
+	narrowCarrierHz    = 5000  // narrower than the tightest standard raster
+)
+
+// expertAnalyzer is the RF Expert-Info layer — the analog of Wireshark's Expert
+// Information. It runs cheap rules over the populated Scene and flags anything
+// notable for an operator: intermittent emitters, frequency hoppers, abnormally
+// wide/narrow carriers, noise-like (high-flatness) or high-randomness/encrypted
+// carriers, and digital carriers that match no known protocol.
+type expertAnalyzer struct{}
+
+func (expertAnalyzer) Name() string        { return "expert" }
+func (expertAnalyzer) Synopsis() string    { return "RF expert-info / anomaly flags" }
+func (expertAnalyzer) DependsOn() []string { return []string{"topology", "timeline", "entropy"} }
+
+func (expertAnalyzer) Analyze(_ context.Context, sc *Scene, _ *Input) error {
+	var out []Anomaly
+
+	// Frequency hoppers (from topology).
+	for _, e := range sc.Emitters {
+		if len(e.HopSet) > 1 {
+			out = append(out, Anomaly{
+				Severity: "note", Kind: "hopper", EmitterID: e.ID, FreqHz: e.Fingerprint.CenterHz,
+				Detail: fmt.Sprintf("emitter hops %d channels", len(e.HopSet)),
+			})
+		}
+	}
+
+	// Per-channel rules (from timeline + segmentation metrics).
+	for _, c := range sc.Channels {
+		if c.DutyCycle < intermittentDuty && c.BurstCount >= intermittentBursts {
+			out = append(out, Anomaly{
+				Severity: "note", Kind: "intermittent", FreqHz: c.FreqHz,
+				Detail: fmt.Sprintf("%d bursts at %.1f%% duty", c.BurstCount, c.DutyCycle*100),
+			})
+		}
+		switch {
+		case c.OccupiedBwHz > wideCarrierHz:
+			out = append(out, Anomaly{Severity: "note", Kind: "wide-carrier", FreqHz: c.FreqHz,
+				Detail: fmt.Sprintf("occupied %d Hz, wider than a standard narrowband channel", c.OccupiedBwHz)})
+		case c.OccupiedBwHz > 0 && c.OccupiedBwHz < narrowCarrierHz:
+			out = append(out, Anomaly{Severity: "note", Kind: "narrow-carrier", FreqHz: c.FreqHz,
+				Detail: fmt.Sprintf("occupied %d Hz, below the tightest standard raster", c.OccupiedBwHz)})
+		}
+		if c.MedianFlatness >= noiseLikeFlatness {
+			out = append(out, Anomaly{Severity: "note", Kind: "noise-like", FreqHz: c.FreqHz,
+				Detail: fmt.Sprintf("spectral flatness %.2f (spread/encrypted-PHY or noise)", c.MedianFlatness)})
+		}
+	}
+
+	// Encryption / structure findings (from the entropy triage).
+	for _, r := range entropyResults(sc) {
+		sev, kind := "note", "unknown-protocol"
+		switch r.Class {
+		case "strong-encrypted":
+			sev, kind = "alert", "encrypted"
+		case "repeating-xor", "lfsr-or-keyless-scrambler", "periodic-scrambler", "substitution-or-shift":
+			sev, kind = "warn", "obfuscated"
+		}
+		out = append(out, Anomaly{
+			Severity: sev, Kind: kind, EmitterID: r.EmitterID, FreqHz: r.FreqHz,
+			Detail: fmt.Sprintf("%s (entropy %.2f) — %s", r.Class, r.EntropyBits, r.Recommended),
+		})
+	}
+
+	// Deterministic ordering: severity (alert→warn→note), then frequency, kind.
+	sort.SliceStable(out, func(i, j int) bool {
+		if sevRank(out[i].Severity) != sevRank(out[j].Severity) {
+			return sevRank(out[i].Severity) > sevRank(out[j].Severity)
+		}
+		if out[i].FreqHz != out[j].FreqHz {
+			return out[i].FreqHz < out[j].FreqHz
+		}
+		return out[i].Kind < out[j].Kind
+	})
+
+	// Append so a caller that pre-seeded anomalies (e.g. the bridge) is preserved.
+	sc.Anomalies = append(sc.Anomalies, out...)
+	return nil
+}
+
+func sevRank(s string) int {
+	switch s {
+	case "alert":
+		return 3
+	case "warn":
+		return 2
+	default:
+		return 1
+	}
+}

--- a/internal/rfscope/expert_test.go
+++ b/internal/rfscope/expert_test.go
@@ -1,0 +1,81 @@
+package rfscope
+
+import (
+	"context"
+	"testing"
+)
+
+func anomalyKinds(as []Anomaly) map[string]Anomaly {
+	m := map[string]Anomaly{}
+	for _, a := range as {
+		m[a.Kind] = a
+	}
+	return m
+}
+
+func TestExpertAnalyzerRules(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{
+		SpanHz: 2_000_000, WindowSec: 10,
+		Emitters: []Emitter{
+			{ID: 1, Fingerprint: Fingerprint{CenterHz: 450_100_000, ClassFamily: "digital"}, HopSet: []uint32{450_100_000, 450_500_000, 450_900_000}},
+		},
+		Channels: []Channel{
+			{FreqHz: 450_200_000, DutyCycle: 0.02, BurstCount: 5, OccupiedBwHz: 12_500, MedianFlatness: 0.1},  // intermittent
+			{FreqHz: 450_700_000, DutyCycle: 0.50, BurstCount: 1, OccupiedBwHz: 12_500, MedianFlatness: 0.92}, // noise-like
+		},
+		AnalyzerOutputs: map[string]any{
+			"entropy": []EntropyResult{
+				{EmitterID: 1, FreqHz: 450_100_000, Class: "strong-encrypted", EntropyBits: 7.99, Recommended: "key material required"},
+			},
+		},
+	}
+
+	if err := (expertAnalyzer{}).Analyze(context.Background(), sc, nil); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	kinds := anomalyKinds(sc.Anomalies)
+	for _, want := range []string{"hopper", "intermittent", "noise-like", "encrypted"} {
+		if _, ok := kinds[want]; !ok {
+			t.Fatalf("missing %q anomaly; got %+v", want, sc.Anomalies)
+		}
+	}
+	if kinds["encrypted"].Severity != "alert" {
+		t.Fatalf("encrypted should be an alert, got %q", kinds["encrypted"].Severity)
+	}
+	// Alerts must sort ahead of notes.
+	if sc.Anomalies[0].Severity != "alert" {
+		t.Fatalf("most severe anomaly should be first, got %q", sc.Anomalies[0].Severity)
+	}
+}
+
+func TestExpertWideNarrowCarrier(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{
+		SpanHz: 10_000_000, WindowSec: 10,
+		Channels: []Channel{
+			{FreqHz: 451_000_000, OccupiedBwHz: 200_000, DutyCycle: 0.5, BurstCount: 1}, // wide vs raster
+		},
+	}
+	if err := (expertAnalyzer{}).Analyze(context.Background(), sc, nil); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if _, ok := anomalyKinds(sc.Anomalies)["wide-carrier"]; !ok {
+		t.Fatalf("want wide-carrier anomaly, got %+v", sc.Anomalies)
+	}
+}
+
+func TestExpertAppendsNotOverwrites(t *testing.T) {
+	t.Parallel()
+	sc := &Scene{
+		Anomalies: []Anomaly{{Severity: "note", Kind: "preexisting", Detail: "seeded"}},
+		Emitters:  []Emitter{{ID: 1, HopSet: []uint32{1, 2}}},
+	}
+	if err := (expertAnalyzer{}).Analyze(context.Background(), sc, nil); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if _, ok := anomalyKinds(sc.Anomalies)["preexisting"]; !ok {
+		t.Fatalf("expert must append, not overwrite pre-seeded anomalies")
+	}
+}

--- a/internal/rfscope/payload.go
+++ b/internal/rfscope/payload.go
@@ -1,0 +1,126 @@
+package rfscope
+
+import (
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// recoverPayload blind-demodulates a digital burst's baseband IQ into a byte
+// payload for entropy/structure triage. It FM-discriminates the burst, slices
+// the discriminator at the detected symbol rate into 2- or 4-level symbols
+// (integrate-and-dump), maps each symbol to bits, and packs MSB-first.
+//
+// This is deliberately triage-grade, not a protocol-exact demod: its job is to
+// produce a bitstream whose entropy/structure tells random-keystream from
+// structured-scrambler-from-plaintext, the question the cryptolab engines answer.
+// FM discrimination covers the FSK/C4FM family that dominates non-WiFi digital
+// RF; a PSK carrier still yields a usable (if noisier) stream.
+func recoverPayload(iq []complex64, rateHz float64, feat survey.ClassFeatures) []byte {
+	if rateHz <= 0 || feat.BaudHz <= 0 || len(iq) == 0 {
+		return nil
+	}
+	sps := rateHz / feat.BaudHz
+	if sps < 2 {
+		return nil
+	}
+	disc := demod.NewFM().Process(nil, iq)
+	nSym := int(float64(len(disc)) / sps)
+	if nSym < 8 {
+		return nil
+	}
+	syms := make([]float64, 0, nSym)
+	for i := 0; i < nSym; i++ {
+		start := int(float64(i) * sps)
+		end := int(float64(i+1) * sps)
+		if end > len(disc) {
+			end = len(disc)
+		}
+		if start >= end {
+			break
+		}
+		var s float64
+		for j := start; j < end; j++ {
+			s += float64(disc[j])
+		}
+		syms = append(syms, s/float64(end-start))
+	}
+
+	levels := 2
+	if feat.IFModality == 4 {
+		levels = 4
+	}
+	return packBits(sliceSymbols(syms, levels))
+}
+
+// sliceSymbols converts integrate-and-dump symbol samples to bits. For 2 levels
+// it slices at the median (1 bit/symbol); for 4 levels it slices at the 25/50/75
+// percentiles and emits the 2-bit level MSB-first. Thresholds are derived from
+// the data so no AGC/DC calibration is required.
+func sliceSymbols(syms []float64, levels int) []byte {
+	if len(syms) == 0 {
+		return nil
+	}
+	sorted := append([]float64(nil), syms...)
+	sort.Float64s(sorted)
+	q := func(p float64) float64 {
+		idx := int(p * float64(len(sorted)-1))
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(sorted) {
+			idx = len(sorted) - 1
+		}
+		return sorted[idx]
+	}
+
+	var bits []byte
+	if levels == 4 {
+		t1, t2, t3 := q(0.25), q(0.50), q(0.75)
+		for _, s := range syms {
+			lvl := 0
+			if s >= t1 {
+				lvl++
+			}
+			if s >= t2 {
+				lvl++
+			}
+			if s >= t3 {
+				lvl++
+			}
+			bits = append(bits, byte((lvl>>1)&1), byte(lvl&1))
+		}
+		return bits
+	}
+	// Strict '>' so the median (which lands on a cluster value for a clean
+	// 2-level signal) splits the two clusters instead of flooding to 1s.
+	t := q(0.50)
+	for _, s := range syms {
+		if s > t {
+			bits = append(bits, 1)
+		} else {
+			bits = append(bits, 0)
+		}
+	}
+	return bits
+}
+
+// packBits packs 0/1 values into bytes, MSB-first, matching the bit order
+// cryptolab's lfsr.BitsFromBytes unpacks. A trailing partial byte is dropped so
+// the payload is whole bytes.
+func packBits(bits []byte) []byte {
+	n := len(bits) / 8
+	if n == 0 {
+		return nil
+	}
+	out := make([]byte, n)
+	for i := 0; i < n; i++ {
+		var b byte
+		for j := 0; j < 8; j++ {
+			b = (b << 1) | (bits[i*8+j] & 1)
+		}
+		out[i] = b
+	}
+	return out
+}

--- a/internal/rfscope/payload_test.go
+++ b/internal/rfscope/payload_test.go
@@ -1,0 +1,81 @@
+package rfscope
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// synthFSK builds a 2-FSK baseband for the given bits: bit 1 → +dev, bit 0 → -dev.
+func synthFSK(bits []int, rate, baud, dev float64) []complex64 {
+	sps := int(rate / baud)
+	iq := make([]complex64, 0, len(bits)*sps)
+	phase := 0.0
+	for _, b := range bits {
+		f := -dev
+		if b == 1 {
+			f = dev
+		}
+		step := 2 * math.Pi * f / rate
+		for i := 0; i < sps; i++ {
+			iq = append(iq, complex64(complex(math.Cos(phase), math.Sin(phase))))
+			phase += step
+		}
+	}
+	return iq
+}
+
+func TestPackBits(t *testing.T) {
+	t.Parallel()
+	got := packBits([]byte{1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1})
+	if len(got) != 2 || got[0] != 0x81 || got[1] != 0x55 {
+		t.Fatalf("packBits = %x, want [81 55]", got)
+	}
+	if packBits([]byte{1, 0, 1}) != nil {
+		t.Fatalf("partial byte should pack to nil")
+	}
+}
+
+func TestSliceSymbolsTwoLevel(t *testing.T) {
+	t.Parallel()
+	bits := sliceSymbols([]float64{-1, 1, -1, 1, -1, 1}, 2)
+	want := []byte{0, 1, 0, 1, 0, 1}
+	if len(bits) != len(want) {
+		t.Fatalf("len %d != %d", len(bits), len(want))
+	}
+	for i := range want {
+		if bits[i] != want[i] {
+			t.Fatalf("bit %d: got %d want %d", i, bits[i], want[i])
+		}
+	}
+}
+
+func TestRecoverPayloadAlternatingFSK(t *testing.T) {
+	t.Parallel()
+	// 64 alternating bits ⇒ after slicing, an alternating bitstream ⇒ 0x55/0xAA.
+	var bits []int
+	for i := 0; i < 64; i++ {
+		bits = append(bits, i%2)
+	}
+	iq := synthFSK(bits, 48000, 4800, 1200)
+	got := recoverPayload(iq, 48000, survey.ClassFeatures{BaudHz: 4800, IFModality: 2})
+	if len(got) == 0 {
+		t.Fatalf("no payload recovered")
+	}
+	for _, b := range got {
+		if b != 0x55 && b != 0xAA {
+			t.Fatalf("alternating FSK should pack to 0x55/0xAA, got %x in %x", b, got)
+		}
+	}
+}
+
+func TestRecoverPayloadGuards(t *testing.T) {
+	t.Parallel()
+	if recoverPayload(nil, 48000, survey.ClassFeatures{BaudHz: 4800}) != nil {
+		t.Fatalf("nil IQ should yield nil")
+	}
+	if recoverPayload(make([]complex64, 100), 48000, survey.ClassFeatures{BaudHz: 0}) != nil {
+		t.Fatalf("zero baud should yield nil")
+	}
+}

--- a/internal/rfscope/rfscope_cryptolab.go
+++ b/internal/rfscope/rfscope_cryptolab.go
@@ -1,0 +1,34 @@
+//go:build cryptolab
+
+package rfscope
+
+import (
+	"context"
+	"io"
+	"log/slog"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	// Blank import registers the toolkit's tools (classify, ks, …) via init(),
+	// the same way cmd/gophertrunk/cryptolab_enabled.go links them.
+	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/tools"
+)
+
+// CryptolabLinked reports whether the cryptolab toolkit is compiled into this
+// binary (true only under -tags cryptolab).
+const CryptolabLinked = true
+
+// RunCryptolabTool runs a cryptolab tool/mode (e.g. "ks"/"reuse" or
+// "classify"/"auto") over args and returns its structured Result. It is the
+// registry-driven half of the bridge — the in-binary triage in entropy.go works
+// without the tag, this adds the full tool result when cryptolab is linked.
+func RunCryptolabTool(ctx context.Context, tool, mode string, args []string) (*cryptolab.Result, error) {
+	_, m, err := cryptolab.LookupMode(tool, mode)
+	if err != nil {
+		return nil, err
+	}
+	env := cryptolab.Env{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Stdout: io.Discard,
+	}
+	return m.Run(ctx, args, env)
+}

--- a/internal/rfscope/rfscope_cryptolab_stub.go
+++ b/internal/rfscope/rfscope_cryptolab_stub.go
@@ -1,0 +1,25 @@
+//go:build !cryptolab
+
+package rfscope
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+)
+
+// CryptolabLinked reports whether the cryptolab toolkit is compiled into this
+// binary. The default build links the stub, so it is false; rebuild with
+// -tags cryptolab to enable the registry-driven tool hand-off.
+const CryptolabLinked = false
+
+// ErrCryptolabNotLinked is returned by RunCryptolabTool in the default build.
+var ErrCryptolabNotLinked = errors.New("rfscope: cryptolab toolkit not linked — rebuild with -tags cryptolab")
+
+// RunCryptolabTool is the stub for the default (untagged) build. The in-binary
+// entropy triage (entropy.go) and the ks frames emission (bridge.go) still work;
+// only the registry-driven tool invocation needs the cryptolab build tag.
+func RunCryptolabTool(_ context.Context, _, _ string, _ []string) (*cryptolab.Result, error) {
+	return nil, ErrCryptolabNotLinked
+}

--- a/internal/rfscope/rfscope_cryptolab_test.go
+++ b/internal/rfscope/rfscope_cryptolab_test.go
@@ -1,0 +1,36 @@
+//go:build cryptolab
+
+package rfscope
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunCryptolabToolClassify(t *testing.T) {
+	t.Parallel()
+	if !CryptolabLinked {
+		t.Fatal("CryptolabLinked must be true under -tags cryptolab")
+	}
+	// Write a random payload and run `classify auto` over it via the registry.
+	path := filepath.Join(t.TempDir(), "payload.bin")
+	if err := os.WriteFile(path, randomBytes(4096, 5), 0o644); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	res, err := RunCryptolabTool(context.Background(), "classify", "auto", []string{"-in", path})
+	if err != nil {
+		t.Fatalf("RunCryptolabTool: %v", err)
+	}
+	if res == nil || res.Tool != "classify" || res.Mode != "auto" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+func TestRunCryptolabToolUnknownTool(t *testing.T) {
+	t.Parallel()
+	if _, err := RunCryptolabTool(context.Background(), "nope", "x", nil); err == nil {
+		t.Fatal("want error for unknown tool")
+	}
+}

--- a/internal/rfscope/segment.go
+++ b/internal/rfscope/segment.go
@@ -179,6 +179,13 @@ func Segment(ctx context.Context, src Source, cfg SegmentConfig) (*Scene, *Input
 				spectrum.AverageDB(slice, 0, outRate, occFFTFor(len(slice))).Bins,
 				outRate, float64(cfg.MinSpacingHz), float64(cfg.MinSpacingHz), float64(cfg.MinSpacingHz),
 			)
+			// Prefer survey's occupied bandwidth (an above-noise-floor outward walk)
+			// over ComputeOccupancy's 99%-power span, which under-measures FM-family
+			// carriers whose strong DC carrier component concentrates the power.
+			occBwHz := cls.OccupiedBwHz
+			if occBwHz == 0 {
+				occBwHz = uint32(math.Round(occ.OccupiedBandwidthHz))
+			}
 
 			nextID++
 			id := nextID
@@ -189,7 +196,7 @@ func Segment(ctx context.Context, src Source, cfg SegmentConfig) (*Scene, *Input
 				EndSec:           float64(sp.endSample) / outRate,
 				PeakDbFS:         pk.PowerDbFS,
 				SNRDb:            pk.SNRDb,
-				OccupiedBwHz:     uint32(math.Round(occ.OccupiedBandwidthHz)),
+				OccupiedBwHz:     occBwHz,
 				ChannelPowerDBFS: occ.ChannelPowerDBFS,
 				ACPRUpperDB:      occ.ACPRUpperDB,
 				ACPRLowerDB:      occ.ACPRLowerDB,


### PR DESCRIPTION
## Summary

Tier 2 of the protocol-agnostic RF network analyzer (`internal/rfscope`). Tiers 0–1 (merged) gave the source-agnostic core, the protocol-hierarchy / activity-timeline / burst-timing analyzers, and the emitter/conversation topology graph. This closes the detection→byte-analysis loop and adds the anomaly layer — the RF analogs of Wireshark's entropy-based "is this flow encrypted?" and Expert Information. It is built **on** the merged #832 cryptolab engines (randomness battery, keystream-reuse, byte-period) rather than re-deriving any crypto, and emits #832's exact `ks` frames format so the toolkit consumes rfscope output directly.

With this tier the six core Wireshark-analog features are complete: `rfscope list` shows hierarchy, timeline, timing, topology, entropy, expert.

## Changes

- **`payload.go`** — `recoverPayload`: blind FM-discriminate a digital burst, integrate-and-dump at the detected symbol rate into 2-/4-level symbols, slice on data-derived thresholds, pack MSB-first to bytes (matching `lfsr.BitsFromBytes`'s bit order). Triage-grade, not a protocol-exact demod.
- **`entropy.go`** — the `entropy` analyzer (depends on `topology`). For each unidentified digital emitter it recovers a payload and runs the cryptolab randomness battery plus the measurements `classify auto` uses, labeling it plaintext / substitution-or-shift / repeating-xor / periodic-scrambler / lfsr-or-keyless-scrambler / strong-encrypted with the toolkit's exact thresholds and recommended next command. Calls the **untagged** `cryptolab/engine/{stats,randomness,lfsr}` directly, so it works in the default binary. Results land in `AnalyzerOutputs["entropy"]`.
- **`bridge.go`** — `EmitFrames` writes recovered payloads as a cryptolab `ks` frames file (JSONL `{label,iv,ct}`, iv/ct hex) — byte-for-byte what `cryptolab/tools/ks.go` parses. `DetectKeystreamReuse` runs `keystream.FindReuse` in-binary. New `-frames-out` CLI flag on `rfscope analyze`/`live`.
- **`rfscope_cryptolab.go` / `rfscope_cryptolab_stub.go`** — `RunCryptolabTool` behind `//go:build cryptolab` (with a `!cryptolab` stub returning a rebuild hint), mirroring `cryptolab_enabled.go`/`cryptolab_disabled.go`; the CLI runs the `ks reuse` hand-off in-process when linked.
- **`segment.go`** — occupied-bandwidth fix: use survey's above-noise-floor outward walk, which doesn't collapse on FM-family carriers the way `ComputeOccupancy`'s 99%-power span does (a P25 C4FM channel now reports ~25 kHz, not ~0.4 kHz).
- **`expert.go`** — the `expert` analyzer (depends on `topology`, `timeline`, `entropy`): flags frequency hoppers, intermittent emitters, abnormally wide/narrow carriers, noise-like (high spectral-flatness) carriers, and the entropy triage's encrypted/obfuscated/unknown-protocol findings; severity-sorted, appended (not overwriting) for stable output.

## Test plan

- [x] `make vet test` is green locally
- [x] `go build -tags cryptolab` + `go test -tags cryptolab ./internal/rfscope/...` green (the tool hand-off path)
- [ ] `make integration` is green locally — n/a, no daemon/DSP path touched
- [x] Added or updated tests where appropriate (payload round-trip, classify taxonomy with shared assertions against the engines, frames-format hex round-trip, keystream-reuse grouping, each expert rule)
- [ ] Smoke-tested against real hardware — n/a; verified end-to-end on a synthesized `gophertrunk gen` P25 capture (all six analyzers run; `-frames-out` emits the ks file)

## Breaking changes

None. Additive: new analyzers in an existing package, a new `-frames-out` flag, and an optional cryptolab-tagged hand-off. The default binary needs no build tag.

## Docs / CHANGELOG

- [ ] CHANGELOG / docs — deferred to the roadmap's polish tier (the feature is surfaced only via the `rfscope` subcommand so far).

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkhQ64GwXMUX4jvYDBQEEC)_