### PR TITLE
docs: post-release v0.6.0–v0.6.4 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,25 +7,7 @@ for tagged releases.
 
 ## [Unreleased]
 
-### Added
-- **Neighbour sites on `GET /api/v1/sites`.** Each `SiteDTO` now carries a
-  `neighbors` array — the adjacent sites the site advertised over the air (P25
-  Adjacent Site Status Broadcast, opcode `0x3C`), each with the neighbour's
-  RFSS/Site and its band-plan-resolved control-channel `downlink_hz` (and
-  `uplink_hz`). This is the same decoded data already surfaced on
-  `GET /api/v1/systems`, now attached to the camped site of each system on the
-  per-site endpoint, so a consumer can backfill the wider network's
-  control-channel map from a single camped site without directly decoding every
-  site. Empty on sites that did not broadcast a neighbour list (issue #864).
-- **Per-site P25 decode quality on `GET /api/v1/sites`.** Each `SiteDTO` now
-  carries `control_channel_tsbk_error_rate` (cumulative % of TSBK blocks failing
-  Viterbi/CRC on that site's control channel), `control_channel_tsbk_count` (the
-  attempts behind it, a confidence weight), and `control_channel_decode_quality`
-  (`clean` / `marginal` / `poor`). This exposes decode health independently of
-  carrier lock — a well-locked carrier at range can still error heavily — so
-  consumers can categorise sites as clean vs marginal rather than approximating
-  from carrier offset alone. Fields are omitted until a TSBK is decoded and on
-  non-TSBK Phase 2 paths (issue #858).
+## [v0.6.4] — 2026-07-08
 
 ### Fixed
 - **DMR (and single-dongle P25) voice now decodes with no extra config.** A
@@ -38,6 +20,21 @@ for tagged releases.
   `voice_taps` explicitly to control concurrency. The shipped DMR samples now set
   `voice_taps`, the "no voice source" startup warning names the fix, and the
   config-builder's stale "voice taps (0–8) / capped at 8" hint is corrected.
+
+## [v0.6.3] — 2026-07-07
+
+### Added
+- **Neighbour sites on `GET /api/v1/sites`.** Each `SiteDTO` now carries a
+  `neighbors` array — the adjacent sites the site advertised over the air (P25
+  Adjacent Site Status Broadcast, opcode `0x3C`), each with the neighbour's
+  RFSS/Site and its band-plan-resolved control-channel `downlink_hz` (and
+  `uplink_hz`). This is the same decoded data already surfaced on
+  `GET /api/v1/systems`, now attached to the camped site of each system on the
+  per-site endpoint, so a consumer can backfill the wider network's
+  control-channel map from a single camped site without directly decoding every
+  site. Empty on sites that did not broadcast a neighbour list (issue #864).
+
+### Fixed
 - **Live browser audio no longer requires a recordings directory.** The voice
   composer and its decoded-PCM tap were gated on the file recorder, which needed
   `recordings.dir`; a listen-only setup got silence. The recorder now supports a
@@ -46,6 +43,95 @@ for tagged releases.
   pinned its `AudioContext` to 8 kHz, which Windows/WASAPI often accepts yet
   renders as silence in every browser. It now runs at the device-native rate and
   upconverts the 8 kHz stream with the existing band-limited resampler.
+- **RadioReference *sites* CSVs now fail with an actionable error, and SOAP
+  faults surface their fault string.** The importer only recognises RadioReference's
+  native *talkgroups* CSV and the multi-section bundle, so a native *sites* table
+  export fell through to the bundle parser and failed with the opaque "data at
+  line 1 before any # Section marker". A sites-shaped CSV (no `# Section` markers,
+  a header with a frequency column plus a site/RFSS/NAC column) is now detected and
+  rejected with a message pointing at the formats that work today (system PDF,
+  Talkgroups CSV, or a bundle). Separately, when RadioReference answers a browse
+  call with an HTTP 500 SOAP fault, the client now surfaces the concise
+  `<faultstring>` instead of dumping the raw XML envelope (issue #849).
+
+## [v0.6.2] — 2026-07-04
+
+### Fixed
+- **P25 Phase 2 superframes now lock on real off-air traffic.** The outbound sync
+  constant was a garbled 48-bit value (`0x575F7DFF77FF`) used where a 40-bit
+  (20-dibit) sync word is expected, so the top byte was silently dropped and the
+  detector matched a pattern that never appears on air — `superframes=0` on every
+  call, so `algorithm_id`/`key_id` never populated. Differentially decoding the
+  spec-conformant outbound sync (`0x575D57F7FF`, TIA-102.BBAC) yields the 20-dibit
+  stream the detector must match; setting it (plus a width guard) lets superframes
+  lock. Verified against a spec-conformant synthetic; issue #813 stays open pending
+  the reporter's real capture (issue #813).
+- **`control_channel_carrier_offset_hz` now reports the *total* control-channel
+  offset, matching the WARN log.** The field on `GET /api/v1/sites` was wired to
+  the receiver's residual AFC only, so with `sdr.autotune` on — once a correction
+  folds into the DDC and the receiver re-centres — it under-reported the offset the
+  "carrier offset" WARN was still flagging: the log and the API disagreed. The
+  published value now adds the applied DDC correction to the residual, so the two
+  agree by construction. With autotune off (the default) the applied correction is
+  0 and the value is unchanged (issue #815).
+
+## [v0.6.1] — 2026-07-03
+
+### Docs
+- **Lab Bench tutorial blog series.** Three concurrent hands-on series — **Signal
+  Lab**, **RF Scope**, and **Crypto Lab** — launch on the docs blog, built on a
+  shared no-CDN, theme-aware, high-DPI canvas charting module (constellation, eye,
+  heatmap, line, bars, timeline) that renders inline figures from post JSON, with
+  per-series hub pages, trilogy cross-links, and Blog-group navigation.
+
+## [v0.6.0] — 2026-07-02
+
+### Added
+- **Every browser console is reachable from the daemon, and they share one design
+  system.** The daemon previously mounted only the operator console (`/`), Config
+  Builder (`/config/`), and Crypto Lab (`/cryptolab/`); Signal Lab and RF Scope
+  were reachable only via their standalone `serve` commands, absent from the nav,
+  and Crypto Lab's header linked to a `/siglab/` path the daemon 404'd. Signal Lab
+  now mounts at `/siglab/` and RF Scope at `/rfscope/`, both advertised via
+  `RuntimeDTO` so the nav only links to what is actually reachable, and every
+  sub-app gains a shared nav back to the operator console and its siblings. RF
+  Scope also joins the shared `--gt-*` design tokens (dark/mono/light themes +
+  reduced-motion), so all consoles look and behave alike.
+- **Per-site P25 decode quality on `GET /api/v1/sites`.** Each `SiteDTO` now
+  carries `control_channel_tsbk_error_rate` (cumulative % of TSBK blocks failing
+  Viterbi/CRC on that site's control channel), `control_channel_tsbk_count` (the
+  attempts behind it, a confidence weight), and `control_channel_decode_quality`
+  (`clean` / `marginal` / `poor`). This exposes decode health independently of
+  carrier lock — a well-locked carrier at range can still error heavily — so
+  consumers can categorise sites as clean vs marginal rather than approximating
+  from carrier offset alone. Fields are omitted until a TSBK is decoded and on
+  non-TSBK Phase 2 paths (issue #858).
+
+### Fixed
+- **Airspy overrun no longer silently freezes the whole decode.** Under high load
+  the wideband DSP consumer could stall, the driver's IQ channel filled, and the
+  blocking send stopped the USB reaper from posting new reads — the endpoint FIFO
+  overflowed and the stream halted with no error or log, which also froze the
+  control-channel decode (field-reported on an Airspy R2 at 2.5 and 10 MS/s when a
+  voice grant spun up a second IQ consumer). The Airspy deliver path is now
+  non-blocking and drops on overrun — matching the RTL-SDR and SoapyRemote paths —
+  counting the drop via `iq_underruns_total` and emitting a rate-limited "host
+  can't keep up — lower `sdr.sample_rate`" WARN, so the reaper always cycles back
+  and the device never underflows.
+- **Strong in-channel signal with no sync now warns and points at `sdr.ppm`.** A
+  narrowband C4FM carrier that is present but off-frequency (an uncorrected RTL-SDR
+  tuner offset beyond the demod's ~±75 Hz tolerance) decoded nothing with no
+  indication why. The wideband engine now emits a per-channel "strong signal but no
+  sync" WARN when a channel holds strong power with zero sync/FEC across several
+  diagnostics windows, naming `sdr.ppm` as the likely fix; the dmr-simplex sample
+  config's ppm note is strengthened accordingly (issue #836).
+- **RadioReference CSVs exported through Excel on Windows now import.** Such files
+  carry a UTF-8 BOM (`EF BB BF`); the raw bytes reached the format sniffer, mangling
+  the first header cell so the native-CSV detector failed and import errored with
+  "native RR CSV header missing decimal/dec column" or "data at line 1 before any
+  # Section marker". A leading BOM is now stripped at the file-read site (covering
+  both the CLI import and the web-UI upload) and, defensively, in the reader-based
+  entry points (issue #849).
 
 ## [v0.5.9] — 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.5.9
+VERSION=v0.6.4
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.5.9" -%}
+  {%- assign ver = "v0.6.4" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.6.4.md
+++ b/docs/announcements/v0.6.4.md
@@ -1,0 +1,56 @@
+# GopherTrunk v0.6.4 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.6.4 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+This draft covers the whole v0.6.x line (v0.6.0 → v0.6.4) — the daily
+releases shipped since the last announced build (v0.5.9).
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.6.4
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.6.4 — DMR & single-dongle P25 voice now decodes out of the box (no config), every browser console is reachable from the daemon, and P25 Phase 2 superframes finally lock on real traffic
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.6.4 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new across the v0.6.x line (since v0.5.9):**
+
+* **DMR (and single-dongle P25) voice decodes with no extra config.** A `role: wideband` dongle used to produce talkgroups/RIDs but no audio and no recordings, because voice grants were dropped for lack of a voice device. The daemon now auto-enables a couple of virtual voice taps on each wideband dongle when trunking is configured and no physical `role: voice` SDR is present — voice decodes out of the box (set `voice_taps` to control concurrency).
+* **Live browser audio fixes.** Listen-only setups no longer need a `recordings.dir` (a decode-only recorder mode streams live audio without writing files), and audio that was silent on Windows now plays — the Web Audio player runs at the device-native rate instead of pinning an 8 kHz `AudioContext` that WASAPI renders as silence.
+* **Every browser console is reachable from the daemon, sharing one design system.** Signal Lab now mounts at `/siglab/` and RF Scope at `/rfscope/` alongside the operator console, Config Builder, and Crypto Lab — advertised so the nav only links to what's actually reachable, with a shared nav between them. RF Scope also joins the shared theming (dark/mono/light + reduced-motion).
+* **P25 Phase 2 superframes now lock on real off-air traffic** (#813) — a garbled outbound sync constant meant `superframes=0` on every call and `algorithm_id`/`key_id` never populated; the spec-conformant sync (TIA-102.BBAC) now locks.
+* **Richer P25 site telemetry on `GET /api/v1/sites`** — per-site decode quality (`clean`/`marginal`/`poor` + TSBK error rate), advertised neighbour sites with their control-channel frequencies, and a `control_channel_carrier_offset_hz` that now matches the WARN log.
+* **Import & capture robustness** — RadioReference CSVs exported through Excel (UTF-8 BOM) import cleanly, native *sites* CSVs get an actionable error, an Airspy overrun no longer silently freezes the whole decode, and a strong-but-unsynced narrowband carrier now warns and points at `sdr.ppm`.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.6.4
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.6.4 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new across the v0.6.x line (since v0.5.9):**
+- **DMR & single-dongle P25 voice with no config** — a `role: wideband` dongle now auto-enables virtual voice taps, so voice decodes and records out of the box.
+- **Live browser audio fixes** — no `recordings.dir` required to listen, and audio that was silent on Windows now plays (native-rate `AudioContext`).
+- **Every console reachable from the daemon** — Signal Lab (`/siglab/`) and RF Scope (`/rfscope/`) join the operator console, Config Builder, and Crypto Lab under one shared nav + design system.
+- **P25 Phase 2 superframes lock on real traffic** (#813) — fixed a garbled outbound sync constant, so `algorithm_id`/`key_id` populate.
+- **Richer `GET /api/v1/sites`** — per-site decode quality, neighbour sites + their control channels, and a carrier-offset field that agrees with the WARN log.
+- **Import/capture robustness** — Excel-exported RadioReference CSVs (UTF-8 BOM) import, native sites CSVs get an actionable error, Airspy overruns no longer freeze the decode, and off-frequency narrowband carriers now warn to set `sdr.ppm`.
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.6.4>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow shipped v0.6.0 through v0.6.4 but the post-release
docs sync was never run, so catch the docs up to the latest release:

- CHANGELOG: promote the accumulated [Unreleased] entries into five dated
  sections, split by tag, and reconstruct the entries for the user-visible
  PRs that shipped without a changelog line:
  - [v0.6.4] — 2026-07-08: DMR/single-dongle voice decodes with no config
    (auto-enabled wideband voice taps).
  - [v0.6.3] — 2026-07-07: neighbour sites on /api/v1/sites, the two live-audio
    fixes (recordings-dir-free listen, native-rate Windows playback), and the
    actionable RadioReference sites-CSV / SOAP-fault error.
  - [v0.6.2] — 2026-07-04: P25 Phase 2 superframe sync-constant fix (#813) and
    the total control-channel carrier-offset field (#815).
  - [v0.6.1] — 2026-07-03: the Lab Bench tutorial blog series (docs).
  - [v0.6.0] — 2026-07-02: every browser console reachable from the daemon +
    shared design system, per-site P25 decode quality (#858), the Airspy
    overrun fix, the strong-signal/no-sync ppm warning (#836), and the
    UTF-8-BOM RadioReference CSV import fix (#849).
  A fresh empty [Unreleased] block sits on top.
- README + latest-version.html: bump the quick-start VERSION and the Pages
  fallback tag from v0.5.9 to v0.6.4.
- Add a v0.6.4 social-announcement draft covering the v0.6.x line.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0165xYqCmGqD1s1ujPTHeXPs