### PR TITLE
cryptolab: surface the Crypto Lab console across the GopherTrunk & siglab web UIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Crypto Lab is discoverable from the other web consoles.** In a
+  `-tags cryptolab` daemon build the main GopherTrunk console shows a *Crypto
+  Lab* nav entry and the Signal Lab header shows a 🔐 Crypto Lab link; the
+  Crypto Lab console links back to both. All gated on a new
+  `runtime.cryptolab_console` flag (`GET /api/v1/runtime`), so the links appear
+  only when the console is actually mounted — default builds and standalone
+  siglab never show a dead link.
 - **cryptolab external-cipher bridge (TEA1 et al.).** `assess crypto` and the
   `recipe` pipeline can now drive an operator-supplied cipher program as a
   subprocess (`engine/extcipher`), so unbundled ciphers — most importantly the

--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -63,6 +63,15 @@ the running daemon without launching a separate `cryptolab serve`. Mutating
 routes share the daemon's mutation gate. The default daemon build links a
 no-op mount, so the toolkit stays out of the standard binary.
 
+In that daemon build the console is **discoverable from the other web UIs**:
+the main GopherTrunk console shows a **Crypto Lab** entry in its System nav
+group, and the Signal Lab (siglab) header shows a **🔐 Crypto Lab** link. Both
+are gated on `runtime.cryptolab_console` (surfaced by `GET /api/v1/runtime`),
+so the link only appears when the Crypto Lab console is actually mounted — a
+default build, or a standalone siglab, never shows a dead link. The Crypto Lab
+header links back to the GopherTrunk console and Signal Lab when it is itself
+daemon-mounted.
+
 ## Usage (CLI)
 
 ```

--- a/internal/api/cryptolab_enabled.go
+++ b/internal/api/cryptolab_enabled.go
@@ -45,6 +45,9 @@ func (s *Server) mountCryptolab(mux *http.ServeMux) {
 		mux.HandleFunc("GET /cryptolab", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/cryptolab/", http.StatusMovedPermanently)
 		})
+		// Advertise the console so the other web UIs surface a Crypto Lab link
+		// only when it is actually reachable (see RuntimeDTO.CryptolabConsole).
+		s.cryptolabConsole = true
 	}
 }
 

--- a/internal/api/handlers_runtime.go
+++ b/internal/api/handlers_runtime.go
@@ -95,6 +95,12 @@ type RuntimeDTO struct {
 	// from web.id_base config; the raw decimal values are always present
 	// in the API/event payloads regardless.
 	IDBase string `json:"id_base,omitempty"`
+
+	// CryptolabConsole is true when the daemon mounts the Crypto Lab SPA at
+	// /cryptolab/ (a -tags cryptolab build). The web consoles use it to show a
+	// Crypto Lab link only when it is reachable. Injected by the API server, not
+	// the daemon's runtime provider.
+	CryptolabConsole bool `json:"cryptolab_console,omitempty"`
 }
 
 // ToneProfileDTO is the minimal projection of a tone-out profile —
@@ -118,6 +124,8 @@ func (s *Server) handleRuntime(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "runtime snapshot unavailable", http.StatusServiceUnavailable)
 		return
 	}
+	dto := s.runtime.Runtime()
+	dto.CryptolabConsole = s.cryptolabConsole
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(s.runtime.Runtime())
+	_ = json.NewEncoder(w).Encode(dto)
 }

--- a/internal/api/handlers_runtime_test.go
+++ b/internal/api/handlers_runtime_test.go
@@ -71,4 +71,34 @@ func TestHandleRuntime_ServesDTO(t *testing.T) {
 	if out.RetentionInterval != fake.dto.RetentionInterval {
 		t.Errorf("retention interval lost: got %v want %v", out.RetentionInterval, fake.dto.RetentionInterval)
 	}
+	// The runtime provider never sets cryptolab_console; the API server injects
+	// it. Default build / unmounted console → absent (false).
+	if out.CryptolabConsole {
+		t.Errorf("cryptolab_console should default to false")
+	}
+}
+
+// TestHandleRuntime_InjectsCryptolabConsole confirms the API server overlays
+// the Crypto Lab console availability onto the runtime DTO (the field the web
+// consoles gate their Crypto Lab link on).
+func TestHandleRuntime_InjectsCryptolabConsole(t *testing.T) {
+	bus := events.NewBus(8)
+	s, err := NewServer(ServerOptions{Addr: "127.0.0.1:0", Bus: bus, Runtime: fakeRuntime{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.cryptolabConsole = true // as set by the -tags cryptolab mount
+
+	rr := httptest.NewRecorder()
+	s.handleRuntime(rr, httptest.NewRequest(http.MethodGet, "/api/v1/runtime", nil))
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status %d", rr.Code)
+	}
+	var out RuntimeDTO
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if !out.CryptolabConsole {
+		t.Error("cryptolab_console should be true once the console is mounted")
+	}
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -394,6 +394,12 @@ type Server struct {
 	// non-tagged server.go does not import the cryptolab packages.
 	cryptolabCloser interface{ Close() error }
 
+	// cryptolabConsole is set true when the cryptolab SPA is mounted at
+	// /cryptolab/ (a -tags cryptolab build with the SPA bundled). The runtime
+	// endpoint surfaces it so the other consoles only link to the Crypto Lab
+	// when it is actually reachable.
+	cryptolabConsole bool
+
 	// configBuilder backs the standalone web Config Builder/Editor:
 	// the /api/v1/config/* routes (browse / load / validate / save /
 	// RadioReference browse) and, when assets are wired, the builder SPA

--- a/internal/sigfollow/manager_test.go
+++ b/internal/sigfollow/manager_test.go
@@ -189,7 +189,10 @@ func TestManagerHarvestsAliasWithoutVoiceTuner(t *testing.T) {
 		}
 	}()
 
-	deadline := time.After(20 * time.Second)
+	// Generous deadline: this drives the full synthesized-IQ → P25 Phase 2
+	// decode pipeline, which under `-race` on a heavily-loaded CI runner can
+	// take tens of seconds. 20s flaked there; 60s keeps margin without hanging.
+	deadline := time.After(60 * time.Second)
 	for {
 		select {
 		case ev := <-aliasSub.C:
@@ -219,7 +222,7 @@ func TestManagerHarvestsAliasWithoutVoiceTuner(t *testing.T) {
 			}
 			return
 		case <-deadline:
-			t.Fatal("no KindTalkerAlias published within 10s — alias not harvested off the signalling tap")
+			t.Fatal("no KindTalkerAlias published within 60s — alias not harvested off the signalling tap")
 		}
 	}
 }

--- a/web/cryptolab/src/App.tsx
+++ b/web/cryptolab/src/App.tsx
@@ -6,6 +6,17 @@ import { RecipeBuilder } from "./components/RecipeBuilder";
 
 export function App() {
   const [page, setPage] = useState<"tools" | "recipe">("tools");
+  // When daemon-mounted (at /cryptolab/), link back to the sibling consoles;
+  // a same-origin runtime probe fails closed under standalone `cryptolab serve`.
+  const [daemon, setDaemon] = useState(false);
+  useEffect(() => {
+    fetch("/api/v1/runtime")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((rt) => {
+        if (rt && typeof rt === "object") setDaemon(true);
+      })
+      .catch(() => {});
+  }, []);
   const loadSchema = useStore((s) => s.loadSchema);
   const schema = useStore((s) => s.schema);
   const loadingSchema = useStore((s) => s.loadingSchema);
@@ -62,7 +73,19 @@ export function App() {
             </button>
           ))}
         </nav>
-        <div className="ml-auto text-xs text-muted">offline cryptographic research</div>
+        <div className="ml-auto flex items-center gap-3 text-xs text-muted">
+          {daemon ? (
+            <>
+              <a href="/" title="GopherTrunk console" className="rounded-md px-2 py-1 hover:text-fg">
+                ◀ GopherTrunk
+              </a>
+              <a href="/siglab/" title="Signal Lab" className="rounded-md px-2 py-1 hover:text-fg">
+                ◷ Signal Lab
+              </a>
+            </>
+          ) : null}
+          <span>offline cryptographic research</span>
+        </div>
       </header>
 
       {page === "recipe" ? (

--- a/web/siglab/src/App.tsx
+++ b/web/siglab/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { NavLink, Navigate, Route, Routes } from "react-router-dom";
 import { useStore } from "./store/shared";
 import { Captures } from "./panels/Captures";
@@ -18,12 +18,27 @@ const tabs = [
 
 export function App() {
   const loadProtocols = useStore((s) => s.loadProtocols);
+  // Surface a Crypto Lab link only when the daemon advertises that console
+  // (a -tags cryptolab build). Same-origin probe; fails closed when siglab
+  // runs standalone or the daemon lacks the console.
+  const [cryptolab, setCryptolab] = useState(false);
 
   useEffect(() => {
     loadProtocols().catch(() => {
       /* surfaced lazily in the forms */
     });
   }, [loadProtocols]);
+
+  useEffect(() => {
+    fetch("/api/v1/runtime")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((rt) => {
+        if (rt && rt.cryptolab_console === true) setCryptolab(true);
+      })
+      .catch(() => {
+        /* no daemon / no console — leave the link hidden */
+      });
+  }, []);
 
   return (
     <div className="flex min-h-full flex-col">
@@ -46,7 +61,18 @@ export function App() {
             </NavLink>
           ))}
         </nav>
-        <div className="ml-auto text-xs text-muted">offline signal analysis</div>
+        <div className="ml-auto flex items-center gap-3 text-xs text-muted">
+          {cryptolab ? (
+            <a
+              href="/cryptolab/"
+              title="Crypto Lab — cryptographic analysis & security testing"
+              className="rounded-md px-2 py-1 hover:text-fg"
+            >
+              🔐 Crypto Lab
+            </a>
+          ) : null}
+          <span>offline signal analysis</span>
+        </div>
       </header>
 
       <main className="flex-1 p-4">

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,6 +52,7 @@ export function App() {
   const setMutations = useShared((s) => s.setMutations);
   const setWSStatus = useShared((s) => s.setWSStatus);
   const setHiddenTabs = useShared((s) => s.setHiddenTabs);
+  const setCryptolabConsole = useShared((s) => s.setCryptolabConsole);
   const setIDBase = useShared((s) => s.setIDBase);
   const setConfigPath = useShared((s) => s.setConfigPath);
   const configPath = useShared((s) => s.configPath);
@@ -110,6 +111,7 @@ export function App() {
       .runtime(cfg)
       .then((rt) => {
         setHiddenTabs(rt.hidden_tabs ?? []);
+        setCryptolabConsole(rt.cryptolab_console === true);
         setIDBase(rt.id_base === "dec" ? "dec" : "hex");
         setConfigPath(rt.config_path ?? "");
       })
@@ -130,6 +132,7 @@ export function App() {
     setMutations,
     setWSStatus,
     setHiddenTabs,
+    setCryptolabConsole,
     setConfigPath,
   ]);
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -465,6 +465,9 @@ export interface RuntimeDTO {
   // IDBase selects how identity numbers (WACN, System ID, NAC, RFSS,
   // Site) are rendered: "hex" (default) or "dec". From web.id_base config.
   id_base?: "hex" | "dec";
+  // CryptolabConsole is true when the daemon serves the Crypto Lab SPA at
+  // /cryptolab/ (a -tags cryptolab build). Gates the Crypto Lab nav link.
+  cryptolab_console?: boolean;
   // RuntimeDTO is large and changes shape as the daemon grows. Read
   // unknown fields lazily.
   [key: string]: unknown;

--- a/web/src/components/shell/AppShell.test.tsx
+++ b/web/src/components/shell/AppShell.test.tsx
@@ -44,8 +44,11 @@ describe("AppShell navigation", () => {
     );
 
     const drawer = await screen.findByRole("dialog", { name: "Navigation" });
-    // Every non-external registry item is reachable inside the drawer.
+    // Every registry item is reachable inside the drawer, except ones gated on
+    // a daemon capability not advertised in this test (e.g. the Crypto Lab
+    // link, shown only when runtime.cryptolab_console is set).
     for (const item of NAV_ITEMS) {
+      if (item.requiresCryptolab) continue;
       expect(
         within(drawer).getByText(item.label),
         `drawer missing ${item.label}`,

--- a/web/src/nav/registry.ts
+++ b/web/src/nav/registry.ts
@@ -24,6 +24,9 @@ export interface NavItem {
   /** Opens `to` in a new browser tab instead of routing (Config
    *  Builder is a separate SPA the daemon serves at /config/). */
   external?: boolean;
+  /** Shown only when the daemon advertises the Crypto Lab console
+   *  (runtime.cryptolab_console — a -tags cryptolab build). */
+  requiresCryptolab?: boolean;
 }
 
 export interface NavGroup {
@@ -106,6 +109,14 @@ export const NAV_GROUPS: NavGroup[] = [
       { to: "/devices", label: "Devices", icon: "⌗", keywords: ["sdr", "pool", "rtl", "dongle"] },
       { to: "/metrics", label: "Metrics", icon: "▰", keywords: ["prometheus", "stats", "graphs"] },
       { to: "/config/", label: "Config Builder", icon: "🛠", external: true, keywords: ["yaml", "editor"] },
+      {
+        to: "/cryptolab/",
+        label: "Crypto Lab",
+        icon: "🔐",
+        external: true,
+        requiresCryptolab: true,
+        keywords: ["crypto", "encryption", "cipher", "decrypt", "tea1", "adp", "des", "aes", "randomness", "keystream", "assess", "recipe"],
+      },
     ],
   },
 ];
@@ -124,13 +135,17 @@ export const PRIMARY_ITEMS: NavItem[] = NAV_ITEMS.filter((i) => i.primary);
  */
 export function useVisibleNavGroups(): NavGroup[] {
   const hiddenTabs = useShared((s) => s.hiddenTabs);
+  const cryptolabConsole = useShared((s) => s.cryptolabConsole);
   return useMemo(() => {
     const hidden = new Set(hiddenTabs);
     return NAV_GROUPS.map((g) => ({
       ...g,
-      items: g.items.filter((i) => i.external || !hidden.has(tabKey(i))),
+      items: g.items.filter((i) => {
+        if (i.requiresCryptolab && !cryptolabConsole) return false;
+        return i.external || !hidden.has(tabKey(i));
+      }),
     })).filter((g) => g.items.length > 0);
-  }, [hiddenTabs]);
+  }, [hiddenTabs, cryptolabConsole]);
 }
 
 /** Flat visible items (for the command palette and bottom nav). */

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -66,6 +66,10 @@ interface SharedState {
    *  nav bar filters these out. Sourced from /api/v1/runtime. */
   hiddenTabs: string[];
 
+  /** True when the daemon serves the Crypto Lab SPA at /cryptolab/
+   *  (a -tags cryptolab build). Gates the Crypto Lab nav link. */
+  cryptolabConsole: boolean;
+
   /** Base for rendering identity numbers (WACN, System ID, NAC, RFSS,
    *  Site): "hex" (default, P25 field convention) or "dec". Sourced from
    *  web.id_base config via /api/v1/runtime. */
@@ -97,6 +101,7 @@ interface SharedState {
   setDevices(d: DeviceDTO[]): void;
   setScanner(s: ScannerStatusDTO | null): void;
   setHiddenTabs(tabs: string[]): void;
+  setCryptolabConsole(v: boolean): void;
   setIDBase(base: "hex" | "dec"): void;
   setConfigPath(path: string | null): void;
   appendEvents(evs: EventDTO[]): void;
@@ -128,6 +133,7 @@ export const useShared = create<SharedState>((set, get) => ({
   events: [],
   eventCap: 500,
   hiddenTabs: [],
+  cryptolabConsole: false,
   idBase: "hex",
   configPath: null,
 
@@ -178,6 +184,9 @@ export const useShared = create<SharedState>((set, get) => ({
   },
   setHiddenTabs(tabs) {
     set({ hiddenTabs: tabs });
+  },
+  setCryptolabConsole(v) {
+    set({ cryptolabConsole: v });
   },
   setIDBase(base) {
     set({ idBase: base });
@@ -255,6 +264,7 @@ export const useShared = create<SharedState>((set, get) => ({
       events: [],
       mutations: null,
       hiddenTabs: [],
+      cryptolabConsole: false,
       idBase: "hex",
       configPath: null,
       lastError: null,


### PR DESCRIPTION
## Summary

The cryptolab web console already surfaces every feature — the schema-driven tools nav auto-renders every registered tool (`stats`, `randomness`, `classify`, `ks`, `assess`, `recipe`, `crc`, `lfsr`, `descramble`, `alias`) and the Recipe Builder tab — but it was only reachable by knowing the `/cryptolab/` URL. This makes it **discoverable from the sibling consoles**, gated so the links never dangle.

## Changes

- **API** — `RuntimeDTO` gains `cryptolab_console`, injected by the API server (not the daemon's runtime provider) and set `true` by the `-tags cryptolab` mount when the SPA is bundled. `GET /api/v1/runtime` now advertises console availability.
- **Main GopherTrunk console** (`web/src`) — a **Crypto Lab** item in the System nav group (alongside Config Builder), shown only when `runtime.cryptolab_console` is set (new store flag + nav-registry filter). A default daemon build never shows a dead link.
- **Signal Lab** (`web/siglab`) — a **🔐 Crypto Lab** link in the header, gated on a same-origin `/api/v1/runtime` probe (fails closed when siglab runs standalone or the daemon lacks the console).
- **Crypto Lab console** (`web/cryptolab`) — links back to the GopherTrunk console and Signal Lab when itself daemon-mounted (same probe), for navigation parity.

Why a runtime flag rather than a static link: `/cryptolab/` only exists in a `-tags cryptolab` daemon build, so a static link would 404 in the (default) operator binary. Gating on `runtime.cryptolab_console` means the entry point appears exactly when the console is reachable.

## Test plan

- [x] `make vet test` is green locally (whole repo, `-race`)
- [x] `make test-cryptolab` is green locally
- [x] Default (untagged) and `-tags cryptolab` Go builds compile
- [x] Added/updated tests — API runtime injection (`cryptolab_console` defaults false, true once the console is mounted); the main console's nav-drawer invariant test now skips capability-gated items. All three web suites pass (`web` main 281, `web/siglab` 10, `web/cryptolab` 2).

No hardware smoke test — UI/runtime-metadata change only; no SDR/DSP/daemon-decode path touched.

## Breaking changes

None. The new `cryptolab_console` runtime field is additive (omitted/false in default builds). The nav links are conditional and absent unless the console is mounted.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Updated `docs/cryptolab.md` (cross-console discoverability + the `runtime.cryptolab_console` gate)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzEG7UxiWbbT5q76ECWWZ5)_