### PR TITLE
docs: post-release v0.6.5–v0.6.6 — promote CHANGELOG, bump refs, announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.6.6] — 2026-07-10
+
 ### Security
 - **Go toolchain bumped to 1.25.12** to close `GO-2026-5856` — an Encrypted
   Client Hello privacy leak in the standard library's `crypto/tls`, which
@@ -31,6 +33,37 @@ for tagged releases.
   and RTL-SDR drivers now record it and the `IQ stream died; retrying` log line
   names the concrete cause — the diagnostic needed to tell a stall from a
   disconnect from an overrun without guessing.
+- **Corrupt / half-length MP3 uploads (Rdio Scanner no-audio).** Call audio
+  uploaded to Rdio Scanner was accepted but transcoded to silence, and ffmpeg
+  rejected the same bytes with "Invalid data found". Three independent defects
+  in how `internal/voice/mp3` drove the Shine encoder combined to cause it: the
+  hard-coded 128 kbps bitrate is illegal for the MPEG-2.5 family (the 8/11.025/12
+  kHz digital-voice rates), corrupting every frame header; mono calls advanced
+  the encoder cursor two frames at a time and dropped every other frame (~half
+  length); and headerless output made ffmpeg's demuxer probe past EOF. The
+  encoder now picks the highest standard bitrate that keeps frames legal per
+  MPEG family, drives mono one frame at a time, and prepends a LAME-style
+  Xing/Info header; Icecast derives its live-mount byte rate from the same table
+  so low-rate streams are paced correctly. Verified end-to-end with ffmpeg
+  across all supported rates; the encode path stays pure-Go / zero-CGO.
+
+### Added
+- **Per-call received signal level in the call log.** Each recorded voice call
+  now carries a `signal_dbfs` figure — the mean received channel power in dBFS,
+  measured by the voice composer over the call's baseband IQ. It surfaces in the
+  persisted `call_log` table and in `GET /api/v1/calls/history`. It is a
+  channel-power / RSSI-style reading (0 = digital full scale; real signals
+  negative), **not** calibrated absolute RSSI and **not** SNR/EVM. Calls ended
+  without a measurement (watchdog timeout, preemption, shutdown) read `null`.
+  Existing databases gain the column automatically on next open.
+- **USRP B210 (UHD) local-setup recipe.** `docs/hardware.md` now documents
+  running `SoapySDRServer` on the same host and pointing the `soapyremote`
+  driver at `127.0.0.1`, with the B210 master-clock / exact-rate,
+  gain-in-tenths-of-dB, and antenna-via-`args` specifics.
+
+## [v0.6.5] — 2026-07-09
+
+### Fixed
 - **Airspy on macOS no longer freezes silently.** After locking a control
   channel and decoding for a few seconds, an Airspy on macOS could go
   completely silent — the process stayed alive (heartbeats kept logging) but no
@@ -46,18 +79,6 @@ for tagged releases.
   self-heals instead of quietly stopping.
 
 ### Added
