### PR TITLE
widebandt2: wire Phase 2 FEC config into hybrid Phase 1 CC decoder

### DIFF
--- a/internal/radio/p25/phase1/control.go
+++ b/internal/radio/p25/phase1/control.go
@@ -230,6 +230,17 @@ func (c *ControlChannel) LastNAC() uint16 { return c.lastNAC }
 // SystemName returns the operator-assigned system name, if any.
 func (c *ControlChannel) SystemName() string { return c.systemName }
 
+// P25Phase2FEC reports the per-system Phase 2 FEC mode codes this
+// Phase 1 CC stamps onto the TDMA voice grants it publishes for hybrid
+// (Phase 1 CC + Phase 2 TC) systems — trellis / RS / interleave /
+// scrambler, in that order (issue #376). Exposed read-only so callers
+// and tests can confirm the decode config was wired in; the wideband
+// path relied on this to catch issue #882, where the modes defaulted to
+// zero and every Phase 2 grant decoded with the FEC chain disabled.
+func (c *ControlChannel) P25Phase2FEC() (trellis, rs, interleave, scrambler uint8) {
+	return c.p25Phase2Trellis, c.p25Phase2RS, c.p25Phase2Interleave, c.p25Phase2Scrambler
+}
+
 // TopologySnapshot builds the protocol-neutral topology snapshot for this
 // control channel: identity, primary/secondary control channels, neighbours,
 // and band plan, with every channel's downlink frequency resolved through the

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -621,13 +621,24 @@ func buildChannel(sys trunking.System, ch ChannelConfig, outRateHz float64, bus 
 				})
 			}
 		}
