### PR TITLE
sdr: expose per-device tuning range via FreqRanger (whole-device hunt prep)

### DIFF
--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -65,6 +65,7 @@ func runHunt(args []string) {
 	var bands repeatedString
 	fs.Var(&bands, "band", "frequency band to sweep as low:high in MHz (repeatable; live mode)")
 	wholeDevice := fs.Bool("whole-device", false, "live: sweep the SDR's entire tuning range (derived from the device) instead of an explicit -band — the full-spectrum survey. Pair with -survey -classify-only for a fast first pass")
+	detectWideband := fs.Bool("detect-wideband", false, "live survey: also detect signals wider than a channel (cellular/WiFi/OFDM) by stitching occupancy across tunes, and surface them as named-but-not-decoded inventory rows (auto-enabled with -whole-device)")
 	candidatesFlag := fs.String("candidates", "", "comma-separated control-channel frequencies in MHz to probe directly (skips the sweep)")
 	noSweep := fs.Bool("no-sweep", false, "with -candidates, probe only the listed frequencies (no spectrum sweep)")
 	sweepDwell := fs.Duration("sweep-dwell", 0, "accumulation time per sweep step (e.g. 200ms; 0 ⇒ one frame)")
@@ -214,6 +215,7 @@ FLAGS:`)
 			classAMCV:        *classAMCV,
 			bands:            []string(bands),
 			wholeDevice:      *wholeDevice,
+			detectWideband:   *detectWideband || *wholeDevice,
 			candidatesMHz:    *candidatesFlag,
 			noSweep:          *noSweep,
 			sampleRateHz:     *sampleRate,

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -64,6 +64,7 @@ func runHunt(args []string) {
 	classAMCV := fs.Float64("class-am-cv", 0, "survey classifier: envelope coefficient-of-variation above which a carrier reads as AM (0 = default 0.15)")
 	var bands repeatedString
 	fs.Var(&bands, "band", "frequency band to sweep as low:high in MHz (repeatable; live mode)")
+	wholeDevice := fs.Bool("whole-device", false, "live: sweep the SDR's entire tuning range (derived from the device) instead of an explicit -band — the full-spectrum survey. Pair with -survey -classify-only for a fast first pass")
 	candidatesFlag := fs.String("candidates", "", "comma-separated control-channel frequencies in MHz to probe directly (skips the sweep)")
 	noSweep := fs.Bool("no-sweep", false, "with -candidates, probe only the listed frequencies (no spectrum sweep)")
 	sweepDwell := fs.Duration("sweep-dwell", 0, "accumulation time per sweep step (e.g. 200ms; 0 ⇒ one frame)")
@@ -212,6 +213,7 @@ FLAGS:`)
 			classDigitalProm: *classDigitalProm,
 			classAMCV:        *classAMCV,
 			bands:            []string(bands),
