### PR TITLE
p25/phase2: fix garbled outbound sync constant so superframes can lock (#813)

### DIFF
--- a/internal/radio/p25/phase2/receiver/superframe_specsync_test.go
+++ b/internal/radio/p25/phase2/receiver/superframe_specsync_test.go
@@ -1,0 +1,106 @@
+package receiver_test
+
+// Regression test for issue #813: P25 Phase 2 superframe sync never locked on
+// real off-air traffic because OutboundSyncHex was a garbled 48-bit constant.
+//
+// The stimulus here is deliberately INDEPENDENT of GopherTrunk's own Phase 2
+// modulator (demod.ModulatePiOver4DQPSK / EncodeSuperframe), which bakes in the
+// same constants the decoder uses and so can never expose a wrong sync word.
+// Instead we synthesize a spec-conformant P25 Phase 2 outbound sync directly
+// from the authoritative value (0x575D57F7FF) and the standard π/4-DQPSK-family
+// differential phase map (SDRtrunk Dibit.java: 00→+π/4, 01→+3π/4, 10→−π/4,
+// 11→−3π/4), RRC pulse-shape it, and push it through the production receiver +
+// SuperframeDecoder. It fails (0 locks) with the old constant and passes with
+// the corrected one.
+
+import (
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/filter"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
+)
+
+// authoritative P25 Phase 2 outbound frame sync (OP25/SDRtrunk, TIA-102.BBAC).
+const specSyncHex uint64 = 0x575D57F7FF
+
+// standard π/4-DQPSK-family differential phase per (standard) dibit value.
+func specSyncPhase(d uint8) float64 {
+	switch d & 3 {
+	case 0:
+		return math.Pi / 4
+	case 1:
+		return 3 * math.Pi / 4
+	case 2:
+		return -math.Pi / 4
+	default:
+		return -3 * math.Pi / 4
+	}
+}
+
+func hexToDibitsMSB(hex uint64, n int) []uint8 {
+	out := make([]uint8, n)
+	for i := 0; i < n; i++ {
+		out[i] = uint8((hex >> uint(2*(n-1-i))) & 3)
+	}
+	return out
+}
+
+// specModulate differentially modulates dibits with the standard phase map and
+// RRC-pulse-shapes to sps samples/symbol — an independent transmit model.
+func specModulate(dibits []uint8, sps, span int, alpha float64) []complex64 {
+	up := make([]complex64, len(dibits)*sps)
+	theta := 0.0
+	for i, d := range dibits {
+		theta += specSyncPhase(d)
+		up[i*sps] = complex(float32(math.Cos(theta)), float32(math.Sin(theta)))
+	}
+	return filter.NewFIR(filter.RootRaisedCosine(sps, span, alpha)).Process(nil, up)
+}
+
+func TestSuperframeLocksOnSpecSync(t *testing.T) {
+	const (
+		sps   = 8
+		span  = 8
+		alpha = 0.20
+	)
+	// Superframe grid: spec sync at the head of sub-frame 0, idle elsewhere.
+	grid := make([]uint8, phase2.DibitsPerSuperframe)
+	copy(grid[:phase2.SyncDibits], hexToDibitsMSB(specSyncHex, phase2.SyncDibits))
+	var dibits []uint8
+	for i := 0; i < 6; i++ {
+		dibits = append(dibits, grid...)
+	}
+	iq := specModulate(dibits, sps, span, alpha)
+
+	var got []uint8
+	r := rx.New(rx.Options{
+		SampleRateHz: sps * rx.SymbolRate,
+		ClockMode:    rx.ClockGardner,
+		DibitSink:    func(d []uint8, _ int) { got = append(got, d...) },
+	})
+	for off := 0; off < len(iq); off += 192 { // production-sized chunks
+		end := off + 192
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[off:end])
+	}
+
+	locks := phase2.NewSuperframeDecoder().Process(got, 0)
+	if len(locks) < 2 {
+		t.Fatalf("spec-conformant P25 Phase 2 sync did not lock: got %d superframes, want >= 2 "+
+			"(OutboundSyncHex=0x%X does not match real-air sync)", len(locks), phase2.OutboundSyncHex)
+	}
+}
+
+// TestOutboundSyncIs40Bit guards the width invariant hexToDibits depends on: a
+// value wider than SyncDibits*2 bits silently drops its top bits (the original
+// issue #813 defect, a 48-bit constant used as 20 dibits).
+func TestOutboundSyncIs40Bit(t *testing.T) {
+	if phase2.OutboundSyncHex>>(2*phase2.SyncDibits) != 0 {
+		t.Fatalf("OutboundSyncHex=0x%X exceeds %d bits; top bits are silently dropped by hexToDibits",
+			phase2.OutboundSyncHex, 2*phase2.SyncDibits)
+	}
+}

