### PR TITLE
rfscope: docs page + CHANGELOG (Tier 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **RF Scope — protocol-agnostic RF network analysis ("Wireshark for the RF
+  physical layer").** A new `gophertrunk rfscope` surface analyzes any band — a
+  recorded IQ capture or a live SDR — with no prior knowledge of the technology,
+  modulation, framing, or encryption, and produces a structured *scene*: an RF
+  protocol hierarchy, per-channel I/O-graph activity, burst timing/periodicity,
+  an emitter/conversation graph (frequency hoppers collapse into one emitter; it
+  defers to `hunt`'s authoritative map when a control channel is present), an
+  entropy/encryption triage built on the cryptolab randomness battery, and an
+  expert-info anomaly list. It ships as a CLI (`rfscope analyze`/`live`/`list`
+  with summary/JSON/JSONL/YAML/CSV export), a Bubbletea cockpit (`rfscope
+  cockpit`, `rfscope live -tui`), and a standalone web console (`rfscope serve`,
+  built with `make rfscope-web-build`). Unidentified digital payloads can be
+  emitted as a cryptolab `ks` frames file (`-frames-out`) that feeds `cryptolab
+  classify auto` / `ks reuse` directly.
 - **Crypto Lab is discoverable from the other web consoles.** In a
   `-tags cryptolab` daemon build the main GopherTrunk console shows a *Crypto
   Lab* nav entry and the Signal Lab header shows a 🔐 Crypto Lab link; the

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -161,6 +161,8 @@ groups:
         url: /hunt.html
       - title: SigLab (offline workbench)
         url: /siglab.html
+      - title: RF Scope (protocol-agnostic scene analysis)
+        url: /rfscope.html
       - title: rigctld integration
         url: /rigctld.html
       - title: Hardening

--- a/docs/rfscope.md
+++ b/docs/rfscope.md
@@ -1,0 +1,105 @@
+# RF Scope — protocol-agnostic RF network analysis
+
+`rfscope` is **Wireshark for the RF physical layer**. Point it at any band — a
+recorded IQ capture or a live SDR — with **no prior knowledge of the technology,
+modulation, framing, or encryption**, and it produces a structured analysis of
+*what is on the air and how it behaves*: an RF protocol hierarchy, per-channel
+activity over time, burst timing and periodicity, an emitter/conversation graph,
+an entropy/encryption triage, and an expert-info anomaly list.
+
+Where `hunt` discovers and maps *known* trunked systems and `siglab` decodes the
+13 named protocols, `rfscope` is the layer below: it says something structural
+about a signal even when it is *not* one of those — an unknown IoT mesh, a
+telemetry link, a paging variant, an encrypted data burst, a frequency hopper.
+It optimizes for non-WiFi RF (slow, channelized, bursty LMR/IoT/paging traffic)
+but the same primitives work for WiFi-style bursty traffic too.
+
+It adds no DSP of its own: it orchestrates the primitives the rest of GopherTrunk
+already ships (the `survey` blind classifier, `carriers` peak detection,
+`spectrum` occupancy metrics, `siglab` protocol identification, the `cryptolab`
+randomness/keystream engines) and accumulates their output into one
+JSON-exportable **Scene**.
+
+## The analyzers
+
+A Scene is built by a registry of pluggable analyzers (`rfscope list` prints
+them). Each is the RF analog of a Wireshark feature:
+
+| Analyzer | Wireshark analog | What it produces |
+|---|---|---|
+| `hierarchy` | Protocol Hierarchy | bursts grouped by modulation class → occupied-bandwidth bucket → identified protocol, with counts, airtime, spectrum/time share |
+| `timeline` | I/O Graphs | per-channel occupancy/power over time, duty cycle, burst rate |
+| `timing` | (timing stats) | burst-length & inter-arrival histograms, and the TDMA/frame **period** recovered by autocorrelating channel occupancy |
+| `topology` | Conversations / Endpoints | bursts clustered into **emitters** by RF fingerprint (frequency hoppers collapse into one), then linked into **conversations** (co-active / request-response / hop-sequence); defers to `hunt`'s authoritative map when a trunking control channel is present |
+| `entropy` | entropy-based encryption detection | for unidentified digital emitters, a byte-level triage (plaintext / substitution / repeating-xor / periodic-scrambler / lfsr-or-keyless-scrambler / strong-encrypted) built on the cryptolab randomness battery |
+| `expert` | Expert Information | anomaly flags: frequency hoppers, intermittent emitters, abnormally wide/narrow carriers, noise-like (high spectral-flatness) carriers, and the encrypted/obfuscated/unknown findings from the entropy triage |
+
+## Command-line
+
+```
+gophertrunk rfscope analyze -in <capture> [flags]            analyze a recorded IQ capture
+gophertrunk rfscope live -serial <sdr> -freq Hz [flags]      analyze a live SDR span
+gophertrunk rfscope cockpit [-in <cap> | -serial <sdr> -freq Hz]   live scene TUI
+gophertrunk rfscope serve [-addr host:port] [-open]          web console (browser)
+gophertrunk rfscope list                                     list registered analyzers
+```
+
+Common flags (shared by `analyze` and `live`): `-format u8|f32`, `-sample-rate`,
+`-freq` (capture centre), `-fft`, `-peak-threshold-db`, `-min-spacing`,
+`-channel-rate`, `-analyzers hierarchy,timing,…` (default: all),
+`-out-format summary|json|jsonl|yaml|csv`, `-out <path>`, and `-frames-out
+<path>` to emit a cryptolab `ks` frames file from any unknown payloads.
+`analyze` adds `-window <sec>`; `live` adds `-duration <sec>` and `-tui` (open
+the cockpit).
+
+### Examples
+
+```
+# Summarize a wideband capture's RF scene
+gophertrunk rfscope analyze -in wide.cfile -format f32 -sample-rate 2400000 -freq 451000000
+
+# Full JSON scene, only the timeline + timing analyzers
+gophertrunk rfscope analyze -in wide.cfile -sample-rate 2400000 \
+    -analyzers timeline,timing -out-format json -out scene.json
+
+# Live scene monitor on an SDR
+gophertrunk rfscope cockpit -serial 00000001 -freq 451000000
+
+# Emit a cryptolab frames file for the unknown payloads, then triage it
+gophertrunk rfscope analyze -in wide.cfile -sample-rate 2400000 -frames-out frames.jsonl
+gophertrunk cryptolab classify auto -in frames.jsonl     # needs -tags cryptolab
+```
+
+## Output formats
+
+`summary` is a human-readable report (hierarchy tree, channel table, top talkers,
+conversations, expert info). `json`/`yaml` emit the whole Scene; `jsonl` streams
+one record per scene-header / burst / channel / emitter / conversation / anomaly;
+`csv` is the burst table. Every float is clamped before encoding so the output is
+always valid JSON.
+
+## The cockpit (TUI)
+
+`rfscope cockpit` (and `rfscope live -tui`) is a Bubbletea terminal dashboard:
+panels for the protocol hierarchy, per-channel I/O-graph sparklines, top talkers,
+conversations, and severity-colored expert info. Keys: `space` freeze/resume, `e`
+export the current scene as JSON, `?` help, `q` quit.
+
+## The web console
+
+`rfscope serve` runs a standalone browser console (default
+`http://127.0.0.1:8098/`): upload a capture and view the same scene with a
+one-click **Crypto Lab** hand-off that downloads the recovered `ks` frames file
+with the suggested next command. Build the SPA first with `make rfscope-web-build`
+(the default binary serves an API-only placeholder until then).
+
+## The Crypto Lab bridge
+
+For a digital signal `siglab` cannot identify, `rfscope` recovers a byte payload
+and triages it with the same measurements cryptolab's `classify auto` uses
+(Shannon entropy, index of coincidence, repeating-XOR key length, a NIST
+SP 800-22 randomness battery). It can emit those payloads as a cryptolab `ks`
+frames file (`{"label","iv","ct"}` JSONL) that feeds `cryptolab classify auto`,
+`ks reuse`/`mtp`, and `brute` directly — the detection→byte-analysis loop, closed
+without leaving GopherTrunk. The in-binary triage needs no build tag; the full
+`ks reuse` hand-off runs in a `-tags cryptolab` build.


### PR DESCRIPTION
## Summary

Tier 5 (final polish) of the protocol-agnostic RF network analyzer
(`internal/rfscope`). Tiers 0–4 (merged) delivered the six analyzers and the CLI,
TUI, and web surfaces; this documents the feature for operators and records it in
the changelog. Docs-only — no Go sources touched.

## Changes

- **`docs/rfscope.md`** — full operator page: the six analyzers and their
  Wireshark analogs (table), the `analyze`/`live`/`cockpit`/`serve`/`list`
  commands with flags and examples, the export formats, the TUI cockpit, the web
  console, and the cryptolab `ks`-frames bridge.
- **`docs/_data/nav.yml`** — "RF Scope" linked in the operator nav next to Hunt
  and SigLab.
- **`CHANGELOG.md`** — the user-visible `[Unreleased] → Added` entry summarizing
  the whole RF Scope feature.

## Test plan

- [x] `make vet test` is green locally — unaffected; this PR changes no Go
- [ ] `make integration` — n/a, docs-only
- [ ] Added or updated tests — n/a, docs-only
- [ ] Hardware — n/a

## Breaking changes

None. Documentation only.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Added `docs/rfscope.md` and linked it in the docs nav

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XkhQ64GwXMUX4jvYDBQEEC)_