### PR TITLE
import: strip UTF-8 BOM before CSV format detection

### DIFF
--- a/cmd/gophertrunk/import_csv.go
+++ b/cmd/gophertrunk/import_csv.go
@@ -21,6 +21,28 @@ type csvImportOpts struct {
 	SysID string
 }
 
+// utf8BOM is the UTF-8 byte-order mark (U+FEFF). RadioReference CSVs
+// exported through Excel on Windows are prefixed with it; left in place
+// it corrupts the first header cell (the BOM bytes prepend "DEC")
+// so both format sniffing and column detection fail. See issue #849.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// stripUTF8BOM returns b without a leading UTF-8 BOM (a no-op otherwise).
+func stripUTF8BOM(b []byte) []byte {
+	return bytes.TrimPrefix(b, utf8BOM)
+}
+
+// bomStrippedReader wraps r so a leading UTF-8 BOM is consumed before
+// the first byte is delivered to the caller. Used by the reader-based
+// CSV entry points that never see the raw file bytes.
+func bomStrippedReader(r io.Reader) io.Reader {
+	br := bufio.NewReader(r)
+	if b, err := br.Peek(len(utf8BOM)); err == nil && bytes.Equal(b, utf8BOM) {
+		_, _ = br.Discard(len(utf8BOM))
+	}
+	return br
+}
+
 // parseCSVFile loads a CSV from disk and turns it into a parsedSystem.
 // Two formats are supported and detected by content sniffing:
 //
@@ -35,6 +57,10 @@ func parseCSVFile(path string, opts csvImportOpts) (parsedSystem, error) {
 	if err != nil {
 		return parsedSystem{}, fmt.Errorf("import-pdf: open %s: %w", path, err)
 	}
+	// RadioReference CSVs exported through Excel on Windows carry a
+	// UTF-8 BOM; strip it before sniffing/parsing so it can't mangle the
+	// first header cell. See issue #849.
+	data = stripUTF8BOM(data)
 	var sys parsedSystem
 	if looksLikeRRNativeCSV(data) {
 		fillOpts := opts
@@ -75,7 +101,7 @@ type csvSection struct {
 // parseCSVStream is the testable entry point — reads a multi-section
 // CSV from any io.Reader.
 func parseCSVStream(r io.Reader) (parsedSystem, error) {
-	sections, err := splitCSVSections(r)
+	sections, err := splitCSVSections(bomStrippedReader(r))
 	if err != nil {
 		return parsedSystem{}, err
 	}
@@ -566,7 +592,7 @@ func looksLikeRRNativeCSV(data []byte) bool {
 // expected to default to the filename stem before calling.
 func parseRRNativeCSVStream(r io.Reader, opts csvImportOpts) (parsedSystem, error) {
 	sys := parsedSystem{Protocol: "p25", Name: opts.Name, SysID: opts.SysID}
-	scanner := bufio.NewScanner(r)
+	scanner := bufio.NewScanner(bomStrippedReader(r))
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var header []string
 	var col map[string]int

--- a/cmd/gophertrunk/import_csv_test.go
+++ b/cmd/gophertrunk/import_csv_test.go
@@ -392,3 +392,61 @@ decimal,alpha_tag
 		t.Errorf("Name = %q, want BundleTest", sys.Name)
 	}
 }
+
+// TestParseCSVFile_BOMNativeRR reproduces issue #849: a native
+// RadioReference CSV exported through Excel on Windows carries a UTF-8
+// BOM. Before the fix the BOM mangled the first header cell so the
+// sniffer misclassified the file as a bundle and parsing failed. The
+// leading "\ufeff" encodes as the UTF-8 BOM (EF BB BF).
+func TestParseCSVFile_BOMNativeRR(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/maricopa-49A.csv"
+	body := "\ufeffDEC,HEX,Mode,Alpha Tag,Description,Tag,Group\n" +
+		"1000,3e8,D,OPS,Operations,Law Dispatch,Police\n" +
+		"1001,3e9,D,TAC1,Tactical 1,Law Tac,Police\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sys, err := parseCSVFile(path, csvImportOpts{})
+	if err != nil {
+		t.Fatalf("parseCSVFile: %v", err)
+	}
+	if sys.Name != "maricopa-49A" {
+		t.Errorf("Name = %q, want maricopa-49A (native RR filename stem)", sys.Name)
+	}
+	if len(sys.Talkgroups) != 2 {
+		t.Fatalf("Talkgroups = %d, want 2 (BOM must not break native RR parsing)", len(sys.Talkgroups))
+	}
+}
+
+// TestParseRRNativeCSVStream_BOM covers the reader entry point used by
+// the web-UI upload path: a BOM ahead of the header must not hide the
+// `decimal` column.
+func TestParseRRNativeCSVStream_BOM(t *testing.T) {
+	const in = "\ufeffDEC,HEX,Mode,Alpha Tag,Description,Tag,Group\n" +
+		"1000,3e8,D,OPS,Operations,Law Dispatch,Police\n"
+	sys, err := parseRRNativeCSVStream(strings.NewReader(in), csvImportOpts{Name: "Test", SysID: "49A"})
+	if err != nil {
+		t.Fatalf("parseRRNativeCSVStream: %v", err)
+	}
+	if len(sys.Talkgroups) != 1 {
+		t.Fatalf("Talkgroups = %d, want 1", len(sys.Talkgroups))
+	}
+}
+
+// TestParseCSVStream_BOM ensures a BOM-prefixed multi-section bundle is
+// still recognised (the first `# Section:` marker must not be masked).
+func TestParseCSVStream_BOM(t *testing.T) {
+	const in = "\ufeff# Section: metadata\nkey,value\nname,BundleTest\nprotocol,p25\n" +
+		"\n# Section: talkgroups\ndecimal,alpha_tag\n1000,OPS\n"
+	sys, err := parseCSVStream(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseCSVStream: %v", err)
+	}
+	if sys.Name != "BundleTest" {
+		t.Errorf("Name = %q, want BundleTest", sys.Name)
+	}
+	if len(sys.Talkgroups) != 1 {
+		t.Errorf("Talkgroups = %d, want 1", len(sys.Talkgroups))
+	}
+}


### PR DESCRIPTION
RadioReference CSVs exported through Excel on Windows carry a UTF-8 BOM
(EF BB BF). parseCSVFile read the raw bytes and handed them straight to
looksLikeRRNativeCSV, where the BOM mangled the first header cell
("﻿DEC" instead of "DEC"). The native-RR sniffer then failed, the file
fell through to the multi-section bundle parser, and import errored with
"native RR CSV header missing decimal/dec column" or "data at line 1
before any # Section marker" — the failure reported in #849.

Strip a leading BOM at the file-read site (covers both the CLI import
command and the web-UI upload, which funnel through parseCSVFile) and,
defensively, in the reader-based entry points parseCSVStream and
parseRRNativeCSVStream. BOM-free input is unaffected.

Adds failing-first regression tests for the native-CSV file path, the
native-CSV reader path, and the bundle reader path.

Refs #849

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CXgcq26S7BXWzGjwEbRm4D