--- a/internal/radio/p25/phase2/sync.go
+++ b/internal/radio/p25/phase2/sync.go
@@ -11,14 +11,39 @@ package phase2
 // Phase 2 CC state machine on live IQ.
 type DibitSink func(dibits []uint8, baseIdx int)
 
-// Phase 2 sync words per TIA-102.BBAB §6. Outbound (BS → MS) and
-// inbound (MS → BS) carry distinct patterns so a receiver can lock
-// onto the appropriate side of the link. Stored as the canonical
-// 40-bit (20-dibit) hex constants, with helpers to materialise the
-// dibits MSB-first.
+// Phase 2 sync words. Outbound (BS → MS) and inbound (MS → BS) carry distinct
+// patterns so a receiver can lock onto the appropriate side of the link.
+// hexToDibits materialises SyncDibits (20) dibits MSB-first from the low 40 bits
+// of each constant, so a correct value must be exactly 40 bits — the previous
+// OutboundSyncHex was 48 bits and its top byte was silently dropped (issue #813).
+//
+// OutboundSyncHex is expressed in GopherTrunk's *decoder* dibit convention, not
+// the P25 standard's. The authoritative P25 Phase 2 outbound frame sync is
+// 0x575D57F7FF (OP25 frame_sync_magics.h / SDRtrunk P25P2_FRAME_SYNC_MAGIC,
+// TIA-102.BBAC). On air that sync is a 20-symbol π/4-DQPSK-family sequence whose
+// differential phases are, per dibit, {00→+π/4, 01→+3π/4, 10→−π/4, 11→−3π/4}
+// (SDRtrunk Dibit.java). Running exactly that physical sequence through this
+// package's differential decoder (demod.DQPSK.Decode, the receiver's actual
+// output) yields the dibit sequence below — 0x565956A6AA — which is what the
+// SyncDetector must match on live traffic. (GopherTrunk's DQPSK.Decode assigns
+// the two negative-phase symbols the dibit values 2 and 3 swapped relative to
+// the P25 standard, so the standard 0x575D57F7FF becomes 0x565956A6AA in the
+// decoded stream. That same swap means the MAC/voice *payload* would also decode
+// with 2↔3 transposed — a likely remaining blocker for ALGID/KID that lives in
+// the shared demod.DQPSK map and must be confirmed against a real capture before
+// touching, since it is also used by the TETRA and P25 Phase 1 CQPSK paths.)
+//
+// The old OutboundSyncHex (0x575F7DFF77FF) was neither the standard value nor
+// this decoded form — a garbled 48-bit constant that never matched real air, so
+// Phase 2 superframes never locked while every synthesized round-trip test (which
+// encodes with the same constant) passed. See TestSuperframeLocksOnSpecSync.
+//
+// InboundSyncHex is the uplink (MS → BS) sync, used only by a diagnostic
+// detector (internal/siglab/detail.go); it is unverified against real air and
+// against this decoder's convention — do not rely on it until confirmed.
 const (
-	OutboundSyncHex uint64 = 0x575_F7DFF_77FF
-	InboundSyncHex  uint64 = 0xDFF_57D75_DF5D
+	OutboundSyncHex uint64 = 0x565956A6AA
+	InboundSyncHex  uint64 = 0xDFF57D75DF5D
 	SyncDibits             = 20
 )
 


### PR DESCRIPTION
P25 Phase 2 superframe sync never locked on real off-air traffic
(`composer: p25p2 call census … superframes=0` on every call, on both an
RTL-SDR and a TCXO Airspy R2), so `algorithm_id`/`key_id` never populated.

Root cause: OutboundSyncHex was 0x575F7DFF77FF — a garbled 48-bit value used
where a 40-bit (20-dibit) sync word is expected, so hexToDibits silently
dropped its top byte and the SyncDetector matched a nonsense pattern that
never appears on air. Every synthesized round-trip test passed because the
test encoder injects sync from the same constant it decodes with, so the bug
was invisible in-tree.

The authoritative P25 Phase 2 outbound sync is 0x575D57F7FF (OP25
frame_sync_magics.h / SDRtrunk, TIA-102.BBAC), a π/4-DQPSK-family symbol
sequence. Feeding that spec-conformant physical sequence (SDRtrunk Dibit.java
phase map) through this package's own differential decoder yields the
20-dibit stream 0x565956A6AA, which is what the SyncDetector must match on
live traffic. Set OutboundSyncHex to that value and add a width guard.

Regression test synthesizes the sync independently of GopherTrunk's own
modulator (so it can actually expose a wrong constant): it fails with 0
superframes on the old constant and locks with the new one.

Verified against a spec-conformant synthetic only — not yet against the
reporter's real capture (egress policy blocked the fork). Issue stays open.

Refs #813

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JVu7gWE5H8rPcYpRMmvAQv