### PR TITLE
ccdecoder: publish total control-channel carrier offset (issue #815)

### DIFF
--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -264,12 +264,16 @@ type Decoder struct {
 	// autotune, when non-nil, tracks the control dongle's carrier error
 	// (Options.Autotune). autotuneApplied records the Hz correction folded
 	// into the DDC offset at the last (re)build, so the next measurement
-	// reports observed + applied as the source's true error (guarded by
-	// mu). locked mirrors the CC lock state from the bus so the pump only
-	// samples AFC on a real lock; lastATSampleAt throttles sampling to
-	// roughly once per second (owned by the pump goroutine).
+	// reports observed + applied as the source's true error, and the
+	// published control_channel_carrier_offset_hz can add it back to the
+	// receiver residual to report the TOTAL offset from the configured
+	// frequency (issue #815). Atomic so the P25 pipeline's CarrierOffsetHz
+	// closure can read it lock-free at site-update publish time. locked
+	// mirrors the CC lock state from the bus so the pump only samples AFC on
+	// a real lock; lastATSampleAt throttles sampling to roughly once per
+	// second (owned by the pump goroutine).
 	autotune        *autotune.Manager
-	autotuneApplied int
+	autotuneApplied atomic.Int64
 	locked          atomic.Bool
 	lastATSampleAt  time.Time
 	// carrierOffsetWarnHz is the large-offset WARN threshold (Options.
@@ -634,6 +638,13 @@ func (d *Decoder) handleProgress(p trunking.HuntProgress) {
 		FrequencyHz:  p.AttemptedFreqHz,
 		SampleRateHz: rate,
 		System:       sys,
+		// Report the autotune correction already folded into the DDC so the
+		// P25 pipeline's published control_channel_carrier_offset_hz is the
+		// TOTAL offset from the configured frequency (applied + receiver
+		// residual), matching the WARN in checkCarrierOffsetLocked. With
+		// autotune off this is always 0, so the published value is unchanged
+		// (issue #815).
+		CarrierBiasHz: func() float64 { return float64(d.autotuneApplied.Load()) },
 	}
 	if d.fec != nil {
 		// Bind the system name so the pipeline reports a per-burst FEC
@@ -731,7 +742,7 @@ func (d *Decoder) ensureDownconverterLocked(targetHz float64) {
 	d.ddc = NewDownconverterWithOffset(d.sampleRateHz, targetHz, offset)
 	d.ddcTarget = targetHz
 	d.ddcOffsetHz = offset
-	d.autotuneApplied = applied
+	d.autotuneApplied.Store(int64(applied))
 	d.pipelineRateHz = d.ddc.outRateHz
 	d.log.Info("ccdecoder: digital down-converter configured",
 		"sdr_rate_hz", d.sampleRateHz,
@@ -799,10 +810,11 @@ func (d *Decoder) sampleAutotuneLocked() {
 	d.lastATSampleAt = now
 
 	observed := int(math.Round(rep.AFCOffsetHz()))
-	d.autotune.AddErrorMeasurement(observed, d.autotuneApplied, d.activeFreqHz)
+	applied := int(d.autotuneApplied.Load())
+	d.autotune.AddErrorMeasurement(observed, applied, d.activeFreqHz)
 	d.log.Info("ccdecoder: "+d.autotune.StatusString(d.activeFreqHz, 0),
 		"system", d.activeAt, "freq_hz", d.activeFreqHz,
-		"observed_hz", observed, "applied_hz", d.autotuneApplied)
+		"observed_hz", observed, "applied_hz", applied)
 }
 
 // checkCarrierOffsetLocked emits a throttled WARN when, while the CC is locked,
@@ -824,7 +836,7 @@ func (d *Decoder) checkCarrierOffsetLocked() {
 	if !ok {
 		return
 	}
-	total := d.autotuneApplied + int(math.Round(rep.AFCOffsetHz()))
+	total := int(d.autotuneApplied.Load()) + int(math.Round(rep.AFCOffsetHz()))
 	if total < 0 {
 		total = -total
 	}

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -1316,16 +1316,37 @@ func TestClearActiveClearsDCRatio(t *testing.T) {
 // encoded TSBK + idle gap) + trailer — mirroring the integration
 // suite's fixture so the C4FM modulator + receiver chain can lock.
 func buildP25CCDibits(nac uint16, repeats int) []uint8 {
+	// A minimal RFSS Status Broadcast with an all-zero identity payload: enough
+	// to exercise the trellis decode path, but publishSiteUpdate skips it (no
+	// RFSS/Site), so callers that only need a lock don't get a SiteUpdate.
+	return buildP25CCDibitsTSBK(nac, repeats, p25phase1.TSBK{
+		LB: true, Opcode: p25phase1.OpRFSSStatusBroadcast,
+	})
+}
+
+// buildP25CCSiteDibits is buildP25CCDibits with an RFSS Status Broadcast that
+// carries a non-zero identity, so a locked decode publishes a KindSiteUpdate
+// (publishSiteUpdate early-returns on all-zero identity). The payload mirrors
+// phase1/network_test.go's TestControlChannelStampsCarrierOffset.
+func buildP25CCSiteDibits(nac uint16, repeats int) []uint8 {
+	return buildP25CCDibitsTSBK(nac, repeats, p25phase1.TSBK{
+		LB: true, Opcode: p25phase1.OpRFSSStatusBroadcast,
+		Payload: [8]byte{9, 0x01, 0x23, 4, 7},
+	})
+}
+
+// buildP25CCDibitsTSBK assembles the shared CC dibit fixture — a warmup pattern
+// + `repeats` × (FSW + NID + trellis-encoded TSBK + idle gap) + trailer — around
+// the supplied TSBK, so the C4FM modulator + receiver chain can lock and decode
+// it.
+func buildP25CCDibitsTSBK(nac uint16, repeats int, tsbk p25phase1.TSBK) []uint8 {
 	frame := make([]uint8, 0, 24+32+98)
 	frame = append(frame, p25phase1.FrameSyncWord[:]...)
 	nidBits := p25phase1.EncodeNIDBits(nac, p25phase1.DUIDTrunkingSignaling)
 	for i := 0; i < 32; i++ {
 		frame = append(frame, (nidBits[2*i]<<1)|nidBits[2*i+1])
 	}
-	tsbk := p25phase1.AssembleTSBK(p25phase1.TSBK{
-		LB: true, Opcode: p25phase1.OpRFSSStatusBroadcast,
-	})
-	frame = append(frame, p25phase1.EncodeTSBKChannel(tsbk)...)
+	frame = append(frame, p25phase1.EncodeTSBKChannel(p25phase1.AssembleTSBK(tsbk))...)
 	// Interleave the P25 status symbols a real transmitter inserts (one
 	// per 36 dibits); the receiver must strip them to decode the NID.
 	frame = p25phase1.InjectControlStatusSymbols(frame)
@@ -1610,8 +1631,8 @@ func TestDecoderAutotuneMeasuresAndCorrectsOffset(t *testing.T) {
 	}
 	// With no measurements yet the DDC must be built with zero correction —
 	// byte-identical to the non-autotune path.
-	if d.autotuneApplied != 0 {
-		t.Fatalf("autotuneApplied = %d before any measurement, want 0", d.autotuneApplied)
+	if got := d.autotuneApplied.Load(); got != 0 {
+		t.Fatalf("autotuneApplied = %d before any measurement, want 0", got)
 	}
 
 	const chunk = 8_192
@@ -2031,7 +2052,7 @@ func TestDecoderWarnsOnLargeCarrierOffset(t *testing.T) {
 			var buf bytes.Buffer
 			d := newOffsetTestDecoder(t, &buf)
 			d.active = &fakeAFCPipeline{offsetHz: tc.offset}
-			d.autotuneApplied = tc.applied
+			d.autotuneApplied.Store(int64(tc.applied))
 			d.locked.Store(tc.locked)
 
 			d.checkCarrierOffsetLocked()
@@ -2265,5 +2286,112 @@ func TestDecoderCarrierOffsetWarnHzConfigurable(t *testing.T) {
 	d2.checkCarrierOffsetLocked()
 	if strings.Contains(buf.String(), carrierOffsetWarnMsg) {
 		t.Errorf("12.5 kHz offset under a 20 kHz threshold should not warn; log: %q", buf.String())
+	}
+}
+
+// TestDecoderPublishesTotalCarrierOffsetWithAutotune is the failing-first
+// regression for the issue #815 follow-up (comment 4830049924): the value
+// published to GET /api/v1/sites as control_channel_carrier_offset_hz must be the
+// TOTAL offset from the configured frequency (the autotune correction already
+// folded into the down-converter + the receiver's residual AFCOffsetHz), matching
+// the checkCarrierOffsetLocked WARN — not the residual alone.
+//
+// Once autotune folds a correction into the DDC and the receiver re-centres, the
+// residual drops toward 0, so a residual-only publish (the bug: pipelines.go
+// wired `func() float64 { return rx.AFCOffsetHz() }`) would hide the applied
+// shift and disagree with the WARN. Here a real ccdecoder.Decoder locks an
+// on-frequency channel (residual ≈ 0) with a non-zero applied bias injected to
+// model that re-centred state; the published SiteUpdate offset must still carry
+// the bias. With the fix reverted this reads ≈ 0 and the test fails.
+func TestDecoderPublishesTotalCarrierOffsetWithAutotune(t *testing.T) {
+	const (
+		nac          = 0x293
+		controlFreq  = 420_075_000 // Geelong, per issue #815
+		narrowRateHz = 48_000.0    // SDR rate == channel rate ⇒ pass-through DDC
+		deviationHz  = 1800.0
+		frameRepeats = 80
+		appliedBias  = 1200 // Hz already folded into the DDC by autotune
+	)
+
+	// On-frequency channel: the DDC leaves it at DC, so the receiver residual
+	// AFCOffsetHz settles near 0. The applied bias is injected directly (below)
+	// to model the post-fold / re-centred state — residual ≈ 0 while
+	// autotuneApplied != 0 — which is exactly what a residual-only publish hides.
+	dibits := buildP25CCSiteDibits(nac, frameRepeats)
+	signal := demod.ModulateP25C4FM(dibits, narrowRateHz, deviationHz)
+
+	bus := events.NewBus(512)
+	defer bus.Close()
+	d, err := New(Options{
+		Bus: bus, IQ: &fakeIQSource{},
+		Systems: []trunking.System{{
+			Name: "Geelong", Protocol: trunking.ProtocolP25,
+			ControlChannels: []uint32{controlFreq},
+		}},
+		SampleRateHz: narrowRateHz,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer d.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	d.handleProgress(trunking.HuntProgress{System: "Geelong", AttemptedFreqHz: controlFreq})
+	if d.active == nil {
+		t.Fatalf("handleProgress did not install a pipeline")
+	}
+	// Model autotune having folded appliedBias into the DDC at this acquisition.
+	// The CarrierBiasHz getter handleProgress wired reads this live, so the
+	// published offset must include it on top of the ~0 residual.
+	d.autotuneApplied.Store(appliedBias)
+
+	const chunk = 8_192
+	var (
+		locked     bool
+		gotSite    bool
+		siteOffset int32
+	)
+	for off := 0; off < len(signal); off += chunk {
+		end := off + chunk
+		if end > len(signal) {
+			end = len(signal)
+		}
+		d.pump(signal[off:end])
+		for drained := false; !drained; {
+			select {
+			case ev := <-sub.C:
+				switch ev.Kind {
+				case events.KindCCLocked:
+					// Mirror the Run loop's lock bookkeeping (decoder.go) so the
+					// pump's offset machinery is armed; the pump never sets it.
+					d.locked.Store(true)
+					locked = true
+				case events.KindSiteUpdate:
+					u, ok := ev.Payload.(trunking.SiteUpdate)
+					if !ok || (u.RFSSID == 0 && u.SiteID == 0) {
+						continue // skip any interim identity-less publish
+					}
+					siteOffset = u.ControlChannelCarrierOffsetHz
+					gotSite = true
+				}
+			default:
+				drained = true
+			}
+		}
+	}
+	if !locked {
+		t.Fatalf("control channel never locked on-frequency")
+	}
+	if !gotSite {
+		t.Fatalf("no KindSiteUpdate with a decoded RFSS/Site identity was published")
+	}
+	// The published offset must include the applied bias. Residual-only (the bug)
+	// would read ≈ 0; the fix reports applied + residual, landing within a
+	// CoarseAFC slack band around appliedBias.
+	const slack = 500
+	if int(siteOffset) < appliedBias-slack || int(siteOffset) > appliedBias+slack {
+		t.Fatalf("control_channel_carrier_offset_hz = %d, want ≈ %d (applied bias + ~0 residual); a residual-only publish would read ≈ 0",
+			siteOffset, appliedBias)
 	}
 }

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -83,6 +83,16 @@ type PipelineOptions struct {
 	// enabled; today only newTETRAPipeline consumes it. nil ⇒ zero
 	// overhead.
 	FECObserver func(channel string, corrections int)
+
+	// CarrierBiasHz, when non-nil, returns the frequency correction (Hz) the
+	// decoder has already folded into the down-converter for the active
+	// acquisition (the autotune-applied shift). newP25Phase1Pipeline adds it
+	// to the receiver's residual AFCOffsetHz so the published
+	// control_channel_carrier_offset_hz reports the TOTAL offset from the
+	// configured frequency — matching the WARN in checkCarrierOffsetLocked —
+	// instead of the residual-only value that drops toward 0 once autotune
+	// re-centres the carrier (issue #815). Nil ⇒ residual only.
+	CarrierBiasHz func() float64
 }
 
 // tapDibits / tapBits forward a recovered-symbol chunk to SymbolTap when
@@ -299,7 +309,18 @@ func newP25Phase1Pipeline(opts PipelineOptions) (ProtocolPipeline, error) {
 		P25Phase2RS:         uint8(p2RS),
 		P25Phase2Interleave: uint8(p2Interleave),
 		P25Phase2Scrambler:  uint8(p2Scrambler),
-		CarrierOffsetHz:     func() float64 { return rx.AFCOffsetHz() },
+		// Report the TOTAL carrier offset from the configured frequency:
+		// the receiver's residual AFC plus any correction the decoder folded
+		// into the DDC (CarrierBiasHz). Residual-only would drop toward 0
+		// once autotune re-centres, hiding an offset the WARN still flags
+		// (issue #815). With autotune off CarrierBiasHz returns 0.
+		CarrierOffsetHz: func() float64 {
+			off := rx.AFCOffsetHz()
+			if opts.CarrierBiasHz != nil {
+				off += opts.CarrierBiasHz()
+			}
+			return off
+		},
 	})
 	rx = p25phase1rx.New(p25phase1rx.Options{
 		SampleRateHz: opts.SampleRateHz,


### PR DESCRIPTION
The checkCarrierOffsetLocked WARN computes the total offset from the
configured control frequency (autotune correction folded into the DDC +
the receiver's residual AFCOffsetHz), so it fires whether or not autotune
is enabled. But the value published to GET /api/v1/sites as
control_channel_carrier_offset_hz was wired residual-only:

    CarrierOffsetHz: func() float64 { return rx.AFCOffsetHz() }

With sdr.autotune on, once a correction is folded into the DDC at a
re-acquisition the receiver re-centres and the residual drops toward 0, so
the API field under-reported the offset the WARN was still flagging — the
log and the API disagreed. With autotune off (the default) autotuneApplied
is always 0, so the two already agreed and nothing changes.

Report the total instead: plumb the applied DDC correction to the P25
pipeline via a new PipelineOptions.CarrierBiasHz getter, and have the
CarrierOffsetHz closure add it to the receiver residual. autotuneApplied
becomes an atomic.Int64 so the publish closure can read it lock-free at
site-update time. With autotune off the getter returns 0, so the published
value is unchanged for the reporter's setup.

Scope note: autotune's plausibility bound (rejectBoundHz, ~1500 Hz at
420 MHz) means the applied correction can never chase a full 12.5 kHz
adjacent carrier, so the real-world under-report is bounded (<= ~1.5 kHz);
the point of the fix is that the log and the API field now agree by
construction.

Adds a failing-first end-to-end regression
(TestDecoderPublishesTotalCarrierOffsetWithAutotune): a real Decoder locks
an on-frequency P25 control channel (residual ~0) with a non-zero applied
bias injected to model the re-centred state, decodes an RFSS Status
Broadcast, and asserts the published SiteUpdate offset carries the bias
(residual-only would read ~0).

Refs #815

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0115dFFuCyW2NykG7mihGFiK