### PR TITLE
cryptolab: NXDN scrambler descramble + 15-bit key brute-force

### DIFF
--- a/cmd/gophertrunk/cryptolab_enabled.go
+++ b/cmd/gophertrunk/cryptolab_enabled.go
@@ -20,6 +20,7 @@ import (
 	cryptolabweb "github.com/MattCheramie/GopherTrunk/web/cryptolab"
 	// Blank imports register the toolkit's tools and subjects via init().
 	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/subjects/motorola"
+	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/subjects/nxdn"
 	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/tools"
 )
 

--- a/internal/cryptolab/schema.go
+++ b/internal/cryptolab/schema.go
@@ -135,6 +135,18 @@ var modeParams = map[string][]Param{
 		{Name: "frame", Label: "Frame length (samples)", Kind: "int", Default: "1024"},
 		{Name: "schedule", Label: "Split schedule (CSV) or 'auto'", Kind: "string", Default: "auto"},
 	},
+	"nxdn/descramble": {
+		{Name: "in", Label: "Scrambled payload", Kind: "file", Required: true, Help: "hex per line (packed bits, MSB-first)"},
+		{Name: "key", Label: "Scrambler key (0-32767)", Kind: "int", Required: true},
+		{Name: "frame-type", Label: "CRC check (optional)", Kind: "select", Default: "", Options: []string{"", "sacch", "cac", "ccitt"}, Help: "verify a frame CRC after descrambling"},
+	},
+	"nxdn/brute": {
+		{Name: "in", Label: "Scrambled frames", Kind: "file", Required: true, Help: "one scrambled frame per line, hex (packed bits, MSB-first)"},
+		{Name: "oracle", Label: "Oracle", Kind: "select", Default: "crc", Options: []string{"crc", "known-pt"}, Help: "how to confirm a key guess"},
+		{Name: "frame-type", Label: "Frame type (crc oracle)", Kind: "select", Default: "sacch", Options: []string{"sacch", "cac", "ccitt"}},
+		{Name: "known-pt", Label: "Known plaintext (known-pt oracle)", Kind: "file", Help: "hex of known descrambled bits for one frame"},
+		{Name: "top", Label: "Max candidate keys to report", Kind: "int", Default: "16"},
+	},
 	"alias/gauge":     {{Name: "csv", Label: "Ground-truth corpus CSV", Kind: "file", Required: true}},
 	"alias/structure": {{Name: "csv", Label: "Ground-truth corpus CSV", Kind: "file", Required: true}},
 	"alias/cells": {

--- a/internal/cryptolab/schema_test.go
+++ b/internal/cryptolab/schema_test.go
@@ -7,6 +7,7 @@ import (
 
 	// Register all tools and subjects so Schema() reflects the full set.
 	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/subjects/motorola"
+	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/subjects/nxdn"
 	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/tools"
 )
 

--- a/internal/cryptolab/subjects/nxdn/modes.go
+++ b/internal/cryptolab/subjects/nxdn/modes.go
@@ -1,0 +1,284 @@
+package nxdn
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	radionxdn "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+)
+
+// loadFrames reads scrambled frames: one frame per non-blank, non-"#" line as
+// hex (packed bits, MSB-first). A file with a single line is one frame. Each
+// frame is returned as a bit slice (0/1, MSB-first) so the scrambler and the
+// bit-oriented CRC checks can operate on it directly.
+func loadFrames(path string) ([][]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var frames [][]byte
+	for i, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		raw, err := hex.DecodeString(line)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: bad hex: %w", i+1, err)
+		}
+		frames = append(frames, framing.UnpackBitsMSB(raw, 8*len(raw)))
+	}
+	if len(frames) == 0 {
+		return nil, fmt.Errorf("no frames parsed from %s", path)
+	}
+	return frames, nil
+}
+
+// oracle decides whether a descrambled frame looks like valid plaintext, which
+// is how a brute-force key guess is confirmed. The interface is deliberately
+// small so the planned AMBE/voice-FEC oracle (roadmap phase 2) can slot in
+// without reshaping the sweep.
+type oracle interface {
+	name() string
+	// check reports a score in [0,1] for ranking (1 = strongest) and whether
+	// the frame passes outright.
+	check(bits []byte) (score float64, pass bool)
+}
+
+// crcOracle confirms a key by re-checking an NXDN frame CRC after descrambling.
+// It reuses the production CRC routines so the oracle matches the real decoder.
+type crcOracle struct{ frameType string }
+
+func (o crcOracle) name() string { return "crc:" + o.frameType }
+
+func (o crcOracle) check(bits []byte) (float64, bool) {
+	switch o.frameType {
+	case "sacch": // 32-bit SACCH info block: 26 payload + CRC-6 trailer.
+		if len(bits) != radionxdn.SACCHInfoBits {
+			return 0, false
+		}
+		if radionxdn.VerifySACCHCRC6(bits) {
+			return 1, true
+		}
+	case "cac": // 88-bit CAC message: type(8) + payload(64) + CRC-CCITT(16).
+		if len(bits) != 88 {
+			return 0, false
+		}
+		if _, err := radionxdn.ParseCAC(framing.PackBitsMSB(bits)); err == nil {
+			return 1, true
+		}
+	case "ccitt": // generic: whole bytes, last two are CRC-CCITT/FALSE over the rest.
+		b := framing.PackBitsMSB(bits)
+		if len(b) < 3 {
+			return 0, false
+		}
+		if framing.CRCCCITT(b[:len(b)-2]) == binary.BigEndian.Uint16(b[len(b)-2:]) {
+			return 1, true
+		}
+	}
+	return 0, false
+}
+
+// knownPtOracle confirms a key when a snippet of known descrambled content is
+// available — it ranks by the fraction of leading bits that match and passes
+// only on an exact match. Works for voice or data, unlike the CRC oracle.
+type knownPtOracle struct{ want []byte }
+
+func (knownPtOracle) name() string { return "known-pt" }
+
+func (o knownPtOracle) check(bits []byte) (float64, bool) {
+	n := len(o.want)
+	if n == 0 || len(bits) < n {
+		return 0, false
+	}
+	match := 0
+	for i := 0; i < n; i++ {
+		if bits[i]&1 == o.want[i]&1 {
+			match++
+		}
+	}
+	return float64(match) / float64(n), match == n
+}
+
+// ---- Mode: descramble ----
+
+type descrambleMode struct{}
+
+func (descrambleMode) Name() string { return "descramble" }
+func (descrambleMode) Synopsis() string {
+	return "descramble an NXDN information field with a known scrambler key"
+}
+
+func (descrambleMode) Run(_ context.Context, args []string, _ cryptolab.Env) (*cryptolab.Result, error) {
+	fs := flag.NewFlagSet("cryptolab nxdn descramble", flag.ContinueOnError)
+	in := fs.String("in", "", "scrambled payload file: hex per line (packed bits, MSB-first) — required")
+	key := fs.Int("key", -1, "scrambler key 0..32767 — required")
+	frameType := fs.String("frame-type", "", "optional CRC check after descramble: sacch|cac|ccitt")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if *in == "" {
+		return nil, fmt.Errorf("nxdn descramble: -in is required")
+	}
+	if *key < 0 || *key > radionxdn.ScramblerKeyMax {
+		return nil, fmt.Errorf("nxdn descramble: -key must be 0..%d", radionxdn.ScramblerKeyMax)
+	}
+	frames, err := loadFrames(*in)
+	if err != nil {
+		return nil, err
+	}
+
+	var orc oracle
+	if *frameType != "" {
+		orc = crcOracle{frameType: *frameType}
+	}
+	res := &cryptolab.Result{Tool: "nxdn", Mode: "descramble"}
+	res.AddField("key", *key)
+	res.AddField("frames", len(frames))
+	okCount := 0
+	for i, f := range frames {
+		plain := radionxdn.Descramble(f, uint16(*key))
+		detail := map[string]any{
+			"hex":  hex.EncodeToString(framing.PackBitsMSB(plain)),
+			"bits": len(plain),
+		}
+		score := 0.0
+		if orc != nil {
+			if _, pass := orc.check(plain); pass {
+				okCount++
+				score = 1
+				detail["crc_ok"] = true
+			} else {
+				detail["crc_ok"] = false
+			}
+		}
+		res.AddFinding(fmt.Sprintf("frame[%d]", i), score, detail)
+	}
+	if orc != nil {
+		res.AddField("crc_ok_frames", okCount)
+		res.Summary = fmt.Sprintf("descrambled %d frame(s) with key %d; %d/%d pass %s CRC",
+			len(frames), *key, okCount, len(frames), *frameType)
+	} else {
+		res.Summary = fmt.Sprintf("descrambled %d frame(s) with key %d", len(frames), *key)
+	}
+	return res, nil
+}
+
+// ---- Mode: brute ----
+
+type bruteMode struct{}
+
+func (bruteMode) Name() string { return "brute" }
+func (bruteMode) Synopsis() string {
+	return "brute-force the 15-bit NXDN scrambler key against a CRC or known-plaintext oracle"
+}
+
+func (bruteMode) Run(_ context.Context, args []string, env cryptolab.Env) (*cryptolab.Result, error) {
+	fs := flag.NewFlagSet("cryptolab nxdn brute", flag.ContinueOnError)
+	in := fs.String("in", "", "scrambled frames file: one frame per line, hex (packed bits, MSB-first) — required")
+	oracleName := fs.String("oracle", "crc", "key-confirmation oracle: crc|known-pt")
+	frameType := fs.String("frame-type", "sacch", "CRC frame type for the crc oracle: sacch|cac|ccitt")
+	knownPt := fs.String("known-pt", "", "known-plaintext file (hex, packed bits) for the known-pt oracle")
+	top := fs.Int("top", 16, "max candidate keys to report")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if *in == "" {
+		return nil, fmt.Errorf("nxdn brute: -in is required")
+	}
+	frames, err := loadFrames(*in)
+	if err != nil {
+		return nil, err
+	}
+
+	var orc oracle
+	switch *oracleName {
+	case "crc":
+		switch *frameType {
+		case "sacch", "cac", "ccitt":
+		default:
+			return nil, fmt.Errorf("nxdn brute: -frame-type must be sacch|cac|ccitt, got %q", *frameType)
+		}
+		orc = crcOracle{frameType: *frameType}
+	case "known-pt":
+		if *knownPt == "" {
+			return nil, fmt.Errorf("nxdn brute: -known-pt file is required for the known-pt oracle")
+		}
+		kp, err := loadFrames(*knownPt)
+		if err != nil {
+			return nil, fmt.Errorf("nxdn brute: known-pt: %w", err)
+		}
+		orc = knownPtOracle{want: kp[0]}
+	case "ambe-fec":
+		return nil, fmt.Errorf("nxdn brute: the ambe-fec oracle needs the NXDN voice decoder (roadmap phase 2); use crc or known-pt")
+	default:
+		return nil, fmt.Errorf("nxdn brute: -oracle must be crc|known-pt, got %q", *oracleName)
+	}
+
+	type candidate struct {
+		key   uint16
+		score float64
+	}
+	var candidates []candidate
+	// The whole point: the key space is only 2^15, so an exhaustive sweep is
+	// instantaneous. A key is a candidate only if it passes the oracle on every
+	// supplied frame — the true key passes them all while false positives from a
+	// short CRC drop out as more frames are added.
+	for k := 0; k <= radionxdn.ScramblerKeyMax; k++ {
+		passAll := true
+		total := 0.0
+		for _, f := range frames {
+			s, pass := orc.check(radionxdn.Descramble(f, uint16(k)))
+			if !pass {
+				passAll = false
+				break
+			}
+			total += s
+		}
+		if passAll {
+			candidates = append(candidates, candidate{key: uint16(k), score: total / float64(len(frames))})
+		}
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return candidates[i].key < candidates[j].key
+	})
+
+	res := &cryptolab.Result{Tool: "nxdn", Mode: "brute"}
+	res.AddField("keyspace", radionxdn.ScramblerKeyMax+1)
+	res.AddField("frames", len(frames))
+	res.AddField("oracle", orc.name())
+	res.AddField("candidates", len(candidates))
+	for i, c := range candidates {
+		if i >= *top {
+			break
+		}
+		res.AddFinding(fmt.Sprintf("key=0x%04x (%d)", c.key, c.key), c.score, map[string]any{
+			"key":     int(c.key),
+			"key_hex": fmt.Sprintf("0x%04x", c.key),
+		})
+	}
+
+	switch len(candidates) {
+	case 0:
+		res.Summary = "no scrambler key satisfied the oracle"
+		res.Note("No key passed. Check that -frame-type matches the payload and that the data is actually scrambled. Note the scrambler model is synthetic (not yet hardware-confirmed) — a known-key capture will settle whether the polynomial/seed mapping needs adjusting.")
+	case 1:
+		res.Summary = fmt.Sprintf("recovered NXDN scrambler key %d (0x%04x)", candidates[0].key, candidates[0].key)
+		env.Logf("nxdn scrambler key recovered", "key", int(candidates[0].key), "frames", len(frames), "oracle", orc.name())
+	default:
+		res.Summary = fmt.Sprintf("%d CRC-consistent candidate keys (a linear coset); a non-linear oracle is needed to pin one", len(candidates))
+		res.Note("These keys are CRC-indistinguishable. The scrambler LFSR and the CRC are both linear, so the keys that satisfy the CRC form a fixed coset of size ~2^(15-crcbits) (e.g. ~2^9 for SACCH's 6-bit CRC) that is the same for every same-type frame — adding more same-type frames does NOT shrink it. Disambiguate with a known-plaintext crib (-oracle known-pt), a mix of different frame types, or — for voice, the way AOR does it — the AMBE/FEC oracle (roadmap phase 2). The true key is always in this set.")
+	}
+	return res, nil
+}