+			wholeDevice:      *wholeDevice,
 			candidatesMHz:    *candidatesFlag,
 			noSweep:          *noSweep,
 			sampleRateHz:     *sampleRate,

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -92,6 +92,14 @@ func runHunt(args []string) {
 	fs.Var(&rrCheckSIDs, "rr-check-sid", "RadioReference system id to compare against (repeatable)")
 
 	commit := fs.Bool("commit", false, "merge the discovered system into config.yaml (like import-pdf)")
+	// List-driven capture: record one signal from a prior survey's JSON and hand
+	// it to SigLab / CryptoLab.
+	surveyCapture := fs.String("survey-capture", "", "record IQ of one signal from a -from survey.json (a frequency in MHz, or #INDEX) and hand it to SigLab/CryptoLab")
+	captureFrom := fs.String("from", "", "survey JSON file (a prior `hunt -survey … -out-format json` export) the -survey-capture row is selected from")
+	captureTo := fs.String("to", "siglab", "with -survey-capture, where to send the capture: siglab | cryptolab")
+	captureSeconds := fs.Float64("capture-seconds", 10, "with -survey-capture, seconds of IQ to record")
+	captureOut := fs.String("capture-out", "", "with -survey-capture, output capture path (default: survey-<MHz>.cfile)")
+
 	configPath := fs.String("config", "config.yaml", "config.yaml path for -commit")
 	csvDir := fs.String("csv-dir", "", "directory for generated talkgroup CSVs on -commit (default: alongside -config)")
 	force := fs.Bool("force", false, "overwrite an existing system with the same name on -commit")
@@ -148,6 +156,23 @@ FLAGS:`)
 	_ = fs.Parse(args)
 	resolveVerbose(*verboseFlag, false)
 	rep := newReporter("hunt")
+
+	// List-driven capture short-circuits the hunt/survey pipeline: it records one
+	// already-discovered signal and routes it to deeper analysis.
+	if *surveyCapture != "" {
+		runSurveyCapture(rep, surveyCaptureParams{
+			selector:     *surveyCapture,
+			from:         *captureFrom,
+			to:           *captureTo,
+			serial:       *serial,
+			seconds:      *captureSeconds,
+			sampleRateHz: *sampleRate,
+			gain:         *gain,
+			ppm:          *ppm,
+			out:          *captureOut,
+		})
+		return
+	}
 
 	live := len(inPaths) == 0
 	if live && *serial == "" {

--- a/cmd/gophertrunk/hunt_cockpit.go
+++ b/cmd/gophertrunk/hunt_cockpit.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -175,6 +176,68 @@ func (c huntCockpit) ExportSurvey(id int, format string) ([]byte, string, error)
 		return nil, "", err
 	}
 	return buf.Bytes(), "survey." + sf.FileExtension(), nil
+}
+
+// CaptureSignal records raw IQ of one signal from the survey inventory and
+// routes it to SigLab/CryptoLab — the daemon side of the CLI's -survey-capture.
+// It acquires an SDR via the manager (refused while a run is active), writes the
+// capture + a metadata sidecar under the OS temp dir, and returns the paths
+// plus a SigLab identify summary or a CryptoLab frames file.
+func (c huntCockpit) CaptureSignal(req api.HuntCaptureRequest) (api.HuntCaptureResult, error) {
+	target := strings.ToLower(strings.TrimSpace(req.Target))
+	if target == "" {
+		target = "siglab"
+	}
+	if target != "siglab" && target != "cryptolab" {
+		return api.HuntCaptureResult{}, fmt.Errorf("target must be siglab or cryptolab (got %q)", req.Target)
+	}
+	seconds := req.Seconds
+	if seconds <= 0 {
+		seconds = 10
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(seconds+30)*time.Second)
+	defer cancel()
+	iq, rate, err := c.mgr.CaptureSignal(ctx, req.FreqHz, seconds)
+	if err != nil {
+		return api.HuntCaptureResult{}, err
+	}
+
+	dir := filepath.Join(os.TempDir(), "gophertrunk-captures")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return api.HuntCaptureResult{}, fmt.Errorf("capture dir: %w", err)
+	}
+	path := filepath.Join(dir, fmt.Sprintf("survey-%.4fMHz.cfile", float64(req.FreqHz)/1e6))
+	buf := siglab.EncodeCapture(iq, siglab.FormatF32)
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		return api.HuntCaptureResult{}, fmt.Errorf("write capture: %w", err)
+	}
+	metaPath := strings.TrimSuffix(path, ext(path)) + ".metadata.json"
+	_ = siglab.WriteMetadata(metaPath, &siglab.Metadata{
+		Source:       fmt.Sprintf("hunt survey-capture @ %.4f MHz", float64(req.FreqHz)/1e6),
+		SampleRateHz: float64(rate),
+		CenterFreqHz: req.FreqHz,
+		Format:       siglab.FormatF32.String(),
+	})
+
+	res := api.HuntCaptureResult{
+		Path: path, MetadataPath: metaPath, SampleRateHz: float64(rate),
+		CenterHz: req.FreqHz, Samples: len(iq),
+	}
+	switch target {
+	case "siglab":
+		res.Identify = identifySummary(buf, float64(rate))
+		res.Note = "open in the Signal Lab console (or `gophertrunk siglab -in <path>`)"
+	case "cryptolab":
+		framesPath, n, ferr := emitCryptolabFramesFromFile(path, req.FreqHz, float64(rate))
+		if ferr != nil {
+			res.Note = fmt.Sprintf("cryptolab frames emit failed: %v", ferr)
+		} else {
+			res.FramesPath = framesPath
+			res.Note = fmt.Sprintf("%d cryptolab frame(s) — `cryptolab classify auto -in %s`", n, framesPath)
+		}
+	}
+	return res, nil
 }
 
 // Export serializes the latest discovered system in the requested format.

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -44,6 +44,7 @@ type huntLiveParams struct {
 	classAMCV        float64
 	bands            []string // "low:high" in MHz
 	wholeDevice      bool     // sweep the SDR's entire tuning range (sdr.FreqRanger)
+	detectWideband   bool     // detect+stitch signals wider than a channel
 	candidatesMHz    string   // comma-separated MHz
 	noSweep          bool
 	sampleRateHz     float64
@@ -181,6 +182,7 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 		County:                p.county,
 		Location:              p.location,
 		ClassifyOnly:          p.classifyOnly,
+		DetectWideband:        p.detectWideband,
 		SurveyDeep:            p.surveyDeep,
 		SurveyAudioDir:        p.surveyAudioDir,
 		SkipFreqs:             skipFreqs,
@@ -356,8 +358,21 @@ func printSurvey(sv *hunt.SignalSurvey) {
 	fmt.Fprintf(os.Stderr, "survey: %d signal(s) — %d trunking, %d analog, %d paging, %d other\n",
 		len(sv.Signals), trunking, analog, paging, other)
 	for _, s := range sv.Signals {
-		line := fmt.Sprintf("  %10.4f MHz  %-13s  bw %5.1f kHz  snr %4.1f dB",
+		line := fmt.Sprintf("  %10.4f MHz  %-13s  bw %6.1f kHz  snr %4.1f dB",
 			float64(s.FreqHz)/1e6, s.Class, float64(s.OccupiedBwHz)/1e3, s.SNRDb)
+		if s.Name != "" {
+			line += "  " + s.Name
+		}
+		if s.Service != "" {
+			line += fmt.Sprintf(" (%s)", s.Service)
+		}
+		if s.Encrypted {
+			if s.EncType != "" {
+				line += "  🔒 " + s.EncType
+			} else {
+				line += "  🔒 encrypted"
+			}
+		}
 		switch {
 		case s.Trunking != nil:
 			line += fmt.Sprintf("  [%s", s.Trunking.Protocol)

--- a/cmd/gophertrunk/hunt_live.go
+++ b/cmd/gophertrunk/hunt_live.go
@@ -13,9 +13,16 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/survey"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// sweepGuardFrac mirrors the hunt.Sweeper default guard fraction
+// (internal/hunt/sweeper.go). It is duplicated here only to estimate the
+// whole-device step count / ETA before the sweep starts; the sweeper
+// remains the source of truth for the actual stepping.
+const sweepGuardFrac = 0.1
 
 // huntLiveParams are the resolved inputs for a live (on-air) hunt.
 type huntLiveParams struct {
@@ -36,6 +43,7 @@ type huntLiveParams struct {
 	classDigitalProm float64
 	classAMCV        float64
 	bands            []string // "low:high" in MHz
+	wholeDevice      bool     // sweep the SDR's entire tuning range (sdr.FreqRanger)
 	candidatesMHz    string   // comma-separated MHz
 	noSweep          bool
 	sampleRateHz     float64
@@ -64,8 +72,11 @@ type huntLiveParams struct {
 func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, *hunt.SignalSurvey, []hunt.CaptureReport) {
 	candidates := parseFreqListMHz(rep, p.candidatesMHz)
 	bands := parseBandsMHz(rep, p.bands)
-	if len(candidates) == 0 && len(bands) == 0 {
-		rep.Fatalf(2, "live hunt needs -band low:high (to sweep) or -candidates f,f (to probe)")
+	if p.wholeDevice && p.noSweep {
+		rep.Fatalf(2, "-whole-device sweeps the spectrum; it can't be combined with -no-sweep")
+	}
+	if !p.wholeDevice && len(candidates) == 0 && len(bands) == 0 {
+		rep.Fatalf(2, "live hunt needs -band low:high (to sweep), -candidates f,f (to probe), or -whole-device (sweep the whole tuner)")
 	}
 	if p.noSweep && len(candidates) == 0 {
 		rep.Fatalf(2, "-no-sweep requires -candidates")
@@ -79,6 +90,21 @@ func runHuntLive(rep *diag.Reporter, p huntLiveParams) (*hunt.DiscoveredSystem, 
 		rep.Fatal(1, err)
 	}
 	defer dev.Close()
+
+	// -whole-device: derive the sweep band from the open device's tuning
+	// range (sdr.FreqRanger). This is the full-spectrum survey — every
+	// frequency the dongle can reach, in one run.
+	if p.wholeDevice {
+		band, err := wholeDeviceBand(dev)
+		if err != nil {
+			rep.Fatalf(2, "-whole-device: %s[%s]: %v (pass explicit -band low:high instead)", info.Driver, info.Serial, err)
+		}
+		bands = append(bands, band)
+		steps := sweepStepCount(band, p.sampleRateHz)
+		fmt.Fprintf(os.Stderr, "%s: whole-device sweep %.4f–%.4f MHz (%d step(s) @ %g MS/s)%s\n",
+			modeLabel(p.survey), float64(band.LowHz)/1e6, float64(band.HighHz)/1e6,
+			steps, p.sampleRateHz/1e6, sweepETANote(steps, p.sweepDwell))
+	}
 	if err := dev.SetSampleRate(uint32(p.sampleRateHz)); err != nil {
 		rep.Fatal(1, fmt.Errorf("set sample rate: %w", err))
 	}
@@ -377,6 +403,74 @@ func parseFreqListMHz(rep *diag.Reporter, s string) []uint32 {
 		out = append(out, uint32(mhz*1e6+0.5))
 	}
 	return out
+}
+
+// modeLabel names the run for log lines: "survey" classifies every
+// carrier, "hunt" maps trunked control channels only.
+func modeLabel(survey bool) string {
+	if survey {
+		return "survey"
+	}
+	return "hunt"
+}
+
+// wholeDeviceBand derives the full-spectrum sweep band from a device that
+// reports its tuning range (sdr.FreqRanger). A device that can't report a
+// usable [min,max] (e.g. a network/file source) returns an error so the
+// caller can tell the operator to pass an explicit -band.
+func wholeDeviceBand(dev sdr.Device) (hunt.Band, error) {
+	fr, ok := dev.(sdr.FreqRanger)
+	if !ok {
+		return hunt.Band{}, fmt.Errorf("device does not report a tuning range")
+	}
+	lo, hi := fr.FreqRange()
+	if hi <= lo {
+		return hunt.Band{}, fmt.Errorf("device reports no usable tuning range (%d..%d Hz)", lo, hi)
+	}
+	return hunt.Band{LowHz: lo, HighHz: hi}, nil
+}
+
+// sweepStepCount reports how many tuned steps the sweeper will take to
+// cover band at sampleRateHz, by simulating the same advance loop
+// hunt.Sweeper.Sweep uses (step = rate·(1−2·guardFrac), centered half a
+// usable bandwidth in from the low edge, stopping once a step's coverage
+// reaches the high edge). Arithmetic is uint64 so the whole-device span of
+// a wide tuner cannot overflow the estimate.
+func sweepStepCount(band hunt.Band, sampleRateHz float64) int {
+	if band.HighHz < band.LowHz || sampleRateHz <= 0 {
+		return 0
+	}
+	rate := uint64(sampleRateHz)
+	step := uint64(float64(rate) * (1 - 2*sweepGuardFrac))
+	if step == 0 {
+		step = rate
+	}
+	halfUsable := step / 2
+	hi := uint64(band.HighHz)
+	n := 0
+	for center := uint64(band.LowHz) + halfUsable; ; center += step {
+		n++
+		if center+halfUsable >= hi {
+			break
+		}
+		if n > 10_000_000 { // safety: never spin forever on a degenerate input
+			break
+		}
+	}
+	return n
+}
+
+// sweepETANote returns a rough, clearly-approximate "time to sweep" note
+// for the whole-device banner. The estimate uses the per-step dwell when
+// set, else a nominal tune+capture budget; identify/decode of each detected
+// carrier adds time beyond the sweep itself.
+func sweepETANote(steps int, dwell time.Duration) string {
+	per := dwell
+	if per <= 0 {
+		per = 50 * time.Millisecond
+	}
+	eta := time.Duration(steps) * per
+	return fmt.Sprintf("; ~%s to sweep, plus identify/decode per detected carrier", eta.Round(time.Second))
 }
 
 // parseBandsMHz parses "low:high" MHz band specs into hunt.Band (Hz).

--- a/cmd/gophertrunk/hunt_live_test.go
+++ b/cmd/gophertrunk/hunt_live_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// TestWholeDeviceBand verifies the full-spectrum band is derived from a
+// device's reported tuning range, and that a device with no range errors
+// (so the CLI can fall back to an explicit -band).
+func TestWholeDeviceBand(t *testing.T) {
+	dev, err := (&sdr.MockDriver{Files: []string{"x.cfile"}}).Open(0)
+	if err != nil {
+		t.Fatalf("open mock: %v", err)
+	}
+	band, err := wholeDeviceBand(dev)
+	if err != nil {
+		t.Fatalf("wholeDeviceBand: %v", err)
+	}
+	// MockDevice reports the R820T family span.
+	if band.LowHz != 24_000_000 || band.HighHz != 1_766_000_000 {
+		t.Errorf("band = %d..%d, want 24_000_000..1_766_000_000", band.LowHz, band.HighHz)
+	}
+
+	if _, err := wholeDeviceBand(noRangeDevice{}); err == nil {
+		t.Error("wholeDeviceBand on a device without FreqRange: want error, got nil")
+	}
+}
+
+// TestSweepStepCountMatchesSweeper pins the whole-device ETA estimator to
+// the real sweeper: the predicted step count must equal the number of
+// tunes the sweeper actually performs over the same band.
+func TestSweepStepCountMatchesSweeper(t *testing.T) {
+	const rate = 2_400_000
+	bands := []hunt.Band{
+		{LowHz: 450_000_000, HighHz: 470_000_000},  // ~20 MHz
+		{LowHz: 24_000_000, HighHz: 1_766_000_000}, // whole R820T span
+		{LowHz: 451_000_000, HighHz: 451_500_000},  // narrower than one step
+	}
+	for _, band := range bands {
+		src := hunt.NewFileIQSource(make([]complex64, 4096), rate) // zero IQ: only step count matters
+		sw, err := hunt.NewSweeper(hunt.SweepOptions{
+			Source:   src,
+			Bands:    []hunt.Band{band},
+			FFTSize:  1024,
+			PeakOpts: hunt.PeakOptions{ThresholdDb: 10},
+		})
+		if err != nil {
+			t.Fatalf("NewSweeper: %v", err)
+		}
+		if _, err := sw.Sweep(context.Background(), nil); err != nil {
+			t.Fatalf("Sweep: %v", err)
+		}
+		want := len(src.TuneCalls())
+		got := sweepStepCount(band, rate)
+		if got != want {
+			t.Errorf("band %d..%d: sweepStepCount = %d, sweeper took %d steps",
+				band.LowHz, band.HighHz, got, want)
+		}
+	}
+}
+
+// noRangeDevice is an sdr.Device that deliberately does NOT implement
+// sdr.FreqRanger, exercising the whole-device fallback error path.
+type noRangeDevice struct{}
+
+func (noRangeDevice) Info() sdr.Info                                       { return sdr.Info{} }
+func (noRangeDevice) SetCenterFreq(uint32) error                           { return nil }
+func (noRangeDevice) SetSampleRate(uint32) error                           { return nil }
+func (noRangeDevice) SetGain(int) error                                    { return nil }
+func (noRangeDevice) SetPPM(int) error                                     { return nil }
+func (noRangeDevice) SetBiasTee(bool) error                                { return nil }
+func (noRangeDevice) StreamIQ(context.Context) (<-chan []complex64, error) { return nil, nil }
+func (noRangeDevice) Close() error                                         { return nil }

--- a/cmd/gophertrunk/survey_capture.go
+++ b/cmd/gophertrunk/survey_capture.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/rfscope"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// surveyCaptureParams drive `gophertrunk hunt -survey-capture`: select one row
+// from a survey inventory, record raw IQ of it, and hand the capture to the
+// offline workbench (SigLab) or the crypto-research toolkit (CryptoLab).
+type surveyCaptureParams struct {
+	selector     string // a frequency in MHz, or "#INDEX" into the inventory
+	from         string // survey JSON file (a prior -survey run's output)
+	to           string // "siglab" | "cryptolab"
+	serial       string
+	seconds      float64
+	sampleRateHz float64
+	gain         int
+	ppm          int
+	out          string // capture path (default: survey-<MHz>.cfile)
+}
+
+// runSurveyCapture records the selected signal and routes the capture. It is the
+// list-driven bridge from the full-spectrum survey to deeper analysis: pick a
+// row, get a `.cfile` + metadata sidecar, and a ready next step in SigLab or
+// CryptoLab.
+func runSurveyCapture(rep *diag.Reporter, p surveyCaptureParams) {
+	to := strings.ToLower(strings.TrimSpace(p.to))
+	if to == "" {
+		to = "siglab"
+	}
+	if to != "siglab" && to != "cryptolab" {
+		rep.Fatalf(2, "-to must be siglab or cryptolab (got %q)", p.to)
+	}
+	if p.from == "" {
+		rep.Fatalf(2, "-survey-capture needs -from <survey.json> (a prior `hunt -survey … -out-format json` run)")
+	}
+	sv, err := loadSurveyJSON(p.from)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	sig, err := selectSurveySignal(sv, p.selector)
+	if err != nil {
+		rep.Fatal(2, err)
+	}
+
+	rate := p.sampleRateHz
+	if rate <= 0 {
+		rate = 2_400_000
+	}
+	truncated := sig.OccupiedBwHz > uint32(rate)
+
+	out := p.out
+	if out == "" {
+		out = fmt.Sprintf("survey-%.4fMHz.cfile", float64(sig.FreqHz)/1e6)
+	}
+
+	dev, info, err := openCaptureDevice(p.serial)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	defer dev.Close()
+
+	fmt.Printf("survey-capture: %s @ %.4f MHz", signalLabel(sig), float64(sig.FreqHz)/1e6)
+	if sig.Service != "" {
+		fmt.Printf(" (%s)", sig.Service)
+	}
+	fmt.Printf(" — recording %.0fs at %g MS/s on %s[%s] → %s\n",
+		p.seconds, rate/1e6, info.Driver, info.Serial, out)
+	if truncated {
+		fmt.Fprintf(os.Stderr, "survey-capture: note — the signal is ~%.1f MHz wide but the capture is %g MHz; "+
+			"this is a slice for analysis, not a full-bandwidth demod (raise -sample-rate to widen, device permitting).\n",
+			float64(sig.OccupiedBwHz)/1e6, rate/1e6)
+	}
+
+	written, err := captureSignalToFile(dev, sig.FreqHz, uint32(rate), p.gain, p.ppm, out, p.seconds)
+	if err != nil && !errors.Is(err, context.Canceled) {
+		rep.Fatal(1, fmt.Errorf("capture: %w (wrote %d samples)", err, written))
+	}
+
+	metaPath := strings.TrimSuffix(out, ext(out)) + ".metadata.json"
+	meta := &siglab.Metadata{
+		Protocol:     surveyCaptureProtocol(sig),
+		Source:       fmt.Sprintf("survey-capture %s @ %.4f MHz", signalLabel(sig), float64(sig.FreqHz)/1e6),
+		SampleRateHz: rate,
+		CenterFreqHz: sig.FreqHz,
+		Format:       siglab.FormatF32.String(),
+	}
+	if err := siglab.WriteMetadata(metaPath, meta); err != nil {
+		rep.Fatal(1, fmt.Errorf("write metadata: %w", err))
+	}
+	fmt.Printf("survey-capture: wrote %d samples → %s  (metadata → %s)\n", written, out, metaPath)
+
+	switch to {
+	case "siglab":
+		routeToSigLab(out, rate)
+	case "cryptolab":
+		routeToCryptoLab(rep, out, sig.FreqHz, rate)
+	}
+}
+
+// captureSignalToFile tunes the device to a signal and records seconds of raw
+// f32 IQ, reusing the shared capture packer. Split out so it is exercisable
+// against a mock device.
+func captureSignalToFile(dev sdr.Device, freqHz, rateHz uint32, gain, ppm int, out string, seconds float64) (int64, error) {
+	if err := dev.SetSampleRate(rateHz); err != nil {
+		return 0, fmt.Errorf("set sample rate: %w", err)
+	}
+	if err := dev.SetCenterFreq(freqHz); err != nil {
+		return 0, fmt.Errorf("set centre frequency: %w", err)
+	}
+	if ppm != 0 {
+		if err := dev.SetPPM(ppm); err != nil {
+			return 0, fmt.Errorf("set ppm: %w", err)
+		}
+	}
+	if err := dev.SetGain(gain); err != nil {
+		return 0, fmt.Errorf("set gain: %w", err)
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	stream, err := dev.StreamIQ(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("start IQ stream: %w", err)
+	}
+	return captureToFile(ctx, out, siglab.FormatF32, stream, rateHz, seconds)
+}
+
+// routeToSigLab runs a quick in-process identify on the capture and prints the
+// command to open it in the full SigLab workbench.
+func routeToSigLab(path string, rateHz float64) {
+	f, err := os.Open(path)
+	if err == nil {
+		defer f.Close()
+		if idr, ierr := siglab.IdentifyReader(f, path, siglab.IdentifyConfig{
+			SampleRateHz: rateHz, Format: siglab.FormatF32, AutoTune: true,
+		}); ierr == nil {
+			if idr.Inconclusive || idr.Winner == "" {
+				fmt.Println("siglab: no protocol locked (inconclusive) — open it in the workbench to dig in")
+			} else {
+				fmt.Printf("siglab: identifies as %s (confidence %.2f)\n", idr.Winner, idr.Confidence)
+			}
+		}
+	}
+	fmt.Printf("siglab: analyze it →  gophertrunk siglab -in %s -sample-rate %g -format f32 -auto-tune\n", path, rateHz)
+	fmt.Println("siglab: or open the browser console →  gophertrunk siglab serve -open")
+}
+
+// routeToCryptoLab runs rfscope over the capture to emit a cryptolab `ks` frames
+// file from any unidentified payloads, then prints the cryptolab next step.
+func routeToCryptoLab(rep *diag.Reporter, path string, centerHz uint32, rateHz float64) {
+	src, err := rfscope.OpenFile(path, siglab.FormatF32, centerHz, rateHz)
+	if err != nil {
+		rep.Fatal(1, fmt.Errorf("rfscope open: %w", err))
+	}
+	defer src.Close()
+	framesOut := path + ".frames.jsonl"
+	cfg := rfscope.SegmentConfig{
+		FFTSize:             4096,
+		ChannelTargetRateHz: 50_000,
+		PeakThresholdDb:     10,
+		MinSpacingHz:        12_500,
+	}
+	rfscopeRunAndExport(rep, src, cfg, nil, path, "summary", "", framesOut)
+	fmt.Printf("cryptolab: triage the recovered payloads →  gophertrunk cryptolab classify auto -in %s\n", framesOut)
+	fmt.Println("cryptolab: (needs a -tags cryptolab build; see docs/cryptolab.md)")
+}
+
+// loadSurveyJSON reads a SignalSurvey from a `hunt -survey` JSON export.
+func loadSurveyJSON(path string) (*hunt.SignalSurvey, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read survey %s: %w", path, err)
+	}
+	var sv hunt.SignalSurvey
+	if err := json.Unmarshal(raw, &sv); err != nil {
+		return nil, fmt.Errorf("parse survey %s: %w", path, err)
+	}
+	if len(sv.Signals) == 0 {
+		return nil, fmt.Errorf("survey %s has no signals", path)
+	}
+	return &sv, nil
+}
+
+// selectSurveySignal resolves a selector to one inventory row. The selector is
+// either "#INDEX" (0-based, into the inventory order) or a frequency in MHz,
+// matched to the nearest signal within a tolerance that scales with the signal's
+// own bandwidth (so a wide signal a little off-centre still matches).
+func selectSurveySignal(sv *hunt.SignalSurvey, selector string) (hunt.DetectedSignal, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return hunt.DetectedSignal{}, errors.New("-survey-capture needs a frequency in MHz or #INDEX")
+	}
+	if strings.HasPrefix(selector, "#") {
+		idx, err := strconv.Atoi(strings.TrimPrefix(selector, "#"))
+		if err != nil || idx < 0 || idx >= len(sv.Signals) {
+			return hunt.DetectedSignal{}, fmt.Errorf("index %q out of range [0,%d)", selector, len(sv.Signals))
+		}
+		return sv.Signals[idx], nil
+	}
+	mhz, err := strconv.ParseFloat(selector, 64)
+	if err != nil {
+		return hunt.DetectedSignal{}, fmt.Errorf("selector %q is not a frequency in MHz or #INDEX", selector)
+	}
+	target := uint32(mhz*1e6 + 0.5)
+	best := -1
+	var bestDiff uint32 = ^uint32(0)
+	for i, s := range sv.Signals {
+		if d := absU32(s.FreqHz, target); d < bestDiff {
+			bestDiff, best = d, i
+		}
+	}
+	tol := uint32(100_000)
+	if half := sv.Signals[best].OccupiedBwHz / 2; half > tol {
+		tol = half
+	}
+	if best < 0 || bestDiff > tol {
+		return hunt.DetectedSignal{}, fmt.Errorf("no signal within %.3f MHz of %.4f MHz", float64(tol)/1e6, mhz)
+	}
+	return sv.Signals[best], nil
+}
+
+// absU32 is |a-b| for unsigned frequencies.
+func absU32(a, b uint32) uint32 {
+	if a > b {
+		return a - b
+	}
+	return b - a
+}
+
+// signalLabel is the human name for a captured row, falling back to the class.
+func signalLabel(s hunt.DetectedSignal) string {
+	if s.Name != "" {
+		return s.Name
+	}
+	return string(s.Class)
+}
+
+// surveyCaptureProtocol returns the decoded protocol for the metadata sidecar
+// (so `test`/`replay` can use it), or empty for an undecoded/wideband row.
+func surveyCaptureProtocol(s hunt.DetectedSignal) string {
+	if s.Trunking != nil {
+		return s.Trunking.Protocol
+	}
+	return ""
+}

--- a/cmd/gophertrunk/survey_capture.go
+++ b/cmd/gophertrunk/survey_capture.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -161,21 +162,74 @@ func routeToSigLab(path string, rateHz float64) {
 // routeToCryptoLab runs rfscope over the capture to emit a cryptolab `ks` frames
 // file from any unidentified payloads, then prints the cryptolab next step.
 func routeToCryptoLab(rep *diag.Reporter, path string, centerHz uint32, rateHz float64) {
-	src, err := rfscope.OpenFile(path, siglab.FormatF32, centerHz, rateHz)
+	framesOut, n, err := emitCryptolabFramesFromFile(path, centerHz, rateHz)
 	if err != nil {
-		rep.Fatal(1, fmt.Errorf("rfscope open: %w", err))
+		rep.Fatal(1, fmt.Errorf("rfscope frames: %w", err))
 	}
-	defer src.Close()
-	framesOut := path + ".frames.jsonl"
-	cfg := rfscope.SegmentConfig{
+	fmt.Printf("cryptolab: wrote %d frame(s) → %s\n", n, framesOut)
+	fmt.Printf("cryptolab: triage them →  gophertrunk cryptolab classify auto -in %s\n", framesOut)
+	fmt.Println("cryptolab: (needs a -tags cryptolab build; see docs/cryptolab.md)")
+}
+
+// defaultRFScopeSegConfig is the carrier-discovery configuration the capture
+// routes use when running rfscope over a recorded signal — the same defaults as
+// the rfscope CLI.
+func defaultRFScopeSegConfig() rfscope.SegmentConfig {
+	return rfscope.SegmentConfig{
 		FFTSize:             4096,
 		ChannelTargetRateHz: 50_000,
 		PeakThresholdDb:     10,
 		MinSpacingHz:        12_500,
 	}
-	rfscopeRunAndExport(rep, src, cfg, nil, path, "summary", "", framesOut)
-	fmt.Printf("cryptolab: triage the recovered payloads →  gophertrunk cryptolab classify auto -in %s\n", framesOut)
-	fmt.Println("cryptolab: (needs a -tags cryptolab build; see docs/cryptolab.md)")
+}
+
+// emitCryptolabFramesFromFile runs an rfscope pass over a recorded capture and
+// writes the recovered payloads as a cryptolab `ks` frames file next to it.
+// Returns the frames path and the number of frames written. Shared by the CLI
+// route and the daemon cockpit so both behave identically.
+func emitCryptolabFramesFromFile(path string, centerHz uint32, rateHz float64) (string, int, error) {
+	src, err := rfscope.OpenFile(path, siglab.FormatF32, centerHz, rateHz)
+	if err != nil {
+		return "", 0, fmt.Errorf("rfscope open: %w", err)
+	}
+	defer src.Close()
+	ctx := context.Background()
+	scene, in, err := rfscope.Segment(ctx, src, defaultRFScopeSegConfig())
+	if err != nil {
+		return "", 0, err
+	}
+	scene.Source = path
+	if err := rfscope.Run(ctx, scene, in); err != nil {
+		return "", 0, err
+	}
+	framesOut := path + ".frames.jsonl"
+	f, err := os.Create(framesOut)
+	if err != nil {
+		return "", 0, fmt.Errorf("create %s: %w", framesOut, err)
+	}
+	n, werr := rfscope.EmitFrames(scene, f)
+	if cerr := f.Close(); werr == nil {
+		werr = cerr
+	}
+	if werr != nil {
+		return "", n, werr
+	}
+	return framesOut, n, nil
+}
+
+// identifySummary runs a quick SigLab identify over an in-memory f32 capture and
+// returns a short label ("p25 (0.82)" / "inconclusive"), or "" on error.
+func identifySummary(buf []byte, rateHz float64) string {
+	idr, err := siglab.IdentifyReader(bytes.NewReader(buf), "survey-capture", siglab.IdentifyConfig{
+		SampleRateHz: rateHz, Format: siglab.FormatF32, AutoTune: true,
+	})
+	if err != nil || idr == nil {
+		return ""
+	}
+	if idr.Inconclusive || idr.Winner == "" {
+		return "inconclusive"
+	}
+	return fmt.Sprintf("%s (%.2f)", idr.Winner, idr.Confidence)
 }
 
 // loadSurveyJSON reads a SignalSurvey from a `hunt -survey` JSON export.

--- a/cmd/gophertrunk/survey_capture_test.go
+++ b/cmd/gophertrunk/survey_capture_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func sampleSurvey() *hunt.SignalSurvey {
+	return &hunt.SignalSurvey{Signals: []hunt.DetectedSignal{
+		{FreqHz: 462_562_500, Class: survey.ClassNBFM, OccupiedBwHz: 12_500, Name: "nbfm", Service: "FRS / GMRS"},
+		{FreqHz: 851_012_500, Class: survey.ClassTrunkControl, OccupiedBwHz: 12_500, Name: "P25 Phase 1",
+			Trunking: &hunt.TrunkingRef{Protocol: "p25", Locked: true}},
+		{FreqHz: 751_000_000, Class: survey.ClassWideband, OccupiedBwHz: 10_000_000, Name: "LTE/5G NR (10 MHz)", Wideband: true},
+	}}
+}
+
+func TestSelectSurveySignal(t *testing.T) {
+	sv := sampleSurvey()
+
+	// By index.
+	if s, err := selectSurveySignal(sv, "#1"); err != nil || s.FreqHz != 851_012_500 {
+		t.Errorf("#1 = %+v, err %v; want the P25 row", s, err)
+	}
+	// By frequency in MHz (nearest within tolerance).
+	if s, err := selectSurveySignal(sv, "462.5625"); err != nil || s.Name != "nbfm" {
+		t.Errorf("462.5625 = %+v, err %v; want the FRS row", s, err)
+	}
+	// Wideband row matches even a few hundred kHz off-centre (tolerance scales
+	// with its bandwidth).
+	if s, err := selectSurveySignal(sv, "752.0"); err != nil || !s.Wideband {
+		t.Errorf("752.0 = %+v, err %v; want the wideband row", s, err)
+	}
+	// Out-of-range index and a far-off frequency both error.
+	if _, err := selectSurveySignal(sv, "#9"); err == nil {
+		t.Error("#9: want out-of-range error")
+	}
+	if _, err := selectSurveySignal(sv, "100.0"); err == nil {
+		t.Error("100.0 MHz: want no-match error")
+	}
+}
+
+func TestLoadSurveyJSONRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "survey.json")
+	raw, _ := json.Marshal(sampleSurvey())
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sv, err := loadSurveyJSON(path)
+	if err != nil {
+		t.Fatalf("loadSurveyJSON: %v", err)
+	}
+	if len(sv.Signals) != 3 {
+		t.Errorf("loaded %d signals, want 3", len(sv.Signals))
+	}
+	if _, err := loadSurveyJSON(filepath.Join(dir, "missing.json")); err == nil {
+		t.Error("missing file: want error")
+	}
+}
+
+func TestCaptureSignalToFile(t *testing.T) {
+	dir := t.TempDir()
+	// A float32 IQ fixture for the mock f32 driver to replay.
+	const fixtureSamples = 8192
+	iq := make([]complex64, fixtureSamples)
+	buf := make([]byte, fixtureSamples*8)
+	encodeF32(buf, iq)
+	fixture := filepath.Join(dir, "fixture.cfile")
+	if err := os.WriteFile(fixture, buf, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	dev, err := (&sdr.MockFloat32Driver{Files: []string{fixture}}).Open(0)
+	if err != nil {
+		t.Fatalf("open mock: %v", err)
+	}
+	defer dev.Close()
+
+	out := filepath.Join(dir, "out.cfile")
+	const rate = 48_000
+	written, err := captureSignalToFile(dev, 751_000_000, rate, -1, 0, out, 0.05) // ~2400 samples
+	if err != nil {
+		t.Fatalf("captureSignalToFile: %v", err)
+	}
+	if written < int64(0.05*rate) {
+		t.Errorf("wrote %d samples, want ≥ %d", written, int64(0.05*rate))
+	}
+	fi, err := os.Stat(out)
+	if err != nil || fi.Size() == 0 {
+		t.Fatalf("capture file missing/empty: %v", err)
+	}
+}

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -123,6 +123,35 @@ gophertrunk hunt -survey -classify-only -whole-device \
 crash-safe and restartable. A device that can't report a tuning range (a
 network or file source) tells you to pass an explicit `-band` instead.
 
+`-whole-device` auto-enables `-detect-wideband`: alongside the narrowband
+carriers, signals far wider than a channel (cellular LTE/5G, WiFi, other OFDM)
+are detected by stitching occupancy across tunes and surfaced as
+**named-but-not-decoded** inventory rows — GopherTrunk identifies and can
+capture them, it does not demodulate them.
+
+### Record a signal from the list and send it to SigLab / CryptoLab
+
+Export a survey to JSON, then pick any row and record raw IQ of it for deeper
+analysis — no need to hand-copy a frequency into `gophertrunk capture`:
+
+```sh
+# Capture the survey to JSON
+gophertrunk hunt -survey -whole-device -serial 00000001 \
+  -out-format json -out survey.json
+
+# Record signal #3 from the list and hand it to SigLab (offline workbench)
+gophertrunk hunt -survey-capture '#3' -from survey.json -to siglab -capture-seconds 30
+
+# …or select by frequency (MHz) and hand it to CryptoLab (crypto research)
+gophertrunk hunt -survey-capture 460.3375 -from survey.json -to cryptolab
+```
+
+The selected row's frequency and occupied bandwidth drive the capture (a signal
+wider than the tune is recorded as a slice, with a note). A `.cfile` + metadata
+sidecar is written; `-to siglab` runs a quick identify and prints the
+`gophertrunk siglab` command to open it, while `-to cryptolab` runs an `rfscope`
+pass to emit a CryptoLab `ks` frames file and prints the `cryptolab` next step.
+
 Live sweep tuning flags: `-band low:high` (MHz, repeatable), `-sweep-dwell`
 (accumulation per step), `-peak-threshold-db` (carrier detection threshold over
 the noise floor), `-min-spacing` (Hz between carriers), `-fft-size`,

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -104,6 +104,25 @@ gophertrunk hunt -serial 00000001 -sample-rate 2400000 \
   -no-sweep -candidates 851.0125,853.5125
 ```
 
+### Whole-device sweep (the full-spectrum survey)
+
+To inventory **everything the dongle can hear** without naming a band, pass
+`-whole-device`: the sweep range is derived from the SDR's own tuning limits
+(e.g. 24 MHz–1.766 GHz for an R820T, 1 MHz–4.294 GHz for a HackRF), so one run
+walks the entire reachable spectrum. It prints the resolved span, the step
+count, and a rough ETA before it starts. Pair it with `-survey -classify-only`
+for a fast first pass that catalogues every carrier:
+
+```sh
+gophertrunk hunt -survey -classify-only -whole-device \
+  -serial 00000001 -sample-rate 2400000 -survey-ndjson hunt.ndjson
+```
+
+`-survey-ndjson` streams each classified carrier to disk as it is found, and
+`-resume` skips carriers already recorded — so a long full-spectrum sweep is
+crash-safe and restartable. A device that can't report a tuning range (a
+network or file source) tells you to pass an explicit `-band` instead.
+
 Live sweep tuning flags: `-band low:high` (MHz, repeatable), `-sweep-dwell`
 (accumulation per step), `-peak-threshold-db` (carrier detection threshold over
 the noise floor), `-min-spacing` (Hz between carriers), `-fft-size`,

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -223,6 +223,7 @@ to force it off even when a key is configured.
   | `POST /api/v1/hunt/start` | Start a run (`{bands, candidates, no_sweep, protocol, name, …}`) |
   | `POST /api/v1/hunt/stop` | Cancel the active run |
   | `GET /api/v1/hunt/export?format=bundle\|trunk-recorder\|rr` | Download the discovery |
