### PR TITLE
voice/mp3: fix corrupt/half-length MP3 uploads (Rdio Scanner no-audio)

### DIFF
--- a/cmd/encodetest/main.go
+++ b/cmd/encodetest/main.go
@@ -1,0 +1,33 @@
+// Command encodetest encodes a 16-bit PCM mono WAV file to MP3 using the same
+// internal/voice/mp3 path the broadcast backends use, writing the result to a
+// file. It exists to reproduce and verify call-audio encoding issues offline —
+// e.g. piping its output through ffmpeg exactly as Rdio Scanner does:
+//
+//	go run ./cmd/encodetest in.wav out.mp3
+//	ffmpeg -i out.mp3 -f null -        # must succeed
+//	cat out.mp3 | ffmpeg -i - -f null - # must succeed (stdin, like Rdio Scanner)
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mp3"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s <in.wav> <out.mp3>\n", os.Args[0])
+		os.Exit(2)
+	}
+	data, rate, err := mp3.EncodeWAVFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "encode error:", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(os.Args[2], data, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "write error:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("sample rate=%d bitrate=%d bytes=%d\n", rate, mp3.BitrateFor(rate), len(data))
+}

--- a/internal/broadcast/icecast.go
+++ b/internal/broadcast/icecast.go
@@ -16,17 +16,14 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/voice/mp3"
 )
 
-// Icecast streaming constants. The shine encoder emits a 128 kbps CBR
-// MP3, so the live mountpoint is paced at 16000 bytes/second; between
-// calls the pacer tops the stream up with pre-encoded silence so the
-// source connection is never starved and the Icecast server does not
-// time it out.
+// Icecast streaming constants. The mountpoint is paced at the encoder's real
+// byte rate for the configured sample rate (mp3.BitrateFor); between calls the
+// pacer tops the stream up with pre-encoded silence so the source connection is
+// never starved and the Icecast server does not time it out.
 const (
-	icecastBitrateBps  = 128000
-	icecastBytesPerSec = icecastBitrateBps / 8
-	icecastTick        = 200 * time.Millisecond
-	icecastReconnect   = 5 * time.Second
-	icecastMaxQueue    = icecastBytesPerSec * 120 // ~2 min of audio
+	icecastTick      = 200 * time.Millisecond
+	icecastReconnect = 5 * time.Second
+	icecastQueueSecs = 120 // buffer at most ~2 min of audio
 )
 
 // IcecastConfig configures one live Icecast/ShoutCast feed.
