### PR TITLE
import: give RadioReference sites CSVs an actionable error; surface SOAP faults on HTTP 500

### DIFF
--- a/cmd/gophertrunk/import_csv.go
+++ b/cmd/gophertrunk/import_csv.go
@@ -62,13 +62,21 @@ func parseCSVFile(path string, opts csvImportOpts) (parsedSystem, error) {
 	// first header cell. See issue #849.
 	data = stripUTF8BOM(data)
 	var sys parsedSystem
-	if looksLikeRRNativeCSV(data) {
+	switch {
+	case looksLikeRRNativeCSV(data):
 		fillOpts := opts
 		if fillOpts.Name == "" {
 			fillOpts.Name = filenameStem(path)
 		}
 		sys, err = parseRRNativeCSVStream(bytes.NewReader(data), fillOpts)
-	} else {
+	case looksLikeRRSitesCSV(data):
+		// A RadioReference native *sites* CSV (trs_sites_<id>.csv) is
+		// neither a talkgroup CSV nor a multi-section bundle. Without a
+		// dedicated importer it would misroute to the bundle parser and
+		// fail with the opaque "before any # Section" error; report an
+		// actionable message instead. See issue #849.
+		err = errRRSitesCSVUnsupported
+	default:
 		sys, err = parseCSVStream(bytes.NewReader(data))
 	}
 	if err != nil {
@@ -583,6 +591,71 @@ func looksLikeRRNativeCSV(data []byte) bool {
 		}
 	}
 	return hits >= 3
+}
+
+// errRRSitesCSVUnsupported is returned when an uploaded CSV looks like a
+// RadioReference native *sites* export (the trs_sites_<id>.csv site /
+// frequency table) rather than a talkgroup CSV or a multi-section bundle.
+// GopherTrunk has no importer for that shape yet (see issue #849), so we
+// surface an actionable message instead of letting it misroute to the
+// bundle parser and fail with the opaque "before any # Section" error.
+var errRRSitesCSVUnsupported = errors.New(
+	"this looks like a RadioReference sites CSV (a site/frequency table, e.g. " +
+		"trs_sites_<id>.csv), which GopherTrunk can't import directly yet — import " +
+		"the system's PDF (Download → PDF) or its Talkgroups CSV, or wrap the data in " +
+		"a multi-section bundle (see docs/import.md)")
+
+// looksLikeRRSitesCSV reports whether data looks like a RadioReference
+// native sites CSV: no `# Section:` markers anywhere AND a header row that
+// carries a frequency column together with a site / RFSS / NAC column. The
+// exact column names in RR's sites export vary, so the match is
+// deliberately loose (case-insensitive substring) — it only needs to tell
+// a sites table apart from a talkgroup table or a hand-authored bundle, not
+// to validate the schema. Kept cheap by scanning only the first 8 KiB.
+func looksLikeRRSitesCSV(data []byte) bool {
+	head := data
+	const peek = 8 * 1024
+	if len(head) > peek {
+		head = head[:peek]
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(head))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var headerLine string
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// A section marker means it's a bundle, not a bare sites CSV.
+		if _, ok := matchSectionMarker(trimmed); ok {
+			return false
+		}
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if headerLine == "" {
+			headerLine = line
+		}
+	}
+	if headerLine == "" {
+		return false
+	}
+	fields, err := splitCSVLine(headerLine)
+	if err != nil {
+		return false
+	}
+	hasFreq, hasSite := false, false
+	for _, f := range fields {
+		norm := strings.ToLower(strings.TrimSpace(f))
+		if strings.Contains(norm, "freq") {
+			hasFreq = true
+		}
+		if strings.Contains(norm, "site") || strings.Contains(norm, "rfss") || strings.Contains(norm, "nac") {
+			hasSite = true
+		}
+	}
+	return hasFreq && hasSite
 }
 
 // parseRRNativeCSVStream parses RadioReference's flat talkgroup CSV

--- a/cmd/gophertrunk/import_csv_test.go
+++ b/cmd/gophertrunk/import_csv_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -431,6 +432,48 @@ func TestParseRRNativeCSVStream_BOM(t *testing.T) {
 	}
 	if len(sys.Talkgroups) != 1 {
 		t.Fatalf("Talkgroups = %d, want 1", len(sys.Talkgroups))
+	}
+}
+
+// TestParseCSVFile_RRSitesCSVUnsupported reproduces the file reported in
+// issue #849: a RadioReference native *sites* CSV (trs_sites_<id>.csv),
+// which has no importer. Before this change it misrouted to the bundle
+// parser and failed with the opaque "before any # Section" error; now it
+// returns an actionable message naming the sites-CSV format.
+func TestParseCSVFile_RRSitesCSVUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/trs_sites_2951HQ.csv"
+	body := "RFSS,Site Dec,Site Hex,Site NAC,Description,County Name,Lat,Lon,Range,Frequencies\n" +
+		"1,1,001,293,Downtown,Maricopa,33.4,-112.0,20,851.0125c 851.2625 852.0125\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := parseCSVFile(path, csvImportOpts{})
+	if err == nil {
+		t.Fatal("parseCSVFile: expected an error for a native RR sites CSV, got nil")
+	}
+	if !errors.Is(err, errRRSitesCSVUnsupported) {
+		t.Fatalf("error = %v, want errRRSitesCSVUnsupported", err)
+	}
+	if strings.Contains(err.Error(), "# Section") {
+		t.Errorf("error still surfaces the opaque bundle message: %v", err)
+	}
+}
+
+// TestLooksLikeRRSitesCSV pins the sites-CSV sniffer: a sites-shaped
+// header matches, while a talkgroup CSV and a multi-section bundle do not.
+func TestLooksLikeRRSitesCSV(t *testing.T) {
+	sites := []byte("RFSS,Site Dec,Site NAC,Description,Frequencies\n1,1,293,Downtown,851.0125c\n")
+	if !looksLikeRRSitesCSV(sites) {
+		t.Error("sites CSV should match looksLikeRRSitesCSV")
+	}
+	tg := []byte("DEC,HEX,Mode,Alpha Tag,Description,Tag,Group\n1000,3e8,D,OPS,Ops,Law,Police\n")
+	if looksLikeRRSitesCSV(tg) {
+		t.Error("talkgroup CSV should not match looksLikeRRSitesCSV")
+	}
+	bundle := []byte("# Section: sites\nrfss,site_id,site_name,county,frequencies\n1,1,Alpha,X,851.0125c\n")
+	if looksLikeRRSitesCSV(bundle) {
+		t.Error("multi-section bundle should not match looksLikeRRSitesCSV")
 	}
 }
 

