### PR TITLE
web/audio: play at native AudioContext rate, not a pinned 8 kHz

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -386,6 +386,12 @@ type Daemon struct {
 	affiliations *trunking.AffiliationTracker
 	siteTracker  *trunking.SiteTracker
 	recorder     *voice.Recorder
+	// voiceDecoder is the recorder the composer decodes digital voice through
+	// and taps PCM from for the live web/gRPC stream. It equals `recorder` when
+	// a recordings directory is configured; otherwise it is a decode-only
+	// recorder (writes no files) so live audio works without recording. Nil
+	// only when there is no SDR pool to source voice from.
+	voiceDecoder *voice.Recorder
 	broadcast    *broadcast.Manager
 	composer     *composer.Composer
 	player       *player.Player
@@ -1218,6 +1224,38 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 		d.recorder = rec
 	}
 
+	// Voice decoder for live audio. When recording is configured the file
+	// recorder above doubles as the decoder; otherwise — as long as there's a
+	// pool to source voice from — build a decode-only recorder (empty OutDir,
+	// writes no files) so digital calls are still decoded and fanned to the web
+	// stream. Without this, live audio silently required recordings.dir: no
+	// recorder meant no composer and no decoded PCM ever reached the browser.
+	d.voiceDecoder = d.recorder
+	if d.voiceDecoder == nil && d.pool != nil {
+		var vocoderMap map[string]string
+		if cfg.Recordings.WarmDMRAudio {
+			vocoderMap = voice.DefaultVocoderForProtocol()
+			for _, proto := range []string{"dmr-tier1", "dmr-tier2", "dmr-tier3"} {
+				vocoderMap[proto] = ambe2.DMRWarmVocoderName
+			}
+		}
+		dec, err := voice.NewRecorder(voice.RecorderOptions{
+			Bus:                d.bus,
+			Log:                log,
+			OutDir:             "", // decode-only: decode + live tap, no files
+			SampleRate:         cfg.Recordings.SampleRate,
+			VocoderForProtocol: vocoderMap,
+			DisplayLoc:         cfg.Display.Location(),
+			// Voice enhancement operates on decoded PCM, so it applies to the
+			// live stream too; loudness/normalize are file-only and omitted.
+			Enhance: enhancerConfigFromYAML(cfg.Recordings.Enhance),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("daemon: voice decoder: %w", err)
+		}
+		d.voiceDecoder = dec
+	}
+
 	// Displayed-timestamp timezone for human-facing output — the logs, the TUI,
 	// and (per the operator's display.timezone opt-in) the API/webhook/rdioscanner
 	// payloads. Local by default; "UTC" or any IANA name. A bad name degrades to
@@ -1373,11 +1411,13 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 	d.audioPub = audioPub
 
 	// Composer is wired when we have a Voice device pool to source IQ
-	// from + a recorder to feed PCM into. Without an SDR pool there's
-	// nothing to demod, and without a recorder PCM has no destination.
-	if d.pool != nil && d.recorder != nil {
-		// Fan PCM to recorder + tone-out (if configured) + live player + gRPC publisher.
-		sinks := []composer.PCMSink{d.recorder}
+	// from + a voice decoder to feed PCM into. Without an SDR pool there's
+	// nothing to demod. The decoder is the file recorder when recording is
+	// configured, otherwise a decode-only recorder — either way it decodes
+	// digital voice and taps PCM to the live stream.
+	if d.pool != nil && d.voiceDecoder != nil {
+		// Fan PCM to the decoder + tone-out (if configured) + live player + gRPC publisher.
+		sinks := []composer.PCMSink{d.voiceDecoder}
 		if d.toneout != nil {
 			sinks = append(sinks, d.toneout)
 		}
@@ -1418,14 +1458,14 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			log.Info("audio: live-loudness AGC enabled for digital stream")
 		}
 		liveSinks = append(liveSinks, liveStreamSink)
-		d.recorder.SetDecodedPCMSink(fanoutSink(liveSinks))
+		d.voiceDecoder.SetDecodedPCMSink(fanoutSink(liveSinks))
 		// Raw vocoder frames fan straight to the publisher (the only raw
 		// consumer): include_raw subscribers get the un-decoded IMBE / AMBE
 		// bytes. This path bypasses live-loudness — that AGC only makes sense
 		// on decoded PCM, not on un-decoded codec frames.
-		d.recorder.SetRawFrameSink(d.audioPub)
+		d.voiceDecoder.SetRawFrameSink(d.audioPub)
 
-		var sink composer.PCMSink = d.recorder
+		var sink composer.PCMSink = d.voiceDecoder
 		if len(sinks) > 1 {
 			sink = fanoutSink(sinks)
 			// Surface the fanout wiring at startup so operators can
@@ -2639,9 +2679,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 			return d.retention.Run(ctx)
 		})
 	}
