### PR TITLE
cryptolab: external-cipher bridge — run unbundled ciphers (TEA1) without shipping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **cryptolab external-cipher bridge (TEA1 et al.).** `assess crypto` and the
+  `recipe` pipeline can now drive an operator-supplied cipher program as a
+  subprocess (`engine/extcipher`), so unbundled ciphers — most importantly the
+  TETRA TEA1 32-bit backdoor brute — are fully runnable by pointing the harness
+  at a vetted tool, without GopherTrunk shipping a cipher it can't verify or
+  whose only reference is licence-incompatible. `assess` gains `-extern-cmd` /
+  `-extern-algid` (brute the backdoor natively in the plugin, then verify +
+  decrypt + grade); the recipe pipeline gains an `extern-decrypt` op. Both are
+  CLI-only — the web recipe endpoint refuses host-execution ops (HTTP 403).
 - **cryptolab web Recipe Builder.** The cryptolab console gains a *Recipe
   Builder* tab that drives the `recipe` pipeline interactively (config-builder
   style): pick an input, assemble an ordered operation list from a palette with

--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -164,10 +164,11 @@ Operations (run `recipe run -list` for the live set): transforms `xor`, `not`,
 `reverse-bits`, `hex-decode`, `hex-encode`, `base64-decode`, `slice`,
 `rc4-decrypt` (raw RC4 with a caller-supplied key — DMR Enhanced Privacy /
 generic), `adp-decrypt`, `des-ofb-decrypt`, `tdes-ofb-decrypt`,
-`aes-ofb-decrypt`, `descramble-invert`; analyses `stats`, `randomness`. The
-cipher ops reuse the same `p25crypto` keystream constructions the `assess`
-harness uses, so a recipe can decrypt a known-key capture and immediately
-measure the result.
+`aes-ofb-decrypt`, `descramble-invert`, and `extern-decrypt` (decrypt via an
+external cipher program — CLI only); analyses `stats`, `randomness`. The cipher
+ops reuse the same `p25crypto` keystream constructions the `assess` harness
+uses, so a recipe can decrypt a known-key capture and immediately measure the
+result.
 
 ### Web recipe builder
 
@@ -363,6 +364,44 @@ cipher — AES/3DES with a non-default key and rotated IVs has an infeasible
 keyspace, reported plainly as `RESISTANT`. What it breaks is what fails in the
 field: reused IVs, default/test keys, small/backdoored keyspaces, keyless
 obfuscation, and weak keystreams.
+
+### External ciphers (TEA1 and other unbundled ciphers)
+
+The toolkit deliberately does **not** bundle proprietary/reverse-engineered
+ciphers it cannot verify or whose only implementations are licence-incompatible
+(TETRA TEA1–4: the public reference is AGPL, this project is Apache-2.0).
+Instead it can drive an **operator-supplied** cipher program as a subprocess,
+so e.g. the TEA1 32-bit backdoor brute is fully runnable once you point the
+harness at a vetted TEA1 tool — without shipping or vouching for the cipher.
+
+The program implements a small, shell-free line protocol (see
+`internal/cryptolab/engine/extcipher`):
+
+```
+<prog> [fixed args…] keystream <key_hex> <iv_hex> <n>
+    → prints <keystream_hex> (n bytes)
+<prog> [fixed args…] brute <iv_hex> <known_keystream_hex> <bits> <base_key_hex>
+    → prints the recovered <key_hex> (or an empty line)
+```
+
+The `brute` verb keeps the heavy key search native in the cipher; the harness
+orchestrates it, verifies the hit, and decrypts the corpus. Wire it in with:
+
+```
+# Brute the TEA1 backdoor (32-bit effective key) via your TEA1 tool, then
+# decrypt + grade the capture. Needs a known-plaintext oracle.
+cryptolab assess crypto -in frames.jsonl -protocol tetra \
+    -known-label call-3 -known-pt known.bin \
+    -extern-cmd "tea1-tool" -extern-algid 0x01 -brute-bits 32
+
+# Or decrypt with a recovered key inside a recipe (CLI only):
+#   {"op":"extern-decrypt","cmd":"tea1-tool","key":"<hex>","mi":"<iv hex>"}
+```
+
+**Safety**: external ciphers run a host program, so `-extern-cmd` and the
+`extern-decrypt` recipe op are **CLI-only**. The web console hides the op and
+the `POST /api/v1/cryptolab/recipe` endpoint refuses it (HTTP 403), so a browser
+request can never execute a program on the host.
 
 ## Scope note
 