--- a/internal/radioreference/client.go
+++ b/internal/radioreference/client.go
@@ -155,6 +155,13 @@ func (c *Client) call(ctx context.Context, methodBody string) ([]byte, error) {
 		return nil, fmt.Errorf("radioreference: read response: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
+		// RadioReference answers an unknown/mismatched operation with an
+		// HTTP 500 whose body is a SOAP fault; surface the concise
+		// <faultstring> rather than dumping the raw XML envelope at the
+		// user. See issue #849.
+		if fault := firstLeaves(raw, "faultstring")["faultstring"]; fault != "" {
+			return nil, fmt.Errorf("radioreference: HTTP %d: %s", resp.StatusCode, fault)
+		}
 		return nil, fmt.Errorf("radioreference: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
 	}
 	if fault := firstLeaves(raw, "faultstring")["faultstring"]; fault != "" {

--- a/internal/radioreference/radioreference_test.go
+++ b/internal/radioreference/radioreference_test.go
@@ -121,6 +121,37 @@ func TestCall_SurfacesSOAPFault(t *testing.T) {
 	}
 }
 
+// TestCall_SurfacesFaultOnHTTP500 covers issue #849: RadioReference can
+// answer an unknown/mismatched operation with HTTP 500 whose body is a
+// SOAP fault. The error must surface the concise <faultstring>, not the
+// raw XML envelope.
+func TestCall_SurfacesFaultOnHTTP500(t *testing.T) {
+	const fault = `<?xml version="1.0"?>
+<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
+ <SOAP-ENV:Body><SOAP-ENV:Fault>
+  <faultcode>SOAP-ENV:Client</faultcode>
+  <faultstring>Operation 'getStateList' is not defined in the WSDL for this service</faultstring>
+ </SOAP-ENV:Fault></SOAP-ENV:Body></SOAP-ENV:Envelope>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(fault))
+	}))
+	defer srv.Close()
+	c, _ := NewClient(Auth{AppKey: "K", Username: "u", Password: "p"})
+	c.SetEndpoint(srv.URL)
+	_, err := c.GetStateList(context.Background())
+	if err == nil {
+		t.Fatal("expected an error for an HTTP 500 SOAP fault, got nil")
+	}
+	msg := err.Error()
+	if !contains(msg, "getStateList' is not defined") {
+		t.Errorf("error should surface the faultstring, got: %s", msg)
+	}
+	if contains(msg, "SOAP-ENV:Envelope") {
+		t.Errorf("error should not dump the raw XML envelope, got: %s", msg)
+	}
+}
+
 func TestGetCountyInfo_ParsesList(t *testing.T) {
 	const resp = `<?xml version="1.0"?>
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">


### PR DESCRIPTION
Issue #849's reported file, trs_sites_2951HQ.csv, is RadioReference's native
*sites* table export. The importer only recognizes the native *talkgroups*
CSV and the multi-section bundle, so a sites CSV fell through to the bundle
parser and failed with the opaque "data at line 1 before any # Section
marker". The earlier BOM-stripping fix (already on main) repairs talkgroup
CSVs but does nothing for a sites table.

Detect a sites-shaped CSV (no # Section markers, header with a frequency
column plus a site/RFSS/NAC column) in parseCSVFile and return a clear,
actionable message pointing at the formats that work today (system PDF or
Talkgroups CSV, or a bundle) instead of the cryptic bundle error. A proper
native sites-CSV importer needs the reporter's real file to avoid guessing
the column/frequency layout, so that stays out of scope here.

Separately, the same screenshot shows RadioReference answering the
browse-by-state call with an HTTP 500 SOAP fault ("Operation 'getStateList'
is not defined in the WSDL"). client.call() dumped the raw XML envelope on
any non-200; now it extracts and surfaces the concise <faultstring> first.

Adds failing-first tests for the sites-CSV sniffer/error and the HTTP-500
fault surfacing.

Refs #849

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012TM8abMLkcvgg9nG2tdMmA