### PR TITLE
cryptolab: external known-key decrypt + recipe split-band/rolling descramblers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,19 @@ for tagged releases.
   built with `make rfscope-web-build`). Unidentified digital payloads can be
   emitted as a cryptolab `ks` frames file (`-frames-out`) that feeds `cryptolab
   classify auto` / `ks reuse` directly.
+- **cryptolab external known-key decrypt (no brute required).** When an operator
+  has already recovered an unbundled cipher's key (e.g. ran their own TEA1
+  brute), `assess crypto` now verifies it through the external cipher and
+  decrypts + grades the capture by passing the key via `-keys` with `-extern-cmd`
+  / `-extern-algid` and a known-plaintext oracle — the weak-key method reports
+  the verified break, so `-brute-bits` is only needed when the key is still
+  unknown.
+- **cryptolab recipe split-band & rolling descramblers.** The `recipe` pipeline
+  gains `descramble-splitband` (`split` fraction of Nyquist) and
+  `descramble-rolling` (`frame` samples, `schedule` of split fractions or
+  `auto`) ops, bringing the inline analog-voice descrambler steps to parity with
+  the standalone `descramble` tool's three modes. The web Recipe Builder renders
+  the new float `split` parameter.
 - **Crypto Lab is discoverable from the other web consoles.** In a
   `-tags cryptolab` daemon build the main GopherTrunk console shows a *Crypto
   Lab* nav entry and the Signal Lab header shows a 🔐 Crypto Lab link; the

--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -173,8 +173,12 @@ Operations (run `recipe run -list` for the live set): transforms `xor`, `not`,
 `reverse-bits`, `hex-decode`, `hex-encode`, `base64-decode`, `slice`,
 `rc4-decrypt` (raw RC4 with a caller-supplied key — DMR Enhanced Privacy /
 generic), `adp-decrypt`, `des-ofb-decrypt`, `tdes-ofb-decrypt`,
-`aes-ofb-decrypt`, `descramble-invert`, and `extern-decrypt` (decrypt via an
-external cipher program — CLI only); analyses `stats`, `randomness`. The cipher
+`aes-ofb-decrypt`, the analog-voice descramblers `descramble-invert`,
+`descramble-splitband` (`split` = fraction of Nyquist), and `descramble-rolling`
+(`frame` samples, `schedule` = comma-separated split fractions or `auto`), and
+`extern-decrypt` (decrypt via an external cipher program — CLI only); analyses
+`stats`, `randomness`. The descramble ops mirror the standalone `descramble`
+tool's three modes so an inversion step can be chained inline. The cipher
 ops reuse the same `p25crypto` keystream constructions the `assess` harness
 uses, so a recipe can decrypt a known-key capture and immediately measure the
 result.
@@ -402,6 +406,14 @@ orchestrates it, verifies the hit, and decrypts the corpus. Wire it in with:
 cryptolab assess crypto -in frames.jsonl -protocol tetra \
     -known-label call-3 -known-pt known.bin \
     -extern-cmd "tea1-tool" -extern-algid 0x01 -brute-bits 32
+
+# Already recovered the key elsewhere? Hand it to assess with -keys (one hex
+# key per line) and no -brute-bits: it verifies the key through the external
+# cipher against the oracle, decrypts every frame under it, and grades the
+# result (the weak-key method reports the verified break).
+cryptolab assess crypto -in frames.jsonl -protocol tetra \
+    -known-label call-3 -known-pt known.bin \
+    -extern-cmd "tea1-tool" -extern-algid 0x01 -keys recovered.keys
 
 # Or decrypt with a recovered key inside a recipe (CLI only):
 #   {"op":"extern-decrypt","cmd":"tea1-tool","key":"<hex>","mi":"<iv hex>"}

--- a/internal/cryptolab/engine/assess/assess.go
+++ b/internal/cryptolab/engine/assess/assess.go
@@ -435,6 +435,82 @@ func externBrute(in Input, oracle *keystream.Frame, total int) (MethodResult, []
 	return m, ks
 }
 
