### PR TITLE
widebandt2: warn on strong signal with no sync; document ppm for narrowband

### DIFF
--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -369,6 +369,14 @@ type engineChannel struct {
 	// pwLowLogAt throttles the "iq power very low" WARN for this channel.
 	pwLowLogAt time.Time
 
+	// strongNoSyncWindows counts consecutive diagnostics windows in which
+	// this channel carried a strong signal yet produced zero sync/FEC — the
+	// signature of an uncorrected tuner frequency offset (issue #836). It
+	// resets the moment any sync is seen or the signal drops.
+	strongNoSyncWindows int
+	// noSyncLogAt throttles the "strong signal but no sync" hint WARN.
+	noSyncLogAt time.Time
+
 	// decoded returns this channel's lifetime decoded-frame count from the
 	// underlying protocol state machine — Tier II FECPass, Tier III CSBKs,
 	// Phase 1 TSBKs, Phase 2 MAC PDUs. maybeLogDiagnostics diffs it against
@@ -820,6 +828,21 @@ func (e *Engine) Run(ctx context.Context) error {
 // of every window. Matches the ccdecoder cadence (decoder.go).
 const lowPowerWarnInterval = 5 * time.Second
 
+// noSyncHintDbFS is the per-channel IQ power (dBFS) at or above which a
+// channel is treated as carrying a real signal for the "strong signal but
+// no sync" diagnostic. Sits ~10 dB above the low-power floor
+// (iqpower.LowPowerThresholdDbFS = -55) so ordinary noise never trips it,
+// while a keyed handheld — the issue #836 capture peaked near -16 dBFS —
+// clears it comfortably.
+const noSyncHintDbFS = -45.0
+
+// strongNoSyncWindowsNeeded is how many consecutive diagnostics windows
+// (~1 s each) a channel must show strong power with zero sync AND zero FEC
+// before the "strong signal but no sync" hint fires. Requiring a sustained
+// run keeps a brief adjacent-carrier splatter or a one-window glitch from
+// tripping it; a real mistuned transmission holds for seconds.
+const strongNoSyncWindowsNeeded = 3
+
 // maybeLogDiagnostics flushes per-channel signal-power and decode-activity
 // diagnostics once per iqpower.Window. It runs inline on the Run pump
 // goroutine — the same goroutine that fed the tap sinks this window — so
@@ -935,20 +958,46 @@ func (e *Engine) maybeLogDiagnostics(now time.Time) {
 				"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag, "dbfs", dbfs)
 		}
 
-		// Per-window decode-activity deltas (Tier II only for now). Lets an
-		// operator tell no-signal / signal-but-no-sync / sync-but-FEC-fail /
-		// decoding apart at a glance. Gated on DEBUG; lifetime locks total
-		// carried alongside the deltas.
-		if debug && ec.tier2Cnt != nil {
+		// Per-window decode-activity deltas (Tier II conventional / Tier I).
+		// Lets an operator tell no-signal / signal-but-no-sync /
+		// sync-but-FEC-fail / decoding apart at a glance, and drives the
+		// "strong signal but no sync" tuner-offset hint below. The deltas are
+		// computed whenever the typed counters exist (not just under DEBUG) so
+		// the hint works at the default log level.
+		if ec.tier2Cnt != nil {
 			c := ec.tier2Cnt.Counters()
-			e.log.Debug("widebandt2: channel decode activity",
-				"freq_hz", ec.freqHz, "system", ec.sysName,
-				"sync_hits", c.SyncHits-ec.lastCnt.SyncHits,
-				"bursts", c.Bursts-ec.lastCnt.Bursts,
-				"fec_pass", c.FECPass-ec.lastCnt.FECPass,
-				"fec_fail", c.FECFail-ec.lastCnt.FECFail,
-				"locks_total", c.Locks)
+			syncDelta := c.SyncHits - ec.lastCnt.SyncHits
+			fecPassDelta := c.FECPass - ec.lastCnt.FECPass
+			if debug {
+				e.log.Debug("widebandt2: channel decode activity",
+					"freq_hz", ec.freqHz, "system", ec.sysName,
+					"sync_hits", syncDelta,
+					"bursts", c.Bursts-ec.lastCnt.Bursts,
+					"fec_pass", fecPassDelta,
+					"fec_fail", c.FECFail-ec.lastCnt.FECFail,
+					"locks_total", c.Locks)
+			}
 			ec.lastCnt = c
+
+			// Strong-signal-but-no-sync hint (issue #836). A real transmission
+			// that never produces a single burst-sync match is the classic
+			// signature of an uncorrected tuner frequency error: the narrowband
+			// 4-level demod tolerates only a tiny carrier offset (~±75 Hz),
+			// while SDR++ still yields FM audio because audio is offset-immune.
+			// Fire only after a sustained run so a brief splatter doesn't trip
+			// it, and reset the instant any sync appears or the signal drops.
+			if dbfs >= noSyncHintDbFS && syncDelta == 0 && fecPassDelta == 0 {
+				ec.strongNoSyncWindows++
+				if ec.strongNoSyncWindows >= strongNoSyncWindowsNeeded &&
+					now.Sub(ec.noSyncLogAt) >= lowPowerWarnInterval {
+					e.log.Warn("widebandt2: strong in-channel signal but no sync — the classic symptom of an uncorrected tuner frequency error on a narrowband carrier. Measure and set sdr.ppm for this dongle; even ~100 Hz of offset stops a DMR/P25/NXDN decode while SDR++ still produces FM audio. Also verify the carrier frequency and that this protocol/mode is supported. issue #836",
+						"freq_hz", ec.freqHz, "system", ec.sysName, "proto", ec.protoTag,
+						"dbfs", dbfs)
+					ec.noSyncLogAt = now
+				}
+			} else {
+				ec.strongNoSyncWindows = 0
+			}
 		}
 	}
 }

--- a/internal/scanner/widebandt2/engine_nosync_hint_test.go
+++ b/internal/scanner/widebandt2/engine_nosync_hint_test.go
@@ -1,0 +1,98 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/iqpower"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/dmr/tier2"
+)
+
+// runNoSyncDiag drives `windows` diagnostics windows on a single Tier II
+// channel whose typed counters stay at zero (no sync, no FEC — a fresh
+// ConventionalChannel that never processed a burst), re-loading `chanIQ`
+// worth of power before each flush. It returns every captured "strong
+// signal but no sync" WARN.
+func runNoSyncDiag(t *testing.T, chanIQ []complex64, windows int) []capturedRecord {
+	t.Helper()
+	handler, recs, mu := newRecordingHandler()
+	bus := events.NewBus(8)
+	defer bus.Close()
+	ec := &engineChannel{
+		freqHz:   446_500_000,
+		sysName:  "dmr-simplex",
+		protoTag: "dmr-tier2",
+		tier2Cnt: tier2.New(tier2.Options{Bus: bus, SystemName: "dmr-simplex", FrequencyHz: 446_500_000}),
+	}
+	e := &Engine{
+		log:      slog.New(handler),
+		channels: []*engineChannel{ec},
+		now:      time.Now,
+	}
+
+	base := time.Unix(1_700_000_000, 0)
+	// First call seeds lastDiagAt (early return, no channel processing); each
+	// subsequent call one Window later flushes exactly one diagnostics window.
+	e.maybeLogDiagnostics(base)
+	for i := 1; i <= windows; i++ {
+		ec.pwr.Add(chanIQ)
+		e.maybeLogDiagnostics(base.Add(time.Duration(i) * (iqpower.Window + time.Second)))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var out []capturedRecord
+	for _, r := range *recs {
+		if r.level == slog.LevelWarn && strings.Contains(r.msg, "no sync") {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestNoSyncHintFiresOnStrongSignal is the issue #836 diagnostic: a channel
+// carrying a strong signal that never syncs (an uncorrected tuner offset)
+// gets a WARN pointing the operator at sdr.ppm.
+func TestNoSyncHintFiresOnStrongSignal(t *testing.T) {
+	const n = 4096
+	// loudIQ ≈ -3 dBFS, comfortably above noSyncHintDbFS (-45).
+	recs := runNoSyncDiag(t, loudIQ(n), strongNoSyncWindowsNeeded+1)
+	if len(recs) == 0 {
+		t.Fatal("expected a 'strong signal but no sync' WARN, got none")
+	}
+	r := recs[0]
+	if !strings.Contains(r.msg, "sdr.ppm") {
+		t.Errorf("WARN msg = %q, want the sdr.ppm hint", r.msg)
+	}
+	if f, ok := r.attrs["freq_hz"]; !ok || f == nil {
+		t.Errorf("WARN missing freq_hz attr; attrs=%v", r.attrs)
+	}
+	if db, ok := r.attrs["dbfs"].(float64); !ok || db < noSyncHintDbFS {
+		t.Errorf("WARN dbfs attr = %v, want a strong (>= %.0f) level", r.attrs["dbfs"], noSyncHintDbFS)
+	}
+}
+
+// TestNoSyncHintNeedsSustainedRun: a strong-but-no-sync condition shorter than
+// strongNoSyncWindowsNeeded must not fire (guards against brief adjacent-carrier
+// splatter tripping the hint).
+func TestNoSyncHintNeedsSustainedRun(t *testing.T) {
+	const n = 4096
+	recs := runNoSyncDiag(t, loudIQ(n), strongNoSyncWindowsNeeded-1)
+	if len(recs) != 0 {
+		t.Errorf("hint fired after only %d windows, want no WARN before %d; got %d",
+			strongNoSyncWindowsNeeded-1, strongNoSyncWindowsNeeded, len(recs))
+	}
+}
+
+// TestNoSyncHintQuietChannelSilent: a channel below the strong-signal floor is
+// a low-power case, not a tuner-offset case, so the no-sync hint stays silent.
+func TestNoSyncHintQuietChannelSilent(t *testing.T) {
+	const n = 4096
+	recs := runNoSyncDiag(t, quietIQ(n), strongNoSyncWindowsNeeded+2)
+	if len(recs) != 0 {
+		t.Errorf("no-sync hint fired on a quiet channel; got %d WARN(s)", len(recs))
+	}
+}

--- a/samples/dmr-simplex/config.yaml
+++ b/samples/dmr-simplex/config.yaml
@@ -54,7 +54,18 @@ sdr:
       tuner_strategy: auto       # auto -> ddc for a single channel
       gain: "auto"               # gains are in TENTHS of a dB if you pin one
                                  #   (e.g. "320" = 32.0 dB). "auto" is the safe start.
-      ppm: 0                     # set your dongle's measured PPM error if you know it
+      # ppm: your dongle's measured frequency error. THIS MATTERS FOR
+      # NARROWBAND DECODE. A single DMR/P25/NXDN carrier is only ~12.5 kHz
+      # wide with ~1.9 kHz deviation, and the demod tolerates only a tiny
+      # residual carrier offset (roughly ±100 Hz). A cheap RTL-SDR is
+      # commonly tens of ppm off — at 446 MHz even 1 ppm is ~450 Hz — which
+      # is enough to stop decoding entirely (no sessions, no audio) while
+      # SDR++ still produces the "helicopter" FM audio, because FM audio is
+      # offset-tolerant and a 4-level symbol slicer is not. If the daemon
+      # logs "strong in-channel signal but no sync", this is almost always
+      # the cause. Measure your dongle's error (e.g. kalibrate-rtl, or a
+      # known reference signal) and set it here.
+      ppm: 0
       channels:
         - frequency_hz: 446_500_000
           system: "dmr-simplex"


### PR DESCRIPTION
Issue #836 (VE5XAM): a DMR simplex carrier on 446.500 MHz decodes nothing —
no sessions, no audio — while SDR++ on the same dongle hears it. The reporter's
log shows the channel IQ power rising to ~-16 dBFS during a transmission with
sync_hits=0 throughout: the signal is clearly present but never syncs.

Investigation traced this to an uncorrected RTL-SDR tuner carrier offset. The
narrowband C4FM demod tolerates only ~±75 Hz of offset (a synthetic sweep
through the live DDC path decodes fully at 0-75 Hz and drops to zero sync at
100 Hz+), and perfectly de-rotating the IQ restores full decode at every
offset. SDR++ still works because FM audio is offset-tolerant and a 4-level
symbol slicer is not. An RTL-SDR at 446 MHz with ppm=0 is easily off by far
more than 75 Hz.

This surfaces that diagnosis to operators instead of leaving them with a silent
failure:

- Add a per-channel "strong in-channel signal but no sync" WARN in the wideband
  engine. It fires when a channel holds strong power (>= -45 dBFS) with zero
  sync and zero FEC for several consecutive diagnostics windows, pointing at
  sdr.ppm as the likely fix. Throttled and reset on the first sync, mirroring
  the existing low-power hint. The Tier II decode-activity deltas are now
  computed at the default log level (not only under DEBUG) to drive it.
- Strengthen the ppm note in the dmr-simplex sample config: for a single
  narrowband carrier, even ~100 Hz of tuner error stops decoding while SDR++
  audio still works, so measuring and setting ppm is effectively required.

A robust automatic carrier-offset correction (a data-immune, decision-directed
AFC) is the real fix but needs the reporter's raw capture to build and verify;
issue #836 stays open pending that. A naive CoarseAFC port was evaluated and
rejected: it chases the burst data mean into the ~±75 Hz cliff and regresses
clean decodes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013HdKmGmeSboS84GwuVCvAt