### PR TITLE
airspy: serialise real-to-IQ converter against concurrent USB reapers

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -258,6 +258,17 @@ sdr:
                            # HackRF One 0–560 (~0–56 dB). HackRF has no true AGC,
                            # so "auto" maps to a fixed LNA 16 / VGA 20 dB split.
       bias_tee: false      # enable the 5V bias-tee output for an external LNA
+      # dc_avoid: true     # control role only: tune the LO off-channel and mix
+                           # the channel back to baseband in the down-converter,
+                           # off the front-end DC spur, 1/f noise and the I/Q
+                           # image (the offset tuning SDRTrunk/OP25 use). Helps a
+                           # marginal control site; off by default. Confirm the
+                           # tsbk-crc/nid-bch error rates drop while the channel
+                           # stays locked (issue #402).
+      # dc_avoid_offset_hz: 0  # LO offset in Hz for dc_avoid; 0 auto-selects
+                           # sample_rate/4. Must be < sample_rate/2; ignored when
+                           # dc_avoid is false or the delivered rate is at/below
+                           # the channel rate.
       # blog_v4: true      # force RTL-SDR Blog V4 mode (28.8 MHz xtal + input
                            # routing) if the V4's USB strings don't auto-identify
                            # it and every frequency mistunes by ~1.8× (issue #264).

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -264,6 +264,10 @@ type Device struct {
 	streamDone chan struct{}
 	rates      []uint32     // supported sample rates, Hz, descending order
 	cnv        *iqConverter // real-to-IQ converter, fresh per stream
+	// lastReqRate is the IQ rate (Hz) from the most recent SetSampleRate,
+	// remembered so ActualSampleRate can report the rate the device will
+	// actually deliver after snapping to the firmware's fixed rate table.
+	lastReqRate uint32
 }
 
 // Info implements sdr.Device.
@@ -298,7 +302,54 @@ func (d *Device) SetSampleRate(hz uint32) error {
 	}
 	param := d.sampleRateCommandParam(hz)
 	_, err := d.t.ControlIn(reqSetSamplerate, 0, param, 1, controlTimeoutMs)
+	if err == nil {
+		d.mu.Lock()
+		d.lastReqRate = hz
+		d.mu.Unlock()
+	}
 	return err
+}
+
+// ActualSampleRate reports the IQ rate the device will actually deliver for the
+// most recent SetSampleRate. The Airspy only streams the discrete rates its
+// firmware advertises, so a requested rate the table can't honour (e.g. 6 MS/s
+// on an R2 that does 2.5/10) is snapped to the nearest one by
+// sampleRateCommandParam — silently changing the delivered rate. Implementing
+// this optional sdr.Device extension lets the daemon (effectiveStreamRate) warn
+// on the mismatch and build its down-converters from the rate that actually
+// arrives, keeping the symbol clock aligned (issue #402). Returns the requested
+// rate unchanged when it maps exactly, so correctly-configured rates stay quiet.
+func (d *Device) ActualSampleRate() (uint32, error) {
+	d.mu.Lock()
+	last := d.lastReqRate
+	d.mu.Unlock()
+	if last == 0 {
+		// SetSampleRate hasn't run yet; let the caller fall back to its
+		// requested value rather than inventing one.
+		return 0, nil
+	}
+	return d.resolvedIQRate(last), nil
+}
+
+// resolvedIQRate returns the IQ rate the firmware delivers for a requested IQ
+// rate, mirroring the index decision in sampleRateCommandParam: the requested
+// rate when 2×iqHz matches an advertised device rate exactly, otherwise half
+// the nearest advertised device rate (the converter decimates by two). With no
+// rate table or a sub-MHz request it returns iqHz unchanged (best effort).
+func (d *Device) resolvedIQRate(iqHz uint32) uint32 {
+	d.mu.Lock()
+	rates := d.rates
+	d.mu.Unlock()
+	if iqHz < minSamplerateHz || len(rates) == 0 {
+		return iqHz
+	}
+	deviceHz := iqHz * 2 // converter decimates by two; see SetSampleRate
+	for _, r := range rates {
+		if deviceHz == r {
+			return iqHz
+		}
+	}
+	return rates[d.closestRateIndex(iqHz)] / 2
 }
 
 // sampleRateCommandParam maps a requested IQ rate to the wIndex the

