### PR TITLE
iq: record narrowband DDC output + replay 2-ch 16-bit WAV captures

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1678,6 +1678,11 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 					Autotune:     d.autotune.Get(controlEntry.Info.Serial),
 					// 0 → ccdecoder's built-in default (issue #815).
 					CarrierOffsetWarnHz: int(cfg.SDR.CarrierOffsetWarnHz),
+					// A baseband record entry with tap: ddc on this control
+					// serial tees the narrowband channelized stream (the DDC
+					// output the decoder sees) to WAV — small, shareable, and
+					// replayable with `replay -format wav`.
+					DDCRecordDir: ddcRecordDirForSerial(cfg, controlEntry.Info.Serial),
 				}
 				d.controlSerial = controlEntry.Info.Serial
 				// The CC decoder owns StreamIQ on this dongle's broker,
@@ -4326,17 +4331,39 @@ func (s sitesProvider) Topology(system string) (*trunking.TopologySnapshot, bool
 	return s.t.Topology(system)
 }
 
+// ddcRecordDirForSerial returns the recording directory for a baseband
+// record entry with tap: ddc on the given serial, or "" if none is
+// configured. This drives ccdecoder.Options.DDCRecordDir so the narrowband
+// DDC output is teed at the decoder rather than by wrapping the raw device.
+func ddcRecordDirForSerial(cfg config.Config, serial string) string {
+	for _, r := range cfg.Baseband.Record {
+		if r.Serial == serial && r.TapDDC() {
+			return r.Dir
+		}
+	}
+	return ""
+}
+
 // wrapBasebandRecorders replaces the Device of every pool entry whose