+// externWeakKey tries operator-supplied candidate keys (-keys) against an
+// unbundled cipher through the external program, verifying each by an exact
+// keystream match to the known-plaintext oracle. This is the "I already
+// recovered the key" path — an operator who ran their own TEA1 brute (or holds
+// a leaked/test key) hands it to assess, which confirms it, decrypts the
+// frames under it, and grades the result, without re-running a brute. It
+// returns the result, the recovered keystream, and whether it handled the
+// external algorithm (so the bundled-suite path is skipped for it).
+func externWeakKey(in Input, total int) (MethodResult, []byte, bool) {
+	m := MethodResult{Name: "weak-key", TotalBytes: total}
+	if in.ExternCmd == "" {
+		return m, nil, false
+	}
+	// Only take over when frames actually carry the external algorithm.
+	hasAlg := false
+	for _, f := range in.Frames {
+		if f.AlgID == in.ExternAlgID {
+			hasAlg = true
+			break
+		}
+	}
+	if !hasAlg {
+		return m, nil, false
+	}
+	m.Applicable = true
+	if len(in.ExtraKeys) == 0 {
+		m.note("external cipher set but no candidate keys supplied — pass a recovered/test key with -keys to verify and decrypt it, or use -brute-bits to search the keyspace.")
+		return m, nil, true
+	}
+	// Verifying an unbundled cipher's key needs a known-plaintext oracle on an
+	// external-algorithm frame; there is no structural fallback for a cipher we
+	// do not carry.
+	var oracle *keystream.Frame
+	for i := range in.Frames {
+		if in.Frames[i].AlgID == in.ExternAlgID && in.Frames[i].Label == in.KnownLabel {
+			oracle = &in.Frames[i]
+			break
+		}
+	}
+	if oracle == nil || len(in.KnownPT) == 0 {
+		m.note("external candidate keys need a known-plaintext oracle (-known-label/-known-pt) on an external-algorithm frame to verify against — an unbundled cipher's key cannot be confirmed without one.")
+		return m, nil, true
+	}
+	cli, err := extcipher.New(in.ExternCmd)
+	if err != nil {
+		m.note("external cipher: " + err.Error())
+		return m, nil, true
+	}
+	want := keystream.XOR(in.KnownPT, oracle.CT)
+	if len(want) == 0 {
+		m.note("oracle plaintext/ciphertext overlap is empty.")
+		return m, nil, true
+	}
+	for i, key := range in.ExtraKeys {
+		cand, err := cli.Keystream(key, oracle.IV, len(want))
+		if err != nil {
+			m.note("external cipher: " + err.Error())
+			return m, nil, true
+		}
+		if !bytesEqual(cand, want) {
+			continue
+		}
+		m.Verified = true
+		m.Effectiveness = effForAlg(in.Frames, in.ExternAlgID, total)
+		m.RecoveredBytes = bytesForAlg(in.Frames, in.ExternAlgID)
+		m.SampleHex = hexPreview(in.KnownPT, 32)
+		m.SampleASCII = asciiPreview(in.KnownPT, 32)
+		m.Detail = map[string]any{"key_hex": hex.EncodeToString(key), "external": in.ExternCmd, "keys_tried": i + 1}
+		m.note(fmt.Sprintf("COMPLETE BREAK: external cipher key %s verified against the known plaintext — every frame under it is decryptable.", hex.EncodeToString(key)))
+		return m, cand, true
+	}
+	m.Detail = map[string]any{"external": in.ExternCmd, "keys_tried": len(in.ExtraKeys)}
+	m.note(fmt.Sprintf("tried %d candidate key(s) through the external cipher against the known plaintext; none verified.", len(in.ExtraKeys)))
+	return m, nil, true
+}
+
 // methodIVReuse: structural keystream reuse. This is an EXPOSURE method, not a
 // turnkey decryption — a collision leaks plaintext⊕plaintext but still needs a
 // crib or known plaintext to fully recover, so it is reported unverified