--- a/internal/cryptolab/subjects/nxdn/nxdn_test.go
+++ b/internal/cryptolab/subjects/nxdn/nxdn_test.go
@@ -1,0 +1,204 @@
+package nxdn
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/framing"
+	radionxdn "github.com/MattCheramie/GopherTrunk/internal/radio/nxdn"
+)
+
+func TestNXDNRegistered(t *testing.T) {
+	t.Parallel()
+	tool, ok := cryptolab.Lookup("nxdn")
+	if !ok {
+		t.Fatal("nxdn tool not registered")
+	}
+	if _, _, err := cryptolab.LookupMode("nxdn", "brute"); err != nil {
+		t.Fatalf("brute mode missing: %v", err)
+	}
+	if _, _, err := cryptolab.LookupMode("nxdn", "descramble"); err != nil {
+		t.Fatalf("descramble mode missing: %v", err)
+	}
+	if len(tool.Modes()) != 2 {
+		t.Fatalf("want 2 modes, got %d", len(tool.Modes()))
+	}
+}
+
+// lcgBits returns n deterministic pseudo-random 0/1 bits (no math/rand, so the
+// test is reproducible and -race clean).
+func lcgBits(seed uint32, n int) []byte {
+	out := make([]byte, n)
+	x := seed
+	for i := range out {
+		x = x*1664525 + 1013904223
+		out[i] = byte((x >> 24) & 1)
+	}
+	return out
+}
+
+// validCACFrame builds an 88-bit CAC message (with a valid CRC-CCITT) as a bit
+// slice, using the production AssembleCAC encoder.
+func validCACFrame(seed uint32) []byte {
+	var payload [8]byte
+	b := lcgBits(seed, 64)
+	for i := 0; i < 64; i++ {
+		payload[i>>3] |= b[i] << uint(7-(i&7))
+	}
+	msg := radionxdn.CACMessage{Type: radionxdn.RCCHVCALL, Payload: payload}
+	return framing.UnpackBitsMSB(radionxdn.AssembleCAC(msg), 88)
+}
+
+// validSACCHFrame builds a 32-bit SACCH info block with a valid CRC-6.
+func validSACCHFrame(seed uint32) []byte {
+	return radionxdn.AppendSACCHCRC6(lcgBits(seed, 26))
+}
+
+func writeHexFrames(t *testing.T, frames [][]byte) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, f := range frames {
+		sb.WriteString(hex.EncodeToString(framing.PackBitsMSB(f)))
+		sb.WriteByte('\n')
+	}
+	p := filepath.Join(t.TempDir(), "frames.hex")
+	if err := os.WriteFile(p, []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func runMode(t *testing.T, mode string, args []string) *cryptolab.Result {
+	t.Helper()
+	_, m, err := cryptolab.LookupMode("nxdn", mode)
+	if err != nil {
+		t.Fatalf("LookupMode %s: %v", mode, err)
+	}
+	res, err := m.Run(context.Background(), args, cryptolab.Env{Stdout: &bytes.Buffer{}, Format: cryptolab.FormatText})
+	if err != nil {
+		t.Fatalf("%s run: %v", mode, err)
+	}
+	return res
+}
+
+func field(t *testing.T, r *cryptolab.Result, key string) any {
+	t.Helper()
+	for _, f := range r.Fields {
+		if f.Key == key {
+			return f.Value
+		}
+	}
+	t.Fatalf("field %q not found in %+v", key, r.Fields)
+	return nil
+}
+
+func findingsHaveKey(r *cryptolab.Result, key uint16) bool {
+	for _, f := range r.Findings {
+		if k, ok := f.Detail["key"].(int); ok && k == int(key) {
+			return true
+		}
+	}
+	return false
+}
+
+// scrambleAll scrambles each plaintext frame with key and returns the scrambled
+// frames (mirroring the on-air TX side: per-frame keystream restart).
+func scrambleAll(plain [][]byte, key uint16) [][]byte {
+	out := make([][]byte, len(plain))
+	for i, f := range plain {
+		out[i] = radionxdn.Scramble(f, key)
+	}
+	return out
+}
+
+// TestBruteCACOracleRetainsKey confirms the CRC oracle keeps the true key among
+// its CRC-consistent candidates. With a linear LFSR scrambler and a linear CRC,
+// the survivors form a coset that always contains the true key; CAC's 16-bit CRC
+// makes that coset tiny.
+func TestBruteCACOracleRetainsKey(t *testing.T) {
+	t.Parallel()
+	const key = uint16(0x2B1F)
+	plain := [][]byte{validCACFrame(1), validCACFrame(2), validCACFrame(3)}
+	in := writeHexFrames(t, scrambleAll(plain, key))
+
+	res := runMode(t, "brute", []string{"-in", in, "-oracle", "crc", "-frame-type", "cac", "-top", "40000"})
+
+	if got := field(t, res, "candidates").(int); got < 1 {
+		t.Fatalf("no candidates (%s)", res.Summary)
+	}
+	if !findingsHaveKey(res, key) {
+		t.Fatalf("true key 0x%04x not among CAC CRC candidates: %s", key, res.Summary)
+	}
+}
+
+// TestBruteSACCHOracleIsACoset documents the linear-coset property: SACCH's
+// 6-bit CRC leaves a large coset (~2^9) of CRC-indistinguishable keys, which
+// same-type frames cannot shrink, but the true key is always inside it.
+func TestBruteSACCHOracleIsACoset(t *testing.T) {
+	t.Parallel()
+	const key = uint16(0x07A4)
+	plain := make([][]byte, 8)
+	for i := range plain {
+		plain[i] = validSACCHFrame(uint32(100 + i))
+	}
+	in := writeHexFrames(t, scrambleAll(plain, key))
+
+	res := runMode(t, "brute", []string{"-in", in, "-oracle", "crc", "-frame-type", "sacch", "-top", "40000"})
+
+	got := field(t, res, "candidates").(int)
+	if got <= 1 {
+		t.Fatalf("expected a coset of CRC-indistinguishable keys, got %d", got)
+	}
+	if !findingsHaveKey(res, key) {
+		t.Fatalf("true key 0x%04x not among SACCH CRC coset of %d: %s", key, got, res.Summary)
+	}
+}
+
+// TestBruteKnownPlaintext confirms the known-plaintext oracle: given a snippet
+// of the descrambled content, the exact-match requirement pins the key with a
+// single frame (no CRC needed — this is the voice path's fallback oracle).
+func TestBruteKnownPlaintext(t *testing.T) {
+	t.Parallel()
+	const key = uint16(0x1234)
+	plain := validCACFrame(42)
+	in := writeHexFrames(t, [][]byte{radionxdn.Scramble(plain, key)})
+	kp := writeHexFrames(t, [][]byte{plain})
+
+	res := runMode(t, "brute", []string{"-in", in, "-oracle", "known-pt", "-known-pt", kp})
+
+	if got := field(t, res, "candidates").(int); got != 1 {
+		t.Fatalf("want exactly 1 candidate, got %d (%s)", got, res.Summary)
+	}
+	if res.Findings[0].Detail["key"].(int) != int(key) {
+		t.Fatalf("recovered wrong key: %+v", res.Findings)
+	}
+}
+
+// TestDescrambleVerifiesCRC checks the descramble mode round-trips against the
+// scrambler and validates the CRC of the recovered frame; the wrong key fails.
+func TestDescrambleVerifiesCRC(t *testing.T) {
+	t.Parallel()
+	const key = uint16(0x0555)
+	plain := validCACFrame(7)
+	in := writeHexFrames(t, [][]byte{radionxdn.Scramble(plain, key)})
+
+	ok := runMode(t, "descramble", []string{"-in", in, "-key", "1365" /* 0x0555 */, "-frame-type", "cac"})
+	if field(t, ok, "crc_ok_frames").(int) != 1 {
+		t.Fatalf("correct key should pass CAC CRC: %s", ok.Summary)
+	}
+	wantHex := hex.EncodeToString(framing.PackBitsMSB(plain))
+	if ok.Findings[0].Detail["hex"].(string) != wantHex {
+		t.Fatalf("descrambled payload mismatch:\n got %s\nwant %s", ok.Findings[0].Detail["hex"], wantHex)
+	}
+
+	bad := runMode(t, "descramble", []string{"-in", in, "-key", "1366", "-frame-type", "cac"})
+	if field(t, bad, "crc_ok_frames").(int) != 0 {
+		t.Fatalf("wrong key should fail CAC CRC: %s", bad.Summary)
+	}
+}

--- a/internal/cryptolab/subjects/nxdn/register.go
+++ b/internal/cryptolab/subjects/nxdn/register.go
@@ -1,0 +1,21 @@
+// Package nxdn is a cryptolab subject: it descrambles NXDN's optional 15-bit
+// scrambler and brute-forces the scrambling key. The key space is only 2^15, so
+// a guess can be confirmed by descrambling and checking an NXDN frame CRC (or a
+// known-plaintext crib). The scrambler primitive itself lives in
+// internal/radio/nxdn so the live decoder can reuse it; this package wires it
+// into the cryptolab Tool/Mode interface.
+package nxdn
+
+import "github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+
+type nxdnTool struct{}
+
+func (nxdnTool) Name() string { return "nxdn" }
+func (nxdnTool) Synopsis() string {
+	return "NXDN 15-bit scrambler: descramble and brute-force the scrambling key"
+}
+func (nxdnTool) Modes() []cryptolab.Mode {
+	return []cryptolab.Mode{descrambleMode{}, bruteMode{}}
+}
+
+func init() { cryptolab.Register(nxdnTool{}) }

--- a/internal/radio/nxdn/scramble.go
+++ b/internal/radio/nxdn/scramble.go
@@ -1,0 +1,78 @@
+package nxdn
+
+// NXDN voice/data scrambler ("encryption"). The optional NXDN scrambler — the
+// privacy mode Kenwood radios expose and AOR receivers auto-brute-force — XORs
+// a pseudo-random keystream over the scrambled information field. The keystream
+// comes from a 15-bit linear-feedback shift register seeded by the scrambling
+// key, a 15-bit value (0..32767). Key 0 yields an all-zero keystream, i.e. no
+// scrambling (clear). Because the key space is only 2^15 = 32768, the scrambler
+// is trivially brute-forceable; the offline cryptolab `nxdn` tool does exactly
+// that, using this primitive plus the NXDN frame CRCs as an oracle.
+//
+// IMPLEMENTATION NOTE — synthetic model, not yet hardware-confirmed. The tap
+// polynomial and seed mapping below are an internally-consistent working model
+// (a maximal-length 15-bit Fibonacci LFSR, x^15 + x^14 + 1): Scramble is its own
+// inverse and the keystream is a balanced m-sequence of period 32767. They have
+// NOT been confirmed bit-exact against a known-key capture. When such a capture
+// is available, adjust the feedback in (*Scrambler).Next and the golden
+// expectations in scramble_test.go; nothing else (the brute-force loop, the CRC
+// oracles) depends on this choice. The XOR-symmetric structure and 15-bit key
+// space are the spec-level facts the brute-forcer relies on.
+
+const (
+	// ScramblerKeyBits is the width of the NXDN scrambler key.
+	ScramblerKeyBits = 15
+	// ScramblerKeyMax is the largest valid key; the key space is
+	// [0, ScramblerKeyMax], i.e. 32768 keys.
+	ScramblerKeyMax = (1 << ScramblerKeyBits) - 1 // 32767
+)
+
+// Scrambler produces the NXDN scrambling keystream one bit at a time. Construct
+// it with NewScrambler; Next returns successive keystream bits. The same helper
+// serves both the scramble (TX) and descramble (RX) sides because XOR is
+// symmetric — see Scramble / Descramble.
+type Scrambler struct {
+	state uint16 // 15-bit LFSR state; the MSB (bit 14) is the next output
+}
+
+// NewScrambler returns a Scrambler seeded by the low 15 bits of key.
+func NewScrambler(key uint16) *Scrambler {
+	return &Scrambler{state: key & ScramblerKeyMax}
+}
+
+// Next advances the LFSR by one step and returns the next keystream bit (0/1).
+// The register is a maximal-length 15-bit Fibonacci LFSR with feedback
+// x^15 + x^14 + 1: the output is the current MSB and the new LSB is the XOR of
+// the top two stages.
+func (s *Scrambler) Next() byte {
+	out := byte((s.state >> 14) & 1)
+	fb := ((s.state >> 14) ^ (s.state >> 13)) & 1
+	s.state = ((s.state << 1) | fb) & ScramblerKeyMax
+	return out
+}
+
+// Generate returns the first n keystream bits (each 0/1).
+func (s *Scrambler) Generate(n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = s.Next()
+	}
+	return out
+}
+
+// Scramble XORs the keystream seeded by key over bits (each entry 0/1,
+// MSB-first), returning a new slice of the same length. The keystream restarts
+// from the key seed for each call, so one Scramble covers one information field.
+func Scramble(bits []byte, key uint16) []byte {
+	s := NewScrambler(key)
+	out := make([]byte, len(bits))
+	for i, b := range bits {
+		out[i] = (b & 1) ^ s.Next()
+	}
+	return out
+}
+
+// Descramble is the inverse of Scramble. XOR with the same keystream is
+// symmetric, so the implementation is identical; the alias exists for
+// call-site readability on the receive side.
+func Descramble(bits []byte, key uint16) []byte { return Scramble(bits, key) }