@@ -62,6 +59,10 @@ type icecastBackend struct {
 	stream  string
 	log     *slog.Logger
 	silence []byte
+	// bytesPerSec is the encoded MP3 byte rate for the configured sample
+	// rate; the pacer and queue cap are sized from it.
+	bytesPerSec int
+	maxQueue    int
 
 	mu     sync.Mutex
 	queue  []byte
@@ -115,6 +116,7 @@ func NewIcecast(cfg IcecastConfig, log *slog.Logger) (Backend, error) {
 	if err != nil {
 		return nil, fmt.Errorf("broadcast/icecast: encode silence: %w", err)
 	}
+	bytesPerSec := mp3.BitrateFor(rate) / 8
 	b := &icecastBackend{
 		systemFilter: newSystemFilter(cfg.Systems),
 		name:         name,
@@ -124,6 +126,8 @@ func NewIcecast(cfg IcecastConfig, log *slog.Logger) (Backend, error) {
 		stream:       stream,
 		log:          log,
 		silence:      silence,
+		bytesPerSec:  bytesPerSec,
+		maxQueue:     bytesPerSec * icecastQueueSecs,
 		done:         make(chan struct{}),
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -147,7 +151,7 @@ func (b *icecastBackend) Send(_ context.Context, c *Call) error {
 	if b.closed {
 		return nil
 	}
-	if len(b.queue)+len(audio) > icecastMaxQueue {
+	if len(b.queue)+len(audio) > b.maxQueue {
 		b.log.Warn("broadcast: icecast queue full, dropping call",
 			"system", c.System, "tg", c.Talkgroup)
 		return nil
@@ -209,7 +213,7 @@ func (b *icecastBackend) runStream(ctx context.Context) error {
 
 	ticker := time.NewTicker(icecastTick)
 	defer ticker.Stop()
-	chunk := icecastBytesPerSec * int(icecastTick) / int(time.Second)
+	chunk := b.bytesPerSec * int(icecastTick) / int(time.Second)
 	silenceOff := 0
 	for {
 		select {
@@ -237,7 +241,7 @@ func (b *icecastBackend) handshake(conn net.Conn) error {
 		"Content-Type: audio/mpeg",
 		"Ice-Name: " + b.stream,
 		"Ice-Public: 0",
-		"Ice-Audio-Info: bitrate=128",
+		"Ice-Audio-Info: bitrate=" + strconv.Itoa(b.bytesPerSec*8/1000),
 		"", "",
 	}, "\r\n")
 	if err := conn.SetWriteDeadline(time.Now().Add(10 * time.Second)); err != nil {

--- a/internal/voice/mp3/mp3.go
+++ b/internal/voice/mp3/mp3.go
@@ -48,14 +48,83 @@ func Encode(samples []int16, sampleRate int) ([]byte, error) {
 	copy(backed, samples)
 
 	enc := shine.NewEncoder(sampleRate, 1)
+	configureBitrate(enc, sampleRate)
+	// Shine's Write advances its read cursor by two frames' worth of samples
+	// per iteration — correct for interleaved stereo, but for a mono stream it
+	// silently drops every other frame. Driving Write one frame at a time keeps
+	// the stride correct so no audio is lost; the encoder carries its reservoir
+	// and subband state across the successive calls. samplesPerFrame matches
+	// Shine's internal per-frame size: 1152 for the MPEG-1 rates (≥32 kHz),
+	// 576 for the MPEG-2 / MPEG-2.5 rates, and shineFrame is a whole multiple
+	// of both, so encodeLen always splits into whole frames.
+	samplesPerFrame := 576
+	if sampleRate >= 32000 {
+		samplesPerFrame = 1152
+	}
 	var buf bytes.Buffer
-	if err := enc.Write(&buf, backed[:encodeLen]); err != nil {
-		return nil, fmt.Errorf("mp3: encode: %w", err)
+	for off := 0; off < encodeLen; off += samplesPerFrame {
+		if err := enc.Write(&buf, backed[off:off+samplesPerFrame]); err != nil {
+			return nil, fmt.Errorf("mp3: encode: %w", err)
+		}
 	}
 	if buf.Len() == 0 {
 		return nil, errors.New("mp3: encoder produced no output")
 	}
-	return buf.Bytes(), nil
+	// Prepend a LAME-style Xing/Info header frame so ffmpeg and other demuxers
+	// parse short clips reliably (see xing.go).
+	return withInfoHeader(buf.Bytes()), nil
+}
+
+// BitrateFor returns the CBR bitrate, in bits per second, the encoder uses for
+// audio at sampleRate. Shine hard-codes 128 kbps, which is wrong on two counts
+// for the low sample rates GopherTrunk records at:
+//
+//   - 128 kbps is not even a legal Layer-III bitrate for the MPEG-2.5 family
+//     (8/11.025/12 kHz), so Shine writes an out-of-range bitrate index that
+//     corrupts every frame header.
+//   - More subtly, Shine's single-granule frames (every rate below 32 kHz)
+//     desync their bit-reservoir stuffing once the per-frame budget grows past
+//     roughly 3300 bits (~420 bytes/frame), emitting oversized frames that no
+//     demuxer can follow. This is why an 8 kHz call uploaded to Rdio Scanner
+//     transcodes to silence / "Invalid data found".
+//
+// So each single-granule family gets the highest standard bitrate that keeps a
+// frame comfortably under that limit — 32 kbps for MPEG-2.5, 64 kbps for
+// MPEG-2 — both well above transparent for 8 kHz mono voice. The MPEG-1 rates
+// (≥32 kHz) split each frame into two granules, halving the per-granule budget,
+// so they keep Shine's 128 kbps default. Callers that pace a stream by bitrate
+// (Icecast) use this so their timing tracks the real encoder output.
+func BitrateFor(sampleRate int) int {
+	switch {
+	case sampleRate >= 32000: // MPEG-1 (two granules per frame)
+		return 128000
+	case sampleRate >= 16000: // MPEG-2
+		return 64000
+	default: // MPEG-2.5
+		return 32000
+	}
+}
+
+// configureBitrate overrides Shine's fixed 128 kbps default with the bitrate
+// BitrateFor selects for sampleRate and recomputes the CBR frame-size
+// bookkeeping NewEncoder derives from it. It is a no-op for the MPEG-1 rates,
+// where 128 kbps is already correct.
+func configureBitrate(enc *shine.Encoder, sampleRate int) {
+	kbps := BitrateFor(sampleRate) / 1000
+	if int(enc.Mpeg.Bitrate) == kbps {
+		return
+	}
+	enc.Mpeg.Bitrate = int64(kbps)
+	enc.Mpeg.BitrateIndex = int64(bitrateIndex(kbps, sampleRate))
+	// Mirror shine.NewEncoder: slots-per-frame scales with the bitrate.
+	avg := float64(enc.Mpeg.GranulesPerFrame) * 576 / float64(sampleRate) *
+		(float64(kbps) * 1000 / float64(enc.Mpeg.BitsPerSlot))
+	enc.Mpeg.WholeSlotsPerFrame = int64(avg)
+	enc.Mpeg.FracSlotsPerFrame = avg - float64(enc.Mpeg.WholeSlotsPerFrame)
+	enc.Mpeg.Slot_lag = -enc.Mpeg.FracSlotsPerFrame
+	if enc.Mpeg.FracSlotsPerFrame == 0 {
+		enc.Mpeg.Padding = 0
+	}
 }
 
 // EncodeWAVFile reads a 16-bit PCM mono WAV file from path and returns

--- a/internal/voice/mp3/mp3_test.go
+++ b/internal/voice/mp3/mp3_test.go
@@ -1,9 +1,11 @@
 package mp3
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -29,6 +31,130 @@ func TestEncodeProducesMP3FrameSync(t *testing.T) {
 		// Every MP3 frame opens with an 11-bit sync word.
 		if out[0] != 0xFF || out[1]&0xE0 != 0xE0 {
 			t.Fatalf("Encode(%d Hz): no MP3 frame sync: %02x %02x", rate, out[0], out[1])
+		}
+	}
+}
+
+// TestEncodeEncodesEveryFrame is the regression for root cause #1: Shine's
+// Write drops every other frame of a mono stream, so a call encoded to ~half
+// its true length (near-silence). Feeding a whole number of frames, the output
+// must contain exactly that many audio frames plus the one Info header frame.
+func TestEncodeEncodesEveryFrame(t *testing.T) {
+	for _, tc := range []struct {
+		rate int
+		spf  int // Shine per-frame samples for this rate family
+	}{
+		{8000, 576}, {22050, 576}, {44100, 1152},
+	} {
+		const wholeFrames = 20
+		n := wholeFrames * shineFrame // whole shineFrames → no padding rounding
+		out, err := Encode(tone(n, tc.rate, 440), tc.rate)
+		if err != nil {
+			t.Fatalf("Encode(%d Hz): %v", tc.rate, err)
+		}
+		wantAudio := n / tc.spf // every frame encoded, not every other
+		if got := countFrames(out); got != wantAudio+1 {
+			t.Fatalf("Encode(%d Hz): counted %d frames, want %d audio + 1 Info = %d",
+				tc.rate, got, wantAudio, wantAudio+1)
+		}
+	}
+}
+
+// supportedRates are the sample rates the Shine encoder accepts, spanning all
+// three MPEG sample-rate families.
+var supportedRates = []int{8000, 11025, 12000, 16000, 22050, 24000, 32000, 44100, 48000}
+
+// TestEncodeFramesTileExactly is the regression for the core defect behind
+// issue #874: at Shine's fixed 128 kbps, every single-granule (sub-32 kHz)
+// frame is either header-corrupt (128 kbps is illegal below 16 kHz) or
+// oversized (Shine's reservoir stuffing desyncs on large frames), so the byte
+// stream cannot be walked frame-by-frame and ffmpeg rejects it. A correctly
+// encoded CBR stream must tile exactly into whole frames from the first byte to
+// the last with nothing left over.
+func TestEncodeFramesTileExactly(t *testing.T) {
+	for _, rate := range supportedRates {
+		out, err := Encode(tone(30*576, rate, 600), rate)
+		if err != nil {
+			t.Fatalf("Encode(%d Hz): %v", rate, err)
+		}
+		pos, n := 0, 0
+		for {
+			h, ok := parseFrameHeader(out[pos:])
+			if !ok {
+				t.Fatalf("Encode(%d Hz): frame %d at byte %d has an invalid header: % x",
+					rate, n, pos, out[pos:min(pos+4, len(out))])
+			}
+			n++
+			next := pos + h.frameLen()
+			if next >= len(out) {
+				// Final frame: Shine leaves the last partial 32-bit word
+				// unflushed, so its declared length can exceed the stream by a
+				// few bytes. A gross overrun means the reservoir-stuffing bug.
+				if next > len(out)+4 {
+					t.Fatalf("Encode(%d Hz): frame %d overruns the stream by %d bytes",
+						rate, n-1, next-len(out))
+				}
+				break
+			}
+			pos = next
+		}
+	}
+}
+
+// TestEncodeStartsWithXingInfoHeader is the regression for root cause #2: Shine
+// emits headerless frames that ffmpeg cannot reliably parse on short clips. The
+// stream must begin with a valid Xing/Info header frame carrying the stream's
+// frame count, exactly as LAME does.
+func TestEncodeStartsWithXingInfoHeader(t *testing.T) {
+	out, err := Encode(tone(10*shineFrame, 8000, 440), 8000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h, ok := parseFrameHeader(out)
+	if !ok {
+		t.Fatalf("first frame is not a valid Layer-III header: % x", out[:4])
+	}
+	off := 4 + h.sideInfoLen()
+	if tag := string(out[off : off+4]); tag != "Info" && tag != "Xing" {
+		t.Fatalf("no Xing/Info tag at offset %d: %q", off, tag)
+	}
+	if flags := binary.BigEndian.Uint32(out[off+4:]); flags&0x0003 != 0x0003 {
+		t.Fatalf("Info flags %#x missing frames+bytes bits", flags)
+	}
+	frameCount := binary.BigEndian.Uint32(out[off+8:])
+	if int(frameCount) != countFrames(out) {
+		t.Fatalf("Info frame count = %d, but stream has %d frames", frameCount, countFrames(out))
+	}
+	byteCount := binary.BigEndian.Uint32(out[off+12:])
+	if int(byteCount) != len(out) {
+		t.Fatalf("Info byte count = %d, but stream is %d bytes", byteCount, len(out))
+	}
+}
+
+// TestEncodeFFmpegParses is the direct end-to-end reproduction from issue #874:
+// pipe the encoded bytes to ffmpeg over stdin, exactly as Rdio Scanner does
+// before transcoding an uploaded call. Every supported rate must parse, and a
+// short clip (few frames) is covered too since that is the case ffmpeg's mp3
+// demuxer handled worst. Skipped when ffmpeg is not installed.
+func TestEncodeFFmpegParses(t *testing.T) {
+	ff, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		t.Skip("ffmpeg not installed")
+	}
+	for _, rate := range supportedRates {
+		for _, frames := range []int{30, 3} { // long and short clips
+			out, err := Encode(tone(frames*576, rate, 600), rate)
+			if err != nil {
+				t.Fatalf("Encode(%d Hz): %v", rate, err)
+			}
+			cmd := exec.Command(ff, "-hide_banner", "-i", "-", "-f", "null", "-")
+			cmd.Stdin = bytes.NewReader(out)
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("ffmpeg rejected %d Hz / %d-frame MP3: %v\n%s",
+					rate, frames, err, stderr.String())
+			}
 		}
 	}
 }

--- a/internal/voice/mp3/xing.go
+++ b/internal/voice/mp3/xing.go
@@ -1,0 +1,171 @@
+package mp3
+
+import "encoding/binary"
+
+// This file adds a LAME-style Xing/Info header frame to Shine's raw output.
+//
+// Shine emits bare MPEG Layer-III frames with no Xing/LAME info frame and no
+// ID3 tag. On short clips (an individual radio call) ffmpeg's mp3 demuxer scores
+// the format low-confidence from the first frame, then tries to confirm by
+// seeking to a computed next-frame offset — which, for the final frame of a
+// short clip, lands past end-of-file and is treated as fatal
+// ("Failed to read frame size: Could not seek to …" / "Invalid data found").
+// LAME (and therefore Trunk Recorder) always writes an Info frame as the very
+// first frame precisely so demuxers read the stream length instead of probing.
+// We reproduce that frame in pure Go, keeping the package's zero-CGO guarantee.
+
+// l3BitrateMPEG1 and l3BitrateMPEG2 map a 4-bit bitrate index to kbps for
+// MPEG-1 and MPEG-2/2.5 Layer III respectively. Index 0 (free) and 15 (bad)
+// are unused by the encoder.
+var (
+	l3BitrateMPEG1 = [16]int{0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0}
+	l3BitrateMPEG2 = [16]int{0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0}
+	srMPEG1        = [4]int{44100, 48000, 32000, 0}
+	srMPEG2        = [4]int{22050, 24000, 16000, 0}
+	srMPEG25       = [4]int{11025, 12000, 8000, 0}
+)
+
+// bitrateIndex returns the 4-bit Layer-III bitrate index for kbps at the given
+// sample rate, or 0 (the "free" slot) if kbps is not a legal value there.
+func bitrateIndex(kbps, sampleRate int) int {
+	tbl := l3BitrateMPEG2
+	if sampleRate >= 32000 { // MPEG-1 family
+		tbl = l3BitrateMPEG1
+	}
+	for i, v := range tbl {
+		if v == kbps {
+			return i
+		}
+	}
+	return 0
+}
+
+// frameHeader is the decoded content of a 4-byte MPEG Layer-III frame header.
+type frameHeader struct {
+	versionBits uint8 // 0=MPEG-2.5, 2=MPEG-2, 3=MPEG-1 (raw header field)
+	bitrate     int   // bits per second
+	sampleRate  int   // Hz
+	padding     int   // 0 or 1 padding slot
+	mono        bool  // single-channel (mode bits == 11)
+}
+
+// parseFrameHeader decodes the 4-byte Layer-III header at the start of b.
+// It returns ok=false for anything that is not a valid Layer-III frame header
+// (bad sync, reserved version, non-Layer-III, or free/reserved bitrate/rate).
+func parseFrameHeader(b []byte) (frameHeader, bool) {
+	if len(b) < 4 || b[0] != 0xFF || b[1]&0xE0 != 0xE0 {
+		return frameHeader{}, false
+	}
+	verBits := (b[1] >> 3) & 0x3
+	layerBits := (b[1] >> 1) & 0x3
+	if verBits == 1 || layerBits != 1 { // reserved version / not Layer III
+		return frameHeader{}, false
+	}
+	brIndex := (b[2] >> 4) & 0xF
+	srIndex := (b[2] >> 2) & 0x3
+	var br, sr int
+	if verBits == 3 { // MPEG-1
+		br = l3BitrateMPEG1[brIndex]
+		sr = srMPEG1[srIndex]
+	} else {
+		br = l3BitrateMPEG2[brIndex]
+		if verBits == 2 {
+			sr = srMPEG2[srIndex]
+		} else {
+			sr = srMPEG25[srIndex]
+		}
+	}
+	if br == 0 || sr == 0 {
+		return frameHeader{}, false
+	}
+	return frameHeader{
+		versionBits: verBits,
+		bitrate:     br * 1000,
+		sampleRate:  sr,
+		padding:     int((b[2] >> 1) & 0x1),
+		mono:        (b[3]>>6)&0x3 == 0x3,
+	}, true
+}
+
+// baseLen is the frame length in bytes excluding the padding slot:
+// 144·bitrate/rate for MPEG-1 (1152 samples/frame), 72·bitrate/rate for
+// MPEG-2/2.5 (576 samples/frame).
+func (h frameHeader) baseLen() int {
+	coef := 72
+	if h.versionBits == 3 {
+		coef = 144
+	}
+	return coef * h.bitrate / h.sampleRate
+}
+
+// frameLen is the total frame length in bytes including any padding slot.
+func (h frameHeader) frameLen() int { return h.baseLen() + h.padding }
+
+// sideInfoLen is the length in bytes of the side-information region that
+// follows the 4-byte header, per MPEG version and channel count.
+func (h frameHeader) sideInfoLen() int {
+	if h.versionBits == 3 { // MPEG-1
+		if h.mono {
+			return 17
+		}
+		return 32
+	}
+	if h.mono {
+		return 9
+	}
+	return 17
+}
+
+// countFrames returns the number of whole MPEG Layer-III frames in a bare
+// Shine stream. It stops at the first byte that is not a valid frame header.
+func countFrames(stream []byte) int {
+	n := 0
+	for pos := 0; pos+4 <= len(stream); {
+		h, ok := parseFrameHeader(stream[pos:])
+		if !ok {
+			break
+		}
+		fl := h.frameLen()
+		if fl <= 0 {
+			break
+		}
+		pos += fl
+		n++
+	}
+	return n
+}
+
+// xingInfoFrame builds a single CBR "Info" header frame that mirrors header h
+// and advertises totalFrames/totalBytes for the whole stream. The audio payload
+// is silent (all-zero side info and main data), so it decodes to a brief silence
+// and is safe to prepend to any stream.
+func xingInfoFrame(h frameHeader, headerBytes []byte, totalFrames, totalBytes int) []byte {
+	frame := make([]byte, h.baseLen())
+	// Reuse Shine's own 4-byte header so version/rate/mode/bitrate always match
+	// the stream, but clear the padding bit — this synthetic frame is exactly
+	// baseLen bytes (no padding slot).
+	copy(frame[:4], headerBytes[:4])
+	frame[2] &^= 0x02
+	off := 4 + h.sideInfoLen()
+	copy(frame[off:], "Info")                                     // CBR tag ("Xing" would signal VBR)
+	binary.BigEndian.PutUint32(frame[off+4:], 0x0003)             // flags: frames + bytes present
+	binary.BigEndian.PutUint32(frame[off+8:], uint32(totalFrames)) //nolint:gosec // small non-negative counts
+	binary.BigEndian.PutUint32(frame[off+12:], uint32(totalBytes)) //nolint:gosec
+	return frame
+}
+
+// withInfoHeader returns stream prefixed with a Xing/Info header frame that
+// describes it. If stream does not begin with a parseable Layer-III frame it is
+// returned unchanged.
+func withInfoHeader(stream []byte) []byte {
+	h, ok := parseFrameHeader(stream)
+	if !ok {
+		return stream
+	}
+	frames := countFrames(stream)
+	info := xingInfoFrame(h, stream, frames+1, h.baseLen()+len(stream))
+	out := make([]byte, 0, len(info)+len(stream))
+	out = append(out, info...)
+	out = append(out, stream...)
+	return out
+}

--- a/internal/voice/mp3/xing.go
+++ b/internal/voice/mp3/xing.go
@@ -147,8 +147,8 @@ func xingInfoFrame(h frameHeader, headerBytes []byte, totalFrames, totalBytes in
 	copy(frame[:4], headerBytes[:4])
 	frame[2] &^= 0x02
 	off := 4 + h.sideInfoLen()
-	copy(frame[off:], "Info")                                     // CBR tag ("Xing" would signal VBR)
-	binary.BigEndian.PutUint32(frame[off+4:], 0x0003)             // flags: frames + bytes present
+	copy(frame[off:], "Info")                                      // CBR tag ("Xing" would signal VBR)
+	binary.BigEndian.PutUint32(frame[off+4:], 0x0003)              // flags: frames + bytes present
 	binary.BigEndian.PutUint32(frame[off+8:], uint32(totalFrames)) //nolint:gosec // small non-negative counts
 	binary.BigEndian.PutUint32(frame[off+12:], uint32(totalBytes)) //nolint:gosec
 	return frame


### PR DESCRIPTION
Call audio uploaded to Rdio Scanner was accepted but transcoded to
silence, and ffmpeg rejected the same bytes with "Invalid data found".
Three independent defects in how internal/voice/mp3 drives the Shine
encoder combined to produce this:

1. Illegal/oversized frames at low sample rates. Shine hard-codes
   128 kbps. That bitrate is not legal for the MPEG-2.5 family
   (8/11.025/12 kHz — exactly the digital-voice rates recorded here), so
   Shine writes an out-of-range bitrate index that corrupts every frame
   header (ff ff ...). Even at a legal bitrate, Shine's single-granule
   frames desync their bit-reservoir stuffing once the per-frame budget
   grows past ~420 bytes, emitting oversized frames no demuxer can walk.
   Fix: BitrateFor picks the highest standard bitrate that keeps frames
   small enough per MPEG family (32 kbps MPEG-2.5, 64 kbps MPEG-2,
   128 kbps MPEG-1), and configureBitrate reprograms the encoder and its
   CBR frame-size bookkeeping accordingly.

2. Mono dropped every other frame. Shine's Write advances its cursor by
   two frames per iteration (correct only for interleaved stereo), so a
   mono call encoded to ~half its length. Fix: drive Write one frame at
   a time, which keeps the stride correct and preserves reservoir/subband
   state across calls — true mono, no dropped audio.

3. No Xing/Info header. Shine emits headerless frames; on short clips
   ffmpeg's demuxer scores the format low and probes past EOF. Fix:
   prepend a LAME-style Xing/Info frame (frame + byte counts), in pure
   Go, matching what LAME/Trunk Recorder write.

Icecast paced the live mount at a fixed 16000 B/s assuming 128 kbps; it
now derives its byte rate from mp3.BitrateFor so 8 kHz streams (32 kbps)
are paced and advertised correctly.

Verified end-to-end with ffmpeg 6.1.1 across all supported rates and
short clips (both `ffmpeg -i file` and `cat | ffmpeg -i -`, plus an
AAC/m4a transcode as Rdio Scanner performs); the encode path stays
pure-Go / zero-CGO. Adds cmd/encodetest for offline reproduction.

Refs #874

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YcBiXBU6yHvujnFRGkFkoS