### PR TITLE
soapyremote: reject SoapyRemote stream args in make() args (#876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ for tagged releases.
   `go.mod` and every CI/build workflow.
 
 ### Fixed
+- **SoapyRemote stream arguments smuggled through `sdr.soapy_remote[].args`
+  were silently ignored.** Everything in `args` is passed to the remote
+  SoapySDR `make()` call, but GopherTrunk builds the `SETUP_STREAM` frame
+  itself, so `remote:mtu` / `remote:window` / `remote:prot` placed in `args`
+  never reached the stream setup — a user who set `remote:mtu=8000` in `args`
+  stayed on the 1500-byte default with no warning (issue #876). Config load now
+  rejects those reserved stream keys in `args` and points at the dedicated
+  `stream_mtu` / `stream_window` / `stream_protocol` keys that actually take
+  effect. `docs/hardware.md` gains a field-tested networked-USRP-X310 example,
+  a B210 `args` snippet, the `SOAPY_SDR_LOG_LEVEL=DEBUG SoapySDRServer` debug
+  invocation, and guidance to prefer a manually chosen gain over AGC for survey
+  work.
 - **Airspy on macOS aborted mid-stream with `usb: ReadPipe: 0xe00002eb`.** After
   a second or two of healthy decoding the bulk-IN pipe was aborted by macOS
   (`kIOReturnAborted`), the daemon retried, hit the same wall, and escalated to a

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -714,6 +714,50 @@ B210 specifics worth knowing before the first run:
   the documented follow-up** (see the support matrix). Field reports from
   a real B210 are welcome.
 
+For a B210 the `args` string is where the UHD device selection lives, e.g.
+`args: "type=b200,num_recv_frames=512,recv_frame_size=16384"` alongside
+`master_clock_rate: 61_440_000` and `sample_rate: 6_144_000`.
+
+### Field-tested example: networked USRP X310
+
+The B210 recipe above runs `SoapySDRServer` on loopback, but the same driver
+works over the network — the antenna host runs `SoapySDRServer` bound to the
+radio's NIC and the daemon connects across the LAN. This config, contributed
+from real field use of a networked X310 (issue #876), shows a full UHD
+`args` string driving subdev/antenna selection, a GPSDO clock/time reference,
+and the bias tee — all passed through to the remote `make()`:
+
+```yaml
+sdr:
+  sample_rate: 6_250_000              # ÷32 of the X310's 200 MHz default clock
+  soapy_remote:
+    - addr: "10.110.162.1:23313"      # antenna host running SoapySDRServer
+      driver: "uhd"
+      # UHD device-selection kwargs go here (num_recv_frames/recv_frame_size
+      # are fine too). But remote:mtu / remote:window are SoapyRemote STREAM
+      # args — set the MTU under stream_mtu below, not in args (config load
+      # rejects remote:* here).
+      args: "addr=10.110.162.17,rx_subdev_spec=A:0,antenna=RX1,clock_source=gpsdo,time_source=gpsdo,enable_bias_tee=1"
+      format: "CS16"
+      role: "auto"
+      gain: "750"                     # 75.0 dB, set manually — see gain note below
+      bias_tee: true
+      stream_mtu: 8192                 # jumbo-frame link; sizes SETUP_STREAM + window
+      connect_timeout_ms: 20000
+```
+
+Two operational notes from that deployment:
+
+- **Prefer a manually chosen gain over AGC.** On UHD front ends, dial in the
+  gain with a familiar SDR app first (e.g. SDR++), then set that value here in
+  tenths of a dB (`gain: "750"` = 75 dB). `gain: "auto"` requests the device's
+  AGC where it exists, but a fixed, known-good gain is more predictable for
+  survey work where you want comparable signal levels run to run.
+- **`SoapySDRServer` can be unstable.** Independent of GopherTrunk, the server
+  has been observed to crash under load or on some devices; run it under a
+  supervisor that restarts it, and see the diagnostics note below for turning on
+  its debug log.
+
 Once it is streaming, the whole toolset works against it — trunked
 decode, plus the user-defined frequency-range survey in
 [`hunt.md`]({{ '/hunt.html' | relative_url }}): `gophertrunk hunt
@@ -739,8 +783,18 @@ classifies every carrier, and streams the inventory to
   `"key=value,key2=value2"` string, merged with `driver` (an explicit
   `driver=` in `args` wins). Use it for server-side device selection and
   configuration that `driver` alone can't express — e.g. a USRP TwinRX needs
-  `args: "rx_subdev_spec=A:0,antenna=RX1"`. This is distinct from the top-level
+  `args: "rx_subdev_spec=A:0,antenna=RX1"`, and a UHD device can take
+  `rx_subdev_spec`, `antenna`, `clock_source`/`time_source` (e.g. `gpsdo`),
+  `enable_bias_tee`, and receive-buffer sizing like
+  `num_recv_frames`/`recv_frame_size`. This is distinct from the top-level
   `serial`, which only names the virtual pool device locally.
+  **Stream arguments do not belong here.** `remote:mtu`, `remote:window`, and
+  `remote:prot` configure SoapyRemote's *stream* setup, which GopherTrunk builds
+  itself — anything `remote:*` placed in `args` reaches `make()` and is silently
+  dropped for streaming (you stay on the 1500-byte default). Config load now
+  rejects those keys in `args` and points you at the dedicated `stream_mtu`,
+  `stream_window`, and `stream_protocol` keys that actually take effect
+  (issue #876).
 - `ppm` (frequency correction) and `bias_tee` map to SoapySDR's
   `setFrequencyCorrection` / `writeSetting` and silently no-op on
   drivers that don't implement them.
@@ -770,6 +824,17 @@ classifies every carrier, and streams the inventory to
 format=... proto=...` on each successful Open, `make device:` with the
 remote exception text when the server can't open the requested device,
 and `dial: connection refused` if the server isn't listening.
+
+On the server side, start `SoapySDRServer` with SoapySDR's debug log enabled to
+see what UHD is doing with the device and stream setup:
+
+```sh
+SOAPY_SDR_LOG_LEVEL=DEBUG SoapySDRServer --bind=10.110.162.17:23313
+```
+
+(bind to the radio host's LAN address for a networked SDR, or `127.0.0.1` for
+the loopback B210 recipe above). This is the first place to look when a device
+opens but never streams, or when the server crashes on a client connect.
 
 > **Note — upstream server crashes.** Some radios were observed crashing
 > `SoapySDRServer` itself (a `zsh: segmentation fault` inside `libuhd`) when the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -972,6 +972,35 @@ func parseDeviceArgs(s string) (map[string]string, error) {
 	return out, nil
 }
 
+// reservedStreamArgs maps SoapyRemote stream-setup keys that GopherTrunk owns
+// (it constructs the SETUP_STREAM frame itself) to the config key that actually
+// applies them. Left in the free-form args string they reach the remote make()
+// call and are silently dropped for streaming, so config load rejects them.
+var reservedStreamArgs = map[string]string{
+	"remote:mtu":    "stream_mtu",
+	"remote:window": "stream_window",
+	"remote:prot":   "stream_protocol",
+}
+
+// reservedStreamArg reports the first reserved SoapyRemote stream key present
+// in the free-form args string, along with the config key that supersedes it.
+// It returns "", "" when args carries no reserved stream key (or is malformed,
+// which DeviceArgs reports separately).
+func reservedStreamArg(argsStr string) (key, dest string) {
+	args, err := parseDeviceArgs(argsStr)
+	if err != nil {
+		return "", ""
+	}
+	// Iterate in a stable order so the reported key is deterministic when args
+	// names more than one.
+	for _, k := range []string{"remote:mtu", "remote:window", "remote:prot"} {
+		if _, ok := args[k]; ok {
+			return k, reservedStreamArgs[k]
+		}
+	}
+	return "", ""
+}
+
 // DeviceArgs returns the SoapySDR make() kwargs for this endpoint: any
 // key=value pairs from Args, merged with the Driver shorthand. An explicit
 // "driver=" in Args wins over the Driver field. It returns nil when no args
@@ -2131,6 +2160,15 @@ func validateSoapyFields(i int, s SoapyRemoteConfig) error {
 	}
 	if _, err := s.DeviceArgs(); err != nil {
 		return fmt.Errorf("sdr.soapy_remote[%d]: args: %w", i, err)
+	}
+	// SoapyRemote stream arguments must not be smuggled through args.
+	// Everything in args goes to the remote make() call, but GopherTrunk
+	// builds the SETUP_STREAM frame itself, so a remote:* stream knob left in
+	// args is silently ignored for streaming (issue #876: a user set
+	// remote:mtu=8000 in args and stayed on the 1500-byte default). Reject the
+	// reserved keys and point at the dedicated field that actually takes effect.
+	if reserved, dest := reservedStreamArg(s.Args); reserved != "" {
+		return fmt.Errorf("sdr.soapy_remote[%d]: args contains stream argument %q, which is ignored in make() args; set the %q config key instead", i, reserved, dest)
 	}
 	// master_clock_rate is in Hz; a non-zero value below 1 MHz is almost
 	// certainly a units slip (e.g. "61" meaning 61 MHz) — catch it early.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -324,6 +324,15 @@ func TestValidate(t *testing.T) {
 		// soapy_remote args: SoapySDR make() kwargs as "k=v,k=v" (issue #542).
 		{"soapy args ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "rx_subdev_spec=A:0,antenna=RX1"}}}}, false},
 		{"soapy args malformed", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "rx_subdev_spec"}}}}, true},
