### PR TITLE
Fix DMR "calls show but no audio / no recordings" — auto-enable wideband voice taps (+ live-audio fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ for tagged releases.
   from carrier offset alone. Fields are omitted until a TSBK is decoded and on
   non-TSBK Phase 2 paths (issue #858).
 
+### Fixed
+- **DMR (and single-dongle P25) voice now decodes with no extra config.** A
+  `role: wideband` dongle produced talkgroups/RIDs but no audio and no
+  recordings, because voice grants were dropped for lack of a voice device: the
+  voice pool is fed only by physical `role: voice` SDRs or virtual `voice_taps`,
+  and `voice_taps` defaulted to 0. When trunking is configured and no physical
+  `role: voice` SDR is present, the daemon now auto-enables a couple of virtual
+  voice taps on each wideband dongle so voice decodes out of the box; set
+  `voice_taps` explicitly to control concurrency. The shipped DMR samples now set
+  `voice_taps`, the "no voice source" startup warning names the fix, and the
+  config-builder's stale "voice taps (0–8) / capped at 8" hint is corrected.
+- **Live browser audio no longer requires a recordings directory.** The voice
+  composer and its decoded-PCM tap were gated on the file recorder, which needed
+  `recordings.dir`; a listen-only setup got silence. The recorder now supports a
+  decode-only mode (decodes and streams live audio without writing files).
+- **Live audio was silent in the browser on Windows.** The Web Audio player
+  pinned its `AudioContext` to 8 kHz, which Windows/WASAPI often accepts yet
+  renders as silence in every browser. It now runs at the device-native rate and
+  upconverts the 8 kHz stream with the existing band-limited resampler.
+
 ## [v0.5.9] — 2026-07-01
 
 ### Added

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2579,7 +2579,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// HandleGrant. Warn once at startup so the operator sees it before
 	// the first grant. Issue #379.
 	if len(d.systems) > 0 && len(d.voicePool.Devices()) == 0 {
-		d.log.Warn("no voice SDR configured but trunking systems are defined; voice grants will be dropped — add a role: voice device (see docs/hardware.md)",
+		d.log.Warn("no voice source configured but trunking systems are defined; voice grants will be dropped — no audio and no recordings — add a role: voice SDR, or a role: wideband dongle (voice taps auto-enable) (see docs/hardware.md)",
 			"systems", len(d.systems))
 	}
 
@@ -3785,6 +3785,13 @@ func cchuntSystems(systems []trunking.System, devices []config.DeviceConfig) []t
 	return out
 }
 
+// autoVoiceTaps is how many virtual voice taps buildVirtualVoiceTuners
+// enables on a wideband dongle that has no explicit voice_taps and no
+// physical role: voice SDR to fall back on. Two lets a typical single-dongle
+// setup follow a couple of concurrent calls without pegging a core; operators
+// who want more (or none) set voice_taps explicitly.
+const autoVoiceTaps = 2
+
 // buildVirtualVoiceTuners spins up one wbvoice.VirtualTuner per voice tap
 // on every `role: wideband` dongle. The taps subscribe to the dongle's
 // iqtap broker on each StreamIQ call, run a single-tap DDC, and emit
@@ -3800,6 +3807,15 @@ func (d *Daemon) buildVirtualVoiceTuners(cfg config.Config, log *slog.Logger) er
 	if d.pool == nil {
 		return nil
 	}
+	// A wideband dongle decodes control metadata (grants → TG/RID) fine with no
+	// voice taps, but every voice grant is then dropped for lack of a voice
+	// device — no audio and no recordings, while calls still appear "active".
+	// When trunking is configured and there's no physical role: voice SDR to
+	// carry those grants, auto-enable a couple of virtual voice taps on each
+	// wideband dongle so voice decodes out of the box. An explicit voice_taps
+	// (including 0 alongside a physical voice SDR) is always honoured.
+	autoEnableVoiceTaps := len(cfg.Trunking.Systems) > 0 &&
+		len(d.pool.AllByRole(sdr.RoleVoice)) == 0
 	for _, devCfg := range cfg.SDR.Devices {
 		if devCfg.Role != "wideband" {
 			continue
@@ -3813,6 +3829,11 @@ func (d *Daemon) buildVirtualVoiceTuners(cfg config.Config, log *slog.Logger) er
 		taps := devCfg.VoiceTaps
 		if taps < 0 {
 			taps = 0
+		}
+		if taps == 0 && autoEnableVoiceTaps {
+			taps = autoVoiceTaps
+			log.Info("daemon: wideband: no role: voice SDR and voice_taps unset; auto-enabling virtual voice taps so trunked voice decodes on this dongle — set voice_taps to change concurrency",
+				"serial", devCfg.Serial, "voice_taps", taps)
 		}
 		br := d.iqBrokers[entry.Info.Serial]
 		if br == nil && taps > 0 {

--- a/cmd/gophertrunk/wideband_voice_taps_autoenable_test.go
+++ b/cmd/gophertrunk/wideband_voice_taps_autoenable_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+)
+
+// multiFakeDriver enumerates several streamingFakeDevices so a test can open a
+// pool with more than one role (e.g. a wideband dongle plus a physical voice
+// SDR) without real hardware.
+type multiFakeDriver struct{ devs []*streamingFakeDevice }
+
+func (m *multiFakeDriver) Name() string { return "fakemulti" }
+
+func (m *multiFakeDriver) Enumerate() ([]sdr.Info, error) {
+	infos := make([]sdr.Info, len(m.devs))
+	for i, dv := range m.devs {
+		infos[i] = sdr.Info{Driver: "fakemulti", Index: i, Serial: dv.serial, Gains: []int{0}}
+	}
+	return infos, nil
+}
+
+func (m *multiFakeDriver) Open(idx int) (sdr.Device, error) { return m.devs[idx], nil }
+
+// openPool builds a Daemon with a pool opened from the given hints, wires the
+// IQ brokers, and returns it ready for buildVirtualVoiceTuners.
+func openPool(t *testing.T, cfg config.Config, hints []sdr.Hint) *Daemon {
+	t.Helper()
+	log := slog.New(slog.DiscardHandler)
+	d := &Daemon{pool: sdr.NewPool(log)}
+	if err := d.pool.OpenWith(sdr.PoolOpenOptions{
+		SampleRateHz: cfg.SDR.SampleRate,
+		Hints:        hints,
+		Strict:       true,
+	}); err != nil {
+		t.Fatalf("pool open: %v", err)
+	}
+	d.wrapIQBrokers(cfg, log)
+	if err := d.buildVirtualVoiceTuners(cfg, log); err != nil {
+		t.Fatalf("buildVirtualVoiceTuners: %v", err)
+	}
+	return d
+}
+
+// TestWidebandAutoEnablesVoiceTapsWithoutPhysicalVoice pins the fix for the DMR
+// "TGs/RIDs show but no audio and no recordings" foot-gun: a single role:
+// wideband dongle with voice_taps unset (0) decodes control metadata but binds
+// no voice tuner, so every grant is dropped. When trunking is configured and no
+// physical role: voice SDR exists, the daemon must auto-enable virtual voice
+// taps so the voice pool is non-empty and voice actually decodes.
+func TestWidebandAutoEnablesVoiceTapsWithoutPhysicalVoice(t *testing.T) {
+	const (
+		wbSerial   = "wb-autoenable"
+		centerHz   = 453_500_000
+		sampleRate = 2_400_000
+	)
+
+	systemCfg := config.SDRConfig{
+		SampleRate: sampleRate,
+		Devices: []config.DeviceConfig{{
+			Serial:       wbSerial,
+			Role:         "wideband",
+			CenterFreqHz: centerHz,
+			// VoiceTaps intentionally left 0 (unset) — the whole point.
+		}},
+	}
+	withSystems := config.Config{
+		SDR: systemCfg,
+		Trunking: config.TrunkingConfig{Systems: []config.SystemConfig{{
+			Name:            "regional-dmr-t2",
+			Protocol:        "dmr-tier2",
+			ControlChannels: []uint32{453_125_000},
+		}}},
+	}
+
+	t.Run("wideband-only trunking auto-enables taps", func(t *testing.T) {
+		sdr.Register(&multiFakeDriver{devs: []*streamingFakeDevice{newStreamingFake(wbSerial)}})
+		d := openPool(t, withSystems, []sdr.Hint{{Serial: wbSerial, Role: sdr.RoleWideband}})
+		if got := len(d.collectVoiceDevices()); got != autoVoiceTaps {
+			t.Fatalf("collectVoiceDevices = %d, want %d (auto-enabled taps for wideband-only DMR)", got, autoVoiceTaps)
+		}
+	})
+
+	t.Run("no trunking systems does not auto-enable", func(t *testing.T) {
+		sdr.Register(&multiFakeDriver{devs: []*streamingFakeDevice{newStreamingFake(wbSerial)}})
+		noSystems := config.Config{SDR: systemCfg} // Trunking.Systems empty
+		d := openPool(t, noSystems, []sdr.Hint{{Serial: wbSerial, Role: sdr.RoleWideband}})
+		if got := len(d.collectVoiceDevices()); got != 0 {
+			t.Fatalf("collectVoiceDevices = %d, want 0 (no trunking systems => no auto-enable)", got)
+		}
+	})
+
+	t.Run("physical voice SDR present does not auto-enable", func(t *testing.T) {
+		const voiceSerial = "voice-autoenable"
+		sdr.Register(&multiFakeDriver{devs: []*streamingFakeDevice{
+			newStreamingFake(wbSerial),
+			newStreamingFake(voiceSerial),
+		}})
+		cfg := withSystems
+		cfg.SDR.Devices = append([]config.DeviceConfig{}, systemCfg.Devices...)
+		cfg.SDR.Devices = append(cfg.SDR.Devices, config.DeviceConfig{Serial: voiceSerial, Role: "voice"})
+		d := openPool(t, cfg, []sdr.Hint{
+			{Serial: wbSerial, Role: sdr.RoleWideband},
+			{Serial: voiceSerial, Role: sdr.RoleVoice},
+		})
+		// A physical voice SDR carries the grants, so no virtual taps are added;
+		// the pool has exactly the one physical voice device.
+		if got := len(d.virtualVoiceTuners); got != 0 {
+			t.Fatalf("virtualVoiceTuners = %d, want 0 (physical voice SDR present => no auto-enable)", got)
+		}
+		if got := len(d.collectVoiceDevices()); got != 1 {
+			t.Fatalf("collectVoiceDevices = %d, want 1 (only the physical voice SDR)", got)
+		}
+	})
+}

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -110,7 +110,7 @@ var fieldMetas = map[string]FieldMeta{
 	"DeviceConfig.CenterFreqHz":   {Label: "Center frequency", Hz: true, Help: "Centre of the IQ band a wideband dongle covers. Every channel must fall within ± sample_rate/2 (5 % guard). Wideband only."},
 	"DeviceConfig.TunerStrategy":  {Help: "DSP layout that extracts each narrow channel from the wide IQ. auto picks by channel count. Wideband only.", Options: opts("", "(auto)", "ddc", "ddc", "polyphase", "polyphase")},
 	"DeviceConfig.Channels":       {Help: "Repeater carriers a wideband dongle monitors; each binds a frequency to a trunking system name."},
-	"DeviceConfig.VoiceTaps":      {Help: "Per-grant DDC voice tuners carved from a wideband dongle so one SDR covers CC + voice. 0 = use the physical voice pool. Capped at 8."},
+	"DeviceConfig.VoiceTaps":      {Help: "Per-grant DDC voice tuners carved from a wideband dongle so one SDR covers CC + voice. 0 = auto: a couple of taps are enabled automatically when this wideband dongle serves a trunking system and no role: voice SDR is present; set a value to control concurrency. No hard cap (CPU scales per tap)."},
 	"DeviceConfig.SignallingTaps": {Help: "P25 Phase 2 talker-alias harvesters: signalling-only DDC taps that decode FACCH-S aliases off granted traffic channels independent of the voice pool. 0 disables; 2-4 suits a busy Phase 2 system."},
 	"DeviceConfig.IQCorrect":      {Label: "I/Q correct", Help: "Blind I/Q-imbalance correction before decimation. Validate with `gophertrunk replay -iq-correct -diag` before enabling."},
 	"DeviceConfig.IQInvert":       {Label: "I/Q invert", Help: "Conjugate raw IQ (negate Q) to undo a spectrum-inverted front end (needed by some Soapy/USRP chains; critical for π/4-DQPSK like TETRA)."},

--- a/samples/dmr-simplex/config.yaml
+++ b/samples/dmr-simplex/config.yaml
@@ -66,6 +66,12 @@ sdr:
       # the cause. Measure your dongle's error (e.g. kalibrate-rtl, or a
       # known reference signal) and set it here.
       ppm: 0
+      # voice_taps carves per-grant voice tuners from this dongle's IQ so voice
+      # decodes (audio + recordings) without a separate role: voice SDR. One is
+      # enough for a single simplex carrier. If you omit this on a wideband
+      # dongle serving a trunking system, the daemon now auto-enables a couple;
+      # set it explicitly to control concurrency.
+      voice_taps: 1
       channels:
         - frequency_hz: 446_500_000
           system: "dmr-simplex"

--- a/samples/dmr-tier2-multi-repeater/config.yaml
+++ b/samples/dmr-tier2-multi-repeater/config.yaml
@@ -65,6 +65,12 @@ sdr:
       center_freq_hz: 453_500_000        # keep every channel below within ±1.08 MHz
       tuner_strategy: auto               # auto: DDC for ≤6 channels, polyphase above 6
       gain: "auto"
+      # Per-grant voice tuners carved from this dongle so voice decodes (audio +
+      # recordings) with no separate role: voice SDR — one per concurrent call.
+      # 4 covers several simultaneous calls in this cluster; raise toward the
+      # channel count for full coverage (each tap is an independent DDC, so CPU
+      # scales per tap). Omit it and the daemon auto-enables a couple.
+      voice_taps: 4
       channels:
         - { frequency_hz: 453_137_500, system: "regional-dmr" }
         - { frequency_hz: 453_262_500, system: "regional-dmr" }
@@ -81,6 +87,7 @@ sdr:
       center_freq_hz: 460_500_000
       tuner_strategy: auto
       gain: "auto"
+      voice_taps: 4                      # per-grant voice tuners on this dongle (see dongle 1)
       channels:
         - { frequency_hz: 460_137_500, system: "regional-dmr" }
         - { frequency_hz: 460_262_500, system: "regional-dmr" }
@@ -97,6 +104,7 @@ sdr:
       center_freq_hz: 465_500_000
       tuner_strategy: auto
       gain: "auto"
+      voice_taps: 4                      # per-grant voice tuners on this dongle (see dongle 1)
       channels:
         - { frequency_hz: 465_137_500, system: "regional-dmr" }
         - { frequency_hz: 465_262_500, system: "regional-dmr" }

--- a/samples/dmr-tier2-multichannel/config.yaml
+++ b/samples/dmr-tier2-multichannel/config.yaml
@@ -26,6 +26,11 @@ sdr:
       center_freq_hz: 453_500_000
       tuner_strategy: auto        # auto | ddc | polyphase
       gain: "auto"
+      # Per-grant voice tuners carved from this dongle so voice decodes (audio +
+      # recordings) with no separate role: voice SDR. One per carrier lets every
+      # repeater be followed at once. Omit it and the daemon auto-enables a
+      # couple; set it here to control concurrency.
+      voice_taps: 4
       channels:
         - frequency_hz: 453_125_000
           system: "regional-dmr-t2"

--- a/web/configbuilder/src/sections/SDR.tsx
+++ b/web/configbuilder/src/sections/SDR.tsx
@@ -192,7 +192,7 @@ function DeviceEditor(props: {
                 { value: "polyphase", label: "polyphase" },
               ]}
             />
-            <NumberField label="Voice taps (0–8)" value={d.VoiceTaps ?? 0} onChange={(x) => onChange({ ...d, VoiceTaps: x })} />
+            <NumberField label="Voice taps" value={d.VoiceTaps ?? 0} onChange={(x) => onChange({ ...d, VoiceTaps: x })} />
             <NumberField label="Signalling taps (P25 P2 alias)" value={d.SignallingTaps ?? 0} onChange={(x) => onChange({ ...d, SignallingTaps: x })} />
           </>
         ) : null}


### PR DESCRIPTION
## Summary

A user monitoring DMR repeaters saw talkgroups/RIDs with live timers but got **no audio and no recordings**. Root cause: a `role: wideband` dongle channelizes the control metadata fine (grants → the "active" TG/RID timers, emitted before any voice bind), but voice grants are dropped for lack of a voice device — the voice pool is fed only by physical `role: voice` SDRs or virtual `voice_taps`, and `voice_taps` defaults to `0`. So a single wideband dongle (the documented single-SDR DMR setup, and **every shipped DMR sample**) has an empty voice pool: `HandleGrant` records the metadata, then drops the grant before `CallStart`, so the composer never runs. Two smaller live-audio defects surfaced while chasing this and are fixed here too.

## Changes

- **Auto-enable wideband voice taps (the core fix)** — `cmd/gophertrunk/daemon.go`. When trunking systems are configured and there is no physical `role: voice` SDR, `buildVirtualVoiceTuners` now auto-enables a couple of virtual voice taps on each wideband dongle, so DMR (and single-dongle P25) voice decodes out of the box. An explicit `voice_taps` (including `0` alongside a physical voice SDR) is always honoured.
- **Guardrails so the foot-gun stays fixed** — sharpened the "no voice source" startup warning to name the symptom and both fixes; added explicit `voice_taps` to the three shipped DMR samples with a teaching comment; corrected the config-builder's stale "voice taps (0–8) / capped at 8" hint (uncapped since v0.3.9) and documented the `0 = auto` behaviour.
- **Live browser audio no longer requires a recordings directory** — `internal/voice/recorder.go`, `cmd/gophertrunk/daemon.go`. The composer + decoded-PCM tap were gated on the file recorder (which needs `recordings.dir`); a decode-only recorder mode now decodes and streams live audio without writing files.
- **Live audio was silent in the browser on Windows** — `web/src/audio/streamPlayer.ts`. The Web Audio player pinned its `AudioContext` to 8 kHz, which Windows/WASAPI often accepts yet renders as silence in every browser. It now runs at the device-native rate and upconverts the 8 kHz stream via the existing band-limited `SincResampler`.

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (daemon wiring changed)
- [x] Added or updated tests where appropriate
  - `cmd/gophertrunk/wideband_voice_taps_autoenable_test.go` — wideband-only + trunking + no physical voice SDR yields a non-empty voice pool; stays empty with no systems or when a physical voice SDR is present. Fails-first verified.
  - `internal/voice/recorder_test.go` — decode-only recorder decodes to the live tap while writing no files. Fails-first verified.
  - `cmd/gophertrunk/daemon_live_audio_test.go` — composer + audio publisher wired with no recordings dir.
  - `web/src/audio/streamPlayer.test.ts` — `createAudioContext` requests no forced sample rate; `WorkletSink` resamples 8k→48k. Fails-first verified (283 web tests pass).
- [ ] Smoke-tested against real hardware — n/a here (no SDR available in this environment). Behaviour verified via unit + integration tests and the DMR decode path traced end-to-end; a real-dongle smoke test on the reporter's wideband setup is the remaining confirmation.

## Breaking changes

Default behaviour change (opt-out available): a `role: wideband` dongle serving a trunking system now auto-provisions ~2 virtual voice taps when no physical `role: voice` SDR is configured. Each tap is an on-demand DDC, so a busy site sees a small CPU increase it did not before. Operators who want a different count — or none — set `voice_taps` explicitly (`voice_taps: 0` still means "no taps" when a physical voice SDR is present). No config keys, flags, endpoints, or schemas changed.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` → `### Fixed` bullets to `CHANGELOG.md`
- [ ] `docs/` unchanged — `docs/hardware.md` already documents `voice_taps`; the sample configs and config-builder hint are updated here

## Linked issues

n/a — reported via Discord, not yet reporter-verified. Deliberately not auto-closing anything (see the issue-closing policy in `CLAUDE.md`); a real-hardware confirmation from the reporter is the outstanding step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRVcBdLDgMgFxQGu1UbU6L

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRVcBdLDgMgFxQGu1UbU6L)_