+		// A Phase 1 CC can issue Phase 2 TDMA voice grants (hybrid
+		// systems such as Victorian MMR — issue #882). The voice
+		// composer's Phase 2 chain needs the per-system FEC config to
+		// decode those grants' MAC PDUs; without it every grant carries
+		// TrellisOff / ScramblerOff / zero seed and MAC decode fails.
+		// Parse and forward the same knobs the ccdecoder pipeline does.
+		p2Trellis, p2RS, p2Interleave, p2Scrambler := parseP25Phase2FECModes(sys, log)
 		cc := p25phase1.New(p25phase1.Options{
-			Bus:         bus,
-			Log:         log.With("system", sys.Name, "freq_hz", freqHz, "phase", 1),
-			SystemName:  sys.Name,
-			FrequencyHz: freqHz,
-			BandPlan:    bandPlan,
-			Rotations:   rotations,
+			Bus:                 bus,
+			Log:                 log.With("system", sys.Name, "freq_hz", freqHz, "phase", 1),
+			SystemName:          sys.Name,
+			FrequencyHz:         freqHz,
+			BandPlan:            bandPlan,
+			Rotations:           rotations,
+			P25Phase2Trellis:    p2Trellis,
+			P25Phase2RS:         p2RS,
+			P25Phase2Interleave: p2Interleave,
+			P25Phase2Scrambler:  p2Scrambler,
 		})
 		rx := p25phase1rx.New(p25phase1rx.Options{
 			SampleRateHz: outRateHz,
@@ -691,6 +702,38 @@ func requireControlChannel(sys trunking.System, freqHz uint32, label string) err
 	return fmt.Errorf("widebandt2: channel freq=%d on system %q (protocol %s) "+
 		"must match one of the system's control_channels %v",
 		freqHz, sys.Name, label, sys.ControlChannels)
+}
+
+// parseP25Phase2FECModes parses the per-system Phase 2 FEC knobs
+// (trellis / RS / interleave / scrambler) into the uint8 codes the
+// p25phase1.Options block carries, mirroring ccdecoder's
+// newP25Phase1Pipeline. A Phase 1 CC on a hybrid system uses these to
+// stamp its Phase 2 TDMA voice grants so the voice composer can decode
+// their MAC PDUs (issue #882). Unrecognised values warn then fall back
+// to the same defaults the ccdecoder path uses; an empty per-system
+// value keeps the default (Trellis=on, everything else=off).
+func parseP25Phase2FECModes(sys trunking.System, log *slog.Logger) (trellis, rs, interleave, scrambler uint8) {
+	p2Trellis, ok := p25phase2.ParseTrellisMode(sys.P25Phase2TrellisMode)
+	if !ok {
+		log.Warn("widebandt2: unrecognised p25_phase2_trellis_mode; falling back to on",
+			"system", sys.Name, "value", sys.P25Phase2TrellisMode)
+	}
+	p2RS, ok := p25phase2.ParseRSMode(sys.P25Phase2RSMode)
+	if !ok {
+		log.Warn("widebandt2: unrecognised p25_phase2_rs_mode; falling back to off",
+			"system", sys.Name, "value", sys.P25Phase2RSMode)
+	}
+	p2Interleave, ok := p25phase2.ParseInterleaveMode(sys.P25Phase2InterleaveMode)
+	if !ok {
+		log.Warn("widebandt2: unrecognised p25_phase2_interleave_mode; falling back to off",
+			"system", sys.Name, "value", sys.P25Phase2InterleaveMode)
+	}
+	p2Scrambler, ok := p25phase2.ParseScramblerMode(sys.P25Phase2ScramblerMode)
+	if !ok {
+		log.Warn("widebandt2: unrecognised p25_phase2_scrambler_mode; falling back to on",
+			"system", sys.Name, "value", sys.P25Phase2ScramblerMode)
+	}
+	return uint8(p2Trellis), uint8(p2RS), uint8(p2Interleave), uint8(p2Scrambler)
 }
 
 // applyP25Phase2Modes mirrors newP25Phase2Pipeline's per-system mode

--- a/internal/scanner/widebandt2/engine_p25phase2fec_test.go
+++ b/internal/scanner/widebandt2/engine_p25phase2fec_test.go
@@ -1,0 +1,64 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	p25phase1 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1"
+	p25phase2 "github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase2"
+)
+
+// TestBuildChannelP25Phase1WiresPhase2FEC is the regression test for
+// issue #882: a wideband Phase 1 control channel on a hybrid system
+// (Phase 1 CC issuing Phase 2 TDMA voice grants — e.g. Victorian MMR)
+// must forward the per-system Phase 2 FEC config (trellis / RS /
+// interleave / scrambler) into the Phase 1 CC decoder. Before the fix
+// buildChannel constructed p25phase1.Options without those fields, so
+// they defaulted to zero (Trellis=off, Scrambler=off) and every Phase 2
+// grant the CC published decoded with the FEC chain disabled — the
+// voice composer then warned and failed all MAC PDU decodes on the
+// traffic channel, even with p25_phase2_trellis_mode=on configured.
+//
+// The equivalent ccdecoder pipeline already wires these (see
+// newP25Phase1Pipeline in ccdecoder/pipelines.go); this pins the
+// wideband path to the same behaviour.
+func TestBuildChannelP25Phase1WiresPhase2FEC(t *testing.T) {
+	bus := events.NewBus(8)
+	defer bus.Close()
+	log := slog.New(slog.NewTextHandler(discardWriter{}, nil))
+
+	const ccHz = 420_012_500
+	sys := p25Phase1System("mmr", ccHz)
+	// Reporter's config: trellis explicitly on. Also pin a non-default
+	// value (RS on) so the test proves the config is actually forwarded
+	// rather than just landing on a coincidental default.
+	sys.P25Phase2TrellisMode = "on"
+	sys.P25Phase2RSMode = "on"
+
+	ch := ChannelConfig{FrequencyHz: ccHz, SystemName: sys.Name}
+	ec, err := buildChannel(sys, ch, narrowbandRateHz, bus, log, nil)
+	if err != nil {
+		t.Fatalf("buildChannel: %v", err)
+	}
+
+	cc, ok := ec.processor.(*p25phase1.ControlChannel)
+	if !ok {
+		t.Fatalf("processor type = %T, want *p25phase1.ControlChannel", ec.processor)
+	}
+
+	trellis, rs, _, scrambler := cc.P25Phase2FEC()
+	if trellis != uint8(p25phase2.TrellisOn) {
+		t.Errorf("Phase 2 trellis = %d, want %d (TrellisOn) — grant FEC not wired (issue #882)",
+			trellis, p25phase2.TrellisOn)
+	}
+	if rs != uint8(p25phase2.RSOn) {
+		t.Errorf("Phase 2 RS = %d, want %d (RSOn) — per-system FEC config not forwarded",
+			rs, p25phase2.RSOn)
+	}
+	// Scrambler defaults to on (empty config), and must survive the wiring.
+	if scrambler != uint8(p25phase2.ScramblerOn) {
+		t.Errorf("Phase 2 scrambler = %d, want %d (ScramblerOn default)",
+			scrambler, p25phase2.ScramblerOn)
+	}
+}


### PR DESCRIPTION
A P25 Phase 1 control channel can issue Phase 2 TDMA voice grants on
hybrid systems (e.g. Victorian MMR). The voice composer's Phase 2 chain
needs the per-system FEC config (trellis / RS / interleave / scrambler)
to decode those grants' MAC PDUs, but buildChannel constructed the
wideband Phase 1 CC's p25phase1.Options without those fields — they
defaulted to zero, so every Phase 2 grant carried Trellis=off /
Scrambler=off and the composer failed all MAC PDU decodes on the traffic
channel, even with p25_phase2_trellis_mode=on configured.

Parse and forward the same knobs the ccdecoder pipeline already does
(newP25Phase1Pipeline), via a shared parseP25Phase2FECModes helper.
Add a read-only P25Phase2FEC accessor on the Phase 1 ControlChannel so
the wiring is observable, and a regression test that fails first (all
modes 0) and passes with the fix.

Refs #882

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Q2U8YpAgBbEhMQ96ycAExu