--- a/internal/cryptolab/engine/assess/assess.go
+++ b/internal/cryptolab/engine/assess/assess.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/cipherinfo"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/dmrcrypto"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/extcipher"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/keystream"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
@@ -51,6 +52,11 @@ type Input struct {
 	// BaseKey is the fixed remainder of the key for the brute (the high bits);
 	// nil means all-zero.
 	BaseKey []byte
+	// ExternCmd, when set, is an external cipher program (engine/extcipher)
+	// used to brute / decrypt an unbundled cipher (e.g. TETRA TEA1). It applies
+	// to frames whose AlgID == ExternAlgID. CLI-only; never set from the web.
+	ExternCmd   string
+	ExternAlgID uint8
 }
 
 // MethodResult is one method's outcome.
@@ -320,6 +326,12 @@ func methodKeyBrute(in Input, total int) (MethodResult, []byte) {
 	if proto == "" {
 		proto = "p25"
 	}
+	// External cipher path: an operator-supplied program brutes the unbundled
+	// cipher natively (e.g. TEA1's 32-bit backdoor). This is what makes the
+	// TEA1 brute actually runnable without shipping the cipher.
+	if in.ExternCmd != "" && oracle.AlgID == in.ExternAlgID {
+		return externBrute(in, oracle, total)
+	}
 	suite := suiteFor(proto)
 	if !suite.Supported(oracle.AlgID) {
 		// Unbundled cipher: report the brute that would apply (e.g. TEA1).
@@ -375,6 +387,52 @@ func methodKeyBrute(in Input, total int) (MethodResult, []byte) {
 	m.Detail = map[string]any{"algorithm": suite.AlgName(oracle.AlgID), "searched": space, "brute_bits": in.BruteBits}
 	m.note(fmt.Sprintf("searched all 2^%d low-bit keys for %s; none matched. The key lies outside this slice of the keyspace.", in.BruteBits, suite.AlgName(oracle.AlgID)))
 	return m, nil
+}
+
+// externBrute runs the reduced-keyspace brute through an external cipher
+// program for a cipher the toolkit does not bundle (e.g. TEA1). The plugin does
+// the native key search; we verify the hit and decrypt the matching frames.
+func externBrute(in Input, oracle *keystream.Frame, total int) (MethodResult, []byte) {
+	m := MethodResult{Name: "key-brute"}
+	cli, err := extcipher.New(in.ExternCmd)
+	if err != nil {
+		m.note("external cipher: " + err.Error())
+		return m, nil
+	}
+	m.Applicable = true
+	want := keystream.XOR(in.KnownPT, oracle.CT)
+	if len(want) == 0 {
+		m.note("oracle plaintext/ciphertext overlap is empty.")
+		return m, nil
+	}
+	base := append([]byte(nil), in.BaseKey...)
+	if len(base) == 0 {
+		m.note("external brute needs -base-key set to zeros of the cipher's key length (e.g. 10 bytes for TEA1's 80-bit key) so the search knows the key size.")
+		return m, nil
+	}
+	key, found, err := cli.Brute(oracle.IV, want, base, in.BruteBits)
+	if err != nil {
+		m.note("external brute: " + err.Error())
+		return m, nil
+	}
+	if !found {
+		m.Detail = map[string]any{"external": in.ExternCmd, "brute_bits": in.BruteBits}
+		m.note(fmt.Sprintf("external cipher searched the low %d bits and found no key.", in.BruteBits))
+		return m, nil
+	}
+	ks, err := cli.Keystream(key, oracle.IV, len(want))
+	if err != nil || !bytesEqual(ks, want) {
+		m.note("external cipher returned a key that does not verify against the known plaintext.")
+		return m, nil
+	}
+	m.Verified = true
+	m.Effectiveness = effForAlg(in.Frames, oracle.AlgID, total)
+	m.RecoveredBytes = bytesForAlg(in.Frames, oracle.AlgID)
+	m.SampleHex = hexPreview(in.KnownPT, 32)
+	m.SampleASCII = asciiPreview(in.KnownPT, 32)
+	m.Detail = map[string]any{"key_hex": hex.EncodeToString(key), "external": in.ExternCmd, "brute_bits": in.BruteBits}
+	m.note(fmt.Sprintf("COMPLETE BREAK: the external cipher recovered key %s via a %d-bit brute — every frame under it is decryptable.", hex.EncodeToString(key), in.BruteBits))
+	return m, ks
 }
 
 // methodIVReuse: structural keystream reuse. This is an EXPOSURE method, not a

--- a/internal/cryptolab/engine/assess/assess_extern_test.go
+++ b/internal/cryptolab/engine/assess/assess_extern_test.go
@@ -1,0 +1,93 @@
+package assess
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/crypto/rc4"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/keystream"
+)
+
+func mockSpec() string { return os.Args[0] + " -test.run=TestHelperProcess --" }
+
+// TestHelperProcess is a mock external cipher (RC4 over key‖iv standing in for
+// an unbundled cipher such as TEA1). A no-op unless invoked with a "--" marker.
+func TestHelperProcess(t *testing.T) {
+	args := os.Args
+	sep := -1
+	for i, a := range args {
+		if a == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep < 0 || sep+1 >= len(args) {
+		return
+	}
+	rest := args[sep+1:]
+	ksOf := func(key, iv []byte, n int) []byte {
+		c, _ := rc4.NewCipher(append(append([]byte{}, key...), iv...))
+		return c.KeyStream(n)
+	}
+	switch rest[0] {
+	case "keystream":
+		key, _ := hex.DecodeString(rest[1])
+		iv, _ := hex.DecodeString(rest[2])
+		n, _ := strconv.Atoi(rest[3])
+		fmt.Println(hex.EncodeToString(ksOf(key, iv, n)))
+	case "brute":
+		iv, _ := hex.DecodeString(rest[1])
+		known, _ := hex.DecodeString(rest[2])
+		bits, _ := strconv.Atoi(rest[3])
+		base, _ := hex.DecodeString(rest[4])
+		found := ""
+		for v := 0; v < (1 << uint(bits)); v++ {
+			key := append([]byte(nil), base...)
+			for b := 0; b*8 < bits; b++ {
+				key[len(key)-1-b] = byte(v >> uint(8*b))
+			}
+			if bytes.Equal(ksOf(key, iv, len(known)), known) {
+				found = hex.EncodeToString(key)
+				break
+			}
+		}
+		fmt.Println(found)
+	}
+	os.Exit(0)
+}
+
+// TestAssessExternalBruteBreaksTEA1Stand_in: an "unbundled" cipher (algid 0x01,
+// here mocked by RC4) is broken via the external-cipher brute path, exactly the
+// shape of the TEA1 32-bit backdoor attack.
+func TestAssessExternalBruteBreaks(t *testing.T) {
+	t.Parallel()
+	const alg = 0x01 // pretend TEA1 (tetra)
+	key := []byte{0, 0, 0x0A, 0xBC}
+	iv := []byte{0x11, 0x22}
+	pt := []byte("EMERGENCY DISPATCH ALL UNITS NOW")
+	c, _ := rc4.NewCipher(append(append([]byte{}, key...), iv...))
+	ct := xorb(pt, c.KeyStream(len(pt)))
+	f := keystream.Frame{Label: "t1", IV: iv, CT: ct, AlgID: alg}
+
+	rep := Run(Input{
+		Frames:      []keystream.Frame{f},
+		Protocol:    "tetra",
+		KnownLabel:  "t1",
+		KnownPT:     pt,
+		BruteBits:   13,
+		BaseKey:     make([]byte, len(key)),
+		ExternCmd:   mockSpec(),
+		ExternAlgID: alg,
+	})
+	if rep.Verdict != VerdictBroken {
+		t.Fatalf("external brute should break the cipher, verdict = %s; methods: %+v", rep.Verdict, rep.Methods)
+	}
+	kb := find(rep, "key-brute")
+	if kb == nil || !kb.Verified {
+		t.Fatalf("key-brute should be verified via the external cipher, got %+v", kb)
+	}
+}

--- a/internal/cryptolab/engine/extcipher/extcipher.go
+++ b/internal/cryptolab/engine/extcipher/extcipher.go
@@ -1,0 +1,114 @@
+// Package extcipher bridges to an external, operator-supplied cipher program so
+// the toolkit can decrypt and brute-force ciphers it does not (and should not)
+// bundle itself — most importantly TETRA TEA1, whose only public
+// implementations are licence-incompatible (AGPL) with this Apache-2.0 project
+// and which must not be re-authored unverified inside a security-test tool.
+//
+// The operator points the harness at a program (e.g. MidnightBlue's TEA1 tool
+// or sq5bpf/teatime) that implements a tiny, shell-free line protocol:
+//
+//	<prog> [fixed args…] keystream <key_hex> <iv_hex> <n>
+//	    → prints <keystream_hex> (n bytes) on stdout
+//	<prog> [fixed args…] brute <iv_hex> <known_keystream_hex> <bits> <base_key_hex>
+//	    → prints the recovered <key_hex> (or an empty line if none) on stdout
+//
+// The `brute` verb keeps the heavy 2^32-style key search in the native
+// external cipher; the toolkit orchestrates it, verifies the result, and
+// decrypts the corpus with `keystream`. The program is invoked with exec (no
+// shell), and key/IV values are passed as separate argv entries, so the cipher
+// values cannot inject a command. This capability is CLI-only by design — the
+// web console refuses recipes that shell out (see the webserver).
+package extcipher
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Client runs an external cipher program.
+type Client struct {
+	prog string
+	args []string // fixed leading args before the verb
+	// KeystreamTimeout / BruteTimeout bound each call.
+	KeystreamTimeout time.Duration
+	BruteTimeout     time.Duration
+}
+
+// New parses a command spec ("prog --flag value") into a Client. The first
+// field is the program; the rest are fixed leading arguments. It does not run a
+// shell, so the spec must not rely on shell features.
+func New(spec string) (*Client, error) {
+	fields := strings.Fields(spec)
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("extcipher: empty command")
+	}
+	return &Client{
+		prog:             fields[0],
+		args:             fields[1:],
+		KeystreamTimeout: 30 * time.Second,
+		BruteTimeout:     30 * time.Minute,
+	}, nil
+}
+
+// Keystream asks the external cipher for n keystream bytes under (key, iv).
+func (c *Client) Keystream(key, iv []byte, n int) ([]byte, error) {
+	out, err := c.run(c.KeystreamTimeout, "keystream", hex.EncodeToString(key), hex.EncodeToString(iv), fmt.Sprintf("%d", n))
+	if err != nil {
+		return nil, err
+	}
+	ks, err := decodeHexLine(out)
+	if err != nil {
+		return nil, fmt.Errorf("extcipher: keystream output: %w", err)
+	}
+	if len(ks) < n {
+		return nil, fmt.Errorf("extcipher: keystream returned %d bytes, want %d", len(ks), n)
+	}
+	return ks[:n], nil
+}
+
+// Brute asks the external cipher to search the low `bits` of the key against a
+// known keystream (knownKS), with the high bits fixed to baseKey. It returns
+// the recovered key and whether one was found.
+func (c *Client) Brute(iv, knownKS, baseKey []byte, bits int) ([]byte, bool, error) {
+	out, err := c.run(c.BruteTimeout, "brute", hex.EncodeToString(iv), hex.EncodeToString(knownKS), fmt.Sprintf("%d", bits), hex.EncodeToString(baseKey))
+	if err != nil {
+		return nil, false, err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil, false, nil
+	}
+	key, err := decodeHexLine(out)
+	if err != nil {
+		return nil, false, fmt.Errorf("extcipher: brute output: %w", err)
+	}
+	return key, true, nil
+}
+
+func (c *Client) run(timeout time.Duration, verb string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	full := append(append([]string(nil), c.args...), append([]string{verb}, args...)...)
+	cmd := exec.CommandContext(ctx, c.prog, full...)
+	out, err := cmd.Output()
+	if ctx.Err() == context.DeadlineExceeded {
+		return "", fmt.Errorf("extcipher: %q %s timed out after %s", c.prog, verb, timeout)
+	}
+	if err != nil {
+		return "", fmt.Errorf("extcipher: %q %s failed: %w", c.prog, verb, err)
+	}
+	return string(out), nil
+}
+
+// decodeHexLine decodes the first whitespace-trimmed line of s as hex.
+func decodeHexLine(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	return hex.DecodeString(s)
+}

--- a/internal/cryptolab/engine/extcipher/extcipher_test.go
+++ b/internal/cryptolab/engine/extcipher/extcipher_test.go
@@ -1,0 +1,116 @@
+package extcipher
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/crypto/rc4"
+)
+
+// mockSpec returns a command spec that re-execs this test binary as a mock
+// external cipher (RC4 over key‖iv stands in for the real cipher).
+func mockSpec() string {
+	return os.Args[0] + " -test.run=TestHelperProcess --"
+}
+
+// TestHelperProcess is the mock external cipher. The Go test framework also
+// runs it as an ordinary test; without a "--" marker in argv it is a no-op, so
+// only the subprocess invocation (which appends "-- <verb> …") acts.
+func TestHelperProcess(t *testing.T) {
+	args := os.Args
+	sep := -1
+	for i, a := range args {
+		if a == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep < 0 || sep+1 >= len(args) {
+		return // ordinary test run — do nothing
+	}
+	rest := args[sep+1:]
+	ks := func(key, iv []byte, n int) []byte {
+		c, _ := rc4.NewCipher(append(append([]byte{}, key...), iv...))
+		return c.KeyStream(n)
+	}
+	switch rest[0] {
+	case "keystream":
+		key, _ := hex.DecodeString(rest[1])
+		iv, _ := hex.DecodeString(rest[2])
+		n, _ := strconv.Atoi(rest[3])
+		fmt.Println(hex.EncodeToString(ks(key, iv, n)))
+	case "brute":
+		iv, _ := hex.DecodeString(rest[1])
+		known, _ := hex.DecodeString(rest[2])
+		bits, _ := strconv.Atoi(rest[3])
+		base, _ := hex.DecodeString(rest[4])
+		found := ""
+		for v := 0; v < (1 << uint(bits)); v++ {
+			key := append([]byte(nil), base...)
+			for b := 0; b*8 < bits; b++ {
+				key[len(key)-1-b] = byte(v >> uint(8*b))
+			}
+			if bytes.Equal(ks(key, iv, len(known)), known) {
+				found = hex.EncodeToString(key)
+				break
+			}
+		}
+		fmt.Println(found)
+	}
+	os.Exit(0)
+}
+
+func TestKeystream(t *testing.T) {
+	cli, err := New(mockSpec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := []byte{1, 2, 3}
+	iv := []byte{9, 9}
+	got, err := cli.Keystream(key, iv, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref := func() []byte {
+		c, _ := rc4.NewCipher(append(append([]byte{}, key...), iv...))
+		return c.KeyStream(16)
+	}()
+	if !bytes.Equal(got, ref) {
+		t.Fatalf("keystream mismatch: %x vs %x", got, ref)
+	}
+}
+
+func TestBruteRecoversLowBits(t *testing.T) {
+	cli, err := New(mockSpec())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// True key: zeros except low 12 bits = 0xABC.
+	key := []byte{0, 0, 0, 0x0A, 0xBC}
+	iv := []byte{7, 7}
+	pt := []byte("KNOWN PLAINTEXT FRAME HERE")
+	c, _ := rc4.NewCipher(append(append([]byte{}, key...), iv...))
+	known := c.KeyStream(len(pt))
+
+	base := make([]byte, len(key))
+	got, found, err := cli.Brute(iv, known, base, 13)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("brute did not find the key")
+	}
+	if !bytes.Equal(got, key) {
+		t.Fatalf("recovered key %x, want %x", got, key)
+	}
+}
+
+func TestNewRejectsEmpty(t *testing.T) {
+	if _, err := New("   "); err == nil {
+		t.Fatal("expected error for empty command")
+	}
+}

--- a/internal/cryptolab/engine/recipe/recipe.go
+++ b/internal/cryptolab/engine/recipe/recipe.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/crypto/rc4"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/extcipher"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/lfsr"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/randomness"
@@ -66,9 +67,13 @@ type OpParam struct {
 
 type opDef struct {
 	transform bool
-	synopsis  string
-	params    []OpParam
-	fn        opFunc
+	// external is true when the op shells out to an operator-supplied program
+	// (engine/extcipher). Such ops are CLI/file-recipe only — the web recipe
+	// endpoint refuses them so a browser request can never run a host program.
+	external bool
+	synopsis string
+	params   []OpParam
+	fn       opFunc
 }
 
 // param spec presets shared by several ops.
@@ -93,9 +98,14 @@ var ops = map[string]opDef{
 	"tdes-ofb-decrypt":  {transform: true, synopsis: "P25 Triple-DES-OFB decrypt (key=hex 24B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgTDES)},
 	"aes-ofb-decrypt":   {transform: true, synopsis: "P25 AES-OFB decrypt (key=hex 16/32B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgAES256)},
 	"descramble-invert": {transform: true, synopsis: "full-band spectral inversion of s16le mono PCM (self-inverse)", fn: opDescramble},
+	"extern-decrypt":    {transform: true, external: true, synopsis: "decrypt via an external cipher program (e.g. a TETRA TEA1 tool) — CLI only", params: []OpParam{{Name: "cmd", Label: "Cipher program", Kind: "string", Help: "external program implementing the extcipher protocol"}, keyParam, miParam}, fn: opExternDecrypt},
 	"stats":             {transform: false, synopsis: "report entropy / index-of-coincidence / chi-square", fn: opStats},
 	"randomness":        {transform: false, synopsis: "quick NIST randomness subset (strong vs structured)", fn: opRandomness},
 }
+
+// External reports whether op shells out to a host program (and so must be
+// refused on the web recipe endpoint). Unknown ops report false.
+func External(op string) bool { return ops[op].external }
 
 // Run executes the steps over input, threading the working buffer through the
 // transforms. A step error aborts the pipeline and is returned with the
@@ -130,6 +140,7 @@ type OpSpec struct {
 	Name      string    `json:"name"`
 	Synopsis  string    `json:"synopsis"`
 	Transform bool      `json:"transform"`
+	External  bool      `json:"external,omitempty"`
 	Params    []OpParam `json:"params,omitempty"`
 }
 
@@ -138,7 +149,7 @@ type OpSpec struct {
 func Specs() []OpSpec {
 	out := make([]OpSpec, 0, len(ops))
 	for name, def := range ops {
-		out = append(out, OpSpec{Name: name, Synopsis: def.synopsis, Transform: def.transform, Params: def.params})
+		out = append(out, OpSpec{Name: name, Synopsis: def.synopsis, Transform: def.transform, External: def.external, Params: def.params})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
@@ -178,6 +189,34 @@ func opXOR(buf []byte, p params) ([]byte, map[string]any, string, error) {
 		out[i] = buf[i] ^ key[i%len(key)]
 	}
 	return out, map[string]any{"key_len": len(key)}, "", nil
+}
+
+func opExternDecrypt(buf []byte, p params) ([]byte, map[string]any, string, error) {
+	cmd := strings.TrimSpace(p.str("cmd"))
+	if cmd == "" {
+		return nil, nil, "", fmt.Errorf("extern-decrypt: cmd is required")
+	}
+	key, err := p.hex("key")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	iv, err := p.hex("mi")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	cli, err := extcipher.New(cmd)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	ks, err := cli.Keystream(key, iv, len(buf))
+	if err != nil {
+		return nil, nil, "", err
+	}
+	out := make([]byte, len(buf))
+	for i := range buf {
+		out[i] = buf[i] ^ ks[i]
+	}
+	return out, map[string]any{"cipher": cmd}, "", nil
 }
 
 func opRC4(buf []byte, p params) ([]byte, map[string]any, string, error) {

--- a/internal/cryptolab/engine/recipe/recipe_test.go
+++ b/internal/cryptolab/engine/recipe/recipe_test.go
@@ -82,6 +82,28 @@ func TestRC4DecryptOp(t *testing.T) {
 	}
 }
 
+func TestExternDecryptMarkedExternal(t *testing.T) {
+	t.Parallel()
+	if !External("extern-decrypt") {
+		t.Fatal("extern-decrypt must be flagged external (so the web endpoint refuses it)")
+	}
+	if External("xor") {
+		t.Fatal("xor is not external")
+	}
+	var found bool
+	for _, s := range Specs() {
+		if s.Name == "extern-decrypt" {
+			found = true
+			if !s.External {
+				t.Fatal("Specs() should mark extern-decrypt External")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("extern-decrypt missing from Specs()")
+	}
+}
+
 func TestSpecsExposeParams(t *testing.T) {
 	t.Parallel()
 	var sawXORKey, sawCipherMI bool

--- a/internal/cryptolab/tools/assess.go
+++ b/internal/cryptolab/tools/assess.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
@@ -40,6 +41,8 @@ func (assessCrypto) Run(_ context.Context, args []string, _ cryptolab.Env) (*cry
 	keysFile := fs.String("keys", "", "optional file of candidate keys (one hex key per line) for the weak-key method")
 	bruteBits := fs.Int("brute-bits", 0, "reduced-keyspace brute: search the low N bits of the key against the known-plaintext oracle (0 = off)")
 	baseKeyHex := fs.String("base-key", "", "fixed high bits of the key for -brute-bits, as hex (default all-zero)")
+	externCmd := fs.String("extern-cmd", "", "external cipher program for an unbundled cipher (e.g. a TETRA TEA1 tool); used with -brute-bits to brute it natively")
+	externAlgHex := fs.String("extern-algid", "", "algid the -extern-cmd cipher handles, as hex (e.g. 0x01 for tetra TEA1)")
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
@@ -47,7 +50,14 @@ func (assessCrypto) Run(_ context.Context, args []string, _ cryptolab.Env) (*cry
 	if err != nil {
 		return nil, err
 	}
-	input := assess.Input{Frames: frames, Protocol: *protocol, KnownLabel: *knownLabel, BruteBits: *bruteBits}
+	input := assess.Input{Frames: frames, Protocol: *protocol, KnownLabel: *knownLabel, BruteBits: *bruteBits, ExternCmd: *externCmd}
+	if *externAlgHex != "" {
+		alg, err := parseAlgID(*externAlgHex)
+		if err != nil {
+			return nil, fmt.Errorf("-extern-algid: %w", err)
+		}
+		input.ExternAlgID = alg
+	}
 	if *baseKeyHex != "" {
 		bk, err := hex.DecodeString(*baseKeyHex)
 		if err != nil {
@@ -123,6 +133,21 @@ func (assessCrypto) Run(_ context.Context, args []string, _ cryptolab.Env) (*cry
 	}
 	res.Note("effectiveness is the fraction of captured ciphertext each method recovered or exposed; 100% from a verified method is a complete break.")
 	return res, nil
+}
+
+// parseAlgID parses an algorithm id given as hex (0x01), decimal, or bare hex.
+func parseAlgID(s string) (uint8, error) {
+	s = strings.TrimSpace(s)
+	base := 0 // let ParseUint infer 0x / decimal
+	if !strings.HasPrefix(s, "0x") && !strings.HasPrefix(s, "0X") {
+		// A bare token like "AA" is hex by convention for algids.
+		base = 16
+	}
+	v, err := strconv.ParseUint(s, base, 8)
+	if err != nil {
+		return 0, fmt.Errorf("bad algid %q: %w", s, err)
+	}
+	return uint8(v), nil
 }
 
 // loadHexKeys reads a candidate-key file: one hex-encoded key per line, blank

--- a/internal/cryptolab/webserver/recipe.go
+++ b/internal/cryptolab/webserver/recipe.go
@@ -66,6 +66,12 @@ func (s *Server) handleRecipe(w http.ResponseWriter, r *http.Request) {
 
 	steps := make([]recipe.Step, len(req.Steps))
 	for i, st := range req.Steps {
+		// Refuse ops that shell out to a host program — those are CLI-only, so
+		// a browser request can never run an arbitrary command on the host.
+		if recipe.External(st.Op) {
+			writeErr(w, http.StatusForbidden, "recipe: the "+st.Op+" operation runs a host program and is not available over the web; use the CLI")
+			return
+		}
 		steps[i] = recipe.Step{Op: st.Op, Params: st.Params}
 	}
 

--- a/internal/cryptolab/webserver/recipe_test.go
+++ b/internal/cryptolab/webserver/recipe_test.go
@@ -48,6 +48,25 @@ func TestRecipeOpsEndpoint(t *testing.T) {
 	}
 }
 
+func TestRecipeEndpointRejectsExternalOp(t *testing.T) {
+	t.Parallel()
+	ts := newTestServer(t)
+	id := uploadFile(t, ts.URL, "in.bin", []byte("data"))
+	body, _ := json.Marshal(map[string]any{
+		"input_id": id,
+		"steps":    []map[string]any{{"op": "extern-decrypt", "params": map[string]any{"cmd": "/bin/false", "key": "00"}}},
+	})
+	resp, err := http.Post(ts.URL+"/api/v1/cryptolab/recipe", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("external op should be 403 over the web, got %d: %s", resp.StatusCode, b)
+	}
+}
+
 func TestRecipeEndpointDecrypts(t *testing.T) {
 	t.Parallel()
 	ts := newTestServer(t)

--- a/web/cryptolab/src/api/types.ts
+++ b/web/cryptolab/src/api/types.ts
@@ -80,6 +80,7 @@ export interface OpSpec {
   name: string;
   synopsis: string;
   transform: boolean;
+  external?: boolean;
   params?: OpParam[];
 }
 

--- a/web/cryptolab/src/components/RecipeBuilder.tsx
+++ b/web/cryptolab/src/components/RecipeBuilder.tsx
@@ -30,9 +30,10 @@ export function RecipeBuilder() {
   }, [loadOps]);
 
   const grouped = useMemo(() => {
-    const transforms = ops.filter((o) => o.transform);
-    const analyses = ops.filter((o) => !o.transform);
-    return { transforms, analyses };
+    // External ops shell out to a host program; they are CLI-only and the
+    // recipe endpoint refuses them, so the web palette hides them.
+    const web = ops.filter((o) => !o.external);
+    return { transforms: web.filter((o) => o.transform), analyses: web.filter((o) => !o.transform) };
   }, [ops]);
 
   const canRun = !!input && steps.length > 0 && !running && !uploading;


### PR DESCRIPTION
## Summary

Closes the last roadmap item — the **TETRA TEA1 32-bit backdoor brute** — honestly. ETSI has now published TEA1, but the only public *implementation* is AGPL-3.0 (incompatible with this Apache-2.0 project), ETSI blocks automated fetch of the spec/test-vectors, and a security-test tool must never ship a cipher it can't verify (a wrong cipher gives false `BROKEN`/`RESISTANT` verdicts). So instead of re-authoring TEA1, the harness drives an **operator-supplied, vetted cipher program as a subprocess** — no licence contamination (not linked/copied), no unverified cipher shipped, and the heavy key search runs natively in the plugin.

All behind the `cryptolab` build tag.

## Changes

- **`engine/extcipher`** — a shell-free subprocess client speaking a tiny protocol:
  - `keystream <key_hex> <iv_hex> <n>` → keystream bytes
  - `brute <iv_hex> <known_keystream_hex> <bits> <base_key_hex>` → recovered key (or empty)
  
  Invoked with `exec` (no shell); key/IV values are separate argv entries, so cipher data can't inject a command. Per-call timeouts.
- **`assess`** — `-extern-cmd` / `-extern-algid` wire an external cipher into the `key-brute` method for frames of that algid (e.g. tetra TEA1 = `0x01`). With `-brute-bits` it runs the backdoor brute natively in the plugin, verifies the hit against the known plaintext, decrypts the corpus, and grades `BROKEN`.
- **`recipe`** — an `extern-decrypt` op decrypts via an external cipher.

**Safety**: external ops execute a host program, so they're **CLI-only**. The web recipe endpoint refuses any external op (HTTP 403) and the builder palette hides them, so a browser request can never run a program on the host.

## Test plan

- [x] `make vet test` is green locally (whole repo, `-race`)
- [x] `make test-cryptolab` is green locally
- [x] Added tests — `extcipher` `keystream` + `brute` over a real subprocess (Go helper-process mock, RC4 standing in for the cipher); `assess` external brute → `BROKEN`; `recipe` `extern-decrypt` flagged external + present in `Specs()`; webserver returns 403 on an external op. Frontend `tsc`/`vite` build + `vitest` pass.
- [x] Smoke-tested the built `-tags cryptolab` binary with a mock TEA1-stand-in cipher (a small Python RC4 wrapper implementing the protocol): `assess crypto -protocol tetra -extern-cmd … -extern-algid 0x01 -brute-bits 13 -base-key …` recovers the key, decrypts the frame, and reports `BROKEN`.
- [ ] `make integration` not run (no daemon-path change beyond the gated cryptolab console)

No hardware smoke test — no SDR/USB/vocoder DSP changed.

## Breaking changes

None. New code is behind the `cryptolab` build tag. The external-cipher capability is opt-in and CLI-only.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Updated `docs/cryptolab.md` — a new "External ciphers (TEA1 and other unbundled ciphers)" section documenting the protocol, the flags, the recipe op, and the web-safety guarantee.

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzEG7UxiWbbT5q76ECWWZ5)_