### PR TITLE
airspy/macos: name the exact USB stream-death cause and stop a flapping stream from killing the daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       # Linux audio playback runs through internal/voice/player/alsa_linux.go,
       # which dlopens libasound2.so.2 via github.com/ebitengine/purego at
       # runtime. No build-time dev headers required; the runtime library
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Build (CGO disabled)
         env:
           CGO_ENABLED: "0"
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Build (CGO disabled)
         env:
           CGO_ENABLED: "0"
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Vet (tagged)
         run: go vet -tags dvsi ./internal/voice/dvsi/...
       - name: Build (tagged)
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - run: make test-integration
 
   # web-test runs the SPA's vitest suite (web/src/**/*.test.tsx) so a
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Scan
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
       - name: Install go-licenses
         run: go install github.com/google/go-licenses/v2@latest
       - name: Regenerate inventory

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -57,7 +57,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - uses: actions/setup-node@v4
         with:
@@ -204,7 +204,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - uses: actions/setup-node@v4
         with:
@@ -284,7 +284,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
 
       - uses: actions/setup-node@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ for tagged releases.
 ## [Unreleased]
 
 ### Fixed
+- **A flapping Airspy no longer kills the whole daemon.** After the silent-freeze
+  fix, a macOS Airspy that keeps *recovering* — the IQ stream dies, the daemon
+  reacquires and streams for a few seconds, then it dies again — still took the
+  process down: the self-heal retry counter only reset after a single 60 s
+  uninterrupted run, so those repeated ~seconds-long recoveries accumulated and
+  the daemon escalated to a fatal shutdown after a handful of deaths (~30 s in).
+  The wideband and control-channel retry loops now **decay** the counter after a
+  run that streamed real data, so a recovering dongle self-heals indefinitely;
+  only a device that re-dies immediately on every reopen (truly gone) escalates.
+- **The exact USB stream-death cause is now surfaced.** The error that killed
+  the bulk-IN reaper (the stall watchdog's `usb: bulk-IN stream stalled`, a
+  `usb: device disconnected`, or a wrapped per-URB error) was discarded, so the
+  daemon only ever logged a generic “IQ stream closed unexpectedly.” The airspy
+  and RTL-SDR drivers now record it and the `IQ stream died; retrying` log line
+  names the concrete cause — the diagnostic needed to tell a stall from a
+  disconnect from an overrun without guessing.
 - **Airspy on macOS no longer freezes silently.** After locking a control
   channel and decoding for a few seconds, an Airspy on macOS could go
   completely silent — the process stayed alive (heartbeats kept logging) but no
@@ -30,6 +46,10 @@ for tagged releases.
   happens. An opt-in `GT_USB_READPIPE_TIMEOUT_MS` switches the reaper to IOKit
   `ReadPipeTO` with a per-read no-data timeout as a candidate root fix. See
   `docs/reference/airspy.md` → Troubleshooting.
+- **Airspy vendor control transfers are now traced under `RTLSDR_DEBUG_USB=1`.**
+  The Airspy shares the RTL-SDR USB transport but never wrapped it for debug, so
+  its control setup (`SET_SAMPLERATE` / `SET_FREQ` / `RECEIVER_MODE` / gain) was
+  invisible even with USB debugging on; it is now wrapped like the RTL-SDR path.
 
 ## [v0.6.4] — 2026-07-08
 

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -3472,9 +3472,26 @@ var ccDecoderRetryBackoffs = []time.Duration{
 }
 
 // ccDecoderHealthyRunDuration is how long a successful Run must last
-// before the retry counter resets. Anything shorter is treated as a
-// repeated failure (e.g. the device immediately re-dies on reopen).
-const ccDecoderHealthyRunDuration = 60 * time.Second
+// before the retry counter resets in full. A run this long is treated as
+// "definitely recovered" — a fresh failure stretch gets the whole budget.
+var ccDecoderHealthyRunDuration = 60 * time.Second
+
+// ccDecoderHealthyProgressDuration is the shorter window that counts as
+// "made real progress": a Run that streamed live IQ for at least this long
+// before dying clearly reacquired and decoded, it did not immediately re-die
+// on reopen. Such a run *decays* the retry counter by one instead of only
+// resetting at the full 60 s mark.
+//
+// This exists because an Airspy that flaps — dies, self-heals, streams for a
+// handful of seconds, dies again — never sustains a single 60 s Run, so under
+// the reset-only rule `attempt` climbed monotonically and the daemon escalated
+// to a process-killing fatal after ~30 s even though every restart succeeded
+// (the 9-Jul captures). With the decay, a genuinely-recovering stream holds at
+// a low attempt count and self-heals indefinitely, while a device that re-dies
+// in under this window on every reopen (truly gone / unplugged) still climbs to
+// fatal for an external supervisor to restart. The per-death cause is logged on
+// every retry regardless, so a flapping device is loud, not silent.
+var ccDecoderHealthyProgressDuration = 10 * time.Second
 
 // runCCDecoderWithRetry drives the ccdecoder under a small restart
 // loop. On ErrIQStreamClosed (the USB reaper died, the consumer
