### PR TITLE
airspy/macos: stall watchdog, USB bulk diagnostics, and wideband self-heal for the silent freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+- **Airspy on macOS no longer freezes silently.** After locking a control
+  channel and decoding for a few seconds, an Airspy on macOS could go
+  completely silent — the process stayed alive (heartbeats kept logging) but no
+  IQ arrived and nothing decoded, with no error, EOF, or drop warning. The
+  cause is a device-side USB endpoint halt that the darwin backend's blocking,
+  no-timeout bulk read never noticed, so none of the existing safety nets (the
+  overrun drop, the reaper-death `onStreamDead`, the enumerate-based pool
+  watchdog) fired. A new **bulk-IN stall watchdog** now aborts a stream that
+  delivers no data for `GT_USB_BULK_STALL_MS` (default 2 s) while the device is
+  still present, converting the silent hang into a real end-of-stream; the
+  wideband decoder is now supervised by a retry loop that reacquires the dongle
+  and restarts (mirroring the control-channel decoder), so the daemon
+  self-heals instead of quietly stopping.
+
+### Added
+- **More USB debugging for the Airspy freeze.** With `RTLSDR_DEBUG_USB=1` the
+  macOS backend now emits periodic bulk-stream telemetry (URBs, bytes,
+  throughput, per-slot completion spread, idle gap) and a one-shot `bulk-IN
+  stalled` line when the watchdog trips — enough to pin when and how a freeze
+  happens. An opt-in `GT_USB_READPIPE_TIMEOUT_MS` switches the reaper to IOKit
+  `ReadPipeTO` with a per-read no-data timeout as a candidate root fix. See
+  `docs/reference/airspy.md` → Troubleshooting.
+
 ## [v0.6.4] — 2026-07-08
 
 ### Fixed

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2729,7 +2729,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 		eng := eng
 		name := fmt.Sprintf("widebandt2-%d", i)
 		d.spawn(runCtx, name, false, func(ctx context.Context) error {
-			return eng.Run(ctx)
+			return d.runWidebandWithRetry(ctx, eng)
 		})
 	}
 	// DMR Tier III autoconfig learners — one per wideband DMR control
@@ -3585,6 +3585,72 @@ func (d *Daemon) runCCDecoderWithRetry(ctx context.Context) error {
 		d.mu.Lock()
 		d.ccDecoder = dec
 		d.mu.Unlock()
+	}
+}
+
+// runWidebandWithRetry drives one widebandt2 engine under the same
+// restart loop the ccdecoder uses (runCCDecoderWithRetry). The wideband
+// engine has no in-stream retry of its own, so a dead IQ stream — a USB
+// disconnect, or the macOS stall watchdog aborting a silently-frozen
+// Airspy endpoint (usb.ErrStreamStalled → widebandt2.ErrIQStreamClosed) —
+// would otherwise stop decoding for that dongle with no recovery until a
+// process restart. On the sentinel it backs off, reacquires the dongle by
+// serial, re-points the engine's iqtap broker at the fresh handle, and
+// restarts Run. Backoff exhaustion escalates to a fatal so an external
+// supervisor restarts a clean process. ctx cancel and any other Run error
+// end the loop without escalation. See issue #345.
+func (d *Daemon) runWidebandWithRetry(ctx context.Context, eng *widebandt2.Engine) error {
+	serial := eng.Serial()
+	var attempt int
+	for {
+		started := time.Now()
+		err := eng.Run(ctx)
+		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		if !errors.Is(err, widebandt2.ErrIQStreamClosed) {
+			return err
+		}
+		// A Run that survived a healthy window means the previous
+		// recovery succeeded; reset the retry budget for a fresh
+		// failure stretch.
+		if time.Since(started) >= ccDecoderHealthyRunDuration {
+			attempt = 0
+		}
+		if attempt >= len(ccDecoderRetryBackoffs) {
+			d.log.Error("daemon: widebandt2: IQ stream died and retries exhausted; escalating to fatal",
+				"serial", serial, "attempts", attempt, "err", err)
+			fatal := fmt.Errorf("widebandt2: %w", err)
+			d.recordFatal(fatal)
+			return fatal
+		}
+		wait := ccDecoderRetryBackoffs[attempt]
+		attempt++
+		d.log.Warn("daemon: widebandt2: IQ stream died; retrying",
+			"serial", serial, "attempt", attempt, "max_attempts", len(ccDecoderRetryBackoffs),
+			"backoff", wait, "err", err)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+		// Reacquire the dongle by serial and re-point the broker the
+		// engine streams through, so the restarted Run subscribes to a
+		// live handle instead of the dead one. When no broker exists for
+		// this serial the engine still holds the stale device; the
+		// escalate-to-fatal path then restarts a clean process. Mirrors
+		// the ccdecoder reacquire above.
+		if d.pool != nil && serial != "" {
+			if newEntry, rerr := d.pool.Reacquire(serial, d.cfg.SDR.SampleRate); rerr != nil {
+				d.log.Warn("daemon: widebandt2: SDR reacquire failed; will retry",
+					"serial", serial, "err", rerr)
+			} else {
+				d.log.Info("daemon: widebandt2: SDR reacquired", "serial", serial)
+				if br := d.iqBrokers[serial]; br != nil {
+					br.SetInner(newEntry.Device)
+				}
+			}
+		}
 	}
 }
 