--- a/internal/sdr/airspy/airspy_test.go
+++ b/internal/sdr/airspy/airspy_test.go
@@ -201,6 +201,43 @@ func TestClosestRateIndex(t *testing.T) {
 	}
 }
 
+func TestActualSampleRateReportsSnap(t *testing.T) {
+	// R2 device-rate table {10 MSPS, 2.5 MSPS} → deliverable IQ rates 5 and
+	// 1.25 MHz. ActualSampleRate reports the IQ rate the firmware actually
+	// delivers so the daemon (effectiveStreamRate) can warn on a snap and
+	// realign its down-converter.
+	cases := []struct {
+		name string
+		req  uint32 // requested IQ rate
+		want uint32 // delivered IQ rate
+	}{
+		{"exact 5MHz (device 10M)", 5_000_000, 5_000_000},
+		{"exact 1.25MHz (device 2.5M)", 1_250_000, 1_250_000},
+		{"6MHz snaps to 5MHz (device 12M→10M)", 6_000_000, 5_000_000},
+		{"2.5MHz snaps to 1.25MHz (device 5M→2.5M)", 2_500_000, 1_250_000},
+	}
+	for _, c := range cases {
+		dev := &Device{rates: []uint32{10_000_000, 2_500_000}, lastReqRate: c.req}
+		got, err := dev.ActualSampleRate()
+		if err != nil {
+			t.Fatalf("%s: ActualSampleRate: %v", c.name, err)
+		}
+		if got != c.want {
+			t.Errorf("%s: ActualSampleRate() = %d, want %d", c.name, got, c.want)
+		}
+	}
+
+	// Before any SetSampleRate the device reports 0 so the caller falls back
+	// to its requested value rather than a fabricated rate.
+	if got, _ := (&Device{rates: []uint32{10_000_000}}).ActualSampleRate(); got != 0 {
+		t.Errorf("ActualSampleRate() before SetSampleRate = %d, want 0", got)
+	}
+	// With no advertised table the requested rate passes through unchanged.
+	if got, _ := (&Device{lastReqRate: 6_000_000}).ActualSampleRate(); got != 6_000_000 {
+		t.Errorf("ActualSampleRate() with no table = %d, want 6000000", got)
+	}
+}
+
 func TestSetSampleRateEncodesByValueWhenNoTable(t *testing.T) {
 	// With no device-rate table the param is a by-value encoding of the
 	// device rate (2×IQ) in kHz: IQ 4 MHz → device 8 MHz → 8000.

--- a/internal/sdr/airspy/iqconverter.go
+++ b/internal/sdr/airspy/iqconverter.go
@@ -1,6 +1,9 @@
 package airspy
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"sync"
+)
 
 // The Airspy R2 / Mini are real-sampling receivers: the firmware streams the
 // bare ADC output — unpacked little-endian uint16 real samples (12-bit, DC at
@@ -49,7 +52,16 @@ var hbKernel = [hbTaps]float32{
 }
 
 // iqConverter holds the running state of the real-to-IQ conversion.