-// serial appears in baseband.record with a RecordingDevice, teeing its
-// live IQ to a WAV recording. Runs once at construction, before any
-// streaming starts, so mutating the entry's Device pointer is safe.
+// serial appears in baseband.record (tap: wideband) with a RecordingDevice,
+// teeing its live IQ to a WAV recording. Runs once at construction, before
+// any streaming starts, so mutating the entry's Device pointer is safe.
 func (d *Daemon) wrapBasebandRecorders(cfg config.Config, log *slog.Logger) {
 	if len(cfg.Baseband.Record) == 0 || d.pool == nil {
 		return
 	}
 	dirBySerial := make(map[string]string, len(cfg.Baseband.Record))
 	for _, r := range cfg.Baseband.Record {
+		if r.TapDDC() {
+			// Narrowband DDC-output recording is teed at the control-channel
+			// decoder (ccDecoderOpts.DDCRecordDir), not by wrapping the raw
+			// device — the device only ever sees the wideband SDR stream.
+			continue
+		}
 		dirBySerial[r.Serial] = r.Dir
+	}
+	if len(dirBySerial) == 0 {
+		return
 	}
 	rate := cfg.SDR.SampleRate
 	if rate == 0 {

--- a/cmd/gophertrunk/replay.go
+++ b/cmd/gophertrunk/replay.go
@@ -31,7 +31,7 @@ func runReplay(args []string) {
 	fs := flag.NewFlagSet("replay", flag.ExitOnError)
 	verboseFlag := fs.Bool("verbose-errors", false, "print full error chain + stack on failures")
 	in := fs.String("in", "", "raw IQ input file (required)")
-	format := fs.String("format", "u8", "sample format: u8 (rtl_sdr 8-bit unsigned interleaved IQ) | f32 (GNU Radio cfile, interleaved float32)")
+	format := fs.String("format", "u8", "sample format: u8 (rtl_sdr 8-bit unsigned interleaved IQ) | f32 (GNU Radio cfile, interleaved float32) | wav (2-channel 16-bit baseband WAV — SDRtrunk/SDR++/GopherTrunk narrowband recording; sample rate is read from the header)")
 	sampleRate := fs.Float64("sample-rate", 2_400_000, "IQ sample rate in Hz")
 	demod := fs.String("demod", "c4fm", "P25 Phase 1 demod mode: c4fm | cqpsk")
 	protocolFlag := fs.String("protocol", "p25p1", "decoder to run: p25p1 | p25-phase2 | dmr | dmr-tier2 | nxdn | dpmr | edacs | motorola | ltr | mpt1327 | tetra | ysf | dstar (aliases: dmr-tier3)")
@@ -45,6 +45,7 @@ func runReplay(args []string) {
 	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation (off by default; see issue #402)")
 	tuneHzFlag := fs.Float64("tune-hz", 0, "frequency-shift the capture so a channel at +tune-hz lands at 0 Hz before demod (0 = no shift)")
 	autoTune := fs.Bool("auto-tune", false, "find the control channel by trying the ranked carrier candidates and keeping the best lock — handles an off-centre / non-dominant control channel in a wideband capture (overrides -tune-hz)")
+	recordDDC := fs.String("record-ddc", "", "also write the post-DDC narrowband IQ (the exact channelized stream the receiver decodes) to this 2-channel 16-bit baseband WAV — shrinks a fat 2.5/10 MS/s capture into a small shareable fixture that `replay -format wav` decodes identically")
 	outFormat := fs.String("out-format", "text", "output format: text | json | jsonl | yaml | csv | csv-events")
 	out := fs.String("out", "", "write structured output to this file (default: stdout for non-text)")
 	fs.Usage = func() {
@@ -116,6 +117,7 @@ FLAGS:`)
 		IQCorrect:            *iqCorrect,
 		CollectIQDiag:        *diag,
 		DemodMode:            *demod,
+		RecordDDCPath:        *recordDDC,
 		NIDSearchSpan:        *nidSearchSpan,
 		EnableDDA:            *enableDDA,
 		EnableAdaptiveSlicer: *enableAdaptiveSlicer,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1228,15 +1228,26 @@ broadcast:
   #     include_audio: false               # true embeds the base64 MP3 in each POST
   #     systems: ["Metro P25"]             # empty = every system
 
-# Wideband baseband (IQ) recording and offline replay. `record` taps a
-# live tuner and writes its raw IQ to a two-channel 16-bit WAV (the
-# same layout SDRtrunk uses). `replay` mounts recorded WAVs as virtual
-# tuners so a capture can be decoded with no radio attached — record at
-# the same rate as sdr.sample_rate for real-time-correct playback.
+# Baseband (IQ) recording and offline replay. `record` taps a tuner and
+# writes IQ to a two-channel 16-bit WAV (the same layout SDRtrunk/SDR++ use);
+# `replay` mounts recorded WAVs as virtual tuners so a capture can be decoded
+# with no radio attached.
+#
+# Each record entry chooses what it taps with `tap`:
+#   tap: wideband (default) — the full-rate raw SDR IQ. Large files; record at
+#     the same rate as sdr.sample_rate for real-time-correct playback.
+#   tap: ddc — the narrowband digital-down-converter output: the channelized
+#     stream the control-channel decoder actually sees, at the pipeline rate
+#     (144 kHz for TETRA, ~48 kHz for the C4FM family). Orders of magnitude
+#     smaller than wideband, and directly decodable offline with
+#     `gophertrunk replay -in rec.wav -format wav -protocol <p>`. Use this to
+#     capture a hard-to-decode control channel for sharing/analysis instead of
+#     a fat 2.5/10 MS/s capture.
 # baseband:
 #   record:
 #     - serial: "00000001"
 #       dir: "../iq/"
+#       tap: wideband            # or: ddc (small narrowband channel recording)
 #   replay:
 #     - file: "../iq/00000001_20260521T120000Z.wav"
 #       serial: "replay-01"

--- a/docs/siglab.md
+++ b/docs/siglab.md
@@ -77,7 +77,7 @@ gophertrunk siglab -in capture.cfile -protocol p25p1 -format u8 -auto-tune
 |------|---------|---------|
 | `-in <path>` | *(required)* | raw IQ capture file |
 | `-protocol <p>` | *(pick in the TUI)* | protocol to decode — empty prompts a picker |
-| `-format u8\|f32` | `f32` | sample format of the capture |
+| `-format u8\|f32\|wav` | `f32` | sample format (`wav` = 2-ch 16-bit baseband; rate from header) |
 | `-sample-rate <Hz>` | `2400000` | IQ sample rate of the capture |
 | `-freq <Hz>` | `0` | informational nominal centre frequency |
 | `-auto-tune` | off | estimate the carrier offset and tune to 0 Hz before demod |
@@ -172,6 +172,19 @@ candidates for you.
   capture rate. A symptom that only appears at a higher capture rate but
   reproduces in offline replay points at the *captured samples* (front-end
   overload / intermod / gain staging), not GopherTrunk's DSP.
-- **`f32` vs `u8`.** GopherTrunk's own `capture` writes interleaved `f32`;
-  many SDR tools (and `.cu8`/`.cfile` from `rtl_sdr`) write `u8`. Set `-format`
-  to match.
+- **`f32` vs `u8` vs `wav`.** GopherTrunk's own `capture` writes interleaved
+  `f32`; many SDR tools (and `.cu8`/`.cfile` from `rtl_sdr`) write `u8`; SDRtrunk
+  and SDR++ baseband recordings (and GopherTrunk's own narrowband recordings)
+  are two-channel 16-bit `wav`. Set `-format` to match. For `wav` the sample rate
+  comes from the file header, so `-sample-rate` is ignored (and `-auto-tune` is
+  rejected — a baseband WAV is already channelized; use `-tune-hz` for a small
+  residual offset).
+- **Shrink a fat capture for sharing.** Add `-record-ddc <out.wav>` to any replay
+  run to tee the post-DDC narrowband stream (the exact channelized IQ the receiver
+  decodes, 144 kHz for TETRA / ~48 kHz for the C4FM family) to a small
+  two-channel 16-bit WAV. That file replays identically with `-format wav` and is
+  orders of magnitude smaller than the wideband capture — the offline counterpart
+  of the live `baseband.record` `tap: ddc` option. A rate that is not an integer
+  multiple of the symbol rate (e.g. a 39 kHz SDR++ decimation of a 2.5 MS/s
+  capture — only 2.17 samples/symbol for TETRA's 18 kbaud) will lock poorly;
+  record the DDC output (a clean 8 samples/symbol) instead.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -493,12 +493,27 @@ type BasebandConfig struct {
 	Replay []BasebandReplayConfig `yaml:"replay"`
 }
 
-// BasebandRecordConfig taps one tuner's live IQ to WAV recordings.
+// BasebandRecordConfig taps one tuner's IQ to WAV recordings.
 type BasebandRecordConfig struct {
 	// Serial is the SDR serial whose IQ stream is recorded.
 	Serial string `yaml:"serial"`
 	// Dir is the directory recordings are written into.
 	Dir string `yaml:"dir"`
+	// Tap selects what is recorded:
+	//   "wideband" (default) — the full-rate raw SDR IQ (large files; the
+	//     historical behaviour), useful for re-channelizing or wideband work.
+	//   "ddc" — the narrowband digital-down-converter output (the channelized
+	//     stream the decoder actually sees, at the pipeline rate: 144 kHz for
+	//     TETRA, ~48 kHz for the C4FM family). Orders of magnitude smaller than
+	//     wideband, and directly replayable with `replay -format wav`. This is
+	//     the "record the DDC output" tap for sharing a hard-to-decode channel.
+	Tap string `yaml:"tap"`
+}
+
+// TapDDC reports whether this record entry taps the narrowband DDC output
+// rather than the wideband SDR stream.
+func (b BasebandRecordConfig) TapDDC() bool {
+	return strings.EqualFold(strings.TrimSpace(b.Tap), "ddc")
 }
 
 // BasebandReplayConfig mounts one recorded WAV as a virtual tuner.
@@ -2344,6 +2359,11 @@ func (c Config) validateBaseband() []error {
 		}
 		if r.Dir == "" {
 			errs = append(errs, fmt.Errorf("baseband.record[%d]: dir required", i))
+		}
+		switch strings.ToLower(strings.TrimSpace(r.Tap)) {
+		case "", "wideband", "ddc":
+		default:
+			errs = append(errs, fmt.Errorf("baseband.record[%d]: tap must be wideband|ddc", i))
 		}
 	}
 	for i, r := range c.Baseband.Replay {

--- a/internal/configbuilder/fieldmeta.go
+++ b/internal/configbuilder/fieldmeta.go
@@ -371,10 +371,11 @@ var fieldMetas = map[string]FieldMeta{
 	"WebhookFeedConfig.Systems":       {Help: "GopherTrunk system names to stream. Empty = every system."},
 
 	// ---- Baseband ----------------------------------------------------------
-	"BasebandConfig.Record":       {Help: "Tap live tuners and write their wideband IQ to WAV."},
+	"BasebandConfig.Record":       {Help: "Tap tuners and write their IQ to WAV (wideband or narrowband DDC output)."},
 	"BasebandConfig.Replay":       {Help: "Mount recorded WAVs as virtual tuners for offline decode."},
 	"BasebandRecordConfig.Serial": {Help: "SDR serial whose IQ stream is recorded."},
 	"BasebandRecordConfig.Dir":    {Label: "Directory", Help: "Directory the IQ recordings are written into."},
+	"BasebandRecordConfig.Tap":    {Help: "What to record: wideband (raw SDR IQ) or ddc (narrowband channel the decoder sees).", Options: opts("", "wideband (default)", "ddc", "ddc")},
 	"BasebandReplayConfig.File":   {Help: "Path to the baseband WAV recording to replay."},
 	"BasebandReplayConfig.Serial": {Help: "Virtual device serial the pool reports. Empty generates one."},
 	"BasebandReplayConfig.Role":   {Help: "Pool role: control / voice / auto.", Options: roleOpts()},

--- a/internal/scanner/ccdecoder/ddcrecord.go
+++ b/internal/scanner/ccdecoder/ddcrecord.go
@@ -1,0 +1,145 @@
+package ccdecoder
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
+)
+
+// ddcRecorder tees the decoder's post-DDC narrowband IQ (the exact
+// channelized complex stream the active pipeline decodes) to a two-channel
+// 16-bit baseband WAV. It is the live half of the "record the digital
+// down-converter output" tooling: instead of a fat wideband capture at the
+// full SDR rate, the operator gets a small file at the pipeline rate (144 kHz
+// for TETRA, ~48 kHz for the C4FM family) of exactly the signal that failed
+// to decode — small enough to share and replay with `replay -format wav`.
+//
+// It is owned by the pump goroutine (all calls happen under Decoder.mu), so
+// it needs no locking of its own. A new file is opened lazily on the first
+// chunk and rolled whenever the system name or the pipeline rate changes (a
+// retune to a different protocol/rate), so each recording holds one
+// contiguous channelized stream at one rate.
+type ddcRecorder struct {
+	dir string
+	log *slog.Logger
+
+	w      *baseband.IQWriter
+	path   string
+	system string
+	rate   uint32
+}
+
+// newDDCRecorder returns a recorder writing into dir, or nil if dir is empty
+// (the zero-cost disabled case).
+func newDDCRecorder(dir string, log *slog.Logger) *ddcRecorder {
+	if strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	if log == nil {
+		log = slog.Default()
+	}
+	return &ddcRecorder{dir: dir, log: log}
+}
+
+// write appends one channelized chunk, opening or rolling the WAV as needed.
+// system is the active system name (for the filename) and rateHz is the DDC
+// output rate. A write/open failure is logged once and disables further
+// recording rather than disrupting decode.
+func (r *ddcRecorder) write(system string, rateHz float64, samples []complex64) {
+	if r == nil || len(samples) == 0 {
+		return
+	}
+	rate := uint32(rateHz + 0.5)
+	if rate == 0 {
+		return
+	}
+	if r.w == nil || r.system != system || r.rate != rate {
+		r.roll(system, rate)
+		if r.w == nil {
+			return // open failed; roll already logged and left us disabled
+		}
+	}
+	if err := r.w.Write(samples); err != nil {
+		r.log.Warn("ccdecoder: DDC recording write failed; recording stopped",
+			"path", r.path, "err", err)
+		r.closeCurrent()
+		r.dir = "" // disable further rolls after a write error
+	}
+}
+
+// roll closes the current file (if any) and opens a fresh one for the given
+// system + rate.
+func (r *ddcRecorder) roll(system string, rate uint32) {
+	r.closeCurrent()
+	if r.dir == "" {
+		return
+	}
+	if err := os.MkdirAll(r.dir, 0o755); err != nil {
+		r.log.Warn("ccdecoder: cannot create DDC recording dir; recording disabled",
+			"dir", r.dir, "err", err)
+		r.dir = ""
+		return
+	}
+	name := fmt.Sprintf("%s_%s_%dhz.wav", ddcRecSanitize(system),
+		time.Now().UTC().Format("20060102T150405Z"), rate)
+	path := filepath.Join(r.dir, name)
+	w, err := baseband.NewIQWriter(path, rate)
+	if err != nil {
+		r.log.Warn("ccdecoder: cannot open DDC recording; recording disabled",
+			"path", path, "err", err)
+		r.dir = ""
+		return
+	}
+	r.w = w
+	r.path = path
+	r.system = system
+	r.rate = rate
+	r.log.Info("ccdecoder: DDC recording started", "path", path, "rate_hz", rate)
+}
+
+// closeCurrent closes the open WAV (if any) and clears the handle.
+func (r *ddcRecorder) closeCurrent() {
+	if r.w == nil {
+		return
+	}
+	if err := r.w.Close(); err != nil {
+		r.log.Warn("ccdecoder: close DDC recording", "path", r.path, "err", err)
+	} else {
+		r.log.Info("ccdecoder: DDC recording stopped",
+			"path", r.path, "bytes", r.w.BytesWritten())
+	}
+	r.w = nil
+}
+
+// close finalizes the recording; safe to call when disabled or already closed.
+func (r *ddcRecorder) close() {
+	if r == nil {
+		return
+	}
+	r.closeCurrent()
+}
+
+// ddcRecSanitize strips path-hostile characters from a system name for use in
+// a filename, mirroring the baseband recorder's serial sanitizer.
+func ddcRecSanitize(s string) string {
+	s = strings.TrimSpace(s)
+	out := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-' || r == '_':
+			return r
+		default:
+			return '_'
+		}
+	}, s)
+	if out == "" {
+		return "system"
+	}
+	return out
+}

--- a/internal/scanner/ccdecoder/ddcrecord_test.go
+++ b/internal/scanner/ccdecoder/ddcrecord_test.go
@@ -1,0 +1,87 @@
+package ccdecoder
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
+)
+
+func tone(n int) []complex64 {
+	s := make([]complex64, n)
+	for i := range s {
+		s[i] = complex(0.3, -0.2)
+	}
+	return s
+}
+
+// TestDDCRecorderWritesWav confirms the narrowband recorder opens a WAV at the
+// pipeline rate and captures the channelized samples it is handed.
+func TestDDCRecorderWritesWav(t *testing.T) {
+	dir := t.TempDir()
+	r := newDDCRecorder(dir, nil)
+	if r == nil {
+		t.Fatal("newDDCRecorder returned nil for a non-empty dir")
+	}
+	r.write("Main_Site_1", 144000, tone(1000))
+	r.write("Main_Site_1", 144000, tone(500))
+	r.close()
+
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.wav"))
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 recording, got %d (%v)", len(matches), matches)
+	}
+	info, err := baseband.ReadIQWavInfo(matches[0])
+	if err != nil {
+		t.Fatalf("ReadIQWavInfo: %v", err)
+	}
+	if info.SampleRate != 144000 {
+		t.Errorf("recording rate = %d, want 144000", info.SampleRate)
+	}
+	if info.Samples != 1500 {
+		t.Errorf("recording samples = %d, want 1500", info.Samples)
+	}
+}
+
+// TestDDCRecorderRollsOnRateChange confirms a change of system or pipeline rate
+// starts a fresh file, so each recording holds one contiguous rate/system.
+func TestDDCRecorderRollsOnRateChange(t *testing.T) {
+	dir := t.TempDir()
+	r := newDDCRecorder(dir, nil)
+	r.write("Site_A", 144000, tone(100))
+	r.write("Site_A", 48000, tone(100)) // rate change → roll
+	r.write("Site_B", 48000, tone(100)) // system change → roll
+	r.close()
+
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.wav"))
+	if len(matches) != 3 {
+		t.Fatalf("expected 3 recordings after rolls, got %d (%v)", len(matches), matches)
+	}
+}
+
+// TestDDCRecorderDisabled confirms an empty dir yields a nil recorder whose
+// methods are safe no-ops (the zero-cost disabled path).
+func TestDDCRecorderDisabled(t *testing.T) {
+	var r *ddcRecorder = newDDCRecorder("", nil)
+	if r != nil {
+		t.Fatal("newDDCRecorder(\"\") should return nil")
+	}
+	// nil-safe
+	r.write("x", 144000, tone(10))
+	r.close()
+}
+
+// TestDDCRecorderIgnoresEmptyAndZeroRate guards the write fast-paths.
+func TestDDCRecorderIgnoresEmptyAndZeroRate(t *testing.T) {
+	dir := t.TempDir()
+	r := newDDCRecorder(dir, nil)
+	r.write("S", 144000, nil)      // empty samples → no file
+	r.write("S", 0, tone(10))      // zero rate → no file
+	r.close()
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.wav"))
+	if len(matches) != 0 {
+		t.Fatalf("expected no recordings, got %v", matches)
+	}
+	_ = os.RemoveAll(dir)
+}

--- a/internal/scanner/ccdecoder/ddcrecord_test.go
+++ b/internal/scanner/ccdecoder/ddcrecord_test.go
@@ -76,8 +76,8 @@ func TestDDCRecorderDisabled(t *testing.T) {
 func TestDDCRecorderIgnoresEmptyAndZeroRate(t *testing.T) {
 	dir := t.TempDir()
 	r := newDDCRecorder(dir, nil)
-	r.write("S", 144000, nil)      // empty samples → no file
-	r.write("S", 0, tone(10))      // zero rate → no file
+	r.write("S", 144000, nil) // empty samples → no file
+	r.write("S", 0, tone(10)) // zero rate → no file
 	r.close()
 	matches, _ := filepath.Glob(filepath.Join(dir, "*.wav"))
 	if len(matches) != 0 {

--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -266,6 +266,14 @@ type Options struct {
 	// (issue #815). Zero selects defaultCarrierOffsetWarnHz. Raise it for a
 	// high-drift dongle to avoid benign warnings.
 	CarrierOffsetWarnHz int
+	// DDCRecordDir, when non-empty, records the post-DDC narrowband IQ (the
+	// channelized stream the active pipeline decodes, at the pipeline rate) to
+	// two-channel 16-bit baseband WAVs in this directory. This is the "record
+	// the digital down-converter output" tap: a small per-channel recording of
+	// exactly the signal being decoded, instead of a fat wideband capture at
+	// the SDR rate. Empty (the default) disables it at zero cost. Driven by a
+	// baseband record entry with tap: ddc.
+	DDCRecordDir string
 }
 
 // Decoder is the long-lived component that converts the control
@@ -351,6 +359,11 @@ type Decoder struct {
 	// hands it to Downconverter.Process each chunk so the decimated
 	// stream doesn't allocate per call.
 	ddcOut []complex64
+
+	// ddcRec, when non-nil (Options.DDCRecordDir set), tees ddcOut to a
+	// narrowband baseband WAV each chunk. Owned by the pump goroutine (all
+	// access is under mu), closed on Run exit.
+	ddcRec *ddcRecorder
 
 	// IQ-power tracking — see observeIQPower for the math. Owned solely by
 	// the forwarder goroutine, which observes every delivered chunk before
@@ -462,6 +475,7 @@ func New(opts Options) (*Decoder, error) {
 	if d.carrierOffsetWarnHz <= 0 {
 		d.carrierOffsetWarnHz = defaultCarrierOffsetWarnHz
 	}
+	d.ddcRec = newDDCRecorder(opts.DDCRecordDir, log)
 	for _, s := range opts.Systems {
 		d.systems[s.Name] = s
 	}
@@ -492,6 +506,7 @@ func (d *Decoder) Run(ctx context.Context) error {
 	}
 
 	defer d.sub.Close()
+	defer d.ddcRec.close() // nil-safe; finalizes any open DDC recording
 
 	// Decouple real-time IQ ingestion from decode (issue #402). The SDR
 	// driver drops a chunk the instant its small delivery channel backs up,
@@ -796,6 +811,9 @@ func (d *Decoder) pump(iq []complex64) {
 		return
 	}
 	d.ddcOut = d.ddc.Process(d.ddcOut, iq)
+	if d.ddcRec != nil {
+		d.ddcRec.write(d.activeAt, d.pipelineRateHz, d.ddcOut)
+	}
 	d.active.Process(d.ddcOut)
 	d.sampleAutotuneLocked()
 	d.checkCarrierOffsetLocked()

--- a/internal/sdr/baseband/baseband_test.go
+++ b/internal/sdr/baseband/baseband_test.go
@@ -2,8 +2,11 @@ package baseband
 
 import (
 	"context"
+	"io"
 	"math"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -47,6 +50,59 @@ func TestIQWriterRoundTrip(t *testing.T) {
 	}
 	if info.Samples != len(samples) {
 		t.Fatalf("samples = %d, want %d", info.Samples, len(samples))
+	}
+}
+
+func TestReadIQWavStreamHeaderRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nb.wav")
+	samples := iqTone(1500)
+	w, err := NewIQWriter(path, 144_000)
+	if err != nil {
+		t.Fatalf("NewIQWriter: %v", err)
+	}
+	if err := w.Write(samples); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	info, err := ReadIQWavStreamHeader(f)
+	if err != nil {
+		t.Fatalf("ReadIQWavStreamHeader: %v", err)
+	}
+	if info.SampleRate != 144_000 || info.Channels != 2 {
+		t.Fatalf("header rate=%d ch=%d, want 144000/2", info.SampleRate, info.Channels)
+	}
+	// The reader must leave the file positioned at the first data byte, so
+	// the remaining payload decodes back to the samples we wrote (within the
+	// int16 quantization the WAV format applies).
+	rest, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("read payload: %v", err)
+	}
+	got := DecodeIQ16(rest)
+	if len(got) != len(samples) {
+		t.Fatalf("decoded %d samples, want %d", len(got), len(samples))
+	}
+	// A few LSB of tolerance: the writer scales by 32767 and the reader
+	// divides by 32768, so round-trip carries a small systematic error.
+	const tol = 1e-4
+	for i := range got {
+		if d := real(got[i]) - real(samples[i]); d > tol || d < -tol {
+			t.Fatalf("sample %d real mismatch: got %v want %v", i, got[i], samples[i])
+		}
+	}
+}
+
+func TestReadIQWavStreamHeaderRejectsNonRIFF(t *testing.T) {
+	if _, err := ReadIQWavStreamHeader(strings.NewReader("not a wav file at all")); err == nil {
+		t.Fatal("ReadIQWavStreamHeader should reject a non-RIFF stream")
 	}
 }
 

--- a/internal/sdr/baseband/wav.go
+++ b/internal/sdr/baseband/wav.go
@@ -197,6 +197,73 @@ func parseIQWavHeader(f *os.File) (dataBytes uint32, info IQWavInfo, err error) 
 	}
 }
 
+// ReadIQWavStreamHeader consumes the RIFF/WAVE header from a forward-only
+// reader, leaving r positioned at the first IQ data byte, and returns the
+// format info. Unlike parseIQWavHeader it never seeks — unknown chunks are
+// discarded by reading past them — so it works on a pipe, an HTTP body, or
+// any non-seekable capture source. info.Samples is left 0 (the data length
+// is not needed when the payload is streamed to EOF).
+func ReadIQWavStreamHeader(r io.Reader) (IQWavInfo, error) {
+	var info IQWavInfo
+	hdr := make([]byte, 12)
+	if _, err := io.ReadFull(r, hdr); err != nil {
+		return info, fmt.Errorf("baseband: read RIFF header: %w", err)
+	}
+	if string(hdr[0:4]) != "RIFF" || string(hdr[8:12]) != "WAVE" {
+		return info, errors.New("baseband: not a RIFF/WAVE file")
+	}
+	var (
+		bits   uint16
+		gotFmt bool
+	)
+	chunkHdr := make([]byte, 8)
+	for {
+		if _, err := io.ReadFull(r, chunkHdr); err != nil {
+			return info, errors.New("baseband: WAV ended before a data chunk")
+		}
+		id := string(chunkHdr[0:4])
+		size := binary.LittleEndian.Uint32(chunkHdr[4:8])
+		switch id {
+		case "fmt ":
+			fmtBuf := make([]byte, size)
+			if _, err := io.ReadFull(r, fmtBuf); err != nil {
+				return info, fmt.Errorf("baseband: read fmt chunk: %w", err)
+			}
+			if len(fmtBuf) < 16 {
+				return info, errors.New("baseband: short fmt chunk")
+			}
+			info.Channels = binary.LittleEndian.Uint16(fmtBuf[2:4])
+			info.SampleRate = binary.LittleEndian.Uint32(fmtBuf[4:8])
+			bits = binary.LittleEndian.Uint16(fmtBuf[14:16])
+			gotFmt = true
+		case "data":
+			if !gotFmt {
+				return info, errors.New("baseband: data chunk before fmt chunk")
+			}
+			if info.Channels != iqWavChannels {
+				return info, fmt.Errorf("baseband: WAV has %d channels, IQ recordings need 2", info.Channels)
+			}
+			if bits != iqWavBitsPerSample {
+				return info, fmt.Errorf("baseband: WAV is %d-bit, IQ recordings need 16-bit", bits)
+			}
+			return info, nil
+		default:
+			skip := int64(size)
+			if size%2 == 1 {
+				skip++
+			}
+			if _, err := io.CopyN(io.Discard, r, skip); err != nil {
+				return info, fmt.Errorf("baseband: skip %q chunk: %w", id, err)
+			}
+		}
+	}
+}
+
+// DecodeIQ16 converts one interleaved 16-bit I/Q PCM block into complex64,
+// matching the normalisation IQWriter uses. Exported so offline replay can
+// decode baseband WAV payloads through the same math the driver uses.
+func DecodeIQ16(buf []byte) []complex64 { return decodeIQ16(buf) }
+
 // floatToI16 clamps a normalised sample to [-1, 1] and scales it to a
 // signed 16-bit value.
 func floatToI16(v float32) int16 {

--- a/internal/siglab/config.go
+++ b/internal/siglab/config.go
@@ -79,6 +79,17 @@ type Config struct {
 	// ChunkSamples is the read-loop chunk size in IQ samples; 0 ⇒ default.
 	ChunkSamples int
 
+	// RecordDDCPath, when non-empty, writes the post-DDC narrowband IQ (the
+	// exact channelized complex stream the receiver decodes, at the DDC output
+	// rate — 144 kHz for TETRA, ~48 kHz for the C4FM family) to a two-channel
+	// 16-bit baseband WAV at that path. This is the offline half of the "record
+	// the digital down-converter output" tooling: point it at a fat 2.5/10 MS/s
+	// cfile and it emits a small narrowband WAV that `replay -format wav`
+	// decodes bit-for-bit the same way — a shareable, reproducible fixture that
+	// is orders of magnitude smaller than the wideband capture. Empty ⇒ no
+	// recording.
+	RecordDDCPath string
+
 	// CaptureIQ enables buffering a stride-decimated copy of the
 	// post-DDC (channelized) IQ and the pre-slicer soft samples into
 	// Result.IQTaps, so a web/visualization consumer can render the

--- a/internal/siglab/decode.go
+++ b/internal/siglab/decode.go
@@ -27,6 +27,12 @@ const (
 	FormatU8 SampleFormat = iota
 	// FormatF32 is GNU Radio's interleaved little-endian float32 cfile.
 	FormatF32
+	// FormatWAV is a two-channel 16-bit signed PCM RIFF/WAVE baseband
+	// recording (I in channel 1, Q in channel 2) — the layout GopherTrunk's
+	// own IQWriter and SDRtrunk/SDR++ write. The sample rate is read from the
+	// WAV header, overriding -sample-rate, and the 44-byte header is skipped
+	// before decoding.
+	FormatWAV
 )
 
 // String renders the format as the flag value operators type.
@@ -34,6 +40,8 @@ func (f SampleFormat) String() string {
 	switch f {
 	case FormatF32:
 		return "f32"
+	case FormatWAV:
+		return "wav"
 	default:
 		return "u8"
 	}
@@ -41,15 +49,18 @@ func (f SampleFormat) String() string {
 
 // ParseSampleFormat maps a -format flag value to a SampleFormat. It accepts
 // the same spellings the replay subcommand always has (u8, f32, plus the
-// float32/cfile aliases) so existing muscle memory keeps working.
+// float32/cfile aliases) so existing muscle memory keeps working, plus wav
+// (aka sw16) for two-channel 16-bit baseband recordings.
 func ParseSampleFormat(s string) (SampleFormat, error) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "u8", "":
 		return FormatU8, nil
 	case "f32", "float32", "cfile":
 		return FormatF32, nil
+	case "wav", "sw16", "s16":
+		return FormatWAV, nil
 	default:
-		return FormatU8, fmt.Errorf("siglab: unknown sample format %q (want u8 or f32)", s)
+		return FormatU8, fmt.Errorf("siglab: unknown sample format %q (want u8, f32, or wav)", s)
 	}
 }
 
@@ -64,6 +75,8 @@ func (f SampleFormat) Decoder() (SampleDecoder, int) {
 	switch f {
 	case FormatF32:
 		return decodeF32, 8
+	case FormatWAV:
+		return decodeSW16, 4
 	default:
 		return decodeU8, 2
 	}
@@ -89,5 +102,18 @@ func decodeF32(buf []byte, out []complex64) {
 		ir := math.Float32frombits(binary.LittleEndian.Uint32(buf[8*i:]))
 		qr := math.Float32frombits(binary.LittleEndian.Uint32(buf[8*i+4:]))
 		out[i] = complex(ir, qr)
+	}
+}
+
+// decodeSW16 converts interleaved 16-bit signed PCM (I in channel 1, Q in
+// channel 2) to complex64, matching the normalisation the baseband IQWriter
+// and SDRtrunk/SDR++ use (÷32768). The 44-byte WAV header is stripped before
+// this decoder is fed any bytes (see the FormatWAV handling in engine.go).
+func decodeSW16(buf []byte, out []complex64) {
+	n := len(buf) / 4
+	for i := 0; i < n; i++ {
+		iv := int16(binary.LittleEndian.Uint16(buf[4*i:]))
+		qv := int16(binary.LittleEndian.Uint16(buf[4*i+2:]))
+		out[i] = complex(float32(iv)/32768, float32(qv)/32768)
 	}
 }

--- a/internal/siglab/engine.go
+++ b/internal/siglab/engine.go
@@ -12,9 +12,36 @@ import (
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
 	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr/rtlsdr"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
+
+// prepareWAVInput handles FormatWAV captures: it reads the RIFF/WAVE header
+// from r (advancing r to the first IQ sample) and overrides cfg.SampleRateHz
+// with the rate the recording was made at, so the DDC target and receiver
+// sizing derive from the file's real rate rather than the -sample-rate flag.
+// For any other format r and cfg are returned untouched. A WAV is an
+// already-channelized narrowband recording, so -auto-tune (which needs to
+// re-seek and re-estimate a wideband carrier) is rejected here — use -tune-hz
+// for a small residual offset instead.
+func prepareWAVInput(r io.Reader, cfg *Config) (io.Reader, error) {
+	if cfg.Format != FormatWAV {
+		return r, nil
+	}
+	if cfg.AutoTune {
+		return nil, fmt.Errorf("siglab: -auto-tune is not supported for wav input (a baseband WAV is already channelized; use -tune-hz for a residual offset)")
+	}
+	info, err := baseband.ReadIQWavStreamHeader(r)
+	if err != nil {
+		return nil, err
+	}
+	if info.SampleRate == 0 {
+		return nil, fmt.Errorf("siglab: wav header reports a zero sample rate")
+	}
+	cfg.SampleRateHz = float64(info.SampleRate)
+	return r, nil
+}
 
 // Run decodes the capture at path through the production pipeline for
 // cfg.Protocol and returns the structured Result. It is the batch entry
@@ -62,6 +89,10 @@ func RunReader(r io.Reader, source string, cfg Config) (*Result, error) {
 // RunReaderStream is RunReader with a live per-event sink (see RunStream).
 // It is the single decode path RunStream and the in-memory callers share.
 func RunReaderStream(r io.Reader, source string, cfg Config, onEvent func(EventRecord)) (*Result, error) {
+	r, err := prepareWAVInput(r, &cfg)
+	if err != nil {
+		return nil, err
+	}
 	if cfg.SampleRateHz <= 0 {
 		return nil, fmt.Errorf("siglab: sample rate must be > 0")
 	}
@@ -128,6 +159,10 @@ func RunReaderMonitor(r io.Reader, source string, cfg Config, tick time.Duration
 	if tick <= 0 {
 		tick = time.Second
 	}
+	r, err := prepareWAVInput(r, &cfg)
+	if err != nil {
+		return nil, err
+	}
 	decode, bytesPerSample := cfg.Format.Decoder()
 	mon := &monitorHook{Interval: tick, OnTick: onTick}
 	return runReader(r, source, decode, bytesPerSample, cfg.TuneHz, cfg, nil, mon)
@@ -143,6 +178,9 @@ func RunReaderMonitor(r io.Reader, source string, cfg Config, tick time.Duration
 // promising failure). r must be an io.ReadSeeker; cfg.AutoTune is implied and
 // cfg.TuneHz is ignored. maxCandidates ≤ 0 uses the package default.
 func RunReaderAutoTuneMulti(r io.ReadSeeker, source string, cfg Config, maxCandidates int) (*Result, error) {
+	if cfg.Format == FormatWAV {
+		return nil, fmt.Errorf("siglab: -auto-tune is not supported for wav input (a baseband WAV is already channelized; use -tune-hz for a residual offset)")
+	}
 	if cfg.SampleRateHz <= 0 {
 		return nil, fmt.Errorf("siglab: sample rate must be > 0")
 	}
@@ -240,6 +278,26 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 	if tuneHz != 0 || ddcTarget < cfg.SampleRateHz {
 		ddc = ccdecoder.NewDownconverterWithOffset(cfg.SampleRateHz, ddcTarget, tuneHz)
 		receiverRate = ddc.OutRateHz()
+	}
+
+	// Optional narrowband DDC-output recorder (-record-ddc): tee the exact
+	// channelized stream the receiver decodes to a small baseband WAV at the
+	// DDC output rate, so a fat wideband capture can be reduced to a shareable
+	// fixture that `replay -format wav` decodes identically.
+	var ddcRec *baseband.IQWriter
+	if cfg.RecordDDCPath != "" {
+		w, werr := baseband.NewIQWriter(cfg.RecordDDCPath, uint32(receiverRate+0.5))
+		if werr != nil {
+			return nil, fmt.Errorf("siglab: open -record-ddc %s: %w", cfg.RecordDDCPath, werr)
+		}
+		ddcRec = w
+		logger.Info("siglab: recording DDC output",
+			"path", cfg.RecordDDCPath, "rate_hz", uint32(receiverRate+0.5))
+		defer func() {
+			if cerr := ddcRec.Close(); cerr != nil {
+				logger.Warn("siglab: close -record-ddc", "path", cfg.RecordDDCPath, "err", cerr)
+			}
+		}()
 	}
 
 	bus := events.NewBus(1024)
@@ -366,6 +424,13 @@ func runReader(r io.Reader, source string, decode SampleDecoder, bytesPerSample 
 			if ddc != nil {
 				ddcOut = ddc.Process(ddcOut, feed)
 				feed = ddcOut
+			}
+			if ddcRec != nil {
+				if werr := ddcRec.Write(feed); werr != nil {
+					logger.Warn("siglab: -record-ddc write failed; continuing",
+						"path", cfg.RecordDDCPath, "err", werr)
+					ddcRec = nil
+				}
 			}
 			if iqTap != nil {
 				iqTap.observeIQ(feed)

--- a/internal/siglab/engine_wavrecord_test.go
+++ b/internal/siglab/engine_wavrecord_test.go
@@ -1,0 +1,118 @@
+package siglab
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestRecordDDCThenReplayWAV proves the "record the DDC output → replay it"
+// loop is faithful: decoding a capture with RecordDDCPath set writes the
+// post-DDC narrowband stream to a two-channel 16-bit WAV, and replaying that
+// WAV with FormatWAV (rate taken from the header) reproduces the same lock and
+// symbol count. This is the offline half of the IQ-record tooling — turning a
+// fat capture into a small, shareable, self-describing fixture.
+func TestRecordDDCThenReplayWAV(t *testing.T) {
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	cfg, err := meta.Config(true)
+	if err != nil {
+		t.Fatalf("meta.Config: %v", err)
+	}
+
+	dir := t.TempDir()
+	capPath := filepath.Join(dir, "p25.cfile")
+	if err := os.WriteFile(capPath, EncodeCapture(iq, FormatF32), 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+	wavPath := filepath.Join(dir, "nb.wav")
+
+	recCfg := cfg
+	recCfg.RecordDDCPath = wavPath
+	rec, err := Run(capPath, recCfg)
+	if err != nil {
+		t.Fatalf("Run(record): %v", err)
+	}
+	if !rec.Locked {
+		t.Fatalf("synthesized clean P25 should lock while recording DDC output")
+	}
+
+	info, err := baseband.ReadIQWavInfo(wavPath)
+	if err != nil {
+		t.Fatalf("ReadIQWavInfo(%s): %v", wavPath, err)
+	}
+	if info.SampleRate == 0 || info.Samples == 0 {
+		t.Fatalf("recorded WAV has rate=%d samples=%d, want both > 0", info.SampleRate, info.Samples)
+	}
+
+	// Replay the recorded narrowband WAV. FormatWAV takes the rate from the
+	// header, so no -sample-rate is needed and the decode must match.
+	replayCfg := cfg
+	replayCfg.Format = FormatWAV
+	rep, err := Run(wavPath, replayCfg)
+	if err != nil {
+		t.Fatalf("Run(replay wav): %v", err)
+	}
+	if !rep.Locked {
+		t.Fatalf("replayed DDC WAV should lock the same as the source capture")
+	}
+	if rep.TotalSamples != int64(info.Samples) {
+		t.Errorf("replay read %d samples, WAV holds %d", rep.TotalSamples, info.Samples)
+	}
+	if rep.Symbols != rec.Symbols {
+		t.Errorf("symbol count changed across record→replay: record=%d replay=%d", rec.Symbols, rep.Symbols)
+	}
+}
+
+// TestFormatWAVRejectsAutoTune confirms a baseband WAV (already channelized)
+// cannot be auto-tuned — the run must fail with a clear error rather than
+// silently mis-estimating a wideband carrier.
+func TestFormatWAVRejectsAutoTune(t *testing.T) {
+	iq, meta, err := Synthesize(SynthOptions{Protocol: trunking.ProtocolP25, Format: FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	cfg, err := meta.Config(true)
+	if err != nil {
+		t.Fatalf("meta.Config: %v", err)
+	}
+	dir := t.TempDir()
+	capPath := filepath.Join(dir, "p25.cfile")
+	if err := os.WriteFile(capPath, EncodeCapture(iq, FormatF32), 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+	wavPath := filepath.Join(dir, "nb.wav")
+	recCfg := cfg
+	recCfg.RecordDDCPath = wavPath
+	if _, err := Run(capPath, recCfg); err != nil {
+		t.Fatalf("Run(record): %v", err)
+	}
+
+	atCfg := cfg
+	atCfg.Format = FormatWAV
+	atCfg.AutoTune = true
+	if _, err := Run(wavPath, atCfg); err == nil {
+		t.Fatal("FormatWAV + AutoTune should be rejected")
+	}
+}
+
+// TestParseSampleFormatWAV covers the flag spellings and the decoder shape.
+func TestParseSampleFormatWAV(t *testing.T) {
+	for _, s := range []string{"wav", "sw16", "s16", "WAV"} {
+		f, err := ParseSampleFormat(s)
+		if err != nil || f != FormatWAV {
+			t.Fatalf("ParseSampleFormat(%q) = %v, %v; want FormatWAV", s, f, err)
+		}
+	}
+	if _, n := FormatWAV.Decoder(); n != 4 {
+		t.Fatalf("FormatWAV bytes-per-sample = %d, want 4", n)
+	}
+	if FormatWAV.String() != "wav" {
+		t.Fatalf("FormatWAV.String() = %q, want wav", FormatWAV.String())
+	}
+}

--- a/web/configbuilder/src/api/types.ts
+++ b/web/configbuilder/src/api/types.ts
@@ -385,6 +385,7 @@ export interface BroadcastConfig {
 export interface BasebandRecordConfig {
   Serial: string;
   Dir: string;
+  Tap: string;
 }
 export interface BasebandReplayConfig {
   File: string;

--- a/web/configbuilder/src/sections/Baseband.tsx
+++ b/web/configbuilder/src/sections/Baseband.tsx
@@ -11,6 +11,11 @@ const ROLES = [
   { value: "auto", label: "auto" },
 ];
 
+const TAPS = [
+  { value: "", label: "wideband (default)" },
+  { value: "ddc", label: "ddc (narrowband channel)" },
+];
+
 // Loop is *bool (nil defaults to true). Map to a tri-state select.
 function loopValue(loop: boolean | null): string {
   if (loop === null || loop === undefined) return "default";
@@ -34,13 +39,14 @@ export function BasebandSection() {
           label="Recorders"
           items={c.Record}
           onChange={(x) => set({ ...c, Record: x })}
-          makeNew={() => ({ Serial: "", Dir: "" })}
+          makeNew={() => ({ Serial: "", Dir: "", Tap: "" })}
           itemTitle={(r) => r.Serial || "recorder"}
           emptyHint="No recorders."
           renderItem={(r, setR) => (
             <div className="grid gap-3 sm:grid-cols-2">
               <TextField label="Serial" value={r.Serial} onChange={(v) => setR({ ...r, Serial: v })} />
               <TextField label="Directory" value={r.Dir} onChange={(v) => setR({ ...r, Dir: v })} />
+              <SelectField label="Tap" value={r.Tap ?? ""} onChange={(v) => setR({ ...r, Tap: v })} options={TAPS} />
             </div>
           )}
         />


### PR DESCRIPTION
Add an easy way to record the digital down-converter output — the narrow
channelized IQ stream the decoder actually sees (144 kHz for TETRA, ~48 kHz
for the C4FM family) — instead of only the fat full-rate SDR stream, and let
replay read those recordings back so a hard-to-decode channel becomes a small,
shareable, reproducible fixture.

- baseband.record: new `tap` field (wideband|ddc). `tap: ddc` tees the live
  control-channel decoder's post-DDC stream to a 2-channel 16-bit WAV at the
  pipeline rate via a new ccdecoder DDC recorder (opened lazily, rolled on a
  system/rate change, closed on decoder exit). `wideband` (default) is the
  existing device-wrap behaviour, unchanged.
- replay -record-ddc <out.wav>: offline tee of the post-DDC stream while
  decoding, so a fat 2.5/10 MS/s cfile shrinks to a small narrowband WAV.
- replay -format wav (aka sw16): read 2-channel 16-bit baseband WAVs
  (SDRtrunk/SDR++/GopherTrunk layout); the sample rate comes from the header,
  and -auto-tune is rejected (an already-channelized capture — use -tune-hz).
- Reuses baseband.IQWriter and adds a forward-only header reader; the
  record -> replay loop is byte-faithful (verified end-to-end and unit-tested).
- Docs: config.example.yaml, configbuilder field help, and docs/siglab.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EMLRBbPdRBxFEcDBEiqfXD