+  | `POST /api/v1/hunt/capture` | Record one inventory signal and route it (`{freq_hz, seconds, target}`) |
   | `POST /api/v1/hunt/commit` | Merge the discovery into `config.yaml` (`{force, dry_run}`) |
 
   Progress streams over the event bus (`hunt.progress` / `hunt.candidate` /

--- a/internal/api/handlers_hunt.go
+++ b/internal/api/handlers_hunt.go
@@ -127,6 +127,34 @@ func (s *Server) handleHuntSurveyExport(w http.ResponseWriter, r *http.Request) 
 	_, _ = w.Write(data)
 }
 
+// handleHuntCapture records raw IQ of one signal from the survey inventory and
+// routes it to SigLab/CryptoLab — the daemon side of the CLI's -survey-capture.
+func (s *Server) handleHuntCapture(w http.ResponseWriter, r *http.Request) {
+	if s.hunt == nil {
+		s.writeError(w, http.StatusServiceUnavailable, "hunt not wired (no SDR available)")
+		return
+	}
+	var req HuntCaptureRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, "invalid json body")
+		return
+	}
+	if req.FreqHz == 0 {
+		s.writeError(w, http.StatusBadRequest, "freq_hz is required")
+		return
+	}
+	res, err := s.hunt.CaptureSignal(req)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if isHuntConflict(err) {
+			status = http.StatusConflict
+		}
+		s.writeError(w, status, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
 // huntCommitRequest is the optional POST /api/v1/hunt/commit body.
 type huntCommitRequest struct {
 	Force  bool `json:"force,omitempty"`

--- a/internal/api/handlers_hunt_test.go
+++ b/internal/api/handlers_hunt_test.go
@@ -22,10 +22,13 @@ type fakeHuntCockpit struct {
 	commitErr  error
 	rrReport   HuntRRReport
 	rrErr      error
+	captureRes HuntCaptureResult
+	captureErr error
 
-	lastStart  HuntStartRequest
-	lastFormat string
-	lastID     int
+	lastStart   HuntStartRequest
+	lastFormat  string
+	lastID      int
+	lastCapture HuntCaptureRequest
 }
 
 func (f *fakeHuntCockpit) Status() HuntStatus { return f.status }
@@ -47,6 +50,11 @@ func (f *fakeHuntCockpit) ExportSurvey(id int, format string) ([]byte, string, e
 func (f *fakeHuntCockpit) Commit(id int, force, dryRun bool) ([]string, error) {
 	f.lastID = id
 	return f.commitChg, f.commitErr
+}
+
+func (f *fakeHuntCockpit) CaptureSignal(req HuntCaptureRequest) (HuntCaptureResult, error) {
+	f.lastCapture = req
+	return f.captureRes, f.captureErr
 }
 
 func (f *fakeHuntCockpit) RadioReference(id, countyID int, checkSIDs []int) (HuntRRReport, error) {
@@ -123,6 +131,51 @@ func TestHuntStart_GatedAndApplies(t *testing.T) {
 	}
 	if len(cock.lastStart.Bands) != 1 || cock.lastStart.Name != "X" {
 		t.Errorf("request not forwarded: %+v", cock.lastStart)
+	}
+}
+
+func TestHuntCapture_GatedAndForwards(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{captureRes: HuntCaptureResult{
+		Path: "/tmp/x.cfile", SampleRateHz: 2_400_000, CenterHz: 751_000_000, Samples: 4800, Identify: "p25 (0.82)",
+	}}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock, AllowMutations: true})
+	defer teardown()
+	resp, err := http.Post(base+"/api/v1/hunt/capture", "application/json",
+		strings.NewReader(`{"freq_hz":751000000,"seconds":5,"target":"siglab"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var got HuntCaptureResult
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != "/tmp/x.cfile" || got.Identify != "p25 (0.82)" {
+		t.Errorf("result not returned: %+v", got)
+	}
+	if cock.lastCapture.FreqHz != 751_000_000 || cock.lastCapture.Target != "siglab" {
+		t.Errorf("request not forwarded: %+v", cock.lastCapture)
+	}
+}
+
+func TestHuntCapture_MissingFreq400(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	cock := &fakeHuntCockpit{}
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Hunt: cock, AllowMutations: true})
+	defer teardown()
+	resp, err := http.Post(base+"/api/v1/hunt/capture", "application/json", strings.NewReader(`{"target":"siglab"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Fatalf("status=%d, want 400", resp.StatusCode)
 	}
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -132,6 +132,10 @@ type HuntCockpit interface {
 	// format (json|csv). id 0 = the latest run. Returns ErrHuntNoSuchRun for an
 	// unknown id, or an error when the run was a plain hunt (no survey).
 	ExportSurvey(id int, format string) (data []byte, filename string, err error)
+	// CaptureSignal records raw IQ of one signal from the inventory and routes
+	// it to SigLab/CryptoLab — the daemon side of the list-driven capture.
+	// Returns an "in progress" error while a run is active.
+	CaptureSignal(req HuntCaptureRequest) (HuntCaptureResult, error)
 	// Commit merges a run's discovered system into config.yaml (id 0 = latest),
 	// returning a human-readable list of changes.
 	Commit(id int, force, dryRun bool) (changes []string, err error)
@@ -1054,6 +1058,7 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/hunt/{id}/export", s.handleHuntExport)
 	mux.HandleFunc("GET /api/v1/hunt/survey", s.handleHuntSurveyExport)
 	mux.HandleFunc("GET /api/v1/hunt/{id}/survey", s.handleHuntSurveyExport)
+	mux.HandleFunc("POST /api/v1/hunt/capture", s.gate(s.handleHuntCapture))
 	mux.HandleFunc("POST /api/v1/hunt/commit", s.gate(s.handleHuntCommit))
 	mux.HandleFunc("GET /api/v1/hunt/radioreference", s.handleHuntRadioReference)
 	mux.HandleFunc("GET /api/v1/hunt/{id}/radioreference", s.handleHuntRadioReference)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -32,6 +32,31 @@ type HuntStatus struct {
 	GainNote            string                    `json:"gain_note,omitempty"`
 }
 
+// HuntCaptureRequest records one signal from the survey inventory and routes it
+// to deeper analysis — the daemon counterpart of the CLI's -survey-capture.
+type HuntCaptureRequest struct {
+	FreqHz  uint32  `json:"freq_hz"`           // signal centre frequency to record
+	Seconds float64 `json:"seconds,omitempty"` // capture length (0 ⇒ a default)
+	Target  string  `json:"target,omitempty"`  // "siglab" (default) | "cryptolab"
+}
+
+// HuntCaptureResult is what the daemon recorded and where it routed it.
+type HuntCaptureResult struct {
+	Path         string  `json:"path"`                    // the written .cfile
+	MetadataPath string  `json:"metadata_path,omitempty"` // the sidecar
+	SampleRateHz float64 `json:"sample_rate_hz"`
+	CenterHz     uint32  `json:"center_hz"`
+	Samples      int     `json:"samples"`
+	// Identify is a short SigLab identify summary (target=siglab), e.g.
+	// "p25 (0.82)" or "inconclusive".
+	Identify string `json:"identify,omitempty"`
+	// FramesPath is the cryptolab `ks` frames file (target=cryptolab), empty
+	// otherwise.
+	FramesPath string `json:"frames_path,omitempty"`
+	// Note carries an advisory (e.g. a wideband signal recorded as a slice).
+	Note string `json:"note,omitempty"`
+}
+
 // HuntRRReport is the GET /api/v1/hunt/radioreference response: the
 // RadioReference cross-reference of a run's discovered system — ranked
 // duplicate-system hints and a frequency/talkgroup diff vs the strongest match.

--- a/internal/carriers/occupancy.go
+++ b/internal/carriers/occupancy.go
@@ -1,0 +1,139 @@
+package carriers
+
+import (
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+)
+
+// Occupancy is one contiguous span of spectrum standing above the noise
+// floor — a signal far wider than a single land-mobile channel, such as an
+// OFDM cellular/WiFi block. Where [DetectPeaks] finds narrow carriers,
+// DetectOccupancy finds these plateaus.
+//
+// EdgeClippedLow/High flag a span whose energy runs right up to the frame's
+// usable edge: the emitter is at least OccupiedBwHz wide, but its true extent
+// continues past what a single tune can see. The live sweeper stitches such
+// clipped spans across adjacent overlapping steps to recover the real width
+// (see internal/hunt). The flags are how it knows two steps' spans are the
+// same emitter seen at a seam.
+type Occupancy struct {
+	CenterHz     uint32  `json:"center_hz"`
+	LowHz        uint32  `json:"low_hz"`
+	HighHz       uint32  `json:"high_hz"`
+	OccupiedBwHz uint32  `json:"occupied_bw_hz"`
+	PowerDbFS    float32 `json:"power_dbfs"` // median power across the span
+	SNRDb        float32 `json:"snr_db"`     // median power above the noise floor
+
+	EdgeClippedLow  bool `json:"edge_clipped_low,omitempty"`
+	EdgeClippedHigh bool `json:"edge_clipped_high,omitempty"`
+}
+
+// OccupancyOptions tune the wideband-occupancy detector.
+type OccupancyOptions struct {
+	// ThresholdDb is the minimum power above the estimated noise floor for a
+	// bin to count as occupied. It is intentionally lower than the peak
+	// detector's: a wide OFDM plateau is flatter and lower per-bin than a
+	// narrow carrier, but contiguous. 0 ⇒ 6 dB.
+	ThresholdDb float32
+	// MinBwHz is the shortest contiguous run reported. The default sits well
+	// above any land-mobile channel so a normal narrowband carrier never
+	// registers as "wideband"; only genuinely wide emitters do. 0 ⇒ 200 kHz.
+	MinBwHz uint32
+	// GuardBins drops this many bins at each band edge (the SDR rolloff) from
+	// detection; a run that reaches the first/last scanned bin is flagged
+	// edge-clipped. 0 ⇒ a default proportional to the FFT size.
+	GuardBins int
+	// FloorDbFS overrides the per-frame noise-floor estimate. A signal wider
+	// than the tune fills a whole step, so that step's own low-quartile floor
+	// sits *inside* the signal and the per-frame estimate detects nothing. The
+	// live sweeper passes a sweep-wide floor (learned from quiet steps) here so
+	// a fully-occupied step is still recognised as occupied and stitches to its
+	// neighbours. 0 ⇒ use the per-frame low-quartile estimate.
+	FloorDbFS float32
+}
+
+// occupancyMinBwHz is the default floor: 200 kHz is ~16× the widest C4FM
+// channel, so a narrowband carrier can never be mistaken for a wideband span.
+const occupancyMinBwHz uint32 = 200_000
+
+// DetectOccupancy finds contiguous spans of occupied spectrum in a frame —
+// the wideband counterpart to [DetectPeaks]. It estimates the same robust
+// noise floor (low-quartile), marks every non-guard bin standing ThresholdDb
+// above it, coalesces adjacent occupied bins into runs, and returns each run
+// at least MinBwHz wide as an [Occupancy] with absolute frequency bounds and
+// edge-clip flags. Spans are returned sorted by ascending low edge so a
+// caller can stitch neighbours.
+func DetectOccupancy(frame spectrum.Frame, opts OccupancyOptions) []Occupancy {
+	n := len(frame.Bins)
+	if n < 8 || frame.SampleRate == 0 {
+		return nil
+	}
+	threshold := opts.ThresholdDb
+	if threshold <= 0 {
+		threshold = 6
+	}
+	minBw := opts.MinBwHz
+	if minBw == 0 {
+		minBw = occupancyMinBwHz
+	}
+	guard := opts.GuardBins
+	if guard <= 0 {
+		guard = n / 64
+		if guard < 1 {
+			guard = 1
+		}
+	}
+
+	floor := opts.FloorDbFS
+	if floor == 0 {
+		floor = spectrum.Percentile(frame.Bins, noiseFloorPercentile)
+	}
+	binHz := float64(frame.SampleRate) / float64(n)
+	lastScan := n - guard - 1 // inclusive index of the last bin we examine
+
+	var out []Occupancy
+	runStart := -1
+	flush := func(start, end int) {
+		if start < 0 {
+			return
+		}
+		// Bin centers; the span spans from the start bin's left edge to the
+		// end bin's right edge, so it is (end-start+1) bins wide.
+		lowHz := binToHz(frame, start, binHz)
+		highHz := binToHz(frame, end, binHz)
+		bwHz := uint32(float64(end-start+1) * binHz)
+		if bwHz < minBw {
+			return
+		}
+		run := frame.Bins[start : end+1]
+		med := spectrum.Percentile(run, 0.5)
+		out = append(out, Occupancy{
+			CenterHz:        uint32((uint64(lowHz) + uint64(highHz)) / 2),
+			LowHz:           lowHz,
+			HighHz:          highHz,
+			OccupiedBwHz:    bwHz,
+			PowerDbFS:       med,
+			SNRDb:           med - floor,
+			EdgeClippedLow:  start == guard,
+			EdgeClippedHigh: end == lastScan,
+		})
+	}
+
+	for i := guard; i <= lastScan; i++ {
+		occupied := frame.Bins[i]-floor >= threshold
+		switch {
+		case occupied && runStart < 0:
+			runStart = i
+		case !occupied && runStart >= 0:
+			flush(runStart, i-1)
+			runStart = -1
+		}
+	}
+	if runStart >= 0 {
+		flush(runStart, lastScan)
+	}
+
+	sort.Slice(out, func(a, b int) bool { return out[a].LowHz < out[b].LowHz })
+	return out
+}

--- a/internal/carriers/occupancy_test.go
+++ b/internal/carriers/occupancy_test.go
@@ -1,0 +1,99 @@
+package carriers
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/spectrum"
+)
+
+// flatBins returns n bins at the given floor dBFS.
+func flatBins(n int, floorDb float32) []float32 {
+	b := make([]float32, n)
+	for i := range b {
+		b[i] = floorDb
+	}
+	return b
+}
+
+func TestDetectOccupancy_MidbandPlateau(t *testing.T) {
+	const n, center, rate = 1024, 751_000_000, 2_048_000 // binHz = 2000
+	bins := flatBins(n, -85)
+	for i := 400; i <= 600; i++ { // 201 bins ≈ 402 kHz, well inside the frame
+		bins[i] = -30
+	}
+	frame := spectrum.Frame{CenterHz: center, SampleRate: rate, Bins: bins}
+
+	occ := DetectOccupancy(frame, OccupancyOptions{})
+	if len(occ) != 1 {
+		t.Fatalf("len(occ) = %d, want 1: %+v", len(occ), occ)
+	}
+	o := occ[0]
+	if o.EdgeClippedLow || o.EdgeClippedHigh {
+		t.Errorf("midband plateau marked edge-clipped: %+v", o)
+	}
+	// 201 bins × 2000 Hz/bin = 402 kHz (±1 bin rounding).
+	if o.OccupiedBwHz < 400_000 || o.OccupiedBwHz > 404_000 {
+		t.Errorf("OccupiedBwHz = %d, want ≈402000", o.OccupiedBwHz)
+	}
+	// Plateau bins 400..600 center on bin 500; binToHz(500) with
+	// base = 751e6 - 1.024e6 and 2000 Hz/bin = 750.976 MHz.
+	wantCenter := uint32(750_976_000)
+	if absDiff(o.CenterHz, wantCenter) > 4_000 {
+		t.Errorf("CenterHz = %d, want ≈%d", o.CenterHz, wantCenter)
+	}
+	if o.SNRDb < 40 {
+		t.Errorf("SNRDb = %.1f, want a strong plateau (>40 dB over floor)", o.SNRDb)
+	}
+}
+
+func TestDetectOccupancy_EdgeClippedFillsFrame(t *testing.T) {
+	const n, center, rate = 1024, 2_600_000_000, 2_048_000
+	bins := flatBins(n, -30) // the whole frame is occupied — a signal wider than the tune
+	frame := spectrum.Frame{CenterHz: center, SampleRate: rate, Bins: bins}
+
+	// A fully-occupied step has no quiet region, so its own percentile floor
+	// sits inside the signal and the per-frame estimate sees nothing — this is
+	// exactly why the sweeper supplies a sweep-wide floor.
+	if occ := DetectOccupancy(frame, OccupancyOptions{}); len(occ) != 0 {
+		t.Errorf("per-frame floor on a flat frame should detect nothing, got %+v", occ)
+	}
+
+	occ := DetectOccupancy(frame, OccupancyOptions{FloorDbFS: -85})
+	if len(occ) != 1 {
+		t.Fatalf("with sweep-wide floor: len(occ) = %d, want 1: %+v", len(occ), occ)
+	}
+	if !occ[0].EdgeClippedLow || !occ[0].EdgeClippedHigh {
+		t.Errorf("frame-filling span not flagged edge-clipped on both sides: %+v", occ[0])
+	}
+}
+
+func TestDetectOccupancy_NarrowCarrierIgnored(t *testing.T) {
+	const n, center, rate = 1024, 460_000_000, 2_048_000
+	bins := flatBins(n, -85)
+	bins[500] = -20 // a single strong narrowband carrier — DetectPeaks territory
+	frame := spectrum.Frame{CenterHz: center, SampleRate: rate, Bins: bins}
+
+	if occ := DetectOccupancy(frame, OccupancyOptions{}); len(occ) != 0 {
+		t.Errorf("narrow carrier produced occupancy spans: %+v", occ)
+	}
+}
+
+func TestDetectOccupancy_TwoSpansSortedByLowEdge(t *testing.T) {
+	const n, center, rate = 1024, 915_000_000, 2_048_000
+	bins := flatBins(n, -85)
+	for i := 200; i <= 350; i++ { // 151 bins ≈ 302 kHz
+		bins[i] = -35
+	}
+	for i := 700; i <= 850; i++ {
+		bins[i] = -35
+	}
+	frame := spectrum.Frame{CenterHz: center, SampleRate: rate, Bins: bins}
+
+	occ := DetectOccupancy(frame, OccupancyOptions{})
+	if len(occ) != 2 {
+		t.Fatalf("len(occ) = %d, want 2: %+v", len(occ), occ)
+	}
+	if occ[0].LowHz >= occ[1].LowHz {
+		t.Errorf("spans not sorted by ascending low edge: %d then %d", occ[0].LowHz, occ[1].LowHz)
+	}
+}

--- a/internal/hunt/capture_signal_test.go
+++ b/internal/hunt/capture_signal_test.go
@@ -1,0 +1,61 @@
+package hunt
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+func TestManagerCaptureSignal(t *testing.T) {
+	const rate = 2_048_000
+	src := NewFileIQSource(make([]complex64, rate), rate) // 1 s of zero IQ, cycles
+	released := false
+	mgr, err := NewManager(ManagerOptions{
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) {
+			return src, func() { released = true }, nil
+		},
+		Bus: events.NewBus(256),
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+
+	iq, gotRate, err := mgr.CaptureSignal(context.Background(), 460_000_000, 0.1)
+	if err != nil {
+		t.Fatalf("CaptureSignal: %v", err)
+	}
+	if gotRate != rate {
+		t.Errorf("rate = %d, want %d", gotRate, rate)
+	}
+	if want := int(0.1 * rate); len(iq) != want {
+		t.Errorf("captured %d samples, want %d", len(iq), want)
+	}
+	if !released {
+		t.Error("the acquired SDR was not released")
+	}
+	// The source was tuned to the requested frequency.
+	if calls := src.TuneCalls(); len(calls) == 0 || calls[len(calls)-1] != 460_000_000 {
+		t.Errorf("tune calls = %v, want last = 460_000_000", calls)
+	}
+}
+
+func TestManagerCaptureSignalRefusesDuringRun(t *testing.T) {
+	const rate = 2_048_000
+	src := NewFileIQSource(make([]complex64, rate), rate)
+	mgr, err := NewManager(ManagerOptions{
+		Acquire: func(context.Context, LiveHuntOptions) (IQSource, func(), error) { return src, func() {}, nil },
+		Bus:     events.NewBus(256),
+	})
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	// Force the "running" state to model an active sweep.
+	mgr.mu.Lock()
+	mgr.state = StateRunActive
+	mgr.mu.Unlock()
+
+	if _, _, err := mgr.CaptureSignal(context.Background(), 460_000_000, 0.1); err == nil {
+		t.Fatal("CaptureSignal during an active run: want a busy error, got nil")
+	}
+}

--- a/internal/hunt/decode.go
+++ b/internal/hunt/decode.go
@@ -143,8 +143,27 @@ func decodeAndAccumulate(sys *DiscoveredSystem, r io.ReadSeeker, source string, 
 	if rep.IdentityNote != "" {
 		log.Warn("hunt: "+rep.IdentityNote, "path", source)
 	}
+	rep.Encrypted, rep.EncType = encryptionFromGrants(proto.String(), res.Grants)
 	rep.Talkgroups = len(sys.Talkgroups) - before
 	return rep
+}
+
+// encryptionFromGrants reports whether any grant on the control channel was
+// encrypted and names the algorithm. P25 Phase 1 carries the ALGID in the
+// voice LDU2 rather than the CC grant, so a CC-only decode may show encrypted
+// with an unknown algorithm (encType empty) — still a useful "encrypted" flag.
+func encryptionFromGrants(protocol string, grants []siglab.GrantRecord) (encrypted bool, encType string) {
+	for _, g := range grants {
+		if !g.Encrypted {
+			continue
+		}
+		encrypted = true
+		if name := encTypeName(protocol, g.AlgorithmID); name != "" {
+			encType = name // first named algorithm wins
+			break
+		}
+	}
+	return encrypted, encType
 }
 
 // identityNote explains, for a locked P25 control channel whose WACN/System ID

--- a/internal/hunt/discover.go
+++ b/internal/hunt/discover.go
@@ -53,10 +53,16 @@ type CaptureReport struct {
 	// ErrorRate is the decode-error events per 1000 symbols from the decode
 	// (siglab Signal.DecodeErrorRate), a protocol-neutral demod-quality proxy.
 	// Zero when no signal analysis was produced. Used by the auto-gain sweep.
-	ErrorRate  float64 `json:"error_rate,omitempty"`
-	Skipped    bool    `json:"skipped"`
-	SkipReason string  `json:"skip_reason,omitempty"`
-	Error      string  `json:"error,omitempty"`
+	ErrorRate float64 `json:"error_rate,omitempty"`
+	// Encrypted is true when any grant on the control channel was encrypted;
+	// EncType names the algorithm when known (e.g. AES-256, ADP/RC4), empty when
+	// the protocol surfaces encryption without the ALGID (P25 P1 ALGID is in the
+	// voice LDU2, not the CC grant).
+	Encrypted  bool   `json:"encrypted,omitempty"`
+	EncType    string `json:"enc_type,omitempty"`
+	Skipped    bool   `json:"skipped"`
+	SkipReason string `json:"skip_reason,omitempty"`
+	Error      string `json:"error,omitempty"`
 	// Verdict is the wideband survey's system-level summary line (set only by
 	// DiscoverWideband). Empty for single-carrier captures.
 	Verdict string `json:"verdict,omitempty"`

--- a/internal/hunt/enctype.go
+++ b/internal/hunt/enctype.go
@@ -1,0 +1,26 @@
+package hunt
+
+import (
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/dmrcrypto"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/p25crypto"
+)
+
+// encTypeName maps a protocol + encryption algorithm id to a human label
+// (AES-256, ADP/RC4, DES-OFB, …) by reusing the cryptolab algorithm-name
+// tables — the same labels the Crypto Lab uses, so the survey and the
+// cryptanalysis toolkit agree. An algid of 0 means the algorithm was not
+// surfaced (e.g. a P25 Phase 1 control channel whose ALGID lives in the voice
+// LDU2), and returns "" so the caller can still flag the call encrypted.
+func encTypeName(protocol string, algid uint8) string {
+	if algid == 0 {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(protocol), "dmr") {
+		return dmrcrypto.AlgName(algid)
+	}
+	// P25 (ADP/DES/AES) covers the common land-mobile algorithm-id namespace;
+	// other protocols fall back to its hex label for an unrecognised id.
+	return p25crypto.AlgName(algid)
+}

--- a/internal/hunt/export_survey.go
+++ b/internal/hunt/export_survey.go
@@ -69,8 +69,11 @@ func WriteSurvey(w io.Writer, sv *SignalSurvey, f SurveyFormat) error {
 // so the CSV is useful without the nested JSON.
 func writeSurveyCSV(w io.Writer, sv *SignalSurvey) error {
 	cw := csv.NewWriter(w)
+	// Existing columns are kept in place; the inventory columns (name … wideband)
+	// are appended so older consumers that index by position keep working.
 	if err := cw.Write([]string{
 		"freq_mhz", "class", "confidence", "snr_db", "occupied_bw_khz", "baud_hz", "decode",
+		"name", "service", "purpose", "encrypted", "enc_type", "wideband",
 	}); err != nil {
 		return err
 	}
@@ -83,6 +86,12 @@ func writeSurveyCSV(w io.Writer, sv *SignalSurvey) error {
 			strconv.FormatFloat(float64(s.OccupiedBwHz)/1e3, 'f', 1, 64),
 			strconv.FormatFloat(s.BaudHz, 'f', 0, 64),
 			surveyDecodeSummary(s),
+			s.Name,
+			s.Service,
+			s.Purpose,
+			strconv.FormatBool(s.Encrypted),
+			s.EncType,
+			strconv.FormatBool(s.Wideband),
 		}
 		if err := cw.Write(row); err != nil {
 			return err

--- a/internal/hunt/livehunt.go
+++ b/internal/hunt/livehunt.go
@@ -106,6 +106,11 @@ type LiveHuntOptions struct {
 	// the rest of the band is inventoried. Live sweeps already do this via the
 	// SDR; this is the offline equivalent. Ignored for live runs.
 	DetectCarriers bool
+	// DetectWideband adds the wideband-occupancy pass to a live survey sweep:
+	// signals far wider than a channel (cellular/WiFi/OFDM) are detected,
+	// stitched across tunes, and surfaced as named-but-not-decoded inventory
+	// rows. Off by default; the whole-device survey turns it on.
+	DetectWideband bool
 
 	// DwellSeconds is how much IQ to capture per candidate for identify+decode.
 	// 0 ⇒ 3 s.

--- a/internal/hunt/livesurvey.go
+++ b/internal/hunt/livesurvey.go
@@ -77,6 +77,20 @@ func RunLiveSurvey(ctx context.Context, opts LiveHuntOptions) (*SignalSurvey, []
 		if err := ctx.Err(); err != nil {
 			return finishSurvey(sv), reports, err
 		}
+
+		// Wideband-occupancy spans (cellular/WiFi/OFDM) are named from their
+		// stitched bandwidth + allocation and never decoded — tuning to the centre
+		// would only sample a sliver of the signal — so they bypass the narrowband
+		// capture/classify path entirely.
+		if cand.IsWideband {
+			ds := widebandSignal(cand)
+			sv.Signals = append(sv.Signals, ds)
+			if opts.OnSignal != nil {
+				opts.OnSignal(ds)
+			}
+			continue
+		}
+
 		progress(LiveHuntProgress{
 			Phase: PhaseIdentifying, CenterHz: cand.FreqHz,
 			CandidateN: i + 1, Candidates: len(candidates),
@@ -228,6 +242,9 @@ func classifyAndRoute(sys *DiscoveredSystem, fullIQ []complex64, fullRate uint32
 		chIQ: chIQ, chRate: chRate,
 		cand: cand, opts: opts, log: log,
 	})
+	// Fill the consolidated inventory fields (Name / Service / Purpose) from the
+	// decode result + frequency allocation, for every carrier.
+	nameSignal(&ds)
 	// Guarantee the signal is JSON-encodable before it is stored, published on
 	// the event bus, or written to NDJSON — a non-finite measurement must not be
 	// able to break the live survey's wire stream (issue #648).
@@ -386,10 +403,16 @@ func identifyTrunking(sys *DiscoveredSystem, ds *DetectedSignal, in routeInputs,
 	switch {
 	case rep.Locked:
 		ds.Class = survey.ClassTrunkControl
-		ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence, Locked: true, ControlHz: rep.ControlHz}
+		ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence, Locked: true, ControlHz: rep.ControlHz,
+			Encrypted: rep.Encrypted, EncType: rep.EncType}
 	case voiceUpgrade && !rep.Skipped && rep.Error == "":
 		ds.Class = survey.ClassTrunkVoice
-		ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence}
+		ds.Trunking = &TrunkingRef{Protocol: rep.Protocol, Confidence: rep.Confidence,
+			Encrypted: rep.Encrypted, EncType: rep.EncType}
+	}
+	if ds.Trunking != nil {
+		ds.Encrypted = ds.Trunking.Encrypted
+		ds.EncType = ds.Trunking.EncType
 	}
 	// Skipped/errored (or non-locked under lock-only) ⇒ keep the classifier label.
 	return &rep
@@ -406,13 +429,14 @@ func surveyCandidates(ctx context.Context, opts LiveHuntOptions, log *slog.Logge
 		return skipSurveyed(out, opts.SkipFreqs), nil
 	}
 	sw, err := NewSweeper(SweepOptions{
-		Source:     opts.Source,
-		Bands:      opts.Bands,
-		FFTSize:    opts.FFTSize,
-		SweepDwell: opts.SweepDwell,
-		GuardFrac:  opts.GuardFrac,
-		PeakOpts:   opts.PeakOpts,
-		Log:        log,
+		Source:         opts.Source,
+		Bands:          opts.Bands,
+		FFTSize:        opts.FFTSize,
+		SweepDwell:     opts.SweepDwell,
+		GuardFrac:      opts.GuardFrac,
+		PeakOpts:       opts.PeakOpts,
+		DetectWideband: opts.DetectWideband,
+		Log:            log,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/hunt/manager.go
+++ b/internal/hunt/manager.go
@@ -431,6 +431,43 @@ func (m *Manager) statusLocked() RunStatus {
 	return st
 }
 
+// CaptureSignal records seconds of raw IQ centred on freqHz by acquiring an SDR
+// the same way a run does (spare-else-borrow), tuning it, and capturing. It is
+// the daemon counterpart of the CLI's list-driven capture: the cockpit/REST
+// hand it a frequency from the survey inventory and it returns the IQ + the
+// source's sample rate for staging into SigLab/CryptoLab. It refuses while a
+// hunt run is active (the SDR is busy) so it can't fight a live sweep.
+func (m *Manager) CaptureSignal(ctx context.Context, freqHz uint32, seconds float64) ([]complex64, uint32, error) {
+	if seconds <= 0 {
+		seconds = 5
+	}
+	m.mu.Lock()
+	active := m.state == StateRunActive
+	m.mu.Unlock()
+	if active {
+		return nil, 0, errors.New("hunt: a run is in progress; stop it before capturing a signal")
+	}
+
+	src, release, err := m.acquire(ctx, LiveHuntOptions{})
+	if err != nil {
+		return nil, 0, fmt.Errorf("hunt: acquire SDR: %w", err)
+	}
+	defer release()
+
+	if err := src.Tune(freqHz); err != nil {
+		return nil, 0, fmt.Errorf("hunt: tune %d Hz: %w", freqHz, err)
+	}
+	rate := src.SampleRateHz()
+	if rate == 0 {
+		return nil, 0, errors.New("hunt: acquired source has zero sample rate")
+	}
+	iq, err := captureN(ctx, src, int(seconds*float64(rate)))
+	if err != nil {
+		return nil, rate, fmt.Errorf("hunt: capture: %w", err)
+	}
+	return iq, rate, nil
+}
+
 // CurrentSurvey returns the latest run's signal inventory, or (nil, false) when
 // the latest run was a plain hunt or none has produced one yet.
 func (m *Manager) CurrentSurvey() (*SignalSurvey, bool) {

--- a/internal/hunt/naming.go
+++ b/internal/hunt/naming.go
@@ -1,0 +1,87 @@
+package hunt
+
+import (
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/blind"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab/sigref"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+// nameRefFloor is the minimum reference-catalog match score at which an
+// undecoded carrier is named a best guess (matching the wideband survey's
+// keep floor). Below it the carrier is named by its modulation class instead.
+const nameRefFloor = 0.40
+
+// nameSignal fills the consolidated inventory fields — Name, Service, Purpose —
+// for any signal, decoded or not. Service/Purpose come from the frequency
+// allocation; Name prefers the decoded protocol, then a best-guess from the
+// reference catalog, then the modulation class. It never overrides a value the
+// router already set and is safe to call once per signal before sanitize.
+func nameSignal(ds *DetectedSignal) {
+	if a, ok := sigref.Lookup(ds.FreqHz); ok {
+		ds.Service = a.Service
+		ds.Purpose = a.Purpose
+	}
+
+	switch {
+	case ds.Trunking != nil && ds.Trunking.Protocol != "":
+		if e, ok := sigref.ByProtocol(ds.Trunking.Protocol); ok {
+			ds.Name = e.DisplayName
+		} else {
+			ds.Name = strings.ToUpper(ds.Trunking.Protocol)
+		}
+	case len(ds.Pages) > 0:
+		ds.Name = ds.Pages[0].Protocol
+	default:
+		obs := sigref.Observation{
+			SymbolRateHz: ds.BaudHz,
+			ModClass:     modClassFor(ds.Class),
+			Levels:       ds.Features.IFModality,
+			ChannelBWHz:  float64(ds.OccupiedBwHz),
+			CenterFreqHz: ds.FreqHz,
+		}
+		if m := sigref.Rank(obs, 1); len(m) > 0 && m[0].Score >= nameRefFloor {
+			ds.Name = m[0].Entry.DisplayName
+			if ds.Confidence == 0 { // fill confidence for an undecoded/wideband row
+				ds.Confidence = m[0].Score
+			}
+		} else if ds.Wideband {
+			ds.Name = "wideband signal"
+		} else {
+			ds.Name = string(ds.Class)
+		}
+	}
+}
+
+// modClassFor maps a survey signal class to the blind modulation class sigref
+// scores against. Classes with no clean blind analog (analog families, data,
+// wideband) map to "" so they don't constrain the reference match.
+func modClassFor(c survey.SignalClass) string {
+	switch c {
+	case survey.ClassFSK:
+		return blind.ModFSK2
+	case survey.ClassC4FM:
+		return blind.ModFSK4
+	case survey.ClassPSK:
+		return blind.ModPSK
+	default:
+		return ""
+	}
+}
+
+// widebandSignal builds the inventory row for a stitched wideband-occupancy
+// candidate: it is named (cellular/WiFi/…) and captured, never decoded.
+// OccupiedBwHz is the stitched bandwidth; SNRDb the span's level over the floor.
+func widebandSignal(cand Candidate) DetectedSignal {
+	ds := DetectedSignal{
+		FreqHz:       cand.FreqHz,
+		SNRDb:        cand.SNRDb,
+		OccupiedBwHz: cand.BwHz,
+		Class:        survey.ClassWideband,
+		Wideband:     true,
+	}
+	nameSignal(&ds)
+	ds.sanitize()
+	return ds
+}

--- a/internal/hunt/naming_test.go
+++ b/internal/hunt/naming_test.go
@@ -1,0 +1,116 @@
+package hunt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/survey"
+)
+
+func TestNameSignal_DecodedProtocol(t *testing.T) {
+	ds := DetectedSignal{
+		FreqHz:   851_012_500,
+		Class:    survey.ClassTrunkControl,
+		Trunking: &TrunkingRef{Protocol: "p25", Locked: true},
+	}
+	nameSignal(&ds)
+	if ds.Name != "P25 Phase 1" {
+		t.Errorf("Name = %q, want P25 Phase 1", ds.Name)
+	}
+	if !strings.Contains(ds.Service, "800 MHz") {
+		t.Errorf("Service = %q, want the 800 MHz public-safety allocation", ds.Service)
+	}
+}
+
+func TestNameSignal_UndecodedNamedByAllocation(t *testing.T) {
+	// An analog carrier in the FRS/GMRS band: no decode, but the allocation
+	// names the service and the modulation class is the fallback name.
+	ds := DetectedSignal{FreqHz: 462_600_000, Class: survey.ClassNBFM, OccupiedBwHz: 12_500}
+	nameSignal(&ds)
+	if ds.Service != "FRS / GMRS" {
+		t.Errorf("Service = %q, want FRS / GMRS", ds.Service)
+	}
+	if ds.Name == "" {
+		t.Error("Name is empty; want at least the class fallback")
+	}
+}
+
+func TestWidebandSignalRow(t *testing.T) {
+	ds := widebandSignal(Candidate{FreqHz: 751_000_000, BwHz: 10_000_000, SNRDb: 30, IsWideband: true})
+	if !ds.Wideband || ds.Class != survey.ClassWideband {
+		t.Fatalf("row not marked wideband: %+v", ds)
+	}
+	if ds.OccupiedBwHz != 10_000_000 {
+		t.Errorf("OccupiedBwHz = %d, want 10_000_000 (stitched width)", ds.OccupiedBwHz)
+	}
+	if !strings.Contains(ds.Name, "LTE") {
+		t.Errorf("Name = %q, want an LTE/5G best guess", ds.Name)
+	}
+	if !strings.Contains(ds.Service, "Cellular 700") {
+		t.Errorf("Service = %q, want the 700 MHz cellular allocation", ds.Service)
+	}
+	if ds.Trunking != nil {
+		t.Error("a wideband row must not carry a trunking decode")
+	}
+}
+
+func TestEncTypeName(t *testing.T) {
+	if got := encTypeName("p25", 0x84); got != "AES-256" {
+		t.Errorf("encTypeName(p25, 0x84) = %q, want AES-256", got)
+	}
+	if got := encTypeName("p25", 0); got != "" {
+		t.Errorf("encTypeName(p25, 0) = %q, want empty (ALGID not surfaced)", got)
+	}
+	if got := encTypeName("dmr", 0x21); got != "RC4 (Enhanced Privacy)" {
+		t.Errorf("encTypeName(dmr, 0x21) = %q, want RC4 (Enhanced Privacy)", got)
+	}
+}
+
+func TestEncryptionFromGrants(t *testing.T) {
+	enc, typ := encryptionFromGrants("p25", []siglab.GrantRecord{
+		{Encrypted: false},
+		{Encrypted: true, AlgorithmID: 0x84},
+	})
+	if !enc || typ != "AES-256" {
+		t.Errorf("got (%v, %q), want (true, AES-256)", enc, typ)
+	}
+	// Encrypted but ALGID not surfaced ⇒ flagged, type empty.
+	if enc, typ := encryptionFromGrants("p25", []siglab.GrantRecord{{Encrypted: true}}); !enc || typ != "" {
+		t.Errorf("got (%v, %q), want (true, \"\")", enc, typ)
+	}
+	if enc, _ := encryptionFromGrants("p25", []siglab.GrantRecord{{Encrypted: false}}); enc {
+		t.Error("clear grants reported encrypted")
+	}
+}
+
+func TestSurveyCSVHasInventoryColumns(t *testing.T) {
+	sv := &SignalSurvey{Signals: []DetectedSignal{
+		{
+			FreqHz: 851_012_500, Class: survey.ClassTrunkControl, OccupiedBwHz: 12_500,
+			Name: "P25 Phase 1", Service: "800 MHz SMR/public safety", Purpose: "trunked land-mobile downlink",
+			Encrypted: true, EncType: "AES-256",
+			Trunking: &TrunkingRef{Protocol: "p25", Locked: true},
+		},
+		{
+			FreqHz: 751_000_000, Class: survey.ClassWideband, OccupiedBwHz: 10_000_000,
+			Name: "LTE/5G NR (10 MHz)", Service: "Cellular 700 MHz DL", Wideband: true,
+		},
+	}}
+	var buf bytes.Buffer
+	if err := WriteSurvey(&buf, sv, SurveyCSV); err != nil {
+		t.Fatalf("WriteSurvey: %v", err)
+	}
+	out := buf.String()
+	for _, col := range []string{"name", "service", "purpose", "encrypted", "enc_type", "wideband"} {
+		if !strings.Contains(out, col) {
+			t.Errorf("CSV header missing column %q", col)
+		}
+	}
+	for _, want := range []string{"P25 Phase 1", "AES-256", "true", "LTE/5G NR (10 MHz)", "Cellular 700 MHz DL"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("CSV missing value %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/hunt/peaks.go
+++ b/internal/hunt/peaks.go
@@ -18,6 +18,18 @@ func DetectPeaks(frame spectrum.Frame, opts PeakOptions) []Peak {
 	return carriers.DetectPeaks(frame, opts)
 }
 
+// Occupancy and OccupancyOptions are re-exported from internal/carriers so the
+// sweeper's wideband-occupancy pass keeps the hunt-package surface while the
+// detector lives in the neutral carriers package.
+type Occupancy = carriers.Occupancy
+type OccupancyOptions = carriers.OccupancyOptions
+
+// DetectOccupancy finds wideband occupancy spans in a spectrum frame. Thin
+// wrapper over carriers.DetectOccupancy.
+func DetectOccupancy(frame spectrum.Frame, opts OccupancyOptions) []Occupancy {
+	return carriers.DetectOccupancy(frame, opts)
+}
+
 // absDiff is the |a-b| helper the sweeper + peak tests use. carriers has its
 // own copy for DetectPeaks; this one stays so the hunt-package tests and
 // sweeper logic don't depend on the carriers internal.

--- a/internal/hunt/survey.go
+++ b/internal/hunt/survey.go
@@ -34,6 +34,28 @@ type DetectedSignal struct {
 	Confidence   float64            `json:"confidence"`
 	BaudHz       float64            `json:"baud_hz,omitempty"`
 
+	// Inventory naming — the consolidated "what is this" the full-spectrum
+	// survey shows for every signal, decodable or not.
+	//   Name    — human label: the decoded protocol, else the best-guess signal
+	//             from the reference catalog (sigref), else the modulation class.
+	//   Service — what the frequency is allocated to (sigref allocation table).
+	//   Purpose — what that service is used for.
+	Name    string `json:"name,omitempty"`
+	Service string `json:"service,omitempty"`
+	Purpose string `json:"purpose,omitempty"`
+
+	// Encrypted / EncType report whether the signal is encrypted and, when known,
+	// the algorithm (AES-256, ADP/RC4, …). Set from the trunking decode's grants;
+	// EncType is empty when the protocol exposes encryption without an ALGID.
+	Encrypted bool   `json:"encrypted,omitempty"`
+	EncType   string `json:"enc_type,omitempty"`
+
+	// Wideband marks a signal far wider than a channel (cellular/WiFi/OFDM)
+	// recovered by the occupancy-stitching pass. Such a signal is named and
+	// captured but never decoded; OccupiedBwHz is its stitched bandwidth (a lower
+	// bound when the signal ran past the swept range).
+	Wideband bool `json:"wideband,omitempty"`
+
 	// Decode summary — set by the router for the carriers it could decode.
 	Trunking *TrunkingRef         `json:"trunking,omitempty"`
 	Analog   *survey.AnalogReport `json:"analog,omitempty"`
@@ -53,6 +75,10 @@ type TrunkingRef struct {
 	Confidence float64 `json:"confidence"`
 	Locked     bool    `json:"locked"`
 	ControlHz  uint32  `json:"control_hz,omitempty"`
+	// Encrypted / EncType mirror the decode's grant encryption onto the
+	// inventory row (also copied to DetectedSignal for the flat view).
+	Encrypted bool   `json:"encrypted,omitempty"`
+	EncType   string `json:"enc_type,omitempty"`
 }
 
 // finiteOr0 returns f unless it is NaN or ±Inf, in which case it returns 0.

--- a/internal/hunt/sweeper.go
+++ b/internal/hunt/sweeper.go
@@ -33,13 +33,34 @@ type SweepOptions struct {
 	// (where the SDR rolloff lives) when advancing the center. 0 ⇒ 0.1.
 	GuardFrac float64
 	PeakOpts  PeakOptions
-	Log       *slog.Logger
+	// DetectWideband enables the wideband-occupancy pass: alongside the
+	// narrowband peak detector, each step is scanned for contiguous occupancy
+	// spans (OFDM cellular/WiFi blocks), and spans clipped at a step edge are
+	// stitched across adjacent overlapping steps to recover a signal wider than
+	// the tune. Off by default — the whole-device survey turns it on.
+	DetectWideband bool
+	// OccupancyOpts tune the wideband detector (see carriers.OccupancyOptions).
+	// The sweeper supplies the sweep-wide floor itself, so FloorDbFS is ignored.
+	OccupancyOpts OccupancyOptions
+	// WidebandFullStepClipDb is how far a step's own noise floor must sit above
+	// the sweep-wide floor before the whole step counts as occupied (a signal
+	// too wide to leave any quiet region in one tune). 0 ⇒ 6 dB.
+	WidebandFullStepClipDb float32
+	Log                    *slog.Logger
 }
 
-// Candidate is a carrier the sweep found, worth identifying.
+// Candidate is a carrier the sweep found, worth identifying. A narrowband
+// carrier carries FreqHz + SNRDb; a wideband span (IsWideband) additionally
+// carries BwHz, its stitched occupied bandwidth, and FreqHz is the span center.
 type Candidate struct {
 	FreqHz uint32  `json:"freq_hz"`
 	SNRDb  float32 `json:"snr_db"`
+	// IsWideband marks a stitched wideband-occupancy span (cellular/WiFi/wide
+	// data) rather than a narrowband carrier. Such a span is named by allocation
+	// + shape, not decoded.
+	IsWideband bool `json:"is_wideband,omitempty"`
+	// BwHz is the occupied bandwidth of a wideband span (0 for narrow carriers).
+	BwHz uint32 `json:"bw_hz,omitempty"`
 }
 
 // Sweeper walks operator-given bands on an IQSource and returns the candidate
@@ -139,6 +160,10 @@ func (s *Sweeper) Sweep(ctx context.Context, onStep OnStep) ([]Candidate, error)
 	}
 	best := map[uint32]Candidate{}
 
+	// Wideband-occupancy collection (per-step summaries, stitched after the
+	// sweep once the sweep-wide noise floor is known). Empty unless enabled.
+	var wbSteps []wbStep
+
 	for _, band := range s.opts.Bands {
 		if band.HighHz < band.LowHz {
 			return nil, fmt.Errorf("hunt: band %d:%d is inverted", band.LowHz, band.HighHz)
@@ -174,6 +199,9 @@ func (s *Sweeper) Sweep(ctx context.Context, onStep OnStep) ([]Candidate, error)
 					best[key] = Candidate{FreqHz: p.FreqHz, SNRDb: p.SNRDb}
 				}
 			}
+			if s.opts.DetectWideband {
+				wbSteps = append(wbSteps, s.occupancyStep(frame))
+			}
 			// Stop once this step's coverage reached the band's high edge.
 			if center+halfUsable >= band.HighHz {
 				break
@@ -187,7 +215,49 @@ func (s *Sweeper) Sweep(ctx context.Context, onStep OnStep) ([]Candidate, error)
 	}
 	out = snapCandidatesToGrid(out, rate, s.fftSize)
 	sort.Slice(out, func(i, j int) bool { return out[i].SNRDb > out[j].SNRDb })
+
+	// Stitch wideband-occupancy spans across steps and append them. They sort
+	// after the narrowband carriers (which keep their SNR ordering); a consumer
+	// distinguishes them by IsWideband.
+	if s.opts.DetectWideband {
+		out = append(out, stitchWideband(wbSteps, s.opts.WidebandFullStepClipDb, uint32(s.binHz()))...)
+	}
 	return out, nil
+}
+
+// occupancyStep summarizes one swept frame for the wideband stitch pass: its
+// per-frame noise floor, its scanned (non-guard) coverage in absolute Hz, and
+// the occupancy spans found with that per-frame floor. The sweep-wide floor —
+// needed to catch a step that sits entirely inside a signal — is applied later
+// in stitchWideband, so frames need not be retained.
+func (s *Sweeper) occupancyStep(frame spectrum.Frame) wbStep {
+	n := len(frame.Bins)
+	guard := s.opts.OccupancyOpts.GuardBins
+	if guard <= 0 {
+		guard = n / 64
+		if guard < 1 {
+			guard = 1
+		}
+	}
+	binHz := float64(frame.SampleRate) / float64(n)
+	base := float64(frame.CenterHz) - float64(frame.SampleRate)/2
+	// DetectOccupancy with the per-frame floor (FloorDbFS left 0) finds spans at
+	// the edges of a wide signal, where part of the step is still quiet.
+	occOpts := s.opts.OccupancyOpts
+	occOpts.FloorDbFS = 0
+	return wbStep{
+		// 0.25 mirrors carriers' robust low-quartile noise-floor estimate.
+		floorDb: spectrum.Percentile(frame.Bins, 0.25),
+		lowHz:   uint32(base + float64(guard)*binHz),
+		highHz:  uint32(base + float64(n-guard-1)*binHz),
+		spans:   DetectOccupancy(frame, occOpts),
+	}
+}
+
+// binHz is the sweep's FFT bin spacing in Hz, used as the stitch seam
+// tolerance.
+func (s *Sweeper) binHz() float64 {
+	return float64(s.opts.Source.SampleRateHz()) / float64(s.fftSize)
 }
 
 // snapCandidatesToGrid corrects the FFT-bin quantization offset in the swept

--- a/internal/hunt/wideband_sweep.go
+++ b/internal/hunt/wideband_sweep.go
@@ -1,0 +1,100 @@
+package hunt
+
+import "sort"
+
+// wbStep is the per-step record the wideband-occupancy pass keeps while
+// sweeping. Frames are not retained (a whole-device sweep is hundreds of
+// steps); only this small summary is, so the stitch pass can run after the
+// sweep-wide noise floor is known.
+type wbStep struct {
+	floorDb float32     // this step's per-frame low-quartile noise floor
+	lowHz   uint32      // low edge of the step's scanned (non-guard) coverage
+	highHz  uint32      // high edge of the step's scanned coverage
+	spans   []Occupancy // occupancy spans found with this step's per-frame floor
+}
+
+// wbInterval is a frequency interval accumulated during stitching.
+type wbInterval struct {
+	lowHz, highHz uint32
+	powerDb       float32 // strongest median power contributing to the interval
+}
+
+// defaultFullStepClipDb is how far a step's own noise floor must sit above the
+// sweep-wide floor before the whole step is treated as occupied (the interior
+// of a signal wider than the tune). 6 dB matches the occupancy threshold.
+const defaultFullStepClipDb float32 = 6
+
+// stitchWideband turns per-step occupancy observations into wideband
+// Candidates. It learns the sweep-wide noise floor (the quietest step's
+// floor), then:
+//
+//   - takes every per-frame occupancy span (these pin the true edges of a wide
+//     signal at the steps where it enters/leaves the tune), and
+//   - for any step whose own floor sits fullStepClipDb above the sweep-wide
+//     floor — i.e. the whole step is inside a signal too wide to show a quiet
+//     region — synthesizes a full-step span over its coverage.
+//
+// It then interval-merges everything (overlapping or within mergeTolHz) so a
+// signal seen across N adjacent overlapping steps collapses into one span whose
+// width is its true occupied bandwidth. Each merged span becomes a Candidate
+// with IsWideband=true and BwHz set.
+func stitchWideband(steps []wbStep, fullStepClipDb float32, mergeTolHz uint32) []Candidate {
+	if len(steps) == 0 {
+		return nil
+	}
+	if fullStepClipDb <= 0 {
+		fullStepClipDb = defaultFullStepClipDb
+	}
+
+	globalFloor := steps[0].floorDb
+	for _, s := range steps {
+		if s.floorDb < globalFloor {
+			globalFloor = s.floorDb
+		}
+	}
+
+	var spans []wbInterval
+	for _, s := range steps {
+		for _, o := range s.spans {
+			spans = append(spans, wbInterval{lowHz: o.LowHz, highHz: o.HighHz, powerDb: o.PowerDbFS})
+		}
+		// Fully-occupied interior step: its per-frame floor is itself elevated,
+		// so DetectOccupancy (run with the per-frame floor) saw nothing. Fill in
+		// the step's whole coverage so the interior stitches to the edge spans.
+		if s.floorDb-globalFloor >= fullStepClipDb && s.highHz > s.lowHz {
+			spans = append(spans, wbInterval{lowHz: s.lowHz, highHz: s.highHz, powerDb: s.floorDb})
+		}
+	}
+	if len(spans) == 0 {
+		return nil
+	}
+
+	sort.Slice(spans, func(a, b int) bool { return spans[a].lowHz < spans[b].lowHz })
+
+	merged := []wbInterval{spans[0]}
+	for _, s := range spans[1:] {
+		cur := &merged[len(merged)-1]
+		// Overlapping, or within the seam tolerance ⇒ same emitter.
+		if s.lowHz <= cur.highHz+mergeTolHz {
+			if s.highHz > cur.highHz {
+				cur.highHz = s.highHz
+			}
+			if s.powerDb > cur.powerDb {
+				cur.powerDb = s.powerDb
+			}
+			continue
+		}
+		merged = append(merged, s)
+	}
+
+	out := make([]Candidate, 0, len(merged))
+	for _, m := range merged {
+		out = append(out, Candidate{
+			FreqHz:     uint32((uint64(m.lowHz) + uint64(m.highHz)) / 2),
+			SNRDb:      m.powerDb - globalFloor,
+			IsWideband: true,
+			BwHz:       m.highHz - m.lowHz,
+		})
+	}
+	return out
+}

--- a/internal/hunt/wideband_sweep_test.go
+++ b/internal/hunt/wideband_sweep_test.go
@@ -1,0 +1,150 @@
+package hunt
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+)
+
+// TestStitchWideband_JoinsAdjacentSpansAcrossSteps feeds the stitcher a wide
+// signal seen across three steps — partial (edge-clipped) spans at the two
+// boundary steps and a fully-occupied interior step (elevated floor, no
+// per-frame span) — and asserts it collapses to one wideband candidate whose
+// width is the signal's true extent.
+func TestStitchWideband_JoinsAdjacentSpansAcrossSteps(t *testing.T) {
+	const floor = float32(-90)
+	steps := []wbStep{
+		{floorDb: floor}, // a quiet step: establishes the sweep-wide floor
+		{ // signal enters from the high edge of this step
+			floorDb: floor,
+			lowHz:   900_000, highHz: 1_100_000,
+			spans: []Occupancy{{LowHz: 1_000_000, HighHz: 1_200_000, PowerDbFS: -40, EdgeClippedHigh: true}},
+		},
+		{ // interior step entirely inside the signal: floor elevated, no per-frame span
+			floorDb: -40,
+			lowHz:   1_200_000, highHz: 1_400_000,
+		},
+		{ // signal leaves through the low edge of this step
+			floorDb: floor,
+			lowHz:   1_400_000, highHz: 1_600_000,
+			spans: []Occupancy{{LowHz: 1_400_000, HighHz: 1_600_000, PowerDbFS: -42, EdgeClippedLow: true}},
+		},
+		{floorDb: floor}, // another quiet step
+	}
+
+	got := stitchWideband(steps, 0, 1_000)
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 stitched span: %+v", len(got), got)
+	}
+	c := got[0]
+	if !c.IsWideband {
+		t.Errorf("IsWideband = false, want true")
+	}
+	// [1.0,1.2] ∪ [1.2,1.4] ∪ [1.4,1.6] MHz = 600 kHz wide, centered at 1.3 MHz.
+	if c.BwHz != 600_000 {
+		t.Errorf("BwHz = %d, want 600000", c.BwHz)
+	}
+	if c.FreqHz != 1_300_000 {
+		t.Errorf("FreqHz = %d, want 1300000 (span center)", c.FreqHz)
+	}
+	if c.SNRDb < 45 { // -40 power over a -90 floor
+		t.Errorf("SNRDb = %.1f, want ≈50", c.SNRDb)
+	}
+}
+
+// TestStitchWideband_SeparateSignalsStayDistinct verifies two wide signals
+// with a clear gap do not merge.
+func TestStitchWideband_SeparateSignalsStayDistinct(t *testing.T) {
+	steps := []wbStep{
+		{floorDb: -90},
+		{floorDb: -90, spans: []Occupancy{{LowHz: 700_000_000, HighHz: 710_000_000, PowerDbFS: -40}}},
+		{floorDb: -90, spans: []Occupancy{{LowHz: 740_000_000, HighHz: 750_000_000, PowerDbFS: -40}}},
+	}
+	got := stitchWideband(steps, 0, 50_000)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2 distinct spans: %+v", len(got), got)
+	}
+}
+
+// TestStitchWideband_NoOccupancyNoCandidates verifies a sweep with only quiet
+// steps (or only narrowband carriers) yields no wideband candidates.
+func TestStitchWideband_NoOccupancyNoCandidates(t *testing.T) {
+	if got := stitchWideband(nil, 0, 1000); got != nil {
+		t.Errorf("nil steps: got %+v, want nil", got)
+	}
+	quiet := []wbStep{{floorDb: -90}, {floorDb: -89}, {floorDb: -91}}
+	if got := stitchWideband(quiet, 0, 1000); len(got) != 0 {
+		t.Errorf("quiet sweep produced wideband candidates: %+v", got)
+	}
+}
+
+// bandNoiseSource is an IQSource that returns loud broadband noise when the
+// tuned frame overlaps a target band and quiet noise otherwise — a synthetic
+// "signal wider than the tune" for the sweeper integration test.
+type bandNoiseSource struct {
+	rate   uint32
+	sigLo  uint32
+	sigHi  uint32
+	center uint32
+	rng    *rand.Rand
+}
+
+func (s *bandNoiseSource) Tune(c uint32) error  { s.center = c; return nil }
+func (s *bandNoiseSource) SampleRateHz() uint32 { return s.rate }
+func (s *bandNoiseSource) Capture(ctx context.Context, n int) ([]complex64, error) {
+	fLo := s.center - s.rate/2
+	fHi := s.center + s.rate/2
+	amp := float32(0.002) // quiet noise floor
+	if fLo < s.sigHi && s.sigLo < fHi {
+		amp = 0.4 // the tuned frame overlaps the wide signal
+	}
+	out := make([]complex64, n)
+	for i := range out {
+		out[i] = complex(amp*float32(s.rng.NormFloat64()), amp*float32(s.rng.NormFloat64()))
+	}
+	return out, nil
+}
+
+// TestSweeperDetectsWidebandSpan runs the real sweeper with DetectWideband over
+// a band containing a synthetic broadband signal and asserts it returns a
+// stitched IsWideband candidate near the signal.
+func TestSweeperDetectsWidebandSpan(t *testing.T) {
+	const rate = 2_048_000
+	src := &bandNoiseSource{
+		rate:  rate,
+		sigLo: 700_000_000,
+		sigHi: 706_000_000, // ~6 MHz wide — far wider than the 2.048 MHz tune
+		rng:   rand.New(rand.NewSource(0x5151)),
+	}
+	sw, err := NewSweeper(SweepOptions{
+		Source:         src,
+		Bands:          []Band{{LowHz: 695_000_000, HighHz: 712_000_000}},
+		FFTSize:        1024,
+		DetectWideband: true,
+	})
+	if err != nil {
+		t.Fatalf("NewSweeper: %v", err)
+	}
+	cands, err := sw.Sweep(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	var wb []Candidate
+	for _, c := range cands {
+		if c.IsWideband {
+			wb = append(wb, c)
+		}
+	}
+	if len(wb) == 0 {
+		t.Fatalf("no wideband candidate found; candidates=%+v", cands)
+	}
+	// The stitched span should be at least a couple MHz wide (it spans every
+	// step whose frame overlapped the signal) and centered in the signal band.
+	w := wb[0]
+	if w.BwHz < 2_000_000 {
+		t.Errorf("widest span BwHz = %d, want a multi-MHz stitched span", w.BwHz)
+	}
+	if w.FreqHz < 698_000_000 || w.FreqHz > 708_000_000 {
+		t.Errorf("span center %d Hz outside the signal neighbourhood", w.FreqHz)
+	}
+}

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -273,6 +273,10 @@ type Device struct {
 // Info implements sdr.Device.
 func (d *Device) Info() sdr.Info { return d.info }
 
+// FreqRange reports the Airspy R2/Mini's documented 24 MHz .. 1.8 GHz
+// tuning span (sdr.FreqRanger), so a whole-device hunt can sweep it.
+func (d *Device) FreqRange() (minHz, maxHz uint32) { return 24_000_000, 1_800_000_000 }
+
 // SetCenterFreq programs the R820T to hz Hz.
 func (d *Device) SetCenterFreq(hz uint32) error {
 	if d.isClosed() {

--- a/internal/sdr/airspyhf/airspyhf.go
+++ b/internal/sdr/airspyhf/airspyhf.go
@@ -223,6 +223,12 @@ type Device struct {
 // Info implements sdr.Device.
 func (d *Device) Info() sdr.Info { return d.info }
 
+// FreqRange reports the Airspy HF+'s documented coverage as a single
+// 9 kHz .. 260 MHz span (sdr.FreqRanger). The HF+ actually serves
+// 9 kHz–31 MHz and 60–260 MHz with a gap between; the conservative outer
+// envelope is reported here and out-of-band tunes still fail at the driver.
+func (d *Device) FreqRange() (minHz, maxHz uint32) { return 9_000, 260_000_000 }
+
 // SetCenterFreq programs the synthesizer to hz Hz. libairspyhf carries
 // the value as a 4-byte little-endian uint32 in the control transfer
 // data stage; wValue and wIndex are unused. The firmware accepts

--- a/internal/sdr/baseband/recorder.go
+++ b/internal/sdr/baseband/recorder.go
@@ -48,10 +48,10 @@ func (r *RecordingDevice) FreqRange() (minHz, maxHz uint32) {
 	}
 	return 0, 0
 }
-func (r *RecordingDevice) SetGain(tenthDB int) error     { return r.inner.SetGain(tenthDB) }
-func (r *RecordingDevice) SetPPM(ppm int) error          { return r.inner.SetPPM(ppm) }
-func (r *RecordingDevice) SetBiasTee(enable bool) error  { return r.inner.SetBiasTee(enable) }
-func (r *RecordingDevice) Close() error                  { return r.inner.Close() }
+func (r *RecordingDevice) SetGain(tenthDB int) error    { return r.inner.SetGain(tenthDB) }
+func (r *RecordingDevice) SetPPM(ppm int) error         { return r.inner.SetPPM(ppm) }
+func (r *RecordingDevice) SetBiasTee(enable bool) error { return r.inner.SetBiasTee(enable) }
+func (r *RecordingDevice) Close() error                 { return r.inner.Close() }
 
 // SetSampleRate records the rate (for the WAV header) and forwards it.
 func (r *RecordingDevice) SetSampleRate(hz uint32) error {

--- a/internal/sdr/baseband/recorder.go
+++ b/internal/sdr/baseband/recorder.go
@@ -38,6 +38,16 @@ func (r *RecordingDevice) Inner() sdr.Device { return r.inner }
 
 func (r *RecordingDevice) Info() sdr.Info                { return r.inner.Info() }
 func (r *RecordingDevice) SetCenterFreq(hz uint32) error { return r.inner.SetCenterFreq(hz) }
+
+// FreqRange forwards the wrapped device's tuning range when it exposes
+// one (sdr.FreqRanger); otherwise it reports (0,0) and callers fall back
+// to an explicit band.
+func (r *RecordingDevice) FreqRange() (minHz, maxHz uint32) {
+	if fr, ok := r.inner.(sdr.FreqRanger); ok {
+		return fr.FreqRange()
+	}
+	return 0, 0
+}
 func (r *RecordingDevice) SetGain(tenthDB int) error     { return r.inner.SetGain(tenthDB) }
 func (r *RecordingDevice) SetPPM(ppm int) error          { return r.inner.SetPPM(ppm) }
 func (r *RecordingDevice) SetBiasTee(enable bool) error  { return r.inner.SetBiasTee(enable) }

--- a/internal/sdr/device.go
+++ b/internal/sdr/device.go
@@ -94,6 +94,17 @@ type BlogV4Forcer interface {
 	SetBlogV4(lite bool) error
 }
 
+// FreqRanger is an optional Device extension that reports the dongle's
+// inclusive tuning range in Hz — the lowest and highest center frequency
+// the front-end can reach. Callers type-assert for it (like
+// TunerDiagnoser) so a backend that cannot model a hard range need not
+// implement it. The whole-device hunt sweep derives its band from here:
+// a caller with no explicit -band asks the open device for [min,max] and
+// sweeps that span end-to-end. Bounds are inclusive and minHz <= maxHz.
+type FreqRanger interface {
+	FreqRange() (minHz, maxHz uint32)
+}
+
 // Driver is the factory each backend exposes.
 type Driver interface {
 	Name() string

--- a/internal/sdr/hackrf/hackrf.go
+++ b/internal/sdr/hackrf/hackrf.go
@@ -318,6 +318,12 @@ type Device struct {
 // Info implements sdr.Device.
 func (d *Device) Info() sdr.Info { return d.info }
 
+// FreqRange reports the HackRF One's tuning span (sdr.FreqRanger). The
+// device documents 1 MHz .. 6 GHz, but the sdr API carries frequency as
+// uint32 Hz (ceiling ~4.294 GHz), so the upper bound is clamped to that
+// ceiling — a whole-device sweep covers 1 MHz .. 4.294 GHz.
+func (d *Device) FreqRange() (minHz, maxHz uint32) { return 1_000_000, 4_294_967_295 }
+
 // SetCenterFreq programs the synthesizer to the requested frequency,
 // in Hz. libhackrf splits the value into MHz + Hz-remainder octets.
 func (d *Device) SetCenterFreq(hz uint32) error {

--- a/internal/sdr/iqtap/broker.go
+++ b/internal/sdr/iqtap/broker.go
@@ -160,6 +160,18 @@ func (b *Broker) Info() sdr.Info {
 	return b.inner.Info()
 }
 
+// FreqRange forwards the wrapped device's tuning range when it exposes
+// one (sdr.FreqRanger); otherwise it reports (0,0) so callers fall back to
+// an explicit band.
+func (b *Broker) FreqRange() (minHz, maxHz uint32) {
+	b.innerMu.RLock()
+	defer b.innerMu.RUnlock()
+	if fr, ok := b.inner.(sdr.FreqRanger); ok {
+		return fr.FreqRange()
+	}
+	return 0, 0
+}
+
 func (b *Broker) SetCenterFreq(hz uint32) error {
 	b.innerMu.RLock()
 	defer b.innerMu.RUnlock()

--- a/internal/sdr/mock.go
+++ b/internal/sdr/mock.go
@@ -20,6 +20,14 @@ type MockDriver struct {
 
 const MockDriverName = "mock"
 
+// mockMinFreqHz / mockMaxFreqHz are the R820T family's tuning bounds, used
+// by the mock devices' FreqRange so the whole-device sweep path is testable
+// without real hardware.
+const (
+	mockMinFreqHz uint32 = 24_000_000
+	mockMaxFreqHz uint32 = 1_766_000_000
+)
+
 func (m *MockDriver) Name() string { return MockDriverName }
 
 func (m *MockDriver) Enumerate() ([]Info, error) {
@@ -54,7 +62,12 @@ type MockDevice struct {
 	closed     bool
 }
 
-func (d *MockDevice) Info() Info                 { return d.info }
+func (d *MockDevice) Info() Info { return d.info }
+
+// FreqRange reports the R820T family's 24 MHz .. 1.766 GHz span so the
+// whole-device hunt sweep (sdr.FreqRanger) is exercised in tests.
+func (d *MockDevice) FreqRange() (minHz, maxHz uint32) { return mockMinFreqHz, mockMaxFreqHz }
+
 func (d *MockDevice) SetCenterFreq(uint32) error { return nil }
 func (d *MockDevice) SetGain(int) error          { return nil }
 func (d *MockDevice) SetPPM(int) error           { return nil }
@@ -154,7 +167,11 @@ type mockF32Device struct {
 	sampleRate uint32
 }
 
-func (d *mockF32Device) Info() Info                    { return d.info }
+func (d *mockF32Device) Info() Info { return d.info }
+
+// FreqRange mirrors MockDevice's R820T span (sdr.FreqRanger).
+func (d *mockF32Device) FreqRange() (minHz, maxHz uint32) { return mockMinFreqHz, mockMaxFreqHz }
+
 func (d *mockF32Device) SetCenterFreq(uint32) error    { return nil }
 func (d *mockF32Device) SetGain(int) error             { return nil }
 func (d *mockF32Device) SetPPM(int) error              { return nil }

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -71,6 +71,11 @@ func (d *Device) DroppedChunks() uint64 { return d.dropped.Load() }
 // chip name, and the tuner's gain ladder.
 func (d *Device) Info() sdr.Info { return d.info }
 
+// FreqRange reports the dongle's inclusive tuning range in Hz by
+// delegating to the detected tuner chip. Satisfies sdr.FreqRanger so a
+// whole-device hunt can derive its sweep band from the open device.
+func (d *Device) FreqRange() (minHz, maxHz uint32) { return d.tuner.FreqRange() }
+
 // SetCenterFreq tunes the LO. Delegates to the tuner; settles
 // briefly afterwards so the PLL has time to lock.
 func (d *Device) SetCenterFreq(hz uint32) error {

--- a/internal/sdr/rtlsdr/purego/stream_test.go
+++ b/internal/sdr/rtlsdr/purego/stream_test.go
@@ -107,8 +107,9 @@ type fakeTuner struct {
 	gainErr, modeErr error
 }
 
-func (f *fakeTuner) Type() tuners.Type { return tuners.TypeR820T2 }
-func (f *fakeTuner) IFFreqHz() uint32  { return 3_570_000 }
+func (f *fakeTuner) Type() tuners.Type                  { return tuners.TypeR820T2 }
+func (f *fakeTuner) IFFreqHz() uint32                   { return 3_570_000 }
+func (f *fakeTuner) FreqRange() (minHz, maxHz uint32)   { return 24_000_000, 1_766_000_000 }
 func (f *fakeTuner) Init() error       { return nil }
 func (f *fakeTuner) Standby() error    { f.standbyCalls++; return nil }
 func (f *fakeTuner) Close() error      { return f.Standby() }

--- a/internal/sdr/rtlsdr/purego/stream_test.go
+++ b/internal/sdr/rtlsdr/purego/stream_test.go
@@ -107,13 +107,13 @@ type fakeTuner struct {
 	gainErr, modeErr error
 }
 
-func (f *fakeTuner) Type() tuners.Type                  { return tuners.TypeR820T2 }
-func (f *fakeTuner) IFFreqHz() uint32                   { return 3_570_000 }
-func (f *fakeTuner) FreqRange() (minHz, maxHz uint32)   { return 24_000_000, 1_766_000_000 }
-func (f *fakeTuner) Init() error       { return nil }
-func (f *fakeTuner) Standby() error    { f.standbyCalls++; return nil }
-func (f *fakeTuner) Close() error      { return f.Standby() }
-func (f *fakeTuner) Gains() []int      { return []int{0, 100, 200} }
+func (f *fakeTuner) Type() tuners.Type                { return tuners.TypeR820T2 }
+func (f *fakeTuner) IFFreqHz() uint32                 { return 3_570_000 }
+func (f *fakeTuner) FreqRange() (minHz, maxHz uint32) { return 24_000_000, 1_766_000_000 }
+func (f *fakeTuner) Init() error                      { return nil }
+func (f *fakeTuner) Standby() error                   { f.standbyCalls++; return nil }
+func (f *fakeTuner) Close() error                     { return f.Standby() }
+func (f *fakeTuner) Gains() []int                     { return []int{0, 100, 200} }
 func (f *fakeTuner) SetFreq(hz uint32) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/internal/sdr/rtlsdr/tuners/e4k.go
+++ b/internal/sdr/rtlsdr/tuners/e4k.go
@@ -110,6 +110,16 @@ func NewE4000(d *rtl2832u.Demod) *E4000 { return &E4000{demod: d} }
 
 func (e *E4000) Type() Type       { return TypeE4000 }
 func (e *E4000) IFFreqHz() uint32 { return e4kIFFreqHz }
+
+// e4kMinFreqHz / e4kMaxFreqHz bound the E4000's 50 MHz .. 2.2 GHz tuning
+// range — the single source for FreqRange and the SetFreq guard.
+const (
+	e4kMinFreqHz uint32 = 50_000_000
+	e4kMaxFreqHz uint32 = 2_200_000_000
+)
+
+// FreqRange returns the E4000's inclusive tuning range in Hz.
+func (e *E4000) FreqRange() (minHz, maxHz uint32) { return e4kMinFreqHz, e4kMaxFreqHz }
 func (e *E4000) Gains() []int {
 	out := make([]int, len(e4kLNAGains))
 	copy(out, e4kLNAGains)
@@ -209,8 +219,8 @@ func (e *E4000) SetFreq(hz uint32) error {
 	if !e.initDone {
 		return errors.New("e4k: Init not called")
 	}
-	if hz < 50_000_000 || hz > 2_200_000_000 {
-		return &ErrUnsupportedFreq{Hz: hz, MinHz: 50_000_000, MaxHz: 2_200_000_000, TunerStr: "E4000"}
+	if minHz, maxHz := e.FreqRange(); hz < minHz || hz > maxHz {
+		return &ErrUnsupportedFreq{Hz: hz, MinHz: minHz, MaxHz: maxHz, TunerStr: "E4000"}
 	}
 	if err := e.demod.SetI2CRepeater(true); err != nil {
 		return err

--- a/internal/sdr/rtlsdr/tuners/fc0012.go
+++ b/internal/sdr/rtlsdr/tuners/fc0012.go
@@ -57,6 +57,16 @@ func NewFC0012(d *rtl2832u.Demod) *FC0012 { return &FC0012{demod: d} }
 
 func (f *FC0012) Type() Type       { return TypeFC0012 }
 func (f *FC0012) IFFreqHz() uint32 { return fc0012IFFreqHz }
+
+// fc0012MinFreqHz / fc0012MaxFreqHz bound the FC0012's 37 MHz .. 1.7 GHz
+// range — the single source for FreqRange and the SetFreq guard.
+const (
+	fc0012MinFreqHz uint32 = 37_000_000
+	fc0012MaxFreqHz uint32 = 1_700_000_000
+)
+
+// FreqRange returns the FC0012's inclusive tuning range in Hz.
+func (f *FC0012) FreqRange() (minHz, maxHz uint32) { return fc0012MinFreqHz, fc0012MaxFreqHz }
 func (f *FC0012) Gains() []int {
 	out := make([]int, len(fc0012Gains))
 	copy(out, fc0012Gains)
@@ -117,8 +127,8 @@ func (f *FC0012) SetFreq(hz uint32) error {
 	if !f.initDone {
 		return errors.New("fc0012: Init not called")
 	}
-	if hz < 37_000_000 || hz > 1_700_000_000 {
-		return &ErrUnsupportedFreq{Hz: hz, MinHz: 37_000_000, MaxHz: 1_700_000_000, TunerStr: "FC0012"}
+	if minHz, maxHz := f.FreqRange(); hz < minHz || hz > maxHz {
+		return &ErrUnsupportedFreq{Hz: hz, MinHz: minHz, MaxHz: maxHz, TunerStr: "FC0012"}
 	}
 	if err := f.demod.SetI2CRepeater(true); err != nil {
 		return err

--- a/internal/sdr/rtlsdr/tuners/fc0013.go
+++ b/internal/sdr/rtlsdr/tuners/fc0013.go
@@ -60,6 +60,16 @@ func NewFC0013(d *rtl2832u.Demod) *FC0013 { return &FC0013{demod: d} }
 
 func (f *FC0013) Type() Type       { return TypeFC0013 }
 func (f *FC0013) IFFreqHz() uint32 { return fc0013IFFreqHz }
+
+// fc0013MinFreqHz / fc0013MaxFreqHz bound the FC0013's 22 MHz .. 1.7 GHz
+// range — the single source for FreqRange and the SetFreq guard.
+const (
+	fc0013MinFreqHz uint32 = 22_000_000
+	fc0013MaxFreqHz uint32 = 1_700_000_000
+)
+
+// FreqRange returns the FC0013's inclusive tuning range in Hz.
+func (f *FC0013) FreqRange() (minHz, maxHz uint32) { return fc0013MinFreqHz, fc0013MaxFreqHz }
 func (f *FC0013) Gains() []int {
 	out := make([]int, len(fc0013LNAGains))
 	copy(out, fc0013LNAGains)
@@ -115,8 +125,8 @@ func (f *FC0013) SetFreq(hz uint32) error {
 	if !f.initDone {
 		return errors.New("fc0013: Init not called")
 	}
-	if hz < 22_000_000 || hz > 1_700_000_000 {
-		return &ErrUnsupportedFreq{Hz: hz, MinHz: 22_000_000, MaxHz: 1_700_000_000, TunerStr: "FC0013"}
+	if minHz, maxHz := f.FreqRange(); hz < minHz || hz > maxHz {
+		return &ErrUnsupportedFreq{Hz: hz, MinHz: minHz, MaxHz: maxHz, TunerStr: "FC0013"}
 	}
 	if err := f.demod.SetI2CRepeater(true); err != nil {
 		return err

--- a/internal/sdr/rtlsdr/tuners/fc2580.go
+++ b/internal/sdr/rtlsdr/tuners/fc2580.go
@@ -90,6 +90,16 @@ func NewFC2580(d *rtl2832u.Demod) *FC2580 { return &FC2580{demod: d, ifFreqHz: f
 
 func (f *FC2580) Type() Type       { return TypeFC2580 }
 func (f *FC2580) IFFreqHz() uint32 { return f.ifFreqHz }
+
+// fc2580MinFreqHz / fc2580MaxFreqHz bound the FC2580's 50 MHz .. 2.6 GHz
+// range — the single source for FreqRange and the SetFreq guard.
+const (
+	fc2580MinFreqHz uint32 = 50_000_000
+	fc2580MaxFreqHz uint32 = 2_600_000_000
+)
+
+// FreqRange returns the FC2580's inclusive tuning range in Hz.
+func (f *FC2580) FreqRange() (minHz, maxHz uint32) { return fc2580MinFreqHz, fc2580MaxFreqHz }
 func (f *FC2580) Gains() []int {
 	out := make([]int, len(fc2580Gains))
 	copy(out, fc2580Gains)
@@ -139,8 +149,8 @@ func (f *FC2580) SetFreq(hz uint32) error {
 	if !f.initDone {
 		return errors.New("fc2580: Init not called")
 	}
-	if hz < 50_000_000 || hz > 2_600_000_000 {
-		return &ErrUnsupportedFreq{Hz: hz, MinHz: 50_000_000, MaxHz: 2_600_000_000, TunerStr: "FC2580"}
+	if minHz, maxHz := f.FreqRange(); hz < minHz || hz > maxHz {
+		return &ErrUnsupportedFreq{Hz: hz, MinHz: minHz, MaxHz: maxHz, TunerStr: "FC2580"}
 	}
 	if err := f.demod.SetI2CRepeater(true); err != nil {
 		return err

--- a/internal/sdr/rtlsdr/tuners/freqrange_test.go
+++ b/internal/sdr/rtlsdr/tuners/freqrange_test.go
@@ -1,0 +1,65 @@
+package tuners
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/rtl2832u"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// freqRanger is the per-chip FreqRange contract the whole-device hunt
+// sweep relies on. Every Tuner satisfies it.
+type freqRanger interface {
+	FreqRange() (minHz, maxHz uint32)
+	SetFreq(hz uint32) error
+}
+
+// TestTunerFreqRange pins each tuner's reported range to its documented
+// PLL limits AND proves the SetFreq guard rejects just-outside-range
+// requests with an ErrUnsupportedFreq whose Min/Max equal FreqRange().
+// Because the guard now reads its bounds from FreqRange(), this is the
+// drift guard for the Phase-1 single-source refactor: the advertised
+// range and the enforced range can never disagree.
+func TestTunerFreqRange(t *testing.T) {
+	newDemod := func() *rtl2832u.Demod { return rtl2832u.New(usb.NewMockTransport()) }
+
+	cases := []struct {
+		name    string
+		tuner   freqRanger
+		wantMin uint32
+		wantMax uint32
+	}{
+		{"R820T2", func() *R82xx { r := NewR82xx(newDemod(), r82xxI2CAddr, TypeR820T2); r.initDone = true; return r }(), 24_000_000, 1_766_000_000},
+		{"E4000", func() *E4000 { e := NewE4000(newDemod()); e.initDone = true; return e }(), 50_000_000, 2_200_000_000},
+		{"FC0012", func() *FC0012 { f := NewFC0012(newDemod()); f.initDone = true; return f }(), 37_000_000, 1_700_000_000},
+		{"FC0013", func() *FC0013 { f := NewFC0013(newDemod()); f.initDone = true; return f }(), 22_000_000, 1_700_000_000},
+		{"FC2580", func() *FC2580 { f := NewFC2580(newDemod()); f.initDone = true; return f }(), 50_000_000, 2_600_000_000},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			min, max := c.tuner.FreqRange()
+			if min != c.wantMin || max != c.wantMax {
+				t.Fatalf("FreqRange() = (%d, %d), want (%d, %d)", min, max, c.wantMin, c.wantMax)
+			}
+			if min >= max {
+				t.Fatalf("FreqRange() min %d >= max %d", min, max)
+			}
+
+			// Below the floor and above the ceiling must both report
+			// ErrUnsupportedFreq carrying exactly the advertised bounds.
+			for _, hz := range []uint32{min - 1, max + 1} {
+				var rangeErr *ErrUnsupportedFreq
+				err := c.tuner.SetFreq(hz)
+				if !errors.As(err, &rangeErr) {
+					t.Fatalf("SetFreq(%d) err = %v, want *ErrUnsupportedFreq", hz, err)
+				}
+				if rangeErr.MinHz != c.wantMin || rangeErr.MaxHz != c.wantMax {
+					t.Errorf("SetFreq(%d) guard bounds = (%d, %d), want (%d, %d)",
+						hz, rangeErr.MinHz, rangeErr.MaxHz, c.wantMin, c.wantMax)
+				}
+			}
+		})
+	}
+}

--- a/internal/sdr/rtlsdr/tuners/r82xx.go
+++ b/internal/sdr/rtlsdr/tuners/r82xx.go
@@ -148,6 +148,17 @@ func (r *R82xx) effectiveXtalHz() uint32 {
 // Type returns the detected chip family.
 func (r *R82xx) Type() Type { return r.chipType }
 
+// r82xxMinFreqHz / r82xxMaxFreqHz bound the R820T family's documented
+// 24 MHz .. 1.766 GHz PLL tuning range. They are the single source for
+// both [R82xx.FreqRange] and the SetFreq guard.
+const (
+	r82xxMinFreqHz uint32 = 24_000_000
+	r82xxMaxFreqHz uint32 = 1_766_000_000
+)
+
+// FreqRange returns the R820T family's inclusive tuning range in Hz.
+func (r *R82xx) FreqRange() (minHz, maxHz uint32) { return r82xxMinFreqHz, r82xxMaxFreqHz }
+
 // XtalHz returns the reference-crystal frequency currently in effect
 // (before any ppm correction). It exists for boot-time diagnostics:
 // 16 MHz on an R828D means the RTL-SDR Blog V4 path did NOT arm, so the
@@ -311,8 +322,8 @@ func (r *R82xx) SetFreq(hz uint32) error {
 	if r.blogV4 && hz <= r82xxV4HFCrossHz {
 		target = hz + r82xxXtalHz
 	}
-	if target < 24_000_000 || target > 1_766_000_000 {
-		return &ErrUnsupportedFreq{Hz: hz, MinHz: 24_000_000, MaxHz: 1_766_000_000, TunerStr: r.chipType.String()}
+	if minHz, maxHz := r.FreqRange(); target < minHz || target > maxHz {
+		return &ErrUnsupportedFreq{Hz: hz, MinHz: minHz, MaxHz: maxHz, TunerStr: r.chipType.String()}
 	}
 	if err := r.demod.SetI2CRepeater(true); err != nil {
 		return err

--- a/internal/sdr/rtlsdr/tuners/tuner.go
+++ b/internal/sdr/rtlsdr/tuners/tuner.go
@@ -79,6 +79,11 @@ type Tuner interface {
 	// of the requested center frequency. Returns an error if the
 	// PLL can't lock or if hz is out of the chip's supported range.
 	SetFreq(hz uint32) error
+	// FreqRange reports the chip's inclusive PLL tuning range in Hz.
+	// SetFreq rejects (with [ErrUnsupportedFreq]) any request outside
+	// it, and callers that need to sweep "the whole device" derive the
+	// span from here. The bounds are the same literals SetFreq enforces.
+	FreqRange() (minHz, maxHz uint32)
 	// SetBandwidth picks the IF filter that matches the requested
 	// occupied bandwidth (typically the same as the sample rate).
 	// Pass 0 to let the driver pick a sensible default.

--- a/internal/sdr/rtltcp/driver.go
+++ b/internal/sdr/rtltcp/driver.go
@@ -188,19 +188,24 @@ func (d *Driver) Open(idx int) (sdr.Device, error) {
 		"addr", spec.Addr,
 		"tuner", info.TunerName,
 		"gain_count", gainCount)
+	minHz, maxHz := tunerFreqRange(tunerType)
 	return &device{
-		addr: spec.Addr,
-		conn: conn,
-		info: info,
-		log:  d.log,
+		addr:  spec.Addr,
+		conn:  conn,
+		info:  info,
+		log:   d.log,
+		minHz: minHz,
+		maxHz: maxHz,
 	}, nil
 }
 
 // device implements sdr.Device on top of an open rtl_tcp connection.
 type device struct {
-	addr string
-	info sdr.Info
-	log  *slog.Logger
+	addr  string
+	info  sdr.Info
+	log   *slog.Logger
+	minHz uint32
+	maxHz uint32
 
 	mu     sync.Mutex
 	conn   net.Conn
@@ -208,6 +213,10 @@ type device struct {
 }
 
 func (d *device) Info() sdr.Info { return d.info }
+
+// FreqRange reports the remote tuner's range in Hz (sdr.FreqRanger),
+// decoded from the rtl_tcp header's tuner-type field at connect time.
+func (d *device) FreqRange() (minHz, maxHz uint32) { return d.minHz, d.maxHz }
 
 func (d *device) SetCenterFreq(hz uint32) error { return d.sendCmd(cmdSetFreq, hz) }
 func (d *device) SetSampleRate(hz uint32) error { return d.sendCmd(cmdSetSampleRate, hz) }
@@ -392,6 +401,25 @@ func tunerName(code uint32) string {
 		return "R828D"
 	default:
 		return fmt.Sprintf("tuner-%d", code)
+	}
+}
+
+// tunerFreqRange decodes the rtl_tcp tuner-type field into the chip's
+// inclusive tuning range in Hz, mirroring the per-chip guards in the
+// local tuners package. An unknown/zero code defaults to the common
+// R820T span (most rtl_tcp servers run an R820T/R828D).
+func tunerFreqRange(code uint32) (minHz, maxHz uint32) {
+	switch code {
+	case 1: // E4000
+		return 50_000_000, 2_200_000_000
+	case 2: // FC0012
+		return 37_000_000, 1_700_000_000
+	case 3: // FC0013
+		return 22_000_000, 1_700_000_000
+	case 4: // FC2580
+		return 50_000_000, 2_600_000_000
+	default: // R820T / R828D / unknown
+		return 24_000_000, 1_766_000_000
 	}
 }
 

--- a/internal/siglab/result.go
+++ b/internal/siglab/result.go
@@ -100,7 +100,12 @@ type GrantRecord struct {
 	Timeslot    uint8   `json:"timeslot" yaml:"timeslot"`
 	FrequencyHz uint32  `json:"frequency_hz" yaml:"frequency_hz"`
 	Encrypted   bool    `json:"encrypted" yaml:"encrypted"`
-	Emergency   bool    `json:"emergency" yaml:"emergency"`
+	// AlgorithmID / KeyID mirror trunking.Grant: the encryption algorithm id and
+	// key selector when Encrypted (0 / 0 otherwise). They let the survey name the
+	// encryption type (e.g. AES-256, ADP/RC4) rather than just "encrypted".
+	AlgorithmID uint8  `json:"algorithm_id,omitempty" yaml:"algorithm_id,omitempty"`
+	KeyID       uint16 `json:"key_id,omitempty" yaml:"key_id,omitempty"`
+	Emergency   bool   `json:"emergency" yaml:"emergency"`
 	// Individual mirrors trunking.Grant.Individual: the GroupID is a
 	// unit-to-unit / telephone / data destination, not a talkgroup. Hunt
 	// skips these when accumulating the talkgroup list.
@@ -178,6 +183,8 @@ func (c *collector) observe(ev events.Event) {
 				Timeslot:    g.Timeslot,
 				FrequencyHz: g.FrequencyHz,
 				Encrypted:   g.Encrypted,
+				AlgorithmID: g.AlgorithmID,
+				KeyID:       g.KeyID,
 				Emergency:   g.Emergency,
 				Individual:  g.Individual,
 			})

--- a/internal/siglab/sigref/allocation.go
+++ b/internal/siglab/sigref/allocation.go
@@ -1,0 +1,104 @@
+package sigref
+
+import "sort"
+
+// Allocation names what a slice of spectrum is *for* — the service and its
+// purpose — independent of any modulation. Where the signal catalog (Entry /
+// Rank) answers "what kind of signal is this" from its shape, the allocation
+// table answers "what is this frequency used for" from where it sits. The
+// full-spectrum survey pairs them: a carrier is named by its modulation and
+// labeled by its allocation, so an undecodable emitter still reads as e.g.
+// "FRS — license-free handheld" or "Cellular 700 MHz downlink".
+//
+// The table is a curated, US-default set (Region is carried for future
+// expansion). Band edges are approximate — they are for human labeling, not
+// regulatory precision.
+type Allocation struct {
+	LoHz    uint32 `json:"lo_hz"`
+	HiHz    uint32 `json:"hi_hz"`
+	Service string `json:"service"`
+	Purpose string `json:"purpose"`
+	Region  string `json:"region"`
+}
+
+// BwHz is the allocation's span.
+func (a Allocation) BwHz() uint32 { return a.HiHz - a.LoHz }
+
+// allocations is the curated freq→service table, US defaults. Order does not
+// matter: Lookup returns the *narrowest* matching band so a specific sub-band
+// (FRS) wins over a broad one (UHF public-safety).
+var allocations = []Allocation{
+	{530_000, 1_710_000, "AM broadcast", "commercial AM radio", "US"},
+	{1_800_000, 2_000_000, "Amateur 160m", "ham radio", "US"},
+	{3_500_000, 4_000_000, "Amateur 80m", "ham radio", "US"},
+	{7_000_000, 7_300_000, "Amateur 40m", "ham radio", "US"},
+	{14_000_000, 14_350_000, "Amateur 20m", "ham radio", "US"},
+	{26_960_000, 27_410_000, "CB radio", "Citizens Band 27 MHz", "US"},
+	{28_000_000, 29_700_000, "Amateur 10m", "ham radio", "US"},
+	{50_000_000, 54_000_000, "Amateur 6m", "ham radio", "US"},
+	{88_000_000, 108_000_000, "FM broadcast", "commercial FM radio", "US"},
+	{108_000_000, 118_000_000, "Aeronautical nav", "VOR / ILS navigation", "US"},
+	{118_000_000, 137_000_000, "Aircraft VHF", "air-traffic voice (AM)", "US"},
+	{137_000_000, 138_000_000, "Weather satellite", "NOAA APT / metsat downlink", "US"},
+	{144_000_000, 148_000_000, "Amateur 2m", "ham radio", "US"},
+	{151_820_000, 154_600_000, "MURS / business", "license-free & business VHF", "US"},
+	{156_000_000, 162_025_000, "Marine VHF", "maritime voice & AIS", "US"},
+	{162_400_000, 162_550_000, "NOAA weather", "weather radio broadcast", "US"},
+	{162_000_000, 174_000_000, "VHF public safety", "land-mobile (police/fire/EMS)", "US"},
+	{225_000_000, 400_000_000, "Military UHF", "DoD air/ground (AM/PSK)", "US"},
+	{420_000_000, 450_000_000, "Amateur 70cm", "ham radio", "US"},
+	{450_000_000, 462_000_000, "UHF business", "land-mobile business", "US"},
+	{462_000_000, 467_725_000, "FRS / GMRS", "license-free handheld", "US"},
+	{470_000_000, 512_000_000, "UHF-T / public safety", "land-mobile & T-band", "US"},
+	{512_000_000, 608_000_000, "TV broadcast", "UHF television (DTV)", "US"},
+	{617_000_000, 652_000_000, "Cellular 600 MHz DL", "LTE/5G downlink", "US"},
+	{663_000_000, 698_000_000, "Cellular 600 MHz UL", "LTE/5G uplink", "US"},
+	{758_000_000, 775_000_000, "700 MHz public safety", "FirstNet / LTE public safety", "US"},
+	{746_000_000, 757_000_000, "Cellular 700 MHz DL", "LTE/5G downlink", "US"},
+	{776_000_000, 788_000_000, "Cellular 700 MHz UL", "LTE/5G uplink", "US"},
+	{806_000_000, 824_000_000, "800 MHz SMR/public safety", "trunked land-mobile uplink", "US"},
+	{824_000_000, 849_000_000, "Cellular 850 MHz UL", "LTE/5G uplink", "US"},
+	{851_000_000, 869_000_000, "800 MHz SMR/public safety", "trunked land-mobile downlink", "US"},
+	{869_000_000, 894_000_000, "Cellular 850 MHz DL", "LTE/5G downlink", "US"},
+	{902_000_000, 928_000_000, "ISM 900 MHz", "license-free IoT/telemetry/LoRa", "US"},
+	{978_000_000, 978_000_000, "ADS-B UAT", "aircraft surveillance (978 MHz)", "US"},
+	{960_000_000, 1_215_000_000, "Aeronautical L-band", "DME / ADS-B / SSR", "US"},
+	{1_090_000_000, 1_090_000_000, "ADS-B 1090ES", "aircraft transponder (1090 MHz)", "US"},
+	{1_525_000_000, 1_559_000_000, "Satellite L-band DL", "Inmarsat / Iridium downlink", "US"},
+	{1_559_000_000, 1_610_000_000, "GNSS L1", "GPS / GLONASS / Galileo", "US"},
+	{1_710_000_000, 1_780_000_000, "Cellular AWS UL", "LTE/5G uplink", "US"},
+	{1_850_000_000, 1_915_000_000, "Cellular PCS UL", "LTE/5G uplink", "US"},
+	{1_930_000_000, 1_995_000_000, "Cellular PCS DL", "LTE/5G downlink", "US"},
+	{2_110_000_000, 2_200_000_000, "Cellular AWS DL", "LTE/5G downlink", "US"},
+	{2_400_000_000, 2_483_500_000, "ISM 2.4 GHz", "WiFi / Bluetooth / license-free", "US"},
+	{2_500_000_000, 2_690_000_000, "Cellular 2.5 GHz (BRS)", "LTE/5G TDD", "US"},
+	{3_550_000_000, 3_700_000_000, "CBRS 3.5 GHz", "shared LTE/5G", "US"},
+	// Note: the U-NII 5 GHz WiFi band (5.15–5.895 GHz) is above the uint32 Hz
+	// ceiling (~4.29 GHz) used throughout, and unreachable by the supported
+	// front-ends, so it is intentionally omitted here.
+}
+
+// Lookup returns the narrowest allocation whose band contains centerHz, and
+// whether one was found. Narrowest-wins so a specific sub-band beats a broad
+// umbrella band that overlaps it.
+func Lookup(centerHz uint32) (Allocation, bool) {
+	var best Allocation
+	found := false
+	for _, a := range allocations {
+		if centerHz < a.LoHz || centerHz > a.HiHz {
+			continue
+		}
+		if !found || a.BwHz() < best.BwHz() {
+			best = a
+			found = true
+		}
+	}
+	return best, found
+}
+
+// Allocations returns the full table (sorted by low edge) for display/export.
+func Allocations() []Allocation {
+	out := append([]Allocation(nil), allocations...)
+	sort.Slice(out, func(i, j int) bool { return out[i].LoHz < out[j].LoHz })
+	return out
+}

--- a/internal/siglab/sigref/allocation_test.go
+++ b/internal/siglab/sigref/allocation_test.go
@@ -1,0 +1,91 @@
+package sigref
+
+import "testing"
+
+func TestAllocationLookup(t *testing.T) {
+	cases := []struct {
+		hz          uint32
+		wantService string
+		wantFound   bool
+	}{
+		{1_090_000_000, "ADS-B 1090ES", true},
+		{915_000_000, "ISM 900 MHz", true},
+		{462_600_000, "FRS / GMRS", true},
+		{162_500_000, "NOAA weather", true}, // narrowest-wins over VHF public safety
+		{98_500_000, "FM broadcast", true},
+		{751_000_000, "Cellular 700 MHz DL", true},
+		{5_000_000, "", false}, // unallocated in the table
+	}
+	for _, c := range cases {
+		a, ok := Lookup(c.hz)
+		if ok != c.wantFound {
+			t.Errorf("Lookup(%d) found = %v, want %v", c.hz, ok, c.wantFound)
+			continue
+		}
+		if ok && a.Service != c.wantService {
+			t.Errorf("Lookup(%d) = %q, want %q", c.hz, a.Service, c.wantService)
+		}
+	}
+}
+
+func TestAllocationLookupNarrowestWins(t *testing.T) {
+	// 162.5 MHz falls in both NOAA weather (162.4–162.55) and the broad VHF
+	// public-safety band (162–174). The narrower one must win.
+	a, ok := Lookup(162_500_000)
+	if !ok || a.Service != "NOAA weather" {
+		t.Fatalf("Lookup(162.5 MHz) = %+v (ok=%v), want NOAA weather", a, ok)
+	}
+}
+
+func TestRankWidebandByBandwidthAndAllocation(t *testing.T) {
+	cases := []struct {
+		name    string
+		obs     Observation
+		wantTop string
+	}{
+		{
+			"10 MHz OFDM at 751 MHz ⇒ cellular, not WiFi",
+			Observation{CenterFreqHz: 751_000_000, ChannelBWHz: 10_000_000},
+			"LTE/5G NR (10 MHz)",
+		},
+		{
+			"20 MHz OFDM at 2.45 GHz ⇒ WiFi",
+			Observation{CenterFreqHz: 2_450_000_000, ChannelBWHz: 20_000_000},
+			"WiFi 802.11 (20 MHz)",
+		},
+		{
+			"20 MHz OFDM at 1.94 GHz PCS ⇒ cellular",
+			Observation{CenterFreqHz: 1_940_000_000, ChannelBWHz: 20_000_000},
+			"LTE/5G NR (20 MHz)",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := Rank(tc.obs, 3)
+			if len(m) == 0 {
+				t.Fatal("no matches")
+			}
+			if m[0].Entry.DisplayName != tc.wantTop {
+				t.Errorf("top = %q (%.2f), want %q", m[0].Entry.DisplayName, m[0].Score, tc.wantTop)
+			}
+			if m[0].Entry.Decodable {
+				t.Errorf("wideband match %q marked decodable; must be false", m[0].Entry.DisplayName)
+			}
+		})
+	}
+}
+
+// TestNarrowbandRankingUnaffectedByWideband guards that adding the wideband
+// catalog + allocation-weighted scoring did not perturb a narrowband signature
+// even when a centre frequency is supplied.
+func TestNarrowbandRankingUnaffectedByWideband(t *testing.T) {
+	// A P25 control channel at 851.0125 MHz: 4800 sym/s C4FM, 12.5 kHz.
+	obs := Observation{
+		SymbolRateHz: 4800, SymbolRateConf: 0.9, ModClass: "fsk4", Levels: 4,
+		ChannelBWHz: 12500, CenterFreqHz: 851_012_500,
+	}
+	m := Rank(obs, 3)
+	if len(m) == 0 || m[0].Entry.Protocol != "p25" {
+		t.Fatalf("P25 signature top match = %+v, want p25", m)
+	}
+}

--- a/internal/siglab/sigref/sigref.go
+++ b/internal/siglab/sigref/sigref.go
@@ -72,7 +72,37 @@ var entries = []Entry{
 	{"", "POCSAG-512", blind.ModFSK2, []string{"2FSK paging"}, 512, 12500, 2, nil, false, "pager"},
 	{"", "FLEX", blind.ModFSK4, []string{"4FSK paging"}, 1600, 25000, 4, nil, false, "pager"},
 	{"", "ACARS", blind.ModFSK2, []string{"MSK"}, 2400, 25000, 2, nil, false, "aviation data"},
+
+	// Wideband, non-LMR catalog entries (no decoder, no measurable symbol
+	// rate). These name a wideband occupancy span the full-spectrum survey
+	// finds — cellular/WiFi/OFDM blocks far wider than any channel. They are
+	// ranked by bandwidth + frequency allocation, not symbol rate, and are
+	// always reported decodable=false: GopherTrunk identifies and captures
+	// them, it does not demodulate them.
+	{"", "LTE/5G NR (5 MHz)", blind.ModQAM, []string{"OFDM", "cellular"}, 0, 5_000_000, 0, cellularBands, false, "cellular"},
+	{"", "LTE/5G NR (10 MHz)", blind.ModQAM, []string{"OFDM", "cellular"}, 0, 10_000_000, 0, cellularBands, false, "cellular"},
+	{"", "LTE/5G NR (15 MHz)", blind.ModQAM, []string{"OFDM", "cellular"}, 0, 15_000_000, 0, cellularBands, false, "cellular"},
+	{"", "LTE/5G NR (20 MHz)", blind.ModQAM, []string{"OFDM", "cellular"}, 0, 20_000_000, 0, cellularBands, false, "cellular"},
+	{"", "WiFi 802.11 (20 MHz)", blind.ModQAM, []string{"OFDM", "802.11"}, 0, 20_000_000, 0, wifiBands, false, "WLAN"},
+	{"", "WiFi 802.11 (40 MHz)", blind.ModQAM, []string{"OFDM", "802.11"}, 0, 40_000_000, 0, wifiBands, false, "WLAN"},
+	{"", "WiFi 802.11 (80 MHz)", blind.ModQAM, []string{"OFDM", "802.11"}, 0, 80_000_000, 0, wifiBands, false, "WLAN"},
+	{"", "Bluetooth / BLE", blind.ModFSK2, []string{"GFSK", "FHSS"}, 0, 1_000_000, 2, ismBands24, false, "PAN"},
+	{"", "ADS-B 1090ES", blind.ModFSK2, []string{"PPM"}, 0, 50_000, 2, adsbBands, false, "aviation"},
 }
+
+// Frequency-allocation band sets for the wideband catalog entries. They scope
+// the bandwidth+allocation match in Rank so a 10 MHz OFDM block at 751 MHz
+// reads as cellular, not WiFi. Edges are approximate (US), for naming only.
+var (
+	cellularBands = []Band{
+		{617e6, 698e6}, {698e6, 806e6}, {824e6, 894e6},
+		{1710e6, 1780e6}, {1850e6, 1995e6}, {2110e6, 2200e6},
+		{2496e6, 2690e6}, {3550e6, 3700e6},
+	}
+	wifiBands  = []Band{{2400e6, 2483.5e6}, {5150e6, 5895e6}}
+	ismBands24 = []Band{{2400e6, 2483.5e6}}
+	adsbBands  = []Band{{1089.9e6, 1090.1e6}, {978e6, 978e6}}
+)
 
 // All returns the full catalog (decodable + reference-only).
 func All() []Entry { return entries }
@@ -136,7 +166,24 @@ func Rank(obs Observation, limit int) []Match {
 	return out
 }
 
+// widebandMinMatchBwHz is the smallest observed bandwidth that may match a
+// wideband catalog entry. It sits far above any land-mobile channel (≤25 kHz)
+// so an OFDM/cellular namer can never latch onto a narrowband carrier or a
+// low-information blob, while still admitting a ~1 MHz Bluetooth channel.
+const widebandMinMatchBwHz = 500_000
+
 func score(obs Observation, e Entry) float64 {
+	// Wideband catalog entries (no symbol rate, allocation-scoped) match ONLY a
+	// genuinely wideband observation sitting inside the entry's allocation. The
+	// allocation is a hard gate, not a soft bonus: an LTE namer fires in a
+	// cellular band, a WiFi namer in an ISM band, and neither fires for a
+	// narrowband carrier or an out-of-band signal.
+	if e.SymbolRateHz == 0 && len(e.Bands) > 0 {
+		if obs.ChannelBWHz < widebandMinMatchBwHz || !inAnyBand(obs.CenterFreqHz, e.Bands) {
+			return 0
+		}
+	}
+
 	var acc, totalW float64
 
 	if obs.SymbolRateHz > 0 && e.SymbolRateHz > 0 {
@@ -191,21 +238,26 @@ func score(obs Observation, e Entry) float64 {
 		return 0
 	}
 	s := acc / totalW
-
-	// Small bonus for a centre frequency inside one of the entry's bands.
-	if obs.CenterFreqHz > 0 {
-		f := float64(obs.CenterFreqHz)
-		for _, b := range e.Bands {
-			if f >= b.LoHz && f <= b.HiHz {
-				s += 0.05
-				break
-			}
-		}
-	}
 	if s > 1 {
 		s = 1
 	}
 	return s
+}
+
+// inAnyBand reports whether centerHz (Hz) falls inside any of the given bands.
+// A zero centre (frequency unknown) is never in-band, so a wideband entry that
+// requires an allocation cannot match a frequency-less observation.
+func inAnyBand(centerHz uint32, bands []Band) bool {
+	if centerHz == 0 {
+		return false
+	}
+	f := float64(centerHz)
+	for _, b := range bands {
+		if f >= b.LoHz && f <= b.HiHz {
+			return true
+		}
+	}
+	return false
 }
 
 // modScore is 1 for an exact class match, 0.5 for the same broad family

--- a/internal/survey/classify.go
+++ b/internal/survey/classify.go
@@ -42,6 +42,7 @@ const (
 	ClassPaging         SignalClass = "paging"        // FSK at a paging baud (512/1200/1600/2400)
 	ClassTrunkControl   SignalClass = "trunk-control" // assigned by the router after a CC lock
 	ClassTrunkVoice     SignalClass = "trunk-voice"   // assigned by the router: decoded, no CC lock
+	ClassWideband       SignalClass = "wideband"      // a span wider than a channel (cellular/WiFi/OFDM); named, not decoded
 )
 
 // ClassFeatures are the raw DSP measurements behind a classification. They are

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -721,6 +721,14 @@ func (m *Model) dispatchWrite(r state.WriteRequest) tea.Cmd {
 			Serial:     r.Hunt.Serial,
 			Protocol:   r.Hunt.Protocol,
 		}, r.Label)
+	case state.WriteKindHuntCapture:
+		if r.HuntCapture == nil {
+			return nil
+		}
+		return cmdHuntCapture(m.cli, client.HuntCaptureRequest{
+			FreqHz: r.HuntCapture.FreqHz,
+			Target: r.HuntCapture.Target,
+		}, r.Label)
 	case state.WriteKindScannerConvHold:
 		return cmdScannerConvHold(m.cli, r.Label)
 	case state.WriteKindScannerConvResume:

--- a/internal/tui/client/types.go
+++ b/internal/tui/client/types.go
@@ -184,6 +184,11 @@ type HuntSignalDTO struct {
 	SNRDb        float32 `json:"snr_db"`
 	OccupiedBwHz uint32  `json:"occupied_bw_hz"`
 	Class        string  `json:"class"`
+	Name         string  `json:"name,omitempty"`
+	Service      string  `json:"service,omitempty"`
+	Encrypted    bool    `json:"encrypted,omitempty"`
+	EncType      string  `json:"enc_type,omitempty"`
+	Wideband     bool    `json:"wideband,omitempty"`
 }
 
 // ScannerStatusDTO mirrors api.ScannerStatus — the unified scanner

--- a/internal/tui/client/write.go
+++ b/internal/tui/client/write.go
@@ -107,6 +107,19 @@ func (c *Client) HuntStop(ctx context.Context) error {
 	return c.do(ctx, http.MethodPost, "/api/v1/hunt/stop", nil, nil)
 }
 
+// HuntCaptureRequest is the POST /api/v1/hunt/capture body — record one signal
+// from the inventory and route it to SigLab/CryptoLab.
+type HuntCaptureRequest struct {
+	FreqHz  uint32  `json:"freq_hz"`
+	Seconds float64 `json:"seconds,omitempty"`
+	Target  string  `json:"target,omitempty"`
+}
+
+// HuntCapture records a signal from the survey inventory and routes it onward.
+func (c *Client) HuntCapture(ctx context.Context, req HuntCaptureRequest) error {
+	return c.do(ctx, http.MethodPost, "/api/v1/hunt/capture", req, nil)
+}
+
 // ScannerHuntHold / ScannerHuntResume / ScannerHuntRetune call the
 // per-system hunt mutation endpoints. system must match a configured
 // trunked system name.

--- a/internal/tui/cmds.go
+++ b/internal/tui/cmds.go
@@ -104,6 +104,13 @@ func cmdHuntStop(cli *client.Client, label string) tea.Cmd {
 	}
 }
 
+func cmdHuntCapture(cli *client.Client, req client.HuntCaptureRequest, label string) tea.Cmd {
+	return func() tea.Msg {
+		err := cli.HuntCapture(context.Background(), req)
+		return writeResultMsg{Label: label, Err: err}
+	}
+}
+
 // Scanner-cockpit write Cmds — one per WriteKind.
 
 func cmdScannerSetMode(cli *client.Client, mode, label string) tea.Cmd {

--- a/internal/tui/panels/hunt.go
+++ b/internal/tui/panels/hunt.go
@@ -21,6 +21,7 @@ type HuntPanel struct {
 	survey     bool // the open form will start a survey rather than a hunt
 	focusName  bool // false ⇒ bands input focused, true ⇒ name input
 	inputErr   string
+	selected   int // cursor into the survey signal inventory (capture target)
 }
 
 func NewHunt() *HuntPanel {
@@ -44,10 +45,14 @@ var (
 	huntSurveyKey = key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "start survey"))
 	huntStopKey   = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "stop run"))
 	huntEscKey    = key.NewBinding(key.WithKeys("esc"), key.WithHelp("esc", "cancel"))
+	huntUpKey     = key.NewBinding(key.WithKeys("up"), key.WithHelp("↑", "prev signal"))
+	huntDownKey   = key.NewBinding(key.WithKeys("down"), key.WithHelp("↓", "next signal"))
+	huntCapKey    = key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "capture → SigLab"))
+	huntCapCryKey = key.NewBinding(key.WithKeys("C"), key.WithHelp("C", "capture → CryptoLab"))
 )
 
 func (HuntPanel) Keys() []key.Binding {
-	return []key.Binding{huntStartKey, huntSurveyKey, huntStopKey}
+	return []key.Binding{huntStartKey, huntSurveyKey, huntStopKey, huntUpKey, huntDownKey, huntCapKey, huntCapCryKey}
 }
 
 func (p *HuntPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
@@ -78,6 +83,7 @@ func (p *HuntPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
 		return p, cmd
 	}
 
+	n := len(s.Hunt.Signals)
 	switch {
 	case key.Matches(km, huntStartKey) && !s.Hunt.Running:
 		p.openForm(false)
@@ -87,8 +93,40 @@ func (p *HuntPanel) Update(msg tea.Msg, s *state.SharedState) (Panel, tea.Cmd) {
 		return p, textinput.Blink
 	case key.Matches(km, huntStopKey) && s.Hunt.Running:
 		return p, Emit(state.WriteRequest{Label: "stop hunt run", Kind: state.WriteKindHuntStop})
+	case key.Matches(km, huntUpKey) && n > 0:
+		if p.selected > 0 {
+			p.selected--
+		}
+		return p, nil
+	case key.Matches(km, huntDownKey) && n > 0:
+		if p.selected < n-1 {
+			p.selected++
+		}
+		return p, nil
+	case key.Matches(km, huntCapKey) && n > 0 && !s.Hunt.Running:
+		return p, p.captureSelected(s, "siglab")
+	case key.Matches(km, huntCapCryKey) && n > 0 && !s.Hunt.Running:
+		return p, p.captureSelected(s, "cryptolab")
 	}
 	return p, nil
+}
+
+// captureSelected emits a capture request for the currently-selected survey
+// signal, routed to SigLab or CryptoLab.
+func (p *HuntPanel) captureSelected(s *state.SharedState, target string) tea.Cmd {
+	sigs := s.Hunt.Signals
+	if len(sigs) == 0 {
+		return nil
+	}
+	sel := p.selected
+	if sel < 0 || sel >= len(sigs) {
+		sel = 0
+	}
+	return Emit(state.WriteRequest{
+		Label:       "capture signal",
+		Kind:        state.WriteKindHuntCapture,
+		HuntCapture: &state.HuntCaptureReq{FreqHz: sigs[sel].FreqHz, Target: target},
+	})
 }
 
 // openForm opens the start form for either a hunt or a survey run.
@@ -208,6 +246,9 @@ func (p *HuntPanel) View(width, height int, focused bool, s *state.SharedState) 
 	// Survey inventory: list the classified carriers (most recent first up to
 	// a height-bounded cap so the panel doesn't overflow).
 	if len(h.Signals) > 0 {
+		if p.selected >= len(h.Signals) {
+			p.selected = len(h.Signals) - 1
+		}
 		fmt.Fprintf(&b, "Signals (%d):\n", len(h.Signals))
 		max := height - 12
 		if max < 1 {
@@ -218,8 +259,23 @@ func (p *HuntPanel) View(width, height int, focused bool, s *state.SharedState) 
 				fmt.Fprintf(&b, "  … %d more\n", len(h.Signals)-i)
 				break
 			}
-			fmt.Fprintf(&b, "  %9.4f MHz  %-13s  %4.1f kHz\n",
-				float64(sig.FreqHz)/1e6, sig.Class, float64(sig.OccupiedBwHz)/1e3)
+			cursor := "  "
+			if i == p.selected {
+				cursor = "> "
+			}
+			name := sig.Name
+			if name == "" {
+				name = string(sig.Class)
+			}
+			enc := ""
+			if sig.Encrypted {
+				enc = " 🔒"
+			}
+			fmt.Fprintf(&b, "%s%9.4f MHz  %-16s  %4.1f kHz%s\n",
+				cursor, float64(sig.FreqHz)/1e6, name, float64(sig.OccupiedBwHz)/1e3, enc)
+		}
+		if !h.Running {
+			b.WriteString("[↑/↓] select   [c] → SigLab   [C] → CryptoLab\n")
 		}
 	}
 

--- a/internal/tui/panels/hunt_test.go
+++ b/internal/tui/panels/hunt_test.go
@@ -45,6 +45,45 @@ func TestHuntPanel_EmptyBandsShowsError(t *testing.T) {
 	}
 }
 
+func TestHuntPanel_CaptureSelectedSignal(t *testing.T) {
+	p := NewHunt()
+	s := &state.SharedState{Hunt: client.HuntStatusDTO{
+		State: "done",
+		Signals: []client.HuntSignalDTO{
+			{FreqHz: 462_562_500, Class: "nbfm", Name: "FRS"},
+			{FreqHz: 751_000_000, Class: "wideband", Name: "LTE/5G NR (10 MHz)"},
+		},
+	}}
+
+	// Move the cursor to the second signal, then capture it to CryptoLab.
+	_, _ = p.Update(tea.KeyMsg{Type: tea.KeyDown}, s)
+	_, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("C")}, s)
+	if cmd == nil {
+		t.Fatal("C should emit a capture request")
+	}
+	wa := cmd().(WriteActionMsg)
+	if wa.Request.Kind != state.WriteKindHuntCapture {
+		t.Fatalf("kind = %v, want HuntCapture", wa.Request.Kind)
+	}
+	if wa.Request.HuntCapture == nil || wa.Request.HuntCapture.FreqHz != 751_000_000 {
+		t.Errorf("capture = %+v, want freq 751_000_000 (the selected row)", wa.Request.HuntCapture)
+	}
+	if wa.Request.HuntCapture.Target != "cryptolab" {
+		t.Errorf("target = %q, want cryptolab", wa.Request.HuntCapture.Target)
+	}
+}
+
+func TestHuntPanel_CaptureSuppressedWhileRunning(t *testing.T) {
+	p := NewHunt()
+	s := &state.SharedState{Hunt: client.HuntStatusDTO{
+		Running: true, State: "running",
+		Signals: []client.HuntSignalDTO{{FreqHz: 462_562_500, Class: "nbfm"}},
+	}}
+	if _, cmd := p.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")}, s); cmd != nil {
+		t.Error("capture must not fire while a run is active (SDR busy)")
+	}
+}
+
 func TestHuntPanel_StopEmitsWhenRunning(t *testing.T) {
 	p := NewHunt()
 	s := &state.SharedState{Hunt: client.HuntStatusDTO{Running: true, State: "running"}}

--- a/internal/tui/state/state.go
+++ b/internal/tui/state/state.go
@@ -173,6 +173,7 @@ type WriteRequest struct {
 	Audio             *AudioReq
 	Settings          *SettingsReq
 	Hunt              *HuntStartReq
+	HuntCapture       *HuntCaptureReq
 }
 
 // HuntStartReq is the payload for WriteKindHuntStart — a live system-discovery
@@ -185,6 +186,13 @@ type HuntStartReq struct {
 	Name       string
 	Serial     string
 	Protocol   string
+}
+
+// HuntCaptureReq is the payload for WriteKindHuntCapture — record one signal
+// from the survey inventory and route it to SigLab/CryptoLab.
+type HuntCaptureReq struct {
+	FreqHz uint32
+	Target string // "siglab" | "cryptolab"
 }
 
 // WriteKind discriminates a WriteRequest's payload.
@@ -210,6 +218,7 @@ const (
 	WriteKindSettings
 	WriteKindHuntStop
 	WriteKindHuntStart
+	WriteKindHuntCapture
 )
 
 // ScannerManualTuneReq adds a temp VFO channel and forces dwell.

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -333,9 +333,35 @@ export interface DetectedSignal {
   class: string;
   confidence: number;
   baud_hz?: number;
-  trunking?: { protocol: string; locked: boolean; control_hz?: number };
+  // Consolidated inventory naming (full-spectrum survey).
+  name?: string;
+  service?: string;
+  purpose?: string;
+  encrypted?: boolean;
+  enc_type?: string;
+  wideband?: boolean;
+  trunking?: { protocol: string; locked: boolean; control_hz?: number; encrypted?: boolean; enc_type?: string };
   analog?: { active: boolean; ctcss_hz?: number; dcs_code?: string };
   pages?: { protocol: string; capcode: number; text: string }[];
+}
+
+// HuntCaptureRequest / HuntCaptureResult mirror the api types for the
+// list-driven capture (POST /api/v1/hunt/capture).
+export interface HuntCaptureRequest {
+  freq_hz: number;
+  seconds?: number;
+  target?: "siglab" | "cryptolab";
+}
+
+export interface HuntCaptureResult {
+  path: string;
+  metadata_path?: string;
+  sample_rate_hz: number;
+  center_hz: number;
+  samples: number;
+  identify?: string;
+  frames_path?: string;
+  note?: string;
 }
 
 // HuntStartRequest mirrors api.HuntStartRequest (frequencies in MHz).

--- a/web/src/api/write.ts
+++ b/web/src/api/write.ts
@@ -5,6 +5,8 @@ import type {
   AudioStatusDTO,
   ConfigActivateResponse,
   HuntStartRequest,
+  HuntCaptureRequest,
+  HuntCaptureResult,
   ImportPreview,
   ImportResult,
   RIDDTO,
@@ -67,6 +69,11 @@ export const writes = {
   huntStart: (c: ClientConfig, req: HuntStartRequest) =>
     request<{ run_id: number }>(c, "POST", "/api/v1/hunt/start", req),
   huntStop: (c: ClientConfig) => request<void>(c, "POST", "/api/v1/hunt/stop"),
+
+  // List-driven capture: record one signal from the inventory and route it to
+  // SigLab / CryptoLab.
+  huntCapture: (c: ClientConfig, req: HuntCaptureRequest) =>
+    request<HuntCaptureResult>(c, "POST", "/api/v1/hunt/capture", req),
 
   huntHold: (c: ClientConfig, system: string) =>
     request<void>(

--- a/web/src/panels/Hunt.tsx
+++ b/web/src/panels/Hunt.tsx
@@ -195,6 +195,19 @@ export function Hunt() {
     }
   }
 
+  // captureSignal records raw IQ of one inventory row and hands it to SigLab or
+  // CryptoLab — the list-driven capture. The daemon must not be mid-run.
+  async function captureSignal(freqHz: number, target: "siglab" | "cryptolab") {
+    try {
+      const res = await writes.huntCapture(cfg, { freq_hz: freqHz, target });
+      const where = res.frames_path ?? res.path;
+      const id = res.identify ? ` — ${res.identify}` : "";
+      notify("success", `Captured ${(freqHz / 1e6).toFixed(4)} MHz → ${target}${id} (${where})`);
+    } catch (e: unknown) {
+      setError(e instanceof Error ? `capture failed: ${e.message}` : "capture failed");
+    }
+  }
+
   // parseCC tunes the hunt engine straight at one trunked control-channel
   // frequency (no sweep) and decodes it for ccDwell seconds, accumulating the
   // band plan / talkgroups / identity into status.system. Keep dwell short:
@@ -685,6 +698,8 @@ export function Hunt() {
                 <th className={`${TH} cursor-pointer`} onClick={() => setSortBy("freq")}>
                   Frequency{sortBy === "freq" ? " ▾" : ""}
                 </th>
+                <th className={TH}>Name</th>
+                <th className={TH}>Service</th>
                 <th className={`${TH} cursor-pointer`} onClick={() => setSortBy("class")}>
                   Class{sortBy === "class" ? " ▾" : ""}
                 </th>
@@ -692,17 +707,45 @@ export function Hunt() {
                 <th className={`${TH} cursor-pointer`} onClick={() => setSortBy("snr")}>
                   SNR (dB){sortBy === "snr" ? " ▾" : ""}
                 </th>
+                <th className={TH}>Enc</th>
                 <th className={TH}>Decode</th>
+                <th className={TH}>Capture</th>
               </tr>
             </thead>
             <tbody>
               {sortSignals(status.signals, sortBy).map((sig) => (
                 <tr key={sig.freq_hz} className="border-t border-panel">
                   <td className={TD}>{(sig.freq_hz / 1e6).toFixed(4)} MHz</td>
-                  <td className={TD}>{sig.class}</td>
+                  <td className={TD}>{sig.name ?? ""}</td>
+                  <td className={TD}>{sig.service ?? ""}</td>
+                  <td className={TD}>
+                    {sig.class}
+                    {sig.wideband ? " (wide)" : ""}
+                  </td>
                   <td className={TD}>{(sig.occupied_bw_hz / 1e3).toFixed(1)}</td>
                   <td className={TD}>{sig.snr_db.toFixed(1)}</td>
+                  <td className={TD}>{sig.encrypted ? `🔒 ${sig.enc_type ?? ""}`.trim() : ""}</td>
                   <td className={TD}>{signalDetail(sig)}</td>
+                  <td className={TD}>
+                    {canMutate && (
+                      <span className="flex gap-1">
+                        <button
+                          className="btn-ghost text-xs"
+                          title="Record IQ and open in Signal Lab"
+                          onClick={() => captureSignal(sig.freq_hz, "siglab")}
+                        >
+                          SigLab
+                        </button>
+                        <button
+                          className="btn-ghost text-xs"
+                          title="Record IQ and emit Crypto Lab frames"
+                          onClick={() => captureSignal(sig.freq_hz, "cryptolab")}
+                        >
+                          CryptoLab
+                        </button>
+                      </span>
+                    )}
+                  </td>
                 </tr>
               ))}
             </tbody>


### PR DESCRIPTION
Add FreqRange() (minHz, maxHz uint32) to the rtlsdr Tuner interface and an
optional sdr.FreqRanger Device extension so callers can derive "the whole
device" tuning span without hand-typing a band. Each tuner now single-sources
its PLL bounds (R820T 24M-1.766G, E4000 50M-2.2G, FC0012 37M-1.7G, FC0013
22M-1.7G, FC2580 50M-2.6G): SetFreq's guard reads the same constants FreqRange
returns, so the advertised and enforced ranges can never drift.

Implement FreqRanger on every backend Device (rtlsdr delegates to its tuner;
airspy/airspyhf/hackrf documented spans, hackrf clamped to the uint32 Hz
ceiling; rtltcp decodes the tuner from the rtl_tcp header; recorder/iqtap
wrappers forward the inner device; mock returns the R820T span for tests).

No behavior change: a drift-guard test asserts FreqRange() equals each chip's
historic guard limits and that an out-of-range SetFreq still returns
ErrUnsupportedFreq carrying those exact bounds.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013e4HTuVhw3CctxCJBWrfqQ