### PR TITLE
web: make all consoles reachable from the daemon and standardize styling

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -66,6 +66,8 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/voice/toneout"
 	gtweb "github.com/MattCheramie/GopherTrunk/web"
 	configbuilderweb "github.com/MattCheramie/GopherTrunk/web/configbuilder"
+	rfscopeweb "github.com/MattCheramie/GopherTrunk/web/rfscope"
+	siglabweb "github.com/MattCheramie/GopherTrunk/web/siglab"
 )
 
 // firstNonEmptyStr returns the first non-empty (after trimming) string of
@@ -2392,7 +2394,22 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		// Offline signal-analysis API (the siglab web console talks to
 		// these routes). Enabled on the daemon too so an operator can
 		// analyze captures without spinning up a separate `siglab serve`.
-		opts.Siglab = api.SiglabOptions{Enabled: true}
+		// Mount the Signal Lab SPA at /siglab/ when it was bundled so the
+		// console is reachable from the main UI (and so the Crypto Lab's
+		// Signal Lab link resolves).
+		siglabOpts := api.SiglabOptions{Enabled: true}
+		if siglabweb.HasAssets() {
+			siglabOpts.Assets = siglabweb.Assets()
+		}
+		opts.Siglab = siglabOpts
+		// RF Scope — offline protocol-agnostic RF-analysis console. Wire the
+		// /api/v1/rfscope/* routes and, when the SPA was bundled, the console
+		// at /rfscope/ so it is reachable from the main UI in a new tab.
+		rfscopeOpts := api.RFScopeOptions{Enabled: true}
+		if rfscopeweb.HasAssets() {
+			rfscopeOpts.Assets = rfscopeweb.Assets()
+		}
+		opts.RFScope = rfscopeOpts
 		// Web Config Builder/Editor — link the editor SPA at /config/ and
 		// the /api/v1/config/* routes so the operator can edit config from
 		// the main web UI in a new tab. Saves are constrained to the live

--- a/docs/web.md
+++ b/docs/web.md
@@ -58,6 +58,16 @@ your default browser at the daemon URL. Same flow when you run
 `gophertrunk` with no flags and pick `[2] Web` from the interactive
 launcher menu (see [`launcher.md`]({{ '/launcher.html' | relative_url }})).
 
+The daemon also serves the auxiliary consoles alongside the operator
+console, each on its own path, so they are reachable from the main
+console's nav (**System** group) and cross-linked in each console's
+header: the **Config Builder** at `/config/`, **Signal Lab** at
+`/siglab/`, **RF Scope** at `/rfscope/`, and — in a `-tags cryptolab`
+build — **Crypto Lab** at `/cryptolab/`. Each link only appears once
+the daemon actually mounts that console (advertised via
+`GET /api/v1/runtime`). The standalone `gophertrunk <console> serve`
+commands still serve each console on its own port for offline use.
+
 On a headless host (SSH session, no `$DISPLAY`) the launcher prints
 the URL + a hint instead of trying to launch a browser, so a remote
 operator can open the URL from their laptop.
@@ -86,7 +96,8 @@ gophertrunk-<version>-<os>-<arch>/
 │   ├── favicon.svg
 │   ├── manifest.webmanifest
 │   ├── sw.js                # PWA service worker
-│   ├── siglab/              # Signal Lab (offline RF analysis) console
+│   ├── siglab/              # Signal Lab (offline signal analysis) console
+│   ├── rfscope/             # RF Scope (protocol-agnostic RF analysis) console
 │   └── configbuilder/       # Config Builder / editor console
 ├── config.example.yaml
 └── samples/…

--- a/internal/api/handlers_runtime.go
+++ b/internal/api/handlers_runtime.go
@@ -101,6 +101,16 @@ type RuntimeDTO struct {
 	// Crypto Lab link only when it is reachable. Injected by the API server, not
 	// the daemon's runtime provider.
 	CryptolabConsole bool `json:"cryptolab_console,omitempty"`
+
+	// SiglabConsole is true when the daemon mounts the Signal Lab SPA at
+	// /siglab/. The web consoles use it to show a Signal Lab link only when it
+	// is reachable. Injected by the API server, not the runtime provider.
+	SiglabConsole bool `json:"siglab_console,omitempty"`
+
+	// RFScopeConsole is true when the daemon mounts the RF Scope SPA at
+	// /rfscope/. The web consoles use it to show an RF Scope link only when it
+	// is reachable. Injected by the API server, not the runtime provider.
+	RFScopeConsole bool `json:"rfscope_console,omitempty"`
 }
 
 // ToneProfileDTO is the minimal projection of a tone-out profile —
@@ -126,6 +136,8 @@ func (s *Server) handleRuntime(w http.ResponseWriter, _ *http.Request) {
 	}
 	dto := s.runtime.Runtime()
 	dto.CryptolabConsole = s.cryptolabConsole
+	dto.SiglabConsole = s.siglabConsole
+	dto.RFScopeConsole = s.rfscopeConsole
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(dto)
 }

