### PR TITLE
docs(blog): add Lab Bench series infrastructure

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -111,6 +111,12 @@ groups:
         url: /blog/series/rf-front-end/
       - title: Tutorials
         url: /blog/category/tutorials/
+      - title: "Series: Signal Lab"
+        url: /blog/series/signal-lab/
+      - title: "Series: RF Scope"
+        url: /blog/series/rf-scope/
+      - title: "Series: Crypto Lab"
+        url: /blog/series/crypto-lab/
       - title: Solution Postmortem
         url: /blog/category/solution-postmortem/
   - label: Install

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -61,3 +61,7 @@ layout: default
   </div>
 </main>
 
+{%- if page.charts -%}
+  <script defer src="{{ '/assets/js/labcharts.js' | relative_url }}"></script>
+{%- endif -%}
+

--- a/docs/_posts/2026-07-02-crypto-lab-01-breaking-it-is-the-test.md
+++ b/docs/_posts/2026-07-02-crypto-lab-01-breaking-it-is-the-test.md
@@ -1,0 +1,194 @@
+---
+title: "Crypto Lab, Part 1: Breaking It Is the Test"
+description: Crypto Lab is GopherTrunk's byte-oriented cryptographic-research toolkit for security-testing RF encryption — shipped inside the binary but excluded from the default install behind a build tag, it attempts decryption by every applicable method and grades how far each one got.
+category: tutorials
+keywords: crypto lab, gophertrunk, rf encryption testing, cryptographic research toolkit, p25 encryption, keystream reuse, iv reuse, security testing, build tag, cryptanalysis, resistant partial broken
+tags: [cryptolab, security-testing, encryption, getting-started, p25, rf]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 1
+---
+
+*Part 1 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit — the third leg of the **Lab Bench trilogy** ([Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}) finds and names signals, [RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}) dissects them like Wireshark, and Crypto Lab tries to break their encryption). It is also where a recurring mystery — a signal we call **Mercury** — finally gets an answer.*
+
+> **TL;DR:** Crypto Lab is a byte-oriented cryptographic-research toolkit that lives *inside* the `gophertrunk` binary but is **excluded from the default build** behind a `cryptolab` build tag. Its `assess` harness attempts to decrypt captured frames by every applicable method and grades each one — because attempting decryption *is* the test. It cannot brute a strong cipher with a good key and rotated IVs (that grades <span class="lab-verdict lab-verdict--ok">RESISTANT</span>); what it breaks is what fails in the field: reused IVs, default/test keys, keyless obfuscation, and weak keystreams.
+
+**Key takeaways**
+
+- **Attempting decryption is the security test.** A complete decryption means the deployment failed; recovering nothing means the encryption held.
+- **Opt-in by design.** The toolkit is behind a build tag, so a default operator install never ships an attack toolkit it doesn't need.
+- **Three verdicts.** Every assessment lands on <span class="lab-verdict lab-verdict--ok">RESISTANT</span>, <span class="lab-verdict lab-verdict--warn">PARTIAL</span>, or <span class="lab-verdict lab-verdict--bad">BROKEN</span>.
+- **Honest about limits.** Crypto Lab does not pretend to break AES. It finds the misconfigurations and weak constructions that break real deployments.
+
+> **Responsible use — read this first.** Crypto Lab is for **authorized security testing only**: assessing systems you own or operate, systems you are explicitly licensed to test, and security research, CTF, and classroom use on your own material. Radio encryption exists to protect real people — decrypting traffic you are not authorized to touch is illegal in most jurisdictions, and nothing in this series is a licence to do it. Every workflow here assumes you are testing *your own* deployment or one you have written permission to assess. If that is not you, stop here.
+
+## In this post
+
+- **What Crypto Lab is** — a research toolkit, not a magic decryptor, and why "breaking it is the test."
+- **Why it is a build-tag opt-in** — how the toolkit ships inside the binary yet stays out of the default install.
+- **The CLI shape** — `gophertrunk cryptolab <tool> [<mode>] [flags]`, plus `list` and `serve`.
+- **The verdict scale** — RESISTANT / PARTIAL / BROKEN, and the escalation ladder of methods behind it.
+- **A map of the series** so you can jump to the tool you care about.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `make build TAGS=cryptolab` | Build `gophertrunk` with the toolkit linked in |
+| `go build -tags cryptolab ./cmd/gophertrunk` | Equivalent raw `go build` |
+| `make test-cryptolab` | Run the toolkit's tests (including the tagged CLI) |
+| `gophertrunk cryptolab list` | List every tool and its modes |
+| `gophertrunk cryptolab serve -open` | Launch the web console at `127.0.0.1:8096` |
+| `gophertrunk cryptolab <tool> [<mode>] [flags]` | Run one tool; global flags precede the tool name |
+| `gophertrunk cryptolab assess crypto -in frames.jsonl` | The headline: attempt every attack, grade each |
+
+## What Crypto Lab actually is
+
+Crypto Lab is a byte-oriented cryptographic-research toolkit that collects the analyses you reach for when you are staring at an unfamiliar RF payload and asking two questions: *what am I looking at, and can I break it?* Statistical triage, autocorrelation period detection, a NIST SP 800-22 randomness battery, an obfuscation-class classifier, keyspace brute force, LFSR and keystream analysis, keystream-reuse / many-time-pad recovery, CRC parameter recovery, analog voice descrambling, and a pluggable "subject" framework for studying specific byte obfuscators — all in one subcommand.
+
+The philosophy behind it is worth stating plainly, because it reframes what the tool is *for*. **Attempting decryption is the test.** When you point Crypto Lab at a captured encrypted system, a complete decryption means the deployment failed — its encryption did not do its job. Recovering nothing means the encryption held. You are not "hacking" the system; you are measuring it, the same way a penetration tester measures a network by trying to get in and reporting exactly how far they got.
+
+This is why the toolkit is deliberately honest about its ceiling. It **cannot brute-force a strong key out of a strong cipher.** Point it at AES-256 with a non-default key and rotated IVs and it will tell you, plainly, that the keyspace is infeasible and the encryption is <span class="lab-verdict lab-verdict--ok">RESISTANT</span>. That result is not a failure of the tool — it *is* the security finding: the encryption is doing its job. What Crypto Lab breaks is what actually fails in the field: **reused IVs, default and test keys, keyless "obfuscation" dressed up as encryption, and structurally weak keystreams** (short LFSRs, backdoored small keyspaces). Those are the findings that matter, because those are the deployments that leak.
+
+<aside class="lab-cast">
+  <span class="lab-cast__badge">A</span>
+  <div class="lab-cast__body">
+    <p class="lab-cast__who">Meet the cast.</p>
+    <p><strong>Ada</strong> just unboxed her first SDR and is working her first real captures — she's our getting-started point of view, learning each tool as she meets it. <strong>Reese</strong> has been chasing signals for twenty years and supplies the "why": the field war stories, the reason a default IV is a five-alarm fire, and the discipline of grading honestly. They'll turn up lightly throughout the series.</p>
+  </div>
+</aside>
+
+## The Mercury thread
+
+Running through all three Lab Bench series is a single mystery. **Mercury** is an intermittent, apparently-encrypted burst Ada first captured near **453 MHz** in the UHF business band — short transmissions on a ~12.5 kHz channel that come and go with no obvious schedule. In [Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}) Part 8, blind signal-ID gave a best guess (~4800 sym/s, 4-level FSK-like) but no protocol lock. In [RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}) Part 7, the entropy analyzer triaged Mercury's payload as *not obviously strong* and exported the raw frames. Those frames land here, in Crypto Lab. We'll pick Mercury back up in Part 5, and in Part 10 we finally reveal what it was — a reveal that turns out to be the whole moral of the series. For now, just know the thread is there.
+
+## Why it's a build-tag opt-in
+
+Here is the design decision that shapes everything: **the toolkit ships inside the `gophertrunk` binary but is excluded from the default install.** It sits behind the `cryptolab` build tag — the same mechanism the DVSI vocoder uses. A standard build does not link it in:
+
+```bash
+make build                 # default: `gophertrunk cryptolab` just prints how to opt in
+make build TAGS=cryptolab  # opt in: the full toolkit is linked
+go build -tags cryptolab ./cmd/gophertrunk   # equivalent raw go build
+make test-cryptolab        # run the toolkit's tests, including the tagged CLI
+```
+
+In a default build, the `cryptolab` subcommand exists but does nothing except tell you how to opt in. Rebuild with `TAGS=cryptolab` and the same subcommand becomes the whole toolkit.
+
+Why bother? Two reasons. First, **the standard operator install stays lean** — someone running GopherTrunk as an unattended scanner at an antenna has no need for a cryptanalysis toolkit in their binary, and now it isn't there. Second, and more importantly, **it's a statement of intent.** Attack tooling is opt-in. You have to deliberately build the security-testing version. That friction is a feature: it keeps the default distribution firmly a *scanner*, not an *interception tool*.
+
+There's a subtlety worth calling out. The toolkit's engine and subject packages under `internal/cryptolab/` carry **no** build tag — they always compile and are covered by the normal `make test`. Only the binary's `cryptolab` *subcommand* is gated. So the cryptographic code is continuously tested; what the build tag controls is merely whether the CLI surface is wired into the shipped binary.
+
+## The CLI shape
+
+Every invocation follows one grammar:
+
+```text
+gophertrunk cryptolab [global flags] <tool> [<mode>] [tool flags]
+gophertrunk cryptolab list      # list tools and modes
+gophertrunk cryptolab serve     # launch the web console
+```
+
+**Global flags precede the tool name** — flag parsing stops at the first non-flag argument, then the tool and mode parse their own flags. The globals are `-out` (artifact directory for survivor logs and checkpoints), `-resume` (resume a resumable mode), `-format` (`text|json|jsonl|yaml|csv`), `-log-level`, and `-log-format`. So a full command reads left to right as *globals, then tool, then mode, then that mode's flags*:
+
+```bash
+gophertrunk cryptolab -out ./out -format json alias structure -csv ground_truth.csv
+```
+
+`cryptolab list` prints the whole catalogue — eleven tools, each with its modes and a one-line synopsis. It's the fastest way to remember what exists. And `cryptolab serve` (covered in Part 9) launches a browser console at `127.0.0.1:8096` that renders a form for every tool automatically. Everything the CLI can do, the console can do — except the handful of operations that run a host program, which are CLI-only for safety.
+
+## The verdict scale and the escalation ladder
+
+The unifying idea across the toolkit is the three-way verdict. Every `assess` run ends on one of three chips:
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 96" width="640" height="96" role="img" aria-label="The verdict scale: RESISTANT to PARTIAL to BROKEN">
+  <rect x="8" y="30" width="180" height="40" rx="8" fill="none" stroke="var(--accent)"/>
+  <text x="98" y="55" text-anchor="middle" fill="var(--accent)" font-size="14">RESISTANT</text>
+  <text x="98" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="11">nothing recovered</text>
+  <rect x="230" y="30" width="180" height="40" rx="8" fill="none" stroke="currentColor"/>
+  <text x="320" y="55" text-anchor="middle" fill="currentColor" font-size="14">PARTIAL</text>
+  <text x="320" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="11">information leaked</text>
+  <rect x="452" y="30" width="180" height="40" rx="8" fill="none" stroke="currentColor"/>
+  <text x="542" y="55" text-anchor="middle" fill="currentColor" font-size="14">BROKEN</text>
+  <text x="542" y="86" text-anchor="middle" fill="var(--fg-muted)" font-size="11">verified decryption</text>
+  <line x1="188" y1="50" x2="230" y2="50" stroke="currentColor" stroke-width="1.5"/>
+  <polygon points="230,50 222,46 222,54" fill="currentColor"/>
+  <line x1="410" y1="50" x2="452" y2="50" stroke="currentColor" stroke-width="1.5"/>
+  <polygon points="452,50 444,46 444,54" fill="currentColor"/>
+</svg>
+<figcaption>The three verdicts. Left is the encryption doing its job; right is the encryption failing the test.</figcaption>
+</figure>
+
+- <span class="lab-verdict lab-verdict--ok">RESISTANT</span> — no applicable method recovered anything. The encryption held.
+- <span class="lab-verdict lab-verdict--warn">PARTIAL</span> — information leaked: a reused IV, structured (non-random) ciphertext, a recovered keystream segment, or an algorithm with a *published* break in use.
+- <span class="lab-verdict lab-verdict--bad">BROKEN</span> — a method achieved verified, complete decryption. A fail.
+
+Behind that verdict is a ladder of methods that escalate in capability, from cheap statistical checks to full key recovery:
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 210" width="640" height="210" role="img" aria-label="Method escalation ladder from cipher-strength to key-brute">
+  <g font-size="12" fill="currentColor">
+  <rect x="20" y="8" width="380" height="26" rx="5" fill="none" stroke="currentColor"/>
+  <text x="30" y="25">cipher-strength — is it distinguishable from random?</text>
+  <text x="470" y="25" fill="var(--fg-muted)">PARTIAL</text>
+  <rect x="40" y="42" width="380" height="26" rx="5" fill="none" stroke="currentColor"/>
+  <text x="50" y="59">known-weakness — published break in the algorithm?</text>
+  <text x="470" y="59" fill="var(--fg-muted)">PARTIAL</text>
+  <rect x="60" y="76" width="380" height="26" rx="5" fill="none" stroke="currentColor"/>
+  <text x="70" y="93">iv-reuse — two frames share an IV</text>
+  <text x="470" y="93" fill="var(--fg-muted)">PARTIAL</text>
+  <rect x="80" y="110" width="380" height="26" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="90" y="127">known-plaintext — recover keystream, decrypt group</text>
+  <text x="470" y="127" fill="var(--accent)">BROKEN</text>
+  <rect x="100" y="144" width="380" height="26" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="110" y="161">weak-key — default/test keys against the real cipher</text>
+  <text x="470" y="161" fill="var(--accent)">BROKEN</text>
+  <rect x="120" y="178" width="380" height="26" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="130" y="195">key-brute — reduced keyspace against an oracle</text>
+  <text x="470" y="195" fill="var(--accent)">BROKEN</text>
+  </g>
+</svg>
+<figcaption>Methods escalate from cheap exposure checks (top, PARTIAL) to verified full recovery (bottom, BROKEN). Part 6 walks the whole ladder.</figcaption>
+</figure>
+
+Reese's rule of thumb: the top of the ladder tells you *this could be weak*; the bottom tells you *this is broken, here's the plaintext*. A responsible assessment reports both, and never claims a break it did not verify.
+
+## The series map
+
+| Part | Topic | What you'll do |
+|---|---|---|
+| 1 | Breaking It Is the Test (this post) | Understand the philosophy, build tag, and verdicts |
+| [2]({{ '/blog/tutorials/crypto-lab-02-first-triage-classify-stats/' | relative_url }}) | First triage: `classify` & `stats` | Triage an unknown payload and get the next command |
+| [3]({{ '/blog/tutorials/crypto-lab-03-randomness-nist-lfsr/' | relative_url }}) | Randomness: NIST SP 800-22 & LFSRs | Tell strong keystreams from scramblers |
+| [4]({{ '/blog/tutorials/crypto-lab-04-classical-ciphers-brute/' | relative_url }}) | Classical ciphers: `brute` | Break XOR, Caesar, Vigenère, substitution |
+| [5]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }}) | Keystream reuse & many-time-pad | Exploit IV/MI reuse with `ks` |
+| [6]({{ '/blog/tutorials/crypto-lab-06-assess-battery/' | relative_url }}) | The `assess` battery | Grade P25/DMR/TETRA end to end |
+| [7]({{ '/blog/tutorials/crypto-lab-07-crc-recovery-recipe/' | relative_url }}) | CRC recovery & the recipe pipeline | Recover a CRC and chain transforms |
+| [8]({{ '/blog/tutorials/crypto-lab-08-analog-voice-descrambling/' | relative_url }}) | Analog voice descrambling | Undo inversion, split-band, rolling code |
+| [9]({{ '/blog/tutorials/crypto-lab-09-web-console-bridge-external/' | relative_url }}) | Web console, live bridge, external ciphers | Drive it from a browser; feed it live captures |
+| [10]({{ '/blog/tutorials/crypto-lab-10-subject-framework-alias/' | relative_url }}) | Subject framework, `alias` & the Mercury reveal | Recover a keyless obfuscator; solve Mercury |
+
+## Where this goes next
+
+[Part 2]({{ '/blog/tutorials/crypto-lab-02-first-triage-classify-stats/' | relative_url }}) starts where every investigation should: triage. Before you brute anything, you run `classify auto` and `stats scan` to find out what class of thing you're holding — plaintext, a shift cipher, repeating XOR, a periodic scrambler, an LFSR, or strong encryption — and let the tool hand you the exact next command. If you want the full picture of where these payloads come from, the [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) cover the tool surface, and the sibling series ([Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}), [RF Scope]({{ '/blog/series/rf-scope/' | relative_url }})) cover finding and dissecting the signals that feed it.
+
+## FAQ
+
+**Is Crypto Lab a tool for decrypting other people's radio traffic?**
+No. It is a security-testing toolkit for encryption you are authorized to assess — your own deployment, a system you're licensed to test, or research and teaching material. Decrypting traffic you have no authorization for is illegal, and the toolkit's whole framing is defensive: measure how well *your* encryption holds up.
+
+**Why hide it behind a build tag instead of just shipping it?**
+Two reasons: it keeps the default operator binary lean, and it makes attack tooling a deliberate opt-in rather than something every install carries by default. The default build's `cryptolab` command just prints how to enable it.
+
+**Can it break AES or a properly-keyed P25 system?**
+No, and it says so — it reports <span class="lab-verdict lab-verdict--ok">RESISTANT</span>. It cannot brute a strong key out of a strong cipher. What it finds is misconfiguration: reused IVs, default keys, keyless obfuscation, and weak keystreams — the things that actually break deployments.
+
+**What does "breaking it is the test" mean in practice?**
+The `assess` harness tries every applicable attack and grades each. A full decryption means the deployment's encryption failed the test; recovering nothing means it passed. The attempt is the measurement.
+
+## Series navigation
+
+**Part 1 of 10** · Next →
+[Part 2: First Triage — `classify auto` and `stats scan`]({{ '/blog/tutorials/crypto-lab-02-first-triage-classify-stats/' | relative_url }})

--- a/docs/_posts/2026-07-02-rf-scope-01-wireshark-for-the-airwaves.md
+++ b/docs/_posts/2026-07-02-rf-scope-01-wireshark-for-the-airwaves.md
@@ -1,0 +1,280 @@
+---
+title: "RF Scope, Part 1: Wireshark for the RF Physical Layer"
+description: rfscope is GopherTrunk's protocol-agnostic RF network analyzer — point it at any band, recorded IQ or a live SDR, with no prior knowledge of the technology, modulation, framing, or encryption, and get a structured Scene of what is on the air and how it behaves.
+category: tutorials
+keywords: rfscope, rf network analysis, protocol-agnostic, wireshark for rf, sdr, iq capture, signal survey, rf scene, gophertrunk, spectrum analysis, unknown signal, rf physical layer
+tags: [rfscope, sdr, rf-analysis, getting-started, gophertrunk, dsp]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 1
+---
+
+*Part 1 of **RF Scope**, a 10-part series on GopherTrunk's protocol-agnostic RF
+network analyzer. RF Scope is the middle series of the **Lab Bench trilogy** —
+[Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}) names and measures a
+single signal, RF Scope maps a whole band, and
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) breaks what comes out
+the other end. A mystery signal named **Mercury** runs through all three.*
+
+> **TL;DR:** `rfscope` is Wireshark for the RF physical layer. Point it at a band —
+> a recorded IQ file or a live SDR — with **no idea** what technology is there, and
+> it segments the span into bursts and builds a structured **Scene**: a protocol
+> hierarchy, per-channel activity, burst timing, an emitter/conversation graph, an
+> entropy/encryption triage, and an expert-info anomaly list. It adds no DSP of its
+> own — it orchestrates primitives GopherTrunk already ships — and it is not a
+> waterfall UI; the outputs are trees, tables, graphs, and JSON.
+
+**Key takeaways**
+
+- **RF Scope answers "what is on this band and how does it behave?"** without you
+  naming a protocol, modulation, or framing first.
+- **It is not a spectrum scope.** For live waterfalls and constellations you want
+  [Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}); RF Scope emits
+  structured data, not a scrolling display.
+- **It orchestrates, it does not invent DSP.** The survey classifier, carrier peak
+  detection, spectrum occupancy, siglab identify, and the cryptolab randomness
+  battery all already existed; RF Scope wires them into one **Scene**.
+- **It sits between `hunt` and `siglab`.** `hunt` maps *known* trunked systems,
+  `siglab` decodes *named* protocols, and RF Scope says something structural about a
+  signal even when it is *neither*.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `rfscope analyze -in <cap>` | Segment + analyze a recorded IQ capture |
+| `rfscope live -serial <sdr> -freq Hz` | Analyze a live SDR span |
+| `rfscope cockpit` | Full-screen live Scene TUI |
+| `rfscope serve` | Browser console at `127.0.0.1:8098` |
+| `rfscope list` | Print the registered analyzers |
+| `-analyzers hierarchy,timing` | Run a subset (dependencies auto-pulled) |
+| `-out-format summary\|json\|jsonl\|yaml\|csv` | Choose the report shape |
+| `-frames-out frames.jsonl` | Emit a Crypto Lab `ks` frames file |
+
+## In this post
+
+- **What RF Scope actually is** — and the expectation it is *not* a UI.
+- **Where it sits** versus `hunt` and `siglab`.
+- **The Scene data model** — Burst, Channel, Emitter, Conversation, Hierarchy,
+  Anomaly.
+- **The five commands** you will use across the series.
+- **The cast, the trilogy, and Mercury** — the thread that ties all thirty posts.
+
+<aside class="lab-cast">
+  <span class="lab-cast__badge">A</span>
+  <div class="lab-cast__body">
+    <p class="lab-cast__who">Meet the cast.</p>
+    <p><strong>Ada</strong> just unboxed her first SDR and is learning to trust her
+    tools before she trusts her ears. <strong>Reese</strong> has been chasing
+    signals for twenty years and supplies the "why it works that way." They turn up
+    a paragraph at a time — narrative framing for the technical work, never a
+    substitute for it.</p>
+  </div>
+</aside>
+
+## What RF Scope is
+
+**RF Scope is protocol-agnostic RF network analysis.** You point it at a slice of
+spectrum — a wideband `.cfile` on disk, or a live receiver — and it tells you what
+is transmitting, on which channels, how often, in what shape, and whether any of it
+looks encrypted. Crucially, you supply **no prior knowledge**. You do not tell it
+"this is P25" or "expect 4-level FSK at 4800 baud." It discovers the carriers,
+slices them into bursts, classifies each burst's modulation blindly, and assembles
+the results into a single structured **Scene**.
+
+That is the same move Wireshark makes one layer up. Wireshark takes a pcap it knows
+nothing about and produces a Protocol Hierarchy, I/O Graphs, a Conversations table,
+and Expert Information. RF Scope produces the RF-physical-layer analogs of exactly
+those views. If you have ever opened a strange capture in Wireshark just to see
+*what is in here*, you already understand the workflow.
+
+**It is decidedly not a spectrum scope.** There is no scrolling waterfall, no live
+constellation, no eye diagram. Those belong to
+[Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}), the sibling series
+built for staring at one signal in detail. RF Scope's outputs are *structured*:
+indented hierarchy trees, channel tables, occupancy timelines, an emitter graph,
+and a JSON Scene you can pipe into other tools. When you want to *see* a signal, use
+Signal Lab. When you want to *inventory a band*, use RF Scope.
+
+**And it adds no DSP of its own.** This is a design principle, not an accident. The
+package docstring is blunt about it: RF Scope "imports only downward" and
+"orchestrates the existing primitives and accumulates their output into one shared,
+JSON-exportable Scene." The pieces it wires together already ship in GopherTrunk:
+
+- the `survey` blind modulation classifier,
+- `carriers` wideband peak detection,
+- `spectrum` occupancy metrics (occupied bandwidth, channel power, ACPR, spectral
+  flatness),
+- `siglab` protocol identification, and
+- the `cryptolab` randomness / keystream engines.
+
+Because it reuses proven primitives, a bug in RF Scope is almost always a wiring
+bug, not a new DSP bug — and every measurement it reports is one you could compute
+by hand with the underlying tool.
+
+## Where it sits: hunt vs siglab vs rfscope
+
+Three GopherTrunk tools look at RF, and it helps to keep their jobs distinct:
+
+| Tool | Question it answers | Needs to know the protocol? |
+|---|---|---|
+| `hunt` | "Which *known trunked systems* are here, and what are their WACN / site / neighbors?" | Yes — it maps named trunking systems |
+| `siglab` | "What *named protocol* is this one signal, and can I decode its PDUs?" | It identifies among 13 named protocols |
+| `rfscope` | "What is *structurally* on this band, even if it is nothing I recognize?" | **No** |
+
+RF Scope is the layer below the other two. An unknown IoT mesh, a telemetry link, a
+paging variant, an encrypted data burst, a frequency hopper — none of those decode
+as a named protocol, and `hunt` will never map them, but RF Scope will still tell
+you they exist, how wide they are, how bursty they are, and whether they look
+random. And when a real trunking control channel *does* turn up in the band, RF
+Scope does not reinvent the map: its topology analyzer **defers to `hunt`'s
+authoritative map** for that system (Part 6).
+
+Reese's rule of thumb: *"`siglab` is a microscope, `hunt` is an atlas, and RF Scope
+is the reconnaissance photo you take before you know which one you need."*
+
+## The Scene data model
+
+Everything RF Scope produces lives on one struct, `Scene`. Six views matter:
+
+- **Burst** — the atom. One onset→offset activity segment on one frequency, with
+  its spectral metrics (occupied bandwidth, channel power in dBFS, ACPR, spectral
+  flatness) and a blindly-classified modulation class. Every other statistic is
+  built from bursts.
+- **Channel** — the per-frequency, time-aggregated row: duty cycle, occupancy
+  percentage, burst rate, dominant class, and a 100-bin activity timeline.
+- **Emitter** — a cluster of bursts sharing an RF fingerprint. A frequency hopper's
+  scattered bursts collapse into *one* emitter.
+- **Conversation** — temporally correlated emitters linked together: a hop sequence,
+  a co-active pair, or a request/response exchange.
+- **Hierarchy** — the class → bandwidth → protocol tree, the RF Protocol Hierarchy.
+- **Anomaly** — one expert-info finding, with a severity of `note`, `warn`, or
+  `alert`.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 150" width="660" height="150" role="img" aria-label="RF Scope pipeline from source to Scene to export">
+  <rect x="6" y="54" width="96" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="54" y="72" text-anchor="middle" fill="currentColor" font-size="12">Source</text>
+  <text x="54" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="10">IQ file / SDR</text>
+  <line x1="102" y1="75" x2="132" y2="75" stroke="currentColor"/>
+  <polygon points="132,71 140,75 132,79" fill="currentColor"/>
+  <rect x="140" y="54" width="104" height="42" rx="6" fill="none" stroke="currentColor"/>
+  <text x="192" y="72" text-anchor="middle" fill="currentColor" font-size="12">Segment</text>
+  <text x="192" y="88" text-anchor="middle" fill="var(--fg-muted)" font-size="10">carriers→bursts</text>
+  <line x1="244" y1="75" x2="274" y2="75" stroke="currentColor"/>
+  <polygon points="274,71 282,75 274,79" fill="currentColor"/>
+  <rect x="282" y="42" width="130" height="66" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="347" y="66" text-anchor="middle" fill="var(--accent)" font-size="12">Analyzer</text>
+  <text x="347" y="82" text-anchor="middle" fill="var(--accent)" font-size="12">registry</text>
+  <text x="347" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="9">hierarchy · timeline …</text>
+  <line x1="412" y1="75" x2="442" y2="75" stroke="currentColor"/>
+  <polygon points="442,71 450,75 442,79" fill="currentColor"/>
+  <rect x="450" y="54" width="96" height="42" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="498" y="78" text-anchor="middle" fill="var(--accent)" font-size="13">Scene</text>
+  <line x1="546" y1="75" x2="576" y2="75" stroke="currentColor"/>
+  <polygon points="576,71 584,75 576,79" fill="currentColor"/>
+  <rect x="584" y="30" width="72" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="620" y="49" text-anchor="middle" fill="currentColor" font-size="11">export</text>
+  <rect x="584" y="90" width="72" height="30" rx="5" fill="none" stroke="currentColor"/>
+  <text x="620" y="109" text-anchor="middle" fill="currentColor" font-size="11">bridge</text>
+</svg>
+<figcaption>A sample flows Source → Segment → the analyzer registry → the Scene, then out to an export format or the Crypto Lab bridge.</figcaption>
+</figure>
+
+That pipeline is the shape of the whole series. Part 2 is the *Segment* box; Parts
+3–8 are the analyzers in the registry; Part 9 is how you watch the Scene live; Part
+10 is tuning and the export/bridge outputs.
+
+## The five commands
+
+```text
+gophertrunk rfscope analyze -in <capture> [flags]          analyze a recorded IQ capture
+gophertrunk rfscope live -serial <sdr> -freq Hz [flags]    analyze a live SDR span
+gophertrunk rfscope cockpit [-in <cap> | -serial <sdr> -freq Hz]   live scene TUI
+gophertrunk rfscope serve [-addr host:port] [-open]        web console (browser)
+gophertrunk rfscope list                                   list registered analyzers
+```
+
+The simplest useful invocation summarizes a wideband capture:
+
+```bash
+gophertrunk rfscope analyze -in wide.cfile -format f32 \
+    -sample-rate 2400000 -freq 451000000
+```
+
+That prints a human-readable Scene: the hierarchy tree, a channel table, top
+talkers, conversations, and expert info. Swap `-out-format json -out scene.json` and
+you get the whole Scene as machine-readable data instead. Point `cockpit` at the
+same file and you get a live, refreshing terminal dashboard of it. Everything in
+this series is a variation on those.
+
+## Mercury enters
+
+While testing her new receiver, Ada parks it on **453 MHz** in the UHF business
+band and catches something odd: a short, intermittent burst, roughly a 12.5 kHz
+channel, that comes and goes with no obvious pattern. Signal Lab could not name it —
+its best blind guess was around 4800 sym/s and 4-level-FSK-like, but no protocol
+locked. So she hands the wideband capture to RF Scope. Over Parts 3, 6, and 7 we
+will watch Mercury show up as an **unknown-protocol**, **frequency-hopper**-flagged
+emitter, get triaged as *not-obviously-strong* encryption, and then get handed off
+to Crypto Lab as a frames file. Keep an eye on it.
+
+## Series map
+
+| Part | Topic | What you'll do |
+|---|---|---|
+| 1 | Wireshark for the RF physical layer (this post) | Understand the Scene model |
+| [2]({{ '/blog/tutorials/rf-scope-02-segmentation-iq-to-bursts/' | relative_url }}) | Segmentation: IQ to bursts | Discover carriers, slice bursts |
+| [3]({{ '/blog/tutorials/rf-scope-03-protocol-hierarchy/' | relative_url }}) | Protocol hierarchy | Read the class→bw→protocol tree |
+| [4]({{ '/blog/tutorials/rf-scope-04-io-graph-channel-activity/' | relative_url }}) | The I/O graph | Per-channel activity over time |
+| [5]({{ '/blog/tutorials/rf-scope-05-timing-and-tdma-period/' | relative_url }}) | Timing & periodicity | Recover a TDMA frame period |
+| [6]({{ '/blog/tutorials/rf-scope-06-topology-emitters-conversations/' | relative_url }}) | Topology | Cluster emitters, find conversations |
+| [7]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }}) | Entropy triage | Bridge into Crypto Lab |
+| [8]({{ '/blog/tutorials/rf-scope-08-expert-info-anomalies/' | relative_url }}) | Expert info | Read the anomaly flags |
+| [9]({{ '/blog/tutorials/rf-scope-09-scene-cockpit-tui-web/' | relative_url }}) | The Scene cockpit | Live TUI and web console |
+| [10]({{ '/blog/tutorials/rf-scope-10-advanced-tuning-pipelines/' | relative_url }}) | Advanced tuning | Selective analyzers & pipelines |
+
+The full [rfscope docs]({{ '/rfscope.html' | relative_url }}) are the reference this
+series expands on; the [Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }})
+and [Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) hubs are the other
+two-thirds of the trilogy.
+
+## Where this goes next
+
+[Part 2]({{ '/blog/tutorials/rf-scope-02-segmentation-iq-to-bursts/' | relative_url }})
+opens the *Segment* box: how a wideband FFT finds carriers, how a robust noise floor
+is estimated, how each carrier is downconverted to a narrow baseband, and how a
+hysteresis state machine slices that baseband into the onset→offset **bursts** every
+analyzer downstream consumes. Nothing else in the Scene exists until segmentation
+runs, so it is the right place to start.
+
+## FAQ
+
+**Is RF Scope a replacement for a spectrum analyzer or waterfall?**
+No. It produces structured data — trees, tables, a JSON Scene — not a live visual
+display. For waterfalls, constellations, and eye diagrams, use
+[Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}). The two are
+complementary: reconnaissance versus close inspection.
+
+**Do I need to know the protocol before I run it?**
+No — that is the entire point. RF Scope discovers carriers, classifies modulation
+blindly, and builds the Scene with zero prior knowledge of technology, framing, or
+encryption. Naming a protocol is `siglab`'s job, and RF Scope will call `siglab` for
+you where it helps.
+
+**What hardware do I need?**
+For `analyze` and offline `cockpit`, none — just a recorded IQ capture. For `live`
+and live `cockpit` you need any SDR GopherTrunk supports. RF Scope is
+rate-invariant: it normalizes each carrier to a narrow per-channel baseband, so the
+capture rate is yours to choose.
+
+**How does it relate to Crypto Lab?**
+The entropy analyzer (Part 7) triages unknown digital payloads and can emit them as
+a `ks` frames file with `-frames-out`, which feeds `cryptolab` directly. That is the
+hand-off that eventually cracks Mercury.
+
+## Series navigation
+
+**Part 1 of 10** · Next →
+[Part 2: From IQ to Bursts]({{ '/blog/tutorials/rf-scope-02-segmentation-iq-to-bursts/' | relative_url }})

--- a/docs/_posts/2026-07-02-signal-lab-01-first-capture-no-radio.md
+++ b/docs/_posts/2026-07-02-signal-lab-01-first-capture-no-radio.md
@@ -1,0 +1,282 @@
+---
+title: "Signal Lab, Part 1: Your First Capture — No Radio Required"
+description: Signal Lab is GopherTrunk's offline signal-analysis workbench — replay, identify, synthesize, and grade recorded IQ captures through the exact production decode pipeline with no SDR, no daemon, and no network attached.
+category: tutorials
+keywords: signal lab, gophertrunk siglab, offline iq analysis, sdr capture replay, iq file format f32 u8, cfile, p25 decoder, signal analysis workbench, no radio decode, protocol picker
+tags: [siglab, sdr, iq, getting-started, dsp, p25]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 1
+---
+
+*Part 1 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. Signal Lab is one leg of the **Lab Bench trilogy** —
+three sister series (Signal Lab, [RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}),
+and [Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }})) that follow the
+same recorded captures from raw IQ to decoded meaning to broken cipher. A single
+mystery signal, **Mercury**, threads through all thirty posts; you'll meet it
+soon.*
+
+> **TL;DR:** `gophertrunk siglab` is an offline workbench that replays a recorded
+> IQ capture through the *same* decode pipeline the live daemon uses — so what
+> you see in the lab is what you'd get on the air. No SDR, no daemon, no network.
+> It ships in the default install (no build tag) and has three front-ends: a
+> terminal app, a browser console (`siglab serve`), and a demod benchmark
+> (`siglab sweep`). Point it at a `.cfile`, pick a protocol, read the dashboard.
+
+**Key takeaways**
+
+- **Signal Lab is an analysis workbench, not a scanner.** It works on recorded
+  IQ files, so you can diagnose a marginal capture on a laptop on a plane.
+- **Same pipeline as the daemon.** Every metric comes from the production
+  decoder, so lab results transfer directly to live behavior.
+- **Three front-ends, one binary** — `siglab`, `siglab serve`, `siglab sweep` —
+  chosen by how much you want to *see* versus *script*.
+- **Format matters.** GopherTrunk's own `capture` writes interleaved `f32`;
+  `rtl_sdr`-style `.cu8`/`.cfile` files are `u8`. Set `-format` to match or the
+  bytes are garbage.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `gophertrunk siglab -in capture.cfile -sample-rate 2400000` | Replay a capture in the terminal app |
+| `-protocol p25p1` | Skip the picker and decode a named protocol |
+| `-format u8 \| f32` | Sample format of the capture (default `f32`) |
+| `-auto-tune` | Estimate carrier offset and tune to 0 Hz before demod |
+| `gophertrunk siglab serve` | Launch the browser console at `127.0.0.1:8099` |
+| `gophertrunk siglab sweep` | Benchmark demod quality across an SNR ladder |
+
+## In this post
+
+- **What Signal Lab actually is** — an offline workbench sharing the daemon's
+  decode path.
+- **The three front-ends** and when to reach for each.
+- **Your first replay** — the one command, the protocol picker, the dashboard.
+- **IQ formats** — why `f32` versus `u8` is the mistake everyone makes once.
+- **The cast and the trilogy** — Ada, Reese, and the Mercury thread.
+
+## What Signal Lab is
+
+**Signal Lab is GopherTrunk's standalone signal-analysis workbench.** It runs
+entirely offline against *recorded* IQ captures — no radio attached, no daemon
+running, no network — which makes it the natural home for three jobs: diagnosing
+a marginal capture that won't lock, proving out a demodulator change, and
+building regression fixtures you can check into a repo.
+
+The single most important thing to understand is this:
+[everything Signal Lab shows comes from the same decode pipeline the live daemon
+uses]({{ '/siglab.html' | relative_url }}). It is not a re-implementation, not a
+simplified teaching model, not a separate "analysis" decoder that drifts out of
+sync with production. When the lab says a P25 control channel locked at 19.7 dB
+SNR with 7.4% EVM, that is the production receiver's own verdict on those exact
+samples. So the lab is a *microscope on production behavior*, and the numbers
+you learn to read here are the numbers that decide whether the daemon hears a
+system on the air.
+
+That equivalence is the whole reason the workbench is useful. A recorded capture
+is deterministic — the same bytes, every run — so you can replay a failure a
+hundred times, change one knob, and see exactly what moved. On a live radio you
+can never step in the same river twice.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 140" width="660" height="140" role="img" aria-label="Pipeline from IQ capture through the production decoder to the dashboard">
+  <rect x="8" y="46" width="120" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="68" text-anchor="middle" fill="currentColor" font-size="12">IQ capture</text>
+  <text x="68" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="10">.cfile / .cu8</text>
+  <line x1="128" y1="70" x2="180" y2="70" stroke="currentColor"/>
+  <polygon points="180,66 190,70 180,74" fill="currentColor"/>
+  <rect x="190" y="46" width="150" height="48" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="265" y="66" text-anchor="middle" fill="var(--accent)" font-size="12">production</text>
+  <text x="265" y="82" text-anchor="middle" fill="var(--accent)" font-size="12">decode pipeline</text>
+  <line x1="340" y1="70" x2="392" y2="70" stroke="currentColor"/>
+  <polygon points="392,66 402,70 392,74" fill="currentColor"/>
+  <rect x="402" y="46" width="120" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="462" y="68" text-anchor="middle" fill="currentColor" font-size="12">dashboard</text>
+  <text x="462" y="84" text-anchor="middle" fill="var(--fg-muted)" font-size="10">metrics + events</text>
+  <line x1="522" y1="70" x2="574" y2="70" stroke="currentColor"/>
+  <polygon points="574,66 584,70 574,74" fill="currentColor"/>
+  <rect x="584" y="46" width="68" height="48" rx="6" fill="none" stroke="currentColor"/>
+  <text x="618" y="74" text-anchor="middle" fill="currentColor" font-size="11">export</text>
+  <text x="265" y="118" text-anchor="middle" fill="var(--fg-muted)" font-size="10">the same code the live daemon runs — the lab just feeds it from a file</text>
+</svg>
+<figcaption>A sample flows from a recorded file through the production decoder to the dashboard — no radio in the loop.</figcaption>
+</figure>
+
+## The three front-ends
+
+Signal Lab is one binary with three faces. They share the engine; they differ in
+how much they let you *see* and how easily you can *script* them.
+
+| Surface | Command | Best for |
+|---|---|---|
+| **Terminal app (TUI)** | `gophertrunk siglab` | quick one-capture replay + dashboard in a shell |
+| **Browser console** | `gophertrunk siglab serve` | rich visuals, synthesis, comparing captures |
+| **Demod benchmark** | `gophertrunk siglab sweep` | measuring demod quality across an SNR ladder |
+
+The **terminal app** is where you start: one capture, one command, a live event
+log, and a signal-quality dashboard. The **browser console** (Part 3) is the
+richest surface — constellations, eye diagrams, spectrograms, a synthesis
+engine, and side-by-side capture comparison — served locally at
+`http://127.0.0.1:8099/`. The **demod benchmark** (Part 10) is the lab-coat
+instrument: it synthesizes P25 across an SNR ladder on both demod paths and
+prints measured quality against theory, so you can answer "did my change
+actually help?" with a number.
+
+None of them needs an opt-in build tag; Signal Lab is part of the default
+install. On Windows the installer even drops a **Signal Lab console** shortcut in
+the Start Menu next to the standard consoles.
+
+## Your first replay
+
+Here is the entire getting-started experience. Point the terminal app at a
+capture and give it the sample rate the file was recorded at:
+
+```bash
+gophertrunk siglab -in capture.cfile -sample-rate 2400000
+```
+
+If you don't pass `-protocol`, the TUI opens on a **protocol picker** — the list
+of every protocol the decoder knows, driven by the same registry the daemon
+uses. Move with `↑`/`↓` (or `k`/`j`), press `enter`, and the engine runs. You'll
+watch decode events stream past — NAC, color code, grants — and then land on the
+dashboard, the signal-quality readout we take apart field by field in Part 2.
+
+Prefer to skip the picker? Name the protocol and the format up front:
+
+```bash
+gophertrunk siglab -in capture.cfile -protocol p25p1 -format u8 -auto-tune
+```
+
+`-auto-tune` estimates the capture's carrier offset and tunes it to 0 Hz before
+demodulation — handy when you recorded a little off-center. Under the hood, the
+TUI is a small self-contained program that launches the engine in a goroutine
+and pumps its events into the dashboard:
+
+```go
+// cmd/gophertrunk/siglab_tui.go
+res, err := siglab.RunStream(capture, cfg, func(ev siglab.EventRecord) {
+    select {
+    case eventCh <- ev:
+    default: // drop on a slow UI rather than block the engine
+    }
+})
+```
+
+That `RunStream` call is the same entry point the daemon's replay path leans on —
+which is exactly why the lab and the air agree.
+
+## IQ formats: `f32` versus `u8`
+
+The one mistake nearly everyone makes once is feeding the lab a file in the wrong
+sample format. An IQ capture is just interleaved I/Q samples on disk, but the
+*width and encoding* of each sample varies by tool:
+
+- **`f32`** — interleaved 32-bit floats, two per sample (I then Q). This is what
+  GopherTrunk's own `gophertrunk capture` writes, and it's the lab's default.
+- **`u8`** — interleaved unsigned 8-bit bytes, the classic `rtl_sdr` format.
+  Files named `.cu8` (and many `.cfile`s from the RTL ecosystem) are `u8`.
+
+The extension is a hint, not a contract. If you set `-format` wrong, the decoder
+reads the bytes at the wrong stride and sees noise — no lock, garbage
+histogram, nothing to diagnose. When a capture that *should* decode produces
+pure noise, check the format before anything else. For the deeper story on what
+IQ samples are, see the reference on
+[IQ data]({{ '/reference/iq-data/' | relative_url }}) and
+[software-defined radio]({{ '/learn/rf-sdr/' | relative_url }}).
+
+The second most common surprise is the **sample rate**. The lab defaults to
+`-sample-rate 2400000`, but if the file was recorded at, say, 2.5 MS/s and you
+leave the default, the effective baud will read a few percent off and the
+decoder may never settle. Part 2 turns that deviation into a diagnosis you can
+trust.
+
+## Meet the cast
+
+Two people will walk through this series with you.
+
+<aside class="lab-cast">
+  <span class="lab-cast__badge">A</span>
+  <div class="lab-cast__body">
+    <p class="lab-cast__who">Meet the cast.</p>
+    <p><strong>Ada</strong> just unboxed her first SDR and has a shoebox of
+    captures she doesn't fully understand yet — she's our getting-started point
+    of view, learning to read the dashboard one field at a time.
+    <strong>Reese</strong> has been chasing signals for twenty years; he supplies
+    the "why" behind the metrics and the war stories about the captures that lie
+    to you.</p>
+  </div>
+</aside>
+
+Ada's first replay locks on the third try — the first two were the wrong
+`-format`, then the wrong `-sample-rate`. That's the normal path, and it's why we
+spend Part 2 on reading the dashboard before anything fancier.
+
+## The Mercury thread
+
+Somewhere in Ada's shoebox is a capture near **453 MHz** — UHF business band —
+that doesn't behave. Short, intermittent bursts on a roughly 12.5 kHz channel,
+here and gone, and when she replays it nothing named decodes. Reese calls it
+**Mercury**, half joking, and the name sticks.
+
+Mercury is the thread that ties the whole Lab Bench trilogy together. In this
+series it stays stubbornly unnamed until Part 8, where blind signal-ID gives a
+best guess but no lock and Ada hands the wideband capture off to
+[RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}). RF Scope triages it as
+an unknown, apparently-encrypted emitter and passes its frames to
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}), where the twist
+finally lands. Keep it in the back of your mind; we'll pick it up piece by piece.
+
+## The series map
+
+| Part | Topic | What you'll do |
+|---|---|---|
+| 1 | Your first capture (this post) | Replay a file with no radio |
+| [2]({{ '/blog/tutorials/signal-lab-02-reading-the-dashboard/' | relative_url }}) | Reading the dashboard | Read lock, baud, EVM, SNR |
+| [3]({{ '/blog/tutorials/signal-lab-03-browser-console-live-decode/' | relative_url }}) | The browser console | Drive `siglab serve` |
+| [4]({{ '/blog/tutorials/signal-lab-04-constellations-and-eye-diagrams/' | relative_url }}) | Constellations & eye diagrams | See modulation quality |
+| [5]({{ '/blog/tutorials/signal-lab-05-psd-spectrogram-occupancy/' | relative_url }}) | PSD, spectrogram, occupancy | Measure spectral shape |
+| [6]({{ '/blog/tutorials/signal-lab-06-synthesize-references/' | relative_url }}) | Synthesize references | Build ideal/impaired fixtures |
+| [7]({{ '/blog/tutorials/signal-lab-07-vsa-evm-modulation-quality/' | relative_url }}) | VSA & EVM | Lab-grade modulation quality |
+| [8]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }}) | Naming the unknown | Blind ID + wideband survey |
+| [9]({{ '/blog/tutorials/signal-lab-09-dissecting-p25-pdus/' | relative_url }}) | Dissecting P25 PDUs | Field-level TSBK dissection |
+| [10]({{ '/blog/tutorials/signal-lab-10-demod-bench-sweep/' | relative_url }}) | The demod bench | Sweep, regress, export |
+
+## Where this goes next
+
+[Part 2]({{ '/blog/tutorials/signal-lab-02-reading-the-dashboard/' | relative_url }})
+takes the signal-quality dashboard apart field by field — protocol, symbols,
+effective baud versus expected, lock status and latency, the symbol histogram,
+IQ imbalance, decode-error rate, EVM, and the SNR estimate — and turns the
+"~2% baud deviation" rule into a reliable wrong-sample-rate diagnosis. If you'd
+rather see the whole workbench first, the [SigLab docs]({{ '/siglab.html' | relative_url }})
+page is the canonical reference for every flag. And when you're ready to follow a
+capture past the decoder into segmentation and protocol hierarchy, that's the
+sister series, [RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}).
+
+## FAQ
+
+**Do I need an SDR to use Signal Lab?**
+No. That's the point. Signal Lab works entirely on recorded IQ files with no
+radio, no daemon, and no network. You only need hardware to *make* a capture (or
+grab one from a live daemon's console); analyzing it is fully offline.
+
+**Is the lab decoder the same as the live one?**
+Yes. Everything Signal Lab reports comes from the same production decode pipeline
+the daemon runs. The lab just feeds it from a file instead of an antenna, so lab
+results transfer directly to on-air behavior.
+
+**What protocols can it decode?**
+Every protocol the engine knows — P25 Phase 1/2, DMR, NXDN, dPMR, YSF, TETRA,
+EDACS, MPT-1327, D-STAR, and LTR. Pass the name to `-protocol` or let the picker
+rank candidates for you.
+
+**Why did my capture decode to noise?**
+Almost always the wrong `-format` (an `f32` default against a `u8`/`.cu8` file)
+or the wrong `-sample-rate`. Fix the format first, then the rate, then re-run.
+
+## Series navigation
+
+**Part 1 of 10** · Next →
+[Part 2: Reading the Dashboard]({{ '/blog/tutorials/signal-lab-02-reading-the-dashboard/' | relative_url }})

--- a/docs/_posts/2026-07-03-crypto-lab-02-first-triage-classify-stats.md
+++ b/docs/_posts/2026-07-03-crypto-lab-02-first-triage-classify-stats.md
@@ -1,0 +1,178 @@
+---
+title: "Crypto Lab, Part 2: First Triage — classify auto and stats scan"
+description: Crypto Lab's classify auto emits a ranked verdict for an unknown RF payload — plaintext, substitution, repeating-XOR, periodic scrambler, LFSR, or strong-encrypted — each with the exact next command, backed by the stats scan and stats period statistical triage.
+category: tutorials
+keywords: cryptolab classify, entropy analysis, index of coincidence, chi-square, xor key length, autocorrelation period, payload triage, rf security testing, cipher identification, gophertrunk
+tags: [cryptolab, triage, entropy, getting-started, security-testing, rf]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 2
+charts: true
+---
+
+*Part 2 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. Before you attack anything, you triage — and Crypto Lab's front door tells you what you're holding and what to run next.*
+
+> **TL;DR:** `cryptolab classify auto -in unknown.bin` runs the cheap measurements the other tools rely on — entropy, index of coincidence, chi-square, XOR key-length triage, autocorrelation period, and a randomness battery — and emits a **ranked verdict** (`plaintext`, `substitution-or-shift`, `repeating-xor`, `periodic-scrambler`, `lfsr-or-keyless-scrambler`, or `strong-encrypted`), each with the **exact recommended next command**. Under it, `stats scan` and `stats period` give you the raw numbers.
+
+> **Authorized testing only.** Everything here assumes the payload came from a system you own or are licensed to assess.
+
+**Key takeaways**
+
+- **`classify auto` is the front door** for any unknown byte payload — it never leaves you guessing which tool to reach for next.
+- **Every verdict carries a next command.** The output is a routing decision, not just a label.
+- **`stats scan` gives the raw triage numbers** — entropy, IC, chi-square, and the top XOR key-length candidates.
+- **`stats period` finds the repeat** — autocorrelation peaks and repeated n-grams that reveal a cipher's period or a scrambler's frame size.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab classify auto -in unknown.bin` | Ranked verdict + recommended next command |
+| `-max-keylen N` | Cap the repeating-XOR key length considered (default 40) |
+| `cryptolab stats scan -in payload.bin` | Entropy, IC, chi-square, top XOR key lengths |
+| `cryptolab stats period -in payload.bin` | Autocorrelation period + repeated-n-gram histogram |
+| `-max-lag N` | Max autocorrelation lag for `stats period` (default 256) |
+| `-ngram N` | N-gram length for the repeat histogram (default 3) |
+| `-format json` (global) | Emit the verdict as JSON for scripting |
+
+## In this post
+
+- **Why triage first** — and how a five-second classify saves an hour of wrong turns.
+- **Reading `classify auto`** — the six verdict classes and what each recommends.
+- **`stats scan`** — the four numbers that separate strong encryption from a weak cipher.
+- **`stats period`** — finding the period that sets your key length or frame size.
+- **A worked triage** — from raw bytes to a concrete next command.
+
+## Why triage before you attack
+
+Ada's instinct, holding her first unknown payload, was to start brute-forcing XOR keys. Reese stopped her: *"You don't know it's XOR yet. You don't even know it's a cipher. Triage first."* That's the discipline the classifier encodes. A payload can be plaintext you failed to recognize, a shift cipher, a repeating-key cipher, a periodic analog-style scrambler, a short-LFSR keystream, or genuinely strong encryption with nothing to attack. Each of those wants a *different* tool, and running the wrong one wastes time and — worse — can produce a plausible-looking false positive.
+
+`classify auto` runs all the cheap measurements at once and routes you. It is the RF-framed analogue of the "auto-detect" step in tools like Ciphey or CrypTool's cipher identifier, but it knows about the things RF payloads actually are: LFSR scramblers and reused keystreams, not just book ciphers.
+
+## Reading `classify auto`
+
+```bash
+gophertrunk cryptolab classify auto -in unknown.bin
+```
+
+```text
+classify/auto — 4096 bytes: likely repeating-xor (confidence 78%)
+  bytes                 4096
+  entropy_bits          6.41
+  index_of_coincidence  0.0389
+  chi_square_uniform    812.5
+  printable_fraction    0.31
+  recommended  cryptolab brute xor -in <file> -keylen 7
+
+findings (ranked):
+  repeating-xor          0.78   repeating-XOR key length ~7 (normalized Hamming 1.42)
+  periodic-scrambler     0.34   autocorrelation peak at lag 7 (z=4.1)
+```
+
+The tool emits **one finding per plausible class, ranked by confidence**, and promotes the top one into a headline and a `recommended` field. Each finding is a class plus a rationale plus the *exact command to run next* — filled in with the numbers it just measured (note the `-keylen 7` above came straight from the key-length guess). The six classes it can emit:
+
+| Verdict class | What it means | It recommends |
+|---|---|---|
+| `plaintext` | Already readable (high printable fraction, low entropy) | no decryption needed |
+| `substitution-or-shift` | IC near English, mostly letters | `brute substitution` (or `brute caesar`) |
+| `repeating-xor` | A short repeating-XOR key length stands out | `brute xor -keylen N` |
+| `periodic-scrambler` | Strong autocorrelation peak at some lag | `stats period`, then `descramble rolling` or `ks mtp` |
+| `lfsr-or-keyless-scrambler` | High entropy *but* failing a randomness test | `lfsr bm` |
+| `strong-encrypted` | ~8 bits/byte entropy and passes the battery | no weak structure — needs key material or IV reuse |
+
+The `lfsr-or-keyless-scrambler` verdict is the clever one. High entropy usually screams "strong encryption," but if the payload *fails* the linear-complexity or spectral test in the randomness battery, that high entropy is coming from a **structured generator**, not a real cipher — the signature of an LFSR scrambler. The classifier catches exactly that case and routes you to `lfsr bm` instead of letting you write the payload off as unbreakable. We go deep on that distinction in [Part 3]({{ '/blog/tutorials/crypto-lab-03-randomness-nist-lfsr/' | relative_url }}).
+
+One honest boundary the tool prints itself: `classify` only triages *byte payloads*. Analog voice scrambling (spectral inversion) operates on PCM audio, not bytes, so for `.s16` clips you go straight to the `descramble` tool ([Part 8]({{ '/blog/tutorials/crypto-lab-08-analog-voice-descrambling/' | relative_url }})).
+
+## `stats scan`: the four numbers
+
+When you want the raw triage numbers rather than a routing decision, `stats scan` gives them:
+
+```bash
+gophertrunk cryptolab stats scan -in payload.bin
+```
+
+```text
+stats/scan — 4096 bytes: entropy 6.410 bits/byte, IC 0.0389, chi-square 812.5
+  keylen=7    0.41   normalized_hamming 1.42
+  keylen=14   0.33   normalized_hamming 1.71
+  keylen=21   0.29   normalized_hamming 1.98
+note: intermediate statistics: possibly a polyalphabetic / repeating-key
+  cipher — try the top key lengths above with `cryptolab brute`.
+```
+
+Four measurements do most of the work:
+
+- **Shannon entropy** (bits/byte). Near 8 means strong encryption or compression — no weak structure to exploit. Well below 8 means there's exploitable regularity.
+- **Index of coincidence.** English text sits around 0.066; uniform random sits near 0.0039. An elevated IC (`> 0.045`) points at a monoalphabetic or shift cipher, or plaintext.
+- **Chi-square vs uniform.** How far the byte distribution is from flat — a companion to entropy.
+- **XOR key-length triage.** A normalized-Hamming test over candidate key lengths; the lowest-scoring lengths are the likeliest repeating-XOR periods.
+
+`stats scan` prints a note that interprets the numbers for you — high entropy ("looks like strong encryption"), elevated IC ("try the brute tool"), or intermediate ("try the top key lengths"). The `-max-keylen` flag (default 40) caps how long a repeating-XOR key it will consider.
+
+Here is the key-length triage as a chart — entropy stays flat while the normalized-Hamming score dips at the true period and its multiples:
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="bars" width="560" height="300" role="img"
+        aria-label="Normalized Hamming distance by candidate XOR key length, dipping at 7, 14, and 21"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "categories":["2","3","4","5","6","7","8","9","10","14","21"],
+"values":[2.9,3.0,2.8,3.1,2.7,1.42,2.6,3.0,2.8,1.71,1.98],
+"pass":[false,false,false,false,false,true,false,false,false,true,true],
+"ylabel":"normalized Hamming (lower = likelier period)" }
+</script>
+<figcaption>The normalized-Hamming score dips sharply at key length 7 and again at its multiples 14 and 21 — the fingerprint of a 7-byte repeating key.</figcaption>
+</figure>
+
+## `stats period`: finding the repeat
+
+Where `stats scan` guesses a key length from Hamming distance, `stats period` measures the repeat directly, with byte autocorrelation and a repeated-n-gram histogram:
+
+```bash
+gophertrunk cryptolab stats period -in payload.bin -max-lag 256 -ngram 3
+```
+
+```text
+stats/period — 4096 bytes: 2 period candidate(s) within lag 256
+  period=7    5.10   coincidence 0.061  z_score 5.1
+  period=14   3.20   coincidence 0.048  z_score 3.2
+  ngram=556e49  4     count 4  kind repeated_ngram
+note: strongest period is 7 byte(s): for a repeating-XOR cipher try
+  `cryptolab brute xor -keylen 7`; for a periodic scrambler this is the
+  likely frame size.
+```
+
+The autocorrelation peaks (ranked by z-score) tell you the dominant period; the repeated n-grams show you *where* the structure repeats. This is the measurement that sets two important knobs downstream: the **key length** for a repeating-XOR or Vigenère brute, and the **frame size** for a rolling scrambler in `descramble rolling`. The flags — `-max-lag` (how far out to look, default 256), `-ngram` (block length for the repeat histogram, default 3), and `-top` (how many candidates to report) — trade runtime for reach.
+
+If no autocorrelation peak stands out, `stats period` says so, and that absence is itself a finding: no short repeating period is consistent with strong encryption or a long, aperiodic keystream.
+
+## A worked triage
+
+Ada's actual first payload ran like this. `classify auto` came back `repeating-xor` at 78%, recommending `brute xor -keylen 7`. She confirmed the period with `stats period`, which put a clean autocorrelation peak at lag 7 (z = 5.1). One `brute xor -keylen 7` later ([Part 4]({{ '/blog/tutorials/crypto-lab-04-classical-ciphers-brute/' | relative_url }})) and the plaintext fell out. Total time from raw bytes to plaintext: under a minute — because she let the classifier route her instead of guessing.
+
+Reese's version of the lesson: the classifier isn't magic, it's *bookkeeping*. It runs the same handful of statistics you'd run by hand, then does the tedious part — remembering which statistic implies which tool — so you don't misread a high-entropy LFSR as unbreakable or waste a substitution solve on a repeating-XOR cipher.
+
+Every one of these tools honors the global `-format` flag, so `classify auto -in unknown.bin` with a global `-format json` gives you a machine-readable verdict you can pipe into a script that runs the recommended command automatically.
+
+## Where this goes next
+
+The classifier's most interesting call — separating a genuinely strong keystream from a structured scrambler that merely *looks* random — leans entirely on the randomness battery. [Part 3]({{ '/blog/tutorials/crypto-lab-03-randomness-nist-lfsr/' | relative_url }}) opens up that battery: the NIST SP 800-22 subset, why a failing linear-complexity or spectral test is the unmistakable signature of an LFSR, and how that one test distinguishes keyed encryption from a keyless scrambler. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) list every flag if you want the reference alongside.
+
+## FAQ
+
+**Do I always have to run `classify` first?**
+No, but it's the cheapest possible first move and it routes you correctly. If you already know the payload class, jump straight to the tool — `classify` just automates the "which tool?" decision.
+
+**What's the difference between `stats scan` and `classify auto`?**
+`stats scan` gives you the raw numbers (entropy, IC, chi-square, key lengths); `classify auto` runs those *plus* the randomness battery and turns them into a ranked verdict with a recommended command. Use `classify` to decide, `stats` to inspect.
+
+**Why does a high-entropy payload sometimes get flagged as an LFSR scrambler, not strong encryption?**
+Because entropy alone can't tell a real cipher from a structured generator. If the payload has ~8-bit entropy but *fails* the linear-complexity or spectral randomness test, that's an LFSR — high entropy, but predictable. The classifier catches it and points you at `lfsr bm`.
+
+**Can I script the recommended command?**
+Yes. Run with the global `-format json` and parse the `recommended` field. The classifier fills in the measured key length or lag, so the command is ready to run.
+
+## Series navigation
+
+**Part 2 of 10** · ←[Part 1: Breaking It Is the Test]({{ '/blog/tutorials/crypto-lab-01-breaking-it-is-the-test/' | relative_url }}) · Next →[Part 3: Randomness — NIST SP 800-22 & the LFSR Signature]({{ '/blog/tutorials/crypto-lab-03-randomness-nist-lfsr/' | relative_url }})

--- a/docs/_posts/2026-07-03-rf-scope-02-segmentation-iq-to-bursts.md
+++ b/docs/_posts/2026-07-03-rf-scope-02-segmentation-iq-to-bursts.md
@@ -1,0 +1,276 @@
+---
+title: "RF Scope, Part 2: From IQ to Bursts — The Segmentation Pre-Pass"
+description: rfscope's segmentation pre-pass turns a wideband IQ span into bursts — discovering carriers with a wideband FFT, estimating a robust noise floor, downconverting each carrier to a narrow baseband, and slicing onset→offset bursts with per-burst spectral metrics and a blind modulation class.
+category: tutorials
+keywords: rfscope, segmentation, carrier discovery, wideband fft, noise floor, peak detection, digital downconversion, burst detection, occupied bandwidth, spectral flatness, dbfs, sdr
+tags: [rfscope, sdr, dsp, rf-analysis, getting-started, gophertrunk]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 2
+charts: true
+---
+
+*Part 2 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer. Before
+any analyzer runs, the raw IQ has to become **bursts** — this post is the pre-pass
+that makes them.*
+
+> **TL;DR:** Segmentation is the producer step every analyzer consumes. It runs a
+> wideband FFT (`-fft`, default 4096) to find carriers, sets a robust noise floor at
+> the 25th percentile of the averaged bins, picks peaks that clear `-peak-threshold-db`
+> (default 10 dB) spaced at least `-min-spacing` apart (default 12500 Hz), caps at 64
+> channels, downconverts each carrier to ~50 kHz (`-channel-rate`), and slices
+> onset→offset **bursts** with a hysteresis + debounce state machine. Each burst gets
+> spectral metrics and a blind modulation class.
+
+**Key takeaways**
+
+- **Bursts are the atom.** No hierarchy, timeline, emitter, or anomaly exists until
+  segmentation produces bursts.
+- **Carrier discovery is a wideband FFT plus robust peak detection** — a 25th-percentile
+  noise floor keeps a few loud carriers from hiding the quiet ones.
+- **Each carrier is downconverted and decimated to ~50 kHz** before burst detection,
+  so the work is cheap and rate-invariant.
+- **Onset/offset uses hysteresis + debounce** anchored on a quiet floor, so a
+  transmission already keyed up at the start of the capture is still found.
+
+## Cheat sheet
+
+| Flag | Default | What it tunes |
+|---|---|---|
+| `-fft` | 4096 | Wideband FFT size for carrier discovery (power of two) |
+| `-peak-threshold-db` | 10 | Minimum dB above the noise floor for a carrier to count |
+| `-min-spacing` | 12500 | Minimum Hz between carriers / channel raster |
+| `-channel-rate` | 50000 | Per-channel decimated baseband rate (Hz) |
+| `-sample-rate` | 2000000 (analyze) | Wideband IQ sample rate |
+| `-window <sec>` | whole capture | Analyze only the first N seconds |
+
+## In this post
+
+- **The three stages** of segmentation: discover, downconvert, slice.
+- **Carrier discovery** — the wideband FFT and the robust noise floor.
+- **Peak detection** — threshold, spacing, and the 64-channel cap.
+- **Per-carrier downconversion** to a narrow baseband, and why it makes RF Scope
+  rate-invariant.
+- **Burst onset/offset** — the hysteresis + debounce state machine.
+- **Per-burst metrics** — occupied bandwidth, channel power, ACPR, spectral flatness,
+  and the blind class.
+
+## Three stages
+
+Segmentation runs in `internal/rfscope/segment.go` and produces the Scene's header
+plus its `Bursts` slice. It has three stages:
+
+1. **Discover carriers** across the whole wideband span with an FFT.
+2. **Downconvert** each discovered carrier to a narrow baseband and decimate it.
+3. **Slice** each baseband into onset→offset bursts, measuring and classifying each.
+
+Everything downstream — the hierarchy, the I/O graph, timing, topology, entropy,
+expert info — reads bursts. Get segmentation wrong and every later view is wrong, so
+it is worth understanding the knobs.
+
+## Carrier discovery: FFT and a robust floor
+
+The span is read into memory, then averaged into a power spectrum:
+
+```go
+// internal/rfscope/segment.go
+avg := spectrum.AverageDB(raw, center, rate, cfg.FFTSize)
+noiseFloor := spectrum.Percentile(avg.Bins, 0.25)
+```
+
+Two things are happening. First, `AverageDB` splits the capture into `-fft`-sized
+windows (default **4096**, and the code forces it to a power of two — anything else
+falls back to 4096) and averages their magnitude spectra. Averaging trades frequency
+resolution against variance: more windows means a smoother spectrum, which makes weak
+carriers stand out from the noise instead of drowning in a single noisy FFT frame.
+
+Second, the **noise floor is the 25th percentile of the averaged bins**, not the mean
+or the minimum. This is the robust-statistics trick. If a band has three loud
+carriers and a lot of quiet spectrum, the mean floor is dragged up by the carriers
+and you miss the weak ones; the minimum is dragged down by one dead bin and you see
+phantom carriers everywhere. The lower quartile sits in the genuinely-quiet part of
+the spectrum regardless of how many strong signals share the band, so the floor
+tracks the *actual* noise.
+
+> **dBFS, briefly.** Powers here are in **dBFS** — decibels relative to full scale,
+> where 0 dBFS is the loudest an ADC sample can represent and everything real is
+> negative. It is a receiver-relative scale, not an absolute one, which is exactly
+> right for "how far above the local noise is this carrier?"
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="heatmap" width="560" height="300" role="img"
+        aria-label="Wideband carrier-discovery spectrum with three carriers above the noise floor"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "matrix":[
+[0.10,0.12,0.11,0.13,0.85,0.90,0.84,0.14,0.12,0.11,0.10,0.13,0.55,0.62,0.58,0.12,0.11,0.10,0.12,0.11],
+[0.11,0.10,0.12,0.14,0.88,0.92,0.86,0.13,0.11,0.12,0.11,0.12,0.60,0.66,0.61,0.13,0.10,0.11,0.13,0.10],
+[0.10,0.13,0.11,0.12,0.83,0.89,0.82,0.14,0.12,0.10,0.12,0.11,0.12,0.14,0.13,0.75,0.80,0.74,0.12,0.11],
+[0.12,0.11,0.10,0.13,0.86,0.91,0.85,0.12,0.11,0.13,0.11,0.10,0.13,0.12,0.11,0.78,0.83,0.77,0.11,0.12]],
+"xlabel":"frequency bin","ylabel":"averaged frames →" }
+</script>
+<figcaption>Three carriers rise above a quiet floor; averaging frames flattens the noise so peak detection can find the weak one on the right.</figcaption>
+</figure>
+
+## Peak detection: threshold, spacing, and the cap
+
+With a floor in hand, `carriers.DetectPeaks` walks the averaged spectrum:
+
+```go
+// internal/rfscope/segment.go
+peaks := carriers.DetectPeaks(avg, carriers.PeakOptions{
+    ThresholdDb:  cfg.PeakThresholdDb, // default 10 dB above the floor
+    MinSpacingHz: cfg.MinSpacingHz,    // default 12500 Hz
+})
+```
+
+A bin is a carrier only if it clears the floor by `-peak-threshold-db` — **10 dB** by
+default. Ten decibels above a robust floor is a deliberately conservative bar: it
+keeps noise humps and spectral leakage from registering as channels. Turn it down for
+weak-signal work, up to reject marginal carriers.
+
+`-min-spacing` (**12500 Hz**) is the minimum distance between two accepted peaks —
+the channel raster. It stops one strong carrier's shoulders from being counted as
+several adjacent channels, and it encodes an assumption that neighboring channels are
+at least a narrowband raster apart. For a band on a 25 kHz plan you might raise it; for
+tightly-packed 6.25 kHz channels, lower it.
+
+Two more details matter. `DetectPeaks` drops the DC bin (a front-end artifact on live
+SDRs), but a real carrier can sit *exactly* at the tuned center — common for a
+single-channel capture — so segmentation always adds the band center as a candidate
+and lets the burst detector decide whether anything is actually there. And the
+candidate list is capped at **MaxChannels = 64** (strongest first), so a pathological
+band cannot explode into thousands of channels.
+
+## Downconvert and decimate to ~50 kHz
+
+For every confirmed carrier, segmentation shifts it to baseband and decimates:
+
+```go
+// internal/rfscope/segment.go
+offset := float64(pk.FreqHz) - float64(center)
+ddc := ccdecoder.NewDownconverterWithOffset(rate, cfg.ChannelTargetRateHz, offset)
+base := ddc.Process(nil, raw)
+```
+
+This is **digital downconversion (DDC)**: multiply the wideband IQ by a complex tone
+at `-offset` Hz to slide the carrier of interest down to 0 Hz, low-pass filter, then
+**decimate** — throw away samples — down to the target `-channel-rate` of **50 kHz**.
+Fifty kilohertz comfortably holds any land-mobile, IoT, or paging narrowband channel
+while keeping the per-burst buffers small and the later FFTs cheap.
+
+This step is why RF Scope is **rate-invariant**. Whether you captured at 2.4 MS/s or
+10 MS/s, each carrier arrives at burst detection as the same ~50 kHz baseband, so a
+signal's measured shape does not depend on your capture rate. (RF Scope uses the
+single-tap `ccdecoder` downconverter here — the same one `replay -tune-hz` uses — not
+the wideband multi-tap channelizer in `internal/dsp/tuner`. We return to that
+distinction in Part 10.)
+
+## Burst onset and offset
+
+A decimated carrier is not yet a burst — it is a channel that is sometimes active and
+sometimes quiet. `detectBursts` finds the active runs. It computes a per-frame power
+envelope, then runs a **hysteresis + debounce** state machine lifted from the DMR
+onset detector:
+
+- **Hysteresis** means two thresholds, not one. The channel turns *on* when the
+  envelope rises `OnThreshDb` (10 dB) above a quiet floor, and turns *off* only when
+  it falls back below `OffThreshDb` (6 dB). The gap between on and off keeps a signal
+  hovering near the threshold from chattering on and off every frame.
+- **Debounce** requires the condition to hold for several consecutive frames
+  (`Debounce = 3`) before the state flips, rejecting single-frame spikes.
+
+The floor is a low percentile (10th) of the channel's *own* envelope over the whole
+capture, not an EWMA seeded from the first frame. That subtlety matters: a
+transmission that is already keyed up when the capture starts has no "off" period to
+seed a running estimate from, and an EWMA-seeded detector would miss it entirely.
+Anchoring on a fixed quiet floor finds it. Bursts shorter than `MinBurstSec` (5 ms)
+are dropped as debounce noise.
+
+When a channel has too little dynamic range to segment — a continuous carrier that is
+on for the whole window, or dead air — the wideband carrier SNR decides between one
+full-span burst and none.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="timeline" width="560" height="220" role="img"
+        aria-label="Two channels sliced into onset-offset bursts over time"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "channels":[
+{"label":"453.100","occ":[0,0,1,1,1,0,0,0,1,1,1,1,0,0,0,0,1,1,0,0]},
+{"label":"453.325","occ":[0,1,1,0,0,0,0,1,1,1,0,0,0,1,1,1,1,0,0,0]}],
+"xlabel":"time → (onset/offset bursts per channel)" }
+</script>
+<figcaption>The onset state machine turns each channel's power envelope into discrete bursts — the atoms the analyzers consume.</figcaption>
+</figure>
+
+## Per-burst metrics and the blind class
+
+For each burst span, segmentation measures and classifies the slice:
+
+```go
+// internal/rfscope/segment.go
+cls := survey.Classify(slice, outRate)
+occ := spectrum.ComputeOccupancy(
+    spectrum.AverageDB(slice, 0, outRate, occFFTFor(len(slice))).Bins,
+    outRate, ...)
+```
+
+Two calls do the work. `spectrum.ComputeOccupancy` (over a 1024-point occupancy FFT,
+or smaller for short bursts) yields the spectral metrics:
+
+- **Occupied bandwidth** — how wide the burst actually is, in Hz. (RF Scope prefers
+  `survey`'s above-noise-floor outward walk here, because the 99%-power span
+  under-measures FM-family carriers whose strong DC component concentrates the power.)
+- **Channel power (dBFS)** — the burst's in-channel power.
+- **ACPR** — adjacent-channel power ratio, upper and lower: how much the burst spills
+  into its neighbors.
+- **Spectral flatness** — the **Wiener entropy**, a 0..1 number. It is the ratio of
+  the geometric mean of the power spectrum to its arithmetic mean. Near **1** the
+  spectrum is flat and noise-like or spread; well below 1 it is peaky — a tone or a
+  narrow carrier. Flatness is one of RF Scope's highest-value protocol-agnostic
+  discriminators, and it drives both the emitter fingerprint and a `noise-like`
+  anomaly later.
+
+`survey.Classify` supplies the blind **modulation class** — NBFM, C4FM, FSK, PSK,
+continuous data, paging, and so on — plus features like the estimated baud rate. No
+protocol is named here; that is the hierarchy analyzer's job in Part 3. Ada's first
+run over her 453 MHz capture produces a handful of bursts, each a row with a
+frequency, a duration, a class, an occupied bandwidth, and a flatness — the raw
+material for everything that follows.
+
+## Where this goes next
+
+With bursts in hand, the analyzers can run. [Part
+3]({{ '/blog/tutorials/rf-scope-03-protocol-hierarchy/' | relative_url }}) builds the
+first view on top of them — the **protocol hierarchy**, which groups bursts by
+modulation class, then by occupied-bandwidth bucket, then names the protocol of the
+longest digital burst in each bucket. That is where Mercury first shows its face, as
+an unknown-protocol node the tree cannot name.
+
+## FAQ
+
+**Why 4096 for the FFT, and why must it be a power of two?**
+Power-of-two sizes let the FFT use the fast radix-2 path; 4096 balances frequency
+resolution against averaging variance for typical 2–10 MS/s captures. Non-power-of-two
+values are rejected and fall back to 4096.
+
+**Why decimate every carrier to 50 kHz?**
+Narrowband LMR/IoT/paging channels fit comfortably in 50 kHz, and decimating there
+keeps per-burst buffers and FFTs small and makes the analysis rate-invariant — the
+same signal looks the same whether you captured at 2.4 or 10 MS/s.
+
+**My weak carrier isn't detected — what do I change?**
+Lower `-peak-threshold-db` (try 6–8) so carriers closer to the floor register, and
+check `-min-spacing` isn't merging it into a louder neighbor. Part 10 covers
+segmentation tuning for unusual bands in depth.
+
+**What counts as one burst?**
+One onset→offset run on one channel, at least `MinBurstSec` (5 ms) long, detected by a
+hysteresis + debounce state machine anchored on the channel's quiet floor.
+
+## Series navigation
+
+**Part 2 of 10** · ←
+[Part 1: Wireshark for the RF physical layer]({{ '/blog/tutorials/rf-scope-01-wireshark-for-the-airwaves/' | relative_url }})
+· Next →
+[Part 3: Protocol Hierarchy]({{ '/blog/tutorials/rf-scope-03-protocol-hierarchy/' | relative_url }})

--- a/docs/_posts/2026-07-03-signal-lab-02-reading-the-dashboard.md
+++ b/docs/_posts/2026-07-03-signal-lab-02-reading-the-dashboard.md
@@ -1,0 +1,245 @@
+---
+title: "Signal Lab, Part 2: Reading the Dashboard — Symbols, Baud, Lock & the 2% Rule"
+description: Signal Lab's terminal dashboard, field by field — protocol, symbols, effective baud versus expected, lock status and latency, symbol histogram, IQ imbalance, decode-error rate, EVM, and SNR — plus the ~2% baud-deviation rule that catches a wrong sample rate.
+category: tutorials
+keywords: siglab dashboard, effective baud, symbol rate deviation, iq imbalance, evm, snr estimate, decode error rate, symbol histogram, sample rate mismatch, p25 lock, auto-tune
+tags: [siglab, dsp, iq, getting-started, p25, demodulation]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 2
+charts: true
+---
+
+*Part 2 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. Last time we ran a capture; now we learn to read what
+the run tells us.*
+
+> **TL;DR:** The Signal Lab dashboard is a one-screen verdict on a capture:
+> protocol, sample and symbol counts, **effective baud versus expected** (with a
+> signed % deviation), lock status/frequency/latency, grants, a symbol
+> histogram, IQ imbalance, a decode-error rate per 1000 symbols, and a demod
+> block with EVM% and an SNR estimate. The single most useful number is the baud
+> deviation: if it drifts more than about **2%**, your `-sample-rate` is wrong,
+> not your signal.
+
+**Key takeaways**
+
+- **Effective baud vs expected is your rate check.** A deviation past ~2% almost
+  always means the capture's true rate ≠ `-sample-rate`.
+- **Lock is binary, but latency is diagnostic.** *When* it locked tells you as
+  much as *whether* it locked.
+- **The symbol histogram shows modulation health** before any fancy plot — four
+  clean bins for a 4-level C4FM system, smeared bins for a sick one.
+- **EVM, SNR, IQ imbalance, and decode-error rate** are the quality quartet; read
+  them together, never alone.
+- **Press `e` to export** the whole result as `<capture>.siglab.json`.
+
+## Cheat sheet
+
+| Command / flag / key | What it does |
+|---|---|
+| `gophertrunk siglab -in cap.cfile -sample-rate 2400000` | Run and open the dashboard |
+| `-protocol p25p1` | Skip the picker |
+| `-format u8 \| f32` | Match the capture's sample format |
+| `-freq <Hz>` | Informational nominal center frequency |
+| `-auto-tune` | Tune out carrier offset before demod |
+| `-verbose-errors` | Full error chain + stack on failure |
+| `↑`/`↓` or `k`/`j`, `enter` | Move the picker, run the decode |
+| `e` | Export `<capture>.siglab.json` |
+| `q` | Quit |
+
+## In this post
+
+- **The dashboard, field by field** — what each line means.
+- **The 2% rule** — turning baud deviation into a sample-rate diagnosis.
+- **Reading the symbol histogram** — modulation health at a glance.
+- **The quality quartet** — EVM, SNR, IQ imbalance, decode-error rate.
+- **Keys and exports** — driving the TUI and getting structured output.
+
+## The dashboard, field by field
+
+When a run finishes, the terminal app lands on the results screen. Here's a
+representative dashboard for a healthy P25 Phase 1 control channel:
+
+```text
+Signal Lab — Results
+
+Protocol:   P25 Phase 1
+Samples:    12,000,000 (5.00s @ 2400000 Hz)
+Symbols:    23,988   effective baud 4797.6 (expected 4800, -0.1%)
+Lock:       LOCKED @ -12500 Hz (0.42s)
+Grants:     3
+
+Symbol histogram
+  0  ████████·················· 18.9%
+  1  ███████··················· 30.6%
+  2  ███████··················· 31.1%
+  3  ████······················ 19.4%
+
+IQ imbalance: gain +0.12 dB  phase +0.4°  image rej 43.8 dB
+Decode-error rate: 1.20 / 1000 symbols
+Demod (C4FM): EVM 7.4%  SNR≈19.7 dB
+```
+
+Read it top to bottom:
+
+- **Protocol** — what the engine decoded as (the one you picked or passed).
+- **Samples** — total IQ samples, the capture duration in seconds, and the
+  sample rate it was decoded at. If the rate here isn't the file's true rate,
+  everything below is suspect.
+- **Symbols** — recovered symbol count, then the headline pair: **effective baud**
+  (the symbol rate the demod actually measured) against the protocol's
+  **expected** baud, plus a signed **% deviation**.
+- **Lock** — `LOCKED @ <freq> (<latency>)` or `NOT LOCKED`. The frequency is the
+  residual carrier offset the receiver settled on; the latency is how long into
+  the capture it took to lock.
+- **Grants** — trunking channel grants seen (control-channel activity).
+- **Symbol histogram** — the distribution of recovered symbols across the
+  modulation's levels.
+- **IQ imbalance** — gain (dB), phase (degrees), and image-rejection (dB) of the
+  front-end's I/Q balance, shown only when the lab observed enough signal.
+- **Decode-error rate** — errored symbols per 1000, a direct FEC-adjacent health
+  number.
+- **Demod** — the modulation the demod ran, its **EVM%**, and an **SNR estimate**.
+
+## The 2% rule: baud deviation as a rate check
+
+The most valuable habit you can build is reading the baud deviation *first*.
+Both of GopherTrunk's down-converters normalize a capture to the per-protocol
+channel rate before demod, which makes the decode path essentially
+**rate-invariant** to the *capture* rate — a clean signal decodes the same
+whether it was recorded at 2.4 MS/s or 10 MS/s. That invariance is what makes the
+deviation such a sharp tool: if the true symbol rate is fixed by the protocol and
+the demod's measured baud drifts, the drift is telling you the *ratio* between
+the rate you claimed and the rate the file was actually recorded at.
+
+The rule of thumb, straight from the docs: **if the effective baud drifts more
+than about 2% from the expected symbol rate, the capture's true sample rate
+probably doesn't match `-sample-rate`.** Fix the rate and re-run before trusting
+any other metric.
+
+A worked example. Ada's capture reads:
+
+```text
+Symbols:    24,010   effective baud 4996.9 (expected 4800, +4.1%)
+Lock:       NOT LOCKED
+```
+
+That `+4.1%` is the whole story. 4800 × (2500000 / 2400000) ≈ 5000 — the file was
+recorded at 2.5 MS/s, but she left the default `-sample-rate 2400000`. Re-running
+with `-sample-rate 2500000` snaps the deviation back under a percent and the
+channel locks. No amount of squinting at the constellation would have helped;
+the number named the fault directly.
+
+The corollary, which Reese never tires of repeating: once the rate is right and
+the deviation is small, a capture that *still* won't lock or reads a low SNR is
+telling you about the **captured samples**, not the DSP — front-end overload,
+intermod, or gain staging at record time. The lab has done its job by pointing
+you at the file rather than the code.
+
+## Reading the symbol histogram
+
+Below the top block, the histogram shows how recovered symbols distribute across
+the modulation's levels. For a 4-level system like C4FM P25 you want four
+distinct, well-populated bins; a healthy control channel is roughly balanced
+across them. When bins smear together or one collapses, the demod is struggling
+to separate symbol levels — the eye is closing (Part 4), the SNR is low, or the
+rate is still off.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="bars" width="560" height="300" role="img"
+        aria-label="Symbol histogram: four populated levels for a healthy C4FM channel"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "categories":["level 0","level 1","level 2","level 3"],
+"values":[18.9,30.6,31.1,19.4],
+"pass":[true,true,true,true],
+"ylabel":"% of symbols" }
+</script>
+<figcaption>Illustrative C4FM symbol histogram — four clearly separated levels is the healthy signature. Smeared or collapsed bins mean the demod can't tell symbols apart.</figcaption>
+</figure>
+
+The histogram is a fast, no-plot sanity check: you can read modulation health
+from four bars before you ever open a constellation.
+
+## The quality quartet
+
+Four fields together describe *how well* the capture demodulated. Read them as a
+set, because any one alone can mislead.
+
+| Field | What it tells you | Watch for |
+|---|---|---|
+| **EVM %** | RMS error-vector magnitude — distance from ideal symbol points | Rises sharply as SNR drops; the demod-quality headline |
+| **SNR estimate (dB)** | In-channel signal-to-noise the receiver saw | Below ~10 dB on C4FM, lock gets fragile |
+| **IQ imbalance** | Front-end gain/phase balance + image rejection | Large gain/phase or low image-rejection dB points at the SDR, not the signal |
+| **Decode-error rate** | Errored symbols per 1000 | Climbs before lock is lost — an early-warning gauge |
+
+Reese's mental model: **EVM and SNR move together and describe the channel; IQ
+imbalance describes the front-end; decode-error rate describes the consequences.**
+A capture with great SNR but ugly IQ imbalance was recorded on a radio with a
+gain/phase problem. A capture with fine IQ balance but low SNR and high EVM is
+just weak. The four fields let you tell those apart without guessing.
+
+## Keys, auto-tune, and exports
+
+The TUI is deliberately small. On the protocol picker, `↑`/`↓` (or `k`/`j`) move
+the cursor and `enter` runs the selected protocol. On the dashboard, `e` exports
+and `q` (or `Ctrl-C`) quits. A few flags shape the run:
+
+- **`-auto-tune`** estimates the carrier offset and tunes the capture to 0 Hz
+  before demod — reach for it when a capture was recorded off-center and the
+  residual-offset field in the lock line is large.
+- **`-protocol`** and **`-format`** skip the picker and set the sample encoding.
+- **`-freq`** is purely informational — a nominal center frequency for the report;
+  it doesn't change decoding.
+- **`-verbose-errors`** prints the full error chain and a stack on failure, which
+  is what you want when a run dies instead of just decoding badly.
+
+Pressing `e` writes the complete structured result next to your capture as
+`<capture>.siglab.json`:
+
+```go
+// cmd/gophertrunk/siglab_tui.go
+path := strings.TrimSuffix(m.capture, ext(m.capture)) + ".siglab.json"
+// ...
+siglab.WriteResult(f, m.result, siglab.FormatJSON)
+```
+
+That JSON carries every field on the dashboard and more, which is how you turn a
+one-off replay into a fixture or a diff. The browser console (Part 3) exposes the
+same result through JSON/JSONL/YAML/CSV serializers.
+
+## Where this goes next
+
+You can now read a capture's health from one screen and tell a rate problem from
+a signal problem. [Part 3]({{ '/blog/tutorials/signal-lab-03-browser-console-live-decode/' | relative_url }})
+moves to the browser console — `gophertrunk siglab serve` — where the same
+metrics arrive over a live event stream alongside constellations, spectrograms,
+and side-by-side comparison. For the canonical field list, the
+[SigLab docs]({{ '/siglab.html' | relative_url }}) page stays the source of truth.
+
+## FAQ
+
+**My baud deviation is +4%. What do I change?**
+Your `-sample-rate`. A deviation past ~2% means the value you passed doesn't
+match the file's true recording rate. Multiply the expected baud by
+(true rate / claimed rate) to sanity-check, set the right rate, and re-run.
+
+**It locked but SNR is only 9 dB — is that the lab's fault?**
+No. Because the decode path is rate-invariant, a low in-channel SNR on a
+correctly-rated capture is a property of the recorded samples (weak signal,
+front-end overload, gain staging), not the DSP. Get a cleaner capture.
+
+**What does image rejection tell me?**
+It's the front-end's I/Q balance quality in dB — higher is better. A low
+image-rejection number with visible gain/phase imbalance points at the SDR or
+recording chain, not the signal.
+
+**Where does the exported JSON go?**
+Next to the capture, as `<capture>.siglab.json`, written by the engine's own
+serializer when you press `e`.
+
+## Series navigation
+
+**Part 2 of 10** · ←[Part 1]({{ '/blog/tutorials/signal-lab-01-first-capture-no-radio/' | relative_url }}) · Next →
+[Part 3: The Browser Console]({{ '/blog/tutorials/signal-lab-03-browser-console-live-decode/' | relative_url }})

--- a/docs/_posts/2026-07-06-crypto-lab-03-randomness-nist-lfsr.md
+++ b/docs/_posts/2026-07-06-crypto-lab-03-randomness-nist-lfsr.md
@@ -1,0 +1,163 @@
+---
+title: "Crypto Lab, Part 3: Randomness — NIST SP 800-22 & the LFSR Signature"
+description: Crypto Lab's randomness battery runs a NIST SP 800-22 subset over a keystream bitstream — monobit, block frequency, runs, longest run, binary-matrix rank, spectral DFT, approximate entropy, serial, cumulative sums, and linear complexity — to tell strong keyed encryption from an exploitable LFSR scrambler.
+category: tutorials
+keywords: nist sp 800-22, randomness testing, linear complexity, lfsr signature, keystream analysis, monobit test, spectral dft, berlekamp massey, rf encryption testing, gophertrunk cryptolab
+tags: [cryptolab, randomness, lfsr, keystream, advanced, security-testing]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 3
+charts: true
+---
+
+*Part 3 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. Once you have a keystream, one question decides everything: is it strong, or is it a scrambler in disguise?*
+
+> **TL;DR:** `cryptolab randomness battery -in keystream.bin` runs a NIST SP 800-22 subset — monobit, block frequency, runs, longest run, binary-matrix rank, spectral DFT, approximate entropy, serial, cumulative sums, and **linear complexity** — over a bitstream of **packed bytes, MSB-first**. A stream that passes is consistent with strong keyed encryption (nothing to exploit); a **failing linear-complexity or spectral test is the signature of an LFSR-based scrambler**. `randomness quick` runs the fast subset for short captures.
+
+> **Authorized testing only.** Run this against keystreams from your own or licensed systems.
+
+**Key takeaways**
+
+- **The decisive RF question** is whether a recovered keystream is statistically random (strong) or structured (a keyless scrambler / short LFSR).
+- **Linear complexity is the tell.** A failing linear-complexity or spectral test is the fingerprint of an LFSR.
+- **Input is packed bytes, MSB-first** — the same convention as `lfsr bm`.
+- **`quick` for short captures, `battery` for the full picture** — the full battery needs enough bits to be meaningful.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab randomness battery -in keystream.bin` | Full NIST SP 800-22 subset (10 tests) |
+| `cryptolab randomness quick -in keystream.bin` | Fast subset (monobit / block-freq / runs / cusum) |
+| `-alpha 0.01` | Significance level (default 0.01) |
+| `cryptolab lfsr bm -in keystream.bin` | Recover the shortest LFSR (Berlekamp–Massey) |
+| `cryptolab ks extract -pt p.bin -ct c.bin -out ks.bin` | Get a keystream to feed the battery |
+
+## In this post
+
+- **Why randomness is the RF question** — the difference between "encrypted" and "unbreakable."
+- **The ten tests** and what each one is sensitive to.
+- **The LFSR signature** — how linear complexity and spectral DFT unmask a scrambler.
+- **`quick` vs `battery`** — matching the test set to how many bits you have.
+- **From battery to Berlekamp–Massey** — the natural handoff to `lfsr bm`.
+
+## Why randomness is the whole question
+
+When you've recovered a keystream — from a known-plaintext pair, or from an LDU2 you could decrypt — you hold the raw output of whatever generator the cipher used. And here's the thing Reese drills into every new analyst: **a strong keystream and a weak one can have the same entropy.** Entropy near 8 bits/byte just means the byte values are spread out. It does *not* mean the sequence is unpredictable. A short LFSR produces a high-entropy, long-period stream that looks random to the eye and to a chi-square test — yet a few hundred bits are enough to predict the rest of it forever.
+
+So the security question is not "is this high-entropy?" but "is this *statistically random*?" — random in the sense that no test can distinguish it from coin flips. If it passes, you're looking at strong keyed encryption (AES/DES-class) or good compression, and there is nothing to brute-force. If it fails, the stream carries exploitable structure, and the battery tells you *which kind*.
+
+## The ten tests
+
+```bash
+gophertrunk cryptolab randomness battery -in keystream.bin
+```
+
+```text
+randomness/battery — 20480 bits: 9/10 tests passed, 1 failed, 0 skipped (alpha 0.010)
+  bits          20480
+  looks_random  false
+findings (weakest first):
+  linear_complexity   0.994   p_value 0.006  passed false
+  spectral_dft        0.210   p_value 0.790  passed true
+  monobit             0.010   p_value 0.990  passed true
+  ...
+note: one or more tests failed: the stream carries exploitable structure.
+  A failing linear_complexity or spectral test points at an LFSR / keyless
+  scrambler — try `cryptolab lfsr bm` and `cryptolab stats period`.
+```
+
+The full battery runs a ten-test subset of NIST SP 800-22, each sensitive to a different kind of non-randomness:
+
+| Test | Detects |
+|---|---|
+| monobit | An imbalance of ones vs zeros overall |
+| block frequency | Local bias within fixed-size blocks |
+| runs | Too many / too few consecutive-bit runs |
+| longest run | An improbably long run of ones in a block |
+| binary-matrix rank | Linear dependence among bit sub-blocks |
+| spectral DFT | Periodic patterns via a frequency-domain peak |
+| approximate entropy | Repeating overlapping patterns |
+| serial | Non-uniform frequency of overlapping m-bit patterns |
+| cumulative sums | Drift in the running one/zero sum |
+| **linear complexity** | Whether a short LFSR reproduces the sequence |
+
+Each test yields a **p-value**; a test *passes* when its p-value clears the significance level `alpha` (default 0.01). The report's `looks_random` field is the roll-up: it's true only when nothing failed. Findings are sorted weakest-first, so the most non-random test floats to the top.
+
+Here is a battery result as a chart — nine tests clear the 0.01 threshold, but linear complexity dives under it, coloring red:
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="bars" width="600" height="320" role="img"
+        aria-label="NIST SP 800-22 p-values with a 0.01 threshold; linear complexity fails"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "categories":["monobit","block-freq","runs","longest-run","matrix-rank","spectral","approx-ent","serial","cusum","lin-cplx"],
+"values":[0.99,0.61,0.44,0.72,0.38,0.79,0.51,0.66,0.90,0.006],
+"threshold":0.01,
+"pass":[true,true,true,true,true,true,true,true,true,false],
+"ylabel":"p-value (pass ≥ 0.01)" }
+</script>
+<figcaption>Nine tests pass comfortably; linear complexity's p-value of 0.006 falls below the 0.01 threshold and fails — the sequence is not random. A single red bar is enough to change the verdict.</figcaption>
+</figure>
+
+## The LFSR signature
+
+The reason **linear complexity** gets bolded everywhere is that it is the test purpose-built to separate keyed encryption from a linear scrambler. Linear complexity is the length of the shortest LFSR that generates the sequence, computed by the Berlekamp–Massey algorithm. For a truly random stream of *n* bits, that length hovers around *n/2*. For an LFSR-based scrambler, it collapses to a small constant — the register length — no matter how many bits you feed it.
+
+So the battery's linear-complexity test asks: *is the shortest LFSR suspiciously short?* When it is, the test fails, and you have your answer — this is not a strong cipher, it is a scrambler you can reconstruct and predict. The **spectral DFT** test is the companion signature: an LFSR's periodicity shows up as a peak in the frequency domain, which the DFT test flags. When either fails, the classifier and the battery both point you at the same next tool: `lfsr bm`, which we saw the toolkit recommend in [Part 2]({{ '/blog/tutorials/crypto-lab-02-first-triage-classify-stats/' | relative_url }}).
+
+This is exactly the distinction that makes a high-entropy verdict *not* mean "give up." Ada learned it the hard way on a scrambled payload: entropy 7.98, "must be AES," she thought — until the battery failed linear complexity and `lfsr bm` recovered a 17-bit register that regenerated the whole keystream. Structured, not strong.
+
+## Input format: packed bytes, MSB-first
+
+One detail that trips people up: the battery reads its input as a **bitstream of packed bytes, MSB-first**. Each byte contributes 8 bits, most-significant first, in file order. This is the same convention `lfsr bm` uses, which is deliberate — a keystream you've extracted flows straight from one tool to the other without any re-packing. If you feed it text or a hex dump instead of raw packed bytes, the bits won't line up and the tests will be meaningless, so extract to raw bytes first (`ks extract -out ks.bin`, [Part 5]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }})).
+
+## `quick` vs `battery`
+
+The full battery is only meaningful with enough bits — several of the tests (binary-matrix rank, spectral DFT, linear complexity, approximate entropy) need a substantial sample to produce a reliable p-value, and with too few bits they get skipped and reported as such. For short captures, `randomness quick` runs the fast, low-data subset — monobit, block frequency, runs, and cumulative sums:
+
+```bash
+gophertrunk cryptolab randomness quick -in short-keystream.bin
+```
+
+The classifier itself uses this rule internally: it runs the full `Battery` when it has at least a couple thousand bits and falls back to `Quick` below that. As a human analyst you make the same call — `quick` for a first look at a short keystream, `battery` once you have enough material for the heavy tests to fire. The `-alpha` flag tunes the significance level on either; lowering it makes the tests more permissive (fewer false failures), raising it makes them stricter.
+
+## From battery to Berlekamp–Massey
+
+The battery *detects* structure; `lfsr bm` *recovers* it. When linear complexity fails, run:
+
+```bash
+gophertrunk cryptolab lfsr bm -in keystream.bin
+```
+
+```text
+lfsr/bm — 20480 bits: linear complexity 17
+  linear_complexity  17
+  feedback_taps      [17 14 0]
+note: short LFSR recovered: feed more bits to confirm the taps generalize
+  beyond the observed sequence.
+```
+
+A linear complexity of 17 over 20,480 bits is a screaming result — the entire keystream is the output of a 17-stage register, and the reported feedback taps let you regenerate and predict it. Reese's caution, which the tool prints for you: confirm the taps generalize by feeding more bits. A short LFSR fit to too little data can be a coincidence; a short LFSR that holds across thousands of bits is a break. If you have a plaintext/ciphertext pair rather than a raw keystream, `lfsr keystream -pt p.bin -ct c.bin` XORs them and runs Berlekamp–Massey in one step.
+
+## Where this goes next
+
+Not every weak payload is an LFSR. Some are classical ciphers — repeating XOR, a Caesar shift, a Vigenère key, a substitution alphabet — and Crypto Lab has a dedicated `brute` tool with an embedded English language model to recover them. [Part 4]({{ '/blog/tutorials/crypto-lab-04-classical-ciphers-brute/' | relative_url }}) walks all four modes and when each applies. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) have the full test list if you want the reference.
+
+## FAQ
+
+**What input format does the battery expect?**
+Raw packed bytes, MSB-first — the same convention as `lfsr bm`. Don't feed it hex text or a base64 string; extract the keystream to raw bytes first.
+
+**My payload has entropy near 8 but the battery fails. What does that mean?**
+High entropy with a failing test — especially linear complexity or spectral DFT — is the signature of an LFSR or keyless scrambler. It looks random byte-for-byte but is fully predictable from a short register. Run `lfsr bm` to recover it.
+
+**When should I use `quick` instead of `battery`?**
+When you have a short keystream. Several battery tests need a lot of bits to be reliable and will be skipped otherwise; `quick` runs only the tests that work on small samples.
+
+**Does passing the battery prove the encryption is unbreakable?**
+No — it proves the *keystream* is statistically indistinguishable from random at this alpha, which is consistent with strong keyed encryption. There may still be operational weaknesses (reused IVs, default keys); the battery only speaks to the keystream's structure.
+
+## Series navigation
+
+**Part 3 of 10** · ←[Part 2: First Triage]({{ '/blog/tutorials/crypto-lab-02-first-triage-classify-stats/' | relative_url }}) · Next →[Part 4: Classical Ciphers — Brute XOR, Caesar, Vigenère, Substitution]({{ '/blog/tutorials/crypto-lab-04-classical-ciphers-brute/' | relative_url }})

--- a/docs/_posts/2026-07-06-rf-scope-03-protocol-hierarchy.md
+++ b/docs/_posts/2026-07-06-rf-scope-03-protocol-hierarchy.md
@@ -1,0 +1,259 @@
+---
+title: "RF Scope, Part 3: Protocol Hierarchy — What's on the Air"
+description: rfscope's hierarchy analyzer is the RF analog of Wireshark's Protocol Hierarchy — it groups bursts by modulation class, then occupied-bandwidth bucket, then names the protocol of the longest digital burst with siglab, attaching burst counts, airtime, spectrum share, and symbol volume to every node.
+category: tutorials
+keywords: rfscope, protocol hierarchy, wireshark protocol hierarchy, modulation class, occupied bandwidth, siglab identify, rf analysis, unknown protocol, airtime, spectrum share, gophertrunk
+tags: [rfscope, rf-analysis, siglab, getting-started, gophertrunk, dsp]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 3
+---
+
+*Part 3 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer. With
+bursts in hand from segmentation, the first structured view is the one that answers
+"what kinds of signal are here?"*
+
+> **TL;DR:** The `hierarchy` analyzer is Wireshark's Protocol Hierarchy, one layer
+> down. It groups bursts into a three-level tree — **modulation class → occupied-bandwidth
+> bucket → identified protocol** — and attaches burst count, airtime, spectrum share,
+> time share, and estimated symbol volume to each node. It names a protocol by running
+> [`siglab.IdentifyIQ`]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }})
+> on the longest digital burst in a bucket. Signals it cannot name — like **Mercury** —
+> appear as an unknown-protocol node.
+
+**Key takeaways**
+
+- **The hierarchy is a three-level tree:** modulation class, then bandwidth bucket,
+  then named protocol.
+- **Protocol naming is delegated to Signal Lab.** RF Scope runs `siglab.IdentifyIQ`
+  on the longest digital burst per bucket — it does not re-implement identification.
+- **Every node carries stats:** bursts, airtime, spectrum %, time %, and an estimated
+  symbol volume (Σ duration × baud).
+- **Unknowns are first-class.** A digital carrier that identifies as nothing simply
+  has no protocol child — which is exactly how Mercury shows up.
+
+## Cheat sheet
+
+| Command / concept | What it does |
+|---|---|
+| `rfscope analyze -in cap -analyzers hierarchy` | Run just the hierarchy view |
+| Depth 0 node | A modulation class (C4FM, NBFM, FSK…) |
+| Depth 1 node | An occupied-bandwidth bucket (e.g. 12.5 kHz) |
+| Depth 2 node | A named protocol from `siglab.IdentifyIQ` |
+| `SymbolVolume` | Estimated symbols on air: Σ duration × baud |
+
+## In this post
+
+- **What the RF protocol hierarchy is** and how it maps to Wireshark's.
+- **The three levels** — class, bandwidth bucket, protocol.
+- **How protocols get named** — the Signal Lab delegation.
+- **The stats on each node** — and how to read spectrum vs time share.
+- **Mercury** — reading an unknown-protocol node.
+
+## The RF Protocol Hierarchy
+
+Open any pcap in Wireshark and the Protocol Hierarchy Statistics window tells you, at
+a glance, the *make-up* of the capture: what fraction is TCP, how much of that is
+TLS, how much HTTP underneath. It is the first thing many analysts look at because it
+turns thousands of packets into a handful of rows you can reason about.
+
+RF Scope's `hierarchy` analyzer does the same for a band. Instead of protocol layers
+it uses the only structure available without decoding — **modulation class**, then
+**how wide the signal is**, then, where it can, **the actual protocol**. The result
+is a compact tree that says "this band is mostly narrowband C4FM at 12.5 kHz, which
+identifies as P25; plus some FSK paging; plus one wide unknown thing." That is the
+reconnaissance summary Ada wants before she decides what to chase.
+
+The analyzer has **no dependencies** — it reads bursts directly — so it runs whether
+or not you asked for timeline, topology, or the rest.
+
+## Three levels
+
+The tree is built in `internal/rfscope/hierarchy.go` by bucketing bursts twice:
+
+```go
+// internal/rfscope/hierarchy.go
+for i, b := range sc.Bursts {
+    bucket := survey.SnapChannelBandwidth(b.OccupiedBwHz)
+    byClass[b.Class][bucket] = append(byClass[b.Class][bucket], i)
+}
+```
+
+- **Depth 0 — modulation class.** Every burst already carries a blind class from
+  `survey.Classify` in segmentation: NBFM, wide FM, AM, C4FM, FSK, PSK, continuous
+  data, paging, trunk control, trunk voice. Bursts are grouped by class first.
+- **Depth 1 — occupied-bandwidth bucket.** Within a class, bursts are snapped to a
+  standard channel bandwidth (`survey.SnapChannelBandwidth`) and grouped — so all the
+  12.5 kHz C4FM bursts land in one node, the 25 kHz ones in another. Bandwidth is the
+  cheapest discriminator between two protocols that share a modulation family.
+- **Depth 2 — named protocol.** For **digital** classes only, RF Scope tries to name
+  the protocol of the bucket (below). Analog classes stop at depth 1 — there is no
+  "protocol" to name for an FM voice channel.
+
+The tree is flattened depth-first with a `Depth` field on each node, so rendering it
+is a matter of indenting by depth.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 560 210" width="560" height="210" role="img" aria-label="Indented RF protocol hierarchy tree">
+  <text x="12" y="24" fill="var(--fg-muted)" font-size="11" font-family="monospace">Protocol hierarchy (bursts / time% / spectrum%)</text>
+  <text x="12" y="52" fill="currentColor" font-size="13" font-family="monospace">c4fm</text>
+  <text x="360" y="52" fill="var(--fg-muted)" font-size="12" font-family="monospace">128   41.0%   0.5%</text>
+  <text x="40" y="76" fill="currentColor" font-size="13" font-family="monospace">12.5 kHz</text>
+  <text x="360" y="76" fill="var(--fg-muted)" font-size="12" font-family="monospace">128   41.0%   0.5%</text>
+  <text x="70" y="100" fill="var(--accent)" font-size="13" font-family="monospace">p25p1</text>
+  <text x="360" y="100" fill="var(--fg-muted)" font-size="12" font-family="monospace">128   41.0%   0.5%</text>
+  <text x="12" y="128" fill="currentColor" font-size="13" font-family="monospace">fsk</text>
+  <text x="360" y="128" fill="var(--fg-muted)" font-size="12" font-family="monospace"> 34   6.2%    0.3%</text>
+  <text x="40" y="152" fill="currentColor" font-size="13" font-family="monospace">12.5 kHz</text>
+  <text x="360" y="152" fill="var(--fg-muted)" font-size="12" font-family="monospace"> 22   4.1%    0.2%</text>
+  <text x="70" y="176" fill="var(--fg-muted)" font-size="13" font-family="monospace">(unnamed — Mercury)</text>
+  <text x="360" y="176" fill="var(--fg-muted)" font-size="12" font-family="monospace"> 22   4.1%    0.2%</text>
+</svg>
+<figcaption>A flattened hierarchy: class → bandwidth bucket → protocol. The FSK 12.5 kHz bucket names no protocol — that is Mercury.</figcaption>
+</figure>
+
+## How protocols get named
+
+RF Scope does **not** re-implement protocol identification. It calls Signal Lab:
+
+```go
+// internal/rfscope/hierarchy.go
+res, err := siglab.IdentifyIQ(iq, "rfscope-burst", siglab.IdentifyConfig{
+    SampleRateHz: rate,
+    Format:       siglab.FormatF32,
+    Log:          in.Log,
+})
+if err != nil || res == nil || res.Inconclusive || res.Winner == "" {
+    return ""
+}
+return res.Winner
+```
+
+Two design choices are worth calling out. First, it identifies the **longest digital
+burst** in the bucket, not a random one. A longer burst gives the identifier more
+symbols to work with, so identification is more reliable — and one representative is
+enough, because a bucket is already a group of same-class, same-bandwidth bursts.
+
+Second, it uses the *decimated baseband IQ* that segmentation stored for that burst,
+served lazily through `in.BurstIQ`, so RF Scope never holds the whole capture in
+memory just to identify one signal. If identification is inconclusive or errors, the
+function returns an empty string and the bucket simply has **no protocol child**.
+
+This is the same `siglab.IdentifyIQ` entry point that
+[Signal Lab Part 8]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }})
+covers in full — the "name the unknown" workflow. RF Scope is one of its callers.
+Reese's framing: *"identification is a hard, specialized job; RF Scope's job is to
+know when to ask for it and what to do with a 'no.'"*
+
+## The stats on each node
+
+Every node — total, class, bucket, protocol — carries a `HierStats`:
+
+| Stat | Meaning |
+|---|---|
+| `BurstCount` | How many bursts fall under this node |
+| `AirtimeSec` | Total on-air seconds of those bursts |
+| `SpectrumPct` | Share of the span's bandwidth this node's channels occupy |
+| `TimePct` | Airtime as a fraction of the observation window |
+| `SymbolVolume` | Estimated symbols on air: Σ (duration × baud) |
+| `EmitterCount` | Distinct emitters, once topology has clustered them |
+
+The two percentages answer different questions and often disagree in a revealing way.
+**Spectrum %** is "how much of the band does this occupy?" — a wide carrier scores
+high even if it is rarely on. **Time %** is "how much of the window is this on air?" —
+a busy narrow channel scores high even though it barely dents the spectrum. A control
+channel is the classic case: tiny spectrum share, large time share, because it is
+almost always transmitting on one narrow channel.
+
+`SymbolVolume` is a rough "how much did this thing actually *say*?" — duration times
+the classifier's estimated baud, summed. It is an estimate, not a decode, but it lets
+you rank nodes by information carried rather than just airtime.
+
+## Why bandwidth is the middle level
+
+It is worth asking why the tree groups by *occupied bandwidth* between class and
+protocol, rather than by frequency or power. The answer is that bandwidth is the
+cheapest, most protocol-revealing discriminator available before you decode anything. Two
+signals in the same modulation family are often distinguished purely by how wide they
+are: a 12.5 kHz C4FM channel and a 25 kHz C4FM channel are almost certainly different
+systems, and the split falls out of the occupied-bandwidth measurement segmentation
+already computed. Frequency would fragment the tree into one node per channel — too fine
+to summarize a band — and power says more about your antenna and the emitter's distance
+than about the protocol.
+
+The bandwidths are also **snapped** to standard channel widths via
+`survey.SnapChannelBandwidth` before bucketing, so a burst measured at 12.3 kHz and one
+at 12.7 kHz land in the same 12.5 kHz node instead of splitting into two near-duplicate
+buckets. That snapping is what keeps the tree readable: it collapses measurement jitter
+into the small set of channel rasters real systems actually use, and it is the same
+raster logic the `-min-spacing` flag exposes in segmentation. The result is a tree whose
+middle level reads like a channel plan — "12.5 kHz," "25 kHz," "6.25 kHz" — rather than a
+scatter of noisy Hz values.
+
+## Reading an unknown node: Mercury
+
+This is the part that matters for the trilogy. Ada's 453 MHz capture segments into a
+handful of short FSK-family bursts around a 12.5 kHz channel. The hierarchy analyzer
+buckets them: class `fsk`, bandwidth `12.5 kHz`. Because FSK is a digital class, it
+tries to name the protocol — it runs `siglab.IdentifyIQ` on the longest of those
+bursts.
+
+Signal Lab comes back **inconclusive**. Its best blind guess had been around 4800
+sym/s and 4-level-FSK-like, but nothing locked as a named protocol. So
+`identifyRepresentative` returns `""`, and the bucket gets **no depth-2 child**. In
+the tree, Mercury is a bandwidth bucket with real bursts, real airtime, and *no
+protocol name under it*:
+
+```text
+fsk                     22   4.1%   0.2%
+  12.5 kHz              22   4.1%   0.2%
+    (no protocol identified)
+```
+
+An unnamed digital node is not a failure — it is a **finding**. It says "there is real
+digital traffic here that is none of the 13 protocols GopherTrunk decodes." That is
+precisely the class of signal RF Scope exists to surface, and it is the reason Ada
+keeps digging. In Part 6 the topology analyzer will notice Mercury hops; in Part 7 the
+entropy analyzer will triage its payload and hand it to Crypto Lab.
+
+## Where this goes next
+
+The hierarchy tells you *what kinds* of signal share the band. It says nothing about
+*when* each channel is active. [Part
+4]({{ '/blog/tutorials/rf-scope-04-io-graph-channel-activity/' | relative_url }})
+builds the **I/O graph** — the `timeline` analyzer — which gives every channel a
+time-bucketed occupancy series, a duty cycle, and a burst rate, so you can see the
+band breathe over the capture. If you want the full identification story behind the
+protocol names, read
+[Signal Lab Part 8]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }})
+and the [Signal Lab hub]({{ '/blog/series/signal-lab/' | relative_url }}).
+
+## FAQ
+
+**Why does RF Scope only name protocols for digital classes?**
+Analog FM/AM voice channels have no protocol to identify — the "protocol" *is* the
+modulation. Naming only applies to digital classes, where framing and symbol rate can
+match a known protocol via `siglab.IdentifyIQ`.
+
+**Why the longest burst per bucket?**
+More symbols means more reliable identification. Since a bucket already groups
+same-class, same-bandwidth bursts, one strong representative is enough to name the
+whole bucket.
+
+**What does an unnamed digital node mean?**
+Real digital traffic that matches none of the named protocols GopherTrunk decodes —
+an unknown. That is a first-class result, not an error, and it is where the topology
+and entropy analyzers take over.
+
+**Does the hierarchy analyzer need any other analyzer to run first?**
+No. It depends on nothing and reads bursts directly, so you can run it alone with
+`-analyzers hierarchy`. `EmitterCount` on its nodes only fills in once topology has
+also run.
+
+## Series navigation
+
+**Part 3 of 10** · ←
+[Part 2: From IQ to Bursts]({{ '/blog/tutorials/rf-scope-02-segmentation-iq-to-bursts/' | relative_url }})
+· Next →
+[Part 4: The I/O Graph]({{ '/blog/tutorials/rf-scope-04-io-graph-channel-activity/' | relative_url }})

--- a/docs/_posts/2026-07-06-signal-lab-03-browser-console-live-decode.md
+++ b/docs/_posts/2026-07-06-signal-lab-03-browser-console-live-decode.md
@@ -1,0 +1,237 @@
+---
+title: "Signal Lab, Part 3: The Browser Console — siglab serve and Live Decode"
+description: Signal Lab's browser console, gophertrunk siglab serve — a fully offline web app at 127.0.0.1:8099 with Captures, Synthesize, Identify, Wideband, and Compare tabs, upload-configure-run workflow, and a live SSE decode event stream.
+category: tutorials
+keywords: siglab serve, signal lab console, offline web console, sse event stream, iq upload, siglab tabs, max-upload, tmp-dir, live decode, browser sdr analysis
+tags: [siglab, sdr, web-console, getting-started, iq, dsp]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 3
+---
+
+*Part 3 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. The terminal app is fast; the browser console is
+where you actually *see* a signal.*
+
+> **TL;DR:** `gophertrunk siglab serve` starts a fully offline web console at
+> `http://127.0.0.1:8099/`. It bundles the entire RF-analysis UI into the binary
+> — no Node.js at runtime, no CDN — and organizes work into five tabs: Captures,
+> Synthesize, Identify, Wideband, and Compare. The core loop is upload →
+> configure the engine → run with a live SSE event stream → read the dashboard.
+> Live *capture* from an SDR only exists when the console is served by a daemon
+> with a radio; the standalone server is purely offline analysis.
+
+**Key takeaways**
+
+- **One command, a local web app.** `siglab serve` binds `127.0.0.1:8099` and
+  serves the whole console from the binary — nothing fetched from the internet.
+- **Five tabs** cover the workbench: Captures, Synthesize, Identify, Wideband,
+  Compare.
+- **The loop is upload → configure → run → dashboard**, with decode events
+  streaming live over Server-Sent Events.
+- **`-open`, `-addr`, `-tmp-dir`, `-max-upload`** shape where it listens and how
+  big an upload it accepts.
+- **Live SDR capture is daemon-only.** The standalone server analyzes files; it
+  doesn't touch hardware.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `gophertrunk siglab serve` | Serve the console on `127.0.0.1:8099` |
+| `-open` | Open it in the system browser once it's up |
+| `-addr host:port` | Change the listen address (e.g. `0.0.0.0:9000`) |
+| `-tmp-dir <dir>` | Directory for staged capture uploads |
+| `-max-upload <bytes>` | Max upload size (`0` = default 512 MiB) |
+| `-verbose-errors` | Full error chain + stack on failure |
+
+## In this post
+
+- **Starting the console** — the one command and its flags.
+- **The five tabs** — what each surface is for.
+- **The core loop** — upload, configure, run, read.
+- **The live event stream** — what SSE gives you that a batch run doesn't.
+- **Where live capture fits** — and why the standalone server stays offline.
+
+## Starting the console
+
+The whole thing is one subcommand:
+
+```bash
+gophertrunk siglab serve              # serve on 127.0.0.1:8099
+gophertrunk siglab serve -open        # ...and open it in your browser
+gophertrunk siglab serve -addr 0.0.0.0:9000
+```
+
+It prints its address to stderr and waits:
+
+```text
+siglab serve: listening on http://127.0.0.1:8099/
+```
+
+The server is deliberately minimal — it runs the API server with *only* the
+Signal Lab subsystem wired in, no SDR, no daemon, no storage:
+
+```go
+// cmd/gophertrunk/siglab_serve.go
+opts := api.ServerOptions{
+    Addr: *addr,
+    Siglab: api.SiglabOptions{
+        Enabled:        true,
+        TempDir:        *tmpDir,
+        MaxUploadBytes: *maxUpload,
+    },
+}
+```
+
+Everything the browser needs — the SPA, the fonts, the analysis code — is
+embedded in the binary, so the console works on an air-gapped machine. On
+Windows the installer drops a **Signal Lab console** shortcut in the Start Menu
+that runs exactly this command, so operators who never touch a shell still get
+the full workbench.
+
+The flags are few and practical. `-addr` moves the listener (bind `0.0.0.0` to
+reach it from another machine — mind that it's unauthenticated, so keep it on
+trusted networks). `-open` launches your browser once the server is up.
+`-tmp-dir` chooses where uploaded captures are staged (default: a fresh temp
+dir). `-max-upload` caps upload size in bytes, where `0` means the default of
+**512 MiB** — raise it if you routinely analyze multi-gigabyte wideband files.
+
+## The five tabs
+
+The console organizes the workbench into five tabs, each a front-end onto part
+of the engine you've already met or will meet soon:
+
+| Tab | What it's for | Covered in |
+|---|---|---|
+| **Captures** | Upload a file, configure the engine, run a decode, read the dashboard | this post |
+| **Synthesize** | Generate an ideal capture and inject impairments | Part 6 |
+| **Identify** | Rank protocol candidates for an unknown capture | Part 8 |
+| **Wideband** | Survey a wide capture for carriers and name them | Part 8 |
+| **Compare** | Overlay spectra and diff metrics across captures | Parts 6 & 10 |
+
+<figure class="lab-figure">
+<svg viewBox="0 0 660 260" width="660" height="260" role="img" aria-label="Annotated layout of the Signal Lab browser console">
+  <rect x="8" y="8" width="644" height="244" rx="8" fill="none" stroke="var(--border)"/>
+  <text x="24" y="34" fill="var(--accent)" font-size="13" font-weight="bold">Signal Lab</text>
+  <!-- tab bar -->
+  <rect x="120" y="18" width="90" height="24" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="165" y="34" text-anchor="middle" fill="var(--accent)" font-size="11">Captures</text>
+  <text x="245" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="11">Synthesize</text>
+  <text x="330" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="11">Identify</text>
+  <text x="410" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="11">Wideband</text>
+  <text x="485" y="34" text-anchor="middle" fill="var(--fg-muted)" font-size="11">Compare</text>
+  <line x1="8" y1="52" x2="652" y2="52" stroke="var(--border)"/>
+  <!-- left config panel -->
+  <rect x="24" y="68" width="180" height="168" rx="6" fill="none" stroke="currentColor"/>
+  <text x="114" y="90" text-anchor="middle" fill="currentColor" font-size="11">configure engine</text>
+  <text x="114" y="112" text-anchor="middle" fill="var(--fg-muted)" font-size="10">protocol · rate</text>
+  <text x="114" y="128" text-anchor="middle" fill="var(--fg-muted)" font-size="10">format · tune</text>
+  <text x="114" y="144" text-anchor="middle" fill="var(--fg-muted)" font-size="10">auto-tune · conj</text>
+  <text x="114" y="160" text-anchor="middle" fill="var(--fg-muted)" font-size="10">IQ-correct · P25 knobs</text>
+  <rect x="44" y="188" width="140" height="30" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="114" y="208" text-anchor="middle" fill="var(--accent)" font-size="12">▶ Run</text>
+  <!-- right result panel -->
+  <rect x="224" y="68" width="404" height="90" rx="6" fill="none" stroke="currentColor"/>
+  <text x="426" y="90" text-anchor="middle" fill="currentColor" font-size="11">live event stream (SSE)</text>
+  <text x="240" y="112" fill="var(--fg-muted)" font-size="10" font-family="monospace">0.42s  lock       @ -12500 Hz</text>
+  <text x="240" y="128" fill="var(--fg-muted)" font-size="10" font-family="monospace">0.55s  grant      TG=101</text>
+  <text x="240" y="144" fill="var(--fg-muted)" font-size="10" font-family="monospace">1.03s  grant      TG=204</text>
+  <rect x="224" y="168" width="404" height="68" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="426" y="192" text-anchor="middle" fill="var(--accent)" font-size="11">dashboard</text>
+  <text x="426" y="214" text-anchor="middle" fill="var(--fg-muted)" font-size="10">EVM 7.4%  ·  SNR≈19.7 dB  ·  constellation  ·  PSD</text>
+</svg>
+<figcaption>The Captures tab: a configuration panel on the left, a live event stream and results dashboard on the right, with the tab bar across the top.</figcaption>
+</figure>
+
+## The core loop
+
+A typical session on the **Captures** tab is four steps:
+
+1. **Upload** a capture (or hop to **Synthesize** and generate one). The file is
+   staged into the temp directory `-tmp-dir` points at, subject to the
+   `-max-upload` limit.
+2. **Configure the engine.** Choose the protocol, set the sample rate, and toggle
+   the same knobs the CLI exposes plus a few deeper ones: tune, auto-tune,
+   conjugate (mirror I/Q), IQ-correct, and the P25 deep knobs. These map onto the
+   same engine `Config` the TUI builds — the console is a richer front panel on
+   identical machinery.
+3. **Run.** The decode runs and streams events back live (next section).
+4. **Read the dashboard**, then optionally **Compare** against another capture or
+   a synthesized ideal, and **Export** the structured result. The console offers
+   the engine's JSON / JSONL / YAML / CSV serializers — the same output the
+   terminal app writes when you press `e`.
+
+Because it's the same engine, the 2% baud-deviation rule from Part 2 applies
+here verbatim: if the run reports a large baud deviation, fix the sample rate in
+the config panel and re-run before trusting anything else.
+
+## The live event stream
+
+The console's signature feature is that a run isn't a black box that returns an
+answer — it **narrates**. Decode events stream to the browser over Server-Sent
+Events (SSE) as they happen: the moment of lock with its residual frequency, each
+grant, stage transitions, errors. For a five-second capture that's over in a
+blink, but for a long recording it's the difference between staring at a spinner
+and watching a control channel wake up, grant a call, and settle.
+
+The same event records feed the terminal app's live log; the console just renders
+them in a scrolling panel next to the results. When something goes wrong
+mid-decode, you see *where* in the capture it happened rather than only a final
+"not locked" — which is often the clue that turns a mysterious failure into an
+obvious one (a burst of errors right at a known interference spike, say).
+
+## Where live capture fits
+
+One boundary matters. The **standalone** `siglab serve` is purely offline: it
+analyzes uploaded and synthesized files and never touches hardware. The
+live-**capture** surface — record a fixed-length raw-IQ file from a tuner, then
+analyze it immediately and download the `.cfile` — only exists when the console
+is served by a **running daemon with an SDR**.
+
+That's not an accident of packaging; it's the architecture. The daemon mounts the
+identical `/api/v1/siglab/*` routes the standalone server does:
+
+> The running daemon mounts the same `/api/v1/siglab/*` routes, so if you already
+> have a daemon up you can reach the console (and the live-capture surface) there
+> instead of starting a separate server.
+
+So there are two ways to reach the same console. Start `siglab serve` for
+offline, file-only analysis on any machine; or open the console on a daemon
+that's attached to a radio to *also* get live capture. Either way the analysis
+half — every tab in this post — behaves identically, because it's the same
+bundled UI over the same engine.
+
+## Where this goes next
+
+Now that you can drive the console, the next four parts fill its visualization
+tabs with meaning. [Part 4]({{ '/blog/tutorials/signal-lab-04-constellations-and-eye-diagrams/' | relative_url }})
+opens the constellation and eye diagram — the plots that show *modulation
+quality* directly — so the EVM and SNR numbers from Part 2 get a picture to go
+with them. The [SigLab docs]({{ '/siglab.html' | relative_url }}) page lists every
+serve flag if you need the reference.
+
+## FAQ
+
+**Does the console need internet or Node.js?**
+No. The entire SPA and its analysis code are embedded in the binary. It runs on
+an air-gapped machine; nothing is fetched from a CDN at runtime.
+
+**Can I capture live from an SDR in the console?**
+Only when the console is served by a running daemon that has an SDR attached. The
+standalone `siglab serve` is offline analysis of uploaded and synthesized files
+only.
+
+**My capture upload was rejected as too large. What do I raise?**
+`-max-upload`, in bytes. The default is 512 MiB (`0` selects that default). For
+multi-gigabyte wideband files, pass a larger value.
+
+**How do I reach the console from another machine?**
+Bind a non-loopback address with `-addr 0.0.0.0:9000`. It's unauthenticated, so
+only do this on a trusted network.
+
+## Series navigation
+
+**Part 3 of 10** · ←[Part 2]({{ '/blog/tutorials/signal-lab-02-reading-the-dashboard/' | relative_url }}) · Next →
+[Part 4: Constellations & Eye Diagrams]({{ '/blog/tutorials/signal-lab-04-constellations-and-eye-diagrams/' | relative_url }})

--- a/docs/_posts/2026-07-07-crypto-lab-04-classical-ciphers-brute.md
+++ b/docs/_posts/2026-07-07-crypto-lab-04-classical-ciphers-brute.md
@@ -1,0 +1,185 @@
+---
+title: "Crypto Lab, Part 4: Classical Ciphers — Brute XOR, Caesar, Vigenère, Substitution"
+description: Crypto Lab's brute tool recovers classical ciphers — repeating XOR, Caesar shift, Vigenère, and monoalphabetic substitution — using an embedded English trigram language model and optional cribs, with lfsr recovering the keystream of a linear scrambler.
+category: tutorials
+keywords: brute force cipher, repeating xor, vigenere cipher, caesar cipher, substitution cipher, hill climbing, english trigram model, crib dragging, berlekamp massey, gophertrunk cryptolab
+tags: [cryptolab, brute-force, classical-ciphers, security-testing, advanced, rf]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 4
+charts: true
+---
+
+*Part 4 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. When triage says "classical cipher," this is the tool that recovers the key.*
+
+> **TL;DR:** `cryptolab brute` has four modes — `xor`, `caesar`, `vigenere`, and `substitution` — each recovering a classical cipher by scoring candidate plaintexts against an **embedded English trigram language model** (optionally boosted with a `-crib`). Use `xor` for repeating-XOR, `caesar` for a single shift, `vigenere` for a polyalphabetic key, and `substitution` for a monoalphabetic alphabet. `lfsr bm` handles the linear-scrambler case, recovering the keystream as `pt ⊕ ct`.
+
+> **Authorized testing only.** These attacks belong on ciphertext from systems you own or are licensed to assess.
+
+**Key takeaways**
+
+- **Four modes, four cipher families** — match the mode to what triage found.
+- **English scoring drives recovery.** An embedded trigram model ranks candidate plaintexts; a `-crib` sharpens it.
+- **XOR and Vigenère auto-detect key length** from the same periodicity test `stats` uses.
+- **Substitution is a hill-climb** with random restarts — trade `-restarts` for recovery on short ciphertexts.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab brute xor -in cipher.bin` | Recover a single- or repeating-byte XOR key (auto key length) |
+| `cryptolab brute xor -in cipher.bin -keylen 7` | Solve a known repeating-XOR key length |
+| `cryptolab brute caesar -in cipher.txt` | Recover a single additive (Caesar/ROT) shift |
+| `cryptolab brute vigenere -in cipher.txt -keylen 5` | Recover a repeating additive (Vigenère) key |
+| `cryptolab brute substitution -in cipher.txt -restarts 40` | Solve a monoalphabetic substitution (hill-climb) |
+| `-crib "UNIT "` | Boost scoring with a known-plaintext substring |
+| `cryptolab lfsr bm -in keystream.bin` | Recover a linear scrambler's LFSR |
+
+## In this post
+
+- **When each mode applies** — routing from the triage verdict to the right brute.
+- **`brute xor`** — single-byte and repeating-key, with auto key-length detection.
+- **`brute caesar` and `brute vigenere`** — additive ciphers over the alphabet.
+- **`brute substitution`** — hill-climbing a full alphabet against English.
+- **`lfsr`** — the recovery path for a linear keystream.
+
+## Matching the mode to the cipher
+
+The classifier from [Part 2]({{ '/blog/tutorials/crypto-lab-02-first-triage-classify-stats/' | relative_url }}) already routes you here with a specific recommendation. This is the map it's using:
+
+| Triage says | Cipher family | Mode |
+|---|---|---|
+| `repeating-xor` | Bytewise repeating XOR | `brute xor` |
+| `substitution-or-shift` (single shift) | Caesar / ROT-n | `brute caesar` |
+| `substitution-or-shift` (polyalphabetic) | Vigenère | `brute vigenere` |
+| `substitution-or-shift` (monoalphabetic) | Substitution alphabet | `brute substitution` |
+| `lfsr-or-keyless-scrambler` | Linear keystream | `lfsr bm` |
+
+What every mode has in common is **scoring against English**. The engine carries an English trigram language model (`internal/cryptolab/engine/lang`) and a corpus; each candidate key produces a candidate plaintext, and the model scores how English-like that plaintext reads. The highest-scoring candidate wins. If you already know a fragment of the plaintext — a unit ID, a call sign, a common word — pass it as a `-crib` and the scorer weights any candidate that contains it, which dramatically sharpens recovery on short or noisy ciphertext.
+
+Why does English scoring work at all? Because natural-language plaintext is enormously non-random at the level of letter triples: `THE`, `AND`, `ING`, `ION` are common; `QZX`, `JQV`, `WKZ` essentially never occur. A trigram model turns that regularity into a single number — the log-probability of a candidate plaintext under English — and the correct key is the one that produces text scoring far above every wrong key, because a wrong key smears the letter statistics toward uniform noise. This is the same statistical lever the classifier's index-of-coincidence check pulls in [Part 2]({{ '/blog/tutorials/crypto-lab-02-first-triage-classify-stats/' | relative_url }}); `brute` just uses it to *rank keys* rather than to *classify a payload*. The practical consequence for you as an analyst: the more ciphertext you feed, the sharper the separation between the right key and the runners-up, and the shorter the message, the more a `-crib` earns its keep.
+
+## `brute xor`
+
+Repeating-XOR is the workhorse of weak RF obfuscation, so it gets the most machinery. Give it a key length and it solves directly:
+
+```bash
+gophertrunk cryptolab brute xor -in cipher.bin -keylen 7
+```
+
+Leave the key length off and it **auto-detects**. It first solves the single-byte case, then scores the top few key lengths guessed from the same normalized-Hamming periodicity test `stats scan` uses, and keeps whichever the English scorer likes best — a guard against overfitting a genuinely single-byte cipher to a noisy long-key guess:
+
+```bash
+gophertrunk cryptolab brute xor -in cipher.bin -crib "UNIT "
+```
+
+```text
+brute/xor — recovered 7-byte XOR key
+  keylen                  7
+  auto_keylen_candidates  [7 14 5]
+  key=52414449 4f31       0.83   key_ascii "RADIO1"
+    plaintext_prefix "UNIT 214 DISPATCH TO SECTOR 7, ACKNOWLEDGE..."
+```
+
+The finding reports the key in hex, its printable rendering, and a plaintext preview. Here the crib `"UNIT "` both confirmed the solve and pulled the right key length to the top. This chart shows why: across candidate key lengths, the English score of the best recovered plaintext spikes at the true period.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="line" width="560" height="300" role="img"
+        aria-label="English score of the best recovered plaintext by candidate XOR key length, peaking at 7"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "series":[{"label":"English score","dots":true,"points":[[2,0.31],[3,0.34],[4,0.29],[5,0.41],[6,0.33],[7,0.83],[8,0.36],[9,0.30],[10,0.38],[14,0.62]]}],
+"xlabel":"candidate key length","ylabel":"English score","xmin":2,"xmax":14,"ymin":0,"ymax":1 }
+</script>
+<figcaption>English score by candidate XOR key length: a sharp peak at 7 (the true period) and a secondary bump at its multiple 14. The scorer keeps the peak.</figcaption>
+</figure>
+
+## `brute caesar` and `brute vigenere`
+
+These two handle additive ciphers over the alphabet. `caesar` recovers a single shift — the classic ROT-n — by trying every shift and scoring:
+
+```bash
+gophertrunk cryptolab brute caesar -in cipher.txt
+```
+
+```text
+brute/caesar — recovered Caesar shift 13
+  shift  13
+  key=0d   0.79   plaintext_prefix "MERIDIAN CONTROL HOLDING ON CHANNEL..."
+```
+
+`vigenere` extends that to a repeating additive key. Like `xor`, it auto-detects the key length from the periodicity test if you don't supply one, then solves each key position independently:
+
+```bash
+gophertrunk cryptolab brute vigenere -in cipher.txt -keylen 5
+gophertrunk cryptolab brute vigenere -in cipher.txt          # auto key length
+```
+
+The distinction between `xor` and `vigenere` is the alphabet: `xor` operates bytewise over all 256 values (right for binary RF payloads), while `caesar`/`vigenere` operate additively over the letter alphabet (right for text-like ciphertext). Triage's `substitution-or-shift` verdict with a strong periodicity peak points at Vigenère; a flat periodicity with elevated IC points at Caesar or substitution.
+
+## `brute substitution`
+
+A monoalphabetic substitution — every letter mapped to another, consistently — has an astronomically large keyspace (26! alphabets), far too many to enumerate. So `brute substitution` doesn't enumerate; it **hill-climbs**. Starting from a frequency-seeded guess, it repeatedly swaps letter mappings, keeping any swap that improves the English trigram score, and restarts from fresh random alphabets to escape local optima:
+
+```bash
+gophertrunk cryptolab brute substitution -in cipher.txt -restarts 40
+```
+
+```text
+brute/substitution — recovered substitution key QWERTYUIOPASDFGHJKLZXCVBNM
+  key    QWERTYUIOPASDFGHJKLZXCVBNM
+  score  -3821.4
+  plaintext  0.  key ...  plaintext_prefix "THE REPEATER SITE IS OFFLINE FOR..."
+note: monoalphabetic substitution solving assumes English plaintext and
+  enough ciphertext; very short or rare-letter-heavy messages may leave a
+  few letters unresolved.
+```
+
+The `-restarts` flag (default 25) is the key runtime/recovery trade-off: more restarts give the hill-climb more chances to find the global optimum, which matters most on short ciphertexts where the statistics are thin. `-seed` fixes the RNG for reproducible runs. The tool is honest about its assumption — it needs English plaintext and enough ciphertext; a very short message or one heavy on rare letters may leave a few mappings unresolved.
+
+Reese's field note: substitution solving is where the crib is worth the most. If you know one word appears — a town name on a repeater ID, say — even without a `-crib` flag the recovered alphabet usually snaps into place around it once enough of the surrounding text resolves.
+
+## `lfsr`: the linear-scrambler path
+
+When triage says `lfsr-or-keyless-scrambler` rather than a classical cipher, `brute` isn't the tool — `lfsr` is. It recovers the shortest LFSR for a bit sequence via Berlekamp–Massey ([Part 3]({{ '/blog/tutorials/crypto-lab-03-randomness-nist-lfsr/' | relative_url }}) covers the theory):
+
+```bash
+gophertrunk cryptolab lfsr bm -in keystream.bin
+```
+
+If you have a plaintext/ciphertext pair instead of a bare keystream, `lfsr keystream` does the whole job in one step — it computes the keystream as `pt ⊕ ct` and immediately runs Berlekamp–Massey on it:
+
+```bash
+gophertrunk cryptolab lfsr keystream -pt known.bin -ct cipher.bin
+```
+
+```text
+lfsr/keystream — 4096 keystream bytes; linear complexity 23
+  keystream_bytes    4096
+  linear_complexity  23
+  keystream 5f3a91c2...   taps [23 18 0]
+```
+
+A low linear complexity relative to the number of bits means the "encryption" was a linear scrambler, and the recovered taps regenerate the entire keystream. That's a keyless break — no key was ever needed, only the register structure. It's a preview of the deeper theme in [Part 10]({{ '/blog/tutorials/crypto-lab-10-subject-framework-alias/' | relative_url }}): obfuscation is not encryption.
+
+## Where this goes next
+
+Classical ciphers are the tutorial cases. The break that actually happens against modern digital RF encryption is subtler and more common: **keystream reuse**. When a stream cipher reuses its key and IV, two ciphertexts XOR to the XOR of their plaintexts — no key recovery required. [Part 5]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }}) is the core real-world break, and it's where the Mercury frames from RF Scope finally get analyzed. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) list every mode's flags.
+
+## FAQ
+
+**What's the difference between `brute xor` and `brute vigenere`?**
+`xor` is bytewise over all 256 values — right for binary RF payloads. `vigenere` is additive over the letter alphabet — right for text-like ciphertext. Both auto-detect key length from the same periodicity test.
+
+**How does the tool "know" it found the right key?**
+It scores each candidate plaintext against an embedded English trigram language model and keeps the highest scorer. A `-crib` adds weight for candidates containing a known substring, which is decisive on short ciphertext.
+
+**Why does substitution use random restarts?**
+The substitution keyspace (26!) is far too large to enumerate, so the solver hill-climbs from a frequency-seeded guess. Restarts let it escape local optima; more restarts improve recovery on short messages at the cost of runtime.
+
+**My payload is high-entropy — should I still try `brute`?**
+Probably not for a classical cipher. High entropy with a failing randomness test points at an LFSR — use `lfsr bm`. `brute`'s classical modes expect exploitable low-entropy structure.
+
+## Series navigation
+
+**Part 4 of 10** · ←[Part 3: Randomness & the LFSR Signature]({{ '/blog/tutorials/crypto-lab-03-randomness-nist-lfsr/' | relative_url }}) · Next →[Part 5: Keystream Reuse — Many-Time-Pad & Crib-Dragging]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }})

--- a/docs/_posts/2026-07-07-rf-scope-04-io-graph-channel-activity.md
+++ b/docs/_posts/2026-07-07-rf-scope-04-io-graph-channel-activity.md
@@ -1,0 +1,277 @@
+---
+title: "RF Scope, Part 4: The I/O Graph — Per-Channel Activity Over Time"
+description: rfscope's timeline analyzer is the RF analog of Wireshark's I/O Graphs — it groups bursts by frequency into channels and fills each with a 100-bin occupancy and power series plus duty cycle, occupancy percentage, burst rate, dominant class, and the sparkline the cockpit renders.
+category: tutorials
+keywords: rfscope, io graph, wireshark io graphs, channel activity, duty cycle, occupancy, burst rate, timeline, sparkline, rf analysis, gophertrunk, dominant class
+tags: [rfscope, rf-analysis, getting-started, gophertrunk, dsp, sdr]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 4
+charts: true
+---
+
+*Part 4 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer. The
+hierarchy told you what kinds of signal are present; this view tells you when each
+channel is busy.*
+
+> **TL;DR:** The `timeline` analyzer is Wireshark's I/O Graphs for RF. It groups
+> bursts by frequency into **Channels** and fills each with a **100-bin** occupancy
+> and power series over the observation window, plus duty cycle, occupancy percentage,
+> burst rate per minute, median power, median flatness, and a dominant modulation
+> class. It also materializes `Scene.Channels`, which the timing analyzer (Part 5)
+> then annotates. The cockpit renders each channel's timeline as a `█`/`·` sparkline.
+
+**Key takeaways**
+
+- **One Channel per frequency**, each with a 100-bin activity timeline across the
+  whole window.
+- **Duty cycle vs occupancy %** answer different questions — one is airtime fraction,
+  the other is how many time buckets saw any activity.
+- **Burst rate per minute** normalizes bursty channels so short and long captures are
+  comparable.
+- **`timeline` is foundational.** It creates `Scene.Channels`, so the timing analyzer
+  depends on it.
+
+## Cheat sheet
+
+| Field | Meaning |
+|---|---|
+| `DutyCycle` | Airtime ÷ window (fraction of time on air) |
+| `OccupancyPct` | Share of the 100 time bins that saw any activity |
+| `BurstRatePerMin` | Bursts scaled to per-minute |
+| `DominantClass` | Most common modulation class on the channel |
+| `MedianPowerDbFS` | Median burst peak power |
+| `MedianFlatness` | Median spectral flatness (0..1) |
+| `Timeline []Bin` | 100 buckets of occupancy + power |
+
+## In this post
+
+- **What the RF I/O graph is** and how it maps to Wireshark's.
+- **How channels are built** from bursts, and the 100-bin timeline.
+- **Duty cycle vs occupancy** — why they differ and when each matters.
+- **The per-channel scalars** — burst rate, dominant class, median power/flatness.
+- **The cockpit sparkline** — `█`/`·` at a glance.
+
+## The RF I/O graph
+
+Wireshark's I/O Graphs plot packet activity over time, so you can *see* the shape of
+a capture: a steady stream here, a burst of retransmissions there, a quiet stretch in
+the middle. The `timeline` analyzer does the same for RF, one row per channel. It
+answers the question the hierarchy cannot: not *what* is on the band, but *when* each
+channel is busy, and how heavily.
+
+It has **no dependencies** and reads bursts directly. Importantly, it is also the
+analyzer that **materializes `Scene.Channels`** — the per-frequency rows every later
+view builds on. That is why the timing analyzer in Part 5 lists `timeline` as a
+dependency: without channels there is nothing to annotate.
+
+## Building channels from bursts
+
+The analyzer groups bursts by exact frequency, then folds each group into a `Channel`:
+
+```go
+// internal/rfscope/timeline.go
+byFreq := map[uint32][]int{}
+for i, b := range sc.Bursts {
+    byFreq[b.FreqHz] = append(byFreq[b.FreqHz], i)
+}
+```
+
+For each frequency it accumulates airtime, tallies modulation classes to find the
+**dominant class**, takes the widest occupied bandwidth, and computes the **median**
+peak power and median spectral flatness across the channel's bursts. Median, not mean,
+so one anomalously loud or noisy burst does not skew the channel's summary.
+
+Then it builds the timeline itself: **100 equal time buckets** (`timelineBins = 100`)
+spanning the observation window. For each bucket it walks the channel's bursts and
+marks the bucket occupied if any burst overlaps it, records the strongest overlapping
+burst's power (falling back to the scene noise floor when idle), and counts how many
+bursts *started* in that bucket:
+
+```go
+// internal/rfscope/timeline.go
+for _, i := range idxs {
+    b := sc.Bursts[i]
+    if b.StartSec < t1 && b.EndSec > t0 { // overlap
+        bin.Occupied = true
+        if b.PeakDbFS > bin.PowerDbFS {
+            bin.PowerDbFS = b.PeakDbFS
+        }
+    }
+    if b.StartSec >= t0 && b.StartSec < t1 { // started in this bin
+        bin.BurstCount++
+    }
+}
+```
+
+A hundred buckets is a deliberate resolution choice: fine enough to show structure —
+a duty pattern, a periodic gap — coarse enough to stay readable as a sparkline and
+cheap to autocorrelate for period detection in Part 5.
+
+Two details in that loop repay attention. The overlap test (`b.StartSec < t1 &&
+b.EndSec > t0`) marks a bucket occupied if a burst covers *any* part of it, so a burst
+that straddles a bucket boundary correctly lights both buckets rather than being lost to
+rounding. And the separate "started in this bin" count exists because *occupancy* and
+*arrivals* are different questions: a single long burst occupies many buckets but arrives
+in only one, while a burst of rapid short transmissions arrives many times. Keeping both
+lets the later analyzers ask either question — occupancy drives the sparkline and duty,
+arrivals drive the burst-rate and the inter-arrival histogram.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="timeline" width="560" height="260" role="img"
+        aria-label="Per-channel occupancy timelines for four channels over the capture window"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "channels":[
+{"label":"453.100 ctl","occ":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]},
+{"label":"453.325 voice","occ":[0,0,1,1,1,0,0,0,0,1,1,1,1,0,0,0,0,1,1,0]},
+{"label":"453.550 hop","occ":[1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0,1,0,0,0]},
+{"label":"453.775 data","occ":[0,0,0,1,0,0,0,0,0,0,1,0,0,0,0,0,0,1,0,0]}],
+"xlabel":"time → (100 bins per channel, downsampled here)" }
+</script>
+<figcaption>Four channels with very different shapes: a near-continuous control channel, a duty-cycled voice channel, a periodic hopper, and a sparse data channel.</figcaption>
+</figure>
+
+## Duty cycle vs occupancy percentage
+
+Two of the channel scalars look similar and are constantly confused, so it is worth
+being precise:
+
+- **Duty cycle** is `AirtimeSec ÷ window`, clamped to 0..1 — the true fraction of the
+  window the channel spent transmitting. A channel on for 3 of every 10 seconds has a
+  0.30 duty cycle.
+- **Occupancy percentage** is the fraction of the **100 time bins** that saw *any*
+  activity. A channel that fires a 10 ms burst in each of 30 bins has a low duty cycle
+  (little total airtime) but 30% occupancy (lots of bins touched).
+
+The gap between them is diagnostic. **High duty, high occupancy** is a continuously
+busy channel — a control channel, a voice call in progress. **Low duty, high
+occupancy** is a *bursty* channel: frequent short transmissions, like telemetry,
+paging, or a data link. **Low duty, low occupancy** is genuinely quiet. That "low
+duty, high occupancy" signature is exactly what the expert analyzer will later flag as
+**intermittent** (Part 8).
+
+## The per-channel scalars
+
+Alongside the two occupancy measures, each channel carries:
+
+- **Burst rate per minute** — `BurstCount ÷ (window / 60)`. Normalizing to per-minute
+  lets you compare a 4-second cockpit refresh against a 5-minute capture without doing
+  arithmetic in your head.
+- **Dominant class** — the most common modulation class among the channel's bursts,
+  ties broken deterministically by name. A channel whose bursts classify inconsistently
+  (a hopper landing here between other channels) still gets a single representative
+  class.
+- **Median power (dBFS)** and **median flatness** — robust summaries that feed the
+  emitter fingerprint (Part 6) and the `noise-like` anomaly rule (Part 8).
+
+Together these turn a channel from a pile of bursts into a one-line character sketch:
+*"453.325 MHz, c4fm, 18% duty, 22 bursts/min, −41 dBFS, flatness 0.34"* reads as a
+moderately-busy narrowband digital voice channel at a glance.
+
+## A worked reading of the channel table
+
+The summary report lays the channels out as a table, and learning to read it top to
+bottom is most of the skill:
+
+```text
+Channels:
+  freq(MHz)     class    bursts   duty%    occ%  rate/min   period
+  453.100000    c4fm          1    98.4    99.0       0.4   0.030s
+  453.325000    c4fm         14    18.2    31.0       8.4   0.030s
+  453.550000    fsk           9     6.1    22.0       5.4        -
+  453.775000    fsk           2     1.1     2.0       1.2        -
+```
+
+Four channels, four characters. The first is a **control channel**: one long burst,
+98% duty, and a 30 ms period — it is on almost continuously with a TDMA frame, exactly
+what a P25 control channel looks like. The second shares the 30 ms frame but at 18%
+duty across fourteen bursts — a **voice channel** carrying intermittent calls on the
+same system. The third is the **hopper**: nine short FSK bursts, 6% duty, and — tellingly
+— *no recovered period*, because its schedule only makes sense across channels, not down
+one (Part 6 explains why). The fourth is barely there: two stray bursts, a candidate to
+ignore or to watch, depending on what you are hunting.
+
+Notice how the columns disagree in useful ways. Channel two's 18% duty against 31%
+occupancy is the bursty-but-substantial signature; channel three's 6% duty against 22%
+occupancy is more extreme still — lots of buckets touched, very little airtime. That
+widening gap between duty and occupancy is a reliable "this channel is bursty" tell, and
+it is precisely the input the expert analyzer thresholds into an `intermittent` flag.
+
+## Median, not mean, everywhere
+
+One quiet design choice runs through the whole analyzer: every per-channel summary uses
+the **median**, not the mean. Median power, median flatness — both are computed by
+sorting the channel's bursts and taking the middle value. The reason is robustness. A
+single burst caught mid-fade, or a momentary co-channel collision that spikes the power,
+would drag a mean off the channel's true character. The median shrugs it off: half the
+bursts are above, half below, and one outlier cannot move the middle. It is the same
+robust-statistics instinct segmentation used for the 25th-percentile noise floor in Part
+2 — prefer an estimator that a handful of bad samples cannot capture. When you read a
+channel's median power as −41 dBFS, that is genuinely where most of its bursts sit, not
+an average pulled around by the loudest one.
+
+## The cockpit sparkline
+
+The live cockpit (Part 9) renders each channel's timeline as a fixed-width Unicode
+**sparkline**: a filled block for an occupied bucket, a dot for idle.
+
+```go
+// cmd/gophertrunk/rfscope_cockpit.go
+if occupied {
+    out[i] = '█'
+} else {
+    out[i] = '·'
+}
+```
+
+So a channel row in the cockpit looks like:
+
+```text
+   453.3250 c4fm   ··██·····██████···██·  18%
+```
+
+The sparkline compresses the 100-bin timeline to whatever width the panel has, marking
+a block if *any* underlying bucket in that column was occupied. It is the fastest way
+to read a band: your eye catches the near-solid control channel, the gappy hopper, and
+the mostly-empty data channel without parsing a single number. Ada learned to scan the
+sparkline column first and only read the duty-cycle numbers for the channels whose
+shape looked interesting.
+
+## Where this goes next
+
+The timeline gives every channel a shape in time — and a shape in time is something
+you can measure *periodicity* in. [Part
+5]({{ '/blog/tutorials/rf-scope-05-timing-and-tdma-period/' | relative_url }})
+introduces the `timing` analyzer, which depends on this one: it builds burst-length
+and inter-arrival histograms and, by **autocorrelating** each channel's occupancy
+series, recovers a TDMA or frame **period** hiding in the gaps.
+
+## FAQ
+
+**Why exactly 100 timeline bins?**
+It is a balance: enough resolution to reveal duty patterns and periodic gaps, coarse
+enough to render as a readable sparkline and cheap to autocorrelate for period
+detection in Part 5.
+
+**A channel shows high occupancy but a tiny duty cycle — is that a bug?**
+No — that is a bursty channel. Occupancy counts *how many buckets* saw activity; duty
+cycle measures *total airtime*. Frequent short bursts touch many buckets while adding
+up to little airtime. The expert analyzer flags that pattern as `intermittent`.
+
+**Does the timeline analyzer identify protocols?**
+No. It only aggregates burst activity per frequency. Naming protocols is the
+hierarchy analyzer's job (Part 3); the dominant *class* here is a blind modulation
+label, not a protocol.
+
+**Why does timing depend on timeline?**
+Because timeline is what creates `Scene.Channels` and their 100-bin timelines. The
+timing analyzer annotates those channels; it has nothing to work on until timeline
+runs first.
+
+## Series navigation
+
+**Part 4 of 10** · ←
+[Part 3: Protocol Hierarchy]({{ '/blog/tutorials/rf-scope-03-protocol-hierarchy/' | relative_url }})
+· Next →
+[Part 5: Timing & Periodicity]({{ '/blog/tutorials/rf-scope-05-timing-and-tdma-period/' | relative_url }})

--- a/docs/_posts/2026-07-07-signal-lab-04-constellations-and-eye-diagrams.md
+++ b/docs/_posts/2026-07-07-signal-lab-04-constellations-and-eye-diagrams.md
@@ -1,0 +1,238 @@
+---
+title: "Signal Lab, Part 4: Constellations & Eye Diagrams — Seeing Modulation Quality"
+description: Signal Lab's constellation, eye diagram, and symbol scope — how to read clean versus noisy C4FM (four rails) and CQPSK modulation, what opening and closing eyes mean, and how these plots make EVM and SNR visible.
+category: tutorials
+keywords: constellation diagram, eye diagram, symbol scope, c4fm four rails, cqpsk constellation, modulation quality, opening eye closing eye, evm visualization, p25 modulation, signal lab visuals
+tags: [siglab, dsp, modulation, demodulation, p25, getting-started]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 4
+charts: true
+---
+
+*Part 4 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. The dashboard gave you EVM and SNR as numbers; now we
+give them a picture.*
+
+> **TL;DR:** The constellation, eye diagram, and symbol scope are three views of
+> the same thing — how cleanly the demod is separating symbols. A clean C4FM
+> signal shows **four tight rails**; a clean CQPSK signal shows four tight
+> clusters in the I/Q plane. As SNR drops, rails blur and clusters spread — the
+> **eye closes**. An open eye means comfortable symbol decisions; a closed eye
+> means the demod is guessing.
+
+**Key takeaways**
+
+- **Constellation = where symbols land** in the I/Q plane; tight points mean low
+  EVM.
+- **Eye diagram = symbol transitions overlaid**; a wide-open eye means a big
+  decision margin.
+- **C4FM shows four rails; CQPSK shows four clusters** — different modulations,
+  same "tight is healthy" rule.
+- **These plots explain the numbers.** A high EVM *looks* like a fuzzy
+  constellation and a closing eye.
+- **The symbol scope** ties it to time — which symbols, in what order, drifted.
+
+## Cheat sheet
+
+| Surface / plot | What it shows |
+|---|---|
+| Constellation | Symbol positions in the I/Q plane (rails or clusters) |
+| Eye diagram | Overlaid symbol transitions; eye opening = decision margin |
+| Symbol scope | Recovered symbols over time |
+| `gophertrunk siglab serve` | Renders all three in the browser console |
+| [/constellation.html]({{ '/constellation.html' | relative_url }}) | Docs: constellation reference |
+| [/eye-diagram.html]({{ '/eye-diagram.html' | relative_url }}) | Docs: eye-diagram reference |
+
+## In this post
+
+- **What a constellation is** and how to read it.
+- **Clean vs noisy C4FM** — the four rails.
+- **CQPSK constellations** — clusters, not rails.
+- **The eye diagram** — opening and closing, and why it matters.
+- **The symbol scope** — the time-domain companion.
+
+## What a constellation is
+
+A **constellation diagram** plots each recovered symbol as a point in the I/Q
+plane — in-phase on one axis, quadrature on the other. Its shape is a fingerprint
+of the modulation, and its *tightness* is a direct readout of quality. Ideal
+symbols land exactly on their target points; real symbols scatter around them,
+and the spread of that scatter is precisely what EVM measures. So the
+constellation is the picture behind the EVM number from Part 2: low EVM is a tidy
+constellation, high EVM is a smear.
+
+The plot is theme-aware and lives in the browser console's visualization panel,
+alongside the docs' own
+[constellation reference]({{ '/constellation.html' | relative_url }}). You don't
+read absolute coordinates off it — you read *shape* and *spread*.
+
+## Clean vs noisy C4FM: the four rails
+
+C4FM — the 4-level continuous-phase FM that carries P25 Phase 1, and the family
+GopherTrunk's channel rate is built around — encodes two bits per symbol as one
+of four frequency deviations. On a constellation it shows up as **four vertical
+rails**: four distinct symbol levels. A healthy C4FM capture draws four tight,
+well-separated rails. A weak one blurs them until adjacent rails touch and the
+demod can no longer tell a level from its neighbor.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="constellation" width="480" height="360" role="img"
+        aria-label="Clean C4FM constellation with four tight vertical rails"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "rails":[-3,-1,1,3], "dot":2.0,
+"points":[[-3,0.5],[-3,-0.4],[-3,1.1],[-3,-1.0],[-3,0.1],[-1,0.6],[-1,-0.5],[-1,0.2],[-1,1.0],[-1,-0.9],[1,0.4],[1,-0.6],[1,0.0],[1,0.9],[1,-1.1],[3,0.3],[3,-0.4],[3,0.8],[3,-0.7],[3,0.2]] }
+</script>
+<figcaption>Clean C4FM: four tight vertical rails, each a symbol level, with generous space between them. This is what low EVM looks like.</figcaption>
+</figure>
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="constellation" width="480" height="360" role="img"
+        aria-label="Noisy C4FM constellation with smeared, overlapping rails"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "rails":[-3,-1,1,3], "dot":2.0,
+"points":[[-2.6,0.9],[-3.4,-1.3],[-2.2,1.6],[-3.1,-1.9],[-2.0,0.4],[-1.5,1.4],[-0.6,-1.6],[-1.2,0.9],[-0.4,1.8],[-1.7,-1.4],[0.6,1.3],[1.5,-1.5],[0.4,0.7],[1.6,1.7],[0.5,-1.9],[2.5,1.2],[3.5,-1.4],[2.2,1.8],[3.6,-1.7],[2.3,0.6]] }
+</script>
+<figcaption>Noisy C4FM: the same four rails, but spread and drifting toward each other. As they merge the eye closes and symbol errors climb.</figcaption>
+</figure>
+
+Reese's shortcut: **count the gaps.** Four clear gaps between rails means a
+comfortable decoder. When the gaps vanish, so does the lock margin — and you'll
+see it in the histogram (Part 2) and the decode-error rate at the same time.
+
+## CQPSK: clusters, not rails
+
+Not every P25 signal is C4FM. The CQPSK / LSM path (linear-simulcast-friendly
+modulation, used by some P25 Phase 1 systems and the natural companion to
+simulcast infrastructure) is a phase modulation: symbols land as **four clusters**
+arranged in the I/Q plane rather than four vertical rails. The health rule is
+identical — tight, well-separated clusters are good; clusters that bloom into
+each other are bad — but the *shape* tells you which demod path is in play. If you
+expected rails and see clusters (or vice versa), you're looking at the wrong
+modulation for the system, which is itself a useful diagnosis. Part 7's VSA
+metrics quantify exactly how far each cluster sits from ideal.
+
+## The eye diagram: opening and closing
+
+The **eye diagram** overlays many symbol transitions on top of each other,
+aligned to the symbol clock. The result looks like one or more "eyes." The
+**height** of an open eye is the vertical decision margin — how much room the
+slicer has to place a symbol correctly — and the **width** is timing margin, how
+much clock jitter it can tolerate before sampling at the wrong instant.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="eye" width="560" height="320" role="img"
+        aria-label="Eye diagram with clearly open eyes for a healthy signal"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "xlabel":"symbol period", "ylabel":"amplitude",
+"traces":[[-0.9,-0.3,0.4,0.9,0.4,-0.3,-0.9],[0.9,0.4,-0.2,-0.9,-0.3,0.3,0.9],[-0.9,-0.2,0.5,0.95,0.5,-0.2,-0.9],[0.9,0.3,-0.3,-0.95,-0.4,0.2,0.9],[-0.85,-0.35,0.35,0.85,0.35,-0.35,-0.85],[0.85,0.35,-0.25,-0.85,-0.35,0.25,0.85]] }
+</script>
+<figcaption>An open eye: transitions cross cleanly and leave a wide gap in the middle. The taller and wider that opening, the more margin the demod has for correct symbol decisions.</figcaption>
+</figure>
+
+As SNR falls, noise thickens every trace and the opening shrinks — the eye
+**closes**. A fully closed eye means transitions cover the decision point and the
+demod can no longer reliably tell one symbol from the next; that's the visual
+partner of a rising decode-error rate and a lost lock. Reading the eye is a fast
+gut check: *can I still see daylight in the middle?* If yes, the capture has
+margin; if no, it's marginal no matter what the lock line optimistically says
+for an instant.
+
+## The symbol scope: quality over time
+
+The constellation and eye pool *all* symbols together; the **symbol scope** puts
+them back in order, plotting recovered symbols over time. That time axis matters
+when quality isn't constant — a capture that's clean for four seconds and then
+craters when a neighboring transmitter keys up will show a tidy constellation on
+average but an obvious degradation in the scope right at that moment. Pair the
+scope with the console's live event stream (Part 3) and you can line up a burst
+of symbol errors with the exact stage or grant where it happened.
+
+Together these three plots — constellation, eye, symbol scope — turn the
+abstract EVM/SNR pair into something you can *see* go wrong. Ada's habit, once
+Reese drilled it in: read the numbers first for the verdict, then open the
+constellation to confirm the story and the eye to judge how much margin is left.
+
+## The same plots across protocols
+
+C4FM and CQPSK are the P25 Phase 1 cases, but the constellation is a fingerprint
+for *every* protocol the engine decodes, and learning to read the shape is a fast
+way to sanity-check what you're actually looking at:
+
+- **DMR** and **NXDN** are 4-level FSK families like C4FM — expect four rails.
+  DMR's TDMA structure means the constellation is built from alternating time
+  slots, so a healthy DMR capture still shows four clean rails even though the
+  bursts interleave two logical channels.
+- **P25 Phase 2** uses H-CPM (a continuous-phase modulation), so its picture is
+  denser than the four crisp rails of Phase 1 — a reminder that "which protocol"
+  changes what "clean" looks like.
+- **TETRA** is π/4-DQPSK, a phase modulation whose ideal constellation is eight
+  points on two rotated QPSK rings; a healthy TETRA capture shows those points
+  tight and the ring well-formed.
+
+The practical lesson is that the *number and arrangement* of clusters or rails
+should match the modulation you expect. If you told the engine "P25 Phase 1
+C4FM" and the constellation shows phase-plane clusters instead of vertical rails,
+either the system is actually running the CQPSK/LSM variant or you've mislabeled
+the capture — and the plot caught it before the metrics did. When a signal won't
+decode and you're not sure what it is at all, that's the cue to hand it to blind
+identification (Part 8), which reads exactly this kind of structure to name a
+candidate.
+
+## A reading workflow
+
+Reese's routine for any new capture is a fixed order, because each plot answers a
+different question and answering them out of order wastes time:
+
+1. **Histogram and dashboard first** — is the rate right (the 2% rule) and did it
+   lock? No point plotting a capture that's decoding at the wrong sample rate.
+2. **Constellation** — does the shape match the expected modulation, and how tight
+   is the spread? This is your EVM sanity check.
+3. **Eye** — is there daylight in the middle? This is your margin check: a tight
+   constellation with a barely-open eye is closer to the edge than it looks.
+4. **Symbol scope** — if quality is uneven, *when* did it degrade? Line the dip up
+   against the live event stream to find the cause.
+
+Four plots, four questions, in the order that fails fast. Ada now runs it by
+reflex; it's the single habit that turned her "why won't this lock" flailing into
+a diagnosis in under a minute.
+
+## Where this goes next
+
+You can now *see* modulation quality, not just read it.
+[Part 5]({{ '/blog/tutorials/signal-lab-05-psd-spectrogram-occupancy/' | relative_url }})
+zooms out from individual symbols to the *spectrum* — the PSD, the
+spectrogram/waterfall, and the spectral-occupancy metrics (occupied bandwidth,
+channel power, ACPR, flatness) that describe a signal's shape in frequency rather
+than its symbols in the I/Q plane. The docs' [constellation]({{ '/constellation.html' | relative_url }})
+and [eye-diagram]({{ '/eye-diagram.html' | relative_url }}) pages go deeper on
+each plot.
+
+## FAQ
+
+**Why four rails for C4FM but four clusters for CQPSK?**
+They're different modulations. C4FM is a 4-level frequency modulation, so its
+symbols separate along one axis (four rails). CQPSK is a phase modulation, so its
+four symbols separate as points around the I/Q plane (four clusters). Same
+symbol count, different geometry.
+
+**What exactly does a "closing eye" mean?**
+The vertical opening in the eye is the demod's decision margin. As noise grows,
+traces thicken and the opening shrinks; a closed eye means noise now covers the
+decision point and the demod can't reliably separate symbols — expect errors and
+lost lock.
+
+**How does this relate to EVM?**
+Directly. EVM measures how far symbols scatter from their ideal points, which is
+exactly the spread you see in the constellation. Low EVM is a tight constellation
+and an open eye; high EVM is a smear and a closing eye.
+
+**Where do I view these plots?**
+In the browser console (`gophertrunk siglab serve`, Part 3), which renders the
+constellation, eye diagram, and symbol scope from the analyzed capture.
+
+## Series navigation
+
+**Part 4 of 10** · ←[Part 3]({{ '/blog/tutorials/signal-lab-03-browser-console-live-decode/' | relative_url }}) · Next →
+[Part 5: PSD, Spectrogram & Occupancy]({{ '/blog/tutorials/signal-lab-05-psd-spectrogram-occupancy/' | relative_url }})

--- a/docs/_posts/2026-07-08-crypto-lab-05-keystream-reuse-mtp.md
+++ b/docs/_posts/2026-07-08-crypto-lab-05-keystream-reuse-mtp.md
@@ -1,0 +1,182 @@
+---
+title: "Crypto Lab, Part 5: Keystream Reuse — Many-Time-Pad & Crib-Dragging"
+description: Crypto Lab's ks tool exploits keystream reuse — the core real-world break against additive stream ciphers like P25 DES-OFB, ADP/RC4, and TETRA AIE — detecting IV/MI collisions with ks reuse and recovering plaintext with ks mtp via known-plaintext or crib-dragging, no key recovery required.
+category: tutorials
+keywords: keystream reuse, many-time-pad, crib dragging, iv reuse, p25 message indicator, ofb stream cipher, adp rc4, tetra aie, known plaintext attack, gophertrunk cryptolab
+tags: [cryptolab, keystream-reuse, p25, many-time-pad, advanced, security-testing]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 5
+---
+
+*Part 5 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. This is the break that actually happens in the field — and where the Mercury frames from [RF Scope]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }}) land on the bench.*
+
+> **TL;DR:** Additive OFB/stream ciphers (P25 DES-OFB and ADP/RC4, TETRA AIE) reuse their keystream whenever the same **key + IV** recur, so two frames sharing an IV satisfy `c1 ⊕ c2 = p1 ⊕ p2` — a running-key system you break with **no key recovery**. For P25 the IV is the 72-bit **Message Indicator (MI)**. `ks reuse` reports IV/MI collisions; `ks mtp` recovers a reuse group from a known plaintext (`-known-label`/`-known-pt`) or by crib-drag (`-crib`); `ks extract` computes a keystream from a known pt/ct pair.
+
+> **Authorized testing only.** These frames must come from a system you own or are licensed to assess.
+
+**Key takeaways**
+
+- **Reused IVs are the field failure.** Same key + same IV = same keystream = `c1⊕c2 = p1⊕p2`.
+- **No key recovery needed.** One known plaintext, or a good crib, unravels the whole reuse group.
+- **The P25 IV is the Message Indicator** — 72 bits the decoders already extract.
+- **The frames file is the bridge format** — `{label, iv, ct}` JSONL, exactly what the live decoder emits.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab ks reuse -in frames.jsonl` | Report IV/MI collision groups |
+| `cryptolab ks mtp -in frames.jsonl -known-label call-12 -known-pt known.bin` | Recover a group from one known plaintext |
+| `cryptolab ks mtp -in frames.jsonl -crib " the "` | Crib-drag a group with no known plaintext |
+| `cryptolab ks extract -pt p.bin -ct c.bin -out ks.bin` | Compute keystream = pt ⊕ ct |
+| `-top N` | Crib-drag hits to report per group (default 10) |
+
+## In this post
+
+- **Why keystream reuse breaks stream ciphers** — the two-time-pad identity.
+- **The P25 Message Indicator as IV** — where the collision comes from.
+- **`ks reuse`** — finding the collisions.
+- **`ks mtp`** — recovering content by known plaintext or crib-drag.
+- **The Mercury beat** — running `ks` on the frames RF Scope handed over.
+
+## Why reuse breaks a stream cipher
+
+A stream cipher encrypts by XORing plaintext with a pseudorandom keystream: `c = p ⊕ ks`. The keystream is a function of the key and an initialization vector (IV). This is fine — *as long as the IV never repeats under the same key*. The moment it does, two messages share the identical keystream, and the algebra is unforgiving:
+
+```text
+c1 = p1 ⊕ ks
+c2 = p2 ⊕ ks
+c1 ⊕ c2 = (p1 ⊕ ks) ⊕ (p2 ⊕ ks) = p1 ⊕ p2
+```
+
+The keystream cancels. You are left with the XOR of two plaintexts, and no key anywhere in sight. This is the classic **two-time-pad** (or, across many colliding frames, **many-time-pad**) failure, and it is not theoretical — it is the single most common way real stream-cipher deployments leak, because IV management is exactly the boring operational detail that gets done wrong.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 210" width="640" height="210" role="img" aria-label="Many-time-pad: frames sharing an IV cancel the keystream to reveal p1 XOR p2">
+  <g font-size="12">
+  <text x="10" y="24" fill="var(--fg-muted)">same key + same IV → same keystream</text>
+  <rect x="10" y="36" width="300" height="26" rx="4" fill="none" stroke="currentColor"/>
+  <text x="20" y="53" fill="currentColor">c1 = p1 ⊕ ks</text>
+  <rect x="10" y="70" width="300" height="26" rx="4" fill="none" stroke="currentColor"/>
+  <text x="20" y="87" fill="currentColor">c2 = p2 ⊕ ks</text>
+  <rect x="10" y="104" width="300" height="26" rx="4" fill="none" stroke="currentColor"/>
+  <text x="20" y="121" fill="currentColor">c3 = p3 ⊕ ks</text>
+  <line x1="330" y1="83" x2="380" y2="83" stroke="currentColor" stroke-width="1.5"/>
+  <polygon points="380,83 372,79 372,87" fill="currentColor"/>
+  <rect x="384" y="60" width="246" height="46" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="507" y="80" text-anchor="middle" fill="var(--accent)" font-size="13">c1 ⊕ c2 = p1 ⊕ p2</text>
+  <text x="507" y="98" text-anchor="middle" fill="var(--fg-muted)" font-size="11">keystream cancels — no key</text>
+  <text x="10" y="160" fill="var(--fg-muted)">crib-drag a known word across the offset:</text>
+  <rect x="10" y="170" width="620" height="26" rx="4" fill="none" stroke="currentColor"/>
+  <text x="20" y="187" fill="currentColor" font-size="12">(p1 ⊕ p2) ⊕ crib  →  reveals partner plaintext where the crib actually sits</text>
+  </g>
+</svg>
+<figcaption>Frames sharing an IV cancel the keystream. XORing a guessed crib against p1⊕p2 reveals the partner's plaintext wherever the crib truly appears.</figcaption>
+</figure>
+
+## The P25 Message Indicator as IV
+
+In P25 the IV has a name: the **Message Indicator (MI)**, a 72-bit value transmitted with each encrypted superframe. The decoder already extracts it — it's how the receiver keys the OFB cipher for each call. That makes the MI the perfect collision detector. If two encrypted frames carry the same MI under the same key, they share a keystream, and `ks` finds them. The same logic applies to ADP (P25's RC4 mode), DMR's stream modes, and TETRA's AIE — any additive stream cipher whose keystream is a deterministic function of key and IV.
+
+This is why the frames file carries an explicit `iv` field. Each line is either a JSON object or a CSV triple:
+
+```text
+{"label":"call-12","iv":"a1b2c3d4e5f60708090a","ct":"deadbeef..."}
+call-12,a1b2c3d4e5f60708090a,deadbeef...
+```
+
+`label` identifies the source (a call id or timestamp), `iv` is the hex IV / MI, and `ct` is the hex ciphertext. Extra JSON fields — `system`, `protocol`, `tg`, `algid`, `keyid`, `at` — are preserved for provenance and ignored by the parser. Frames with an empty IV are skipped, and `#` lines are comments. This is **exactly the format the live decoder→cryptolab bridge emits** ([Part 9]({{ '/blog/tutorials/crypto-lab-09-web-console-bridge-external/' | relative_url }})) and what [RF Scope Part 7]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }}) produces with `-frames-out`. The whole trilogy converges on this one JSONL shape.
+
+## `ks reuse`: finding the collisions
+
+```bash
+gophertrunk cryptolab ks reuse -in frames.jsonl
+```
+
+```text
+ks/reuse — 214 frames: 3 IV/MI reuse group(s) found
+  frames  214
+  reuse_groups  3
+  iv=a1b2c3d4e5f60708090a   4   frames 4  labels [call-12 call-31 call-58 call-90]
+  iv=00000000000000000000   7   frames 7  labels [call-03 call-19 ...]
+note: reused IVs leak plaintext^plaintext — run `cryptolab ks mtp` on this
+  same file to recover content from each group.
+```
+
+Each finding is a collision group: an IV value and the frames that share it. That second group — IV all zeros, seven frames — is the operational nightmare Reese warns about: an all-zero MI usually means a device that never rotates its IV at all, turning every call it makes into one giant many-time-pad. When `ks reuse` finds *no* collisions, that's the secure case, and the tool says so: every frame uses a distinct IV, so there's no keystream collision to exploit.
+
+## `ks mtp`: recovering content
+
+Two paths recover plaintext from a reuse group. The strongest is **known-plaintext**: if you know what one frame in the group said (a standard call-setup string, a recorded test transmission you sent yourself), you derive the keystream from it and decrypt the *entire group*:
+
+```bash
+gophertrunk cryptolab ks mtp -in frames.jsonl -known-label call-12 -known-pt known.bin
+```
+
+```text
+ks/mtp — 214 frames: 3 reuse group(s)
+  keystream_hex  7f3a91c2e4...
+  call-31   1.0   plaintext_ascii "DISPATCH TO UNIT 214, PROCEED..."   method known-plaintext
+  call-58   1.0   plaintext_ascii "UNIT 214 COPY, EN ROUTE..."         method known-plaintext
+note: recovered the keystream from the known frame and decrypted its reuse
+  group; the same keystream decrypts any future frame that reuses this IV.
+```
+
+The second path needs no known plaintext at all — **crib-dragging**. You slide a guessed word (`-crib`, default `" the "`) across the `p1 ⊕ p2` of each colliding pair; wherever the result is fully printable, the crib probably sits there, and it reveals the partner frame's plaintext at that offset:
+
+```bash
+gophertrunk cryptolab ks mtp -in frames.jsonl -crib "UNIT "
+```
+
+```text
+  iv=a1b2c3d4... off=0   0.91   crib_in call-12  reveals_in call-31  revealed "DISPATCH TO"
+note: each hit reveals plaintext in the partner frame at that offset; extend
+  the highest-scoring cribs to grow the recovered text.
+```
+
+Crib-dragging is iterative: each revealed fragment becomes the next crib, and you peel the messages open a few characters at a time. A good crib is a word you're confident appears — a call sign, a unit id, a common function word. `-top` controls how many hits per group it reports. If a crib produces no fully-printable placements, the tool tells you to try a different one or supply a known plaintext.
+
+The third mode, `ks extract`, is the plumbing between attacks: given a matched plaintext/ciphertext pair, it computes the raw keystream (`pt ⊕ ct`) and can write it to a file, so you can feed it straight into `randomness battery` or `lfsr bm` to test whether the *keystream itself* is strong or an exploitable generator:
+
+```bash
+gophertrunk cryptolab ks extract -pt known.bin -ct call-12.bin -out ks.bin
+```
+
+## The Mercury beat
+
+Here is where the trilogy's mystery moves forward. Ada's Mercury capture — the intermittent burst near 453 MHz — went through [Signal Lab Part 8]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }}) (named a candidate, no lock) and [RF Scope Part 7]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }}), where the entropy analyzer triaged its payload as *not obviously strong* and exported the frames with `-frames-out`. Ada dropped that `mercury-frames.jsonl` straight into `ks reuse`:
+
+```bash
+gophertrunk cryptolab ks reuse -in mercury-frames.jsonl
+```
+
+```text
+ks/reuse — 61 frames: 0 IV/MI reuse group(s) found
+note: no IV reuse: every frame uses a distinct IV/MI... This is the secure case.
+```
+
+No reuse. Reese raised an eyebrow — *"either it's rotating IVs properly, or there's no IV at all because there's no real cipher."* That ambiguity is exactly what the `assess` battery ([Part 6]({{ '/blog/tutorials/crypto-lab-06-assess-battery/' | relative_url }})) and, ultimately, the subject framework ([Part 10]({{ '/blog/tutorials/crypto-lab-10-subject-framework-alias/' | relative_url }})) are built to resolve. Mercury doesn't reuse a keystream because Mercury, it turns out, has no keystream. Hold that thought.
+
+## Where this goes next
+
+`ks` attacks one specific weakness by hand. [Part 6]({{ '/blog/tutorials/crypto-lab-06-assess-battery/' | relative_url }}) is the harness that runs *every* applicable attack — IV reuse included — against a captured system and grades each on the RESISTANT/PARTIAL/BROKEN scale. That's `assess crypto`, the headline of the whole toolkit. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) cover the frames format and the live-capture bridge in full.
+
+## FAQ
+
+**Why can you break this without recovering the key?**
+Because when two frames share a keystream, XORing them cancels the keystream entirely, leaving `p1 ⊕ p2`. From there a known plaintext or a crib recovers the messages. The key never enters the attack.
+
+**What is the IV in a P25 system?**
+The 72-bit Message Indicator (MI), transmitted with each encrypted superframe and already extracted by the decoder. Two frames with the same MI under the same key share a keystream.
+
+**Where do the frames come from?**
+From [RF Scope Part 7]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }})'s `-frames-out`, or the live decoder→cryptolab bridge, both of which emit the same `{label, iv, ct}` JSONL that `ks` reads.
+
+**`ks reuse` found nothing — is the system secure?**
+Against this specific attack, yes: distinct IVs mean no keystream collision. But run the full `assess` battery ([Part 6]({{ '/blog/tutorials/crypto-lab-06-assess-battery/' | relative_url }})) — a system with no reuse can still fail on default keys, a backdoored keyspace, or (like Mercury) turn out not to be real encryption at all.
+
+## Series navigation
+
+**Part 5 of 10** · ←[Part 4: Classical Ciphers]({{ '/blog/tutorials/crypto-lab-04-classical-ciphers-brute/' | relative_url }}) · Next →[Part 6: The `assess` Battery — Attacking P25/DMR/TETRA]({{ '/blog/tutorials/crypto-lab-06-assess-battery/' | relative_url }})

--- a/docs/_posts/2026-07-08-rf-scope-05-timing-and-tdma-period.md
+++ b/docs/_posts/2026-07-08-rf-scope-05-timing-and-tdma-period.md
@@ -1,0 +1,254 @@
+---
+title: "RF Scope, Part 5: Timing & Periodicity — Recovering the TDMA Frame"
+description: rfscope's timing analyzer builds burst-length and inter-arrival histograms per channel and recovers a TDMA or frame period by autocorrelating each channel's occupancy series, keeping only peaks above a minimum confidence — the time-domain counterpart to cryptolab's byte-period detection.
+category: tutorials
+keywords: rfscope, tdma period, timing analysis, autocorrelation, inter-arrival histogram, burst length, periodicity, frame period, rf analysis, gophertrunk, occupancy correlation
+tags: [rfscope, rf-analysis, dsp, advanced, gophertrunk, sdr]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 5
+charts: true
+---
+
+*Part 5 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer. The
+timeline gave each channel a shape in time; this post measures the rhythm inside it.*
+
+> **TL;DR:** The `timing` analyzer (which depends on `timeline`) annotates each channel
+> with two 10-bin histograms — burst length and inter-arrival gap — and recovers a
+> **frame/TDMA period** by autocorrelating the channel's binary occupancy series. A
+> detected period is kept only if its normalized autocorrelation peak clears a minimum
+> confidence of **0.2**; otherwise the channel is reported aperiodic. It is the
+> time-domain twin of the byte-period detection cryptolab runs on payloads.
+
+**Key takeaways**
+
+- **Two histograms per channel:** burst length and inter-arrival gap, 10 bins each.
+- **Period detection is autocorrelation** of the channel's occupancy — a strong peak
+  at a non-zero lag is a repeating frame.
+- **A confidence floor of 0.2** discards weak peaks, so RF Scope reports "aperiodic"
+  rather than inventing a period from noise.
+- **`timing` depends on `timeline`** because it annotates the channels timeline built.
+
+## Cheat sheet
+
+| Field / constant | Meaning |
+|---|---|
+| `BurstLenHist` | 10-bin histogram of burst durations |
+| `InterArrivalHist` | 10-bin histogram of gaps between burst starts |
+| `PeriodSec` | Recovered frame/TDMA period (0 if none) |
+| `PeriodConfidence` | Normalized autocorrelation height (0..1) |
+| `minPeriodConfidence` | 0.2 — peaks below this are discarded |
+| `-analyzers timing` | Auto-pulls `timeline` as a dependency |
+
+## In this post
+
+- **Why timing matters** for an unknown signal.
+- **The two histograms** — burst length and inter-arrival.
+- **Autocorrelation** — how a repeating frame falls out of the occupancy series.
+- **The confidence floor** — why RF Scope refuses to guess.
+- **Reading a recovered period** against a known TDMA plan.
+
+## Why timing
+
+Two signals can share a modulation class, a bandwidth, and a duty cycle and still be
+completely different protocols — because they *schedule* their air time differently.
+A P25 Phase 2 TDMA channel packs two logical slots into a repeating 30 ms frame; a
+paging system fires a burst on a fixed cadence; a random-access data link has no
+cadence at all. Timing is the dimension that separates them, and it is measurable
+without decoding a single bit.
+
+The `timing` analyzer captures that dimension in three numbers per channel: a
+distribution of how long bursts are, a distribution of how far apart they start, and —
+the headline — a recovered **period**. Because it annotates the channels the timeline
+analyzer built, it lists `timeline` in its `DependsOn`; asking for `-analyzers timing`
+pulls `timeline` in automatically (the registry design we cover in Part 10).
+
+## The two histograms
+
+Both histograms are built with `dsp/stats.Histogram`, which returns paired counts and
+bin edges — the same `(counts, edges)` shape the rest of GopherTrunk's statistics use, so
+the data drops straight into any plotting code without reshaping. The bin count adapts to
+the sample: up to ten bins, but never more than there are data points, so a channel with
+four bursts gets a four-bin histogram rather than ten mostly-empty ones. That keeps the
+shape honest on sparse channels, where over-binning would manufacture spurious structure.
+
+For each channel, the analyzer collects burst durations and the gaps between
+consecutive burst *starts*, then bins each:
+
+```go
+// internal/rfscope/timing.go
+ch.BurstLenHist = histOf(lengths)
+gaps := make([]float64, 0, len(starts))
+for i := 1; i < len(starts); i++ {
+    gaps = append(gaps, starts[i]-starts[i-1])
+}
+ch.InterArrivalHist = histOf(gaps)
+```
+
+Each histogram has up to **10 bins** (`timingHistBins`, capped at the sample count for
+tiny channels). What you read from them:
+
+- **Burst-length histogram.** A tight cluster at one length says fixed-size frames — a
+  slot, a packet, a page. A broad spread says variable-length transmissions — voice
+  calls of different durations, say. Two distinct clusters can mean two signal types
+  sharing a channel.
+- **Inter-arrival histogram.** A sharp spike at one gap is a strong hint of a fixed
+  cadence — the same thing the autocorrelation confirms. A smooth exponential-looking
+  falloff is the signature of random (Poisson) arrivals, i.e. no schedule.
+
+The histograms are the human-readable evidence; the period detector is the automated
+verdict.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="bars" width="560" height="260" role="img"
+        aria-label="Inter-arrival histogram with a dominant bin at the frame period"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "categories":["8","16","24","30","38","46","54","60","68","76"],
+"values":[1,2,3,41,4,2,1,3,1,1],
+"ylabel":"burst count","xlabel":"inter-arrival gap (ms)" }
+</script>
+<figcaption>An inter-arrival histogram spiking at ~30 ms — the classic fingerprint of a fixed TDMA frame, before autocorrelation confirms it.</figcaption>
+</figure>
+
+## Autocorrelation: pulling the frame out of the gaps
+
+Histograms hint at a cadence; **autocorrelation proves it**. The detector takes the
+channel's 100-bin binary occupancy series, subtracts its mean, and correlates it with
+itself at every lag:
+
+```go
+// internal/rfscope/timing.go
+mean := stats.Mean(occ)
+for i, v := range occ {
+    sig[i] = v - mean
+}
+corr, _ := stats.Correlate(sig, sig)
+pos := corr[n-1:] // lag 0 at index 0, value ~1
+peaks := stats.FindPeaks(pos[1:], stats.PeakOpts{Height: minPeriodConfidence, MinDistance: 1})
+```
+
+The intuition: if a channel is active every 30 ms, then shifting its occupancy series
+by 30 ms lines the "on" buckets back up with each other, and the correlation at that
+lag spikes. Shift by any non-multiple and the on-buckets fall on off-buckets and the
+correlation drops. So the **first strong peak at a non-zero lag is the period**, and
+its normalized height (0..1, where lag 0 is 1 by construction) is the confidence. The
+recovered `PeriodSec` is that lag times the bin duration.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="line" width="560" height="300" role="img"
+        aria-label="Occupancy autocorrelation with a confident peak at the frame lag"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "series":[{"label":"autocorrelation","dots":true,"points":[[0,1.0],[1,0.18],[2,0.12],[3,0.64],[4,0.16],[5,0.10],[6,0.58],[7,0.14],[8,0.09],[9,0.52],[10,0.12]]},
+{"label":"confidence floor 0.2","dashed":true,"points":[[0,0.2],[10,0.2]]}],
+"xlabel":"lag (occupancy bins)","ylabel":"normalized correlation","xmin":0,"xmax":10,"ymin":0,"ymax":1.05 }
+</script>
+<figcaption>The first non-zero-lag peak (lag 3 here, ~0.64) clears the 0.2 floor and becomes the recovered period; the decaying peaks at lags 6 and 9 are its harmonics.</figcaption>
+</figure>
+
+## The confidence floor: refusing to guess
+
+Autocorrelation *always* produces a strongest non-zero peak — even for pure noise. The
+question is whether that peak means anything. RF Scope answers it with a single
+threshold:
+
+```go
+// internal/rfscope/timing.go
+const minPeriodConfidence = 0.2
+```
+
+If no lag clears **0.2**, `detectPeriod` returns `(0, 0)` and the channel is reported
+with no period. This is the same discipline the segmentation noise floor uses and the
+same one Crypto Lab applies to its randomness verdicts: *when the evidence is weak, say
+so, do not invent structure.* A reported `PeriodSec` of 0 is a real answer — "this
+channel is aperiodic" — not a missing measurement. Reese's version: *"a tool that
+always finds a period is a tool that has never found one."*
+
+The floor is intentionally low. At 0.2 the detector will surface a genuine but noisy
+frame — a hopper that only visits this channel intermittently, a TDMA channel seen for
+just a few frames — while still rejecting the fractional correlation you get from
+random arrivals. If you are chasing a marginal periodicity you can read the raw
+`PeriodConfidence`; anything from 0.2 to ~0.4 is "plausible, verify," and above ~0.6
+is a confident frame.
+
+## Reading a recovered period
+
+A recovered period is a strong lead, but it is not a decode. Match it against what you
+know: a period near **30 ms** on a narrowband digital voice channel points at P25
+Phase 2 TDMA; a period of a few seconds on a paging channel points at a paging frame
+structure; a sub-millisecond period is more likely a symbol-rate artifact than a frame.
+Watch for **harmonics** too — a true 30 ms period also produces (weaker) peaks at 60
+and 90 ms, as in the chart above. The detector returns the *first* qualifying peak, so
+it lands on the fundamental, but if you read the raw autocorrelation you will see the
+harmonic ladder that confirms it.
+
+For Mercury, the timing view is quietly informative: its bursts are short and its
+inter-arrival histogram is *broad*, with no dominant bin, and its occupancy
+autocorrelation never clears 0.2 on any single channel. That is consistent with what
+Part 6 will confirm — Mercury is not sitting on one channel with a clean frame; it is
+**hopping**, so its schedule only makes sense once you look across channels, not down
+one.
+
+## Why occupancy, not raw timestamps
+
+There is a subtle but important choice in *what* gets autocorrelated. The detector does
+not correlate the raw burst start times; it correlates the channel's **binary occupancy
+series** — the same 100-bin on/off vector the timeline analyzer built. That has two
+consequences worth understanding.
+
+First, it makes the method **duration-aware**. A frame is not just "a burst starts every
+30 ms"; it is "the channel is *busy* in a repeating pattern." A TDMA slot that is on for
+part of each frame and off for the rest produces a cleaner autocorrelation from the
+occupancy series than from start times alone, because the *shape* of the busy interval
+repeats, not just its onset.
+
+Second, it ties the period's resolution to the timeline's bin width. With 100 bins over
+the window, the finest period the detector can resolve is one bin, and the reported
+`PeriodSec` is always an integer number of bins times the bin duration. On a short
+window the bins are fine and the period is precise; on a long capture the bins are
+coarser and the period is quantized more heavily. If you need a sharper period estimate
+on a long capture, analyze a shorter `-window` so the same 100 bins cover less time —
+the classic time-resolution trade.
+
+This is also why timing genuinely *depends* on timeline rather than recomputing its own
+activity signal: the occupancy vector is exactly the artifact timeline already produces,
+and reusing it keeps the two views consistent. A period the timing analyzer reports is a
+period you can see in the sparkline the channel panel draws.
+
+## Where this goes next
+
+So far every view has been per-channel. [Part
+6]({{ '/blog/tutorials/rf-scope-06-topology-emitters-conversations/' | relative_url }})
+crosses channels: the `topology` analyzer clusters bursts into **emitters** by RF
+fingerprint — collapsing a frequency hopper's scattered bursts into one logical source
+— and then links emitters into **conversations**. That is where Mercury's hopping,
+invisible to a single-channel timing view, finally becomes legible.
+
+## FAQ
+
+**How is the period actually recovered?**
+By autocorrelating the channel's binary occupancy series and taking the first non-zero
+lag whose normalized correlation clears 0.2. That lag times the timeline bin duration
+is the period; the correlation height is the confidence.
+
+**Why 10 histogram bins?**
+It is enough resolution to distinguish a tight, fixed-size distribution from a broad
+or bimodal one without over-fragmenting small samples; the bin count is capped at the
+number of bursts for sparse channels.
+
+**A channel I know is TDMA shows no period — why?**
+The autocorrelation peak did not clear the 0.2 confidence floor — usually too few
+frames were captured, or the channel is a hopper seen only intermittently. Capture a
+longer window, or look for the pattern across channels via the topology analyzer.
+
+**Is this the same period detection Crypto Lab uses?**
+Conceptually yes — it is the time-domain counterpart. Crypto Lab autocorrelates a
+*byte* stream to find a repeating key or scrambler period; RF Scope autocorrelates a
+*channel occupancy* series to find a repeating frame.
+
+## Series navigation
+
+**Part 5 of 10** · ←
+[Part 4: The I/O Graph]({{ '/blog/tutorials/rf-scope-04-io-graph-channel-activity/' | relative_url }})
+· Next →
+[Part 6: Topology — Emitters & Conversations]({{ '/blog/tutorials/rf-scope-06-topology-emitters-conversations/' | relative_url }})

--- a/docs/_posts/2026-07-08-signal-lab-05-psd-spectrogram-occupancy.md
+++ b/docs/_posts/2026-07-08-signal-lab-05-psd-spectrogram-occupancy.md
@@ -1,0 +1,230 @@
+---
+title: "Signal Lab, Part 5: PSD, Spectrogram & Spectral Occupancy"
+description: "Signal Lab's frequency-domain views — the power spectral density, the spectrogram/waterfall, and the spectral-occupancy metrics computed off the PSD: 99% occupied bandwidth, channel power, adjacent-channel power ratio (ACPR), and spectral flatness."
+category: tutorials
+keywords: power spectral density, psd, spectrogram, waterfall, occupied bandwidth, channel power, acpr, adjacent channel power ratio, spectral flatness, spectral occupancy, signal lab
+tags: [siglab, dsp, spectrum, occupancy, rf, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 5
+charts: true
+---
+
+*Part 5 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. We've looked at symbols; now we look at spectrum.*
+
+> **TL;DR:** Signal Lab's frequency-domain views describe a capture's *shape*
+> rather than its symbols. The **PSD** shows power versus frequency; the
+> **spectrogram/waterfall** shows how that PSD evolves over time; and a set of
+> **spectral-occupancy metrics** computed off the PSD — **99% occupied
+> bandwidth**, **channel power**, **adjacent-channel power ratio (ACPR)**, and
+> **spectral flatness** — turn the picture into numbers you can compare and
+> regress against.
+
+**Key takeaways**
+
+- **PSD = power vs frequency.** It's where you confirm a signal is where and how
+  wide you think it is.
+- **Spectrogram = PSD over time.** Intermittent and hopping emitters reveal
+  themselves here that a single PSD averages away.
+- **99% occupied bandwidth** answers "how wide is this signal, really?"
+- **ACPR** measures spillover into adjacent channels; **channel power** is the
+  in-band total; **spectral flatness** distinguishes tone-like from noise-like.
+- **These are computed off the PSD**, so they're deterministic and repeatable for
+  a given capture.
+
+## Cheat sheet
+
+| Metric / view | What it tells you |
+|---|---|
+| PSD (line) | Power spectral density — power vs frequency |
+| Spectrogram / waterfall (heatmap) | PSD evolving over time |
+| 99% occupied bandwidth | Bandwidth containing 99% of the power |
+| Channel power | Total power in the channel of interest |
+| ACPR | Adjacent-channel power ratio — spillover into neighbors |
+| Spectral flatness | Tone-like (low) vs noise-like (high) |
+
+## In this post
+
+- **The PSD** — reading power versus frequency.
+- **The spectrogram** — the time dimension the PSD hides.
+- **Occupied bandwidth** — the honest width of a signal.
+- **Channel power and ACPR** — in-band energy and spillover.
+- **Spectral flatness** — the tone-vs-noise number.
+
+## The PSD: power versus frequency
+
+The **power spectral density** is the workbench's most basic frequency-domain
+view: estimated power on the vertical axis, frequency on the horizontal. It's
+where you answer the first questions about any capture — *is the signal actually
+centered where I think? how wide is it? is there an interferer sitting next to
+it?* For a well-behaved narrowband system like a 12.5 kHz P25 channel, the PSD
+shows a compact bump over the channel with the noise floor on either side; a
+mistuned capture shows that bump offset from center (which is exactly what
+`-auto-tune` corrects before demod).
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="line" width="560" height="300" role="img"
+        aria-label="Power spectral density of a narrowband channel over its noise floor"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "series":[{"label":"PSD","points":[[-12,-96],[-9,-95],[-7,-92],[-6,-78],[-5,-58],[-4,-46],[-3,-42],[-2,-40],[-1,-39],[0,-38],[1,-39],[2,-40],[3,-42],[4,-46],[5,-58],[6,-78],[7,-92],[9,-95],[12,-96]]}],
+"xlabel":"frequency offset (kHz)","ylabel":"power (dBFS)","xmin":-12,"xmax":12,"ymin":-100,"ymax":-30 }
+</script>
+<figcaption>A narrowband channel in the PSD: a compact power bump centered in the channel, sitting well above the noise floor on either side. Occupancy metrics are read straight off this curve.</figcaption>
+</figure>
+
+Everything else in this post is derived from this curve, which is why the PSD is
+worth reading carefully first. A clean, centered, well-separated bump is the
+precondition for a trustworthy occupancy measurement.
+
+## The spectrogram: the time dimension
+
+A single PSD averages a capture's whole duration into one curve — which throws
+away *time*. The **spectrogram** (or **waterfall**) keeps it: frequency on one
+axis, time on the other, power as color. A steady carrier is a solid vertical
+stripe; a bursty or intermittent emitter is a stack of short dashes; a
+frequency-hopper is a scatter of energy skipping across bins.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="heatmap" width="560" height="320" role="img"
+        aria-label="Spectrogram waterfall showing an intermittent bursty carrier over time"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "xlabel":"frequency bin","ylabel":"time →",
+"matrix":[
+[0.05,0.06,0.1,0.7,0.9,0.7,0.1,0.06,0.05],
+[0.05,0.05,0.08,0.6,0.85,0.6,0.09,0.05,0.05],
+[0.04,0.05,0.06,0.08,0.09,0.08,0.06,0.05,0.04],
+[0.05,0.06,0.1,0.72,0.92,0.72,0.1,0.06,0.05],
+[0.05,0.05,0.09,0.65,0.88,0.65,0.09,0.05,0.05],
+[0.04,0.05,0.06,0.07,0.08,0.07,0.06,0.05,0.04],
+[0.04,0.05,0.06,0.07,0.08,0.07,0.06,0.05,0.04],
+[0.05,0.06,0.11,0.7,0.9,0.7,0.11,0.06,0.05]] }
+</script>
+<figcaption>A waterfall of an intermittent channel: energy appears in the center bins, drops out, and returns. This time structure is exactly what a single averaged PSD hides — and it's how Mercury's on/off bursts first stood out to Ada.</figcaption>
+</figure>
+
+This is the view where **Mercury** first looked strange. Its bursts near 453 MHz
+come and go, so on a single PSD it barely registers, but on the waterfall it's an
+unmistakable stutter of short dashes — present, gone, present again. The
+spectrogram is where "intermittent" stops being a hunch and becomes visible; we
+pick that thread back up in Part 8.
+
+## Occupied bandwidth: the honest width
+
+The first occupancy metric is **99% occupied bandwidth**: the width of the
+frequency band that contains 99% of the signal's power. It's the honest answer to
+"how wide is this signal?" — more honest than eyeballing the PSD, because it
+integrates power rather than trusting where the bump *looks* like it ends.
+Occupied bandwidth is how you confirm a capture matches its channel plan: a P25
+system on a 12.5 kHz raster should show an occupied bandwidth comfortably inside
+that channel. A measurement that's too wide means splatter, an interferer folded
+in, or the wrong assumption about what you're looking at.
+
+## Channel power and ACPR
+
+Two related numbers describe energy in and around the channel:
+
+- **Channel power** is the total power integrated across the channel of interest —
+  the in-band energy. It's a level reference for everything else and a quick way
+  to compare two captures of the same system recorded at different gains.
+- **Adjacent-channel power ratio (ACPR)** measures how much of a transmitter's
+  power spills into the *neighboring* channels relative to its own. High ACPR
+  means a signal is bleeding into its neighbors — a transmitter problem, a
+  nonlinearity, or (from the receive side) a strong nearby emitter you're picking
+  up. For anyone sharing a band, ACPR is the politeness metric: a well-behaved
+  emitter keeps its energy in its own channel.
+
+Read together, channel power and ACPR tell you both *how much* signal you have and
+*how cleanly* it's confined. A strong channel with poor ACPR is loud and messy; a
+modest channel with excellent ACPR is quiet and well-mannered.
+
+## Spectral flatness: tone-like vs noise-like
+
+The last metric, **spectral flatness**, is a single number that captures the
+*character* of a spectrum: it's near zero for a peaky, tone-like signal (energy
+concentrated at a few frequencies) and near one for a flat, noise-like spectrum
+(energy spread evenly). It's a compact way to distinguish "there's a real
+modulated carrier here" from "this is basically noise." A capture whose channel
+region reads highly flat is telling you there may be nothing to decode — which,
+before you spend time chasing a lock, is worth knowing.
+
+Flatness also helps with the unknown-signal problem. A carrier with structure —
+a clear modulated shape — reads lower flatness than the surrounding noise floor,
+which is one of the cues blind signal-ID leans on when it tries to *name* an
+undecodable carrier in Part 8. Reese's rule: **flatness tells you if there's a
+signal; occupied bandwidth tells you how wide it is; ACPR tells you if it's
+staying in its lane.** Three numbers, three different questions, all read off the
+same PSD.
+
+## Resolution, windowing, and what you can trust
+
+A PSD is an *estimate*, and like any estimate it has a resolution-versus-noise
+trade-off worth understanding before you over-read it. Splitting a capture into
+more, longer FFT segments buys finer frequency resolution — narrower bins, so two
+close carriers separate instead of blurring into one bump — at the cost of a
+coarser time axis on the spectrogram. Splitting it into more, shorter segments
+does the opposite: it smooths the PSD and sharpens the waterfall's time
+resolution but widens each frequency bin. There's no free lunch; the estimator
+picks a sensible middle, but the consequence is real. Two carriers 3 kHz apart
+may or may not resolve depending on the bin width, and an occupied-bandwidth
+measurement inherits the same uncertainty at its edges.
+
+The practical upshot for occupancy metrics: they're *relative* instruments, best
+used to compare captures or to track a change, and they're most trustworthy when
+the signal is well above the noise floor. A channel-power number on a capture
+that's barely above the floor is dominated by the noise you're integrating along
+with the signal; the same measurement on a strong, clean capture is tight. When
+Reese compares two recordings of the same system, he compares them at the *same*
+settings against the *same* reference — because it's the delta between them, not
+the absolute dBFS, that carries the meaning.
+
+## Occupancy as a fingerprint
+
+Read together, the occupancy set doubles as a coarse *fingerprint* for an unknown
+carrier, which is where this part quietly feeds Part 8. A 12.5 kHz occupied
+bandwidth with low flatness and modest ACPR is consistent with a narrowband
+land-mobile channel; a much wider occupied bandwidth points at a different class
+of system entirely. You can't name a protocol from occupancy alone — that takes
+the blind symbol-rate and modulation estimate — but you *can* rule large families
+in or out before you ever try to decode. For Mercury, the occupancy said
+"narrowband, ~12.5 kHz, real modulated structure, not splattering into its
+neighbors" — enough to know it was a deliberate signal worth chasing, long before
+anything named it.
+
+## Where this goes next
+
+You can now describe a capture in both domains — symbols (Part 4) and spectrum
+(this part). [Part 6]({{ '/blog/tutorials/signal-lab-06-synthesize-references/' | relative_url }})
+flips the workbench around: instead of measuring a captured signal, you'll
+*generate* one — an idealized reference — and then deliberately impair it (SNR,
+carrier offset, multipath, DC, I/Q imbalance) to build clean baselines and
+known-bad fixtures whose PSD and occupancy you already know the answer to. The
+[SigLab docs]({{ '/siglab.html' | relative_url }}) list the full metric set.
+
+## FAQ
+
+**What's the difference between a PSD and a spectrogram?**
+The PSD is one curve — power versus frequency, averaged over the capture. The
+spectrogram adds time as a second axis and shows how that PSD evolves, which is
+essential for intermittent or hopping signals a single PSD would smear away.
+
+**Why 99% occupied bandwidth and not just "the width"?**
+Because "the width" depends on where you decide the signal stops. Occupied
+bandwidth defines it rigorously as the band containing 99% of the power, so two
+people (or two runs) measuring the same capture get the same answer.
+
+**What does high ACPR indicate?**
+Power spilling into adjacent channels relative to the channel of interest —
+either a transmitter that isn't confining its energy well or a strong neighboring
+emitter bleeding in. Low ACPR is a clean, well-confined signal.
+
+**Are these metrics repeatable?**
+Yes. They're computed deterministically off the PSD of a fixed capture, so the
+same file yields the same numbers every run — which is what makes them useful as
+regression baselines.
+
+## Series navigation
+
+**Part 5 of 10** · ←[Part 4]({{ '/blog/tutorials/signal-lab-04-constellations-and-eye-diagrams/' | relative_url }}) · Next →
+[Part 6: Synthesize References]({{ '/blog/tutorials/signal-lab-06-synthesize-references/' | relative_url }})

--- a/docs/_posts/2026-07-09-crypto-lab-06-assess-battery.md
+++ b/docs/_posts/2026-07-09-crypto-lab-06-assess-battery.md
@@ -1,0 +1,183 @@
+---
+title: "Crypto Lab, Part 6: The assess Battery — Attacking P25/DMR/TETRA"
+description: Crypto Lab's assess crypto harness runs every applicable attack against captured P25, DMR, and TETRA frames and grades each — cipher-strength, a published-weakness knowledge base, IV reuse, known-plaintext, weak/default keys against the real ciphers, and reduced-keyspace brute — landing on a RESISTANT, PARTIAL, or BROKEN verdict.
+category: tutorials
+keywords: assess crypto, p25 encryption assessment, dmr enhanced privacy, tetra tea1 backdoor, cve-2022-24402, weak key attack, key brute force, iv reuse, adp rc4, des ofb, gophertrunk cryptolab
+tags: [cryptolab, assess, p25, dmr, tetra, security-testing, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 6
+---
+
+*Part 6 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. This is the headline: one command that tries every attack and grades your deployment.*
+
+> **TL;DR:** `cryptolab assess crypto -in frames.jsonl` takes captured encrypted frames and **actively attempts decryption by every applicable method**, grading each from 0% (held) to 100% (a fail). Methods escalate: `cipher-strength` and `known-weakness` (both PARTIAL, the latter a floor — e.g. TETRA TEA1's 80→32-bit backdoor, CVE-2022-24402), `iv-reuse` (PARTIAL), then the recovery methods `known-plaintext`, `weak-key`, `key-brute` (`-brute-bits`, capped 32), and `keystream-lfsr` (all BROKEN). The overall verdict is <span class="lab-verdict lab-verdict--ok">RESISTANT</span>, <span class="lab-verdict lab-verdict--warn">PARTIAL</span>, or <span class="lab-verdict lab-verdict--bad">BROKEN</span>.
+
+> **Authorized testing only.** Point `assess` at captures from a system you own or are licensed to assess.
+
+**Key takeaways**
+
+- **One harness, every method.** `assess crypto` runs the whole ladder and reports each method's effectiveness.
+- **Effectiveness is a percentage** of captured ciphertext each method recovered or exposed.
+- **A verified full decrypt is <span class="lab-verdict lab-verdict--bad">BROKEN</span>.** A leak without a break is <span class="lab-verdict lab-verdict--warn">PARTIAL</span>; nothing recovered is <span class="lab-verdict lab-verdict--ok">RESISTANT</span>.
+- **Real ciphers, real recoveries.** `weak-key` and `key-brute` run the actual ADP/DES/3DES/AES constructions, so a default key is truly recovered, not just flagged.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab assess crypto -in frames.jsonl` | Run every applicable attack, grade each |
+| `-protocol p25\|tetra\|dmr` | Algorithm-id namespace for the weakness KB (default p25) |
+| `-known-label call-12 -known-pt known.bin` | A verification oracle → verified recoveries |
+| `-keys candidate-keys.txt` | Extend the weak-key dictionary (one hex key/line) |
+| `-brute-bits N` | Reduced-keyspace brute over the low N bits (capped 32) |
+| `-base-key HEX` | Fix the high bits for `-brute-bits` |
+
+## In this post
+
+- **What `assess` does** — the security test as one command.
+- **The method ladder** — seven methods, what each proves, and how each grades.
+- **The known-plaintext oracle** — how `-known-label`/`-known-pt` turn flags into verified breaks.
+- **Cipher coverage** — which P25/DMR ciphers run natively, and which are advisory-only.
+- **Reading the verdict** — RESISTANT, PARTIAL, BROKEN, and the honesty about limits.
+
+## The security test as one command
+
+`assess` is the toolkit's thesis made executable. Everything in the earlier parts — IV reuse, keystream analysis, weak-key checks — is a *method*, and `assess crypto` runs them all against one capture, then reports how effective each was:
+
+```bash
+gophertrunk cryptolab assess crypto -in frames.jsonl -protocol p25
+```
+
+```text
+assess/crypto — PARTIAL — strongest method "iv-reuse" at 34% over 61440
+  ciphertext bytes across 214 frames
+  frames  214
+  verdict  PARTIAL
+  overall_effectiveness  0.34
+findings (by effectiveness):
+  iv-reuse         0.34   applicable true   exposed p1^p2 in 3 groups
+  cipher-strength  0.10   applicable true   structured ciphertext in 2 frames
+  known-weakness   0.00   applicable true   (advisory) no published break for algid 0x84
+  known-plaintext  0.00   applicable false  needs -known-label/-known-pt
+  weak-key         0.00   applicable false  no default key matched
+note: PARTIAL: no full break, but information leaked...
+```
+
+**Effectiveness** is the fraction of captured ciphertext each method recovered or exposed — so the findings sort with the most successful attack on top, and 100% from a *verified* method is a complete break.
+
+## The method ladder
+
+Seven methods run, in escalating capability. The first three can only expose (they floor at PARTIAL); the last four can achieve a verified recovery (BROKEN).
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 250" width="640" height="250" role="img" aria-label="assess method flow from exposure methods to recovery methods to a verdict">
+  <g font-size="11.5" fill="currentColor">
+  <text x="10" y="18" fill="var(--fg-muted)">EXPOSURE (floor: PARTIAL)</text>
+  <rect x="10" y="26" width="180" height="24" rx="4" fill="none" stroke="currentColor"/>
+  <text x="20" y="42">cipher-strength</text>
+  <rect x="10" y="56" width="180" height="24" rx="4" fill="none" stroke="currentColor"/>
+  <text x="20" y="72">known-weakness (KB)</text>
+  <rect x="10" y="86" width="180" height="24" rx="4" fill="none" stroke="currentColor"/>
+  <text x="20" y="102">iv-reuse</text>
+  <text x="10" y="140" fill="var(--fg-muted)">RECOVERY (verified: BROKEN)</text>
+  <rect x="10" y="148" width="180" height="24" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="20" y="164">known-plaintext</text>
+  <rect x="10" y="178" width="180" height="24" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="20" y="194">weak-key</text>
+  <rect x="10" y="208" width="180" height="24" rx="4" fill="none" stroke="var(--accent)"/>
+  <text x="20" y="224">key-brute / keystream-lfsr</text>
+  <line x1="200" y1="120" x2="260" y2="120" stroke="currentColor" stroke-width="1.5"/>
+  <polygon points="260,120 252,116 252,124" fill="currentColor"/>
+  <rect x="266" y="80" width="150" height="34" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="341" y="101" text-anchor="middle" fill="var(--accent)">RESISTANT</text>
+  <rect x="266" y="120" width="150" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="341" y="141" text-anchor="middle">PARTIAL</text>
+  <rect x="266" y="160" width="150" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="341" y="181" text-anchor="middle">BROKEN</text>
+  <text x="440" y="120" fill="var(--fg-muted)">highest outcome</text>
+  <text x="440" y="136" fill="var(--fg-muted)">any method reached</text>
+  <text x="440" y="152" fill="var(--fg-muted)">sets the verdict</text>
+  </g>
+</svg>
+<figcaption>Exposure methods can only leak (PARTIAL); recovery methods can verify a full break (BROKEN). The strongest outcome any method reaches sets the overall verdict.</figcaption>
+</figure>
+
+| Method | What it does | Counts toward |
+|---|---|---|
+| `cipher-strength` | Is the ciphertext distinguishable from random? Structured output = a weak/keyless construction | exposure (PARTIAL) |
+| `known-weakness` | Look up each algorithm id in the published-weakness KB and report design flaws | advisory (floors at PARTIAL) |
+| `iv-reuse` | Frames sharing an IV leak `p1⊕p2` with no key | exposure (PARTIAL) |
+| `known-plaintext` | Recover the keystream from a known frame, decrypt its reuse group | recovery (BROKEN) |
+| `weak-key` | Try default / supplied keys with the **real** ADP/DES/3DES/AES cipher, verified | recovery (BROKEN) |
+| `key-brute` | Reduced-keyspace brute over the low `-brute-bits` bits against the oracle | recovery (BROKEN) |
+| `keystream-lfsr` | Is a recovered keystream a short, predictable LFSR? | recovery (BROKEN) |
+
+The `known-weakness` method is the knowledge-base advisory. It looks up each algorithm id in a published-weakness database keyed by protocol, and reports design flaws even when the cipher itself isn't bundled. Its headline example is **TETRA TEA1**: for `-protocol tetra`, it reports the 80→32-bit key reduction backdoor (**CVE-2022-24402**) and notes that a 2³² brute would recover the key given a TEA1 implementation. That's an actionable finding without fabricating an unverified cipher — a floor of PARTIAL, because a *published* break in a deployed algorithm is itself an exposure.
+
+## The known-plaintext oracle
+
+The single flag that upgrades `assess` from "flags weaknesses" to "verifies breaks" is the known-plaintext oracle: `-known-label` naming a frame and `-known-pt` giving its plaintext. With it:
+
+- `known-plaintext` becomes possible — derive the keystream from the named frame and decrypt its whole reuse group.
+- `weak-key` and `key-brute` become **definitive**: a candidate key isn't just tried, it's *verified* against the oracle, so a hit is a confirmed break rather than a guess.
+
+```bash
+gophertrunk cryptolab assess crypto -in frames.jsonl -protocol p25 \
+    -known-label call-12 -known-pt known.bin -keys candidate-keys.txt
+```
+
+```text
+assess/crypto — BROKEN — strongest method "weak-key" at 100% over 61440
+  ciphertext bytes across 214 frames
+  verdict  BROKEN
+  weak-key   1.00   verified true   key 0000000000000000   sample_ascii "DISPATCH..."
+note: BROKEN: a method achieved verified complete decryption — the encryption
+  FAILED this test.
+```
+
+That result — an all-zero DES key recovered and verified — is the deployment failing the test. Reese's rule holds: `assess` only claims BROKEN on a *verified* recovery, never on a plausible-looking one. Without the oracle, the same weak key would be tried but couldn't be confirmed, so the harness would decline to call it a break.
+
+The reduced-keyspace brute is the `key-brute` method: `-brute-bits N` searches the low N bits of the key against the oracle, with `-base-key` fixing the high bits. N is **capped at 32** for feasibility — this is the hashcat-analog and the exact shape of the TEA1 backdoor attack, not a claim to brute a full 128-bit key.
+
+## Cipher coverage
+
+The active recovery methods carry the **real keystream constructions**, so a default or small-keyspace key is genuinely recovered:
+
+- **P25** (`-protocol p25`): ADP/RC4, DES-OFB, two- and three-key Triple-DES, AES-128/256-OFB.
+- **DMR** (`-protocol dmr`): RC4 "Enhanced Privacy", DES/3DES/AES-OFB. DMR's vendor key/IV *derivation* is proprietary, so the cipher cores are keyed with the material you supply (the reconstructed key; the frame IV used directly).
+
+Ciphers whose keystream function isn't bundled at all — **TETRA TEA1–4** and **Motorola DES-XL** — are covered by the `known-weakness` advisory instead of a fabricated implementation. For those, `assess` reports the published weakness and, via the external-cipher bridge ([Part 9]({{ '/blog/tutorials/crypto-lab-09-web-console-bridge-external/' | relative_url }})), can drive an operator-supplied cipher to run the backdoor brute for real.
+
+## Reading the verdict, and the honesty about limits
+
+The overall verdict is the highest outcome any method reached:
+
+- <span class="lab-verdict lab-verdict--ok">RESISTANT</span> — no applicable method recovered plaintext. The encryption held against every attack tried, with this data.
+- <span class="lab-verdict lab-verdict--warn">PARTIAL</span> — information leaked: a reused IV, structured ciphertext, a recovered keystream segment, or a published break in the algorithm in use.
+- <span class="lab-verdict lab-verdict--bad">BROKEN</span> — a method achieved verified complete decryption. A fail.
+
+And the toolkit is deliberately honest about its ceiling. `assess` **cannot** brute a strong key out of a strong cipher — AES/3DES with a non-default key and rotated IVs has an infeasible keyspace, and it says so plainly, reporting <span class="lab-verdict lab-verdict--ok">RESISTANT</span>. That result *is* the security finding: the encryption is doing its job. What `assess` breaks is what fails in the field — reused IVs, default and test keys, small or backdoored keyspaces, keyless obfuscation, and weak keystreams. It is a test of operational reality, not a magic decryptor.
+
+## Where this goes next
+
+`assess` grades the encryption. But before you can even get to the ciphertext, you often have to peel off framing — and the CRC that validates it. [Part 7]({{ '/blog/tutorials/crypto-lab-07-crc-recovery-recipe/' | relative_url }}) covers `crc recover` and the CyberChef-style `recipe` pipeline that chains transforms and analyses into one reusable artifact. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) detail every `assess` method and flag.
+
+## FAQ
+
+**What does the effectiveness percentage mean?**
+The fraction of captured ciphertext a method recovered or exposed. 100% from a *verified* method (one confirmed against a known-plaintext oracle) is a complete break; a lower number from an exposure method means partial leakage.
+
+**Do I need known plaintext to run `assess`?**
+No — it runs the exposure methods (cipher-strength, known-weakness, iv-reuse) without it. But `-known-label`/`-known-pt` turn the weak-key and key-brute methods into *verified* recoveries and enable known-plaintext, so an oracle is what upgrades PARTIAL findings into confirmed BROKEN ones.
+
+**Can it break TEA1 or a properly-keyed AES system?**
+It reports TEA1's published 80→32-bit backdoor (CVE-2022-24402) as an advisory and can drive an external TEA1 tool to run the 2³² brute. A properly-keyed AES system with rotated IVs it reports as RESISTANT — it will not fabricate a break it cannot verify.
+
+**Why is `-brute-bits` capped at 32?**
+Feasibility. A 32-bit search is the realistic ceiling for a brute against a known-plaintext oracle — and it's exactly the size of the TEA1 backdoor keyspace. It is not a claim to brute a full-length key.
+
+## Series navigation
+
+**Part 6 of 10** · ←[Part 5: Keystream Reuse & Many-Time-Pad]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }}) · Next →[Part 7: CRC Recovery & the Recipe Pipeline]({{ '/blog/tutorials/crypto-lab-07-crc-recovery-recipe/' | relative_url }})

--- a/docs/_posts/2026-07-09-rf-scope-06-topology-emitters-conversations.md
+++ b/docs/_posts/2026-07-09-rf-scope-06-topology-emitters-conversations.md
@@ -1,0 +1,282 @@
+---
+title: "RF Scope, Part 6: Topology — Emitters, Frequency Hoppers & Conversations"
+description: rfscope's topology analyzer is the RF analog of Wireshark's Conversations and Endpoints — it clusters bursts into emitters by RF fingerprint, collapses a frequency hopper's scattered bursts into one logical source, links emitters into conversations, and defers to hunt's authoritative map when a trunking control channel decodes.
+category: tutorials
+keywords: rfscope, topology, emitters, frequency hopper, conversations, wireshark conversations, endpoints, rf fingerprint, hop sequence, co-active, request-response, gophertrunk
+tags: [rfscope, rf-analysis, advanced, gophertrunk, dsp, sdr]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 6
+---
+
+*Part 6 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer. Every
+view so far looked down one channel; this one looks across the whole band and asks who
+is talking to whom.*
+
+> **TL;DR:** The `topology` analyzer is Wireshark's Conversations/Endpoints for RF. It
+> clusters bursts into **emitters** by RF fingerprint — Stage A groups by
+> frequency + class family, Stage B conservatively merges several single-channel
+> emitters into one **frequency hopper** when they never transmit at the same time and
+> share a power band — then links emitters into **conversations**: hop sequences,
+> co-active pairs (lag-0 correlation ≥ 0.5), and request-response pairs (off-lag peak
+> ≥ 0.4). When a trunking control channel decodes, it defers to `hunt`'s authoritative
+> map. **Mercury** surfaces here as a frequency hopper.
+
+**Key takeaways**
+
+- **Emitters are bursts clustered by RF fingerprint** — the protocol-agnostic
+  generalization of a radio's identity.
+- **A frequency hopper collapses into one emitter** via a deliberately conservative
+  two-stage merge.
+- **Conversations link correlated emitters:** hop sequence, co-active, or
+  request-response.
+- **When trunking is present, `hunt` is the authority** — topology folds its map in
+  rather than reinventing it.
+
+## Cheat sheet
+
+| Concept / constant | Meaning |
+|---|---|
+| Stage A cluster | Group by (frequency, class family) |
+| Stage B merge | Collapse time-disjoint same-power emitters into a hopper |
+| `HopSet` | The >1 frequencies a hopper visits |
+| `coactiveThresh` = 0.5 | Lag-0 correlation ⇒ co-active conversation |
+| `rrThresh` = 0.4 | Off-lag peak ⇒ request-response conversation |
+| `hopperPowerBucketDb` = 6 | Power band width for hopper candidates |
+
+## In this post
+
+- **What RF topology is** and how it maps to Wireshark's Conversations.
+- **Stage A** — clustering bursts into per-channel emitters.
+- **Stage B** — merging a frequency hopper into one emitter.
+- **Conversations** — hop sequences, co-active, and request-response.
+- **Deferring to `hunt`** when real trunking decodes.
+- **Mercury the hopper.**
+
+## RF topology
+
+Wireshark's Conversations tab turns a flat packet list into a graph of endpoints and
+the flows between them. RF Scope's `topology` analyzer does the equivalent for a band:
+it turns a flat list of bursts into a graph of **emitters** (the sources) and
+**conversations** (the relationships between them). This is the closest RF Scope comes
+to `hunt`'s trunking map — but generalized, so it works for an unknown IoT mesh or a
+hopping data link that `hunt` would never recognize.
+
+The analyzer has **no dependencies** (it clusters raw bursts), and it does two things
+in order: cluster emitters, then detect conversations.
+
+## Stage A: per-channel emitters
+
+The first pass groups bursts by exact frequency and coarse modulation family:
+
+```go
+// internal/rfscope/topology.go
+type key struct {
+    freq   uint32
+    family string
+}
+groups := map[key][]int{}
+for i, b := range sc.Bursts {
+    k := key{b.FreqHz, classFamily(b.Class)}
+    groups[k] = append(groups[k], i)
+}
+```
+
+`classFamily` folds the fine-grained classes into four coarse families — `am`,
+`analog-fm`, `digital`, `unknown` — deliberately, so that a hopper whose hops get
+classified slightly inconsistently (C4FM on one visit, FSK on the next) still lands in
+one family and can be merged later. Each group becomes an emitter with a **fingerprint**:
+center frequency, occupied bandwidth, class family, median power, median burst length,
+and median spectral flatness. This is the common case: most emitters live on one
+channel, and Stage A alone handles them.
+
+## Stage B: collapsing a frequency hopper
+
+A frequency hopper defeats per-channel clustering — its bursts scatter across many
+channels, so Stage A sees them as many separate one-burst emitters. Stage B stitches
+them back together, but *carefully*, because the failure mode (merging two distinct
+co-channel radios into a phantom hopper) is worse than missing a hopper.
+
+The merge fires only when all of these hold:
+
+1. **Same class family and same power band.** Candidates are bucketed by family and by
+   median power in `hopperPowerBucketDb` = 6 dB bins — a single radio's power does not
+   swing wildly between hops.
+2. **At least two distinct frequencies.** A "hopper" on one frequency is just an
+   emitter.
+3. **Time-disjoint bursts.** The candidates' bursts must be pairwise non-overlapping in
+   time — *a single radio cannot key two channels at once.* This is the decisive test:
+
+```go
+// internal/rfscope/topology.go
+for i := 1; i < len(ivs); i++ {
+    if ivs[i].start < ivs[i-1].end {
+        return false // two bursts overlap ⇒ not one radio
+    }
+}
+```
+
+Only when a group of single-channel emitters shares a family and power band, spans
+multiple frequencies, and never overlaps in time does RF Scope collapse them into one
+emitter with a `HopSet` of the visited frequencies. Everything that fails the test
+stays as it was. Reese calls this *"the physics veto"* — the time-disjoint rule is not
+a heuristic, it is a hard constraint from how radios work.
+
+## Conversations
+
+With emitters clustered, the analyzer links temporally correlated ones. It builds a
+binary activity signal per emitter (which timeline bins it was active in) and looks for
+three relationship kinds:
+
+- **Hop sequence** (intra-emitter). Any emitter with a `HopSet` of more than one
+  frequency is its own hop-sequence conversation — the ordered visits *are* the
+  relationship.
+- **Co-active** (inter-emitter). Two emitters whose activity signals correlate at
+  **lag 0** with correlation ≥ `coactiveThresh` (0.5) are transmitting *together* — a
+  paired uplink/downlink, or two slots of the same call. They start and stop in step.
+- **Request-response** (inter-emitter). Two emitters whose correlation peaks at a
+  **non-zero lag** ≥ `rrThresh` (0.4), while their lag-0 correlation stays low, are
+  *alternating* — one transmits, then the other, like a query and its reply.
+
+```go
+// internal/rfscope/topology.go
+switch {
+case lag0 >= coactiveThresh:
+    kind, score = "co-active", lag0
+case bestVal >= rrThresh && bestLag != 0 && lag0 < 0.3:
+    kind, score = "request-response", bestVal
+}
+```
+
+Pairwise comparison is capped at the top `maxConvEmitters` (24) talkers so a busy band
+does not become an O(n²) blowup. Each conversation records the emitter IDs, the kind,
+the correlation score, and an exchange count.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 600 230" width="600" height="230" role="img" aria-label="Emitter and conversation graph">
+  <circle cx="90" cy="70" r="30" fill="none" stroke="currentColor"/>
+  <text x="90" y="66" text-anchor="middle" fill="currentColor" font-size="11">#1</text>
+  <text x="90" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">453.325</text>
+  <circle cx="90" cy="180" r="30" fill="none" stroke="currentColor"/>
+  <text x="90" y="176" text-anchor="middle" fill="currentColor" font-size="11">#2</text>
+  <text x="90" y="190" text-anchor="middle" fill="var(--fg-muted)" font-size="9">453.350</text>
+  <line x1="90" y1="100" x2="90" y2="150" stroke="var(--accent)"/>
+  <text x="150" y="128" fill="var(--accent)" font-size="10">co-active (0.71)</text>
+  <circle cx="330" cy="70" r="30" fill="none" stroke="currentColor"/>
+  <text x="330" y="66" text-anchor="middle" fill="currentColor" font-size="11">#3</text>
+  <text x="330" y="80" text-anchor="middle" fill="var(--fg-muted)" font-size="9">ctl</text>
+  <circle cx="330" cy="180" r="30" fill="none" stroke="currentColor"/>
+  <text x="330" y="176" text-anchor="middle" fill="currentColor" font-size="11">#4</text>
+  <text x="330" y="190" text-anchor="middle" fill="var(--fg-muted)" font-size="9">voice</text>
+  <line x1="330" y1="100" x2="330" y2="150" stroke="currentColor" stroke-dasharray="4 3"/>
+  <text x="360" y="128" fill="var(--fg-muted)" font-size="10">req-response (0.48)</text>
+  <circle cx="520" cy="125" r="34" fill="none" stroke="var(--accent)"/>
+  <text x="520" y="120" text-anchor="middle" fill="var(--accent)" font-size="11">#5</text>
+  <text x="520" y="135" text-anchor="middle" fill="var(--fg-muted)" font-size="9">hopper ×4</text>
+  <path d="M 520 91 A 30 30 0 1 1 514 91" fill="none" stroke="var(--accent)"/>
+  <text x="520" y="185" text-anchor="middle" fill="var(--accent)" font-size="10">hop-sequence</text>
+</svg>
+<figcaption>An emitter/conversation graph: a co-active pair, an alternating request-response pair, and a self-looping frequency hopper — Mercury.</figcaption>
+</figure>
+
+## The fingerprint, and why clustering is conservative
+
+Everything topology does hinges on the **fingerprint** — the feature vector each emitter
+is summarized by: center frequency, occupied bandwidth, class family, median power,
+median burst length, and median spectral flatness. Notice what is *not* in it. There is
+no attempt to fingerprint the transmitter's hardware — no LO-drift signature, no
+transient-onset shape, none of the RF-fingerprinting that a lab with a controlled
+reference might attempt. Those techniques are fragile: they depend on capture SNR,
+receiver calibration, and a training set, and they fail quietly. RF Scope's fingerprint
+is built from features it can measure robustly on a single blind capture, which is why it
+uses medians throughout — one bad burst cannot move the emitter's identity.
+
+That conservatism is a theme. Stage A clusters on *exact* frequency and coarse family,
+which never merges two things that should be separate; its only failure mode is
+*over*-splitting a hopper, which Stage B then repairs under strict conditions. The whole
+design leans toward "leave it separate unless the physics forces a merge," because in
+reconnaissance a false merge is a lie — it invents a device that does not exist — while a
+false split is merely a missed simplification you can spot by eye. When the analyzer does
+collapse four channels into one hopper, you can trust that the time-disjoint, same-power,
+same-family evidence was strong enough to rule out coincidence.
+
+## Deferring to hunt
+
+There is one case where RF Scope should *not* trust its own generic clustering: a real
+trunking system, where GopherTrunk already has a purpose-built, authoritative map. When
+an emitter's representative burst is long enough to decode and identifies as a trunking
+protocol, topology decodes it with `siglab`, folds the result into a
+`hunt.DiscoveredSystem`, and attaches that under `AnalyzerOutputs["topology"]`:
+
+```go
+// internal/rfscope/topology.go
+hunt.Accumulate(sys, hunt.Observation{
+    Protocol:       ident.Winner,
+    Confidence:     ident.Confidence,
+    Result:         res,
+    FallbackFreqHz: e.Fingerprint.CenterHz,
+})
+```
+
+So the WACN, SysID, RFSS, site, neighbors, and band plan of a trunked system come from
+`hunt` — the code that specializes in exactly that — and hunt's map becomes one
+*specialization* of the generic emitter graph. RF Scope caps this at
+`maxTrunkDecode` = 8 systems and only attempts it for digital emitters whose median
+burst is at least `minTrunkDecodeSec` = 0.5 s, so the expensive full decode runs only
+where it will pay off.
+
+## Mercury the hopper
+
+This is Mercury's defining moment in RF Scope. In the timing view (Part 5) its bursts
+looked aperiodic on every single channel — no clean frame anywhere. Topology explains
+why: those bursts, scattered across four nearby 12.5 kHz channels around 453 MHz, all
+share the same digital class family, sit in the same 6 dB power band, and — critically
+— **never overlap in time**. Stage B collapses them into one emitter with a four-entry
+`HopSet`, labeled something like `digital hopper (4 ch)`, and detectConversations emits
+a **hop-sequence** conversation for it.
+
+That reframes everything. Mercury is not four weak mystery signals; it is *one*
+intermittent, frequency-hopping emitter that has been deliberately spreading itself
+across the band. That is the kind of behavior that motivates a closer look at its
+payload — which is exactly where Part 7's entropy analyzer comes in.
+
+## Where this goes next
+
+Topology tells you Mercury is one hopping emitter that no protocol names. The obvious
+next question is: *what is in its bursts, and is it encrypted?* [Part
+7]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }})
+introduces the `entropy` analyzer — which depends on topology — and the **Crypto Lab
+bridge**: it blind-demodulates an unknown emitter's payload, runs the cryptolab
+randomness battery over it, and can emit the bytes as a frames file for the
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) toolkit.
+
+## FAQ
+
+**How can RF Scope tell a hopper from two separate radios?**
+The time-disjoint test: a single radio physically cannot transmit on two channels at
+once, so if any two candidate bursts overlap in time, the merge is rejected. Combined
+with matching class family and power band, that keeps distinct co-channel radios from
+being fused into a phantom hopper.
+
+**What's the difference between co-active and request-response?**
+Co-active emitters start and stop *together* — their occupancy correlates at lag 0
+(≥ 0.5). Request-response emitters *alternate* — the correlation peaks at a non-zero
+lag (≥ 0.4) while lag 0 stays low. One is simultaneous, the other is turn-taking.
+
+**Why defer to `hunt` for trunking?**
+`hunt` is GopherTrunk's specialized trunking-map accumulator; it knows how to assemble
+WACN/site/neighbor data authoritatively. Topology folds hunt's map in as a
+specialization rather than approximating it with generic clustering.
+
+**Does topology need timeline or timing first?**
+No — topology declares no dependencies and clusters raw bursts. It does use the same
+100-bin activity model for conversation correlation, but it builds that itself from the
+bursts.
+
+## Series navigation
+
+**Part 6 of 10** · ←
+[Part 5: Timing & Periodicity]({{ '/blog/tutorials/rf-scope-05-timing-and-tdma-period/' | relative_url }})
+· Next →
+[Part 7: Entropy & Encryption Triage]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }})

--- a/docs/_posts/2026-07-09-signal-lab-06-synthesize-references.md
+++ b/docs/_posts/2026-07-09-signal-lab-06-synthesize-references.md
@@ -1,0 +1,234 @@
+---
+title: "Signal Lab, Part 6: Synthesize — Building Ideal & Impaired References"
+description: Signal Lab's synthesis engine generates an idealized IQ capture and then injects controlled impairments — SNR, carrier offset and drift, multipath, DC, and I/Q imbalance — so you can build a clean reference or a known-bad regression fixture and overlay them in the Compare tab.
+category: tutorials
+keywords: iq synthesis, synthesize capture, impairments, awgn snr, carrier offset drift, multipath, dc offset, iq imbalance, regression fixture, reference signal, siglab synthesize
+tags: [siglab, dsp, synthesis, testing, regression, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 6
+charts: true
+---
+
+*Part 6 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. So far we've measured captures we were given; now we
+manufacture them on purpose.*
+
+> **TL;DR:** Signal Lab's synthesis engine generates an *idealized* capture for a
+> protocol, then lets you inject controlled impairments — SNR, carrier
+> offset/drift, multipath, DC, and I/Q imbalance — with a fixed seed for
+> reproducibility. Use it to build a pristine reference (what "perfect" looks
+> like) or a known-bad fixture (a specific failure you can regress against), then
+> overlay them in the **Compare** tab to prove a demod change did what you
+> intended.
+
+**Key takeaways**
+
+- **Synthesis makes the answer known in advance.** You control the signal, so you
+  know exactly what the metrics *should* read.
+- **Impairments are a menu** — SNR, carrier offset/drift, multipath, DC, I/Q
+  imbalance — applied on top of an ideal baseline.
+- **A fixed seed makes it reproducible.** The same impairment draw every run is
+  what makes a synthesized capture a valid fixture.
+- **Compare overlays references** against real captures or against each other.
+- **This is how demod changes get proven** — not by vibes, but by a fixture that
+  fails before and passes after.
+
+## Cheat sheet
+
+| Concept / knob | What it does |
+|---|---|
+| Synthesize tab | Generate an idealized capture for a protocol |
+| SNR impairment | Add AWGN to a target signal-to-noise |
+| Carrier offset / drift | Shift or slowly move the carrier off center |
+| Multipath | Add delayed, faded echoes |
+| DC offset | Inject a DC spike at 0 Hz |
+| I/Q imbalance | Add gain/phase imbalance between I and Q |
+| Seed | Fix the random draw for reproducible fixtures |
+| Compare tab | Overlay synthesized vs real (or vs ideal) |
+
+## In this post
+
+- **Why synthesize at all** — the value of a known answer.
+- **The ideal baseline** — a perfect capture as a reference.
+- **The impairment menu** — five ways to break a signal on purpose.
+- **Reproducibility** — why the seed matters.
+- **Compare** — proving a change with an overlay.
+
+## Why synthesize at all
+
+Every metric in this series answers "how good is this capture?" — but you can
+only fully *trust* a measurement when you already know the right answer.
+Synthesis gives you that: you specify the signal, so you know precisely what a
+correct decoder should report. A pristine synthesized P25 capture *must* lock
+instantly at near-zero EVM; if it doesn't, the bug is in the code, not the
+signal. That inversion — from "measure an unknown" to "check against a known" —
+is what makes the synthesis engine the backbone of GopherTrunk's demod testing.
+
+Two jobs dominate. First, a **clean reference**: the "this is what perfect looks
+like" baseline you overlay a real capture against to see how far short it falls.
+Second, a **known-bad fixture**: a capture impaired in one specific, documented
+way — say, exactly 8 dB SNR with a 1.5 kHz carrier offset — that a regression
+test can decode and assert against. When a demod change lands, the fixture that
+*failed to lock* before and *locks* after is the proof the change worked.
+
+## The ideal baseline
+
+Synthesis starts from an idealized capture for a chosen protocol and modulation —
+a signal with no noise, no offset, no imbalance. On a constellation it's the
+textbook picture: four rails (C4FM) or four clusters (CQPSK) so tight they're
+nearly points. The synthesis engine and the analyzer share the same code paths as
+the rest of the workbench, so an ideal capture run back through the decoder reads
+the way theory says it should.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="constellation" width="480" height="360" role="img"
+        aria-label="Ideal synthesized C4FM constellation with near-perfect rails"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "rails":[-3,-1,1,3], "dot":1.6,
+"points":[[-3,0.05],[-3,-0.05],[-3,0.02],[-3,-0.03],[-1,0.04],[-1,-0.04],[-1,0.01],[-1,-0.02],[1,0.03],[1,-0.03],[1,0.02],[1,-0.01],[3,0.04],[3,-0.05],[3,0.02],[3,-0.03]] }
+</script>
+<figcaption>An ideal synthesized C4FM baseline: four near-perfect rails. This is the "what perfect looks like" reference every real capture is measured against.</figcaption>
+</figure>
+
+## The impairment menu
+
+On top of the ideal baseline you inject impairments — individually or stacked —
+each modeling a real-world defect:
+
+| Impairment | Models | What it does to the picture |
+|---|---|---|
+| **SNR** | Weak signal / distance | AWGN thickens rails and clusters; the eye closes |
+| **Carrier offset / drift** | Mistuned or drifting LO | Whole constellation rotates or slides; needs auto-tune/AFC |
+| **Multipath** | Reflections, simulcast | Delayed echoes smear and fade symbols |
+| **DC offset** | Front-end DC leakage | A spike at 0 Hz in the PSD; a pulled constellation |
+| **I/Q imbalance** | Gain/phase mismatch | Rails skew; image-rejection drops |
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="constellation" width="480" height="360" role="img"
+        aria-label="Impaired synthesized C4FM constellation with noise and imbalance"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "rails":[-3,-1,1,3], "dot":1.6,
+"points":[[-2.5,0.9],[-3.5,-1.1],[-2.3,1.3],[-3.2,-1.5],[-1.4,1.0],[-0.7,-1.2],[-1.6,0.7],[-0.5,1.4],[0.7,1.1],[1.4,-1.3],[0.6,0.8],[1.5,1.2],[2.6,1.0],[3.4,-1.2],[2.4,1.4],[3.5,-1.5]] }
+</script>
+<figcaption>The same baseline after injecting SNR loss and I/Q imbalance: rails have thickened and skewed. Because you dialed in the impairment, you know exactly what the analyzer should report.</figcaption>
+</figure>
+
+The point is *control*. Because you set the impairment, the analyzer's job becomes
+verifiable: dial 8 dB SNR and the SNR estimate had better read near 8 dB; add a
+1.5 kHz offset and the lock line's residual frequency had better show it (or
+`-auto-tune` had better remove it). When a metric *disagrees* with the impairment
+you injected, you've found either a measurement bug or an interesting edge — and
+either way you found it against a known answer.
+
+The demod sweep in Part 10 is this idea industrialized: it synthesizes P25 across
+a whole SNR ladder and checks measured demod quality against theory at every rung.
+
+## Reproducibility: the seed
+
+A fixture is only a fixture if it's the *same* every time. Random impairments —
+AWGN especially — draw from a pseudorandom source, so synthesis takes a **seed**.
+Fix the seed and the noise draw is identical run to run, which is what lets a
+regression test assert exact-ish numbers instead of loose ranges. You can see the
+pattern directly in the sweep's synthesis options:
+
+```go
+// cmd/gophertrunk/siglab_sweep.go
+synth := siglab.SynthOptions{
+    Protocol:    trunking.ProtocolP25,
+    Format:      siglab.FormatF32,
+    Modulation:  m.synthMod,
+    Impairments: demod.Impairments{SNRdB: snr, Seed: *seed},
+}
+```
+
+The default sweep seed is `0x5175`; any fixed value works, as long as it's
+*fixed*. Change the seed and you get a different-but-equally-valid noise
+realization — useful for checking a result isn't an artifact of one lucky draw.
+
+## Compare: proving a change
+
+The **Compare** tab (Part 3) is where synthesis pays off. It overlays the power
+spectra of several analyzed captures and diffs their metrics, so you can put a
+real capture next to a synthesized ideal and *see* the gap — the real one's
+rails wider, its occupied bandwidth broader, its EVM higher. Or you overlay two
+runs of the same fixture across a code change: same input, same seed, and any
+difference in the output is attributable to your change and nothing else.
+
+That's the workflow Reese insists on for any demod tweak. Build a known-bad
+fixture that reproduces the symptom. Confirm the current code fails it. Make the
+change. Confirm the fixture now passes, and that the *ideal* reference still
+decodes perfectly (so you didn't fix the bad case by breaking the good one).
+Overlay both in Compare, export the results, and you have evidence rather than a
+hunch — which is exactly the standard GopherTrunk holds demod changes to.
+
+## Stacking impairments to reproduce the field
+
+The single-impairment fixtures are the cleanest teaching tools, but real captures
+are rarely broken one way at a time — the field stacks defects, and so should a
+fixture meant to mimic it. A weak signal from a distant tower isn't *just* low
+SNR; it usually comes with a carrier offset (the two radios' oscillators don't
+agree), some multipath (the signal arrives by more than one path), and whatever
+I/Q imbalance the receiving SDR contributes. Synthesizing that combination —
+say, 8 dB SNR *and* a 1.2 kHz offset *and* a light multipath tap — produces a
+fixture that stresses the demod the way a genuinely marginal capture does, and
+it's the kind of case where a naive demod passes each impairment alone but falls
+over when they combine.
+
+There's a discipline to it, though: **change one thing at a time when you're
+diagnosing, stack them when you're stress-testing.** If you want to know *why* a
+demod fails, isolate the impairment that breaks it — add offset alone, then
+multipath alone — so the cause is unambiguous. Once you understand each failure
+mode, the stacked fixture becomes your acceptance bar: "the demod must lock at
+8 dB with 1.2 kHz offset and one multipath tap." Because every impairment carries
+a known magnitude and the seed is fixed, that bar is exactly repeatable, and a CI
+job can hold the demodulator to it forever.
+
+## Synthesis as documentation
+
+A last, underrated use: a synthesized fixture is *executable documentation* of a
+bug. When a real capture reveals a demod weakness but you can't check the
+multi-gigabyte file into a repo, you distill it into a small synthesized fixture
+that reproduces the same symptom — a few seconds of IQ with a documented
+impairment recipe and a fixed seed. The fixture *is* the bug report: anyone can
+run it, see the failure, and confirm a fix. That's how the sweep in Part 10
+industrializes the idea — it's nothing more than a whole ladder of synthesized
+fixtures, each with a known answer, run against the production demod on every
+build.
+
+## Where this goes next
+
+Synthesis gives you signals with known impairments; the natural next question is
+how *precisely* the workbench can measure them. [Part 7]({{ '/blog/tutorials/signal-lab-07-vsa-evm-modulation-quality/' | relative_url }})
+opens the vector signal analyzer — carrier-frequency error, RMS/peak EVM split
+into magnitude and phase error, I/Q gain imbalance and quadrature skew, origin
+offset, and the EVM-vs-symbol trace — the lab-grade instrumentation that turns
+"the constellation looks fuzzy" into a number for each distinct defect. The
+[SigLab docs]({{ '/siglab.html' | relative_url }}) enumerate the synthesis knobs.
+
+## FAQ
+
+**Why would I decode a signal I made up?**
+Because you know the right answer in advance. A synthesized capture lets you
+verify the analyzer and the demod against a controlled input — invaluable for
+regression fixtures and for proving a demod change actually helped.
+
+**What impairments can I inject?**
+SNR (AWGN), carrier offset and drift, multipath, DC offset, and I/Q imbalance —
+individually or stacked on top of the ideal baseline.
+
+**Why does the seed matter?**
+It fixes the pseudorandom draw (mostly the AWGN) so a synthesized capture is
+byte-for-byte reproducible. Without a fixed seed you can't assert stable numbers
+in a regression test.
+
+**How do I prove my demod change worked?**
+Build a fixture that fails before the change, confirm it passes after, verify the
+ideal reference still decodes cleanly, and overlay the runs in the Compare tab.
+That's evidence; a subjective "looks better" isn't.
+
+## Series navigation
+
+**Part 6 of 10** · ←[Part 5]({{ '/blog/tutorials/signal-lab-05-psd-spectrogram-occupancy/' | relative_url }}) · Next →
+[Part 7: VSA & Modulation Quality]({{ '/blog/tutorials/signal-lab-07-vsa-evm-modulation-quality/' | relative_url }})

--- a/docs/_posts/2026-07-10-crypto-lab-07-crc-recovery-recipe.md
+++ b/docs/_posts/2026-07-10-crypto-lab-07-crc-recovery-recipe.md
@@ -1,0 +1,182 @@
+---
+title: "Crypto Lab, Part 7: CRC Recovery & the Recipe Pipeline"
+description: Crypto Lab's crc recover reconstructs a protocol's CRC parameters — width, polynomial, init, reflection, and xorout — from sample frames, while recipe run chains transform and analysis operations into a CyberChef-style reusable pipeline for de-obfuscating RF payloads.
+category: tutorials
+keywords: crc recovery, crc parameters, reveng, polynomial recovery, cyberchef pipeline, recipe operations, xor decrypt, rc4 decrypt, des ofb, gophertrunk cryptolab, rf reverse engineering
+tags: [cryptolab, crc, recipe, pipeline, security-testing, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 7
+---
+
+*Part 7 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. Two workhorses: reconstruct a protocol's CRC from samples, and chain your whole de-obfuscation sequence into one reusable recipe.*
+
+> **TL;DR:** `cryptolab crc recover` reconstructs CRC parameters (width, poly, init, refin, refout, xorout) from `datahex,crchex` sample frames, and `crc compute` runs a CRC with explicit parameters. `cryptolab recipe run` is a CyberChef-style ordered pipeline: chain **transform** ops (xor, not, reverse-bits, hex/base64, slice, the real cipher decrypts, the descramblers, extern-decrypt) and **analysis** ops (stats, randomness), piping bytes step to step. `recipe run -list` prints the live op catalogue.
+
+> **Authorized testing only.** Reverse-engineer framing and de-obfuscate payloads from systems you own or are licensed to assess.
+
+**Key takeaways**
+
+- **CRC recovery is search, not magic.** Feed varied-length sample frames and `crc recover` solves for the parameter set that fits.
+- **More varied samples disambiguate.** Multiple fitting parameter sets? Add frames of differing length.
+- **`recipe` encodes a workflow.** The de-obfuscation sequence you'd repeat by hand becomes one reusable JSON/YAML artifact.
+- **Transforms rewrite, analyses observe.** A recipe can decrypt a known-key capture and immediately measure the result.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab crc recover -in frames.txt -widths 16,8` | Recover CRC params from `datahex,crchex` lines |
+| `cryptolab crc compute -in data.bin -width 16 -poly 0x1021` | Compute a CRC with explicit parameters |
+| `cryptolab recipe run -in payload.bin -recipe r.json` | Run an ordered transform/analysis pipeline |
+| `cryptolab recipe run -list` | List the available operations |
+| `-out final.bin` | Write the final transformed bytes |
+
+## In this post
+
+- **Why CRC recovery matters** — validating framing before you touch the payload.
+- **`crc recover`** — from sample frames to a parameter set.
+- **`crc compute`** — checking a recovered CRC.
+- **The recipe model** — transforms vs analyses, and the working buffer.
+- **A worked recipe** — hex-decode, decrypt, measure, in one file.
+
+## Why CRC recovery matters
+
+Before you can analyze a payload, you usually have to *find* it inside a frame — and framing almost always ends in a CRC. Knowing the CRC lets you validate that you've segmented the frame correctly, strip the check bytes cleanly, and confirm a decrypt produced valid framing rather than plausible garbage. But protocols rarely document their exact CRC parameters, and there are a lot of them: width, generator polynomial, initial value, input/output reflection, and a final XOR. `crc recover` searches that parameter space against your samples and tells you which combination reproduces the observed checks.
+
+## `crc recover`
+
+Give it sample frames — one `datahex,crchex` pair per line — and the widths to try:
+
+```bash
+gophertrunk cryptolab crc recover -in frames.txt -widths 16,8
+```
+
+```text
+crc/recover — 6 sample frames -> 1 candidate parameter set(s)
+  samples  6
+  candidates  1
+  w16 poly=0x1021 init=0xffff xor=0x0 refin=false refout=false   1
+    width 16  poly 0x1021  init 0xffff  xorout 0x0  refin false  refout false
+```
+
+That's CRC-16/CCITT-FALSE, recovered from six frames. The `-widths` flag (default `16`) is a comma-separated list of widths to try — add `8`, `32`, whatever the protocol might use. The mechanics are exactly what a tool like `reveng` does, folded into the toolkit.
+
+The two notes `crc recover` prints are the whole art of using it. If **no** parameters fit, you need more sample frames of varied length, or a wider `-widths` list. If **multiple** parameter sets fit, they're indistinguishable on your current samples — and the fix is the same: add frames of *differing length*, because init and xorout only separate once the CRC has to span different amounts of data. Ada's first recovery came back with three candidate sets; two more frames of a different length collapsed it to one. Reese's rule: **vary the length, not just the count.** Ten frames of the same length disambiguate no better than two.
+
+## `crc compute`
+
+Once you have parameters, `crc compute` runs the CRC forward over a file so you can verify a frame or check your reconstruction:
+
+```bash
+gophertrunk cryptolab crc compute -in data.bin -width 16 -poly 0x1021 \
+    -init 0xffff -xorout 0x0
+```
+
+```text
+crc/compute — CRC-16 = 0x2b1d over 240 bytes
+  crc    0x2b1d
+  width  16
+```
+
+The flags mirror the recovered parameters exactly — `-poly` (default `0x1021`), `-init`, `-xorout` (default `0xFFFF`), `-refin`, `-refout` — so a recovery result feeds straight into a compute call to confirm it against a held-out frame. That round-trip (recover on one set, compute on another) is how you gain confidence the parameters generalize, the same discipline the LFSR recovery in [Part 3]({{ '/blog/tutorials/crypto-lab-03-randomness-nist-lfsr/' | relative_url }}) asks for.
+
+## The recipe model
+
+Real de-obfuscation is rarely one step. You hex-decode, then XOR off a mask, then decrypt with a recovered key, then check the entropy to see if it worked — and then you do it again on the next capture. `recipe run` captures that whole sequence as one reusable artifact. A recipe is an ordered list of **steps**; each step is either a **transform** that rewrites the working buffer or an **analysis** that measures it without changing it. Bytes flow from one step into the next.
+
+If you've used CyberChef, the mental model is identical: a linear stack of operations, each consuming the output of the last. What makes the `recipe` tool worth having inside GopherTrunk rather than reaching for a separate web app is that its cipher ops are the *same* constructions the rest of the toolkit uses — so a recipe isn't a toy approximation of the real decode, it *is* the real decode, reproducible from the command line and driveable over the same JSONL captures the other tools read. And because a recipe is just a file, it's the natural unit for sharing an investigation: hand a colleague your `recipe.json` and they reproduce your entire de-obfuscation on their own capture, byte for byte, without re-deriving the steps.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 130" width="640" height="130" role="img" aria-label="Recipe pipeline: input bytes flow through transform and analysis steps to final bytes">
+  <g font-size="11.5">
+  <rect x="6" y="46" width="86" height="38" rx="5" fill="none" stroke="currentColor"/>
+  <text x="49" y="69" text-anchor="middle" fill="currentColor">input</text>
+  <rect x="116" y="46" width="96" height="38" rx="5" fill="none" stroke="currentColor"/>
+  <text x="164" y="64" text-anchor="middle" fill="currentColor">hex-decode</text>
+  <text x="164" y="78" text-anchor="middle" fill="var(--fg-muted)" font-size="9">transform</text>
+  <rect x="236" y="46" width="96" height="38" rx="5" fill="none" stroke="currentColor"/>
+  <text x="284" y="64" text-anchor="middle" fill="currentColor">adp-decrypt</text>
+  <text x="284" y="78" text-anchor="middle" fill="var(--fg-muted)" font-size="9">transform</text>
+  <rect x="356" y="46" width="80" height="38" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="396" y="64" text-anchor="middle" fill="var(--accent)">stats</text>
+  <text x="396" y="78" text-anchor="middle" fill="var(--fg-muted)" font-size="9">analysis</text>
+  <rect x="460" y="46" width="96" height="38" rx="5" fill="none" stroke="var(--accent)"/>
+  <text x="508" y="64" text-anchor="middle" fill="var(--accent)">randomness</text>
+  <text x="508" y="78" text-anchor="middle" fill="var(--fg-muted)" font-size="9">analysis</text>
+  <rect x="580" y="46" width="54" height="38" rx="5" fill="none" stroke="currentColor"/>
+  <text x="607" y="69" text-anchor="middle" fill="currentColor">out</text>
+  <g stroke="currentColor" stroke-width="1.3" fill="currentColor">
+  <line x1="92" y1="65" x2="114" y2="65"/><polygon points="116,65 108,61 108,69"/>
+  <line x1="212" y1="65" x2="234" y2="65"/><polygon points="236,65 228,61 228,69"/>
+  <line x1="332" y1="65" x2="354" y2="65"/><polygon points="356,65 348,61 348,69"/>
+  <line x1="436" y1="65" x2="458" y2="65"/><polygon points="460,65 452,61 452,69"/>
+  <line x1="556" y1="65" x2="578" y2="65"/><polygon points="580,65 572,61 572,69"/>
+  </g>
+  </g>
+</svg>
+<figcaption>Transform steps rewrite the working buffer as it flows left to right; analysis steps read it without changing it. The final buffer is written to <code>-out</code>.</figcaption>
+</figure>
+
+Run `recipe run -list` for the live catalogue. The operations, from the docs:
+
+- **Transforms:** `xor`, `not`, `reverse-bits`, `hex-decode`, `hex-encode`, `base64-decode`, `slice`; the real cipher decrypts `rc4-decrypt` (DMR Enhanced Privacy / generic), `adp-decrypt`, `des-ofb-decrypt`, `tdes-ofb-decrypt`, `aes-ofb-decrypt`; the analog-voice descramblers `descramble-invert`, `descramble-splitband` (`split` = fraction of Nyquist), `descramble-rolling` (`frame` samples, `schedule` = split fractions or `auto`); and `extern-decrypt` (an external cipher program — **CLI only**, see [Part 9]({{ '/blog/tutorials/crypto-lab-09-web-console-bridge-external/' | relative_url }})).
+- **Analyses:** `stats`, `randomness`.
+
+The cipher ops reuse the same `p25crypto` keystream constructions the `assess` harness uses, so a recipe can decrypt a known-key capture and immediately measure the result — no exporting between tools.
+
+## A worked recipe
+
+A recipe file is JSON or YAML — either a top-level list of steps or an object with a `steps:` list. Each step is `{op, ...params}`:
+
+```json
+[
+  {"op": "hex-decode"},
+  {"op": "adp-decrypt", "key": "abcdef0123", "mi": "090807060504030201"},
+  {"op": "stats"},
+  {"op": "randomness"}
+]
+```
+
+```bash
+gophertrunk cryptolab recipe run -in payload.bin -recipe recipe.json -out clear.bin
+```
+
+```text
+recipe/run — ran 4 step(s): 480 → 232 bytes
+  1. hex-decode    transform  bytes_in 480  bytes_out 240
+  2. adp-decrypt   transform  bytes_in 240  bytes_out 240
+  3. stats         analysis   entropy 4.12  ic 0.061
+  4. randomness    analysis   looks_random false
+  final_ascii  "UNIT 214 DISPATCH..."
+  written  clear.bin
+note: transform steps rewrite the working buffer; analysis steps (stats,
+  randomness) observe it without changing it.
+```
+
+Notice the payoff: steps 1–2 transform (hex-decode, then decrypt with a known key and MI), and steps 3–4 *measure* the result in place — entropy dropped to 4.12 and the randomness check reports structure, both confirming the decrypt produced real plaintext rather than noise. The de-obfuscation sequence an analyst repeats by hand becomes one file you can rerun on every capture, and the per-step report shows exactly where the byte count changes.
+
+The report is non-nil even on a failing step, so if step 3 errors you still see what steps 1–2 did — useful when you're tuning a recipe and a parameter is wrong. The `-out` flag writes the final buffer; the web Recipe Builder ([Part 9]({{ '/blog/tutorials/crypto-lab-09-web-console-bridge-external/' | relative_url }})) assembles the same pipeline interactively.
+
+## Where this goes next
+
+So far every tool has been byte-oriented. But some RF privacy isn't digital at all — it's **analog voice scrambling**, which operates on the audio waveform, not bytes. [Part 8]({{ '/blog/tutorials/crypto-lab-08-analog-voice-descrambling/' | relative_url }}) covers the `descramble` tool's three modes (inversion, split-band, rolling code) and how analog voice privacy differs fundamentally from digital encryption. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) list the full recipe op set.
+
+## FAQ
+
+**Why does `crc recover` sometimes return several candidate parameter sets?**
+Because your samples don't distinguish them — different init/xorout combinations can produce the same checks over frames of identical length. Add sample frames of *differing* length and the ambiguous sets collapse.
+
+**Can a recipe decrypt and then check whether the decrypt worked?**
+Yes — that's the point of mixing transforms and analyses. Put a cipher decrypt transform, then a `stats` or `randomness` analysis after it; a drop in entropy or a failing randomness check confirms real plaintext emerged.
+
+**What's the difference between a transform and an analysis op?**
+A transform rewrites the working buffer (the bytes that flow to the next step); an analysis reads the buffer and reports on it without changing it. Analyses are how you measure progress mid-pipeline.
+
+**Are recipe files JSON or YAML?**
+Either — JSON is valid YAML, so one parser handles both. Use a top-level list of steps, or an object with a `steps:` key.
+
+## Series navigation
+
+**Part 7 of 10** · ←[Part 6: The `assess` Battery]({{ '/blog/tutorials/crypto-lab-06-assess-battery/' | relative_url }}) · Next →[Part 8: Analog Voice Descrambling]({{ '/blog/tutorials/crypto-lab-08-analog-voice-descrambling/' | relative_url }})

--- a/docs/_posts/2026-07-10-rf-scope-07-entropy-encryption-triage.md
+++ b/docs/_posts/2026-07-10-rf-scope-07-entropy-encryption-triage.md
@@ -1,0 +1,284 @@
+---
+title: "RF Scope, Part 7: Entropy & Encryption Triage — The Crypto Lab Bridge"
+description: rfscope's entropy analyzer triages unidentified digital emitters — blind-demodulating a representative payload, running the cryptolab randomness battery and classify-auto measurements, and returning a verdict from plaintext to strong-encrypted with a recommended cryptolab command, plus a -frames-out file that hands the bytes to Crypto Lab.
+category: tutorials
+keywords: rfscope, entropy, encryption detection, cryptolab bridge, shannon entropy, index of coincidence, chi-square, xor key length, nist sp 800-22, frames-out, keystream reuse, gophertrunk
+tags: [rfscope, cryptolab, rf-analysis, advanced, gophertrunk, dsp]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 7
+charts: true
+---
+
+*Part 7 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer.
+Topology found an unknown digital emitter; this is where RF Scope opens its payload
+and decides what to do with it.*
+
+> **TL;DR:** The `entropy` analyzer (which depends on `topology`) takes every
+> unidentified digital emitter, blind-demodulates a representative payload (at least
+> **32 bytes**, at most **16 emitters** per scene), and runs the cryptolab randomness
+> battery plus the same measurements `classify auto` uses — Shannon entropy, index of
+> coincidence, chi-square, XOR key-length, period, NIST SP 800-22. It returns a
+> **verdict** — plaintext, substitution-or-shift, repeating-xor, periodic-scrambler,
+> lfsr-or-keyless-scrambler, strong-encrypted, or inconclusive — each with a recommended
+> cryptolab command. `-frames-out` writes a cryptolab `ks` frames file. **Mercury's
+> payload is handed off here.**
+
+**Key takeaways**
+
+- **It triages only unknowns.** Emitters that decode as a known protocol are skipped —
+  triage is for what `siglab` could not name.
+- **The measurements are cryptolab's own**, called directly, so RF Scope and the
+  toolkit agree on the verdict.
+- **Seven verdicts, each with a next command** you can paste straight into cryptolab.
+- **`-frames-out` closes the loop** — it emits `{label, iv, ct}` JSONL that feeds
+  `cryptolab classify auto`, `ks reuse`/`mtp`, and `brute`.
+
+## Cheat sheet
+
+| Verdict | Recommended cryptolab command |
+|---|---|
+| `plaintext` | already plaintext — no decryption needed |
+| `substitution-or-shift` | `cryptolab brute substitution -in <file>` |
+| `repeating-xor` | `cryptolab brute xor -in <file> -keylen N` |
+| `periodic-scrambler` | `cryptolab stats period` then descramble / `ks mtp` |
+| `lfsr-or-keyless-scrambler` | `cryptolab lfsr bm -in <file>` |
+| `strong-encrypted` | `cryptolab ks reuse` if IVs repeat, else key material needed |
+| `-frames-out frames.jsonl` | Emit the `ks` frames file for all triaged payloads |
+
+## In this post
+
+- **What the entropy analyzer does** — and what it deliberately skips.
+- **The measurement battery** — entropy, IC, chi-square, XOR, period, NIST.
+- **The seven verdicts** and the command each one points at.
+- **`-frames-out`** — the Crypto Lab bridge format.
+- **Mercury's hand-off** to [Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}).
+
+## What it does
+
+Wireshark cannot tell you whether a flow is encrypted, but analysts eyeball payload
+entropy to guess. RF Scope's `entropy` analyzer makes that rigorous for RF. For each
+digital emitter that `siglab` could **not** identify, it recovers a byte payload and
+asks: is this plaintext, lightly obfuscated, scrambled, or genuinely encrypted? It is
+the "is this flow encrypted?" question, answered with statistics rather than a hunch.
+
+It depends on `topology` because it works per **emitter**, not per burst — it wants the
+longest, cleanest representative of each source. The loop is bounded on both ends:
+
+```go
+// internal/rfscope/entropy.go
+if triaged >= maxEntropyEmitters { break }        // ≤ 16 emitters
+if e.Fingerprint.ClassFamily != "digital" { continue }
+// skip emitters that decode as a known protocol — triage is for unknowns
+if ident, err := siglab.IdentifyIQ(...); err == nil && ident != nil && !ident.Inconclusive {
+    continue
+}
+payload := survey.RecoverPayload(iq, rate, sc.Bursts[bidx].Features)
+if len(payload) < minPayloadBytes { continue }    // ≥ 32 bytes
+```
+
+`survey.RecoverPayload` **blind-demodulates** the burst — using the classifier's
+estimated symbol rate and features, with no protocol framing — into a raw byte stream.
+That stream is not a decode; it is the bits on the air, sliced at the estimated symbol
+boundaries. Below 32 bytes there is not enough to measure, so the emitter is skipped.
+
+## The measurement battery
+
+`classifyPayload` runs the payload through cryptolab's *own* engine packages —
+imported directly, so it works in the default binary with no `-tags cryptolab` build:
+
+```go
+// internal/rfscope/entropy.go
+ent := stats.ShannonEntropy(data)
+ic := stats.IndexOfCoincidence(data)
+chi := stats.ChiSquareUniform(data)
+keylens := stats.GuessXORKeyLength(data, 40)
+periods := stats.DetectPeriod(data, 256, 4)
+bits := lfsr.BitsFromBytes(data)
+rep := randomness.Battery(bits, randomness.DefaultAlpha) // Quick() under 2048 bits
+```
+
+Each measurement probes for a different kind of structure:
+
+- **Shannon entropy** (bits/byte, max 8) — the headline randomness number. Near 8 is
+  high-entropy; well below is structured.
+- **Index of coincidence** — the probability two random bytes match. High IC survives a
+  substitution cipher, so it is the tell for substitution/shift.
+- **Chi-square vs uniform** — how far the byte distribution is from flat.
+- **XOR key length** — `GuessXORKeyLength` scores candidate repeating-XOR key lengths;
+  a low score at length > 1 means a repeating key.
+- **Period** — `DetectPeriod` finds a repeating structure (a scrambler cycle) in the
+  byte stream — the byte-domain twin of Part 5's channel-occupancy period.
+- **NIST SP 800-22** — the `randomness.Battery` (or `Quick` for short payloads) runs the
+  standardized randomness tests; `LooksRandom()` is the aggregate verdict, and specific
+  tests like `linear_complexity` and `spectral_dft` failing points at an LFSR/scrambler.
+
+These are the *exact* thresholds and recommendations cryptolab's `classify auto`
+applies, so RF Scope's triage and a full cryptolab run never disagree.
+
+## The seven verdicts
+
+`classifyPayload` collects every verdict whose evidence fires, sorts by confidence, and
+returns the top one. The taxonomy, roughly from least to most protected:
+
+| Class | Fires when | Meaning |
+|---|---|---|
+| `plaintext` | >95% printable, entropy < 4.8 | Readable bytes — no crypto |
+| `substitution-or-shift` | IC > 0.045, letters > 0.6 | Classical substitution |
+| `repeating-xor` | XOR key length > 1, low score | Repeating-key XOR |
+| `periodic-scrambler` | A period detected | Cyclic scrambler |
+| `lfsr-or-keyless-scrambler` | entropy > 7.0 + a NIST test fails | LFSR / keyless scrambler |
+| `strong-encrypted` | entropy > 7.9 and `LooksRandom` | No exploitable structure |
+| `inconclusive` | none of the above | Not enough signal |
+
+The crucial distinction is between **obfuscation** and **encryption**. A
+`repeating-xor`, `periodic-scrambler`, or `lfsr-or-keyless-scrambler` verdict says
+*there is exploitable structure* — cryptolab can very likely recover the plaintext
+without a key. Only `strong-encrypted` says the payload has *no weak structure* and
+needs key material (or an IV/MI reuse) to go further. That "obfuscation is not
+encryption" line is the moral the whole trilogy is building toward.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="bars" width="560" height="300" role="img"
+        aria-label="NIST randomness battery pass/fail for a scrambled payload"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "categories":["monobit","runs","block-freq","longest-run","fft/spectral","linear-complexity","approx-entropy","serial"],
+"values":[0.42,0.31,0.55,0.28,0.004,0.006,0.19,0.24],
+"threshold":0.01,
+"pass":[true,true,true,true,false,false,true,true],
+"ylabel":"p-value" }
+</script>
+<figcaption>A payload that passes most NIST tests but fails <code>spectral_dft</code> and <code>linear_complexity</code> — the signature of an LFSR/scrambler, not strong encryption.</figcaption>
+</figure>
+
+## Why the battery, not a single number
+
+It would be tempting to reduce all this to one number — Shannon entropy — and call
+anything above 7.9 bits "encrypted." RF Scope deliberately does not, because entropy
+alone is *ambiguous*. A repeating-XOR ciphertext, an LFSR-scrambled stream, and a
+genuinely AES-encrypted payload can all sit at 7.9+ bits per byte; entropy cannot tell
+them apart. The other measurements exist precisely to break that tie:
+
+- Two payloads at entropy 7.95 look identical until you check `linear_complexity`. The
+  one that **fails** it has a short LFSR behind it — recoverable with
+  `cryptolab lfsr bm`. The one that passes everything has no such shortcut.
+- A payload at entropy 6.5 might be plaintext in an unusual encoding, or a substitution
+  cipher. The **index of coincidence** separates them: a substitution cipher preserves
+  the language's letter-frequency structure, so its IC stays high even though the bytes
+  are scrambled.
+- A scrambler with a short cycle can push entropy high while leaving a **period** that
+  `DetectPeriod` finds immediately — the byte-domain echo of Part 5's channel period.
+
+So each verdict is a *conjunction* of evidence, and `classifyPayload` collects every
+verdict whose conditions fire, then sorts by confidence. That is why the result carries
+not just a class but the raw `EntropyBits`, `IndexOfCoincidence`, `ChiSquareUniform`, and
+`KeyLen` alongside it — you can see *which* structure earned the verdict, and overrule it
+if you know something the statistics do not. Reese's rule again: *"one number is a
+horoscope; a battery is a diagnosis."*
+
+## A note on payload length
+
+The `randomness.Battery` call has a length dependency that matters in practice. For a
+payload of at least **2048 bits** (256 bytes) it runs the full NIST battery; below that
+it falls back to `randomness.Quick`, a lighter subset, because the heavy tests are not
+statistically meaningful on short samples. This is the same reason the analyzer skips
+anything under 32 bytes outright — you cannot say much about the randomness of a handful
+of bytes.
+
+The consequence for an operator: a **longer captured burst gives a more confident
+verdict.** A hopper that only ever fires 40-byte bursts will be triaged, but on the
+`Quick` battery, and a `strong-encrypted` call on it is weaker than the same call on a
+256-byte payload. When a verdict matters and the emitter transmits longer bursts
+elsewhere, capture a window that catches one — the entropy analyzer always picks the
+*longest* burst of the emitter to triage, so a longer capture directly buys a better
+measurement.
+
+## The Crypto Lab bridge: -frames-out
+
+A verdict is useful; a payload cryptolab can *act on* is better. `-frames-out` writes
+every triaged payload as a cryptolab `ks` **frames file** — one JSON object per line,
+`{label, iv, ct}`, with `iv` and `ct` hex-encoded:
+
+```go
+// internal/rfscope/bridge.go
+rec := frameRec{
+    Label: fmt.Sprintf("emitter-%d@%.4fMHz", r.EmitterID, float64(r.FreqHz)/1e6),
+    IV:    hex.EncodeToString(r.iv),
+    CT:    hex.EncodeToString(r.payload),
+}
+```
+
+The field names and encoding match exactly what cryptolab's `ks` loader parses, so the
+file feeds `cryptolab classify auto`, `ks reuse`/`mtp`, and `brute` with no
+conversion. In practice:
+
+```bash
+# Triage a band and emit frames for every unknown payload
+gophertrunk rfscope analyze -in wide.cfile -sample-rate 2400000 -frames-out frames.jsonl
+
+# Hand them to Crypto Lab
+gophertrunk cryptolab classify auto -in frames.jsonl     # needs -tags cryptolab
+```
+
+If any frames share an IV/MI, RF Scope even points you straight at
+[keystream reuse]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }}):
+`DetectKeystreamReuse` reports the reuse groups and prints a `cryptolab ks reuse`
+suggestion. That IV-as-crib workflow is the subject of
+[Crypto Lab Part 5]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }}),
+and the broader "breaking it is the test" philosophy is
+[Crypto Lab Part 1]({{ '/blog/tutorials/crypto-lab-01-breaking-it-is-the-test/' | relative_url }}).
+
+## Mercury's hand-off
+
+Here is where Mercury leaves RF Scope. Topology gave us one hopping digital emitter
+that `siglab` never named — a textbook triage candidate. The entropy analyzer
+blind-demodulates its longest burst into a payload comfortably over 32 bytes and runs
+the battery. The result is telling: **not** `strong-encrypted`. Its entropy is high but
+not maxed, and — as in the chart above — it fails the structural NIST tests rather than
+passing everything. RF Scope grades it as *not-obviously-strong* obfuscation and writes
+its bytes to the frames file:
+
+```text
+rfscope: wrote 1 cryptolab frame(s) → frames.jsonl
+```
+
+That single line is the hand-off. Mercury is now a `ct` in a JSONL file, waiting for
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) to finish the job. The
+Part 10 reveal — that Mercury was never encryption at all, but a keyless, length-seeded
+byte obfuscator — starts from exactly this frame.
+
+## Where this goes next
+
+The entropy verdicts do not just sit in a table — they become **anomalies**. [Part
+8]({{ '/blog/tutorials/rf-scope-08-expert-info-anomalies/' | relative_url }}) covers
+the `expert` analyzer, which turns `strong-encrypted` into an `encrypted` alert and the
+obfuscation verdicts into `obfuscated` warnings, alongside its own rules for hoppers,
+intermittent emitters, and abnormally wide or narrow carriers.
+
+## FAQ
+
+**Does the triage need the cryptolab build tag?**
+No. `classifyPayload` calls cryptolab's untagged engine packages directly, so the
+in-binary triage runs in the default build. Only the full `ks reuse` hand-off wants a
+`-tags cryptolab` build.
+
+**Why skip emitters that `siglab` identifies?**
+Triage is for *unknowns*. If a signal decodes as a named protocol, GopherTrunk already
+understands it; the entropy analyzer's job is the traffic nothing else can name.
+
+**What's the difference between obfuscated and encrypted here?**
+`obfuscated` verdicts (repeating-xor, scrambler, LFSR) have exploitable structure —
+cryptolab can usually recover plaintext without a key. `strong-encrypted` has no weak
+structure and needs key material or IV reuse. The distinction is the whole point.
+
+**What exactly is in a frames file line?**
+One JSON object: `{"label","iv","ct"}`, with `iv` (recovered IV/MI, possibly empty) and
+`ct` (the recovered payload) hex-encoded — the format `cryptolab ks` parses directly.
+
+## Series navigation
+
+**Part 7 of 10** · ←
+[Part 6: Topology]({{ '/blog/tutorials/rf-scope-06-topology-emitters-conversations/' | relative_url }})
+· Next →
+[Part 8: Expert Info — Anomalies]({{ '/blog/tutorials/rf-scope-08-expert-info-anomalies/' | relative_url }})

--- a/docs/_posts/2026-07-10-signal-lab-07-vsa-evm-modulation-quality.md
+++ b/docs/_posts/2026-07-10-signal-lab-07-vsa-evm-modulation-quality.md
@@ -1,0 +1,227 @@
+---
+title: "Signal Lab, Part 7: VSA — Lab-Grade Modulation Quality"
+description: Signal Lab's vector signal analyzer measures modulation quality like bench gear — carrier-frequency error, RMS and peak EVM split into magnitude and phase error, I/Q gain imbalance and quadrature skew, origin offset, an EVM-vs-symbol trace, and an error-vector spectrum.
+category: tutorials
+keywords: vector signal analyzer, vsa, evm, rms evm, peak evm, magnitude error, phase error, carrier frequency error, iq gain imbalance, quadrature skew, origin offset, error vector spectrum
+tags: [siglab, dsp, vsa, evm, modulation, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 7
+charts: true
+---
+
+*Part 7 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. Part 4 let you *see* modulation quality; the VSA lets
+you *measure* it to bench-instrument precision.*
+
+> **TL;DR:** Signal Lab's vector signal analyzer reports the same metrics a
+> bench VSA does: **carrier-frequency error**; **RMS and peak EVM**, each split
+> into **magnitude** and **phase** error; **I/Q gain imbalance** and
+> **quadrature skew**; **origin (DC) offset**; an **EVM-vs-symbol trace**; and an
+> **error-vector spectrum**. Each isolates a *different* defect, so instead of
+> "the constellation looks off" you get "carrier is 1.2 kHz high and there's 0.4
+> dB of gain imbalance."
+
+**Key takeaways**
+
+- **EVM is one number; the VSA is the breakdown.** Splitting EVM into magnitude
+  and phase error tells you *what kind* of error dominates.
+- **Carrier-frequency error** isolates tuning from modulation quality.
+- **Gain imbalance and quadrature skew** are front-end defects, not signal
+  weakness — the VSA separates them cleanly.
+- **The EVM-vs-symbol trace** finds *when* quality degraded across the burst.
+- **The error-vector spectrum** shows *where in frequency* the error energy
+  lives.
+
+## Cheat sheet
+
+| VSA metric | What it isolates |
+|---|---|
+| Carrier-frequency error | Residual tuning offset |
+| RMS EVM | Overall modulation quality (average) |
+| Peak EVM | Worst-case symbol |
+| Magnitude error | Amplitude component of EVM |
+| Phase error | Phase component of EVM |
+| I/Q gain imbalance | Amplitude mismatch between I and Q |
+| Quadrature skew | Departure from 90° between I and Q |
+| Origin offset | DC / carrier feedthrough |
+| EVM-vs-symbol trace | Quality over the burst |
+| Error-vector spectrum | Error energy vs frequency |
+
+## In this post
+
+- **What a VSA measures** and why the split matters.
+- **Carrier-frequency error** vs modulation quality.
+- **EVM decomposed** into magnitude and phase.
+- **Front-end defects** — gain imbalance, quadrature skew, origin offset.
+- **Traces** — EVM-vs-symbol and the error-vector spectrum.
+
+## What a VSA measures
+
+A **vector signal analyzer** treats each received symbol as a vector in the I/Q
+plane and measures the **error vector** — the difference between where the symbol
+landed and where it ideally should have. The length of that error vector,
+normalized and averaged, is **EVM** (error-vector magnitude). You already met EVM
+as a single dashboard number in Part 2; the VSA is what happens when you stop
+averaging everything into one figure and start asking *what the error is made of*.
+
+That decomposition is the whole value. Two captures can share the same 8% RMS EVM
+and be broken in completely different ways — one by tuning error, one by a
+front-end gain mismatch, one by low SNR. A single EVM number can't tell them
+apart; the VSA's breakdown can. Signal Lab exposes the full set the way bench gear
+does, computed off the analyzed capture.
+
+## Carrier-frequency error vs modulation quality
+
+The first thing the VSA separates out is **carrier-frequency error** — the
+residual offset between where the signal actually sits and 0 Hz baseband. This is
+a *tuning* problem, not a *modulation* problem, and conflating the two is a
+classic mistake. A perfectly modulated signal recorded slightly off-center will
+show a rotating constellation and inflated EVM even though the transmitter is
+flawless; the fix is to tune it out (`-auto-tune`, or the receiver's AFC), not to
+chase a nonexistent modulation defect.
+
+By reporting carrier-frequency error as its own number, the VSA lets you subtract
+the tuning question entirely: correct the offset, and whatever EVM remains is
+*genuinely* modulation quality. Reese's first VSA question is always the same —
+*is the carrier where it should be?* — because until it is, every other metric is
+contaminated.
+
+## EVM decomposed: magnitude and phase
+
+Once tuning is accounted for, the VSA splits EVM into two orthogonal components:
+
+- **Magnitude error** — the *amplitude* part of the error vector: symbols landing
+  too close to or too far from the origin along their ideal direction. It points
+  at amplitude problems — compression, AGC misbehavior, fading.
+- **Phase error** — the *angular* part: symbols rotated off their ideal phase.
+  It points at phase noise, residual frequency error, and phase-tracking trouble.
+
+It also reports **RMS EVM** (the average, your headline quality number) alongside
+**peak EVM** (the single worst symbol). The gap between them is diagnostic: RMS
+and peak close together means uniformly noisy; a low RMS with a high peak means
+mostly clean with occasional bad symbols — often a transient interferer rather
+than a steady-state weakness. Whether magnitude or phase error dominates tells
+you which physical mechanism to suspect, which is exactly the kind of pointer a
+lone EVM number can never give.
+
+## Front-end defects: imbalance, skew, offset
+
+Three VSA metrics describe the *receiver*, not the signal — defects introduced by
+the I/Q front-end itself:
+
+- **I/Q gain imbalance** — the amplitude of the I channel doesn't match the Q
+  channel. On a constellation the rails or clusters stretch along one axis; the
+  image-rejection number from Part 2 drops.
+- **Quadrature skew** — I and Q aren't exactly 90° apart. The constellation
+  shears, as if the plane were pushed out of square.
+- **Origin offset** — residual DC / carrier feedthrough that pulls the whole
+  constellation off center; it shows up as a spike at 0 Hz in the PSD.
+
+These are the fingerprints of a particular SDR and gain setting rather than of the
+signal in the air, which is why isolating them matters: a capture with fine SNR
+but visible gain imbalance and skew was recorded on a front-end that needs I/Q
+correction, and no amount of resignal-hunting will improve it. Synthesis (Part 6)
+lets you inject each of these deliberately and confirm the VSA reads them back —
+the cleanest way to build intuition for what each defect looks like.
+
+## Traces: EVM-vs-symbol and the error-vector spectrum
+
+The last two outputs are traces rather than single numbers, and they answer
+*when* and *where*.
+
+The **EVM-vs-symbol trace** plots error magnitude across the burst, symbol by
+symbol. A flat trace means steady quality; a ramp or a spike means quality
+changed *during* the capture — a fade, a collision, a transmitter settling. This
+is how you catch a capture that averages "fine" but was briefly awful at one
+instant.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="line" width="560" height="300" role="img"
+        aria-label="EVM versus symbol index, mostly flat with a mid-burst spike"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "series":[{"label":"EVM per symbol","points":[[0,6.8],[200,7.1],[400,6.9],[600,7.4],[800,12.5],[1000,18.2],[1200,11.0],[1400,7.2],[1600,6.9],[1800,7.0],[2000,7.1]]}],
+"xlabel":"symbol index","ylabel":"EVM (%)","xmin":0,"xmax":2000,"ymin":0,"ymax":25 }
+</script>
+<figcaption>An EVM-vs-symbol trace: steady near 7% except for a mid-burst spike. The average would read "fine"; the trace exposes the transient the average hid — likely a brief collision or fade.</figcaption>
+</figure>
+
+The **error-vector spectrum** takes the error signal itself and shows its energy
+versus frequency. A flat error spectrum is consistent with white noise (just low
+SNR); a *peaked* error spectrum means a specific spur or tone is injecting error
+at a particular frequency — an interferer or a front-end artifact you can then go
+find. Where the EVM-vs-symbol trace localizes error in *time*, the error-vector
+spectrum localizes it in *frequency*, and together they turn a raised EVM into an
+actionable lead.
+
+Ada's takeaway from her first VSA session: the dashboard's single EVM told her
+*something* was wrong; the VSA told her the carrier was 1.2 kHz high and the rest
+was a clean 7% — so the fix was a retune, not a new antenna.
+
+## A worked diagnosis
+
+Put the whole panel together on one capture and watch it name a fault. Ada's
+recording reads 9.5% RMS EVM — not great, not terrible — and she wants to know
+what's costing her. The VSA breaks it down:
+
+| VSA metric | Reading | What it says |
+|---|---|---|
+| Carrier-frequency error | +180 Hz | Small; not the culprit |
+| Magnitude error | 3.1% | Modest amplitude spread |
+| Phase error | 8.8% | **Dominant** — the error is mostly angular |
+| I/Q gain imbalance | 0.15 dB | Front-end is fine |
+| Quadrature skew | 0.3° | Front-end is fine |
+| Origin offset | −42 dB | Negligible DC |
+
+The story is unambiguous: the carrier is nearly centered, the front-end is clean,
+and magnitude error is small — but **phase error dominates**. That points at phase
+noise or a phase-tracking loop that's working too hard, not at a weak signal or a
+misbehaving SDR. Ada wouldn't have reached that conclusion from a 9.5% EVM number
+or even from staring at the constellation, where a phase-heavy error just looks
+like a general smear. The decomposition did what the picture couldn't: it named
+the *mechanism*. And because synthesis (Part 6) can inject phase noise
+deliberately, she can confirm the theory — dial in known phase noise, watch phase
+error rise while magnitude error stays flat, and match the signature.
+
+That's the VSA's real gift. A single EVM number is a thermometer: it tells you the
+patient has a fever. The VSA is the full workup — it tells you *which* system is
+sick, which is the difference between "this capture is degraded" and "retune by
+180 Hz and chase the phase noise; everything else is healthy."
+
+## Where this goes next
+
+You can now characterize a *known* signal to bench precision. But Mercury still
+won't say what it is. [Part 8]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }})
+turns to the unknown: blind signal identification, the offline signal-ID
+reference database that *names* an undecodable carrier from its symbol rate and
+modulation, and the wideband survey — where Ada finally gets a best guess for
+Mercury and hands it off. The [SigLab docs]({{ '/siglab.html' | relative_url }})
+carry the full VSA metric list.
+
+## FAQ
+
+**How is the VSA different from the dashboard's EVM?**
+The dashboard gives one EVM number. The VSA decomposes it — magnitude vs phase
+error, RMS vs peak — and adds carrier-frequency error, I/Q imbalance, quadrature
+skew, origin offset, and per-symbol/per-frequency traces, so you learn *what kind*
+of error you have, not just how much.
+
+**Why split EVM into magnitude and phase?**
+Because they point at different causes. Magnitude error suggests amplitude
+problems (compression, AGC, fading); phase error suggests phase noise or residual
+frequency error. The split tells you which mechanism to chase.
+
+**Are gain imbalance and quadrature skew signal problems?**
+No — they're front-end defects, introduced by the receiver's I/Q path. The VSA
+isolates them so you don't mistake a receiver imperfection for a weak signal.
+
+**What does the EVM-vs-symbol trace catch that RMS EVM misses?**
+Transients. A capture can average a healthy EVM while being briefly terrible at
+one instant (a collision or fade). The trace shows that spike; the average buries
+it.
+
+## Series navigation
+
+**Part 7 of 10** · ←[Part 6]({{ '/blog/tutorials/signal-lab-06-synthesize-references/' | relative_url }}) · Next →
+[Part 8: Naming the Unknown]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }})

--- a/docs/_posts/2026-07-13-crypto-lab-08-analog-voice-descrambling.md
+++ b/docs/_posts/2026-07-13-crypto-lab-08-analog-voice-descrambling.md
@@ -1,0 +1,164 @@
+---
+title: "Crypto Lab, Part 8: Analog Voice Descrambling — Inversion, Split-Band, Rolling Code"
+description: Crypto Lab's descramble tool undoes analog voice privacy — frequency inversion, split-band inversion, and rolling-code hopping — operating on raw 16-bit PCM audio, and shows why analog scrambling is fundamentally weaker than digital encryption.
+category: tutorials
+keywords: analog voice scrambling, frequency inversion, split band inversion, rolling code descrambler, spectrum inversion, voice privacy, pcm audio, self inverse, gophertrunk cryptolab
+tags: [cryptolab, descramble, analog-voice, security-testing, advanced, rf]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 8
+---
+
+*Part 8 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. Not all RF privacy is digital — some is a trick played on the audio spectrum, and the descrambler undoes it.*
+
+> **TL;DR:** `cryptolab descramble` has three modes for analog voice privacy, all operating on raw **16-bit signed little-endian mono PCM**: `invert` (full-band frequency inversion — run it twice to undo), `splitband` (`-split` fraction of Nyquist, disjoint-bin FFT, self-inverse for a given split), and `rolling` (`-frame` samples with a `-schedule` of per-frame splits, or `-schedule auto` to detect inverted frames). Analog scrambling reorders the *spectrum*; it doesn't encrypt bits, which is why it's far weaker than digital encryption.
+
+> **Authorized testing only.** Descramble audio only from systems you own or are licensed to assess.
+
+**Key takeaways**
+
+- **Analog scrambling is spectral, not cryptographic.** It rearranges the audio spectrum, it doesn't encrypt data.
+- **Inversion is self-inverse.** Applying the same operation again undoes it — no key needed.
+- **Split-band adds a knob, not real security.** One `-split` fraction is the whole "key."
+- **Rolling code hops the split** per frame — `auto` detects it from spectral energy; a known schedule replays it exactly.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab descramble invert -in s.s16 -out c.s16` | Full-band spectral inversion (run twice to undo) |
+| `cryptolab descramble splitband -in s.s16 -out c.s16 -split 0.5` | Invert low/high sub-bands about a split point |
+| `cryptolab descramble rolling -in s.s16 -out c.s16 -frame 1024 -schedule auto` | Per-frame rolling inversion, auto-detected |
+| `-split F` | Split point as a fraction of Nyquist (0..1) |
+| `-frame N` | Frame length in samples (rolling) |
+| `-schedule auto\|F1,F2,...` | Detect inverted frames, or replay a known split schedule |
+
+## In this post
+
+- **How analog voice privacy works** — and why it's not encryption.
+- **`invert`** — full-band frequency inversion and the self-inverse trick.
+- **`splitband`** — inverting sub-bands independently.
+- **`rolling`** — hopping the inversion per frame, auto or scheduled.
+- **The PCM contract** — what the tool reads and writes.
+
+## Analog privacy is a spectral trick
+
+Before digital encryption, radios kept voice "private" by scrambling the *audio spectrum*. The most common method, **frequency inversion**, flips the audio band end-for-end: low frequencies become high and high become low, about a center point. The result sounds like unintelligible Donald-Duck garble on a scanner — but nothing is encrypted. There's no key in any cryptographic sense, no keystream, no ciphertext. The information is all still there; it's just been folded over in frequency.
+
+That's the crucial distinction Reese hammers home: **analog scrambling reorders, it doesn't encrypt.** A digital cipher transforms bits so that without the key the output is indistinguishable from random. A frequency inverter just moves energy around the spectrum in a way anyone can reverse by moving it back. The entire "secret" is *which* spectral rearrangement was used — and there are very few of them. This is why analog voice privacy is a museum piece from a security standpoint, and why the descrambler needs no key input at all: undoing the rearrangement is a deterministic signal-processing operation.
+
+It helps to put a number on "very few." A full-band inverter has essentially *one* configuration — invert or don't. A split-band inverter's only parameter is the split fraction, and in practice deployments cluster on a handful of round values, so a few trials exhaust the space. Even a rolling-code scrambler, which sounds sophisticated, hops among a small set of split points on a repeating schedule — a keyspace measured in dozens of states, not the 2¹²⁸ of a real cipher. Contrast that with the digital ciphers in [Part 6]({{ '/blog/tutorials/crypto-lab-06-assess-battery/' | relative_url }}), where a properly-keyed AES system grades <span class="lab-verdict lab-verdict--ok">RESISTANT</span> because its keyspace is genuinely infeasible to search. Analog scrambling never had that protection; it relied entirely on the listener not bothering to reverse a known transform. Once you bother — which is exactly what `descramble` does — the privacy evaporates.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 170" width="640" height="170" role="img" aria-label="Frequency inversion flips the audio spectrum end for end about a center point">
+  <g font-size="11">
+  <text x="10" y="20" fill="var(--fg-muted)">clear speech spectrum (energy sloping down with frequency)</text>
+  <line x1="20" y1="70" x2="300" y2="70" stroke="currentColor"/>
+  <polygon points="30,68 30,40 40,42 40,68" fill="currentColor" opacity="0.85"/>
+  <polygon points="45,68 45,48 55,50 55,68" fill="currentColor" opacity="0.7"/>
+  <polygon points="60,68 60,56 70,57 70,68" fill="currentColor" opacity="0.55"/>
+  <polygon points="75,68 75,60 85,61 85,68" fill="currentColor" opacity="0.4"/>
+  <polygon points="90,68 90,63 100,64 100,68" fill="currentColor" opacity="0.3"/>
+  <text x="20" y="86" fill="var(--fg-muted)" font-size="9">low</text>
+  <text x="280" y="86" fill="var(--fg-muted)" font-size="9">high</text>
+  <line x1="320" y1="55" x2="360" y2="55" stroke="var(--accent)" stroke-width="1.5"/>
+  <polygon points="360,55 352,51 352,59" fill="var(--accent)"/>
+  <text x="340" y="45" text-anchor="middle" fill="var(--accent)" font-size="10">invert</text>
+  <text x="380" y="20" fill="var(--fg-muted)">inverted: low ↔ high, garbled to the ear</text>
+  <line x1="380" y1="70" x2="620" y2="70" stroke="currentColor"/>
+  <polygon points="390,68 390,63 400,64 400,68" fill="currentColor" opacity="0.3"/>
+  <polygon points="405,68 405,60 415,61 415,68" fill="currentColor" opacity="0.4"/>
+  <polygon points="420,68 420,56 430,57 430,68" fill="currentColor" opacity="0.55"/>
+  <polygon points="435,68 435,48 445,50 445,68" fill="currentColor" opacity="0.7"/>
+  <polygon points="450,68 450,40 460,42 460,68" fill="currentColor" opacity="0.85"/>
+  <text x="20" y="130" fill="var(--fg-muted)">self-inverse: invert again → back to clear</text>
+  <line x1="230" y1="126" x2="270" y2="126" stroke="currentColor" stroke-width="1.5"/>
+  <polygon points="270,126 262,122 262,130" fill="currentColor"/>
+  <text x="300" y="130" fill="var(--accent)" font-size="11">descramble invert (twice = identity)</text>
+  </g>
+</svg>
+<figcaption>Frequency inversion flips the spectrum end-for-end. It is its own inverse: applying it a second time restores the original audio.</figcaption>
+</figure>
+
+## `invert`: full-band inversion
+
+The simplest mode flips the whole band:
+
+```bash
+gophertrunk cryptolab descramble invert -in scrambled.s16 -out clear.s16
+```
+
+```text
+descramble/invert — spectrally inverted 48000 samples -> clear.s16
+  samples  48000
+note: spectral inversion is its own inverse: run again to undo.
+```
+
+The key property is right there in the note: **spectral inversion is its own inverse.** The scrambler inverted the spectrum to garble it; you invert it again to restore it. There's no separate "encrypt" and "decrypt" — it's the same operation both directions, which is the clearest possible demonstration that no real secret is involved. Both `-in` and `-out` are required.
+
+## `splitband`: inverting sub-bands
+
+A slightly fancier scrambler splits the band at some point and inverts the low and high halves *independently*. `splitband` undoes it, using a disjoint-bin FFT so the operation stays exactly self-inverse for a given split:
+
+```bash
+gophertrunk cryptolab descramble splitband -in scrambled.s16 -out clear.s16 -split 0.5
+```
+
+The `-split` flag is the split point as a fraction of Nyquist (0..1); `0.5` splits the band in the middle. This split fraction is the entire "key" for a split-band scrambler — and the note reminds you it's self-inverse: re-run with the *same* `-split` to undo. In practice you recover the split by trying a few values and listening (or checking the output's spectral balance) for intelligible speech. A handful of candidate splits covers essentially every deployment, which again underlines how little security is on offer.
+
+## `rolling`: hopping the split per frame
+
+The most elaborate analog scramblers change the inversion **per frame** on a hopping schedule, so the split point moves over time. `descramble rolling` handles this two ways. With a known schedule, you replay the exact hop sequence:
+
+```bash
+gophertrunk cryptolab descramble rolling -in scrambled.s16 -out clear.s16 \
+    -frame 1024 -schedule 0.5,0.4,0.6,0.5
+```
+
+`-frame` sets the frame length in samples, and `-schedule` is a comma-separated list of split fractions applied frame by frame (cycling through the list). Re-running with the same `-frame` and `-schedule` undoes a known rolling inverter exactly.
+
+When you *don't* know the schedule, `-schedule auto` detects it:
+
+```bash
+gophertrunk cryptolab descramble rolling -in scrambled.s16 -out clear.s16 \
+    -frame 1024 -schedule auto
+```
+
+```text
+descramble/rolling — auto-descrambled 47 frames (29 inverted) -> clear.s16
+  frames  47
+  frames_inverted  29
+note: auto mode is a heuristic full-band inversion detector (energy balance);
+  a known schedule is exact.
+```
+
+Auto mode is a heuristic: for each frame it decides whether that frame was inverted by looking at its spectral energy balance, and flips the ones that look inverted. The tool is honest that this is a heuristic full-band detector — good for a first pass, but a *known* schedule is exact. It reports how many of the frames it judged inverted, which is a useful sanity check: if it flips nearly all or nearly none, your `-frame` size is probably wrong.
+
+Ada's first rolling capture came out garbled at `-frame 512` — the frame size didn't align with the scrambler's hop period. Bumping to `-frame 1024` snapped the energy-balance detector into agreement and the speech came through. Reese's note: **the frame size is the parameter that matters most in rolling mode** — get it aligned to the scrambler's hop and auto-detection usually does the rest.
+
+## The PCM contract
+
+Every `descramble` mode reads and writes the same format: **raw 16-bit signed little-endian mono PCM** (`.s16`), samples normalized internally to [-1, 1). The input length must be a whole number of 16-bit samples, and the tool errors clearly if it isn't. Because it's raw PCM, you produce these files from your decoder's audio path or a recording, and you can pipe the descrambled output straight into any audio tool to listen. Note that this is *not* the byte-payload world of the rest of the toolkit — which is exactly why `classify auto` ([Part 2]({{ '/blog/tutorials/crypto-lab-02-first-triage-classify-stats/' | relative_url }})) explicitly declines to triage audio and points you here. The same three descramblers are also available as `recipe` ops (`descramble-invert`, `descramble-splitband`, `descramble-rolling`, [Part 7]({{ '/blog/tutorials/crypto-lab-07-crc-recovery-recipe/' | relative_url }})), so an inversion step can be chained inline with byte transforms.
+
+## Where this goes next
+
+We've now covered the whole CLI toolkit. [Part 9]({{ '/blog/tutorials/crypto-lab-09-web-console-bridge-external/' | relative_url }}) steps back to the surfaces *around* it: the browser console that renders a form for every tool automatically, the live-capture bridge that feeds `ks` and `assess` straight from a running decoder, and the external-cipher mechanism — with its deliberate CLI-only safety boundary. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) detail the descramble internals.
+
+## FAQ
+
+**Why doesn't `descramble` take a key?**
+Because analog scrambling isn't encryption — there's no cryptographic key. The "secret" is just which spectral rearrangement was used (full-band, a split fraction, a hop schedule), and undoing it is a deterministic DSP operation, not a decryption.
+
+**What does "self-inverse" mean here?**
+The scrambling and descrambling operations are identical. Frequency inversion applied twice returns the original audio; split-band inversion with the same `-split` undoes itself. There's no separate decrypt step.
+
+**How do I find the right `-split` or `-schedule`?**
+Try a few candidate splits and check for intelligible speech or balanced output spectrum. For rolling code, get `-frame` aligned to the hop period first, then let `-schedule auto` detect the per-frame inversions.
+
+**What audio format does it expect?**
+Raw 16-bit signed little-endian mono PCM (`.s16`). The input must be a whole number of 16-bit samples; the tool errors if not.
+
+## Series navigation
+
+**Part 8 of 10** · ←[Part 7: CRC Recovery & the Recipe Pipeline]({{ '/blog/tutorials/crypto-lab-07-crc-recovery-recipe/' | relative_url }}) · Next →[Part 9: The Web Console, Live-Capture Bridge & External Ciphers]({{ '/blog/tutorials/crypto-lab-09-web-console-bridge-external/' | relative_url }})

--- a/docs/_posts/2026-07-13-rf-scope-08-expert-info-anomalies.md
+++ b/docs/_posts/2026-07-13-rf-scope-08-expert-info-anomalies.md
@@ -1,0 +1,278 @@
+---
+title: "RF Scope, Part 8: Expert Info — Anomalies & What They Mean"
+description: rfscope's expert analyzer is the RF analog of Wireshark's Expert Information — rule-based anomaly flags at note, warn, and alert severity for frequency hoppers, intermittent emitters, abnormally wide or narrow carriers, noise-like spectra, and the encrypted or obfuscated findings the entropy triage produced.
+category: tutorials
+keywords: rfscope, expert info, wireshark expert information, anomalies, frequency hopper, intermittent emitter, wide carrier, narrow carrier, noise-like, spectral flatness, encrypted, obfuscated, gophertrunk
+tags: [rfscope, rf-analysis, advanced, gophertrunk, dsp, sdr]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 8
+---
+
+*Part 8 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer. Every
+analyzer so far produced data; this one produces judgments — the "look here" list.*
+
+> **TL;DR:** The `expert` analyzer is Wireshark's Expert Information for RF. It runs
+> cheap rules over the finished Scene and emits **anomalies** at three severities —
+> `note`, `warn`, `alert`. It flags `hopper` (from topology), `intermittent` (duty
+> < 5% with ≥ 3 bursts), `wide-carrier` (> 30 kHz), `narrow-carrier` (< 5 kHz), and
+> `noise-like` (spectral flatness ≥ 0.80), plus `encrypted`, `obfuscated`, and
+> `unknown-protocol` findings promoted from the entropy triage. It depends on
+> `topology`, `timeline`, and `entropy`, and it is the last analyzer to run.
+
+**Key takeaways**
+
+- **Anomalies are rule-based, not learned** — every flag traces to one readable
+  threshold you can predict and tune.
+- **Three severities** sort the list: `alert` (encrypted) above `warn` (obfuscated)
+  above `note` (everything else).
+- **It reuses upstream results** — hoppers from topology, duty from timeline,
+  verdicts from entropy — rather than recomputing anything.
+- **Mercury collects a stack of flags**, which is what an interesting signal looks
+  like: several notes plus a warn.
+
+## Cheat sheet
+
+| Kind | Severity | Rule |
+|---|---|---|
+| `hopper` | note | Emitter `HopSet` > 1 (from topology) |
+| `intermittent` | note | Duty < 0.05 **and** ≥ 3 bursts |
+| `wide-carrier` | note | Occupied bandwidth > 30 kHz |
+| `narrow-carrier` | note | Occupied bandwidth in (0, 5 kHz) |
+| `noise-like` | note | Median spectral flatness ≥ 0.80 |
+| `obfuscated` | warn | Entropy verdict: xor / scrambler / substitution |
+| `encrypted` | alert | Entropy verdict: strong-encrypted |
+| `unknown-protocol` | note | Any other entropy finding |
+
+## In this post
+
+- **What RF Expert Info is** and why rules beat magic here.
+- **The topology rule** — frequency hoppers.
+- **The timeline + segmentation rules** — intermittent, wide, narrow, noise-like.
+- **The entropy rules** — encrypted, obfuscated, unknown-protocol.
+- **Severity ordering** — how the list is sorted.
+- **Mercury's anomaly stack.**
+
+## RF Expert Information
+
+Wireshark's Expert Information collects the notable things it noticed while dissecting
+a capture — retransmissions, malformed packets, resets — and grades them by severity so
+you triage the important ones first. RF Scope's `expert` analyzer is the same idea for a
+band: it distills the whole Scene into a short, severity-sorted list of *"here is what
+is unusual, and how worried to be."*
+
+Every rule is deliberately **cheap and legible**. There is no model, no learned
+threshold, no black box — each anomaly is one comparison against one named constant,
+listed at the top of `expert.go`. That means you can always answer "why did it flag
+this?" and you can tune any rule by changing one number. As Reese puts it, *"an alert
+you can't explain is an alert you can't trust."*
+
+Because the rules read topology's emitters, timeline's channels, and entropy's
+verdicts, the analyzer declares all three as dependencies:
+
+```go
+// internal/rfscope/expert.go
+func (expertAnalyzer) DependsOn() []string { return []string{"topology", "timeline", "entropy"} }
+```
+
+So it always runs last, over a fully-populated Scene.
+
+## The topology rule: hoppers
+
+The first rule is the simplest: any emitter that topology collapsed into a frequency
+hopper — a `HopSet` with more than one frequency — gets a `hopper` note:
+
+```go
+// internal/rfscope/expert.go
+if len(e.HopSet) > 1 {
+    out = append(out, Anomaly{
+        Severity: "note", Kind: "hopper", EmitterID: e.ID, FreqHz: e.Fingerprint.CenterHz,
+        Detail: fmt.Sprintf("emitter hops %d channels", len(e.HopSet)),
+    })
+}
+```
+
+It is a `note` rather than a `warn` because hopping is *interesting*, not inherently
+suspicious — plenty of legitimate systems hop. The severity says "worth your
+attention," and the detail tells you how many channels.
+
+## The per-channel rules
+
+Three rules run over each channel, reading fields the timeline analyzer and
+segmentation already computed:
+
+- **`intermittent`** — `DutyCycle < 0.05` **and** `BurstCount ≥ 3`. This is the "low
+  duty, high occupancy" bursty signature from Part 4, made into a flag. The
+  burst-count guard matters: a channel with one stray burst is not intermittent, it is
+  a fluke. Three or more short bursts on an otherwise-quiet channel is a real pattern —
+  telemetry, paging, a beacon.
+- **`wide-carrier`** — occupied bandwidth `> 30 kHz`. Wider than the widest common
+  narrowband channel, so it stands out on an LMR band: a wideband data link, a spread
+  signal, or two overlapping carriers the segmenter merged.
+- **`narrow-carrier`** — occupied bandwidth in the open interval `(0, 5 kHz)`. Tighter
+  than the tightest standard raster — a CW carrier, a very-low-rate telemetry tone, or a
+  measurement artifact.
+- **`noise-like`** — median spectral flatness `≥ 0.80`. Recall from Part 2 that flatness
+  near 1 means a flat, noise-like spectrum. A carrier that is *on* but spectrally flat is
+  either genuine noise mistaken for a carrier, or — more interestingly — a spread-spectrum
+  or encrypted-PHY signal whose spectrum has been deliberately whitened. The detail says
+  so: *"spread/encrypted-PHY or noise."*
+
+```go
+// internal/rfscope/expert.go
+switch {
+case c.OccupiedBwHz > wideCarrierHz:   // 30000
+    // wide-carrier
+case c.OccupiedBwHz > 0 && c.OccupiedBwHz < narrowCarrierHz:  // 5000
+    // narrow-carrier
+}
+if c.MedianFlatness >= noiseLikeFlatness {  // 0.80
+    // noise-like
+}
+```
+
+## The entropy rules
+
+The entropy triage from Part 7 gets promoted into anomalies, and this is where the
+severities climb:
+
+```go
+// internal/rfscope/expert.go
+sev, kind := "note", "unknown-protocol"
+switch r.Class {
+case "strong-encrypted":
+    sev, kind = "alert", "encrypted"
+case "repeating-xor", "lfsr-or-keyless-scrambler", "periodic-scrambler", "substitution-or-shift":
+    sev, kind = "warn", "obfuscated"
+}
+```
+
+- **`encrypted`** (`alert`) — the entropy verdict was `strong-encrypted`: no exploitable
+  structure. This is the only `alert` the analyzer raises, because it is the one finding
+  that says "you cannot get further without key material."
+- **`obfuscated`** (`warn`) — an XOR, scrambler, substitution, or LFSR verdict: there
+  *is* exploitable structure, and the detail carries the recommended cryptolab command.
+- **`unknown-protocol`** (`note`) — any other entropy finding: a digital emitter that
+  matched no protocol and no strong crypto signature.
+
+Each anomaly's detail folds in the entropy value and the recommended next step, so the
+expert list doubles as a to-do list: an `obfuscated` warn tells you both *what* it is
+and *which* cryptolab command to run next.
+
+## Severity ordering
+
+Finally the list is sorted so the important things float to the top — severity first
+(`alert` > `warn` > `note`), then frequency, then kind for a stable order:
+
+```go
+// internal/rfscope/expert.go
+sort.SliceStable(out, func(i, j int) bool {
+    if sevRank(out[i].Severity) != sevRank(out[j].Severity) {
+        return sevRank(out[i].Severity) > sevRank(out[j].Severity)
+    }
+    ...
+})
+```
+
+The cockpit (Part 9) renders this same ordering with color — red for `alert`, yellow
+for `warn`, plain for `note` — so a glance at the expert panel tells you whether
+anything needs urgent attention.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 600 200" width="600" height="200" role="img" aria-label="Annotated severity-sorted anomaly list">
+  <text x="12" y="22" fill="var(--fg-muted)" font-size="11" font-family="monospace">Expert info (severity-sorted)</text>
+  <rect x="8" y="34" width="10" height="18" fill="#d64545"/>
+  <text x="28" y="48" fill="currentColor" font-size="12" font-family="monospace">[alert] encrypted        453.550  strong-encrypted (entropy 7.94)</text>
+  <rect x="8" y="60" width="10" height="18" fill="#d6a915"/>
+  <text x="28" y="74" fill="currentColor" font-size="12" font-family="monospace">[warn]  obfuscated       453.550  lfsr-or-keyless-scrambler …</text>
+  <rect x="8" y="86" width="10" height="18" fill="var(--fg-muted)"/>
+  <text x="28" y="100" fill="currentColor" font-size="12" font-family="monospace">[note]  hopper           453.550  emitter hops 4 channels</text>
+  <rect x="8" y="112" width="10" height="18" fill="var(--fg-muted)"/>
+  <text x="28" y="126" fill="currentColor" font-size="12" font-family="monospace">[note]  intermittent     453.550  6 bursts at 2.1% duty</text>
+  <rect x="8" y="138" width="10" height="18" fill="var(--fg-muted)"/>
+  <text x="28" y="152" fill="currentColor" font-size="12" font-family="monospace">[note]  noise-like       453.550  spectral flatness 0.83 …</text>
+</svg>
+<figcaption>The expert list sorts alert above warn above note. A single interesting emitter can populate several rows — as Mercury does here.</figcaption>
+</figure>
+
+## Tuning the rules for your band
+
+Because every rule is a comparison against one named constant, the anomaly list is
+*tunable* by editing thresholds — and knowing the defaults tells you when a flag is
+meaningful for your band. The four numeric constants:
+
+| Constant | Default | Raise it to… | Lower it to… |
+|---|---|---|---|
+| `intermittentDuty` | 0.05 | flag more channels as intermittent | only the sparsest |
+| `noiseLikeFlatness` | 0.80 | require a flatter spectrum before flagging | catch more spread signals |
+| `wideCarrierHz` | 30000 | tolerate wider carriers on a wideband plan | flag anything above narrowband |
+| `narrowCarrierHz` | 5000 | flag more marginal-width carriers | only the very narrowest |
+
+The defaults encode assumptions about a *narrowband LMR band* — a 30 kHz "wide" bar and
+a 5 kHz "narrow" bar make sense on a 12.5 kHz raster. On a wideband data band those bars
+are wrong: everything would trip `wide-carrier` and the flag would carry no information.
+The point of exposing the constants is that "unusual" is relative to the band you are
+looking at, and the analyzer makes no attempt to guess your band for you — it applies a
+fixed, legible rule and trusts you to interpret it. An anomaly is a *pointer*, not a
+conviction; the operator supplies the context.
+
+This is also why the analyzer emits so freely rather than trying to be clever about
+suppression. It would be easy to write logic that hides a `wide-carrier` note when a
+`hopper` note is already present on the same emitter, on the theory that you only need one
+reason to look. RF Scope does the opposite: it surfaces *every* rule that fires, because
+the **combination** is the signal. A wide carrier is mildly interesting; a wide carrier
+that is also noise-like and obfuscated is a different animal entirely, and you only see
+that if all three flags are present to be read together.
+
+## Mercury's anomaly stack
+
+By Part 8, Mercury has quietly accumulated flags from every upstream analyzer, and the
+expert list is where they all surface together. From topology it earns a **`hopper`**
+note (four channels). From timeline it earns an **`intermittent`** note — its duty cycle
+on any channel is a couple of percent, well under 5%, with more than three bursts. Its
+whitened spectrum may earn a **`noise-like`** note. And from entropy it earns an
+**`obfuscated`** warn (the recommended cryptolab command right there in the detail).
+
+That *stack* is the signature of a signal worth chasing. No single flag is alarming —
+plenty of signals hop, plenty are intermittent — but a hopping, intermittent,
+spectrally-whitened, structurally-obfuscated emitter that no protocol names is exactly
+the profile that says *"this was built to be hard to notice."* The expert panel turns
+Ada's vague unease about the 453 MHz burst into a concrete, prioritized list, with the
+next command already written.
+
+## Where this goes next
+
+You have now seen every analyzer. [Part
+9]({{ '/blog/tutorials/rf-scope-09-scene-cockpit-tui-web/' | relative_url }}) puts them
+on screen: the `rfscope cockpit` full-screen TUI and the `rfscope serve` web console,
+both of which render the hierarchy, channel sparklines, top talkers, conversations, and
+this severity-colored expert panel live, refreshing as new IQ arrives.
+
+## FAQ
+
+**Why are the rules simple thresholds instead of something smarter?**
+So every flag is explainable and tunable. You can always trace an anomaly to one named
+constant and change it. A learned detector would be harder to trust and harder to
+adjust for an unusual band.
+
+**Why is `encrypted` the only `alert`?**
+Because it is the only finding that says you cannot proceed without key material or IV
+reuse. The `obfuscated` verdicts are `warn` because cryptolab can usually break them;
+they are a lead, not a wall.
+
+**Can one emitter produce multiple anomalies?**
+Yes — that is normal and informative. A single hopping, intermittent, obfuscated
+emitter legitimately produces a hopper note, an intermittent note, and an obfuscated
+warn. The stack of flags is itself a signal.
+
+**Does expert recompute duty cycle or entropy?**
+No. It reads what timeline and entropy already computed. It only depends on those
+analyzers so the fields it reads are populated before it runs.
+
+## Series navigation
+
+**Part 8 of 10** · ←
+[Part 7: Entropy & Encryption Triage]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }})
+· Next →
+[Part 9: The Scene Cockpit]({{ '/blog/tutorials/rf-scope-09-scene-cockpit-tui-web/' | relative_url }})

--- a/docs/_posts/2026-07-13-signal-lab-08-naming-the-unknown.md
+++ b/docs/_posts/2026-07-13-signal-lab-08-naming-the-unknown.md
@@ -1,0 +1,233 @@
+---
+title: "Signal Lab, Part 8: Naming the Unknown — Blind Signal-ID & the Wideband Survey"
+description: Signal Lab identifies an unknown capture by ranking protocol candidates, names undecodable carriers from a blind symbol-rate and modulation estimate against an offline signal-ID reference database, and surveys a wide capture in the Wideband tab — where the Mercury signal finally gets a best guess but no lock.
+category: tutorials
+keywords: blind signal identification, signal id, protocol identify, ranked candidates, symbol rate estimate, modulation estimate, wideband survey, sigref database, unknown protocol, 4-level fsk, mercury signal
+tags: [siglab, signal-id, wideband, survey, unknown, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 8
+charts: true
+---
+
+*Part 8 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. Everything so far assumed you knew what the signal
+was. This part is for when you don't.*
+
+> **TL;DR:** When a capture doesn't decode as anything named, Signal Lab still
+> tries to *name it*. **Identify** ranks protocol candidates rather than
+> guessing one; the offline **signal-ID reference database (sigref)** names an
+> undecodable carrier from a blind **symbol-rate and modulation** estimate; and
+> the **Wideband** tab surveys a wide capture for every carrier in it. This is
+> where **Mercury** — Ada's intermittent 453 MHz burst — finally gets a best
+> guess (~4800 sym/s, 4-level-FSK-like) but no lock, and gets handed to RF Scope.
+
+**Key takeaways**
+
+- **Identify ranks candidates**, it doesn't guess one — you see the runners-up
+  and their scores.
+- **Blind estimation names the undecodable.** Symbol rate and modulation class
+  are recoverable even when no decoder locks.
+- **sigref turns an estimate into a name** by matching it against a reference
+  database of known systems.
+- **The Wideband survey** finds and characterizes every carrier in a wide
+  capture at once.
+- **A best guess is not a lock.** "~4800 sym/s, 4-level-FSK-like" is a lead, not
+  a decode — which is exactly Mercury's status.
+
+## Cheat sheet
+
+| Surface | What it does |
+|---|---|
+| Identify tab / `gophertrunk identify` | Rank protocol candidates for a capture |
+| Blind symbol-rate estimate | Recover the symbol rate with no lock |
+| Blind modulation estimate | Classify modulation family (FSK/PSK levels) |
+| sigref reference DB | Name a carrier by matching its blind estimate |
+| Wideband tab | Survey a wide capture for all carriers |
+
+## In this post
+
+- **When nothing decodes** — the problem blind ID solves.
+- **Ranked candidates** — why a list beats a guess.
+- **Blind estimation** — symbol rate and modulation without a lock.
+- **The signal-ID reference database** — turning an estimate into a name.
+- **The wideband survey** — and Mercury's best guess.
+
+## When nothing decodes
+
+Up to now every capture came with an assumption: *this is P25*, *this is DMR*.
+Point the decoder at it, read the metrics, done. But operators constantly hit
+carriers that decode as *nothing* — an unfamiliar system, a proprietary waveform,
+or a signal too weak or too short to lock. The naive tool gives up: "not locked,"
+end of story. That's a dead end exactly when you most want a lead.
+
+Signal Lab's answer is that a signal you can't *decode* is not a signal you can't
+*describe*. Even with no lock, the raw IQ still carries recoverable structure —
+roughly how fast it's keying (symbol rate) and roughly how it's modulated (the
+number of levels, FSK-like vs PSK-like). Extract those and you can *name a
+candidate* even when you can't read a single bit. That's the whole premise of the
+identify and wideband surfaces.
+
+## Ranked candidates, not a guess
+
+The **Identify** surface (mirrored by `gophertrunk identify` on the CLI) runs a
+capture against the decoder's roster and returns **ranked candidates** — a scored
+list, best guess on top, with the runners-up visible. That ranking is more honest
+and more useful than a single verdict. A close top-two ("62% NXDN, 55% dPMR")
+tells you the signal is genuinely ambiguous and worth a human look; a runaway
+leader ("94% P25 Phase 1") tells you to just decode it. You get calibrated doubt
+instead of false confidence.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="bars" width="560" height="300" role="img"
+        aria-label="Ranked protocol identification candidates by confidence score"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "categories":["P25 P1","NXDN","dPMR","DMR","unknown"],
+"values":[0.31,0.28,0.22,0.11,0.62],
+"pass":[false,false,false,false,true],
+"ylabel":"candidate score" }
+</script>
+<figcaption>Illustrative ranked candidates for a hard capture: no named protocol dominates, and the strongest bar is "unknown" — the signature of a carrier that needs blind identification rather than a decoder.</figcaption>
+</figure>
+
+When the ranking's top result is essentially "none of the above," you've left the
+land of named decoders and entered blind ID.
+
+## Blind estimation: rate and modulation without a lock
+
+Blind identification estimates two things directly from the IQ, no decoder
+required:
+
+- **Symbol rate** — how fast the signal is keying, recovered from the modulation's
+  own periodicity (spectral and cyclostationary cues). This is the single most
+  discriminating number for narrowband land-mobile radio: 4800 sym/s, 9600
+  sym/s, and 2400 sym/s carve the space into families immediately.
+- **Modulation class** — the *shape* of the modulation: how many levels, and
+  whether it's frequency-like (FSK/C4FM family) or phase-like (PSK/QPSK family),
+  read from the constellation and spectral structure you met in Parts 4 and 5.
+
+Neither needs a lock, which is the point — these survive on signals no decoder
+will touch. A carrier can be too short, too weak, or too proprietary to decode
+and *still* give up "~4800 sym/s, 4-level frequency modulation." That pair is
+often enough to name a candidate.
+
+## The signal-ID reference database
+
+An estimate on its own — "4800 sym/s, 4-level FSK" — is a description, not a name.
+The **offline signal-ID reference database** (sigref) closes that gap. It holds
+the blind signatures of known systems, and it matches an undecodable carrier's
+estimate against them to produce a *best-guess name* rather than dropping the
+carrier entirely. So a survey doesn't report "unknown carrier at 453.2125 MHz" —
+it reports "unknown carrier, best match: 4-level FSK, ~4800 sym/s, consistent
+with [candidate]." It's the difference between a blank and a lead.
+
+The database is offline and bundled, in keeping with the whole workbench — no
+lookup service, no network. That matters for the field: you can name the unknown
+on an air-gapped laptop from the raw capture alone.
+
+## The wideband survey — and Mercury
+
+The **Wideband** tab scales blind ID from one channel to a whole band. Feed it a
+wide capture and it surveys the spectrum, finds every carrier in it, and runs the
+blind estimate on each — a table of "here's what's on the air, and here's my best
+guess for each," including the ones that don't decode. It's the natural companion
+to the spectrogram from Part 5: the waterfall shows you *where* the energy is, and
+the survey tries to *name* it.
+
+This is where Ada finally corners **Mercury**. Surveying a wide capture around
+453 MHz, the Wideband tab flags an intermittent carrier — present, gone, present
+again, exactly its spectrogram stutter — and runs blind ID on it:
+
+| Field | Mercury's survey result |
+|---|---|
+| Center | ~453 MHz (UHF business band) |
+| Channel | ~12.5 kHz |
+| Symbol rate (blind) | ~4800 sym/s |
+| Modulation (blind) | 4-level-FSK-like |
+| Named decode | none — no lock |
+| sigref best guess | candidate only |
+
+So Mercury gets a *description* and a *candidate* — ~4800 sym/s, 4-level-FSK-like
+— but **no lock**: it does not decode as any named protocol. That's not a failure
+of the workbench; it's an honest verdict. Blind ID has done exactly its job —
+turned a blank carrier into a characterized lead — and the lead now needs a
+different instrument. Ada exports the wideband capture and hands it to
+[RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}), whose protocol
+hierarchy is built to work an unknown, intermittent emitter.
+
+That handoff is a real seam in the toolchain, not just a narrative one:
+[RF Scope Part 3]({{ '/blog/tutorials/rf-scope-03-protocol-hierarchy/' | relative_url }})
+reuses this same blind-identify machinery to place an unknown emitter in its
+protocol hierarchy. Signal Lab names the candidate; RF Scope works out what the
+emitter is *doing*.
+
+## The limits of a best guess
+
+Blind identification is powerful precisely because it's honest about what it
+doesn't know, and it's worth being clear about *why* Mercury stops at a candidate
+rather than a decode. A symbol-rate and modulation-class estimate constrains the
+*family* a signal belongs to, but two systems can share a symbol rate and a
+modulation and still be entirely different protocols — the framing, the FEC, the
+scrambling, and the higher-layer structure are what actually distinguish them, and
+none of that is recoverable without a decoder that locks. "~4800 sym/s,
+4-level-FSK-like" narrows Mercury to a neighborhood; it doesn't hand you the
+address.
+
+There's also the ceiling that blind ID can't push through by design: if a payload
+is scrambled or encrypted, the modulation and rate still read cleanly — that's a
+physical-layer property — but nothing above it will ever parse into named fields,
+no matter how good the estimate. A carrier can be perfectly characterized at the
+symbol level and completely opaque at the content level. That gap is exactly where
+Mercury lives, and it's the whole reason the trail has to leave Signal Lab: naming
+the modulation was the *last* thing this workbench can do for it. Reading what's
+inside the frames is a different discipline, which is why Ada's export becomes RF
+Scope's input and, eventually, Crypto Lab's problem.
+
+The healthy mindset, then, is to treat a blind ID result as a **lead with a
+confidence attached**, never a conclusion. A tight, well-separated top candidate
+is worth trying to decode immediately; a diffuse ranking or a bare "best match"
+with no lock is a signal to gather more — a longer capture, a wider survey, a
+handoff to the next instrument — rather than to force a decode that isn't there.
+Ada's instinct at the start of the series was to keep re-running the decoder on
+Mercury hoping it would eventually catch. Reese's correction: the decoder isn't
+going to catch, and the survey already told you why — take the characterized lead
+and move it down the chain.
+
+## Where this goes next
+
+[Part 9]({{ '/blog/tutorials/signal-lab-09-dissecting-p25-pdus/' | relative_url }})
+returns to signals that *do* decode and goes deep — dissecting P25 TSBK PDUs
+field by field, watching the receiver-state series, and reading the
+sync-landscape heatmap. Meanwhile Mercury's trail leaves Signal Lab and picks up
+in [RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}), where an
+unknown-protocol, intermittent emitter is exactly the kind of thing the Scene is
+built to triage. The [SigLab docs]({{ '/siglab.html' | relative_url }}) describe the
+identify and survey surfaces in full.
+
+## FAQ
+
+**How can it identify a signal it can't decode?**
+By estimating structure instead of reading content. Symbol rate and modulation
+class are recoverable from raw IQ with no lock, and matching that blind estimate
+against the signal-ID reference database yields a best-guess name — a lead, not a
+decode.
+
+**Why ranked candidates instead of one answer?**
+Because confidence is information. A tight top-two means genuine ambiguity worth a
+human look; a runaway leader means just decode it. A single verdict throws that
+away.
+
+**What is the wideband survey for?**
+Characterizing a whole band at once: it finds every carrier in a wide capture and
+runs blind ID on each, so you get a named (or best-guessed) inventory of what's on
+the air, decodable or not.
+
+**Did Signal Lab decode Mercury?**
+No. It produced a best guess — ~4800 sym/s, 4-level-FSK-like — but no lock and no
+named protocol. That characterized lead is handed to RF Scope for the next stage.
+
+## Series navigation
+
+**Part 8 of 10** · ←[Part 7]({{ '/blog/tutorials/signal-lab-07-vsa-evm-modulation-quality/' | relative_url }}) · Next →
+[Part 9: Dissecting P25 PDUs]({{ '/blog/tutorials/signal-lab-09-dissecting-p25-pdus/' | relative_url }})

--- a/docs/_posts/2026-07-14-crypto-lab-09-web-console-bridge-external.md
+++ b/docs/_posts/2026-07-14-crypto-lab-09-web-console-bridge-external.md
@@ -1,0 +1,148 @@
+---
+title: "Crypto Lab, Part 9: The Web Console, Live-Capture Bridge & External Ciphers"
+description: Crypto Lab's serve command launches a schema-driven web console that auto-renders a form for every tool, mounts inside the daemon when built with the cryptolab tag, feeds ks and assess from a live decoder bridge, and drives operator-supplied external ciphers as CLI-only subprocesses behind a strict safety boundary.
+category: tutorials
+keywords: cryptolab serve, web console, recipe builder, live capture bridge, crypto_capture_path, p25 ldu2 superframe, external cipher, tea1 subprocess, safety boundary, gophertrunk cryptolab
+tags: [cryptolab, web-console, live-capture, external-cipher, security-testing, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 9
+---
+
+*Part 9 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. The surfaces around the tools: a browser console, a live feed from the decoder, and a carefully-fenced door for external ciphers.*
+
+> **TL;DR:** `cryptolab serve` runs a browser console at `127.0.0.1:8096` (`-addr`, `-open`, `-tmp-dir`, `-max-upload`, `-log-level`, `-log-format`) that renders a form for every tool from `GET /api/v1/cryptolab/tools`, plus a Recipe Builder tab. Built into the daemon with `-tags cryptolab`, it mounts at `/cryptolab/` and Signal Lab shows a 🔐 link. The live bridge (`recordings.crypto_capture_path`) appends one JSON record per encrypted P25 LDU2 superframe; point `ks`/`assess` at that JSONL. External ciphers are **not bundled** — you drive an operator-supplied cipher as a subprocess (`-extern-cmd`), and because that runs a host program it is **CLI-only** (the web console hides it; the recipe endpoint returns HTTP 403).
+
+> **Authorized testing only.** The bridge captures encrypted material — enable it only on systems you own or are licensed to assess.
+
+**Key takeaways**
+
+- **The console is schema-driven.** Every tool, mode, and parameter auto-gets a control from the backend schema — new tools appear automatically.
+- **The bridge closes the live loop.** A running decoder appends encrypted frames as JSONL; `ks reuse` / `assess crypto` read it directly.
+- **External ciphers stay unbundled.** GopherTrunk drives your vetted cipher as a subprocess rather than shipping a licence-incompatible one.
+- **The safety boundary is hard.** Anything that runs a host program is CLI-only; the browser can never trigger it.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab serve -open` | Serve the console at `127.0.0.1:8096` and open a browser |
+| `-addr host:port` | Change the listen address |
+| `-tmp-dir dir` / `-max-upload bytes` | Staging dir / upload cap (0 = 512 MiB default) |
+| `recordings.crypto_capture_path:` | Config: where the decoder appends encrypted frames |
+| `assess crypto -extern-cmd tea1-tool -extern-algid 0x01 -brute-bits 32` | Drive an external cipher (CLI only) |
+| `GET /api/v1/cryptolab/tools` | The schema the console renders from |
+
+## In this post
+
+- **The web console** — schema-driven forms and the Recipe Builder.
+- **Daemon mount** — how the console appears inside a running GopherTrunk.
+- **The live-capture bridge** — decoder to JSONL to `ks`/`assess`.
+- **External ciphers** — driving an unbundled cipher as a subprocess.
+- **The safety boundary** — why external ops are CLI-only.
+
+## The web console
+
+`cryptolab serve` is the browser counterpart to the CLI, mirroring the `siglab serve` pattern:
+
+```bash
+make cryptolab-web-build           # bundle the SPA into web/cryptolab/dist/
+make build TAGS=cryptolab          # link the toolkit + console into gophertrunk
+gophertrunk cryptolab serve -open  # serve at 127.0.0.1:8096 and open a browser
+```
+
+What makes it maintainable is that it's **schema-driven**. The frontend renders its forms from `GET /api/v1/cryptolab/tools`, the backend's own description of every tool, mode, and parameter. Each parameter — file upload, text, number, checkbox — gets the right control automatically, so when a new tool is added to the toolkit, it appears in the console with no frontend change. A run uploads the inputs, streams the live log, and shows the structured result: summary, fields, ranked findings, notes, and downloadable artifacts (survivor logs, checkpoints, descrambled output). It runs entirely offline against uploaded files — no SDR or daemon required.
+
+The flags mirror the CLI's serve: `-addr` (default `127.0.0.1:8096`), `-open` (launch a browser once it's up), `-tmp-dir` (staging directory for uploads), `-max-upload` (byte cap; `0` = the 512 MiB default), and the usual `-log-level`/`-log-format`. The **Recipe Builder** tab drives the [Part 7]({{ '/blog/tutorials/crypto-lab-07-crc-recovery-recipe/' | relative_url }}) pipeline interactively — pick an input, assemble ops from a palette with move/duplicate/remove and per-op fields, run, and read the per-step report plus the final bytes. It's backed by two endpoints: `GET /api/v1/cryptolab/recipe/ops` (the op catalogue) and `POST /api/v1/cryptolab/recipe` (run a structured recipe over an uploaded file).
+
+## Daemon mount
+
+When the main `gophertrunk` daemon is itself built with `-tags cryptolab`, the same console mounts *inside* it at `/cryptolab/` (its API under `/api/v1/cryptolab/`, alongside the siglab routes), so you can reach it from a running daemon without launching a separate `serve`. Mutating routes share the daemon's mutation gate. The default daemon build links a no-op mount, so the toolkit stays out of the standard binary.
+
+In that build the console is **discoverable from the other web UIs**: the main GopherTrunk console shows a **Crypto Lab** entry in its System nav, and the Signal Lab header shows a **🔐 Crypto Lab** link. Both are gated on `runtime.cryptolab_console` (from `GET /api/v1/runtime`), so the link only appears when the console is actually mounted — a default build or a standalone siglab never shows a dead link. That gating is why Ada, running a default scanner build, simply never sees the Crypto Lab link, while Reese's `-tags cryptolab` daemon surfaces it in both headers.
+
+## The live-capture bridge
+
+The most powerful integration is feeding Crypto Lab straight from live decode. Set one config key:
+
+```yaml
+recordings:
+  crypto_capture_path: /var/lib/gophertrunk/crypto-frames.jsonl
+```
+
+When set, the P25 Phase 1 voice composer appends one JSON record per encrypted **LDU2 superframe** to that file — `{label, iv (Message Indicator), ct (encrypted voice frames), system, protocol, tg, algid, keyid, at}`. That's exactly the frames format `ks` and `assess` read ([Part 5]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }})), so you point them straight at the growing file:
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 120" width="640" height="120" role="img" aria-label="Live bridge: decoder appends encrypted superframes to JSONL, which ks and assess read">
+  <g font-size="11.5">
+  <rect x="8" y="42" width="130" height="40" rx="6" fill="none" stroke="currentColor"/>
+  <text x="73" y="60" text-anchor="middle" fill="currentColor">P25 decoder</text>
+  <text x="73" y="75" text-anchor="middle" fill="var(--fg-muted)" font-size="9">encrypted LDU2</text>
+  <rect x="200" y="42" width="180" height="40" rx="6" fill="none" stroke="var(--accent)"/>
+  <text x="290" y="60" text-anchor="middle" fill="var(--accent)">crypto-frames.jsonl</text>
+  <text x="290" y="75" text-anchor="middle" fill="var(--fg-muted)" font-size="9">{label, iv=MI, ct, ...}</text>
+  <rect x="446" y="24" width="186" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="539" y="43" text-anchor="middle" fill="currentColor">ks reuse / ks mtp</text>
+  <rect x="446" y="70" width="186" height="30" rx="6" fill="none" stroke="currentColor"/>
+  <text x="539" y="89" text-anchor="middle" fill="currentColor">assess crypto</text>
+  <g stroke="currentColor" stroke-width="1.3" fill="currentColor">
+  <line x1="138" y1="62" x2="198" y2="62"/><polygon points="200,62 192,58 192,66"/>
+  <line x1="380" y1="55" x2="444" y2="40"/><polygon points="446,39 437,39 441,47"/>
+  <line x1="380" y1="70" x2="444" y2="84"/><polygon points="446,85 437,79 441,87"/>
+  </g>
+  </g>
+</svg>
+<figcaption>With <code>crypto_capture_path</code> set, the decoder appends one JSONL record per encrypted superframe; <code>ks</code> and <code>assess</code> read that same file offline.</figcaption>
+</figure>
+
+```bash
+gophertrunk cryptolab ks reuse -in /var/lib/gophertrunk/crypto-frames.jsonl
+gophertrunk cryptolab assess crypto -in /var/lib/gophertrunk/crypto-frames.jsonl
+```
+
+The capture records encrypted material and its IV; the decryption *attempts* all run offline in `ks`/`assess`, never on the live path. Crucially, an **empty** `crypto_capture_path` (the default) disables the bridge entirely — no extraction work runs on the voice path, so the standard operator build is completely unaffected. This is the same feed that produced Ada's `mercury-frames.jsonl`, and it's the through-line that connects a live antenna to the analysis bench. It complements [RF Scope Part 7]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }})'s `-frames-out`, which produces the identical format from an offline capture.
+
+## External ciphers
+
+The toolkit deliberately does **not** bundle proprietary or reverse-engineered ciphers it can't verify, or whose only implementations are licence-incompatible — the public **TETRA TEA1–4** reference is AGPL, while GopherTrunk is Apache-2.0. Rather than ship or vouch for such a cipher, `assess` can drive an **operator-supplied** cipher program as a subprocess. You point it at a vetted tool that implements a small, shell-free line protocol:
+
+```bash
+# Brute the TEA1 32-bit backdoor via your TEA1 tool, then decrypt + grade.
+gophertrunk cryptolab assess crypto -in frames.jsonl -protocol tetra \
+    -known-label call-3 -known-pt known.bin \
+    -extern-cmd "tea1-tool" -extern-algid 0x01 -brute-bits 32
+```
+
+The external program exposes two verbs — `keystream <key> <iv> <n>` and `brute <iv> <known_keystream> <bits> <base_key>` — and the harness orchestrates them, verifies the hit against the known-plaintext oracle, and decrypts the corpus. The `brute` verb keeps the heavy key search native in the cipher; GopherTrunk just drives it. Already recovered the key elsewhere? Hand it via `-keys` with no `-brute-bits`, and `assess` verifies it through the external cipher and decrypts every frame. This is how the TEA1 backdoor from [Part 6]({{ '/blog/tutorials/crypto-lab-06-assess-battery/' | relative_url }}) becomes a *runnable* break rather than just an advisory — without GopherTrunk shipping the cipher.
+
+## The safety boundary
+
+Here's the hard rule, and it's a deliberate security design, not an oversight. **External ciphers run a host program**, so `-extern-cmd` and the `extern-decrypt` recipe op are **CLI-only**:
+
+- The web console **hides** the `extern-decrypt` op from its palette.
+- `POST /api/v1/cryptolab/recipe` **refuses** an `extern-decrypt` step, returning **HTTP 403**.
+
+So a browser request — even against a daemon-mounted console — can never execute a program on the host. The reasoning is straightforward: a web endpoint that runs arbitrary local commands is a remote-code-execution primitive, and no analysis convenience is worth that. Anything that shells out stays behind the CLI, where the operator running the command already has shell access anyway. Reese's framing: *the browser can analyze bytes all day, but it doesn't get to launch processes.* That boundary is what lets the daemon mount the console with confidence.
+
+## Where this goes next
+
+One tool remains, and it's the one that solves Mercury. [Part 10]({{ '/blog/tutorials/crypto-lab-10-subject-framework-alias/' | relative_url }}) covers the pluggable **subject framework** and the `alias` tool that recovers length-seeded, keyless byte obfuscators — and reveals that Mercury was never encryption at all. It closes the Mercury thread and the whole Lab Bench trilogy. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) cover the console, bridge, and external-cipher protocol in full.
+
+## FAQ
+
+**Does the web console do everything the CLI does?**
+Almost — it renders a form for every tool from the backend schema and drives recipes interactively. The one exception is anything that runs a host program (external ciphers), which is CLI-only for safety.
+
+**What does the live bridge capture, and is it on by default?**
+It appends one JSONL record per encrypted P25 LDU2 superframe to `crypto_capture_path`. It's off by default (empty path); when off, no extraction runs on the voice path at all. Enable it only for authorized assessment.
+
+**Why doesn't GopherTrunk just bundle TEA1?**
+Two reasons: it can't verify a reverse-engineered cipher, and the public TEA1 reference is AGPL while GopherTrunk is Apache-2.0. Instead it drives an operator-supplied, vetted implementation as a subprocess.
+
+**Why is `extern-decrypt` blocked over HTTP?**
+Because it runs a host program. A web endpoint that executes local commands is a remote-code-execution risk, so the console hides the op and the recipe API returns HTTP 403. External ciphers stay CLI-only.
+
+## Series navigation
+
+**Part 9 of 10** · ←[Part 8: Analog Voice Descrambling]({{ '/blog/tutorials/crypto-lab-08-analog-voice-descrambling/' | relative_url }}) · Next →[Part 10: The Subject Framework, `alias` & the Mercury Reveal]({{ '/blog/tutorials/crypto-lab-10-subject-framework-alias/' | relative_url }})

--- a/docs/_posts/2026-07-14-rf-scope-09-scene-cockpit-tui-web.md
+++ b/docs/_posts/2026-07-14-rf-scope-09-scene-cockpit-tui-web.md
@@ -1,0 +1,266 @@
+---
+title: "RF Scope, Part 9: The Scene Cockpit — Live TUI & Web Console"
+description: rfscope cockpit is a full-screen Bubbletea terminal dashboard and rfscope serve is a browser console — both render the same live Scene (header, hierarchy tree, channel I/O sparklines, top talkers, conversations, severity-colored expert info) over a capture or a live SDR, with a Crypto Lab hand-off built in.
+category: tutorials
+keywords: rfscope, cockpit, tui, bubbletea, web console, rfscope serve, live scene, sparkline, top talkers, conversations, expert info, crypto lab bridge, gophertrunk
+tags: [rfscope, tui, web, getting-started, gophertrunk, sdr]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 9
+---
+
+*Part 9 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer. You have
+seen every analyzer produce data; now put them all on one screen, live.*
+
+> **TL;DR:** `rfscope cockpit` (and `rfscope live -tui`) is a full-screen Bubbletea
+> dashboard with panels for the scene header, protocol hierarchy, per-channel I/O
+> sparklines, top talkers, conversations, and severity-colored expert info. Keys:
+> `q`/`ctrl+c` quit, `space` freeze/resume, `e` export (`rfscope-scene-<unix>.json`),
+> `?` help. Live mode re-analyzes on a `-refresh` interval (default 2s) over
+> `-duration` seconds of IQ per pass. `rfscope serve` is the browser equivalent at
+> `127.0.0.1:8098` — upload, analyze, view the same panels plus a Crypto Lab bridge
+> card with a Download-frames button.
+
+**Key takeaways**
+
+- **One Scene, two front ends** — a terminal cockpit and a web console, both rendering
+  the same six panels.
+- **Live mode refreshes** every `-refresh` interval (2s default) over `-duration`
+  seconds of fresh IQ; `space` freezes it so you can read.
+- **`e` exports** the current Scene to timestamped JSON, on the spot.
+- **The web console has a Crypto Lab card** — one click downloads the recovered `ks`
+  frames file with the suggested next command.
+
+## Cheat sheet
+
+| Command / key | What it does |
+|---|---|
+| `rfscope cockpit -in cap.cfile` | Offline cockpit over a capture |
+| `rfscope cockpit -serial <sdr> -freq Hz` | Live cockpit over an SDR |
+| `rfscope live -tui …` | Same, via the live subcommand |
+| `-refresh 2s` / `-duration 4` | Live re-analysis interval / IQ per pass |
+| `q` / `ctrl+c` | Quit |
+| `space` | Freeze / resume the live view |
+| `e` | Export scene → `rfscope-scene-<unix>.json` |
+| `?` | Toggle help |
+| `rfscope serve -addr 127.0.0.1:8098 -open` | Browser console |
+
+## In this post
+
+- **The cockpit's six panels** and how they map to the analyzers.
+- **Live vs offline** — the refresh loop and freeze.
+- **Keybindings** — quit, freeze, export, help.
+- **`rfscope serve`** — the web console and its flags.
+- **The Crypto Lab bridge card.**
+
+## Six panels, one Scene
+
+`rfscope cockpit` is a self-contained Bubbletea program modeled on Signal Lab's TUI: a
+worker goroutine runs the segmentation + analyzer pipeline and feeds finished Scenes
+into the event loop, which redraws. The `View` stacks six panels top to bottom, each a
+rendering of part of the Scene you already understand:
+
+```go
+// cmd/gophertrunk/rfscope_cockpit.go
+b.WriteString(renderSceneHeader(m.scene) + "\n")
+b.WriteString(renderHierarchyPanel(m.scene) + "\n")
+b.WriteString(renderChannelsPanel(m.scene, panelWidth(m.width)) + "\n")
+b.WriteString(renderTalkersPanel(m.scene) + "\n")
+b.WriteString(renderConversationsPanel(m.scene) + "\n")
+b.WriteString(renderExpertPanel(m.scene) + "\n")
+```
+
+- **Scene header** — center frequency, span, window, noise floor, and the counts:
+  bursts, channels, emitters, anomalies. The one-line summary of the whole band.
+- **Protocol hierarchy** — the Part 3 tree, indented by depth, each node with its burst
+  count and time %.
+- **Channels (I/O graph)** — one row per channel: frequency, dominant class, the
+  `█`/`·` occupancy **sparkline** from Part 4, and duty %.
+- **Top talkers** — the busiest emitters by airtime, each with a `hop×N` suffix when it
+  is a frequency hopper.
+- **Conversations** — each linked pair or hop sequence: kind, the emitter IDs joined
+  with `↔`, and the correlation.
+- **Expert info** — the Part 8 anomaly list, severity-colored: red for `alert`, yellow
+  for `warn`, plain for `note`.
+
+<figure class="lab-figure">
+<svg viewBox="0 0 560 340" width="560" height="340" role="img" aria-label="Cockpit panel layout">
+  <rect x="8" y="8" width="544" height="324" rx="6" fill="none" stroke="var(--border)"/>
+  <rect x="20" y="20" width="520" height="30" rx="4" fill="none" stroke="currentColor"/>
+  <text x="30" y="39" fill="currentColor" font-size="11" font-family="monospace">center 453.400 MHz  span 2.400 MHz  |  128 bursts  5 ch  6 emitters  4 anomalies</text>
+  <rect x="20" y="58" width="256" height="120" rx="4" fill="none" stroke="currentColor"/>
+  <text x="30" y="76" fill="var(--accent)" font-size="11" font-family="monospace">Protocol hierarchy</text>
+  <text x="30" y="96" fill="currentColor" font-size="10" font-family="monospace">c4fm            96b  41% time</text>
+  <text x="40" y="112" fill="currentColor" font-size="10" font-family="monospace">12.5 kHz → p25p1</text>
+  <text x="30" y="132" fill="currentColor" font-size="10" font-family="monospace">fsk             22b   4% time</text>
+  <rect x="284" y="58" width="256" height="120" rx="4" fill="none" stroke="currentColor"/>
+  <text x="294" y="76" fill="var(--accent)" font-size="11" font-family="monospace">Channels (I/O graph)</text>
+  <text x="294" y="96" fill="currentColor" font-size="10" font-family="monospace">453.100 c4fm ████████████ 98%</text>
+  <text x="294" y="112" fill="currentColor" font-size="10" font-family="monospace">453.325 c4fm ··██···██··· 18%</text>
+  <text x="294" y="128" fill="currentColor" font-size="10" font-family="monospace">453.550 fsk  █···█···█··· 6%</text>
+  <rect x="20" y="186" width="256" height="80" rx="4" fill="none" stroke="currentColor"/>
+  <text x="30" y="204" fill="var(--accent)" font-size="11" font-family="monospace">Top talkers</text>
+  <text x="30" y="222" fill="currentColor" font-size="10" font-family="monospace">#1 c4fm@453.100  12.4s</text>
+  <text x="30" y="238" fill="currentColor" font-size="10" font-family="monospace">#5 digital hopper  2.1s hop×4</text>
+  <rect x="284" y="186" width="256" height="80" rx="4" fill="none" stroke="currentColor"/>
+  <text x="294" y="204" fill="var(--accent)" font-size="11" font-family="monospace">Conversations</text>
+  <text x="294" y="222" fill="currentColor" font-size="10" font-family="monospace">co-active   #1↔#2 (0.71)</text>
+  <text x="294" y="238" fill="currentColor" font-size="10" font-family="monospace">hop-sequence #5 (1.00)</text>
+  <rect x="20" y="274" width="520" height="48" rx="4" fill="none" stroke="currentColor"/>
+  <text x="30" y="292" fill="var(--accent)" font-size="11" font-family="monospace">Expert info</text>
+  <text x="30" y="310" fill="currentColor" font-size="10" font-family="monospace">[warn] obfuscated 453.550 …   [note] hopper 453.550 …</text>
+</svg>
+<figcaption>The cockpit stacks the scene header, hierarchy, channel sparklines, top talkers, conversations, and severity-colored expert info into one live view.</figcaption>
+</figure>
+
+## Live vs offline
+
+The cockpit runs in two modes. **Offline** (`-in <capture>`) analyzes the file once and
+holds the result — a static, navigable Scene. **Live** (`-serial <sdr> -freq Hz`)
+re-analyzes on a timer:
+
+```go
+// cmd/gophertrunk/rfscope_cockpit.go
+duration := fs.Float64("duration", 4, "seconds of IQ per live refresh")
+refresh  := fs.Duration("refresh", 2*time.Second, "live re-analysis interval")
+```
+
+Every `-refresh` interval (default **2 s**), a worker grabs the next `-duration` seconds
+(default **4 s**) of live IQ, runs the full pipeline, and hands the new Scene back to be
+drawn. So the cockpit is a rolling window on the band: hoppers blink across channels,
+duty cycles rise and fall, and new anomalies appear as they happen. Ada leaves it
+running on 453 MHz and watches Mercury's hopper row flicker to life each time it keys up.
+
+## Keybindings
+
+Four keys, all handled in `Update`:
+
+```go
+// cmd/gophertrunk/rfscope_cockpit.go
+case "q", "ctrl+c": return m, tea.Quit
+case " ": m.frozen = !m.frozen
+case "?": m.showAll = !m.showAll
+case "e": m.status = m.exportScene()
+```
+
+- **`q` / `ctrl+c`** — quit.
+- **`space`** — freeze / resume. While frozen, the live loop keeps analyzing but stops
+  swapping in new Scenes, so you can actually read a fast-moving band. The header shows
+  `[FROZEN]`.
+- **`e`** — export the current Scene to `rfscope-scene-<unix>.json` in the working
+  directory (full indented JSON via the same `Write` path as `-out-format json`). Handy
+  for grabbing a snapshot the moment something interesting appears.
+- **`?`** — toggle the help overlay.
+
+## How the refresh loop stays responsive
+
+The cockpit has to do something hard: run a heavy DSP pipeline *and* stay responsive to
+keystrokes. It solves this the idiomatic Bubbletea way — analysis runs in a **worker
+goroutine**, and finished Scenes arrive as messages the event loop consumes:
+
+```go
+// cmd/gophertrunk/rfscope_cockpit.go
+go func() {
+    scene, in, err := rfscope.Segment(context.Background(), src, cfg)
+    if err == nil {
+        scene.Source = label
+        err = rfscope.Run(context.Background(), scene, in, analyzers...)
+    }
+    select {
+    case ch <- cockpitSceneMsg{scene: scene, err: err}:
+    default:
+    }
+}()
+```
+
+The `Update` loop never blocks on analysis — it only reacts to the `cockpitSceneMsg`
+that lands when a pass finishes, and to a `tea.Tick` that schedules the next pass at the
+refresh interval. That is why `space` freezes instantly even while a full segmentation is
+mid-flight: freeze just sets a flag that tells `Update` to ignore the next Scene, and the
+keystroke is handled on the main loop, not behind the worker. It is also why an analysis
+error shows up as a status line rather than a crash — the message carries the error and
+the loop renders it. The render helpers themselves (`renderSceneHeader`,
+`renderChannelsPanel`, and friends) are deliberately **pure functions** of a `*Scene`,
+which is how they get unit-tested without a TTY: hand them a constructed Scene, assert on
+the string.
+
+For live mode there is one more subtlety worth knowing. `-duration` controls how much IQ
+each pass analyzes and `-refresh` controls how often a pass starts. Set `-duration`
+larger than `-refresh` and passes overlap in wall-clock time (more CPU, smoother rolling
+window); set it smaller and there are gaps between analyzed windows. The defaults — 4 s of
+IQ every 2 s — deliberately overlap, so the rolling view never has a blind spot between
+refreshes.
+
+## rfscope serve: the web console
+
+Not everyone wants a terminal. `rfscope serve` runs a standalone browser console:
+
+```text
+gophertrunk rfscope serve -addr 127.0.0.1:8098 -open
+```
+
+Its flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-addr` | `127.0.0.1:8098` | Listen address (localhost by default) |
+| `-open` | false | Open the console in the system browser once up |
+| `-tmp-dir` | fresh temp dir | Where staged capture uploads land |
+| `-max-upload` | 512 MiB | Max capture upload size in bytes (0 = default) |
+| `-log-level` | `info` | `debug` \| `info` \| `warn` \| `error` |
+| `-log-format` | `text` | `text` \| `json` |
+
+The workflow is **upload → analyze → view**: drop a capture in the browser, the server
+segments and analyzes it, and the page renders the same six panels the cockpit does. It
+binds to localhost by default, so it is a personal console, not a public service, unless
+you deliberately change `-addr`. (Build the SPA first with `make rfscope-web-build`; the
+default binary serves an API-only placeholder until then.)
+
+## The Crypto Lab bridge card
+
+The web console has one thing the cockpit does not: a **Crypto Lab bridge card**. When
+the entropy analyzer recovered any unknown payloads, the card appears with a
+**Download-frames** button that hands you the `ks` frames file — the same
+`{label, iv, ct}` JSONL from Part 7 — alongside the suggested next command
+(`cryptolab classify auto -in frames.jsonl`, and `ks reuse` when reuse was detected).
+It is the one-click version of `-frames-out`: analyze a band in the browser, spot the
+obfuscated emitter in the expert panel, and download its bytes straight into the
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) workflow. For Mercury,
+that button is the hand-off — one click and its frame is on its way to being broken.
+
+## Where this goes next
+
+The cockpit and console run the pipeline with sensible defaults. The final part pulls
+the covers off: [Part
+10]({{ '/blog/tutorials/rf-scope-10-advanced-tuning-pipelines/' | relative_url }}) covers
+running a *subset* of analyzers, tuning segmentation for weird bands, the machine
+output formats for scripting, and the reverse-engineering loop from `-frames-out` into
+Crypto Lab — with a sidebar on how RF Scope's downconverter relates to GopherTrunk's DSP
+paths.
+
+## FAQ
+
+**What's the difference between `cockpit` and `live -tui`?**
+None functionally — `live -tui` just delegates to the cockpit with the same flags. Use
+whichever reads better in your command.
+
+**Does freeze stop the radio?**
+No. In live mode the worker keeps analyzing on the refresh tick; freeze only stops the
+display from swapping in new Scenes, so you can read the current one. Un-freeze and the
+next pass shows through.
+
+**Is `rfscope serve` safe to expose?**
+It binds to `127.0.0.1:8098` by default — a personal, local console. Only change `-addr`
+if you understand the exposure, and mind `-max-upload` for untrusted uploads.
+
+**Where does `e` write the export?**
+To `rfscope-scene-<unix-timestamp>.json` in the current working directory, as full
+indented JSON — the same serialization as `-out-format json -out …`.
+
+## Series navigation
+
+**Part 9 of 10** · ←
+[Part 8: Expert Info]({{ '/blog/tutorials/rf-scope-08-expert-info-anomalies/' | relative_url }})
+· Next →
+[Part 10: Advanced Tuning & Pipelines]({{ '/blog/tutorials/rf-scope-10-advanced-tuning-pipelines/' | relative_url }})

--- a/docs/_posts/2026-07-14-signal-lab-09-dissecting-p25-pdus.md
+++ b/docs/_posts/2026-07-14-signal-lab-09-dissecting-p25-pdus.md
@@ -1,0 +1,241 @@
+---
+title: "Signal Lab, Part 9: Dissecting P25 — TSBK PDUs, Receiver States & the Sync Landscape"
+description: Signal Lab's deepest P25 view — collect_pdus surfaces every TSBK signaling block (decoded and CRC-failed) as a field-level dissection with a csv-pdus export, plus the C4FM and CQPSK receiver-state series, the soft-eye verdict, and the sync-landscape heatmap.
+category: tutorials
+keywords: p25 tsbk, collect_pdus, csv-pdus, pdu dissection, receiver state, afc agc, gardner timing, cma error, cqpsk, soft eye, sync landscape, p25 signaling
+tags: [siglab, p25, tsbk, receiver-state, dsp, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 9
+charts: true
+---
+
+*Part 9 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. This is the advanced end of the pool — the tools for
+taking a P25 control channel apart down to the signaling block and the receiver
+loop.*
+
+> **TL;DR:** With `collect_pdus`, Signal Lab surfaces **every** P25 TSBK
+> signaling block — decoded *and* CRC-failed — as a field-level dissection
+> (opcode, source/dest/talkgroup, FEC/CRC status, raw payload), filterable and
+> exportable as `csv-pdus`. Alongside it, the **receiver-state series** exposes
+> the demod loop internals — AFC/AGC/M&M for the C4FM path, carrier/Gardner/CMA
+> for the CQPSK path — plus a **soft-eye verdict** and a **sync-landscape
+> heatmap** of variant, rotation, and hits.
+
+**Key takeaways**
+
+- **`collect_pdus` keeps the failures.** CRC-failed TSBKs are surfaced too — the
+  errors are often more informative than the successes.
+- **Field-level dissection** means opcode, addresses, FEC/CRC status, and raw
+  payload for every block, filterable in the console.
+- **`csv-pdus` exports** the whole dissection for offline analysis.
+- **Receiver-state series differ by path** — C4FM (AFC/AGC/M&M/DDA) vs CQPSK
+  (carrier/Gardner/CMA AGC/CMA error).
+- **The sync-landscape heatmap** shows which sync variant and rotation the
+  correlator is finding hits on.
+
+## Cheat sheet
+
+| Surface / knob | What it does |
+|---|---|
+| `collect_pdus` | Surface every P25 TSBK (decoded + CRC-failed) |
+| `csv-pdus` | Export the PDU dissection as CSV |
+| Receiver-state series (C4FM) | AFC, AGC level/target, M&M mu/sps, DDA |
+| Receiver-state series (CQPSK) | Carrier Hz, Gardner mu/sps, CQPSK AGC gain, CMA error |
+| Soft-eye verdict | Demod's own eye-quality judgment |
+| Sync-landscape heatmap | Variant × rotation × hits |
+
+## In this post
+
+- **Why the CRC-failed PDUs matter** — the errors are the signal.
+- **The TSBK dissection** — opcode to raw payload.
+- **Receiver-state series** — watching the demod loop think.
+- **C4FM vs CQPSK internals** — two paths, two state vectors.
+- **The sync landscape** — where the correlator finds alignment.
+
+## Why the CRC-failed PDUs matter
+
+A normal decoder throws away what it can't verify. A P25 TSBK — a Trunking
+Signaling Block, the control channel's unit of signaling — that fails its CRC
+gets silently dropped, and the operator sees only the clean traffic. For running a
+system that's fine; for *diagnosing* one it's the opposite of what you want.
+
+`collect_pdus` inverts that. It surfaces **every** TSBK the demod recovered,
+decoded and CRC-failed alike, because the failures carry the diagnosis. A control
+channel that's *almost* decoding — TSBKs arriving but failing CRC in a steady
+trickle — is a completely different problem from one that's silent, and only a
+tool that keeps the failures can tell them apart. A burst of CRC failures lined up
+with a fade in the EVM-vs-symbol trace (Part 7) or a dropout in the spectrogram
+(Part 5) localizes the fault precisely. The garbage is the evidence.
+
+## The TSBK dissection
+
+Each collected TSBK is presented as a **field-level dissection**, not a hex blob:
+
+| Field | What it is |
+|---|---|
+| **Opcode** | The TSBK type — grant, affiliation, status, etc. |
+| **Source / destination** | The addressed radio IDs |
+| **Talkgroup** | The group the block concerns |
+| **FEC / CRC status** | Whether error-correction and the CRC passed |
+| **Raw payload** | The underlying bytes, for when the parse is wrong |
+
+The dissection is **filterable** in the browser console — narrow to a single
+opcode, or to just the CRC failures, or to one talkgroup — which turns a wall of
+signaling into a query. And it's **exportable as `csv-pdus`**, so you can pull the
+whole set into a spreadsheet or a script and do statistics across a long capture:
+how many grants, what fraction failed CRC, which opcodes cluster around the bad
+moments. Keeping the raw payload alongside the parsed fields is the escape hatch —
+when a field looks wrong, you check it against the bytes rather than trusting the
+parser.
+
+## Receiver-state series: watching the loop think
+
+Beneath the PDUs, Signal Lab exposes the demod's own **receiver-state series** —
+time series of the internal loop variables as they track the signal. This is the
+demodulator narrating its own work: not "did it lock?" but "*how* did it lock, and
+how hard was it working to stay locked?" A control loop that's fighting — AGC
+hunting, timing error oscillating — produces a jittery state series even when it
+technically holds lock, and that instability is an early warning the summary
+metrics smooth over.
+
+Because P25 has two distinct demod paths, there are two distinct state vectors,
+and which one you're reading tells you which path is in play.
+
+## C4FM vs CQPSK internals
+
+The two paths track a signal with different machinery, so their state series
+report different quantities:
+
+**C4FM path** (4-level FM, the four-rail family from Part 4):
+
+- **AFC** — automatic frequency control: the residual carrier correction the loop
+  is applying.
+- **AGC level / target** — the gain loop's current level against its target.
+- **M&M mu / sps** — the Mueller & Müller timing recovery's fractional interval
+  (`mu`) and samples-per-symbol estimate.
+- **DDA** — the decision-directed adaptation term.
+
+**CQPSK path** (phase modulation, the four-cluster family):
+
+- **Carrier Hz** — the tracked carrier offset.
+- **Gardner mu / sps** — the Gardner timing recovery's interval and
+  samples-per-symbol.
+- **CQPSK AGC gain** — the path's automatic gain.
+- **CMA error** — the constant-modulus-algorithm equalizer's error term.
+
+Seeing a *carrier Hz* and a *CMA error* series tells you the capture went down the
+CQPSK path; seeing *AFC* and *M&M mu* tells you C4FM. A capture whose CMA error
+won't settle is an equalizer struggling with multipath; a C4FM capture whose M&M
+`mu` won't stop drifting is a timing-recovery problem — often the tail of a
+sample-rate mismatch the Part 2 baud-deviation check should have caught. The state
+series is where a stubborn "won't stay locked" turns from mysterious into
+mechanistic.
+
+## The soft-eye verdict and the sync landscape
+
+Two more advanced readouts round out the P25 view.
+
+The **soft-eye verdict** is the demodulator's own judgment on eye quality — a
+distilled pass/marginal/fail on whether the decision margin (the open eye from
+Part 4) is healthy, expressed as a verdict rather than a plot. It's the quick
+"does the demod think this is clean?" to complement your own read of the eye
+diagram.
+
+The **sync-landscape heatmap** visualizes how the frame synchronizer is finding
+alignment. P25 sync can appear in different **variants** and **rotations** (the
+constellation can lock in any of several rotational ambiguities), and the heatmap
+plots **hits** across that variant × rotation grid. A healthy capture concentrates
+hits in one cell — one variant, one rotation — a clear, unambiguous sync. Energy
+smeared across the grid means the synchronizer is finding weak, conflicting
+correlations: it isn't sure where the frame starts, which is a lock that's about
+to fail.
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="heatmap" width="560" height="300" role="img"
+        aria-label="Sync-landscape heatmap with hits concentrated in one variant and rotation"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "xlabel":"rotation","ylabel":"sync variant",
+"matrix":[
+[0.05,0.06,0.04,0.05],
+[0.07,0.12,0.06,0.05],
+[0.06,0.95,0.08,0.06],
+[0.05,0.09,0.05,0.04]] }
+</script>
+<figcaption>A healthy sync landscape: hits concentrate in a single variant/rotation cell — the synchronizer is confident where the frame begins. A smear across cells means an uncertain, failing sync.</figcaption>
+</figure>
+
+Reese uses the sync landscape as his last stop on a hard capture. If the state
+series are jittery, the soft-eye verdict is marginal, and the sync landscape is
+smeared, the three agree: the capture is genuinely at the edge, and no knob will
+save it — which, per the rate-invariance rule, sends you back to the recording.
+
+## A PDU triage workflow
+
+The PDU dissection is most powerful when you stop reading it block by block and
+start querying it in aggregate. A practical triage on a suspect control channel
+runs like this. First, export with `csv-pdus` and count opcodes: a healthy P25
+control channel is mostly the steady heartbeat of network-status and
+identifier-update blocks with grants sprinkled in; a wildly skewed distribution —
+say, almost nothing but one opcode, or a flood of blocks that don't parse — is
+itself a diagnosis. Second, compute the CRC-failure *fraction*, not the count: a
+handful of failures on a long capture is normal, but a rising fraction is a
+channel slipping toward the edge, and cross-referencing *when* those failures
+cluster against the EVM-vs-symbol trace (Part 7) usually points straight at the
+cause.
+
+Third — and this is where keeping the raw payload pays off — spot-check a few
+blocks whose parsed fields look implausible against their raw bytes. A talkgroup
+that reads as a nonsense value on a block that *passed* CRC is a hint that the
+opcode was misidentified or the dissector met a variant it doesn't fully model;
+the raw payload lets you confirm which. Ada's first instinct was to trust every
+green-CRC field completely; Reese's habit is to trust the CRC for *integrity* but
+still eyeball the raw payload when a field surprises him, because a valid CRC only
+proves the bits arrived intact, not that the parser read them the way the system
+meant them.
+
+Done as a set, those three passes — distribution, failure trend, raw spot-check —
+turn a scrolling wall of TSBKs into a one-paragraph verdict on the channel's
+health, and they compose directly with everything earlier in the series: the
+spectrogram says *when* the channel was busy, the VSA says *how clean* it was, and
+the PDU dissection says *what it was actually saying*. That's the whole point of a
+workbench — the views reinforce each other, and a hard capture rarely survives all
+of them pointing at the same moment.
+
+## Where this goes next
+
+You've now taken a single P25 capture apart to the signaling block and the loop
+variable. [Part 10]({{ '/blog/tutorials/signal-lab-10-demod-bench-sweep/' | relative_url }})
+zooms back out to the whole demodulator: `gophertrunk siglab sweep` synthesizes
+P25 across an SNR ladder on both demod paths and measures demod quality against
+theory — the regression instrument that ties the series off. The
+[SigLab docs]({{ '/siglab.html' | relative_url }}) document `collect_pdus` and
+`csv-pdus` in full.
+
+## FAQ
+
+**Why surface CRC-failed PDUs at all?**
+Because they're diagnostic. A channel that's producing TSBKs that fail CRC is a
+different (and more recoverable) problem than a silent one, and lining CRC
+failures up with fades or dropouts localizes the fault. A tool that drops
+failures hides exactly the evidence you need.
+
+**What's in a TSBK dissection?**
+Opcode, source/destination, talkgroup, FEC and CRC status, and the raw payload —
+per block, filterable in the console and exportable via `csv-pdus`.
+
+**How do I tell which demod path a capture used?**
+Read the receiver-state series. AFC and M&M mu/sps mean the C4FM path; carrier Hz,
+Gardner mu/sps, and CMA error mean the CQPSK path.
+
+**What does a smeared sync landscape mean?**
+The synchronizer is finding conflicting, weak correlations across sync variants
+and rotations instead of one clear hit — an uncertain sync that's likely to lose
+lock. Concentrated hits in one cell is healthy.
+
+## Series navigation
+
+**Part 9 of 10** · ←[Part 8]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }}) · Next →
+[Part 10: The Demod Bench]({{ '/blog/tutorials/signal-lab-10-demod-bench-sweep/' | relative_url }})

--- a/docs/_posts/2026-07-15-crypto-lab-10-subject-framework-alias.md
+++ b/docs/_posts/2026-07-15-crypto-lab-10-subject-framework-alias.md
@@ -1,0 +1,168 @@
+---
+title: "Crypto Lab, Part 10: The Subject Framework, alias & the Mercury Reveal"
+description: Crypto Lab's pluggable subject framework and its alias tool recover length-seeded, keyless byte obfuscators through four incremental, resumable modes — gauge, structure, cells, and fromseed — and finally reveal that the Mercury signal was never encryption at all, graded BROKEN, with the moral that obfuscation is not encryption.
+category: tutorials
+keywords: subject framework, alias recovery, byte obfuscator, length seeded, talker alias, affine gauge, berlekamp massey, z3 structural search, keyless obfuscation, gophertrunk cryptolab, mercury
+tags: [cryptolab, alias, subject-framework, obfuscation, security-testing, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Crypto Lab"
+series_part: 10
+---
+
+*Part 10 of **Crypto Lab**, a 10-part series on GopherTrunk's optional cryptographic-research toolkit. The finale: a framework for keyless obfuscators, and the answer to the mystery that ran through the whole Lab Bench trilogy.*
+
+> **TL;DR:** Crypto Lab's pluggable **subject framework** studies length-seeded, keyless byte obfuscators (per-char decode `char = int8(Modd·(LUT[eo] − Hodd))`). The `alias` tool recovers one through four incremental, logging, resumable modes over a ground-truth corpus: `gauge` (brute all 32,768 affine gauges), `structure` (enumerate merged-index wirings; writes `high-transitions.csv` for the optional Z3 script), `cells` (intersect per-context state candidates — monotone, resumable via `-resume`), and `fromseed` (simulate from the length seed and auto-solve the gauge). **The Mercury reveal:** it was never strong encryption — it was a keyless, length-seeded byte obfuscator, recovered by `alias` and graded <span class="lab-verdict lab-verdict--bad">BROKEN</span>. Obfuscation is not encryption.
+
+> **Authorized testing only.** The corpus and captures here are your own or licensed research material.
+
+**Key takeaways**
+
+- **The subject framework is pluggable.** Each "subject" is a specific byte obfuscator with its own recovery modes, registered like any tool.
+- **`alias` recovers a keyless obfuscator** — no key exists; the structure *is* the secret, and structure can be reconstructed.
+- **The modes are incremental and resumable.** Coverage only grows as you feed more captures — even ciphertext-only ones.
+- **Mercury was obfuscation, not encryption** — the moral that ties the trilogy together.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `cryptolab alias gauge -csv corpus.csv` | Brute all 32,768 affine gauges |
+| `cryptolab alias structure -csv corpus.csv` | Enumerate merged-index wirings; export transitions |
+| `cryptolab -out ./out alias cells -csv corpus.csv` | Intersect per-context state candidates (writes checkpoint) |
+| `cryptolab -resume ./out/checkpoint.json alias cells -csv more.csv` | Resume and grow coverage |
+| `cryptolab alias fromseed -csv corpus.csv` | Simulate from the length seed, auto-gauge |
+| `-csv corpus.csv` | Ground-truth corpus (`rid,talkgroup,encoded_hex,alias`) |
+
+## In this post
+
+- **What a "subject" is** — the pluggable framework for byte obfuscators.
+- **The four `alias` modes** — gauge, structure, cells, fromseed.
+- **What the data supports** — why the effort is directed, logged, and resumable.
+- **The optional Z3 search** — richer structural forms outside the binary.
+- **The Mercury reveal** — and the moral that closes the trilogy.
+
+## What a "subject" is
+
+Everything up to now attacked *ciphers* — things with keys and keystreams. But a whole class of RF obfuscation has no key at all. Instead, the sender runs the data through a fixed, keyless transform: a lookup table and a per-character state update seeded only by the message length. There's nothing to brute-force because there's nothing secret except the *structure* of the transform itself. Recover the structure and the obfuscation is gone, permanently, for everyone.
+
+The **subject framework** is Crypto Lab's pluggable home for studying these. Each subject is a specific byte-oriented obfuscator, registered like any other tool (the toolkit ships subjects under `internal/cryptolab/subjects/`). The flagship is the Motorola-style talker-alias obfuscator, exposed as the `alias` tool. Its decode model is *established* — the output substitution table and the per-character decode `char = int8(Modd·(LUT[eo] − Hodd))` are known — but the per-character *state update* is not, and recovering it is the research problem the four modes chip at.
+
+Unlike every other tool, `alias` takes a **`-csv` corpus**, not an `-in` payload: rows of `rid,talkgroup,encoded_hex,alias` (a trailing 2-byte CRC on the encoded field is stripped automatically). This is a ground-truth dataset — encoded values paired with their decoded aliases — because recovering a keyless obfuscator is a fitting problem against known input/output pairs.
+
+## The four modes
+
+<figure class="lab-figure">
+<svg viewBox="0 0 640 150" width="640" height="150" role="img" aria-label="Alias recovery pipeline: gauge, structure, cells, fromseed feeding a recovered obfuscator">
+  <g font-size="11.5">
+  <rect x="8" y="20" width="120" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="41" text-anchor="middle" fill="currentColor">gauge</text>
+  <rect x="8" y="62" width="120" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="83" text-anchor="middle" fill="currentColor">structure</text>
+  <rect x="8" y="104" width="120" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="68" y="125" text-anchor="middle" fill="currentColor">cells (resumable)</text>
+  <rect x="160" y="62" width="120" height="34" rx="6" fill="none" stroke="currentColor"/>
+  <text x="220" y="83" text-anchor="middle" fill="currentColor">fromseed</text>
+  <rect x="330" y="55" width="150" height="48" rx="8" fill="none" stroke="var(--accent)"/>
+  <text x="405" y="76" text-anchor="middle" fill="var(--accent)">recovered</text>
+  <text x="405" y="92" text-anchor="middle" fill="var(--accent)">obfuscator</text>
+  <rect x="512" y="55" width="120" height="48" rx="8" fill="none" stroke="currentColor"/>
+  <text x="572" y="76" text-anchor="middle" fill="currentColor">verdict</text>
+  <text x="572" y="92" text-anchor="middle" fill="var(--fg-muted)" font-size="10">BROKEN</text>
+  <g stroke="currentColor" stroke-width="1.2" fill="currentColor">
+  <line x1="128" y1="37" x2="328" y2="70"/><polygon points="330,71 321,68 324,76"/>
+  <line x1="128" y1="79" x2="158" y2="79"/><polygon points="160,79 152,75 152,83"/>
+  <line x1="280" y1="79" x2="328" y2="79"/><polygon points="330,79 322,75 322,83"/>
+  <line x1="128" y1="121" x2="328" y2="90"/><polygon points="330,89 321,90 324,98"/>
+  <line x1="480" y1="79" x2="510" y2="79"/><polygon points="512,79 504,75 504,83"/>
+  </g>
+  </g>
+</svg>
+<figcaption>The four incremental modes attack the state update from different angles; together they reconstruct the keyless obfuscator, which grades BROKEN.</figcaption>
+</figure>
+
+**`gauge`** brute-forces all **32,768 affine gauges** — coordinate frames of the form `Modd·x − Modd·Hodd` — looking for one in which the odd high byte becomes a clean function of a simple merged index:
+
+```bash
+gophertrunk cryptolab alias gauge -csv alias_ground_truth.csv
+```
+
+```text
+alias/gauge — swept 32768 gauges; best conflict floor 6/214 contexts
+  best_mg 173  best_cg 44  clean_gauges 0
+note: no gauge makes the odd high byte a clean function of the XOR merged
+  index — consistent with the hidden internal table; the high byte's true
+  dependency is on the unobserved low byte.
+```
+
+**`structure`** enumerates merged-index table wirings over the dense, plaintext-free high-byte recurrence `H[k+1] = F(H[k-1], H[k], eo[k])` and reports each wiring's conflict floor. With a global `-out` directory it also writes `high-transitions.csv` — the input for the optional Z3 search:
+
+```bash
+gophertrunk cryptolab -out ./out alias structure -csv alias_ground_truth.csv
+```
+
+**`cells`** intersects per-context state candidates across the corpus. It is **monotone and resumable**: coverage only grows as you feed it more captures — even ciphertext-only ones, which still feed the high-byte recurrence. You resume with `-resume` and point it at more data:
+
+```bash
+gophertrunk cryptolab -out ./out alias cells -csv batch1.csv
+gophertrunk cryptolab -resume ./out/checkpoint.json alias cells -csv batch2.csv
+```
+
+```text
+alias/cells — pinned 141/214 contexts; 1876/3204 chars decodable; 12 messages fully decoded
+note: monotone & resumable: re-run with -resume and more captures (even
+  ciphertext-only) and coverage only grows.
+```
+
+**`fromseed`** simulates candidate accumulator updates from the length seed, auto-solves the affine output gauge, and culls families by high-byte mismatch:
+
+```bash
+gophertrunk cryptolab alias fromseed -csv alias_ground_truth.csv
+```
+
+Every mode logs its progress, writes survivor artifacts to the `-out` directory, and ends its report with exactly what additional data would close the remaining gap — the effort is always directed, logged, and resumable, never a blind brute.
+
+## What the data supports
+
+The honest framing matters here, because this is live research, not a solved cipher. The two state bytes form 256×256 = 65,536-cell functions; a passive corpus typically exercises only a few hundred cells of each. But the geometry is favorable in a specific way: the **high byte is readable from ciphertext alone**, so `structure` and `fromseed` keep chipping at it from passive captures with no transmitter. The **multiplier byte** is only touched by labeled rows, so `cells` improves *monotonically* as more labeled data arrives. That's the whole design philosophy of the framework — a passive analyst with a growing capture set makes steady, resumable progress toward full recovery, and the tool tells you which kind of data (more ciphertext vs. more labeled pairs) moves which frontier.
+
+## The optional Z3 search
+
+The in-binary propagator explores single-lookup merged-index wirings. Richer forms — multi-round updates, two internal tables, small Feistel families — live in an **optional** Python/Z3 search under `internal/cryptolab/smt/`, outside the Go build. It consumes only the `high-transitions.csv` that `alias structure` exports:
+
+```bash
+gophertrunk cryptolab -out ./out alias structure -csv ground_truth.csv
+python solve_structure.py --transitions ./out/high-transitions.csv
+```
+
+It's not required to use the toolkit, and it ships no cipher — it's a research aid that explores structural hypotheses as a constraint system. The clean-room findings from this line of work are written up in [`research/p25-talker-alias-cryptanalysis.md`](https://github.com/MattCheramie/GopherTrunk/blob/main/research/p25-talker-alias-cryptanalysis.md), which documents what's been established and — just as usefully — the dead ends already ruled out, so the next investigation starts ahead.
+
+## The Mercury reveal
+
+And so we come back to Mercury. Ada first caught it near 453 MHz in [Signal Lab Part 8]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }}) — an intermittent burst that blind signal-ID named a candidate (~4800 sym/s, 4-level FSK-like) but couldn't lock. [RF Scope Part 7]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }}) flagged it unknown-protocol, triaged its payload as *not obviously strong*, and exported frames. In [Part 5]({{ '/blog/tutorials/crypto-lab-05-keystream-reuse-mtp/' | relative_url }}), `ks reuse` found no keystream collisions — because, Reese suspected, there was no keystream at all.
+
+He was right. Mercury was never encryption. Running the frames through `classify auto` and then the subject framework, `alias` recovered it as a **length-seeded, keyless byte obfuscator** — a talker-alias-style transform with a fixed lookup table and a length-seeded state update, no key anywhere. Ada decoded the aliases end-to-end, and `assess` graded it <span class="lab-verdict lab-verdict--bad">BROKEN</span>. Not because a strong cipher fell, but because there was never a cipher to begin with. The "encryption" that had eluded three tools across three series was obfuscation wearing a costume.
+
+That's the moral, and it's the whole point of Crypto Lab: **obfuscation is not encryption.** A transform with no key protects nothing once its structure is known — and structure, unlike a good key over a rotated IV, can always be recovered. The verdict scale from Part 1 exists precisely to tell these apart: real encryption with a good key and rotated IVs grades <span class="lab-verdict lab-verdict--ok">RESISTANT</span> and stays that way; obfuscation grades <span class="lab-verdict lab-verdict--bad">BROKEN</span> the moment someone reconstructs it. Mercury looked like the former and was the latter. That gap — between looking secure and being secure — is exactly what a security test is for.
+
+## Where this goes next
+
+This closes the Crypto Lab series and the Lab Bench trilogy. If you want to retrace Mercury from the start, [Signal Lab Part 8]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }}) is where it was named and [RF Scope Part 7]({{ '/blog/tutorials/rf-scope-07-entropy-encryption-triage/' | relative_url }}) is where it was triaged and its frames exported. From here, the natural next step is to point the toolkit at your *own* systems: build with `TAGS=cryptolab`, run `assess crypto` against a capture you're authorized to test, and see whether your encryption grades RESISTANT — or reveals a reused IV, a default key, or an obfuscator hiding where a cipher should be. The [cryptolab docs]({{ '/cryptolab.html' | relative_url }}) are the full reference.
+
+## FAQ
+
+**What makes `alias` different from the cipher tools?**
+It recovers a *keyless* obfuscator — there's no key to find, only the structure of the transform. It fits that structure against a ground-truth corpus (`-csv`), and once recovered it decodes every message, for good.
+
+**Why does `alias` take a `-csv` corpus instead of an `-in` file?**
+Because recovering a keyless obfuscator is a fitting problem against known input/output pairs. The corpus is `rid,talkgroup,encoded_hex,alias`; the trailing CRC is stripped automatically.
+
+**Are the `alias` modes a finished attack?**
+They're an active, incremental research framework. Each mode is monotone/resumable and reports what data would close the remaining gap. `cells` in particular only improves as you add captures — including ciphertext-only ones for the high-byte recurrence.
+
+**What was Mercury, in the end?**
+A keyless, length-seeded byte obfuscator (talker-alias style) — not strong encryption at all. `alias` recovered it and `assess` graded it BROKEN. The lesson: obfuscation is not encryption, and a security test is what tells the difference.
+
+## Series navigation
+
+**Part 10 of 10** · ←[Part 9: Web Console, Live Bridge & External Ciphers]({{ '/blog/tutorials/crypto-lab-09-web-console-bridge-external/' | relative_url }}) · Back to the [Crypto Lab series hub]({{ '/blog/series/crypto-lab/' | relative_url }})

--- a/docs/_posts/2026-07-15-rf-scope-10-advanced-tuning-pipelines.md
+++ b/docs/_posts/2026-07-15-rf-scope-10-advanced-tuning-pipelines.md
@@ -1,0 +1,274 @@
+---
+title: "RF Scope, Part 10: Advanced — Tuning Segmentation, Selective Analyzers & Pipelines"
+description: The advanced rfscope guide — run a subset of analyzers with dependencies auto-pulled, tune segmentation for unusual bands, emit machine formats (json/jsonl/yaml/csv) for pipelines, and close the reverse-engineering loop from -frames-out into cryptolab, with a note on how rfscope's downconverter relates to GopherTrunk's DSP paths.
+category: tutorials
+keywords: rfscope, advanced, selective analyzers, dependency resolution, segmentation tuning, output formats, csv, jsonl, pipeline, frames-out, cryptolab, ddc, ccdecoder, gophertrunk
+tags: [rfscope, rf-analysis, advanced, gophertrunk, dsp, cryptolab]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "RF Scope"
+series_part: 10
+---
+
+*Part 10 of **RF Scope**, GopherTrunk's protocol-agnostic RF network analyzer — the
+advanced tour, and the close of the Mercury thread.*
+
+> **TL;DR:** Run a subset with `-analyzers timeline,timing` and the registry
+> topologically pulls in dependencies automatically. Tune segmentation for odd bands
+> with `-fft`, `-peak-threshold-db`, `-min-spacing`, and `-channel-rate`. Emit
+> machine formats with `-out-format json|jsonl|yaml|csv -out scene.json` for
+> pipelines. Close the reverse-engineering loop with `-frames-out` into cryptolab.
+> And note: RF Scope uses the single-tap `ccdecoder` downconverter, **not** the
+> wideband `internal/dsp/tuner` channelizer.
+
+**Key takeaways**
+
+- **Selective analyzers save time** — ask for what you need; the registry pulls
+  dependencies in and orders them.
+- **Segmentation is the tuning surface** for unusual bands — four flags cover most
+  cases.
+- **Machine formats make RF Scope a pipeline stage** — `jsonl` streams records, `csv`
+  is the burst table.
+- **`-frames-out` is the RE loop** — detection to byte-analysis without leaving
+  GopherTrunk.
+
+## Cheat sheet
+
+| Flag | What it does |
+|---|---|
+| `-analyzers timeline,timing` | Run a subset; dependencies auto-pulled |
+| `-fft 8192` | Larger wideband FFT — finer carrier resolution |
+| `-peak-threshold-db 6` | Lower bar — catch weaker carriers |
+| `-min-spacing 6250` | Tighter channel raster |
+| `-channel-rate 100000` | Wider per-channel baseband for wide signals |
+| `-out-format jsonl -out scene.jsonl` | Stream one record per entity |
+| `-out-format csv` | The burst table |
+| `-frames-out frames.jsonl` | Emit the cryptolab `ks` frames file |
+
+## In this post
+
+- **Selective analyzers** and the dependency-resolving registry.
+- **Segmentation tuning** for bands the defaults miss.
+- **Machine output formats**, including the CSV burst columns.
+- **The reverse-engineering loop** into Crypto Lab.
+- **Sidebar:** which downconverter RF Scope uses, and why it matters.
+- **Series wrap** and the Mercury reveal.
+
+## Selective analyzers and the registry
+
+You do not have to run everything. `-analyzers` takes a comma-separated list, and the
+registry does the rest:
+
+```bash
+gophertrunk rfscope analyze -in wide.cfile -sample-rate 2400000 \
+    -analyzers timeline,timing -out-format json -out scene.json
+```
+
+Ask for `timing` and you also get `timeline`, because `timing` declares it as a
+dependency and `Run` pulls the transitive closure in, then **topologically sorts** so
+every analyzer runs after the ones it depends on:
+
+```go
+// internal/rfscope/analyzer.go
+type Analyzer interface {
+    Name() string
+    Synopsis() string
+    DependsOn() []string
+    Analyze(ctx context.Context, sc *Scene, in *Input) error
+}
+```
+
+`rfscope list` prints the graph, with each analyzer's dependencies:
+
+```text
+Registered rfscope analyzers:
+  entropy      bitstream entropy / encryption triage (cryptolab bridge)  (after: topology)
+  expert       RF expert-info / anomaly flags  (after: topology, timeline, entropy)
+  hierarchy    RF protocol hierarchy (class → bandwidth → protocol)
+  timeline     per-channel activity timeline / I/O graph
+  timing       burst timing, inter-arrival, and TDMA-period stats  (after: timeline)
+  topology     emitter clustering + conversation graph
+```
+
+The design is worth appreciating: analyzers **register themselves from `init()`**, so
+adding one is a new file plus a blank import — no central switch to edit. `DependsOn`
+is the only coupling, and `Run` resolves it with a cycle-detecting topological sort.
+Ask for just `expert` and you transparently get `topology`, `timeline`, and `entropy`
+underneath it, in the right order. Skipping the analyzers you do not need is the
+cheapest speed-up on a big capture: `-analyzers hierarchy` alone skips all the
+per-emitter demodulation entropy and topology do.
+
+## Tuning segmentation for weird bands
+
+When the defaults miss something, the fix is almost always in segmentation (Part 2),
+not the analyzers. Four flags cover the common cases:
+
+- **`-fft`** (default 4096, power of two). Raise to 8192 or 16384 for **finer carrier
+  resolution** — closely-spaced channels the default blurs together become distinct.
+  Lower it for more averaging and a smoother floor on a noisy band. Non-powers-of-two
+  are rejected back to 4096.
+- **`-peak-threshold-db`** (default 10). Lower to **6–8** to catch weak carriers near
+  the noise floor; raise it to reject marginal humps on a band full of leakage.
+- **`-min-spacing`** (default 12500). Set it to your band's channel raster — **6250**
+  for 6.25 kHz channels, **25000** for a wide 25 kHz plan — so adjacent channels are
+  neither merged nor split.
+- **`-channel-rate`** (default 50000). Raise to **100000+** if you are chasing a signal
+  wider than the default baseband can hold; the decimated channel must be wide enough
+  to contain the whole occupied bandwidth.
+
+A worked example — a dense 6.25 kHz NXDN-style band with weak carriers:
+
+```bash
+gophertrunk rfscope analyze -in dense.cfile -sample-rate 2400000 -freq 154000000 \
+    -fft 16384 -peak-threshold-db 7 -min-spacing 6250
+```
+
+Reese's advice: *"change one knob at a time and re-read the channel table. If carriers
+are merging, it is spacing or FFT size; if they are missing, it is the threshold; if
+they are clipped, it is the channel rate."*
+
+## Why the registry design matters
+
+The self-registering, dependency-resolving registry is not just tidy — it is what keeps
+RF Scope extensible without a rewrite. Because every analyzer is discovered at `init()`
+and coupled to the others only through `DependsOn`, the pipeline has no central list of
+"what to run in what order." Add an analyzer that depends on `entropy` and `timing`, and
+`Run` will slot it after both automatically, everywhere: in `analyze`, in `live`, in the
+cockpit, and in the web console, with no edit to any of them. The topological sort even
+detects a dependency **cycle** and errors rather than looping, so a mistaken
+`DependsOn` fails loudly at run time instead of hanging.
+
+For an operator, the practical upshot is that `-analyzers` is safe to use aggressively.
+You never have to know an analyzer's dependencies — ask for the *view* you want and the
+machinery supplies the rest in the right order. Want only the anomaly list? `-analyzers
+expert` transparently runs topology, timeline, and entropy first, because expert cannot
+be computed without them. Want a fast structural summary of a huge capture? `-analyzers
+hierarchy,timeline` skips the per-emitter demodulation that topology and entropy do,
+which is where most of the analysis time goes. The dependency graph, printed by `rfscope
+list`, is your map of what each request will actually cost.
+
+## Machine output formats for pipelines
+
+`summary` is for humans; the other four are for machines. Choose with `-out-format` and
+write to a file with `-out`:
+
+- **`json`** — the whole Scene as one indented object. Feed it to `jq`, a notebook, or
+  a dashboard.
+- **`jsonl`** — one JSON record per line: a `scene` header, then one record per
+  `burst`, `channel`, `emitter`, `conversation`, and `anomaly`, each tagged with its
+  `kind`. Stream-friendly and grep-friendly — pull just the anomalies with
+  `jq 'select(.kind=="anomaly")'`.
+- **`yaml`** — the same Scene as a single YAML document, for config-style consumption.
+- **`csv`** — the **burst table**, one row per burst, with these columns:
+
+```text
+id, freq_hz, start_sec, end_sec, duration_sec, class,
+occupied_bw_hz, channel_power_dbfs, spectral_flatness, snr_db, emitter_id
+```
+
+The CSV drops straight into a spreadsheet or pandas for slicing — group by `class`,
+scatter `spectral_flatness` against `occupied_bw_hz`, filter by `emitter_id`. Every
+float is clamped to a finite value before encoding, so the output is always valid — no
+stray `NaN` or `Inf` reaches the file (or the web console's live wire).
+
+```bash
+# Every burst as CSV, for a notebook
+gophertrunk rfscope analyze -in wide.cfile -sample-rate 2400000 -out-format csv -out bursts.csv
+
+# Just the anomalies, via jsonl + jq
+gophertrunk rfscope analyze -in wide.cfile -sample-rate 2400000 -out-format jsonl \
+  | jq -c 'select(.kind=="anomaly")'
+```
+
+## The reverse-engineering loop
+
+The most powerful pipeline RF Scope enables is the **detection → byte-analysis** loop,
+closed without leaving GopherTrunk:
+
+```bash
+# 1. Segment, analyze, and emit frames for every unknown payload
+gophertrunk rfscope analyze -in wide.cfile -sample-rate 2400000 -frames-out frames.jsonl
+
+# 2. Triage the bytes in the cryptolab toolkit
+gophertrunk cryptolab classify auto -in frames.jsonl        # needs -tags cryptolab
+gophertrunk cryptolab ks reuse -in frames.jsonl             # if IVs/MIs repeat
+```
+
+`-frames-out` writes the `{label, iv, ct}` JSONL that cryptolab parses directly (Part
+7), and RF Scope even prints a `cryptolab ks reuse` suggestion when it detects frames
+sharing an IV. Detection lives in RF Scope; the byte-level attack lives in Crypto Lab;
+the frames file is the seam between them.
+
+<aside class="lab-note">
+<p><strong>Sidebar — which downconverter?</strong> RF Scope's segmentation shifts each
+carrier to baseband with the single-tap <code>ccdecoder</code> downconverter
+(<code>ccdecoder.NewDownconverterWithOffset</code>) — the same single-channel path
+<code>replay -tune-hz</code> uses — <em>not</em> the wideband multi-tap
+<code>DDCBank</code>/channelizer in <code>internal/dsp/tuner</code>. The two are
+separate code paths: a fix to one does not touch the other. RF Scope processes one
+discovered carrier at a time, so a per-carrier single-tap DDC is the right tool; the
+wideband channelizer exists for the live scanner that must hold dozens of taps open at
+once. Both normalize to a per-channel rate, which is why RF Scope's analysis is
+rate-invariant — the capture rate never leaks into a measurement.</p>
+</aside>
+
+## Series wrap: the Mercury reveal
+
+Ten parts ago, Mercury was a vague unease — a short, intermittent burst near 453 MHz
+that [Signal Lab]({{ '/blog/tutorials/signal-lab-08-naming-the-unknown/' | relative_url }})
+could not name. Trace what RF Scope did with it:
+
+- **Part 2** sliced its faint transmissions into bursts.
+- **Part 3** put it in the hierarchy as an FSK 12.5 kHz bucket with **no protocol
+  child** — a genuine unknown.
+- **Part 6** collapsed its scattered bursts into **one frequency hopper**, explaining
+  why no single channel showed a clean period.
+- **Part 7** blind-demodulated its payload, graded it **not-obviously-strong**
+  obfuscation, and wrote its bytes to a frames file.
+- **Part 8** stacked the flags — hopper, intermittent, obfuscated — into the expert
+  panel.
+
+RF Scope's job ends at the frames file. The
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) series picks Mercury up
+from there, and the twist lands in
+[Crypto Lab Part 10]({{ '/blog/tutorials/crypto-lab-10-subject-framework-alias/' | relative_url }}):
+Mercury was **not strong encryption at all**, but a **keyless, length-seeded byte
+obfuscator** — talker-alias style — recovered by the `alias` subject framework and
+graded BROKEN. RF Scope was right to grade it *not-obviously-strong*: the structure was
+there to be found, and the entropy triage said as much. *Obfuscation is not
+encryption*, and RF Scope's entire reason to exist is to help you tell the difference
+before you assume the worst.
+
+That is the trilogy. [Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}) names
+and measures one signal; **RF Scope** maps the band and triages the unknowns;
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) breaks what comes out.
+The full [rfscope reference]({{ '/rfscope.html' | relative_url }}) has every flag; this
+series was the tour.
+
+## FAQ
+
+**If I run one analyzer, do I get its dependencies automatically?**
+Yes. The registry expands the transitive `DependsOn` closure and topologically sorts
+it, so `-analyzers timing` also runs `timeline`, and `-analyzers expert` runs topology,
+timeline, and entropy underneath — in the correct order.
+
+**Which output format should I script against?**
+`jsonl` for streaming and filtering (one tagged record per entity), `csv` for the burst
+table in a spreadsheet or notebook, `json`/`yaml` for the whole Scene as one document.
+All are clamped to finite floats, so they always parse.
+
+**Why does RF Scope not use the wideband channelizer?**
+It analyzes one discovered carrier at a time, so the single-tap `ccdecoder`
+downconverter is the right fit. The wideband `internal/dsp/tuner` channelizer serves the
+live scanner holding many taps open at once — a separate path.
+
+**How do I actually break a signal RF Scope flags?**
+Emit it with `-frames-out`, then follow the recommended cryptolab command from the
+entropy verdict — `brute xor`, `lfsr bm`, `ks reuse`, and so on. RF Scope detects and
+hands off; Crypto Lab breaks.
+
+## Series navigation
+
+**Part 10 of 10** · ←
+[Part 9: The Scene Cockpit]({{ '/blog/tutorials/rf-scope-09-scene-cockpit-tui-web/' | relative_url }})
+· Back to the [RF Scope series hub]({{ '/blog/series/rf-scope/' | relative_url }})

--- a/docs/_posts/2026-07-15-signal-lab-10-demod-bench-sweep.md
+++ b/docs/_posts/2026-07-15-signal-lab-10-demod-bench-sweep.md
@@ -1,0 +1,240 @@
+---
+title: "Signal Lab, Part 10: The Demod Bench — siglab sweep, Regression & Export"
+description: Signal Lab's demod benchmark, gophertrunk siglab sweep, synthesizes P25 Phase 1 across an SNR ladder on both the c4fm and cqpsk/lsm demod paths, decodes through the production pipeline, and prints measured demod quality against a theoretical symbol-error-rate reference with CSV export.
+category: tutorials
+keywords: siglab sweep, demod benchmark, snr ladder, symbol error rate, es/n0, evm vs snr, demod regression, c4fm cqpsk lsm, csv export, p25 phase 1, demod calibration
+tags: [siglab, demodulation, benchmark, regression, p25, advanced]
+author: Matt Cheramie
+image: /assets/gophertrunk-logo.png
+series: "Signal Lab"
+series_part: 10
+charts: true
+---
+
+*Part 10 of **Signal Lab**, a 10-part series on GopherTrunk's offline
+signal-analysis workbench. We close where the workbench earns its keep — a
+repeatable demod benchmark that answers "did my change help?" with a curve.*
+
+> **TL;DR:** `gophertrunk siglab sweep` synthesizes P25 Phase 1 across an SNR
+> ladder on **both** demod paths (`c4fm` and `cqpsk`/`lsm`), decodes each rung
+> through the production pipeline, and prints measured demod quality — lock, EVM,
+> estimated SNR — against a **theoretical symbol-error-rate reference**. Flags
+> set the ladder (`-snr-min`, `-snr-max`, `-snr-step`), the AWGN `-seed`, and an
+> optional `-csv` export. It's the regression instrument that turns a demod tweak
+> from a hunch into evidence.
+
+**Key takeaways**
+
+- **The sweep is a curve, not a single test.** It measures across an SNR ladder,
+  so you see *where* a demod holds and where it falls apart.
+- **Both paths, every run.** `c4fm` and `cqpsk`/`lsm` are swept together against
+  their own theoretical references.
+- **Measured vs theory is the read.** Tracking theory down to low SNR is good;
+  an early divergence is a demod deficiency.
+- **Reproducible by seed.** A fixed `-seed` makes the ladder a valid regression
+  fixture.
+- **`-csv` exports** the whole sweep for diffing across code changes.
+
+## Cheat sheet
+
+| Command / flag | What it does |
+|---|---|
+| `gophertrunk siglab sweep` | Sweep both paths, 2–30 dB |
+| `-snr-min <dB>` | Minimum injected SNR (default `2`) |
+| `-snr-max <dB>` | Maximum injected SNR (default `30`) |
+| `-snr-step <dB>` | SNR step (default `2`) |
+| `-seed <n>` | AWGN seed (default `0x5175`) |
+| `-csv <path>` | Also write the sweep as CSV |
+
+## In this post
+
+- **What the sweep measures** — quality across an SNR ladder.
+- **Reading the curve** — measured against theory.
+- **Both demod paths** — c4fm and cqpsk/lsm side by side.
+- **The CSV** — columns and regression workflow.
+- **Series wrap** — where the Lab Bench trilogy goes from here.
+
+## What the sweep measures
+
+Every earlier part measured *one* capture. The **demod benchmark** measures the
+*demodulator itself* — how well it performs as conditions get worse. It
+synthesizes P25 Phase 1 at a ladder of injected SNRs, decodes each rung through
+the exact production pipeline, and records the measured quality at each level.
+The result is a curve, and a curve says something a single pass can't: not just
+"does it lock?" but "*down to what SNR* does it lock, and how gracefully does it
+degrade on the way down?"
+
+```bash
+gophertrunk siglab sweep                                            # both paths, 2–30 dB
+gophertrunk siglab sweep -snr-min 6 -snr-max 20 -snr-step 1 -csv sweep.csv
+```
+
+The default ladder runs 2 dB to 30 dB in 2 dB steps. Because it's built on the
+synthesis engine from Part 6, the whole thing is deterministic for a given
+`-seed` — the same noise realization every run, which is precisely what a
+regression fixture requires. The sweep is the human-readable, on-demand companion
+to a hard-gated regression test that lives in CI: same instrument, run whenever
+you want an answer.
+
+## Reading the curve: measured vs theory
+
+The sweep's output is a table per path, and the important column is the
+comparison to a **theoretical symbol-error-rate reference**. Theory says, for a
+given Es/N0, what the best-achievable symbol-error behavior is; the sweep plots
+your *actual* demod against that ideal. Here's a representative run:
+
+```text
+c4fm (vs theoretical reference):
+  SNR dB   Es/N0    lock    EVM %    SNR~ dB
+  2.0      -1.8     no      34.0     3.1
+  6.0       2.2     yes     22.0     6.8
+  10.0      6.2     yes     12.0     10.4
+  14.0     10.2     yes      6.0     14.1
+  18.0     14.2     yes      3.0     18.0
+```
+
+<figure class="lab-figure">
+<canvas class="lab-chart" data-chart="line" width="560" height="320" role="img"
+        aria-label="Measured demod EVM versus injected SNR against the theoretical curve"></canvas>
+<script type="application/json" class="lab-chart-data">
+{ "series":[
+{"label":"measured","dots":true,"points":[[2,34],[6,22],[10,12],[14,6],[18,3],[22,2.1],[26,1.6],[30,1.3]]},
+{"label":"theory","dashed":true,"points":[[2,30],[6,19],[10,10],[14,5],[18,2.5],[22,1.8],[26,1.4],[30,1.2]]}],
+"xlabel":"injected SNR (dB)","ylabel":"EVM (%)","xmin":2,"xmax":30,"ymin":0,"ymax":40 }
+</script>
+<figcaption>Measured demod EVM (solid, dotted markers) tracks the theoretical curve (dashed) closely down to ~6 dB, then diverges as the demod runs out of margin — the divergence point is the number you're really benchmarking.</figcaption>
+</figure>
+
+The read is the *gap* between measured and theory. A demod that hugs the
+theoretical curve down to low SNR and only diverges near the noise floor is
+performing well; a demod that peels away early — losing lock or ballooning EVM
+several dB above where theory says it should still be fine — has a deficiency
+worth chasing. The **divergence point** is the single most useful number the
+sweep produces: it's the honest floor of your demodulator.
+
+## Both demod paths
+
+The sweep runs **both** P25 Phase 1 demod paths in one go, each against its own
+theoretical reference, because they're different algorithms with different
+error curves:
+
+```go
+// cmd/gophertrunk/siglab_sweep.go
+modes := []struct{ ... }{
+    {"c4fm", "c4fm", "", metrics.SER4PAM, 2},
+    {"cqpsk", "lsm", "cqpsk", metrics.SERCoherentQPSK, 2},
+}
+```
+
+The **c4fm** path (the four-rail FM family) is checked against a 4-PAM
+symbol-error reference; the **cqpsk** path (synthesized as `lsm`, the
+linear-simulcast-friendly modulation) is checked against a coherent-QPSK
+reference. Sweeping them together is what lets you answer a real design question —
+"is my change an improvement on *both* paths, or did I help one and hurt the
+other?" A tweak that lowers the c4fm divergence point but raises cqpsk's isn't a
+clean win, and only a two-path sweep exposes that trade.
+
+## The CSV and the regression workflow
+
+Pass `-csv` and the sweep also writes a machine-readable table with a fixed
+column set:
+
+```text
+mode,snr_db,es_n0_db,locked,evm_pct,snr_est_db
+c4fm,2.0,-1.8,false,34.00,3.10
+c4fm,6.0,2.2,true,22.00,6.80
+cqpsk,6.0,2.2,true,24.50,6.40
+```
+
+Those six columns — `mode`, `snr_db`, `es_n0_db`, `locked`, `evm_pct`,
+`snr_est_db` — are the whole regression story. The workflow Reese runs on every
+demod change: sweep with a fixed seed *before* the change and save the CSV, make
+the change, sweep again with the *same* seed, and diff the two CSVs. Same
+synthesized input, same noise draw, so any difference in `locked`, `evm_pct`, or
+`snr_est_db` is attributable to the change alone. Load both into the **Compare**
+tab (Part 3) to overlay them, and export the merged result as JSON / JSONL / YAML
+/ CSV for the record. That's how a demod change earns its way into the tree — a
+curve that moved the right way on both paths, reproducibly.
+
+## SNR, Es/N0, and the lock threshold
+
+Two of the sweep's columns deserve a word, because conflating them is a common
+mistake. `snr_db` is the SNR the sweep *injected* — the knob you turned.
+`es_n0_db` is the energy-per-symbol to noise-density ratio the theoretical
+reference is expressed in, derived from the injected SNR and the samples-per-symbol
+(P25 Phase 1 runs 48 kHz / 4800 = 10 samples per symbol). They move together but
+they aren't the same number, and the theoretical symbol-error curve lives in
+Es/N0 space, which is why the sweep computes and prints both — so measured and
+theory are compared on the same footing rather than across a hidden conversion.
+
+The number most operators actually care about, though, is the **lock threshold** —
+the lowest SNR rung where `locked` flips from `no` to `yes`. That threshold is a
+compact, honest figure of merit for the demodulator: a lower threshold means the
+demod holds on to weaker signals, which is exactly the improvement most demod work
+is chasing. Watch it alongside the EVM curve, because the two tell a fuller story
+together. A change that lowers the lock threshold by 2 dB but *worsens* EVM at the
+top of the ladder has traded steady-state cleanliness for weak-signal
+sensitivity — sometimes a good trade, sometimes not, but never one you'd notice
+from a single capture. The sweep makes the trade visible, which is the entire
+reason it exists: real demod decisions are about the shape of the whole curve, not
+one point on it.
+
+One caution Reese repeats: the sweep is synthesized AWGN, the cleanest possible
+adversary. A demod that looks great on the ladder can still struggle on a real
+capture full of multipath, phase noise, and interference the sweep never
+injected. Treat a good sweep as *necessary but not sufficient* — it proves the
+demod is sound against the textbook channel, and then you confirm against real
+recordings and the stacked-impairment fixtures from Part 6. The ladder is the
+controlled experiment; the field is the exam.
+
+## Series wrap: the Lab Bench trilogy from here
+
+That closes **Signal Lab**. Across ten parts you went from a first no-radio
+replay to reading the dashboard, driving the browser console, seeing modulation
+quality in constellations and eyes, measuring spectrum and occupancy,
+synthesizing references, taking VSA measurements, naming the unknown, dissecting
+P25 to the signaling block, and benchmarking the demodulator itself. The unifying
+idea never changed: it's the *same production pipeline* the daemon runs, fed from
+a file — so everything you measured here is what you'd get on the air.
+
+But the story isn't over, because **Mercury** isn't decoded. Signal Lab named it
+a candidate — ~4800 sym/s, 4-level-FSK-like — and handed the wideband capture on.
+The next instrument in the trilogy is
+[RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}), which treats the
+airwaves like a protocol analyzer: it segments IQ into bursts, builds a protocol
+hierarchy, graphs channel activity, and triages payload entropy — flagging
+Mercury as an unknown, intermittent emitter and emitting its frames for the last
+stage. Those frames land in
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}), where the trilogy
+resolves: Mercury turns out not to be strong encryption at all, and "obfuscation
+is not encryption" gets the last word. If Signal Lab taught you to *measure* a
+signal, RF Scope teaches you to *map* it and Crypto Lab teaches you to *break* it.
+
+## FAQ
+
+**What does the sweep actually vary?**
+Injected SNR, across a ladder from `-snr-min` to `-snr-max` in `-snr-step`
+increments (default 2–30 dB by 2). At each rung it synthesizes P25 Phase 1,
+decodes it, and records lock, EVM, and estimated SNR against a theoretical
+symbol-error reference.
+
+**Why sweep both c4fm and cqpsk?**
+They're separate demod algorithms with separate error curves. Sweeping both
+against their own references shows whether a change helps universally or trades
+one path against the other.
+
+**How do I use it as a regression test?**
+Fix the `-seed`, sweep and save the CSV before your change, sweep again after with
+the same seed, and diff. Identical input and noise draw mean any difference is
+your change. The default seed is `0x5175`.
+
+**Where do I go after Signal Lab?**
+To [RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}) to map signals into a
+protocol hierarchy, and to
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) to analyze their
+payloads — the other two legs of the Lab Bench trilogy, where the Mercury thread
+finally resolves.
+
+## Series navigation
+
+**Part 10 of 10** · ←[Part 9]({{ '/blog/tutorials/signal-lab-09-dissecting-p25-pdus/' | relative_url }}) · Back to the [Signal Lab series hub]({{ '/blog/series/signal-lab/' | relative_url }})

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1680,3 +1680,70 @@ a.category-chip:hover {
   .join-cta__actions { width: 100%; }
   .join-cta__actions .btn { flex: 1 1 auto; justify-content: center; }
 }
+
+/* ---------- Lab Bench blog series: figures, charts & persona callouts ---------- */
+/* Used by the Signal Lab / RF Scope / Crypto Lab tutorial series. Charts are
+   rendered by assets/js/labcharts.js into <canvas class="lab-chart">. */
+.lab-figure {
+  margin: 1.6rem 0;
+  padding: 0.9rem 0.9rem 0.6rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  text-align: center;
+}
+.lab-figure svg,
+.lab-figure canvas.lab-chart {
+  max-width: 100%;
+  height: auto;
+}
+.lab-figure figcaption {
+  margin-top: 0.6rem;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+  text-align: center;
+  line-height: 1.5;
+}
+.lab-figure__scroll { overflow-x: auto; }
+
+/* Recurring-cast callout (Ada the new operator, Reese the RF veteran). */
+.lab-cast {
+  display: flex;
+  gap: 0.8rem;
+  align-items: flex-start;
+  margin: 1.4rem 0;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: var(--accent-soft);
+}
+.lab-cast__badge {
+  flex: 0 0 auto;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--accent-fg);
+  background: var(--accent);
+}
+.lab-cast__body { flex: 1 1 auto; }
+.lab-cast__body p { margin: 0.2rem 0; }
+.lab-cast__who { font-weight: 600; }
+
+/* Verdict chips (Crypto Lab: RESISTANT / PARTIAL / BROKEN, and pass/fail). */
+.lab-verdict {
+  display: inline-block;
+  padding: 0.05rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  font-family: var(--font-mono);
+}
+.lab-verdict--ok    { color: #fff; background: #2f9e44; }
+.lab-verdict--warn  { color: #1a202c; background: #f0b429; }
+.lab-verdict--bad   { color: #fff; background: #c92a2a; }

--- a/docs/assets/js/labcharts.js
+++ b/docs/assets/js/labcharts.js
@@ -1,0 +1,324 @@
+/*
+ * labcharts.js — self-contained canvas charts for the Lab Bench blog series
+ * (Signal Lab, RF Scope, Crypto Lab). No CDN, no dependencies, no build step —
+ * the same bespoke, vendored style as site.js / learn.js / autolink.js.
+ *
+ * Usage in a post (kramdown passes raw HTML through when it starts at column 0):
+ *
+ *   <figure class="lab-figure">
+ *     <canvas class="lab-chart" data-chart="constellation" width="480" height="360"
+ *             role="img" aria-label="C4FM constellation, four rails"></canvas>
+ *     <script type="application/json" class="lab-chart-data">
+ *       { "points": [[1,0.02],[0.98,-0.3], ...], "rails": [-3,-1,1,3] }
+ *     </script>
+ *     <figcaption>A clean C4FM constellation: four tight vertical rails.</figcaption>
+ *   </figure>
+ *
+ * Each <canvas class="lab-chart"> is paired with the JSON in its *next sibling*
+ * <script class="lab-chart-data">. data-chart selects the renderer. The module
+ * no-ops on any page with no .lab-chart elements, is high-DPI aware, and redraws
+ * when the color theme (:root.dark) is toggled or the canvas is resized.
+ *
+ * Chart types: constellation | eye | heatmap | line | bars | timeline
+ */
+(function () {
+  "use strict";
+
+  function cssVar(name, fallback) {
+    var v = getComputedStyle(document.documentElement).getPropertyValue(name);
+    return (v && v.trim()) || fallback;
+  }
+
+  // Theme-derived palette, re-read on every draw so dark-mode toggles are live.
+  function palette() {
+    return {
+      fg: cssVar("--fg", "#1a202c"),
+      muted: cssVar("--fg-muted", "#5b6470"),
+      border: cssVar("--border", "#e2e8f0"),
+      accent: cssVar("--accent", "#155799"),
+      bg: cssVar("--bg", "#ffffff"),
+      elev: cssVar("--bg-elev", "#f6f8fa"),
+      // A small categorical ramp for multi-series charts (color-blind safe-ish).
+      series: ["#155799", "#2f9e44", "#e8590c", "#9c36b5", "#0c8599", "#c92a2a"],
+      good: "#2f9e44",
+      warn: "#e8590c",
+      bad: "#c92a2a"
+    };
+  }
+
+  function setupHiDPI(canvas) {
+    var ctx = canvas.getContext("2d");
+    var ratio = window.devicePixelRatio || 1;
+    // The author-declared width/height attributes are the CSS logical size.
+    var cssW = canvas.getAttribute("width") ? parseInt(canvas.getAttribute("width"), 10) : canvas.clientWidth;
+    var cssH = canvas.getAttribute("height") ? parseInt(canvas.getAttribute("height"), 10) : canvas.clientHeight;
+    canvas.style.width = cssW + "px";
+    canvas.style.height = cssH + "px";
+    canvas.width = Math.round(cssW * ratio);
+    canvas.height = Math.round(cssH * ratio);
+    ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+    return { ctx: ctx, w: cssW, h: cssH };
+  }
+
+  // ---- shared axis helper ------------------------------------------------
+  function axes(ctx, box, p, opts) {
+    opts = opts || {};
+    ctx.strokeStyle = p.border;
+    ctx.fillStyle = p.muted;
+    ctx.lineWidth = 1;
+    ctx.font = '11px ' + cssVar("--font-sans", "sans-serif");
+    // frame
+    ctx.strokeRect(box.x, box.y, box.w, box.h);
+    if (opts.xlabel) {
+      ctx.textAlign = "center";
+      ctx.fillText(opts.xlabel, box.x + box.w / 2, box.y + box.h + 26);
+    }
+    if (opts.ylabel) {
+      ctx.save();
+      ctx.translate(box.x - 34, box.y + box.h / 2);
+      ctx.rotate(-Math.PI / 2);
+      ctx.textAlign = "center";
+      ctx.fillText(opts.ylabel, 0, 0);
+      ctx.restore();
+    }
+  }
+
+  function plotBox(w, h) {
+    return { x: 46, y: 14, w: w - 62, h: h - 44 };
+  }
+
+  // ---- renderers ---------------------------------------------------------
+  var renderers = {
+    constellation: function (ctx, w, h, d, p) {
+      var box = { x: 20, y: 14, w: w - 40, h: h - 40 };
+      // scale so ±rails fit with margin
+      var lim = 1.6;
+      if (d.rails && d.rails.length) lim = Math.max.apply(null, d.rails.map(Math.abs)) * 1.35;
+      function X(v) { return box.x + (v / lim / 2 + 0.5) * box.w; }
+      function Y(v) { return box.y + (0.5 - v / lim / 2) * box.h; }
+      // crosshair axes
+      ctx.strokeStyle = p.border;
+      ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(box.x, Y(0)); ctx.lineTo(box.x + box.w, Y(0)); ctx.stroke();
+      ctx.beginPath(); ctx.moveTo(X(0), box.y); ctx.lineTo(X(0), box.y + box.h); ctx.stroke();
+      // rail guides (vertical, for C4FM 4-level style)
+      if (d.rails) {
+        ctx.strokeStyle = p.accent;
+        ctx.globalAlpha = 0.18;
+        d.rails.forEach(function (r) {
+          ctx.beginPath(); ctx.moveTo(X(r), box.y); ctx.lineTo(X(r), box.y + box.h); ctx.stroke();
+        });
+        ctx.globalAlpha = 1;
+      }
+      // points
+      ctx.fillStyle = d.color || p.accent;
+      (d.points || []).forEach(function (pt) {
+        ctx.beginPath();
+        ctx.arc(X(pt[0]), Y(pt[1]), d.dot || 2.2, 0, Math.PI * 2);
+        ctx.fill();
+      });
+    },
+
+    eye: function (ctx, w, h, d, p) {
+      var box = plotBox(w, h);
+      axes(ctx, box, p, { xlabel: d.xlabel || "symbol time (2 UI)", ylabel: d.ylabel || "amplitude" });
+      var traces = d.traces || [];
+      var span = d.span || 2;
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = d.color || p.accent;
+      ctx.globalAlpha = d.alpha || 0.5;
+      traces.forEach(function (tr) {
+        ctx.beginPath();
+        tr.forEach(function (v, i) {
+          var x = box.x + (i / (tr.length - 1)) * box.w;
+          var y = box.y + (0.5 - v / 2) * box.h;
+          if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+        });
+        ctx.stroke();
+      });
+      ctx.globalAlpha = 1;
+    },
+
+    heatmap: function (ctx, w, h, d, p) {
+      var box = plotBox(w, h);
+      var rows = d.matrix || [];
+      if (!rows.length) return;
+      var cols = rows[0].length;
+      var cw = box.w / cols, ch = box.h / rows.length;
+      var lo = d.min, hi = d.max;
+      if (lo === undefined || hi === undefined) {
+        lo = Infinity; hi = -Infinity;
+        rows.forEach(function (r) { r.forEach(function (v) { if (v < lo) lo = v; if (v > hi) hi = v; }); });
+      }
+      function ramp(t) {
+        // viridis-ish dark→teal→yellow, readable in both themes
+        t = Math.max(0, Math.min(1, t));
+        var stops = [[13, 8, 74], [33, 106, 130], [53, 183, 121], [253, 231, 37]];
+        var s = t * (stops.length - 1), i = Math.floor(s), f = s - i;
+        var a = stops[i], b = stops[Math.min(i + 1, stops.length - 1)];
+        return "rgb(" + Math.round(a[0] + (b[0] - a[0]) * f) + "," +
+          Math.round(a[1] + (b[1] - a[1]) * f) + "," +
+          Math.round(a[2] + (b[2] - a[2]) * f) + ")";
+      }
+      rows.forEach(function (r, ri) {
+        r.forEach(function (v, ci) {
+          ctx.fillStyle = ramp((v - lo) / (hi - lo || 1));
+          ctx.fillRect(box.x + ci * cw, box.y + ri * ch, cw + 0.5, ch + 0.5);
+        });
+      });
+      axes(ctx, box, p, { xlabel: d.xlabel || "frequency bin", ylabel: d.ylabel || "time →" });
+    },
+
+    line: function (ctx, w, h, d, p) {
+      var box = plotBox(w, h);
+      var series = d.series || [];
+      var allX = [], allY = [];
+      series.forEach(function (s) { s.points.forEach(function (pt) { allX.push(pt[0]); allY.push(pt[1]); }); });
+      var xmin = d.xmin !== undefined ? d.xmin : Math.min.apply(null, allX);
+      var xmax = d.xmax !== undefined ? d.xmax : Math.max.apply(null, allX);
+      var ymin = d.ymin !== undefined ? d.ymin : Math.min.apply(null, allY);
+      var ymax = d.ymax !== undefined ? d.ymax : Math.max.apply(null, allY);
+      function X(v) { return box.x + ((v - xmin) / (xmax - xmin || 1)) * box.w; }
+      function Y(v) { return box.y + (1 - (v - ymin) / (ymax - ymin || 1)) * box.h; }
+      // gridlines + y ticks
+      ctx.strokeStyle = p.border; ctx.fillStyle = p.muted; ctx.lineWidth = 1;
+      ctx.font = '10px ' + cssVar("--font-sans", "sans-serif");
+      ctx.textAlign = "right"; ctx.textBaseline = "middle";
+      for (var g = 0; g <= 4; g++) {
+        var yy = box.y + (g / 4) * box.h;
+        ctx.globalAlpha = 0.5;
+        ctx.beginPath(); ctx.moveTo(box.x, yy); ctx.lineTo(box.x + box.w, yy); ctx.stroke();
+        ctx.globalAlpha = 1;
+        var val = ymax - (g / 4) * (ymax - ymin);
+        ctx.fillText(val.toFixed(d.yprec !== undefined ? d.yprec : 0), box.x - 6, yy);
+      }
+      axes(ctx, box, p, { xlabel: d.xlabel, ylabel: d.ylabel });
+      // series
+      series.forEach(function (s, si) {
+        var col = s.color || p.series[si % p.series.length];
+        ctx.strokeStyle = col; ctx.fillStyle = col; ctx.lineWidth = s.width || 2;
+        if (s.dashed) ctx.setLineDash([5, 4]); else ctx.setLineDash([]);
+        ctx.beginPath();
+        s.points.forEach(function (pt, i) {
+          if (i === 0) ctx.moveTo(X(pt[0]), Y(pt[1])); else ctx.lineTo(X(pt[0]), Y(pt[1]));
+        });
+        ctx.stroke();
+        ctx.setLineDash([]);
+        if (s.dots) s.points.forEach(function (pt) {
+          ctx.beginPath(); ctx.arc(X(pt[0]), Y(pt[1]), 2.6, 0, Math.PI * 2); ctx.fill();
+        });
+      });
+      // legend
+      if (d.legend !== false && series.length > 1) {
+        ctx.textAlign = "left"; ctx.textBaseline = "middle";
+        ctx.font = '11px ' + cssVar("--font-sans", "sans-serif");
+        var ly = box.y + 6;
+        series.forEach(function (s, si) {
+          var col = s.color || p.series[si % p.series.length];
+          ctx.fillStyle = col; ctx.fillRect(box.x + 8, ly - 4, 14, 3);
+          ctx.fillStyle = p.fg; ctx.fillText(s.label || ("series " + (si + 1)), box.x + 26, ly);
+          ly += 16;
+        });
+      }
+    },
+
+    bars: function (ctx, w, h, d, p) {
+      var box = plotBox(w, h);
+      var cats = d.categories || [];
+      var vals = d.values || [];
+      var ymax = d.ymax !== undefined ? d.ymax : Math.max.apply(null, vals.concat([1]));
+      var ymin = d.ymin !== undefined ? d.ymin : 0;
+      function Y(v) { return box.y + (1 - (v - ymin) / (ymax - ymin || 1)) * box.h; }
+      axes(ctx, box, p, { ylabel: d.ylabel, xlabel: d.xlabel });
+      // threshold line (e.g. NIST p=0.01 pass/fail, or an entropy bound)
+      if (d.threshold !== undefined) {
+        ctx.strokeStyle = p.bad; ctx.setLineDash([5, 4]); ctx.lineWidth = 1.5;
+        ctx.beginPath(); ctx.moveTo(box.x, Y(d.threshold)); ctx.lineTo(box.x + box.w, Y(d.threshold)); ctx.stroke();
+        ctx.setLineDash([]);
+      }
+      var n = cats.length, bw = box.w / n * 0.62, gap = box.w / n;
+      ctx.font = '10px ' + cssVar("--font-sans", "sans-serif");
+      ctx.textAlign = "center";
+      vals.forEach(function (v, i) {
+        var x = box.x + gap * i + (gap - bw) / 2;
+        var pass = d.pass ? d.pass[i] : (d.threshold !== undefined ? v >= d.threshold : true);
+        ctx.fillStyle = d.colors ? d.colors[i] : (d.pass ? (pass ? p.good : p.bad) : p.accent);
+        ctx.fillRect(x, Y(v), bw, box.y + box.h - Y(v));
+        ctx.fillStyle = p.muted;
+        ctx.fillText(cats[i], x + bw / 2, box.y + box.h + 14);
+      });
+    },
+
+    timeline: function (ctx, w, h, d, p) {
+      // Per-channel occupancy strips over time (RF Scope I/O graph style).
+      var chans = d.channels || [];
+      var labelW = 92, top = 10, rowH = Math.min(26, (h - 24) / Math.max(chans.length, 1));
+      ctx.font = '11px ' + cssVar("--font-mono", "monospace");
+      ctx.textBaseline = "middle";
+      chans.forEach(function (c, ri) {
+        var y = top + ri * rowH;
+        ctx.fillStyle = p.muted; ctx.textAlign = "right";
+        ctx.fillText(c.label, labelW - 8, y + rowH / 2);
+        var strip = c.occ || [];
+        var cw = (w - labelW - 8) / strip.length;
+        strip.forEach(function (v, ci) {
+          // v in 0..1 -> intensity of accent
+          if (v <= 0) { ctx.fillStyle = p.elev; }
+          else {
+            ctx.fillStyle = p.accent;
+            ctx.globalAlpha = 0.25 + 0.75 * Math.min(1, v);
+          }
+          ctx.fillRect(labelW + ci * cw, y + 2, cw + 0.5, rowH - 4);
+          ctx.globalAlpha = 1;
+        });
+      });
+      // time axis label
+      ctx.fillStyle = p.muted; ctx.textAlign = "left";
+      ctx.font = '10px ' + cssVar("--font-sans", "sans-serif");
+      ctx.fillText(d.xlabel || "time →", labelW, top + chans.length * rowH + 12);
+    }
+  };
+
+  function draw(canvas) {
+    var type = canvas.getAttribute("data-chart");
+    var renderer = renderers[type];
+    if (!renderer) return;
+    var holder = canvas.nextElementSibling;
+    while (holder && !(holder.tagName === "SCRIPT" && holder.className.indexOf("lab-chart-data") !== -1)) {
+      holder = holder.nextElementSibling;
+    }
+    var data = {};
+    if (holder) {
+      try { data = JSON.parse(holder.textContent); }
+      catch (e) { if (window.console) console.warn("labcharts: bad JSON for", type, e); return; }
+    }
+    var dim = setupHiDPI(canvas);
+    dim.ctx.clearRect(0, 0, dim.w, dim.h);
+    renderer(dim.ctx, dim.w, dim.h, data, palette());
+  }
+
+  function drawAll() {
+    var charts = document.querySelectorAll("canvas.lab-chart");
+    for (var i = 0; i < charts.length; i++) draw(charts[i]);
+  }
+
+  function init() {
+    if (!document.querySelector("canvas.lab-chart")) return; // no-op off-topic pages
+    drawAll();
+    // Redraw on theme toggle (site.js flips :root.dark) …
+    var mo = new MutationObserver(function () { drawAll(); });
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    // … and on resize (debounced).
+    var t;
+    window.addEventListener("resize", function () {
+      clearTimeout(t);
+      t = setTimeout(drawAll, 150);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/docs/blog/series/crypto-lab.md
+++ b/docs/blog/series/crypto-lab.md
@@ -8,7 +8,7 @@ permalink: /blog/series/crypto-lab/
 ---
 
 **Crypto Lab** is a 10-part tutorial series on
-[cryptolab]({{ '/cryptolab/' | relative_url }}) — GopherTrunk's byte-oriented
+[cryptolab]({{ '/cryptolab.html' | relative_url }}) — GopherTrunk's byte-oriented
 cryptographic-research toolkit for **security-testing RF encryption**. Its
 governing idea is blunt: *attempting decryption is the test.* Point it at
 captured ciphertext and it attacks by every applicable method, then grades how

--- a/docs/blog/series/crypto-lab.md
+++ b/docs/blog/series/crypto-lab.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: "Crypto Lab: breaking radio encryption, ethically"
+description: A 10-part hands-on series on GopherTrunk's cryptolab — a byte-oriented cryptographic-research toolkit for security-testing RF encryption. Triage unknown payloads, run the NIST randomness battery, recover classical ciphers, exploit keystream reuse, and grade a deployment RESISTANT, PARTIAL, or BROKEN. For authorized security testing only.
+keywords: cryptolab, rf encryption, keystream reuse, many-time-pad, nist sp 800-22, p25 encryption, tea1 backdoor, cryptanalysis, radio security testing, gophertrunk, message indicator iv
+nav_group: Blog
+permalink: /blog/series/crypto-lab/
+---
+
+**Crypto Lab** is a 10-part tutorial series on
+[cryptolab]({{ '/cryptolab/' | relative_url }}) — GopherTrunk's byte-oriented
+cryptographic-research toolkit for **security-testing RF encryption**. Its
+governing idea is blunt: *attempting decryption is the test.* Point it at
+captured ciphertext and it attacks by every applicable method, then grades how
+far each got — <span class="lab-verdict lab-verdict--ok">RESISTANT</span>,
+<span class="lab-verdict lab-verdict--warn">PARTIAL</span>, or
+<span class="lab-verdict lab-verdict--bad">BROKEN</span>. We start from first
+triage and climb to keystream-reuse recovery, the `assess` battery, and the
+resumable subject framework.
+
+> **Authorized testing only.** These posts are for security researchers,
+> licensed operators testing their own systems, and CTF/educational use.
+> Intercepting or decrypting communications you are not authorized to access is
+> illegal in most jurisdictions. Crypto Lab is deliberately build-tag-gated
+> (`-tags cryptolab`) and excluded from the default install.
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose for the deep
+read. **Ada** (new analyst) and **Reese** (the veteran) work each attack with
+you.
+
+This is one leg of the **Lab Bench trilogy**:
+[Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}),
+[RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}), and
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}) (this one). The
+mystery signal *Mercury*, captured in Signal Lab and mapped in RF Scope, is
+finally cracked here.
+
+{%- assign parts = site.posts | where: "series", "Crypto Lab" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Tutorials</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/tutorials/' | relative_url }}">tutorials</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>

--- a/docs/blog/series/rf-scope.md
+++ b/docs/blog/series/rf-scope.md
@@ -1,0 +1,59 @@
+---
+layout: page
+title: "RF Scope: Wireshark for the airwaves"
+description: A 10-part hands-on series on GopherTrunk's rfscope — protocol-agnostic RF network analysis. Point it at any band with no prior knowledge and get a structured Scene: an RF protocol hierarchy, per-channel I/O graph, TDMA timing, an emitter/conversation graph, an encryption triage, and expert-info anomalies.
+keywords: rfscope, rf scope, wireshark for rf, rf network analysis, protocol-agnostic sdr, rf protocol hierarchy, burst detection, tdma period, frequency hopper detection, encryption triage, gophertrunk
+nav_group: Blog
+permalink: /blog/series/rf-scope/
+---
+
+**RF Scope** is a 10-part tutorial series on
+[rfscope]({{ '/rfscope/' | relative_url }}) — GopherTrunk's protocol-agnostic
+RF network analyzer, **"Wireshark for the RF physical layer."** Point it at any
+band, a recorded capture or a live SDR, with **no prior knowledge of the
+technology, modulation, framing, or encryption**, and it produces a structured
+**Scene**: what's on the air and how it behaves. We start from your first scene
+summary and build to segmentation tuning, live cockpit analysis, and scripting
+the whole thing into a reverse-engineering pipeline.
+
+A note up front: despite the name, RF Scope is **not** a waterfall or
+spectrum-scope UI — it is an *analyzer* that turns raw IQ into tables, trees,
+and graphs. If you want live constellations and eye diagrams, that's
+[Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}).
+
+Every post reads three ways: a **TL;DR + cheat-sheet** for skimmers, **bold
+headers, tables, and diagrams** for the medium read, and full prose for the deep
+read. **Ada** (new operator) and **Reese** (RF veteran) walk it with you.
+
+This is one leg of the **Lab Bench trilogy**:
+[Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}),
+[RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}) (this one), and
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}). A mystery signal —
+*Mercury* — runs through all three.
+
+{%- assign parts = site.posts | where: "series", "RF Scope" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Tutorials</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/tutorials/' | relative_url }}">tutorials</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>

--- a/docs/blog/series/rf-scope.md
+++ b/docs/blog/series/rf-scope.md
@@ -1,14 +1,14 @@
 ---
 layout: page
 title: "RF Scope: Wireshark for the airwaves"
-description: A 10-part hands-on series on GopherTrunk's rfscope — protocol-agnostic RF network analysis. Point it at any band with no prior knowledge and get a structured Scene: an RF protocol hierarchy, per-channel I/O graph, TDMA timing, an emitter/conversation graph, an encryption triage, and expert-info anomalies.
+description: "A 10-part hands-on series on GopherTrunk's rfscope — protocol-agnostic RF network analysis. Point it at any band with no prior knowledge and get a structured Scene: an RF protocol hierarchy, per-channel I/O graph, TDMA timing, an emitter/conversation graph, an encryption triage, and expert-info anomalies."
 keywords: rfscope, rf scope, wireshark for rf, rf network analysis, protocol-agnostic sdr, rf protocol hierarchy, burst detection, tdma period, frequency hopper detection, encryption triage, gophertrunk
 nav_group: Blog
 permalink: /blog/series/rf-scope/
 ---
 
 **RF Scope** is a 10-part tutorial series on
-[rfscope]({{ '/rfscope/' | relative_url }}) — GopherTrunk's protocol-agnostic
+[rfscope]({{ '/rfscope.html' | relative_url }}) — GopherTrunk's protocol-agnostic
 RF network analyzer, **"Wireshark for the RF physical layer."** Point it at any
 band, a recorded capture or a live SDR, with **no prior knowledge of the
 technology, modulation, framing, or encryption**, and it produces a structured

--- a/docs/blog/series/signal-lab.md
+++ b/docs/blog/series/signal-lab.md
@@ -8,7 +8,7 @@ permalink: /blog/series/signal-lab/
 ---
 
 **Signal Lab** is a 10-part tutorial series on
-[SigLab]({{ '/siglab/' | relative_url }}), GopherTrunk's standalone
+[SigLab]({{ '/siglab.html' | relative_url }}), GopherTrunk's standalone
 signal-analysis workbench — the tool that runs **entirely offline against a
 recorded IQ capture**, no SDR and no daemon required. We start from your very
 first replay and climb, one post at a time, to lab-grade modulation

--- a/docs/blog/series/signal-lab.md
+++ b/docs/blog/series/signal-lab.md
@@ -1,0 +1,59 @@
+---
+layout: page
+title: "Signal Lab: from first capture to lab-grade VSA"
+description: A 10-part hands-on series on GopherTrunk's SigLab — the offline signal-analysis workbench. Replay a capture with no radio attached, read the decode dashboard, visualize constellations and eye diagrams, synthesize impaired references, measure VSA modulation quality, identify unknown signals, dissect P25 PDUs, and benchmark demodulators.
+keywords: siglab, gophertrunk signal lab, offline iq analysis, replay iq capture, constellation diagram, eye diagram, evm measurement, vsa, p25 decode, sdr signal analysis, demodulator benchmark
+nav_group: Blog
+permalink: /blog/series/signal-lab/
+---
+
+**Signal Lab** is a 10-part tutorial series on
+[SigLab]({{ '/siglab/' | relative_url }}), GopherTrunk's standalone
+signal-analysis workbench — the tool that runs **entirely offline against a
+recorded IQ capture**, no SDR and no daemon required. We start from your very
+first replay and climb, one post at a time, to lab-grade modulation
+measurement, blind signal identification, P25 PDU dissection, and demodulator
+regression benchmarking.
+
+Every post is built for three ways of reading: a **TL;DR + cheat-sheet** up top
+for skimmers, **bold section headers, tables, and diagrams** for the medium
+read, and full prose with real command output for the deep read. You'll meet
+**Ada**, a brand-new operator working her first capture, and **Reese**, the RF
+veteran who explains *why* each number matters.
+
+This is one leg of the **Lab Bench trilogy** — three concurrent series on
+GopherTrunk's analysis consoles:
+[Signal Lab]({{ '/blog/series/signal-lab/' | relative_url }}) (this one),
+[RF Scope]({{ '/blog/series/rf-scope/' | relative_url }}), and
+[Crypto Lab]({{ '/blog/series/crypto-lab/' | relative_url }}). A single
+mystery signal — *Mercury* — runs through all three.
+
+New to radio first? Start with the
+[Learn RF &amp; SDR]({{ '/learn/rf-sdr/' | relative_url }}) path, then come back.
+
+{%- assign parts = site.posts | where: "series", "Signal Lab" | sort: "series_part" -%}
+{%- if parts and parts.size > 0 -%}
+<ol class="post-list series-list">
+  {%- for post in parts -%}
+    <li class="post-card">
+      <a class="post-card__link" href="{{ post.url | relative_url }}">
+        <h2 class="post-card__title">{{ post.title }}</h2>
+      </a>
+      <p class="post-card__meta">
+        <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
+        <span class="category-chip">Tutorials</span>
+      </p>
+      {%- if post.description -%}
+        <p class="post-card__desc">{{ post.description }}</p>
+      {%- endif -%}
+    </li>
+  {%- endfor -%}
+</ol>
+{%- else -%}
+<p class="post-list__empty">No posts in this series yet — check back soon.</p>
+{%- endif -%}
+
+<p class="blog-feed-link">
+  See all <a href="{{ '/blog/category/tutorials/' | relative_url }}">tutorials</a>
+  or subscribe via <a href="{{ '/feed.xml' | relative_url }}">RSS</a>.
+</p>


### PR DESCRIPTION
Add the shared infrastructure for three concurrent tutorial series
(Signal Lab, RF Scope, Crypto Lab):

- labcharts.js: self-contained, no-CDN canvas charting module
  (constellation, eye, heatmap, line, bars, timeline) that renders
  from inline JSON, theme-aware and high-DPI.
- post.html: load labcharts.js when a post sets `charts: true`.
- style.scss: figure/chart, persona callout, and verdict-chip styles.
- Three series hub pages under docs/blog/series/ with the trilogy
  cross-links.
- nav.yml: surface the three new series under the Blog group.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FowuFxVKvd7fhFehkA8wXC