@@ -3495,11 +3512,15 @@ func (d *Daemon) runCCDecoderWithRetry(ctx context.Context) error {
 		if !errors.Is(err, ccdecoder.ErrIQStreamClosed) {
 			return err
 		}
-		// A Run that survived a healthy window means the previous
-		// recovery succeeded; reset the attempt counter so a fresh
-		// failure stretch gets its own retry budget.
-		if time.Since(started) >= ccDecoderHealthyRunDuration {
+		// Credit the retry budget for how long the just-ended Run survived:
+		// a full-length healthy run resets it, and a run that at least made
+		// real progress (streamed for the shorter window) decays it by one so
+		// a stream that keeps recovering never accumulates to a fatal.
+		switch ran := time.Since(started); {
+		case ran >= ccDecoderHealthyRunDuration:
 			attempt = 0
+		case ran >= ccDecoderHealthyProgressDuration && attempt > 0:
+			attempt--
 		}
 		if attempt >= len(ccDecoderRetryBackoffs) {
 			d.log.Error("daemon: ccdecoder: IQ stream died and retries exhausted; escalating to fatal",
@@ -3611,11 +3632,16 @@ func (d *Daemon) runWidebandWithRetry(ctx context.Context, eng *widebandt2.Engin
 		if !errors.Is(err, widebandt2.ErrIQStreamClosed) {
 			return err
 		}
-		// A Run that survived a healthy window means the previous
-		// recovery succeeded; reset the retry budget for a fresh
-		// failure stretch.
-		if time.Since(started) >= ccDecoderHealthyRunDuration {
+		// Credit the retry budget for how long the just-ended Run survived
+		// (see runCCDecoderWithRetry): a full-length healthy run resets it, a
+		// run that made real progress decays it by one. A flapping-but-
+		// recovering Airspy therefore self-heals indefinitely instead of
+		// escalating the whole daemon to a fatal after a handful of deaths.
+		switch ran := time.Since(started); {
+		case ran >= ccDecoderHealthyRunDuration:
 			attempt = 0
+		case ran >= ccDecoderHealthyProgressDuration && attempt > 0:
+			attempt--
 		}
 		if attempt >= len(ccDecoderRetryBackoffs) {
 			d.log.Error("daemon: widebandt2: IQ stream died and retries exhausted; escalating to fatal",

--- a/cmd/gophertrunk/wideband_retry_test.go
+++ b/cmd/gophertrunk/wideband_retry_test.go
@@ -136,7 +136,7 @@ type flappingWidebandDevice struct {
 	calls     atomic.Int64
 }
 
-func (*flappingWidebandDevice) Info() sdr.Info          { return sdr.Info{Driver: "mock", Serial: "WB-FLAP"} }
+func (*flappingWidebandDevice) Info() sdr.Info             { return sdr.Info{Driver: "mock", Serial: "WB-FLAP"} }
 func (*flappingWidebandDevice) SetCenterFreq(uint32) error { return nil }
 func (*flappingWidebandDevice) SetSampleRate(uint32) error { return nil }
 func (*flappingWidebandDevice) SetGain(int) error          { return nil }

--- a/cmd/gophertrunk/wideband_retry_test.go
+++ b/cmd/gophertrunk/wideband_retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -120,6 +121,117 @@ func TestRunWidebandWithRetry_CleanStopOnCancel(t *testing.T) {
 	}
 	if d.takeFatal() != nil {
 		t.Errorf("recordFatal fired on a clean ctx-cancel stop: %v", d.takeFatal())
+	}
+}
+
+// flappingWidebandDevice models a dongle that keeps recovering: each of its
+// first maxDeaths StreamIQ sessions streams for `healthy` (long enough to count
+// as real progress) then the reaper dies with the ctx still live; after that it
+// parks the stream open until ctx cancels. It is the 9-Jul Airspy signature — a
+// stream that heals, runs a few seconds, dies, repeatedly — never sustaining a
+// single 60 s Run.
+type flappingWidebandDevice struct {
+	healthy   time.Duration
+	maxDeaths int64
+	calls     atomic.Int64
+}
+
+func (*flappingWidebandDevice) Info() sdr.Info          { return sdr.Info{Driver: "mock", Serial: "WB-FLAP"} }
+func (*flappingWidebandDevice) SetCenterFreq(uint32) error { return nil }
+func (*flappingWidebandDevice) SetSampleRate(uint32) error { return nil }
+func (*flappingWidebandDevice) SetGain(int) error          { return nil }
+func (*flappingWidebandDevice) SetPPM(int) error           { return nil }
+func (*flappingWidebandDevice) SetBiasTee(bool) error      { return nil }
+func (*flappingWidebandDevice) Close() error               { return nil }
+func (d *flappingWidebandDevice) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
+	n := d.calls.Add(1)
+	ch := make(chan []complex64)
+	go func() {
+		defer close(ch)
+		if n > d.maxDeaths {
+			<-ctx.Done() // stopped flapping: keep the stream healthy
+			return
+		}
+		select {
+		case <-time.After(d.healthy): // healed, ran a while, now the reaper dies
+		case <-ctx.Done():
+		}
+	}()
+	return ch, nil
+}
+
+// TestRunWidebandWithRetry_SurvivesRecoveringFlaps pins the decay fix: a stream
+// that dies, self-heals, streams past the healthy-progress window, and dies
+// again — repeatedly, more times than the backoff schedule is long — must NOT
+// escalate the whole daemon to a fatal. Before the decay (reset only after one
+// uninterrupted 60 s Run) `attempt` climbed monotonically across these ~seconds-
+// long runs and the daemon killed itself after a handful of deaths even though
+// every restart succeeded (the 9-Jul captures). It fails on the pre-fix code
+// (fatal recorded, supervisor returns before the device stops flapping) and
+// passes with the decay.
+func TestRunWidebandWithRetry_SurvivesRecoveringFlaps(t *testing.T) {
+	oldBackoffs := ccDecoderRetryBackoffs
+	oldProgress := ccDecoderHealthyProgressDuration
+	oldHealthy := ccDecoderHealthyRunDuration
+	ccDecoderRetryBackoffs = []time.Duration{2 * time.Millisecond, 2 * time.Millisecond}
+	ccDecoderHealthyProgressDuration = 15 * time.Millisecond
+	ccDecoderHealthyRunDuration = 10 * time.Second // never reached in-test
+	defer func() {
+		ccDecoderRetryBackoffs = oldBackoffs
+		ccDecoderHealthyProgressDuration = oldProgress
+		ccDecoderHealthyRunDuration = oldHealthy
+	}()
+
+	const maxDeaths = 6 // > len(backoffs): pre-fix this escalates long before here
+	dev := &flappingWidebandDevice{healthy: 30 * time.Millisecond, maxDeaths: maxDeaths}
+
+	bus := events.NewBus(8)
+	defer bus.Close()
+	eng, err := widebandt2.New(widebandt2.Options{
+		Log:          slog.New(slog.DiscardHandler),
+		Bus:          bus,
+		Device:       dev,
+		SampleRateHz: 2_400_000,
+		CenterFreqHz: 453_500_000,
+		Channels:     []widebandt2.ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "wbsys"}},
+		Systems:      []trunking.System{{Name: "wbsys", Protocol: trunking.ProtocolDMRTier2}},
+	})
+	if err != nil {
+		t.Fatalf("widebandt2.New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := &Daemon{log: slog.New(slog.DiscardHandler), bus: bus, cancel: cancel}
+	done := make(chan error, 1)
+	go func() { done <- d.runWidebandWithRetry(ctx, eng) }()
+
+	// The supervisor must survive every flap and reach the parked session
+	// (call maxDeaths+1). If it escalated instead, it returns early and calls
+	// stalls below maxDeaths+1 — the poll times out and the test fails.
+	deadline := time.After(4 * time.Second)
+	for dev.calls.Load() <= maxDeaths {
+		select {
+		case err := <-done:
+			t.Fatalf("supervisor returned early (%v) instead of surviving flaps; fatal=%v", err, d.takeFatal())
+		case <-deadline:
+			t.Fatalf("supervisor did not survive flaps: reached only %d/%d StreamIQ calls", dev.calls.Load(), maxDeaths+1)
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+	if f := d.takeFatal(); f != nil {
+		t.Fatalf("recordFatal fired on a recovering stream: %v", f)
+	}
+
+	// Clean shutdown from the parked state.
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Errorf("runWidebandWithRetry on cancel = %v, want nil/Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("supervisor did not return after ctx cancel")
 	}
 }
 

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -86,18 +86,39 @@ for a couple of seconds while the device is still enumerated, GopherTrunk aborts
 the pipe, surfaces the death as a real end-of-stream, and the daemon reacquires
 the dongle and restarts the wideband decoder automatically.
 
+When a reaper dies, the daemon's `IQ stream died; retrying` log line now names
+the **concrete USB cause** — e.g. `... closed unexpectedly: usb: bulk-IN stream
+stalled ...` (the stall watchdog fired) versus `usb: device disconnected` (an
+unplug) versus a wrapped per-URB error. That distinction tells a genuinely
+stalling endpoint apart from a disconnect or an overrun without needing any env
+var. The wideband/control retry loops also **self-heal indefinitely** across a
+dongle that keeps recovering — a stream that dies, reacquires, streams for a few
+seconds and dies again no longer accumulates to a process-killing fatal; only a
+device that re-dies immediately on every reopen (truly gone) still escalates.
+
 Knobs for diagnosing and tuning it:
 
 - `RTLSDR_DEBUG_USB=1` — emits a periodic bulk-stream telemetry line (URBs,
   bytes, throughput, per-slot spread, idle gap) plus a one-shot **`bulk-IN
-  stalled`** line at the moment the stream freezes. Capture this to pin down
-  *when* and *how* a freeze happens.
+  stalled`** line at the moment the stream freezes. It now **also traces the
+  Airspy's vendor control transfers** (`SET_SAMPLERATE` / `SET_FREQ` /
+  `RECEIVER_MODE` / gain) — previously only the RTL-SDR driver wrapped its
+  transport for this, so Airspy control setup was invisible. Capture this to pin
+  down *when* and *how* a freeze happens.
 - `GT_USB_BULK_STALL_MS` — the stall window in milliseconds (default `2000`).
   Set `0` to disable the watchdog.
 - `GT_USB_READPIPE_TIMEOUT_MS` — opt-in: switch the reaper to IOKit's
   `ReadPipeTO` with this per-read no-data timeout so a halted endpoint returns a
   timeout directly instead of relying on the watchdog. Off by default; try e.g.
   `200` if the watchdog alone doesn't recover cleanly.
+
+> **10 MS/s note.** If the daemon warns that the capture is *oversampled for the
+> channel plan* (`sdr.sample_rate` far wider than the carriers span), a lower
+> rate cuts DSP + USB load and overrun pressure for no loss of coverage. A run
+> at 10 MS/s that logs `dropping live IQ chunks; consumer can't keep up` is
+> shedding samples on the host — that is an overrun (degraded decode), *not* the
+> reaper death above, which the `IQ stream died` cause line identifies
+> separately.
 
 ## Sources
 

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,16 @@ module github.com/MattCheramie/GopherTrunk
 
 go 1.25.0
 
-// Toolchain pinned to 1.25.11 to close the stdlib CVEs govulncheck
+// Toolchain pinned to 1.25.12 to close the stdlib CVEs govulncheck
 // surfaced against earlier 1.25.x (html/template XSS, crypto/tls
-// KeyUpdate DoS + ALPN info leak, crypto/x509 chain build + policy
+// KeyUpdate DoS + ALPN info leak + the Encrypted Client Hello privacy
+// leak GO-2026-5856 fixed in 1.25.12, crypto/x509 chain build + policy
 // validation + inefficient hostname parsing, net/url IPv6 + query
 // parse, net/textproto unescaped error inputs, etc.). The toolchain
-// directive auto-downloads 1.25.11 on a build host running an older
+// directive auto-downloads 1.25.12 on a build host running an older
 // 1.25.x; CI's setup-go is pinned to the same version so the toolchain
 // download doesn't run at every CI step.
-toolchain go1.25.11
+toolchain go1.25.12
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -111,6 +111,25 @@ type FECObserver interface {
 // cause. See issue #345.
 var ErrIQStreamClosed = errors.New("ccdecoder: IQ stream closed unexpectedly")
 
+// streamDeadCauser is the optional extension a driver (airspy, rtlsdr-purego,
+// or the iqtap broker wrapping them) implements to report the concrete USB
+// error that killed its last bulk-IN stream.
+type streamDeadCauser interface{ StreamDeadCause() error }
+
+// streamClosedErr returns ErrIQStreamClosed, wrapping the IQ source's concrete
+// stream-death cause when it exposes one, so the daemon's "IQ stream died" log
+// names the real USB error (usb.ErrStreamStalled / usb.ErrDeviceGone / ...)
+// instead of a bare message. Still satisfies errors.Is(err, ErrIQStreamClosed),
+// so the retry loop's classification is unchanged.
+func streamClosedErr(iq IQSource) error {
+	if c, ok := iq.(streamDeadCauser); ok {
+		if cause := c.StreamDeadCause(); cause != nil {
+			return fmt.Errorf("%w: %w", ErrIQStreamClosed, cause)
+		}
+	}
+	return ErrIQStreamClosed
+}
+
 // iqPowerWindow is how long the pump aggregates samples before
 // recomputing the mean dBFS and updating the gauge / debug log.
 const iqPowerWindow = time.Second
@@ -523,7 +542,7 @@ func (d *Decoder) Run(ctx context.Context) error {
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
-				return ErrIQStreamClosed
+				return streamClosedErr(d.iq)
 			}
 			d.pump(iq)
 			d.putIQBuf(iq) // decode done — recycle the queue buffer

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -788,6 +788,25 @@ func (e *Engine) DMRTier3ControlChannel(freqHz uint32) *tier3.ControlChannel {
 // ctx-cancel shutdown still returns nil.
 var ErrIQStreamClosed = errors.New("widebandt2: IQ stream closed unexpectedly")
 
+// streamDeadCauser is the optional extension a driver (airspy, rtlsdr-purego,
+// or the iqtap broker that wraps them) implements to report the concrete USB
+// error that killed its last bulk-IN stream.
+type streamDeadCauser interface{ StreamDeadCause() error }
+
+// streamClosedErr returns ErrIQStreamClosed, wrapping the device's concrete
+// stream-death cause when it exposes one, so the daemon's "IQ stream died" log
+// names e.g. "usb: bulk-IN stream stalled ..." instead of a bare message. The
+// result still satisfies errors.Is(err, ErrIQStreamClosed), so the retry loop's
+// classification is unchanged.
+func streamClosedErr(dev sdr.Device) error {
+	if c, ok := dev.(streamDeadCauser); ok {
+		if cause := c.StreamDeadCause(); cause != nil {
+			return fmt.Errorf("%w: %w", ErrIQStreamClosed, cause)
+		}
+	}
+	return ErrIQStreamClosed
+}
+
 func (e *Engine) Run(ctx context.Context) error {
 	if err := e.device.SetCenterFreq(e.centerHz); err != nil {
 		return fmt.Errorf("widebandt2: SetCenterFreq %d Hz: %w", e.centerHz, err)
@@ -826,7 +845,7 @@ func (e *Engine) Run(ctx context.Context) error {
 				if ctx.Err() != nil {
 					return nil
 				}
-				return ErrIQStreamClosed
+				return streamClosedErr(e.device)
 			}
 			if e.suspended.Load() {
 				// SDR borrowed by a hunt and retuned: drop the off-frequency

--- a/internal/scanner/widebandt2/engine_test.go
+++ b/internal/scanner/widebandt2/engine_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/iqpower"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -745,6 +746,52 @@ func TestEngineRunReturnsStreamClosedOnUnexpectedClose(t *testing.T) {
 	err := e.Run(ctx)
 	if !errors.Is(err, ErrIQStreamClosed) {
 		t.Fatalf("Run on unexpected stream close = %v, want ErrIQStreamClosed", err)
+	}
+}
+
+// deadCauseDevice is a mockDevice that also reports a concrete stream-death
+// cause, modelling the airspy / rtlsdr-purego StreamDeadCause() extension (and
+// the iqtap broker that forwards it).
+type deadCauseDevice struct {
+	*mockDevice
+	cause error
+}
+
+func (d *deadCauseDevice) StreamDeadCause() error { return d.cause }
+
+// TestEngineRunWrapsStreamDeadCause pins the diagnostic fix: when the device
+// exposes the concrete USB error that killed the stream, Run must fold it into
+// ErrIQStreamClosed so the daemon's "IQ stream died" log names the real cause
+// (e.g. usb.ErrStreamStalled) instead of a bare message. The wrapped error must
+// still satisfy errors.Is(err, ErrIQStreamClosed) so the retry loop is
+// unchanged. Pre-fix Run returned the bare sentinel and the cause was lost.
+func TestEngineRunWrapsStreamDeadCause(t *testing.T) {
+	bus := events.NewBus(64)
+	defer bus.Close()
+	dev := &deadCauseDevice{mockDevice: newMockDevice(nil), cause: usb.ErrStreamStalled}
+	e, err := New(Options{
+		Log:          slog.Default(),
+		Device:       dev,
+		Bus:          bus,
+		Serial:       "WB-CAUSE",
+		SampleRateHz: 2_400_000,
+		CenterFreqHz: 453_500_000,
+		Channels:     []ChannelConfig{{FrequencyHz: 453_125_000, SystemName: "wbsys"}},
+		Systems:      []trunking.System{t2System("wbsys")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No chunks + no holdOpen: the mock closes the stream immediately with the
+	// ctx still live — a reaper death.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	got := e.Run(ctx)
+	if !errors.Is(got, ErrIQStreamClosed) {
+		t.Fatalf("Run = %v, want wrapped ErrIQStreamClosed", got)
+	}
+	if !errors.Is(got, usb.ErrStreamStalled) {
+		t.Fatalf("Run = %v, want the concrete cause usb.ErrStreamStalled folded in", got)
 	}
 }
 

--- a/internal/sdr/airspy/airspy.go
+++ b/internal/sdr/airspy/airspy.go
@@ -188,6 +188,13 @@ func (d *Driver) openDevice(desc usb.Descriptor, idx int, serial string) (*Devic
 	if err != nil {
 		return nil, fmt.Errorf("airspy: open %s: %w", desc.Path, err)
 	}
+	// When RTLSDR_DEBUG_USB is set, trace every vendor control transfer
+	// (SET_SAMPLERATE / SET_FREQ / RECEIVER_MODE / gain). The RTL-SDR driver
+	// already wraps its transport this way; the Airspy shares the same USB
+	// transport but never wrapped it, so its control setup was invisible even
+	// with debugging on. No-op when the env var is unset. (Bulk-IN is left
+	// untouched — the stall watchdog + telemetry live inside the transport.)
+	t = usb.MaybeWrapDebug(t, desc)
 	if err := t.ClaimInterface(0); err != nil {
 		_ = t.Close()
 		return nil, fmt.Errorf("airspy: claim interface 0: %w", err)
@@ -274,6 +281,28 @@ type Device struct {
 	// purego driver's Device.dropped so a live overrun is visible rather
 	// than silently wedging the USB reaper.
 	dropped atomic.Uint64
+	// streamDeadErr holds the USB error that killed the most recent bulk-IN
+	// stream — the error the transport hands to onStreamDead (usb.ErrStreamStalled
+	// when the stall watchdog aborted a frozen endpoint, usb.ErrDeviceGone on a
+	// disconnect, or a wrapped per-URB error). It was previously discarded, so an
+	// operator only ever saw the generic "IQ stream closed unexpectedly" with no
+	// cause; StreamDeadCause surfaces it so widebandt2/ccdecoder can name the real
+	// reason in the daemon's "IQ stream died" log. Reset to nil at the start of
+	// each StreamIQ so a prior death never leaks into a later clean shutdown.
+	streamDeadErr atomic.Pointer[error]
+}
+
+// StreamDeadCause reports the USB error that terminated the most recent bulk-IN
+// stream, or nil if the stream ended cleanly (ctx cancel / Close) or has not
+// died. The daemon's IQ-stream retry loop (via widebandt2 / ccdecoder) wraps it
+// into ErrIQStreamClosed so the "IQ stream died" log line names the concrete
+// cause instead of a generic message. Satisfies the optional
+// interface{ StreamDeadCause() error } those consumers probe for.
+func (d *Device) StreamDeadCause() error {
+	if p := d.streamDeadErr.Load(); p != nil {
+		return *p
+	}
+	return nil
 }
 
 // Info implements sdr.Device.
@@ -547,6 +576,10 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	d.streamDone = done
 	d.mu.Unlock()
 
+	// Clear any cause recorded by a previous stream's death so it can't be
+	// misattributed to this session (e.g. a later clean ctx-cancel shutdown).
+	d.streamDeadErr.Store(nil)
+
 	// Fresh real-to-IQ converter per stream so filter memory never carries
 	// over from a previous session. The device streams bare real samples;
 	// the converter turns them into complex baseband (see iqconverter.go).
@@ -587,8 +620,17 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	// (issue #345).
 	streamDead := make(chan struct{})
 	var streamDeadOnce sync.Once
-	onStreamDead := func(error) {
-		streamDeadOnce.Do(func() { close(streamDead) })
+	onStreamDead := func(cause error) {
+		streamDeadOnce.Do(func() {
+			// Record the killing error (before closing streamDead so it is
+			// visible by the time the cleanup goroutine closes `out` and the
+			// IQ consumer observes EOF). StreamDeadCause exposes it so the
+			// daemon log names the real cause instead of a generic message.
+			if cause != nil {
+				d.streamDeadErr.Store(&cause)
+			}
+			close(streamDead)
+		})
 	}
 	if err := d.t.StartBulkIn(bulkInEP, usb.DefaultRingBuffers, usb.DefaultBufferLen, onPacket, onStreamDead); err != nil {
 		_ = d.setReceiver(receiverModeOff)

--- a/internal/sdr/airspy/airspy_streamdead_test.go
+++ b/internal/sdr/airspy/airspy_streamdead_test.go
@@ -1,0 +1,108 @@
+package airspy
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr/usb"
+)
+
+// TestStreamIQRecordsDeadCause pins the diagnostic fix: when the USB reaper
+// dies (the transport fires onStreamDead with a concrete error — here the
+// stall-watchdog's usb.ErrStreamStalled), the driver must record it so
+// StreamDeadCause() surfaces the real reason. Previously onStreamDead discarded
+// its argument, so an operator only ever saw the generic "IQ stream closed
+// unexpectedly" with no way to tell a stall from a disconnect.
+func TestStreamIQRecordsDeadCause(t *testing.T) {
+	dev, mt := withDevice(t)
+	mt.Script = []usb.CtrlExchange{
+		{BRequest: reqReceiverMode, WValue: receiverModeOn},
+		{BRequest: reqReceiverMode, WValue: receiverModeOff},
+	}
+	mt.BulkPackets = [][]byte{make([]byte, 64)}
+	mt.BulkSimulateDeath = true
+	mt.BulkDeathErr = usb.ErrStreamStalled
+
+	if c := dev.StreamDeadCause(); c != nil {
+		t.Fatalf("StreamDeadCause before streaming = %v, want nil", c)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := dev.StreamIQ(ctx)
+	if err != nil {
+		t.Fatalf("StreamIQ: %v", err)
+	}
+	// Drain until the driver closes the channel — the death path stores the
+	// cause before it closes `out`, so no sleep/poll is needed.
+	for range ch {
+	}
+
+	if got := dev.StreamDeadCause(); !errors.Is(got, usb.ErrStreamStalled) {
+		t.Fatalf("StreamDeadCause after reaper death = %v, want usb.ErrStreamStalled", got)
+	}
+}
+
+// airspyDebugEnum builds a MockEnumerator whose opened transports carry the
+// samplerate-table script Open reads, so openDevice succeeds. It records the
+// last raw mock returned so a test can check whether the driver wrapped it.
+func airspyDebugEnum(record func(*usb.MockTransport)) *usb.MockEnumerator {
+	return &usb.MockEnumerator{
+		Devices: []usb.Descriptor{
+			{Bus: 1, Address: 4, VID: vidAirspy, PID: pidAirspy, Serial: "AS1", Product: "Airspy R2", Path: "mock/1"},
+		},
+		OpenFunc: func(usb.Descriptor) (*usb.MockTransport, error) {
+			mt := usb.NewMockTransport()
+			count := make([]byte, 4)
+			binary.LittleEndian.PutUint32(count, 1)
+			list := make([]byte, 4)
+			binary.LittleEndian.PutUint32(list, 10_000_000)
+			mt.Script = []usb.CtrlExchange{
+				{BRequest: reqReceiverMode, WValue: receiverModeOff},
+				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 0, Reply: count, N: 4},
+				{In: true, BRequest: reqGetSamplerates, WValue: 0, WIndex: 1, Reply: list, N: 4},
+			}
+			record(mt)
+			return mt, nil
+		},
+	}
+}
+
+// TestOpenWrapsTransportForUSBDebug pins that airspy honours RTLSDR_DEBUG_USB by
+// wrapping its transport with usb.MaybeWrapDebug, so control transfers
+// (SET_SAMPLERATE / SET_FREQ / RECEIVER_MODE / gain) are traced. The Airspy
+// shares the RTL-SDR USB transport but never wrapped it, so its control setup
+// was invisible even with debugging on. With the env unset the transport is the
+// raw handle; with it set the device holds the wrapper, not the raw mock.
+func TestOpenWrapsTransportForUSBDebug(t *testing.T) {
+	openOne := func(t *testing.T) (inner usb.Transport, raw *usb.MockTransport) {
+		t.Helper()
+		drv := New(airspyDebugEnum(func(mt *usb.MockTransport) { raw = mt }))
+		dev, err := drv.Open(0)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		if raw == nil {
+			t.Fatal("OpenFunc never ran")
+		}
+		return dev.(*Device).t, raw
+	}
+
+	t.Run("debug off leaves transport unwrapped", func(t *testing.T) {
+		t.Setenv("RTLSDR_DEBUG_USB", "")
+		inner, raw := openOne(t)
+		if inner != usb.Transport(raw) {
+			t.Fatal("RTLSDR_DEBUG_USB unset but transport was wrapped anyway")
+		}
+	})
+
+	t.Run("debug on wraps transport", func(t *testing.T) {
+		t.Setenv("RTLSDR_DEBUG_USB", "1")
+		inner, raw := openOne(t)
+		if inner == usb.Transport(raw) {
+			t.Fatal("RTLSDR_DEBUG_USB set but transport was not wrapped by MaybeWrapDebug")
+		}
+	})
+}

--- a/internal/sdr/iqtap/broker.go
+++ b/internal/sdr/iqtap/broker.go
@@ -240,6 +240,23 @@ func (b *Broker) Close() error {
 	return b.inner.Close()
 }
 
+// StreamDeadCause forwards the wrapped device's stream-death cause when it
+// exposes the optional interface{ StreamDeadCause() error } extension
+// (airspy / rtlsdr-purego), otherwise nil. The wideband engine streams the
+// dongle through the broker, so without this pass-through the concrete USB
+// error that killed the reaper would never reach the daemon's "IQ stream died"
+// log — the same gap the broker had for ActualSampleRate. It reads the
+// currently-wrapped inner: the engine queries it on stream-close before the
+// daemon swaps in a reacquired handle, so it observes the dead device's cause.
+func (b *Broker) StreamDeadCause() error {
+	b.innerMu.RLock()
+	defer b.innerMu.RUnlock()
+	if c, ok := b.inner.(interface{ StreamDeadCause() error }); ok {
+		return c.StreamDeadCause()
+	}
+	return nil
+}
+
 // StreamIQ opens a stream against the currently-wrapped inner, starts
 // a fan-out goroutine that copies each chunk to every active
 // Subscriber, and returns the primary's channel. Multiple sequential

--- a/internal/sdr/rtlsdr/purego/device.go
+++ b/internal/sdr/rtlsdr/purego/device.go
@@ -57,6 +57,14 @@ type Device struct {
 	// and as the per-drop signal behind the dropObserver hook.
 	dropped atomic.Uint64
 
+	// streamDeadErr holds the USB error the transport handed to onStreamDead
+	// when the most recent bulk-IN reaper died (usb.ErrStreamStalled,
+	// usb.ErrDeviceGone, or a wrapped per-URB error). Previously discarded, so
+	// the ccdecoder retry loop only ever logged the generic "IQ stream closed
+	// unexpectedly"; StreamDeadCause exposes it so the daemon names the concrete
+	// cause. Cleared at the start of each StreamIQ.
+	streamDeadErr atomic.Pointer[error]
+
 	closed atomic.Bool
 }
 
@@ -65,6 +73,17 @@ type Device struct {
 // device-level signal behind the iq_underruns_total metric — deliver
 // also reports each drop via [sdr.NotifyIQDrop].
 func (d *Device) DroppedChunks() uint64 { return d.dropped.Load() }
+
+// StreamDeadCause reports the USB error that terminated the most recent bulk-IN
+// stream, or nil if it ended cleanly or has not died. The ccdecoder retry loop
+// wraps it into ErrIQStreamClosed so the daemon's "IQ stream died" log names the
+// concrete cause. Satisfies the optional interface{ StreamDeadCause() error }.
+func (d *Device) StreamDeadCause() error {
+	if p := d.streamDeadErr.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
 
 // Info returns the descriptor populated by [Driver.Open] — driver
 // name, USB index, serial / manufacturer / product strings, tuner

--- a/internal/sdr/rtlsdr/purego/stream.go
+++ b/internal/sdr/rtlsdr/purego/stream.go
@@ -63,6 +63,9 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 	out := make(chan []complex64, streamChanDepth)
 	d.out = out
 	d.stopOnce = sync.Once{}
+	// Drop any cause from a previous stream so it can't be misattributed to
+	// this session's eventual (possibly clean) end.
+	d.streamDeadErr.Store(nil)
 
 	// Provision the reuse ring for this stream (issue #489). Sized
 	// streamChanDepth+2: at most streamChanDepth buffers can sit queued
@@ -100,8 +103,12 @@ func (d *Device) StreamIQ(ctx context.Context) (<-chan []complex64, error) {
 // real EOF rather than hanging forever. Idempotent via d.stopOnce.
 // The underlying error surfaces upstream as ccdecoder.ErrIQStreamClosed;
 // the daemon logs it once and decides whether to retry / exit. See
-// issue #345.
-func (d *Device) onStreamDead(error) {
+// issue #345. The cause is recorded (StreamDeadCause) so that log line names
+// the concrete USB error instead of a generic message.
+func (d *Device) onStreamDead(cause error) {
+	if cause != nil {
+		d.streamDeadErr.Store(&cause)
+	}
 	d.cancelStream()
 }
 


### PR DESCRIPTION
The macOS Airspy silent-freeze fix (PR #875) turned the freeze into a real EOF
plus a self-heal retry loop. The 9-Jul captures show the next layer: at both
2.5 MS/s and 10 MS/s the IQ stream dies every ~1-11 s with "IQ stream closed
unexpectedly", self-heals (reacquire + restart) and decodes for a few seconds,
then dies again — and after a handful of deaths the daemon escalated to a fatal
and shut the whole process down ~30 s in, even though every restart succeeded.
Two defects, both addressed here (diagnostics-first, per CLAUDE.md — no macOS
hardware in CI):

- The error that killed the bulk reaper was discarded. onStreamDead(error)
  ignored its argument in both the airspy and rtlsdr-purego drivers, so the
  operator only ever saw a generic message and could not tell a stall-watchdog
  abort (usb.ErrStreamStalled) from a disconnect (usb.ErrDeviceGone) or a
  per-URB error. The drivers now record the cause (StreamDeadCause), the iqtap
  broker forwards it, and widebandt2 / ccdecoder fold it into ErrIQStreamClosed
  so the daemon's "IQ stream died; retrying" line names the concrete USB error.
  errors.Is(err, ErrIQStreamClosed) still holds, so retry classification is
  unchanged.

- The self-heal retry counter only reset after one uninterrupted 60 s Run, so a
  stream that keeps recovering in ~seconds never reset it and the count climbed
  monotonically to a fatal. runWidebandWithRetry and runCCDecoderWithRetry now
  decay the counter after a Run that streamed real data
  (ccDecoderHealthyProgressDuration), so a recovering dongle self-heals
  indefinitely while a device that re-dies immediately on every reopen (truly
  gone) still escalates.

- Airspy now wraps its transport with usb.MaybeWrapDebug, so RTLSDR_DEBUG_USB=1
  traces its vendor control transfers (SET_SAMPLERATE / SET_FREQ /
  RECEIVER_MODE / gain) — previously only the RTL-SDR driver did.

Failing-first regression tests: airspy StreamDeadCause records the reaper's
error; widebandt2 Run folds the cause into ErrIQStreamClosed; the wideband
retry loop survives repeated recovering flaps instead of escalating. docs +
CHANGELOG updated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Bi3jEJWfGde94WZLMxVVyf