-	if d.recorder != nil {
+	// voiceDecoder equals recorder when recording, else the decode-only
+	// recorder; running it covers both (they are never distinct non-nil
+	// recorders) so the voice decode/tap loop is always driven.
+	if d.voiceDecoder != nil {
 		d.spawn(runCtx, "recorder", false, func(ctx context.Context) error {
-			return d.recorder.Run(ctx)
+			return d.voiceDecoder.Run(ctx)
 		})
 	}
 	if d.broadcast != nil {
@@ -3263,8 +3306,10 @@ func (d *Daemon) Close() {
 		if d.broadcast != nil {
 			_ = d.broadcast.Close()
 		}
-		if d.recorder != nil {
-			_ = d.recorder.Close()
+		// Closes the file recorder or the decode-only recorder (same object
+		// when recording; voiceDecoder is a superset of recorder).
+		if d.voiceDecoder != nil {
+			_ = d.voiceDecoder.Close()
 		}
 		if d.callLog != nil {
 			_ = d.callLog.Close()

--- a/cmd/gophertrunk/daemon_live_audio_test.go
+++ b/cmd/gophertrunk/daemon_live_audio_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// TestDaemonWiresLiveAudioWithoutRecordings pins the fix that live browser
+// audio no longer requires a recordings directory. A DMR user who never
+// configured recordings still needs decoded voice to reach the web/gRPC audio
+// stream — before the fix the whole composer + decoded-PCM tap was gated on the
+// recorder, which itself required recordings.dir, so calls appeared in the UI
+// but no audio ever played.
+//
+// With no recordings.dir the daemon must build a decode-only voice decoder,
+// wire the composer through it, and keep the audio publisher live; with a
+// recordings.dir the file recorder doubles as the decoder (unchanged behaviour).
+func TestDaemonWiresLiveAudioWithoutRecordings(t *testing.T) {
+	const (
+		controlFreqHz = 460_500_000
+		sampleRateHz  = 48_000
+		sps           = 10
+		span          = 8
+		alpha         = 0.20
+		deviationHz   = 1944.0
+		colorCode     = 0x7
+		groupID       = 0x123
+		sourceID      = 0x456789
+		burstRepeats  = 4
+	)
+
+	dibits := buildDMRTier2VoiceLCHeaderDibits(burstRepeats, colorCode, groupID, sourceID)
+	iq := demod.ModulateC4FM(dibits, sps, span, alpha, sampleRateHz, deviationHz)
+	iqPath := filepath.Join(t.TempDir(), "dmr-tier2-cc.cfile")
+	if err := writeIQToU8File(iqPath, iq); err != nil {
+		t.Fatalf("write IQ: %v", err)
+	}
+	sdr.Register(&sdr.MockDriver{Files: []string{iqPath}})
+
+	newDaemon := func(t *testing.T, recordingsDir string) *Daemon {
+		t.Helper()
+		cfg := config.Default()
+		cfg.SDR.SampleRate = sampleRateHz
+		cfg.SDR.Devices = []config.DeviceConfig{{Serial: "mock-00", Role: "control"}}
+		cfg.Trunking.Systems = []config.SystemConfig{
+			{Name: "DMRTier2Repeater", Protocol: "dmr-tier2", ControlChannels: []uint32{controlFreqHz}},
+		}
+		cfg.API.HTTPAddr = freeAddr(t)
+		cfg.Recordings.Dir = recordingsDir
+
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		d, err := NewDaemon(cfg, "test-live-audio", logger)
+		if err != nil {
+			t.Fatalf("NewDaemon: %v", err)
+		}
+		t.Cleanup(d.Close)
+		return d
+	}
+
+	t.Run("no recordings dir builds a decode-only decoder", func(t *testing.T) {
+		d := newDaemon(t, "")
+		if d.recorder != nil {
+			t.Error("recorder should be nil without a recordings dir (nothing to persist)")
+		}
+		if d.voiceDecoder == nil {
+			t.Fatal("voiceDecoder is nil: digital voice would never be decoded, so live audio is silent")
+		}
+		if d.composer == nil {
+			t.Error("composer is nil: no voice demod would run, so no PCM reaches the stream")
+		}
+		if d.audioPub == nil {
+			t.Error("audioPub is nil: the /api/v1/audio/stream endpoint has no source")
+		}
+	})
+
+	t.Run("recordings dir reuses the file recorder as the decoder", func(t *testing.T) {
+		d := newDaemon(t, t.TempDir())
+		if d.recorder == nil {
+			t.Fatal("recorder should be built when a recordings dir is set")
+		}
+		if d.voiceDecoder != d.recorder {
+			t.Error("voiceDecoder must be the file recorder when recording (no separate decoder)")
+		}
+		if d.composer == nil {
+			t.Error("composer is nil: recording + live audio both need it")
+		}
+	})
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -75,6 +75,14 @@ type Recorder struct {
 	normalize          NormalizeConfig
 	vocoderForProtocol map[string]string
 
+	// decodeOnly runs the recorder as a live decoder that writes NO files:
+	// every call still builds its per-protocol vocoder and fans decoded PCM
+	// to decodedTap (the web/gRPC stream), but no WAV or .raw is opened. Set
+	// when OutDir is empty, so live browser audio works even when the operator
+	// has not configured a recordings directory. When false the recorder
+	// behaves exactly as before (decode + persist).
+	decodeOnly bool
+
 	// enhance is the current voice enhancement config, read when a new
 	// call's vocoder is built (buildSession). Guarded by enhanceMu so the
 	// settings endpoint can swap it at runtime via SetVoiceEnhance — the
@@ -276,17 +284,20 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 	if opts.Bus == nil {
 		return nil, errors.New("voice/recorder: events.Bus is required")
 	}
-	if opts.OutDir == "" {
-		return nil, errors.New("voice/recorder: OutDir is required")
-	}
+	// An empty OutDir runs the recorder in decode-only mode: it still decodes
+	// each call and feeds the live-audio tap, it just never writes files. This
+	// is how live browser audio works without a configured recordings dir.
+	decodeOnly := opts.OutDir == ""
 	if opts.SampleRate == 0 {
 		opts.SampleRate = pcmHzDefault
 	}
 	if opts.Log == nil {
 		opts.Log = slog.Default()
 	}
-	if err := os.MkdirAll(opts.OutDir, 0o755); err != nil {
-		return nil, fmt.Errorf("voice/recorder: mkdir: %w", err)
+	if !decodeOnly {
+		if err := os.MkdirAll(opts.OutDir, 0o755); err != nil {
+			return nil, fmt.Errorf("voice/recorder: mkdir: %w", err)
+		}
 	}
 	vocoderMap := opts.VocoderForProtocol
 	if vocoderMap == nil {
@@ -313,6 +324,7 @@ func NewRecorder(opts RecorderOptions) (*Recorder, error) {
 		enhance:            opts.Enhance,
 		vocoderForProtocol: vocoderMap,
 		displayLoc:         loc,
+		decodeOnly:         decodeOnly,
 		sessions:           make(map[string]*recordingSession),
 		runDone:            make(chan struct{}),
 	}
@@ -448,6 +460,12 @@ func (r *Recorder) WritePCM(deviceSerial string, samples []int16) error {
 	if s == nil {
 		return nil
 	}
+	// Decode-only sessions never open a WAV. Analog PCM still reaches the live
+	// stream via the composer's direct audioPub fanout, so there is nothing to
+	// do here but drop it.
+	if s.wav == nil {
+		return nil
+	}
 	return s.wav.WriteSamples(samples)
 }
 
@@ -471,6 +489,14 @@ func (r *Recorder) sessionForWrite(serial string, callID uint64) *recordingSessi
 	}
 	if callID != 0 && s.callID != 0 && callID != s.callID {
 		return nil
+	}
+	// Decode-only: no files are ever opened. The session already carries its
+	// per-protocol vocoder (buildSession), so WriteRawFrame can decode and fan
+	// PCM to the live tap; hand it back with wav == nil. Segment rolls never
+	// park a decode-only session (handleSegment bails on wav == nil), so the
+	// dormant-rebuild path below is unreachable here.
+	if r.decodeOnly {
+		return s
 	}
 	if s.wav == nil {
 		// A dormant post-segment park carries only cs+callID with no paths
@@ -573,8 +599,13 @@ func (r *Recorder) writeRawFrame(deviceSerial string, callID uint64, frame []byt
 		if n := len(samples); n > 0 {
 			s.lastSample = samples[n-1]
 		}
-		if err := s.wav.WriteSamples(samples); err != nil {
-			return err
+		// Decode-only sessions have no WAV — skip the file write but still fan
+		// the decoded PCM to the live tap below so browser audio works without
+		// a recordings directory.
+		if s.wav != nil {
+			if err := s.wav.WriteSamples(samples); err != nil {
+				return err
+			}
 		}
 		// Fan the freshly-decoded PCM to the live consumers (web
 		// stream, host player, tone-out). For digital protocols this
@@ -606,9 +637,11 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 		// completion via handleEnd.
 		return
 	}
-	if cs.Talkgroup != nil && !cs.Talkgroup.Record {
+	if !r.decodeOnly && cs.Talkgroup != nil && !cs.Talkgroup.Record {
 		// Talkgroup is flagged record=false — follow and play the
-		// call live, but write no WAV/raw files for it.
+		// call live, but write no WAV/raw files for it. A decode-only
+		// recorder writes nothing regardless, so it must NOT drop the
+		// call here or the talkgroup would be silent live too.
 		return
 	}
 	if r.skipEncrypted && cs.Grant.Encrypted {
@@ -838,6 +871,13 @@ func (r *Recorder) normalizeIfEnabled(wavPath string) {
 // publish when audio was written; an empty file (no PCM) is removed and
 // nil returned. Caller holds r.mu and publishes after releasing it.
 func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt time.Time, reason trunking.EndReason) *trunking.CallComplete {
+	// Callers only reach here with an open WAV (handleEnd/handleSegment guard on
+	// s.wav != nil); a decode-only session has no file to finalize. Guard anyway
+	// so a future caller can't panic on the nil writer.
+	if s.wav == nil {
+		_ = s.close()
+		return nil
+	}
 	dataBytes := s.wav.DataBytes()
 	vs, haveStats := r.voiceStatsFor(s)
 	r.logVoiceStats(serial, s)
@@ -996,9 +1036,17 @@ func (r *Recorder) handleEnd(ce trunking.CallEnd) {
 	if ok {
 		delete(r.sessions, ce.DeviceSerial)
 	}
-	if !ok || s.wav == nil {
-		// No session, or a dormant post-segment session whose next over
-		// never arrived — nothing to finalize.
+	if !ok {
+		r.mu.Unlock()
+		return
+	}
+	if s.wav == nil {
+		// No open WAV: a decode-only session (never writes files), a dormant
+		// post-segment park whose next over never arrived, or a dead-key call
+		// that built a vocoder but decoded no frame. finalizeLocked assumes an
+		// open WAV and there's nothing to publish, but the session may still
+		// hold a live vocoder — close it so it isn't leaked.
+		_ = s.close()
 		r.mu.Unlock()
 		return
 	}

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -738,6 +738,115 @@ func TestRecorderForwardsDecodedPCMToCallAwareTap(t *testing.T) {
 	}
 }
 
+// countingPCMTap tallies the total number of decoded PCM samples the recorder
+// fans to the live stream — enough to prove audio flows without inspecting it.
+type countingPCMTap struct {
+	mu    sync.Mutex
+	total int
+}
+
+func (c *countingPCMTap) WritePCM(_ string, samples []int16) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.total += len(samples)
+	return nil
+}
+func (c *countingPCMTap) sum() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.total
+}
+
+// TestRecorderDecodeOnlyFeedsTapWithoutFiles pins the fix that decouples live
+// audio from recording: a recorder built with an empty OutDir must still decode
+// each call and fan the PCM to the live tap (so browser audio works with no
+// recordings directory), while writing NO files to disk. Before the fix,
+// NewRecorder rejected an empty OutDir outright, so live digital audio silently
+// required recordings.dir.
+func TestRecorderDecodeOnlyFeedsTapWithoutFiles(t *testing.T) {
+	// Any accidental file write lands in this dir (directoryFor joins a relative
+	// path onto the empty OutDir), so we can assert the tree stays empty.
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	bus := events.NewBus(8)
+	r, err := NewRecorder(RecorderOptions{
+		Bus:                bus,
+		OutDir:             "", // decode-only
+		SampleRate:         8000,
+		VocoderForProtocol: map[string]string{"test-null": "null"},
+	})
+	if err != nil {
+		t.Fatalf("NewRecorder(OutDir: \"\") decode-only: %v", err)
+	}
+	defer r.Close()
+	defer bus.Close()
+
+	tap := &countingPCMTap{}
+	r.SetDecodedPCMSink(tap)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go r.Run(ctx)
+
+	cs := trunking.CallStart{
+		Grant:        trunking.Grant{System: "S", Protocol: "test-null", GroupID: 1, CallID: 42},
+		DeviceSerial: "tap-0",
+		StartedAt:    time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC),
+	}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if r.HasSession("tap-0") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !r.HasSession("tap-0") {
+		t.Fatal("decode-only session never started")
+	}
+
+	const frames = 5
+	for i := 0; i < frames; i++ {
+		if err := r.WriteRawFrameForCall("tap-0", 42, make([]byte, 11), 0); err != nil {
+			t.Fatalf("WriteRawFrameForCall: %v", err)
+		}
+	}
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant:        cs.Grant,
+		DeviceSerial: "tap-0",
+		StartedAt:    cs.StartedAt,
+		EndedAt:      cs.StartedAt.Add(time.Second),
+		Reason:       trunking.EndReasonNormal,
+	}})
+	deadline = time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !r.HasSession("tap-0") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// The null vocoder emits 160 samples per 11-byte frame; every decoded chunk
+	// must reach the live tap even though nothing is written to disk.
+	if got := tap.sum(); got < frames*160 {
+		t.Errorf("decode-only tap received %d samples, want >= %d — live audio would be silent",
+			got, frames*160)
+	}
+
+	// Nothing must have been written to disk.
+	var files []string
+	_ = filepath.Walk(tmp, func(path string, info os.FileInfo, err error) error {
+		if err == nil && info != nil && !info.IsDir() {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if len(files) != 0 {
+		t.Errorf("decode-only recorder wrote files: %v, want none", files)
+	}
+}
+
 // fakeRawTap implements RawFrameCallSink, recording the verbatim bytes, vocoder
 // name, and CallID the recorder forwards for each raw frame so a test can
 // confirm the raw fan-out carries the codec label and is fenced by the

--- a/web/src/audio/sincResampler.ts
+++ b/web/src/audio/sincResampler.ts
@@ -1,13 +1,13 @@
 // High-quality band-limited resampler for the live-audio worklet path.
 //
 // The daemon streams PCM at the call's sample rate (8 kHz for digital and the
-// analog default). The AudioWorklet that plays it runs at the AudioContext
-// rate — normally the 8 kHz we pin, but the hardware rate (~44.1/48 kHz) when a
-// browser rejects the explicit rate (older Safari throws). When those differ we
-// must resample 8k -> 48k, and the cheap LinearResampler does it with linear
-// interpolation: weak anti-imaging that leaks audible aliases above the 4 kHz
-// input Nyquist, the "harsh / tinny" character that makes live sound worse than
-// the recorded .wav (the file is resampled by the browser's native sinc path).
+// analog default). The AudioWorklet that plays it runs at the AudioContext rate,
+// which is the hardware-native rate (~44.1/48 kHz) — we no longer pin the context
+// to 8 kHz because that silently rendered nothing on Windows/WASAPI. So the
+// common path now resamples 8k -> 48k, and the cheap LinearResampler does it with
+// linear interpolation: weak anti-imaging that leaks audible aliases above the
+// 4 kHz input Nyquist, the "harsh / tinny" character that makes live sound worse
+// than the recorded .wav (the file is resampled by the browser's native sinc path).
 //
 // SincResampler closes that gap with a windowed-sinc polyphase kernel — the
 // same class of filter the browser uses for a recorded buffer — while keeping
@@ -15,8 +15,8 @@
 //   1. Continuous state across network chunks: one instance spans the whole
 //      stream, carrying a history tail and a fractional read cursor so feeding
 //      [a,b] then [c,d] yields exactly what feeding [a,b,c,d] at once would.
-//   2. Zero-work passthrough when input and output rates match (the common
-//      8 kHz-context case), returning the input buffer unchanged.
+//   2. Zero-work passthrough when input and output rates match (e.g. a device
+//      whose native rate happens to be 8 kHz), returning the input unchanged.
 //
 // It is a drop-in for LinearResampler: same constructor, `passthrough` getter,
 // and process() contract.

--- a/web/src/audio/streamPlayer.test.ts
+++ b/web/src/audio/streamPlayer.test.ts
@@ -6,6 +6,7 @@ import {
   WAV_HEADER_SIZE,
   createAudioContext,
   STREAM_SAMPLE_RATE,
+  WorkletSink,
 } from "./streamPlayer";
 
 // Build a canonical 44-byte RIFF/WAVE header byte-for-byte the way the
@@ -170,38 +171,70 @@ describe("PcmFramer", () => {
 });
 
 describe("createAudioContext", () => {
-  // Pinning the context to the stream's 8 kHz rate is what lets Web Audio skip
-  // per-chunk resampling (#598); assert the rate is actually requested.
-  it("builds the context at the requested sample rate", () => {
+  // Regression (#598 follow-up): the context must run at the hardware-native
+  // rate. Forcing the stream's 8 kHz here made Windows/WASAPI accept the context
+  // yet render silence in every browser. Assert we request NO explicit
+  // sampleRate so the OS picks a rate its audio engine can actually play.
+  it("builds the context at the hardware-native rate (no forced sampleRate)", () => {
     const seen: (AudioContextOptions | undefined)[] = [];
     class FakeCtx {
       constructor(opts?: AudioContextOptions) {
         seen.push(opts);
       }
     }
-    const ctx = createAudioContext(
-      FakeCtx as unknown as typeof AudioContext,
-      STREAM_SAMPLE_RATE,
-    );
+    const ctx = createAudioContext(FakeCtx as unknown as typeof AudioContext);
     expect(ctx).toBeInstanceOf(FakeCtx);
-    expect(seen).toEqual([{ sampleRate: 8000 }]);
+    expect(seen).toEqual([undefined]); // constructed with no sampleRate option
+  });
+});
+
+describe("WorkletSink", () => {
+  // A minimal AudioWorkletNode stand-in capturing what push() posts to the
+  // audio thread.
+  function fakeNode() {
+    const posts: { type: string; samples?: Float32Array }[] = [];
+    const node = {
+      port: {
+        postMessage: (msg: { type: string; samples?: Float32Array }) => {
+          posts.push(msg);
+        },
+      },
+    };
+    return { node: node as unknown as AudioWorkletNode, posts };
+  }
+
+  // With the context at the native 48 kHz and the stream at 8 kHz, the sink must
+  // upsample so audio actually reaches the ring buffer — this is the path that
+  // replaced the silent 8 kHz-pinned context.
+  it("resamples an 8 kHz stream up to a 48 kHz context", () => {
+    const { node, posts } = fakeNode();
+    const sink = new WorkletSink(node, 48000);
+    sink.configure(STREAM_SAMPLE_RATE); // 8000
+
+    const input = new Float32Array(64).fill(0.5);
+    sink.push(input);
+
+    const pushed = posts.filter((p) => p.type === "push");
+    expect(pushed.length).toBe(1);
+    const out = pushed[0].samples!;
+    // ~6x the input length (48000/8000), minus the resampler's kernel-warmup
+    // tail it defers to the next chunk — so well above the input count and
+    // clearly non-empty (audio is flowing at the native rate).
+    expect(out.length).toBeGreaterThan(input.length * 4);
   });
 
-  // Older Safari throws when handed an explicit sampleRate; we must still get a
-  // usable (hardware-default) context rather than failing playback outright.
-  it("falls back to a default context when the rate is rejected", () => {
-    let calls = 0;
-    class PickyCtx {
-      constructor(opts?: AudioContextOptions) {
-        calls++;
-        if (opts) throw new Error("sampleRate not supported");
-      }
-    }
-    const ctx = createAudioContext(
-      PickyCtx as unknown as typeof AudioContext,
-      STREAM_SAMPLE_RATE,
-    );
-    expect(ctx).toBeInstanceOf(PickyCtx);
-    expect(calls).toBe(2); // first (with opts) throws, second (no opts) succeeds
+  // A device whose native rate is already 8 kHz needs no resampling: the sink
+  // passes samples straight through unchanged.
+  it("passes through when context and stream rates match", () => {
+    const { node, posts } = fakeNode();
+    const sink = new WorkletSink(node, STREAM_SAMPLE_RATE);
+    sink.configure(STREAM_SAMPLE_RATE);
+
+    const input = new Float32Array([0.1, -0.2, 0.3, -0.4]);
+    sink.push(input);
+
+    const pushed = posts.filter((p) => p.type === "push");
+    expect(pushed.length).toBe(1);
+    expect(Array.from(pushed[0].samples!)).toEqual(Array.from(input));
   });
 });

--- a/web/src/audio/streamPlayer.ts
+++ b/web/src/audio/streamPlayer.ts
@@ -156,12 +156,18 @@ const MAX_RING_SECONDS = 2;
 type AudioContextCtor = typeof AudioContext;
 
 // The daemon streams 8 kHz PCM (vocoder-native for digital; the analog
-// default). Creating the AudioContext at this rate makes Web Audio do ZERO
-// per-chunk resampling — every scheduled buffer matches the context rate and
-// plays back-to-back seamlessly, and the OS does one continuous resample to the
-// output device, exactly like a recorded .wav. Without it, every small chunk is
-// resampled 8k->48k independently with no interpolation state across chunk
-// boundaries, the artifacts that make live sound worse than the file (#598).
+// default). This is the wire rate, NOT the AudioContext rate: the WAV header
+// carries it, PcmFramer reports it, and it seeds LegacySink before the header
+// arrives. The playback context runs at the hardware-native rate instead (see
+// createAudioContext) and WorkletSink's continuous SincResampler bridges
+// 8k->native band-limited, like a recorded .wav.
+//
+// We used to pin the context to 8 kHz to skip resampling, but on Windows/WASAPI
+// an 8 kHz AudioContext is often accepted without error yet renders no output —
+// silent playback in every browser (#598 follow-up). Running at the native rate
+// and letting the SincResampler (#629) do the 8k->48k upconversion is reliable
+// across platforms and keeps the "as good as the file" quality the resampler
+// was built for.
 export const STREAM_SAMPLE_RATE = 8000;
 
 function resolveAudioContext(): AudioContextCtor | null {
@@ -172,18 +178,13 @@ function resolveAudioContext(): AudioContextCtor | null {
   return w.AudioContext ?? w.webkitAudioContext ?? null;
 }
 
-// createAudioContext pins the context to the stream rate, falling back to the
-// hardware-default context if the browser rejects an explicit sampleRate (older
-// Safari throws). Pure except for the Ctor it is handed, so it is unit-testable.
-export function createAudioContext(
-  Ctor: AudioContextCtor,
-  rate: number,
-): AudioContext {
-  try {
-    return new Ctor({ sampleRate: rate });
-  } catch {
-    return new Ctor();
-  }
+// createAudioContext builds the context at the hardware-native sample rate — no
+// explicit sampleRate is requested. Forcing the stream's 8 kHz here made
+// Windows/WASAPI silently render nothing (#598 follow-up); WorkletSink's
+// SincResampler upconverts 8k->native instead. Pure except for the Ctor it is
+// handed, so it is unit-testable.
+export function createAudioContext(Ctor: AudioContextCtor): AudioContext {
+  return new Ctor();
 }
 
 // A PcmSink consumes the decoded Float32 stream and renders it. configure() is
@@ -197,13 +198,13 @@ interface PcmSink {
 }
 
 // WorkletSink feeds the ring-buffer AudioWorklet (issue #629). It resamples the
-// stream to the context rate with one continuous SincResampler (so chunk
-// boundaries don't glitch and the 8k->48k fallback path is band-limited like a
-// recorded .wav, not the harsh linear interpolation of the old resampler) and
-// hands the samples to the audio thread via a transferred buffer. The worklet
+// 8 kHz stream up to the native context rate with one continuous SincResampler
+// (so chunk boundaries don't glitch and the 8k->48k conversion is band-limited
+// like a recorded .wav, not the harsh linear interpolation of the old resampler)
+// and hands the samples to the audio thread via a transferred buffer. The worklet
 // emits silence on underrun, so network jitter no longer skips/realigns the
 // playback cursor the way the legacy scheduler did.
-class WorkletSink implements PcmSink {
+export class WorkletSink implements PcmSink {
   private resampler: SincResampler | null = null;
 
   constructor(
@@ -232,8 +233,10 @@ class WorkletSink implements PcmSink {
 
 // LegacySink is the original per-chunk AudioBufferSource scheduler, kept as a
 // fallback for browsers without AudioWorklet (or when the worklet module can't
-// load). The context resamples each buffer to the device rate; the 8 kHz
-// context pin keeps that a no-op for the common case.
+// load). It hands each buffer to the context at the stream rate and lets the
+// context resample per-chunk to the native device rate — lower quality than the
+// WorkletSink's continuous SincResampler, but audible (and far better than the
+// silence the old 8 kHz context pin produced on Windows).
 class LegacySink implements PcmSink {
   private nextStartTime = 0;
   private streamRate = STREAM_SAMPLE_RATE;
@@ -306,7 +309,7 @@ export function createStreamPlayer(
         opts.onStateChange("error");
         return false;
       }
-      ctx = createAudioContext(Ctor, STREAM_SAMPLE_RATE);
+      ctx = createAudioContext(Ctor);
     }
     if (gain === null) {
       gain = ctx.createGain();


### PR DESCRIPTION
The live-audio player created its AudioContext at the stream's 8 kHz
rate (new AudioContext({ sampleRate: 8000 })). On Windows/WASAPI an
8 kHz context is frequently accepted without error yet renders no
output, so decoded voice was silent in Chrome, Edge, and Firefox alike
while calls and elapsed time kept updating.

Create the context at the hardware-native rate instead and let
WorkletSink's existing continuous SincResampler upconvert 8k->native
(band-limited, "as good as the file" per #629). The resampler was
already wired off audioCtx.sampleRate and only sat idle because the
context was pinned to the stream rate. The no-AudioWorklet LegacySink
falls back to the browser's per-chunk resample — lower quality but
audible, and far better than silence.

Regression test asserts createAudioContext requests no explicit
sampleRate, plus WorkletSink cases proving samples flow (and resample)
when the context runs at 48 kHz.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FRVcBdLDgMgFxQGu1UbU6L