### PR TITLE
docs(field-guide): add diagrams to 22 reference concept/hardware articles

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,51 @@ daemon behaves like a high-end digital-trunking police scanner end-to-end.
 
 ## Layered overview
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 494" role="img" aria-label="The GopherTrunk signal pipeline as a vertical stack of stages. The daemon and CLI sit on top; IQ samples flow from the SDR pool through DSP, then radio framing, trunking, and the scanner, and out to the voice, API, storage, and TUI sinks over the event bus. Each arrow is labelled with the channel type passed between stages." xmlns="http://www.w3.org/2000/svg">
+  <text x="230" y="18" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">Signal pipeline — pipelined goroutines over typed channels</text>
+  <g text-anchor="middle" fill="currentColor">
+    <rect x="88" y="30" width="284" height="34" rx="5" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.2"/>
+    <text x="230" y="50" font-size="9.5" font-weight="600">cmd/gophertrunk — daemon · CLI · TUI cockpit</text>
+    <rect x="88" y="88" width="284" height="44" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="230" y="108" font-size="10" font-weight="600">internal/sdr</text>
+    <text x="230" y="123" font-size="8">SDR pool · RTL-SDR / HackRF / Airspy</text>
+    <rect x="88" y="156" width="284" height="44" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="230" y="176" font-size="10" font-weight="600">internal/dsp</text>
+    <text x="230" y="191" font-size="8">filters · channelizer · demod · sync</text>
+    <rect x="88" y="224" width="284" height="44" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="230" y="244" font-size="10" font-weight="600">internal/radio</text>
+    <text x="230" y="259" font-size="8">framing · P25 · DMR · NXDN · TETRA · …</text>
+    <rect x="88" y="292" width="284" height="44" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="230" y="312" font-size="10" font-weight="600">internal/trunking</text>
+    <text x="230" y="327" font-size="8">engine · grant · priority · site · cc cache</text>
+    <rect x="88" y="360" width="284" height="44" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="230" y="380" font-size="10" font-weight="600">internal/scanner</text>
+    <text x="230" y="395" font-size="8">multi-system CC hunt · conventional FM</text>
+    <rect x="88" y="428" width="284" height="50" rx="5" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.2"/>
+    <text x="230" y="447" font-size="9.5" font-weight="600">voice · api · storage · metrics · tui</text>
+    <text x="230" y="461" font-size="8">record · HTTP/SSE/gRPC · SQLite · cockpit</text>
+    <text x="230" y="472" font-size="7.5" fill-opacity="0.8">(subscribers on events.Bus)</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <line x1="230" y1="64" x2="230" y2="88" marker-end="url(#arch_ar)"/>
+    <line x1="230" y1="132" x2="230" y2="156" marker-end="url(#arch_ar)"/>
+    <line x1="230" y1="200" x2="230" y2="224" marker-end="url(#arch_ar)"/>
+    <line x1="230" y1="268" x2="230" y2="292" marker-end="url(#arch_ar)"/>
+    <line x1="230" y1="336" x2="230" y2="360" marker-end="url(#arch_ar)"/>
+    <line x1="230" y1="404" x2="230" y2="428" marker-end="url(#arch_ar)"/>
+  </g>
+  <g font-size="8" fill="currentColor" fill-opacity="0.9" text-anchor="start" font-style="italic">
+    <text x="240" y="147">chan []complex64</text>
+    <text x="240" y="215">symbol streams</text>
+    <text x="240" y="283">control-channel events</text>
+    <text x="240" y="351">grants · scan state</text>
+    <text x="240" y="419">events.Bus</text>
+  </g>
+</svg>
+<figcaption>The engine is a chain of pipelined goroutines joined by typed channels: raw IQ from the SDR pool becomes baseband in DSP, symbols become protocol frames in radio, frames become call events in trunking, and the scanner drives it all — with voice, API, storage, and the TUI hanging off the event bus. Config, logging, and the event bus are cross-cutting. The detailed module map follows.</figcaption>
+</figure>
+
 ```
               ┌────────────────────────────────────────────┐
               │  cmd/gophertrunk  ── daemon + sdr list CLI │

--- a/docs/learn/ai-software-dev/agentic-cli-tools.md
+++ b/docs/learn/ai-software-dev/agentic-cli-tools.md
@@ -36,6 +36,27 @@ Then it loops back to plan again, using what it just observed. This **plan → a
 
 The key enabler is **tools** — functions the model is allowed to call. Reading a file, writing a file, and running a command are tools. Given those, an agent can explore an unfamiliar codebase, make a change, check whether it worked, and fix it if it didn't — much like a developer would, just faster and tirelessly.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 380 222" role="img" aria-label="The agent loop as a cycle: plan the next step, act by calling a tool, observe the result, then feed what was learned back into planning and repeat until the goal is met." xmlns="http://www.w3.org/2000/svg">
+  <g text-anchor="middle" fill="currentColor">
+    <rect x="132" y="26" width="116" height="42" rx="6" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.3"/><text x="190" y="45" font-size="9.5" font-weight="600">1 · Plan</text><text x="190" y="58" font-size="7.5" fill-opacity="0.85">pick the next step</text>
+    <rect x="248" y="150" width="116" height="42" rx="6" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.3"/><text x="306" y="169" font-size="9.5" font-weight="600">2 · Act</text><text x="306" y="182" font-size="7.5" fill-opacity="0.85">use a tool: read · run · edit</text>
+    <rect x="16" y="150" width="116" height="42" rx="6" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.3"/><text x="74" y="169" font-size="9.5" font-weight="600">3 · Observe</text><text x="74" y="182" font-size="7.5" fill-opacity="0.85">read the result</text>
+  </g>
+  <text x="190" y="112" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.95" font-weight="600">loop until</text>
+  <text x="190" y="124" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.95" font-weight="600">the goal is met</text>
+  <g stroke="currentColor" stroke-width="1.5" fill="none">
+    <path d="M248 60 C 300 78 314 112 306 148" marker-end="url(#agent_ar)"/>
+    <path d="M248 178 C 200 196 158 196 134 180" marker-end="url(#agent_ar)"/>
+    <path d="M64 148 C 70 100 92 82 130 66" marker-end="url(#agent_ar)"/>
+  </g>
+  <text x="332" y="108" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">act</text>
+  <text x="44" y="108" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">feedback</text>
+  <defs><marker id="agent_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>"Agentic" just means a loop with feedback. The model plans a step, acts by calling a tool (reading a file, running a command, editing code), and observes the result — then feeds what it learned back into the next plan, repeating until the goal is met. That observe-to-plan feedback edge is exactly what separates an agent from a one-shot chat reply.</figcaption>
+</figure>
+
 ## Agentic tools live in your terminal
 
 These tools typically run in your **terminal** (the command-line shell) and operate on the **whole project** — the entire repository, not just the file you have open. Common examples include Anthropic's **Claude Code**, OpenAI's **Codex CLI**, and **Aider**. They differ in details, but the shape is the same: you describe a goal in plain language, and the agent works through the repo to accomplish it.

--- a/docs/learn/ai-software-dev/context-windows.md
+++ b/docs/learn/ai-software-dev/context-windows.md
@@ -37,6 +37,37 @@ This is lesson 4 of the path, and the one to slow down on. Almost every frustrat
 
 All of it is concatenated into one long sequence of tokens and fed to the model at once. The model has no memory between calls beyond this — it doesn't "remember" your last session unless that information is in the context this time. Anything outside the context window might as well not exist to the model. This is why two people can get wildly different answers to the same question: their context differed.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 158" role="img" aria-label="One fixed context window drawn as a token-budget bar split into system prompt, conversation history, files, current message, and reserved output; beside it a U-shaped recall curve shows attention is strongest at the start and end of the window and weakest in the middle." xmlns="http://www.w3.org/2000/svg">
+  <text x="160" y="20" text-anchor="middle" font-size="9" font-weight="600" fill="currentColor">one fixed token budget</text>
+  <g stroke="currentColor" stroke-width="1.1">
+    <rect x="20" y="30" width="28" height="42" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="48" y="30" width="84" height="42" fill="currentColor" fill-opacity="0.2"/>
+    <rect x="132" y="30" width="84" height="42" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="216" y="30" width="34" height="42" fill="currentColor" fill-opacity="0.24"/>
+    <rect x="250" y="30" width="50" height="42" fill="currentColor" fill-opacity="0.06" stroke-dasharray="4 3"/>
+  </g>
+  <g font-size="7.5" fill="currentColor" text-anchor="middle">
+    <text x="34" y="86">system</text>
+    <text x="90" y="86">history</text>
+    <text x="174" y="86">files</text>
+    <text x="233" y="100">message</text>
+    <text x="275" y="86">reserved</text>
+    <text x="275" y="95">output</text>
+  </g>
+  <line x1="233" y1="72" x2="233" y2="94" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.6"/>
+  <text x="160" y="124" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">input and output share one ceiling — overflow drops the oldest</text>
+  <text x="395" y="20" text-anchor="middle" font-size="8" font-weight="600" fill="currentColor">lost in the middle</text>
+  <line x1="335" y1="98" x2="335" y2="34" stroke="currentColor" stroke-width="1" stroke-opacity="0.6" marker-end="url(#ctx_ar)"/>
+  <line x1="335" y1="98" x2="458" y2="98" stroke="currentColor" stroke-width="1" stroke-opacity="0.6" marker-end="url(#ctx_ar)"/>
+  <path d="M340 44 C 366 60 380 92 397 92 C 414 92 428 60 454 44" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <text x="326" y="40" text-anchor="middle" font-size="6.5" fill="currentColor" fill-opacity="0.85" transform="rotate(-90 326 40)">recall</text>
+  <text x="397" y="112" text-anchor="middle" font-size="6.5" fill="currentColor" fill-opacity="0.85">start → middle → end</text>
+  <defs><marker id="ctx_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>One fixed token budget holds everything at once — the hidden system prompt, the conversation history, attached files, your current message, and the room reserved for the reply. Input and output share the same ceiling, so a packed session leaves less space to answer. And attention isn't even: recall is strongest at the start and end of the window and weakest in the middle, so place what matters most where it will be seen.</figcaption>
+</figure>
+
 ## The window is a hard limit
 
 The **context window** is the maximum number of tokens a model can handle in one pass — and it counts *both* the input (everything above) *and* the output the model is about to generate. It is a hard architectural limit, not a guideline. As a rough illustration, models today range from tens of thousands of tokens up to a million or more, and the numbers keep climbing — so don't memorize a figure; check the provider's docs for any specific model.

--- a/docs/learn/ai-software-dev/how-models-decide.md
+++ b/docs/learn/ai-software-dev/how-models-decide.md
@@ -51,6 +51,34 @@ With the input tokenized, generation runs as a tight loop. The word for it is **
 
 So a paragraph of output is this loop run hundreds of times, one token at a time, each new token chosen in light of everything before it. Crucially, the model commits to each token before generating the next — it can't go back and revise an earlier word once it's out. That one-directional, one-token-at-a-time nature explains a lot of LLM behaviour, including why a single early misstep can send an answer down the wrong path.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 182" role="img" aria-label="The autoregressive generation loop: the model reads the tokens so far, produces a probability distribution over the vocabulary, samples one token, appends it, and feeds the longer sequence back to the start to repeat." xmlns="http://www.w3.org/2000/svg">
+  <path d="M401 78 C 401 34 59 34 59 78" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="5 4" marker-end="url(#hmd_ar)"/>
+  <text x="230" y="26" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">append, then feed the longer sequence back in — repeat</text>
+  <g text-anchor="middle" fill="currentColor" font-size="8.5">
+    <rect x="12" y="78" width="94" height="46" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="59" y="99" font-weight="600">read tokens</text><text x="59" y="112" font-size="7.5" fill-opacity="0.85">prompt so far</text>
+    <rect x="126" y="78" width="94" height="46" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="173" y="96" font-weight="600">probability</text><text x="173" y="108" font-weight="600">distribution</text>
+    <rect x="240" y="78" width="94" height="46" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="287" y="99" font-weight="600">sample one</text><text x="287" y="112" font-size="7.5" fill-opacity="0.85">token</text>
+    <rect x="354" y="78" width="94" height="46" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="401" y="99" font-weight="600">append it</text><text x="401" y="112" font-size="7.5" fill-opacity="0.85">commit · no revise</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="106" y1="101" x2="126" y2="101" marker-end="url(#hmd_ar)"/>
+    <line x1="220" y1="101" x2="240" y2="101" marker-end="url(#hmd_ar)"/>
+    <line x1="334" y1="101" x2="354" y2="101" marker-end="url(#hmd_ar)"/>
+  </g>
+  <g stroke="currentColor" stroke-width="0.9" fill="currentColor">
+    <rect x="140" y="150" width="8" height="8" fill-opacity="0.35"/>
+    <rect x="152" y="142" width="8" height="16" fill-opacity="0.5"/>
+    <rect x="164" y="146" width="8" height="12" fill-opacity="0.35"/>
+    <rect x="176" y="152" width="8" height="6" fill-opacity="0.35"/>
+    <rect x="188" y="154" width="8" height="4" fill-opacity="0.35"/>
+  </g>
+  <text x="205" y="157" text-anchor="start" font-size="7.5" fill="currentColor" fill-opacity="0.9">pick one from the distribution</text>
+  <defs><marker id="hmd_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Generation is <strong>autoregressive</strong>: the model reads every token so far, produces a probability distribution over the whole vocabulary, samples one token, and appends it — then feeds the longer sequence back in and repeats. Because it commits to each token before choosing the next and never revises, a single early misstep can steer the whole answer.</figcaption>
+</figure>
+
 ## Sampling: how the token gets picked
 
 Step 3 — *picks one token* — is where you have control. Several strategies exist for turning the probability distribution into an actual choice.

--- a/docs/learn/ai-software-dev/providing-context.md
+++ b/docs/learn/ai-software-dev/providing-context.md
@@ -52,6 +52,38 @@ When the material is far bigger than any context window — a million-line codeb
 
 The trick relies on **embeddings**, which we met in [types of models](/learn/ai-software-dev/types-of-models/): a model turns each chunk of text into a vector — a list of numbers — positioned so that passages about similar things sit near each other. Your question gets embedded the same way, and the system retrieves the chunks whose vectors are closest to it. Those few chunks get pasted into the prompt, and the model answers grounded in *your* content rather than its general training. That's the whole shape of RAG: embed everything once, retrieve the nearest matches per question, generate from them. It's how a tool can answer about a codebase it could never hold in memory all at once.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 476 214" role="img" aria-label="A retrieval-augmented-generation pipeline: offline, the corpus is embedded into a vector store; per query, the question is embedded, its nearest chunks are retrieved from the store, injected into the prompt alongside the question, and passed to the model to generate an answer." xmlns="http://www.w3.org/2000/svg">
+  <text x="150" y="14" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">index once · offline</text>
+  <g text-anchor="middle" fill="currentColor" font-size="8">
+    <rect x="18" y="24" width="78" height="40" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="57" y="42" font-weight="600">corpus</text><text x="57" y="54" font-size="7">code · docs</text>
+    <rect x="120" y="24" width="56" height="40" rx="5" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/><text x="148" y="48" font-weight="600">embed</text>
+    <rect x="206" y="18" width="92" height="52" rx="5" fill="currentColor" fill-opacity="0.16" stroke="currentColor" stroke-width="1.3"/><text x="252" y="40" font-weight="600">vector</text><text x="252" y="52">store</text>
+    <rect x="250" y="86" width="120" height="32" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="310" y="106" font-weight="600">nearest chunks</text>
+  </g>
+  <text x="57" y="142" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">per query</text>
+  <g text-anchor="middle" fill="currentColor" font-size="8">
+    <rect x="18" y="150" width="78" height="40" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="57" y="168" font-weight="600">question</text><text x="57" y="180" font-size="7">'control channel'</text>
+    <rect x="120" y="150" width="56" height="40" rx="5" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/><text x="148" y="174" font-weight="600">embed</text>
+    <rect x="250" y="150" width="140" height="40" rx="5" fill="currentColor" fill-opacity="0.16" stroke="currentColor" stroke-width="1.3"/><text x="320" y="168" font-weight="600">prompt</text><text x="320" y="180" font-size="7">question + chunks</text>
+    <rect x="398" y="150" width="70" height="40" rx="5" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/><text x="433" y="168" font-weight="600">model</text><text x="433" y="180" font-size="7">answer</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <line x1="96" y1="44" x2="120" y2="44" marker-end="url(#rag_ar)"/>
+    <line x1="176" y1="44" x2="206" y2="44" marker-end="url(#rag_ar)"/>
+    <line x1="252" y1="70" x2="300" y2="86" marker-end="url(#rag_ar)"/>
+    <line x1="310" y1="118" x2="320" y2="150" marker-end="url(#rag_ar)"/>
+    <line x1="96" y1="170" x2="120" y2="170" marker-end="url(#rag_ar)"/>
+    <line x1="176" y1="170" x2="240" y2="74" marker-end="url(#rag_ar)"/>
+    <line x1="390" y1="170" x2="398" y2="170" marker-end="url(#rag_ar)"/>
+  </g>
+  <text x="196" y="118" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.9">retrieve</text>
+  <text x="330" y="136" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.9">inject</text>
+  <defs><marker id="rag_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>RAG has two phases. Once, <strong>offline</strong>, every chunk of the corpus is embedded into a vector store. Then <strong>per question</strong> the query is embedded too, the nearest chunks are retrieved by vector similarity, and those few chunks are injected into the prompt so the model answers grounded in your content — never holding the whole corpus in context at once.</figcaption>
+</figure>
+
 ### Tools and MCP for live data
 
 Some context isn't a file at all — it's the current state of a database, a live API response, or today's open issues. **Tools** let a model reach out and fetch such things during a conversation. The **Model Context Protocol (MCP)** is an open standard for these connections: an MCP *server* exposes a source — files, docs, an API, a database, an issue tracker — through a common interface, and any MCP-aware client can use it. The point of a standard is leverage: expose your data source once, and every MCP-capable tool can read it, instead of writing custom glue for each tool. This is increasingly how an agent grounds itself in current, external reality rather than a static snapshot.

--- a/docs/learn/ai-software-dev/the-spectrum.md
+++ b/docs/learn/ai-software-dev/the-spectrum.md
@@ -36,6 +36,28 @@ Line the modes up and a pattern appears immediately. The thing that varies from 
 
 That's a smooth gradient from "your hands on every keystroke" to "your hands off entirely," not four unrelated boxes. You can even move along it within a single session: vibe-code a rough prototype, then drop back to chat to harden the part that matters, then use completion as you polish it line by line.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 464 168" role="img" aria-label="A delegation spectrum from you-drive to AI-drives across four modes — completion, chat, agentic, and vibe coding — where moving right increases speed and risk while decreasing how much you understand and review." xmlns="http://www.w3.org/2000/svg">
+  <line x1="34" y1="42" x2="430" y2="42" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#spec_ar)"/>
+  <text x="232" y="32" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">more delegated · faster · more risk</text>
+  <g text-anchor="middle" fill="currentColor">
+    <circle cx="70" cy="90" r="7" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="70" y="112" font-size="9" font-weight="600">Completion</text><text x="70" y="124" font-size="7.5" fill-opacity="0.85">you type</text>
+    <circle cx="180" cy="90" r="7" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="180" y="112" font-size="9" font-weight="600">Chat</text><text x="180" y="124" font-size="7.5" fill-opacity="0.85">you direct</text>
+    <circle cx="290" cy="90" r="7" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="290" y="112" font-size="9" font-weight="600">Agentic</text><text x="290" y="124" font-size="7.5" fill-opacity="0.85">you supervise</text>
+    <circle cx="400" cy="90" r="7" fill="currentColor" fill-opacity="0.35" stroke="currentColor" stroke-width="1.4"/><text x="400" y="112" font-size="9" font-weight="600">Vibe coding</text><text x="400" y="124" font-size="7.5" fill-opacity="0.85">AI runs</text>
+  </g>
+  <line x1="77" y1="90" x2="173" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <line x1="187" y1="90" x2="283" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <line x1="297" y1="90" x2="393" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <line x1="430" y1="138" x2="34" y2="138" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#spec_ar)"/>
+  <text x="232" y="152" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">more understanding · more control · you review more</text>
+  <text x="70" y="72" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">you drive</text>
+  <text x="400" y="72" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">AI drives</text>
+  <defs><marker id="spec_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Completion, chat, agentic, and vibe coding are one continuous <strong>spectrum of delegation</strong>, from "you drive" to "the AI drives." Moving right buys speed but costs understanding and adds risk, because you write and review less of what lands in the codebase. The skill is choosing the point that fits the task — not picking a favourite mode.</figcaption>
+</figure>
+
 ## The core trade-off
 
 Moving up the spectrum always trades the same currencies. It's worth stating bluntly because it's the heart of every choice you'll make:

--- a/docs/learn/ai-software-dev/types-of-models.md
+++ b/docs/learn/ai-software-dev/types-of-models.md
@@ -54,6 +54,35 @@ An **embedding model** does something that doesn't look like chatting at all. It
 
 That single trick powers **semantic search** and **retrieval-augmented generation (RAG)**. To find the most relevant docs for a question, you embed the question and compare its vector to the embedded documents, retrieving the closest ones by meaning rather than keyword. Then you hand those documents to an LLM as [context](/learn/ai-software-dev/context-windows/) — which is exactly the "give the model the right material" move we keep returning to, and which we'll build out in [Providing context](/learn/ai-software-dev/providing-context/). Embeddings don't talk to you; they're a **component** other systems are built from.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 240" role="img" aria-label="A two-dimensional sketch of a vector space in which texts about similar things cluster together: protocol terms in one group, antenna terms in another, memory terms in a third, with an embedded query point retrieving its two nearest neighbours." xmlns="http://www.w3.org/2000/svg">
+  <rect x="28" y="34" width="384" height="182" rx="4" fill="currentColor" fill-opacity="0.03" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <g stroke="currentColor" stroke-width="0.7" stroke-opacity="0.15">
+    <line x1="124" y1="34" x2="124" y2="216"/><line x1="220" y1="34" x2="220" y2="216"/><line x1="316" y1="34" x2="316" y2="216"/>
+    <line x1="28" y1="94" x2="412" y2="94"/><line x1="28" y1="155" x2="412" y2="155"/>
+  </g>
+  <text x="220" y="230" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">a 2-D sketch of a high-dimensional vector space</text>
+  <g fill="currentColor">
+    <text x="110" y="52" text-anchor="middle" font-size="8" font-weight="600">'P25' · 'DMR' · 'trunking'</text>
+    <circle cx="100" cy="74" r="4" fill-opacity="0.5"/><circle cx="122" cy="68" r="4" fill-opacity="0.5"/><circle cx="112" cy="94" r="4" fill-opacity="0.5"/><circle cx="132" cy="86" r="4" fill-opacity="0.5"/>
+    <text x="330" y="78" text-anchor="middle" font-size="8" font-weight="600">'antenna' · 'coax' · 'SWR'</text>
+    <circle cx="316" cy="100" r="4" fill-opacity="0.5"/><circle cx="340" cy="104" r="4" fill-opacity="0.5"/><circle cx="324" cy="124" r="4" fill-opacity="0.5"/><circle cx="346" cy="118" r="4" fill-opacity="0.5"/>
+    <text x="190" y="206" text-anchor="middle" font-size="8" font-weight="600">'malloc' · 'GC pause'</text>
+    <circle cx="178" cy="176" r="4" fill-opacity="0.5"/><circle cx="202" cy="184" r="4" fill-opacity="0.5"/><circle cx="186" cy="192" r="4" fill-opacity="0.5"/>
+  </g>
+  <circle cx="128" cy="112" r="38" fill="none" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 3" stroke-opacity="0.7"/>
+  <circle cx="128" cy="112" r="5.5" fill="currentColor" fill-opacity="0.9"/>
+  <text x="128" y="130" text-anchor="middle" font-size="7.5" fill="currentColor" font-weight="600">query</text>
+  <g stroke="currentColor" stroke-width="1.1" fill="none">
+    <line x1="128" y1="112" x2="114" y2="96" marker-end="url(#tom_ar)"/>
+    <line x1="128" y1="112" x2="132" y2="90" marker-end="url(#tom_ar)"/>
+  </g>
+  <text x="150" y="150" text-anchor="start" font-size="7" fill="currentColor" fill-opacity="0.9">retrieve nearest neighbours</text>
+  <defs><marker id="tom_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An embedding model places each piece of text at a point in a high-dimensional space (sketched here in 2-D) so that texts about similar things land near each other — protocol terms cluster apart from antenna terms. Embedding your question puts it in the same space; retrieving its nearest neighbours returns the most relevant chunks, which is the engine under semantic search and RAG.</figcaption>
+</figure>
+
 ## Multimodal and vision models
 
 A **multimodal** model accepts more than text — most usefully for developers, images. A **vision**-capable model can take a screenshot of a broken UI, a photo of a whiteboard architecture sketch, a diagram, or an error dialog, and reason about it alongside your words. You can paste a picture of a misaligned layout and ask what's wrong, or hand it a flowchart and ask for the code. Many leading chat models are now multimodal, so this is often a capability *of* an LLM rather than a wholly separate model.

--- a/docs/learn/git/branches.md
+++ b/docs/learn/git/branches.md
@@ -88,6 +88,41 @@ before:   C1 ── C2          after:   C1 ── C2 ── C3
                main                            main  ← HEAD
 ```
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 158" role="img" aria-label="Before and after making a commit. On the left, HEAD points at main which points at commit C2. On the right, a new commit C3 has been created with C2 as its parent, and the main pointer — with HEAD following it — has slid forward from C2 onto C3." xmlns="http://www.w3.org/2000/svg">
+  <text x="30" y="22" font-size="9" fill="currentColor" font-weight="600">before</text>
+  <text x="240" y="22" font-size="9" fill="currentColor" font-weight="600">after — commit, main slides forward</text>
+  <line x1="210" y1="12" x2="210" y2="146" stroke="currentColor" stroke-width="1" stroke-opacity="0.35" stroke-dasharray="4 3"/>
+  <line x1="116" y1="58" x2="60" y2="58" stroke="currentColor" stroke-width="1.4" fill="none" marker-end="url(#br_ar)"/>
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <circle cx="48" cy="58" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="48" y="61">C1</text>
+    <circle cx="128" cy="58" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="128" y="61">C2</text>
+  </g>
+  <g font-size="8.5" text-anchor="middle" font-weight="600">
+    <line x1="128" y1="70" x2="128" y2="88" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="96" y="88" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="128" y="100" fill="currentColor">main</text>
+    <line x1="128" y1="114" x2="128" y2="106" stroke="currentColor" stroke-width="1.2" marker-end="url(#br_ar)"/>
+    <rect x="96" y="114" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="128" y="126" fill="currentColor">HEAD</text>
+  </g>
+  <line x1="326" y1="58" x2="270" y2="58" stroke="currentColor" stroke-width="1.4" fill="none" marker-end="url(#br_ar)"/>
+  <line x1="406" y1="58" x2="350" y2="58" stroke="currentColor" stroke-width="1.4" fill="none" marker-end="url(#br_ar)"/>
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <circle cx="258" cy="58" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="258" y="61">C1</text>
+    <circle cx="338" cy="58" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="338" y="61">C2</text>
+    <circle cx="418" cy="58" r="12" fill="currentColor" fill-opacity="0.30" stroke="currentColor" stroke-width="1.6"/><text x="418" y="61">C3</text>
+  </g>
+  <text x="418" y="34" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">new</text>
+  <g font-size="8.5" text-anchor="middle" font-weight="600">
+    <line x1="418" y1="70" x2="418" y2="88" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="386" y="88" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="418" y="100" fill="currentColor">main</text>
+    <line x1="418" y1="114" x2="418" y2="106" stroke="currentColor" stroke-width="1.2" marker-end="url(#br_ar)"/>
+    <rect x="386" y="114" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="418" y="126" fill="currentColor">HEAD</text>
+  </g>
+  <defs><marker id="br_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Committing doesn't copy anything or rearrange history — Git adds one new commit whose parent is the old tip, then advances the current branch pointer onto it. <strong>HEAD</strong> is attached to <strong>main</strong>, so it follows along automatically. That single pointer move is the whole of "making progress" on a branch.</figcaption>
+</figure>
+
 Every commit you make slides the current branch pointer one step forward. Switch to a
 different branch and commit, and *that* branch's pointer moves instead — the two lines
 of work diverge from their shared history.

--- a/docs/learn/git/cherry-pick-bisect-reflog.md
+++ b/docs/learn/git/cherry-pick-bisect-reflog.md
@@ -89,6 +89,39 @@ Bisecting: 97 revisions left to test after this (roughly 7 steps)
 [c4d5e6f] Refactor session store
 ```
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 182" role="img" aria-label="A row of nine commits runs from a known good commit on the left to a known bad commit on the right. Three shrinking brackets below show git bisect testing the midpoint of the range and halving it each step, converging in about log base two N steps on the first bad commit." xmlns="http://www.w3.org/2000/svg">
+  <line x1="52" y1="52" x2="412" y2="52" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.4"/>
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <circle cx="40" cy="52" r="9" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="88" cy="52" r="9" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="136" cy="52" r="9" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="184" cy="52" r="9" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="232" cy="52" r="9" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="280" cy="52" r="9" fill="currentColor" fill-opacity="0.32" stroke="currentColor" stroke-width="1.7"/>
+    <circle cx="328" cy="52" r="9" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="376" cy="52" r="9" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <circle cx="424" cy="52" r="9" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+  </g>
+  <g font-size="8" text-anchor="middle" font-weight="600">
+    <line x1="40" y1="43" x2="40" y2="40" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="16" y="22" width="48" height="16" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="40" y="34" fill="currentColor">good ✓</text>
+    <line x1="424" y1="43" x2="424" y2="40" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="400" y="22" width="48" height="16" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="424" y="34" fill="currentColor">bad ✗</text>
+  </g>
+  <g stroke="currentColor" fill="currentColor" font-size="7.5">
+    <path d="M40 84 v5 M40 84 H424 M424 84 v5" stroke-width="1.1" fill="none" stroke-opacity="0.8"/>
+    <circle cx="232" cy="84" r="2.4" stroke="none"/><text x="232" y="79" text-anchor="middle" stroke="none">test 1 → good</text>
+    <path d="M232 108 v5 M232 108 H424 M424 108 v5" stroke-width="1.1" fill="none" stroke-opacity="0.8"/>
+    <circle cx="328" cy="108" r="2.4" stroke="none"/><text x="328" y="103" text-anchor="middle" stroke="none">test 2 → bad</text>
+    <path d="M232 132 v5 M232 132 H328 M328 132 v5" stroke-width="1.1" fill="none" stroke-opacity="0.8"/>
+    <circle cx="280" cy="132" r="2.4" stroke="none"/><text x="280" y="127" text-anchor="middle" stroke="none">test 3 → first bad</text>
+  </g>
+  <text x="235" y="170" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">each test halves the range · ~log₂N tests to pinpoint the culprit</text>
+</svg>
+<figcaption>You mark one <strong>good</strong> and one <strong>bad</strong> commit; Git checks out the midpoint, you test it, and it discards the half that can't contain the regression. Halving repeatedly finds the first bad commit in about <strong>log₂N</strong> steps — roughly 8 tests across 200 commits instead of 200.</figcaption>
+</figure>
+
 Build and test that checkout, then report the result. Git halves the range and checks out
 the next midpoint:
 

--- a/docs/learn/git/forking.md
+++ b/docs/learn/git/forking.md
@@ -108,6 +108,36 @@ project's `main`. That's the next lesson.
   upstream (original)  ◄── pull request ──  origin (your fork)  ◄── push ──  your laptop
 ```
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 176" role="img" aria-label="The fork and pull-request flow. Your laptop pushes to your fork, called origin, on GitHub. Your fork opens a pull request to the upstream original repository. A return arrow along the bottom shows git fetch upstream syncing changes from upstream back down to your laptop." xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <rect x="14" y="44" width="112" height="46" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/>
+    <rect x="179" y="44" width="112" height="46" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/>
+    <rect x="344" y="44" width="112" height="46" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/>
+  </g>
+  <g text-anchor="middle" fill="currentColor">
+    <text x="70" y="66" font-size="9" font-weight="600">your laptop</text>
+    <text x="70" y="80" font-size="8" fill-opacity="0.85">local clone</text>
+    <text x="235" y="66" font-size="9" font-weight="600">your fork</text>
+    <text x="235" y="80" font-size="8" fill-opacity="0.85">origin</text>
+    <text x="400" y="66" font-size="9" font-weight="600">upstream</text>
+    <text x="400" y="80" font-size="8" fill-opacity="0.85">the original</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.5" fill="none">
+    <line x1="126" y1="60" x2="176" y2="60" marker-end="url(#fork_ar)"/>
+    <line x1="291" y1="60" x2="341" y2="60" marker-end="url(#fork_ar)"/>
+    <path d="M400 90 V128 H70 V98" marker-end="url(#fork_ar)"/>
+  </g>
+  <g text-anchor="middle" fill="currentColor" font-size="8.5">
+    <text x="151" y="52">push</text>
+    <text x="316" y="52">pull request</text>
+    <text x="235" y="146">git fetch upstream — keep your fork in sync</text>
+  </g>
+  <defs><marker id="fork_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>You can't push to the original, so you push to your own <strong>fork</strong> (origin) and propose changes back with a <strong>pull request</strong>. Because the fork doesn't update itself, you periodically <strong>fetch upstream</strong> and merge or rebase its latest commits back down — the loop that keeps a long-lived fork current.</figcaption>
+</figure>
+
 ## Keeping a fork in sync
 
 Here's the catch with forks: **they don't update themselves**. While you work, the

