### PR TITLE
api: expose per-site P25 TSBK decode quality on /api/v1/sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Added
+- **Per-site P25 decode quality on `GET /api/v1/sites`.** Each `SiteDTO` now
+  carries `control_channel_tsbk_error_rate` (cumulative % of TSBK blocks failing
+  Viterbi/CRC on that site's control channel), `control_channel_tsbk_count` (the
+  attempts behind it, a confidence weight), and `control_channel_decode_quality`
+  (`clean` / `marginal` / `poor`). This exposes decode health independently of
+  carrier lock — a well-locked carrier at range can still error heavily — so
+  consumers can categorise sites as clean vs marginal rather than approximating
+  from carrier offset alone. Fields are omitted until a TSBK is decoded and on
+  non-TSBK Phase 2 paths (issue #858).
+
 ## [v0.5.9] — 2026-07-01
 
 ### Added

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -25,7 +25,7 @@ func (s *Server) handleListSites(w http.ResponseWriter, _ *http.Request) {
 	if s.sites != nil {
 		for _, si := range s.sites.Sites() {
 			k := key{si.System, si.RFSSID, si.SiteID}
-			byKey[k] = &SiteDTO{
+			dto := &SiteDTO{
 				System:                        si.System,
 				RFSSID:                        si.RFSSID,
 				SiteID:                        si.SiteID,
@@ -34,6 +34,16 @@ func (s *Server) handleListSites(w http.ResponseWriter, _ *http.Request) {
 				WACN:                          si.WACN,
 				SystemID:                      si.SystemID,
 			}
+			// Surface per-site decode quality only once a TSBK has been
+			// attempted, so a fresh lock (or a non-TSBK path) omits the fields
+			// rather than reporting a misleading 0% (issue #858).
+			if si.ControlChannelTSBKCount > 0 {
+				rate := si.ControlChannelTSBKErrorRate
+				dto.ControlChannelTSBKErrorRate = &rate
+				dto.ControlChannelTSBKCount = si.ControlChannelTSBKCount
+				dto.ControlChannelDecodeQuality = decodeQuality(rate)
+			}
+			byKey[k] = dto
 		}
 	}
 

--- a/internal/api/handlers_sites_test.go
+++ b/internal/api/handlers_sites_test.go
@@ -20,7 +20,8 @@ func TestListSitesUnionAndNameMerge(t *testing.T) {
 	// One discovered site (rfss 1 / site 1) that is also named in config,
 	// and one configured-but-unseen site (rfss 2 / site 9).
 	discovered := fakeSites{sites: []trunking.SiteInfo{
-		{System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 420012500, WACN: 0xBEE00, SystemID: 0x123},
+		{System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 420012500, WACN: 0xBEE00, SystemID: 0x123,
+			ControlChannelTSBKErrorRate: 8.0, ControlChannelTSBKCount: 250},
 	}}
 	systems := []trunking.System{{
 		Name: "MMR",
@@ -59,6 +60,19 @@ func TestListSitesUnionAndNameMerge(t *testing.T) {
 	if first.ControlChannelHz != 420012500 {
 		t.Errorf("discovered control_channel_hz = %d, want 420012500", first.ControlChannelHz)
 	}
+	// Per-site decode quality surfaces from the TSBK stats (issue #858).
+	if first.ControlChannelTSBKErrorRate == nil {
+		t.Fatalf("discovered site missing control_channel_tsbk_error_rate")
+	}
+	if *first.ControlChannelTSBKErrorRate != 8.0 {
+		t.Errorf("control_channel_tsbk_error_rate = %v, want 8.0", *first.ControlChannelTSBKErrorRate)
+	}
+	if first.ControlChannelTSBKCount != 250 {
+		t.Errorf("control_channel_tsbk_count = %d, want 250", first.ControlChannelTSBKCount)
+	}
+	if first.ControlChannelDecodeQuality != "poor" {
+		t.Errorf("control_channel_decode_quality = %q, want %q", first.ControlChannelDecodeQuality, "poor")
+	}
 
 	second := body.Sites[1]
 	if second.RFSSID != 2 || second.SiteID != 9 || second.Name != "Murradoc Hill" {
@@ -66,6 +80,15 @@ func TestListSitesUnionAndNameMerge(t *testing.T) {
 	}
 	if second.ControlChannelHz != 0 {
 		t.Errorf("unseen site should have no control_channel_hz, got %d", second.ControlChannelHz)
+	}
+	// A site with no TSBK data (count 0) omits the decode-quality fields
+	// rather than reporting a misleading 0% / "clean".
+	if second.ControlChannelTSBKErrorRate != nil {
+		t.Errorf("unseen site should have no tsbk_error_rate, got %v", *second.ControlChannelTSBKErrorRate)
+	}
+	if second.ControlChannelTSBKCount != 0 || second.ControlChannelDecodeQuality != "" {
+		t.Errorf("unseen site should have no tsbk quality, got count=%d quality=%q",
+			second.ControlChannelTSBKCount, second.ControlChannelDecodeQuality)
 	}
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -504,15 +504,51 @@ type SiteDTO struct {
 	// of the locked control carrier relative to the tuned centre. A large value
 	// flags a control lock sitting well off the configured frequency — e.g. an
 	// adjacent site bleeding through at 12.5 kHz spacing (issue #815).
-	ControlChannelCarrierOffsetHz int32  `json:"control_channel_carrier_offset_hz,omitempty"`
-	Name                          string `json:"name"`
-	WACN                          uint32 `json:"wacn,omitempty"`
-	SystemID                      uint16 `json:"system_id,omitempty"`
+	ControlChannelCarrierOffsetHz int32 `json:"control_channel_carrier_offset_hz,omitempty"`
+	// ControlChannelTSBKErrorRate is the cumulative percentage of TSBK blocks on
+	// this site's control channel that failed Viterbi/CRC — a decode-quality
+	// signal independent of carrier lock, since a well-locked carrier at range
+	// can still show a high rate (issue #858). It is a frame-error rate, not a
+	// pre-FEC bit-error rate. A pointer so a genuine 0.0 (perfect decode) is
+	// distinguishable from "no data" (nil): nil until a TSBK has been attempted,
+	// and on non-TSBK Phase 2 (TDMA) paths. ControlChannelTSBKCount is the total
+	// attempts the rate was measured over (a confidence weight).
+	ControlChannelTSBKErrorRate *float64 `json:"control_channel_tsbk_error_rate,omitempty"`
+	ControlChannelTSBKCount     int64    `json:"control_channel_tsbk_count,omitempty"`
+	// ControlChannelDecodeQuality buckets the error rate into clean / marginal /
+	// poor (SDRTrunk-style), for consumers that want a category rather than a
+	// number. Empty when there is no TSBK data yet. See decodeQuality.
+	ControlChannelDecodeQuality string `json:"control_channel_decode_quality,omitempty"`
+	Name                        string `json:"name"`
+	WACN                        uint32 `json:"wacn,omitempty"`
+	SystemID                    uint16 `json:"system_id,omitempty"`
 	// Hex renderings of the identity numbers, alongside the decimal fields.
 	WACNHex     string `json:"wacn_hex,omitempty"`
 	SystemIDHex string `json:"system_id_hex,omitempty"`
 	RFSSIDHex   string `json:"rfss_id_hex,omitempty"`
 	SiteIDHex   string `json:"site_id_hex,omitempty"`
+}
+
+// TSBK frame-error-rate thresholds (percent) that bucket a control channel's
+// decode quality for ControlChannelDecodeQuality. Starting values chosen to be
+// legible as percentages; tune as field data accumulates (issue #858).
+const (
+	tsbkCleanMaxPct    = 1.0 // ≤ this → "clean"
+	tsbkMarginalMaxPct = 5.0 // ≤ this → "marginal"; above → "poor"
+)
+
+// decodeQuality buckets a TSBK frame-error rate (percent) into an SDRTrunk-style
+// quality category. Only meaningful when at least one TSBK has been attempted;
+// callers gate on the attempt count before calling.
+func decodeQuality(ratePct float64) string {
+	switch {
+	case ratePct <= tsbkCleanMaxPct:
+		return "clean"
+	case ratePct <= tsbkMarginalMaxPct:
+		return "marginal"
+	default:
+		return "poor"
+	}
 }
 
 // fillIdentityHex derives the *_hex fields from the decimal identity fields.

--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -195,6 +195,21 @@ type CCStats struct {
 	LocRegSeen int64
 }
 
+// TSBKErrorRate returns the percentage (0..100) of decode-attempted TSBK
+// blocks that failed Viterbi or CRC on this control channel, together with
+// the total number of attempts (the denominator, which doubles as a
+// confidence weight). attempts == 0 means no TSBK has been attempted yet —
+// a fresh lock — in which case the rate is undefined and returned as 0.
+// This is a frame-error rate, not a pre-FEC bit-error rate. Issue #858.
+func (s CCStats) TSBKErrorRate() (ratePct float64, attempts int64) {
+	failed := s.TSBKTrellisFailed + s.TSBKCRCFailed
+	attempts = s.TSBKDecoded + failed
+	if attempts == 0 {
+		return 0, 0
+	}
+	return 100 * float64(failed) / float64(attempts), attempts
+}
+
 // NetworkSnapshot returns the system topology accumulated from the
 // site's Network / RFSS / Secondary-CC / Adjacent-Site status TSBKs.
 func (c *ControlChannel) NetworkSnapshot() NetworkConfig {
@@ -1683,6 +1698,9 @@ func (c *ControlChannel) publishSiteUpdate() {
 	if c.carrierOffsetHz != nil {
 		carrierOffsetHz = int32(math.Round(c.carrierOffsetHz()))
 	}
+	// Snapshot the live TSBK decode-quality counters onto the update so the
+	// site table can surface a per-site frame-error rate (issue #858).
+	tsbkErrorRate, tsbkCount := c.Stats().TSBKErrorRate()
 	c.bus.Publish(events.Event{
 		Kind: events.KindSiteUpdate,
 		Payload: trunking.SiteUpdate{
@@ -1691,6 +1709,8 @@ func (c *ControlChannel) publishSiteUpdate() {
 			SiteID:                        net.Site,
 			ControlChannelHz:              c.freqHz,
 			ControlChannelCarrierOffsetHz: carrierOffsetHz,
+			ControlChannelTSBKErrorRate:   tsbkErrorRate,
+			ControlChannelTSBKCount:       tsbkCount,
 			WACN:                          net.WACN,
 			SystemID:                      net.SystemID,
 			WACNHex:                       trunking.IDHex(uint64(net.WACN)),

--- a/internal/radio/p25/phase1/control_test.go
+++ b/internal/radio/p25/phase1/control_test.go
@@ -1708,3 +1708,29 @@ func TestControlChannelStatsCountsNIDFailure(t *testing.T) {
 		t.Errorf("garbage stream produced a TSBK decode: %d", got.TSBKDecoded)
 	}
 }
+
+// TestCCStatsTSBKErrorRate pins the frame-error-rate arithmetic that feeds the
+// per-site decode-quality field on GET /api/v1/sites (issue #858).
+func TestCCStatsTSBKErrorRate(t *testing.T) {
+	// 90 good + 6 trellis + 4 CRC failures = 10 failed / 100 attempts = 10%.
+	s := CCStats{TSBKDecoded: 90, TSBKTrellisFailed: 6, TSBKCRCFailed: 4}
+	rate, attempts := s.TSBKErrorRate()
+	if attempts != 100 {
+		t.Errorf("attempts = %d, want 100", attempts)
+	}
+	if rate != 10.0 {
+		t.Errorf("rate = %v, want 10.0", rate)
+	}
+
+	// No attempts yet: undefined rate reported as 0, attempts 0.
+	rate, attempts = CCStats{}.TSBKErrorRate()
+	if rate != 0 || attempts != 0 {
+		t.Errorf("empty stats = (%v, %d), want (0, 0)", rate, attempts)
+	}
+
+	// A perfectly clean channel: 0% over a real sample, not the no-data case.
+	rate, attempts = CCStats{TSBKDecoded: 50}.TSBKErrorRate()
+	if rate != 0 || attempts != 50 {
+		t.Errorf("clean stats = (%v, %d), want (0, 50)", rate, attempts)
+	}
+}

--- a/internal/radio/p25/phase1/network_test.go
+++ b/internal/radio/p25/phase1/network_test.go
@@ -438,6 +438,15 @@ func TestControlChannelPublishesSiteUpdate(t *testing.T) {
 				u.RFSSIDHex != "4" || u.SiteIDHex != "7" {
 				t.Fatalf("site update hex fields wrong: %+v", u)
 			}
+			// The update carries the live TSBK decode-quality stats: both
+			// broadcasts decoded cleanly, so the count is non-zero and the
+			// error rate is 0% (issue #858).
+			if u.ControlChannelTSBKCount == 0 {
+				t.Fatalf("site update carries no TSBK count: %+v", u)
+			}
+			if u.ControlChannelTSBKErrorRate != 0 {
+				t.Fatalf("clean decode reported error rate %v, want 0", u.ControlChannelTSBKErrorRate)
+			}
 			return
 		case <-deadline:
 			t.Fatal("no KindSiteUpdate published within deadline")

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -338,8 +338,18 @@ type SiteUpdate struct {
 	// identity may not belong to the configured frequency. Zero on demod paths
 	// without an AFC stage (CQPSK) or when the offset is genuinely ~0.
 	ControlChannelCarrierOffsetHz int32 `json:"control_channel_carrier_offset_hz,omitempty"`
-	WACN                          uint32
-	SystemID                      uint16
+	// ControlChannelTSBKErrorRate is the percentage (0..100) of TSBK blocks on
+	// this control channel that failed Viterbi or CRC, cumulative since the
+	// decoder started — a frame-error rate, not a pre-FEC bit-error rate. It
+	// tracks decode quality independently of carrier lock: a well-locked carrier
+	// at range can still show a high rate (issue #858). ControlChannelTSBKCount
+	// is the total attempts the rate was measured over (the denominator, and a
+	// confidence weight); zero means no TSBK has been attempted yet — a fresh
+	// lock, or a non-TSBK path such as Phase 2 TDMA — and the rate is undefined.
+	ControlChannelTSBKErrorRate float64 `json:"control_channel_tsbk_error_rate,omitempty"`
+	ControlChannelTSBKCount     int64   `json:"control_channel_tsbk_count,omitempty"`
+	WACN                        uint32
+	SystemID                    uint16
 	// Hex renderings of the identity numbers (P25 field convention),
 	// alongside the decimal fields above so JSON consumers get both. Empty
 	// when the corresponding value is unknown (zero).

--- a/internal/trunking/site_tracker.go
+++ b/internal/trunking/site_tracker.go
@@ -24,11 +24,18 @@ type SiteInfo struct {
 	// of the locked control carrier relative to the tuned centre, as of LastSeen.
 	// A large value flags a control lock sitting well off the configured
 	// frequency — e.g. an adjacent site bleeding through (issue #815).
-	ControlChannelCarrierOffsetHz int32     `json:"control_channel_carrier_offset_hz,omitempty"`
-	WACN                          uint32    `json:"wacn,omitempty"`
-	SystemID                      uint16    `json:"system_id,omitempty"`
-	FirstSeen                     time.Time `json:"first_seen"`
-	LastSeen                      time.Time `json:"last_seen"`
+	ControlChannelCarrierOffsetHz int32 `json:"control_channel_carrier_offset_hz,omitempty"`
+	// ControlChannelTSBKErrorRate is the cumulative percentage of TSBK blocks
+	// that failed Viterbi/CRC on this site's control channel, as of LastSeen —
+	// a frame-error rate, not a pre-FEC bit-error rate (issue #858).
+	// ControlChannelTSBKCount is the total attempts it was measured over; zero
+	// means no TSBK data yet (fresh lock, or a non-TSBK Phase 2 path).
+	ControlChannelTSBKErrorRate float64   `json:"control_channel_tsbk_error_rate,omitempty"`
+	ControlChannelTSBKCount     int64     `json:"control_channel_tsbk_count,omitempty"`
+	WACN                        uint32    `json:"wacn,omitempty"`
+	SystemID                    uint16    `json:"system_id,omitempty"`
+	FirstSeen                   time.Time `json:"first_seen"`
+	LastSeen                    time.Time `json:"last_seen"`
 }
 
 // SiteTracker maintains a live table of the P25 sites GT has decoded
@@ -135,6 +142,13 @@ func (t *SiteTracker) observe(u SiteUpdate) {
 	// frequency, or a demod path with no AFC stage), so the surfaced value
 	// tracks the most recent lock (issue #815).
 	s.ControlChannelCarrierOffsetHz = u.ControlChannelCarrierOffsetHz
+	// Refresh decode-quality only when the update actually carries TSBK stats,
+	// so a zero-stat update (a fresh lock, or a non-TSBK Phase 2 site-update on
+	// the same key) never clobbers a real rate (issue #858).
+	if u.ControlChannelTSBKCount > 0 {
+		s.ControlChannelTSBKErrorRate = u.ControlChannelTSBKErrorRate
+		s.ControlChannelTSBKCount = u.ControlChannelTSBKCount
+	}
 	if u.WACN != 0 {
 		s.WACN = u.WACN
 	}

--- a/internal/trunking/site_tracker_test.go
+++ b/internal/trunking/site_tracker_test.go
@@ -54,6 +54,37 @@ func TestSiteTrackerObservesSiteUpdates(t *testing.T) {
 	}
 }
 
+// TestSiteTrackerTSBKQualityGuard checks that a per-site TSBK error rate is
+// recorded from an update that carries stats, and that a later zero-stat update
+// (a fresh lock, or a non-TSBK Phase 2 site-update on the same key) does not
+// clobber it (issue #858).
+func TestSiteTrackerTSBKQualityGuard(t *testing.T) {
+	bus := events.NewBus(16)
+	defer bus.Close()
+	tr, err := NewSiteTracker(SiteTrackerOptions{Bus: bus})
+	if err != nil {
+		t.Fatalf("NewSiteTracker: %v", err)
+	}
+	t.Cleanup(func() { tr.Close() })
+
+	// Observe directly to keep the ordering deterministic.
+	tr.observe(SiteUpdate{System: "MMR", RFSSID: 1, SiteID: 1,
+		ControlChannelHz: 420012500, ControlChannelTSBKErrorRate: 8.0, ControlChannelTSBKCount: 250})
+	got := tr.Snapshot()[0]
+	if got.ControlChannelTSBKErrorRate != 8.0 || got.ControlChannelTSBKCount != 250 {
+		t.Fatalf("after stats update: rate=%v count=%d, want 8.0 / 250",
+			got.ControlChannelTSBKErrorRate, got.ControlChannelTSBKCount)
+	}
+
+	// A zero-stat update must leave the recorded rate untouched.
+	tr.observe(SiteUpdate{System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 420012500})
+	got = tr.Snapshot()[0]
+	if got.ControlChannelTSBKErrorRate != 8.0 || got.ControlChannelTSBKCount != 250 {
+		t.Fatalf("zero-stat update clobbered quality: rate=%v count=%d, want 8.0 / 250",
+			got.ControlChannelTSBKErrorRate, got.ControlChannelTSBKCount)
+	}
+}
+
 func TestSiteTrackerReportFromTopology(t *testing.T) {
 	bus := events.NewBus(16)
 	defer bus.Close()


### PR DESCRIPTION
Add control_channel_tsbk_error_rate, control_channel_tsbk_count, and
control_channel_decode_quality (clean/marginal/poor) to SiteDTO so a
reception map can categorise sites by decode health rather than
approximating from carrier offset. A well-locked carrier at range can
still error heavily, so this surfaces decode quality independently of
lock.

The data already exists per control channel in CCStats (TSBKDecoded /
TSBKTrellisFailed / TSBKCRCFailed). A new CCStats.TSBKErrorRate() derives
the frame-error rate; publishSiteUpdate stamps it onto SiteUpdate,
SiteTracker folds it into SiteInfo (guarded so a zero-stat update never
clobbers a real rate), and the sites handler surfaces it. The rate is a
frame-error rate, not a pre-FEC BER, and is named accordingly. Fields are
omitted until a TSBK is decoded and on non-TSBK Phase 2 paths.

Refs #858

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019sge1YGNsoFbuhk5sqjzxM