@@ -512,6 +588,15 @@ func methodKnownPlaintext(in Input, total int) (MethodResult, []byte) {
 // complete break); otherwise candidate decryptions are scored by structure and
 // reported unverified.
 func methodWeakKey(in Input, total int) (MethodResult, []byte) {
+	// External-cipher known-key path: when an operator has already recovered a
+	// key for an unbundled cipher (e.g. ran their own TEA1 brute) and supplies
+	// it via -keys, verify and decrypt it through the external program — no
+	// reduced-keyspace brute required. This handles the assessment for the
+	// external algorithm, mirroring how key-brute fully delegates to externBrute.
+	if m, ks, handled := externWeakKey(in, total); handled {
+		return m, ks
+	}
+
 	m := MethodResult{Name: "weak-key", TotalBytes: total}
 	suite := suiteFor(in.Protocol)
 

--- a/internal/cryptolab/engine/assess/assess_extern_test.go
+++ b/internal/cryptolab/engine/assess/assess_extern_test.go
@@ -91,3 +91,67 @@ func TestAssessExternalBruteBreaks(t *testing.T) {
 		t.Fatalf("key-brute should be verified via the external cipher, got %+v", kb)
 	}
 }
+
+// TestAssessExternalKnownKeyDecrypts: an operator who already holds the key for
+// an unbundled cipher hands it to assess via -keys (no brute). assess verifies
+// it through the external program, decrypts the frames, and grades BROKEN.
+func TestAssessExternalKnownKeyDecrypts(t *testing.T) {
+	t.Parallel()
+	const alg = 0x01 // pretend TEA1 (tetra)
+	key := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	iv := []byte{0x33, 0x44}
+	pt := []byte("EMERGENCY DISPATCH ALL UNITS NOW")
+	c, _ := rc4.NewCipher(append(append([]byte{}, key...), iv...))
+	ct := xorb(pt, c.KeyStream(len(pt)))
+	f := keystream.Frame{Label: "t1", IV: iv, CT: ct, AlgID: alg}
+
+	rep := Run(Input{
+		Frames:      []keystream.Frame{f},
+		Protocol:    "tetra",
+		KnownLabel:  "t1",
+		KnownPT:     pt,
+		ExtraKeys:   [][]byte{{0, 0, 0, 0}, key}, // a decoy then the real key
+		ExternCmd:   mockSpec(),
+		ExternAlgID: alg,
+		// No BruteBits — this is the known-key path, not a search.
+	})
+	if rep.Verdict != VerdictBroken {
+		t.Fatalf("known external key should break the cipher, verdict = %s; methods: %+v", rep.Verdict, rep.Methods)
+	}
+	wk := find(rep, "weak-key")
+	if wk == nil || !wk.Verified {
+		t.Fatalf("weak-key should be verified via the external cipher, got %+v", wk)
+	}
+	if got := wk.Detail["key_hex"]; got != hex.EncodeToString(key) {
+		t.Errorf("recovered key_hex = %v, want %s", got, hex.EncodeToString(key))
+	}
+}
+
+// TestAssessExternalKnownKeyNeedsOracle: without a known-plaintext oracle the
+// external known-key path cannot verify an unbundled cipher's key, so it
+// reports inapplicable rather than claiming a break.
+func TestAssessExternalKnownKeyNeedsOracle(t *testing.T) {
+	t.Parallel()
+	const alg = 0x01
+	key := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	iv := []byte{0x33, 0x44}
+	pt := []byte("EMERGENCY DISPATCH ALL UNITS NOW")
+	c, _ := rc4.NewCipher(append(append([]byte{}, key...), iv...))
+	ct := xorb(pt, c.KeyStream(len(pt)))
+	f := keystream.Frame{Label: "t1", IV: iv, CT: ct, AlgID: alg}
+
+	rep := Run(Input{
+		Frames:      []keystream.Frame{f},
+		Protocol:    "tetra",
+		ExtraKeys:   [][]byte{key}, // correct key, but no oracle to verify it
+		ExternCmd:   mockSpec(),
+		ExternAlgID: alg,
+	})
+	if rep.Verdict == VerdictBroken {
+		t.Fatalf("a key cannot be confirmed without an oracle; verdict should not be BROKEN, got %s", rep.Verdict)
+	}
+	wk := find(rep, "weak-key")
+	if wk == nil || wk.Verified {
+		t.Fatalf("weak-key must not be verified without an oracle, got %+v", wk)
+	}
+}

--- a/internal/cryptolab/engine/recipe/recipe.go
+++ b/internal/cryptolab/engine/recipe/recipe.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math/bits"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/crypto/rc4"
@@ -85,22 +86,24 @@ var (
 
 // ops is the operation registry.
 var ops = map[string]opDef{
-	"xor":               {transform: true, synopsis: "repeating-key XOR (key=hex)", params: []OpParam{keyParam}, fn: opXOR},
-	"not":               {transform: true, synopsis: "bitwise NOT of every byte", fn: opNot},
-	"reverse-bits":      {transform: true, synopsis: "reverse the bit order within each byte (MSB↔LSB framing)", fn: opReverseBits},
-	"hex-decode":        {transform: true, synopsis: "decode an ASCII hex string to bytes", fn: opHexDecode},
-	"hex-encode":        {transform: true, synopsis: "encode bytes as an ASCII hex string", fn: opHexEncode},
-	"base64-decode":     {transform: true, synopsis: "decode standard base64 to bytes", fn: opBase64Decode},
-	"slice":             {transform: true, synopsis: "keep bytes [offset, offset+length) (length=0 → to end)", params: []OpParam{{Name: "offset", Label: "Offset", Kind: "int"}, {Name: "length", Label: "Length", Kind: "int"}}, fn: opSlice},
-	"rc4-decrypt":       {transform: true, synopsis: "raw RC4 decrypt with a caller-supplied key (DMR Enhanced Privacy / generic)", params: []OpParam{{Name: "key", Label: "Full RC4 key (hex)", Kind: "hex", Help: "the complete RC4 key bytes, e.g. privacy key ‖ IV"}}, fn: opRC4},
-	"adp-decrypt":       {transform: true, synopsis: "P25 ADP/RC4 decrypt (key=hex 5B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgADP)},
-	"des-ofb-decrypt":   {transform: true, synopsis: "P25 DES-OFB decrypt (key=hex 8B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgDESOFB)},
-	"tdes-ofb-decrypt":  {transform: true, synopsis: "P25 Triple-DES-OFB decrypt (key=hex 24B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgTDES)},
-	"aes-ofb-decrypt":   {transform: true, synopsis: "P25 AES-OFB decrypt (key=hex 16/32B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgAES256)},
-	"descramble-invert": {transform: true, synopsis: "full-band spectral inversion of s16le mono PCM (self-inverse)", fn: opDescramble},
-	"extern-decrypt":    {transform: true, external: true, synopsis: "decrypt via an external cipher program (e.g. a TETRA TEA1 tool) — CLI only", params: []OpParam{{Name: "cmd", Label: "Cipher program", Kind: "string", Help: "external program implementing the extcipher protocol"}, keyParam, miParam}, fn: opExternDecrypt},
-	"stats":             {transform: false, synopsis: "report entropy / index-of-coincidence / chi-square", fn: opStats},
-	"randomness":        {transform: false, synopsis: "quick NIST randomness subset (strong vs structured)", fn: opRandomness},
+	"xor":                  {transform: true, synopsis: "repeating-key XOR (key=hex)", params: []OpParam{keyParam}, fn: opXOR},
+	"not":                  {transform: true, synopsis: "bitwise NOT of every byte", fn: opNot},
+	"reverse-bits":         {transform: true, synopsis: "reverse the bit order within each byte (MSB↔LSB framing)", fn: opReverseBits},
+	"hex-decode":           {transform: true, synopsis: "decode an ASCII hex string to bytes", fn: opHexDecode},
+	"hex-encode":           {transform: true, synopsis: "encode bytes as an ASCII hex string", fn: opHexEncode},
+	"base64-decode":        {transform: true, synopsis: "decode standard base64 to bytes", fn: opBase64Decode},
+	"slice":                {transform: true, synopsis: "keep bytes [offset, offset+length) (length=0 → to end)", params: []OpParam{{Name: "offset", Label: "Offset", Kind: "int"}, {Name: "length", Label: "Length", Kind: "int"}}, fn: opSlice},
+	"rc4-decrypt":          {transform: true, synopsis: "raw RC4 decrypt with a caller-supplied key (DMR Enhanced Privacy / generic)", params: []OpParam{{Name: "key", Label: "Full RC4 key (hex)", Kind: "hex", Help: "the complete RC4 key bytes, e.g. privacy key ‖ IV"}}, fn: opRC4},
+	"adp-decrypt":          {transform: true, synopsis: "P25 ADP/RC4 decrypt (key=hex 5B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgADP)},
+	"des-ofb-decrypt":      {transform: true, synopsis: "P25 DES-OFB decrypt (key=hex 8B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgDESOFB)},
+	"tdes-ofb-decrypt":     {transform: true, synopsis: "P25 Triple-DES-OFB decrypt (key=hex 24B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgTDES)},
+	"aes-ofb-decrypt":      {transform: true, synopsis: "P25 AES-OFB decrypt (key=hex 16/32B, mi=hex)", params: cipherKeys, fn: cipherOp(p25crypto.AlgAES256)},
+	"descramble-invert":    {transform: true, synopsis: "full-band spectral inversion of s16le mono PCM (self-inverse)", fn: opDescramble},
+	"descramble-splitband": {transform: true, synopsis: "split-band spectral inversion of s16le mono PCM (invert low/high sub-bands about a split)", params: []OpParam{{Name: "split", Label: "Split (fraction of Nyquist)", Kind: "float", Help: "0..1; re-run with the same split to undo"}}, fn: opDescrambleSplit},
+	"descramble-rolling":   {transform: true, synopsis: "rolling spectral inversion of s16le mono PCM (per-frame split schedule, or auto-detect)", params: []OpParam{{Name: "frame", Label: "Frame length (samples)", Kind: "int", Help: "samples per frame (default 1024)"}, {Name: "schedule", Label: "Schedule", Kind: "string", Help: "comma-separated split fractions, or 'auto' to detect inverted frames"}}, fn: opDescrambleRolling},
+	"extern-decrypt":       {transform: true, external: true, synopsis: "decrypt via an external cipher program (e.g. a TETRA TEA1 tool) — CLI only", params: []OpParam{{Name: "cmd", Label: "Cipher program", Kind: "string", Help: "external program implementing the extcipher protocol"}, keyParam, miParam}, fn: opExternDecrypt},
+	"stats":                {transform: false, synopsis: "report entropy / index-of-coincidence / chi-square", fn: opStats},
+	"randomness":           {transform: false, synopsis: "quick NIST randomness subset (strong vs structured)", fn: opRandomness},
 }
 
 // External reports whether op shells out to a host program (and so must be
@@ -332,6 +335,97 @@ func opDescramble(buf []byte, _ params) ([]byte, map[string]any, string, error) 
 	return out, map[string]any{"samples": len(samples)}, "", nil
 }
 
+func opDescrambleSplit(buf []byte, p params) ([]byte, map[string]any, string, error) {
+	samples, err := pcmToFloat(buf)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("descramble-splitband: %w", err)
+	}
+	split := p.floatDefault("split", 0.5)
+	out := floatToPCM(voice.SplitBandInvert(samples, split))
+	return out, map[string]any{"samples": len(samples), "split": split}, "", nil
+}
+
+func opDescrambleRolling(buf []byte, p params) ([]byte, map[string]any, string, error) {
+	samples, err := pcmToFloat(buf)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("descramble-rolling: %w", err)
+	}
+	frame := p.intDefault("frame", 1024)
+	if frame <= 0 {
+		return nil, nil, "", fmt.Errorf("descramble-rolling: frame must be > 0, got %d", frame)
+	}
+	sched := strings.TrimSpace(p.str("schedule"))
+	if sched == "" || strings.EqualFold(sched, "auto") {
+		inv, flags := voice.RollingAuto(samples, frame)
+		inverted := 0
+		for _, f := range flags {
+			if f {
+				inverted++
+			}
+		}
+		return floatToPCM(inv),
+			map[string]any{"samples": len(samples), "frames": len(flags), "frames_inverted": inverted},
+			"auto mode is a heuristic inversion detector (energy balance); a known schedule is exact", nil
+	}
+	splits, err := parseSplitList(sched)
+	if err != nil {
+		return nil, nil, "", fmt.Errorf("descramble-rolling: %w", err)
+	}
+	out := floatToPCM(voice.RollingInvert(samples, frame, splits))
+	return out, map[string]any{"samples": len(samples), "schedule_steps": len(splits)}, "", nil
+}
+
+// pcmToFloat decodes s16le mono PCM bytes to float64 samples in [-1,1), the
+// representation the band-inversion engine works in.
+func pcmToFloat(buf []byte) ([]float64, error) {
+	if len(buf)%2 != 0 {
+		return nil, fmt.Errorf("need s16le PCM (even byte count), got %d", len(buf))
+	}
+	s := make([]float64, len(buf)/2)
+	for i := range s {
+		s[i] = float64(int16(uint16(buf[2*i])|uint16(buf[2*i+1])<<8)) / 32768.0
+	}
+	return s, nil
+}
+
+// floatToPCM re-encodes float64 samples to s16le mono PCM bytes, clamping to
+// the int16 range.
+func floatToPCM(s []float64) []byte {
+	out := make([]byte, len(s)*2)
+	for i, v := range s {
+		x := v * 32768.0
+		switch {
+		case x > 32767:
+			x = 32767
+		case x < -32768:
+			x = -32768
+		}
+		u := uint16(int16(x))
+		out[2*i] = byte(u)
+		out[2*i+1] = byte(u >> 8)
+	}
+	return out
+}
+
+func parseSplitList(s string) ([]float64, error) {
+	var out []float64
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		v, err := strconv.ParseFloat(p, 64)
+		if err != nil {
+			return nil, fmt.Errorf("bad split %q: %w", p, err)
+		}
+		out = append(out, v)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("empty schedule")
+	}
+	return out, nil
+}
+
 // --- analysis ops (buffer unchanged) ---
 
 func opStats(buf []byte, _ params) ([]byte, map[string]any, string, error) {
@@ -394,6 +488,29 @@ func (p params) hex(key string) ([]byte, error) {
 		return nil, fmt.Errorf("param %q: bad hex %q: %w", key, s, err)
 	}
 	return b, nil
+}
+
+func (p params) floatDefault(key string, def float64) float64 {
+	if p == nil {
+		return def
+	}
+	switch v := p[key].(type) {
+	case float64:
+		return v
+	case float32:
+		return float64(v)
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case string:
+		if s := strings.TrimSpace(v); s != "" {
+			if f, err := strconv.ParseFloat(s, 64); err == nil {
+				return f
+			}
+		}
+	}
+	return def
 }
 
 func (p params) intDefault(key string, def int) int {

--- a/internal/cryptolab/engine/recipe/recipe_test.go
+++ b/internal/cryptolab/engine/recipe/recipe_test.go
@@ -180,3 +180,93 @@ func TestOpsListed(t *testing.T) {
 		t.Fatal("expected both transform and analysis ops")
 	}
 }
+
+// pcm builds s16le mono PCM bytes from a ramp so the descramble ops have a
+// non-trivial spectrum to invert.
+func pcm(n int) []byte {
+	b := make([]byte, n*2)
+	for i := 0; i < n; i++ {
+		v := int16((i*257 - 12000) % 20000)
+		b[2*i] = byte(uint16(v))
+		b[2*i+1] = byte(uint16(v) >> 8)
+	}
+	return b
+}
+
+// TestDescrambleSplitbandSelfInverse: split-band inversion at a fixed split is
+// its own inverse, so two passes restore the input (within rounding).
+func TestDescrambleSplitbandSelfInverse(t *testing.T) {
+	t.Parallel()
+	in := pcm(256)
+	rep, err := Run(in, []Step{
+		{Op: "descramble-splitband", Params: map[string]any{"split": 0.4}},
+		{Op: "descramble-splitband", Params: map[string]any{"split": 0.4}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rep.FinalBytes) != len(in) {
+		t.Fatalf("length changed: got %d want %d", len(rep.FinalBytes), len(in))
+	}
+	a, _ := pcmToFloat(in)
+	b, _ := pcmToFloat(rep.FinalBytes)
+	for i := range a {
+		if d := a[i] - b[i]; d > 1e-3 || d < -1e-3 {
+			t.Fatalf("sample %d not restored: %.4f vs %.4f", i, a[i], b[i])
+		}
+	}
+}
+
+// TestDescrambleSplitbandFloatParam confirms the float param is honored whether
+// it arrives as a JSON number (web) or a string (CLI/file recipe).
+func TestDescrambleSplitbandFloatParam(t *testing.T) {
+	t.Parallel()
+	in := pcm(128)
+	for _, sp := range []any{0.3, "0.3"} {
+		rep, err := Run(in, []Step{{Op: "descramble-splitband", Params: map[string]any{"split": sp}}})
+		if err != nil {
+			t.Fatalf("split=%v: %v", sp, err)
+		}
+		if got := rep.Steps[0].Info["split"]; got != 0.3 {
+			t.Fatalf("split=%v: info split = %v, want 0.3", sp, got)
+		}
+	}
+}
+
+// TestDescrambleRollingSchedule runs an explicit per-frame schedule and the
+// auto detector, asserting both produce same-length PCM and surface frame info.
+func TestDescrambleRollingSchedule(t *testing.T) {
+	t.Parallel()
+	in := pcm(4096)
+	sched, err := Run(in, []Step{
+		{Op: "descramble-rolling", Params: map[string]any{"frame": 1024, "schedule": "0.5,0.4"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sched.FinalBytes) != len(in) {
+		t.Fatalf("schedule pass changed length: %d", len(sched.FinalBytes))
+	}
+	if sched.Steps[0].Info["schedule_steps"] != 2 {
+		t.Fatalf("schedule_steps = %v, want 2", sched.Steps[0].Info["schedule_steps"])
+	}
+
+	auto, err := Run(in, []Step{
+		{Op: "descramble-rolling", Params: map[string]any{"frame": 1024, "schedule": "auto"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := auto.Steps[0].Info["frames"]; !ok {
+		t.Fatalf("auto mode should report a frame count, got %v", auto.Steps[0].Info)
+	}
+}
+
+// TestDescrambleOddPCMErrors: the PCM ops reject a buffer that is not a whole
+// number of 16-bit samples instead of corrupting the tail.
+func TestDescrambleOddPCMErrors(t *testing.T) {
+	t.Parallel()
+	if _, err := Run([]byte{0x01, 0x02, 0x03}, []Step{{Op: "descramble-splitband"}}); err == nil {
+		t.Fatal("expected an error for odd-length PCM")
+	}
+}

--- a/internal/cryptolab/tools/assess.go
+++ b/internal/cryptolab/tools/assess.go
@@ -41,7 +41,7 @@ func (assessCrypto) Run(_ context.Context, args []string, _ cryptolab.Env) (*cry
 	keysFile := fs.String("keys", "", "optional file of candidate keys (one hex key per line) for the weak-key method")
 	bruteBits := fs.Int("brute-bits", 0, "reduced-keyspace brute: search the low N bits of the key against the known-plaintext oracle (0 = off)")
 	baseKeyHex := fs.String("base-key", "", "fixed high bits of the key for -brute-bits, as hex (default all-zero)")
-	externCmd := fs.String("extern-cmd", "", "external cipher program for an unbundled cipher (e.g. a TETRA TEA1 tool); used with -brute-bits to brute it natively")
+	externCmd := fs.String("extern-cmd", "", "external cipher program for an unbundled cipher (e.g. a TETRA TEA1 tool); with -brute-bits it brutes natively, with -keys it verifies/decrypts an already-recovered key")
 	externAlgHex := fs.String("extern-algid", "", "algid the -extern-cmd cipher handles, as hex (e.g. 0x01 for tetra TEA1)")
 	if err := fs.Parse(args); err != nil {
 		return nil, err

--- a/web/cryptolab/src/api/types.ts
+++ b/web/cryptolab/src/api/types.ts
@@ -72,7 +72,7 @@ export interface LogEvent {
 export interface OpParam {
   name: string;
   label: string;
-  kind: "hex" | "int";
+  kind: "hex" | "int" | "float" | "string";
   help?: string;
 }
 

--- a/web/cryptolab/src/components/RecipeBuilder.tsx
+++ b/web/cryptolab/src/components/RecipeBuilder.tsx
@@ -210,7 +210,8 @@ function StepCard({ step, index, count }: { step: BuilderStep; index: number; co
               <span className="label">{p.label}</span>
               <input
                 className="input"
-                type={p.kind === "int" ? "number" : "text"}
+                type={p.kind === "int" || p.kind === "float" ? "number" : "text"}
+                step={p.kind === "float" ? "any" : undefined}
                 value={step.params[p.name] ?? ""}
                 placeholder={p.kind === "hex" ? "hex" : ""}
                 onChange={(e) => setStepParam(step.id, p.name, e.target.value)}

--- a/web/cryptolab/src/store/recipe.ts
+++ b/web/cryptolab/src/store/recipe.ts
@@ -131,7 +131,7 @@ export const useRecipe = create<RecipeStore>((set, get) => ({
       for (const p of spec?.params ?? []) {
         const v = st.params[p.name];
         if (v == null || v === "") continue;
-        params[p.name] = p.kind === "int" ? Number(v) : v;
+        params[p.name] = p.kind === "int" || p.kind === "float" ? Number(v) : v;
       }
       return { op: st.op, params };
     });


### PR DESCRIPTION
## Summary

Two deferred follow-up items from the cryptolab security-test work, each a real
capability gap rather than a cleanup. The external-cipher bridge could only be
driven through a key *search* (`-brute-bits`), leaving an operator who already
holds an unbundled cipher's key with no way to verify and use it; and the
`recipe` pipeline exposed only one of the standalone `descramble` tool's three
spectral-inversion modes. This closes both gaps so the cryptolab feature set has
no holes against its own standalone tools and external bridge.

## Changes

- **assess — external known-key decrypt (no brute required).** When an operator
  has already recovered an unbundled cipher's key (e.g. ran their own TEA1
  brute), passing it via `-keys` together with `-extern-cmd` / `-extern-algid`
  and a known-plaintext oracle now verifies the key through the external cipher,
  decrypts every frame under it, and grades the break via the **weak-key**
  method — `-brute-bits` is only needed when the key is still unknown. Without an
  oracle the path reports *inapplicable* rather than claiming a break (an
  unbundled cipher's key cannot be confirmed without one).
- **recipe — split-band & rolling descramblers.** Adds `descramble-splitband`
  (`split` = fraction of Nyquist) and `descramble-rolling` (`frame` samples,
  `schedule` = comma-separated split fractions or `auto`) ops, bringing the
  inline analog-voice descrambler steps to parity with the standalone
  `descramble` tool's three modes.
- **recipe float param kind.** New `float` `OpParam` kind (the split fraction),
  rendered by the web Recipe Builder as a decimal (`step="any"`) number input and
  coerced to a JSON number on submit.
- Docs: `docs/cryptolab.md` recipe-op list and assess external-cipher examples;
  `CHANGELOG.md` Unreleased bullets.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (no daemon/DSP/replay paths touched)
- [x] Added or updated tests where appropriate:
  - assess: `TestAssessExternalKnownKeyDecrypts` (verified break via a supplied
    key), `TestAssessExternalKnownKeyNeedsOracle` (no oracle ⇒ not BROKEN)
  - recipe: split-band self-inverse round-trip, float-param coercion
    (number *and* string forms), rolling schedule + `auto`, odd-PCM guard
  - `make test-cryptolab` is green; cryptolab web `tsc` + vite build passes
- [ ] Smoke-tested against real hardware — n/a (offline analysis tooling)
- End-to-end: built `-tags cryptolab`, ran a two-step `descramble-splitband`
  recipe over synthesized PCM and confirmed it round-trips (max sample diff ≤2
  from int16/FFT rounding).

## Breaking changes

None. New flags reuse existing names (`-keys`, `-extern-cmd`, `-extern-algid`);
the new recipe ops and param kind are additive. External ciphers remain
CLI-only — the web recipe endpoint still refuses host-execution ops (HTTP 403).

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md`
- [x] Updated `docs/cryptolab.md` (recipe-op list + assess external-cipher
      examples)

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzEG7UxiWbbT5q76ECWWZ5)_