### PR TITLE
p25/phase2: canonicalise receiver dibits so MAC ALGID/KID decode on real air (#813)

### DIFF
--- a/cmd/gophertrunk/integration_cc_p25p2_test.go
+++ b/cmd/gophertrunk/integration_cc_p25p2_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"math"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -54,7 +53,7 @@ func TestDaemonCCDecodesP25Phase2(t *testing.T) {
 	)
 
 	dibits := buildP25Phase2MACPTTStream(superframeRepeats)
-	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+	iq := demod.ModulateHDQPSKSpec(dibits, sps, span, alpha)
 
 	dir := t.TempDir()
 	iqPath := filepath.Join(dir, "p25p2-cc.cfile")

--- a/internal/dsp/demod/piover4_dqpsk_modulator.go
+++ b/internal/dsp/demod/piover4_dqpsk_modulator.go
@@ -145,6 +145,40 @@ func ModulatePiOver4DQPSK(dibits []uint8, sps, span int, alpha, rotation float64
 	return NewPiOver4DQPSKModulator(sps, span, alpha, rotation).Modulate(dibits)
 }
 
+// ModulateHDQPSKSpec synthesises a P25 Phase 2 H-DQPSK IQ stream from a dibit
+// sequence using the STANDARD π/4-DQPSK-family differential phase map
+// (TIA-102.BBAC / SDRtrunk Dibit.java: 00→+π/4, 01→+3π/4, 10→−π/4, 11→−3π/4) —
+// the mapping a real base station transmits. This differs from
+// ModulatePiOver4DQPSK, whose phase map is the inverse of DQPSK.Decode's own
+// (non-canonical) convention and so encodes the two negative-phase symbols with
+// the dibit values 2↔3 transposed relative to real air. Phase 2 fixtures must
+// use THIS modulator so the IQ round-trips through the production receiver's
+// canonicalising dibit remap (issue #813): spec-modulate → receiver → the
+// original canonical dibits.
+//
+// sps is samples per symbol; span is the RRC half-span in symbols; alpha is the
+// RRC roll-off. Single-shot: an impulse train × unit-energy RRC (matching the
+// receiver's RRC matched filter, Nyquist → zero ISI at symbol centres), with no
+// cross-call state, since fixtures modulate a whole stream at once.
+func ModulateHDQPSKSpec(dibits []uint8, sps, span int, alpha float64) []complex64 {
+	up := make([]complex64, len(dibits)*sps)
+	theta := 0.0
+	for i, d := range dibits {
+		switch d & 3 {
+		case 0b00:
+			theta += math.Pi / 4
+		case 0b01:
+			theta += 3 * math.Pi / 4
+		case 0b10:
+			theta += -math.Pi / 4
+		default: // 0b11
+			theta += -3 * math.Pi / 4
+		}
+		up[i*sps] = complex(float32(math.Cos(theta)), float32(math.Sin(theta)))
+	}
+	return filter.NewFIR(filter.RootRaisedCosine(sps, span, alpha)).Process(nil, up)
+}
+
 // dibitToDQPSKPhase returns the raw differential phase
 // increment encoded by a 0..3 dibit value. Inverse of the
 // quadrant decode in DQPSK.Decode (after the rotation offset is

--- a/internal/radio/p25/phase2/receiver/receiver.go
+++ b/internal/radio/p25/phase2/receiver/receiver.go
@@ -6,6 +6,7 @@
 //	  → naive decimation to one sample per symbol (offset by the
 //	    RRC group delay so the centre tap lands on the eye)
 //	  → π/8-rotated differential decode → 0..3 dibit
+//	  → canonicalise to TIA-102 dibit convention (issue #813)
 //	  → phase2.DibitSink
 //
 // P25 Phase 2 uses H-DQPSK at 6000 sym/s with α = 0.20 RRC pulse
@@ -338,9 +339,33 @@ func (r *Receiver) Process(iq []complex64) {
 		return
 	}
 	r.dibits = r.dq.Decode(r.dibits, r.symbols)
+	// Canonicalise the dibit convention (issue #813). demod.DQPSK.Decode
+	// assigns the two negative-phase symbols the dibit values 3 and 2 where
+	// the P25 standard (TIA-102.BBAC; SDRtrunk Dibit.java) uses 2 and 3 —
+	// i.e. its quadrant slicer emits 2 and 3 swapped for a real, standard
+	// π/4-DQPSK-family transmitter. Left uncorrected, every downstream stage
+	// (20-dibit outbound sync correlation, ISCH Golay, and the MAC
+	// trellis/RS FEC) sees a 2↔3-transposed stream and never decodes real
+	// air, so `algorithm_id`/`key_id` never populate. The swap is an
+	// involution, so remapping [0,1,3,2] converts DQPSK.Decode's output to
+	// the canonical TIA-102 dibits the whole superframe/MAC chain and the
+	// authoritative OutboundSyncHex (0x575D57F7FF) are written against. This
+	// mirrors the verified P25 Phase 1 CQPSK path, which applies the
+	// identical lsmDibitRemap (issue #492); Phase 2 was missing it.
+	for i, d := range r.dibits {
+		r.dibits[i] = canonicalDibitRemap[d&3]
+	}
 	r.dibitSink(r.dibits, r.dibitBase)
 	r.dibitBase += len(r.dibits)
 }
+
+// canonicalDibitRemap converts demod.DQPSK.Decode's π/4-DQPSK quadrant
+// output to the canonical TIA-102 dibit convention. The decoder lands the
+// four differential phases at dibits {+π/4→0, +3π/4→1, −π/4→3, −3π/4→2};
+// the P25 standard assigns −π/4→2 and −3π/4→3, so the last two are swapped.
+// Swapping 2↔3 is its own inverse. Identical to the Phase 1 CQPSK path's
+// lsmDibitRemap (issue #492); see the remap comment in Process (issue #813).
+var canonicalDibitRemap = [4]uint8{0, 1, 3, 2}
 
 // Reset returns the receiver to its initial state. Call on stream
 // re-sync (control-channel hunt success, IQ underrun recovery) so

--- a/internal/radio/p25/phase2/receiver/receiver_test.go
+++ b/internal/radio/p25/phase2/receiver/receiver_test.go
@@ -74,7 +74,7 @@ func makeP2HDQPSKIQ(dibits []uint8) ([]complex64, int) {
 	return iq, sps
 }
 
-// makeP2HDQPSKIQWithOffset is makeP2HDQPSKIQ plus a constant carrier
+// makeP2HDQPSKIQWithOffset is stdModulateHDQPSK plus a constant carrier
 // rotation of offsetHz: every emitted sample n is additionally rotated
 // by e^{+j·2π·offsetHz·n/fs}, modelling the residual frequency error a
 // real (non-TCXO) RTL-SDR tuner carries. A differential decoder removes
@@ -82,14 +82,13 @@ func makeP2HDQPSKIQ(dibits []uint8) ([]complex64, int) {
 // (2π·offsetHz/SymbolRate), so without carrier recovery the dibits land
 // a quadrant over and the 20-dibit outbound sync never correlates —
 // exactly the issue #813 field symptom (superframes=0). offsetHz=0 is
-// byte-identical to makeP2HDQPSKIQ.
+// byte-identical to stdModulateHDQPSK.
 func makeP2HDQPSKIQWithOffset(dibits []uint8, offsetHz, fs float64) ([]complex64, int) {
 	sps := int(fs/SymbolRate + 0.5)
-	// Use the proper RRC-pulse-shaping modulator (the inverse of the
-	// receiver's RRC matched filter, Nyquist → zero ISI at symbol
-	// centres). A rectangular symbol hold would not round-trip through the
-	// matched filter and would self-corrupt fast-varying data.
-	iq := demod.ModulatePiOver4DQPSK(dibits, sps, PulseSpanSymbols, RolloffAlpha, Rotation)
+	// STANDARD π/4-DQPSK-family modulation (what a real base station transmits),
+	// deliberately not GopherTrunk's own (2↔3-transposed) modulator, so the IQ
+	// round-trips through the receiver's canonicalising dibit remap (issue #813).
+	iq := demod.ModulateHDQPSKSpec(dibits, sps, PulseSpanSymbols, RolloffAlpha)
 	if offsetHz != 0 {
 		w := 2 * math.Pi * offsetHz / fs
 		for n := range iq {

--- a/internal/radio/p25/phase2/receiver/superframe_payload_test.go
+++ b/internal/radio/p25/phase2/receiver/superframe_payload_test.go
@@ -1,0 +1,138 @@
+package receiver_test
+
+// Regression test for issue #813: on real P25 Phase 2 traffic the ALGID/KID
+// (algorithm_id/key_id) never populated even when superframes locked, because
+// the receiver emitted dibits in demod.DQPSK.Decode's convention (the two
+// negative-phase symbols 2↔3 transposed relative to TIA-102.BBAC). Sync could
+// be made to lock by matching that transposed convention, but the MAC PDU
+// FEC (ISCH Golay + trellis) is written against canonical TIA-102 dibits, so
+// the payload never decoded. The fix canonicalises the receiver's dibit output
+// (canonicalDibitRemap, mirroring the verified Phase 1 CQPSK lsmDibitRemap).
+//
+// This test is deliberately INDEPENDENT of GopherTrunk's own Phase 2 modulator:
+// it drives a real MAC_PTT-borne Encryption Sync through the production receiver
+// via demod.ModulateHDQPSKSpec — the standard π/4-DQPSK-family phase map a real
+// transmitter uses — and asserts the ALGID/KID come back out. It fails without
+// the remap
+// (superframes either never lock against the authoritative OutboundSyncHex, or,
+// if the transposed sync constant is restored, the MAC trellis never decodes)
+// and passes with it.
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+	rx "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2/receiver"
+)
+
+// leadInDibits returns n deterministic varied dibits so the receiver's coarse
+// carrier seed and Gardner timing loop warm up before the first superframe sync.
+func leadInDibits(n int, seed uint32) []uint8 {
+	out := make([]uint8, n)
+	x := seed | 1
+	for i := range out {
+		x ^= x << 13
+		x ^= x >> 17
+		x ^= x << 5
+		out[i] = uint8(x & 0x3)
+	}
+	return out
+}
+
+func TestReceiverRecoversEncryptionSyncPayload(t *testing.T) {
+	const (
+		sps   = 8
+		span  = 8
+		alpha = 0.20
+	)
+
+	// A MAC_PTT message carrying an Encryption Sync with a distinctive
+	// ALGID/KID (the operationally useful fields of issue #813).
+	const wantAlg, wantKey = 0x84, 0x1234
+	es := phase2.EncryptionSync{
+		AlgorithmID:      wantAlg,
+		KeyID:            wantKey,
+		MessageIndicator: [9]byte{9, 8, 7, 6, 5, 4, 3, 2, 1},
+	}
+	ptt := phase2.EncodePushToTalk(es)
+	if b := phase2.AssembleMACPDU(ptt); len(b) < 18 {
+		ptt.Payload = append(ptt.Payload, make([]byte, 18-len(b))...) // pad to 144-bit MAC PDU
+	}
+
+	// One superframe: MAC_PTT-slot PDU at sub-frame 0 (the sync-bearing
+	// sub-frame; sync occupies dibits [0,20), the ISCH+MAC follow), voice
+	// elsewhere. EncodeSuperframe injects the outbound sync.
+	vpay := make([][]byte, phase2.VoiceFrameCount(phase2.SlotTypeVoice4V))
+	for i := range vpay {
+		vpay[i] = make([]byte, phase2.VoiceFrameBytes)
+	}
+	var subs [phase2.SubframesPerSuperframe][]uint8
+	for i := range subs {
+		if i == 0 {
+			subs[i] = phase2.EncodeMACSubframe(phase2.SlotTypeMACPTT, uint8(i), ptt,
+				phase2.TrellisOn, phase2.InterleaveOff)
+		} else {
+			subs[i] = phase2.EncodeVoiceSubframe(phase2.SlotTypeVoice4V, uint8(i), vpay)
+		}
+	}
+	superframe := phase2.EncodeSuperframe(subs)
+	// Overwrite the sync region with the AUTHORITATIVE standard outbound sync
+	// (0x575D57F7FF), independent of OutboundSyncHex, so the stimulus is exactly
+	// what a real base station transmits. This isolates the payload bug: with
+	// the pre-fix transposed OutboundSyncHex and no remap, sync still LOCKS
+	// (the transposed constant matches the un-remapped decoder) yet the MAC
+	// trellis never decodes — so this test fails specifically on ALGID/KID, not
+	// on sync. hexToDibitsMSB / specSyncHex are shared with the specsync test.
+	base := phase2.SyncSubframeIndex * phase2.DibitsPerSubframe
+	copy(superframe[base:base+phase2.SyncDibits], hexToDibitsMSB(specSyncHex, phase2.SyncDibits))
+
+	// Lead-in (past the coarse-seed budget) + several superframes so at least
+	// one arrives after warmup.
+	dibits := leadInDibits(800, 0xB813)
+	for n := 0; n < 6; n++ {
+		dibits = append(dibits, superframe...)
+	}
+
+	iq := demod.ModulateHDQPSKSpec(dibits, sps, span, alpha)
+
+	var got []uint8
+	r := rx.New(rx.Options{
+		SampleRateHz: sps * rx.SymbolRate,
+		ClockMode:    rx.ClockGardner,
+		GardnerGain:  0.005, // the value the voice/CC paths use
+		DibitSink:    func(d []uint8, _ int) { got = append(got, d...) },
+	})
+	for off := 0; off < len(iq); off += 192 { // production-sized chunks
+		end := off + 192
+		if end > len(iq) {
+			end = len(iq)
+		}
+		r.Process(iq[off:end])
+	}
+
+	sfs := phase2.NewSuperframeDecoder().Process(got, 0)
+	if len(sfs) == 0 {
+		t.Fatalf("no superframes locked from standard-modulated air "+
+			"(OutboundSyncHex=0x%X); receiver dibit convention does not match real air (issue #813)",
+			phase2.OutboundSyncHex)
+	}
+
+	cfg := phase2.MACDecodeConfig{Trellis: phase2.TrellisOn}
+	var gotAlg, gotKey int = -1, -1
+	for _, sf := range sfs {
+		for _, tagged := range phase2.DecodeSuperframeMACPDUsWithSlot(sf, cfg) {
+			if tagged.SlotType != phase2.SlotTypeMACPTT {
+				continue
+			}
+			if es2, ok := tagged.PDU.AsPushToTalk(); ok {
+				gotAlg, gotKey = int(es2.AlgorithmID), int(es2.KeyID)
+			}
+		}
+	}
+	if gotAlg != wantAlg || gotKey != wantKey {
+		t.Fatalf("ALGID/KID not recovered from standard-modulated Phase 2 air: "+
+			"got alg=%#x key=%#x, want alg=%#x key=%#x (issue #813: MAC payload decoded 2↔3 transposed)",
+			gotAlg, gotKey, wantAlg, wantKey)
+	}
+}

--- a/internal/radio/p25/phase2/sync.go
+++ b/internal/radio/p25/phase2/sync.go
@@ -17,32 +17,35 @@ type DibitSink func(dibits []uint8, baseIdx int)
 // of each constant, so a correct value must be exactly 40 bits — the previous
 // OutboundSyncHex was 48 bits and its top byte was silently dropped (issue #813).
 //
-// OutboundSyncHex is expressed in GopherTrunk's *decoder* dibit convention, not
-// the P25 standard's. The authoritative P25 Phase 2 outbound frame sync is
+// OutboundSyncHex is the authoritative P25 Phase 2 outbound frame sync
 // 0x575D57F7FF (OP25 frame_sync_magics.h / SDRtrunk P25P2_FRAME_SYNC_MAGIC,
-// TIA-102.BBAC). On air that sync is a 20-symbol π/4-DQPSK-family sequence whose
-// differential phases are, per dibit, {00→+π/4, 01→+3π/4, 10→−π/4, 11→−3π/4}
-// (SDRtrunk Dibit.java). Running exactly that physical sequence through this
-// package's differential decoder (demod.DQPSK.Decode, the receiver's actual
-// output) yields the dibit sequence below — 0x565956A6AA — which is what the
-// SyncDetector must match on live traffic. (GopherTrunk's DQPSK.Decode assigns
-// the two negative-phase symbols the dibit values 2 and 3 swapped relative to
-// the P25 standard, so the standard 0x575D57F7FF becomes 0x565956A6AA in the
-// decoded stream. That same swap means the MAC/voice *payload* would also decode
-// with 2↔3 transposed — a likely remaining blocker for ALGID/KID that lives in
-// the shared demod.DQPSK map and must be confirmed against a real capture before
-// touching, since it is also used by the TETRA and P25 Phase 1 CQPSK paths.)
+// TIA-102.BBAC), expressed in the canonical TIA-102 dibit convention. On air
+// that sync is a 20-symbol π/4-DQPSK-family sequence whose differential phases
+// are, per dibit, {00→+π/4, 01→+3π/4, 10→−π/4, 11→−3π/4} (SDRtrunk Dibit.java).
 //
-// The old OutboundSyncHex (0x575F7DFF77FF) was neither the standard value nor
-// this decoded form — a garbled 48-bit constant that never matched real air, so
-// Phase 2 superframes never locked while every synthesized round-trip test (which
-// encodes with the same constant) passed. See TestSuperframeLocksOnSpecSync.
+// The receiver decodes those symbols with demod.DQPSK.Decode, whose quadrant
+// slicer assigns the two negative-phase symbols the dibit values 3 and 2 where
+// the standard uses 2 and 3 — so its raw output for real air is 2↔3 transposed
+// (the standard 0x575D57F7FF would read as 0x565956A6AA). The Phase 2 receiver
+// therefore canonicalises with a [0,1,3,2] remap (canonicalDibitRemap, mirroring
+// the verified Phase 1 CQPSK lsmDibitRemap, issue #492) BEFORE emitting dibits,
+// so this detector, the ISCH decode and the MAC FEC all match against the
+// canonical value here. An earlier fix instead set OutboundSyncHex to the
+// transposed 0x565956A6AA to match the un-remapped decoder; that locked sync but
+// left the MAC/voice payload 2↔3 transposed, so ALGID/KID never populated — the
+// remap fixes the whole chain and restores the authoritative constant here.
+//
+// The pre-#813 OutboundSyncHex (0x575F7DFF77FF) was neither the standard value
+// nor its transposed form — a garbled 48-bit constant that never matched real
+// air, so Phase 2 superframes never locked while every synthesized round-trip
+// test (which encodes with the same constant) passed. See
+// TestSuperframeLocksOnSpecSync.
 //
 // InboundSyncHex is the uplink (MS → BS) sync, used only by a diagnostic
 // detector (internal/siglab/detail.go); it is unverified against real air and
 // against this decoder's convention — do not rely on it until confirmed.
 const (
-	OutboundSyncHex uint64 = 0x565956A6AA
+	OutboundSyncHex uint64 = 0x575D57F7FF
 	InboundSyncHex  uint64 = 0xDFF57D75DF5D
 	SyncDibits             = 20
 )

--- a/internal/sigfollow/manager_test.go
+++ b/internal/sigfollow/manager_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"log/slog"
-	"math"
 	"testing"
 	"time"
 
@@ -104,7 +103,7 @@ func TestManagerHarvestsAliasWithoutVoiceTuner(t *testing.T) {
 	)
 
 	dibits, wantSrc, wantAlias := aliasDibits(8, 8)
-	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+	iq := demod.ModulateHDQPSKSpec(dibits, sps, span, alpha)
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	fake := newFakeDevice()

--- a/internal/siglab/fixtures.go
+++ b/internal/siglab/fixtures.go
@@ -68,7 +68,7 @@ var fixtures = map[trunking.Protocol]fixture{
 	},
 	trunking.ProtocolP25Phase2: {
 		build:       func() []uint8 { return buildP25Phase2MACPTTStream(8) },
-		modulate:    func(d []uint8, _ float64) []complex64 { return demod.ModulatePiOver4DQPSK(d, 8, 8, 0.20, math.Pi/8) },
+		modulate:    func(d []uint8, _ float64) []complex64 { return demod.ModulateHDQPSKSpec(d, 8, 8, 0.20) },
 		sampleRate:  48_000,
 		systemKnobs: map[string]string{"p25_phase2_trellis_mode": "on"},
 		expected:    Acceptance{Lock: boolPtr(true)},

--- a/internal/voice/composer/p25p2_voice_test.go
+++ b/internal/voice/composer/p25p2_voice_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
-	"math"
 	"strings"
 	"testing"
 	"time"
@@ -94,7 +93,7 @@ func TestComposerP25Phase2VoiceChainExtractsRawFrames(t *testing.T) {
 	framesPerSuperframe := p25p2.SubframesPerSuperframe * p25p2.Voice4VFrameCount
 
 	dibits, want := buildP25P2VoiceStream(superframes)
-	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+	iq := demod.ModulateHDQPSKSpec(dibits, sps, span, alpha)
 
 	src := newFakeSource()
 	bus := events.NewBus(8)
@@ -218,7 +217,7 @@ func TestComposerP25Phase2TalkerAliasFires(t *testing.T) {
 	)
 
 	dibits, wantSrc, wantAlias := buildP25P2AliasStream(superframes)
-	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+	iq := demod.ModulateHDQPSKSpec(dibits, sps, span, alpha)
 
 	src := newFakeSource()
 	bus := events.NewBus(64)
@@ -378,7 +377,7 @@ func TestComposerP25Phase2InCallMetadataFires(t *testing.T) {
 	)
 
 	dibits, wantSrc, wantAlias, wantAlgID, wantKeyID := buildP25P2MetadataStream(superframes)
-	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+	iq := demod.ModulateHDQPSKSpec(dibits, sps, span, alpha)
 
 	src := newFakeSource()
 	bus := events.NewBus(128)
@@ -577,7 +576,7 @@ func TestComposerP25Phase2CallCensusCountsMAC(t *testing.T) {
 		alpha      = 0.20
 	)
 	dibits, _, _, _, _ := buildP25P2MetadataStream(6)
-	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/8)
+	iq := demod.ModulateHDQPSKSpec(dibits, sps, span, alpha)
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))


### PR DESCRIPTION
Real P25 Phase 2 traffic locked superframes (after the #867 sync-constant
fix) but algorithm_id/key_id never populated: every sampled encrypted call
was flagged encrypted yet the MAC PDUs carrying the encryption sync never
decoded.

Root cause: the shared demod.DQPSK.Decode quadrant slicer assigns the two
negative-phase symbols the dibit values 3 and 2 where TIA-102.BBAC (SDRtrunk
Dibit.java) uses 2 and 3 — a 2<->3 transposition on real, standard
pi/4-DQPSK-family air. The verified Phase 1 CQPSK path already corrects this
with lsmDibitRemap [0,1,3,2] (#492); the Phase 2 receiver was missing the
equivalent. Left uncorrected, the whole downstream chain (outbound sync
correlation, ISCH Golay, MAC trellis/RS FEC) saw a transposed stream. The
earlier #867 fix worked around it for sync only by setting OutboundSyncHex to
the transposed 0x565956A6AA, which locked sync but left the MAC/voice payload
transposed — exactly the "flagged encrypted, alg/key never populate" symptom.

Fix: canonicalise the Phase 2 receiver's dibit output with the same [0,1,3,2]
remap (canonicalDibitRemap) right after DQPSK.Decode, and restore
OutboundSyncHex to the authoritative standard 0x575D57F7FF. The receiver is
the sole IQ->dibit source, so this single point makes sync detection, ISCH,
the MAC FEC and the siglab detector all operate on canonical TIA-102 dibits
that match real air. On a zero-offset synthetic the remap is the only change;
sync still locks. The shared demod.DQPSK / modulator (also used by TETRA and
Phase 1 CQPSK) is left untouched.

Regression test (fails first, passes with the fix): drive a MAC_PTT-borne
Encryption Sync through the production receiver using the new standard-map
demod.ModulateHDQPSKSpec (independent of GopherTrunk's own transposed
modulator) and assert ALGID/KID come back. Against the pre-fix state it
reproduces the field symptom precisely: superframes lock but the PDU decodes
to garbage (alg=0x75 key=0x555d) instead of the encoded 0x84/0x1234.

Phase 2 IQ fixtures (composer, sigfollow, siglab, ccdecoder integration,
receiver) now modulate with ModulateHDQPSKSpec so their synthetic IQ matches
real air and round-trips through the remap.

make vet test and make integration are green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A9buS9TbWjCJaHUY3j2Sr6