--- a/internal/api/rfscope.go
+++ b/internal/api/rfscope.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"io/fs"
+	"net/http"
+	"strings"
+
+	rfscopeweb "github.com/MattCheramie/GopherTrunk/internal/rfscope/webserver"
+)
+
+// RFScopeOptions configures the optional RF Scope console. When Enabled,
+// NewServer wires the RF Scope web subsystem and routes() mounts the
+// /api/v1/rfscope/* analysis routes plus — when Assets carries an index.html —
+// the RF Scope SPA at /rfscope/. The daemon sets it so operators can reach the
+// offline RF-analysis console from the main UI in a new tab; the standalone
+// `gophertrunk rfscope serve` command keeps using its own webserver at /.
+type RFScopeOptions struct {
+	Enabled bool
+	// Assets is the embedded RF Scope SPA file tree. nil mounts the API only.
+	Assets fs.FS
+}
+
+// mountRFScope registers the RF Scope console on the daemon mux: the
+// /api/v1/rfscope/* routes (the analyze mutation gated like every other write
+// route) and, when the SPA is bundled, the console at /rfscope/. A no-op when
+// the subsystem was not enabled. The webserver owns a lazily-created temp dir
+// that shutdown() reclaims via rfscopeCloser. Advertised via
+// RuntimeDTO.RFScopeConsole so the other consoles only link here when the SPA
+// is actually reachable.
+func (s *Server) mountRFScope(mux *http.ServeMux) {
+	if !s.rfscopeOpts.Enabled {
+		return
+	}
+	svc, err := rfscopeweb.New(rfscopeweb.Options{Assets: s.rfscopeOpts.Assets, Logger: s.log})
+	if err != nil {
+		if s.log != nil {
+			s.log.Warn("rfscope console disabled", "err", err)
+		}
+		return
+	}
+	s.rfscopeCloser = svc
+	svc.RegisterAPI(mux, s.gate)
+
+	// Secondary SPA at /rfscope/ (daemon path); the standalone `rfscope serve`
+	// serves it at / instead. The /rfscope/ matcher is more specific than the
+	// GET / catch-all, so both trees coexist.
+	if s.rfscopeOpts.Assets != nil {
+		if _, err := fs.Stat(s.rfscopeOpts.Assets, "index.html"); err == nil {
+			mux.Handle("GET /rfscope/", s.rfscopeSpaHandler())
+			mux.HandleFunc("GET /rfscope", func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, "/rfscope/", http.StatusMovedPermanently)
+			})
+			s.rfscopeConsole = true
+		}
+	}
+}
+
+// rfscopeSpaHandler serves the RF Scope SPA mounted under /rfscope/ on the
+// daemon, stripping the prefix and falling back to index.html for client-side
+// routes (mirrors siglabSpaHandler / cryptolabSpaHandler).
+func (s *Server) rfscopeSpaHandler() http.Handler {
+	assets := s.rfscopeOpts.Assets
+	fileSrv := http.FileServerFS(assets)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/rfscope/"), "/")
+		if rel != "" {
+			if _, err := fs.Stat(assets, rel); err == nil {
+				r2 := r.Clone(r.Context())
+				r2.URL.Path = "/" + rel
+				fileSrv.ServeHTTP(w, r2)
+				return
+			}
+		}
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/"
+		fileSrv.ServeHTTP(w, r2)
+	})
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -390,6 +390,28 @@ type Server struct {
 	siglab *siglabService
 	// siglabStop signals the siglab TTL sweeper to exit on shutdown.
 	siglabStop chan struct{}
+	// siglabAssets is the optional Signal Lab SPA file tree. When non-nil (and
+	// carrying an index.html) the daemon mounts the console at /siglab/. Set
+	// from ServerOptions.Siglab.Assets.
+	siglabAssets fs.FS
+	// siglabConsole is set true when the Signal Lab SPA is mounted at /siglab/.
+	// The runtime endpoint surfaces it so the other consoles only link to
+	// Signal Lab when it is actually reachable.
+	siglabConsole bool
+
+	// rfscopeOpts holds the RF Scope console configuration (enabled flag + SPA
+	// assets). mountRFScope reads it when building the mux. Set from
+	// ServerOptions.RFScope.
+	rfscopeOpts RFScopeOptions
+	// rfscopeCloser holds the optional RF Scope web subsystem (the /rfscope/
+	// console + /api/v1/rfscope/* routes). Constructed by mountRFScope when
+	// ServerOptions.RFScope.Enabled. Typed as a minimal closer so shutdown can
+	// reclaim its temp dir without server.go importing the concrete type.
+	rfscopeCloser interface{ Close() error }
+	// rfscopeConsole is set true when the RF Scope SPA is mounted at /rfscope/.
+	// Surfaced on the runtime endpoint so the other consoles only link to RF
+	// Scope when it is actually reachable.
+	rfscopeConsole bool
 
 	// cryptolabCloser holds the optional cryptolab web subsystem (the
 	// /cryptolab/ console + /api/v1/cryptolab/* routes). It is only
@@ -694,6 +716,12 @@ type ServerOptions struct {
 	// from the main UI in a new tab; the standalone `gophertrunk config
 	// serve` command sets it (with the SPA in WebAssets, served at /).
 	ConfigBuilder ConfigBuilderOptions
+	// RFScope, when Enabled, mounts the RF Scope analysis routes
+	// (/api/v1/rfscope/*) and — when Assets is non-nil — the RF Scope SPA at
+	// /rfscope/. The daemon sets it so operators can reach the offline
+	// RF-analysis console from the main UI; the standalone `gophertrunk rfscope
+	// serve` command keeps its own webserver instead.
+	RFScope RFScopeOptions
 	// Diagnostics is the shared error-diagnostics collector (banner +
 	// system info). The daemon injects one seeded with its SDR pool
 	// snapshot so the error path never re-enumerates USB. Optional; nil
@@ -873,6 +901,8 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		mixer:          opts.Mixer,
 		siglab:         siglabSvc,
 		siglabStop:     siglabStop,
+		siglabAssets:   opts.Siglab.Assets,
+		rfscopeOpts:    opts.RFScope,
 		configBuilder:  configBuilderSvc,
 		diagnostics:    opts.Diagnostics,
 		verboseErrors:  opts.VerboseErrors,
@@ -985,6 +1015,11 @@ func (s *Server) shutdown(ctx context.Context) error {
 	if s.cryptolabCloser != nil {
 		_ = s.cryptolabCloser.Close()
 		s.cryptolabCloser = nil
+	}
+	// Tear down the optional RF Scope subsystem (removes its temp dir).
+	if s.rfscopeCloser != nil {
+		_ = s.rfscopeCloser.Close()
+		s.rfscopeCloser = nil
 	}
 	// 30 s shutdown window: SSE / WebSocket / audio-stream subscribers
 	// get up to 30 s to drain rather than the 5 s the old bound gave
@@ -1152,7 +1187,27 @@ func (s *Server) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/siglab/capture/devices", s.handleSiglabCaptureDevices)
 		mux.HandleFunc("POST /api/v1/siglab/capture", s.gate(s.handleSiglabCapture))
 		mux.HandleFunc("GET /api/v1/siglab/captures/{id}/download", s.handleSiglabCaptureDownload)
+
+		// Secondary SPA at /siglab/ (daemon path). The standalone `siglab
+		// serve` puts the SPA in WebAssets (served at /) instead, so this only
+		// fires on the daemon. The /siglab/ matcher is more specific than the
+		// GET / catch-all, so both trees coexist. Advertised via
+		// RuntimeDTO.SiglabConsole so the other consoles only link here when the
+		// SPA is actually reachable.
+		if s.siglabAssets != nil {
+			if _, err := fs.Stat(s.siglabAssets, "index.html"); err == nil {
+				mux.Handle("GET /siglab/", s.siglabSpaHandler())
+				mux.HandleFunc("GET /siglab", func(w http.ResponseWriter, r *http.Request) {
+					http.Redirect(w, r, "/siglab/", http.StatusMovedPermanently)
+				})
+				s.siglabConsole = true
+			}
+		}
 	}
+
+	// Optional RF Scope console (/rfscope/ SPA + /api/v1/rfscope/* routes).
+	// Mounted only when ServerOptions.RFScope.Enabled; a no-op otherwise.
+	s.mountRFScope(mux)
 
 	// Config Builder/Editor — browse/load/validate/save config files,
 	// browse RadioReference, and parse PDF/CSV into a draft. Reads are
@@ -1288,6 +1343,32 @@ func (s *Server) configSpaHandler() http.Handler {
 			return
 		}
 		// Unknown sub-path → serve index.html so the builder's client
+		// router can resolve it.
+		r2 := r.Clone(r.Context())
+		r2.URL.Path = "/"
+		fileSrv.ServeHTTP(w, r2)
+	})
+}
+
+// siglabSpaHandler serves the Signal Lab SPA mounted under /siglab/ on the
+// daemon (the standalone `siglab serve` serves it at / via spaHandler). It
+// strips the /siglab/ prefix before hitting the embedded file tree and falls
+// back to the SPA's index.html for client-side routes, mirroring
+// configSpaHandler but rooted at /siglab/.
+func (s *Server) siglabSpaHandler() http.Handler {
+	assets := s.siglabAssets
+	fileSrv := http.FileServerFS(assets)
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rel := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/siglab/"), "/")
+		if rel != "" {
+			if _, err := fs.Stat(assets, rel); err == nil {
+				r2 := r.Clone(r.Context())
+				r2.URL.Path = "/" + rel
+				fileSrv.ServeHTTP(w, r2)
+				return
+			}
+		}
+		// Root or unknown sub-path → serve index.html so the SPA's client
 		// router can resolve it.
 		r2 := r.Clone(r.Context())
 		r2.URL.Path = "/"

--- a/internal/api/siglab_jobs.go
+++ b/internal/api/siglab_jobs.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync"
@@ -36,6 +37,12 @@ type SiglabOptions struct {
 	TempDir string
 	// MaxUploadBytes bounds one capture upload. 0 ⇒ defaultSiglabMaxUploadBytes.
 	MaxUploadBytes int64
+	// Assets, when non-nil and containing an index.html, mounts the Signal
+	// Lab SPA at /siglab/ on the daemon (the standalone `siglab serve` command
+	// serves it at / via ServerOptions.WebAssets instead). Set it to
+	// siglabweb.Assets() so the daemon hosts the console alongside the main
+	// operator UI; nil keeps only the /api/v1/siglab/* routes.
+	Assets fs.FS
 }
 
 // siglabCapture is one staged capture (uploaded or synthesized-to-disk)

--- a/internal/api/spa_aux_test.go
+++ b/internal/api/spa_aux_test.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"testing/fstest"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+)
+
+// auxSPAFS is a minimal SPA tree for the /siglab/ and /rfscope/ mount tests.
+func auxSPAFS(marker string) fstest.MapFS {
+	return fstest.MapFS{
+		"index.html":   &fstest.MapFile{Data: []byte("<html>" + marker + "</html>")},
+		"assets/app.js": &fstest.MapFile{Data: []byte("console.log('" + marker + "');")},
+	}
+}
+
+func TestSPA_SiglabMountedOnDaemon(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	// Daemon-style: main SPA at /, Signal Lab SPA at /siglab/.
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:       bus,
+		WebAssets: fakeSPAFS(),
+		Runtime:   fakeRuntime{},
+		Siglab:    SiglabOptions{Enabled: true, Assets: auxSPAFS("siglab-root")},
+	})
+	defer teardown()
+
+	// /siglab/ serves the Signal Lab index.
+	resp, err := http.Get(base + "/siglab/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 || !bytesContains(body, "siglab-root") {
+		t.Fatalf("/siglab/ status=%d body=%q", resp.StatusCode, body)
+	}
+
+	// A deep client route falls back to the Signal Lab index.
+	resp2, err := http.Get(base + "/siglab/captures")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if !bytesContains(body2, "siglab-root") {
+		t.Fatalf("/siglab/captures did not fall back to Signal Lab index: %q", body2)
+	}
+
+	// A real asset is served directly.
+	resp3, err := http.Get(base + "/siglab/assets/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body3, _ := io.ReadAll(resp3.Body)
+	resp3.Body.Close()
+	if resp3.StatusCode != 200 || !bytesContains(body3, "console.log") {
+		t.Fatalf("/siglab/assets/app.js status=%d body=%q", resp3.StatusCode, body3)
+	}
+
+	// The runtime endpoint advertises the console so the other UIs link to it.
+	assertConsoleFlag(t, base, "siglab_console", true)
+
+	// The main SPA still owns /.
+	resp4, err := http.Get(base + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body4, _ := io.ReadAll(resp4.Body)
+	resp4.Body.Close()
+	if !bytesContains(body4, "spa-root") {
+		t.Fatalf("main SPA no longer owns /: %q", body4)
+	}
+}
+
+func TestSPA_RFScopeMountedOnDaemon(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:       bus,
+		WebAssets: fakeSPAFS(),
+		Runtime:   fakeRuntime{},
+		RFScope:   RFScopeOptions{Enabled: true, Assets: auxSPAFS("rfscope-root")},
+	})
+	defer teardown()
+
+	// /rfscope/ serves the RF Scope index.
+	resp, err := http.Get(base + "/rfscope/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 || !bytesContains(body, "rfscope-root") {
+		t.Fatalf("/rfscope/ status=%d body=%q", resp.StatusCode, body)
+	}
+
+	// The RF Scope analysis API is mounted alongside the SPA.
+	resp2, err := http.Get(base + "/api/v1/rfscope/analyzers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Fatalf("/api/v1/rfscope/analyzers status=%d want 200", resp2.StatusCode)
+	}
+
+	assertConsoleFlag(t, base, "rfscope_console", true)
+}
+
+// TestSPA_AuxConsolesAbsentWhenNotMounted confirms the runtime flags stay off
+// (and the routes 404) when the aux consoles aren't wired — e.g. a daemon whose
+// SPAs weren't bundled.
+func TestSPA_AuxConsolesAbsentWhenNotMounted(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	base, teardown := mkServer(t, ServerOptions{
+		Bus:       bus,
+		WebAssets: fakeSPAFS(),
+		Runtime:   fakeRuntime{},
+		// Siglab API enabled but no SPA assets → no /siglab/ mount.
+		Siglab: SiglabOptions{Enabled: true},
+	})
+	defer teardown()
+
+	assertConsoleFlag(t, base, "siglab_console", false)
+	assertConsoleFlag(t, base, "rfscope_console", false)
+
+	// /siglab/ falls through to the main SPA (client route), not a siglab mount.
+	resp, err := http.Get(base + "/siglab/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if bytesContains(body, "siglab-root") {
+		t.Fatalf("/siglab/ served a Signal Lab mount that should not exist: %q", body)
+	}
+}
+
+// assertConsoleFlag fetches GET /api/v1/runtime and asserts the boolean field
+// `key` equals `want` (absent counts as false, since the fields are omitempty).
+func assertConsoleFlag(t *testing.T, base, key string, want bool) {
+	t.Helper()
+	resp, err := http.Get(base + "/api/v1/runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("/api/v1/runtime status=%d want 200", resp.StatusCode)
+	}
+	var m map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		t.Fatalf("decode runtime: %v", err)
+	}
+	got, _ := m[key].(bool)
+	if got != want {
+		t.Errorf("runtime.%s = %v, want %v (full=%v)", key, got, want, m)
+	}
+}