--- a/internal/radio/nxdn/scramble_test.go
+++ b/internal/radio/nxdn/scramble_test.go
@@ -1,0 +1,74 @@
+package nxdn
+
+import "testing"
+
+// TestScrambleRoundTrip is the core invariant: descrambling with the same key
+// recovers the original bits for any key, because the keystream XOR is
+// symmetric.
+func TestScrambleRoundTrip(t *testing.T) {
+	t.Parallel()
+	// A deterministic pseudo-random bit pattern (no math/rand to keep the test
+	// reproducible and -race friendly).
+	bits := make([]byte, 288) // one NXDN information field's worth of bits
+	x := uint32(0x1234_5678)
+	for i := range bits {
+		x = x*1664525 + 1013904223 // LCG
+		bits[i] = byte((x >> 24) & 1)
+	}
+	for _, key := range []uint16{1, 2, 7, 0x1F, 0x2A3, 0x4000, ScramblerKeyMax} {
+		sc := Scramble(bits, key)
+		// Scrambling must actually change the data (key != 0).
+		same := true
+		for i := range bits {
+			if sc[i] != bits[i] {
+				same = false
+				break
+			}
+		}
+		if same {
+			t.Errorf("key %d: scrambled output identical to input", key)
+		}
+		got := Descramble(sc, key)
+		for i := range bits {
+			if got[i] != bits[i] {
+				t.Fatalf("key %d: round-trip mismatch at bit %d", key, i)
+			}
+		}
+	}
+}
+
+// TestScrambleKeyZeroIsClear documents that key 0 is the "no scrambling" case:
+// the keystream is all zero, so Scramble is the identity.
+func TestScrambleKeyZeroIsClear(t *testing.T) {
+	t.Parallel()
+	bits := []byte{1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 0}
+	got := Scramble(bits, 0)
+	for i := range bits {
+		if got[i] != bits[i] {
+			t.Fatalf("key 0 changed bit %d: got %d want %d", i, got[i], bits[i])
+		}
+	}
+}
+
+// TestKeystreamIsBalancedMSequence checks the LFSR is maximal length: over one
+// full period (2^15-1 = 32767 bits) a maximal m-sequence is balanced, with
+// exactly 2^14 = 16384 ones and 16383 zeros. This pins the tap choice — a
+// non-primitive polynomial would fail balance and/or period.
+func TestKeystreamIsBalancedMSequence(t *testing.T) {
+	t.Parallel()
+	const period = ScramblerKeyMax // 32767
+	ks := NewScrambler(1).Generate(period)
+	ones := 0
+	for _, b := range ks {
+		ones += int(b)
+	}
+	if ones != 16384 {
+		t.Fatalf("m-sequence not balanced: %d ones over period %d, want 16384", ones, period)
+	}
+	// The state must return to its seed after exactly one period.
+	s := NewScrambler(1)
+	s.Generate(period)
+	if s.state != 1 {
+		t.Fatalf("LFSR period != %d: state after one period is %#x, want seed 0x1", period, s.state)
+	}
+}


