### PR TITLE
airspy: drop IQ chunks on overrun instead of wedging the USB reaper

### DIFF
--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -268,6 +269,11 @@ type Device struct {
 	// remembered so ActualSampleRate can report the rate the device will
 	// actually deliver after snapping to the firmware's fixed rate table.
 	lastReqRate uint32
+	// dropped counts IQ chunks the reaper discarded because the primary
+	// consumer fell behind (see StreamIQ's onPacket). Mirrors the RTL-SDR
+	// purego driver's Device.dropped so a live overrun is visible rather
+	// than silently wedging the USB reaper.
+	dropped atomic.Uint64
 }
 
 // Info implements sdr.Device.
@@ -559,7 +565,18 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 		samples := d.cnv.processRaw(buf)
 		select {
 		case out <- samples:
-		case <-ctx.Done():
+		default:
+			// Consumer fell behind. Drop the chunk rather than block the USB
+			// reaper: each bulkLoop goroutine posts its next ReadPipe only after
+			// onPacket returns, so a blocked send stops posting reads. Stall all
+			// of them (macOS runs DefaultRingBuffers=32 concurrent reapers) and
+			// no reads are outstanding — the device FIFO overflows and the whole
+			// stream silently wedges with no error, no EOF, no log (the Airspy
+			// freeze). Shed the chunk and surface it instead: the daemon's IQ-drop
+			// observer bumps iq_underruns_total and emits a rate-limited "host
+			// can't keep up — lower sdr.sample_rate" WARN.
+			d.dropped.Add(1)
+			sdr.NotifyIQDrop(d.info)
 		}
 	}
 	// streamDead fires (exactly once, via streamDeadOnce) when the USB

--- a/internal/sdr/airspy/airspy_overrun_test.go
+++ b/internal/sdr/airspy/airspy_overrun_test.go
@@ -1,0 +1,72 @@
+package airspy
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// TestStreamIQDropsInsteadOfBlockingWhenConsumerStalls is the regression for the
+// Airspy decode freeze: a stalled IQ consumer must never wedge the USB reaper.
+//
+// Each usb transport bulkLoop goroutine posts its next ReadPipe only after
+// onPacket returns, so a blocking send in onPacket stops the device from being
+// read. On macOS DefaultRingBuffers=32 reapers all block at once, no USB reads
+// stay outstanding, the endpoint FIFO overflows and the whole stream silently
+// wedges with no error/EOF/log. onPacket must instead shed the chunk (counted
+// via sdr.NotifyIQDrop) so the reaper keeps cycling and the device stays alive.
+//
+// Here the consumer never drains the returned channel. With the blocking
+// implementation the mock's delivery goroutine wedges after the 8-deep channel
+// fills and no drops are ever observed → this test times out at zero drops. With
+// the drop-on-overrun fix every packet past the buffer is shed and counted.
+func TestStreamIQDropsInsteadOfBlockingWhenConsumerStalls(t *testing.T) {
+	dev, mt := withDevice(t)
+	// StreamIQ flips the receiver on at start and off again on teardown.
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqReceiverMode, WValue: receiverModeOn},
+		{BRequest: reqReceiverMode, WValue: receiverModeOff},
+	}
+
+	// Feed far more packets than the 8-deep primary channel can hold, back to
+	// back, to a consumer that never reads. 64 bytes → 16 complex samples each.
+	const packets = 64
+	const bufBytes = 64
+	mt.BulkPackets = make([][]byte, packets)
+	for i := range mt.BulkPackets {
+		mt.BulkPackets[i] = make([]byte, bufBytes)
+	}
+
+	var drops atomic.Uint64
+	sdr.SetIQDropObserver(func(sdr.Info) { drops.Add(1) })
+	t.Cleanup(func() { sdr.SetIQDropObserver(nil) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	// Deliberately never read ch — simulate a stalled downstream consumer.
+
+	// The channel buffers 8, so exactly packets-8 chunks must be shed. Poll with
+	// a deadline: a blocking reaper never reaches this count and the test fails
+	// loudly instead of hanging forever.
+	wantMin := uint64(packets - cap(ch))
+	deadline := time.Now().Add(2 * time.Second)
+	for drops.Load() < wantMin {
+		if time.Now().After(deadline) {
+			t.Fatalf("reaper wedged: got %d drops, want >= %d — a blocking onPacket "+
+				"stopped the USB reads (freeze regression)", drops.Load(), wantMin)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if mt.Err != nil {
+		t.Fatalf("transport: %v", mt.Err)
+	}
+}


### PR DESCRIPTION
At high load the wideband DSP consumer momentarily stalls, the driver's
8-deep IQ channel fills, and StreamIQ's onPacket blocked on the send. Each
usb bulkLoop goroutine posts its next ReadPipe only after onPacket returns,
so a blocked send stops posting reads; on macOS all DefaultRingBuffers=32
reapers wedge at once, no USB reads stay outstanding, the endpoint FIFO
overflows and the whole stream silently halts — no error, no EOF, no log.
Because the Airspy is the broker's inner device, that back-propagates and
stops the control-channel decode too, so decoding freezes entirely. Field
reports saw this on an Airspy R2 at both 2.5 and 10 MS/s: control locks,
then a P25 voice grant spins up a second IQ consumer (the voice tap's DDC)
and everything freezes with no further debug output.

Make onPacket non-blocking and drop-on-overrun, matching the RTL-SDR purego
deliver path and the soapyremote sendOrDrop fix: shed the chunk, count it,
and report it via sdr.NotifyIQDrop so the daemon bumps iq_underruns_total
and emits a rate-limited "host can't keep up — lower sdr.sample_rate" WARN.
The reaper now always cycles back to ReadPipe, so the device never
underflows and control decoding survives the transient. Dropping the
ctx.Done() escape is safe: with a non-blocking send the reaper never
stalls, StopBulkIn's AbortPipe unblocks its ReadPipe, and StopBulkIn joins
every reaper before the cleanup goroutine closes out — so no send can land
on a closed channel.

Adds a failing-first regression test: a stalled consumer that never drains
the stream must see the overrun surface as counted drops rather than wedge
the reaper (0 drops → freeze).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRrdFqEbktBLSEhcZv9uiS