### PR TITLE
usb/darwin: async bulk-IN to fix Airspy macOS kIOReturnAborted (0xe00002eb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ for tagged releases.
   `go.mod` and every CI/build workflow.
 
 ### Fixed
+- **Airspy on macOS aborted mid-stream with `usb: ReadPipe: 0xe00002eb`.** After
+  a second or two of healthy decoding the bulk-IN pipe was aborted by macOS
+  (`kIOReturnAborted`), the daemon retried, hit the same wall, and escalated to a
+  fatal. It was **not** bandwidth — it reproduced at 2.5 MS/s (~10 MB/s) exactly
+  as at 10 MS/s. The cause was the transport model: the darwin backend issued 32
+  *concurrent synchronous* `ReadPipe` calls on one pipe, which is not a supported
+  IOUSBLib usage and macOS aborts under sustained streaming. The macOS bulk-IN
+  path now defaults to **asynchronous** transfers (`ReadPipeAsync` serviced by one
+  CFRunLoop thread, re-arming each transfer on completion) — the model libusb (and
+  SDR#/SDRtrunk) use to stream the same hardware cleanly. `GT_USB_SYNC_BULK=1`
+  restores the legacy synchronous reapers. Additionally, the Airspy driver now
+  runs its real→IQ conversion on a dedicated goroutine instead of inline on the
+  USB reaper, keeping the transfer servicing responsive. The daemon's
+  retries-exhausted fatal also no longer double-prefixes the subsystem name
+  (`widebandt2: widebandt2: …`).
 - **A flapping Airspy no longer kills the whole daemon.** After the silent-freeze
   fix, a macOS Airspy that keeps *recovering* — the IQ stream dies, the daemon
   reacquires and streams for a few seconds, then it dies again — still took the

--- a/docs/reference/airspy.md
+++ b/docs/reference/airspy.md
@@ -112,23 +112,29 @@ Knobs for diagnosing and tuning it:
   timeout directly instead of relying on the watchdog. Off by default; try e.g.
   `200` if the watchdog alone doesn't recover cleanly.
 
-### Stream aborts at 10 MS/s (macOS): `usb: ReadPipe: 0xe00002eb`
+### Stream aborts with `usb: ReadPipe: 0xe00002eb` (macOS)
 
-A raw `usb: ReadPipe: 0xe00002eb` in the `IQ stream died` cause line is macOS's
-`kIOReturnAborted` — the host controller aborting the bulk-IN pipe. It is a
-distinct failure from the two above: the stall watchdog reports `bulk-IN stream
-stalled` and an overrun reports `dropping live IQ chunks`; this is neither. At
-10 MS/s the Airspy streams ~40 MB/s (the real ADC at 2× the IQ rate), near the
-USB 2.0 ceiling, and the host must keep bulk transfers continuously outstanding
-or the controller aborts.
+A raw `usb: ReadPipe: 0xe00002eb` (or `ReadPipeAsync: 0xe00002eb`) in the `IQ
+stream died` cause line is macOS's `kIOReturnAborted` — the host controller
+aborting the bulk-IN pipe mid-stream. It is distinct from the two failures above:
+the stall watchdog reports `bulk-IN stream stalled` and an overrun reports
+`dropping live IQ chunks`; this is neither. It is **not** a bandwidth problem — it
+reproduces at 2.5 MS/s (~10 MB/s, well under USB 2.0) just as at 10 MS/s, always
+after a second or two of healthy decoding.
 
-GopherTrunk now runs the real→IQ conversion on a dedicated goroutine rather than
-inline on the USB reapers, so a reaper re-posts its next read immediately and the
-outstanding-transfer queue no longer collapses under the conversion (the earlier
-cause of this abort on macOS). If you still hit `ReadPipe: 0xe00002eb` at 10 MS/s,
-the host genuinely can't sustain the rate on that machine/port — the surest fix is
-a lower `sdr.sample_rate` (2.5 MS/s on an R2), which usually covers the channel
-plan anyway (watch for the *oversampled for the channel plan* warning below).
+The cause was the transport model. The macOS backend used to issue 32 *concurrent
+synchronous* `ReadPipe` calls on a single pipe, which is not a supported IOUSBLib
+usage and macOS aborts intermittently under sustained streaming, at any rate.
+GopherTrunk now defaults to an **asynchronous** bulk-IN path (`ReadPipeAsync`
+serviced by one CFRunLoop thread, re-arming each transfer on completion) — the
+same model libusb (and hence SDR#/SDRtrunk) use, which stream this hardware
+cleanly.
+
+- `GT_USB_SYNC_BULK=1` forces the legacy synchronous reapers (the pre-async path)
+  if you need to compare behaviour.
+- If the abort persists on the async path, capture a run with `RTLSDR_DEBUG_USB=1`
+  and open an issue — that points at something host- or hardware-specific rather
+  than the transfer model.
 
 > **10 MS/s note.** If the daemon warns that the capture is *oversampled for the
 > channel plan* (`sdr.sample_rate` far wider than the carriers span), a lower

--- a/internal/sdr/rtlsdr/usb/usb_darwin.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin.go
@@ -23,22 +23,23 @@
 //   - Control transfers go through IOUSBDeviceInterface::DeviceRequest
 //     with an IOUSBDevRequest struct that mirrors the USB 2.0 setup
 //     packet plus a data pointer.
-//   - Bulk-IN runs N goroutines, each pinned to its own OS thread
-//     via runtime.LockOSThread, doing synchronous ReadPipe calls in
-//     a loop. Cancellation is via AbortPipe — pending reads return
-//     with kIOReturnAborted, the goroutines see the closed-flag and
-//     exit. This sidesteps CFRunLoop callbacks entirely; trade-off
-//     is one OS thread per slot (32 by default) instead of one
-//     reaper-loop thread for the whole ring.
+//   - Bulk-IN defaults to the asynchronous path (usb_darwin_async.go):
+//     a ring of ReadPipeAsync transfers serviced by one CFRunLoop
+//     thread, each re-armed on completion — the model libusb uses. The
+//     legacy synchronous path (one OS-thread-pinned goroutine per slot,
+//     each blocking in ReadPipe) is retained behind GT_USB_SYNC_BULK=1.
+//     The switch exists because 32 *concurrent synchronous* ReadPipe
+//     calls on one pipe are not a supported IOUSBLib usage and macOS
+//     aborts them intermittently with kIOReturnAborted (0xe00002eb)
+//     under sustained streaming at any rate (Airspy R2, 2.5 and
+//     10 MS/s); the async ring avoids the concurrent-sync-read pattern.
 //
 // **Hardware validation status**: this code compiles cleanly under
 // `GOOS=darwin GOARCH={amd64,arm64} CGO_ENABLED=0` and the FFI
-// surface is structurally complete — but it has not been exercised
-// against real RTL-SDR hardware on macOS. Contributors with the
-// hardware should diff USB control-transfer captures (Wireshark +
-// usbmon-equivalent) against the Linux backend's output to verify
-// wire format. See the PR description for the manual-test
-// follow-up checklist.
+// surface is structurally complete. The synchronous path has field
+// history; the asynchronous ReadPipeAsync + CFRunLoop path is new and
+// needs confirmation against real hardware on macOS (see the async
+// file's notes and the reporter-verification checklist in the PR).
 
 package usb
 
@@ -467,6 +468,17 @@ type darwinTransport struct {
 	bulkStopFlag atomic.Int32
 	bulkDone     chan struct{}
 
+	// Async bulk-IN state (usb_darwin_async.go). When bulkAsync is set (the
+	// default; GT_USB_SYNC_BULK=1 selects the legacy synchronous reapers), the
+	// transport streams via ReadPipeAsync serviced by a single CFRunLoop thread
+	// — the model libusb uses. This replaces 32 concurrent synchronous ReadPipe
+	// calls on one pipe, which macOS aborts intermittently with kIOReturnAborted
+	// (0xe00002eb) under sustained streaming regardless of rate.
+	bulkAsync       bool
+	bulkOnPacket    func([]byte)
+	bulkRunLoopRef  atomic.Uintptr // CFRunLoopRef of the servicing thread; published by it
+	bulkAsyncSource uintptr        // CFRunLoopSourceRef from CreateInterfaceAsyncEventSource
+
 	// Stream-death aggregation. bulkAlive starts at len(bulkSlots) when
 	// StartBulkIn spawns the per-slot reapers; each goroutine decrements
 	// it on exit. When the count hits zero with bulkStopFlag still
@@ -505,6 +517,14 @@ func (t *darwinTransport) recordBulkErr(err error) {
 type darwinBulkSlot struct {
 	idx int
 	buf []byte
+
+	// Async-path fields (unused on the synchronous path). t back-references the
+	// owning transport so the single process-wide async completion callback can
+	// route a completion (keyed by refcon) to it; refcon is the registry key
+	// passed to ReadPipeAsync; pipeRef is the resolved bulk-IN pipe.
+	t       *darwinTransport
+	refcon  uintptr
+	pipeRef uint8
 }
 
 func (t *darwinTransport) ControlIn(bRequest uint8, wValue, wIndex uint16, n int, timeoutMs int) ([]byte, error) {
@@ -653,6 +673,7 @@ func (t *darwinTransport) ReleaseInterface(int) error {
 	if t.ifaceIface == 0 {
 		return nil
 	}
+	t.releaseAsyncSource()
 	vtableCall(t.ifaceIface, ifaceUSBInterfaceClose)
 	release(t.ifaceIface)
 	t.ifaceIface = 0
@@ -671,12 +692,16 @@ func (t *darwinTransport) Reset() error {
 }
 
 // StartBulkIn spawns one OS-thread-pinned goroutine per slot. Each
-// loops in ReadPipe; AbortPipe unblocks them all on Stop.
+// AbortPipe unblocks/cancels them all on Stop.
 //
-// Trade-off vs. CFRunLoop async: simpler, no callback marshalling
-// across the C/Go boundary, no run-loop thread to babysit. Cost is
-// ringBufs OS threads (32 default → ~32 MB stack). Acceptable for
-// a foreground SDR daemon.
+// By default (GT_USB_SYNC_BULK unset) the transport uses the asynchronous
+// ReadPipeAsync + CFRunLoop path in usb_darwin_async.go — many transfers queued
+// against the kernel, serviced by one run-loop thread, the model libusb uses.
+// The legacy synchronous path (one OS-thread-pinned goroutine per slot, each
+// looping in a blocking ReadPipe) is kept as a fallback because 32 *concurrent
+// synchronous* ReadPipe calls on a single pipe are not a supported IOUSBLib
+// usage and macOS aborts them intermittently with kIOReturnAborted (0xe00002eb)
+// under sustained streaming at any rate. Set GT_USB_SYNC_BULK=1 to force it.
 func (t *darwinTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacket func([]byte), onStreamDead func(error)) error {
 	if t.closed.Load() {
 		return ErrClosed
@@ -698,20 +723,35 @@ func (t *darwinTransport) StartBulkIn(epAddr byte, ringBufs, bufLen int, onPacke
 	}
 	slots := make([]*darwinBulkSlot, ringBufs)
 	for i := range slots {
-		slots[i] = &darwinBulkSlot{idx: i, buf: make([]byte, bufLen)}
+		slots[i] = &darwinBulkSlot{idx: i, buf: make([]byte, bufLen), t: t, pipeRef: pipeRef}
 	}
 	t.bulkPipeRef = pipeRef
 	t.bulkSlots = slots
 	t.bulkActive = true
 	t.bulkStopFlag.Store(0)
-	t.bulkDone = make(chan struct{}, ringBufs)
 	t.bulkOnDead = onStreamDead
+	t.bulkOnPacket = onPacket
 	t.bulkErrMu.Lock()
 	t.bulkDeadErr = nil
 	t.bulkErrMu.Unlock()
 	t.bulkDeadOnce = sync.Once{}
 	t.bulkAlive.Store(int32(len(slots)))
+	t.bulkAsync = !syncBulkEnabled()
 	t.startBulkWatch(pipeRef, len(slots))
+
+	if t.bulkAsync {
+		if err := t.startBulkInAsyncLocked(); err != nil {
+			t.stopBulkWatch()
+			t.bulkActive = false
+			t.bulkSlots = nil
+			t.bulkOnPacket = nil
+			return err
+		}
+		return nil
+	}
+
+	// Legacy synchronous fallback: one reaper goroutine per slot.
+	t.bulkDone = make(chan struct{}, ringBufs)
 	for _, s := range slots {
 		go t.bulkLoop(pipeRef, s, onPacket)
 	}
@@ -939,6 +979,7 @@ func (t *darwinTransport) StopBulkIn() error {
 	t.bulkStopFlag.Store(1)
 	pipeRef := t.bulkPipeRef
 	slotCount := len(t.bulkSlots)
+	async := t.bulkAsync
 	t.bulkActive = false
 	t.bulkMu.Unlock()
 
@@ -946,6 +987,15 @@ func (t *darwinTransport) StopBulkIn() error {
 	// we touch the pipe, so a normal teardown never trips a stall abort
 	// and no watch AbortPipe can race the interface release in Close.
 	t.stopBulkWatch()
+
+	if async {
+		err := t.stopBulkInAsync(pipeRef)
+		t.bulkMu.Lock()
+		t.bulkSlots = nil
+		t.bulkOnPacket = nil
+		t.bulkMu.Unlock()
+		return err
+	}
 
 	// AbortPipe makes every blocked ReadPipe return with
 	// kIOReturnAborted; goroutines see it and exit.
@@ -986,6 +1036,7 @@ func (t *darwinTransport) Close() error {
 		t.closed.Store(true)
 	}
 	if t.ifaceIface != 0 {
+		t.releaseAsyncSource()
 		vtableCall(t.ifaceIface, ifaceUSBInterfaceClose)
 		release(t.ifaceIface)
 		t.ifaceIface = 0

--- a/internal/sdr/rtlsdr/usb/usb_darwin_async.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_async.go
@@ -1,0 +1,281 @@
+//go:build darwin
+
+package usb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+)
+
+// Asynchronous macOS bulk-IN path.
+//
+// The legacy path (usb_darwin.go bulkLoop) runs one OS-thread-pinned goroutine
+// per ring slot, each blocking in a synchronous ReadPipe on the SAME pipe. That
+// is not a supported IOUSBLib usage: under sustained streaming macOS aborts the
+// concurrent synchronous reads with kIOReturnAborted (0xe00002eb), independent
+// of data rate (reproduced on an Airspy R2 at both 2.5 and 10 MS/s). SDRtrunk
+// streams the same hardware fine because libusb uses asynchronous transfers.
+//
+// This path mirrors that model: it queues a ring of ReadPipeAsync transfers and
+// services their completions on a single dedicated CFRunLoop thread, re-arming
+// each transfer as it completes so the kernel always has the full ring
+// outstanding. One process-wide IOAsyncCallback1 (created once via purego) routes
+// each completion — keyed by an integer refcon, never a Go pointer — back to the
+// owning transport and slot.
+
+// syncBulkEnabled reports whether the operator forced the legacy synchronous
+// reaper path via GT_USB_SYNC_BULK (a truthy value). Default (unset/empty) uses
+// the async path.
+func syncBulkEnabled() bool {
+	switch os.Getenv("GT_USB_SYNC_BULK") {
+	case "", "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+// Async completion routing. IOKit hands the callback only the integer refcon we
+// registered, so a process-wide registry maps refcon → slot. The single C
+// callback is created once (purego.NewCallback registrations are permanent, so
+// re-creating per stream would leak the callback pool).
+var (
+	asyncReg    sync.Map // uintptr refcon -> *darwinBulkSlot
+	asyncRefctr atomic.Uintptr
+	asyncCBOnce sync.Once
+	asyncCBPtr  uintptr
+)
+
+func nextAsyncRefcon() uintptr {
+	// Start at 1 so a zero refcon (never registered) can't accidentally match.
+	return asyncRefctr.Add(1)
+}
+
+// usbRunLoopMode returns a private CFRunLoop mode (CFStringRef) for the async USB
+// event source, created once. A dedicated mode — rather than the
+// kCFRunLoopDefaultMode global — is used deliberately: reading that global means
+// dereferencing its Dlsym'd address (a bare uintptr→unsafe.Pointer conversion go
+// vet flags), whereas creating our own mode string is clean. The source is both
+// added to and run in this mode, so completions are delivered normally.
+var (
+	usbModeOnce sync.Once
+	usbModeRef  uintptr
+)
+
+func usbRunLoopMode() uintptr {
+	usbModeOnce.Do(func() {
+		name := append([]byte("GopherTrunkUSBBulk"), 0)
+		usbModeRef = cfStringCreateWithCString(kCFAllocatorDefault, &name[0], kCFStringEncodingUTF8)
+	})
+	return usbModeRef
+}
+
+// asyncCompletionCallback returns the process-wide IOAsyncCallback1 trampoline,
+// creating it once. IOAsyncCallback1 is void(*)(void *refcon, IOReturn result,
+// void *arg0); for ReadPipeAsync arg0 is the byte count transferred. The Go
+// callback returns uintptr(0) — IOKit expects void and ignores the return.
+func asyncCompletionCallback() uintptr {
+	asyncCBOnce.Do(func() {
+		asyncCBPtr = purego.NewCallback(func(refcon, result, arg0 uintptr) uintptr {
+			if v, ok := asyncReg.Load(refcon); ok {
+				s := v.(*darwinBulkSlot)
+				s.t.onAsyncComplete(s, result, arg0)
+			}
+			return 0
+		})
+	})
+	return asyncCBPtr
+}
+
+// startBulkInAsyncLocked launches the async streaming path. Called under bulkMu
+// from StartBulkIn with the slots, pipe, and stream-death/onPacket callbacks
+// already installed on t. On error the caller unwinds the shared bulk state.
+func (t *darwinTransport) startBulkInAsyncLocked() error {
+	if cfRunLoopGetCurrent == nil || cfRunLoopRunInMode == nil ||
+		cfRunLoopAddSource == nil || cfStringCreateWithCString == nil {
+		return errors.New("usb: CoreFoundation run-loop symbols unavailable for async bulk-IN")
+	}
+	if usbRunLoopMode() == 0 {
+		return errors.New("usb: could not create CFRunLoop mode for async bulk-IN")
+	}
+	// Create the async event source once per transport and reuse it across
+	// streams; it is released in releaseAsyncSource (ReleaseInterface/Close).
+	if t.bulkAsyncSource == 0 {
+		var src uintptr
+		rc := vtableCall(t.ifaceIface, ifaceCreateInterfaceAsyncEventSource,
+			uintptr(unsafe.Pointer(&src)))
+		if err := translateIOReturn(rc); err != nil {
+			return fmt.Errorf("usb: CreateInterfaceAsyncEventSource: %w", err)
+		}
+		if src == 0 {
+			return errors.New("usb: CreateInterfaceAsyncEventSource returned a nil source")
+		}
+		t.bulkAsyncSource = src
+	}
+	// Register every slot so the shared completion callback can route to it.
+	for _, s := range t.bulkSlots {
+		s.refcon = nextAsyncRefcon()
+		asyncReg.Store(s.refcon, s)
+	}
+	t.bulkDone = make(chan struct{})
+	ready := make(chan error, 1)
+	go t.bulkAsyncRunLoop(ready)
+	if err := <-ready; err != nil {
+		for _, s := range t.bulkSlots {
+			asyncReg.Delete(s.refcon)
+		}
+		return err
+	}
+	return nil
+}
+
+// bulkAsyncRunLoop owns the CFRunLoop that services async completions. It pins
+// its OS thread (CFRunLoop is thread-local), publishes the run-loop ref for
+// teardown, adds the async event source, submits the initial ring, then runs
+// bounded run-loop slices until StopBulkIn sets the stop flag.
+func (t *darwinTransport) bulkAsyncRunLoop(ready chan<- error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	defer close(t.bulkDone)
+
+	mode := usbRunLoopMode()
+	rl := cfRunLoopGetCurrent()
+	t.bulkRunLoopRef.Store(rl)
+	cfRunLoopAddSource(rl, t.bulkAsyncSource, mode)
+	defer func() {
+		cfRunLoopRemoveSource(rl, t.bulkAsyncSource, mode)
+		t.bulkRunLoopRef.Store(0)
+	}()
+
+	// Submit the initial ring. A submit failure here aborts whatever was queued
+	// and fails the StartBulkIn.
+	for i, s := range t.bulkSlots {
+		if rc := t.submitAsyncRead(s); uint32(rc) != kIOReturnSuccess {
+			if i > 0 && t.ifaceIface != 0 {
+				vtableCall(t.ifaceIface, ifaceAbortPipe, uintptr(t.bulkPipeRef))
+			}
+			ready <- fmt.Errorf("usb: ReadPipeAsync submit: 0x%08x", uint32(rc))
+			return
+		}
+	}
+	ready <- nil
+
+	// Service completions in bounded slices, checking the stop flag between
+	// them. 0.25 s keeps teardown latency low; when idle (e.g. after a stream
+	// death, before StopBulkIn) the slice simply times out and loops.
+	for t.bulkStopFlag.Load() == 0 {
+		cfRunLoopRunInMode(mode, 0.25, false)
+	}
+}
+
+// submitAsyncRead arms one ReadPipeAsync transfer for slot s. Returns the raw
+// IOReturn.
+func (t *darwinTransport) submitAsyncRead(s *darwinBulkSlot) uintptr {
+	return vtableCall(t.ifaceIface, ifaceReadPipeAsync,
+		uintptr(s.pipeRef),
+		uintptr(unsafe.Pointer(&s.buf[0])),
+		uintptr(uint32(len(s.buf))),
+		asyncCompletionCallback(),
+		s.refcon,
+	)
+}
+
+// onAsyncComplete handles one ReadPipeAsync completion (on the run-loop thread).
+// On success it delivers the payload and re-arms the slot; on error or during
+// teardown it retires the slot. bulkOnPacket must not block — it runs on the
+// single servicing thread, so a stall there stalls every slot (the Airspy driver
+// copies + hands off, keeping it O(1)).
+func (t *darwinTransport) onAsyncComplete(s *darwinBulkSlot, result, arg0 uintptr) {
+	if t.bulkStopFlag.Load() != 0 {
+		t.asyncSlotDone(s)
+		return
+	}
+	if uint32(result) != kIOReturnSuccess {
+		// The stall watchdog records ErrStreamStalled before it AbortPipes, and
+		// recordBulkErr is first-wins, so a watchdog abort keeps that cause; any
+		// other kernel error surfaces its raw code.
+		t.recordBulkErr(fmt.Errorf("usb: ReadPipeAsync: 0x%08x", uint32(result)))
+		t.asyncSlotDone(s)
+		return
+	}
+	if n := int(arg0); n > 0 {
+		t.markBulkActivity(s.idx, n)
+		if t.bulkOnPacket != nil {
+			t.bulkOnPacket(s.buf[:n])
+		}
+	}
+	if rc := t.submitAsyncRead(s); uint32(rc) != kIOReturnSuccess {
+		if t.bulkStopFlag.Load() == 0 {
+			t.recordBulkErr(fmt.Errorf("usb: ReadPipeAsync resubmit: 0x%08x", uint32(rc)))
+		}
+		t.asyncSlotDone(s)
+	}
+}
+
+// asyncSlotDone retires one slot from the outstanding ring. When the last slot
+// retires with the stop flag unset, the stream died on its own (device gone /
+// stall / kernel error): fire bulkOnDead exactly once with the recorded cause so
+// the driver surfaces EOF and the daemon reacquires — the issue-#345 path.
+func (t *darwinTransport) asyncSlotDone(s *darwinBulkSlot) {
+	if t.bulkAlive.Add(-1) != 0 {
+		return
+	}
+	if t.bulkStopFlag.Load() != 0 || t.bulkOnDead == nil {
+		return
+	}
+	t.bulkDeadOnce.Do(func() {
+		t.bulkErrMu.Lock()
+		err := t.bulkDeadErr
+		t.bulkErrMu.Unlock()
+		if err == nil {
+			err = ErrDeviceGone
+		}
+		// Dispatch from a fresh goroutine: bulkOnDead typically calls StopBulkIn,
+		// which waits on the run loop this callback is running under.
+		go t.bulkOnDead(err)
+	})
+}
+
+// stopBulkInAsync tears down the async stream: abort + reset the pipe (which
+// completes outstanding transfers), let the run-loop goroutine observe the stop
+// flag and exit, then drop the slot registrations. Called from StopBulkIn after
+// the stop flag is set and the watchdog is disarmed.
+func (t *darwinTransport) stopBulkInAsync(pipeRef uint8) error {
+	if t.ifaceIface != 0 {
+		// AbortPipe completes every outstanding async transfer with
+		// kIOReturnAborted; ResetPipe clears the halt so the next StartBulkIn
+		// works without re-Open.
+		vtableCall(t.ifaceIface, ifaceAbortPipe, uintptr(pipeRef))
+		vtableCall(t.ifaceIface, ifaceResetPipe, uintptr(pipeRef))
+	}
+	var err error
+	if t.bulkDone != nil {
+		select {
+		case <-t.bulkDone:
+		case <-time.After(2 * time.Second):
+			err = errors.New("usb: async bulk run loop did not exit within 2 s")
+		}
+	}
+	for _, s := range t.bulkSlots {
+		asyncReg.Delete(s.refcon)
+	}
+	return err
+}
+
+// releaseAsyncSource drops the per-transport async event source. Called from
+// ReleaseInterface/Close before the interface handle goes away; safe to call
+// when no source was created.
+func (t *darwinTransport) releaseAsyncSource() {
+	if t.bulkAsyncSource != 0 {
+		cfRelease(t.bulkAsyncSource)
+		t.bulkAsyncSource = 0
+	}
+}

--- a/internal/sdr/rtlsdr/usb/usb_darwin_async_test.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_async_test.go
@@ -1,0 +1,33 @@
+//go:build darwin
+
+package usb
+
+import "testing"
+
+// TestSyncBulkEnabled pins the GT_USB_SYNC_BULK fallback toggle: unset/empty and
+// the usual falsey spellings keep the default asynchronous ReadPipeAsync path;
+// any other value forces the legacy synchronous reapers. This is the operator's
+// escape hatch if the async path misbehaves on a given macOS host, so its
+// parsing must not silently invert.
+func TestSyncBulkEnabled(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"false", false},
+		{"no", false},
+		{"off", false},
+		{"1", true},
+		{"true", true},
+		{"yes", true},
+		{"anything", true},
+	}
+	for _, c := range cases {
+		t.Setenv("GT_USB_SYNC_BULK", c.val)
+		if got := syncBulkEnabled(); got != c.want {
+			t.Errorf("syncBulkEnabled(%q) = %v, want %v", c.val, got, c.want)
+		}
+	}
+}

--- a/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
+++ b/internal/sdr/rtlsdr/usb/usb_darwin_iokit.go
@@ -126,13 +126,26 @@ const (
 
 // IOUSBInterfaceInterface vtable indices (post-IUnknown).
 const (
-	ifaceUSBInterfaceOpen  = 8
-	ifaceUSBInterfaceClose = 9
-	ifaceGetNumEndpoints   = 19
-	ifaceGetPipeProperties = 26
-	ifaceAbortPipe         = 28
-	ifaceResetPipe         = 29
-	ifaceReadPipe          = 31
+	// ifaceCreateInterfaceAsyncEventSource is CreateInterfaceAsyncEventSource
+	// (self, CFRunLoopSourceRef *source): creates the async I/O event source
+	// (and its mach port) that delivers ReadPipeAsync completion callbacks to a
+	// CFRunLoop. First entry after the IUnknown header (QueryInterface/AddRef/
+	// Release at 1/2/3).
+	ifaceCreateInterfaceAsyncEventSource = 4
+	ifaceUSBInterfaceOpen                = 8
+	ifaceUSBInterfaceClose               = 9
+	ifaceGetNumEndpoints                 = 19
+	ifaceGetPipeProperties               = 26
+	ifaceAbortPipe                       = 28
+	ifaceResetPipe                       = 29
+	ifaceReadPipe                        = 31
+	// ifaceReadPipeAsync is ReadPipeAsync in the base interface:
+	//   IOReturn ReadPipeAsync(self, UInt8 pipeRef, void *buf, UInt32 size,
+	//                          IOAsyncCallback1 callback, void *refcon)
+	// The callback (IOAsyncCallback1) is void(*)(void *refcon, IOReturn result,
+	// void *arg0), where arg0 is the byte count actually transferred. Completions
+	// are dispatched on whatever run loop the async event source was added to.
+	ifaceReadPipeAsync = 33
 	// ifaceReadPipeTO is ReadPipeTO, present only in the v182+ interface
 	// (kIOUSBInterfaceInterfaceID182). Signature adds noDataTimeout and
 	// completionTimeout (ms) after the base ReadPipe args:
@@ -187,6 +200,18 @@ var (
 	// can't marshal the 16-byte struct, so the two 8-byte halves are
 	// passed as separate register-sized args — see makeCFUUID.
 	cfUUIDCreateFromUUIDBytes func(alloc cfAllocatorRef, lo, hi uint64) cfTypeRef
+
+	// CoreFoundation run-loop entry points, used by the asynchronous bulk-IN
+	// path (usb_darwin_async.go). The async USB event source delivers
+	// ReadPipeAsync completions to whatever CFRunLoop it is added to, so one
+	// dedicated OS thread services them — the model libusb's darwin backend
+	// uses. We drive the loop with bounded CFRunLoopRunInMode slices and a stop
+	// flag rather than CFRunLoopRun + CFRunLoopStop, which avoids the documented
+	// race where a stop issued before the run loop starts is lost.
+	cfRunLoopGetCurrent   func() uintptr
+	cfRunLoopRunInMode    func(mode uintptr, seconds float64, returnAfterSourceHandled bool) int32
+	cfRunLoopAddSource    func(rl, source, mode uintptr)
+	cfRunLoopRemoveSource func(rl, source, mode uintptr)
 )
 
 // IOKit function pointers.
@@ -249,6 +274,10 @@ func loadIOKit() (err error) {
 	purego.RegisterLibFunc(&cfStringGetCString, cf, "CFStringGetCString")
 	purego.RegisterLibFunc(&cfNumberGetValue, cf, "CFNumberGetValue")
 	purego.RegisterLibFunc(&cfUUIDCreateFromUUIDBytes, cf, "CFUUIDCreateFromUUIDBytes")
+	purego.RegisterLibFunc(&cfRunLoopGetCurrent, cf, "CFRunLoopGetCurrent")
+	purego.RegisterLibFunc(&cfRunLoopRunInMode, cf, "CFRunLoopRunInMode")
+	purego.RegisterLibFunc(&cfRunLoopAddSource, cf, "CFRunLoopAddSource")
+	purego.RegisterLibFunc(&cfRunLoopRemoveSource, cf, "CFRunLoopRemoveSource")
 	purego.RegisterLibFunc(&ioServiceMatching, io, "IOServiceMatching")
 	purego.RegisterLibFunc(&ioServiceGetMatchingServices, io, "IOServiceGetMatchingServices")
 	purego.RegisterLibFunc(&ioIteratorNext, io, "IOIteratorNext")


### PR DESCRIPTION
## Summary

A macOS Airspy R2 dies mid-stream with `widebandt2: IQ stream closed unexpectedly: usb: ReadPipe: 0xe00002eb` (`kIOReturnAborted` — the host controller aborting the bulk-IN pipe), retries, and escalates to a fatal. Reporter debug logs show it aborts after ~1–2 s of healthy P25 decoding and — critically — **reproduces identically at 2.5 MS/s (~10 MB/s, consumer keeping up, zero drops) and at 10 MS/s**, so it is not bandwidth and not conversion load. The one thing that differs from SDRtrunk (libusb, which streams the same hardware fine at 10 MS/s) is the transfer model: the darwin backend issued **32 concurrent *synchronous* `ReadPipe` calls on a single pipe**, which is not a supported IOUSBLib usage and macOS aborts intermittently under sustained streaming.

## Changes

- **Asynchronous macOS bulk-IN path (`internal/sdr/rtlsdr/usb/usb_darwin_async.go`, new).** A ring of `ReadPipeAsync` transfers serviced by one CFRunLoop thread, each re-armed on completion so the kernel always holds the full ring outstanding — the model libusb uses. A single process-wide `IOAsyncCallback1` (created once via purego) routes completions by an integer refcon (never a Go pointer) through a registry back to the owning transport/slot. The stall watchdog, first-error-wins death aggregation, and the `onStreamDead` EOF contract (#345) are preserved.
- **`StartBulkIn`/`StopBulkIn` branch to the async path by default** (`usb_darwin.go`); the legacy synchronous reapers remain behind **`GT_USB_SYNC_BULK=1`** as a fallback.
- **New IOKit/CF bindings** (`usb_darwin_iokit.go`): `CreateInterfaceAsyncEventSource` (vtable 4), `ReadPipeAsync` (vtable 33), and `CFRunLoopGetCurrent`/`AddSource`/`RemoveSource`/`RunInMode`. Uses a private CFRunLoop mode string rather than dereferencing the `kCFRunLoopDefaultMode` global, keeping the darwin `go vet` (usb-macos CI) clean.
- **Airspy driver decouples USB reaping from IQ conversion** (`internal/sdr/airspy/airspy.go`): the reaper now copies each payload and hands it to a single converter goroutine, so servicing stays responsive (and the converter mutex, now single-writer, is removed). This is complementary hygiene that also keeps the async run-loop thread from stalling on the FIR.
- **Daemon no longer double-prefixes the retries-exhausted fatal** (`cmd/gophertrunk/daemon.go`): `widebandt2: widebandt2: …` / `ccdecoder: ccdecoder: …` → single prefix.
- Docs + CHANGELOG updated (corrected troubleshooting entry: the abort is rate-independent, not a 10 MS/s bandwidth ceiling).

## Test plan

- [x] `make vet test` is green locally
- [x] `make integration` is green locally (touches the daemon retry path)
- [x] Added / updated tests: `TestStreamIQReaperNotSerializedByConversion` (proven failing-first against inline conversion), overrun/dead-cause regressions preserved, `wideband_retry` asserts a single prefix, `TestSyncBulkEnabled` covers the fallback toggle
- [ ] **Smoke-tested against real hardware — NOT done, needs the reporter.** The macOS transport (`//go:build darwin`) does not build or run on Linux CI. It is validated by cross-compiling + `go vet` for `darwin/{arm64,amd64}` (both clean), but the ReadPipeAsync + CFRunLoop path is new and needs confirmation on an Airspy R2 on macOS: rebuild, run at 2.5 and 10 MS/s, and confirm no `ReadPipeAsync: 0xe00002eb` fatal. `RTLSDR_DEBUG_USB=1` and `GT_USB_SYNC_BULK=1` (to A/B against the old path) help if it recurs.

## Breaking changes

None. macOS bulk-IN silently switches from synchronous to asynchronous transfers with the same `Transport` contract; `GT_USB_SYNC_BULK=1` restores the previous behaviour. Linux/Windows paths are untouched.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Updated `docs/reference/airspy.md` (Troubleshooting: the `0xe00002eb` abort, the async default, and the `GT_USB_SYNC_BULK` knob)

## Linked issues

Refs the long-running macOS Airspy `IQ stream closed` report (Discord; no tracked issue). Left as `Refs` rather than `Closes` — this is unverified against hardware and per the repo's issue-closing policy must not auto-close on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dad4eGw5HV5maub4HUCZB)_