--- a/docs/learn/git/git-mental-model.md
+++ b/docs/learn/git/git-mental-model.md
@@ -141,6 +141,39 @@ HEAD ─▶ main ─▶ D            "I'm on main, whose latest commit is D"
         feature ─▶ G
 ```
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 210" role="img" aria-label="A commit graph: commits A through D form the main line and commits E and F branch off commit B, each commit linked to its parent by an arrow. Small rounded pills labelled HEAD, main, feature, and a v1.0 tag point at individual commits, showing that branches, tags, and HEAD are just movable labels attached to commits." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="138" y1="120" x2="72" y2="120" marker-end="url(#mm_ar)"/>
+    <line x1="238" y1="120" x2="162" y2="120" marker-end="url(#mm_ar)"/>
+    <line x1="338" y1="120" x2="262" y2="120" marker-end="url(#mm_ar)"/>
+    <line x1="242" y1="64" x2="160" y2="110" marker-end="url(#mm_ar)"/>
+    <line x1="338" y1="56" x2="262" y2="56" marker-end="url(#mm_ar)"/>
+  </g>
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <circle cx="60" cy="120" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="60" y="123">A</text>
+    <circle cx="150" cy="120" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="150" y="123">B</text>
+    <circle cx="250" cy="120" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="250" y="123">C</text>
+    <circle cx="350" cy="120" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="350" y="123">D</text>
+    <circle cx="250" cy="56" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="250" y="59">E</text>
+    <circle cx="350" cy="56" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="350" y="59">F</text>
+  </g>
+  <g font-size="8.5" text-anchor="middle" font-weight="600">
+    <line x1="350" y1="44" x2="350" y2="36" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="318" y="18" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="350" y="30" fill="currentColor">feature</text>
+    <line x1="350" y1="132" x2="350" y2="150" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="318" y="150" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="350" y="162" fill="currentColor">main</text>
+    <rect x="236" y="150" width="58" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="265" y="162" fill="currentColor">HEAD</text>
+    <line x1="294" y1="159" x2="314" y2="159" stroke="currentColor" stroke-width="1.2" marker-end="url(#mm_ar)"/>
+    <line x1="150" y1="132" x2="150" y2="150" stroke="currentColor" stroke-width="1" stroke-opacity="0.6" stroke-dasharray="3 2"/>
+    <rect x="118" y="150" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1" stroke-dasharray="3 2"/><text x="150" y="162" fill="currentColor">tag v1.0</text>
+  </g>
+  <text x="230" y="192" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">every arrow points at a parent · every pill is just a label pointing at a commit</text>
+  <defs><marker id="mm_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Commits link to their parents to form the graph (a merge commit would point at two). Everything else — <strong>main</strong>, <strong>feature</strong>, the <strong>v1.0</strong> tag, and <strong>HEAD</strong> — is just a lightweight label pointing at one commit. HEAD points at the branch you're on; making a commit slides that branch's pill forward.</figcaption>
+</figure>
+
 Make a commit and Git creates the new snapshot, then nudges the current branch
 pointer forward to it. That's why creating a branch is instant: it writes a 41-byte
 file, not a copy of your project. These pointers are called **refs**, and you'll see

--- a/docs/learn/git/github-actions.md
+++ b/docs/learn/git/github-actions.md
@@ -75,6 +75,58 @@ The four nouns to know:
 | `runs-on:` | The **runner** OS image (`ubuntu-latest`, `windows-latest`, `macos-latest`) |
 | `steps:` | The ordered actions inside a job |
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 248" role="img" aria-label="A GitHub Actions pipeline. An on-push event triggers a workflow whose jobs build and test run in parallel; inside a job an ordered list of steps runs top to bottom — checkout, setup-node, npm ci, npm test. A matrix inset below shows one job expanded across a two-by-three matrix of operating systems and versions, producing six runs." xmlns="http://www.w3.org/2000/svg">
+  <rect x="14" y="42" width="84" height="30" rx="6" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+  <text x="56" y="61" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">on: push</text>
+  <line x1="98" y1="57" x2="138" y2="57" stroke="currentColor" stroke-width="1.5" fill="none" marker-end="url(#gha_ar)"/>
+  <text x="188" y="18" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">jobs — run in parallel</text>
+  <rect x="142" y="26" width="92" height="26" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+  <text x="188" y="43" text-anchor="middle" font-size="8.5" fill="currentColor">job: build</text>
+  <rect x="142" y="62" width="92" height="26" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+  <text x="188" y="79" text-anchor="middle" font-size="8.5" fill="currentColor">job: test</text>
+  <line x1="234" y1="75" x2="292" y2="66" stroke="currentColor" stroke-width="1.5" fill="none" marker-end="url(#gha_ar)"/>
+  <text x="262" y="60" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">steps</text>
+  <rect x="296" y="24" width="160" height="106" rx="6" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  <text x="376" y="40" text-anchor="middle" font-size="8.5" fill="currentColor" font-weight="600">steps — in order</text>
+  <line x1="312" y1="50" x2="312" y2="122" stroke="currentColor" stroke-width="1.3" fill="none" marker-end="url(#gha_ar)"/>
+  <g font-size="8.5" fill="currentColor">
+    <text x="322" y="58">uses: checkout</text>
+    <text x="322" y="80">uses: setup-node</text>
+    <text x="322" y="102">run: npm ci</text>
+    <text x="322" y="124">run: npm test</text>
+  </g>
+  <line x1="14" y1="150" x2="456" y2="150" stroke="currentColor" stroke-width="1" stroke-opacity="0.35" stroke-dasharray="4 3"/>
+  <text x="235" y="166" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">a matrix fans one job out across versions</text>
+  <rect x="16" y="188" width="78" height="30" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+  <text x="55" y="207" text-anchor="middle" font-size="8.5" fill="currentColor">1 job</text>
+  <text x="108" y="208" text-anchor="middle" font-size="12" fill="currentColor">×</text>
+  <g font-size="7.5" fill="currentColor" text-anchor="middle">
+    <text x="160" y="184">ubuntu</text>
+    <text x="214" y="184">windows</text>
+  </g>
+  <g font-size="7.5" fill="currentColor" text-anchor="end">
+    <text x="130" y="200">18</text>
+    <text x="130" y="218">20</text>
+    <text x="130" y="236">22</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1">
+    <rect x="136" y="188" width="48" height="16" rx="2" fill="currentColor" fill-opacity="0.15"/>
+    <rect x="190" y="188" width="48" height="16" rx="2" fill="currentColor" fill-opacity="0.15"/>
+    <rect x="136" y="206" width="48" height="16" rx="2" fill="currentColor" fill-opacity="0.15"/>
+    <rect x="190" y="206" width="48" height="16" rx="2" fill="currentColor" fill-opacity="0.15"/>
+    <rect x="136" y="224" width="48" height="16" rx="2" fill="currentColor" fill-opacity="0.15"/>
+    <rect x="190" y="224" width="48" height="16" rx="2" fill="currentColor" fill-opacity="0.15"/>
+  </g>
+  <text x="256" y="220" text-anchor="middle" font-size="12" fill="currentColor">=</text>
+  <rect x="274" y="196" width="80" height="36" rx="6" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.3"/>
+  <text x="314" y="214" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">6 runs</text>
+  <text x="314" y="227" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">2 × 3</text>
+  <defs><marker id="gha_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An event (<strong>on: push</strong>) triggers the workflow; its <strong>jobs</strong> run in parallel, and within each job the <strong>steps</strong> run in order — <code>checkout</code> first so the runner has your code. A <strong>matrix</strong> expands one job definition across every combination of values: two operating systems times three versions is six runs.</figcaption>
+</figure>
+
 ## Events: the `on:` trigger
 
 `on:` decides when a workflow runs. The common events:

--- a/docs/learn/git/interactive-rebase.md
+++ b/docs/learn/git/interactive-rebase.md
@@ -97,6 +97,39 @@ fixup m0n1o2p wip more
 pick q3r4s5t Add tests for login
 ```
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 176" role="img" aria-label="An interactive rebase todo list on the left holds five commits: one pick followed by three fixups, then another pick. An arrow labelled rebase dash i leads to the result on the right, where the three fixups have been folded into the commit above them, leaving just two clean commits." xmlns="http://www.w3.org/2000/svg">
+  <text x="18" y="20" font-size="9" fill="currentColor" font-weight="600">todo list (before)</text>
+  <g font-size="8.5">
+    <rect x="16" y="30" width="198" height="18" rx="3" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.4"/>
+    <rect x="22" y="33" width="38" height="12" rx="2" fill="currentColor" fill-opacity="0.20" stroke="currentColor" stroke-width="0.9"/><text x="41" y="42" text-anchor="middle" fill="currentColor" font-weight="600">pick</text>
+    <text x="66" y="42" fill="currentColor">Add login form</text>
+    <rect x="16" y="52" width="198" height="18" rx="3" fill="currentColor" fill-opacity="0.03" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.3" stroke-dasharray="3 2"/>
+    <rect x="30" y="55" width="38" height="12" rx="2" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="0.9" stroke-dasharray="3 2"/><text x="49" y="64" text-anchor="middle" fill="currentColor">fixup</text>
+    <text x="74" y="64" fill="currentColor" fill-opacity="0.6">wip</text>
+    <rect x="16" y="74" width="198" height="18" rx="3" fill="currentColor" fill-opacity="0.03" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.3" stroke-dasharray="3 2"/>
+    <rect x="30" y="77" width="38" height="12" rx="2" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="0.9" stroke-dasharray="3 2"/><text x="49" y="86" text-anchor="middle" fill="currentColor">fixup</text>
+    <text x="74" y="86" fill="currentColor" fill-opacity="0.6">fix typo</text>
+    <rect x="16" y="96" width="198" height="18" rx="3" fill="currentColor" fill-opacity="0.03" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.3" stroke-dasharray="3 2"/>
+    <rect x="30" y="99" width="38" height="12" rx="2" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="0.9" stroke-dasharray="3 2"/><text x="49" y="108" text-anchor="middle" fill="currentColor">fixup</text>
+    <text x="74" y="108" fill="currentColor" fill-opacity="0.6">wip more</text>
+    <rect x="16" y="118" width="198" height="18" rx="3" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.4"/>
+    <rect x="22" y="121" width="38" height="12" rx="2" fill="currentColor" fill-opacity="0.20" stroke="currentColor" stroke-width="0.9"/><text x="41" y="130" text-anchor="middle" fill="currentColor" font-weight="600">pick</text>
+    <text x="66" y="130" fill="currentColor">Add tests for login</text>
+  </g>
+  <line x1="222" y1="83" x2="288" y2="83" stroke="currentColor" stroke-width="1.4" fill="none" marker-end="url(#ireb_ar)"/>
+  <text x="255" y="76" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">rebase -i</text>
+  <text x="298" y="20" font-size="9" fill="currentColor" font-weight="600">clean history (after)</text>
+  <g font-size="8.5">
+    <rect x="296" y="56" width="158" height="26" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="375" y="72" text-anchor="middle" fill="currentColor" font-weight="600">Add login form</text>
+    <rect x="296" y="102" width="158" height="26" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="375" y="118" text-anchor="middle" fill="currentColor" font-weight="600">Add tests for login</text>
+  </g>
+  <text x="235" y="162" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">five messy commits → two clean ones · each survivor gets a new hash</text>
+  <defs><marker id="ireb_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Marking the three throwaway commits <strong>fixup</strong> melds each into the <strong>pick</strong> above it and discards its message. The five-line todo collapses to two coherent commits — the tidy, reviewable story you'd put in front of a teammate. (Use <strong>squash</strong> instead when a message is worth keeping.)</figcaption>
+</figure>
+
 Here the three throwaway commits melt into "Add login form" and their useless messages
 vanish. Use `squash` instead of `fixup` for any commit whose message is worth keeping —
 Git then opens an editor so you can write one combined message:

--- a/docs/learn/git/merge-conflicts.md
+++ b/docs/learn/git/merge-conflicts.md
@@ -70,6 +70,34 @@ retries: 3
 log_level: info
 ```
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 208" role="img" aria-label="A conflicted file with Git's three conflict markers. Between the marker less-than signs HEAD and the equals-sign divider is the current branch's version, bracketed and labelled ours. Between the divider and the greater-than signs feature-slash-login marker is the incoming branch's version, bracketed and labelled theirs. Lines outside the markers are unchanged context." xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="28" width="272" height="164" rx="5" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1" stroke-opacity="0.5"/>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10" fill="currentColor">
+    <text x="28" y="48" fill-opacity="0.5">timeout: 30</text>
+    <text x="28" y="67" font-weight="600">&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</text>
+    <text x="28" y="86">retries: 5</text>
+    <text x="28" y="105">backoff: exponential</text>
+    <text x="28" y="124" font-weight="600">=======</text>
+    <text x="28" y="143">retries: 3</text>
+    <text x="28" y="162" font-weight="600">&gt;&gt;&gt;&gt;&gt;&gt;&gt; feature/login</text>
+    <text x="28" y="181" fill-opacity="0.5">log_level: info</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <path d="M306 76 H298 V112 H306"/>
+    <path d="M306 133 H298 V151 H306"/>
+  </g>
+  <g fill="currentColor">
+    <text x="312" y="90" font-size="9" font-weight="600">ours</text>
+    <text x="312" y="102" font-size="7.5" fill-opacity="0.85">HEAD — your branch</text>
+    <text x="312" y="144" font-size="9" font-weight="600">theirs</text>
+    <text x="312" y="156" font-size="7.5" fill-opacity="0.85">the incoming branch</text>
+  </g>
+  <text x="152" y="205" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">delete all three marker lines and keep the text you actually want</text>
+</svg>
+<figcaption>Git wraps the disputed region in three markers. Everything from <strong>&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD</strong> to <strong>=======</strong> is <em>your</em> current branch's version; everything from there to <strong>&gt;&gt;&gt;&gt;&gt;&gt;&gt; feature/login</strong> is <em>theirs</em>. Lines outside the markers merged cleanly. Resolve by editing the region to its final form and deleting all three marker lines.</figcaption>
+</figure>
+
 Read it like this:
 
 | Section | Meaning |

--- a/docs/learn/git/merging.md
+++ b/docs/learn/git/merging.md
@@ -110,6 +110,40 @@ Merge made by the 'recursive' strategy.
 C1 ── C2 ── C5 ── C6 ── M   ← main
 ```
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 205" role="img" aria-label="A three-way merge. Commit C2 is the common merge base; from it the feature line (C3, C4) and the main line (C5, C6) have diverged. A merge commit M joins them, with arrows to two parents — the tip of main and the tip of feature — becoming the new tip of main." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="108" y1="120" x2="52" y2="120" marker-end="url(#mrg_ar)"/>
+    <line x1="198" y1="120" x2="132" y2="120" marker-end="url(#mrg_ar)"/>
+    <line x1="278" y1="120" x2="222" y2="120" marker-end="url(#mrg_ar)"/>
+    <line x1="200" y1="60" x2="133" y2="111" marker-end="url(#mrg_ar)"/>
+    <line x1="278" y1="56" x2="222" y2="56" marker-end="url(#mrg_ar)"/>
+    <line x1="369" y1="94" x2="302" y2="115" marker-end="url(#mrg_ar)"/>
+    <line x1="369" y1="82" x2="302" y2="61" marker-end="url(#mrg_ar)"/>
+  </g>
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <circle cx="40" cy="120" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="40" y="123">C1</text>
+    <circle cx="120" cy="120" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="120" y="123">C2</text>
+    <circle cx="210" cy="120" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="210" y="123">C5</text>
+    <circle cx="290" cy="120" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="290" y="123">C6</text>
+    <circle cx="210" cy="56" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="210" y="59">C3</text>
+    <circle cx="290" cy="56" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="290" y="59">C4</text>
+    <circle cx="380" cy="88" r="12" fill="currentColor" fill-opacity="0.30" stroke="currentColor" stroke-width="1.6"/><text x="380" y="91">M</text>
+  </g>
+  <g font-size="8.5" text-anchor="middle" font-weight="600">
+    <line x1="290" y1="44" x2="290" y2="36" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="258" y="18" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="290" y="30" fill="currentColor">feature</text>
+    <line x1="380" y1="100" x2="380" y2="110" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="348" y="110" width="64" height="18" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="380" y="122" fill="currentColor">main</text>
+    <line x1="120" y1="132" x2="120" y2="150" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="82" y="150" width="76" height="18" rx="4" fill="currentColor" fill-opacity="0.10" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 2"/><text x="120" y="162" fill="currentColor">merge base</text>
+  </g>
+  <text x="250" y="192" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">the merge commit M records two parents — one tip from each diverged branch</text>
+  <defs><marker id="mrg_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Because both lines gained commits after they split at the <strong>merge base</strong> (C2), Git can't just move a pointer. It compares each tip against that base, combines the two sets of changes, and records the result as a <strong>merge commit</strong> (M) with <strong>two parents</strong> — which is what a fork-and-rejoin looks like in the graph.</figcaption>
+</figure>
+
 If both sides changed the *same lines*, Git can't decide automatically and you get a
 [merge conflict](/learn/git/merge-conflicts/) — the subject of the next lesson.
 

--- a/docs/learn/git/rebasing.md
+++ b/docs/learn/git/rebasing.md
@@ -64,6 +64,56 @@ C1 ── C2 ── C5 ── C6 ── C3' ── C4'   ← feature
                   replayed, new hashes
 ```
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 188" role="img" aria-label="Before and after a rebase. Before, the feature commits C3 and C4 branch off C2 while main has advanced to C6. After, C3 and C4 have been lifted off their old base and replayed on top of C6 as new commits C3-prime and C4-prime, producing one straight linear history with new commit hashes." xmlns="http://www.w3.org/2000/svg">
+  <text x="24" y="20" font-size="9" fill="currentColor" font-weight="600">before</text>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="106" y1="88" x2="52" y2="88" marker-end="url(#reb_ar)"/>
+    <line x1="193" y1="88" x2="130" y2="88" marker-end="url(#reb_ar)"/>
+    <line x1="271" y1="88" x2="217" y2="88" marker-end="url(#reb_ar)"/>
+    <line x1="195" y1="44" x2="130" y2="80" marker-end="url(#reb_ar)"/>
+    <line x1="271" y1="42" x2="217" y2="42" marker-end="url(#reb_ar)"/>
+  </g>
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <circle cx="40" cy="88" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="40" y="91">C1</text>
+    <circle cx="118" cy="88" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="118" y="91">C2</text>
+    <circle cx="205" cy="88" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="205" y="91">C5</text>
+    <circle cx="283" cy="88" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="283" y="91">C6</text>
+    <circle cx="205" cy="42" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="205" y="45">C3</text>
+    <circle cx="283" cy="42" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="283" y="45">C4</text>
+  </g>
+  <g font-size="8.5" text-anchor="middle" font-weight="600">
+    <line x1="283" y1="24" x2="283" y2="30" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="251" y="8" width="64" height="16" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="283" y="20" fill="currentColor">feature</text>
+    <line x1="283" y1="100" x2="283" y2="108" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+    <rect x="251" y="108" width="64" height="16" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="283" y="120" fill="currentColor">main</text>
+  </g>
+  <line x1="14" y1="134" x2="456" y2="134" stroke="currentColor" stroke-width="1" stroke-opacity="0.35" stroke-dasharray="4 3"/>
+  <text x="24" y="150" font-size="9" fill="currentColor" font-weight="600">after — replayed onto main, new hashes</text>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="104" y1="164" x2="52" y2="164" marker-end="url(#reb_ar)"/>
+    <line x1="180" y1="164" x2="128" y2="164" marker-end="url(#reb_ar)"/>
+    <line x1="256" y1="164" x2="204" y2="164" marker-end="url(#reb_ar)"/>
+    <line x1="332" y1="164" x2="280" y2="164" marker-end="url(#reb_ar)"/>
+    <line x1="408" y1="164" x2="356" y2="164" marker-end="url(#reb_ar)"/>
+  </g>
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <circle cx="40" cy="164" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="40" y="167">C1</text>
+    <circle cx="116" cy="164" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="116" y="167">C2</text>
+    <circle cx="192" cy="164" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="192" y="167">C5</text>
+    <circle cx="268" cy="164" r="12" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/><text x="268" y="167">C6</text>
+    <circle cx="344" cy="164" r="12" fill="currentColor" fill-opacity="0.30" stroke="currentColor" stroke-width="1.6"/><text x="344" y="167" font-size="8">C3'</text>
+    <circle cx="420" cy="164" r="12" fill="currentColor" fill-opacity="0.30" stroke="currentColor" stroke-width="1.6"/><text x="420" y="167" font-size="8">C4'</text>
+  </g>
+  <g font-size="8.5" text-anchor="middle" font-weight="600">
+    <rect x="388" y="124" width="64" height="16" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="420" y="136" fill="currentColor">feature</text>
+    <line x1="420" y1="140" x2="420" y2="150" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  </g>
+  <defs><marker id="reb_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Rebase sets your feature commits aside, moves the branch to the tip of <strong>main</strong> (C6), then replays each one on top. The changes are the same but every replayed commit gets a <strong>new hash</strong> — C3′, C4′ — so the originals are abandoned and history becomes one clean straight line.</figcaption>
+</figure>
+
 Notice `C3'` and `C4'` — the prime marks matter. Because each replayed commit now has a
 *different parent*, Git computes a **new hash** for it. The original `C3`/`C4` are
 abandoned. Same changes, brand-new commits, perfectly linear result.

--- a/docs/learn/git/undoing-changes.md
+++ b/docs/learn/git/undoing-changes.md
@@ -78,6 +78,39 @@ index, and the working tree.
 | `--mixed` *(default)* | yes | yes | no | undone changes become **unstaged** |
 | `--hard` | yes | yes | yes | undone changes are **discarded** |
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 210" role="img" aria-label="A grid of three git reset modes against Git's three trees. Rows are reset dash dash soft, dash dash mixed, and dash dash hard; columns are HEAD, the index or staging area, and the working tree. Filled cells show which trees each mode resets: soft reaches only HEAD, mixed also resets the index, and hard resets all three, forming a staircase of increasing reach." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="9" text-anchor="middle" font-weight="600">
+    <text x="162" y="38">HEAD</text>
+    <text x="258" y="38">Index</text>
+    <text x="354" y="38">Working tree</text>
+  </g>
+  <g fill="currentColor" font-size="9" text-anchor="end">
+    <text x="108" y="72">--soft</text>
+    <text x="108" y="110">--mixed</text>
+    <text x="108" y="148">--hard</text>
+  </g>
+  <g stroke="currentColor">
+    <rect x="118" y="52" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="214" y="52" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+    <rect x="310" y="52" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+    <rect x="118" y="90" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="214" y="90" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="310" y="90" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+    <rect x="118" y="128" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="214" y="128" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="310" y="128" width="88" height="32" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+  </g>
+  <g font-size="8" fill="currentColor">
+    <rect x="118" y="180" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <text x="138" y="190" text-anchor="start">resets this tree</text>
+    <rect x="250" y="180" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+    <text x="270" y="190" text-anchor="start">left untouched</text>
+  </g>
+</svg>
+<figcaption>All three modes move <strong>HEAD</strong> back; they differ in how far the reset reaches. <strong>--soft</strong> stops at HEAD (your changes stay staged), <strong>--mixed</strong> also resets the index (changes become unstaged), and <strong>--hard</strong> resets the working tree too — the only mode that discards your files. Reach grows one tree per step.</figcaption>
+</figure>
+
 ```bash
 # Undo the last commit but keep everything staged (e.g. to re-commit)
 $ git reset --soft HEAD~1

--- a/docs/learn/intro-hardware/building-blocks.md
+++ b/docs/learn/intro-hardware/building-blocks.md
@@ -67,7 +67,44 @@ I/O is often what actually decides which machine fits a job. A Raspberry Pi runn
 
 ## Putting it together across the spectrum
 
-Each block scales independently, but they tend to move together: powerful machines have lots of everything, tiny ones have little of anything. Here's the rough shape of it, from largest to smallest:
+Each block scales independently, but they tend to move together: powerful machines have lots of everything, tiny ones have little of anything.
+
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="A block diagram of the four building blocks. Storage on the left loads programs into RAM in the middle, which the CPU on the right fetches and runs; the CPU also exchanges data with input and output below it. Storage is non-volatile and keeps its contents with the power off, while RAM is volatile and clears when the power is cut." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="112" height="58" rx="6" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/>
+    <text x="76" y="78" font-weight="600">Storage</text>
+    <text x="76" y="94" font-size="8">non-volatile</text>
+    <rect x="174" y="52" width="112" height="58" rx="6" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+    <text x="230" y="78" font-weight="600">RAM</text>
+    <text x="230" y="94" font-size="8">volatile · working</text>
+    <rect x="328" y="52" width="112" height="58" rx="6" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.3"/>
+    <text x="384" y="78" font-weight="600">CPU</text>
+    <text x="384" y="94" font-size="8">runs instructions</text>
+    <rect x="328" y="140" width="112" height="42" rx="6" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.2"/>
+    <text x="384" y="160" font-weight="600" font-size="9">I/O</text>
+    <text x="384" y="173" font-size="8">USB · net · GPIO</text>
+  </g>
+  <g stroke="currentColor" fill="none">
+    <line x1="132" y1="74" x2="174" y2="74" stroke-width="1.6" marker-end="url(#bb_ar)"/>
+    <line x1="286" y1="74" x2="328" y2="74" stroke-width="1.6" marker-end="url(#bb_ar)"/>
+    <line x1="384" y1="110" x2="384" y2="140" stroke-width="1.4" marker-end="url(#bb_ar)"/>
+    <line x1="374" y1="140" x2="374" y2="110" stroke-width="1.4" marker-end="url(#bb_ar)"/>
+  </g>
+  <g fill="currentColor" text-anchor="middle" font-size="7.5" fill-opacity="0.9">
+    <text x="153" y="68">load</text>
+    <text x="307" y="68">fetch</text>
+  </g>
+  <g fill="currentColor" text-anchor="middle" font-size="8" fill-opacity="0.75">
+    <text x="76" y="126">kept when power off</text>
+    <text x="230" y="126">wiped when power off</text>
+  </g>
+  <defs><marker id="bb_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The four parts and how data moves between them. A program lives permanently in storage, is loaded into fast volatile RAM to run, and the CPU fetches and executes it while trading data with I/O. Cut the power and RAM empties; storage keeps everything — that volatile-versus-permanent split is the whole reason both exist.</figcaption>
+</figure>
+
+Here's the rough shape of it, from largest to smallest:
 
 | Platform | Typical RAM | Typical storage | Typical I/O |
 |----------|-------------|-----------------|-------------|

--- a/docs/learn/intro-hardware/combining-tiers.md
+++ b/docs/learn/intro-hardware/combining-tiers.md
@@ -34,6 +34,40 @@ Think of hardware in a real system as three rough tiers, from the physical world
 
 Not every system needs all three. A single sensor reporting to a phone is one tier and a half. But once a project has several devices, or needs both local responsiveness and remote access, the layering pays off.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 190" role="img" aria-label="Three tiers side by side — edge devices such as sensors and microcontrollers on the left, a gateway like a Raspberry Pi or home server in the middle, and the cloud on the right. Paired arrows between each tier show raw data flowing up toward the cloud and results or commands flowing back down toward the edge." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="16" y="62" width="104" height="62" rx="6" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/>
+    <text x="68" y="86" font-weight="600">Edge</text>
+    <text x="68" y="101" font-size="8">sensors · MCUs</text>
+    <text x="68" y="113" font-size="8">physically there</text>
+    <rect x="178" y="62" width="104" height="62" rx="6" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+    <text x="230" y="86" font-weight="600">Gateway</text>
+    <text x="230" y="101" font-size="8">Pi / home server</text>
+    <text x="230" y="113" font-size="8">aggregates</text>
+    <rect x="340" y="62" width="104" height="62" rx="6" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/>
+    <text x="392" y="86" font-weight="600">Cloud</text>
+    <text x="392" y="101" font-size="8">storage · remote</text>
+    <text x="392" y="113" font-size="8">reach anywhere</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.5">
+    <line x1="120" y1="82" x2="178" y2="82" marker-end="url(#ct_ar)"/>
+    <line x1="178" y1="104" x2="120" y2="104" marker-end="url(#ct_ar)"/>
+    <line x1="282" y1="82" x2="340" y2="82" marker-end="url(#ct_ar)"/>
+    <line x1="340" y1="104" x2="282" y2="104" marker-end="url(#ct_ar)"/>
+  </g>
+  <g fill="currentColor" text-anchor="middle" font-size="7.5" fill-opacity="0.9">
+    <text x="149" y="76">data up</text>
+    <text x="149" y="119">commands down</text>
+    <text x="311" y="76">data up</text>
+    <text x="311" y="119">results down</text>
+  </g>
+  <text x="230" y="38" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">edge → gateway → cloud</text>
+  <defs><marker id="ct_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A real system is layered, not single-tier. Raw, high-rate data flows up from the physically-present edge to a gateway that aggregates it and on to the cloud; results and commands flow back down. Each tier does what it is best at, and the middle keeps working even when the link to the cloud drops.</figcaption>
+</figure>
+
 ## Edge vs cloud: why work moves
 
 The central decision in a layered system is *where each piece of work runs*. Five forces pull the answer one way or the other:

--- a/docs/learn/intro-hardware/cost-power-performance.md
+++ b/docs/learn/intro-hardware/cost-power-performance.md
@@ -56,6 +56,48 @@ Rent cloud hosting and you control little — but the provider handles the hardw
 
 The reason hardware choice is interesting — and why there's no universal best answer — is that these axes fight one another. You rarely improve one without giving ground on another:
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 214" role="img" aria-label="Five trade-off axes — cost, power draw, performance, control, and effort — drawn as horizontal spectra either side of a central dividing line. Two opposing arrows at the top pull toward a frugal, low-effort left pole and a powerful, high-control right pole, and a shared vertical position line shows the five axes are coupled, so pulling toward one pole drags every axis with it." xmlns="http://www.w3.org/2000/svg">
+  <line x1="230" y1="52" x2="34" y2="52" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#cpp_ar)"/>
+  <line x1="230" y1="52" x2="426" y2="52" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#cpp_ar)"/>
+  <text x="130" y="44" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">cheaper · frugal · less effort</text>
+  <text x="330" y="44" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">more power · control · cost</text>
+  <line x1="230" y1="64" x2="230" y2="200" stroke="currentColor" stroke-width="1" stroke-opacity="0.4" stroke-dasharray="4 3"/>
+  <g fill="currentColor" font-size="8.5">
+    <g>
+      <text x="14" y="80" font-weight="600">Cost</text>
+      <text x="222" y="80" text-anchor="end" font-size="7.5" fill-opacity="0.8">low upfront</text>
+      <text x="238" y="80" text-anchor="start" font-size="7.5" fill-opacity="0.8">high upfront</text>
+    </g>
+    <g>
+      <text x="14" y="108" font-weight="600">Power draw</text>
+      <text x="222" y="108" text-anchor="end" font-size="7.5" fill-opacity="0.8">milliwatts</text>
+      <text x="238" y="108" text-anchor="start" font-size="7.5" fill-opacity="0.8">always-on watts</text>
+    </g>
+    <g>
+      <text x="14" y="136" font-weight="600">Performance</text>
+      <text x="222" y="136" text-anchor="end" font-size="7.5" fill-opacity="0.8">just enough</text>
+      <text x="238" y="136" text-anchor="start" font-size="7.5" fill-opacity="0.8">abundant</text>
+    </g>
+    <g>
+      <text x="14" y="164" font-weight="600">Control</text>
+      <text x="222" y="164" text-anchor="end" font-size="7.5" fill-opacity="0.8">managed for you</text>
+      <text x="238" y="164" text-anchor="start" font-size="7.5" fill-opacity="0.8">all yours</text>
+    </g>
+    <g>
+      <text x="14" y="192" font-weight="600">Effort</text>
+      <text x="222" y="192" text-anchor="end" font-size="7.5" fill-opacity="0.8">minimal</text>
+      <text x="238" y="192" text-anchor="start" font-size="7.5" fill-opacity="0.8">hands-on</text>
+    </g>
+  </g>
+  <g fill="currentColor">
+    <circle cx="230" cy="76" r="3"/><circle cx="230" cy="104" r="3"/><circle cx="230" cy="132" r="3"/><circle cx="230" cy="160" r="3"/><circle cx="230" cy="188" r="3"/>
+  </g>
+  <defs><marker id="cpp_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Five axes, two poles. You'd love the left of cost, power, and effort but the right of performance and control — and the coupling line shows why you can't have both: sliding toward one pole drags every axis with it. Gaining capability costs money, watts, and work; going frugal gives some up.</figcaption>
+</figure>
+
 | Axis | Cheap end | Expensive / demanding end | The tension |
 |------|-----------|----------------------------|-------------|
 | **Cost** | Low upfront (cloud, MCU) | High upfront (owned server) | Pay now or pay forever |

--- a/docs/learn/intro-hardware/hardware-spectrum.md
+++ b/docs/learn/intro-hardware/hardware-spectrum.md
@@ -32,6 +32,28 @@ Here is the full range, ordered from the most powerful and abstract down to the 
 
 At the top, you don't own a machine at all — you rent a slice of someone else's, and they handle the physical hardware. In the middle sit the personal computers most people picture. Toward the bottom, the machines get small, cheap, and physical: boards you hold in your hand and wire to the world. Nothing about this is a quality ranking. It's a map of trade-offs, and which end you reach for depends entirely on what you're building.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 182" role="img" aria-label="Eight computing platforms laid on one spectrum line — cloud, VPS, server, desktop, laptop, phone, single-board computer, and microcontroller — read with two opposing axes: raw power and capability grow toward the cloud end on the left, while control, low cost, and low power grow toward the microcontroller end on the right." xmlns="http://www.w3.org/2000/svg">
+  <line x1="446" y1="46" x2="34" y2="46" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#hws_ar)"/>
+  <text x="240" y="37" text-anchor="middle" font-size="9" fill="currentColor" fill-opacity="0.9">more raw power · capability</text>
+  <line x1="40" y1="96" x2="440" y2="96" stroke="currentColor" stroke-width="1" stroke-opacity="0.35"/>
+  <g text-anchor="middle" fill="currentColor" font-size="8.5">
+    <circle cx="40" cy="96" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="40" y="115" font-weight="600">cloud</text>
+    <circle cx="97" cy="96" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="97" y="115" font-weight="600">VPS</text>
+    <circle cx="154" cy="96" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="154" y="115" font-weight="600">server</text>
+    <circle cx="211" cy="96" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="211" y="115" font-weight="600">desktop</text>
+    <circle cx="269" cy="96" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="269" y="115" font-weight="600">laptop</text>
+    <circle cx="326" cy="96" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="326" y="115" font-weight="600">phone</text>
+    <circle cx="383" cy="96" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="383" y="115" font-weight="600">SBC</text>
+    <circle cx="440" cy="96" r="6.5" fill="currentColor" fill-opacity="0.35" stroke="currentColor" stroke-width="1.4"/><text x="440" y="115" font-weight="600">MCU</text>
+  </g>
+  <line x1="34" y1="150" x2="446" y2="150" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#hws_ar)"/>
+  <text x="240" y="168" text-anchor="middle" font-size="9" fill="currentColor" fill-opacity="0.9">more control · cheaper · lower power · yours to manage</text>
+  <defs><marker id="hws_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The whole path on one line. Read left to right, power and capability fall away while control, low cost, and low power draw rise — the two axes pull in opposite directions, which is why there's no single best platform, only the best fit for a job's constraints.</figcaption>
+</figure>
+
 ## Ordering by raw power
 
 The most obvious way to read the spectrum is by capability — CPU, memory, storage, and how much work the machine can do at once. This tracks closely with the building blocks from the last lesson.

--- a/docs/learn/intro-hardware/what-is-a-microcontroller.md
+++ b/docs/learn/intro-hardware/what-is-a-microcontroller.md
@@ -26,6 +26,29 @@ This module zooms all the way down to the smallest computers in the path. After 
 
 A **microcontroller**, or **MCU**, packs everything a computer needs onto a single piece of silicon: a processor to do the work, a small amount of RAM for working data, flash memory to hold the program, and a set of built-in **peripherals** — the hardware blocks that read sensors, drive pins, talk to other chips, and keep time. Plug in power and it runs.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 208" role="img" aria-label="On the left, one microcontroller die enclosing a CPU, RAM, flash, and peripherals as blocks on a single chip that runs bare-metal with no operating system. On the right, a single-board computer for contrast, drawn as a separate system-on-chip plus a separate removable storage card wired together." xmlns="http://www.w3.org/2000/svg">
+  <text x="116" y="26" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Microcontroller (MCU)</text>
+  <rect x="18" y="38" width="196" height="152" rx="10" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.6"/>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="34" y="56" width="76" height="42" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="72" y="81">CPU</text>
+    <rect x="122" y="56" width="76" height="42" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="160" y="81">RAM</text>
+    <rect x="34" y="106" width="76" height="42" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="72" y="131">flash</text>
+    <rect x="122" y="106" width="76" height="42" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="160" y="127">peripherals</text><text x="160" y="139" font-size="7">pins · timers</text>
+    <text x="116" y="176" font-size="8" fill-opacity="0.85">one chip · bare-metal · no OS</text>
+  </g>
+  <line x1="234" y1="44" x2="234" y2="184" stroke="currentColor" stroke-width="1" stroke-opacity="0.35" stroke-dasharray="4 3"/>
+  <text x="346" y="26" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Single-board computer</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="286" y="52" width="120" height="52" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/><text x="346" y="76">SoC</text><text x="346" y="90" font-size="7.5">CPU · GPU · RAM</text>
+    <rect x="286" y="132" width="120" height="42" rx="6" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.2" stroke-dasharray="5 3"/><text x="346" y="152">SD / eMMC card</text><text x="346" y="165" font-size="7.5">separate storage</text>
+  </g>
+  <line x1="346" y1="104" x2="346" y2="132" stroke="currentColor" stroke-width="1.4" marker-end="url(#mcu_ar)"/>
+  <defs><marker id="mcu_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An MCU folds the whole computer — CPU, RAM, flash, and peripherals — onto one die, running your program bare-metal with no operating system. An SBC keeps its parts separate: a system-on-chip plus a removable storage card holding a full OS. That integration is what makes the MCU cheap, tiny, and instant to boot.</figcaption>
+</figure>
+
 That integration is the whole point. A desktop CPU needs separate memory sticks, a storage drive, and a motherboard full of support chips. An MCU folds all of that into one part you can buy for a dollar or two. Common families you'll meet are Microchip's 8-bit **ATmega** (the classic Arduino brain), the huge range of 32-bit **ARM Cortex-M** chips, the Raspberry Pi Foundation's **RP2040**, and Espressif's Wi-Fi-capable **ESP** chips.
 
 Because the chip *is* the computer, you measure it in units that would be rounding errors on a laptop: kilobytes of RAM rather than gigabytes, megahertz rather than gigahertz, and milliwatts or even microwatts rather than watts. That smallness is a feature, not a limitation — it's what lets the same chip live inside a coin-cell-powered sensor for years.

--- a/docs/learn/intro-software-dev/architectural-patterns.md
+++ b/docs/learn/intro-software-dev/architectural-patterns.md
@@ -34,6 +34,38 @@ A **layered** (or *n-tier*) architecture organizes the system into horizontal la
 
 The rule that makes it work is *directional dependency*: the UI calls the logic, the logic calls the data, and nothing calls upward. Because each layer talks only to its neighbour through a defined interface, you can replace one (swap a web UI for a CLI, swap one database for another) without disturbing the rest. This is the system-scale version of the [abstraction and coupling](/learn/intro-software-dev/abstraction-coupling/) ideas: clear boundaries, dependencies pointing one way. The cost is that a request often passes through every layer, which adds some ceremony for trivial operations — but the structure keeps a growing codebase comprehensible.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 464 210" role="img" aria-label="On the left a layered architecture stacks presentation, business logic, and data with dependency arrows pointing only downward; on the right a small scanner core with P25, DMR, and NXDN decoder plugins registering through one shared interface." xmlns="http://www.w3.org/2000/svg">
+  <text x="138" y="24" text-anchor="middle" font-size="9" font-weight="600" fill="currentColor">Layered — depend downward</text>
+  <g text-anchor="middle" fill="currentColor">
+    <rect x="48" y="40" width="180" height="42" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.2"/><text x="138" y="60" font-size="9" font-weight="600">Presentation (UI)</text><text x="138" y="73" font-size="7.5" fill-opacity="0.85">dashboard · CLI</text>
+    <rect x="48" y="98" width="180" height="42" rx="5" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.2"/><text x="138" y="118" font-size="9" font-weight="600">Business logic</text><text x="138" y="131" font-size="7.5" fill-opacity="0.85">trunk-follow · filtering</text>
+    <rect x="48" y="156" width="180" height="42" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="138" y="176" font-size="9" font-weight="600">Data</text><text x="138" y="189" font-size="7.5" fill-opacity="0.85">call DB · config</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="138" y1="82" x2="138" y2="98" marker-end="url(#arch_ar)"/>
+    <line x1="138" y1="140" x2="138" y2="156" marker-end="url(#arch_ar)"/>
+  </g>
+  <text x="176" y="93" text-anchor="start" font-size="7" fill="currentColor" fill-opacity="0.85">uses</text>
+  <text x="176" y="151" text-anchor="start" font-size="7" fill="currentColor" fill-opacity="0.85">uses</text>
+  <text x="360" y="24" text-anchor="middle" font-size="9" font-weight="600" fill="currentColor">Plugin — core plus modules</text>
+  <rect x="300" y="92" width="120" height="40" rx="5" fill="currentColor" fill-opacity="0.16" stroke="currentColor" stroke-width="1.3"/><text x="360" y="112" text-anchor="middle" font-size="9" font-weight="600" fill="currentColor">scanner core</text><text x="360" y="124" text-anchor="middle" font-size="6.8" fill="currentColor" fill-opacity="0.85">knows only the interface</text>
+  <g text-anchor="middle" fill="currentColor" font-size="8">
+    <rect x="300" y="160" width="36" height="28" rx="3" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="318" y="178">P25</text>
+    <rect x="342" y="160" width="36" height="28" rx="3" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="360" y="178">DMR</text>
+    <rect x="384" y="160" width="36" height="28" rx="3" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="402" y="178" font-size="7.5">NXDN</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" fill="none">
+    <line x1="318" y1="160" x2="345" y2="132" marker-end="url(#arch_ar)"/>
+    <line x1="360" y1="160" x2="360" y2="132" marker-end="url(#arch_ar)"/>
+    <line x1="402" y1="160" x2="375" y2="132" marker-end="url(#arch_ar)"/>
+  </g>
+  <text x="360" y="202" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">new protocol = new plugin, core unchanged</text>
+  <defs><marker id="arch_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A <strong>layered</strong> architecture stacks responsibilities so each layer depends only on the one beneath it — the UI calls the logic, the logic calls the data, and nothing calls upward — which lets any layer be swapped behind its interface. The <strong>plugin (microkernel)</strong> idea is the complement: a small stable core plus decoders that register through one interface, so a new protocol is added without touching the core.</figcaption>
+</figure>
+
 ## Client-server
 
 In a **client-server** architecture, work is split between **clients** that request services and a **server** that provides them, communicating over a network. The server centralizes shared resources and logic; many clients connect to it. The web is the giant example: browsers (clients) request pages from web servers.

--- a/docs/learn/intro-software-dev/compiled-vs-interpreted.md
+++ b/docs/learn/intro-software-dev/compiled-vs-interpreted.md
@@ -140,6 +140,40 @@ runtime optimises, predicts the speed, startup and distribution characteristics
 better than any single label. When you read that a language is "fast" or "slow",
 ask *which* of these stages it is doing and *when*.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 476 214" role="img" aria-label="Three translation paths compared across a build-time and run-time divider: ahead-of-time compilation turns source to a native binary before running; a bytecode VM translates on the fly every run; and a JIT ships bytecode but compiles hot paths to native while the program runs." xmlns="http://www.w3.org/2000/svg">
+  <line x1="300" y1="36" x2="300" y2="206" stroke="currentColor" stroke-width="1.1" stroke-dasharray="5 4" stroke-opacity="0.6"/>
+  <text x="176" y="30" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">before run · build time</text>
+  <text x="388" y="30" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">during run · run time</text>
+  <g text-anchor="middle" fill="currentColor" font-size="7">
+    <text x="30" y="62" font-size="8.5" font-weight="600">AOT</text><text x="30" y="72">C·Go·Rust</text>
+    <text x="30" y="122" font-size="8.5" font-weight="600">VM</text><text x="30" y="132">Python</text>
+    <text x="30" y="182" font-size="8.5" font-weight="600">JIT</text><text x="30" y="192">JVM·V8</text>
+  </g>
+  <g text-anchor="middle" font-size="8" fill="currentColor">
+    <rect x="68" y="44" width="46" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="91" y="63">source</text>
+    <rect x="124" y="44" width="60" height="30" rx="4" fill="currentColor" fill-opacity="0.24" stroke="currentColor" stroke-width="1.3"/><text x="154" y="60" font-weight="600">compiler</text><text x="154" y="70" font-size="6.5">translate</text>
+    <rect x="196" y="44" width="66" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="229" y="60">native</text><text x="229" y="70" font-size="7">binary</text>
+    <rect x="410" y="44" width="52" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="436" y="63">CPU</text>
+    <rect x="68" y="104" width="46" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="91" y="123">source</text>
+    <rect x="124" y="104" width="60" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="154" y="123">bytecode</text>
+    <rect x="318" y="104" width="120" height="30" rx="4" fill="currentColor" fill-opacity="0.24" stroke="currentColor" stroke-width="1.3"/><text x="378" y="120" font-weight="600">VM interprets</text><text x="378" y="130" font-size="6.5">translate each run</text>
+    <rect x="68" y="164" width="56" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="96" y="183">bytecode</text>
+    <rect x="318" y="164" width="120" height="30" rx="4" fill="currentColor" fill-opacity="0.24" stroke="currentColor" stroke-width="1.3"/><text x="378" y="180" font-weight="600">VM · JIT</text><text x="378" y="190" font-size="6.5">hot paths to native, mid-run</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <line x1="114" y1="59" x2="124" y2="59" marker-end="url(#ci_ar)"/>
+    <line x1="184" y1="59" x2="196" y2="59" marker-end="url(#ci_ar)"/>
+    <line x1="262" y1="59" x2="410" y2="59" marker-end="url(#ci_ar)"/>
+    <line x1="114" y1="119" x2="124" y2="119" marker-end="url(#ci_ar)"/>
+    <line x1="184" y1="119" x2="318" y2="119" marker-end="url(#ci_ar)"/>
+    <line x1="124" y1="179" x2="318" y2="179" marker-end="url(#ci_ar)"/>
+  </g>
+  <defs><marker id="ci_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The useful question isn't which box a language sits in but <strong>where translation to machine code happens</strong>. An ahead-of-time compiler does it once at build time, so the CPU later runs native code directly. A bytecode VM translates on the fly, every run. A JIT ships bytecode but compiles the hot paths to native while the program runs — portability up front, near-native speed once warmed up.</figcaption>
+</figure>
+
 ## Why this matters for GopherTrunk
 
 Two concerns from radio software make the choice concrete.

--- a/docs/learn/intro-software-dev/concurrency-and-pipelines.md
+++ b/docs/learn/intro-software-dev/concurrency-and-pipelines.md
@@ -39,6 +39,40 @@ Each arrow is a queue; each box is a stage running on its own thread or task. Wh
 - **Separation of concerns.** Each stage does one job and knows nothing about its neighbours except the data format on the queue — very low coupling.
 - **Composability.** Insert, remove, or swap a stage (add a new filter, change the demodulator) by rewiring queues, not rewriting the whole flow.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 472 150" role="img" aria-label="A dataflow pipeline of four concurrent stages — capture, filter, demodulate, and decode — joined by bounded queues; the queue feeding the slow decode stage is full, and a feedback arrow shows backpressure forcing the upstream demodulate stage to wait." xmlns="http://www.w3.org/2000/svg">
+  <text x="236" y="22" text-anchor="middle" font-size="9" fill="currentColor" fill-opacity="0.9">each box a concurrent stage · each arrow a bounded queue</text>
+  <g font-size="9.5" text-anchor="middle" fill="currentColor">
+    <rect x="16" y="52" width="74" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="53" y="71" font-weight="600">capture</text><text x="53" y="83" font-size="7.5" fill-opacity="0.85">SDR</text>
+    <rect x="138" y="52" width="74" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="175" y="71" font-weight="600">filter</text><text x="175" y="83" font-size="7.5" fill-opacity="0.85">decimate</text>
+    <rect x="260" y="52" width="74" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="297" y="71" font-weight="600">demod</text><text x="297" y="83" font-size="7.5" fill-opacity="0.85">to audio</text>
+    <rect x="382" y="52" width="74" height="38" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+    <text x="419" y="71" font-weight="600">decode</text><text x="419" y="83" font-size="7.5" fill-opacity="0.85">slow · to data</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="90" y1="71" x2="138" y2="71" marker-end="url(#pipe_ar)"/>
+    <line x1="212" y1="71" x2="260" y2="71" marker-end="url(#pipe_ar)"/>
+    <line x1="334" y1="71" x2="382" y2="71" marker-end="url(#pipe_ar)"/>
+  </g>
+  <g stroke="currentColor" stroke-width="0.9">
+    <rect x="100" y="64" width="7" height="14" rx="1.5" fill="none"/>
+    <rect x="109" y="64" width="7" height="14" rx="1.5" fill="currentColor" fill-opacity="0.2"/>
+    <rect x="222" y="64" width="7" height="14" rx="1.5" fill="currentColor" fill-opacity="0.2"/>
+    <rect x="231" y="64" width="7" height="14" rx="1.5" fill="none"/>
+    <rect x="344" y="64" width="7" height="14" rx="1.5" fill="currentColor" fill-opacity="0.38"/>
+    <rect x="353" y="64" width="7" height="14" rx="1.5" fill="currentColor" fill-opacity="0.38"/>
+  </g>
+  <text x="356" y="46" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.95">queue full</text>
+  <path d="M352 98 C 340 116 316 112 300 96" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3" marker-end="url(#pipe_ar)"/>
+  <text x="300" y="132" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">backpressure: a full queue makes the upstream stage wait</text>
+  <defs><marker id="pipe_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A receive chain is literally a pipeline: capture, filter, demodulate, and decode each run at once on their own core, passing work forward through bounded queues. When a downstream stage can't keep up its queue fills, and <strong>backpressure</strong> forces the stage feeding it to wait — pacing the whole pipeline to its slowest stage instead of growing an unbounded backlog.</figcaption>
+</figure>
+
 A stage is, in effect, both a consumer of its input queue and a producer for its output queue — which brings us to the core relationship.
 
 ## Producer/consumer and bounded buffers

--- a/docs/learn/intro-software-dev/memory-management.md
+++ b/docs/learn/intro-software-dev/memory-management.md
@@ -44,6 +44,37 @@ function that created it, a growing list. Heap memory must be explicitly
 *allocated* and eventually *released*. **All the hard memory problems live on the
 heap**, because something has to decide when each piece is no longer needed.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 462 188" role="img" aria-label="Two memory regions side by side: on the left a call stack of frames for main, process, and decode, with the newest decode frame just pushed and popped on return; on the right a heap of variously sized blocks, one referenced by a pointer held in a stack frame." xmlns="http://www.w3.org/2000/svg">
+  <text x="104" y="26" text-anchor="middle" font-size="9.5" font-weight="600" fill="currentColor">call stack</text>
+  <g font-size="8.5" text-anchor="middle" fill="currentColor">
+    <rect x="44" y="40" width="120" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="104" y="59">main( ) frame</text>
+    <rect x="44" y="72" width="120" height="30" rx="4" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/><text x="104" y="91">process( ) frame</text>
+    <rect x="44" y="104" width="120" height="30" rx="4" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/><text x="104" y="123">decode( ) frame</text>
+  </g>
+  <line x1="30" y1="40" x2="30" y2="134" stroke="currentColor" stroke-width="1.1" marker-end="url(#mem_ar)"/>
+  <text x="20" y="87" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.9" transform="rotate(-90 20 87)">grows each call</text>
+  <text x="104" y="150" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">newest frame on top —</text>
+  <text x="104" y="160" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">pushed on call, popped on return</text>
+  <text x="356" y="26" text-anchor="middle" font-size="9.5" font-weight="600" fill="currentColor">heap</text>
+  <rect x="250" y="34" width="196" height="104" rx="5" fill="currentColor" fill-opacity="0.03" stroke="currentColor" stroke-width="1" stroke-dasharray="3 3"/>
+  <g stroke="currentColor" stroke-width="1">
+    <rect x="264" y="46" width="42" height="22" rx="3" fill="currentColor" fill-opacity="0.22"/>
+    <rect x="318" y="42" width="34" height="26" rx="3" fill="currentColor" fill-opacity="0.14"/>
+    <rect x="364" y="48" width="30" height="20" rx="3" fill="currentColor" fill-opacity="0.26"/>
+    <rect x="404" y="44" width="30" height="28" rx="3" fill="currentColor" fill-opacity="0.18"/>
+    <rect x="270" y="86" width="46" height="22" rx="3" fill="currentColor" fill-opacity="0.12"/>
+    <rect x="330" y="90" width="34" height="24" rx="3" fill="currentColor" fill-opacity="0.22"/>
+    <rect x="382" y="88" width="42" height="20" rx="3" fill="currentColor" fill-opacity="0.16"/>
+  </g>
+  <text x="348" y="128" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">any size · any lifetime · must be freed</text>
+  <line x1="164" y1="119" x2="262" y2="63" stroke="currentColor" stroke-width="1.2" marker-end="url(#mem_ar)"/>
+  <text x="205" y="102" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.9">pointer</text>
+  <defs><marker id="mem_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Two regions with opposite rules. The <strong>stack</strong> holds a frame per active call — pushed on call, popped on return — so its storage is automatic and fixed-size. The <strong>heap</strong> is a free-form pool for data whose size or lifetime the compiler can't predict; a stack variable often just holds a pointer into it. Every hard memory bug lives on the heap, because something must decide when each block is no longer needed.</figcaption>
+</figure>
+
 ```text
 stack:  fast, auto-freed, fixed-size, function-scoped
 heap:   flexible, manually/automatically managed, the source of memory bugs

--- a/docs/learn/intro-software-dev/performance-vs-productivity.md
+++ b/docs/learn/intro-software-dev/performance-vs-productivity.md
@@ -50,6 +50,24 @@ collection and, historically, fewer features (it lacked generics until 2022). **
 and C#** also occupy a managed middle, with big ecosystems and JIT-driven speed.
 There's no free lunch — every position pays for what it gains.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 464 168" role="img" aria-label="A single spectrum from fast-to-run to fast-to-write languages: C, C++, and Rust on the left trade productivity for control and speed; Go, Java, and C# form a middle; Python, JavaScript, and Ruby on the right trade run-time efficiency for quick, concise development." xmlns="http://www.w3.org/2000/svg">
+  <line x1="34" y1="42" x2="430" y2="42" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#pv_ar)"/>
+  <text x="232" y="32" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">fewer lines · quicker to write · more productive</text>
+  <g text-anchor="middle" fill="currentColor">
+    <circle cx="80" cy="90" r="7" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="1.3"/><text x="80" y="112" font-size="9" font-weight="600">C · C++ · Rust</text><text x="80" y="124" font-size="7.5" fill-opacity="0.85">fast to run</text>
+    <circle cx="232" cy="90" r="7" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="232" y="112" font-size="9" font-weight="600">Go · Java · C#</text><text x="232" y="124" font-size="7.5" fill-opacity="0.85">the middle</text>
+    <circle cx="384" cy="90" r="7" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="1.3"/><text x="384" y="112" font-size="9" font-weight="600">Python · JS · Ruby</text><text x="384" y="124" font-size="7.5" fill-opacity="0.85">fast to write</text>
+  </g>
+  <line x1="87" y1="90" x2="225" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <line x1="239" y1="90" x2="377" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <line x1="430" y1="138" x2="34" y2="138" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#pv_ar)"/>
+  <text x="232" y="152" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">less CPU and memory · predictable timing · more control</text>
+  <defs><marker id="pv_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>One axis, two opposing pulls. Toward the left, languages give more control and predictable speed at the cost of ceremony; toward the right, they trade run-time efficiency for fewer lines and quicker iteration. Go and the managed languages sit in a deliberate middle. Most of choosing a language is deciding which end your problem actually rewards.</figcaption>
+</figure>
+
 ## Productivity often beats raw speed — because of economics
 
 Here's the uncomfortable truth for performance purists: for most software,

--- a/docs/learn/software-licensing/copyleft-in-products.md
+++ b/docs/learn/software-licensing/copyleft-in-products.md
@@ -52,6 +52,32 @@ The hard part is that "derivative work" is a copyright concept, not a precise te
 | Separate process, talking over IPC/CLI/socket | Low — strong evidence of independence |
 | Two independent programs shipped together | Mere aggregation — not derivative |
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 178" role="img" aria-label="A coupling gradient of four ways to combine with copyleft code — static link, dynamic link, separate process over IPC, and mere aggregation — ordered from tightest coupling on the left to loosest on the right. A shaded band under the left half marks where the copyleft obligation likely reaches, and a dashed contested boundary sits between dynamic linking and a separate process, past which the code is likely independent." xmlns="http://www.w3.org/2000/svg">
+  <text x="230" y="22" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Coupling gradient: where copyleft reach fades</text>
+  <text x="44" y="46" text-anchor="start" font-size="8" fill="currentColor" fill-opacity="0.85">◄ tighter coupling</text>
+  <text x="416" y="46" text-anchor="end" font-size="8" fill="currentColor" fill-opacity="0.85">looser coupling ►</text>
+  <line x1="40" y1="72" x2="430" y2="72" stroke="currentColor" stroke-width="1" stroke-opacity="0.35"/>
+  <g text-anchor="middle" fill="currentColor">
+    <circle cx="66" cy="72" r="6" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1.3"/>
+    <text x="66" y="90" font-size="8" font-weight="600">static link</text><text x="66" y="101" font-size="7">compiled in</text>
+    <circle cx="176" cy="72" r="6" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.2"/>
+    <text x="176" y="90" font-size="8" font-weight="600">dynamic link</text><text x="176" y="101" font-size="7">shared library</text>
+    <circle cx="296" cy="72" r="6" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <text x="296" y="90" font-size="8" font-weight="600">separate process</text><text x="296" y="101" font-size="7">IPC · CLI · socket</text>
+    <circle cx="410" cy="72" r="6" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.2"/>
+    <text x="410" y="90" font-size="8" font-weight="600">aggregation</text><text x="410" y="101" font-size="7">bundled only</text>
+  </g>
+  <rect x="40" y="118" width="196" height="20" rx="3" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="0.8"/>
+  <text x="138" y="131" text-anchor="middle" font-size="7.5" fill="currentColor">obligation likely reaches</text>
+  <rect x="236" y="118" width="194" height="20" rx="3" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+  <text x="333" y="131" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">likely independent</text>
+  <line x1="236" y1="56" x2="236" y2="142" stroke="currentColor" stroke-width="1" stroke-opacity="0.5" stroke-dasharray="4 3"/>
+  <text x="236" y="158" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">contested boundary</text>
+</svg>
+<figcaption>How tightly you bind to copyleft code is the lever. Static linking fuses it into your binary (high reach); a separate process talking over IPC keeps it at arm's length (low reach). The obligation fades as coupling loosens, and the exact stopping point — somewhere around the dynamic-link boundary — is contested, which is why a clean separation is the strongest defense.</figcaption>
+</figure>
+
 ### LGPL's relink allowance
 
 The [LGPL](/learn/software-licensing/weak-copyleft-licenses/) — "Lesser GPL," a weak copyleft license — was designed for exactly the linking case. It lets your proprietary program link against an LGPL library while keeping your own code closed, **on the condition** that the user can replace the library with a modified version. In practice that means dynamic linking (so the user can swap the `.so`/`.dll`), or shipping object files for relinking. The library itself stays copyleft — changes to *it* must be shared — but your application doesn't.

--- a/docs/learn/software-licensing/dual-licensing-and-relicensing.md
+++ b/docs/learn/software-licensing/dual-licensing-and-relicensing.md
@@ -31,6 +31,33 @@ The previous lesson showed how a [CLA](/learn/software-licensing/contributor-agr
 
 The clever part is that the GPL does the selling for you. Because the GPL would force a commercial user to open their product, it creates demand for the paid escape hatch. The community gets genuinely free software; the vendor gets paying customers among those who need to stay closed. The two licenses aren't in conflict — they're offered to *different audiences* by the one party allowed to offer them.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 196" role="img" aria-label="One codebase owned by a single copyright holder splits into two licensing paths: an arrow to the left leads to an open GPL path for the community with free copyleft use, and an arrow to the right leads to a paid commercial path for customers who embed the code in closed products." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="16" y="30" width="170" height="54" rx="6" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.3"/>
+    <text x="101" y="52" font-weight="600">Open / GPL path</text>
+    <text x="101" y="67" font-size="7.5">community · free · copyleft</text>
+    <rect x="274" y="30" width="170" height="54" rx="6" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.3"/>
+    <text x="359" y="52" font-weight="600">Commercial path</text>
+    <text x="359" y="67" font-size="7.5">paying customers · closed</text>
+    <rect x="175" y="122" width="110" height="56" rx="6" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.5"/>
+    <text x="230" y="146" font-weight="600">One codebase</text>
+    <text x="230" y="160" font-size="7.5">single owner</text>
+    <text x="230" y="171" font-size="7.5">(or CLA rights)</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.6">
+    <line x1="205" y1="124" x2="120" y2="84" marker-end="url(#dl_ar)"/>
+    <line x1="255" y1="124" x2="340" y2="84" marker-end="url(#dl_ar)"/>
+  </g>
+  <g fill="currentColor" text-anchor="middle" font-size="7.5" fill-opacity="0.9">
+    <text x="138" y="108">GPL license</text>
+    <text x="322" y="108">paid license</text>
+  </g>
+  <defs><marker id="dl_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Dual licensing is one codebase, two offers. Because a single party owns all the rights, it can hand the same code to the community under the GPL and sell a copyleft-free commercial license to customers who need to stay closed. The GPL itself drives that sale — and it only works while one owner (or a CLA) holds every line.</figcaption>
+</figure>
+
 This is exactly the **open-core / commercial open-source** model behind famous examples: **MySQL** was dual-licensed (GPL plus a commercial license for embedding in closed products), and **Qt** has long offered both an open-source license and a paid commercial one. The community edition drives adoption and contributions; the commercial license funds the company.
 
 ## Why you must own (or have rights to) all the code

--- a/docs/learn/software-licensing/license-compatibility.md
+++ b/docs/learn/software-licensing/license-compatibility.md
@@ -53,6 +53,33 @@ Here is the key mental model — **one-way compatibility**:
 
 So compatibility has a *direction*. Code flows "uphill" from permissive into copyleft, but copyleft code can't flow "downhill" into something more permissive. People get burned when they assume "it's all open source, so it must mix" — adding one GPL dependency can force your entire distributable work to become GPL, or block the combination entirely if you can't accept that.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 186" role="img" aria-label="Three license boxes in a row: permissive licenses like MIT, BSD, and Apache on the left, a copyleft GPL project in the middle, and a proprietary or permissive work on the right. A solid arrow marked allowed flows from permissive into the GPL, while a barred, crossed-out arrow marked blocked shows GPL code cannot flow out into the proprietary or permissive work." xmlns="http://www.w3.org/2000/svg">
+  <text x="230" y="26" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">One-way compatibility</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="16" y="64" width="118" height="56" rx="6" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/>
+    <text x="75" y="88" font-weight="600">Permissive</text><text x="75" y="102" font-size="7.5">MIT · BSD · Apache</text>
+    <rect x="172" y="64" width="112" height="56" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+    <text x="228" y="88" font-weight="600">Copyleft</text><text x="228" y="102" font-size="7.5">GPL</text>
+    <rect x="326" y="64" width="118" height="56" rx="6" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.3"/>
+    <text x="385" y="88" font-weight="600">Proprietary</text><text x="385" y="102" font-size="7.5">or permissive</text>
+  </g>
+  <line x1="134" y1="92" x2="172" y2="92" stroke="currentColor" stroke-width="1.8" marker-end="url(#lc_ar)"/>
+  <text x="153" y="82" text-anchor="middle" font-size="8" fill="currentColor" font-weight="600">✓</text>
+  <text x="153" y="138" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">flows in</text>
+  <g stroke="currentColor" stroke-width="1.8">
+    <line x1="284" y1="92" x2="316" y2="92" stroke-dasharray="4 3" stroke-opacity="0.6"/>
+    <line x1="320" y1="84" x2="320" y2="100"/>
+    <line x1="300" y1="84" x2="308" y2="100"/>
+    <line x1="308" y1="84" x2="300" y2="100"/>
+  </g>
+  <text x="305" y="138" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">can't flow out</text>
+  <text x="230" y="166" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.8">combined result ships as GPL</text>
+  <defs><marker id="lc_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Copyleft compatibility runs one way. Permissive code (MIT, BSD, Apache) can be pulled <em>into</em> a GPL project and the combined work ships as GPL — but GPL code can't be folded back out into a proprietary or permissive work without forcing that work to become GPL too. The blocked arrow is where most people get burned.</figcaption>
+</figure>
+
 ## The specific pairings that trip people up
 
 Beyond the broad rule, a handful of named incompatibilities cause most real-world headaches.

--- a/docs/learn/software-licensing/permissive-vs-copyleft.md
+++ b/docs/learn/software-licensing/permissive-vs-copyleft.md
@@ -70,6 +70,39 @@ Copyleft is not all-or-nothing. It comes in two strengths that differ in *how fa
 
 Weak copyleft is the middle ground between "anything goes" permissive and "the whole thing must be free" strong copyleft.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="Three products side by side showing the escalating share-alike obligation. Under a permissive license nothing in the product must stay open; under weak copyleft only the licensed component must stay open; under strong copyleft the entire combined work must stay open. A top arrow points right to show the obligation growing across the three." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="30" x2="420" y2="30" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#pc_ar)"/>
+  <text x="230" y="22" text-anchor="middle" font-size="9" fill="currentColor" fill-opacity="0.9">share-alike obligation grows →</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <text x="78" y="52" font-weight="600">Permissive</text>
+    <rect x="18" y="58" width="120" height="88" rx="6" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="1.3"/>
+    <text x="78" y="98" font-size="8" fill-opacity="0.85">your product</text>
+    <text x="78" y="132" font-size="7.5" fill-opacity="0.7">nothing must open</text>
+    <text x="78" y="162" font-size="7.5">MIT · BSD · Apache</text>
+
+    <text x="230" y="52" font-weight="600">Weak copyleft</text>
+    <rect x="170" y="58" width="120" height="88" rx="6" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="1.3"/>
+    <text x="230" y="80" font-size="7.5" fill-opacity="0.7">your product</text>
+    <rect x="182" y="100" width="96" height="36" rx="4" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="1"/>
+    <text x="230" y="122" font-size="7.5">the component</text>
+    <text x="230" y="162" font-size="7.5">LGPL · MPL · EPL</text>
+
+    <text x="382" y="52" font-weight="600">Strong copyleft</text>
+    <rect x="322" y="58" width="120" height="88" rx="6" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="1.3"/>
+    <text x="382" y="106" font-size="7.5">entire combined</text>
+    <text x="382" y="117" font-size="7.5">work</text>
+    <text x="382" y="162" font-size="7.5">GPL · AGPL</text>
+  </g>
+  <g font-size="7.5" fill="currentColor">
+    <rect x="150" y="180" width="12" height="10" rx="2" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="0.8"/>
+    <text x="168" y="189" text-anchor="start">shaded = must stay open downstream</text>
+  </g>
+  <defs><marker id="pc_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The obligation escalates left to right. Permissive asks nothing to stay open; weak copyleft keeps just the licensed component open so the rest of your product can stay closed; strong copyleft pulls the whole combined work open. The shaded region — what must stay open downstream — widens at every step.</figcaption>
+</figure>
+
 ## The comparison at a glance
 
 This table is the one to keep in your head. It frames the next several lessons.

--- a/docs/learn/software-licensing/the-licensing-spectrum.md
+++ b/docs/learn/software-licensing/the-licensing-spectrum.md
@@ -34,6 +34,30 @@ From most restrictive to least, the five main bands are:
 
 Notice the spectrum has two axes hiding inside it: *can you see the source?* and *what may you do with it?* They don't move in lockstep — source-available shows you the code without granting the freedoms, which is exactly why "I can see it" tells you almost nothing about "I can use it." Keep the four actions from [lesson one](/learn/software-licensing/what-is-a-software-license/) in mind — use, copy, modify, distribute — because each band answers them differently.
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 176" role="img" aria-label="A horizontal licensing spectrum of five bands — proprietary, source-available, permissive, copyleft, and public domain — from left to right. A top arrow pointing right shows freedoms and rights growing toward public domain, while a bottom arrow pointing left shows restrictions and obligations growing back toward proprietary." xmlns="http://www.w3.org/2000/svg">
+  <line x1="34" y1="44" x2="446" y2="44" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#spec_ar)"/>
+  <text x="240" y="35" text-anchor="middle" font-size="9" fill="currentColor" fill-opacity="0.9">freedoms &amp; rights grow →</text>
+  <line x1="40" y1="90" x2="440" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.35"/>
+  <g text-anchor="middle" fill="currentColor">
+    <circle cx="52" cy="90" r="6.5" fill="currentColor" fill-opacity="0.35" stroke="currentColor" stroke-width="1.4"/>
+    <text x="52" y="110" font-size="8.5" font-weight="600">proprietary</text><text x="52" y="121" font-size="7.5" fill-opacity="0.85">source hidden</text>
+    <circle cx="151" cy="90" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/>
+    <text x="151" y="110" font-size="8.5" font-weight="600">source-available</text><text x="151" y="121" font-size="7.5" fill-opacity="0.85">visible, restricted</text>
+    <circle cx="250" cy="90" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/>
+    <text x="250" y="110" font-size="8.5" font-weight="600">permissive</text><text x="250" y="121" font-size="7.5" fill-opacity="0.85">few conditions</text>
+    <circle cx="349" cy="90" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/>
+    <text x="349" y="110" font-size="8.5" font-weight="600">copyleft</text><text x="349" y="121" font-size="7.5" fill-opacity="0.85">share-alike</text>
+    <circle cx="440" cy="90" r="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/>
+    <text x="440" y="110" font-size="8.5" font-weight="600">public domain</text><text x="440" y="121" font-size="7.5" fill-opacity="0.85">no conditions</text>
+  </g>
+  <line x1="446" y1="146" x2="34" y2="146" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#spec_ar)"/>
+  <text x="240" y="164" text-anchor="middle" font-size="9" fill="currentColor" fill-opacity="0.9">← restrictions &amp; obligations grow</text>
+  <defs><marker id="spec_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The five bands on one line. Moving right — proprietary to public domain — the rights you're granted grow while the obligations placed on you shrink. The two arrows pull in opposite directions, which is why placing a license on this map tells you most of what it lets you do before you read the fine print.</figcaption>
+</figure>
+
 ## Band 1: Proprietary / closed-source
 
 **Proprietary** software is the default-restrictive end. The source code is kept secret (protected as a [trade secret](/learn/software-licensing/other-ip-in-software/)), and the license grants you a narrow right — usually just to *use* the binary, often on specific terms, with no right to copy beyond your license, modify, or redistribute. Most commercial desktop and enterprise software lives here. This is the world of EULAs, seat licenses, and subscriptions, which we cover in [Proprietary & closed-source licensing](/learn/software-licensing/proprietary-licensing/).

--- a/docs/reference/ai-accelerator.md
+++ b/docs/reference/ai-accelerator.md
@@ -18,6 +18,31 @@ cite_urls:
 
 An **AI accelerator** is specialized hardware designed to run machine-learning workloads — above all the dense matrix multiplications of neural networks — far faster and more efficiently than a general-purpose [CPU](/reference/central-processing-unit/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 196" role="img" aria-label="A spectrum of four ways to run neural-network math, from general to specialized: a CPU with a couple of cores, a GPU with a wide grid, a TPU or NPU with a denser array, and a fixed-function ASIC. Moving right adds parallel multiply-accumulate lanes and throughput per watt but gives up general-purpose flexibility." xmlns="http://www.w3.org/2000/svg">
+  <text x="230" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">One workload, general to specialized</text>
+  <g text-anchor="middle" font-size="9" fill="currentColor">
+    <rect x="30" y="30" width="76" height="34" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1"/><text x="68" y="46">CPU</text><text x="68" y="58" font-size="7" fill-opacity="0.85">general</text>
+    <rect x="144" y="30" width="76" height="34" rx="4" fill="currentColor" fill-opacity="0.11" stroke="currentColor" stroke-width="1.1"/><text x="182" y="46">GPU</text><text x="182" y="58" font-size="7" fill-opacity="0.85">wide SIMD</text>
+    <rect x="258" y="30" width="76" height="34" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="296" y="46">TPU · NPU</text><text x="296" y="58" font-size="7" fill-opacity="0.85">matrix array</text>
+    <rect x="372" y="30" width="76" height="34" rx="4" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.1"/><text x="410" y="46">ASIC</text><text x="410" y="58" font-size="7" fill-opacity="0.85">fixed-function</text>
+  </g>
+  <g fill="currentColor" fill-opacity="0.3" stroke="none">
+    <rect x="59" y="76" width="8" height="8" rx="1"/><rect x="69" y="76" width="8" height="8" rx="1"/>
+    <rect x="168" y="76" width="7" height="7" rx="1"/><rect x="177" y="76" width="7" height="7" rx="1"/><rect x="186" y="76" width="7" height="7" rx="1"/><rect x="168" y="85" width="7" height="7" rx="1"/><rect x="177" y="85" width="7" height="7" rx="1"/><rect x="186" y="85" width="7" height="7" rx="1"/>
+    <rect x="278" y="76" width="7" height="7" rx="1"/><rect x="287" y="76" width="7" height="7" rx="1"/><rect x="296" y="76" width="7" height="7" rx="1"/><rect x="305" y="76" width="7" height="7" rx="1"/><rect x="278" y="85" width="7" height="7" rx="1"/><rect x="287" y="85" width="7" height="7" rx="1"/><rect x="296" y="85" width="7" height="7" rx="1"/><rect x="305" y="85" width="7" height="7" rx="1"/>
+    <rect x="388" y="76" width="7" height="7" rx="1"/><rect x="397" y="76" width="7" height="7" rx="1"/><rect x="406" y="76" width="7" height="7" rx="1"/><rect x="415" y="76" width="7" height="7" rx="1"/><rect x="424" y="76" width="7" height="7" rx="1"/><rect x="388" y="85" width="7" height="7" rx="1"/><rect x="397" y="85" width="7" height="7" rx="1"/><rect x="406" y="85" width="7" height="7" rx="1"/><rect x="415" y="85" width="7" height="7" rx="1"/><rect x="424" y="85" width="7" height="7" rx="1"/>
+  </g>
+  <text x="230" y="108" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">more parallel multiply-accumulate lanes →</text>
+  <line x1="30" y1="132" x2="446" y2="132" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.8" marker-end="url(#aia_ar)"/>
+  <text x="230" y="127" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">throughput per watt (efficiency)</text>
+  <line x1="446" y1="152" x2="30" y2="152" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.6" stroke-dasharray="5 3" marker-end="url(#aia_ar)"/>
+  <text x="230" y="166" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">general-purpose flexibility</text>
+  <defs><marker id="aia_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>"AI accelerator" is an umbrella, not one chip. As you move from a general CPU through the GPU and TPU/NPU to a fixed-function ASIC, you add parallel multiply-accumulate lanes and win throughput per watt on tensor math — but give up flexibility. The right tool is a point on that trade-off, not the far end.</figcaption>
+</figure>
+
 ## Overview
 
 "AI accelerator" is an umbrella term, not a single chip. It covers the [GPU](/reference/graphics-processing-unit/) (the workhorse of deep-learning training), Google's [TPU](/reference/tensor-processing-unit/), the on-device [NPU](/reference/neural-processing-unit/) found in phones and laptops, and custom [ASIC](/reference/application-specific-integrated-circuit/) and [FPGA](/reference/field-programmable-gate-array/) designs. What they share is an architecture built for *throughput on parallel, reduced-precision arithmetic* — many multiply-accumulate units fed by high-bandwidth memory — rather than the low-latency, branch-heavy execution a CPU optimizes for.

--- a/docs/reference/application-specific-integrated-circuit.md
+++ b/docs/reference/application-specific-integrated-circuit.md
@@ -20,6 +20,27 @@ cite_urls:
 
 An **application-specific integrated circuit** (**ASIC**) is an [integrated circuit](/reference/integrated-circuit/) custom-designed for a single, fixed task — trading away general-purpose flexibility for the best achievable speed, power efficiency, and per-unit cost.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="A spectrum from CPU to GPU to FPGA to ASIC. Moving right, flexibility and reprogrammability fall while efficiency, speed per watt, and cost-at-scale rise. A CPU runs any task; an ASIC does one fixed job." xmlns="http://www.w3.org/2000/svg">
+  <line x1="40" y1="42" x2="360" y2="42" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#as_ar)"/>
+  <text x="200" y="32" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">more flexible · reprogrammable</text>
+  <line x1="60" y1="90" x2="60" y2="90" stroke="currentColor"/>
+  <g text-anchor="middle" fill="currentColor" font-size="10">
+    <circle cx="70" cy="90" r="7" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="70" y="112" font-weight="600" font-size="9.5">CPU</text><text x="70" y="124" font-size="7.5" fill-opacity="0.85">any task</text>
+    <circle cx="180" cy="90" r="7" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="180" y="112" font-weight="600" font-size="9.5">GPU</text><text x="180" y="124" font-size="7.5" fill-opacity="0.85">parallel</text>
+    <circle cx="290" cy="90" r="7" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="290" y="112" font-weight="600" font-size="9.5">FPGA</text><text x="290" y="124" font-size="7.5" fill-opacity="0.85">reconfigurable</text>
+    <circle cx="400" cy="90" r="7" fill="currentColor" fill-opacity="0.35" stroke="currentColor" stroke-width="1.4"/><text x="400" y="112" font-weight="600" font-size="9.5">ASIC</text><text x="400" y="124" font-size="7.5" fill-opacity="0.85">one fixed task</text>
+  </g>
+  <line x1="63" y1="90" x2="177" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <line x1="187" y1="90" x2="283" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <line x1="297" y1="90" x2="393" y2="90" stroke="currentColor" stroke-width="1" stroke-opacity="0.4"/>
+  <line x1="420" y1="138" x2="100" y2="138" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#as_ar)"/>
+  <text x="260" y="152" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">more efficient · faster · cheaper at scale · higher up-front (NRE) cost</text>
+  <defs><marker id="as_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The classic hardware spectrum: from a fully programmable CPU to a permanently etched ASIC, flexibility falls and efficiency rises at each step. An ASIC wins decisively on performance-per-watt and cost at volume but can't be changed and is slow to build — so an FPGA is the hedge when volumes are low or the design might still change.</figcaption>
+</figure>
+
 ## Overview
 
 Where a CPU or [FPGA](/reference/field-programmable-gate-array/) is built to run many possible workloads, an ASIC's circuit is etched permanently into silicon to do exactly one job — a network switch chip, a Bitcoin miner, a phone's modem, a [TPU](/reference/tensor-processing-unit/). The design is fabricated at a foundry such as [TSMC](/reference/tsmc/) from a set of photomasks; this *non-recurring engineering* cost is large and a finished ASIC cannot be changed, so the economics only work at high volume or where nothing else meets the performance target.

--- a/docs/reference/bootloader.md
+++ b/docs/reference/bootloader.md
@@ -19,6 +19,34 @@ cite_urls:
 
 **A bootloader** is a small program that runs first when a device powers on or resets, then loads and starts the main [firmware](/reference/firmware/) or operating system.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 168" role="img" aria-label="A boot handoff chain reading left to right: power-on or reset starts built-in ROM firmware, which hands control to the bootloader, which loads and verifies the operating-system kernel or application, which then takes over. Each stage passes control to the next in boot order." xmlns="http://www.w3.org/2000/svg">
+  <text x="230" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Each stage hands control to the next</text>
+  <g font-size="8.5" text-anchor="middle" fill="currentColor">
+    <rect x="20" y="46" width="84" height="42" rx="5" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1"/><text x="62" y="64">power-on</text><text x="62" y="76">/ reset</text>
+    <rect x="128" y="46" width="84" height="42" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="170" y="64">ROM</text><text x="170" y="76">firmware</text>
+    <rect x="236" y="46" width="84" height="42" rx="5" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/><text x="278" y="70" font-weight="600">bootloader</text>
+    <rect x="344" y="46" width="96" height="42" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/><text x="392" y="64">OS kernel</text><text x="392" y="76">/ app</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3">
+    <line x1="106" y1="67" x2="126" y2="67" marker-end="url(#bl_ar)"/>
+    <line x1="214" y1="67" x2="234" y2="67" marker-end="url(#bl_ar)"/>
+    <line x1="322" y1="67" x2="342" y2="67" marker-end="url(#bl_ar)"/>
+  </g>
+  <g font-size="7" text-anchor="middle" fill="currentColor" fill-opacity="0.85">
+    <text x="62" y="104">runs first</text>
+    <text x="170" y="104">built-in</text>
+    <text x="278" y="102">loads &amp; verifies</text>
+    <text x="278" y="112">image · can reflash</text>
+    <text x="392" y="104">your program</text>
+  </g>
+  <line x1="20" y1="134" x2="440" y2="134" stroke="currentColor" stroke-width="1" stroke-opacity="0.6" marker-end="url(#bl_ar)"/>
+  <text x="230" y="150" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">boot order (time) →</text>
+  <defs><marker id="bl_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Booting is a relay of control: power-on starts built-in ROM firmware, which hands off to the bootloader, which loads and verifies the OS or application and jumps to it. The bootloader is the small program in the middle — and because it can also reflash the image, it is how a board updates itself over USB or the air.</figcaption>
+</figure>
+
 ## Overview
 
 On a desktop the bootloader chain hands off to an OS; on a [microcontroller](/reference/microcontroller/) the bootloader is often the only thing between reset and your application. Many MCUs ship with a factory bootloader in ROM that speaks USB DFU, [UART](/reference/uart/), or [SPI](/reference/spi/)/[I²C](/reference/i2c/), so new code can be loaded without a dedicated programmer. Custom bootloaders add over-the-air (OTA) updates, integrity checks, and fallback to a known-good image if an update fails.

--- a/docs/reference/cache-memory.md
+++ b/docs/reference/cache-memory.md
@@ -18,6 +18,33 @@ cite_urls:
 
 **Cache memory** is a small, very fast memory close to the [CPU](/reference/central-processing-unit/) that keeps recently and frequently used data and instructions on hand, hiding the latency of slower [main memory](/reference/random-access-memory/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 168" role="img" aria-label="A row from CPU outward: CPU, then on-chip caches L1, L2, and L3 growing larger and slower, then main memory RAM. A cache hit returns immediately; a miss travels one level further out toward RAM." xmlns="http://www.w3.org/2000/svg">
+  <line x1="96" y1="44" x2="332" y2="44" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  <line x1="96" y1="44" x2="96" y2="52" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  <line x1="332" y1="44" x2="332" y2="52" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  <text x="214" y="38" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.85">on-chip cache · SRAM</text>
+  <g text-anchor="middle" fill="currentColor" font-size="10">
+    <rect x="18" y="60" width="58" height="46" rx="5" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="47" y="87">CPU</text>
+    <rect x="96" y="60" width="52" height="46" rx="5" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="1.2"/><text x="122" y="82">L1</text><text x="122" y="96" font-size="7.5">tiny</text>
+    <rect x="168" y="60" width="62" height="46" rx="5" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.2"/><text x="199" y="82">L2</text><text x="199" y="96" font-size="7.5">bigger</text>
+    <rect x="250" y="60" width="82" height="46" rx="5" fill="currentColor" fill-opacity="0.13" stroke="currentColor" stroke-width="1.2"/><text x="291" y="82">L3</text><text x="291" y="96" font-size="7.5">shared</text>
+    <rect x="360" y="60" width="102" height="46" rx="5" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.2"/><text x="411" y="82">RAM</text><text x="411" y="96" font-size="7.5">large · slow</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" stroke-opacity="0.75">
+    <line x1="76" y1="83" x2="96" y2="83" marker-end="url(#ch_ar)"/>
+    <line x1="148" y1="83" x2="168" y2="83" marker-end="url(#ch_ar)"/>
+    <line x1="230" y1="83" x2="250" y2="83" marker-end="url(#ch_ar)"/>
+    <line x1="332" y1="83" x2="360" y2="83" marker-end="url(#ch_ar)"/>
+  </g>
+  <text x="122" y="126" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">hit → return</text>
+  <text x="278" y="126" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">miss → try the next level out</text>
+  <text x="240" y="150" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.85">fast &amp; small near the core · large &amp; slow further out</text>
+  <defs><marker id="ch_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Cache bridges the speed gap between the fast CPU and slow RAM. A hit in L1 returns almost instantly; a miss walks outward — L2, L3, then RAM — each level larger but slower. Locality of reference is what keeps most accesses in the small, fast levels.</figcaption>
+</figure>
+
 ## Overview
 
 Caches are usually built from fast SRAM on the processor die and arranged in *levels*: a tiny, fastest L1 per core, a larger L2, and a big shared L3. When the CPU needs data, a *cache hit* serves it immediately; a *cache miss* forces a slow trip to RAM over the [system bus](/reference/system-bus/). Caches work because programs show *locality of reference* — they tend to reuse the same data and access nearby addresses — so a small store captures most accesses.

--- a/docs/reference/central-processing-unit.md
+++ b/docs/reference/central-processing-unit.md
@@ -20,6 +20,37 @@ cite_urls:
 
 **The central processing unit (CPU)** is the chip that carries out a program's instructions — the part of [computer hardware](/reference/computer-hardware/) most often called the "brain."[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 480 190" role="img" aria-label="On the left, one CPU core repeats a three-step instruction cycle — fetch, decode, execute — looping back to fetch. On the right, a CPU package holds four such cores sharing a cache, exchanging data with separate RAM." xmlns="http://www.w3.org/2000/svg">
+  <text x="130" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">One core: the instruction cycle</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="20" y="52" width="66" height="30" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="53" y="71">Fetch</text>
+    <rect x="97" y="52" width="66" height="30" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="130" y="71">Decode</text>
+    <rect x="174" y="52" width="66" height="30" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="207" y="71">Execute</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <line x1="86" y1="67" x2="97" y2="67" marker-end="url(#cpu_ar)"/>
+    <line x1="163" y1="67" x2="174" y2="67" marker-end="url(#cpu_ar)"/>
+    <path d="M207 82 V 108 H 53 V 82" marker-end="url(#cpu_ar)"/>
+  </g>
+  <text x="130" y="126" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.8">cycles per second = clock speed (GHz)</text>
+  <text x="375" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">One package: many cores</text>
+  <rect x="288" y="30" width="122" height="96" rx="7" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.4"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <rect x="298" y="40" width="46" height="30" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="321" y="58">core</text>
+    <rect x="354" y="40" width="46" height="30" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="377" y="58">core</text>
+    <rect x="298" y="74" width="46" height="30" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="321" y="92">core</text>
+    <rect x="354" y="74" width="46" height="30" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="377" y="92">core</text>
+    <rect x="298" y="108" width="102" height="12" rx="3" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="0.8"/><text x="349" y="117">shared cache</text>
+  </g>
+  <rect x="288" y="146" width="122" height="26" rx="5" fill="none" stroke="currentColor" stroke-width="1.2"/><text x="349" y="163" text-anchor="middle" font-size="9" fill="currentColor">RAM</text>
+  <line x1="349" y1="126" x2="349" y2="146" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3 2" marker-end="url(#cpu_ar)"/>
+  <text x="428" y="139" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.8">data</text>
+  <defs><marker id="cpu_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A single core runs the same loop — fetch, decode, execute — billions of times a second; that rate is the clock speed. A modern CPU packs several cores that share a cache and pass data to and from separate RAM, so it can genuinely work on many tasks at once.</figcaption>
+</figure>
+
 ## Overview
 A CPU fetches instructions, decodes them, and executes them one after another, very fast. Modern CPUs contain several **cores**: each core is a self-contained processing unit, so a multi-core CPU can genuinely work on several tasks at the same time. This is what makes [concurrency](/reference/concurrency/) and parallel work practical.
 

--- a/docs/reference/chipset.md
+++ b/docs/reference/chipset.md
@@ -17,6 +17,37 @@ cite_urls:
 
 A **chipset** is the set of support chips on a [motherboard](/reference/motherboard/) that manages the flow of data between the [CPU](/reference/central-processing-unit/), memory, and peripherals.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 400 232" role="img" aria-label="The CPU, now holding the memory and graphics controllers that were once the northbridge, links directly to RAM and the x16 GPU, and connects down over a DMI link to the chipset or Platform Controller Hub, which fans out to USB, SATA, and PCIe peripherals." xmlns="http://www.w3.org/2000/svg">
+  <rect x="60" y="24" width="150" height="54" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="135" y="46" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">CPU</text>
+  <text x="135" y="62" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">on-die memory + graphics</text>
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <rect x="248" y="24" width="86" height="24" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="291" y="40">RAM</text>
+    <rect x="248" y="54" width="86" height="24" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="291" y="70">GPU · PCIe x16</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" stroke-opacity="0.6" fill="none">
+    <line x1="210" y1="40" x2="248" y2="36"/><line x1="210" y1="60" x2="248" y2="66"/>
+  </g>
+  <text x="291" y="94" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.5">(was the northbridge)</text>
+  <line x1="135" y1="78" x2="135" y2="112" stroke="currentColor" stroke-width="1.4" fill="none" marker-end="url(#cs_ar)"/>
+  <text x="152" y="98" font-size="7.5" fill="currentColor" fill-opacity="0.85">DMI</text>
+  <rect x="60" y="112" width="150" height="46" rx="6" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+  <text x="135" y="132" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">chipset · PCH</text>
+  <text x="135" y="147" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">I/O hub</text>
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <rect x="24" y="188" width="84" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="66" y="207">USB</text>
+    <rect x="118" y="188" width="84" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="160" y="207">SATA</text>
+    <rect x="212" y="188" width="110" height="30" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="267" y="207">PCIe lanes</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" stroke-opacity="0.6" fill="none">
+    <line x1="120" y1="158" x2="66" y2="188"/><line x1="135" y1="158" x2="160" y2="188"/><line x1="150" y1="158" x2="267" y2="188"/>
+  </g>
+  <defs><marker id="cs_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Modern PCs have one chipset chip — Intel's Platform Controller Hub — bridging the CPU to slower I/O: USB, SATA, and spare PCIe lanes. The old northbridge that once handled memory and graphics has moved onto the CPU die, so the RAM and the x16 GPU link now attach straight to the processor.</figcaption>
+</figure>
+
 ## Overview
 
 Historically a PC chipset split into a *northbridge* (fast links to memory and graphics) and a *southbridge* (slower I/O like storage, USB, and audio). As CPUs absorbed the memory controller and graphics link onto the die, the northbridge's job moved into the processor, leaving a single I/O hub — Intel calls it the Platform Controller Hub (PCH). Today the chipset mainly provides the extra [PCIe](/reference/pci-express/) lanes, [USB](/reference/usb/) ports, SATA connectors, and other I/O that a platform exposes.

--- a/docs/reference/clock-speed.md
+++ b/docs/reference/clock-speed.md
@@ -18,6 +18,22 @@ cite_urls:
 
 **Clock speed** (or clock rate) is the frequency at which a processor's internal clock ticks, measured in hertz, setting the basic pace at which the chip steps through its work.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 180" role="img" aria-label="A square-wave clock signal alternating between low and high over time. One low-to-high-to-low span is marked as a single cycle; the number of cycles per second is the frequency in hertz, so a three-gigahertz processor completes three billion cycles each second. Heat and power cap how fast the wave can go." xmlns="http://www.w3.org/2000/svg">
+  <line x1="34" y1="130" x2="34" y2="40" stroke="currentColor" stroke-width="1" stroke-opacity="0.6" marker-end="url(#cs_ar)"/>
+  <text x="30" y="86" font-size="8" fill="currentColor" fill-opacity="0.85" text-anchor="middle" transform="rotate(-90 30 86)">voltage</text>
+  <line x1="34" y1="120" x2="410" y2="120" stroke="currentColor" stroke-width="1" stroke-opacity="0.6" marker-end="url(#cs_ar)"/>
+  <text x="400" y="134" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">time</text>
+  <path d="M44 118 V56 H76 V118 H108 V56 H140 V118 H172 V56 H204 V118 H236 V56 H268 V118 H300 V56 H332 V118 H364" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <line x1="44" y1="44" x2="108" y2="44" stroke="currentColor" stroke-width="1" stroke-opacity="0.8" marker-start="url(#cs_ar)" marker-end="url(#cs_ar)"/>
+  <text x="76" y="40" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">1 cycle (tick)</text>
+  <text x="220" y="152" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">frequency = cycles per second (Hz) — a 3 GHz CPU ticks 3 billion times a second</text>
+  <text x="220" y="170" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">heat &amp; power cap how fast it can tick</text>
+  <defs><marker id="cs_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto-start-reverse"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A clock is a square wave: each low-to-high tick, or cycle, lets the logic settle and advance one step. How many cycles fit in a second is the frequency — 3 GHz means three billion a second. But heat and power cap how fast it can tick, and how much work each cycle does matters just as much, so clock speed alone does not equal performance.</figcaption>
+</figure>
+
 ## Overview
 
 A digital chip advances in time with a clock signal; each tick, or *cycle*, lets the logic settle and move to its next state. A 3 GHz [CPU](/reference/central-processing-unit/) ticks three billion times a second. But clock speed alone does not equal performance — *how much work per cycle* (instructions per cycle, dependent on the [microarchitecture](/reference/instruction-set-architecture/), [cache](/reference/cache-memory/) behavior, and parallelism) matters just as much. Comparing clock speeds across different designs is therefore unreliable.

--- a/docs/reference/cloud-computing.md
+++ b/docs/reference/cloud-computing.md
@@ -21,6 +21,61 @@ cite_urls:
 
 **Cloud computing** is computing power and storage provided over the internet on demand, instead of from machines you own and run.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 464 268" role="img" aria-label="A grid of who manages each layer across four tiers — on-premises, IaaS, PaaS, and SaaS — with an arrow across the top showing that your responsibility shrinks as you move right. Rows are application, data, runtime, operating system, virtualization, and hardware. Filled cells are managed by you and light cells by the provider; moving right, the filled region shrinks from the bottom up until nothing is left." xmlns="http://www.w3.org/2000/svg">
+  <text x="270" y="14" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.85">your responsibility shrinks &#8594;</text>
+  <line x1="116" y1="24" x2="452" y2="24" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#cc_ar)"/>
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <text x="144" y="42" font-weight="600">On-prem</text>
+    <text x="234" y="42" font-weight="600">IaaS</text>
+    <text x="324" y="42" font-weight="600">PaaS</text>
+    <text x="414" y="42" font-weight="600">SaaS</text>
+  </g>
+  <g fill="currentColor" font-size="8.5" text-anchor="end">
+    <text x="94" y="63">Application</text>
+    <text x="94" y="93">Data</text>
+    <text x="94" y="123">Runtime</text>
+    <text x="94" y="153">OS</text>
+    <text x="94" y="183">Virtualization</text>
+    <text x="94" y="213">Hardware</text>
+  </g>
+  <g stroke="currentColor">
+    <rect x="103" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="193" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="283" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="283" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+  </g>
+  <g font-size="8" fill="currentColor">
+    <rect x="150" y="242" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <text x="170" y="252" text-anchor="start">you manage</text>
+    <rect x="252" y="242" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5"/>
+    <text x="272" y="252" text-anchor="start">provider manages</text>
+  </g>
+  <defs><marker id="cc_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Cloud computing is an umbrella over several service tiers. Each column is a line drawn through one stack: on-premises you run everything, and each step right hands the provider more layers from the hardware up — until, at SaaS, you manage nothing but your data. Picking a tier is choosing how much of the stack you still want to own.</figcaption>
+</figure>
+
 ## Overview
 
 The defining trait is elasticity: you can scale resources up when traffic spikes and back down when it fades, with near-zero upfront cost and ongoing fees for what you use. Under the hood it is [virtualization](/reference/virtualization/) at scale, run across large data centers — the same technology behind a single [virtual private server](/reference/virtual-private-server/), multiplied.

--- a/docs/reference/container.md
+++ b/docs/reference/container.md
@@ -17,6 +17,42 @@ cite_urls:
 
 A **container** is a lightweight, isolated package that bundles an application with its dependencies and runs as an ordinary process on a shared [operating-system](/reference/operating-system/) kernel — making software portable and reproducible across machines.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 236" role="img" aria-label="Two towers side by side. On the left, virtual machines each stack an application on top of its own guest operating system, above a hypervisor and the host hardware. On the right, containers hold only the application and sit directly on one shared host operating system, so the container tower is shorter and lighter because there is no per-container guest OS." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" text-anchor="middle" font-size="8.5">
+    <text x="122" y="20" font-size="9" font-weight="600">Virtual machines</text>
+    <g stroke="currentColor">
+      <rect x="25" y="40" width="93" height="92" rx="4" fill="none" stroke-width="1.1" stroke-dasharray="4 3"/>
+      <rect x="32" y="62" width="79" height="26" rx="3" fill="currentColor" fill-opacity="0.2" stroke-width="1"/><text x="71" y="79">App</text>
+      <rect x="32" y="92" width="79" height="34" rx="3" fill="currentColor" fill-opacity="0.1" stroke-width="1"/><text x="71" y="112">Guest OS</text>
+      <rect x="124" y="40" width="93" height="92" rx="4" fill="none" stroke-width="1.1" stroke-dasharray="4 3"/>
+      <rect x="131" y="62" width="79" height="26" rx="3" fill="currentColor" fill-opacity="0.2" stroke-width="1"/><text x="170" y="79">App</text>
+      <rect x="131" y="92" width="79" height="34" rx="3" fill="currentColor" fill-opacity="0.1" stroke-width="1"/><text x="170" y="112">Guest OS</text>
+    </g>
+    <rect x="20" y="140" width="200" height="26" rx="4" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/><text x="120" y="157" font-weight="600">Hypervisor</text>
+    <rect x="20" y="170" width="200" height="26" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.2"/><text x="120" y="187">Host hardware</text>
+  </g>
+  <g fill="currentColor" text-anchor="middle" font-size="8.5">
+    <text x="350" y="20" font-size="9" font-weight="600">Containers</text>
+    <g stroke="currentColor">
+      <rect x="250" y="86" width="58" height="46" rx="4" fill="currentColor" fill-opacity="0.2" stroke-width="1" stroke-dasharray="4 3"/><text x="279" y="112">App</text>
+      <rect x="316" y="86" width="58" height="46" rx="4" fill="currentColor" fill-opacity="0.2" stroke-width="1" stroke-dasharray="4 3"/><text x="345" y="112">App</text>
+      <rect x="382" y="86" width="58" height="46" rx="4" fill="currentColor" fill-opacity="0.2" stroke-width="1" stroke-dasharray="4 3"/><text x="411" y="112">App</text>
+    </g>
+    <rect x="250" y="140" width="190" height="26" rx="4" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/><text x="345" y="157" font-weight="600">Container engine</text>
+    <rect x="250" y="170" width="190" height="26" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.4"/><text x="345" y="187" font-weight="600">One shared host OS + kernel</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.5">
+    <line x1="71" y1="132" x2="71" y2="140"/>
+    <line x1="170" y1="132" x2="170" y2="140"/>
+    <line x1="279" y1="132" x2="279" y2="140"/>
+    <line x1="345" y1="132" x2="345" y2="140"/>
+    <line x1="411" y1="132" x2="411" y2="140"/>
+  </g>
+</svg>
+<figcaption>Same job, two weights. Each virtual machine carries a full guest OS, so the tower is tall; a container holds only the app and shares the one host OS and kernel underneath. Dropping the per-container OS is what makes containers start in a blink and pack far more densely — at the cost of the harder isolation a separate kernel gives.</figcaption>
+</figure>
+
 ## Overview
 
 Containers are a form of OS-level [virtualization](/reference/virtualization/). Unlike a virtual machine, a container does not carry its own kernel or boot an operating system; it shares the host's kernel and is isolated using kernel features such as namespaces (separate views of processes, files, and networking) and cgroups (resource limits). A container starts from an *image* — a layered, read-only template — so the same image runs identically on a laptop, a server, or the cloud. The result is fast startup, low overhead, and "it works the same everywhere" packaging.

--- a/docs/reference/content-delivery-network.md
+++ b/docs/reference/content-delivery-network.md
@@ -18,6 +18,38 @@ cite_urls:
 
 A **content delivery network** (**CDN**) is a geographically distributed group of servers that cache and serve web content from locations close to users, cutting latency and offloading the origin servers.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 452 220" role="img" aria-label="A single origin server on the left feeds three geographically distributed edge caches in the middle, each in a different region. Each edge cache serves the nearby user on the right over a short hop, while the dashed links back to the origin are only used to fill a cache on a miss." xmlns="http://www.w3.org/2000/svg">
+  <rect x="18" y="88" width="78" height="44" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+  <text x="57" y="108" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">Origin</text>
+  <text x="57" y="122" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">one source</text>
+  <g fill="currentColor" font-size="8.5" text-anchor="middle">
+    <rect x="188" y="24" width="98" height="40" rx="4" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/><text x="237" y="42">Edge PoP</text><text x="237" y="55" font-size="7">region A</text>
+    <rect x="188" y="90" width="98" height="40" rx="4" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/><text x="237" y="108">Edge PoP</text><text x="237" y="121" font-size="7">region B</text>
+    <rect x="188" y="156" width="98" height="40" rx="4" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/><text x="237" y="174">Edge PoP</text><text x="237" y="187" font-size="7">region C</text>
+  </g>
+  <g fill="currentColor" font-size="7.5" text-anchor="middle">
+    <circle cx="392" cy="44" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="392" y="47">user</text>
+    <circle cx="392" cy="110" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="392" y="113">user</text>
+    <circle cx="392" cy="176" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="392" y="179">user</text>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1" stroke-opacity="0.4" stroke-dasharray="4 3">
+    <line x1="96" y1="106" x2="188" y2="44"/>
+    <line x1="96" y1="110" x2="188" y2="110"/>
+    <line x1="96" y1="114" x2="188" y2="176"/>
+  </g>
+  <g stroke="currentColor" fill="none" stroke-width="1.2" stroke-opacity="0.8">
+    <line x1="286" y1="44" x2="378" y2="44" marker-end="url(#cdn_ar)"/>
+    <line x1="286" y1="110" x2="378" y2="110" marker-end="url(#cdn_ar)"/>
+    <line x1="286" y1="176" x2="378" y2="176" marker-end="url(#cdn_ar)"/>
+  </g>
+  <text x="140" y="140" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.6">fill on miss</text>
+  <text x="226" y="212" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">each user is served from the nearest edge cache, not the distant origin</text>
+  <defs><marker id="cdn_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The origin is copied out to caching nodes — points of presence — spread around the world. A user is routed to the closest one and served over a short hop; the origin is touched only on a cache miss (the dashed links). Most traffic never reaches the origin, so it stays fast and lightly loaded even far away.</figcaption>
+</figure>
+
 ## Overview
 
 A CDN places caching nodes — *points of presence* — in many [data centers](/reference/data-center/) around the world. When a user requests a file, they are routed to the nearest node, which serves a cached copy if it has one or fetches it from the origin and keeps it for the next request. Because most of the traffic (images, video, scripts, static pages) is served from the edge, the origin sees far less load and distant users get content over a short network hop instead of a transcontinental one. CDNs also commonly absorb traffic spikes and blunt denial-of-service attacks.

--- a/docs/reference/data-storage.md
+++ b/docs/reference/data-storage.md
@@ -20,6 +20,27 @@ cite_urls:
 
 **Storage** is where a computer keeps data long-term, so that files and programs survive a power cycle.[^wiki] It is the permanent counterpart to [RAM](/reference/random-access-memory/).
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 230" role="img" aria-label="A pyramid of storage tiers: RAM at the narrow fast top, then SSD, then hard disk, then magnetic tape widening toward the bottom. A dashed line between RAM and SSD marks the volatile split — everything above is lost at power-off, everything below is kept. An arrow up the left reads faster and smaller; an arrow down the right reads larger, cheaper, and slower." xmlns="http://www.w3.org/2000/svg">
+  <g text-anchor="middle" fill="currentColor" font-size="10">
+    <rect x="150" y="40" width="140" height="32" rx="3" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="1.1"/><text x="220" y="60">RAM · working memory</text>
+    <rect x="110" y="76" width="220" height="32" rx="3" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.1"/><text x="220" y="96">SSD · flash — no moving parts</text>
+    <rect x="70" y="112" width="300" height="32" rx="3" fill="currentColor" fill-opacity="0.13" stroke="currentColor" stroke-width="1.1"/><text x="220" y="132">HDD · spinning platters</text>
+    <rect x="30" y="148" width="380" height="32" rx="3" fill="currentColor" fill-opacity="0.07" stroke="currentColor" stroke-width="1.1"/><text x="220" y="168">magnetic tape · archive</text>
+  </g>
+  <line x1="30" y1="74" x2="410" y2="74" stroke="currentColor" stroke-width="1.1" stroke-dasharray="5 3" stroke-opacity="0.7"/>
+  <text x="352" y="58" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">volatile ↑</text>
+  <text x="360" y="100" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">non-volatile ↓</text>
+  <line x1="16" y1="176" x2="16" y2="44" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.7" marker-end="url(#ds_ar)"/>
+  <text x="14" y="112" font-size="8" fill="currentColor" fill-opacity="0.85" text-anchor="middle" transform="rotate(-90 14 112)">faster · smaller</text>
+  <line x1="424" y1="44" x2="424" y2="176" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.7" marker-end="url(#ds_ar)"/>
+  <text x="422" y="112" font-size="8" fill="currentColor" fill-opacity="0.85" text-anchor="middle" transform="rotate(90 422 112)">larger · cheaper · slower</text>
+  <text x="220" y="204" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">the CPU works in RAM; anything worth keeping sinks to the tiers below</text>
+  <defs><marker id="ds_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Every storage device is a point on one speed-versus-cost curve: RAM at the top is fast but volatile, and each step down — SSD, hard disk, tape — is larger and cheaper per byte but slower. The dashed line is the volatile/non-volatile split: only RAM loses its contents at power-off, which is why the CPU works in memory and writes anything lasting to the tiers below.</figcaption>
+</figure>
+
 ## Overview
 Storage comes in a few common forms:
 

--- a/docs/reference/digital-to-analog-converter.md
+++ b/docs/reference/digital-to-analog-converter.md
@@ -20,6 +20,30 @@ cite_urls:
 
 **A digital-to-analog converter (DAC)** turns a sequence of digital numbers into a continuous analog voltage — the inverse of an [analog-to-digital converter](/reference/analog-to-digital-converter/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 168" role="img" aria-label="A signal path: a stream of digital sample values feeds a DAC, which produces a stepped staircase voltage; a low-pass filter then smooths that staircase into a continuous analog waveform." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <rect x="14" y="58" width="52" height="48" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/>
+    <text x="40" y="74">80</text><text x="40" y="87">110</text><text x="40" y="100">95</text>
+    <text x="40" y="122" font-size="8">samples</text>
+    <rect x="80" y="64" width="52" height="36" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="106" y="86" font-size="9" font-weight="600">DAC</text>
+    <rect x="286" y="64" width="66" height="36" rx="4" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.2"/><text x="319" y="82" font-size="8.5" font-weight="600">low-pass</text><text x="319" y="93" font-size="7">filter</text>
+  </g>
+  <polyline points="150,116 165,116 165,98 180,98 180,70 195,70 195,52 210,52 210,56 225,56 225,78 240,78 240,104 255,104 255,118 270,118" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <text x="210" y="138" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">staircase</text>
+  <path d="M372 116 C 398 44 426 44 452 116" fill="none" stroke="currentColor" stroke-width="1.7"/>
+  <text x="412" y="138" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">smooth analog</text>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <line x1="66" y1="82" x2="80" y2="82" marker-end="url(#dac_ar)"/>
+    <line x1="132" y1="82" x2="150" y2="82" marker-end="url(#dac_ar)"/>
+    <line x1="270" y1="82" x2="286" y2="82" marker-end="url(#dac_ar)"/>
+    <line x1="352" y1="82" x2="372" y2="82" marker-end="url(#dac_ar)"/>
+  </g>
+  <defs><marker id="dac_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Feed the DAC a stream of numbers at a fixed rate and it holds each as a proportional voltage — a stepped staircase. A low-pass filter rounds those steps into a smooth continuous wave. Resolution (bits) sets how fine the steps are; update rate sets how fast new samples arrive.</figcaption>
+</figure>
+
 ## Overview
 
 A DAC takes a binary value and produces a proportional voltage on its output; feeding it a stream of values at a fixed rate reconstructs a waveform. Its two headline specs mirror the ADC's: **resolution** (bits, which sets how finely the output is quantized) and **update rate** (how fast new samples are accepted). Some [microcontrollers](/reference/microcontroller/) — such as parts of the [STM32](/reference/stm32/) line — include a true on-chip DAC; others approximate one by low-pass filtering [PWM](/reference/pulse-width-modulation/).

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -19,6 +19,38 @@ cite_urls:
 
 **Docker** is a popular platform and toolset for building, sharing, and running [containers](/reference/container/). Introduced in 2013, it standardized container images and a simple command line and brought containerization into the mainstream.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 224" role="img" aria-label="A flow from left to right. A Dockerfile is built into an image made of stacked read-only layers — a base image, dependencies, and the app. Running the image produces a container: the same read-only layers with a thin writable layer added on top." xmlns="http://www.w3.org/2000/svg">
+  <rect x="18" y="80" width="80" height="56" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.2"/>
+  <text x="58" y="104" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">Dockerfile</text>
+  <text x="58" y="118" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">the recipe</text>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <rect x="152" y="120" width="104" height="24" rx="3" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1"/><text x="204" y="136">base image</text>
+    <rect x="152" y="96" width="104" height="24" rx="3" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1"/><text x="204" y="112">dependencies</text>
+    <rect x="152" y="72" width="104" height="24" rx="3" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1"/><text x="204" y="88">app</text>
+    <text x="204" y="62" font-size="9" font-weight="600">Image · read-only</text>
+  </g>
+  <g font-size="8" fill="currentColor" text-anchor="middle">
+    <rect x="330" y="120" width="104" height="24" rx="3" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1"/><text x="382" y="136">base image</text>
+    <rect x="330" y="96" width="104" height="24" rx="3" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="382" y="112">dependencies</text>
+    <rect x="330" y="72" width="104" height="24" rx="3" fill="currentColor" fill-opacity="0.16" stroke="currentColor" stroke-width="1"/><text x="382" y="88">app</text>
+    <rect x="330" y="48" width="104" height="24" rx="3" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="1" stroke-dasharray="4 3"/><text x="382" y="64">writable layer</text>
+    <text x="382" y="38" font-size="9" font-weight="600">Container · running</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <line x1="98" y1="108" x2="150" y2="108" stroke-opacity="0.8" marker-end="url(#dk_ar)"/>
+    <line x1="258" y1="108" x2="328" y2="108" stroke-opacity="0.8" marker-end="url(#dk_ar)"/>
+  </g>
+  <g font-size="7.5" fill="currentColor" fill-opacity="0.85" text-anchor="middle">
+    <text x="124" y="100">docker build</text>
+    <text x="293" y="100">docker run</text>
+  </g>
+  <text x="230" y="176" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">the read-only layers are shared and cached; only the top writable layer differs per container</text>
+  <defs><marker id="dk_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A Dockerfile is built into an image: a stack of read-only layers — base, dependencies, then your app — each cached and reusable. Running the image adds a thin writable layer on top, and that is the container. Because the heavy layers are shared, many containers from one image cost almost nothing extra.</figcaption>
+</figure>
+
 ## Overview
 
 A developer describes an image in a *Dockerfile* — a recipe listing a base image, dependencies, and the application — and Docker builds it into a layered, portable image. That image can be pushed to a registry such as Docker Hub and pulled to run identically anywhere Docker is installed. Docker did not invent the underlying kernel features (namespaces and cgroups), but its tooling and image format made them easy enough that containers became the default way to ship server software.[^home]

--- a/docs/reference/field-programmable-gate-array.md
+++ b/docs/reference/field-programmable-gate-array.md
@@ -20,6 +20,39 @@ cite_urls:
 
 A **field-programmable gate array** (**FPGA**) is an [integrated circuit](/reference/integrated-circuit/) whose internal digital logic can be reconfigured *after* manufacture — letting an engineer describe a custom hardware circuit in software and load it onto the chip.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 236" role="img" aria-label="Left: an FPGA fabric — a grid of logic blocks threaded by horizontal and vertical routing channels that meet at switch boxes, with one bold configured path snaking between blocks. Right: the inside of one logic block, a lookup table feeding a flip-flop. Loading a bitstream sets every lookup table and switch, so the chip becomes the circuit the designer described." xmlns="http://www.w3.org/2000/svg">
+  <text x="118" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Reconfigurable fabric</text>
+  <g stroke="currentColor" stroke-width="0.8" stroke-opacity="0.28">
+    <line x1="24" y1="34" x2="24" y2="210"/><line x1="70" y1="34" x2="70" y2="210"/><line x1="116" y1="34" x2="116" y2="210"/><line x1="162" y1="34" x2="162" y2="210"/><line x1="208" y1="34" x2="208" y2="210"/>
+    <line x1="24" y1="34" x2="208" y2="34"/><line x1="24" y1="80" x2="208" y2="80"/><line x1="24" y1="126" x2="208" y2="126"/><line x1="24" y1="172" x2="208" y2="172"/><line x1="24" y1="210" x2="208" y2="210"/>
+  </g>
+  <g fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1">
+    <rect x="35" y="45" width="24" height="24" rx="2"/><rect x="81" y="45" width="24" height="24" rx="2"/><rect x="127" y="45" width="24" height="24" rx="2"/><rect x="173" y="45" width="24" height="24" rx="2"/>
+    <rect x="35" y="91" width="24" height="24" rx="2"/><rect x="81" y="91" width="24" height="24" rx="2"/><rect x="127" y="91" width="24" height="24" rx="2"/><rect x="173" y="91" width="24" height="24" rx="2"/>
+    <rect x="35" y="137" width="24" height="24" rx="2"/><rect x="81" y="137" width="24" height="24" rx="2"/><rect x="127" y="137" width="24" height="24" rx="2"/><rect x="173" y="137" width="24" height="24" rx="2"/>
+  </g>
+  <g fill="currentColor" fill-opacity="0.55" stroke="currentColor" stroke-width="0.6">
+    <rect x="66" y="76" width="8" height="8"/><rect x="158" y="76" width="8" height="8"/><rect x="112" y="122" width="8" height="8"/>
+  </g>
+  <path d="M47 69 L70 80 L116 80 L116 126 L162 126 L173 149" fill="none" stroke="currentColor" stroke-width="2" stroke-opacity="0.9"/>
+  <text x="116" y="228" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">logic blocks + routing channels + switch boxes</text>
+  <rect x="256" y="66" width="172" height="96" rx="5" fill="none" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 3"/>
+  <text x="342" y="60" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">one logic block</text>
+  <line x1="230" y1="112" x2="252" y2="112" stroke="currentColor" stroke-width="1" stroke-opacity="0.7" marker-end="url(#fpga_ar)"/>
+  <rect x="270" y="92" width="60" height="40" rx="4" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/>
+  <text x="300" y="110" text-anchor="middle" font-size="8.5" fill="currentColor">LUT</text>
+  <text x="300" y="122" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">truth table</text>
+  <rect x="356" y="92" width="60" height="40" rx="4" fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="1.1"/>
+  <text x="386" y="110" text-anchor="middle" font-size="8" fill="currentColor">flip-flop</text>
+  <text x="386" y="122" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">register</text>
+  <line x1="330" y1="112" x2="356" y2="112" stroke="currentColor" stroke-width="1.1" marker-end="url(#fpga_ar)"/>
+  <text x="342" y="150" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">any Boolean function, then clocked</text>
+  <defs><marker id="fpga_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An FPGA is a grid of small logic blocks — each a lookup table plus a flip-flop — linked by routing channels that meet at configurable switch boxes. A bitstream programs every lookup table and every switch, wiring a bold path like the one shown, so instead of running instructions the chip physically becomes the circuit you designed.</figcaption>
+</figure>
+
 ## Overview
 
 An FPGA is a fabric of programmable logic blocks — lookup tables (LUTs) and flip-flops — wired together by a configurable interconnect, plus dedicated blocks for arithmetic (DSP slices) and memory. A designer writes the circuit in a hardware description language (VHDL or Verilog); a toolchain *synthesizes* and *places-and-routes* it into a bitstream that configures the chip. Unlike a CPU running instructions, an FPGA *becomes* the circuit, executing many operations truly in parallel and on every clock cycle.

--- a/docs/reference/flash-memory.md
+++ b/docs/reference/flash-memory.md
@@ -18,6 +18,37 @@ cite_urls:
 
 **Flash memory** is non-volatile solid-state storage that retains data without power by trapping electric charge in floating-gate transistor cells.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 234" role="img" aria-label="Top: one flash cell in cross-section — a control gate over an isolated floating gate that traps charge, above a channel with source and drain. The trapped charge is the stored bit. Bottom: a grid of cells, with a dashed outline marking one erase block, because flash is written a page at a time but erased a whole block at a time." xmlns="http://www.w3.org/2000/svg">
+  <text x="140" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">One flash cell</text>
+  <g fill="currentColor" font-size="8.5">
+    <rect x="160" y="28" width="100" height="18" rx="2" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.1"/>
+    <text x="210" y="40" text-anchor="middle" font-size="8">control gate</text>
+    <rect x="160" y="52" width="100" height="16" rx="2" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1" stroke-dasharray="3 2"/>
+    <circle cx="185" cy="60" r="1.7" fill="currentColor"/><circle cx="210" cy="60" r="1.7" fill="currentColor"/><circle cx="235" cy="60" r="1.7" fill="currentColor"/>
+    <rect x="140" y="76" width="140" height="24" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.1"/>
+    <rect x="140" y="76" width="26" height="24" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <rect x="254" y="76" width="26" height="24" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <text x="153" y="91" text-anchor="middle" font-size="7.5">S</text>
+    <text x="267" y="91" text-anchor="middle" font-size="7.5">D</text>
+    <text x="210" y="91" text-anchor="middle" font-size="7">channel</text>
+    <text x="288" y="60" text-anchor="start" font-size="8">floating gate</text>
+    <text x="288" y="71" text-anchor="start" font-size="7.5" fill-opacity="0.85">traps charge = the bit</text>
+  </g>
+  <line x1="280" y1="60" x2="286" y2="60" stroke="currentColor" stroke-width="0.9" stroke-opacity="0.6"/>
+  <text x="220" y="130" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Cells erase a block at a time</text>
+  <g fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="0.8">
+    <rect x="90" y="150" width="26" height="14" rx="2"/><rect x="118" y="150" width="26" height="14" rx="2"/><rect x="146" y="150" width="26" height="14" rx="2"/><rect x="174" y="150" width="26" height="14" rx="2"/><rect x="202" y="150" width="26" height="14" rx="2"/><rect x="230" y="150" width="26" height="14" rx="2"/><rect x="258" y="150" width="26" height="14" rx="2"/><rect x="286" y="150" width="26" height="14" rx="2"/><rect x="314" y="150" width="26" height="14" rx="2"/><rect x="342" y="150" width="26" height="14" rx="2"/>
+    <rect x="90" y="168" width="26" height="14" rx="2"/><rect x="118" y="168" width="26" height="14" rx="2"/><rect x="146" y="168" width="26" height="14" rx="2"/><rect x="174" y="168" width="26" height="14" rx="2"/><rect x="202" y="168" width="26" height="14" rx="2"/><rect x="230" y="168" width="26" height="14" rx="2"/><rect x="258" y="168" width="26" height="14" rx="2"/><rect x="286" y="168" width="26" height="14" rx="2"/><rect x="314" y="168" width="26" height="14" rx="2"/><rect x="342" y="168" width="26" height="14" rx="2"/>
+    <rect x="90" y="186" width="26" height="14" rx="2"/><rect x="118" y="186" width="26" height="14" rx="2"/><rect x="146" y="186" width="26" height="14" rx="2"/><rect x="174" y="186" width="26" height="14" rx="2"/><rect x="202" y="186" width="26" height="14" rx="2"/><rect x="230" y="186" width="26" height="14" rx="2"/><rect x="258" y="186" width="26" height="14" rx="2"/><rect x="286" y="186" width="26" height="14" rx="2"/><rect x="314" y="186" width="26" height="14" rx="2"/><rect x="342" y="186" width="26" height="14" rx="2"/>
+  </g>
+  <rect x="86" y="146" width="146" height="58" rx="3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/>
+  <text x="159" y="220" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">one erase block</text>
+  <text x="312" y="220" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">wear leveling spreads writes</text>
+</svg>
+<figcaption>Each cell stores a bit (or several) as charge trapped on an isolated floating gate — it stays put with the power off. Cells can be written a page at a time but only erased a whole block at a time, and each block wears out after many cycles, so controllers spread writes with wear leveling.</figcaption>
+</figure>
+
 ## Overview
 
 Each cell holds one or more bits as the presence or absence of trapped charge; reading senses that charge, while writing and erasing move it through the insulating layer. Flash comes in two main families: **NOR**, which allows fast random reads and is used to store firmware, and **NAND**, which is denser and cheaper per bit and underlies most mass storage. Cells can be erased only a block at a time and endure a finite number of erase cycles, so controllers use *wear leveling* to spread writes evenly. Packing more bits per cell (SLC, MLC, TLC, QLC) raises capacity at the cost of endurance and speed.

--- a/docs/reference/gateway.md
+++ b/docs/reference/gateway.md
@@ -17,6 +17,35 @@ cite_urls:
 
 A **gateway** is a network node that joins two networks, acting as the entry and exit point through which traffic leaves a local network for another — most commonly the wider internet.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 452 210" role="img" aria-label="Three hosts on a local network on the left all funnel through a single gateway node in the middle, which is the one entry and exit point at the network boundary, and out to the internet or another network on the right. A dashed line marks the boundary between the local and external sides." xmlns="http://www.w3.org/2000/svg">
+  <text x="86" y="24" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.85" font-weight="600">local network</text>
+  <text x="382" y="24" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.85" font-weight="600">external</text>
+  <line x1="226" y1="18" x2="226" y2="192" stroke="currentColor" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="5 4"/>
+  <g fill="currentColor" font-size="7.5" text-anchor="middle">
+    <circle cx="48" cy="55" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="48" y="58">host</text>
+    <circle cx="48" cy="103" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="48" y="106">host</text>
+    <circle cx="48" cy="151" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="48" y="154">host</text>
+  </g>
+  <rect x="170" y="76" width="104" height="54" rx="6" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1.4"/>
+  <text x="222" y="98" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">Gateway</text>
+  <text x="222" y="112" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">one entry / exit point</text>
+  <g stroke="currentColor" stroke-width="1.2" stroke-opacity="0.75" fill="none">
+    <line x1="61" y1="57" x2="170" y2="96" marker-end="url(#gw_ar)"/>
+    <line x1="61" y1="103" x2="170" y2="103" marker-end="url(#gw_ar)"/>
+    <line x1="61" y1="149" x2="170" y2="110" marker-end="url(#gw_ar)"/>
+  </g>
+  <rect x="340" y="76" width="96" height="54" rx="8" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="388" y="99" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">Internet</text>
+  <text x="388" y="113" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">/ another network</text>
+  <line x1="274" y1="103" x2="340" y2="103" stroke="currentColor" stroke-width="1.4" stroke-opacity="0.8" fill="none" marker-end="url(#gw_ar)"/>
+  <text x="307" y="94" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.7">egress</text>
+  <text x="226" y="204" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">all traffic between the two networks passes through the one boundary node</text>
+  <defs><marker id="gw_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A gateway is the single node where one network meets another. Hosts on the local side send anything bound off-network to it, and it forwards traffic out the one egress point — often translating between the two networks along the way. It names a role at the boundary, not one specific box; on a home LAN the router fills it.</figcaption>
+</figure>
+
 ## Overview
 
 On a home or office network the *default gateway* is usually the [router](/reference/router/): the address a host sends packets to when their destination is not on the local [LAN](/reference/lan-and-wan/). More broadly, a gateway can translate between dissimilar networks or protocols — bridging an IoT radio network onto IP, for instance — doing more than a router that merely forwards [IP](/reference/ip-address/) packets. The term describes a *role* at a network boundary rather than one specific box.

--- a/docs/reference/graphics-processing-unit.md
+++ b/docs/reference/graphics-processing-unit.md
@@ -18,6 +18,29 @@ cite_urls:
 
 A **graphics processing unit** (**GPU**) is a processor built from many small cores that run the same operation across large blocks of data in parallel — originally for rendering graphics, now also for general computation.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 176" role="img" aria-label="A comparison of two processors. On the left, a CPU has four large cores tuned for sequential work. On the right, a GPU has a dense grid of many small cores that apply the same operation across a wide block of data at once." xmlns="http://www.w3.org/2000/svg">
+  <text x="110" y="16" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">CPU: a few powerful cores</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="22" y="30" width="85" height="46" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="64" y="57">core</text>
+    <rect x="115" y="30" width="85" height="46" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="157" y="57">core</text>
+    <rect x="22" y="82" width="85" height="46" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="64" y="109">core</text>
+    <rect x="115" y="82" width="85" height="46" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="157" y="109">core</text>
+  </g>
+  <text x="111" y="150" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.8">sequential, branchy work</text>
+  <line x1="230" y1="24" x2="230" y2="134" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.35" stroke-dasharray="3 3"/>
+  <text x="350" y="16" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">GPU: hundreds of small cores</text>
+  <g fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="0.8">
+    <rect x="252" y="30" width="22" height="18" rx="2"/><rect x="278" y="30" width="22" height="18" rx="2"/><rect x="304" y="30" width="22" height="18" rx="2"/><rect x="330" y="30" width="22" height="18" rx="2"/><rect x="356" y="30" width="22" height="18" rx="2"/><rect x="382" y="30" width="22" height="18" rx="2"/><rect x="408" y="30" width="22" height="18" rx="2"/>
+    <rect x="252" y="52" width="22" height="18" rx="2"/><rect x="278" y="52" width="22" height="18" rx="2"/><rect x="304" y="52" width="22" height="18" rx="2"/><rect x="330" y="52" width="22" height="18" rx="2"/><rect x="356" y="52" width="22" height="18" rx="2"/><rect x="382" y="52" width="22" height="18" rx="2"/><rect x="408" y="52" width="22" height="18" rx="2"/>
+    <rect x="252" y="74" width="22" height="18" rx="2"/><rect x="278" y="74" width="22" height="18" rx="2"/><rect x="304" y="74" width="22" height="18" rx="2"/><rect x="330" y="74" width="22" height="18" rx="2"/><rect x="356" y="74" width="22" height="18" rx="2"/><rect x="382" y="74" width="22" height="18" rx="2"/><rect x="408" y="74" width="22" height="18" rx="2"/>
+    <rect x="252" y="96" width="22" height="18" rx="2"/><rect x="278" y="96" width="22" height="18" rx="2"/><rect x="304" y="96" width="22" height="18" rx="2"/><rect x="330" y="96" width="22" height="18" rx="2"/><rect x="356" y="96" width="22" height="18" rx="2"/><rect x="382" y="96" width="22" height="18" rx="2"/><rect x="408" y="96" width="22" height="18" rx="2"/>
+  </g>
+  <text x="341" y="150" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.8">same op across all lanes (SIMD)</text>
+</svg>
+<figcaption>A CPU spends its silicon on a few powerful cores for sequential, branchy work; a GPU spends it on hundreds of simple cores that apply one operation across a wide block of data at once. That data-parallel shape is what suits graphics, AI, and batched DSP.</figcaption>
+</figure>
+
 ## Overview
 
 Where a [CPU](/reference/central-processing-unit/) has a few powerful cores tuned for sequential work, a GPU has hundreds or thousands of simpler cores that excel at *data-parallel* math: the same calculation applied to many pixels, vertices, or array elements at once. A discrete GPU is a card that plugs into a [PCIe](/reference/pci-express/) slot with its own high-bandwidth memory; integrated GPUs share the CPU's memory. Modern GPUs are large [integrated circuits](/reference/integrated-circuit/) whose transistor counts have ridden [Moore's law](/reference/moores-law/) upward for decades.

--- a/docs/reference/hard-disk-drive.md
+++ b/docs/reference/hard-disk-drive.md
@@ -19,6 +19,38 @@ cite_urls:
 
 A **hard disk drive (HDD)** is a non-volatile storage device that records data on rapidly spinning magnetic platters, read and written by heads on a moving arm.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 232" role="img" aria-label="Top-down view of a hard disk: a platter of concentric tracks spins on a central spindle while an actuator arm pivots from the corner, swinging a read/write head in an arc to the target track. Reaching data therefore takes seek time for the arm to move plus rotational delay for the platter to turn the data under the head." xmlns="http://www.w3.org/2000/svg">
+  <circle cx="140" cy="120" r="92" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.2"/>
+  <g fill="none" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.4">
+    <circle cx="140" cy="120" r="26"/><circle cx="140" cy="120" r="46"/><circle cx="140" cy="120" r="66"/><circle cx="140" cy="120" r="86"/>
+  </g>
+  <circle cx="140" cy="120" r="6" fill="currentColor"/>
+  <line x1="250" y1="206" x2="120" y2="52" stroke="currentColor" stroke-width="5" stroke-opacity="0.4" stroke-linecap="round"/>
+  <circle cx="250" cy="206" r="6" fill="currentColor" fill-opacity="0.5" stroke="currentColor" stroke-width="1"/>
+  <rect x="112" y="46" width="18" height="13" rx="2" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1"/>
+  <path d="M140 96 A 24 24 0 0 1 163 121" fill="none" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.8" marker-end="url(#hdd_ar)"/>
+  <path d="M232 200 A 26 26 0 0 1 256 181" fill="none" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.8" marker-end="url(#hdd_ar)"/>
+  <g font-size="8" fill="currentColor" stroke="none">
+    <line x1="298" y1="52" x2="132" y2="52" stroke="currentColor" stroke-width="0.7" stroke-opacity="0.5"/>
+    <text x="300" y="55" text-anchor="start">read/write head</text>
+    <line x1="298" y1="92" x2="178" y2="116" stroke="currentColor" stroke-width="0.7" stroke-opacity="0.5"/>
+    <text x="300" y="95" text-anchor="start">actuator arm</text>
+    <line x1="298" y1="124" x2="232" y2="122" stroke="currentColor" stroke-width="0.7" stroke-opacity="0.5"/>
+    <text x="300" y="127" text-anchor="start">platter</text>
+    <line x1="298" y1="160" x2="196" y2="150" stroke="currentColor" stroke-width="0.7" stroke-opacity="0.5"/>
+    <text x="300" y="163" text-anchor="start">track</text>
+    <line x1="298" y1="196" x2="150" y2="124" stroke="currentColor" stroke-width="0.7" stroke-opacity="0.5"/>
+    <text x="300" y="199" text-anchor="start">spindle</text>
+  </g>
+  <text x="300" y="176" text-anchor="start" font-size="7" fill="currentColor" fill-opacity="0.8">(one of several</text>
+  <text x="300" y="186" text-anchor="start" font-size="7" fill="currentColor" fill-opacity="0.8">stacked platters)</text>
+  <text x="150" y="226" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">access = seek (arm swings) + rotational delay (platter turns)</text>
+  <defs><marker id="hdd_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Bits sit on concentric tracks of a platter spinning on the spindle. To read one, the actuator arm swings its head to the right track (seek time) and then waits for the platter to rotate that spot under the head (rotational delay). That mechanical two-step is the latency an SSD, with no moving parts, avoids.</figcaption>
+</figure>
+
 ## Overview
 
 Inside the sealed enclosure, one or more rigid platters spin on a spindle at a fixed rate — commonly 5400 or 7200 RPM. A read/write head floats nanometres above each surface, magnetising tiny regions to store bits. Because the head must physically seek to the right track and wait for the platter to rotate into position, access has mechanical latency that an [SSD](/reference/solid-state-drive/) avoids. HDDs are still the cheapest way to hold large amounts of data per terabyte, which keeps them in servers, archives, and bulk storage.

--- a/docs/reference/hypervisor.md
+++ b/docs/reference/hypervisor.md
@@ -18,6 +18,36 @@ cite_urls:
 
 A **hypervisor** is software or firmware that creates and runs virtual machines, dividing one physical computer's CPU, memory, and I/O among several isolated guest operating systems.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 420 232" role="img" aria-label="One physical computer at the bottom, an emphasized hypervisor layer above it drawn with a heavier border, and three isolated virtual machines stacked on top, each with its own guest operating system and application. A note below explains that a Type 1 hypervisor runs on bare metal while a Type 2 runs on a host operating system." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <g stroke="currentColor">
+      <rect x="48" y="44" width="104" height="92" rx="5" fill="none" stroke-width="1.2" stroke-dasharray="4 3"/>
+      <text x="100" y="59" font-size="8.5" font-weight="600">VM 1</text>
+      <rect x="55" y="66" width="90" height="28" rx="3" fill="currentColor" fill-opacity="0.2" stroke-width="1"/><text x="100" y="84">App</text>
+      <rect x="55" y="98" width="90" height="32" rx="3" fill="currentColor" fill-opacity="0.1" stroke-width="1"/><text x="100" y="118" font-size="8.5">Guest OS</text>
+      <rect x="162" y="44" width="104" height="92" rx="5" fill="none" stroke-width="1.2" stroke-dasharray="4 3"/>
+      <text x="214" y="59" font-size="8.5" font-weight="600">VM 2</text>
+      <rect x="169" y="66" width="90" height="28" rx="3" fill="currentColor" fill-opacity="0.2" stroke-width="1"/><text x="214" y="84">App</text>
+      <rect x="169" y="98" width="90" height="32" rx="3" fill="currentColor" fill-opacity="0.1" stroke-width="1"/><text x="214" y="118" font-size="8.5">Guest OS</text>
+      <rect x="276" y="44" width="96" height="92" rx="5" fill="none" stroke-width="1.2" stroke-dasharray="4 3"/>
+      <text x="324" y="59" font-size="8.5" font-weight="600">VM 3</text>
+      <rect x="283" y="66" width="82" height="28" rx="3" fill="currentColor" fill-opacity="0.2" stroke-width="1"/><text x="324" y="84">App</text>
+      <rect x="283" y="98" width="82" height="32" rx="3" fill="currentColor" fill-opacity="0.1" stroke-width="1"/><text x="324" y="118" font-size="8.5">Guest OS</text>
+    </g>
+    <rect x="40" y="142" width="340" height="30" rx="4" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="2"/><text x="210" y="161" font-weight="600">Hypervisor — creates &amp; isolates the VMs</text>
+    <rect x="40" y="176" width="340" height="26" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.2"/><text x="210" y="193">One physical computer · CPU · memory · storage</text>
+    <text x="210" y="223" font-size="8" fill-opacity="0.85">Type 1 sits on the bare hardware; Type 2 runs on a host OS</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.5">
+    <line x1="100" y1="136" x2="100" y2="142"/>
+    <line x1="214" y1="136" x2="214" y2="142"/>
+    <line x1="324" y1="136" x2="324" y2="142"/>
+  </g>
+</svg>
+<figcaption>The hypervisor is the emphasized band in the middle — the engine that turns one machine into many. It carves the host's CPU, memory, and storage into virtual machines and walls each off, so one guest's crash or load can't reach another. A Type 1 hypervisor runs straight on the hardware; a Type 2 runs as an app on a host OS.</figcaption>
+</figure>
+
 ## Overview
 
 Each virtual machine believes it has its own hardware; the hypervisor mediates access to the real resources and keeps the guests separated. There are two broad kinds. A *Type 1* (bare-metal) hypervisor runs directly on the hardware and is what data centers and cloud platforms use for performance and density. A *Type 2* (hosted) hypervisor runs as an application on top of an ordinary [operating system](/reference/operating-system/), which is convenient for desktops and testing. Either way, the hypervisor is the engine that makes [virtualization](/reference/virtualization/) possible.

--- a/docs/reference/i2c.md
+++ b/docs/reference/i2c.md
@@ -20,6 +20,36 @@ cite_urls:
 
 **I²C** (Inter-Integrated Circuit) is a two-wire serial bus that lets one controller communicate with many peripheral chips over a shared clock and data line.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 190" role="img" aria-label="An I2C bus: one controller and three peripherals all share just two wires — SCL for the clock and SDA for data — with pull-up resistors to Vcc. Each peripheral has a unique address, so many chips fan out from the same pair of lines." xmlns="http://www.w3.org/2000/svg">
+  <text x="150" y="14" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">Vcc · pull-ups</text>
+  <line x1="132" y1="18" x2="168" y2="18" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  <line x1="140" y1="18" x2="140" y2="40" stroke="currentColor" stroke-width="1" stroke-opacity="0.5"/>
+  <line x1="160" y1="18" x2="160" y2="62" stroke="currentColor" stroke-width="1" stroke-opacity="0.5"/>
+  <line x1="24" y1="40" x2="426" y2="40" stroke="currentColor" stroke-width="1.6"/>
+  <line x1="24" y1="62" x2="426" y2="62" stroke="currentColor" stroke-width="1.6"/>
+  <text x="432" y="43" font-size="9" fill="currentColor" font-weight="600">SCL</text>
+  <text x="432" y="65" font-size="9" fill="currentColor" font-weight="600">SDA</text>
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <rect x="24" y="86" width="88" height="52" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+    <text x="68" y="108" font-weight="600">controller</text>
+    <text x="68" y="123" font-size="8">(MCU)</text>
+    <rect x="150" y="112" width="84" height="42" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="192" y="130">sensor</text><text x="192" y="144" font-size="8">0x1D</text>
+    <rect x="252" y="112" width="84" height="42" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="294" y="130">RTC</text><text x="294" y="144" font-size="8">0x68</text>
+    <rect x="354" y="112" width="72" height="42" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="390" y="130">display</text><text x="390" y="144" font-size="8">0x3C</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" stroke-opacity="0.6">
+    <line x1="48" y1="86" x2="48" y2="40"/><line x1="88" y1="86" x2="88" y2="62"/>
+    <line x1="174" y1="112" x2="174" y2="40"/><line x1="210" y1="112" x2="210" y2="62"/>
+    <line x1="276" y1="112" x2="276" y2="40"/><line x1="312" y1="112" x2="312" y2="62"/>
+    <line x1="378" y1="112" x2="378" y2="40"/><line x1="402" y1="112" x2="402" y2="62"/>
+  </g>
+  <g fill="currentColor"><circle cx="174" cy="40" r="2"/><circle cx="210" cy="62" r="2"/><circle cx="276" cy="40" r="2"/><circle cx="312" cy="62" r="2"/><circle cx="378" cy="40" r="2"/><circle cx="402" cy="62" r="2"/></g>
+  <text x="235" y="178" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">two shared wires · every peripheral answers to its own address</text>
+</svg>
+<figcaption>I²C fans out from just two open-drain wires — a shared clock (SCL) and a bidirectional data line (SDA), both pulled up to Vcc. Because every chip has a numeric address, one pair of lines can reach dozens of devices, which is why it's the go-to bus for wiring many small sensors to an MCU.</figcaption>
+</figure>
+
 ## Overview
 
 I²C needs just two signals: a clock (SCL) and a bidirectional data line (SDA), both open-drain with pull-up resistors. Every peripheral has a numeric address, so a single pair of wires can fan out to dozens of devices on the same bus. It is slower than [SPI](/reference/spi/) — typically 100 kHz to a few MHz — but its low pin count and addressing make it ideal for connecting many small chips. A [microcontroller's](/reference/microcontroller/) I²C peripheral handles the bit-level timing in hardware.

--- a/docs/reference/infrastructure-as-a-service.md
+++ b/docs/reference/infrastructure-as-a-service.md
@@ -20,6 +20,58 @@ cite_urls:
 
 **Infrastructure as a service** (**IaaS**) is a [cloud computing](/reference/cloud-computing/) model in which the provider rents out raw compute, storage, and networking — usually as virtual machines — and you manage everything above the bare hardware.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 464 268" role="img" aria-label="A grid of who manages each layer across four tiers. Rows are application, data, runtime, operating system, virtualization, and hardware. Columns are on-premises, IaaS, PaaS, and SaaS. Filled cells are managed by you; light cells are managed by the provider. Moving right, the provider takes over more layers from the bottom up." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <text x="144" y="36" font-weight="600">On-prem</text>
+    <text x="234" y="36" font-weight="600">IaaS</text>
+    <text x="324" y="36" font-weight="600">PaaS</text>
+    <text x="414" y="36" font-weight="600">SaaS</text>
+  </g>
+  <g fill="currentColor" font-size="8.5" text-anchor="end">
+    <text x="94" y="63">Application</text>
+    <text x="94" y="93">Data</text>
+    <text x="94" y="123">Runtime</text>
+    <text x="94" y="153">OS</text>
+    <text x="94" y="183">Virtualization</text>
+    <text x="94" y="213">Hardware</text>
+  </g>
+  <g stroke="currentColor">
+    <rect x="103" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="193" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="283" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="283" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+  </g>
+  <g font-size="8" fill="currentColor">
+    <rect x="150" y="242" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <text x="170" y="252" text-anchor="start">you manage</text>
+    <rect x="252" y="242" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5"/>
+    <text x="272" y="252" text-anchor="start">provider manages</text>
+  </g>
+</svg>
+<figcaption>Each tier is a line drawn through the same stack. On-premises you run everything; IaaS hands you a virtual machine and up (you keep the OS and above); PaaS also runs the runtime; SaaS is a finished application. Moving right, the provider absorbs more layers from the hardware up.</figcaption>
+</figure>
+
 ## Overview
 
 With IaaS the provider owns the [data center](/reference/data-center/), the physical servers, and the [virtualization](/reference/virtualization/) layer; you receive a virtual machine and are responsible for the [operating system](/reference/operating-system/), patching, services, and your application. It is the most flexible cloud tier and the closest to running your own server, billed on demand by the hour or second. A [virtual private server](/reference/virtual-private-server/) is essentially a small, fixed slice of IaaS.

--- a/docs/reference/input-output.md
+++ b/docs/reference/input-output.md
@@ -20,6 +20,33 @@ cite_urls:
 
 **Input/output (I/O)** is the set of channels through which a computer takes in and sends out data — everything that connects the [CPU](/reference/central-processing-unit/) to the world beyond the chip.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 210" role="img" aria-label="The CPU on the left connects through three I/O controllers in the middle to a keyboard, a disk, and a network port on the right, with data flowing both into and out of the processor through those controllers." xmlns="http://www.w3.org/2000/svg">
+  <rect x="18" y="78" width="90" height="54" rx="6" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+  <text x="63" y="102" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">CPU</text>
+  <text x="63" y="117" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">runs code</text>
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <rect x="168" y="30" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="218" y="51">kbd controller</text>
+    <rect x="168" y="88" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="218" y="109">disk controller</text>
+    <rect x="168" y="146" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="218" y="167">NIC</text>
+    <rect x="332" y="30" width="104" height="34" rx="4" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.1"/><text x="384" y="47">keyboard</text><text x="384" y="58" font-size="7" fill-opacity="0.8">in</text>
+    <rect x="332" y="88" width="104" height="34" rx="4" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.1"/><text x="384" y="105">disk</text><text x="384" y="116" font-size="7" fill-opacity="0.8">in ⇄ out</text>
+    <rect x="332" y="146" width="104" height="34" rx="4" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.1"/><text x="384" y="163">network</text><text x="384" y="174" font-size="7" fill-opacity="0.8">in ⇄ out</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <line x1="108" y1="105" x2="168" y2="47" marker-start="url(#io_ar)" marker-end="url(#io_ar)"/>
+    <line x1="108" y1="105" x2="168" y2="105" marker-start="url(#io_ar)" marker-end="url(#io_ar)"/>
+    <line x1="108" y1="105" x2="168" y2="163" marker-start="url(#io_ar)" marker-end="url(#io_ar)"/>
+    <line x1="268" y1="47" x2="332" y2="47" marker-start="url(#io_ar)" marker-end="url(#io_ar)"/>
+    <line x1="268" y1="105" x2="332" y2="105" marker-start="url(#io_ar)" marker-end="url(#io_ar)"/>
+    <line x1="268" y1="163" x2="332" y2="163" marker-start="url(#io_ar)" marker-end="url(#io_ar)"/>
+  </g>
+  <text x="240" y="202" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">every device reaches the CPU through a controller — data in and out</text>
+  <defs><marker id="io_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The CPU never touches devices directly — each keyboard, disk, or network port sits behind an I/O controller that the processor talks to. Input flows in (keystrokes, packets, disk reads) and output flows back out (writes, packets). A computer with no I/O is sealed off and useless.</figcaption>
+</figure>
+
 ## Overview
 **Input** brings data in: a keyboard, a mouse, a microphone, a sensor reading, a packet arriving on the network. **Output** sends data back out: pixels to a screen, sound to a speaker, a packet onto the network, a signal to an actuator. Many channels are bidirectional — USB and network ports carry data both ways.
 

--- a/docs/reference/integrated-circuit.md
+++ b/docs/reference/integrated-circuit.md
@@ -18,6 +18,33 @@ cite_urls:
 
 An **integrated circuit** (**IC**, or chip) is a set of electronic circuits fabricated together on a single small piece of [semiconductor](/reference/semiconductor/) material, usually silicon.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 232" role="img" aria-label="On the left, a chip package with rows of pins; a zoom expands its interior on the right to reveal a single silicon die holding labelled logic and memory blocks above a dense field of tiny squares standing in for millions of transistors, all etched together." xmlns="http://www.w3.org/2000/svg">
+  <rect x="46" y="76" width="104" height="82" rx="4" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="98" y="112" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">chip</text>
+  <text x="98" y="126" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">package</text>
+  <g stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7">
+    <line x1="40" y1="88" x2="46" y2="88"/><line x1="40" y1="104" x2="46" y2="104"/><line x1="40" y1="120" x2="46" y2="120"/><line x1="40" y1="136" x2="46" y2="136"/>
+    <line x1="150" y1="88" x2="156" y2="88"/><line x1="150" y1="104" x2="156" y2="104"/><line x1="150" y1="120" x2="156" y2="120"/><line x1="150" y1="136" x2="156" y2="136"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.45" stroke-dasharray="4 3" fill="none">
+    <line x1="150" y1="76" x2="230" y2="34"/><line x1="150" y1="158" x2="230" y2="198"/>
+  </g>
+  <text x="190" y="26" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.7">zoom in</text>
+  <rect x="230" y="34" width="190" height="164" rx="4" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.5"/>
+  <text x="325" y="50" text-anchor="middle" font-size="8" fill="currentColor" font-weight="600">one silicon die</text>
+  <rect x="242" y="58" width="80" height="40" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="282" y="82" text-anchor="middle" font-size="8" fill="currentColor">logic</text>
+  <rect x="330" y="58" width="78" height="40" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="369" y="82" text-anchor="middle" font-size="8" fill="currentColor">SRAM</text>
+  <g fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="0.5" stroke-opacity="0.5">
+    <rect x="242" y="112" width="12" height="12"/><rect x="262" y="112" width="12" height="12"/><rect x="282" y="112" width="12" height="12"/><rect x="302" y="112" width="12" height="12"/><rect x="322" y="112" width="12" height="12"/><rect x="342" y="112" width="12" height="12"/><rect x="362" y="112" width="12" height="12"/><rect x="382" y="112" width="12" height="12"/>
+    <rect x="242" y="132" width="12" height="12"/><rect x="262" y="132" width="12" height="12"/><rect x="282" y="132" width="12" height="12"/><rect x="302" y="132" width="12" height="12"/><rect x="322" y="132" width="12" height="12"/><rect x="342" y="132" width="12" height="12"/><rect x="362" y="132" width="12" height="12"/><rect x="382" y="132" width="12" height="12"/>
+    <rect x="242" y="152" width="12" height="12"/><rect x="262" y="152" width="12" height="12"/><rect x="282" y="152" width="12" height="12"/><rect x="302" y="152" width="12" height="12"/><rect x="322" y="152" width="12" height="12"/><rect x="342" y="152" width="12" height="12"/><rect x="362" y="152" width="12" height="12"/><rect x="382" y="152" width="12" height="12"/>
+  </g>
+  <text x="325" y="186" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.8">millions of transistors, etched together</text>
+</svg>
+<figcaption>A chip is a package wrapped around a single sliver of silicon — the die. Zoom in and the whole circuit is there: logic and memory blocks plus millions or billions of transistors, all etched and wired together in one fabrication step. That integration is what made computers small, cheap, and reliable.</figcaption>
+</figure>
+
 ## Overview
 
 Instead of wiring individual [transistors](/reference/transistor/), resistors, and other parts by hand, an IC etches them and their connections onto one *die* in a single manufacturing process. Independently invented by Jack Kilby and Robert Noyce around 1958–1959, this packed whole circuits into a tiny, reliable, cheap chip. Successive process generations shrank the features and multiplied the transistor count — the trend captured by [Moore's law](/reference/moores-law/) — until a single chip could hold billions of switches.

--- a/docs/reference/interrupt.md
+++ b/docs/reference/interrupt.md
@@ -20,6 +20,28 @@ cite_urls:
 
 **An interrupt** is a hardware signal that pauses a processor's normal program flow to run a short handler in response to an event, then resumes where it left off.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 176" role="img" aria-label="A timeline of the main program running. An event raises an interrupt; the processor jumps via the vector table down to an interrupt service routine, runs it, then returns and resumes the main program where it left off." xmlns="http://www.w3.org/2000/svg">
+  <line x1="30" y1="60" x2="150" y2="60" stroke="currentColor" stroke-width="1.8"/>
+  <line x1="150" y1="60" x2="352" y2="60" stroke="currentColor" stroke-width="1.2" stroke-dasharray="4 3" stroke-opacity="0.5"/>
+  <line x1="352" y1="60" x2="440" y2="60" stroke="currentColor" stroke-width="1.8"/>
+  <text x="88" y="50" text-anchor="middle" font-size="8.5" fill="currentColor">main program</text>
+  <text x="398" y="50" text-anchor="middle" font-size="8.5" fill="currentColor">resumes</text>
+  <line x1="150" y1="60" x2="150" y2="30" stroke="currentColor" stroke-width="1.2" marker-end="url(#ir_ar)"/>
+  <text x="150" y="22" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">interrupt raised</text>
+  <line x1="150" y1="60" x2="196" y2="102" stroke="currentColor" stroke-width="1.3" marker-end="url(#ir_ar)"/>
+  <text x="150" y="92" text-anchor="end" font-size="7.5" fill="currentColor" fill-opacity="0.85">vector → jump</text>
+  <rect x="196" y="104" width="120" height="34" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+  <text x="256" y="121" text-anchor="middle" font-size="8.5" fill="currentColor" font-weight="600">ISR — handler</text>
+  <text x="256" y="132" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">short: set a flag</text>
+  <line x1="316" y1="112" x2="352" y2="66" stroke="currentColor" stroke-width="1.3" marker-end="url(#ir_ar)"/>
+  <text x="360" y="98" text-anchor="start" font-size="7.5" fill="currentColor" fill-opacity="0.85">return</text>
+  <text x="235" y="164" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">the CPU can sleep until an event wakes it — no wasteful polling</text>
+  <defs><marker id="ir_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Instead of polling, the processor runs the main program until a peripheral raises an interrupt — a timer, a UART byte, a GPIO change. It jumps through the vector table to the matching service routine, runs it, and returns to where it left off. Between events the CPU can idle in low power, which is how battery devices last for years.</figcaption>
+</figure>
+
 ## Overview
 
 When a peripheral needs attention — a timer expires, a byte arrives on a [UART](/reference/uart/), a [GPIO](/reference/gpio/) pin changes — it raises an interrupt. The processor jumps to the matching **interrupt service routine (ISR)** via a vector table, runs it, and returns. On [ARM Cortex-M](/reference/arm-cortex-m/) parts a nested vectored interrupt controller (NVIC) prioritizes and arbitrates these requests with deterministic latency. The alternative, polling, wastes cycles repeatedly checking; interrupts let a [microcontroller](/reference/microcontroller/) sleep until something actually happens.

--- a/docs/reference/kubernetes.md
+++ b/docs/reference/kubernetes.md
@@ -20,6 +20,39 @@ cite_urls:
 
 **Kubernetes** (often "K8s") is an open-source system for automating the deployment, scaling, and management of containerized applications across a cluster of machines.[^wiki] It was created at Google and released in 2014, and is now stewarded by the Cloud Native Computing Foundation.[^home]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 224" role="img" aria-label="Incoming traffic reaches a single Kubernetes Service, which load-balances requests across four identical replica Pods. The pods are grouped two-per-box into two worker nodes, showing that the Service spreads load evenly over replicas scheduled across the cluster." xmlns="http://www.w3.org/2000/svg">
+  <circle cx="40" cy="110" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/>
+  <text x="40" y="90" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">traffic</text>
+  <rect x="92" y="86" width="92" height="48" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="138" y="106" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">Service</text>
+  <text x="138" y="120" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">load-balances</text>
+  <line x1="53" y1="110" x2="92" y2="110" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.75" fill="none" marker-end="url(#k8s_ar)"/>
+  <g stroke="currentColor">
+    <rect x="316" y="16" width="124" height="94" rx="6" fill="none" stroke-width="1.1" stroke-dasharray="5 4"/>
+    <rect x="316" y="116" width="124" height="94" rx="6" fill="none" stroke-width="1.1" stroke-dasharray="5 4"/>
+  </g>
+  <g fill="currentColor" font-size="8.5" text-anchor="middle">
+    <rect x="328" y="24" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="378" y="45">Pod</text>
+    <rect x="328" y="62" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="378" y="83">Pod</text>
+    <rect x="328" y="124" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="378" y="145">Pod</text>
+    <rect x="328" y="162" width="100" height="34" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="378" y="183">Pod</text>
+  </g>
+  <g fill="currentColor" font-size="7" text-anchor="middle" fill-opacity="0.65">
+    <text x="378" y="106">worker node</text>
+    <text x="378" y="206">worker node</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" stroke-opacity="0.75" fill="none">
+    <line x1="184" y1="106" x2="328" y2="41" marker-end="url(#k8s_ar)"/>
+    <line x1="184" y1="108" x2="328" y2="79" marker-end="url(#k8s_ar)"/>
+    <line x1="184" y1="112" x2="328" y2="141" marker-end="url(#k8s_ar)"/>
+    <line x1="184" y1="114" x2="328" y2="179" marker-end="url(#k8s_ar)"/>
+  </g>
+  <defs><marker id="k8s_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A Service is one stable address that spreads traffic across a set of identical replica Pods, which Kubernetes schedules onto whatever worker nodes have room. Add replicas and the Service balances over more of them; lose a node and its pods are rescheduled elsewhere — scaling and self-healing without changing the front door.</figcaption>
+</figure>
+
 ## Overview
 
 Kubernetes groups [containers](/reference/container/) into *pods*, schedules them onto a pool of worker nodes, and continuously reconciles the cluster toward a desired state you declare. If a node dies, it reschedules the affected pods elsewhere; if load rises, it can add replicas. It also wires up service discovery and internal [load balancing](/reference/load-balancer/), rolling updates, and self-healing restarts. The containers themselves are usually built with [Docker](/reference/docker/) or another compatible runtime.

--- a/docs/reference/load-balancer.md
+++ b/docs/reference/load-balancer.md
@@ -17,6 +17,41 @@ cite_urls:
 
 A **load balancer** distributes incoming network traffic across multiple [servers](/reference/server/) so that no single machine is overwhelmed, improving capacity, responsiveness, and availability.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 210" role="img" aria-label="Clients on the left send requests to a load balancer in the middle, which spreads them across a pool of four identical backend servers on the right. One server has failed its health check and is greyed out and removed from the pool, so no traffic is routed to it." xmlns="http://www.w3.org/2000/svg">
+  <text x="52" y="24" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">clients</text>
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <circle cx="52" cy="60" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/>
+    <circle cx="52" cy="105" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/>
+    <circle cx="52" cy="150" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/>
+  </g>
+  <rect x="152" y="80" width="96" height="50" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="200" y="100" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">Load balancer</text>
+  <text x="200" y="115" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">spread · health-check</text>
+  <g stroke="currentColor" stroke-width="1.2" stroke-opacity="0.75" fill="none">
+    <line x1="65" y1="62" x2="152" y2="98" marker-end="url(#lb_ar)"/>
+    <line x1="65" y1="105" x2="152" y2="105" marker-end="url(#lb_ar)"/>
+    <line x1="65" y1="148" x2="152" y2="112" marker-end="url(#lb_ar)"/>
+  </g>
+  <g fill="currentColor" font-size="8.5" text-anchor="middle">
+    <rect x="340" y="20" width="82" height="32" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="381" y="40">server</text>
+    <rect x="340" y="62" width="82" height="32" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="381" y="82">server</text>
+    <rect x="340" y="104" width="82" height="32" rx="4" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="1" stroke-opacity="0.5" stroke-dasharray="4 3"/><text x="381" y="124" fill-opacity="0.5">server ✕</text>
+    <rect x="340" y="146" width="82" height="32" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="381" y="166">server</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" fill="none">
+    <line x1="248" y1="100" x2="340" y2="36" stroke-opacity="0.75" marker-end="url(#lb_ar)"/>
+    <line x1="248" y1="103" x2="340" y2="78" stroke-opacity="0.75" marker-end="url(#lb_ar)"/>
+    <line x1="248" y1="112" x2="340" y2="120" stroke-opacity="0.3" stroke-dasharray="4 3"/>
+    <line x1="248" y1="115" x2="340" y2="162" stroke-opacity="0.75" marker-end="url(#lb_ar)"/>
+  </g>
+  <text x="294" y="128" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.6">removed</text>
+  <text x="220" y="198" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">a failed health check is pulled from the pool — the rest keep serving</text>
+  <defs><marker id="lb_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The balancer fronts a pool of identical backends and spreads requests among them (round-robin, least-connections, or client hashing). Health checks pull a dead server out automatically, so the pool survives losing any one member — the basis of both scaling out and staying available.</figcaption>
+</figure>
+
 ## Overview
 
 A load balancer sits in front of a pool of identical backends and spreads requests among them using rules such as round-robin, least-connections, or hashing on the client. It also runs *health checks*, automatically removing a server that stops responding so users are not routed to a dead machine. Balancers operate at the transport layer (L4, forwarding TCP/UDP) or the application layer (L7, inspecting HTTP to route by path or host). They may be dedicated hardware appliances or software running on commodity servers.

--- a/docs/reference/logic-gate.md
+++ b/docs/reference/logic-gate.md
@@ -17,6 +17,51 @@ cite_urls:
 
 A **logic gate** is a basic building block of digital circuits that computes a simple Boolean function — such as AND, OR, or NOT — on one or more binary inputs.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 208" role="img" aria-label="Three logic gates with their truth tables. AND outputs 1 only when both inputs are 1. OR outputs 1 when either input is 1. NOT inverts its single input. Each is drawn as its standard symbol above a small truth table." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" fill="currentColor">
+    <g transform="translate(64,44)">
+      <path d="M0 0 H20 A20 20 0 0 1 20 40 H0 Z" fill-opacity="0.12" stroke-width="1.4"/>
+      <line x1="-20" y1="10" x2="0" y2="10" stroke-width="1.2" fill="none"/>
+      <line x1="-20" y1="30" x2="0" y2="30" stroke-width="1.2" fill="none"/>
+      <line x1="40" y1="20" x2="60" y2="20" stroke-width="1.2" fill="none"/>
+      <text x="20" y="24" text-anchor="middle" font-size="9" stroke="none" font-weight="600">AND</text>
+    </g>
+    <g transform="translate(210,44)">
+      <path d="M0 0 C10 12 10 28 0 40 C22 40 40 28 48 20 C40 12 22 0 0 0 Z" fill-opacity="0.12" stroke-width="1.4"/>
+      <line x1="-20" y1="10" x2="6" y2="10" stroke-width="1.2" fill="none"/>
+      <line x1="-20" y1="30" x2="6" y2="30" stroke-width="1.2" fill="none"/>
+      <line x1="48" y1="20" x2="66" y2="20" stroke-width="1.2" fill="none"/>
+      <text x="20" y="24" text-anchor="middle" font-size="9" stroke="none" font-weight="600">OR</text>
+    </g>
+    <g transform="translate(356,44)">
+      <path d="M0 0 L0 40 L36 20 Z" fill-opacity="0.12" stroke-width="1.4"/>
+      <circle cx="42" cy="20" r="5" fill="none" stroke-width="1.4"/>
+      <line x1="-20" y1="20" x2="0" y2="20" stroke-width="1.2" fill="none"/>
+      <line x1="47" y1="20" x2="66" y2="20" stroke-width="1.2" fill="none"/>
+      <text x="14" y="24" text-anchor="middle" font-size="8.5" stroke="none" font-weight="600">NOT</text>
+    </g>
+  </g>
+  <g font-family="ui-monospace, monospace" font-size="9" fill="currentColor" stroke="none">
+    <text x="40" y="128">A B → Y</text>
+    <text x="40" y="142">0 0 → 0</text>
+    <text x="40" y="156">0 1 → 0</text>
+    <text x="40" y="170">1 0 → 0</text>
+    <text x="40" y="184">1 1 → 1</text>
+    <text x="190" y="128">A B → Y</text>
+    <text x="190" y="142">0 0 → 0</text>
+    <text x="190" y="156">0 1 → 1</text>
+    <text x="190" y="170">1 0 → 1</text>
+    <text x="190" y="184">1 1 → 1</text>
+    <text x="344" y="128">A → Y</text>
+    <text x="344" y="142">0 → 1</text>
+    <text x="344" y="156">1 → 0</text>
+  </g>
+  <text x="230" y="202" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">built from transistor switches · NAND and NOR alone can build any of them</text>
+</svg>
+<figcaption>Each gate maps binary inputs to an output by a fixed truth table: AND needs all inputs high, OR needs any, NOT inverts. Physically they're a handful of transistor switches — and from these primitives (especially the universal NAND and NOR) you can build adders, memory, and ultimately a whole processor.</figcaption>
+</figure>
+
 ## Overview
 
 Each gate takes inputs that are either 0 or 1 and produces an output defined by a *truth table*: an AND gate outputs 1 only when all inputs are 1, an OR when any is 1, a NOT inverts its input. Physically, gates are built from a handful of [transistors](/reference/transistor/) acting as switches. From these primitives — especially the universal NAND and NOR — you can construct adders, memory cells, and ultimately every part of a processor.

--- a/docs/reference/magnetic-tape.md
+++ b/docs/reference/magnetic-tape.md
@@ -19,6 +19,30 @@ cite_urls:
 
 **Magnetic tape** stores data on a long, thin ribbon of magnetic film wound on reels, written and read sequentially by a tape drive.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 192" role="img" aria-label="A tape drive threads a ribbon from a supply reel across guide rollers and over a read/write head to a take-up reel. Because the data is laid end to end along the ribbon, reaching a given block means spooling through every block before it — sequential access, unlike a disk that seeks directly." xmlns="http://www.w3.org/2000/svg">
+  <text x="220" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Tape runs reel-to-reel past one head</text>
+  <g fill="none" stroke="currentColor" stroke-width="1.1">
+    <circle cx="88" cy="92" r="40" stroke-opacity="0.9"/><circle cx="88" cy="92" r="30" stroke-opacity="0.4"/><circle cx="88" cy="92" r="20" stroke-opacity="0.3"/>
+    <circle cx="352" cy="92" r="40" stroke-opacity="0.9"/><circle cx="352" cy="92" r="30" stroke-opacity="0.4"/><circle cx="352" cy="92" r="20" stroke-opacity="0.3"/>
+  </g>
+  <circle cx="88" cy="92" r="9" fill="currentColor"/><circle cx="352" cy="92" r="9" fill="currentColor"/>
+  <line x1="88" y1="52" x2="352" y2="52" stroke="currentColor" stroke-width="1.4"/>
+  <circle cx="150" cy="52" r="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/>
+  <circle cx="290" cy="52" r="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/>
+  <rect x="198" y="52" width="44" height="22" rx="2" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/>
+  <text x="220" y="46" text-anchor="middle" font-size="8" fill="currentColor">read/write head</text>
+  <line x1="120" y1="52" x2="138" y2="52" stroke="currentColor" stroke-width="1.1" marker-end="url(#mt_ar)"/>
+  <line x1="304" y1="52" x2="322" y2="52" stroke="currentColor" stroke-width="1.1" marker-end="url(#mt_ar)"/>
+  <text x="88" y="150" text-anchor="middle" font-size="8.5" fill="currentColor">supply reel</text>
+  <text x="352" y="150" text-anchor="middle" font-size="8.5" fill="currentColor">take-up reel</text>
+  <line x1="50" y1="168" x2="386" y2="168" stroke="currentColor" stroke-width="1.1" stroke-dasharray="5 3" stroke-opacity="0.8" marker-end="url(#mt_ar)"/>
+  <text x="218" y="184" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">sequential: to reach a block you must spool through every block before it</text>
+  <defs><marker id="mt_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A drive pulls the ribbon from the supply reel, across guide rollers and over a single read/write head, onto the take-up reel. The data is written end to end, so unlike a disk that seeks straight to a spot, tape must be spooled through everything ahead of the block you want — sequential access, which is why it is slow but very cheap per terabyte.</figcaption>
+</figure>
+
 ## Overview
 
 A drive pulls the tape past a head that magnetises regions to record bits, much like a [hard disk drive](/reference/hard-disk-drive/) but on flexible media that must be streamed end to end rather than seeked. The dominant modern format is LTO (Linear Tape-Open), whose cartridges now hold many terabytes each and improve with every generation. Because there are no fast random-access mechanics, the medium itself is extremely cheap, and a tape sitting on a shelf consumes no power and keeps data for decades.

--- a/docs/reference/memory-hierarchy.md
+++ b/docs/reference/memory-hierarchy.md
@@ -20,6 +20,26 @@ cite_urls:
 
 The **memory hierarchy** is the layered arrangement of a computer's storage, ordered so that each level trades speed for capacity and cost against the one below it.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 250" role="img" aria-label="A pyramid of storage levels, narrow and fast at the top widening to large and slow at the bottom: CPU registers, then cache, then RAM, then SSD, then hard disk, then magnetic tape. An arrow up the left marks faster, smaller, costlier per byte; an arrow down the right marks larger, cheaper, slower." xmlns="http://www.w3.org/2000/svg">
+  <g text-anchor="middle" fill="currentColor" font-size="10">
+    <rect x="175" y="28" width="90" height="30" rx="3" fill="currentColor" fill-opacity="0.3" stroke="currentColor" stroke-width="1.1"/><text x="220" y="47">registers</text>
+    <rect x="145" y="60" width="150" height="30" rx="3" fill="currentColor" fill-opacity="0.24" stroke="currentColor" stroke-width="1.1"/><text x="220" y="79">CPU cache · L1/L2/L3</text>
+    <rect x="115" y="92" width="210" height="30" rx="3" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.1"/><text x="220" y="111">RAM · main memory</text>
+    <rect x="85" y="124" width="270" height="30" rx="3" fill="currentColor" fill-opacity="0.13" stroke="currentColor" stroke-width="1.1"/><text x="220" y="143">SSD · flash</text>
+    <rect x="55" y="156" width="330" height="30" rx="3" fill="currentColor" fill-opacity="0.09" stroke="currentColor" stroke-width="1.1"/><text x="220" y="175">hard disk</text>
+    <rect x="25" y="188" width="390" height="30" rx="3" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.1"/><text x="220" y="207">magnetic tape · archive</text>
+  </g>
+  <line x1="14" y1="216" x2="14" y2="32" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.7" marker-end="url(#mh_ar)"/>
+  <text x="12" y="126" font-size="8" fill="currentColor" fill-opacity="0.85" text-anchor="middle" transform="rotate(-90 12 126)">faster · smaller · costlier/byte</text>
+  <line x1="428" y1="32" x2="428" y2="216" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.7" marker-end="url(#mh_ar)"/>
+  <text x="426" y="124" font-size="8" fill="currentColor" fill-opacity="0.85" text-anchor="middle" transform="rotate(90 426 124)">larger · cheaper · slower</text>
+  <text x="220" y="238" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.85">locality keeps hot data in the fast upper levels</text>
+  <defs><marker id="mh_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Every storage device is really a point on one curve. The top levels are tiny, fast, and expensive per byte; each step down is larger and cheaper but slower to reach. It works because programs reuse the same and nearby data (locality), so a small fast top captures most accesses.</figcaption>
+</figure>
+
 ## Overview
 
 At the top sit the [CPU](/reference/central-processing-unit/) registers and [cache memory](/reference/cache-memory/): tiny, blisteringly fast, and expensive per byte. Below them is main memory, [RAM](/reference/random-access-memory/), which is larger but slower. Further down comes persistent storage — a [solid-state drive](/reference/solid-state-drive/), then a [hard disk drive](/reference/hard-disk-drive/), and finally archival [magnetic tape](/reference/magnetic-tape/) — each step larger and cheaper but slower to reach. The hierarchy works because programs exhibit *locality*: they tend to reuse the same data and nearby data, so keeping hot items in the fast upper levels gives most of the speed of fast memory at most of the cost of slow storage.

--- a/docs/reference/moores-law.md
+++ b/docs/reference/moores-law.md
@@ -19,6 +19,28 @@ cite_urls:
 
 **Moore's law** is the observation, made by Intel co-founder Gordon Moore in 1965, that the number of [transistors](/reference/transistor/) on an [integrated circuit](/reference/integrated-circuit/) roughly doubles about every two years.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 214" role="img" aria-label="A chart on a logarithmic vertical axis. Transistor count rises as a straight line, meaning exponential doubling roughly every two years. Clock speed rises alongside it until the mid-2000s, then flattens as Dennard scaling ends, pushing designers toward multiple cores." xmlns="http://www.w3.org/2000/svg">
+  <line x1="52" y1="28" x2="52" y2="176" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.6"/>
+  <line x1="52" y1="176" x2="432" y2="176" stroke="currentColor" stroke-width="1.1" stroke-opacity="0.6"/>
+  <g stroke="currentColor" stroke-width="0.6" stroke-opacity="0.2">
+    <line x1="52" y1="140" x2="432" y2="140"/><line x1="52" y1="104" x2="432" y2="104"/><line x1="52" y1="68" x2="432" y2="68"/><line x1="52" y1="32" x2="432" y2="32"/>
+  </g>
+  <text x="24" y="105" font-size="8" fill="currentColor" fill-opacity="0.85" text-anchor="middle" transform="rotate(-90 24 105)">count (log)</text>
+  <g font-size="8" fill="currentColor" fill-opacity="0.85" text-anchor="middle">
+    <text x="80" y="190">1970</text><text x="200" y="190">1990</text><text x="320" y="190">2010</text>
+  </g>
+  <line x1="66" y1="168" x2="420" y2="40" stroke="currentColor" stroke-width="1.8"/>
+  <text x="360" y="52" font-size="8" fill="currentColor" font-weight="600">transistors · 2× / 2 yr</text>
+  <path d="M66 158 L150 128 L240 92 L300 78 Q340 74 420 74" fill="none" stroke="currentColor" stroke-width="1.5" stroke-dasharray="5 3"/>
+  <text x="392" y="88" font-size="8" fill="currentColor" fill-opacity="0.9">clock speed</text>
+  <line x1="300" y1="28" x2="300" y2="176" stroke="currentColor" stroke-width="0.9" stroke-opacity="0.45" stroke-dasharray="3 3"/>
+  <text x="300" y="24" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">~2005: Dennard scaling ends</text>
+  <text x="242" y="208" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">clocks stopped rising → progress shifted to more cores &amp; accelerators</text>
+</svg>
+<figcaption>On a log axis, steady doubling is a straight line — that's Moore's law, an empirical trend, not a physical one. Clock speed rode along until the mid-2000s, when Dennard scaling broke and frequencies plateaued. Transistors kept growing, so the industry turned to multiple cores, specialized accelerators, and advanced packaging.</figcaption>
+</figure>
+
 ## Overview
 
 It is not a law of physics but an empirical trend that held for decades as [semiconductor](/reference/semiconductor/) makers steadily shrank feature sizes, packing ever more switches onto a chip at falling cost per transistor. That exponential scaling is what turned room-sized computers into pocket-sized ones and made each generation of [CPUs](/reference/central-processing-unit/) and [GPUs](/reference/graphics-processing-unit/) dramatically more capable. A related trend, Dennard scaling, once let [clock speeds](/reference/clock-speed/) rise as transistors shrank — but that broke down in the mid-2000s, pushing designers toward multiple cores.

--- a/docs/reference/motherboard.md
+++ b/docs/reference/motherboard.md
@@ -18,6 +18,41 @@ cite_urls:
 
 A **motherboard** (or mainboard) is the main printed circuit board of a computer — the backbone that holds the [CPU](/reference/central-processing-unit/), memory, and [chipset](/reference/chipset/) and wires every other part together.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 284" role="img" aria-label="A top-down block diagram of a motherboard PCB showing the CPU socket and RAM slots grouped at the top, the chipset below them, and PCIe expansion slots, USB, and SATA connectors around the edges, all joined by traces on the board." xmlns="http://www.w3.org/2000/svg">
+  <rect x="12" y="12" width="416" height="260" rx="10" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="1.5"/>
+  <text x="26" y="30" font-size="8" fill="currentColor" fill-opacity="0.7">motherboard · top view</text>
+  <rect x="44" y="44" width="120" height="96" rx="6" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.3"/>
+  <text x="104" y="88" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">CPU</text>
+  <text x="104" y="102" text-anchor="middle" font-size="8" fill="currentColor">socket</text>
+  <text x="224" y="40" text-anchor="middle" font-size="8" fill="currentColor" font-weight="600">RAM slots</text>
+  <g fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1">
+    <rect x="196" y="46" width="9" height="94" rx="2"/><rect x="212" y="46" width="9" height="94" rx="2"/><rect x="228" y="46" width="9" height="94" rx="2"/><rect x="244" y="46" width="9" height="94" rx="2"/>
+  </g>
+  <rect x="64" y="176" width="100" height="60" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="114" y="205" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">chipset</text>
+  <text x="114" y="219" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">PCH</text>
+  <rect x="196" y="196" width="196" height="14" rx="2" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="294" y="207" text-anchor="middle" font-size="8" fill="currentColor">PCIe x16</text>
+  <rect x="196" y="224" width="140" height="14" rx="2" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="266" y="235" text-anchor="middle" font-size="8" fill="currentColor">PCIe x1</text>
+  <g fill="currentColor" font-size="7.5" text-anchor="middle">
+    <rect x="196" y="248" width="42" height="14" rx="2" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="217" y="258">USB</text>
+    <rect x="244" y="248" width="42" height="14" rx="2" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="265" y="258">USB</text>
+  </g>
+  <text x="408" y="144" text-anchor="middle" font-size="7.5" fill="currentColor" font-weight="600">SATA</text>
+  <g fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1">
+    <rect x="392" y="150" width="26" height="12" rx="2"/><rect x="392" y="166" width="26" height="12" rx="2"/><rect x="392" y="182" width="26" height="12" rx="2"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.45" fill="none">
+    <line x1="164" y1="70" x2="196" y2="70"/><line x1="164" y1="96" x2="196" y2="96"/>
+    <line x1="104" y1="140" x2="104" y2="176"/>
+    <line x1="164" y1="200" x2="196" y2="203"/><line x1="164" y1="216" x2="196" y2="231"/>
+    <line x1="164" y1="188" x2="392" y2="160"/>
+    <line x1="140" y1="236" x2="217" y2="248"/>
+  </g>
+</svg>
+<figcaption>Seen from above, the motherboard is the backbone everything plugs into: the CPU socket and RAM slots sit close together up top, the chipset routes slower I/O, and the PCIe, USB, and SATA connectors fan out to expansion cards and drives. Its copper traces wire all of them together on one PCB.</figcaption>
+</figure>
+
 ## Overview
 
 The board provides a socket for the CPU, slots for [RAM](/reference/random-access-memory/), and connectors and [expansion buses](/reference/system-bus/) such as [PCIe](/reference/pci-express/), [USB](/reference/usb/), and SATA. Its [chipset](/reference/chipset/) and traces route signals between the processor, memory, [storage](/reference/data-storage/), and [I/O](/reference/input-output/). Firmware ([BIOS/UEFI](/reference/bios-uefi/)) lives in a chip on the board and brings the system up at power-on. Physical size and mounting follow a *form factor* — common ones are ATX, microATX, and Mini-ITX.

--- a/docs/reference/network-interface-card.md
+++ b/docs/reference/network-interface-card.md
@@ -18,6 +18,31 @@ cite_urls:
 
 A **network interface card** (**NIC**, or network adapter) is the hardware that connects a computer to a network, turning the machine's data into electrical, optical, or radio signals and back again.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 188" role="img" aria-label="A host's data passes to its network interface card, which frames it and drives the bits onto the network cable — and pulls incoming frames back off the wire — identified on the link by the MAC address burned into the card." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="52" width="118" height="84" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/>
+  <text x="79" y="88" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">host</text>
+  <text x="79" y="104" text-anchor="middle" font-size="8" fill="currentColor">operating system</text>
+  <rect x="186" y="44" width="120" height="100" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="246" y="70" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">NIC</text>
+  <text x="246" y="88" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.9">MAC 00:1B:44:11:3A:B7</text>
+  <line x1="196" y1="98" x2="296" y2="98" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.4"/>
+  <text x="246" y="120" text-anchor="middle" font-size="8" fill="currentColor">frames ⇄ signals</text>
+  <rect x="354" y="62" width="90" height="64" rx="6" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.2" stroke-dasharray="5 3"/>
+  <text x="399" y="90" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">network</text>
+  <text x="399" y="105" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">the wire</text>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="138" y1="82" x2="186" y2="82" marker-end="url(#nic_ar)"/>
+    <line x1="186" y1="104" x2="138" y2="104" marker-end="url(#nic_ar)"/>
+    <line x1="306" y1="82" x2="354" y2="82" marker-end="url(#nic_ar)"/>
+    <line x1="354" y1="104" x2="306" y2="104" marker-end="url(#nic_ar)"/>
+  </g>
+  <text x="246" y="176" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">the card frames data and puts it on (and takes it off) the wire</text>
+  <defs><marker id="nic_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The NIC is the bridge between a host and the medium: it frames the machine's outgoing data and drives it onto the cable, and pulls incoming frames back off it. Its burned-in MAC address is what names the card on the local link, so a switch or router can find it.</figcaption>
+</figure>
+
 ## Overview
 
 A NIC handles the lowest layers of networking: framing data into packets, putting them on the medium, and pulling incoming frames off it. Each NIC carries a globally unique **MAC address** burned in at manufacture, which identifies it on the local link. Adapters come as wired [Ethernet](/reference/ethernet/) ports, [Wi-Fi](/reference/wi-fi/) radios, or fiber interfaces, and may be a discrete card in a [PCI Express](/reference/pci-express/) slot, a [USB](/reference/usb/) dongle, or — most commonly today — circuitry integrated onto the [motherboard](/reference/motherboard/) or [system-on-a-chip](/reference/system-on-a-chip/).

--- a/docs/reference/network-switch.md
+++ b/docs/reference/network-switch.md
@@ -18,6 +18,31 @@ cite_urls:
 
 A **network switch** is a device that connects multiple machines on the same [local network](/reference/lan-and-wan/), forwarding each [Ethernet](/reference/ethernet/) frame only out the port that leads to its destination.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 214" role="img" aria-label="Four hosts plug into a central switch; a frame from host A addressed to host C's MAC is forwarded only out the port leading to C, while the ports to B and D stay quiet — unlike an old hub, which would flood the frame to every port." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <rect x="24" y="26" width="74" height="32" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="61" y="46">host A</text>
+    <rect x="134" y="26" width="74" height="32" rx="4" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.1"/><text x="171" y="46">host B</text>
+    <rect x="244" y="26" width="74" height="32" rx="4" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/><text x="281" y="42">host C</text><text x="281" y="53" font-size="7">dest MAC</text>
+    <rect x="354" y="26" width="74" height="32" rx="4" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.1"/><text x="391" y="46">host D</text>
+  </g>
+  <rect x="150" y="120" width="140" height="46" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="220" y="140" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">switch</text>
+  <text x="220" y="155" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">MAC → port table</text>
+  <g stroke="currentColor" fill="none">
+    <line x1="61" y1="58" x2="200" y2="120" stroke-width="1.6" marker-end="url(#nsw_ar)"/>
+    <line x1="230" y1="120" x2="281" y2="58" stroke-width="1.6" marker-end="url(#nsw_ar)"/>
+    <line x1="210" y1="120" x2="171" y2="58" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="4 3"/>
+    <line x1="240" y1="120" x2="391" y2="58" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="4 3"/>
+  </g>
+  <text x="104" y="86" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">frame for C</text>
+  <text x="332" y="100" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.5">no flood</text>
+  <text x="220" y="196" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">forwarded to the one matching port — a hub copies it to all</text>
+  <defs><marker id="nsw_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A switch learns which MAC sits on each port, so a frame goes only out the port for its destination — here just host C, while B and D stay idle. An older hub had no table and copied every frame to every port; that switched forwarding is why modern wired LANs are fast and quiet.</figcaption>
+</figure>
+
 ## Overview
 
 A switch learns which MAC address lives on which port and builds a forwarding table, so traffic between two hosts does not flood every other port — this is what makes a modern wired LAN fast and quiet compared with the old shared hubs. Switches range from cheap unmanaged boxes with a handful of ports to managed units offering VLANs, monitoring, and [Power over Ethernet](/reference/power-over-ethernet/). A switch works within one network; moving traffic *between* networks is the job of a [router](/reference/router/).

--- a/docs/reference/neural-processing-unit.md
+++ b/docs/reference/neural-processing-unit.md
@@ -20,6 +20,36 @@ cite_urls:
 
 A **neural processing unit** (**NPU**) is an on-device accelerator built to run neural-network inference efficiently — typically integrated into a phone, laptop, or edge device's main chip so AI features work without the cloud.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 214" role="img" aria-label="Inside a system-on-a-chip sit a CPU, a GPU, and an NPU. The NPU is a block of parallel multiply-accumulate lanes that runs a trained neural network right on the device. A dashed link to a crossed-out cloud shows the inference stays local, for low power and low latency, with no round-trip to a server." xmlns="http://www.w3.org/2000/svg">
+  <rect x="18" y="34" width="286" height="152" rx="6" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="5 3"/>
+  <text x="28" y="48" text-anchor="start" font-size="8" fill="currentColor" fill-opacity="0.85">system-on-a-chip (phone / SBC)</text>
+  <rect x="30" y="58" width="52" height="30" rx="3" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="56" y="77" text-anchor="middle" font-size="8.5" fill="currentColor">CPU</text>
+  <rect x="30" y="96" width="52" height="30" rx="3" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1"/><text x="56" y="115" text-anchor="middle" font-size="8.5" fill="currentColor">GPU</text>
+  <rect x="98" y="56" width="196" height="120" rx="4" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.1"/>
+  <text x="196" y="70" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">NPU — parallel MAC lanes</text>
+  <g fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="0.8">
+    <rect x="112" y="80" width="24" height="16" rx="2"/><rect x="140" y="80" width="24" height="16" rx="2"/><rect x="168" y="80" width="24" height="16" rx="2"/><rect x="196" y="80" width="24" height="16" rx="2"/><rect x="224" y="80" width="24" height="16" rx="2"/>
+    <rect x="112" y="102" width="24" height="16" rx="2"/><rect x="140" y="102" width="24" height="16" rx="2"/><rect x="168" y="102" width="24" height="16" rx="2"/><rect x="196" y="102" width="24" height="16" rx="2"/><rect x="224" y="102" width="24" height="16" rx="2"/>
+    <rect x="112" y="124" width="24" height="16" rx="2"/><rect x="140" y="124" width="24" height="16" rx="2"/><rect x="168" y="124" width="24" height="16" rx="2"/><rect x="196" y="124" width="24" height="16" rx="2"/><rect x="224" y="124" width="24" height="16" rx="2"/>
+  </g>
+  <g fill="currentColor" text-anchor="middle" font-size="7">
+    <text x="124" y="92">×+</text><text x="152" y="92">×+</text><text x="180" y="92">×+</text><text x="208" y="92">×+</text><text x="236" y="92">×+</text>
+    <text x="124" y="114">×+</text><text x="152" y="114">×+</text><text x="180" y="114">×+</text><text x="208" y="114">×+</text><text x="236" y="114">×+</text>
+    <text x="124" y="136">×+</text><text x="152" y="136">×+</text><text x="180" y="136">×+</text><text x="208" y="136">×+</text><text x="236" y="136">×+</text>
+  </g>
+  <text x="196" y="158" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">trained model runs here · measured in TOPS</text>
+  <line x1="304" y1="90" x2="336" y2="90" stroke="currentColor" stroke-width="1.1" stroke-dasharray="4 2" marker-end="url(#npu_ar)"/>
+  <rect x="338" y="70" width="72" height="40" rx="8" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1"/>
+  <text x="374" y="94" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.7">cloud</text>
+  <line x1="346" y1="72" x2="402" y2="108" stroke="currentColor" stroke-width="1.4"/>
+  <text x="374" y="128" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">no round-trip</text>
+  <text x="196" y="200" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">many multiply-accumulate lanes run inference on-device, at low power</text>
+  <defs><marker id="npu_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An NPU is one block inside a system-on-a-chip, alongside the CPU and GPU: a wide array of multiply-accumulate lanes that runs an already-trained neural network right on the device. Keeping inference local — no round-trip to the cloud — is what makes on-device AI fast and low-power, and its headline figure is TOPS, trillions of operations per second.</figcaption>
+</figure>
+
 ## Overview
 
 An NPU is a class of [AI accelerator](/reference/ai-accelerator/) optimized for *inference at the edge*: running an already-trained model with low latency and minimal power, rather than the large-scale training that data-center [TPUs](/reference/tensor-processing-unit/) and GPUs handle. NPUs are usually one block inside a larger [system-on-a-chip](/reference/system-on-a-chip/), sitting alongside the CPU and GPU and handling tasks such as camera processing, voice recognition, and background-blur. Their headline spec is TOPS (trillions of operations per second) at a given power budget.

--- a/docs/reference/pci-express.md
+++ b/docs/reference/pci-express.md
@@ -18,6 +18,40 @@ cite_urls:
 
 **PCI Express** (**PCIe**) is the high-speed serial expansion standard that connects add-in cards — graphics, storage, networking — to a computer's [chipset](/reference/chipset/) and CPU.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 236" role="img" aria-label="The top half shows an old shared parallel bus where three devices tap one common set of wires and contend for its bandwidth; the bottom half shows PCI Express giving each device — a GPU, an SSD, and a NIC — its own dedicated point-to-point link of x16, x4, or x1 lanes to a root or switch." xmlns="http://www.w3.org/2000/svg">
+  <text x="150" y="20" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">shared parallel bus (old)</text>
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <rect x="52" y="30" width="64" height="26" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="84" y="47">device</text>
+    <rect x="162" y="30" width="64" height="26" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="194" y="47">device</text>
+    <rect x="272" y="30" width="64" height="26" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="304" y="47">device</text>
+  </g>
+  <line x1="52" y1="74" x2="352" y2="74" stroke="currentColor" stroke-width="3"/>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.6"><line x1="84" y1="56" x2="84" y2="74"/><line x1="194" y1="56" x2="194" y2="74"/><line x1="304" y1="56" x2="304" y2="74"/></g>
+  <text x="204" y="92" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">one set of wires — devices contend for bandwidth</text>
+  <line x1="20" y1="108" x2="440" y2="108" stroke="currentColor" stroke-width="1" stroke-opacity="0.3" stroke-dasharray="5 3"/>
+  <text x="160" y="126" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">PCI Express — point-to-point</text>
+  <rect x="40" y="146" width="100" height="60" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="90" y="172" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">root /</text>
+  <text x="90" y="186" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">switch</text>
+  <g fill="currentColor" font-size="8.5" text-anchor="middle">
+    <rect x="316" y="138" width="110" height="26" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="371" y="155">GPU</text>
+    <rect x="316" y="172" width="110" height="26" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="371" y="189">SSD</text>
+    <rect x="316" y="206" width="110" height="26" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="371" y="223">NIC</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="140" y1="164" x2="316" y2="151" marker-end="url(#pcie_ar)"/>
+    <line x1="140" y1="176" x2="316" y2="185" marker-end="url(#pcie_ar)"/>
+    <line x1="140" y1="188" x2="316" y2="219" marker-end="url(#pcie_ar)"/>
+  </g>
+  <g fill="currentColor" font-size="7.5" text-anchor="middle">
+    <text x="238" y="150">x16</text><text x="238" y="176">x4</text><text x="238" y="212">x1</text>
+  </g>
+  <defs><marker id="pcie_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The old parallel bus wired every device to one shared set of lines, so they competed for bandwidth. PCIe instead gives each device its own point-to-point link to a switch or the CPU's root complex, built from 1, 4, or 16 lanes (x1/x4/x16). Adding a card no longer slows the others.</figcaption>
+</figure>
+
 ## Overview
 
 PCIe replaced older shared parallel buses with scalable *point-to-point* links built from one or more *lanes*, each a pair of differential wires in each direction. A slot is described by its lane count — x1, x4, x8, x16 — and each new generation roughly doubles per-lane bandwidth. Unlike a classic [system bus](/reference/system-bus/), devices do not share one set of wires; each gets a dedicated link to a switch, so adding cards does not slow the others.

--- a/docs/reference/platform-as-a-service.md
+++ b/docs/reference/platform-as-a-service.md
@@ -20,6 +20,59 @@ cite_urls:
 
 **Platform as a service** (**PaaS**) is a [cloud computing](/reference/cloud-computing/) model in which the provider runs the servers, operating system, and application runtime, and you simply deploy code without managing the infrastructure underneath.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 464 268" role="img" aria-label="A grid of who manages each layer across four cloud tiers — on-premises, IaaS, PaaS, and SaaS — with the PaaS column outlined for emphasis. Rows are application, data, runtime, operating system, virtualization, and hardware. In the PaaS column only the application and data cells are filled as managed by you; the runtime and everything below are light, managed by the provider." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <text x="144" y="36" font-weight="600">On-prem</text>
+    <text x="234" y="36" font-weight="600">IaaS</text>
+    <text x="324" y="36" font-weight="600">PaaS</text>
+    <text x="414" y="36" font-weight="600">SaaS</text>
+  </g>
+  <g fill="currentColor" font-size="8.5" text-anchor="end">
+    <text x="94" y="63">Application</text>
+    <text x="94" y="93">Data</text>
+    <text x="94" y="123">Runtime</text>
+    <text x="94" y="153">OS</text>
+    <text x="94" y="183">Virtualization</text>
+    <text x="94" y="213">Hardware</text>
+  </g>
+  <g stroke="currentColor">
+    <rect x="103" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="193" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="283" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="283" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+  </g>
+  <rect x="281" y="44" width="86" height="180" rx="3" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <g font-size="8" fill="currentColor">
+    <rect x="150" y="242" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <text x="170" y="252" text-anchor="start">you manage</text>
+    <rect x="252" y="242" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5"/>
+    <text x="272" y="252" text-anchor="start">provider manages</text>
+  </g>
+</svg>
+<figcaption>PaaS draws the line higher than IaaS. In the outlined PaaS column only your application and data stay yours; the platform runs the runtime, operating system, virtualization, and hardware beneath. You push code and the provider operates everything under it.</figcaption>
+</figure>
+
 ## Overview
 
 PaaS is the middle tier of the cloud stack. You push an application — a web app, an API, a background worker — and the platform builds, runs, scales, and patches it for you, often using [containers](/reference/container/) behind the scenes. You do not log in to servers, install an [operating system](/reference/operating-system/), or configure load balancing; those are the platform's job. In exchange you accept its conventions about how apps are packaged and deployed.

--- a/docs/reference/pulse-width-modulation.md
+++ b/docs/reference/pulse-width-modulation.md
@@ -20,6 +20,27 @@ cite_urls:
 
 **Pulse-width modulation (PWM)** encodes an analog level as the fraction of time a fast digital square wave spends switched on — its **duty cycle**.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 220" role="img" aria-label="Three digital square waves at 25, 50, and 75 percent duty cycle. Each is fully on or off, but a dashed line marks the average voltage the load actually sees, rising from about a quarter to about three quarters of the supply as the on-time widens." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="9" fill="currentColor" text-anchor="end" font-weight="600">
+    <text x="46" y="46">25%</text>
+    <text x="46" y="106">50%</text>
+    <text x="46" y="166">75%</text>
+  </g>
+  <polyline points="70,40 100,40 100,64 190,64 190,40 220,40 220,64 310,64 310,40 340,40 340,64 430,64" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <line x1="70" y1="58" x2="430" y2="58" stroke="currentColor" stroke-width="1.2" stroke-dasharray="5 3" stroke-opacity="0.8"/>
+  <text x="438" y="61" font-size="7.5" fill="currentColor" fill-opacity="0.85" text-anchor="start">≈¼</text>
+  <polyline points="70,100 130,100 130,124 190,124 190,100 250,100 250,124 310,124 310,100 370,100 370,124 430,124" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <line x1="70" y1="112" x2="430" y2="112" stroke="currentColor" stroke-width="1.2" stroke-dasharray="5 3" stroke-opacity="0.8"/>
+  <text x="438" y="115" font-size="7.5" fill="currentColor" fill-opacity="0.85" text-anchor="start">≈½</text>
+  <polyline points="70,160 160,160 160,184 190,184 190,160 280,160 280,184 310,184 310,160 400,160 400,184 430,184" fill="none" stroke="currentColor" stroke-width="1.6"/>
+  <line x1="70" y1="166" x2="430" y2="166" stroke="currentColor" stroke-width="1.2" stroke-dasharray="5 3" stroke-opacity="0.8"/>
+  <text x="438" y="169" font-size="7.5" fill="currentColor" fill-opacity="0.85" text-anchor="start">≈¾</text>
+  <text x="240" y="208" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">wider on-time → higher average — the load is too slow to see the switching (dashed = average)</text>
+</svg>
+<figcaption>The pin is only ever fully on or fully off, but it switches far faster than the load can respond, so an LED, motor, or heater sees only the average — the dashed line. Widen the on-time (the duty cycle) and that average rises, giving an effectively analog output from a purely digital pin.</figcaption>
+</figure>
+
 ## Overview
 
 A pin toggled at, say, 20 kHz that is high 25% of the time delivers, on average, a quarter of the supply voltage. Because the switching is far faster than the load can respond, an LED, motor, or heater simply sees the average. A [microcontroller](/reference/microcontroller/) generates PWM in hardware timers, so it costs no CPU once configured, and the duty cycle can be changed on the fly. Servos and many [sensors](/reference/sensor/) also use PWM as their signaling format.

--- a/docs/reference/raid.md
+++ b/docs/reference/raid.md
@@ -18,6 +18,51 @@ cite_urls:
 
 **RAID** (Redundant Array of Independent Disks) combines multiple physical drives into one logical unit to gain redundancy, performance, or both — so data can survive a disk failure or be read and written faster.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 214" role="img" aria-label="Three RAID schemes side by side. RAID 0 stripes blocks A1 to A6 across two disks for speed with no redundancy. RAID 1 mirrors identical copies on two disks. RAID 5 spreads data blocks and rotating parity blocks across three disks so the array can rebuild any one failed disk." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <text x="86" y="20" font-size="9.5" font-weight="600">RAID 0 · stripe</text>
+    <rect x="40" y="40" width="40" height="120" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="43" y="44" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="60" y="65">A1</text>
+    <rect x="43" y="80" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="60" y="101">A3</text>
+    <rect x="43" y="116" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="60" y="137">A5</text>
+    <rect x="92" y="40" width="40" height="120" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="95" y="44" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="112" y="65">A2</text>
+    <rect x="95" y="80" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="112" y="101">A4</text>
+    <rect x="95" y="116" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="112" y="137">A6</text>
+    <text x="86" y="176" font-size="8" fill-opacity="0.85">fast · no redundancy</text>
+
+    <text x="236" y="20" font-size="9.5" font-weight="600">RAID 1 · mirror</text>
+    <rect x="190" y="40" width="40" height="120" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="193" y="44" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="210" y="65">A1</text>
+    <rect x="193" y="80" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="210" y="101">A2</text>
+    <rect x="193" y="116" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="210" y="137">A3</text>
+    <rect x="242" y="40" width="40" height="120" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="245" y="44" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="262" y="65">A1</text>
+    <rect x="245" y="80" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="262" y="101">A2</text>
+    <rect x="245" y="116" width="34" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="262" y="137">A3</text>
+    <text x="236" y="176" font-size="8" fill-opacity="0.85">identical copy</text>
+
+    <text x="380" y="20" font-size="9.5" font-weight="600">RAID 5 · parity</text>
+    <rect x="312" y="40" width="38" height="120" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="315" y="44" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="331" y="65">A1</text>
+    <rect x="315" y="80" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="331" y="101">B1</text>
+    <rect x="315" y="116" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="0.8" stroke-dasharray="3 2"/><text x="331" y="137">P</text>
+    <rect x="356" y="40" width="38" height="120" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="359" y="44" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="375" y="65">A2</text>
+    <rect x="359" y="80" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="0.8" stroke-dasharray="3 2"/><text x="375" y="101">P</text>
+    <rect x="359" y="116" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="375" y="137">C1</text>
+    <rect x="400" y="40" width="38" height="120" rx="4" fill="none" stroke="currentColor" stroke-width="1.2"/>
+    <rect x="403" y="44" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.28" stroke="currentColor" stroke-width="0.8" stroke-dasharray="3 2"/><text x="419" y="65">P</text>
+    <rect x="403" y="80" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="419" y="101">B2</text>
+    <rect x="403" y="116" width="32" height="34" rx="2" fill="currentColor" fill-opacity="0.15"/><text x="419" y="137">C2</text>
+    <text x="375" y="176" font-size="8" fill-opacity="0.85">rebuild any one disk</text>
+  </g>
+  <text x="230" y="200" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">RAID guards against a <tspan font-style="italic">drive</tspan> failure — it is not a backup</text>
+</svg>
+<figcaption>Three building blocks, mixed into the numbered levels. RAID 0 stripes for speed but loses everything if a disk dies; RAID 1 keeps a full mirror; RAID 5 rotates parity so any single disk can be rebuilt. None of them replaces a backup — they don't protect against deletion, corruption, or disaster.</figcaption>
+</figure>
+
 ## Overview
 
 RAID uses three basic techniques, mixed in different *levels*. *Striping* spreads data across drives for speed (RAID 0, no redundancy). *Mirroring* keeps identical copies so either drive can fail (RAID 1). *Parity* stores recovery information that lets the array rebuild a lost drive (RAID 5 tolerates one failure, RAID 6 tolerates two). Combined levels like RAID 10 mirror and stripe together. A key caveat: RAID protects against *drive* failure, not against deletion, corruption, or disaster — it is not a backup.

--- a/docs/reference/random-access-memory.md
+++ b/docs/reference/random-access-memory.md
@@ -20,6 +20,38 @@ cite_urls:
 
 **Random-access memory (RAM)** is a computer's fast, temporary working storage — it holds the data and programs in active use so the [CPU](/reference/central-processing-unit/) can reach them quickly.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 236" role="img" aria-label="Top: one DRAM cell — a single access transistor gated by a word line and switched onto a bit line, storing one bit as charge on a tiny capacitor. Bottom: those cells packed into a grid addressed by rows and columns; the charge leaks away so each row must be refreshed constantly, and every bit vanishes when power is removed." xmlns="http://www.w3.org/2000/svg">
+  <text x="150" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">One DRAM cell: 1 transistor + 1 capacitor</text>
+  <g fill="currentColor" font-size="8">
+    <line x1="208" y1="30" x2="208" y2="52" stroke="currentColor" stroke-width="1.1"/>
+    <text x="213" y="37" text-anchor="start">bit line</text>
+    <rect x="190" y="52" width="36" height="22" rx="2" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.1"/>
+    <text x="208" y="66" text-anchor="middle">T</text>
+    <line x1="120" y1="63" x2="190" y2="63" stroke="currentColor" stroke-width="1.1"/>
+    <text x="117" y="60" text-anchor="end">word line (select)</text>
+    <line x1="208" y1="74" x2="208" y2="82" stroke="currentColor" stroke-width="1.1"/>
+    <line x1="188" y1="82" x2="228" y2="82" stroke="currentColor" stroke-width="1.6"/>
+    <line x1="188" y1="90" x2="228" y2="90" stroke="currentColor" stroke-width="1.6"/>
+    <circle cx="198" cy="86" r="1.6" fill="currentColor"/><circle cx="208" cy="86" r="1.6" fill="currentColor"/><circle cx="218" cy="86" r="1.6" fill="currentColor"/>
+    <line x1="208" y1="90" x2="208" y2="99" stroke="currentColor" stroke-width="1.1"/>
+    <line x1="200" y1="99" x2="216" y2="99" stroke="currentColor" stroke-width="1.1"/>
+    <text x="234" y="84" text-anchor="start">capacitor holds</text>
+    <text x="234" y="94" text-anchor="start" fill-opacity="0.85">charge = the bit</text>
+  </g>
+  <text x="220" y="128" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Cells in a grid — addressed by row × column</text>
+  <g fill="currentColor" fill-opacity="0.14" stroke="currentColor" stroke-width="0.8">
+    <rect x="104" y="150" width="26" height="14" rx="2"/><rect x="132" y="150" width="26" height="14" rx="2"/><rect x="160" y="150" width="26" height="14" rx="2"/><rect x="188" y="150" width="26" height="14" rx="2"/><rect x="216" y="150" width="26" height="14" rx="2"/><rect x="244" y="150" width="26" height="14" rx="2"/><rect x="272" y="150" width="26" height="14" rx="2"/><rect x="300" y="150" width="26" height="14" rx="2"/><rect x="328" y="150" width="26" height="14" rx="2"/>
+    <rect x="104" y="168" width="26" height="14" rx="2"/><rect x="132" y="168" width="26" height="14" rx="2"/><rect x="160" y="168" width="26" height="14" rx="2"/><rect x="188" y="168" width="26" height="14" rx="2"/><rect x="216" y="168" width="26" height="14" rx="2"/><rect x="244" y="168" width="26" height="14" rx="2"/><rect x="272" y="168" width="26" height="14" rx="2"/><rect x="300" y="168" width="26" height="14" rx="2"/><rect x="328" y="168" width="26" height="14" rx="2"/>
+    <rect x="104" y="186" width="26" height="14" rx="2"/><rect x="132" y="186" width="26" height="14" rx="2"/><rect x="160" y="186" width="26" height="14" rx="2"/><rect x="188" y="186" width="26" height="14" rx="2"/><rect x="216" y="186" width="26" height="14" rx="2"/><rect x="244" y="186" width="26" height="14" rx="2"/><rect x="272" y="186" width="26" height="14" rx="2"/><rect x="300" y="186" width="26" height="14" rx="2"/><rect x="328" y="186" width="26" height="14" rx="2"/>
+  </g>
+  <rect x="100" y="146" width="258" height="22" rx="3" fill="none" stroke="currentColor" stroke-width="1.3" stroke-dasharray="4 3"/>
+  <text x="368" y="160" text-anchor="start" font-size="8" fill="currentColor" fill-opacity="0.9">one row</text>
+  <text x="220" y="220" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">charge leaks → rows refreshed constantly · all lost at power-off (volatile)</text>
+</svg>
+<figcaption>Each DRAM cell is just one transistor guarding one tiny capacitor, and the stored bit is the charge on that capacitor. Cells pack into a row-and-column grid, read by selecting a word line onto a bit line. Because the charge leaks, every row must be refreshed thousands of times a second — and it all disappears the instant power is removed, which is what makes RAM volatile.</figcaption>
+</figure>
+
 ## Overview
 RAM is **volatile**: its contents are lost the moment power is removed. That is the key contrast with [storage](/reference/data-storage/), which is permanent. When you open a program, the device copies what it needs from storage into RAM, works there at high speed, then saves anything worth keeping back to storage before shutting down.
 

--- a/docs/reference/read-only-memory.md
+++ b/docs/reference/read-only-memory.md
@@ -19,6 +19,40 @@ cite_urls:
 
 **Read-only memory (ROM)** is non-volatile memory whose contents are written once or rarely and retained without power, traditionally used to hold code a device needs the moment it switches on.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 214" role="img" aria-label="A mask-ROM array: a decoder drives one horizontal word line at a time across a grid of vertical bit lines, and a transistor is present or absent at each crossing. That fixed pattern of present-versus-absent connections is the stored data, etched into the wiring at manufacture and unchangeable." xmlns="http://www.w3.org/2000/svg">
+  <text x="220" y="18" text-anchor="middle" font-size="10.5" fill="currentColor" font-weight="600">Mask ROM: the data is the wiring pattern</text>
+  <rect x="24" y="52" width="50" height="120" rx="4" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.1"/>
+  <text x="49" y="108" text-anchor="middle" font-size="8" fill="currentColor">row</text>
+  <text x="49" y="119" text-anchor="middle" font-size="8" fill="currentColor">decoder</text>
+  <g stroke="currentColor" stroke-width="1.1" stroke-opacity="0.7">
+    <line x1="74" y1="68" x2="360" y2="68"/>
+    <line x1="74" y1="98" x2="360" y2="98"/>
+    <line x1="74" y1="128" x2="360" y2="128"/>
+    <line x1="74" y1="158" x2="360" y2="158"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" stroke-opacity="0.4">
+    <line x1="110" y1="56" x2="110" y2="182"/>
+    <line x1="150" y1="56" x2="150" y2="182"/>
+    <line x1="190" y1="56" x2="190" y2="182"/>
+    <line x1="230" y1="56" x2="230" y2="182"/>
+    <line x1="270" y1="56" x2="270" y2="182"/>
+    <line x1="310" y1="56" x2="310" y2="182"/>
+  </g>
+  <g fill="currentColor">
+    <circle cx="150" cy="68" r="3.4"/><circle cx="230" cy="68" r="3.4"/><circle cx="270" cy="68" r="3.4"/>
+    <circle cx="110" cy="98" r="3.4"/><circle cx="190" cy="98" r="3.4"/><circle cx="310" cy="98" r="3.4"/>
+    <circle cx="110" cy="128" r="3.4"/><circle cx="150" cy="128" r="3.4"/><circle cx="230" cy="128" r="3.4"/><circle cx="270" cy="128" r="3.4"/>
+    <circle cx="190" cy="158" r="3.4"/><circle cx="270" cy="158" r="3.4"/><circle cx="310" cy="158" r="3.4"/>
+  </g>
+  <text x="366" y="60" text-anchor="start" font-size="7.5" fill="currentColor" fill-opacity="0.85">bit lines</text>
+  <text x="366" y="128" text-anchor="start" font-size="7.5" fill="currentColor" fill-opacity="0.9">● present = 1</text>
+  <text x="366" y="140" text-anchor="start" font-size="7.5" fill="currentColor" fill-opacity="0.85">blank = 0</text>
+  <text x="220" y="200" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">the 1s and 0s are fixed by the factory mask — non-volatile and read-only</text>
+</svg>
+<figcaption>Classic mask ROM stores each bit physically: at every crossing of a word line and a bit line there either is or isn't a transistor, and that pattern is decided by the photomask at manufacture. Reading just selects a row and senses the columns. Nothing rewrites it in normal use, and it keeps its contents with the power off.</figcaption>
+</figure>
+
 ## Overview
 
 Classic *mask ROM* has its data baked in during manufacture and can never be changed. Later variants made ROM progressively more editable: PROM (programmable once), EPROM (erasable with ultraviolet light), and EEPROM (electrically erasable). [Flash memory](/reference/flash-memory/) is the modern, block-erasable descendant of EEPROM and now fills most roles once handled by ROM chips. Despite the name, today's "ROM" is usually rewritable — but only deliberately, which is the point: it survives power loss and is not casually overwritten like [RAM](/reference/random-access-memory/).

--- a/docs/reference/reverse-proxy.md
+++ b/docs/reference/reverse-proxy.md
@@ -17,6 +17,41 @@ cite_urls:
 
 A **reverse proxy** is a [server](/reference/server/) that sits in front of one or more backend servers and forwards client requests to them, presenting a single front door while handling routing, encryption, caching, and security on their behalf.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 448 210" role="img" aria-label="Clients on the left reach a single reverse proxy in the middle over HTTPS. The proxy terminates TLS and routes each request by its URL path over plain HTTP to one of three hidden private backends, labelled slash-app, slash-api, and slash-static." xmlns="http://www.w3.org/2000/svg">
+  <text x="52" y="24" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">clients</text>
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <circle cx="52" cy="60" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/>
+    <circle cx="52" cy="105" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/>
+    <circle cx="52" cy="150" r="13" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/>
+  </g>
+  <rect x="150" y="78" width="104" height="54" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="202" y="100" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">Reverse proxy</text>
+  <text x="202" y="114" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">TLS · route by path/host</text>
+  <g stroke="currentColor" stroke-width="1.2" stroke-opacity="0.75" fill="none">
+    <line x1="65" y1="62" x2="150" y2="98" marker-end="url(#rp_ar)"/>
+    <line x1="65" y1="105" x2="150" y2="105" marker-end="url(#rp_ar)"/>
+    <line x1="65" y1="148" x2="150" y2="112" marker-end="url(#rp_ar)"/>
+  </g>
+  <text x="105" y="46" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.7">https</text>
+  <g fill="currentColor" font-size="8.5" text-anchor="middle">
+    <rect x="346" y="20" width="92" height="32" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="392" y="40">/app</text>
+    <rect x="346" y="62" width="92" height="32" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="392" y="82">/api</text>
+    <rect x="346" y="104" width="92" height="32" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.1"/><text x="392" y="124">/static</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" stroke-opacity="0.75" fill="none">
+    <line x1="254" y1="100" x2="346" y2="36" marker-end="url(#rp_ar)"/>
+    <line x1="254" y1="105" x2="346" y2="78" marker-end="url(#rp_ar)"/>
+    <line x1="254" y1="112" x2="346" y2="120" marker-end="url(#rp_ar)"/>
+  </g>
+  <text x="300" y="60" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.7">http</text>
+  <text x="392" y="150" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.7">private backends</text>
+  <text x="224" y="198" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">one public front door; the backends stay hidden and speak plain HTTP</text>
+  <defs><marker id="rp_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>To the client the reverse proxy is the whole site. It terminates HTTPS at the edge, then routes each request by path or hostname to the right backend over plain internal HTTP — so several private services hide behind one public address, and TLS, caching, and security live in one place.</figcaption>
+</figure>
+
 ## Overview
 
 To the client, the reverse proxy *is* the website; it then decides which backend should handle each request. Along the way it commonly terminates TLS (so backends speak plain HTTP internally), routes by hostname or URL path, caches responses, compresses output, and shields backends from direct exposure. This contrasts with a *forward* proxy, which sits in front of clients to reach the wider internet. Popular reverse proxies include nginx, HAProxy, and Caddy.

--- a/docs/reference/router.md
+++ b/docs/reference/router.md
@@ -17,6 +17,31 @@ cite_urls:
 
 A **router** is a networking device that forwards data packets between separate networks, deciding which path each packet should take toward its destination.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="A router sits between two networks — a home LAN on the 192.168.1.0/24 subnet with two hosts on the left, and the wider internet on the right — reading each packet's destination IP and forwarding it from one network to the other." xmlns="http://www.w3.org/2000/svg">
+  <rect x="16" y="40" width="150" height="120" rx="6" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="1.1" stroke-dasharray="5 3"/>
+  <text x="91" y="34" text-anchor="middle" font-size="8.5" fill="currentColor" font-weight="600">LAN · 192.168.1.0/24</text>
+  <g fill="currentColor" font-size="8.5" text-anchor="middle">
+    <rect x="36" y="66" width="110" height="30" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="91" y="85">host .10</text>
+    <rect x="36" y="106" width="110" height="30" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="91" y="125">host .20</text>
+  </g>
+  <rect x="198" y="80" width="66" height="46" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="231" y="100" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">router</text>
+  <text x="231" y="114" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">routing table</text>
+  <rect x="300" y="66" width="144" height="74" rx="6" fill="currentColor" fill-opacity="0.06" stroke="currentColor" stroke-width="1.2"/>
+  <text x="372" y="99" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">internet / WAN</text>
+  <text x="372" y="114" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">other networks</text>
+  <g stroke="currentColor" stroke-width="1.5" fill="none">
+    <line x1="166" y1="103" x2="198" y2="103" marker-end="url(#rtr_ar)"/>
+    <line x1="264" y1="103" x2="300" y2="103" marker-end="url(#rtr_ar)"/>
+  </g>
+  <text x="231" y="150" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">forwards by destination IP</text>
+  <text x="230" y="184" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">joins separate networks — a switch only moves traffic within one</text>
+  <defs><marker id="rtr_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A router straddles two networks — here a home LAN and the internet — and reads each packet's destination IP against a routing table to pick the next hop across the boundary. That is what sets it apart from a switch, which only forwards frames inside a single network.</figcaption>
+</figure>
+
 ## Overview
 
 A router reads the destination [IP address](/reference/ip-address/) on each packet and consults a *routing table* to choose the next hop, moving traffic between networks rather than within one — that distinguishes it from a [switch](/reference/network-switch/), which forwards frames inside a single network. The familiar home "router" is really several devices in one box: a router, a [switch](/reference/network-switch/), a [wireless access point](/reference/wireless-access-point/), and often a [modem](/reference/modem/), bridging a home [LAN](/reference/lan-and-wan/) to the internet and performing address translation (NAT).

--- a/docs/reference/software-as-a-service.md
+++ b/docs/reference/software-as-a-service.md
@@ -20,6 +20,59 @@ cite_urls:
 
 **Software as a service** (**SaaS**) is a model in which finished applications are hosted by a provider and accessed over the internet — usually by subscription — with no software to install and no servers for the user to run.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 464 268" role="img" aria-label="A grid of who manages each layer across four cloud tiers — on-premises, IaaS, PaaS, and SaaS — with the SaaS column outlined for emphasis. Rows are application, data, runtime, operating system, virtualization, and hardware. Every cell in the SaaS column is light, meaning the provider manages the entire stack from the application down to the hardware." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <text x="144" y="36" font-weight="600">On-prem</text>
+    <text x="234" y="36" font-weight="600">IaaS</text>
+    <text x="324" y="36" font-weight="600">PaaS</text>
+    <text x="414" y="36" font-weight="600">SaaS</text>
+  </g>
+  <g fill="currentColor" font-size="8.5" text-anchor="end">
+    <text x="94" y="63">Application</text>
+    <text x="94" y="93">Data</text>
+    <text x="94" y="123">Runtime</text>
+    <text x="94" y="153">OS</text>
+    <text x="94" y="183">Virtualization</text>
+    <text x="94" y="213">Hardware</text>
+  </g>
+  <g stroke="currentColor">
+    <rect x="103" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="103" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="193" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="193" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="283" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="283" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="283" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="46" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="76" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="106" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="136" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="166" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="373" y="196" width="82" height="26" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+  </g>
+  <rect x="371" y="44" width="86" height="180" rx="3" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <g font-size="8" fill="currentColor">
+    <rect x="150" y="242" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <text x="170" y="252" text-anchor="start">you manage</text>
+    <rect x="252" y="242" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5"/>
+    <text x="272" y="252" text-anchor="start">provider manages</text>
+  </g>
+</svg>
+<figcaption>SaaS is the far end of the stack: the outlined column has no cells left for you. The provider runs the application, its data plumbing, the runtime, the operating system, virtualization, and hardware — you bring only your account and your data and reach it through a browser.</figcaption>
+</figure>
+
 ## Overview
 
 SaaS is the top tier of the cloud stack: the provider runs the application, the runtime, the operating system, and the hardware, and you interact only through a browser or API. Email, document suites, chat tools, and CRM systems are common examples. Billing is typically per user or per month, and updates roll out centrally, so every customer runs the same maintained version.

--- a/docs/reference/spi.md
+++ b/docs/reference/spi.md
@@ -20,6 +20,33 @@ cite_urls:
 
 **SPI** (Serial Peripheral Interface) is a fast, full-duplex serial bus that connects a controller to one or more peripheral chips.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 208" role="img" aria-label="An SPI link between a controller and a peripheral over four lines: SCLK the clock, MOSI carrying data from controller to peripheral, MISO carrying data back at the same time (full-duplex), and CS the chip-select. Each additional peripheral needs its own chip-select line." xmlns="http://www.w3.org/2000/svg">
+  <rect x="20" y="42" width="104" height="104" rx="6" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+  <text x="72" y="90" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">SPI</text>
+  <text x="72" y="104" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">controller</text>
+  <rect x="336" y="42" width="104" height="104" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/>
+  <text x="388" y="97" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">peripheral</text>
+  <g stroke="currentColor" stroke-width="1.3" fill="none">
+    <line x1="124" y1="60" x2="336" y2="60" marker-end="url(#spi_ar)"/>
+    <line x1="124" y1="88" x2="336" y2="88" marker-end="url(#spi_ar)"/>
+    <line x1="336" y1="116" x2="124" y2="116" marker-end="url(#spi_ar)"/>
+    <line x1="124" y1="140" x2="336" y2="140" marker-end="url(#spi_ar)"/>
+  </g>
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <text x="230" y="54">SCLK — clock</text>
+    <text x="230" y="82">MOSI — controller → peripheral</text>
+    <text x="230" y="110">MISO — peripheral → controller</text>
+    <text x="230" y="134">CS — chip-select</text>
+  </g>
+  <path d="M132 70 h-8 v40 h8" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity="0.55"/>
+  <text x="108" y="93" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85" transform="rotate(-90 108 93)">full-duplex</text>
+  <text x="230" y="182" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">fast &amp; full-duplex · but each extra chip needs its own CS line</text>
+  <defs><marker id="spi_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>SPI trades wires for speed: a shared clock (SCLK) plus two data lines that move bits both ways on every clock edge — MOSI out and MISO back at the same time, so it's full-duplex and can run at tens of MHz. The catch is the chip-select: every additional peripheral needs its own CS line rather than a shared address.</figcaption>
+</figure>
+
 ## Overview
 
 SPI uses four lines: a clock (SCLK), data out (MOSI), data in (MISO), and a chip-select (CS) per peripheral. Because data flows both directions on every clock edge, it is full-duplex and can run at tens of MHz — much faster than [I²C](/reference/i2c/). The cost is wiring: each additional peripheral needs its own chip-select line rather than an address. A [microcontroller's](/reference/microcontroller/) SPI peripheral shifts the bits in hardware.

--- a/docs/reference/system-bus.md
+++ b/docs/reference/system-bus.md
@@ -17,6 +17,31 @@ cite_urls:
 
 A **system bus** is the shared set of electrical conductors that moves data, addresses, and control signals between a computer's [CPU](/reference/central-processing-unit/), [memory](/reference/random-access-memory/), and [I/O](/reference/input-output/) devices.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 214" role="img" aria-label="A system bus drawn as three parallel shared lines — an address bus, a data bus, and a control bus — with the CPU tapping them from above and RAM and I/O devices tapping the same lines from below, so all three components exchange signals over the one interconnect." xmlns="http://www.w3.org/2000/svg">
+  <rect x="44" y="22" width="120" height="32" rx="5" fill="currentColor" fill-opacity="0.18" stroke="currentColor" stroke-width="1.3"/>
+  <text x="104" y="42" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">CPU</text>
+  <line x1="24" y1="68" x2="384" y2="68" stroke="currentColor" stroke-width="1.6"/>
+  <line x1="24" y1="92" x2="384" y2="92" stroke="currentColor" stroke-width="1.6"/>
+  <line x1="24" y1="116" x2="384" y2="116" stroke="currentColor" stroke-width="1.6"/>
+  <text x="390" y="71" font-size="8.5" fill="currentColor" font-weight="600">address bus</text>
+  <text x="390" y="95" font-size="8.5" fill="currentColor" font-weight="600">data bus</text>
+  <text x="390" y="119" font-size="8.5" fill="currentColor" font-weight="600">control bus</text>
+  <rect x="60" y="150" width="108" height="42" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/>
+  <text x="114" y="176" text-anchor="middle" font-size="9" fill="currentColor">RAM</text>
+  <rect x="240" y="150" width="124" height="42" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.2"/>
+  <text x="302" y="176" text-anchor="middle" font-size="9" fill="currentColor">I/O devices</text>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.6">
+    <line x1="72" y1="54" x2="72" y2="68"/><line x1="104" y1="54" x2="104" y2="92"/><line x1="136" y1="54" x2="136" y2="116"/>
+    <line x1="88" y1="150" x2="88" y2="68"/><line x1="114" y1="150" x2="114" y2="92"/><line x1="140" y1="150" x2="140" y2="116"/>
+    <line x1="266" y1="150" x2="266" y2="68"/><line x1="292" y1="150" x2="292" y2="92"/><line x1="318" y1="150" x2="318" y2="116"/>
+  </g>
+  <g fill="currentColor"><circle cx="72" cy="68" r="2"/><circle cx="104" cy="92" r="2"/><circle cx="136" cy="116" r="2"/><circle cx="88" cy="68" r="2"/><circle cx="114" cy="92" r="2"/><circle cx="140" cy="116" r="2"/><circle cx="266" cy="68" r="2"/><circle cx="292" cy="92" r="2"/><circle cx="318" cy="116" r="2"/></g>
+  <text x="205" y="208" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">where a value goes · what the value is · when to move it</text>
+</svg>
+<figcaption>A classic system bus is really three buses working together: the address bus names a location, the data bus carries the value, and the control bus says read or write and when. CPU, RAM, and I/O all hang off the same shared lines — which is why heavy traffic makes the bus a bottleneck, and why modern machines split it into point-to-point links.</figcaption>
+</figure>
+
 ## Overview
 
 Classically a bus has three parts: a *data bus* (the values being moved), an *address bus* (which memory location or device they go to), and a *control bus* (timing and read/write signals). The bus *width* — how many bits cross at once — and its clock set the bandwidth. This shared design comes straight from the [von Neumann architecture](/reference/von-neumann-architecture/), where one path connects the processor to a common memory and devices.

--- a/docs/reference/system-on-a-chip.md
+++ b/docs/reference/system-on-a-chip.md
@@ -19,6 +19,44 @@ cite_urls:
 
 A **system on a chip (SoC)** is an integrated circuit that combines a computer's major subsystems — processor cores, graphics, memory and I/O controllers, and often radios and accelerators — onto a single die.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 236" role="img" aria-label="A single system-on-chip die containing labelled blocks — CPU cores, GPU, and NPU across the top, and a memory controller, cellular modem, and GPS below — all wired to a shared on-chip interconnect running across the middle." xmlns="http://www.w3.org/2000/svg">
+  <text x="230" y="18" text-anchor="middle" font-size="11" fill="currentColor" font-weight="600">One SoC die</text>
+  <rect x="15" y="30" width="430" height="196" rx="10" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="1.5"/>
+  <g font-size="10" fill="currentColor" text-anchor="middle">
+    <rect x="34" y="46" width="116" height="40" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <text x="92" y="63">CPU cores</text>
+    <text x="92" y="77" font-size="8">general compute</text>
+    <rect x="172" y="46" width="100" height="40" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <text x="222" y="63">GPU</text>
+    <text x="222" y="77" font-size="8">graphics</text>
+    <rect x="294" y="46" width="120" height="40" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/>
+    <text x="354" y="63">NPU</text>
+    <text x="354" y="77" font-size="8">on-device ML</text>
+    <rect x="34" y="112" width="380" height="20" rx="4" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/>
+    <text x="224" y="126" font-size="9" font-weight="600">on-chip interconnect</text>
+    <rect x="34" y="158" width="120" height="40" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.2"/>
+    <text x="94" y="175">memory ctrl</text>
+    <text x="94" y="189" font-size="8">to RAM</text>
+    <rect x="176" y="158" width="110" height="40" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.2"/>
+    <text x="231" y="175">cellular modem</text>
+    <text x="231" y="189" font-size="8">radio</text>
+    <rect x="308" y="158" width="106" height="40" rx="5" fill="currentColor" fill-opacity="0.1" stroke="currentColor" stroke-width="1.2"/>
+    <text x="361" y="175">GPS</text>
+    <text x="361" y="189" font-size="8">location</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.55">
+    <line x1="92" y1="86" x2="92" y2="112"/>
+    <line x1="222" y1="86" x2="222" y2="112"/>
+    <line x1="354" y1="86" x2="354" y2="112"/>
+    <line x1="94" y1="132" x2="94" y2="158"/>
+    <line x1="231" y1="132" x2="231" y2="158"/>
+    <line x1="361" y1="132" x2="361" y2="158"/>
+  </g>
+</svg>
+<figcaption>An SoC pulls the parts a desktop spreads across a motherboard onto one die: compute blocks (CPU, GPU, NPU) and I/O blocks (memory, modem, GPS) all share a single on-chip interconnect. Shorter traces mean smaller, cheaper, and lower-power — at the cost of upgradability.</figcaption>
+</figure>
+
 ## Overview
 
 Where a desktop spreads its parts across a [motherboard](/reference/motherboard/), an SoC packs them into one chip: one or more [CPU](/reference/central-processing-unit/) cores, a [GPU](/reference/graphics-processing-unit/), a memory controller, and blocks such as a [cellular modem](/reference/cellular-modem/), [GPS receiver](/reference/gps-receiver/), and an [NPU](/reference/neural-processing-unit/) for on-device machine learning. Most are built on the [Arm architecture](/reference/arm-architecture/). Familiar examples include Qualcomm's Snapdragon, Apple Silicon, and the Broadcom parts inside the [Raspberry Pi](/reference/raspberry-pi/).

--- a/docs/reference/tensor-processing-unit.md
+++ b/docs/reference/tensor-processing-unit.md
@@ -21,6 +21,49 @@ cite_urls:
 
 A **tensor processing unit** (**TPU**) is a custom chip designed by Google to accelerate machine-learning workloads, built around large arrays that perform the matrix multiplications at the heart of neural networks.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 420 240" role="img" aria-label="A systolic array: a four-by-four grid of multiply-accumulate cells. Weights stream down from the top and activations stream in from the left; each cell multiplies and accumulates as data passes through, and partial sums flow out of the bottom, computing a matrix product with high throughput." xmlns="http://www.w3.org/2000/svg">
+  <text x="210" y="16" text-anchor="middle" font-size="10.5" fill="currentColor" font-weight="600">Systolic array: one grid, data streams through</text>
+  <text x="210" y="33" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.85">weights ↓</text>
+  <text x="26" y="128" font-size="8.5" fill="currentColor" fill-opacity="0.85" transform="rotate(-90 26 128)">activations →</text>
+  <g font-size="9" fill="currentColor" text-anchor="middle">
+    <rect x="100" y="52" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="122" y="72">×+</text>
+    <rect x="148" y="52" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="170" y="72">×+</text>
+    <rect x="196" y="52" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="218" y="72">×+</text>
+    <rect x="244" y="52" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="266" y="72">×+</text>
+    <rect x="100" y="90" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="122" y="110">×+</text>
+    <rect x="148" y="90" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="170" y="110">×+</text>
+    <rect x="196" y="90" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="218" y="110">×+</text>
+    <rect x="244" y="90" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="266" y="110">×+</text>
+    <rect x="100" y="128" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="122" y="148">×+</text>
+    <rect x="148" y="128" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="170" y="148">×+</text>
+    <rect x="196" y="128" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="218" y="148">×+</text>
+    <rect x="244" y="128" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="266" y="148">×+</text>
+    <rect x="100" y="166" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="122" y="186">×+</text>
+    <rect x="148" y="166" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="170" y="186">×+</text>
+    <rect x="196" y="166" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="218" y="186">×+</text>
+    <rect x="244" y="166" width="44" height="34" rx="4" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1"/><text x="266" y="186">×+</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.1" stroke-opacity="0.7">
+    <line x1="122" y1="40" x2="122" y2="52" marker-end="url(#tpu_ar)"/>
+    <line x1="170" y1="40" x2="170" y2="52" marker-end="url(#tpu_ar)"/>
+    <line x1="218" y1="40" x2="218" y2="52" marker-end="url(#tpu_ar)"/>
+    <line x1="266" y1="40" x2="266" y2="52" marker-end="url(#tpu_ar)"/>
+    <line x1="62" y1="69" x2="100" y2="69" marker-end="url(#tpu_ar)"/>
+    <line x1="62" y1="107" x2="100" y2="107" marker-end="url(#tpu_ar)"/>
+    <line x1="62" y1="145" x2="100" y2="145" marker-end="url(#tpu_ar)"/>
+    <line x1="62" y1="183" x2="100" y2="183" marker-end="url(#tpu_ar)"/>
+    <line x1="122" y1="200" x2="122" y2="214" marker-end="url(#tpu_ar)"/>
+    <line x1="170" y1="200" x2="170" y2="214" marker-end="url(#tpu_ar)"/>
+    <line x1="218" y1="200" x2="218" y2="214" marker-end="url(#tpu_ar)"/>
+    <line x1="266" y1="200" x2="266" y2="214" marker-end="url(#tpu_ar)"/>
+  </g>
+  <text x="210" y="232" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.85">partial sums out</text>
+  <defs><marker id="tpu_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A TPU dedicates almost all its silicon to a systolic array: a grid of multiply-accumulate cells. Weights and activations stream in from two edges and ripple through the cells, so one matrix multiply flows through the array at high throughput per watt — very fast at tensor math, and little else.</figcaption>
+</figure>
+
 ## Overview
 
 A TPU is an [application-specific integrated circuit](/reference/application-specific-integrated-circuit/) (ASIC): rather than the general flexibility of a CPU or GPU, it dedicates almost all its silicon to a *systolic array* — a grid of multiply-accumulate units that streams data through to compute matrix products with very high throughput per watt. The trade-off is narrow specialization: a TPU runs tensor math (typically in reduced precision such as bfloat16) extremely well and little else. Google introduced TPUs in 2016 to power its own services and now offers them through its cloud, with the small Coral Edge TPU bringing the design to embedded devices.[^cloud]

--- a/docs/reference/thunderbolt.md
+++ b/docs/reference/thunderbolt.md
@@ -19,6 +19,26 @@ cite_urls:
 
 **Thunderbolt** is a high-speed connection standard that carries data, video, and power over a single cable, tunnelling [PCI Express](/reference/pci-express/) and DisplayPort and sharing the [USB-C](/reference/usb/) connector.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 470 168" role="img" aria-label="A Thunderbolt daisy-chain runs from the host to a dock, on to a display, and then to an external SSD, each hop a bidirectional 40 gigabit-per-second link that tunnels PCI Express, DisplayPort, and power along the same cable." xmlns="http://www.w3.org/2000/svg">
+  <text x="235" y="36" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">one cable carries PCIe + DisplayPort + power</text>
+  <g font-size="9" text-anchor="middle">
+    <rect x="16" y="58" width="86" height="48" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/><text x="59" y="86" fill="currentColor" font-weight="600">host</text>
+    <rect x="132" y="58" width="86" height="48" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="175" y="86" fill="currentColor">dock</text>
+    <rect x="248" y="58" width="86" height="48" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="291" y="86" fill="currentColor">display</text>
+    <rect x="364" y="58" width="90" height="48" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="409" y="86" fill="currentColor">SSD</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.5" fill="none">
+    <line x1="102" y1="82" x2="132" y2="82" marker-start="url(#tb_ar)" marker-end="url(#tb_ar)"/>
+    <line x1="218" y1="82" x2="248" y2="82" marker-start="url(#tb_ar)" marker-end="url(#tb_ar)"/>
+    <line x1="334" y1="82" x2="364" y2="82" marker-start="url(#tb_ar)" marker-end="url(#tb_ar)"/>
+  </g>
+  <text x="235" y="132" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">40 Gb/s per hop — each device passes the link along to the next</text>
+  <defs><marker id="tb_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Thunderbolt lets devices daisy-chain: one cable from the host to the first device, another on to the next, and so on. Because it tunnels PCI Express and DisplayPort together at 40 Gb/s, a single chain can carry storage, displays, and power at once — closer to an external expansion slot than an ordinary cable.</figcaption>
+</figure>
+
 ## Overview
 
 Developed by Intel and Apple, Thunderbolt 3 and 4 run at 40 Gb/s over a USB-C plug, with Thunderbolt 5 reaching 80 Gb/s; a single cable can drive displays, attach external SSDs and GPUs, deliver power, and even act as a peer-to-peer network link. Because it tunnels PCI Express, a Thunderbolt port behaves almost like an external expansion slot, which is why one cable to a dock can fan out to Ethernet, displays, and storage at once. Thunderbolt 3 onward is compatible with USB-C but offers far more bandwidth than plain [USB](/reference/usb/).

--- a/docs/reference/transistor.md
+++ b/docs/reference/transistor.md
@@ -17,6 +17,35 @@ cite_urls:
 
 A **transistor** is a [semiconductor](/reference/semiconductor/) device that switches or amplifies electrical signals — and as a tiny, electrically controlled on/off switch it is the fundamental building block of all modern digital electronics.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 196" role="img" aria-label="A transistor shown as a voltage-controlled switch between source and drain. With no voltage on the gate the switch is open and no current flows; with a voltage on the gate the switch closes and current flows from source to drain." xmlns="http://www.w3.org/2000/svg">
+  <g font-size="8.5" fill="currentColor" text-anchor="middle">
+    <text x="52" y="46">Source</text>
+    <text x="388" y="46">Drain</text>
+    <text x="52" y="146">Source</text>
+    <text x="388" y="146">Drain</text>
+  </g>
+  <circle cx="52" cy="60" r="4" fill="currentColor"/><circle cx="388" cy="60" r="4" fill="currentColor"/>
+  <line x1="52" y1="60" x2="176" y2="60" stroke="currentColor" stroke-width="1.4"/>
+  <line x1="264" y1="60" x2="388" y2="60" stroke="currentColor" stroke-width="1.4"/>
+  <line x1="176" y1="60" x2="238" y2="38" stroke="currentColor" stroke-width="1.6"/>
+  <circle cx="176" cy="60" r="3" fill="currentColor"/><circle cx="264" cy="60" r="3" fill="currentColor"/>
+  <line x1="220" y1="92" x2="220" y2="66" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3 2" marker-end="url(#tr_ar)"/>
+  <text x="220" y="104" text-anchor="middle" font-size="8.5" fill="currentColor" font-weight="600">Gate 0 V</text>
+  <text x="330" y="78" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">OFF — no current</text>
+  <circle cx="52" cy="160" r="4" fill="currentColor"/><circle cx="388" cy="160" r="4" fill="currentColor"/>
+  <line x1="52" y1="160" x2="388" y2="160" stroke="currentColor" stroke-width="1.4"/>
+  <circle cx="176" cy="160" r="3" fill="currentColor"/><circle cx="264" cy="160" r="3" fill="currentColor"/>
+  <line x1="120" y1="160" x2="150" y2="160" stroke="currentColor" stroke-width="2.4" marker-end="url(#tr_ar)"/>
+  <line x1="290" y1="160" x2="320" y2="160" stroke="currentColor" stroke-width="2.4" marker-end="url(#tr_ar)"/>
+  <line x1="220" y1="192" x2="220" y2="166" stroke="currentColor" stroke-width="1.2" marker-end="url(#tr_ar)"/>
+  <text x="220" y="184" text-anchor="middle" font-size="8.5" fill="currentColor" font-weight="600">Gate +V</text>
+  <text x="330" y="150" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">ON — current flows</text>
+  <defs><marker id="tr_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>A small voltage on the gate controls a much larger current between source and drain: no gate voltage leaves the switch open (off), a gate voltage closes it (on). Billions of these MOSFET switches, etched together on one chip and wired into logic gates, are what carry out every computation.</figcaption>
+</figure>
+
 ## Overview
 
 A transistor uses a small voltage or current at one terminal to control a much larger current between two others, so it can act as an *amplifier* or as a *switch*. Invented at Bell Labs in 1947, it replaced the bulky, hot vacuum tube. The dominant type in digital chips is the **MOSFET**, billions of which are etched together on a single [integrated circuit](/reference/integrated-circuit/). Wired together, transistors form the [logic gates](/reference/logic-gate/) that implement all computation.

--- a/docs/reference/uart.md
+++ b/docs/reference/uart.md
@@ -20,6 +20,27 @@ cite_urls:
 
 **A UART** (Universal Asynchronous Receiver/Transmitter) is a hardware block that sends and receives serial data over two wires without a shared clock.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 468 156" role="img" aria-label="A UART frame on one line. The line idles high, drops for one start bit, sends eight data bits least-significant first, then returns high for a stop bit. There is no clock line; both ends agree on a baud rate and the receiver recovers timing from the falling edge of the start bit." xmlns="http://www.w3.org/2000/svg">
+  <g stroke="currentColor" stroke-width="0.7" stroke-opacity="0.25">
+    <line x1="60" y1="34" x2="60" y2="104"/><line x1="96" y1="34" x2="96" y2="104"/><line x1="132" y1="34" x2="132" y2="104"/><line x1="168" y1="34" x2="168" y2="104"/><line x1="204" y1="34" x2="204" y2="104"/><line x1="240" y1="34" x2="240" y2="104"/><line x1="276" y1="34" x2="276" y2="104"/><line x1="312" y1="34" x2="312" y2="104"/><line x1="348" y1="34" x2="348" y2="104"/><line x1="384" y1="34" x2="384" y2="104"/><line x1="420" y1="34" x2="420" y2="104"/>
+  </g>
+  <polyline points="24,44 60,44 60,90 96,90 96,44 132,44 132,90 168,90 168,44 204,44 240,44 240,90 276,90 276,44 312,44 312,90 348,90 348,44 384,44 420,44 452,44" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <g font-size="8" fill="currentColor" text-anchor="middle" fill-opacity="0.9">
+    <text x="42" y="30">idle</text>
+    <text x="78" y="30">start</text>
+    <text x="240" y="26">8 data bits (LSB first)</text>
+    <text x="402" y="30">stop</text>
+  </g>
+  <line x1="96" y1="20" x2="384" y2="20" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5"/>
+  <line x1="96" y1="20" x2="96" y2="26" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5"/>
+  <line x1="384" y1="20" x2="384" y2="26" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5"/>
+  <text x="18" y="47" text-anchor="end" font-size="8" fill="currentColor">TX</text>
+  <text x="234" y="128" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">no clock line — both ends agree on a baud rate; the start bit re-syncs the receiver each byte</text>
+</svg>
+<figcaption>A UART has no clock wire. The line idles high; a falling edge marks the start bit, eight data bits follow (least-significant first), and a stop bit returns the line high. Because both ends are set to the same baud rate, the receiver recovers timing from that start edge — which is what makes it the simplest point-to-point serial link.</figcaption>
+</figure>
+
 ## Overview
 
 Instead of a clock line, both ends agree on a **baud rate** and frame each byte with start and stop bits, so the receiver can recover timing from the data itself. The link uses just transmit (TX) and receive (RX), making it the simplest of the common serial interfaces. A [microcontroller](/reference/microcontroller/) usually has several UARTs; one is often wired to a USB-serial adapter to provide a console. Classic RS-232 ports are UARTs with higher voltage line drivers.

--- a/docs/reference/usb.md
+++ b/docs/reference/usb.md
@@ -19,6 +19,31 @@ cite_urls:
 
 **USB** (Universal Serial Bus) is the most common standard for connecting peripherals to a computer and for delivering power, using a hot-pluggable, host-controlled serial bus.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 236" role="img" aria-label="A tiered USB tree: one host controller at the top branches to two hubs, and each hub in turn branches to two devices — a mouse and a drive under one, a camera and a dongle under the other — the nesting that lets the bus reach up to 127 devices." xmlns="http://www.w3.org/2000/svg">
+  <rect x="178" y="18" width="104" height="36" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="230" y="35" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">host controller</text>
+  <text x="230" y="48" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.85">root</text>
+  <g fill="currentColor" font-size="8.5" text-anchor="middle">
+    <rect x="70" y="96" width="80" height="30" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="110" y="115">hub</text>
+    <rect x="310" y="96" width="80" height="30" rx="5" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.2"/><text x="350" y="115">hub</text>
+  </g>
+  <g fill="currentColor" font-size="8" text-anchor="middle">
+    <rect x="24" y="176" width="64" height="28" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1"/><text x="56" y="194">mouse</text>
+    <rect x="100" y="176" width="64" height="28" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1"/><text x="132" y="194">drive</text>
+    <rect x="270" y="176" width="64" height="28" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1"/><text x="302" y="194">camera</text>
+    <rect x="346" y="176" width="64" height="28" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.1"/><text x="378" y="194">dongle</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" fill="none">
+    <line x1="205" y1="54" x2="110" y2="96"/><line x1="255" y1="54" x2="350" y2="96"/>
+    <line x1="95" y1="126" x2="56" y2="176"/><line x1="125" y1="126" x2="132" y2="176"/>
+    <line x1="335" y1="126" x2="302" y2="176"/><line x1="365" y1="126" x2="378" y2="176"/>
+  </g>
+  <text x="230" y="224" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">a host-controlled tree of tiers — up to 127 devices, all hot-pluggable</text>
+</svg>
+<figcaption>USB is a strict tree: one host controller at the root, hubs branching below it, and devices at the leaves. Every transfer is directed by the host, and the tiers can nest until the bus reaches its limit of 127 devices — any of which can be plugged or unplugged while the system runs.</figcaption>
+</figure>
+
 ## Overview
 
 A USB system has one *host* (the computer) that controls a tree of *devices* through hubs — keyboards, mice, drives, cameras, dongles. Ports are hot-pluggable, so devices can be attached and removed while running. Successive versions (USB 2.0, 3.x, 4) raised speeds by orders of magnitude, and the reversible USB-C connector added high power delivery (USB-PD), letting one cable both run and charge a device. It is part of a machine's [I/O](/reference/input-output/), distinct from internal expansion buses like [PCIe](/reference/pci-express/).

--- a/docs/reference/virtualization.md
+++ b/docs/reference/virtualization.md
@@ -21,6 +21,35 @@ cite_urls:
 
 **Virtualization** is splitting one physical computer into several isolated virtual machines, each behaving like a separate computer with its own operating system.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 420 214" role="img" aria-label="One physical computer at the bottom, a hypervisor layer above it, and three isolated virtual machines stacked on top, each with its own guest operating system and application. The hypervisor divides the host's resources and walls the virtual machines off from one another." xmlns="http://www.w3.org/2000/svg">
+  <g fill="currentColor" font-size="9" text-anchor="middle">
+    <g stroke="currentColor">
+      <rect x="48" y="44" width="104" height="92" rx="5" fill="none" stroke-width="1.2" stroke-dasharray="4 3"/>
+      <text x="100" y="59" font-size="8.5" font-weight="600">VM 1</text>
+      <rect x="55" y="66" width="90" height="28" rx="3" fill="currentColor" fill-opacity="0.2" stroke-width="1"/><text x="100" y="84">App</text>
+      <rect x="55" y="98" width="90" height="32" rx="3" fill="currentColor" fill-opacity="0.1" stroke-width="1"/><text x="100" y="118" font-size="8.5">Guest OS</text>
+      <rect x="162" y="44" width="104" height="92" rx="5" fill="none" stroke-width="1.2" stroke-dasharray="4 3"/>
+      <text x="214" y="59" font-size="8.5" font-weight="600">VM 2</text>
+      <rect x="169" y="66" width="90" height="28" rx="3" fill="currentColor" fill-opacity="0.2" stroke-width="1"/><text x="214" y="84">App</text>
+      <rect x="169" y="98" width="90" height="32" rx="3" fill="currentColor" fill-opacity="0.1" stroke-width="1"/><text x="214" y="118" font-size="8.5">Guest OS</text>
+      <rect x="276" y="44" width="96" height="92" rx="5" fill="none" stroke-width="1.2" stroke-dasharray="4 3"/>
+      <text x="324" y="59" font-size="8.5" font-weight="600">VM 3</text>
+      <rect x="283" y="66" width="82" height="28" rx="3" fill="currentColor" fill-opacity="0.2" stroke-width="1"/><text x="324" y="84">App</text>
+      <rect x="283" y="98" width="82" height="32" rx="3" fill="currentColor" fill-opacity="0.1" stroke-width="1"/><text x="324" y="118" font-size="8.5">Guest OS</text>
+    </g>
+    <rect x="40" y="142" width="340" height="28" rx="4" fill="currentColor" fill-opacity="0.25" stroke="currentColor" stroke-width="1.2"/><text x="210" y="160" font-weight="600">Hypervisor — divides &amp; isolates</text>
+    <rect x="40" y="174" width="340" height="28" rx="4" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.2"/><text x="210" y="192">One physical computer · CPU · memory · storage</text>
+  </g>
+  <g stroke="currentColor" stroke-width="1" stroke-opacity="0.5">
+    <line x1="100" y1="136" x2="100" y2="142"/>
+    <line x1="214" y1="136" x2="214" y2="142"/>
+    <line x1="324" y1="136" x2="324" y2="142"/>
+  </g>
+</svg>
+<figcaption>The hypervisor is the layer that makes one machine act like many: it carves the host's CPU, memory, and storage into virtual machines and walls each off from its neighbours, so one tenant's crash or load can't spill into another's. A rented VPS is one such VM; a cloud is this run across whole data centers.</figcaption>
+</figure>
+
 ## Overview
 
 The piece that makes this work is the *hypervisor*: a software layer that creates and runs the virtual machines and divides the host's CPU, memory, and storage between them. Each VM is walled off from its neighbors, so one tenant's crash or workload does not spill into another's.

--- a/docs/reference/von-neumann-architecture.md
+++ b/docs/reference/von-neumann-architecture.md
@@ -19,6 +19,31 @@ cite_urls:
 
 The **von Neumann architecture** is the *stored-program* computer design in which both instructions and data live in the same [memory](/reference/random-access-memory/), accessed by the processor over a common [bus](/reference/system-bus/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 200" role="img" aria-label="A CPU containing a control unit and an ALU on the left connects over a single shared bus to one main memory holding both program and data, and to input/output. Because instructions and data share that one path, it is the von Neumann bottleneck." xmlns="http://www.w3.org/2000/svg">
+  <rect x="24" y="46" width="132" height="104" rx="6" fill="currentColor" fill-opacity="0.05" stroke="currentColor" stroke-width="1.3"/>
+  <text x="90" y="62" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">CPU</text>
+  <rect x="34" y="72" width="112" height="30" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="90" y="91" text-anchor="middle" font-size="8.5" fill="currentColor">control unit</text>
+  <rect x="34" y="110" width="112" height="30" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1"/><text x="90" y="129" text-anchor="middle" font-size="8.5" fill="currentColor">ALU</text>
+  <rect x="300" y="56" width="134" height="48" rx="5" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.2"/><text x="367" y="76" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">Main memory</text><text x="367" y="91" text-anchor="middle" font-size="8" fill="currentColor">program + data</text>
+  <rect x="300" y="120" width="134" height="42" rx="5" fill="currentColor" fill-opacity="0.08" stroke="currentColor" stroke-width="1.2"/><text x="367" y="145" text-anchor="middle" font-size="9" fill="currentColor">Input / Output</text>
+  <line x1="248" y1="80" x2="248" y2="140" stroke="currentColor" stroke-width="1.4"/>
+  <g stroke="currentColor" stroke-width="2" fill="none">
+    <line x1="200" y1="100" x2="156" y2="100" marker-end="url(#vn_ar)"/>
+    <line x1="200" y1="100" x2="248" y2="100"/>
+  </g>
+  <g stroke="currentColor" stroke-width="1.4" fill="none">
+    <line x1="248" y1="80" x2="300" y2="80" marker-end="url(#vn_ar)"/>
+    <line x1="248" y1="140" x2="300" y2="140" marker-end="url(#vn_ar)"/>
+  </g>
+  <text x="202" y="90" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">shared bus</text>
+  <path d="M158 158 V164 H246 V158" fill="none" stroke="currentColor" stroke-width="1" stroke-opacity="0.6"/>
+  <text x="202" y="180" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">instructions + data on one path = the bottleneck</text>
+  <defs><marker id="vn_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Both the program and its data live in one memory, reached by the CPU over a single shared bus. Storing the program alongside the data — rather than wiring it as fixed hardware — is what makes the machine general-purpose. The cost is the von Neumann bottleneck: that one path caps throughput, which is exactly why caches and wide buses exist.</figcaption>
+</figure>
+
 ## Overview
 
 In this model a computer has a [CPU](/reference/central-processing-unit/) (with a control unit and an arithmetic/logic unit), a single main memory holding both program and data, and I/O — and the processor works by repeatedly *fetching* an instruction from memory, *decoding* it, and *executing* it. Storing the program in the same memory as the data, rather than wiring it as fixed hardware, is what makes a computer general-purpose: change the program, change what the machine does.

--- a/docs/reference/watchdog-timer.md
+++ b/docs/reference/watchdog-timer.md
@@ -20,6 +20,35 @@ cite_urls:
 
 **A watchdog timer (WDT)** is a hardware counter that resets a system if the software fails to signal it within a set interval.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 196" role="img" aria-label="A sawtooth timeline of a watchdog counter: it falls from full toward zero, and each time the software kicks it the count jumps back to full. After the software hangs the kicks stop, the counter reaches zero, and the watchdog forces a hardware reset." xmlns="http://www.w3.org/2000/svg">
+  <text x="230" y="18" text-anchor="middle" font-size="10" fill="currentColor" font-weight="600">Kick it in time, or it resets you</text>
+  <line x1="34" y1="50" x2="440" y2="50" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.4" stroke-dasharray="4 3"/>
+  <text x="30" y="53" text-anchor="end" font-size="7.5" fill="currentColor" fill-opacity="0.85">full</text>
+  <line x1="34" y1="140" x2="440" y2="140" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.4" stroke-dasharray="4 3"/>
+  <text x="30" y="143" text-anchor="end" font-size="7.5" fill="currentColor" fill-opacity="0.85">0</text>
+  <line x1="34" y1="150" x2="34" y2="40" stroke="currentColor" stroke-width="1" stroke-opacity="0.6" marker-end="url(#wdt_ar)"/>
+  <text x="26" y="96" font-size="7.5" fill="currentColor" fill-opacity="0.85" text-anchor="middle" transform="rotate(-90 26 96)">count left</text>
+  <path d="M46 50 L120 110 L120 50 L200 110 L200 50 L280 110 L280 50 L430 140" fill="none" stroke="currentColor" stroke-width="1.8"/>
+  <g stroke="currentColor" stroke-width="1.2">
+    <line x1="120" y1="30" x2="120" y2="48" marker-end="url(#wdt_ar)"/>
+    <line x1="200" y1="30" x2="200" y2="48" marker-end="url(#wdt_ar)"/>
+    <line x1="280" y1="30" x2="280" y2="48" marker-end="url(#wdt_ar)"/>
+  </g>
+  <g fill="currentColor" font-size="7.5" text-anchor="middle" fill-opacity="0.9">
+    <text x="120" y="26">kick</text><text x="200" y="26">kick</text><text x="280" y="26">kick</text>
+  </g>
+  <text x="352" y="86" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.9">hang — kicks stop</text>
+  <circle cx="430" cy="140" r="3.5" fill="currentColor"/>
+  <rect x="356" y="150" width="96" height="24" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/>
+  <text x="404" y="165" text-anchor="middle" font-size="8" fill="currentColor">hardware reset</text>
+  <line x1="430" y1="143" x2="430" y2="150" stroke="currentColor" stroke-width="1.1" marker-end="url(#wdt_ar)"/>
+  <text x="230" y="188" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">healthy code pets the dog before zero; a crashed one never does — so it reboots</text>
+  <defs><marker id="wdt_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>The watchdog counts down continuously, and healthy firmware must "kick" it back to full before it reaches zero. Each kick resets the count; but if the code hangs or crashes the kicks stop, the counter runs out, and the watchdog forces a hardware reset — recovering an unattended device with no human present.</figcaption>
+</figure>
+
 ## Overview
 
 The watchdog counts down continuously; healthy [firmware](/reference/firmware/) must periodically "kick" (reset) it before it reaches zero. If the code hangs in an infinite loop, deadlocks, or crashes, it stops kicking, the counter expires, and the watchdog forces a hardware reset — bringing the device back to a known state with no human intervention. Most [microcontrollers](/reference/microcontroller/) include one as a dedicated peripheral, often clocked independently so it survives even if the main clock fails.

--- a/docs/reference/web-hosting.md
+++ b/docs/reference/web-hosting.md
@@ -21,6 +21,49 @@ cite_urls:
 
 **Web hosting** is a service that runs your website on someone else's [servers](/reference/server/) so it is reachable on the internet.[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 440 214" role="img" aria-label="Four hosting tiers side by side — shared, VPS, dedicated, and cloud — each drawn as a bar split into a provider-managed portion on top and a you-managed portion below. Moving from shared to dedicated the you-managed portion grows, and an arrow marks that control and responsibility increase across those three. Cloud is drawn with a dashed border as a separate elastic option." xmlns="http://www.w3.org/2000/svg">
+  <text x="167" y="13" text-anchor="middle" font-size="8" fill="currentColor" fill-opacity="0.85">more control &amp; responsibility &#8594;</text>
+  <line x1="63" y1="22" x2="271" y2="22" stroke="currentColor" stroke-width="1.2" stroke-opacity="0.7" marker-end="url(#wh_ar)"/>
+  <g fill="currentColor" font-size="9" text-anchor="middle" font-weight="600">
+    <text x="63" y="36">Shared</text>
+    <text x="167" y="36">VPS</text>
+    <text x="271" y="36">Dedicated</text>
+    <text x="375" y="36">Cloud</text>
+  </g>
+  <g stroke="currentColor">
+    <rect x="18" y="42" width="90" height="106" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="18" y="148" width="90" height="22" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="122" y="42" width="90" height="68" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="122" y="110" width="90" height="60" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="226" y="42" width="90" height="28" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="226" y="70" width="90" height="100" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="330" y="42" width="90" height="73" rx="2" fill="currentColor" fill-opacity="0.04" stroke-width="0.8" stroke-opacity="0.5"/>
+    <rect x="330" y="115" width="90" height="55" rx="2" fill="currentColor" fill-opacity="0.22" stroke-width="1"/>
+    <rect x="330" y="42" width="90" height="128" rx="2" fill="none" stroke-width="1.2" stroke-dasharray="5 4"/>
+  </g>
+  <g fill="currentColor" font-size="7.5" text-anchor="middle">
+    <text x="63" y="98" fill-opacity="0.75">provider</text>
+    <text x="63" y="162">you</text>
+    <text x="167" y="79" fill-opacity="0.75">provider</text>
+    <text x="167" y="143">you</text>
+    <text x="271" y="59" fill-opacity="0.75">provider</text>
+    <text x="271" y="123">you</text>
+    <text x="375" y="82" fill-opacity="0.75">provider</text>
+    <text x="375" y="145">you</text>
+  </g>
+  <text x="375" y="184" text-anchor="middle" font-size="7" fill="currentColor" fill-opacity="0.7">elastic · scales on demand</text>
+  <g font-size="8" fill="currentColor">
+    <rect x="40" y="192" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.22" stroke="currentColor" stroke-width="1"/>
+    <text x="60" y="202" text-anchor="start">you manage</text>
+    <rect x="150" y="192" width="14" height="12" rx="2" fill="currentColor" fill-opacity="0.04" stroke="currentColor" stroke-width="0.8" stroke-opacity="0.5"/>
+    <text x="170" y="202" text-anchor="start">provider manages</text>
+  </g>
+  <defs><marker id="wh_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>Hosting tiers trade convenience for control. Shared hosting is almost entirely managed for you but gives little control; a VPS hands you your own slice, and a dedicated server the whole machine — each step down puts more of the stack in your hands. Cloud sits apart, billed on demand and scaling elastically.</figcaption>
+</figure>
+
 ## Overview
 
 Shared hosting is the cheapest tier: many customers' sites live on one server, sharing its CPU, memory, and disk. It is managed for you — you upload files and the provider keeps the machine running — but you get limited control in exchange. It comfortably runs the common cases: [PHP](/reference/php-language/) apps, [Python](/reference/python-language/) sites, and plain static pages.

--- a/docs/reference/wireless-access-point.md
+++ b/docs/reference/wireless-access-point.md
@@ -18,6 +18,34 @@ cite_urls:
 
 A **wireless access point** (WAP, or just AP) is a device that lets [Wi-Fi](/reference/wi-fi/) clients join a wired network, bridging their radio links onto the [LAN](/reference/lan-and-wan/).[^wiki]
 
+<figure class="figure" markdown="0">
+<svg viewBox="0 0 460 208" role="img" aria-label="Three wireless clients — a laptop, a phone, and a tablet — associate over Wi-Fi shown as dashed radio links with a central access point, which bridges their traffic over a solid wired Ethernet link to the LAN switch." xmlns="http://www.w3.org/2000/svg">
+  <text x="52" y="24" text-anchor="middle" font-size="9" fill="currentColor" font-weight="600">Wi-Fi clients</text>
+  <g fill="currentColor" font-size="8.5" text-anchor="middle">
+    <rect x="18" y="44" width="70" height="28" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="53" y="62">laptop</text>
+    <rect x="18" y="92" width="70" height="28" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="53" y="110">phone</text>
+    <rect x="18" y="140" width="70" height="28" rx="4" fill="currentColor" fill-opacity="0.15" stroke="currentColor" stroke-width="1.1"/><text x="53" y="158">tablet</text>
+  </g>
+  <rect x="176" y="82" width="98" height="48" rx="6" fill="currentColor" fill-opacity="0.2" stroke="currentColor" stroke-width="1.3"/>
+  <text x="225" y="102" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">access point</text>
+  <text x="225" y="117" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">SSID · bridge</text>
+  <rect x="350" y="82" width="94" height="48" rx="6" fill="currentColor" fill-opacity="0.12" stroke="currentColor" stroke-width="1.3"/>
+  <text x="397" y="102" text-anchor="middle" font-size="9.5" fill="currentColor" font-weight="600">switch</text>
+  <text x="397" y="117" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.85">wired LAN</text>
+  <g stroke="currentColor" stroke-width="1.1" stroke-opacity="0.55" fill="none" stroke-dasharray="4 3">
+    <line x1="88" y1="58" x2="176" y2="98"/>
+    <line x1="88" y1="106" x2="176" y2="106"/>
+    <line x1="88" y1="154" x2="176" y2="114"/>
+  </g>
+  <text x="128" y="150" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.8">Wi-Fi · 802.11</text>
+  <line x1="274" y1="106" x2="350" y2="106" stroke="currentColor" stroke-width="1.6" fill="none" marker-end="url(#wap_ar)"/>
+  <text x="312" y="98" text-anchor="middle" font-size="7.5" fill="currentColor" fill-opacity="0.9">Ethernet</text>
+  <text x="230" y="192" text-anchor="middle" font-size="8.5" fill="currentColor" fill-opacity="0.9">radio links on one side, a wired uplink on the other</text>
+  <defs><marker id="wap_ar" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0 0 L6 3 L0 6 z" fill="currentColor"/></marker></defs>
+</svg>
+<figcaption>An access point is a bridge with a foot in each world: wireless clients associate to its SSID over the air (dashed 802.11 links), and it relays their traffic down a wired Ethernet uplink to the switch. That is the whole job — it puts Wi-Fi on the air for a network that is otherwise wired.</figcaption>
+</figure>
+
 ## Overview
 
 An access point broadcasts one or more named networks (SSIDs) and relays traffic between associated wireless clients and the wired side, usually plugging into a [switch](/reference/network-switch/). Standalone APs are common in larger buildings, where several units share an SSID so devices roam seamlessly, often as a controller-managed or mesh system. Many are powered over the data cable by [Power over Ethernet](/reference/power-over-ethernet/), simplifying mounting. In a home, the AP is typically built into the same box as the [router](/reference/router/) and [modem](/reference/modem/).


### PR DESCRIPTION
The RF/SDR Field Guide articles are richly illustrated, but the newer
computing hardware, cloud, and software-concept articles had no visuals.
This adds one hand-crafted, monochrome inline SVG figure to each of 22
of the highest-value un-illustrated pages, matching the site's existing
diagram convention: currentColor only (auto light/dark), wrapped in
<figure class="figure" markdown="0"> with a teaching <figcaption>, placed
after the lede.

The set deliberately seeds a reusable diagram vocabulary so later passes
can fan out cheaply:
- chip block: system-on-a-chip, central-processing-unit
- parallel-lanes / SIMD: graphics-processing-unit, tensor-processing-unit
- hierarchy pyramid: memory-hierarchy, cache-memory
- memory-cell array: flash-memory
- storage layout: raid
- cloud shared-responsibility stack: infrastructure-as-a-service
- layered VM tower: virtualization
- fan-out topology: load-balancer
- bus topology / waveform: i2c, spi, uart, pulse-width-modulation
- signal path: digital-to-analog-converter
- datapath: von-neumann-architecture
- gate/truth-table: logic-gate
- transistor switch: transistor
- control-flow timeline: interrupt
- growth curve: moores-law
- flexibility spectrum: application-specific-integrated-circuit

Verified: all figures parse as well-formed XML, pass the kramdown (GFM)
converter intact (rendered once, not escaped or <p>-wrapped), carry
role="img" + aria-label + figcaption, use no hardcoded colors, and render
legibly in both light and dark themes with no overflow.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ATYt5VyexfwKmTKSuffcR2