### PR DESCRIPTION
## Summary

NXDN's optional "scrambler" privacy mode — the one Kenwood radios expose and AOR receivers auto-brute-force — is keyed by a **15-bit** value, only 2^15 = 32768 keys, so it is trivially brute-forceable. This adds an offline NXDN scrambler descramble + key brute-force capability to Cryptolab. It's phase 1 of a phased feature; cracking scrambled voice straight from IQ (the way AOR does) is a follow-on that needs an NXDN voice/AMBE decoder GopherTrunk doesn't have yet.

(The Airspy R2 macOS-crash work that previously shared this branch already merged as #843; this PR is the follow-up NXDN change only.)

## Changes

- **`internal/radio/nxdn/scramble.go`** — the scrambler primitive: a 15-bit Fibonacci LFSR keystream (`NewScrambler`/`Next`/`Generate`) XORed over the information field (`Scramble`/`Descramble`, XOR-symmetric), modelled on `framing/scramble_tetra.go`. Lives in `radio/nxdn` so the future voice decoder can reuse it. The exact polynomial/seed mapping is a synthetic, internally-consistent model flagged in-code as needing hardware confirmation; the brute-force machinery and CRC oracles don't depend on that choice.
- **`internal/cryptolab/subjects/nxdn`** — the `nxdn` Cryptolab tool: `descramble` (known key → plaintext, optional frame-CRC check) and `brute` (sweep all 32768 keys, confirm via a pluggable oracle). The `crc` oracle reuses the production NXDN CRC routines (SACCH CRC-6, CAC CRC-CCITT-16, generic trailing CCITT); the `known-pt` oracle ranks by a known-plaintext crib and uniquely pins the key. An `ambe-fec` voice oracle is reserved for phase 2.
- **`schema.go` / `schema_test.go` / `cryptolab_enabled.go`** — register and wire the tool into the CLI and web schema.

A real limitation the tool surfaces honestly: because the LFSR scrambler **and** the CRC are both linear, the CRC-satisfying keys form a fixed coset (~2^(15−crcbits)) that same-type frames cannot shrink — which is exactly why AOR cracks NXDN from non-linear voice/FEC structure, not CRC. The true key is always in the coset; a known-plaintext (or, later, AMBE-FEC) oracle pins it uniquely.

## Test plan

Tests are synthetic and self-contained: scramble a CRC-bearing frame with a known key, then recover it.

- [x] `make vet test` green locally (affected packages, untagged + `-race`)
- [x] cryptolab suite green: `go test -tags cryptolab -race ./internal/cryptolab/... ./cmd/gophertrunk/ ./internal/api/`
- [x] Added tests: scrambler round-trip / m-sequence balance + period; `brute` known-plaintext recovers the unique key; CRC oracle retains the true key within the documented coset; `descramble` validates the frame CRC
- [ ] Smoke-tested against real hardware — **not yet**. The scrambler polynomial/seed is validated on synthetic vectors only; a known-key NXDN capture is needed to confirm it bit-exact against real NXDN.

## Breaking changes

None. The NXDN tool is new and the CLI dispatch is behind the `cryptolab` build tag; the scrambler primitive is additive in `internal/radio/nxdn`.

## Docs / CHANGELOG

- [ ] No `CHANGELOG.md` bullet added yet — can add on request.
- [ ] n/a for README/docs (build-tagged research tool).

## Linked issues

n/a — no tracked issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5RmoaWgyv69n4x7s3eeHW

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5RmoaWgyv69n4x7s3eeHW)_