+//
+// processRaw is serialised by mu: on macOS the USB transport delivers each
+// bulk-IN payload from one of usb.DefaultRingBuffers (32) concurrent reaper
+// goroutines, all calling processRaw on this one shared converter. Without the
+// lock those goroutines race on the mutable filter state below — corrupting it
+// and eventually reading qline[12] out of a length-12 array, panicking with
+// "index out of range [12] with length 12". Linux delivers from a single reaper
+// so it never contends; the lock is uncontended there.
 type iqConverter struct {
+	mu      sync.Mutex      // serialises processRaw across concurrent USB reapers
 	avg     float32         // leaky DC-blocker accumulator
 	phase   int             // Fs/4 mix phase, 0..3, persists across packets
 	iwin    [hbTaps]float32 // in-phase FIR window (newest written at iwinPos)
@@ -67,6 +79,8 @@ func newIQConverter() *iqConverter { return &iqConverter{} }
 // into complex64 baseband. It returns len(buf)/4 complex samples (two real
 // samples collapse to one complex sample).
 func (c *iqConverter) processRaw(buf []byte) []complex64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	nReal := len(buf) / 2
 	out := make([]complex64, 0, nReal/2+1)
 	for i := 0; i < nReal; i++ {

--- a/internal/sdr/airspy/iqconverter_test.go
+++ b/internal/sdr/airspy/iqconverter_test.go
@@ -1,0 +1,66 @@
+package airspy
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// TestProcessRawConcurrent reproduces the macOS crash from issue: the darwin USB
+// transport runs one bulk-IN reaper goroutine per ring slot
+// (usb.DefaultRingBuffers = 32), all of which call onPacket -> processRaw on the
+// single shared iqConverter. Linux uses a single reaper so the bug never showed
+// there, but on macOS the concurrent goroutines race on the converter's mutable
+// filter state (qpos, phase, avg, iwin, qline), eventually reading qline[12]
+// (out of a length-12 array) and panicking with
+// "index out of range [12] with length 12".
+//
+// Without the converter mutex this fails: under `go test -race` the detector
+// flags the concurrent qpos/avg access, and the recover() guard catches the
+// index-out-of-range panic even without the race detector. With the mutex it
+// passes.
+func TestProcessRawConcurrent(t *testing.T) {
+	c := newIQConverter()
+
+	// A full-size bulk-IN payload, matching the real URB length the transport
+	// hands to onPacket. Contents are arbitrary real samples.
+	buf := make([]byte, usb.DefaultBufferLen)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+
+	const (
+		goroutines = usb.DefaultRingBuffers // 32, as the macOS transport spawns
+		iterations = 200
+	)
+
+	var (
+		wg       sync.WaitGroup
+		panicMu  sync.Mutex
+		panicVal any
+	)
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicMu.Lock()
+					if panicVal == nil {
+						panicVal = r
+					}
+					panicMu.Unlock()
+				}
+			}()
+			for i := 0; i < iterations; i++ {
+				c.processRaw(buf)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if panicVal != nil {
+		t.Fatalf("processRaw panicked under concurrent delivery: %v", panicVal)
+	}
+}


### PR DESCRIPTION
The Airspy real-to-IQ converter carries filter state (DC blocker, Fs/4 mix
phase, half-band FIR window, quadrature delay line) across USB packets. The
macOS USB transport delivers each bulk-IN payload from one of
usb.DefaultRingBuffers (32) concurrent reaper goroutines, all calling
processRaw on the single shared iqConverter. Those goroutines race on the
converter's mutable cursors: when one is mid-`qpos++` (transiently 12, before
the `>= hbHalf` reset) and another reads `qline[qpos]`, the read indexes
qline[12] out of a length-12 array and the process panics with
"index out of range [12] with length 12".

This only reproduced on macOS: the Linux transport reaps from a single
goroutine and delivers serially, so the converter never contends. RTL-SDR,
HackRF and AirspyHF survive on macOS because their per-packet conversion is
stateless; airspy is the only driver whose converter is order-dependent.

Guard processRaw with a mutex so the conversion runs serially regardless of how
many reaper goroutines the transport spawns. The lock is uncontended on Linux
and the channel send in StreamIQ's onPacket stays outside it. Adds a
failing-first regression test that drives processRaw from 32 concurrent
goroutines (fails the race detector / panics without the lock, passes with it).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H5RmoaWgyv69n4x7s3eeHW