### PR TITLE
docs: fix GitHub Pages 404s and broken internal links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,12 +51,21 @@ jobs:
             # SEO-optimal "GopherTrunk · <site.description>" string
             # instead of "Home | GopherTrunk".
             printf -- '---\nlayout: home\n---\n\n'
-            # Three transforms:
+            # Five transforms:
             # 1. docs/assets/foo -> /assets/foo (docs/ is the Jekyll
             #    source root, so the asset publishes at /assets/foo).
             # 2. ](docs/foo.md) -> ](/foo.html) so README cross-links
             #    resolve on the Pages site.
-            # 3. Strip everything from the start of the README through
+            # 3/4. Remaining repo-relative links (CHANGELOG.md, LICENSE,
+            #    CONTRIBUTING.md, samples/…, etc.) point at files that
+            #    live in the repo but NOT on the Pages site, so on the
+            #    homepage they'd 404. Rewrite them to absolute GitHub
+            #    URLs — tree/main for directories (trailing slash),
+            #    blob/main for files. These run AFTER rule 2, so the
+            #    already-rewritten /foo.html links (leading `/`) and any
+            #    http(s):// links (the `[^):#]` class stops at the `:`)
+            #    are left untouched.
+            # 5. Strip everything from the start of the README through
             #    the first `---` horizontal-rule separator. That cuts
             #    the README hero (logo + H1 + tagline + badges) which
             #    is already rendered by the home.html layout's own
@@ -65,6 +74,8 @@ jobs:
             sed -E \
               -e 's|docs/assets/|/assets/|g' \
               -e 's|\]\(docs/([a-z0-9_-]+)\.md(#[^)]*)?\)|](/\1.html\2)|g' \
+              -e 's|\]\(([A-Za-z][^):#]*/)\)|](https://github.com/MattCheramie/GopherTrunk/tree/main/\1)|g' \
+              -e 's|\]\(([A-Za-z][^):#]*)(#[^)]*)?\)|](https://github.com/MattCheramie/GopherTrunk/blob/main/\1\2)|g' \
               README.md \
               | sed '0,/^---$/d'
           } > docs/index.md

--- a/docs/hardening.md
+++ b/docs/hardening.md
@@ -143,7 +143,7 @@ explicit `auth.mode` at the next config edit:
 
 GopherTrunk exposes Prometheus metrics on the HTTP API at
 `GET /metrics` when the daemon is started with metrics enabled. The
-collector lives in [`internal/metrics`](../internal/metrics).
+collector lives in [`internal/metrics`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/metrics).
 
 Series exposed:
 
@@ -319,7 +319,7 @@ docker build -t gophertrunk:dev .
 ```
 
 For a single-daemon, single-dongle deployment use the
-[`docker-compose.yml`](../docker-compose.yml) at the repo root. It
+[`docker-compose.yml`](https://github.com/MattCheramie/GopherTrunk/blob/main/docker-compose.yml) at the repo root. It
 bind-mounts `config.yaml`, `recordings/`, and `calls.db` from the
 host so data persists across container restarts.
 

--- a/docs/import.md
+++ b/docs/import.md
@@ -166,7 +166,7 @@ files exported from that tool import without modification.
 ### Annotated example
 
 A complete example bundle lives at
-[`samples/rr-import/example.csv`](../samples/rr-import/example.csv).
+[`samples/rr-import/example.csv`](https://github.com/MattCheramie/GopherTrunk/blob/main/samples/rr-import/example.csv).
 
 ```csv
 # Section: metadata
@@ -347,7 +347,7 @@ the struct-level and node-level YAML schema validations pass.
 The PDF importer always sets `protocol: p25` for the parsed system,
 since the RadioReference Phase 1 and Phase 2 PDFs share the same
 on-page schema and the daemon's runtime distinguishes the two via the