--- a/cmd/gophertrunk/wideband_retry_test.go
+++ b/cmd/gophertrunk/wideband_retry_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/widebandt2"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// dyingWidebandDevice is a minimal sdr.Device whose IQ stream always
+// closes immediately without a ctx-cancel — modelling a wideband dongle
+// whose USB reaper keeps dying (or the macOS stall watchdog repeatedly
+// aborting a frozen endpoint). Every StreamIQ hands back a channel that
+// closes at once, so widebandt2.Engine.Run returns ErrIQStreamClosed on
+// each attempt.
+type dyingWidebandDevice struct{}
+
+func (dyingWidebandDevice) Info() sdr.Info             { return sdr.Info{Driver: "mock", Serial: "WB-FATAL"} }
+func (dyingWidebandDevice) SetCenterFreq(uint32) error { return nil }
+func (dyingWidebandDevice) SetSampleRate(uint32) error { return nil }
+func (dyingWidebandDevice) SetGain(int) error          { return nil }
+func (dyingWidebandDevice) SetPPM(int) error           { return nil }
+func (dyingWidebandDevice) SetBiasTee(bool) error      { return nil }
+func (dyingWidebandDevice) Close() error               { return nil }
+func (dyingWidebandDevice) StreamIQ(context.Context) (<-chan []complex64, error) {
+	ch := make(chan []complex64)
+	close(ch) // immediate reaper death: channel closes with the ctx still live
+	return ch, nil
+}
+
+// TestRunWidebandWithRetry_FatalsAfterRetriesExhausted pins the wideband
+// self-heal supervisor's terminal escalation: when the engine's IQ stream
+// keeps dying (widebandt2.ErrIQStreamClosed) with no healthy window, the
+// retry loop must exhaust its backoff schedule and record a fatal so an
+// external supervisor restarts a clean process — the recovery the bare
+// eng.Run(ctx) spawn (which just returned nil and stopped decoding) never
+// provided for the macOS Airspy freeze.
+func TestRunWidebandWithRetry_FatalsAfterRetriesExhausted(t *testing.T) {
+	oldBackoffs := ccDecoderRetryBackoffs
+	ccDecoderRetryBackoffs = []time.Duration{
+		5 * time.Millisecond,
+		5 * time.Millisecond,
+	}
+	defer func() { ccDecoderRetryBackoffs = oldBackoffs }()
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	eng, err := widebandt2.New(widebandt2.Options{
+		Log:          slog.New(slog.DiscardHandler),
+		Bus:          bus,
+		Device:       dyingWidebandDevice{},
+		SampleRateHz: 2_400_000,
+		CenterFreqHz: 453_500_000,
+		Channels:     []widebandt2.ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "wbsys"}},
+		Systems:      []trunking.System{{Name: "wbsys", Protocol: trunking.ProtocolDMRTier2}},
+	})
+	if err != nil {
+		t.Fatalf("widebandt2.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// pool nil: the retry loop skips reacquire and just re-runs the engine,
+	// which keeps dying, so the backoff schedule is exhausted.
+	d := &Daemon{
+		log:    slog.New(slog.DiscardHandler),
+		bus:    bus,
+		cancel: cancel,
+	}
+
+	got := d.runWidebandWithRetry(ctx, eng)
+	if !errors.Is(got, widebandt2.ErrIQStreamClosed) {
+		t.Errorf("runWidebandWithRetry = %v, want wrapped ErrIQStreamClosed", got)
+	}
+	if d.takeFatal() == nil {
+		t.Error("expected recordFatal to fire after wideband retries exhausted")
+	}
+}
+
+// TestRunWidebandWithRetry_CleanStopOnCancel confirms a ctx-cancel is a
+// clean shutdown, not a stream death: the supervisor returns without
+// recording a fatal so daemon teardown stays quiet.
+func TestRunWidebandWithRetry_CleanStopOnCancel(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	// A device whose stream stays open until ctx cancels.
+	dev := &liveWidebandDevice{}
+	eng, err := widebandt2.New(widebandt2.Options{
+		Log:          slog.New(slog.DiscardHandler),
+		Bus:          bus,
+		Device:       dev,
+		SampleRateHz: 2_400_000,
+		CenterFreqHz: 453_500_000,
+		Channels:     []widebandt2.ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "wbsys"}},
+		Systems:      []trunking.System{{Name: "wbsys", Protocol: trunking.ProtocolDMRTier2}},
+	})
+	if err != nil {
+		t.Fatalf("widebandt2.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d := &Daemon{log: slog.New(slog.DiscardHandler), bus: bus, cancel: cancel}
+	done := make(chan error, 1)
+	go func() { done <- d.runWidebandWithRetry(ctx, eng) }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("runWidebandWithRetry on cancel = %v, want nil/Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not return after ctx cancel")
+	}
+	if d.takeFatal() != nil {
+		t.Errorf("recordFatal fired on a clean ctx-cancel stop: %v", d.takeFatal())
+	}
+}
+
+// liveWidebandDevice keeps its IQ stream open until ctx cancels.
+type liveWidebandDevice struct{}
+
+func (liveWidebandDevice) Info() sdr.Info             { return sdr.Info{Driver: "mock", Serial: "WB-LIVE"} }
+func (liveWidebandDevice) SetCenterFreq(uint32) error { return nil }
+func (liveWidebandDevice) SetSampleRate(uint32) error { return nil }
+func (liveWidebandDevice) SetGain(int) error          { return nil }
+func (liveWidebandDevice) SetPPM(int) error           { return nil }
+func (liveWidebandDevice) SetBiasTee(bool) error      { return nil }
+func (liveWidebandDevice) Close() error               { return nil }
+func (liveWidebandDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	ch := make(chan []complex64)
+	go func() {
+		defer close(ch)
+		<-ctx.Done()
+	}()
+	return ch, nil
+}

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -73,6 +73,32 @@ Diagnostics: each tap's level is on `gophertrunk_sdr_iq_power_dbfs` labelled
 whole-capture power to tell a weak site apart from a decode problem, and watch
 the clip ratio for overload.
 
