### PR TITLE
docs: post-release v0.5.8 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.8] — 2026-06-30
+
+Headlined by two new analysis surfaces. **RF Scope** (`gophertrunk rfscope`)
+is a protocol-agnostic "Wireshark for the RF physical layer" — point it at any
+band and it produces a structured *scene* (protocol hierarchy, per-channel
+activity, burst timing, an emitter/conversation graph, entropy/encryption
+triage, and an expert-info anomaly list) with no prior knowledge of the
+technology, across a CLI, a Bubbletea cockpit, and a standalone web console.
+The **`cryptolab`** research toolkit grows a full RF crypto security-test suite
+(`assess crypto`, randomness battery, classifier, keystream-reuse, period
+detection), a CyberChef-style `recipe` pipeline with a web Recipe Builder, an
+external-cipher bridge for unbundled ciphers (TEA1), DMR active decryption, and
+an NXDN 15-bit scrambler brute-force — and is now discoverable from the other
+web consoles. **SigLab** gains lab-grade VSA modulation-quality metrics,
+spectral-occupancy metrics, a blind modulation/symbol-rate estimator with an
+offline signal-ID database, and a data-over-RF PDU inspector. Rounded out by a
+macOS-only **Airspy concurrency crash fix**.
+
 ### Added
 - **RF Scope — protocol-agnostic RF network analysis ("Wireshark for the RF
   physical layer").** A new `gophertrunk rfscope` surface analyzes any band — a
@@ -92,6 +110,52 @@ for tagged releases.
   each encrypted superframe's Message Indicator + encrypted voice frames as
   JSONL for `cryptolab assess`/`ks`. Off by default (no effect on the voice
   path when unset).
+- **cryptolab NXDN scrambler descramble + 15-bit key brute-force.** NXDN's
+  optional scrambler privacy mode is keyed by only 15 bits (32768 keys), so it
+  is trivially brute-forceable. The new cryptolab `nxdn` tool descrambles an
+  info field with a known key or sweeps the whole keyspace, confirming each key
+  via a pluggable CRC or known-plaintext oracle (phase 1, offline tool; an
+  AMBE-FEC voice oracle is reserved for the future NXDN voice decoder).
+- **SigLab VSA-class modulation-quality metrics.** SigLab surfaces a lab
+  vector-signal-analyzer breakdown beside the constellation — RMS/peak EVM,
+  magnitude/phase error, origin offset, a per-symbol EVM trace, an FFT
+  error-vector spectrum, IQ gain/quadrature imbalance, and the receiver's
+  settled carrier-frequency error — all derived from the symbols it already
+  recovers, with no new estimation.
+- **SigLab spectral-occupancy metrics** — occupied bandwidth, channel power,
+  ACPR, and spectral flatness per analyzed signal (also carried into the RF
+  Scope scene model as clustering/triage dimensions).
+- **SigLab blind modulation estimator + offline signal-ID reference.** A pure
+  blind symbol-rate and coarse modulation-class (FSK2/FSK4/PSK/QAM) estimator
+  names carriers no decoder can lock, and a curated offline signal-ID reference
+  catalog matches them, so `identify` and the wideband survey no longer drop
+  undecodable carriers silently.
+- **SigLab data-over-RF PDU inspector.** The P25 data PDUs (TSBKs) the decoder
+  already parses are surfaced as a field-level dissection — opcode, MFID, NAC,
+  src/dest/talkgroup, raw payload, and CRC/FEC outcome per block, decoded and
+  CRC/trellis-failed blocks alike — instead of being consumed and discarded.
+
+### Changed
+- **Airspy reports its delivered sample rate via `ActualSampleRate()`** (#402).
+  The Airspy only streams the discrete rates its firmware advertises; a
+  requested rate it couldn't honour was silently snapped to the nearest one
+  while the down-converters were still built for the requested rate. The daemon
+  now warns on the mismatch and rebuilds its down-converters from the rate that
+  actually arrives, keeping the symbol clock aligned. Exact-match rates are
+  unchanged.
+- **Documented `dc_avoid` / `dc_avoid_offset_hz`** (LO-offset DC-spike
+  avoidance, #402) in `config.example.yaml` — the config builder already
+  emitted them, but the example config carried no reference stanza.
+
+### Fixed
+- **Airspy crash when decoding on macOS** (`panic: index out of range [12] with
+  length 12`). The Airspy real-to-IQ converter carries filter state across USB
+  packets, but the macOS USB transport delivers packets from up to 32
+  concurrent reaper goroutines that all raced on the single shared converter's
+  cursors. The conversion now runs serially behind a mutex (uncontended on
+  Linux, which already reaps from one goroutine); adds a failing-first
+  32-goroutine regression test. RTL-SDR/HackRF/AirspyHF were unaffected — their
+  per-packet conversion is stateless.
 
 ## [v0.5.7] — 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.7
+VERSION=v0.5.8
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.7" -%}
+  {%- assign ver = "v0.5.8" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.8.md
+++ b/docs/announcements/v0.5.8.md
@@ -1,0 +1,51 @@
+# GopherTrunk v0.5.8 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.8 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.8
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.8 — new "RF Scope" protocol-agnostic RF analyzer (a Wireshark for the RF physical layer), a full cryptolab RF crypto security-test suite + CyberChef-style recipe pipeline, lab-grade SigLab VSA/occupancy metrics + blind signal ID, and an Airspy-on-macOS crash fix
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.8 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.5.7:**
+
+* **RF Scope — a "Wireshark for the RF physical layer."** A new `gophertrunk rfscope` surface analyzes any band — a recorded IQ capture or a live SDR — with no prior knowledge of the technology, modulation, framing, or encryption, and produces a structured *scene*: an RF protocol hierarchy, per-channel I/O-graph activity, burst timing/periodicity, an emitter/conversation graph (frequency hoppers collapse into one emitter), an entropy/encryption triage, and an expert-info anomaly list. Ships as a CLI (`analyze`/`live`/`list` with JSON/JSONL/YAML/CSV export), a Bubbletea cockpit, and a standalone web console (`rfscope serve`). Unidentified digital payloads can be exported straight into cryptolab for further analysis.
+* **cryptolab grew a full RF crypto security-test suite** (`-tags cryptolab`). `assess crypto` attempts to decrypt captured encrypted frames by every applicable method (cipher-strength, a cross-protocol P25/TETRA/DMR known-weakness advisory, IV reuse, known-plaintext, default/weak keys against the real ADP/DES/3DES/AES ciphers, reduced-keyspace brute force, keystream-LFSR prediction) and grades each `RESISTANT`/`PARTIAL`/`BROKEN` — a verified complete decryption means the deployment failed the test. Plus a NIST SP 800-22 randomness battery, an unknown-payload classifier, keystream-reuse / many-time-pad recovery, and autocorrelation period detection.
+* **cryptolab `recipe` — a CyberChef-style operation pipeline** with a web Recipe Builder. Chain byte transforms (XOR, real ADP/DES/3DES/AES decrypts, bit reversal, spectral inversion, split-band/rolling descramble, hex/base64) and analyses (entropy, randomness) from a JSON/YAML recipe, or assemble it interactively in the browser. An external-cipher bridge runs unbundled ciphers (most importantly the TETRA TEA1 32-bit backdoor brute) without GopherTrunk shipping a cipher it can't verify. New: DMR active decryption, generic RC4, and an NXDN 15-bit scrambler brute-force (only 32768 keys).
+* **SigLab gained lab-grade signal metrics.** VSA-class modulation-quality breakdown beside the constellation (RMS/peak EVM, magnitude/phase error, origin offset, EVM trace, error-vector spectrum, IQ imbalance, carrier-frequency error), spectral-occupancy metrics (occupied BW, channel power, ACPR, flatness), a blind symbol-rate + modulation-class estimator with an offline signal-ID reference DB so undecodable carriers get named, and a data-over-RF PDU inspector that dissects P25 TSBKs field-by-field.
+* **Airspy-on-macOS crash fixed.** Decoding on macOS could panic (`index out of range [12] with length 12`) because the macOS USB transport delivers packets from up to 32 concurrent goroutines that raced on the Airspy real-to-IQ converter's shared filter state; the conversion now runs serially behind a mutex (a no-op on Linux). Airspy also now reports its true delivered sample rate so the down-converters build for the rate that actually arrives.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.8
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.8 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.5.7:**
+- **RF Scope — a "Wireshark for the RF physical layer"** (`gophertrunk rfscope`) — point it at any band and get a structured scene (protocol hierarchy, per-channel activity, burst timing, emitter/conversation graph, encryption triage, anomalies) with no prior knowledge of the tech. CLI + Bubbletea cockpit + standalone web console.
+- **cryptolab RF crypto security-test suite** — `assess crypto` grades a deployment `RESISTANT`/`PARTIAL`/`BROKEN`, plus a NIST randomness battery, payload classifier, keystream-reuse recovery, and period detection.
+- **cryptolab `recipe` pipeline + web Recipe Builder** — CyberChef-style chained byte transforms/analyses, an external-cipher bridge (TEA1), DMR active decryption, and an NXDN 15-bit scrambler brute-force.
+- **SigLab VSA + occupancy metrics + blind signal ID** — lab-grade EVM/carrier-error decomposition, occupied BW / channel power / ACPR / flatness, blind modulation/symbol-rate estimation, and a P25 TSBK PDU inspector.
+- **Airspy-on-macOS crash fixed** — serialised the real-to-IQ converter against the macOS transport's concurrent USB reapers.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.8>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow shipped v0.5.8, so catch the post-release docs
up to it:

- CHANGELOG: promote a dated [v0.5.8] section from [Unreleased] (RF Scope
  protocol-agnostic analyzer, the cryptolab security-test suite + recipe
  pipeline + external-cipher bridge + web Recipe Builder + DMR/RC4/NXDN
  decrypt, and the live-decoder crypto-frame bridge), and fill in the merged
  PRs the section was missing: the SigLab VSA/occupancy/blind-ID/PDU-inspector
  additions (#831), the Airspy macOS concurrency crash fix + ActualSampleRate
  + dc_avoid config docs (#843, #402), and the cryptolab NXDN scrambler
  brute-force (#845). Open a fresh empty [Unreleased] for the next cycle.
- README + latest-version.html: bump the quick-start VERSION and the Pages
  fallback tag from v0.5.7 to v0.5.8.
- Add the v0.5.8 social-announcement drafts.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EwfdiwpYTD3mrqbNi9ijCL