### PR TITLE
api: expose P25 neighbour sites on GET /api/v1/sites (#864)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ for tagged releases.
 ## [Unreleased]
 
 ### Added
+- **Neighbour sites on `GET /api/v1/sites`.** Each `SiteDTO` now carries a
+  `neighbors` array — the adjacent sites the site advertised over the air (P25
+  Adjacent Site Status Broadcast, opcode `0x3C`), each with the neighbour's
+  RFSS/Site and its band-plan-resolved control-channel `downlink_hz` (and
+  `uplink_hz`). This is the same decoded data already surfaced on
+  `GET /api/v1/systems`, now attached to the camped site of each system on the
+  per-site endpoint, so a consumer can backfill the wider network's
+  control-channel map from a single camped site without directly decoding every
+  site. Empty on sites that did not broadcast a neighbour list (issue #864).
 - **Per-site P25 decode quality on `GET /api/v1/sites`.** Each `SiteDTO` now
   carries `control_channel_tsbk_error_rate` (cumulative % of TSBK blocks failing
   Viterbi/CRC on that site's control channel), `control_channel_tsbk_count` (the

--- a/internal/api/handlers_sites.go
+++ b/internal/api/handlers_sites.go
@@ -64,6 +64,27 @@ func (s *Server) handleListSites(w http.ResponseWriter, _ *http.Request) {
 		}
 	}
 
+	// Overlay each system's advertised neighbour sites onto its camped-site row.
+	// The topology snapshot is keyed per system and describes the site that
+	// broadcast the adjacent-site list (snap.RFSS/snap.Site), so the neighbours
+	// belong on exactly that row — not on every site of the system (issue #864).
+	if tp, ok := s.sites.(NetworkTopologyProvider); ok {
+		seen := make(map[string]struct{})
+		for k := range byKey {
+			if _, done := seen[k.system]; done {
+				continue
+			}
+			seen[k.system] = struct{}{}
+			snap, ok := tp.Topology(k.system)
+			if !ok {
+				continue
+			}
+			if dto, ok := byKey[key{k.system, snap.RFSS, snap.Site}]; ok {
+				dto.Neighbors = neighborsFromTopology(snap)
+			}
+		}
+	}
+
 	out := make([]SiteDTO, 0, len(byKey))
 	for _, dto := range byKey {
 		dto.fillIdentityHex()

--- a/internal/api/handlers_sites_test.go
+++ b/internal/api/handlers_sites_test.go
@@ -92,6 +92,104 @@ func TestListSitesUnionAndNameMerge(t *testing.T) {
 	}
 }
 
+// fakeSitesTopo is a SitesProvider that also implements NetworkTopologyProvider,
+// returning discovered rows plus one system's topology snapshot.
+type fakeSitesTopo struct {
+	sites  []trunking.SiteInfo
+	system string
+	snap   *trunking.TopologySnapshot
+}
+
+func (f fakeSitesTopo) Sites() []trunking.SiteInfo { return f.sites }
+func (f fakeSitesTopo) Topology(system string) (*trunking.TopologySnapshot, bool) {
+	if system == f.system && f.snap != nil {
+		return f.snap, true
+	}
+	return nil, false
+}
+
+// TestListSitesNeighbors checks that the live topology's adjacent sites are
+// overlaid onto the camped-site row of GET /api/v1/sites (issue #864), with
+// band-plan-resolved downlink frequencies, and that a non-camped site of the
+// same system carries no neighbours.
+func TestListSitesNeighbors(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+
+	// Camped site (rfss 1 / site 1) advertises two neighbours; a second
+	// discovered site (rfss 1 / site 2) of the same system is not camped.
+	snap := &trunking.TopologySnapshot{
+		WACN:     0xBEE00,
+		SystemID: 0x2C2,
+		RFSS:     1,
+		Site:     1,
+		BandPlan: []trunking.TopoBandPlanSlot{
+			{ChannelID: 2, BaseHz: 450_000_000, SpacingHz: 12_500, TxOffsetHz: 10_000_000},
+		},
+		Neighbors: []trunking.TopoNeighborRef{
+			// Site 9 first in the slice; expect it sorted after Site 7.
+			{RFSS: 1, Site: 9, ChannelID: 2, ChannelNumber: 1654, FrequencyHz: 450_337_500},
+			{RFSS: 1, Site: 7, ChannelID: 2, ChannelNumber: 1754, FrequencyHz: 450_962_500},
+		},
+	}
+	prov := fakeSitesTopo{
+		system: "MMR",
+		snap:   snap,
+		sites: []trunking.SiteInfo{
+			{System: "MMR", RFSSID: 1, SiteID: 1, ControlChannelHz: 450_012_500},
+			{System: "MMR", RFSSID: 1, SiteID: 2, ControlChannelHz: 450_137_500},
+		},
+	}
+
+	base, teardown := mkServer(t, ServerOptions{Bus: bus, Systems: []trunking.System{{Name: "MMR"}}, Sites: prov})
+	defer teardown()
+
+	resp := mustGet(t, base+"/api/v1/sites")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Sites []SiteDTO `json:"sites"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Sites) != 2 {
+		t.Fatalf("got %d sites, want 2: %+v", len(body.Sites), body.Sites)
+	}
+
+	// Sorted by (system, rfss, site): camped site (1,1) first.
+	camped := body.Sites[0]
+	if camped.RFSSID != 1 || camped.SiteID != 1 {
+		t.Fatalf("first site = %+v, want rfss 1 / site 1", camped)
+	}
+	if len(camped.Neighbors) != 2 {
+		t.Fatalf("camped site Neighbors = %d, want 2: %+v", len(camped.Neighbors), camped.Neighbors)
+	}
+	// Sorted by (RFSS, Site): Site 7 before Site 9.
+	if camped.Neighbors[0].Site != 7 || camped.Neighbors[1].Site != 9 {
+		t.Errorf("neighbors not sorted by site: %+v", camped.Neighbors)
+	}
+	n := camped.Neighbors[0]
+	if n.DownlinkHz != 450_962_500 {
+		t.Errorf("neighbour downlink_hz = %d, want 450962500", n.DownlinkHz)
+	}
+	// Uplink = downlink + band-plan tx offset (+10 MHz).
+	if n.UplinkHz != 460_962_500 {
+		t.Errorf("neighbour uplink_hz = %d, want 460962500 (downlink + 10 MHz offset)", n.UplinkHz)
+	}
+
+	// The non-camped site of the same system did not broadcast the list.
+	other := body.Sites[1]
+	if other.RFSSID != 1 || other.SiteID != 2 {
+		t.Fatalf("second site = %+v, want rfss 1 / site 2", other)
+	}
+	if len(other.Neighbors) != 0 {
+		t.Errorf("non-camped site should carry no neighbours, got %+v", other.Neighbors)
+	}
+}
+
 // TestListSitesNoProvider confirms the route degrades gracefully when no
 // site tracker is wired (empty list, not a 500).
 func TestListSitesNoProvider(t *testing.T) {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -527,6 +527,15 @@ type SiteDTO struct {
 	SystemIDHex string `json:"system_id_hex,omitempty"`
 	RFSSIDHex   string `json:"rfss_id_hex,omitempty"`
 	SiteIDHex   string `json:"site_id_hex,omitempty"`
+	// Neighbors are the adjacent sites this site advertised over the air (P25
+	// Adjacent Site Status Broadcast, opcode 0x3C), overlaid from the live
+	// topology snapshot. Each carries the neighbour's RFSS/Site and its
+	// band-plan-resolved control-channel downlink (and uplink) frequency, so a
+	// consumer can backfill the wider network's control-channel map from a
+	// single camped site without decoding every site directly. Only the camped
+	// site of a system carries them (that is the site that broadcast the list);
+	// other rows leave it empty (issue #864).
+	Neighbors []NeighborDTO `json:"neighbors,omitempty"`
 }
 
 // TSBK frame-error-rate thresholds (percent) that bucket a control channel's


### PR DESCRIPTION
The adjacent-site list a P25 control channel advertises (ADJ_STS_BCST,
opcode 0x3C) is decoded, stored per system in the SiteTracker topology
snapshot, and already served on GET /api/v1/systems as SystemDTO.Neighbors.
It was not surfaced on the per-site endpoint, which issue #864 asks for so a
consumer can backfill the wider network's control-channel map from a single
camped site without decoding every site directly.

Attach the neighbour list to each system's camped-site row in
handleListSites, keyed off the snapshot's own RFSS/Site (the site that
broadcast the list), reusing the existing NeighborDTO and
neighborsFromTopology helper. Non-camped and configured-but-unseen sites
correctly carry no neighbours.

Refs #864

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NuBXjT7BmuFoQhzX3VN5Q7