+## Troubleshooting
+
+### Stream goes silent after a few seconds (macOS)
+
+On macOS the pure-Go USB backend reaps the Airspy's bulk-IN endpoint with
+blocking reads. If the device silently halts its endpoint — no USB error, no
+disconnect — those reads never return, and older builds wedged with the process
+alive but decoding nothing (only the periodic `runtime: heartbeat` kept
+logging). A **stall watchdog** now guards this: if the stream delivers no data
+for a couple of seconds while the device is still enumerated, GopherTrunk aborts
+the pipe, surfaces the death as a real end-of-stream, and the daemon reacquires
+the dongle and restarts the wideband decoder automatically.
+
+Knobs for diagnosing and tuning it:
+
+- `RTLSDR_DEBUG_USB=1` — emits a periodic bulk-stream telemetry line (URBs,
+  bytes, throughput, per-slot spread, idle gap) plus a one-shot **`bulk-IN
+  stalled`** line at the moment the stream freezes. Capture this to pin down
+  *when* and *how* a freeze happens.
+- `GT_USB_BULK_STALL_MS` — the stall window in milliseconds (default `2000`).
+  Set `0` to disable the watchdog.
+- `GT_USB_READPIPE_TIMEOUT_MS` — opt-in: switch the reaper to IOKit's
+  `ReadPipeTO` with this per-read no-data timeout so a halted endpoint returns a
+  timeout directly instead of relying on the watchdog. Off by default; try e.g.
+  `200` if the watchdog alone doesn't recover cleanly.
+
 ## Sources
 
 [^wiki]: [Software-defined radio](https://en.wikipedia.org/wiki/Software-defined_radio) — Wikipedia, for background on Airspy-class high-performance VHF/UHF SDR receivers.

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -778,6 +778,16 @@ func (e *Engine) DMRTier3ControlChannel(freqHz uint32) *tier3.ControlChannel {
 // barriers before returning, so successive chunks — and the post-Process
 // diagnostics below — never overlap a running tap and each receiver still
 // sees its chunks in order.
+// ErrIQStreamClosed is returned by Run when the SDR's IQ channel closed
+// unexpectedly — the USB reaper died (a physical disconnect, or the macOS
+// stall watchdog aborting a silently-frozen Airspy endpoint; see
+// internal/sdr/rtlsdr/usb.ErrStreamStalled) — rather than the engine being
+// asked to stop via ctx cancellation. The daemon's runWidebandWithRetry
+// supervisor treats it as a signal to reacquire the dongle and restart,
+// mirroring the control-channel decoder's retry loop (issue #345). A clean
+// ctx-cancel shutdown still returns nil.
+var ErrIQStreamClosed = errors.New("widebandt2: IQ stream closed unexpectedly")
+
 func (e *Engine) Run(ctx context.Context) error {
 	if err := e.device.SetCenterFreq(e.centerHz); err != nil {
 		return fmt.Errorf("widebandt2: SetCenterFreq %d Hz: %w", e.centerHz, err)
@@ -808,7 +818,15 @@ func (e *Engine) Run(ctx context.Context) error {
 			return nil
 		case chunk, ok := <-stream:
 			if !ok {
-				return nil
+				// The driver closed the IQ channel. A concurrent
+				// ctx-cancel means a clean shutdown; otherwise the
+				// stream died under us (USB reaper death or the stall
+				// watchdog aborting a frozen endpoint) and the daemon
+				// supervisor should reacquire the dongle and restart.
+				if ctx.Err() != nil {
+					return nil
+				}
+				return ErrIQStreamClosed
 			}
 			if e.suspended.Load() {
 				// SDR borrowed by a hunt and retuned: drop the off-frequency

--- a/internal/scanner/widebandt2/engine_diag_test.go
+++ b/internal/scanner/widebandt2/engine_diag_test.go
@@ -2,6 +2,7 @@ package widebandt2
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"sync"
@@ -148,7 +149,7 @@ func TestEngineDiagnosticsLowPowerWarns(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := e.Run(ctx); err != nil {
+	if err := e.Run(ctx); err != nil && !errors.Is(err, ErrIQStreamClosed) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 
@@ -220,7 +221,7 @@ func TestEngineDiagnosticsCountersOnDecode(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
 	defer cancel()
-	if err := e.Run(ctx); err != nil {
+	if err := e.Run(ctx); err != nil && !errors.Is(err, ErrIQStreamClosed) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 
@@ -281,7 +282,7 @@ func TestEngineDiagnosticsMetricsGauge(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := e.Run(ctx); err != nil {
+	if err := e.Run(ctx); err != nil && !errors.Is(err, ErrIQStreamClosed) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 
@@ -350,7 +351,7 @@ func TestEngineDiagnosticsOverloadWarns(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if err := e.Run(ctx); err != nil {
+	if err := e.Run(ctx); err != nil && !errors.Is(err, ErrIQStreamClosed) {
 		t.Fatalf("Run returned error: %v", err)
 	}
 

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -46,6 +46,7 @@ type mockDevice struct {
 	chunks       [][]complex64
 	chunkCh      chan []complex64
 	streamErr    error
+	holdOpen     bool // keep the stream open until ctx cancels (models a live stream)
 	centerFreqHz atomic.Uint32
 	sampleRateHz atomic.Uint32
 	startOnce    sync.Once
@@ -76,6 +77,12 @@ func (m *mockDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 					return
 				case m.chunkCh <- c:
 				}
+			}
+			// holdOpen models a live SDR whose stream only ends on
+			// ctx-cancel (a clean stop) rather than closing on its own —
+			// the case Run must report as nil, not a stream death.
+			if m.holdOpen {
+				<-ctx.Done()
 			}
 		}()
 	})
@@ -527,7 +534,7 @@ func TestEngineRunSetsCenterFreqAndDrainsStream(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := e.Run(ctx); err != nil {
+	if err := e.Run(ctx); err != nil && !errors.Is(err, ErrIQStreamClosed) {
 		t.Errorf("Run: %v", err)
 	}
 	if got := dev.centerFreqHz.Load(); got != 453_500_000 {
@@ -723,6 +730,48 @@ func engineWithChunks(t *testing.T, obs IQPowerObserver, serial string, n int) (
 	return e, dev
 }
 
+// TestEngineRunReturnsStreamClosedOnUnexpectedClose is the self-heal
+// regression: when the SDR's IQ channel closes while the engine was NOT
+// asked to stop (a USB reaper death or the macOS stall watchdog aborting a
+// frozen endpoint), Run must return ErrIQStreamClosed so the daemon's
+// runWidebandWithRetry supervisor reacquires and restarts. A plain nil
+// (the pre-fix behaviour) would silently stop decoding with no recovery.
+func TestEngineRunReturnsStreamClosedOnUnexpectedClose(t *testing.T) {
+	e, _ := engineWithChunks(t, &countingIQObserver{}, "WB-DEAD", 3)
+	// A long-lived ctx: the mock closes the stream after its 3 chunks
+	// while the ctx is still active, modelling a stream death.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := e.Run(ctx)
+	if !errors.Is(err, ErrIQStreamClosed) {
+		t.Fatalf("Run on unexpected stream close = %v, want ErrIQStreamClosed", err)
+	}
+}
+
+// TestEngineRunReturnsNilOnContextCancel is the paired control: a clean
+// shutdown (ctx cancelled) must NOT be reported as a stream death, so the
+// supervisor lets the engine stop instead of thrashing on reacquire.
+func TestEngineRunReturnsNilOnContextCancel(t *testing.T) {
+	// A stream that stays open (no chunks queued, channel never closed by
+	// the mock until ctx cancels its producer) so Run blocks until cancel.
+	e, dev := engineWithChunks(t, &countingIQObserver{}, "WB-STOP", 0)
+	dev.holdOpen = true
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() { runDone <- e.Run(ctx) }()
+	// Give Run a moment to enter its pump loop, then cancel.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("Run on ctx-cancel = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}
+
 // TestEngineSuspendDrainsWithoutDecoding: a suspended engine consumes its IQ
 // stream (so the SDR/broker never blocks) but processes nothing — no per-window
 // diagnostics are recorded. Resume restores the dongle's centre frequency.
@@ -743,7 +792,7 @@ func TestEngineSuspendDrainsWithoutDecoding(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := e.Run(ctx); err != nil {
+	if err := e.Run(ctx); err != nil && !errors.Is(err, ErrIQStreamClosed) {
 		t.Fatalf("Run: %v", err)
 	}
 	if got := obs.wbPower.Load(); got != 0 {
@@ -766,7 +815,7 @@ func TestEngineProcessesWhenNotSuspended(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	if err := e.Run(ctx); err != nil {
+	if err := e.Run(ctx); err != nil && !errors.Is(err, ErrIQStreamClosed) {
 		t.Fatalf("Run: %v", err)
 	}
 	if got := obs.wbPower.Load(); got == 0 {

--- a/internal/sdr/rtlsdr/usb/bulk_stall.go
+++ b/internal/sdr/rtlsdr/usb/bulk_stall.go
@@ -1,0 +1,246 @@
+package usb
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// defaultBulkStallTimeout is how long a bulk-IN stream may go without
+// delivering a single packet before the stall watchdog acts. A real
+// Airspy fills a 16 KiB URB in well under a millisecond even at its
+// slowest rate, so seconds of dead air unambiguously means the endpoint
+// has halted — 2 s never false-positives on a live stream.
+const defaultBulkStallTimeout = 2 * time.Second
+
+// bulkStallEnv overrides the stall window (milliseconds). 0 disables the
+// watchdog entirely.
+const bulkStallEnv = "GT_USB_BULK_STALL_MS"
+
+// readPipeTimeoutEnv is the opt-in that switches the darwin reaper from
+// the blocking ReadPipe to ReadPipeTO with a bounded no-data timeout
+// (milliseconds). A halted endpoint then returns kIOReturnTimeout so the
+// reaper dies and the stream surfaces EOF instead of hanging. Off by
+// default; the stall watchdog covers the default read path.
+const readPipeTimeoutEnv = "GT_USB_READPIPE_TIMEOUT_MS"
+
+// bulkStallTimeout resolves the effective stall window from the
+// environment, falling back to defaultBulkStallTimeout. 0 disables the
+// watchdog; a negative or unparseable value falls back to the default.
+func bulkStallTimeout() time.Duration {
+	v := os.Getenv(bulkStallEnv)
+	if v == "" {
+		return defaultBulkStallTimeout
+	}
+	ms, err := strconv.Atoi(v)
+	if err != nil || ms < 0 {
+		return defaultBulkStallTimeout
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// bulkWatchTickInterval bounds the watchdog poll/telemetry cadence: half
+// the stall window (so a stall is caught within ~1.5× the timeout) but no
+// coarser than 1 s so the RTLSDR_DEBUG_USB telemetry stays readable.
+func bulkWatchTickInterval(stall time.Duration) time.Duration {
+	iv := stall / 2
+	if iv > time.Second || iv <= 0 {
+		iv = time.Second
+	}
+	return iv
+}
+
+// readPipeTimeoutMs returns the configured ReadPipeTO no-data timeout and
+// whether the opt-in is active. A missing, zero, negative, or unparseable
+// value leaves the reaper on the default blocking ReadPipe.
+func readPipeTimeoutMs() (uint32, bool) {
+	v := os.Getenv(readPipeTimeoutEnv)
+	if v == "" {
+		return 0, false
+	}
+	ms, err := strconv.Atoi(v)
+	if err != nil || ms <= 0 {
+		return 0, false
+	}
+	return uint32(ms), true
+}
+
+// bulkStallWatch is the platform-neutral core of the bulk-IN stall
+// detector wired into the macOS transport (usb_darwin.go). It tracks
+// when the reaper last delivered a packet plus per-slot throughput so a
+// supervisor goroutine can notice a silently-frozen endpoint: the device
+// stops sending, the darwin backend's blocking ReadPipe never returns,
+// and the stream wedges with no error, no EOF, and no drop — the macOS
+// Airspy freeze. None of the existing safety nets catch that case
+// (onStreamDead needs the reapers to *error*, the overrun drop needs
+// onPacket to *block*, and Pool.RunWatchdog only reacts to a device that
+// vanishes from USB enumerate), so this watch converts the silent hang
+// into a real stream-death the driver can surface.
+//
+// The timing and counter logic is deliberately OS-independent and
+// clock-injectable so it is unit-tested on any CI runner without darwin
+// hardware (bulk_stall_test.go). usb_darwin.go supplies the real clock,
+// ticker, and AbortPipe-based stall action.
+type bulkStallWatch struct {
+	startNanos   atomic.Int64 // unix nanos when the stream armed
+	lastActivity atomic.Int64 // unix nanos of the most recent successful read
+	totalURBs    atomic.Uint64
+	totalBytes   atomic.Uint64
+	stopped      atomic.Bool
+	fired        atomic.Bool
+
+	mu      sync.Mutex
+	perSlot []uint64
+}
+
+// newBulkStallWatch returns a watch sized for the given number of reaper
+// slots. slots may be zero (per-slot accounting is simply skipped).
+func newBulkStallWatch(slots int) *bulkStallWatch {
+	if slots < 0 {
+		slots = 0
+	}
+	return &bulkStallWatch{perSlot: make([]uint64, slots)}
+}
+
+// start seeds the activity clock so a stream that never delivers a first
+// packet is still caught stallTimeout after the seed instant.
+func (w *bulkStallWatch) start(atNanos int64) {
+	w.startNanos.Store(atNanos)
+	w.lastActivity.Store(atNanos)
+}
+
+// markActivity records one successful read of n bytes on the given slot,
+// using the wall clock. Called on the reaper hot path.
+func (w *bulkStallWatch) markActivity(slot, n int) {
+	w.markActivityAt(time.Now().UnixNano(), slot, n)
+}
+
+// markActivityAt is the clock-injected form used by tests.
+func (w *bulkStallWatch) markActivityAt(atNanos int64, slot, n int) {
+	w.lastActivity.Store(atNanos)
+	w.totalURBs.Add(1)
+	if n > 0 {
+		w.totalBytes.Add(uint64(n))
+	}
+	w.mu.Lock()
+	if slot >= 0 && slot < len(w.perSlot) {
+		w.perSlot[slot]++
+	}
+	w.mu.Unlock()
+}
+
+// stop disarms the watch so a normal teardown (StopBulkIn/Close) never
+// trips the stall path.
+func (w *bulkStallWatch) stop() { w.stopped.Store(true) }
+
+// shouldFire reports whether the stream has been idle longer than
+// stallTimeout while the watch is still armed (not stopped, not already
+// fired). Pure — the seam the unit test drives with an injected clock.
+func (w *bulkStallWatch) shouldFire(nowNanos, stallTimeoutNanos int64) bool {
+	if w.stopped.Load() || w.fired.Load() {
+		return false
+	}
+	return nowNanos-w.lastActivity.Load() > stallTimeoutNanos
+}
+
+// run polls tick, optionally emits telemetry via onTick, and fires
+// onStall exactly once when the stream stalls, then returns. now supplies
+// the current unix-nanos clock; now/tick/stop are injected by tests and
+// satisfied by the runtime clock + a time.Ticker in production.
+func (w *bulkStallWatch) run(now func() int64, tick <-chan time.Time, stop <-chan struct{}, stallTimeoutNanos int64, onTick func(), onStall func()) {
+	for {
+		select {
+		case <-stop:
+			return
+		case <-tick:
+			if onTick != nil {
+				onTick()
+			}
+			if w.shouldFire(now(), stallTimeoutNanos) {
+				if w.fired.CompareAndSwap(false, true) {
+					if onStall != nil {
+						onStall()
+					}
+				}
+				return
+			}
+		}
+	}
+}
+
+// bulkStallStats is a point-in-time snapshot of the watch counters.
+type bulkStallStats struct {
+	elapsed time.Duration
+	idle    time.Duration
+	urbs    uint64
+	bytes   uint64
+	perSlot []uint64
+}
+
+// stats snapshots the counters relative to nowNanos.
+func (w *bulkStallWatch) stats(nowNanos int64) bulkStallStats {
+	w.mu.Lock()
+	per := append([]uint64(nil), w.perSlot...)
+	w.mu.Unlock()
+	last := w.lastActivity.Load()
+	start := w.startNanos.Load()
+	return bulkStallStats{
+		elapsed: time.Duration(nowNanos - start),
+		idle:    time.Duration(nowNanos - last),
+		urbs:    w.totalURBs.Load(),
+		bytes:   w.totalBytes.Load(),
+		perSlot: per,
+	}
+}
+
+// telemetryLine renders a compact one-line summary for the periodic
+// RTLSDR_DEBUG_USB bulk trace: elapsed, URB count, MB transferred,
+// throughput, current idle gap, and the per-slot completion spread. Kept
+// here (untagged) so its formatting is exercised by the portable test.
+func (s bulkStallStats) telemetryLine() string {
+	mb := float64(s.bytes) / (1024 * 1024)
+	var mbps float64
+	if s.elapsed > 0 {
+		mbps = mb / s.elapsed.Seconds()
+	}
+	return fmt.Sprintf("elapsed=%s urbs=%d mb=%.2f throughput=%.2fMB/s idle=%s slots=%s",
+		s.elapsed.Round(time.Millisecond), s.urbs, mb, mbps,
+		s.idle.Round(time.Millisecond), formatSlotSpread(s.perSlot))
+}
+
+// stalledLine renders the one-shot "bulk-IN stalled" summary emitted when
+// the watch fires: how long the stream was idle, how much data it carried
+// before the freeze, and the per-slot completion spread that localises
+// whether every reaper died together or one slot starved.
+func (s bulkStallStats) stalledLine(stallTimeout time.Duration) string {
+	mb := float64(s.bytes) / (1024 * 1024)
+	return fmt.Sprintf("idle=%s (threshold=%s) after elapsed=%s urbs=%d mb=%.2f slots=%s",
+		s.idle.Round(time.Millisecond), stallTimeout,
+		s.elapsed.Round(time.Millisecond), s.urbs, mb, formatSlotSpread(s.perSlot))
+}
+
+// formatSlotSpread renders per-slot completion counts compactly. When the
+// slots are perfectly balanced it collapses to "N×count"; otherwise it
+// lists min/max so an uneven reaper (one slot starved while others cycled)
+// is visible at a glance.
+func formatSlotSpread(perSlot []uint64) string {
+	if len(perSlot) == 0 {
+		return "[]"
+	}
+	min, max := perSlot[0], perSlot[0]
+	for _, v := range perSlot[1:] {
+		if v < min {
+			min = v
+		}
+		if v > max {
+			max = v
+		}
+	}
+	if min == max {
+		return fmt.Sprintf("%dx%d", len(perSlot), min)
+	}
+	return fmt.Sprintf("%d slots min=%d max=%d", len(perSlot), min, max)
+}

--- a/internal/sdr/rtlsdr/usb/bulk_stall_test.go
+++ b/internal/sdr/rtlsdr/usb/bulk_stall_test.go
@@ -1,0 +1,175 @@
+package usb
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const testStallTimeoutNanos = int64(2 * time.Second)
+
+// TestBulkStallWatchFiresOnceAfterTimeout is the core regression for the
+// macOS Airspy silent freeze: a bulk-IN stream that stops delivering must
+// be detected. The watch is driven with an injected clock and manual
+// ticks so the timing is deterministic and hardware-free.
+func TestBulkStallWatchFiresOnceAfterTimeout(t *testing.T) {
+	w := newBulkStallWatch(4)
+	w.start(0)
+
+	var now atomic.Int64
+	nowFn := func() int64 { return now.Load() }
+	tick := make(chan time.Time)
+	stop := make(chan struct{})
+	ticked := make(chan struct{}, 1)
+	stalled := make(chan struct{}, 4)
+	onTick := func() { ticked <- struct{}{} }
+	onStall := func() { stalled <- struct{}{} }
+
+	go w.run(nowFn, tick, stop, testStallTimeoutNanos, onTick, onStall)
+
+	// A tick below the threshold must NOT fire.
+	now.Store(int64(1 * time.Second))
+	tick <- time.Time{}
+	<-ticked
+	select {
+	case <-stalled:
+		t.Fatal("stall fired before the timeout elapsed")
+	default:
+	}
+
+	// A tick past the threshold fires exactly once and returns.
+	now.Store(int64(3 * time.Second))
+	tick <- time.Time{}
+	<-ticked
+	select {
+	case <-stalled:
+	case <-time.After(time.Second):
+		t.Fatal("stall did not fire after the idle window exceeded the timeout")
+	}
+
+	// The run loop has returned; the fired guard prevents a second fire.
+	if w.shouldFire(int64(10*time.Second), testStallTimeoutNanos) {
+		t.Fatal("shouldFire returned true after the watch already fired")
+	}
+	close(stop)
+}
+
+// TestBulkStallWatchStaysQuietWhileActive proves a healthy stream — one
+// that keeps delivering packets — never trips the stall path, and that
+// the throughput counters accumulate as data flows.
+func TestBulkStallWatchStaysQuietWhileActive(t *testing.T) {
+	w := newBulkStallWatch(2)
+	w.start(0)
+
+	var now atomic.Int64
+	nowFn := func() int64 { return now.Load() }
+	tick := make(chan time.Time)
+	stop := make(chan struct{})
+	ticked := make(chan struct{}, 1)
+	fired := make(chan struct{}, 1)
+	onTick := func() { ticked <- struct{}{} }
+	onStall := func() { fired <- struct{}{} }
+
+	go w.run(nowFn, tick, stop, testStallTimeoutNanos, onTick, onStall)
+
+	// Advance well past a single stall window, but keep delivering data
+	// just before each tick so the idle gap never exceeds the timeout.
+	for i := int64(1); i <= 10; i++ {
+		at := i * int64(time.Second)
+		w.markActivityAt(at, int(i%2), 16*1024)
+		now.Store(at)
+		tick <- time.Time{}
+		<-ticked
+		select {
+		case <-fired:
+			t.Fatalf("stall fired on a live stream at t=%ds", i)
+		default:
+		}
+	}
+	close(stop)
+
+	if got := w.totalURBs.Load(); got != 10 {
+		t.Fatalf("totalURBs = %d, want 10", got)
+	}
+	if got := w.totalBytes.Load(); got != 10*16*1024 {
+		t.Fatalf("totalBytes = %d, want %d", got, 10*16*1024)
+	}
+	s := w.stats(int64(10 * time.Second))
+	if len(s.perSlot) != 2 || s.perSlot[0]+s.perSlot[1] != 10 {
+		t.Fatalf("per-slot counts = %v, want two slots summing to 10", s.perSlot)
+	}
+}
+
+// TestBulkStallWatchStopDisarms confirms a normal teardown disarms the
+// watch so a quiescent-but-intentionally-stopped stream never fires.
+func TestBulkStallWatchStopDisarms(t *testing.T) {
+	w := newBulkStallWatch(1)
+	w.start(0)
+	w.stop()
+	if w.shouldFire(int64(1*time.Hour), testStallTimeoutNanos) {
+		t.Fatal("shouldFire returned true after stop() disarmed the watch")
+	}
+}
+
+func TestBulkStallTimeoutEnv(t *testing.T) {
+	t.Setenv(bulkStallEnv, "")
+	if got := bulkStallTimeout(); got != defaultBulkStallTimeout {
+		t.Errorf("unset: got %s, want %s", got, defaultBulkStallTimeout)
+	}
+	t.Setenv(bulkStallEnv, "500")
+	if got := bulkStallTimeout(); got != 500*time.Millisecond {
+		t.Errorf("500: got %s, want 500ms", got)
+	}
+	t.Setenv(bulkStallEnv, "0")
+	if got := bulkStallTimeout(); got != 0 {
+		t.Errorf("0 (disabled): got %s, want 0", got)
+	}
+	t.Setenv(bulkStallEnv, "garbage")
+	if got := bulkStallTimeout(); got != defaultBulkStallTimeout {
+		t.Errorf("garbage: got %s, want default", got)
+	}
+}
+
+func TestReadPipeTimeoutEnv(t *testing.T) {
+	t.Setenv(readPipeTimeoutEnv, "")
+	if ms, ok := readPipeTimeoutMs(); ok || ms != 0 {
+		t.Errorf("unset: got (%d,%v), want (0,false)", ms, ok)
+	}
+	t.Setenv(readPipeTimeoutEnv, "200")
+	if ms, ok := readPipeTimeoutMs(); !ok || ms != 200 {
+		t.Errorf("200: got (%d,%v), want (200,true)", ms, ok)
+	}
+	t.Setenv(readPipeTimeoutEnv, "0")
+	if _, ok := readPipeTimeoutMs(); ok {
+		t.Error("0 should not enable ReadPipeTO")
+	}
+}
+
+func TestBulkWatchTickInterval(t *testing.T) {
+	if got := bulkWatchTickInterval(2 * time.Second); got != time.Second {
+		t.Errorf("2s stall: got %s, want 1s", got)
+	}
+	if got := bulkWatchTickInterval(400 * time.Millisecond); got != 200*time.Millisecond {
+		t.Errorf("400ms stall: got %s, want 200ms", got)
+	}
+	if got := bulkWatchTickInterval(10 * time.Second); got != time.Second {
+		t.Errorf("10s stall: got %s, want capped 1s", got)
+	}
+}
+
+func TestFormatSlotSpread(t *testing.T) {
+	tests := []struct {
+		name    string
+		perSlot []uint64
+		want    string
+	}{
+		{"empty", nil, "[]"},
+		{"balanced", []uint64{7, 7, 7}, "3x7"},
+		{"uneven", []uint64{7, 0, 3}, "3 slots min=0 max=7"},
+	}
+	for _, tt := range tests {
+		if got := formatSlotSpread(tt.perSlot); got != tt.want {
+			t.Errorf("%s: formatSlotSpread(%v) = %q, want %q", tt.name, tt.perSlot, got, tt.want)
+		}
+	}
+}

--- a/internal/sdr/rtlsdr/usb/usb.go
+++ b/internal/sdr/rtlsdr/usb/usb.go
@@ -150,6 +150,16 @@ var (
 	// within the supplied timeoutMs window.
 	ErrTimeout = errors.New("usb: transfer timed out")
 
+	// ErrStreamStalled is surfaced via a bulk-IN stream's onStreamDead
+	// when the reaper stopped delivering packets for the stall-watch
+	// window while the device is still enumerated — the macOS Airspy
+	// "silent freeze", where a blocking ReadPipe never returns so no
+	// per-URB error is ever raised. The stall watchdog aborts the pipe
+	// to unblock the reaper, which then dies like any other reaper death
+	// (issue #345), converting a silent hang into a real EOF the driver
+	// and daemon can act on. See bulk_stall.go.
+	ErrStreamStalled = errors.New("usb: bulk-IN stream stalled (no data within watchdog window)")
+
 	// ErrPipeStalled is returned when the device stalled the USB pipe
 	// (CLEAR_FEATURE(ENDPOINT_HALT) recoverable). Maps to ERROR_GEN_FAILURE
 	// on Windows/WinUSB — the clone-dongle cold-boot symptom where the

--- a/internal/sdr/rtlsdr/usb/usb_darwin.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin.go
@@ -452,6 +452,14 @@ type darwinTransport struct {
 	desc       Descriptor
 	closed     atomic.Bool
 
+	// readPipeTimeoutMs, when non-zero, makes bulkLoop use ReadPipeTO
+	// (the v182 timeout variant) with this no-data timeout instead of the
+	// blocking ReadPipe, so a halted endpoint returns kIOReturnTimeout
+	// rather than wedging. Set by ClaimInterface only when the
+	// GT_USB_READPIPE_TIMEOUT_MS opt-in is present AND the v182 interface
+	// was obtained; 0 keeps the default (blocking) read path.
+	readPipeTimeoutMs uint32
+
 	bulkMu       sync.Mutex
 	bulkActive   bool
 	bulkPipeRef  uint8
@@ -470,6 +478,18 @@ type darwinTransport struct {
 	bulkErrMu    sync.Mutex
 	bulkDeadErr  error // first non-stop slot error wins
 	bulkDeadOnce sync.Once
+
+	// Stall watchdog. The darwin reaper blocks in a no-timeout ReadPipe,
+	// so a device that silently halts its bulk-IN endpoint (the macOS
+	// Airspy freeze) never errors, never fires bulkOnDead, and wedges
+	// forever. bulkWatch tracks last-delivery time; when the stream goes
+	// idle past the stall window it aborts the pipe, which unblocks every
+	// reaper and routes through the ordinary reaper-death path with
+	// ErrStreamStalled. See bulk_stall.go and StartBulkIn.
+	bulkWatch     *bulkStallWatch
+	bulkWatchStop chan struct{}
+	bulkWatchDone chan struct{}
+	bulkWatchOnce sync.Once
 }
 
 // recordBulkErr stashes err as the first-failing-slot reason if no
@@ -483,6 +503,7 @@ func (t *darwinTransport) recordBulkErr(err error) {
 }
 
 type darwinBulkSlot struct {
+	idx int
 	buf []byte
 }
 
@@ -592,7 +613,17 @@ func (t *darwinTransport) ClaimInterface(num int) error {
 	}
 	defer release(uintptr(unsafe.Pointer(plugin)))
 
-	ifaceIface, err := queryInterface(uintptr(unsafe.Pointer(plugin)), uuidIOUSBInterfaceInterface)
+	// Default to the base interface. When the ReadPipeTO opt-in is set,
+	// query the v182 superset instead so bulkLoop can call ReadPipeTO
+	// (index 39); fall back to the base interface if the v182 query fails
+	// so an unusual host still streams (on the blocking read path).
+	timeoutMs, wantTO := readPipeTimeoutMs()
+	ifaceIface, err := queryInterface(uintptr(unsafe.Pointer(plugin)), interfaceUUIDFor(wantTO))
+	if err != nil && wantTO {
+		debugLogf("bulk", "%s v182 interface unavailable (%v); falling back to blocking ReadPipe", t.bulkLabel(), err)
+		wantTO = false
+		ifaceIface, err = queryInterface(uintptr(unsafe.Pointer(plugin)), uuidIOUSBInterfaceInterface)
+	}
 	if err != nil {
 		return fmt.Errorf("usb: QueryInterface(IOUSBInterfaceInterface): %w", err)
 	}
@@ -601,7 +632,21 @@ func (t *darwinTransport) ClaimInterface(num int) error {
 		return fmt.Errorf("usb: USBInterfaceOpen: %w", translateIOReturn(uintptr(rc)))
 	}
 	t.ifaceIface = ifaceIface
+	if wantTO {
+		t.readPipeTimeoutMs = timeoutMs
+		debugLogf("bulk", "%s ReadPipeTO enabled: no-data timeout %dms", t.bulkLabel(), timeoutMs)
+	}
 	return nil
+}
+
+// interfaceUUIDFor picks the IOUSBInterfaceInterface UUID to query: the
+// v182 superset when the ReadPipeTO timeout path is requested, otherwise
+// the base interface.
+func interfaceUUIDFor(wantTimeout bool) cfUUIDBytes {
+	if wantTimeout {
+		return uuidIOUSBInterfaceInterface182
+	}
+	return uuidIOUSBInterfaceInterface
 }
 
 func (t *darwinTransport) ReleaseInterface(int) error {
@@ -653,7 +698,7 @@ func (t *darwinTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacke
 	}
 	slots := make([]*darwinBulkSlot, ringBufs)
 	for i := range slots {
-		slots[i] = &darwinBulkSlot{buf: make([]byte, bufLen)}
+		slots[i] = &darwinBulkSlot{idx: i, buf: make([]byte, bufLen)}
 	}
 	t.bulkPipeRef = pipeRef
 	t.bulkSlots = slots
@@ -666,10 +711,109 @@ func (t *darwinTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacke
 	t.bulkErrMu.Unlock()
 	t.bulkDeadOnce = sync.Once{}
 	t.bulkAlive.Store(int32(len(slots)))
+	t.startBulkWatch(pipeRef, len(slots))
 	for _, s := range slots {
 		go t.bulkLoop(pipeRef, s, onPacket)
 	}
 	return nil
+}
+
+// startBulkWatch arms the stall watchdog for a freshly-started stream.
+// Called under bulkMu from StartBulkIn. When the stall window is disabled
+// (GT_USB_BULK_STALL_MS=0) it installs no watch and markBulkActivity
+// becomes a no-op. See bulk_stall.go for the portable core.
+func (t *darwinTransport) startBulkWatch(pipeRef uint8, slots int) {
+	stall := bulkStallTimeout()
+	t.bulkWatch = nil
+	t.bulkWatchStop = nil
+	t.bulkWatchDone = nil
+	t.bulkWatchOnce = sync.Once{}
+	if stall <= 0 {
+		return
+	}
+	w := newBulkStallWatch(slots)
+	w.start(time.Now().UnixNano())
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	t.bulkWatch = w
+	t.bulkWatchStop = stop
+	t.bulkWatchDone = done
+
+	interval := bulkWatchTickInterval(stall)
+	stallNanos := int64(stall)
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		onTick := func() {
+			if debugUSBEnabled() {
+				debugLogf("bulk", "%s telemetry %s", t.bulkLabel(), w.stats(time.Now().UnixNano()).telemetryLine())
+			}
+		}
+		onStall := func() { t.onBulkStall(pipeRef, w, stall) }
+		w.run(func() int64 { return time.Now().UnixNano() }, ticker.C, stop, stallNanos, onTick, onStall)
+	}()
+}
+
+// onBulkStall fires (at most once) when the watchdog detects the stream
+// has gone idle past the stall window. It records ErrStreamStalled as the
+// stream-death reason (first error wins, so it survives the aborted-read
+// errors the reapers then report) and aborts the pipe. AbortPipe unblocks
+// every reaper's ReadPipe with kIOReturnAborted; because bulkStopFlag is
+// still unset (no StopBulkIn), the last reaper to exit fires bulkOnDead —
+// the ordinary #345 reaper-death path — surfacing a real EOF instead of a
+// silent hang. It does NOT call StopBulkIn itself (the driver's onDead
+// callback does that); it only breaks the wedge.
+func (t *darwinTransport) onBulkStall(pipeRef uint8, w *bulkStallWatch, stall time.Duration) {
+	// Re-check under the lock: a concurrent StopBulkIn may have won the
+	// race and already torn the pipe down, in which case the iface handle
+	// is about to be released and must not be touched.
+	t.bulkMu.Lock()
+	active := t.bulkActive && t.bulkStopFlag.Load() == 0
+	iface := t.ifaceIface
+	t.bulkMu.Unlock()
+	if !active || iface == 0 {
+		return
+	}
+	debugLogf("bulk", "%s bulk-IN stalled: %s", t.bulkLabel(), w.stats(time.Now().UnixNano()).stalledLine(stall))
+	t.recordBulkErr(ErrStreamStalled)
+	vtableCall(iface, ifaceAbortPipe, uintptr(pipeRef))
+}
+
+// markBulkActivity records a delivered URB with the stall watchdog. Safe
+// to call when the watch is disabled (nil).
+func (t *darwinTransport) markBulkActivity(slot, n int) {
+	if w := t.bulkWatch; w != nil {
+		w.markActivity(slot, n)
+	}
+}
+
+// stopBulkWatch disarms the watchdog and waits for its goroutine to exit,
+// so a teardown (StopBulkIn/Close) can safely release the interface handle
+// without racing an in-flight AbortPipe from the watch. Idempotent.
+func (t *darwinTransport) stopBulkWatch() {
+	t.bulkWatchOnce.Do(func() {
+		if t.bulkWatch != nil {
+			t.bulkWatch.stop()
+		}
+		if t.bulkWatchStop != nil {
+			close(t.bulkWatchStop)
+		}
+		if t.bulkWatchDone != nil {
+			select {
+			case <-t.bulkWatchDone:
+			case <-time.After(2 * time.Second):
+			}
+		}
+	})
+}
+
+// bulkLabel is a short identifier for the transport's debug traces.
+func (t *darwinTransport) bulkLabel() string {
+	if t.desc.Serial != "" {
+		return "serial=" + t.desc.Serial
+	}
+	return "path=" + t.desc.Path
 }
 
 // findPipeRef walks the interface's pipe list to find the pipeRef
@@ -742,22 +886,45 @@ func (t *darwinTransport) bulkLoop(pipeRef uint8, slot *darwinBulkSlot, onPacket
 			return
 		}
 		size := uint32(len(slot.buf))
-		rc := vtableCall(t.ifaceIface, ifaceReadPipe,
-			uintptr(pipeRef),
-			uintptr(unsafe.Pointer(&slot.buf[0])),
-			uintptr(unsafe.Pointer(&size)),
-		)
+		var rc uintptr
+		if to := t.readPipeTimeoutMs; to > 0 {
+			// ReadPipeTO with a no-data timeout: a halted endpoint
+			// returns kIOReturnTimeout after `to` ms of dead air
+			// instead of blocking forever. completionTimeout=0 leaves
+			// the overall transfer uncapped so a normally-filling URB
+			// is never cut short.
+			rc = vtableCall(t.ifaceIface, ifaceReadPipeTO,
+				uintptr(pipeRef),
+				uintptr(unsafe.Pointer(&slot.buf[0])),
+				uintptr(unsafe.Pointer(&size)),
+				uintptr(to),
+				0,
+			)
+		} else {
+			rc = vtableCall(t.ifaceIface, ifaceReadPipe,
+				uintptr(pipeRef),
+				uintptr(unsafe.Pointer(&slot.buf[0])),
+				uintptr(unsafe.Pointer(&size)),
+			)
+		}
 		if t.bulkStopFlag.Load() != 0 {
 			return
 		}
 		if rc != kIOReturnSuccess {
 			// kIOReturnAborted (cancellation) and any other
 			// transport error both exit the loop. ResetPipe
-			// below would be needed before re-Start.
-			t.recordBulkErr(fmt.Errorf("usb: ReadPipe: 0x%08x", uint32(rc)))
+			// below would be needed before re-Start. A ReadPipeTO
+			// no-data timeout means the endpoint halted — surface it
+			// as ErrStreamStalled so the death reason names the freeze.
+			if uint32(rc) == kIOReturnTimeout {
+				t.recordBulkErr(ErrStreamStalled)
+			} else {
+				t.recordBulkErr(fmt.Errorf("usb: ReadPipe: 0x%08x", uint32(rc)))
+			}
 			return
 		}
 		if size > 0 {
+			t.markBulkActivity(slot.idx, int(size))
 			onPacket(slot.buf[:size])
 		}
 	}
@@ -774,6 +941,11 @@ func (t *darwinTransport) StopBulkIn() error {
 	slotCount := len(t.bulkSlots)
 	t.bulkActive = false
 	t.bulkMu.Unlock()
+
+	// Disarm the stall watchdog and wait for its goroutine to exit before
+	// we touch the pipe, so a normal teardown never trips a stall abort
+	// and no watch AbortPipe can race the interface release in Close.
+	t.stopBulkWatch()
 
 	// AbortPipe makes every blocked ReadPipe return with
 	// kIOReturnAborted; goroutines see it and exit.

--- a/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
@@ -86,6 +86,17 @@ var (
 		0x73, 0xC9, 0x7A, 0xE8, 0x9E, 0xF3, 0x11, 0xD4,
 		0xB1, 0xD0, 0x00, 0x0A, 0x27, 0x05, 0x28, 0x61,
 	}
+	// kIOUSBInterfaceInterfaceID182 (6C0D38C3-B093-11D4-95C1-000A27052861)
+	// from IOKit/usb/IOUSBLib.h. A superset of the base
+	// IOUSBInterfaceInterface vtable — every base index is unchanged — that
+	// additionally exposes the *TO (timeout) transfer variants, including
+	// ReadPipeTO (index 39). Queried only when the ReadPipeTO opt-in
+	// (GT_USB_READPIPE_TIMEOUT_MS) is set; the default path stays on the
+	// base interface untouched.
+	uuidIOUSBInterfaceInterface182 = cfUUIDBytes{
+		0x6C, 0x0D, 0x38, 0xC3, 0xB0, 0x93, 0x11, 0xD4,
+		0x95, 0xC1, 0x00, 0x0A, 0x27, 0x05, 0x28, 0x61,
+	}
 )
 
 // cfUUIDBytes mirrors Apple's CFUUIDBytes — 16 raw bytes of a UUID.
@@ -122,6 +133,14 @@ const (
 	ifaceAbortPipe         = 28
 	ifaceResetPipe         = 29
 	ifaceReadPipe          = 31
+	// ifaceReadPipeTO is ReadPipeTO, present only in the v182+ interface
+	// (kIOUSBInterfaceInterfaceID182). Signature adds noDataTimeout and
+	// completionTimeout (ms) after the base ReadPipe args:
+	//   IOReturn ReadPipeTO(self, UInt8 pipeRef, void *buf, UInt32 *size,
+	//                       UInt32 noDataTimeout, UInt32 completionTimeout)
+	// Only invoked when ClaimInterface obtained the v182 interface (see
+	// darwinTransport.readPipeTimeoutMs).
+	ifaceReadPipeTO = 39
 )
 
 // iousbDevRequest mirrors IOUSBDevRequest from IOUSBLib.h. Layout:


### PR DESCRIPTION
On macOS the Airspy could lock a control channel, decode for a few seconds,
then go completely silent — process alive (heartbeats still logging) but no IQ
and no decode, with no error, EOF, or drop warning. The darwin USB backend
reaps the bulk-IN endpoint with a blocking, no-timeout ReadPipe; when the
device halts its endpoint (no USB error), every reaper blocks forever, so
bulkAlive never reaches zero, onStreamDead never fires, the IQ channel never
closes, and none of the existing safety nets (overrun drop, reaper-death
onStreamDead, enumerate-based pool watchdog) can see it.

This adds three layers, matching CLAUDE.md's "diagnose, don't guess at an
unverifiable fix" guidance since there is no macOS hardware in CI:

- bulk_stall.go: a portable, clock-injectable bulkStallWatch (URB/byte/per-slot
  counters + stall detection), unit-tested without hardware.
- usb_darwin.go: wire the watch into StartBulkIn/bulkLoop/StopBulkIn. When the
  stream delivers no data for GT_USB_BULK_STALL_MS (default 2s) while the device
  is still enumerated, it records ErrStreamStalled and AbortPipes — the proven
  unblock path — so the last reaper fires onStreamDead and the freeze surfaces
  as a real EOF instead of a silent hang. RTLSDR_DEBUG_USB now emits periodic
  bulk telemetry and a one-shot "bulk-IN stalled" line.
- Opt-in GT_USB_READPIPE_TIMEOUT_MS: query the v182 IOKit interface and use
  ReadPipeTO with a per-read no-data timeout as a candidate root fix; the
  default (blocking ReadPipe) path is byte-for-byte unchanged.
- widebandt2.Engine.Run now returns ErrIQStreamClosed on an unexpected channel
  close, and the daemon supervises the wideband engine with runWidebandWithRetry
  (reacquire + restart, escalate to fatal), mirroring runCCDecoderWithRetry, so
  the daemon self-heals instead of quietly stopping.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NBa6XyWXKFZFgDxxodiZeg