+		// soapy_remote args must not carry SoapyRemote stream knobs: GT builds
+		// the SETUP_STREAM frame itself and ignores remote:* in make() args, so
+		// they belong in the dedicated stream_* keys, not args (issue #876).
+		{"soapy args remote:mtu rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "remote:mtu=8000"}}}}, true},
+		{"soapy args remote:window rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "remote:window=16777216"}}}}, true},
+		{"soapy args remote:prot rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "remote:prot=tcp"}}}}, true},
+		{"soapy args remote:mtu mixed rejected", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "antenna=RX1,remote:mtu=8000"}}}}, true},
+		// UHD frame-size make() args are legitimate and stay allowed.
+		{"soapy args recv_frame_size ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", Args: "num_recv_frames=512,recv_frame_size=16384"}}}}, false},
 		// soapy_remote stream_mtu: 0 = default; a real MTU is fine; out-of-range fails.
 		{"soapy stream_mtu zero ok", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1"}}}}, false},
 		{"soapy stream_mtu valid", Config{SDR: SDRConfig{SoapyRemote: []SoapyRemoteConfig{{Addr: "h:1", StreamMTU: 8192}}}}, false},


### PR DESCRIPTION
Everything in sdr.soapy_remote[].args is passed to the remote SoapySDR
make() call, but GopherTrunk builds the SETUP_STREAM frame itself and
only honors the dedicated stream_mtu / stream_window / stream_protocol
config keys. A remote:mtu / remote:window / remote:prot left in args
therefore reached make() and was silently dropped for streaming — a
field user (issue #876) set remote:mtu=8000 in args and unknowingly
stayed on the 1500-byte default.

Config load now rejects those reserved stream keys in args with a message
pointing at the dedicated key that takes effect. Adds a failing-first
regression test (rejects remote:*; still allows legitimate UHD make()
kwargs like num_recv_frames/recv_frame_size).

docs/hardware.md gains a field-tested networked-USRP-X310 example, a B210
args snippet, the SOAPY_SDR_LOG_LEVEL=DEBUG SoapySDRServer debug
invocation, and guidance to prefer a manually chosen gain over AGC for
survey work.

Refs #876

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HkuF4xnTBfJTV7eHfLmddf