-[`p25_phase2_*` keys](../config.example.yaml). Operators on
+[`p25_phase2_*` keys](https://github.com/MattCheramie/GopherTrunk/blob/main/config.example.yaml). Operators on
 pure-Phase-2 systems may want to hand-add
 `p25_phase2_clock_mode: gardner` to the imported entry — defaults are
 correct for Phase 1 captures.
@@ -390,9 +390,9 @@ re-importing.
 
 ## See also
 
-- [`config.example.yaml`](../config.example.yaml) — full schema for
+- [`config.example.yaml`](https://github.com/MattCheramie/GopherTrunk/blob/main/config.example.yaml) — full schema for
   `trunking.systems[]`.
-- [`internal/trunking/talkgroup.go`](../internal/trunking/talkgroup.go) —
+- [`internal/trunking/talkgroup.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/trunking/talkgroup.go) —
   source of truth for the CSV format the importer writes.
-- [`samples/rr-import/example.csv`](../samples/rr-import/example.csv) —
+- [`samples/rr-import/example.csv`](https://github.com/MattCheramie/GopherTrunk/blob/main/samples/rr-import/example.csv) —
   worked example of the multi-section CSV bundle.

--- a/docs/learn/git/glossary.md
+++ b/docs/learn/git/glossary.md
@@ -19,279 +19,279 @@ ordered roughly from fundamentals to workflows.
 
 **Version control** — A system that records changes to files over time so you can
 review history, undo mistakes, and collaborate. See
-[What is version control?](/learn/what-is-version-control/)
+[What is version control?](/learn/git/what-is-version-control/)
 
 **Git** — The distributed version-control system this path teaches; every clone holds
-the full history. See [What is version control?](/learn/what-is-version-control/)
+the full history. See [What is version control?](/learn/git/what-is-version-control/)
 
 **Repository (repo)** — The project folder Git tracks, including all its history,
 branches, and configuration stored in the hidden `.git` directory. See
-[Your first repository](/learn/first-repository/)
+[Your first repository](/learn/git/first-repository/)
 
 **Working tree (working directory)** — The actual files you see and edit on disk, as
-checked out from a particular commit. See [Git's mental model](/learn/git-mental-model/)
+checked out from a particular commit. See [Git's mental model](/learn/git/git-mental-model/)
 
 **Staging area (index)** — The in-between space where you assemble exactly the changes
-that will go into your next commit. See [Staging & commits](/learn/staging-and-commits/)
+that will go into your next commit. See [Staging & commits](/learn/git/staging-and-commits/)
 
 **Commit** — A saved snapshot of your project at a point in time, with an author,
-message, and a link to its parent commit. See [Staging & commits](/learn/staging-and-commits/)
+message, and a link to its parent commit. See [Staging & commits](/learn/git/staging-and-commits/)
 
 **Stage / unstage** — Adding a change to the staging area (`git add`) or removing it
 again (`git restore --staged`) before committing. See
-[Staging & commits](/learn/staging-and-commits/)
+[Staging & commits](/learn/git/staging-and-commits/)
 
 **`.gitignore`** — A file listing patterns Git should leave untracked, such as build
-output and secrets. See [Ignoring files](/learn/gitignore/)
+output and secrets. See [Ignoring files](/learn/git/gitignore/)
 
 ## How Git stores data
 
 **SHA / hash** — The 40-character SHA-1 (or SHA-256) identifier Git computes for every
 object; it names a commit, tree, or blob uniquely. Often abbreviated to its first
-seven characters. See [Git's mental model](/learn/git-mental-model/)
+seven characters. See [Git's mental model](/learn/git/git-mental-model/)
 
 **Blob** — The Git object that stores the raw contents of a single file. See
-[Git's mental model](/learn/git-mental-model/)
+[Git's mental model](/learn/git/git-mental-model/)
 
 **Tree** — The Git object that represents a directory, listing the blobs and subtrees
-inside it. See [Git's mental model](/learn/git-mental-model/)
+inside it. See [Git's mental model](/learn/git/git-mental-model/)
 
 **Ref** — A human-friendly name that points to a commit, such as a branch or tag.
-Refs live under `.git/refs`. See [Git's mental model](/learn/git-mental-model/)
+Refs live under `.git/refs`. See [Git's mental model](/learn/git/git-mental-model/)
 
 **HEAD** — A special ref pointing to your current location — usually the tip of the
-branch you have checked out. See [Git's mental model](/learn/git-mental-model/)
+branch you have checked out. See [Git's mental model](/learn/git/git-mental-model/)
 
 **Detached HEAD** — The state when HEAD points directly at a commit instead of a
-branch; new commits aren't on any branch until you make one. See [Branches](/learn/branches/)
+branch; new commits aren't on any branch until you make one. See [Branches](/learn/git/branches/)
 
 ## Inspecting your work
 
 **`git init`** — The command that creates a new, empty Git repository in the current
-folder. See [Your first repository](/learn/first-repository/)
+folder. See [Your first repository](/learn/git/first-repository/)
 
 **`git status`** — Shows which files are staged, modified, or untracked right now. See
-[Status & diffs](/learn/status-and-diffs/)
+[Status & diffs](/learn/git/status-and-diffs/)
 
 **Diff** — The line-by-line comparison showing what changed between two versions of
-your files. See [Status & diffs](/learn/status-and-diffs/)
+your files. See [Status & diffs](/learn/git/status-and-diffs/)
 
 **Hunk** — A contiguous block of changed lines within a diff; you can stage hunks
-individually. See [Status & diffs](/learn/status-and-diffs/)
+individually. See [Status & diffs](/learn/git/status-and-diffs/)
 
 **`git log`** — Lists the commit history, most recent first. See
-[Viewing history](/learn/viewing-history/)
+[Viewing history](/learn/git/viewing-history/)
 
 **`git blame`** — Annotates each line of a file with the commit and author that last
-changed it. See [Viewing history](/learn/viewing-history/)
+changed it. See [Viewing history](/learn/git/viewing-history/)
 
 ## Moving around & undoing
 
 **Checkout** — The classic command (`git checkout`) for switching branches or
 restoring files; now often split into `switch` and `restore`. See
-[Branches](/learn/branches/)
+[Branches](/learn/git/branches/)
 
 **Switch** — The newer command (`git switch`) dedicated to changing the branch you
-have checked out. See [Branches](/learn/branches/)
+have checked out. See [Branches](/learn/git/branches/)
 
 **Restore** — The newer command (`git restore`) for discarding changes in the working
-tree or unstaging files. See [Undoing changes](/learn/undoing-changes/)
+tree or unstaging files. See [Undoing changes](/learn/git/undoing-changes/)
 
 **Reset** — Moves the current branch to another commit. `--soft` keeps your changes
 staged, `--mixed` (the default) unstages them, and `--hard` discards them entirely.
-See [Undoing changes](/learn/undoing-changes/)
+See [Undoing changes](/learn/git/undoing-changes/)
 
 **Revert** — Creates a new commit that undoes an earlier one, leaving history intact —
-the safe way to undo shared commits. See [Undoing changes](/learn/undoing-changes/)
+the safe way to undo shared commits. See [Undoing changes](/learn/git/undoing-changes/)
 
 **Reflog** — A local log of where HEAD and branches have pointed, letting you recover
-commits that seem lost. See [Cherry-pick, bisect & reflog](/learn/cherry-pick-bisect-reflog/)
+commits that seem lost. See [Cherry-pick, bisect & reflog](/learn/git/cherry-pick-bisect-reflog/)
 
 **Stash** — A place to shelve uncommitted changes temporarily so you can switch tasks,
-then reapply them later. See [Stashing changes](/learn/stashing/)
+then reapply them later. See [Stashing changes](/learn/git/stashing/)
 
 ## Branching & merging
 
 **Branch** — A movable pointer to a line of development, letting you work without
-disturbing the main branch. See [Branches](/learn/branches/)
+disturbing the main branch. See [Branches](/learn/git/branches/)
 
 **Tag** — A fixed, named pointer to a specific commit, typically marking a release.
-See [Releases & tags](/learn/releases-and-tags/)
+See [Releases & tags](/learn/git/releases-and-tags/)
 
 **Merge** — Combining the histories of two branches into one, usually creating a
-merge commit. See [Merging branches](/learn/merging/)
+merge commit. See [Merging branches](/learn/git/merging/)
 
 **Fast-forward** — A merge with no divergence, where Git simply slides the branch
-pointer forward instead of making a merge commit. See [Merging branches](/learn/merging/)
+pointer forward instead of making a merge commit. See [Merging branches](/learn/git/merging/)
 
 **Merge base** — The most recent common ancestor of two branches, used as the starting
-point for a merge. See [Merging branches](/learn/merging/)
+point for a merge. See [Merging branches](/learn/git/merging/)
 
 **Merge conflict** — When the same lines were changed differently on two branches and
 Git can't decide automatically; you resolve it by hand. See
-[Resolving merge conflicts](/learn/merge-conflicts/)
+[Resolving merge conflicts](/learn/git/merge-conflicts/)
 
 **Rebase** — Replaying your commits onto a new base to create a linear history, instead
-of merging. See [Rebasing](/learn/rebasing/)
+of merging. See [Rebasing](/learn/git/rebasing/)
 
 **Interactive rebase** — A rebase (`git rebase -i`) that lets you reorder, edit,
-squash, or drop commits one by one. See [Interactive rebase](/learn/interactive-rebase/)
+squash, or drop commits one by one. See [Interactive rebase](/learn/git/interactive-rebase/)
 
 **Squash** — Combining several commits into one, often during an interactive rebase or
-when merging a pull request. See [Interactive rebase](/learn/interactive-rebase/)
+when merging a pull request. See [Interactive rebase](/learn/git/interactive-rebase/)
 
 **Fixup** — A commit (or rebase action) that folds changes silently into an earlier
-commit, discarding its own message. See [Interactive rebase](/learn/interactive-rebase/)
+commit, discarding its own message. See [Interactive rebase](/learn/git/interactive-rebase/)
 
 **Cherry-pick** — Copying a single commit from one branch onto another. See
-[Cherry-pick, bisect & reflog](/learn/cherry-pick-bisect-reflog/)
+[Cherry-pick, bisect & reflog](/learn/git/cherry-pick-bisect-reflog/)
 
 **Bisect** — A guided binary search (`git bisect`) that finds the commit which
-introduced a bug. See [Cherry-pick, bisect & reflog](/learn/cherry-pick-bisect-reflog/)
+introduced a bug. See [Cherry-pick, bisect & reflog](/learn/git/cherry-pick-bisect-reflog/)
 
 ## Remotes & collaboration
 
 **Clone** — Making a complete local copy of a remote repository, including its full
-history. See [Working with remotes](/learn/remotes/)
+history. See [Working with remotes](/learn/git/remotes/)
 
 **Remote** — A named link to another copy of the repository, usually hosted on a server
-like GitHub. See [Working with remotes](/learn/remotes/)
+like GitHub. See [Working with remotes](/learn/git/remotes/)
 
 **Origin** — The default name Git gives the remote you cloned from. See
-[Working with remotes](/learn/remotes/)
+[Working with remotes](/learn/git/remotes/)
 
 **Upstream** — The remote that a branch tracks, or the original repo a fork was made
-from. See [Working with remotes](/learn/remotes/)
+from. See [Working with remotes](/learn/git/remotes/)
 
 **Tracking branch** — A local branch configured to follow a specific remote branch, so
-`pull` and `push` know where to go. See [Working with remotes](/learn/remotes/)
+`pull` and `push` know where to go. See [Working with remotes](/learn/git/remotes/)
 
 **Fetch** — Downloading new commits from a remote without changing your working tree.
-See [Working with remotes](/learn/remotes/)
+See [Working with remotes](/learn/git/remotes/)
 
 **Pull** — Fetching from a remote and then merging (or rebasing) those changes into
-your branch. See [Working with remotes](/learn/remotes/)
+your branch. See [Working with remotes](/learn/git/remotes/)
 
 **Push** — Uploading your local commits to a remote. See
-[Working with remotes](/learn/remotes/)
+[Working with remotes](/learn/git/remotes/)
 
 ## GitHub basics
 
 **GitHub** — A popular web platform for hosting Git repositories and collaborating
-through pull requests, issues, and more. See [What is GitHub?](/learn/what-is-github/)
+through pull requests, issues, and more. See [What is GitHub?](/learn/git/what-is-github/)
 
 **Fork** — Your own copy of someone else's repository on GitHub, where you can make
-changes and propose them back. See [Forking a repository](/learn/forking/)
+changes and propose them back. See [Forking a repository](/learn/git/forking/)
 
 **Pull request (PR)** — A GitHub proposal to merge one branch into another, where
-others can review and discuss the changes. See [Pull requests](/learn/pull-requests/)
+others can review and discuss the changes. See [Pull requests](/learn/git/pull-requests/)
 
 **Draft PR** — A pull request marked as not yet ready for review or merging. See
-[Pull requests](/learn/pull-requests/)
+[Pull requests](/learn/git/pull-requests/)
 
 **Code review** — Teammates reading and commenting on a pull request before it is
-merged. See [Pull requests](/learn/pull-requests/)
+merged. See [Pull requests](/learn/git/pull-requests/)
 
 **CODEOWNERS** — A file that designates who must review changes to particular paths in
-the repository. See [Branch protection](/learn/branch-protection/)
+the repository. See [Branch protection](/learn/git/branch-protection/)
 
 **Issue** — A GitHub tracker item for a bug, task, or feature request. See
-[Issues & Projects](/learn/issues-and-projects/)
+[Issues & Projects](/learn/git/issues-and-projects/)
 
 **Label** — A colored tag applied to issues and pull requests for sorting and
-filtering. See [Issues & Projects](/learn/issues-and-projects/)
+filtering. See [Issues & Projects](/learn/git/issues-and-projects/)
 
 **Milestone** — A group of issues and pull requests tied to a target, such as a
-release. See [Issues & Projects](/learn/issues-and-projects/)
+release. See [Issues & Projects](/learn/git/issues-and-projects/)
 
 **Projects** — GitHub's built-in boards and tables for planning and tracking work
-across issues and PRs. See [Issues & Projects](/learn/issues-and-projects/)
+across issues and PRs. See [Issues & Projects](/learn/git/issues-and-projects/)
 
 **Discussions** — A GitHub forum space for questions and open-ended conversation,
-separate from issues. See [GitHub Pages & more](/learn/github-pages-and-more/)
+separate from issues. See [GitHub Pages & more](/learn/git/github-pages-and-more/)
 
 **Wiki** — A repository's built-in collection of editable documentation pages. See
-[GitHub Pages & more](/learn/github-pages-and-more/)
+[GitHub Pages & more](/learn/git/github-pages-and-more/)
 
 **Gist** — A lightweight, shareable snippet or small file hosted on GitHub. See
-[GitHub Pages & more](/learn/github-pages-and-more/)
+[GitHub Pages & more](/learn/git/github-pages-and-more/)
 
 **GitHub Pages** — Free static-site hosting served directly from a repository. See
-[GitHub Pages & more](/learn/github-pages-and-more/)
+[GitHub Pages & more](/learn/git/github-pages-and-more/)
 
 ## Authentication & security
 
 **SSH key** — A cryptographic key pair used to authenticate to GitHub without typing a
-password each time. See [Authentication](/learn/authentication/)
+password each time. See [Authentication](/learn/git/authentication/)
 
 **Personal access token (PAT)** — A generated token that stands in for your password
-when using HTTPS or the API. See [Authentication](/learn/authentication/)
+when using HTTPS or the API. See [Authentication](/learn/git/authentication/)
 
 **Branch protection** — Rules that guard a branch, requiring reviews or passing checks
-before changes can merge. See [Branch protection](/learn/branch-protection/)
+before changes can merge. See [Branch protection](/learn/git/branch-protection/)
 
 **Status check** — An automated test or report that must pass before a pull request can
-be merged. See [Branch protection](/learn/branch-protection/)
+be merged. See [Branch protection](/learn/git/branch-protection/)
 
 ## Automation: CI/CD & Actions
 
 **GitHub Actions** — GitHub's built-in automation platform for running workflows on
-events like pushes and pull requests. See [GitHub Actions](/learn/github-actions/)
+events like pushes and pull requests. See [GitHub Actions](/learn/git/github-actions/)
 
 **Workflow** — A configurable automated process defined in a YAML file under
-`.github/workflows`. See [GitHub Actions](/learn/github-actions/)
+`.github/workflows`. See [GitHub Actions](/learn/git/github-actions/)
 
 **Job** — A set of steps in a workflow that runs on a single runner. See
-[GitHub Actions](/learn/github-actions/)
+[GitHub Actions](/learn/git/github-actions/)
 
 **Step** — An individual task within a job, either a shell command or a reusable
-action. See [GitHub Actions](/learn/github-actions/)
+action. See [GitHub Actions](/learn/git/github-actions/)
 
 **Runner** — The machine (GitHub-hosted or self-hosted) that executes a job's steps.
-See [GitHub Actions](/learn/github-actions/)
+See [GitHub Actions](/learn/git/github-actions/)
 
 **CI/CD** — Continuous Integration and Continuous Delivery/Deployment: automatically
 building, testing, and shipping code on every change. See
-[GitHub Actions](/learn/github-actions/)
+[GitHub Actions](/learn/git/github-actions/)
 
 ## Releases & versioning
 
 **Release** — A packaged, named version of a project, usually built around a tag and
-including notes and assets. See [Releases & tags](/learn/releases-and-tags/)
+including notes and assets. See [Releases & tags](/learn/git/releases-and-tags/)
 
 **Semantic versioning (SemVer)** — A version scheme of MAJOR.MINOR.PATCH that signals
-the kind of changes in a release. See [Releases & tags](/learn/releases-and-tags/)
+the kind of changes in a release. See [Releases & tags](/learn/git/releases-and-tags/)
 
 **Conventional commits** — A commit-message convention (e.g. `feat:`, `fix:`) that
-enables automated changelogs and version bumps. See [Best practices](/learn/best-practices/)
+enables automated changelogs and version bumps. See [Best practices](/learn/git/best-practices/)
 
 ## Advanced & workflow
 
 **Submodule** — A repository embedded inside another repository at a pinned commit.
-See [Submodules, hooks & worktrees](/learn/submodules-hooks-worktrees/)
+See [Submodules, hooks & worktrees](/learn/git/submodules-hooks-worktrees/)
 
 **Hook** — A script Git runs automatically at certain points, such as before a commit
-or after a merge. See [Submodules, hooks & worktrees](/learn/submodules-hooks-worktrees/)
+or after a merge. See [Submodules, hooks & worktrees](/learn/git/submodules-hooks-worktrees/)
 
 **Worktree** — An additional working tree linked to the same repository, letting you
 check out several branches at once. See
-[Submodules, hooks & worktrees](/learn/submodules-hooks-worktrees/)
+[Submodules, hooks & worktrees](/learn/git/submodules-hooks-worktrees/)
 
 **Git LFS (Large File Storage)** — An extension that stores large binary files outside
 the main repo to keep it lean. See
-[Submodules, hooks & worktrees](/learn/submodules-hooks-worktrees/)
+[Submodules, hooks & worktrees](/learn/git/submodules-hooks-worktrees/)
 
 **Monorepo** — A single repository holding many projects or packages together. See
-[Workflow strategies](/learn/workflow-strategies/)
+[Workflow strategies](/learn/git/workflow-strategies/)
 
 **Trunk-based development** — A workflow where everyone commits to one main branch with
-very short-lived branches. See [Workflow strategies](/learn/workflow-strategies/)
+very short-lived branches. See [Workflow strategies](/learn/git/workflow-strategies/)
 
 **GitHub Flow** — A lightweight branching workflow: branch off main, open a pull
-request, review, and merge. See [Workflow strategies](/learn/workflow-strategies/)
+request, review, and merge. See [Workflow strategies](/learn/git/workflow-strategies/)
 
 **Git Flow** — A more structured branching model with long-lived develop, release, and
-hotfix branches. See [Workflow strategies](/learn/workflow-strategies/)
+hotfix branches. See [Workflow strategies](/learn/git/workflow-strategies/)
 
 ---
 

--- a/docs/learn/software-licensing/apache-license.md
+++ b/docs/learn/software-licensing/apache-license.md
@@ -61,13 +61,13 @@ Apache 2.0 is explicit that it does **not** grant any trademark rights (Section 
 
 ## GopherTrunk as the concrete example
 
-You don't have to go far for a real Apache-2.0 project: **GopherTrunk is licensed under Apache 2.0**, and the full text lives in [`/LICENSE`](/LICENSE) at the repo root. Everything above applies to it directly:
+You don't have to go far for a real Apache-2.0 project: **GopherTrunk is licensed under Apache 2.0**, and the full text lives in [`/LICENSE`](https://github.com/MattCheramie/GopherTrunk/blob/main/LICENSE) at the repo root. Everything above applies to it directly:
 
 - Anyone may use, modify, and ship GopherTrunk, including in a commercial product, as long as they keep the license and notices.
 - Every contributor to GopherTrunk grants the Apache 2.0 patent license over their contributions, and the retaliation clause applies.
 - A fork must state its changes and can't use the GopherTrunk name to imply endorsement.
 
-GopherTrunk also ships a [`/THIRD_PARTY_LICENSES.md`](/THIRD_PARTY_LICENSES.md) file inventorying the licenses of the code it depends on — a mix of MIT, BSD, and Apache-2.0 modules. That file is a preview of the *attribution* side of using open source: when you build on other people's code, you have to track and reproduce their notices. We'll dig into doing this properly in [Meeting permissive obligations](/learn/software-licensing/permissive-compliance/) and [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/).
+GopherTrunk also ships a [`/THIRD_PARTY_LICENSES.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/THIRD_PARTY_LICENSES.md) file inventorying the licenses of the code it depends on — a mix of MIT, BSD, and Apache-2.0 modules. That file is a preview of the *attribution* side of using open source: when you build on other people's code, you have to track and reproduce their notices. We'll dig into doing this properly in [Meeting permissive obligations](/learn/software-licensing/permissive-compliance/) and [Auditing dependencies & SBOMs](/learn/software-licensing/auditing-dependencies/).
 
 ## Apache 2.0 vs MIT
 

--- a/docs/opt-in-features.md
+++ b/docs/opt-in-features.md
@@ -34,7 +34,7 @@ default applies, why, and (where relevant) how to opt out.
 ## 1. Protocol-layer FEC defaults
 
 **On by default for every protocol.** The ccdecoder connector at
-[`internal/scanner/ccdecoder/pipelines.go`](../internal/scanner/ccdecoder/pipelines.go)
+[`internal/scanner/ccdecoder/pipelines.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/scanner/ccdecoder/pipelines.go)
 always runs the per-protocol `Parse*Mode` function over the
 configured YAML value — empty strings map to the spec-correct
 on-default. Operators with pre-stripped capture files (DSD-FME
@@ -57,7 +57,7 @@ per-system with `<key>: off`.
 | Motorola Type II | `motorola_bch_mode` | `BCHOn` | `off` |
 | D-STAR | `dstar_fec_mode` | `FECOff` (info-bits passthrough) | `on` flips to the JARL DV-mode FEC chain |
 
-The README's [FEC opt-outs section](../README.md#fec-opt-outs)
+The README's [FEC opt-outs section](https://github.com/MattCheramie/GopherTrunk/blob/main/README.md#fec-opt-outs)
 documents the full reference table with on-default behaviour
 descriptions.
 
@@ -86,7 +86,7 @@ frames.
 **Gardner timing recovery on by default.** Both the P25 Phase 2
 and TETRA receivers route the matched-filter output through the
 Gardner symbol-timing-recovery loop in
-[`internal/dsp/sync/gardner.go`](../internal/dsp/sync/gardner.go).
+[`internal/dsp/sync/gardner.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/dsp/sync/gardner.go).
 Operators with sample-aligned synthesized IQ fixtures (some tests,
 some replay tools) can opt back to the naive sps-th-sample
 decimator per system.
@@ -133,8 +133,8 @@ captures.
 
 ## 3. Daemon-level features
 
-Sources are [`config.example.yaml`](../config.example.yaml) plus
-the config struct in [`internal/config/config.go`](../internal/config/config.go).
+Sources are [`config.example.yaml`](https://github.com/MattCheramie/GopherTrunk/blob/main/config.example.yaml) plus
+the config struct in [`internal/config/config.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/config/config.go).
 
 | Feature | YAML key | Default | Why |
 | --- | --- | --- | --- |
@@ -144,7 +144,7 @@ the config struct in [`internal/config/config.go`](../internal/config/config.go)
 | **CMA blind equalizer** | `recordings.equalizer.enabled` | `false` | Simulcast mitigation costs CPU and may distort clean-RF capture. Benefit is site-specific — operators not on a simulcast site pay the CPU without payoff. Stays a global opt-in until a per-call auto-tune heuristic ships. |
 | **Voice enhancement ("sound-good" chain)** | `recordings.enhance.enabled` | `false` | A post-vocoder chain for decoded digital voice — rumble high-pass (~250 Hz), warmth high-shelf, telephone-band low-pass (~3.4 kHz like OP25), a louder AGC target (22000 vs the faithful 18000), and an optional soft-knee compressor. Deliberately trades a little faithfulness for the cleaner/louder sound rival decoders produce (OP25 band-limits; Trunk Recorder normalizes loudness on by default; DSD/DSDPlus run an aggressive AGC). Applied at the single per-call decode point, so it shapes **both** recordings and live monitoring. Off by default (faithful output is byte-identical); surfaced near the top of the Config Builder, and `enhance.enabled` hot-reloads via `PATCH /api/v1/settings`. Supersedes `warm_dmr_audio` by extending the warmth shelf to all protocols. |
 | **Loudness normalization** | `recordings.normalize.enabled` | `false` | EBU R128 / BS.1770 per-call loudness normalization (default target -16 LUFS, true peak -1.5 dBTP), pure Go — no ffmpeg. Each finished call is measured and a single linear gain (true-peak limited) is applied so calls from different talkgroups/sources play back evenly. `apply_to` selects the target: `recording` (default — rewrite the on-disk WAV; the distributed MP3 inherits it), `distributed` (leave the WAV pristine, normalize only the outbound broadcast/stream copy), or `both`. Opt-in because it changes recorded/streamed levels and not every operator wants that; live monitoring is unaffected. |
-| **Tone-out paging-tone detection** | `tone_out.profiles` | empty list | Two-tone sequential (Quick Call II) profiles are per-site / per-agency. No useful zero-config default exists. [`config.example.yaml`](../config.example.yaml) ships an example profile plus three commented-out alternatives (single-tone, system+talkgroup scoped, tightened tolerance) so operators discover the schema without grepping source. |
+| **Tone-out paging-tone detection** | `tone_out.profiles` | empty list | Two-tone sequential (Quick Call II) profiles are per-site / per-agency. No useful zero-config default exists. [`config.example.yaml`](https://github.com/MattCheramie/GopherTrunk/blob/main/config.example.yaml) ships an example profile plus three commented-out alternatives (single-tone, system+talkgroup scoped, tightened tolerance) so operators discover the schema without grepping source. |
 | **Scan mode = list** | `scanner.scan_mode` | `"all"` | "all" is the backwards-compatible behaviour. Tag-based talkgroup curation must be done by the operator before "list" is useful. Per-deployment choice. Emergency grants bypass the gate regardless. |
 | **CTCSS / DCS squelch** | per-channel `tone:` block | omitted (no gating) | Sub-audible CTCSS tone / DCS code is per-channel signalling that varies by site, repeater, and agency. No useful zero-config default. Omitting the block reverts to carrier-only squelch. |
 | **Raw frame sidecar** | `recordings.write_raw` | `true` in `config.example.yaml` | On in the shipped example. Operators who don't want the `.raw` sidecar set `false`. |
@@ -197,7 +197,7 @@ robustness for specific noise conditions or fully-spec-correct
 encoding.
 
 Captures that close each follow-up belong in the
-[`samples/`](../samples/) directory at the repo root — one
+[`samples/`](https://github.com/MattCheramie/GopherTrunk/tree/main/samples/) directory at the repo root — one
 subfolder per protocol. Each subfolder's `README.md` documents the
 capture format and the metadata schema GopherTrunk needs to
 validate the decode end-to-end.

--- a/docs/specs/p25-motorola-opcodes.md
+++ b/docs/specs/p25-motorola-opcodes.md
@@ -5,14 +5,14 @@ systems. Most P25 systems run Motorola gear, so these come up constantly.
 
 > ⚠️ **Nothing here is wired into the system map.** Opcodes `0x05` and `0x09`
 > (MFID 0x90) are named and their raw payload is captured by `logVendorProbe`
-> ([`control.go`](../../internal/radio/p25/phase1/control.go)) for the record;
+> ([`control.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/radio/p25/phase1/control.go)) for the record;
 > no fields are decoded and nothing is published. A guessed bit layout would
 > inject phantom data — the bad-data class the corroboration/identity work
 > removed.
 
 ## Already decoded (MFID 0x90)
 
-See [`tsbk_vendor.go`](../../internal/radio/p25/phase1/tsbk_vendor.go): patch /
+See [`tsbk_vendor.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/radio/p25/phase1/tsbk_vendor.go): patch /
 group-regroup add (0x00) / delete (0x01), patch-group channel grant (0x02) /
 update (0x03), and talker-alias fragments (0x15). Note also that the **standard**
 band-plan and network/site/secondary broadcasts (`0x33/0x34/0x39/0x3A/0x3B/0x3C/0x3D`)

--- a/docs/specs/p25-tsbk-opcodes.md
+++ b/docs/specs/p25-tsbk-opcodes.md
@@ -2,14 +2,14 @@
 
 Reference table for the P25 Phase 1 (FDMA) Trunking Signalling Block (TSBK)
 **Outbound Signalling Packet (OSP)** opcodes the control-channel decoder in
-[`internal/radio/p25/phase1`](../../internal/radio/p25/phase1/) recognises.
+[`internal/radio/p25/phase1`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/radio/p25/phase1/) recognises.
 
-The Go constant identifiers in [`opcodes.go`](../../internal/radio/p25/phase1/opcodes.go)
+The Go constant identifiers in [`opcodes.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/radio/p25/phase1/opcodes.go)
 stay descriptive/CamelCase (idiomatic Go), while `Opcode.String()` and the
 trailing comment on each constant carry the canonical **TIA designation** — so
 debug logs read in spec terms (`opcode=NET_STS_BCST`, `opcode=UU_ANS_REQ`)
 rather than the OP25-derived names they used to. This mirrors the convention
-already used in [`internal/radio/nxdn`](../../internal/radio/nxdn/) for NXDN
+already used in [`internal/radio/nxdn`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/radio/nxdn/) for NXDN
 message names.
 
 **Source:** TIA-102.AABC-D, *Project 25 — FDMA Common Air Interface — Trunking
@@ -68,7 +68,7 @@ walk-throughs (e.g. UU_V_REQ → UU_ANS_REQ → UU_ANS_RSP call setup).
 | 0x3F | `PROT_PARM_BCST` | Protection Parameter Broadcast | — |
 
 "Dispatched" marks opcodes the control channel acts on (`dispatchTSBK` in
-[`control.go`](../../internal/radio/p25/phase1/control.go)); the rest are
+[`control.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/radio/p25/phase1/control.go)); the rest are
 decoded enough to log at debug and otherwise ignored. The
 standard-broadcast/band-plan opcodes (`0x29/0x33/0x34/0x39/0x3A/0x3B/0x3C/0x3D`)
 are dispatched **regardless of MFID**, because they live in the standard TIA

--- a/docs/spectrum.md
+++ b/docs/spectrum.md
@@ -1,0 +1,84 @@
+---
+layout: page
+title: Spectrum waterfall
+description: The wideband Spectrum panel — a live FFT analyzer and scrolling waterfall over a whole SDR's tuned span, with click-to-tune and bookmark markers
+nav_group: Operate
+---
+
+# Spectrum waterfall
+
+The **Spectrum panel** (web `/spectrum`) is GopherTrunk's **wideband
+FFT view**: a live spectrum analyzer above a scrolling waterfall, drawn
+over a whole SDR's tuned span rather than a single channel baseband. It
+answers "what's on the air right now, and where?" — the wide-angle
+counterpart to the per-channel [Plots](plots.html) scopes.
+
+Unlike the [Mixer](mixer.html) and other plots (which tap a single
+channelized receiver), the Spectrum panel streams the SDR's full FFT, so
+it stays its own top-level tab instead of a `/plots` sub-tab.
+
+## What you see
+
+Two stacked, width-aligned views sharing one FFT-shifted bin → x mapping,
+so a peak in the analyzer lines up vertically with its streak in the
+waterfall below:
+
+- **Spectrum analyzer** — the latest frame as a **Power (dBFS) vs
+  Frequency** line plot across the tuned span.
+- **Waterfall** — the last few hundred frames stacked newest-on-top, each
+  frame one row. dBFS is colour-mapped on a fixed **[−100, 0] dB** range
+  with a **blue → cyan → yellow → red** palette, so a hot carrier reads
+  red against a blue noise floor.
+
+Hovering reads out the **frequency and dBFS** under the cursor, and any
+[bookmarks](bookmarks.html) whose frequency falls in view are drawn as
+markers along the top of the waterfall.
+
+| What you see | Reading |
+| --- | --- |
+| A red vertical streak | A steady carrier — click it to tune |
+| Bursty streaks that come and go | Intermittent transmissions (voice/data) |
+| A raised, textured noise floor | Broadband noise, gain too high, or a nearby overload |
+| A flat blue field | Quiet span — nothing active, or the SDR isn't streaming |
+
+## Click-to-tune
+
+Clicking anywhere on the waterfall or analyzer retunes the selected SDR to
+that frequency: the panel POSTs to
+`/api/v1/spectrum/devices/{serial}/tune`, and downstream panels
+(constellation, CC Activity, the per-channel scopes) follow the new centre.
+Bookmark markers make known control/voice channels a single click away —
+see [Bookmarks](bookmarks.html) for how the overlay is populated.
+
+## Controls
+
+Pick the SDR from the daemon's broker pool; the panel opens a stream to
+that device and starts filling the waterfall. Because the view is the
+device's full span, there is no per-channel **Offset/Mode** here — those
+belong to the single-channel [Plots](plots.html). Use click-to-tune (or a
+bookmark) to move the centre frequency.
+
+## How it works
+
+- The panel discovers SDRs with `GET /api/v1/spectrum/devices`, then opens
+  `WS /api/v1/spectrum/stream?device=...&fps=...&bins=...`. Frames arrive
+  as JSON text messages at the negotiated rate (default **10 fps**, a
+  **4096-bin** FFT; both are query-tunable, and the server pings every
+  30 s to keep idle proxies from reaping the socket).
+- Each frame is an FFT-shifted dBFS array computed by the shared
+  `internal/dsp/spectrum` helpers — the same `PowerDB` normalization the
+  [Mixer](mixer.html) plot uses, so absolute dBFS levels are comparable
+  across the two views.
+- Retunes go through `POST /api/v1/spectrum/devices/{serial}/tune`, gated
+  by the API's write guard.
+
+## Implementation
+
+| Path | Role |
+| --- | --- |
+| `internal/dsp/spectrum/spectrum.go` | `PowerDB` — shared windowed-FFT dBFS helper |
+| `internal/api/spectrum.go` | `devices` / `stream` / `tune` handlers |
+| `internal/api/server.go` | Route registration for `/api/v1/spectrum/*` |
+| `cmd/gophertrunk/spectrum_provider.go` | Daemon provider over the SDR broker pool |
+| `web/src/api/spectrum.ts` | Device list, stream, and tune API client |
+| `web/src/panels/Spectrum.tsx` | Spectrum-analyzer line plot + scrolling waterfall canvas |

--- a/docs/vocoders.md
+++ b/docs/vocoders.md
@@ -162,7 +162,7 @@ This is exactly what SDR# / OP25 / DSD do. The key benefits:
    (no CGO, no system shared library, no install scripts).
 2. Users with DVSI hardware can opt in by building with `-tags dvsi`.
    The Vocoder + AMBE-3003 wire protocol + voice.Vocoder interface
-   conformance ship in [`internal/voice/dvsi/`](../internal/voice/dvsi/);
+   conformance ship in [`internal/voice/dvsi/`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/voice/dvsi/);
    the USB / FTDI transport that talks to the physical chip is a stub
    today (returns `ErrNoDevice`) so the recorder fallback chain
    activates cleanly. Hardware integration with a real DVSI USB-3000
@@ -175,7 +175,7 @@ This is exactly what SDR# / OP25 / DSD do. The key benefits:
 
 ## DVSI backend layout (`-tags dvsi`)
 
-[`internal/voice/dvsi/`](../internal/voice/dvsi/):
+[`internal/voice/dvsi/`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/voice/dvsi/):
 
 - `packet.go` — AMBE-3003 wire format (sync byte + length + type +
   payload). Always compiled — no patent surface in describing a
@@ -198,17 +198,17 @@ the same target on Ubuntu.
 
 The calibration harness ships end-to-end:
 
-- [`internal/voice/calibrate`](../internal/voice/calibrate/) — RMS-
+- [`internal/voice/calibrate`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/voice/calibrate/) — RMS-
   ratio + best-alignment cross-correlation comparison against a
   reference WAV from DSD-FME / OP25.
-- [`internal/voice/imbe/testdata/`](../internal/voice/imbe/testdata/)
+- [`internal/voice/imbe/testdata/`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/voice/imbe/testdata/)
   and
-  [`internal/voice/ambe2/testdata/`](../internal/voice/ambe2/testdata/)
+  [`internal/voice/ambe2/testdata/`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/voice/ambe2/testdata/)
   — fixture drop zones with READMEs documenting the file layout
   the calibrate tests expect.
 - [`docs/voice-calibration.md`](voice-calibration.md) — operator-
   facing capture-and-validate recipe.
-- [`cmd/voice-calibrate`](../cmd/voice-calibrate/) — CLI wrapper
+- [`cmd/voice-calibrate`](https://github.com/MattCheramie/GopherTrunk/tree/main/cmd/voice-calibrate/) — CLI wrapper
   around `calibrate.Compare` so a one-off check doesn't require
   writing a test.
 
@@ -222,7 +222,7 @@ registration, the decoder routes those frames through silence.
 
 Operators with a per-vendor reference can register one
 (freqA, freqB) pair at a time via
-[`ambe2.SetKnoxTone`](../internal/voice/ambe2/knox.go) (typically
+[`ambe2.SetKnoxTone`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/ambe2/knox.go) (typically
 from a per-vendor sub-package `init()`):
 
 ```go
@@ -238,7 +238,7 @@ func init() {
 
 For curated tables (a service-manual extract, an open-source
 receiver's vendor table), use
-[`ambe2.RegisterPreset`](../internal/voice/ambe2/knox.go) instead
+[`ambe2.RegisterPreset`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/ambe2/knox.go) instead
 of repeated `SetKnoxTone` calls. The preset name shows up in
 `ambe2.ListPresets()` for operator diagnostics:
 

--- a/docs/voice-calibration.md
+++ b/docs/voice-calibration.md
@@ -10,18 +10,18 @@ nav_group: Reference
 GopherTrunk's pure-Go IMBE (P25 P1) and AMBE+2 (DMR, NXDN, dPMR,
 D-STAR) decoders produce intelligible end-to-end audio. The remaining
 polish work is **absolute-level calibration**: tune the AGC `TargetPeak`
-in [`internal/voice/mbe/agc.go`](../internal/voice/mbe/agc.go) so the
+in [`internal/voice/mbe/agc.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/mbe/agc.go) so the
 in-tree decoders' loudness matches the reference output from
 DSD-FME or OP25. This document is the operator-facing recipe.
 
 ## What's already shipping
 
 - The comparison harness at
-  [`internal/voice/calibrate`](../internal/voice/calibrate/) reads a
+  [`internal/voice/calibrate`](https://github.com/MattCheramie/GopherTrunk/tree/main/internal/voice/calibrate/) reads a
   `.raw` vocoder-frame stream and a reference `.wav` and computes
   RMS-ratio (dB) + best-alignment normalised cross-correlation.
 - The RMS + cross-correlation math is exposed separately as
-  [`calibrate.CompareSamples([]int16, []int16) Result`](../internal/voice/calibrate/calibrate.go)
+  [`calibrate.CompareSamples([]int16, []int16) Result`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/calibrate/calibrate.go)
   for callers that already have PCM in memory — and so the
   math is unconditionally test-covered against synthetic
   fixtures (e.g. a +3 dB-louder reference must produce
@@ -31,14 +31,14 @@ DSD-FME or OP25. This document is the operator-facing recipe.
   but a regression in the loudness / similarity math now
   fails CI without that step.
 - The vendor-extension hook
-  [`ambe2.SetKnoxTone(b1, freqA, freqB)`](../internal/voice/ambe2/knox.go)
+  [`ambe2.SetKnoxTone(b1, freqA, freqB)`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/ambe2/knox.go)
   lets operators register per-vendor knox / call-alert dual-tone
   pairs (b1 ∈ [144, 163]) the public AMBE+2 spec doesn't document.
   For curated tables, the bundle API
-  [`ambe2.RegisterPreset(KnoxPreset)`](../internal/voice/ambe2/knox.go)
+  [`ambe2.RegisterPreset(KnoxPreset)`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/ambe2/knox.go)
   registers many entries at once with a name surfacing through
   `ambe2.ListPresets()` for diagnostics.
-- The wrapper CLI [`cmd/voice-calibrate`](../cmd/voice-calibrate/main.go)
+- The wrapper CLI [`cmd/voice-calibrate`](https://github.com/MattCheramie/GopherTrunk/blob/main/cmd/voice-calibrate/main.go)
   exposes `calibrate.Compare` so a one-off check doesn't require a
   test.
 
@@ -112,14 +112,14 @@ LagSamples, sample counts). Acceptance criteria:
 ### 4. Tune if the thresholds miss
 
 A failing RMSRatioDb means the in-tree AGC's `TargetPeak` is off.
-[`internal/voice/mbe/agc.go`](../internal/voice/mbe/agc.go) holds
+[`internal/voice/mbe/agc.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/mbe/agc.go) holds
 the knob; lowering `TargetPeak` quietens the in-tree decoder
 relative to the reference and vice versa.
 
 A failing PeakXcorr (with a clean RMSRatio) means the synthesis
 path itself is producing a different waveform. That's deeper than a
 gain knob — check the spectral envelope decoder
-([`internal/voice/mbe/synth.go`](../internal/voice/mbe/synth.go))
+([`internal/voice/mbe/synth.go`](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/mbe/synth.go))
 and the prediction-residual gain path.
 
 ## Reading P25 Phase 1 decode quality
@@ -169,9 +169,9 @@ summed-sinewave dual-tones (identical synthesis path to DTMF).
 Per-vocoder testdata directories:
 
 - `internal/voice/imbe/testdata/` — IMBE fixtures
-  ([README](../internal/voice/imbe/testdata/README.md))
+  ([README](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/imbe/testdata/README.md))
 - `internal/voice/ambe2/testdata/` — AMBE+2 fixtures
-  ([README](../internal/voice/ambe2/testdata/README.md))
+  ([README](https://github.com/MattCheramie/GopherTrunk/blob/main/internal/voice/ambe2/testdata/README.md))
 
 Both READMEs document the file naming the calibrate tests expect.
 Tests `t.Skip` when files are absent; CI stays green.


### PR DESCRIPTION
Google Search Console reported 404s for pages the docs linked to but the
Pages site never published. Root causes and fixes:

- Repo-relative links (`../internal/...`, `../README.md`,
  `../docker-compose.yml`, `../config.example.yaml`, `../samples/...`) in
  7 docs pages pointed at files that live in the repo but not on the
  Pages site, so the browser resolved them against the site root and
  404'd. Rewrote all 38 to absolute GitHub URLs (blob/main for files,
  tree/main for directories), matching the convention already used
  elsewhere in the docs.

- The synthesized homepage (built from README.md) left root-file links
  (CHANGELOG.md, CONTRIBUTING.md, SECURITY.md, THIRD_PARTY_LICENSES.md,
  LICENSE, samples/) relative, so they 404'd at the site root. Extended
  the pages.yml synthesize transform to rewrite remaining repo-relative
  links to absolute GitHub URLs, keeping README.md canonical for GitHub.

- Added the missing docs/spectrum.md — plots.md and mixer.md linked to
  spectrum.html but the page never existed, unlike every sibling scope
  (constellation/eye/histogram/mixer/tuning). The new page documents the
  wideband Spectrum waterfall and self-registers in both sitemaps.

Also fixed broken internal links found while reviewing the rest of the
site: 82 links in learn/git/glossary.md were missing the `/git/` path
segment (/learn/<slug>/ -> /learn/git/<slug>/), and two site-absolute
repo-file links in learn/software-licensing/apache-license.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HNBabfhXTKz6NPJm1xkNJk