-- **Per-call received signal level in the call log.** Each recorded voice call
-  now carries a `signal_dbfs` figure — the mean received channel power in dBFS,
-  measured by the voice composer over the call's baseband IQ. It surfaces in the
-  persisted `call_log` table and in `GET /api/v1/calls/history`. It is a
-  channel-power / RSSI-style reading (0 = digital full scale; real signals
-  negative), **not** calibrated absolute RSSI and **not** SNR/EVM. Calls ended
-  without a measurement (watchdog timeout, preemption, shutdown) read `null`.
-  Existing databases gain the column automatically on next open.
-- **USRP B210 (UHD) local-setup recipe.** `docs/hardware.md` now documents
-  running `SoapySDRServer` on the same host and pointing the `soapyremote`
-  driver at `127.0.0.1`, with the B210 master-clock / exact-rate,
-  gain-in-tenths-of-dB, and antenna-via-`args` specifics.
 - **More USB debugging for the Airspy freeze.** With `RTLSDR_DEBUG_USB=1` the
   macOS backend now emits periodic bulk-stream telemetry (URBs, bytes,
   throughput, per-slot completion spread, idle gap) and a one-shot `bulk-IN

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.6.4
+VERSION=v0.6.6
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.6.4" -%}
+  {%- assign ver = "v0.6.6" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}

--- a/docs/announcements/v0.6.6.md
+++ b/docs/announcements/v0.6.6.md
@@ -1,0 +1,54 @@
+# GopherTrunk v0.6.6 — social announcement drafts
+
+One-click copy-paste blurbs for posting the v0.6.6 release. Each block
+below is a fenced code block so the rendered-markdown "copy" button
+grabs exactly what you'd paste.
+
+This draft covers the daily releases since the last announced build
+(v0.6.4) — i.e. v0.6.5 → v0.6.6.
+
+Release: https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.6.6
+
+---
+
+## Reddit — title
+
+```
+GopherTrunk v0.6.6 — macOS Airspy no longer freezes or dies silently, Rdio Scanner uploads actually play (MP3 encoder rewrite), and every call now logs its received signal level
+```
+
+## Reddit — body
+
+```markdown
+**[GopherTrunk](https://gophertrunk.org) v0.6.6 is out** — pure-Go digital-trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25 (Phase 1+2), DMR (AMBE+2 voice), NXDN, Motorola Type II, EDACS, LTR, MPT 1327, dPMR, D-STAR, YSF, M17, plus APRS, POCSAG + FLEX paging, and AIS / DSC / ADS-B. No CGO, single static binary for Linux / macOS / Windows.
+
+**What's new since v0.6.4 (v0.6.5 → v0.6.6):**
+
+* **macOS Airspy reliability overhaul.** An Airspy on macOS could lock a control channel, decode for a few seconds, then go completely silent — process alive, heartbeats logging, but no IQ and no error. A new **bulk-IN stall watchdog** turns that silent hang into a real end-of-stream, and the wideband decoder is now supervised by a retry loop that reacquires the dongle and self-heals. A follow-up fix stops a *flapping* dongle (one that keeps recovering for a few seconds then dying) from escalating to a fatal shutdown — the retry counter now decays after any run that streamed real data, so a recovering Airspy self-heals indefinitely. The `IQ stream died; retrying` log line now also names the concrete cause (stall vs. disconnect vs. overrun).
+* **Rdio Scanner uploads finally play.** Call audio uploaded to Rdio Scanner was accepted but transcoded to silence (ffmpeg reported "Invalid data found"). Three defects in the pure-Go MP3 encoder combined to cause it — an illegal 128 kbps bitrate for the low digital-voice sample rates, mono calls dropping every other frame (~half length), and a missing Xing/Info header. All three are fixed and verified end-to-end with ffmpeg across every supported rate; the encode path stays pure-Go / zero-CGO.
+* **Per-call received signal level.** Every recorded voice call now carries a `signal_dbfs` figure — the mean received channel power in dBFS — in the `call_log` table and on `GET /api/v1/calls/history`. It's a channel-power / RSSI-style reading, not calibrated absolute RSSI or SNR/EVM; existing databases gain the column automatically.
+* **USRP B210 (UHD) local-setup recipe** in the hardware docs — running `SoapySDRServer` on the same host and pointing the `soapyremote` driver at `127.0.0.1`, with the B210 master-clock / exact-rate, gain-in-tenths-of-dB, and antenna-via-`args` specifics.
+* **Security:** the Go toolchain is pinned to 1.25.12 to close `GO-2026-5856`, an Encrypted Client Hello privacy leak in the standard library's `crypto/tls` that govulncheck flagged as reachable through the TLS/gRPC and rtl_tcp paths. No source changes — just the pin.
+
+**Downloads** (Linux / macOS / Windows, x64 + ARM64): https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.6.6
+
+**Docs:** https://gophertrunk.org
+
+Heads-up: the v0.x line is still flagged prerelease — actively developed, feedback / captures / bug reports very welcome.
+```
+
+## Discord
+
+```markdown
+**GopherTrunk v0.6.6 is out** — pure-Go trunking scanner for RTL-SDR / HackRF / Airspy / USRP. P25, DMR, NXDN, M17, analog trunked, APRS, POCSAG + FLEX paging, AIS / DSC / ADS-B. Single static binary, zero CGO.
+
+**What's new since v0.6.4 (v0.6.5 → v0.6.6):**
+- **macOS Airspy no longer freezes or dies silently** — a bulk-IN stall watchdog + supervised wideband retry loop turn a silent USB hang into a self-heal, and a flapping dongle no longer escalates to a fatal shutdown.
+- **Rdio Scanner uploads actually play** — the pure-Go MP3 encoder was writing corrupt / half-length frames (illegal low-rate bitrate, dropped mono frames, no Xing header); all three fixed and verified with ffmpeg.
+- **Per-call signal level** — each call now logs `signal_dbfs` (mean received channel power) in the call log and on `GET /api/v1/calls/history`.
+- **USRP B210 (UHD) local-setup recipe** added to the hardware docs (SoapySDRServer on `127.0.0.1`, master-clock/exact-rate, gain-in-tenths).
+- **Security** — Go toolchain pinned to 1.25.12 (crypto/tls ECH privacy leak, `GO-2026-5856`).
+
+Download: <https://github.com/MattCheramie/GopherTrunk/releases/tag/v0.6.6>
+Docs: <https://gophertrunk.org>
+```


### PR DESCRIPTION
The daily release workflow shipped v0.6.5 and v0.6.6 but the post-release
docs sync hadn't run, so catch the docs up to the latest release (v0.6.6):

- CHANGELOG: split the accumulated [Unreleased] entries into two dated
  sections and open a fresh empty [Unreleased] on top:
  - [v0.6.6] — 2026-07-10: the Go 1.25.12 security pin (GO-2026-5856), the
    flapping-Airspy self-heal and named USB stream-death cause (#877), the
    per-call signal_dbfs figure and USRP B210 (UHD) recipe (#878), plus a
    reconstructed entry for the corrupt/half-length MP3 upload fix (#879)
    that shipped without a changelog line.
  - [v0.6.5] — 2026-07-09: the macOS Airspy silent-freeze fix — bulk-IN
    stall watchdog + supervised wideband retry — and the extra USB
    debugging / Airspy vendor-transfer tracing (#875).
- README + latest-version.html: bump the quick-start VERSION and the Pages
  fallback tag from v0.6.4 to v0.6.6.
- Add a v0.6.6 social-announcement draft covering the v0.6.5–v0.6.6 releases.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J7byQsQwJ4BHW8rRP5k1B8