--- a/internal/api/spa_aux_test.go
+++ b/internal/api/spa_aux_test.go
@@ -13,7 +13,7 @@ import (
 // auxSPAFS is a minimal SPA tree for the /siglab/ and /rfscope/ mount tests.
 func auxSPAFS(marker string) fstest.MapFS {
 	return fstest.MapFS{
-		"index.html":   &fstest.MapFile{Data: []byte("<html>" + marker + "</html>")},
+		"index.html":    &fstest.MapFile{Data: []byte("<html>" + marker + "</html>")},
 		"assets/app.js": &fstest.MapFile{Data: []byte("console.log('" + marker + "');")},
 	}
 }

--- a/web/configbuilder/src/App.tsx
+++ b/web/configbuilder/src/App.tsx
@@ -3,6 +3,7 @@ import { FileBar } from "./components/FileBar";
 import { YamlPreview } from "./components/YamlPreview";
 import { SECTIONS } from "./sections";
 import { useStore } from "./store/shared";
+import { ConsoleNav } from "./ConsoleNav";
 
 export function App() {
   const init = useStore((s) => s.init);
@@ -91,6 +92,7 @@ export function App() {
           {busy ? <span className="text-xs text-accent animate-pulse">working…</span> : null}
         </div>
         <div className="flex items-center gap-2">
+          <ConsoleNav self="config" />
           {validation ? (
             errList.length > 0 ? (
               <button

--- a/web/configbuilder/src/ConsoleNav.tsx
+++ b/web/configbuilder/src/ConsoleNav.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+
+/** The GopherTrunk web consoles that cross-link to one another. `self` is the
+ *  current console and is omitted from its own switcher. */
+export type Console = "config" | "siglab" | "rfscope" | "cryptolab";
+
+type Advertised = { cryptolab: boolean; siglab: boolean; rfscope: boolean };
+
+// ConsoleNav renders links to the sibling GopherTrunk consoles the daemon
+// advertises as reachable. It probes GET /api/v1/runtime once; the probe fails
+// closed under a standalone `… serve` (which wires no RuntimeProvider, so the
+// route 503s), meaning the links only surface when this SPA is daemon-mounted
+// alongside its siblings. The daemon always mounts the operator console at /
+// and the Config Builder at /config/; Signal Lab, RF Scope, and Crypto Lab are
+// gated on their respective runtime.*_console flags. Kept in sync across the
+// sub-apps by convention, mirroring the duplicated --gt-* token blocks.
+export function ConsoleNav({ self }: { self: Console }) {
+  const [rt, setRt] = useState<Advertised | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/v1/runtime")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (alive && j && typeof j === "object")
+          setRt({
+            cryptolab: j.cryptolab_console === true,
+            siglab: j.siglab_console === true,
+            rfscope: j.rfscope_console === true,
+          });
+      })
+      .catch(() => {
+        /* no daemon / standalone serve — leave the switcher hidden */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  if (!rt) return null;
+  const cls = "rounded-md px-2 py-1 hover:text-fg";
+  return (
+    <nav className="flex flex-wrap items-center gap-1 text-xs text-muted">
+      <a href="/" title="GopherTrunk console" className={cls}>
+        ◀ GopherTrunk
+      </a>
+      {self !== "config" ? (
+        <a href="/config/" title="Config Builder" className={cls}>
+          🛠 Config
+        </a>
+      ) : null}
+      {rt.siglab && self !== "siglab" ? (
+        <a href="/siglab/" title="Signal Lab" className={cls}>
+          ◷ Signal Lab
+        </a>
+      ) : null}
+      {rt.rfscope && self !== "rfscope" ? (
+        <a href="/rfscope/" title="RF Scope" className={cls}>
+          ⧉ RF Scope
+        </a>
+      ) : null}
+      {rt.cryptolab && self !== "cryptolab" ? (
+        <a href="/cryptolab/" title="Crypto Lab" className={cls}>
+          🔐 Crypto Lab
+        </a>
+      ) : null}
+    </nav>
+  );
+}

--- a/web/cryptolab/src/App.tsx
+++ b/web/cryptolab/src/App.tsx
@@ -3,20 +3,10 @@ import { useStore } from "./store/shared";
 import { ParamField } from "./components/ParamField";
 import { ResultView } from "./components/ResultView";
 import { RecipeBuilder } from "./components/RecipeBuilder";
+import { ConsoleNav } from "./ConsoleNav";
 
 export function App() {
   const [page, setPage] = useState<"tools" | "recipe">("tools");
-  // When daemon-mounted (at /cryptolab/), link back to the sibling consoles;
-  // a same-origin runtime probe fails closed under standalone `cryptolab serve`.
-  const [daemon, setDaemon] = useState(false);
-  useEffect(() => {
-    fetch("/api/v1/runtime")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((rt) => {
-        if (rt && typeof rt === "object") setDaemon(true);
-      })
-      .catch(() => {});
-  }, []);
   const loadSchema = useStore((s) => s.loadSchema);
   const schema = useStore((s) => s.schema);
   const loadingSchema = useStore((s) => s.loadingSchema);
@@ -74,16 +64,7 @@ export function App() {
           ))}
         </nav>
         <div className="ml-auto flex items-center gap-3 text-xs text-muted">
-          {daemon ? (
-            <>
-              <a href="/" title="GopherTrunk console" className="rounded-md px-2 py-1 hover:text-fg">
-                ◀ GopherTrunk
-              </a>
-              <a href="/siglab/" title="Signal Lab" className="rounded-md px-2 py-1 hover:text-fg">
-                ◷ Signal Lab
-              </a>
-            </>
-          ) : null}
+          <ConsoleNav self="cryptolab" />
           <span>offline cryptographic research</span>
         </div>
       </header>

--- a/web/cryptolab/src/ConsoleNav.tsx
+++ b/web/cryptolab/src/ConsoleNav.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+
+/** The GopherTrunk web consoles that cross-link to one another. `self` is the
+ *  current console and is omitted from its own switcher. */
+export type Console = "config" | "siglab" | "rfscope" | "cryptolab";
+
+type Advertised = { cryptolab: boolean; siglab: boolean; rfscope: boolean };
+
+// ConsoleNav renders links to the sibling GopherTrunk consoles the daemon
+// advertises as reachable. It probes GET /api/v1/runtime once; the probe fails
+// closed under a standalone `… serve` (which wires no RuntimeProvider, so the
+// route 503s), meaning the links only surface when this SPA is daemon-mounted
+// alongside its siblings. The daemon always mounts the operator console at /
+// and the Config Builder at /config/; Signal Lab, RF Scope, and Crypto Lab are
+// gated on their respective runtime.*_console flags. Kept in sync across the
+// sub-apps by convention, mirroring the duplicated --gt-* token blocks.
+export function ConsoleNav({ self }: { self: Console }) {
+  const [rt, setRt] = useState<Advertised | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/v1/runtime")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (alive && j && typeof j === "object")
+          setRt({
+            cryptolab: j.cryptolab_console === true,
+            siglab: j.siglab_console === true,
+            rfscope: j.rfscope_console === true,
+          });
+      })
+      .catch(() => {
+        /* no daemon / standalone serve — leave the switcher hidden */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  if (!rt) return null;
+  const cls = "rounded-md px-2 py-1 hover:text-fg";
+  return (
+    <nav className="flex flex-wrap items-center gap-1 text-xs text-muted">
+      <a href="/" title="GopherTrunk console" className={cls}>
+        ◀ GopherTrunk
+      </a>
+      {self !== "config" ? (
+        <a href="/config/" title="Config Builder" className={cls}>
+          🛠 Config
+        </a>
+      ) : null}
+      {rt.siglab && self !== "siglab" ? (
+        <a href="/siglab/" title="Signal Lab" className={cls}>
+          ◷ Signal Lab
+        </a>
+      ) : null}
+      {rt.rfscope && self !== "rfscope" ? (
+        <a href="/rfscope/" title="RF Scope" className={cls}>
+          ⧉ RF Scope
+        </a>
+      ) : null}
+      {rt.cryptolab && self !== "cryptolab" ? (
+        <a href="/cryptolab/" title="Crypto Lab" className={cls}>
+          🔐 Crypto Lab
+        </a>
+      ) : null}
+    </nav>
+  );
+}

--- a/web/rfscope/index.html
+++ b/web/rfscope/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#0f172a" />
     <title>GopherTrunk RF Scope</title>
   </head>
-  <body class="bg-slate-900 text-slate-100 antialiased">
+  <body class="bg-bg text-fg antialiased">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/web/rfscope/src/App.tsx
+++ b/web/rfscope/src/App.tsx
@@ -7,6 +7,7 @@ import {
   type Channel,
   type Scene,
 } from "./api";
+import { ConsoleNav } from "./ConsoleNav";
 
 export function App() {
   const [file, setFile] = useState<File | null>(null);
@@ -49,11 +50,17 @@ export function App() {
 
   return (
     <div className="mx-auto max-w-5xl p-4">
-      <header className="mb-4 flex items-baseline justify-between">
-        <h1 className="text-lg font-bold text-sky-400">GopherTrunk RF Scope</h1>
-        <span className="text-xs text-slate-400">
-          protocol-agnostic RF network analysis · {analyzerList.length} analyzers
-        </span>
+      <header className="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-line pb-3">
+        <div className="flex items-center gap-2">
+          <span className="text-accent">⧉</span>
+          <h1 className="text-lg font-bold">GopherTrunk RF Scope</h1>
+        </div>
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted">
+          <ConsoleNav self="rfscope" />
+          <span>
+            protocol-agnostic RF network analysis · {analyzerList.length} analyzers
+          </span>
+        </div>
       </header>
 
       <form className="card mb-4 grid grid-cols-1 gap-3 sm:grid-cols-5" onSubmit={onAnalyze}>
@@ -87,7 +94,7 @@ export function App() {
         </div>
       </form>
 
-      {err && <div className="card mb-4 border-red-500 text-red-300">{err}</div>}
+      {err && <div className="card mb-4 border-err text-err">{err}</div>}
 
       {result && <SceneView resp={result} />}
     </div>
@@ -112,12 +119,12 @@ function SceneView({ resp }: { resp: AnalyzeResponse }) {
 function SceneHeader({ sc }: { sc: Scene }) {
   return (
     <div className="card text-sm">
-      <div className="font-semibold text-sky-300">{sc.source || "scene"}</div>
-      <div className="mt-1 text-slate-300">
+      <div className="font-semibold text-accent">{sc.source || "scene"}</div>
+      <div className="mt-1 text-fg">
         center {(sc.center_hz / 1e6).toFixed(4)} MHz · span {(sc.span_hz / 1e6).toFixed(3)} MHz ·
         window {sc.window_sec.toFixed(1)}s · floor {sc.noise_floor_dbfs.toFixed(0)} dBFS
       </div>
-      <div className="mt-1 text-slate-400">
+      <div className="mt-1 text-muted">
         {(sc.bursts?.length ?? 0)} bursts · {(sc.channels?.length ?? 0)} channels ·{" "}
         {(sc.emitters?.length ?? 0)} emitters · {(sc.anomalies?.length ?? 0)} anomalies
       </div>
@@ -128,8 +135,8 @@ function SceneHeader({ sc }: { sc: Scene }) {
 function Panel({ title, empty, children }: { title: string; empty: boolean; children: React.ReactNode }) {
   return (
     <div className="card">
-      <h2 className="mb-2 text-sm font-semibold text-sky-300">{title}</h2>
-      {empty ? <p className="text-xs text-slate-500">(none)</p> : children}
+      <h2 className="mb-2 text-sm font-semibold text-accent">{title}</h2>
+      {empty ? <p className="text-xs text-muted">(none)</p> : children}
     </div>
   );
 }
@@ -140,9 +147,9 @@ function Hierarchy({ sc }: { sc: Scene }) {
     <Panel title="Protocol hierarchy" empty={nodes.length === 0}>
       <ul className="text-sm">
         {nodes.map((n, i) => (
-          <li key={i} style={{ paddingLeft: `${n.depth * 16}px` }} className="text-slate-300">
+          <li key={i} style={{ paddingLeft: `${n.depth * 16}px` }} className="text-fg">
             <span className={n.depth === 0 ? "font-semibold" : ""}>{n.label}</span>{" "}
-            <span className="text-slate-500">
+            <span className="text-muted">
               {n.stats.burst_count} bursts · {n.stats.time_pct.toFixed(0)}% time ·{" "}
               {n.stats.spectrum_pct.toFixed(1)}% spectrum
             </span>
@@ -172,7 +179,7 @@ function Channels({ sc }: { sc: Scene }) {
   return (
     <Panel title="Channels (I/O graph)" empty={chans.length === 0}>
       <table className="w-full text-sm">
-        <thead className="text-left text-xs text-slate-400">
+        <thead className="text-left text-xs text-muted">
           <tr>
             <th className="pr-3">Freq (MHz)</th>
             <th className="pr-3">Class</th>
@@ -183,7 +190,7 @@ function Channels({ sc }: { sc: Scene }) {
         </thead>
         <tbody>
           {chans.map((c, i) => (
-            <tr key={i} className="text-slate-300">
+            <tr key={i} className="text-fg">
               <td className="pr-3 font-mono">{(c.freq_hz / 1e6).toFixed(4)}</td>
               <td className="pr-3">{c.dominant_class}</td>
               <td className="pr-3 spark">{sparkline(c)}</td>
@@ -203,11 +210,11 @@ function Talkers({ sc }: { sc: Scene }) {
     <Panel title="Top talkers" empty={ems.length === 0}>
       <ul className="text-sm">
         {ems.slice(0, 10).map((e) => (
-          <li key={e.id} className="text-slate-300">
-            <span className="text-slate-500">#{e.id}</span> {e.label}{" "}
-            <span className="text-slate-500">{e.total_airtime_sec.toFixed(2)}s</span>
+          <li key={e.id} className="text-fg">
+            <span className="text-muted">#{e.id}</span> {e.label}{" "}
+            <span className="text-muted">{e.total_airtime_sec.toFixed(2)}s</span>
             {e.hop_set && e.hop_set.length > 1 && (
-              <span className="ml-1 text-amber-400">hop×{e.hop_set.length}</span>
+              <span className="ml-1 text-warn">hop×{e.hop_set.length}</span>
             )}
           </li>
         ))}
@@ -222,10 +229,10 @@ function Conversations({ sc }: { sc: Scene }) {
     <Panel title="Conversations" empty={convs.length === 0}>
       <ul className="text-sm">
         {convs.map((c) => (
-          <li key={c.id} className="text-slate-300">
+          <li key={c.id} className="text-fg">
             <span className="font-mono">{c.kind}</span>{" "}
-            <span className="text-slate-500">{c.emitter_ids.map((id) => `#${id}`).join(" ↔ ")}</span>{" "}
-            <span className="text-slate-500">(corr {c.correlation.toFixed(2)})</span>
+            <span className="text-muted">{c.emitter_ids.map((id) => `#${id}`).join(" ↔ ")}</span>{" "}
+            <span className="text-muted">(corr {c.correlation.toFixed(2)})</span>
           </li>
         ))}
       </ul>
@@ -234,9 +241,9 @@ function Conversations({ sc }: { sc: Scene }) {
 }
 
 function severityColor(sev: string): string {
-  if (sev === "alert") return "text-red-400";
-  if (sev === "warn") return "text-amber-400";
-  return "text-slate-300";
+  if (sev === "alert") return "text-err";
+  if (sev === "warn") return "text-warn";
+  return "text-fg";
 }
 
 function Expert({ sc }: { sc: Scene }) {
@@ -267,16 +274,16 @@ function CryptoBridge({ resp }: { resp: AnalyzeResponse }) {
   }
   return (
     <div className="card text-sm">
-      <h2 className="mb-2 text-sm font-semibold text-sky-300">Crypto Lab bridge</h2>
-      <p className="text-slate-300">
+      <h2 className="mb-2 text-sm font-semibold text-accent">Crypto Lab bridge</h2>
+      <p className="text-fg">
         {resp.frame_count} unknown payload{resp.frame_count === 1 ? "" : "s"} recovered as a cryptolab{" "}
-        <code className="text-sky-400">ks</code> frames file.
+        <code className="text-accent">ks</code> frames file.
       </p>
       <div className="mt-2 flex gap-2">
         <button className="btn" onClick={download}>
           Download frames
         </button>
-        <span className="self-center text-xs text-slate-500">
+        <span className="self-center text-xs text-muted">
           then: <code>cryptolab classify auto -in rfscope-frames.jsonl</code> or{" "}
           <code>cryptolab ks reuse -in rfscope-frames.jsonl</code>
         </span>

--- a/web/rfscope/src/ConsoleNav.tsx
+++ b/web/rfscope/src/ConsoleNav.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+
+/** The GopherTrunk web consoles that cross-link to one another. `self` is the
+ *  current console and is omitted from its own switcher. */
+export type Console = "config" | "siglab" | "rfscope" | "cryptolab";
+
+type Advertised = { cryptolab: boolean; siglab: boolean; rfscope: boolean };
+
+// ConsoleNav renders links to the sibling GopherTrunk consoles the daemon
+// advertises as reachable. It probes GET /api/v1/runtime once; the probe fails
+// closed under a standalone `… serve` (which wires no RuntimeProvider, so the
+// route 503s), meaning the links only surface when this SPA is daemon-mounted
+// alongside its siblings. The daemon always mounts the operator console at /
+// and the Config Builder at /config/; Signal Lab, RF Scope, and Crypto Lab are
+// gated on their respective runtime.*_console flags. Kept in sync across the
+// sub-apps by convention, mirroring the duplicated --gt-* token blocks.
+export function ConsoleNav({ self }: { self: Console }) {
+  const [rt, setRt] = useState<Advertised | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/v1/runtime")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (alive && j && typeof j === "object")
+          setRt({
+            cryptolab: j.cryptolab_console === true,
+            siglab: j.siglab_console === true,
+            rfscope: j.rfscope_console === true,
+          });
+      })
+      .catch(() => {
+        /* no daemon / standalone serve — leave the switcher hidden */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  if (!rt) return null;
+  const cls = "rounded-md px-2 py-1 hover:text-fg";
+  return (
+    <nav className="flex flex-wrap items-center gap-1 text-xs text-muted">
+      <a href="/" title="GopherTrunk console" className={cls}>
+        ◀ GopherTrunk
+      </a>
+      {self !== "config" ? (
+        <a href="/config/" title="Config Builder" className={cls}>
+          🛠 Config
+        </a>
+      ) : null}
+      {rt.siglab && self !== "siglab" ? (
+        <a href="/siglab/" title="Signal Lab" className={cls}>
+          ◷ Signal Lab
+        </a>
+      ) : null}
+      {rt.rfscope && self !== "rfscope" ? (
+        <a href="/rfscope/" title="RF Scope" className={cls}>
+          ⧉ RF Scope
+        </a>
+      ) : null}
+      {rt.cryptolab && self !== "cryptolab" ? (
+        <a href="/cryptolab/" title="Crypto Lab" className={cls}>
+          🔐 Crypto Lab
+        </a>
+      ) : null}
+    </nav>
+  );
+}

--- a/web/rfscope/src/main.tsx
+++ b/web/rfscope/src/main.tsx
@@ -3,6 +3,21 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./styles.css";
 
+// Honor the theme/density the operator picked in the main console
+// (shared via localStorage), applied pre-render so there's no flash.
+(() => {
+  try {
+    const theme = localStorage.getItem("gt.ui.theme");
+    document.documentElement.dataset.theme =
+      theme === "monochrome" ? "mono" : theme === "light" ? "light" : "dark";
+    const density = localStorage.getItem("gt.ui.density");
+    document.documentElement.dataset.density =
+      density === "compact" ? "compact" : "comfortable";
+  } catch {
+    document.documentElement.dataset.theme = "dark";
+  }
+})();
+
 const root = document.getElementById("root");
 if (!root) throw new Error("missing #root");
 

--- a/web/rfscope/src/styles.css
+++ b/web/rfscope/src/styles.css
@@ -2,6 +2,56 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Theme tokens shared with the main console (data-theme on <html>). */
+:root,
+[data-theme="dark"] {
+  --gt-bg: 15 23 42;
+  --gt-panel: 30 41 59;
+  --gt-muted: 100 116 139;
+  --gt-fg: 226 232 240;
+  --gt-accent: 56 189 248;
+  --gt-ok: 34 197 94;
+  --gt-warn: 234 179 8;
+  --gt-err: 239 68 68;
+  --gt-surface-1: 15 23 42;
+  --gt-surface-2: 30 41 59;
+  --gt-surface-3: 51 65 85;
+  --gt-border: 51 65 85;
+  color-scheme: dark;
+}
+
+[data-theme="mono"] {
+  --gt-bg: 17 17 17;
+  --gt-panel: 33 33 33;
+  --gt-muted: 130 130 130;
+  --gt-fg: 235 235 235;
+  --gt-accent: 235 235 235;
+  --gt-ok: 235 235 235;
+  --gt-warn: 235 235 235;
+  --gt-err: 235 235 235;
+  --gt-surface-1: 17 17 17;
+  --gt-surface-2: 33 33 33;
+  --gt-surface-3: 51 51 51;
+  --gt-border: 64 64 64;
+  color-scheme: dark;
+}
+
+[data-theme="light"] {
+  --gt-bg: 241 245 249;
+  --gt-panel: 226 232 240;
+  --gt-muted: 100 116 139;
+  --gt-fg: 15 23 42;
+  --gt-accent: 2 132 199;
+  --gt-ok: 22 163 74;
+  --gt-warn: 202 138 4;
+  --gt-err: 220 38 38;
+  --gt-surface-1: 241 245 249;
+  --gt-surface-2: 255 255 255;
+  --gt-surface-3: 226 232 240;
+  --gt-border: 203 213 225;
+  color-scheme: light;
+}
+
 html,
 body,
 #root {
@@ -12,23 +62,35 @@ body {
   margin: 0;
 }
 
+/* Respect the OS "reduce motion" setting (parity with the main console). */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 @layer components {
   .card {
-    @apply rounded-lg border border-slate-700 bg-slate-800/60 p-4;
+    @apply rounded-lg border border-line bg-panel p-4;
   }
   .btn {
-    @apply rounded-md bg-sky-500 px-3 py-1.5 text-sm font-medium text-slate-900 hover:bg-sky-400 disabled:opacity-40;
+    @apply rounded-md bg-accent/90 px-3 py-1.5 text-sm font-medium text-bg hover:bg-accent disabled:opacity-40;
   }
   .btn-ghost {
-    @apply rounded-md border border-slate-600 px-3 py-1.5 text-sm hover:bg-slate-700 disabled:opacity-40;
+    @apply rounded-md border border-line px-3 py-1.5 text-sm hover:bg-panel disabled:opacity-40;
   }
   .input {
-    @apply w-full rounded-md border border-slate-600 bg-slate-900 px-2 py-1.5 text-sm focus:border-sky-400 focus:outline-none;
+    @apply w-full rounded-md border border-line bg-bg px-2 py-1.5 text-sm focus:border-accent focus:outline-none;
   }
   .label {
-    @apply mb-1 block text-xs uppercase tracking-wide text-slate-400;
+    @apply mb-1 block text-xs uppercase tracking-wide text-muted;
   }
   .spark {
-    @apply font-mono text-sky-400;
+    @apply font-mono text-accent;
   }
 }

--- a/web/rfscope/tailwind.config.ts
+++ b/web/rfscope/tailwind.config.ts
@@ -5,6 +5,20 @@ export default {
   darkMode: "class",
   theme: {
     extend: {
+      colors: {
+        bg: "rgb(var(--gt-bg) / <alpha-value>)",
+        panel: "rgb(var(--gt-panel) / <alpha-value>)",
+        muted: "rgb(var(--gt-muted) / <alpha-value>)",
+        fg: "rgb(var(--gt-fg) / <alpha-value>)",
+        accent: "rgb(var(--gt-accent) / <alpha-value>)",
+        ok: "rgb(var(--gt-ok) / <alpha-value>)",
+        warn: "rgb(var(--gt-warn) / <alpha-value>)",
+        err: "rgb(var(--gt-err) / <alpha-value>)",
+        surface: "rgb(var(--gt-surface-1) / <alpha-value>)",
+        surface2: "rgb(var(--gt-surface-2) / <alpha-value>)",
+        surface3: "rgb(var(--gt-surface-3) / <alpha-value>)",
+        line: "rgb(var(--gt-border) / <alpha-value>)",
+      },
       fontFamily: {
         mono: ["ui-monospace", "SFMono-Regular", "Menlo", "Consolas", "monospace"],
       },

--- a/web/siglab/src/App.tsx
+++ b/web/siglab/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { NavLink, Navigate, Route, Routes } from "react-router-dom";
 import { useStore } from "./store/shared";
 import { Captures } from "./panels/Captures";
@@ -7,6 +7,7 @@ import { Synthesize } from "./panels/Synthesize";
 import { Identify } from "./panels/Identify";
 import { Wideband } from "./panels/Wideband";
 import { Compare } from "./panels/Compare";
+import { ConsoleNav } from "./ConsoleNav";
 
 const tabs = [
   { to: "/captures", label: "Captures" },
@@ -18,27 +19,12 @@ const tabs = [
 
 export function App() {
   const loadProtocols = useStore((s) => s.loadProtocols);
-  // Surface a Crypto Lab link only when the daemon advertises that console
-  // (a -tags cryptolab build). Same-origin probe; fails closed when siglab
-  // runs standalone or the daemon lacks the console.
-  const [cryptolab, setCryptolab] = useState(false);
 
   useEffect(() => {
     loadProtocols().catch(() => {
       /* surfaced lazily in the forms */
     });
   }, [loadProtocols]);
-
-  useEffect(() => {
-    fetch("/api/v1/runtime")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((rt) => {
-        if (rt && rt.cryptolab_console === true) setCryptolab(true);
-      })
-      .catch(() => {
-        /* no daemon / no console — leave the link hidden */
-      });
-  }, []);
 
   return (
     <div className="flex min-h-full flex-col">
@@ -62,15 +48,7 @@ export function App() {
           ))}
         </nav>
         <div className="ml-auto flex items-center gap-3 text-xs text-muted">
-          {cryptolab ? (
-            <a
-              href="/cryptolab/"
-              title="Crypto Lab — cryptographic analysis & security testing"
-              className="rounded-md px-2 py-1 hover:text-fg"
-            >
-              🔐 Crypto Lab
-            </a>
-          ) : null}
+          <ConsoleNav self="siglab" />
           <span>offline signal analysis</span>
         </div>
       </header>

--- a/web/siglab/src/ConsoleNav.tsx
+++ b/web/siglab/src/ConsoleNav.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+
+/** The GopherTrunk web consoles that cross-link to one another. `self` is the
+ *  current console and is omitted from its own switcher. */
+export type Console = "config" | "siglab" | "rfscope" | "cryptolab";
+
+type Advertised = { cryptolab: boolean; siglab: boolean; rfscope: boolean };
+
+// ConsoleNav renders links to the sibling GopherTrunk consoles the daemon
+// advertises as reachable. It probes GET /api/v1/runtime once; the probe fails
+// closed under a standalone `… serve` (which wires no RuntimeProvider, so the
+// route 503s), meaning the links only surface when this SPA is daemon-mounted
+// alongside its siblings. The daemon always mounts the operator console at /
+// and the Config Builder at /config/; Signal Lab, RF Scope, and Crypto Lab are
+// gated on their respective runtime.*_console flags. Kept in sync across the
+// sub-apps by convention, mirroring the duplicated --gt-* token blocks.
+export function ConsoleNav({ self }: { self: Console }) {
+  const [rt, setRt] = useState<Advertised | null>(null);
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/v1/runtime")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (alive && j && typeof j === "object")
+          setRt({
+            cryptolab: j.cryptolab_console === true,
+            siglab: j.siglab_console === true,
+            rfscope: j.rfscope_console === true,
+          });
+      })
+      .catch(() => {
+        /* no daemon / standalone serve — leave the switcher hidden */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+  if (!rt) return null;
+  const cls = "rounded-md px-2 py-1 hover:text-fg";
+  return (
+    <nav className="flex flex-wrap items-center gap-1 text-xs text-muted">
+      <a href="/" title="GopherTrunk console" className={cls}>
+        ◀ GopherTrunk
+      </a>
+      {self !== "config" ? (
+        <a href="/config/" title="Config Builder" className={cls}>
+          🛠 Config
+        </a>
+      ) : null}
+      {rt.siglab && self !== "siglab" ? (
+        <a href="/siglab/" title="Signal Lab" className={cls}>
+          ◷ Signal Lab
+        </a>
+      ) : null}
+      {rt.rfscope && self !== "rfscope" ? (
+        <a href="/rfscope/" title="RF Scope" className={cls}>
+          ⧉ RF Scope
+        </a>
+      ) : null}
+      {rt.cryptolab && self !== "cryptolab" ? (
+        <a href="/cryptolab/" title="Crypto Lab" className={cls}>
+          🔐 Crypto Lab
+        </a>
+      ) : null}
+    </nav>
+  );
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -53,6 +53,8 @@ export function App() {
   const setWSStatus = useShared((s) => s.setWSStatus);
   const setHiddenTabs = useShared((s) => s.setHiddenTabs);
   const setCryptolabConsole = useShared((s) => s.setCryptolabConsole);
+  const setSiglabConsole = useShared((s) => s.setSiglabConsole);
+  const setRFScopeConsole = useShared((s) => s.setRFScopeConsole);
   const setIDBase = useShared((s) => s.setIDBase);
   const setConfigPath = useShared((s) => s.setConfigPath);
   const configPath = useShared((s) => s.configPath);
@@ -112,6 +114,8 @@ export function App() {
       .then((rt) => {
         setHiddenTabs(rt.hidden_tabs ?? []);
         setCryptolabConsole(rt.cryptolab_console === true);
+        setSiglabConsole(rt.siglab_console === true);
+        setRFScopeConsole(rt.rfscope_console === true);
         setIDBase(rt.id_base === "dec" ? "dec" : "hex");
         setConfigPath(rt.config_path ?? "");
       })
@@ -133,6 +137,8 @@ export function App() {
     setWSStatus,
     setHiddenTabs,
     setCryptolabConsole,
+    setSiglabConsole,
+    setRFScopeConsole,
     setConfigPath,
   ]);
 

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -496,6 +496,12 @@ export interface RuntimeDTO {
   // CryptolabConsole is true when the daemon serves the Crypto Lab SPA at
   // /cryptolab/ (a -tags cryptolab build). Gates the Crypto Lab nav link.
   cryptolab_console?: boolean;
+  // SiglabConsole is true when the daemon serves the Signal Lab SPA at
+  // /siglab/. Gates the Signal Lab nav link.
+  siglab_console?: boolean;
+  // RFScopeConsole is true when the daemon serves the RF Scope SPA at
+  // /rfscope/. Gates the RF Scope nav link.
+  rfscope_console?: boolean;
   // RuntimeDTO is large and changes shape as the daemon grows. Read
   // unknown fields lazily.
   [key: string]: unknown;

--- a/web/src/components/shell/AppShell.test.tsx
+++ b/web/src/components/shell/AppShell.test.tsx
@@ -45,10 +45,12 @@ describe("AppShell navigation", () => {
 
     const drawer = await screen.findByRole("dialog", { name: "Navigation" });
     // Every registry item is reachable inside the drawer, except ones gated on
-    // a daemon capability not advertised in this test (e.g. the Crypto Lab
-    // link, shown only when runtime.cryptolab_console is set).
+    // a daemon capability not advertised in this test (e.g. the Crypto Lab /
+    // Signal Lab / RF Scope links, shown only when the matching
+    // runtime.*_console flag is set).
     for (const item of NAV_ITEMS) {
-      if (item.requiresCryptolab) continue;
+      if (item.requiresCryptolab || item.requiresSiglab || item.requiresRFScope)
+        continue;
       expect(
         within(drawer).getByText(item.label),
         `drawer missing ${item.label}`,

--- a/web/src/nav/registry.test.ts
+++ b/web/src/nav/registry.test.ts
@@ -121,6 +121,35 @@ describe("nav registry", () => {
     expect(result.current.some((i) => i.external)).toBe(true);
   });
 
+  it("gates Signal Lab / RF Scope / Crypto Lab on the runtime console flags", () => {
+    // Default: none of the auxiliary consoles are advertised, so none show.
+    const hidden = renderHook(() => useVisibleNavItems());
+    const hiddenTargets = new Set(hidden.result.current.map((i) => i.to));
+    expect(hiddenTargets.has("/siglab/")).toBe(false);
+    expect(hiddenTargets.has("/rfscope/")).toBe(false);
+    expect(hiddenTargets.has("/cryptolab/")).toBe(false);
+    // Config Builder is unconditional, so it is always present.
+    expect(hiddenTargets.has("/config/")).toBe(true);
+
+    // Advertise all three → they appear.
+    useShared.setState({
+      siglabConsole: true,
+      rfscopeConsole: true,
+      cryptolabConsole: true,
+    });
+    const shown = renderHook(() => useVisibleNavItems());
+    const shownTargets = new Set(shown.result.current.map((i) => i.to));
+    expect(shownTargets.has("/siglab/")).toBe(true);
+    expect(shownTargets.has("/rfscope/")).toBe(true);
+    expect(shownTargets.has("/cryptolab/")).toBe(true);
+
+    useShared.setState({
+      siglabConsole: false,
+      rfscopeConsole: false,
+      cryptolabConsole: false,
+    });
+  });
+
   it("keeps every group definition non-empty by default", () => {
     for (const g of NAV_GROUPS) {
       expect(g.items.length).toBeGreaterThan(0);

--- a/web/src/nav/registry.ts
+++ b/web/src/nav/registry.ts
@@ -27,6 +27,12 @@ export interface NavItem {
   /** Shown only when the daemon advertises the Crypto Lab console
    *  (runtime.cryptolab_console — a -tags cryptolab build). */
   requiresCryptolab?: boolean;
+  /** Shown only when the daemon advertises the Signal Lab console
+   *  (runtime.siglab_console — the SPA is mounted at /siglab/). */
+  requiresSiglab?: boolean;
+  /** Shown only when the daemon advertises the RF Scope console
+   *  (runtime.rfscope_console — the SPA is mounted at /rfscope/). */
+  requiresRFScope?: boolean;
 }
 
 export interface NavGroup {
@@ -110,6 +116,22 @@ export const NAV_GROUPS: NavGroup[] = [
       { to: "/metrics", label: "Metrics", icon: "▰", keywords: ["prometheus", "stats", "graphs"] },
       { to: "/config/", label: "Config Builder", icon: "🛠", external: true, keywords: ["yaml", "editor"] },
       {
+        to: "/siglab/",
+        label: "Signal Lab",
+        icon: "◷",
+        external: true,
+        requiresSiglab: true,
+        keywords: ["siglab", "signal", "analysis", "capture", "iq", "demod", "synthesize", "identify", "offline"],
+      },
+      {
+        to: "/rfscope/",
+        label: "RF Scope",
+        icon: "⧉",
+        external: true,
+        requiresRFScope: true,
+        keywords: ["rfscope", "rf scope", "protocol", "analyzer", "network", "capture", "offline"],
+      },
+      {
         to: "/cryptolab/",
         label: "Crypto Lab",
         icon: "🔐",
@@ -136,16 +158,20 @@ export const PRIMARY_ITEMS: NavItem[] = NAV_ITEMS.filter((i) => i.primary);
 export function useVisibleNavGroups(): NavGroup[] {
   const hiddenTabs = useShared((s) => s.hiddenTabs);
   const cryptolabConsole = useShared((s) => s.cryptolabConsole);
+  const siglabConsole = useShared((s) => s.siglabConsole);
+  const rfscopeConsole = useShared((s) => s.rfscopeConsole);
   return useMemo(() => {
     const hidden = new Set(hiddenTabs);
     return NAV_GROUPS.map((g) => ({
       ...g,
       items: g.items.filter((i) => {
         if (i.requiresCryptolab && !cryptolabConsole) return false;
+        if (i.requiresSiglab && !siglabConsole) return false;
+        if (i.requiresRFScope && !rfscopeConsole) return false;
         return i.external || !hidden.has(tabKey(i));
       }),
     })).filter((g) => g.items.length > 0);
-  }, [hiddenTabs, cryptolabConsole]);
+  }, [hiddenTabs, cryptolabConsole, siglabConsole, rfscopeConsole]);
 }
 
 /** Flat visible items (for the command palette and bottom nav). */

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -70,6 +70,14 @@ interface SharedState {
    *  (a -tags cryptolab build). Gates the Crypto Lab nav link. */
   cryptolabConsole: boolean;
 
+  /** True when the daemon serves the Signal Lab SPA at /siglab/.
+   *  Gates the Signal Lab nav link. */
+  siglabConsole: boolean;
+
+  /** True when the daemon serves the RF Scope SPA at /rfscope/.
+   *  Gates the RF Scope nav link. */
+  rfscopeConsole: boolean;
+
   /** Base for rendering identity numbers (WACN, System ID, NAC, RFSS,
    *  Site): "hex" (default, P25 field convention) or "dec". Sourced from
    *  web.id_base config via /api/v1/runtime. */
@@ -102,6 +110,8 @@ interface SharedState {
   setScanner(s: ScannerStatusDTO | null): void;
   setHiddenTabs(tabs: string[]): void;
   setCryptolabConsole(v: boolean): void;
+  setSiglabConsole(v: boolean): void;
+  setRFScopeConsole(v: boolean): void;
   setIDBase(base: "hex" | "dec"): void;
   setConfigPath(path: string | null): void;
   appendEvents(evs: EventDTO[]): void;
@@ -134,6 +144,8 @@ export const useShared = create<SharedState>((set, get) => ({
   eventCap: 500,
   hiddenTabs: [],
   cryptolabConsole: false,
+  siglabConsole: false,
+  rfscopeConsole: false,
   idBase: "hex",
   configPath: null,
 
@@ -187,6 +199,12 @@ export const useShared = create<SharedState>((set, get) => ({
   },
   setCryptolabConsole(v) {
     set({ cryptolabConsole: v });
+  },
+  setSiglabConsole(v) {
+    set({ siglabConsole: v });
+  },
+  setRFScopeConsole(v) {
+    set({ rfscopeConsole: v });
   },
   setIDBase(base) {
     set({ idBase: base });
@@ -265,6 +283,8 @@ export const useShared = create<SharedState>((set, get) => ({
       mutations: null,
       hiddenTabs: [],
       cryptolabConsole: false,
+      siglabConsole: false,
+      rfscopeConsole: false,
       idBase: "hex",
       configPath: null,
       lastError: null,


### PR DESCRIPTION
The daemon only mounted the operator console (/), Config Builder (/config/),
and Crypto Lab (/cryptolab/, tagged builds). Signal Lab and RF Scope were
reachable only via their standalone `serve` commands, so they were absent from
the main console's nav, and Crypto Lab's header linked to /siglab/ — a path the
daemon never served (a 404). RF Scope was also the one SPA that opted out of the
shared GopherTrunk --gt-* design tokens (raw slate/sky palette, no dark/mono/
light theme, no reduced-motion support).

Reachability:
- Mount the Signal Lab SPA at /siglab/ on the daemon (SiglabOptions.Assets +
  siglabSpaHandler), mirroring the /config/ and /cryptolab/ mounts.
- Mount the RF Scope SPA at /rfscope/ (new internal/api/rfscope.go with
  RFScopeOptions + mountRFScope, reusing the webserver's RegisterAPI); reclaim
  its temp dir on shutdown.
- Advertise both via RuntimeDTO (siglab_console / rfscope_console) so consoles
  only link to what is actually reachable.
- Wire the daemon to bundle both SPAs when built; add Signal Lab + RF Scope
  nav entries (runtime-gated) to the main console.

Organization:
- Add a shared-by-convention ConsoleNav to every sub-app so each links back to
  the operator console and to the sibling consoles the daemon advertises;
  Config Builder previously had no way back.

Styling:
- Bring RF Scope onto the --gt-* token contract: tailwind tokens, themed
  styles.css (dark/mono/light + reduced-motion), semantic classes, and the
  pre-render theme application shared with the other consoles.

Tests: internal/api/spa_aux_test.go covers the /siglab/ and /rfscope/ mounts +
runtime advertisement; nav registry / AppShell tests updated for the new gates.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SGhapVVhBGkrbYa3meMXqZ