### PR TITLE
docs: post-release v0.5.8 + v0.5.9 — CHANGELOG, version refs, announcements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.5.9] — 2026-07-01
+
 ### Added
 - **Full-spectrum survey — scan the whole device, name everything, capture any
   signal.** `gophertrunk hunt -survey` gains an end-to-end "what's on the air"
@@ -36,6 +38,26 @@ for tagged releases.
     pass that emits a CryptoLab `ks` frames file. The same action is a per-row
     button in the web **Hunt** tab, an `↑/↓` + `c`/`C` keybinding in the TUI Hunt
     panel, and `POST /api/v1/hunt/capture` on the daemon.
+
+### Fixed
+- **Airspy R2/Mini reported half its true IQ rate, so wideband decoded
+  nothing.** The driver treated the firmware's `GET_SAMPLERATES` table as 2×
+  "device" rates and reported half the rate the hardware actually delivers, so
+  `ActualSampleRate()` returned e.g. 5 MS/s for an R2 streaming 10 MS/s. The
+  daemon then built its wideband down-converter at half rate (logging the
+  spurious "SDR streams a different sample rate than requested" warning, issue
+  #402), the symbol clock ran 2× off, and no packets decoded. The table is in
+  IQ output rates (R2 `{10, 2.5}` MSPS, Mini `{6, 3}` MSPS); the driver now
+  matches the requested IQ rate against it directly. The IQ converter is
+  unchanged — the firmware still streams the real ADC at 2× and the host
+  decimates back down. The same bug also broke the **control channel on an R2
+  at 2.5 MS/s** (`sample_rate: 2500000` → `actual_hz=1250000`, continuous
+  `no FSW hits`); the daemon now builds the control down-converter at the true
+  2.5 MS/s so the symbol clock stays aligned (#851, same root cause as #764).
+
+## [v0.5.8] — 2026-06-30
+
+### Added
 - **RF Scope — protocol-agnostic RF network analysis ("Wireshark for the RF
   physical layer").** A new `gophertrunk rfscope` surface analyzes any band — a
   recorded IQ capture or a live SDR — with no prior knowledge of the technology,
@@ -120,22 +142,6 @@ for tagged releases.
   each encrypted superframe's Message Indicator + encrypted voice frames as
   JSONL for `cryptolab assess`/`ks`. Off by default (no effect on the voice
   path when unset).
-
-### Fixed
-- **Airspy R2/Mini reported half its true IQ rate, so wideband decoded
-  nothing.** The driver treated the firmware's `GET_SAMPLERATES` table as 2×
-  "device" rates and reported half the rate the hardware actually delivers, so
-  `ActualSampleRate()` returned e.g. 5 MS/s for an R2 streaming 10 MS/s. The
-  daemon then built its wideband down-converter at half rate (logging the
-  spurious "SDR streams a different sample rate than requested" warning, issue
-  #402), the symbol clock ran 2× off, and no packets decoded. The table is in
-  IQ output rates (R2 `{10, 2.5}` MSPS, Mini `{6, 3}` MSPS); the driver now
-  matches the requested IQ rate against it directly. The IQ converter is
-  unchanged — the firmware still streams the real ADC at 2× and the host
-  decimates back down. The same bug also broke the **control channel on an R2
-  at 2.5 MS/s** (`sample_rate: 2500000` → `actual_hz=1250000`, continuous
-  `no FSW hits`); the daemon now builds the control down-converter at the true
-  2.5 MS/s so the symbol clock stays aligned (#851, same root cause as #764).
 
 ## [v0.5.7] — 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.7
+VERSION=v0.5.9
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.7" -%}
+  {%- assign ver = "v0.5.9" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.5.8.md
+++ b/docs/announcements/v0.5.8.md
@@ -1,0 +1,49 @@
+# GopherTrunk v0.5.8 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.8 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.8
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.8 — RF Scope ("Wireshark for the RF physical layer") analyzes any band with no prior knowledge, plus a Crypto Lab security-test suite that grades a capture's encryption RESISTANT / PARTIAL / BROKEN
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.8 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.5.7:**
+
+* **RF Scope — protocol-agnostic RF network analysis ("Wireshark for the RF physical layer").** A new `gophertrunk rfscope` surface analyzes any band — a recorded IQ capture or a live SDR — with no prior knowledge of the technology, modulation, framing, or encryption, and produces a structured *scene*: an RF protocol hierarchy, per-channel I/O-graph activity, burst timing/periodicity, an emitter/conversation graph (frequency hoppers collapse into one emitter), an entropy/encryption triage, and an expert-info anomaly list. Ships as a CLI (`analyze`/`live`/`list` with summary/JSON/JSONL/YAML/CSV export), a Bubbletea cockpit, and a standalone web console (`rfscope serve`).
+* **Crypto Lab security-test suite** (`-tags cryptolab`). `assess crypto` attempts to decrypt captured encrypted frames by every applicable method (cipher-strength, a cross-protocol P25/TETRA/DMR known-weakness advisory, IV reuse, known-plaintext, default/weak keys against the real ADP/DES/3DES/AES ciphers, reduced-keyspace brute force, keystream-LFSR prediction) and grades each with an overall **RESISTANT / PARTIAL / BROKEN** verdict. Rounded out by a NIST SP 800-22 `randomness battery`, `classify auto` triage, keystream-reuse / many-time-pad recovery (`ks`), autocorrelation `stats period`, and a CyberChef-style `recipe` operation pipeline.
+* **External-cipher bridge (TEA1 et al.).** `assess crypto` and the recipe pipeline can drive an operator-supplied cipher program as a subprocess, so unbundled ciphers — most importantly the TETRA TEA1 32-bit backdoor brute (CVE-2022-24402) — are fully runnable without GopherTrunk shipping a cipher it can't verify. When you've already recovered a key, `assess` verifies and decrypts through it directly — no brute required.
+* **DMR active decryption + generic RC4**, a **web Recipe Builder**, and a **live decoder → Crypto Lab crypto-frame bridge** (`recordings.crypto_capture_path`) that feeds encrypted P25 Phase 1 superframes straight into `assess`/`ks`.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.8
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.8 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.5.7:**
+- **RF Scope** — "Wireshark for the RF physical layer": `gophertrunk rfscope` analyzes any band (file or live SDR) with no prior knowledge and builds a structured scene — protocol hierarchy, I/O graph, burst timing, emitter/conversation graph, encryption triage, expert-info. CLI + TUI cockpit + web console.
+- **Crypto Lab security-test suite** (`-tags cryptolab`) — `assess crypto` attacks a capture by every applicable method and grades it **RESISTANT / PARTIAL / BROKEN**; plus a NIST SP 800-22 randomness battery, keystream-reuse recovery, and a CyberChef-style recipe pipeline.
+- **External-cipher bridge** — run unbundled ciphers (e.g. the TETRA TEA1 backdoor brute) as a subprocess, or verify/decrypt with a key you've already recovered.
+- **DMR active decryption + generic RC4**, a **web Recipe Builder**, and a **live decoder → Crypto Lab crypto-frame bridge**.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.8>
+Docs: <https://gophertrunk.org>
+```

--- a/docs/announcements/v0.5.9.md
+++ b/docs/announcements/v0.5.9.md
@@ -1,0 +1,50 @@
+# GopherTrunk v0.5.9 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.5.9 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.9
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.5.9 — full-spectrum survey scans the whole device, names everything on the air, and captures any signal to SigLab/CryptoLab; plus an Airspy R2/Mini fix that restores decode at 2.5 & 10 MS/s
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.5.9 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.5.8:**
+
+* **Full-spectrum survey — scan the whole device, name everything, capture any signal.** `gophertrunk hunt -survey` gains an end-to-end "what's on the air" workflow for undocumented, protocol-dense areas:
+  * **`-whole-device`** sweeps the SDR's *entire* tuning range (derived from the device itself — 24 MHz–1.766 GHz for an R820T, etc.) instead of a hand-typed band, printing the resolved span, step count, and ETA.
+  * **Wideband detect + name + stitch** — `-detect-wideband` finds signals far wider than a channel (cellular LTE/5G, WiFi, other OFDM) by detecting occupancy plateaus and stitching them across tunes to recover the true occupied bandwidth, surfaced as named-but-not-decoded rows.
+  * **Unified inventory row** — every detected signal carries a name, frequency, service/purpose (from a curated frequency-allocation table), quality, encrypted? + encryption type, and a wideband flag. A new `-detect-encryption` entropy triage flags *unknown* digital bursts that look encrypted.
+  * **List-driven capture → SigLab / CryptoLab** — from a survey's JSON, `-survey-capture` records raw IQ of a chosen signal and hands it to SigLab identify or a CryptoLab `ks` frames file. Also a per-row button in the web Hunt tab, a TUI keybinding, and `POST /api/v1/hunt/capture`.
+* **Airspy R2/Mini decode fix** (#851, #764). The driver was misreading the firmware `GET_SAMPLERATES` table as 2× "device" rates, so it built its down-converter at half the delivered IQ rate — the symbol clock ran 2× off and nothing decoded (wideband at 10 MS/s, and the control channel at 2.5 MS/s). The table is in IQ output rates; the driver now matches the requested rate against it directly, so an R2/Mini locks at its native rates again.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.9
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.5.9 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.5.8:**
+- **Full-spectrum survey** — `gophertrunk hunt -survey -whole-device` sweeps the SDR's entire tuning range and builds a unified inventory: every signal gets a name, frequency, service/purpose, quality, encrypted? flag, and a wideband flag. `-detect-wideband` names + stitches signals wider than a channel (cellular/WiFi/OFDM); `-detect-encryption` flags unknown bursts that look encrypted.
+- **List-driven capture** — from a survey's JSON, `-survey-capture` records raw IQ of any signal straight into SigLab or a CryptoLab `ks` frames file (also a web-Hunt button, a TUI keybinding, and a REST endpoint).
+- **Airspy R2/Mini decode fix** (#851, #764) — the driver was building its down-converter at half the true IQ rate (symbol clock 2× off, nothing decoded); it now reads the `GET_SAMPLERATES` table as IQ rates, so wideband at 10 MS/s and the control channel at 2.5 MS/s lock again.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.5.9>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
## Summary

The daily release workflow tagged **v0.5.8** and **v0.5.9** but the manual post-release docs sync (cf. the v0.5.7 sync in `68c7ecb0`) was never run for either, so `main` still showed everything under `## [Unreleased]` and pointed operators at v0.5.7. This catches the docs up to both shipped releases.

## Changes

- **`CHANGELOG.md`** — promoted the accumulated `[Unreleased]` entries into two dated sections, split by tag range:
  - **`[v0.5.9] — 2026-07-01`** — the full-spectrum survey (`hunt -whole-device`, wideband detect/name/stitch, unified inventory row, list-driven capture → SigLab/CryptoLab) and the Airspy R2/Mini IQ-rate `Fixed` entry (#851, same root cause as #764).
  - **`[v0.5.8] — 2026-06-30`** — RF Scope, and the Crypto Lab security-test suite (`assess`/randomness/classify/`ks`/stats/recipe), external-cipher bridge (TEA1), DMR/RC4 decryption, web Recipe Builder, and the live-decoder crypto-frame bridge.
  - Fresh empty `[Unreleased]` block on top.
- **`README.md`** — quick-start `VERSION=v0.5.7` → `v0.5.9`.
- **`docs/_includes/latest-version.html`** — Pages fallback tag `v0.5.7` → `v0.5.9` (the `downloads.md` snippet renders off this include; Pages otherwise resolves the latest release from the GitHub API).
- **`docs/announcements/v0.5.8.md`, `docs/announcements/v0.5.9.md`** — new social-announcement drafts, matching the format of prior releases.

Left untouched deliberately (matching the established post-release commit): `Makefile` / `internal/version` (version is injected from the git tag via `git describe`), and the installer `.iss` / `workflow_dispatch` version defaults (dev fallbacks the release workflow overrides at build time).

## Test plan

- [x] Docs-only change; no code touched. CHANGELOG section structure verified (`Unreleased → v0.5.9 → v0.5.8 → v0.5.7`), and no hardcoded `v0.5.7`/`v0.5.6` refs remain outside the historical CHANGELOG/announcement archives.
- [ ] `make vet test` — n/a (no code change)

## Breaking changes

None.

## Docs / CHANGELOG

- [x] `CHANGELOG.md` promoted (this PR is the promotion)
- [x] README / Pages version references bumped

## Linked issues

Refs #851 (its fix is included in the v0.5.9 CHANGELOG section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0179VyouyPE9xmZuwRh8kJDw)_