### PR TITLE
feat(gtbundle): add GopherTrunk Bundle (.gtb.tar.gz) core package

### DIFF
--- a/cmd/gophertrunk/analyze.go
+++ b/cmd/gophertrunk/analyze.go
@@ -28,6 +28,7 @@ func runAnalyze(args []string) {
 	iqCorrect := fs.Bool("iq-correct", false, "apply blind I/Q-imbalance correction to the raw IQ before decimation")
 	out := fs.String("out", "", "write structured output to this file (default: stdout)")
 	outFormat := fs.String("out-format", "text", "output format: text | json | jsonl | yaml | csv | csv-events")
+	bundlePath := fs.String("bundle", "", "read the capture from this GopherTrunk Bundle (.gtb.tar.gz) and write the result back into it (siglab/result.yaml + events.jsonl)")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk analyze — decode + analyze a raw IQ capture, with structured export.
 
@@ -52,9 +53,36 @@ FLAGS:`)
 	resolveVerbose(*verboseFlag, false)
 	rep := newReporter("analyze")
 
+	// When a bundle is given, source the capture (and defaults) from it so a
+	// bundled case analyzes without unpacking by hand.
+	var bundleCleanup func()
+	if *bundlePath != "" {
+		iqPath, meta, cleanup, err := extractBundleCapture(*bundlePath)
+		if err != nil {
+			rep.Fatal(1, err)
+		}
+		bundleCleanup = cleanup
+		defer bundleCleanup()
+		*in = iqPath
+		if meta != nil {
+			if !flagPassed(fs, "sample-rate") && meta.SampleRateHz > 0 {
+				*sampleRate = meta.SampleRateHz
+			}
+			if !flagPassed(fs, "format") && meta.Format != "" {
+				*format = meta.Format
+			}
+			if !flagPassed(fs, "protocol") && meta.Protocol != "" {
+				*protocolFlag = meta.Protocol
+			}
+			if !flagPassed(fs, "tune-hz") && meta.TuneHz != 0 {
+				*tuneHz = meta.TuneHz
+			}
+		}
+	}
+
 	if *in == "" {
 		fs.Usage()
-		rep.Fatalf(2, "-in is required")
+		rep.Fatalf(2, "-in is required (or pass -bundle to read the capture from a GopherTrunk Bundle)")
 	}
 	proto, err := siglab.ParseProtocolCLI(*protocolFlag)
 	if err != nil {
@@ -98,6 +126,26 @@ FLAGS:`)
 	if err := emitResult(res, of, *out); err != nil {
 		rep.Fatal(1, err)
 	}
+
+	if *bundlePath != "" {
+		if err := writeResultToBundle(*bundlePath, res); err != nil {
+			rep.Fatal(1, fmt.Errorf("write result to bundle: %w", err))
+		}
+		fmt.Fprintf(os.Stderr, "analyze: wrote result → %s (siglab/result.yaml)\n", *bundlePath)
+	}
+}
+
+// flagPassed reports whether the named flag was explicitly set on the command
+// line (as opposed to left at its default), so a bundle's metadata can supply a
+// default only when the operator did not override it.
+func flagPassed(fs *flag.FlagSet, name string) bool {
+	found := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
 }
 
 // emitResult writes res in the requested format to outPath (or stdout when

--- a/cmd/gophertrunk/bundle.go
+++ b/cmd/gophertrunk/bundle.go
@@ -1,0 +1,526 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+)
+
+// runBundle dispatches `gophertrunk bundle <subcommand>`. The GopherTrunk
+// Bundle (.gtb.tar.gz) is the single-file case container that packages a
+// capture together with its logs, signal analysis, crypto analysis, and
+// site/network mapping. This is distinct from hunt's CSV "import bundle" (that
+// CSV is stored *inside* a GopherTrunk Bundle as a mapping-export artifact).
+func runBundle(args []string) {
+	if len(args) == 0 {
+		printBundleUsage(os.Stderr)
+		os.Exit(2)
+	}
+	sub, rest := args[0], args[1:]
+	switch sub {
+	case "pack":
+		runBundlePack(rest)
+	case "info", "ls":
+		runBundleInfo(rest)
+	case "verify":
+		runBundleVerify(rest)
+	case "extract":
+		runBundleExtract(rest)
+	case "add":
+		runBundleAdd(rest)
+	case "commit", "import":
+		runBundleCommit(rest)
+	case "help", "-h", "--help":
+		printBundleUsage(os.Stdout)
+	default:
+		fmt.Fprintf(os.Stderr, "bundle: unknown subcommand %q\n\n", sub)
+		printBundleUsage(os.Stderr)
+		os.Exit(2)
+	}
+}
+
+func printBundleUsage(w *os.File) {
+	fmt.Fprint(w, `gophertrunk bundle — build and inspect GopherTrunk Bundles (.gtb.tar.gz).
+
+A GopherTrunk Bundle packages one capture-to-analysis case in a single sharable
+archive: the raw IQ capture, logs, SigLab signal analysis, CryptoLab crypto
+analysis, and the hunt site/network mapping, indexed by MANIFEST.yaml.
+
+SUBCOMMANDS:
+  pack      assemble a bundle from a capture and/or analysis files
+  info|ls   print a bundle's manifest summary
+  verify    recompute and check every file's sha256
+  extract   unpack a whole bundle, or one role's files, to a directory
+  add       append an artifact to an existing bundle
+  commit    merge the bundle's discovered system into config.yaml
+
+Run "gophertrunk bundle <subcommand> -h" for flags.
+`)
+}
+
+// --- pack ---
+
+func runBundlePack(args []string) {
+	fs := flag.NewFlagSet("bundle pack", flag.ExitOnError)
+	out := fs.String("out", "", "output bundle path (.gtb.tar.gz) (required)")
+	name := fs.String("name", "", "bundle name / top-level dir (default: derived from -out)")
+	intent := fs.String("intent", "general", "capture intent: cc-map | crypto | survey | general")
+	title := fs.String("title", "", "human title for the case")
+	source := fs.String("source", "", "free-text capture provenance")
+	notes := fs.String("notes-text", "", "free-text notes stored in the manifest")
+
+	capture := fs.String("capture", "", "raw IQ capture (.cfile/.bin) → capture-iq")
+	meta := fs.String("meta", "", "capture metadata sidecar (json/yaml) → capture-meta")
+	slice := fs.String("slice", "", "narrowband DDC slice (.wav) → capture-slice")
+	events := fs.String("events", "", "session event log (jsonl) → log-events")
+	messages := fs.String("messages", "", "human decoded-message log → log-messages")
+	mappingSystem := fs.String("mapping-system", "", "discovered system (json) → mapping-system")
+	survey := fs.String("survey", "", "survey stream (jsonl) → mapping-survey")
+	mappingExport := multiFlag{}
+	fs.Var(&mappingExport, "mapping-export", "a hunt export file (csv/json/md) → mapping-export (repeatable)")
+	siglabResult := fs.String("siglab-result", "", "SigLab result (yaml/json) → siglab-result")
+	siglabEvents := fs.String("siglab-events", "", "SigLab events (jsonl) → siglab-events")
+	cryptoFrames := fs.String("cryptolab-frames", "", "crypto frames (jsonl) → cryptolab-frames")
+	cryptoResult := fs.String("cryptolab-result", "", "CryptoLab result (yaml/json) → cryptolab-result")
+	notesFile := fs.String("notes", "", "notes.md file → notes")
+	fromDir := fs.String("from-dir", "", "pack a pre-laid-out directory (capture/, logs/, mapping/, …)")
+	_ = fs.Parse(args)
+
+	rep := newReporter("bundle pack")
+	if *out == "" {
+		rep.Fatalf(2, "-out is required")
+	}
+	nm := *name
+	if nm == "" {
+		nm = strings.TrimSuffix(filepath.Base(*out), gtbundle.Ext)
+		nm = strings.TrimSuffix(nm, ".tar.gz")
+		nm = strings.TrimSuffix(nm, ".gtb")
+	}
+
+	f, err := os.Create(*out)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	defer f.Close()
+
+	w, err := gtbundle.NewWriter(f, gtbundle.WriterOptions{
+		Name:          nm,
+		CaptureIntent: gtbundle.CaptureIntent(*intent),
+		Title:         *title,
+		Notes:         *notes,
+		Provenance:    gtbundle.Provenance{Source: *source},
+	})
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+
+	added := 0
+	add := func(role gtbundle.Role, path, producedBy string) {
+		if path == "" {
+			return
+		}
+		src, oerr := os.Open(path)
+		if oerr != nil {
+			rep.Fatal(1, oerr)
+		}
+		defer src.Close()
+		if _, aerr := w.Add(role, filepath.Base(path), src, producedBy); aerr != nil {
+			rep.Fatal(1, fmt.Errorf("add %s: %w", path, aerr))
+		}
+		added++
+	}
+
+	if *fromDir != "" {
+		added += packFromDir(rep, w, *fromDir)
+	}
+	add(gtbundle.RoleCaptureIQ, *capture, "gophertrunk capture")
+	add(gtbundle.RoleCaptureMeta, *meta, "gophertrunk capture")
+	add(gtbundle.RoleCaptureSlice, *slice, "gophertrunk bundle")
+	add(gtbundle.RoleLogEvents, *events, "daemon")
+	add(gtbundle.RoleLogMessages, *messages, "daemon")
+	add(gtbundle.RoleMappingSystem, *mappingSystem, "hunt")
+	add(gtbundle.RoleMappingSurvey, *survey, "hunt")
+	for _, me := range mappingExport {
+		add(gtbundle.RoleMappingExport, me, "hunt")
+	}
+	add(gtbundle.RoleSiglabResult, *siglabResult, "siglab")
+	add(gtbundle.RoleSiglabEvents, *siglabEvents, "siglab")
+	add(gtbundle.RoleCryptolabFrames, *cryptoFrames, "cryptolab")
+	add(gtbundle.RoleCryptolabResult, *cryptoResult, "cryptolab")
+	add(gtbundle.RoleNotes, *notesFile, "operator")
+
+	if added == 0 {
+		rep.Fatalf(2, "nothing to pack — give at least one artifact (e.g. -capture) or -from-dir")
+	}
+	if err := w.Close(); err != nil {
+		rep.Fatal(1, err)
+	}
+	fmt.Printf("bundle: wrote %s (%d files)\n", *out, added)
+}
+
+// packFromDir walks a laid-out directory and adds every file under a recognized
+// subdirectory to the writer, inferring the role from the subdir + filename. It
+// returns the count added. Unrecognized files are skipped with a note.
+func packFromDir(rep *diag.Reporter, w *gtbundle.Writer, dir string) int {
+	added := 0
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, rerr := filepath.Rel(dir, path)
+		if rerr != nil {
+			return rerr
+		}
+		role, ok := roleForRelPath(filepath.ToSlash(rel))
+		if !ok {
+			fmt.Fprintf(os.Stderr, "bundle: skipping unrecognized %s\n", rel)
+			return nil
+		}
+		src, oerr := os.Open(path)
+		if oerr != nil {
+			return oerr
+		}
+		defer src.Close()
+		if _, aerr := w.Add(role, filepath.Base(path), src, "from-dir"); aerr != nil {
+			return aerr
+		}
+		added++
+		return nil
+	})
+	if err != nil {
+		rep.Fatal(1, fmt.Errorf("from-dir: %w", err))
+	}
+	return added
+}
+
+// roleForRelPath infers a role from a directory-relative path inside a laid-out
+// case tree.
+func roleForRelPath(rel string) (gtbundle.Role, bool) {
+	base := strings.ToLower(filepath.Base(rel))
+	switch {
+	case strings.HasPrefix(rel, "capture/") && strings.HasSuffix(base, ".wav"):
+		return gtbundle.RoleCaptureSlice, true
+	case strings.HasPrefix(rel, "capture/") && (strings.Contains(base, "meta")):
+		return gtbundle.RoleCaptureMeta, true
+	case strings.HasPrefix(rel, "capture/"):
+		return gtbundle.RoleCaptureIQ, true
+	case strings.HasPrefix(rel, "logs/") && strings.HasSuffix(base, ".jsonl"):
+		return gtbundle.RoleLogEvents, true
+	case strings.HasPrefix(rel, "logs/"):
+		return gtbundle.RoleLogMessages, true
+	case strings.HasPrefix(rel, "mapping/") && base == "system.json":
+		return gtbundle.RoleMappingSystem, true
+	case strings.HasPrefix(rel, "mapping/") && strings.HasSuffix(base, ".jsonl"):
+		return gtbundle.RoleMappingSurvey, true
+	case strings.HasPrefix(rel, "mapping/"):
+		return gtbundle.RoleMappingExport, true
+	case strings.HasPrefix(rel, "siglab/") && strings.HasSuffix(base, ".jsonl"):
+		return gtbundle.RoleSiglabEvents, true
+	case strings.HasPrefix(rel, "siglab/"):
+		return gtbundle.RoleSiglabResult, true
+	case strings.HasPrefix(rel, "cryptolab/") && strings.HasSuffix(base, ".jsonl"):
+		return gtbundle.RoleCryptolabFrames, true
+	case strings.HasPrefix(rel, "cryptolab/"):
+		return gtbundle.RoleCryptolabResult, true
+	case base == "notes.md":
+		return gtbundle.RoleNotes, true
+	default:
+		return "", false
+	}
+}
+
+// --- info ---
+
+func runBundleInfo(args []string) {
+	fs := flag.NewFlagSet("bundle info", flag.ExitOnError)
+	in := fs.String("in", "", "bundle path (.gtb.tar.gz) (required)")
+	showFiles := fs.Bool("files", false, "list the full file inventory")
+	_ = fs.Parse(args)
+
+	rep := newReporter("bundle info")
+	if *in == "" {
+		rep.Fatalf(2, "-in is required")
+	}
+	r, err := gtbundle.Open(*in)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	m := r.Manifest()
+	if r.FutureSchema() {
+		fmt.Fprintf(os.Stderr, "bundle: warning — schema_version %d is newer than this build supports (%d); reading best-effort\n",
+			m.SchemaVersion, gtbundle.SchemaVersion)
+	}
+	fmt.Printf("name:     %s\n", m.Name)
+	if m.Title != "" {
+		fmt.Printf("title:    %s\n", m.Title)
+	}
+	fmt.Printf("intent:   %s\n", m.CaptureIntent)
+	fmt.Printf("created:  %s\n", m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	fmt.Printf("by:       %s %s\n", m.Generator.Tool, m.Generator.Version)
+	if m.Provenance.Source != "" {
+		fmt.Printf("source:   %s\n", m.Provenance.Source)
+	}
+	if m.Provenance.Protocol != "" {
+		fmt.Printf("protocol: %s\n", m.Provenance.Protocol)
+	}
+	fmt.Printf("files:    %d\n", len(m.Files))
+	if *showFiles {
+		for _, f := range m.Files {
+			fmt.Printf("  %-18s %-40s %10d  %s\n", f.Role, f.Path, f.SizeBytes, f.ProducedBy)
+		}
+	}
+}
+
+// --- verify ---
+
+func runBundleVerify(args []string) {
+	fs := flag.NewFlagSet("bundle verify", flag.ExitOnError)
+	in := fs.String("in", "", "bundle path (.gtb.tar.gz) (required)")
+	quiet := fs.Bool("quiet", false, "print nothing on success")
+	_ = fs.Parse(args)
+
+	rep := newReporter("bundle verify")
+	if *in == "" {
+		rep.Fatalf(2, "-in is required")
+	}
+	r, err := gtbundle.Open(*in)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	bad, untracked := 0, 0
+	for _, v := range r.Verify() {
+		switch {
+		case v.Untracked:
+			untracked++
+			if !*quiet {
+				fmt.Printf("untracked  %s\n", v.Path)
+			}
+		case !v.OK:
+			bad++
+			fmt.Fprintf(os.Stderr, "FAIL       %s: %v\n", v.Path, v.Err)
+		case !*quiet:
+			fmt.Printf("ok         %s\n", v.Path)
+		}
+	}
+	if bad > 0 {
+		rep.Fatalf(1, "%d file(s) failed verification", bad)
+	}
+	if !*quiet {
+		fmt.Printf("bundle: OK (%d untracked)\n", untracked)
+	}
+}
+
+// --- extract ---
+
+func runBundleExtract(args []string) {
+	fs := flag.NewFlagSet("bundle extract", flag.ExitOnError)
+	in := fs.String("in", "", "bundle path (.gtb.tar.gz) (required)")
+	out := fs.String("out", ".", "destination directory")
+	role := fs.String("role", "", "extract only this role's files (flattened to leaf names)")
+	_ = fs.Parse(args)
+
+	rep := newReporter("bundle extract")
+	if *in == "" {
+		rep.Fatalf(2, "-in is required")
+	}
+	r, err := gtbundle.Open(*in)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	if *role != "" {
+		written, werr := r.ExtractRole(gtbundle.Role(*role), *out)
+		if werr != nil {
+			rep.Fatal(1, werr)
+		}
+		for _, p := range written {
+			fmt.Println(p)
+		}
+		return
+	}
+	if err := r.Extract(*out); err != nil {
+		rep.Fatal(1, err)
+	}
+	fmt.Printf("bundle: extracted %s → %s\n", *in, *out)
+}
+
+// --- add ---
+
+func runBundleAdd(args []string) {
+	fs := flag.NewFlagSet("bundle add", flag.ExitOnError)
+	in := fs.String("in", "", "bundle path to rewrite in place (required)")
+	role := fs.String("role", "", "role for the new file (required)")
+	file := fs.String("file", "", "file to add (required)")
+	producedBy := fs.String("produced-by", "", "tool/step that produced the file")
+	_ = fs.Parse(args)
+
+	rep := newReporter("bundle add")
+	if *in == "" || *role == "" || *file == "" {
+		rep.Fatalf(2, "-in, -role and -file are required")
+	}
+	if err := bundleAddFile(*in, gtbundle.Role(*role), *file, *producedBy); err != nil {
+		rep.Fatal(1, err)
+	}
+	fmt.Printf("bundle: added %s (%s) → %s\n", filepath.Base(*file), *role, *in)
+}
+
+// bundleAddFile appends one artifact to an existing bundle. tar.gz cannot be
+// appended in place, so it reads the bundle, re-packs it plus the new file into
+// a temp archive, and renames over the original.
+func bundleAddFile(bundlePath string, role gtbundle.Role, file, producedBy string) error {
+	r, err := gtbundle.Open(bundlePath)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(bundlePath)
+	staging, err := os.MkdirTemp(dir, ".gtb-add-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(staging)
+	if err := r.Extract(staging); err != nil {
+		return err
+	}
+	// The extracted tree lives under staging/<name>/…; copy the new file into
+	// the role's directory, then re-pack from that laid-out tree.
+	caseDir := filepath.Join(staging, r.Manifest().Name)
+	dst := filepath.Join(caseDir, roleSubdir(role), filepath.Base(file))
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	body, err := os.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(dst, body, 0o644); err != nil {
+		return err
+	}
+	_ = producedBy // producedBy is recorded via role inference on repack
+
+	tmpOut, err := os.CreateTemp(dir, ".gtb-out-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmpOut.Name()
+	m := r.Manifest()
+	w, err := gtbundle.NewWriter(tmpOut, gtbundle.WriterOptions{
+		Name:          m.Name,
+		CaptureIntent: m.CaptureIntent,
+		Title:         m.Title,
+		Notes:         m.Notes,
+		Provenance:    m.Provenance,
+	})
+	if err != nil {
+		tmpOut.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if n := packFromDirSilent(w, caseDir); n == 0 {
+		w.Close()
+		tmpOut.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("bundle add: nothing to repack")
+	}
+	if err := w.Close(); err != nil {
+		tmpOut.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmpOut.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, bundlePath)
+}
+
+// roleSubdir returns the on-disk subdirectory a role extracts into.
+func roleSubdir(role gtbundle.Role) string {
+	switch role {
+	case gtbundle.RoleCaptureIQ, gtbundle.RoleCaptureSlice, gtbundle.RoleCaptureMeta, gtbundle.RoleCaptureSigMF:
+		return "capture"
+	case gtbundle.RoleLogEvents, gtbundle.RoleLogMessages:
+		return "logs"
+	case gtbundle.RoleMappingSystem, gtbundle.RoleMappingSurvey, gtbundle.RoleMappingExport:
+		return "mapping"
+	case gtbundle.RoleSiglabResult, gtbundle.RoleSiglabEvents:
+		return "siglab"
+	case gtbundle.RoleCryptolabFrames, gtbundle.RoleCryptolabResult:
+		return "cryptolab"
+	default:
+		return "."
+	}
+}
+
+// packFromDirSilent is packFromDir without a reporter (used on the add repack
+// path), returning the count added.
+func packFromDirSilent(w *gtbundle.Writer, dir string) int {
+	added := 0
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, rerr := filepath.Rel(dir, path)
+		if rerr != nil {
+			return rerr
+		}
+		role, ok := roleForRelPath(filepath.ToSlash(rel))
+		if !ok {
+			return nil
+		}
+		src, oerr := os.Open(path)
+		if oerr != nil {
+			return oerr
+		}
+		defer src.Close()
+		if _, aerr := w.Add(role, filepath.Base(path), src, "repack"); aerr == nil {
+			added++
+		}
+		return nil
+	})
+	return added
+}
+
+// --- commit ---
+
+func runBundleCommit(args []string) {
+	fs := flag.NewFlagSet("bundle commit", flag.ExitOnError)
+	in := fs.String("in", "", "bundle path (.gtb.tar.gz) (required)")
+	configPath := fs.String("config", "config.yaml", "config.yaml to merge into")
+	csvDir := fs.String("csv-dir", "", "directory for generated talkgroup CSVs")
+	force := fs.Bool("force", false, "overwrite conflicting entries")
+	dryRun := fs.Bool("dry-run", false, "report changes without writing config.yaml")
+	markEncrypted := fs.Bool("mark-encrypted", true, "fold a confirmed CryptoLab encryption verdict onto talkgroups")
+	_ = fs.Parse(args)
+
+	rep := newReporter("bundle commit")
+	if *in == "" {
+		rep.Fatalf(2, "-in is required")
+	}
+	r, err := gtbundle.Open(*in)
+	if err != nil {
+		rep.Fatal(1, err)
+	}
+	sys, err := r.MappingSystem()
+	if err != nil {
+		rep.Fatal(1, fmt.Errorf("bundle has no mapping-system to commit: %w", err))
+	}
+	if *markEncrypted {
+		if n := enrichFromCryptoVerdict(r, sys); n > 0 {
+			fmt.Fprintf(os.Stderr, "bundle: folded CryptoLab verdict onto %d talkgroup(s)\n", n)
+		}
+	}
+	commitDiscovery(rep, sys, *configPath, *csvDir, *force, *dryRun)
+}
+
+// multiFlag collects a repeatable string flag.
+type multiFlag []string
+
+func (m *multiFlag) String() string { return strings.Join(*m, ",") }
+func (m *multiFlag) Set(v string) error {
+	*m = append(*m, v)
+	return nil
+}

--- a/cmd/gophertrunk/bundle_analyze.go
+++ b/cmd/gophertrunk/bundle_analyze.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// extractBundleCapture pulls the raw IQ and capture metadata out of a bundle to
+// a temp working directory so the SigLab engine (which reads a file path) can
+// run against it. The returned cleanup removes the temp dir. The metadata may be
+// nil if the bundle carries none.
+func extractBundleCapture(bundlePath string) (iqPath string, meta *siglab.Metadata, cleanup func(), err error) {
+	r, err := gtbundle.Open(bundlePath)
+	if err != nil {
+		return "", nil, func() {}, err
+	}
+	tmp, err := os.MkdirTemp("", "gtb-analyze-*")
+	if err != nil {
+		return "", nil, func() {}, err
+	}
+	cleanup = func() { os.RemoveAll(tmp) }
+
+	written, err := r.ExtractRole(gtbundle.RoleCaptureIQ, tmp)
+	if err != nil {
+		cleanup()
+		return "", nil, func() {}, fmt.Errorf("bundle has no capture-iq: %w", err)
+	}
+	iqPath = written[0]
+
+	if m, merr := r.CaptureMeta(); merr == nil {
+		meta = m
+	}
+	return iqPath, meta, cleanup, nil
+}
+
+// writeResultToBundle deposits a SigLab result into an existing bundle as
+// siglab/result.yaml plus siglab/events.jsonl. It writes the two artifacts to a
+// temp dir and folds them in via the bundle add (repack) path.
+func writeResultToBundle(bundlePath string, res *siglab.Result) error {
+	tmp, err := os.MkdirTemp("", "gtb-result-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+
+	resPath := filepath.Join(tmp, "result.yaml")
+	rf, err := os.Create(resPath)
+	if err != nil {
+		return err
+	}
+	if werr := siglab.WriteResult(rf, res, siglab.FormatYAML); werr != nil {
+		rf.Close()
+		return werr
+	}
+	rf.Close()
+
+	evPath := filepath.Join(tmp, "events.jsonl")
+	ef, err := os.Create(evPath)
+	if err != nil {
+		return err
+	}
+	if werr := siglab.WriteResult(ef, res, siglab.FormatJSONL); werr != nil {
+		ef.Close()
+		return werr
+	}
+	ef.Close()
+
+	if err := bundleAddFile(bundlePath, gtbundle.RoleSiglabResult, resPath, "siglab"); err != nil {
+		return err
+	}
+	return bundleAddFile(bundlePath, gtbundle.RoleSiglabEvents, evPath, "siglab")
+}

--- a/cmd/gophertrunk/bundle_commit.go
+++ b/cmd/gophertrunk/bundle_commit.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25"
+)
+
+// cryptoFrame is the minimal shape of a cryptolab-frames record we need to fold
+// a confirmed encryption observation back onto the mapping: which talkgroup was
+// carrying encrypted traffic under which algorithm. It mirrors the fields the
+// live decoder→cryptolab bridge writes (internal/voice/cryptocap); every other
+// field is ignored.
+type cryptoFrame struct {
+	TG    uint32 `json:"tg"`
+	AlgID uint8  `json:"algid"`
+}
+
+// enrichFromCryptoVerdict folds the bundle's crypto observations onto the
+// discovered system before it is committed to config.yaml: any talkgroup seen
+// carrying traffic under a non-clear algorithm is marked Encrypted. It reads the
+// cryptolab-frames artifact (tg + algid per encrypted frame); the ALGID → name
+// mapping is via internal/radio/p25. It is a no-op when the bundle carries no
+// crypto frames. Returns the number of talkgroups newly marked encrypted.
+//
+// This deliberately reads the frames rather than the CryptoLab Result prose, so
+// `bundle commit` stays in the always-compiled tree (no -tags cryptolab needed).
+func enrichFromCryptoVerdict(r *gtbundle.Reader, sys *hunt.DiscoveredSystem) int {
+	body, err := r.CryptolabFramesRaw()
+	if err != nil {
+		if errors.Is(err, gtbundle.ErrNotFound) {
+			return 0
+		}
+		fmt.Fprintf(os.Stderr, "bundle: crypto frames unreadable (%v); skipping enrichment\n", err)
+		return 0
+	}
+
+	// algByTG records the strongest (non-clear) algorithm seen per talkgroup.
+	algByTG := map[uint32]uint8{}
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		var fr cryptoFrame
+		if json.Unmarshal(line, &fr) != nil {
+			continue
+		}
+		if fr.TG == 0 || isClearAlg(fr.AlgID) {
+			continue
+		}
+		algByTG[fr.TG] = fr.AlgID
+	}
+
+	marked := 0
+	for i := range sys.Talkgroups {
+		tg := &sys.Talkgroups[i]
+		alg, ok := algByTG[tg.Dec]
+		if !ok {
+			continue
+		}
+		if !tg.Encrypted {
+			tg.Encrypted = true
+			marked++
+		}
+		fmt.Fprintf(os.Stderr, "bundle: talkgroup %d confirmed encrypted (%s)\n",
+			tg.Dec, p25.FormatAlgorithm(alg))
+	}
+	return marked
+}
+
+// isClearAlg reports whether an ALGID means "no encryption". 0x80 is the P25
+// CLEAR algorithm id; 0 is an absent/unknown id in the frame.
+func isClearAlg(id uint8) bool { return id == 0x00 || id == 0x80 }

--- a/cmd/gophertrunk/bundle_slice.go
+++ b/cmd/gophertrunk/bundle_slice.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/sdr/baseband"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// baseName is filepath.Base; stemOf strips the final extension from a leaf.
+func baseName(p string) string { return filepath.Base(p) }
+func stemOf(leaf string) string {
+	return strings.TrimSuffix(leaf, filepath.Ext(leaf))
+}
+
+// sliceSeconds is the narrowband-slice length carved from a full capture, by
+// intent. The slice is the small, shareable channelized stream; the full
+// wideband IQ remains the source of truth in the bundle. These mirror the
+// capture-intent policy documented for the bundle format.
+func sliceSeconds(intent gtbundle.CaptureIntent) float64 {
+	switch intent {
+	case gtbundle.IntentCrypto:
+		return 60
+	case gtbundle.IntentCCMap:
+		return 30
+	case gtbundle.IntentSurvey:
+		return 10
+	default:
+		return 15
+	}
+}
+
+// carveSlice reads a raw IQ capture, downconverts it to the per-protocol
+// channel rate (48 kHz C4FM family / 144 kHz TETRA — the exact stream the
+// decoder sees), trims it to the intent-driven length, and writes it as a
+// 2-channel s16 baseband WAV. It reuses the production single-channel
+// Downconverter and the baseband IQWriter, so the slice replays identically via
+// `siglab -format wav`. protoName may be empty (undecoded carrier), in which
+// case the C4FM-family target rate is used. Returns the achieved output rate.
+func carveSlice(capturePath string, format siglab.SampleFormat, sampleRateHz, tuneHz float64, protoName string, intent gtbundle.CaptureIntent, outWav string) (uint32, error) {
+	raw, err := os.ReadFile(capturePath)
+	if err != nil {
+		return 0, err
+	}
+	decode, bytesPerSample := format.Decoder()
+	if bytesPerSample <= 0 {
+		return 0, fmt.Errorf("carve slice: unknown sample format %q", format)
+	}
+	nSamples := len(raw) / bytesPerSample
+	if nSamples == 0 {
+		return 0, fmt.Errorf("carve slice: capture %s has no samples", capturePath)
+	}
+	iq := make([]complex64, nSamples)
+	decode(raw[:nSamples*bytesPerSample], iq)
+
+	proto := trunking.ProtocolP25 // default target family; TETRA needs the wide rate
+	if protoName != "" {
+		if p, perr := trunking.ParseProtocol(protoName); perr == nil {
+			proto = p
+		}
+	}
+	target := ccdecoder.DDCTargetForProtocol(proto)
+	ddc := ccdecoder.NewDownconverterWithOffset(sampleRateHz, target, tuneHz)
+	outRate := uint32(ddc.OutRateHz() + 0.5)
+
+	w, err := baseband.NewIQWriter(outWav, outRate)
+	if err != nil {
+		return 0, err
+	}
+
+	maxOut := int(sliceSeconds(intent) * float64(outRate))
+	const chunk = 65536
+	var dst []complex64
+	written := 0
+	for off := 0; off < len(iq) && written < maxOut; off += chunk {
+		end := off + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		out := ddc.Process(dst[:0], iq[off:end])
+		if len(out) == 0 {
+			continue
+		}
+		if written+len(out) > maxOut {
+			out = out[:maxOut-written]
+		}
+		if err := w.Write(out); err != nil {
+			w.Close()
+			return 0, err
+		}
+		written += len(out)
+	}
+	if err := w.Close(); err != nil {
+		return 0, err
+	}
+	return outRate, nil
+}
+
+// captureBundleParams carries the inputs for writing a capture straight into a
+// new bundle (the `capture -bundle` path).
+type captureBundleParams struct {
+	bundlePath   string
+	name         string
+	intent       gtbundle.CaptureIntent
+	capturePath  string
+	format       siglab.SampleFormat
+	sampleRateHz float64
+	centerHz     uint32
+	tuneHz       float64
+	protocol     string
+	source       string
+	meta         *siglab.Metadata
+}
+
+// writeCaptureBundle assembles a bundle from a just-recorded capture: the raw
+// IQ, the metadata sidecar (as YAML), and a carved narrowband slice. Slice
+// carving failures are non-fatal (the full IQ still lands) so a bundle is always
+// produced.
+func writeCaptureBundle(p captureBundleParams) error {
+	f, err := os.Create(p.bundlePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w, err := gtbundle.NewWriter(f, gtbundle.WriterOptions{
+		Name:          p.name,
+		CaptureIntent: p.intent,
+		Provenance: gtbundle.Provenance{
+			Source:       p.source,
+			Protocol:     p.protocol,
+			CenterFreqHz: p.centerHz,
+			SampleRateHz: p.sampleRateHz,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	src, err := os.Open(p.capturePath)
+	if err != nil {
+		return err
+	}
+	iqLeaf := baseName(p.capturePath)
+	if _, err := w.Add(gtbundle.RoleCaptureIQ, iqLeaf, src, "gophertrunk capture"); err != nil {
+		src.Close()
+		return err
+	}
+	src.Close()
+
+	if p.meta != nil {
+		if _, err := w.AddYAML(gtbundle.RoleCaptureMeta, stemOf(iqLeaf)+".meta.yaml", p.meta, "gophertrunk capture"); err != nil {
+			return err
+		}
+	}
+
+	// Carve a narrowband slice next to the capture, then fold it in. Best-effort.
+	sliceTmp := p.capturePath + ".slice.wav"
+	if rate, cerr := carveSlice(p.capturePath, p.format, p.sampleRateHz, p.tuneHz, p.protocol, p.intent, sliceTmp); cerr == nil {
+		if sf, oerr := os.Open(sliceTmp); oerr == nil {
+			_, aerr := w.Add(gtbundle.RoleCaptureSlice, stemOf(iqLeaf)+".slice.wav", sf, "gophertrunk bundle")
+			sf.Close()
+			os.Remove(sliceTmp)
+			if aerr != nil {
+				return aerr
+			}
+			w.SetNote(fmt.Sprintf("narrowband DDC slice @ %d Hz (%gs)", rate, sliceSeconds(p.intent)))
+		}
+	} else {
+		fmt.Fprintf(os.Stderr, "capture: note — slice carving skipped (%v); full IQ still bundled\n", cerr)
+		os.Remove(sliceTmp)
+	}
+
+	return w.Close()
+}

--- a/cmd/gophertrunk/bundle_slice_test.go
+++ b/cmd/gophertrunk/bundle_slice_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+	"github.com/MattCheramie/GopherTrunk/internal/scanner/ccdecoder"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// TestCarveSliceRate synthesizes a P25 capture, carves a narrowband slice, and
+// asserts the slice lands at the per-protocol channel rate as a non-empty
+// 2-channel s16 WAV.
+func TestCarveSliceRate(t *testing.T) {
+	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{Protocol: trunking.ProtocolP25, Format: siglab.FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	dir := t.TempDir()
+	capPath := filepath.Join(dir, "cc.cfile")
+	if err := os.WriteFile(capPath, siglab.EncodeCapture(iq, siglab.FormatF32), 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+
+	outWav := filepath.Join(dir, "cc.slice.wav")
+	rate, err := carveSlice(capPath, siglab.FormatF32, meta.SampleRateHz, 0, "p25", gtbundle.IntentSurvey, outWav)
+	if err != nil {
+		t.Fatalf("carveSlice: %v", err)
+	}
+	wantRate := uint32(ccdecoder.DDCTargetForProtocol(trunking.ProtocolP25) + 0.5)
+	if rate != wantRate {
+		t.Errorf("slice rate = %d, want %d", rate, wantRate)
+	}
+	info, err := os.Stat(outWav)
+	if err != nil {
+		t.Fatalf("stat slice: %v", err)
+	}
+	// A WAV header is 44 bytes; a real slice must carry samples beyond it.
+	if info.Size() <= 44 {
+		t.Errorf("slice WAV too small (%d bytes) — no samples carved", info.Size())
+	}
+}
+
+// TestCarveSliceUnknownProtocol confirms an undecoded carrier (empty protocol)
+// still carves at the C4FM-family default rate rather than erroring.
+func TestCarveSliceUnknownProtocol(t *testing.T) {
+	iq, meta, err := siglab.Synthesize(siglab.SynthOptions{Protocol: trunking.ProtocolP25, Format: siglab.FormatF32})
+	if err != nil {
+		t.Fatalf("Synthesize: %v", err)
+	}
+	dir := t.TempDir()
+	capPath := filepath.Join(dir, "u.cfile")
+	if err := os.WriteFile(capPath, siglab.EncodeCapture(iq, siglab.FormatF32), 0o644); err != nil {
+		t.Fatalf("write capture: %v", err)
+	}
+	rate, err := carveSlice(capPath, siglab.FormatF32, meta.SampleRateHz, 0, "", gtbundle.IntentGeneral, filepath.Join(dir, "u.slice.wav"))
+	if err != nil {
+		t.Fatalf("carveSlice(empty proto): %v", err)
+	}
+	if rate == 0 {
+		t.Errorf("slice rate = 0 for undecoded carrier")
+	}
+}

--- a/cmd/gophertrunk/bundle_test.go
+++ b/cmd/gophertrunk/bundle_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+)
+
+// writeSmokeBundle packs a small bundle with a discovered system and crypto
+// frames, returning its path.
+func writeSmokeBundle(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "smoke.gtb.tar.gz")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	w, err := gtbundle.NewWriter(f, gtbundle.WriterOptions{Name: "smoke", CaptureIntent: gtbundle.IntentCrypto})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	sys := &hunt.DiscoveredSystem{
+		Name:     "Smoke",
+		Protocol: "p25",
+		Talkgroups: []hunt.DiscoveredTalkgroup{
+			{Dec: 101, Hex: "65", Count: 3},
+			{Dec: 202, Hex: "ca", Count: 1},
+		},
+	}
+	if _, err := w.AddJSON(gtbundle.RoleMappingSystem, "system.json", sys, "hunt"); err != nil {
+		t.Fatalf("add system: %v", err)
+	}
+	// TG 101 under AES-256 (0x84) encrypted; TG 202 under CLEAR (0x80).
+	frames := `{"tg":101,"algid":132,"iv":"aa","ct":"bb"}` + "\n" +
+		`{"tg":202,"algid":128,"iv":"cc","ct":"dd"}` + "\n"
+	if _, err := w.AddBytes(gtbundle.RoleCryptolabFrames, "frames.jsonl", []byte(frames), "cryptolab"); err != nil {
+		t.Fatalf("add frames: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return path
+}
+
+// TestEnrichFromCryptoVerdict verifies the commit-time enrichment marks only the
+// talkgroup carrying a non-clear algorithm.
+func TestEnrichFromCryptoVerdict(t *testing.T) {
+	path := writeSmokeBundle(t)
+	r, err := gtbundle.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	sys, err := r.MappingSystem()
+	if err != nil {
+		t.Fatalf("MappingSystem: %v", err)
+	}
+	n := enrichFromCryptoVerdict(r, sys)
+	if n != 1 {
+		t.Fatalf("enriched %d talkgroups, want 1", n)
+	}
+	byDec := map[uint32]bool{}
+	for _, tg := range sys.Talkgroups {
+		byDec[tg.Dec] = tg.Encrypted
+	}
+	if !byDec[101] {
+		t.Errorf("TG 101 (AES-256) not marked encrypted")
+	}
+	if byDec[202] {
+		t.Errorf("TG 202 (CLEAR) wrongly marked encrypted")
+	}
+}
+
+// TestEnrichNoFramesIsNoOp confirms a bundle without crypto frames enriches
+// nothing rather than erroring.
+func TestEnrichNoFramesIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nf.gtb.tar.gz")
+	f, _ := os.Create(path)
+	w, err := gtbundle.NewWriter(f, gtbundle.WriterOptions{Name: "nf"})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	sys := &hunt.DiscoveredSystem{Name: "nf", Talkgroups: []hunt.DiscoveredTalkgroup{{Dec: 1}}}
+	if _, err := w.AddJSON(gtbundle.RoleMappingSystem, "system.json", sys, "hunt"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	w.Close()
+	f.Close()
+
+	r, err := gtbundle.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	got, _ := r.MappingSystem()
+	if n := enrichFromCryptoVerdict(r, got); n != 0 {
+		t.Errorf("enriched %d, want 0 for a frameless bundle", n)
+	}
+}
+
+// TestRoleForRelPath spot-checks the from-dir role inference.
+func TestRoleForRelPath(t *testing.T) {
+	cases := map[string]gtbundle.Role{
+		"capture/cc.cfile":          gtbundle.RoleCaptureIQ,
+		"capture/cc.slice.wav":      gtbundle.RoleCaptureSlice,
+		"capture/cc.meta.yaml":      gtbundle.RoleCaptureMeta,
+		"logs/events.jsonl":         gtbundle.RoleLogEvents,
+		"logs/messages.log":         gtbundle.RoleLogMessages,
+		"mapping/system.json":       gtbundle.RoleMappingSystem,
+		"mapping/survey.jsonl":      gtbundle.RoleMappingSurvey,
+		"mapping/system.bundle.csv": gtbundle.RoleMappingExport,
+		"siglab/result.yaml":        gtbundle.RoleSiglabResult,
+		"cryptolab/frames.jsonl":    gtbundle.RoleCryptolabFrames,
+		"cryptolab/assess.yaml":     gtbundle.RoleCryptolabResult,
+		"notes.md":                  gtbundle.RoleNotes,
+	}
+	for rel, want := range cases {
+		got, ok := roleForRelPath(rel)
+		if !ok || got != want {
+			t.Errorf("roleForRelPath(%q) = %q,%v; want %q", rel, got, ok, want)
+		}
+	}
+	if _, ok := roleForRelPath("random/thing.txt"); ok {
+		t.Errorf("roleForRelPath accepted an unrecognized path")
+	}
+}

--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
 	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 )
@@ -42,6 +43,8 @@ func runCapture(args []string) {
 	autoTune := fs.Bool("auto-tune", false, "set auto_tune in the metadata sidecar")
 	conjugate := fs.Bool("conjugate", false, "set conjugate (spectrum-inverted / I-Q-swapped front end) in the metadata sidecar")
 	metaOut := fs.String("meta", "", "metadata sidecar path (default: <out stem>.metadata.json; \"none\" skips it)")
+	bundleOut := fs.String("bundle", "", "also package the capture (+ metadata + a carved narrowband slice) into a GopherTrunk Bundle (.gtb.tar.gz) at this path")
+	bundleIntent := fs.String("intent", "general", "bundle capture intent: cc-map | crypto | survey | general (sets the slice length)")
 	listDevices := fs.Bool("list", false, "list the SDRs available to capture from and exit")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk capture — record raw IQ off a live SDR to a .cfile + metadata sidecar.
@@ -137,6 +140,17 @@ FLAGS:`)
 		rep.Fatal(1, fmt.Errorf("capture: %w (wrote %d samples to %s)", capErr, written, *out))
 	}
 
+	meta := &siglab.Metadata{
+		Protocol:     *protocol,
+		Source:       *source,
+		SampleRateHz: float64(*sampleRate),
+		CenterFreqHz: uint32(*freq),
+		Format:       sampleFormat.String(),
+		TuneHz:       *tune,
+		AutoTune:     *autoTune,
+		Conjugate:    *conjugate,
+	}
+
 	metaPath := *metaOut
 	switch {
 	case strings.EqualFold(metaPath, "none"):
@@ -145,16 +159,6 @@ FLAGS:`)
 		metaPath = strings.TrimSuffix(*out, ext(*out)) + ".metadata.json"
 	}
 	if metaPath != "" {
-		meta := &siglab.Metadata{
-			Protocol:     *protocol,
-			Source:       *source,
-			SampleRateHz: float64(*sampleRate),
-			CenterFreqHz: uint32(*freq),
-			Format:       sampleFormat.String(),
-			TuneHz:       *tune,
-			AutoTune:     *autoTune,
-			Conjugate:    *conjugate,
-		}
 		if err := siglab.WriteMetadata(metaPath, meta); err != nil {
 			rep.Fatal(1, fmt.Errorf("write metadata: %w", err))
 		}
@@ -167,6 +171,27 @@ FLAGS:`)
 	}
 	if *protocol == "" && metaPath != "" {
 		fmt.Fprintln(os.Stderr, "capture: note — no -protocol set; sidecar is informational only (the `test` harness needs a protocol).")
+	}
+
+	if *bundleOut != "" {
+		name := strings.TrimSuffix(baseName(*bundleOut), gtbundle.Ext)
+		name = strings.TrimSuffix(strings.TrimSuffix(name, ".tar.gz"), ".gtb")
+		if err := writeCaptureBundle(captureBundleParams{
+			bundlePath:   *bundleOut,
+			name:         name,
+			intent:       gtbundle.CaptureIntent(*bundleIntent),
+			capturePath:  *out,
+			format:       sampleFormat,
+			sampleRateHz: float64(*sampleRate),
+			centerHz:     uint32(*freq),
+			tuneHz:       *tune,
+			protocol:     *protocol,
+			source:       *source,
+			meta:         meta,
+		}); err != nil {
+			rep.Fatal(1, fmt.Errorf("write bundle: %w", err))
+		}
+		fmt.Printf("capture: packaged → %s\n", *bundleOut)
 	}
 }
 

--- a/cmd/gophertrunk/hunt.go
+++ b/cmd/gophertrunk/hunt.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
 	"github.com/MattCheramie/GopherTrunk/internal/huntrr"
 	"github.com/MattCheramie/GopherTrunk/internal/radioreference"
@@ -100,6 +102,7 @@ func runHunt(args []string) {
 	captureTo := fs.String("to", "siglab", "with -survey-capture, where to send the capture: siglab | cryptolab")
 	captureSeconds := fs.Float64("capture-seconds", 10, "with -survey-capture, seconds of IQ to record")
 	captureOut := fs.String("capture-out", "", "with -survey-capture, output capture path (default: survey-<MHz>.cfile)")
+	captureBundle := fs.String("bundle", "", "package the result into a GopherTrunk Bundle (.gtb.tar.gz) at this path: the discovered mapping (system + survey + exports), or with -survey-capture the capture + metadata + SigLab/CryptoLab handoff")
 
 	configPath := fs.String("config", "config.yaml", "config.yaml path for -commit")
 	csvDir := fs.String("csv-dir", "", "directory for generated talkgroup CSVs on -commit (default: alongside -config)")
@@ -171,6 +174,7 @@ FLAGS:`)
 			gain:         *gain,
 			ppm:          *ppm,
 			out:          *captureOut,
+			bundle:       *captureBundle,
 		})
 		return
 	}
@@ -349,6 +353,7 @@ FLAGS:`)
 		csvDir:     *csvDir,
 		force:      *force,
 		dryRun:     *dryRun,
+		bundlePath: *captureBundle,
 	})
 }
 
@@ -366,6 +371,7 @@ type huntExportParams struct {
 	csvDir     string
 	force      bool
 	dryRun     bool
+	bundlePath string // optional GopherTrunk Bundle to package the mapping into
 }
 
 // finishHunt prints the per-candidate reports, runs the optional RadioReference
@@ -450,9 +456,83 @@ func finishHunt(rep *diag.Reporter, sys *hunt.DiscoveredSystem, reports []hunt.C
 		fmt.Fprintf(os.Stderr, "hunt: wrote %s (%s)\n", fname, hf)
 	}
 
+	if p.bundlePath != "" {
+		if err := packHuntBundle(p.bundlePath, sys, p.survey, outDir); err != nil {
+			rep.Fatal(1, fmt.Errorf("write bundle: %w", err))
+		}
+		fmt.Fprintf(os.Stderr, "hunt: packaged mapping → %s\n", p.bundlePath)
+	}
+
 	if p.commit {
 		commitDiscovery(rep, sys, p.configPath, p.csvDir, p.force, p.dryRun)
 	}
+}
+
+// packHuntBundle assembles a GopherTrunk Bundle carrying the discovered system
+// map: mapping/system.json (the DiscoveredSystem), mapping/survey.jsonl (the
+// classified inventory, when a survey ran), and every hunt export file already
+// written to outDir as mapping-export artifacts. This is the mapping half of a
+// case bundle — a SigLab/CryptoLab capture can be added to it later with
+// `bundle add`.
+func packHuntBundle(bundlePath string, sys *hunt.DiscoveredSystem, sv *hunt.SignalSurvey, outDir string) error {
+	f, err := os.Create(bundlePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	name := strings.TrimSuffix(baseName(bundlePath), gtbundle.Ext)
+	name = strings.TrimSuffix(strings.TrimSuffix(name, ".tar.gz"), ".gtb")
+
+	w, err := gtbundle.NewWriter(f, gtbundle.WriterOptions{
+		Name:          name,
+		CaptureIntent: gtbundle.IntentCCMap,
+		Title:         sys.DisplayName(),
+		Provenance:    gtbundle.Provenance{Protocol: sys.Protocol, Source: "gophertrunk hunt"},
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err := w.AddJSON(gtbundle.RoleMappingSystem, "system.json", sys, "hunt"); err != nil {
+		return err
+	}
+	if sv != nil && len(sv.Signals) > 0 {
+		var b strings.Builder
+		for _, ds := range sv.Signals {
+			line, merr := json.Marshal(ds)
+			if merr != nil {
+				return merr
+			}
+			b.Write(line)
+			b.WriteByte('\n')
+		}
+		if _, err := w.AddBytes(gtbundle.RoleMappingSurvey, "survey.jsonl", []byte(b.String()), "hunt"); err != nil {
+			return err
+		}
+	}
+	// Fold in the human/interchange exports already written to outDir.
+	entries, _ := os.ReadDir(outDir)
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ename := e.Name()
+		if !strings.HasSuffix(ename, ".csv") && !strings.HasSuffix(ename, ".json") &&
+			!strings.HasSuffix(ename, ".md") && !strings.HasSuffix(ename, ".txt") {
+			continue
+		}
+		src, oerr := os.Open(filepath.Join(outDir, ename))
+		if oerr != nil {
+			continue
+		}
+		_, aerr := w.Add(gtbundle.RoleMappingExport, ename, src, "hunt")
+		src.Close()
+		if aerr != nil {
+			return aerr
+		}
+	}
+	return w.Close()
 }
 
 // writeSurveyFiles writes the classified signal inventory to <outDir>/

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -139,6 +139,7 @@ USAGE:
   gophertrunk hunt [flags]            discover & map an unknown trunked system, export it + an RR submission package
   gophertrunk gen [flags]             synthesize a test IQ capture + metadata for a protocol
   gophertrunk capture [flags]         record raw IQ off a live SDR to a .cfile + metadata sidecar
+  gophertrunk bundle <cmd> [flags]    build/inspect a GopherTrunk Bundle (.gtb.tar.gz): pack|info|verify|extract|add|commit
   gophertrunk test [flags]            decode a capture and grade it against acceptance criteria
   gophertrunk cryptolab <tool> ...    cryptographic-research toolkit (optional; build with -tags cryptolab)
   gophertrunk siglab [flags]          standalone replay/test/analysis TUI

--- a/cmd/gophertrunk/main.go
+++ b/cmd/gophertrunk/main.go
@@ -103,6 +103,11 @@ func main() {
 		// linked only with -tags cryptolab; the default build links a stub
 		// that explains how to opt in (see cryptolab_{enabled,disabled}.go).
 		runCryptolab(os.Args[2:])
+	case "bundle":
+		// GopherTrunk Bundle (.gtb.tar.gz): pack/inspect/verify/extract/commit a
+		// single-file capture-to-analysis case. Distinct from hunt's CSV
+		// "import bundle" (that CSV is stored inside a GopherTrunk Bundle).
+		runBundle(os.Args[2:])
 	case "import-pdf":
 		runImport(os.Args[2:])
 	case "daemon", "run":

--- a/cmd/gophertrunk/survey_capture.go
+++ b/cmd/gophertrunk/survey_capture.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/MattCheramie/GopherTrunk/internal/diag"
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
 	"github.com/MattCheramie/GopherTrunk/internal/hunt"
 	"github.com/MattCheramie/GopherTrunk/internal/rfscope"
 	"github.com/MattCheramie/GopherTrunk/internal/sdr"
@@ -31,6 +32,7 @@ type surveyCaptureParams struct {
 	gain         int
 	ppm          int
 	out          string // capture path (default: survey-<MHz>.cfile)
+	bundle       string // optional GopherTrunk Bundle (.gtb.tar.gz) to package into
 }
 
 // runSurveyCapture records the selected signal and routes the capture. It is the
@@ -104,12 +106,77 @@ func runSurveyCapture(rep *diag.Reporter, p surveyCaptureParams) {
 	}
 	fmt.Printf("survey-capture: wrote %d samples → %s  (metadata → %s)\n", written, out, metaPath)
 
+	var framesPath string
 	switch to {
 	case "siglab":
 		routeToSigLab(out, rate)
 	case "cryptolab":
-		routeToCryptoLab(rep, out, sig.FreqHz, rate)
+		framesPath = routeToCryptoLab(rep, out, sig.FreqHz, rate)
 	}
+
+	if p.bundle != "" {
+		if err := packSurveyCaptureBundle(surveyBundleInputs{
+			bundlePath:  p.bundle,
+			to:          to,
+			capturePath: out,
+			meta:        meta,
+			sampleRate:  rate,
+			protocol:    meta.Protocol,
+			framesPath:  framesPath,
+		}); err != nil {
+			rep.Fatal(1, fmt.Errorf("write bundle: %w", err))
+		}
+		fmt.Printf("survey-capture: packaged → %s\n", p.bundle)
+	}
+}
+
+// surveyBundleInputs carries what packSurveyCaptureBundle needs to assemble a
+// bundle from a survey-capture run.
+type surveyBundleInputs struct {
+	bundlePath  string
+	to          string
+	capturePath string
+	meta        *siglab.Metadata
+	sampleRate  float64
+	protocol    string
+	framesPath  string // cryptolab frames.jsonl, when -to cryptolab
+}
+
+// packSurveyCaptureBundle packages a survey-capture into a GopherTrunk Bundle:
+// the raw IQ + metadata + a carved narrowband slice, plus the CryptoLab frames
+// when the capture was routed there. Intent follows the routing target (crypto
+// vs cc-map) so the slice length matches the workflow.
+func packSurveyCaptureBundle(in surveyBundleInputs) error {
+	intent := gtbundle.IntentCCMap
+	if in.to == "cryptolab" {
+		intent = gtbundle.IntentCrypto
+	}
+	name := strings.TrimSuffix(baseName(in.bundlePath), gtbundle.Ext)
+	name = strings.TrimSuffix(strings.TrimSuffix(name, ".tar.gz"), ".gtb")
+
+	// Reuse the capture-bundle assembler for IQ + meta + slice.
+	if err := writeCaptureBundle(captureBundleParams{
+		bundlePath:   in.bundlePath,
+		name:         name,
+		intent:       intent,
+		capturePath:  in.capturePath,
+		format:       siglab.FormatF32,
+		sampleRateHz: in.sampleRate,
+		centerHz:     in.meta.CenterFreqHz,
+		tuneHz:       in.meta.TuneHz,
+		protocol:     in.protocol,
+		source:       in.meta.Source,
+		meta:         in.meta,
+	}); err != nil {
+		return err
+	}
+	// Fold the CryptoLab frames in as a second step (bundle add semantics).
+	if in.framesPath != "" {
+		if err := bundleAddFile(in.bundlePath, gtbundle.RoleCryptolabFrames, in.framesPath, "cryptolab"); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // captureSignalToFile tunes the device to a signal and records seconds of raw
@@ -160,8 +227,9 @@ func routeToSigLab(path string, rateHz float64) {
 }
 
 // routeToCryptoLab runs rfscope over the capture to emit a cryptolab `ks` frames
-// file from any unidentified payloads, then prints the cryptolab next step.
-func routeToCryptoLab(rep *diag.Reporter, path string, centerHz uint32, rateHz float64) {
+// file from any unidentified payloads, then prints the cryptolab next step. It
+// returns the frames-file path so a caller can fold it into a bundle.
+func routeToCryptoLab(rep *diag.Reporter, path string, centerHz uint32, rateHz float64) string {
 	framesOut, n, err := emitCryptolabFramesFromFile(path, centerHz, rateHz)
 	if err != nil {
 		rep.Fatal(1, fmt.Errorf("rfscope frames: %w", err))
@@ -169,6 +237,7 @@ func routeToCryptoLab(rep *diag.Reporter, path string, centerHz uint32, rateHz f
 	fmt.Printf("cryptolab: wrote %d frame(s) → %s\n", n, framesOut)
 	fmt.Printf("cryptolab: triage them →  gophertrunk cryptolab classify auto -in %s\n", framesOut)
 	fmt.Println("cryptolab: (needs a -tags cryptolab build; see docs/cryptolab.md)")
+	return framesOut
 }
 
 // defaultRFScopeSegConfig is the carrier-discovery configuration the capture

--- a/docs/bundle.md
+++ b/docs/bundle.md
@@ -1,0 +1,123 @@
+---
+layout: page
+title: GopherTrunk Bundle — the capture-to-analysis case format
+description: Package a capture, logs, signal analysis, crypto analysis, and site/network mapping into one sharable .gtb.tar.gz that flows from the scanner to SigLab to CryptoLab and back
+nav_group: Operate
+---
+
+# GopherTrunk Bundle (`.gtb.tar.gz`)
+
+A **GopherTrunk Bundle** packages one SDR *case* — a capture together with
+everything an investigation produces from it — into a single archive you can
+share with the community as one file. It carries the raw IQ capture, a small
+narrowband slice, the session logs, the SigLab signal analysis, the CryptoLab
+crypto analysis, and the hunt site/network mapping, all indexed by a
+human-and-machine-readable `MANIFEST.yaml`.
+
+The goal is a **seamless loop**: hunt a signal → capture it into a bundle →
+analyze it in SigLab → assess its encryption in CryptoLab → commit the enriched
+mapping back into `config.yaml` and start scanning it — without hand-collecting a
+dozen loose files at each step.
+
+> **Naming note.** "Bundle" is overloaded in GopherTrunk. The *hunt CSV import
+> bundle* (`hunt … -formats bundle`) is a multi-section CSV that round-trips a
+> discovered system into `config.yaml`. That CSV is **stored inside** a
+> GopherTrunk Bundle (as `mapping/system.bundle.csv`); it is not the archive
+> itself. This page is always about the `.gtb.tar.gz` archive.
+
+## What's inside
+
+A single top-level directory (named after the case) holds:
+
+```
+mesa-p25-2026-07-14/
+  MANIFEST.yaml          index: schema, provenance, and a role-tagged file list with sha256
+  README.md              auto-generated human summary (open the tarball and read it)
+  capture/               raw IQ (.cfile), a narrowband DDC slice (.wav), metadata (.yaml)
+  logs/                  events.jsonl (all bus events), messages.log (human decoded messages)
+  mapping/               system.json (the discovered system), survey.jsonl, hunt exports
+  siglab/                result.yaml (SigLab analysis), events.jsonl
+  cryptolab/             frames.jsonl (encrypted frames), assess.result.yaml (verdict)
+```
+
+Every file is listed in the manifest with its **role**, size, and **sha256**, so
+`bundle verify` catches any corruption or tampering. The manifest and analysis
+summaries are **YAML** (snake_case, editable by hand); streams are **JSONL**; the
+IQ stays raw binary. Frequencies are integer Hz, timestamps UTC RFC3339 — the
+same conventions as the rest of GopherTrunk.
+
+## Capture-length policy
+
+The manifest records a **capture intent** that documents why the case was
+collected and sets the length of the auto-carved narrowband slice:
+
+| Intent | Full IQ | DDC slice | Why |
+|---|---|---|---|
+| `cc-map` | ~60 s | 30 s | several status broadcasts + band plan + neighbor list |
+| `crypto` | 60–120 s | 60 s | gather IV/MI reuse across calls |
+| `survey` | ~30 s | 10 s | classification only |
+| `general` | operator | 15 s | default |
+
+The full wideband IQ is the source of truth; the slice is the small, shareable
+channelized stream (48 kHz for the C4FM family, 144 kHz for TETRA — exactly what
+the decoder sees) that replays identically with `siglab -format wav`.
+
+## The workflow, end to end
+
+```sh
+# 1. Capture a control channel straight into a bundle (raw IQ + metadata + slice)
+gophertrunk capture -freq 851012500 -sample-rate 2400000 -seconds 60 \
+  -protocol p25 -out cc.cfile -bundle mesa-p25.gtb.tar.gz -intent cc-map
+
+# 2. Or record one signal off a survey list and route it, packaging as you go
+gophertrunk hunt -survey-capture '#3' -from survey.json -to cryptolab \
+  -bundle mesa-p25.gtb.tar.gz
+
+# 3. Analyze the bundled capture — protocol/rate come from the bundle itself —
+#    and the SigLab result is written back into the same bundle
+gophertrunk analyze -bundle mesa-p25.gtb.tar.gz
+
+# 4. Inspect and check integrity
+gophertrunk bundle info   -in mesa-p25.gtb.tar.gz -files
+gophertrunk bundle verify -in mesa-p25.gtb.tar.gz
+
+# 5. Hand just the crypto frames to a colleague
+gophertrunk bundle extract -in mesa-p25.gtb.tar.gz -role cryptolab-frames -out ./send
+
+# 6. Commit the discovered system back into config.yaml. Talkgroups the bundle's
+#    crypto frames show under a non-clear algorithm are marked encrypted first.
+gophertrunk bundle commit -in mesa-p25.gtb.tar.gz -config config.yaml -dry-run
+```
+
+## The `bundle` subcommands
+
+| Subcommand | What it does |
+|---|---|
+| `pack` | assemble a bundle from a capture and/or analysis files, or a laid-out `-from-dir` |
+| `info` (`ls`) | print the manifest summary; `-files` lists the full inventory |
+| `verify` | recompute and check every file's sha256; non-zero exit on a mismatch |
+| `extract` | unpack the whole tree, or one role's files with `-role` |
+| `add` | append an artifact to an existing bundle |
+| `commit` (`import`) | merge the bundle's discovered system into `config.yaml`, enriched by the crypto verdict |
+
+Seams that write bundles directly: `capture -bundle`, `hunt -bundle` (mapping),
+`hunt -survey-capture … -bundle` (a recorded signal + its SigLab/CryptoLab
+handoff), and `analyze -bundle` (reads the capture from a bundle and writes the
+result back).
+
+## In the web consoles
+
+The daemon serves the bundle endpoints under `/api/v1/bundle/*`
+(`info`, `verify`, `download`), gated behind the `bundle` capability in
+`GET /api/v1/runtime` so the consoles only surface them when reachable. The
+SigLab and CryptoLab consoles use them to open a `.gtb`, load its capture or
+frames into the workbench, and save results back; the main console's **Bundles**
+view lists, inspects, verifies, and commits cases. Packing runs through the CLI;
+the web side is read/inspect/commit.
+
+## Forward compatibility
+
+The manifest carries a `schema_version` (currently `1`). A newer bundle opens
+best-effort in an older build — unknown manifest keys and unrecognized file
+roles are preserved, not rejected — so the format can grow without breaking
+older tools. Roles are only ever appended, never renamed.

--- a/internal/api/handlers_bundle.go
+++ b/internal/api/handlers_bundle.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+)
+
+// bundleInfoDTO is the web-facing projection of a bundle's manifest: enough for
+// a console to render a case summary and its file inventory without unpacking
+// the archive.
+type bundleInfoDTO struct {
+	Name          string          `json:"name"`
+	Title         string          `json:"title,omitempty"`
+	Format        string          `json:"format"`
+	SchemaVersion int             `json:"schema_version"`
+	CaptureIntent string          `json:"capture_intent"`
+	CreatedAt     string          `json:"created_at"`
+	Generator     string          `json:"generator"`
+	Protocol      string          `json:"protocol,omitempty"`
+	Source        string          `json:"source,omitempty"`
+	FutureSchema  bool            `json:"future_schema,omitempty"`
+	Files         []bundleFileDTO `json:"files"`
+	Counts        map[string]int  `json:"role_counts"`
+}
+
+type bundleFileDTO struct {
+	Path       string `json:"path"`
+	Role       string `json:"role"`
+	MediaType  string `json:"media_type"`
+	SizeBytes  int64  `json:"size_bytes"`
+	SHA256     string `json:"sha256"`
+	ProducedBy string `json:"produced_by,omitempty"`
+}
+
+// bundleVerifyDTO reports the per-file integrity outcome of a bundle.
+type bundleVerifyDTO struct {
+	OK        bool                  `json:"ok"`
+	Files     []bundleVerifyFileDTO `json:"files"`
+	Failures  int                   `json:"failures"`
+	Untracked int                   `json:"untracked"`
+}
+
+type bundleVerifyFileDTO struct {
+	Path      string `json:"path"`
+	Role      string `json:"role,omitempty"`
+	OK        bool   `json:"ok"`
+	Untracked bool   `json:"untracked,omitempty"`
+	Error     string `json:"error,omitempty"`
+}
+
+// resolveBundlePath validates and resolves a client-supplied bundle path against
+// the server's allowed roots. It requires a .gtb / .tar.gz suffix and, when
+// bundleRoot is configured, that the path stays under it — so the endpoint can't
+// be used to read arbitrary files off the host.
+func (s *Server) resolveBundlePath(p string) (string, bool) {
+	if p == "" {
+		return "", false
+	}
+	if !strings.HasSuffix(p, ".gtb.tar.gz") && !strings.HasSuffix(p, ".tar.gz") && !strings.HasSuffix(p, ".gtb") {
+		return "", false
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", false
+	}
+	if s.bundleRoot != "" {
+		rel, err := filepath.Rel(s.bundleRoot, abs)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			return "", false
+		}
+	}
+	if fi, err := os.Stat(abs); err != nil || fi.IsDir() {
+		return "", false
+	}
+	return abs, true
+}
+
+// handleBundleInfo serves GET /api/v1/bundle/info?path=… — the manifest summary
+// of a bundle reachable on the daemon host.
+func (s *Server) handleBundleInfo(w http.ResponseWriter, r *http.Request) {
+	path, ok := s.resolveBundlePath(r.URL.Query().Get("path"))
+	if !ok {
+		http.Error(w, "invalid or disallowed bundle path", http.StatusBadRequest)
+		return
+	}
+	rd, err := gtbundle.Open(path)
+	if err != nil {
+		http.Error(w, "open bundle: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	m := rd.Manifest()
+	dto := bundleInfoDTO{
+		Name:          m.Name,
+		Title:         m.Title,
+		Format:        m.Format,
+		SchemaVersion: m.SchemaVersion,
+		CaptureIntent: string(m.CaptureIntent),
+		CreatedAt:     m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		Generator:     m.Generator.Tool + " " + m.Generator.Version,
+		Protocol:      m.Provenance.Protocol,
+		Source:        m.Provenance.Source,
+		FutureSchema:  rd.FutureSchema(),
+		Counts:        map[string]int{},
+	}
+	for _, f := range m.Files {
+		dto.Files = append(dto.Files, bundleFileDTO{
+			Path:       f.Path,
+			Role:       string(f.Role),
+			MediaType:  f.MediaType,
+			SizeBytes:  f.SizeBytes,
+			SHA256:     f.SHA256,
+			ProducedBy: f.ProducedBy,
+		})
+		dto.Counts[string(f.Role)]++
+	}
+	writeJSON(w, http.StatusOK, dto)
+}
+
+// handleBundleVerify serves POST /api/v1/bundle/verify with a JSON body
+// {"path": "..."} — recompute and check every file's sha256.
+func (s *Server) handleBundleVerify(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	path, ok := s.resolveBundlePath(body.Path)
+	if !ok {
+		http.Error(w, "invalid or disallowed bundle path", http.StatusBadRequest)
+		return
+	}
+	rd, err := gtbundle.Open(path)
+	if err != nil {
+		http.Error(w, "open bundle: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	out := bundleVerifyDTO{OK: true}
+	for _, v := range rd.Verify() {
+		fd := bundleVerifyFileDTO{Path: v.Path, Role: string(v.Role), OK: v.OK, Untracked: v.Untracked}
+		if v.Err != nil {
+			fd.Error = v.Err.Error()
+		}
+		if v.Untracked {
+			out.Untracked++
+		} else if !v.OK {
+			out.Failures++
+			out.OK = false
+		}
+		out.Files = append(out.Files, fd)
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// handleBundleDownload serves GET /api/v1/bundle/download?path=… — stream a
+// bundle to the client for download.
+func (s *Server) handleBundleDownload(w http.ResponseWriter, r *http.Request) {
+	path, ok := s.resolveBundlePath(r.URL.Query().Get("path"))
+	if !ok {
+		http.Error(w, "invalid or disallowed bundle path", http.StatusBadRequest)
+		return
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		http.Error(w, "open bundle: "+err.Error(), http.StatusNotFound)
+		return
+	}
+	defer f.Close()
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Disposition", "attachment; filename=\""+filepath.Base(path)+"\"")
+	http.ServeContent(w, r, filepath.Base(path), fileModTime(f), f)
+}
+
+func fileModTime(f *os.File) time.Time {
+	if fi, err := f.Stat(); err == nil {
+		return fi.ModTime()
+	}
+	return time.Time{}
+}

--- a/internal/api/handlers_bundle_test.go
+++ b/internal/api/handlers_bundle_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+)
+
+// writeTestBundle packs a minimal bundle on disk and returns its path.
+func writeTestBundle(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "case.gtb.tar.gz")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer f.Close()
+	w, err := gtbundle.NewWriter(f, gtbundle.WriterOptions{Name: "case", CaptureIntent: gtbundle.IntentCCMap})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	sys := &hunt.DiscoveredSystem{Name: "Web Case", Protocol: "p25"}
+	if _, err := w.AddJSON(gtbundle.RoleMappingSystem, "system.json", sys, "hunt"); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return path
+}
+
+func TestHandleBundleInfo(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestBundle(t, dir)
+	s := &Server{bundleRoot: dir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bundle/info?path="+path, nil)
+	rec := httptest.NewRecorder()
+	s.handleBundleInfo(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var dto bundleInfoDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &dto); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if dto.Name != "case" || dto.Format != gtbundle.FormatID {
+		t.Errorf("dto = %+v", dto)
+	}
+	if dto.Counts["mapping-system"] != 1 {
+		t.Errorf("role counts = %v", dto.Counts)
+	}
+}
+
+func TestHandleBundleVerify(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestBundle(t, dir)
+	s := &Server{bundleRoot: dir}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/bundle/verify",
+		strings.NewReader(`{"path":"`+path+`"}`))
+	rec := httptest.NewRecorder()
+	s.handleBundleVerify(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var out bundleVerifyDTO
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !out.OK || out.Failures != 0 {
+		t.Errorf("verify dto = %+v", out)
+	}
+}
+
+// TestHandleBundleInfoRejectsOutsideRoot confirms the bundleRoot confinement.
+func TestHandleBundleInfoRejectsOutsideRoot(t *testing.T) {
+	dir := t.TempDir()
+	other := t.TempDir()
+	path := writeTestBundle(t, other) // bundle lives outside the configured root
+	s := &Server{bundleRoot: dir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bundle/info?path="+path, nil)
+	rec := httptest.NewRecorder()
+	s.handleBundleInfo(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a path outside bundleRoot", rec.Code)
+	}
+}
+
+// TestHandleBundleInfoRejectsNonBundleSuffix confirms arbitrary host files
+// cannot be read through the endpoint.
+func TestHandleBundleInfoRejectsNonBundleSuffix(t *testing.T) {
+	dir := t.TempDir()
+	secret := filepath.Join(dir, "secret.txt")
+	os.WriteFile(secret, []byte("nope"), 0o644)
+	s := &Server{bundleRoot: dir}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/bundle/info?path="+secret, nil)
+	rec := httptest.NewRecorder()
+	s.handleBundleInfo(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a non-.gtb path", rec.Code)
+	}
+}

--- a/internal/api/handlers_runtime.go
+++ b/internal/api/handlers_runtime.go
@@ -111,6 +111,12 @@ type RuntimeDTO struct {
 	// /rfscope/. The web consoles use it to show an RF Scope link only when it
 	// is reachable. Injected by the API server, not the runtime provider.
 	RFScopeConsole bool `json:"rfscope_console,omitempty"`
+
+	// Bundle is true when the daemon serves the GopherTrunk Bundle endpoints
+	// (/api/v1/bundle/*). The web consoles use it to show the Bundles view and
+	// the "Save to Bundle" / "Open Bundle" actions only when reachable. Always
+	// true for a standard daemon build; injected by the API server.
+	Bundle bool `json:"bundle,omitempty"`
 }
 
 // ToneProfileDTO is the minimal projection of a tone-out profile —
@@ -138,6 +144,7 @@ func (s *Server) handleRuntime(w http.ResponseWriter, _ *http.Request) {
 	dto.CryptolabConsole = s.cryptolabConsole
 	dto.SiglabConsole = s.siglabConsole
 	dto.RFScopeConsole = s.rfscopeConsole
+	dto.Bundle = true // the bundle endpoints are part of the standard build
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(dto)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -426,6 +426,12 @@ type Server struct {
 	// when it is actually reachable.
 	cryptolabConsole bool
 
+	// bundleRoot, when non-empty, confines the /api/v1/bundle/* endpoints to
+	// GopherTrunk Bundles under this directory, so a web client cannot read
+	// arbitrary files off the host. Empty allows any .gtb path the daemon can
+	// stat (the standalone/dev default).
+	bundleRoot string
+
 	// configBuilder backs the standalone web Config Builder/Editor:
 	// the /api/v1/config/* routes (browse / load / validate / save /
 	// RadioReference browse) and, when assets are wired, the builder SPA
@@ -1056,6 +1062,13 @@ func (s *Server) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/devices", s.handleListDevices)
 	mux.HandleFunc("GET /api/v1/events", s.handleSSE)
 	mux.HandleFunc("GET /api/v1/events/ws", s.handleWS)
+
+	// GopherTrunk Bundle endpoints: inspect, verify, and download a .gtb case
+	// from the web consoles. Part of the standard build (read-side only; packing
+	// runs through the CLI). Confined to bundleRoot when set.
+	mux.HandleFunc("GET /api/v1/bundle/info", s.handleBundleInfo)
+	mux.HandleFunc("POST /api/v1/bundle/verify", s.handleBundleVerify)
+	mux.HandleFunc("GET /api/v1/bundle/download", s.handleBundleDownload)
 	if s.metrics != nil {
 		mux.Handle("GET /metrics", s.metrics)
 	}

--- a/internal/gtbundle/doc.go
+++ b/internal/gtbundle/doc.go
@@ -1,0 +1,36 @@
+// Package gtbundle reads and writes the GopherTrunk Bundle — a single
+// portable .gtb.tar.gz archive that packages one SDR capture-to-analysis
+// "case": the raw IQ capture(s), a narrowband slice, the session logs, the
+// SigLab signal-analysis result, the CryptoLab crypto-assessment result, and
+// the hunt site/network mapping, all tied together by a human-and-machine
+// readable MANIFEST.yaml.
+//
+// One bundle carries a whole investigation so it can be shared with the
+// community as a single file and flow seamlessly capture → SigLab → CryptoLab
+// → back into the scanner config.
+//
+// Disambiguation: the word "bundle" is overloaded in this repo. The hunt
+// package's FormatBundle (internal/hunt/export.go) is a multi-section CSV that
+// round-trips a discovered system into config.yaml — the "hunt CSV import
+// bundle". That CSV is *stored inside* a GopherTrunk Bundle (as
+// mapping/system.bundle.csv, role mapping-export); it is not this archive. This
+// package is always spelled "GopherTrunk Bundle" / .gtb, and its Go identifier
+// is gtbundle, never bundle.
+//
+// On-disk layout, under a single top-level directory named after the bundle:
+//
+//	<name>/
+//	  MANIFEST.yaml          index: schema_version, provenance, file inventory
+//	  README.md              auto-generated human summary
+//	  notes.md               free-form operator notes (optional)
+//	  capture/               raw IQ (.cfile), narrowband slice (.wav), meta (.yaml)
+//	  logs/                  events.jsonl (all bus events), messages.log (human)
+//	  mapping/               system.json (DiscoveredSystem), survey.jsonl, exports
+//	  siglab/                result.yaml (siglab.Result), events.jsonl
+//	  cryptolab/             frames.jsonl, assess.result.yaml (cryptolab.Result)
+//
+// Serialization follows the repo conventions: YAML (snake_case) for the
+// manifest and analysis summaries whose models carry yaml tags; JSON for
+// hunt.DiscoveredSystem (which has only json tags); JSONL for streams; raw
+// binary for IQ. Frequencies are integer Hz, timestamps UTC RFC3339.
+package gtbundle

--- a/internal/gtbundle/manifest.go
+++ b/internal/gtbundle/manifest.go
@@ -1,0 +1,189 @@
+package gtbundle
+
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// SchemaVersion is the on-disk manifest schema version. Readers accept any
+	// bundle whose schema_version is <= this value; a higher version is read
+	// best-effort with a warning rather than rejected (see reader.go).
+	SchemaVersion = 1
+	// FormatID identifies the archive family; it is written into the manifest's
+	// `format` field so a consumer can tell a GopherTrunk Bundle from any other
+	// tar.gz at a glance.
+	FormatID = "gophertrunk-bundle"
+	// ManifestName / ReadmeName are the fixed filenames at the bundle root.
+	ManifestName = "MANIFEST.yaml"
+	ReadmeName   = "README.md"
+	// Ext is the conventional archive extension.
+	Ext = ".gtb.tar.gz"
+)
+
+// CaptureIntent classifies why a case was collected. It documents the
+// operator's purpose and drives the default narrowband-slice length when a
+// bundle is produced from a live capture.
+type CaptureIntent string
+
+const (
+	IntentCCMap   CaptureIntent = "cc-map"  // control-channel mapping / hunt
+	IntentCrypto  CaptureIntent = "crypto"  // encryption assessment
+	IntentSurvey  CaptureIntent = "survey"  // wideband classification survey
+	IntentGeneral CaptureIntent = "general" // unspecified / general purpose
+)
+
+// Valid reports whether i is a recognized intent.
+func (i CaptureIntent) Valid() bool {
+	switch i {
+	case IntentCCMap, IntentCrypto, IntentSurvey, IntentGeneral:
+		return true
+	default:
+		return false
+	}
+}
+
+// Manifest is the machine-and-human index stored at <name>/MANIFEST.yaml. It is
+// YAML with snake_case keys. Unknown top-level keys and unknown file roles are
+// tolerated on read so a newer bundle still opens in an older binary.
+type Manifest struct {
+	SchemaVersion int           `yaml:"schema_version"`
+	Format        string        `yaml:"format"`
+	Name          string        `yaml:"name"`
+	CaptureIntent CaptureIntent `yaml:"capture_intent"`
+	CreatedAt     time.Time     `yaml:"created_at"`
+
+	Generator  Generator  `yaml:"generator"`
+	Provenance Provenance `yaml:"provenance"`
+
+	Title string `yaml:"title,omitempty"`
+	Notes string `yaml:"notes,omitempty"`
+
+	Files []FileEntry `yaml:"files"`
+}
+
+// Generator records the tool that produced the bundle.
+type Generator struct {
+	Tool    string `yaml:"tool"`
+	Version string `yaml:"version"`
+	Commit  string `yaml:"commit,omitempty"`
+}
+
+// Provenance is the capture-side context: where, when, and how the RF was
+// collected. Every field is optional — a bundle packed from loose files may
+// know little about the capture — but recording what is known makes a shared
+// case reproducible. Frequencies are integer Hz; timestamps are UTC RFC3339.
+type Provenance struct {
+	Source       string    `yaml:"source,omitempty"`
+	Operator     string    `yaml:"operator,omitempty"`
+	CenterFreqHz uint32    `yaml:"center_freq_hz,omitempty"`
+	SampleRateHz float64   `yaml:"sample_rate_hz,omitempty"`
+	Protocol     string    `yaml:"protocol,omitempty"`
+	Location     string    `yaml:"location,omitempty"`
+	CapturedAt   time.Time `yaml:"captured_at,omitempty"`
+	DeviceDriver string    `yaml:"device_driver,omitempty"`
+	DeviceSerial string    `yaml:"device_serial,omitempty"`
+}
+
+// FileEntry is one archived artifact. Path is bundle-relative (including the
+// top-level dir) and always uses forward slashes, e.g.
+// "mesa-p25/capture/cc.cfile". SHA256 is lowercase hex over the file bytes.
+type FileEntry struct {
+	Path       string `yaml:"path"`
+	Role       Role   `yaml:"role"`
+	MediaType  string `yaml:"media_type"`
+	SizeBytes  int64  `yaml:"size_bytes"`
+	SHA256     string `yaml:"sha256"`
+	ProducedBy string `yaml:"produced_by,omitempty"`
+	Note       string `yaml:"note,omitempty"`
+}
+
+// newManifest builds an in-memory manifest header from writer options and a
+// generator stamp. Files are appended as artifacts are written.
+func newManifest(name string, intent CaptureIntent, prov Provenance, gen Generator, createdAt time.Time, title, notes string) *Manifest {
+	if !intent.Valid() {
+		intent = IntentGeneral
+	}
+	return &Manifest{
+		SchemaVersion: SchemaVersion,
+		Format:        FormatID,
+		Name:          name,
+		CaptureIntent: intent,
+		CreatedAt:     createdAt.UTC(),
+		Generator:     gen,
+		Provenance:    prov,
+		Title:         title,
+		Notes:         notes,
+		Files:         nil,
+	}
+}
+
+// MarshalManifest renders m as YAML with two-space indentation, matching the
+// repo's siglab/cryptolab YAML export style.
+func MarshalManifest(m *Manifest) ([]byte, error) {
+	return marshalYAML(m)
+}
+
+// ParseManifest decodes a MANIFEST.yaml. It validates the format id and that
+// the schema version is not from the future beyond what this build supports;
+// an unsupported-but-higher version is returned with a non-nil *Manifest and a
+// non-fatal ErrFutureSchema so the caller can warn and proceed.
+func ParseManifest(raw []byte) (*Manifest, error) {
+	var m Manifest
+	if err := yaml.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("gtbundle: parse manifest: %w", err)
+	}
+	if m.Format != FormatID {
+		return nil, fmt.Errorf("gtbundle: not a %s manifest (format=%q)", FormatID, m.Format)
+	}
+	if m.SchemaVersion > SchemaVersion {
+		return &m, fmt.Errorf("%w: manifest schema_version %d newer than supported %d",
+			ErrFutureSchema, m.SchemaVersion, SchemaVersion)
+	}
+	return &m, nil
+}
+
+// Find returns the first file entry with the given role, or ok=false.
+func (m *Manifest) Find(r Role) (FileEntry, bool) {
+	for _, f := range m.Files {
+		if f.Role == r {
+			return f, true
+		}
+	}
+	return FileEntry{}, false
+}
+
+// List returns every file entry with the given role, in manifest order.
+func (m *Manifest) List(r Role) []FileEntry {
+	var out []FileEntry
+	for _, f := range m.Files {
+		if f.Role == r {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// marshalYAML is the shared two-space YAML encoder used for the manifest and
+// any YAML artifact the Writer produces.
+func marshalYAML(v any) ([]byte, error) {
+	var b yamlBuffer
+	enc := yaml.NewEncoder(&b)
+	enc.SetIndent(2)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	if err := enc.Close(); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// yamlBuffer is a tiny bytes.Buffer alias kept local so marshalYAML has no
+// import beyond what the file already needs; it satisfies io.Writer.
+type yamlBuffer struct{ buf []byte }
+
+func (b *yamlBuffer) Write(p []byte) (int, error) { b.buf = append(b.buf, p...); return len(p), nil }
+func (b *yamlBuffer) Bytes() []byte               { return b.buf }

--- a/internal/gtbundle/paths.go
+++ b/internal/gtbundle/paths.go
@@ -1,0 +1,80 @@
+package gtbundle
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// nameSanitizer keeps a bundle name to a filesystem- and archive-safe token:
+// letters, digits, dash, underscore, dot. Everything else collapses to a dash.
+var nameSanitizer = regexp.MustCompile(`[^A-Za-z0-9._-]+`)
+
+// SanitizeName reduces a proposed bundle name to the safe token used as the
+// single top-level directory inside the archive. It never returns "" (falls
+// back to "bundle") and strips any leading dots/dashes so the name can't hide
+// or look like a flag.
+func SanitizeName(s string) string {
+	s = nameSanitizer.ReplaceAllString(strings.TrimSpace(s), "-")
+	s = strings.Trim(s, ".-")
+	if s == "" {
+		return "bundle"
+	}
+	return s
+}
+
+// safeLeaf validates a single-path-component filename supplied to the Writer.
+// It rejects anything that could escape the intended directory: path
+// separators, parent refs, absolute or drive-qualified forms, and a leading
+// "~". The returned name is safe to join under a bundle subdirectory.
+func safeLeaf(name string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("gtbundle: empty filename")
+	}
+	if strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("gtbundle: filename %q must be a single path component", name)
+	}
+	if strings.Contains(name, "..") {
+		return "", fmt.Errorf("gtbundle: filename %q must not contain %q", name, "..")
+	}
+	if strings.HasPrefix(name, "~") {
+		return "", fmt.Errorf("gtbundle: filename %q must not start with %q", name, "~")
+	}
+	// A Windows drive-qualified leaf ("C:foo") would still be a single
+	// component but is not portable/safe.
+	if len(name) >= 2 && name[1] == ':' {
+		return "", fmt.Errorf("gtbundle: filename %q must not be drive-qualified", name)
+	}
+	return name, nil
+}
+
+// bundlePath composes the archive-relative path for a file: the single
+// top-level dir, then the role's subdirectory (if any), then the leaf. It
+// always uses forward slashes (tar convention) regardless of host OS.
+func bundlePath(topDir string, r Role, leaf string) string {
+	if d := r.dir(); d != "" {
+		return path.Join(topDir, d, leaf)
+	}
+	return path.Join(topDir, leaf)
+}
+
+// safeMemberPath validates a path read *out* of an archive before it is joined
+// to an extraction directory — defense in depth against a crafted tar whose
+// member escapes via "..", an absolute path, or a leading top-level that isn't
+// the declared name. It returns the cleaned, slash-form relative path.
+func safeMemberPath(member string) (string, error) {
+	if member == "" {
+		return "", fmt.Errorf("gtbundle: empty archive member path")
+	}
+	// Normalize separators; tar uses forward slashes but be defensive.
+	m := strings.ReplaceAll(member, `\`, "/")
+	if path.IsAbs(m) || (len(m) >= 2 && m[1] == ':') {
+		return "", fmt.Errorf("gtbundle: archive member %q must be relative", member)
+	}
+	clean := path.Clean(m)
+	if clean == ".." || strings.HasPrefix(clean, "../") {
+		return "", fmt.Errorf("gtbundle: archive member %q escapes the bundle", member)
+	}
+	return clean, nil
+}

--- a/internal/gtbundle/reader.go
+++ b/internal/gtbundle/reader.go
@@ -1,0 +1,333 @@
+package gtbundle
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+	"gopkg.in/yaml.v3"
+)
+
+// ErrChecksum is returned when a file's bytes do not match the sha256 recorded
+// in the manifest.
+var ErrChecksum = errors.New("gtbundle: sha256 mismatch")
+
+// ErrFutureSchema is returned (wrapped, non-fatal) by ParseManifest/Open when a
+// bundle's schema_version is newer than this build supports. The bundle is
+// still usable best-effort.
+var ErrFutureSchema = errors.New("gtbundle: manifest schema newer than supported")
+
+// ErrNotFound is returned when a requested role/path is absent.
+var ErrNotFound = errors.New("gtbundle: not found")
+
+// Reader provides random access to a bundle. Because tar is sequential, the
+// whole archive is read into memory on open; bundles are small (a manifest plus
+// a handful of analysis files and one raw IQ), and the large IQ member can be
+// streamed straight to a working file with ExtractRole/CaptureIQ. A Reader is
+// read-only and safe for concurrent reads after construction.
+type Reader struct {
+	man    *Manifest
+	blobs  map[string][]byte // archive member path -> bytes (excludes dirs)
+	future bool              // schema_version newer than supported
+}
+
+// Open reads a .gtb.tar.gz from disk.
+func Open(path string) (*Reader, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return NewReader(f)
+}
+
+// NewReader reads a bundle from any stream.
+func NewReader(r io.Reader) (*Reader, error) {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, fmt.Errorf("gtbundle: gunzip: %w", err)
+	}
+	defer gz.Close()
+
+	blobs := map[string][]byte{}
+	tr := tar.NewReader(gz)
+	var manRaw []byte
+	var manPath string
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("gtbundle: read tar: %w", err)
+		}
+		if hdr.Typeflag == tar.TypeDir {
+			continue
+		}
+		clean, err := safeMemberPath(hdr.Name)
+		if err != nil {
+			return nil, err
+		}
+		body, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, fmt.Errorf("gtbundle: read member %s: %w", hdr.Name, err)
+		}
+		blobs[clean] = body
+		if strings.HasSuffix(clean, "/"+ManifestName) || clean == ManifestName {
+			manRaw, manPath = body, clean
+		}
+	}
+	if manRaw == nil {
+		return nil, fmt.Errorf("gtbundle: no %s in archive", ManifestName)
+	}
+	man, perr := ParseManifest(manRaw)
+	future := false
+	if perr != nil {
+		if errors.Is(perr, ErrFutureSchema) && man != nil {
+			future = true // tolerate, read best-effort
+		} else {
+			return nil, perr
+		}
+	}
+	_ = manPath
+	return &Reader{man: man, blobs: blobs, future: future}, nil
+}
+
+// Manifest returns the parsed manifest.
+func (r *Reader) Manifest() *Manifest { return r.man }
+
+// FutureSchema reports whether the bundle declares a schema newer than this
+// build supports (it was still read best-effort).
+func (r *Reader) FutureSchema() bool { return r.future }
+
+// Bytes returns the verified bytes of the first file with role, or ErrNotFound.
+// The sha256 is checked against the manifest; a mismatch returns ErrChecksum.
+func (r *Reader) Bytes(role Role) ([]byte, *FileEntry, error) {
+	e, ok := r.man.Find(role)
+	if !ok {
+		return nil, nil, fmt.Errorf("%w: role %s", ErrNotFound, role)
+	}
+	body, err := r.verified(e)
+	if err != nil {
+		return nil, nil, err
+	}
+	return body, &e, nil
+}
+
+// Open returns a reader over the verified bytes of the first file with role.
+func (r *Reader) Open(role Role) (io.ReadCloser, *FileEntry, error) {
+	body, e, err := r.Bytes(role)
+	if err != nil {
+		return nil, nil, err
+	}
+	return io.NopCloser(bytes.NewReader(body)), e, nil
+}
+
+// verified fetches a member's bytes and checks its size and sha256 against the
+// manifest entry.
+func (r *Reader) verified(e FileEntry) ([]byte, error) {
+	body, ok := r.blobs[e.Path]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s (listed in manifest, missing from archive)", ErrNotFound, e.Path)
+	}
+	if int64(len(body)) != e.SizeBytes {
+		return nil, fmt.Errorf("%w: %s size %d != manifest %d", ErrChecksum, e.Path, len(body), e.SizeBytes)
+	}
+	sum := sha256.Sum256(body)
+	if got := hex.EncodeToString(sum[:]); got != e.SHA256 {
+		return nil, fmt.Errorf("%w: %s (%s != %s)", ErrChecksum, e.Path, got, e.SHA256)
+	}
+	return body, nil
+}
+
+// VerifyResult is one file's integrity outcome.
+type VerifyResult struct {
+	Path      string
+	Role      Role
+	OK        bool
+	Untracked bool // present in archive but not in the manifest
+	Err       error
+}
+
+// Verify checks every manifest file's size+sha256 and flags any archive member
+// not listed in the manifest as Untracked (non-fatal). It returns one result
+// per manifest file plus one per untracked member.
+func (r *Reader) Verify() []VerifyResult {
+	var out []VerifyResult
+	listed := map[string]bool{}
+	for _, e := range r.man.Files {
+		listed[e.Path] = true
+		_, err := r.verified(e)
+		out = append(out, VerifyResult{Path: e.Path, Role: e.Role, OK: err == nil, Err: err})
+	}
+	for p := range r.blobs {
+		if listed[p] {
+			continue
+		}
+		if strings.HasSuffix(p, "/"+ManifestName) || p == ManifestName ||
+			strings.HasSuffix(p, "/"+ReadmeName) || p == ReadmeName {
+			continue // index files aren't inventory
+		}
+		out = append(out, VerifyResult{Path: p, Untracked: true, OK: true})
+	}
+	return out
+}
+
+// Extract writes the whole bundle tree under dstDir, verifying each listed file
+// as it goes. Untracked members are extracted too (best-effort). It re-validates
+// every member path against traversal.
+func (r *Reader) Extract(dstDir string) error {
+	for path, body := range r.blobs {
+		if err := writeUnder(dstDir, path, body); err != nil {
+			return err
+		}
+	}
+	// Verify listed files after extraction so a tamper is still reported.
+	for _, v := range r.Verify() {
+		if v.Err != nil {
+			return v.Err
+		}
+	}
+	return nil
+}
+
+// ExtractRole writes just the files of one role under dstDir (flattened to
+// their leaf names) and returns the written paths. Handy for handing one
+// subtree onward — e.g. the cryptolab frames to a colleague.
+func (r *Reader) ExtractRole(role Role, dstDir string) ([]string, error) {
+	var written []string
+	for _, e := range r.man.List(role) {
+		body, err := r.verified(e)
+		if err != nil {
+			return written, err
+		}
+		leaf := filepath.Base(filepath.FromSlash(e.Path))
+		full := filepath.Join(dstDir, leaf)
+		if err := os.MkdirAll(dstDir, 0o755); err != nil {
+			return written, err
+		}
+		if err := os.WriteFile(full, body, 0o644); err != nil {
+			return written, err
+		}
+		written = append(written, full)
+	}
+	if len(written) == 0 {
+		return nil, fmt.Errorf("%w: role %s", ErrNotFound, role)
+	}
+	return written, nil
+}
+
+// writeUnder safely writes body to dstDir/member, refusing any path that would
+// escape dstDir.
+func writeUnder(dstDir, member string, body []byte) error {
+	clean, err := safeMemberPath(member)
+	if err != nil {
+		return err
+	}
+	full := filepath.Join(dstDir, filepath.FromSlash(clean))
+	// Defense in depth: ensure the resolved path stays under dstDir.
+	rel, err := filepath.Rel(dstDir, full)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return fmt.Errorf("gtbundle: refusing to extract %q outside %q", member, dstDir)
+	}
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(full, body, 0o644)
+}
+
+// --- typed accessors (verify + decode the reused models) ---
+
+// CaptureMeta decodes the capture metadata sidecar (siglab.Metadata, YAML).
+func (r *Reader) CaptureMeta() (*siglab.Metadata, error) {
+	body, _, err := r.Bytes(RoleCaptureMeta)
+	if err != nil {
+		return nil, err
+	}
+	var m siglab.Metadata
+	if err := yaml.Unmarshal(body, &m); err != nil {
+		return nil, fmt.Errorf("gtbundle: decode capture meta: %w", err)
+	}
+	return &m, nil
+}
+
+// SiglabResult decodes the SigLab analysis result (siglab.Result, YAML).
+func (r *Reader) SiglabResult() (*siglab.Result, error) {
+	body, _, err := r.Bytes(RoleSiglabResult)
+	if err != nil {
+		return nil, err
+	}
+	var res siglab.Result
+	if err := yaml.Unmarshal(body, &res); err != nil {
+		return nil, fmt.Errorf("gtbundle: decode siglab result: %w", err)
+	}
+	return &res, nil
+}
+
+// MappingSystem decodes the discovered system map (hunt.DiscoveredSystem, JSON).
+func (r *Reader) MappingSystem() (*hunt.DiscoveredSystem, error) {
+	body, _, err := r.Bytes(RoleMappingSystem)
+	if err != nil {
+		return nil, err
+	}
+	var sys hunt.DiscoveredSystem
+	if err := json.Unmarshal(body, &sys); err != nil {
+		return nil, fmt.Errorf("gtbundle: decode mapping system: %w", err)
+	}
+	return &sys, nil
+}
+
+// MappingSurvey reconstructs a SignalSurvey from the survey NDJSON stream: one
+// DetectedSignal per line. The System pointer is left nil (it lives in
+// mapping/system.json); callers that need it use MappingSystem.
+func (r *Reader) MappingSurvey() (*hunt.SignalSurvey, error) {
+	body, _, err := r.Bytes(RoleMappingSurvey)
+	if err != nil {
+		return nil, err
+	}
+	sv := &hunt.SignalSurvey{}
+	sc := bufio.NewScanner(bytes.NewReader(body))
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := bytes.TrimSpace(sc.Bytes())
+		if len(line) == 0 || line[0] == '#' {
+			continue
+		}
+		var ds hunt.DetectedSignal
+		if err := json.Unmarshal(line, &ds); err != nil {
+			return nil, fmt.Errorf("gtbundle: decode survey line: %w", err)
+		}
+		sv.Signals = append(sv.Signals, ds)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return sv, nil
+}
+
+// CryptolabResultRaw returns the verified bytes of the cryptolab result
+// (cryptolab/assess.result.yaml). It is exposed as raw YAML rather than a typed
+// accessor so this package needn't import internal/cryptolab; the caller (which
+// already links cryptolab) decodes it. Returns ErrNotFound when absent.
+func (r *Reader) CryptolabResultRaw() ([]byte, error) {
+	body, _, err := r.Bytes(RoleCryptolabResult)
+	return body, err
+}
+
+// CaptureIQ returns the verified raw-IQ bytes and its entry. For a large
+// capture prefer ExtractRole(RoleCaptureIQ, dir) to stream it to a working file.
+func (r *Reader) CaptureIQ() ([]byte, *FileEntry, error) {
+	return r.Bytes(RoleCaptureIQ)
+}

--- a/internal/gtbundle/reader.go
+++ b/internal/gtbundle/reader.go
@@ -317,6 +317,13 @@ func (r *Reader) MappingSurvey() (*hunt.SignalSurvey, error) {
 	return sv, nil
 }
 
+// CryptolabFramesRaw returns the verified bytes of the cryptolab frames stream
+// (cryptolab/frames.jsonl). Returns ErrNotFound when absent.
+func (r *Reader) CryptolabFramesRaw() ([]byte, error) {
+	body, _, err := r.Bytes(RoleCryptolabFrames)
+	return body, err
+}
+
 // CryptolabResultRaw returns the verified bytes of the cryptolab result
 // (cryptolab/assess.result.yaml). It is exposed as raw YAML rather than a typed
 // accessor so this package needn't import internal/cryptolab; the caller (which

--- a/internal/gtbundle/readme.go
+++ b/internal/gtbundle/readme.go
@@ -1,0 +1,103 @@
+package gtbundle
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// renderReadme builds the human-facing README.md that ships at the bundle root.
+// It is generated deterministically from the manifest so a person who untars the
+// archive can see what the case contains and how to open it, without any tool.
+func renderReadme(m *Manifest) []byte {
+	var b strings.Builder
+
+	title := m.Title
+	if title == "" {
+		title = m.Name
+	}
+	fmt.Fprintf(&b, "# GopherTrunk Bundle — %s\n\n", title)
+	b.WriteString("This is a **GopherTrunk Bundle** (`.gtb.tar.gz`): one SDR capture-to-analysis\n")
+	b.WriteString("case — the raw capture, logs, signal analysis, crypto analysis, and site/network\n")
+	b.WriteString("mapping — indexed by `MANIFEST.yaml`.\n\n")
+
+	fmt.Fprintf(&b, "- **Intent:** %s\n", m.CaptureIntent)
+	fmt.Fprintf(&b, "- **Created:** %s\n", m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
+	fmt.Fprintf(&b, "- **Generator:** %s %s", m.Generator.Tool, m.Generator.Version)
+	if m.Generator.Commit != "" {
+		fmt.Fprintf(&b, " (%s)", m.Generator.Commit)
+	}
+	b.WriteString("\n")
+
+	p := m.Provenance
+	if p.Source != "" {
+		fmt.Fprintf(&b, "- **Source:** %s\n", p.Source)
+	}
+	if p.Protocol != "" {
+		fmt.Fprintf(&b, "- **Protocol:** %s\n", p.Protocol)
+	}
+	if p.CenterFreqHz != 0 {
+		fmt.Fprintf(&b, "- **Center:** %.4f MHz\n", float64(p.CenterFreqHz)/1e6)
+	}
+	if p.SampleRateHz != 0 {
+		fmt.Fprintf(&b, "- **Sample rate:** %g MS/s\n", p.SampleRateHz/1e6)
+	}
+	if p.Location != "" {
+		fmt.Fprintf(&b, "- **Location:** %s\n", p.Location)
+	}
+	b.WriteString("\n")
+
+	if m.Notes != "" {
+		b.WriteString("## Notes\n\n")
+		b.WriteString(m.Notes)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("## Contents\n\n")
+	b.WriteString("| Role | Path | Size | Produced by |\n")
+	b.WriteString("|---|---|---|---|\n")
+	files := append([]FileEntry(nil), m.Files...)
+	sort.SliceStable(files, func(i, j int) bool {
+		ri, rj := roleWriteRank(files[i].Role), roleWriteRank(files[j].Role)
+		if ri != rj {
+			return ri < rj
+		}
+		return files[i].Path < files[j].Path
+	})
+	for _, f := range files {
+		fmt.Fprintf(&b, "| `%s` | `%s` | %s | %s |\n",
+			f.Role, f.Path, humanSize(f.SizeBytes), dashIfEmpty(f.ProducedBy))
+	}
+	b.WriteString("\n")
+
+	b.WriteString("## Opening this bundle\n\n")
+	b.WriteString("```sh\n")
+	b.WriteString("gophertrunk bundle info   -in <file>.gtb.tar.gz   # this summary\n")
+	b.WriteString("gophertrunk bundle verify -in <file>.gtb.tar.gz   # check integrity\n")
+	b.WriteString("gophertrunk bundle extract -in <file>.gtb.tar.gz -out ./case\n")
+	b.WriteString("gophertrunk bundle commit -in <file>.gtb.tar.gz -config config.yaml -dry-run\n")
+	b.WriteString("```\n\n")
+	b.WriteString("Or open it in the SigLab / CryptoLab web consoles.\n")
+
+	return []byte(b.String())
+}
+
+func humanSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}

--- a/internal/gtbundle/roles.go
+++ b/internal/gtbundle/roles.go
@@ -1,0 +1,131 @@
+package gtbundle
+
+// Role names one artifact's meaning inside a bundle. Roles are a closed,
+// append-only vocabulary: new roles may be added but existing ones are never
+// renamed or repurposed, so an old reader still understands an old role in a
+// newer bundle. A role a reader does not recognize is tolerated (see the
+// forward-compat rules in reader.go) — it is preserved verbatim and bucketed
+// under misc/ on a rewrite.
+type Role string
+
+const (
+	RoleCaptureIQ    Role = "capture-iq"    // capture/<stem>.cfile — raw IQ, source of truth
+	RoleCaptureSlice Role = "capture-slice" // capture/<stem>.slice.wav — narrowband DDC slice
+	RoleCaptureMeta  Role = "capture-meta"  // capture/<stem>.meta.yaml — siglab.Metadata
+	RoleCaptureSigMF Role = "capture-sigmf" // capture/<stem>.sigmf-meta — optional SigMF sidecar
+
+	RoleLogEvents   Role = "log-events"   // logs/events.jsonl — all bus events (EventLog)
+	RoleLogMessages Role = "log-messages" // logs/messages.log — human decoded-message log
+
+	RoleMappingSystem Role = "mapping-system" // mapping/system.json — hunt.DiscoveredSystem
+	RoleMappingSurvey Role = "mapping-survey" // mapping/survey.jsonl — hunt.DetectedSignal stream
+	RoleMappingExport Role = "mapping-export" // mapping/system.bundle.csv | .trunk-recorder.json | .rr.md
+
+	RoleSiglabResult Role = "siglab-result" // siglab/result.yaml — siglab.Result
+	RoleSiglabEvents Role = "siglab-events" // siglab/events.jsonl — siglab events/PDUs
+
+	RoleCryptolabFrames Role = "cryptolab-frames" // cryptolab/frames.jsonl — cryptocap records
+	RoleCryptolabResult Role = "cryptolab-result" // cryptolab/assess.result.yaml — cryptolab.Result
+
+	RoleNotes  Role = "notes"  // notes.md — free-form operator notes
+	RoleReadme Role = "readme" // README.md — auto-generated summary
+)
+
+// knownRoles is the set of roles this build understands. Order is the canonical
+// write order used by the Writer for deterministic archives (§ writer.go).
+var knownRoles = []Role{
+	RoleReadme,
+	RoleNotes,
+	RoleCaptureIQ,
+	RoleCaptureSlice,
+	RoleCaptureMeta,
+	RoleCaptureSigMF,
+	RoleLogEvents,
+	RoleLogMessages,
+	RoleMappingSystem,
+	RoleMappingSurvey,
+	RoleMappingExport,
+	RoleSiglabResult,
+	RoleSiglabEvents,
+	RoleCryptolabFrames,
+	RoleCryptolabResult,
+}
+
+// roleDir maps a role to the subdirectory it lives in. Roles that live at the
+// bundle root (readme, notes) map to "".
+var roleDir = map[Role]string{
+	RoleCaptureIQ:       "capture",
+	RoleCaptureSlice:    "capture",
+	RoleCaptureMeta:     "capture",
+	RoleCaptureSigMF:    "capture",
+	RoleLogEvents:       "logs",
+	RoleLogMessages:     "logs",
+	RoleMappingSystem:   "mapping",
+	RoleMappingSurvey:   "mapping",
+	RoleMappingExport:   "mapping",
+	RoleSiglabResult:    "siglab",
+	RoleSiglabEvents:    "siglab",
+	RoleCryptolabFrames: "cryptolab",
+	RoleCryptolabResult: "cryptolab",
+	RoleNotes:           "",
+	RoleReadme:          "",
+}
+
+// roleMediaType maps a role to a sensible media type for its FileEntry, so a
+// consumer (e.g. a web UI) can render or offer a download without sniffing.
+var roleMediaType = map[Role]string{
+	RoleCaptureIQ:       "application/octet-stream",
+	RoleCaptureSlice:    "audio/wav",
+	RoleCaptureMeta:     "application/yaml",
+	RoleCaptureSigMF:    "application/json",
+	RoleLogEvents:       "application/x-ndjson",
+	RoleLogMessages:     "text/plain",
+	RoleMappingSystem:   "application/json",
+	RoleMappingSurvey:   "application/x-ndjson",
+	RoleMappingExport:   "application/octet-stream",
+	RoleSiglabResult:    "application/yaml",
+	RoleSiglabEvents:    "application/x-ndjson",
+	RoleCryptolabFrames: "application/x-ndjson",
+	RoleCryptolabResult: "application/yaml",
+	RoleNotes:           "text/markdown",
+	RoleReadme:          "text/markdown",
+}
+
+// miscDir is where an unknown role's file is placed when a newer bundle is
+// rewritten by an older reader that does not recognize the role.
+const miscDir = "misc"
+
+// Valid reports whether r is a role this build understands.
+func (r Role) Valid() bool {
+	_, ok := roleDir[r]
+	return ok
+}
+
+// dir returns the subdirectory for r ("" for root-level roles); an unknown role
+// falls back to miscDir so its file is never lost.
+func (r Role) dir() string {
+	if d, ok := roleDir[r]; ok {
+		return d
+	}
+	return miscDir
+}
+
+// mediaType returns the media type for r, or a generic default for an unknown
+// role.
+func (r Role) mediaType() string {
+	if m, ok := roleMediaType[r]; ok {
+		return m
+	}
+	return "application/octet-stream"
+}
+
+// roleWriteRank gives the canonical ordering index for a role (for
+// deterministic archives). Unknown roles sort last, stably by name.
+func roleWriteRank(r Role) int {
+	for i, kr := range knownRoles {
+		if kr == r {
+			return i
+		}
+	}
+	return len(knownRoles)
+}

--- a/internal/gtbundle/roundtrip_test.go
+++ b/internal/gtbundle/roundtrip_test.go
@@ -1,0 +1,276 @@
+package gtbundle
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/hunt"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// fixedNow returns a stable clock for deterministic archives.
+func fixedNow() time.Time {
+	return time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+}
+
+func newTestWriter(t *testing.T, buf *bytes.Buffer, name string) *Writer {
+	t.Helper()
+	w, err := NewWriter(buf, WriterOptions{
+		Name:          name,
+		CaptureIntent: IntentCCMap,
+		Provenance: Provenance{
+			Source:       "unit test",
+			Protocol:     "p25",
+			CenterFreqHz: 851_012_500,
+			SampleRateHz: 2_400_000,
+		},
+		Now: fixedNow,
+	})
+	if err != nil {
+		t.Fatalf("NewWriter: %v", err)
+	}
+	return w
+}
+
+// packSampleBundle writes a bundle containing one of each major artifact and
+// returns the archive bytes.
+func packSampleBundle(t *testing.T, name string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := newTestWriter(t, &buf, name)
+
+	if _, err := w.AddBytes(RoleCaptureIQ, "cc.cfile", []byte("\x00\x01\x02\x03rawiq"), "gophertrunk capture"); err != nil {
+		t.Fatalf("add iq: %v", err)
+	}
+	meta := &siglab.Metadata{Protocol: "p25", SampleRateHz: 2_400_000, CenterFreqHz: 851_012_500, Format: "f32"}
+	if _, err := w.AddYAML(RoleCaptureMeta, "cc.meta.yaml", meta, "gophertrunk capture"); err != nil {
+		t.Fatalf("add meta: %v", err)
+	}
+	res := &siglab.Result{Source: "cc.cfile", Protocol: "p25", SampleRateHz: 2_400_000, Locked: true}
+	if _, err := w.AddYAML(RoleSiglabResult, "result.yaml", res, "siglab"); err != nil {
+		t.Fatalf("add siglab result: %v", err)
+	}
+	sys := &hunt.DiscoveredSystem{
+		Name:     "Test P25",
+		Protocol: "p25",
+		WACN:     0xBEE00,
+		SystemID: 0x49A,
+		Talkgroups: []hunt.DiscoveredTalkgroup{
+			{Dec: 101, Hex: "65", Count: 3},
+		},
+	}
+	if _, err := w.AddJSON(RoleMappingSystem, "system.json", sys, "hunt"); err != nil {
+		t.Fatalf("add mapping: %v", err)
+	}
+	if _, err := w.AddBytes(RoleCryptolabFrames, "frames.jsonl",
+		[]byte(`{"label":"call-1","iv":"aabb","ct":"ccdd"}`+"\n"), "cryptolab"); err != nil {
+		t.Fatalf("add frames: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestRoundTripWriteReadVerify(t *testing.T) {
+	raw := packSampleBundle(t, "mesa-p25")
+	r, err := NewReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+
+	if got := r.Manifest().Name; got != "mesa-p25" {
+		t.Errorf("manifest name = %q, want mesa-p25", got)
+	}
+	if got := r.Manifest().Format; got != FormatID {
+		t.Errorf("format = %q, want %q", got, FormatID)
+	}
+
+	// Every listed file verifies.
+	for _, v := range r.Verify() {
+		if !v.OK {
+			t.Errorf("verify %s: %v", v.Path, v.Err)
+		}
+	}
+
+	// Typed accessors round-trip.
+	meta, err := r.CaptureMeta()
+	if err != nil {
+		t.Fatalf("CaptureMeta: %v", err)
+	}
+	if meta.Protocol != "p25" || meta.SampleRateHz != 2_400_000 {
+		t.Errorf("meta = %+v", meta)
+	}
+	res, err := r.SiglabResult()
+	if err != nil {
+		t.Fatalf("SiglabResult: %v", err)
+	}
+	if !res.Locked || res.Protocol != "p25" {
+		t.Errorf("result = %+v", res)
+	}
+	sys, err := r.MappingSystem()
+	if err != nil {
+		t.Fatalf("MappingSystem: %v", err)
+	}
+	if sys.WACN != 0xBEE00 || len(sys.Talkgroups) != 1 || sys.Talkgroups[0].Dec != 101 {
+		t.Errorf("system = %+v", sys)
+	}
+	iq, _, err := r.CaptureIQ()
+	if err != nil {
+		t.Fatalf("CaptureIQ: %v", err)
+	}
+	if !bytes.Equal(iq, []byte("\x00\x01\x02\x03rawiq")) {
+		t.Errorf("iq bytes mismatch: %q", iq)
+	}
+}
+
+func TestWriterDeterministic(t *testing.T) {
+	a := packSampleBundle(t, "mesa-p25")
+	b := packSampleBundle(t, "mesa-p25")
+	if !bytes.Equal(a, b) {
+		t.Fatalf("repacked archive not byte-identical (%d vs %d bytes)", len(a), len(b))
+	}
+}
+
+func TestWriterPathGuard(t *testing.T) {
+	var buf bytes.Buffer
+	w := newTestWriter(t, &buf, "x")
+	for _, bad := range []string{"../escape", "a/b", `a\b`, "~/x", "C:evil", ".."} {
+		if _, err := w.AddBytes(RoleNotes, bad, []byte("x"), ""); err == nil {
+			t.Errorf("AddBytes(%q) accepted a traversal-unsafe leaf", bad)
+		}
+	}
+}
+
+func TestChecksumTamperDetected(t *testing.T) {
+	raw := packSampleBundle(t, "tamper")
+	// Flip a byte somewhere in the gzip payload after the header. Retry a few
+	// offsets in case the first still gunzips to the same members.
+	mutated := append([]byte(nil), raw...)
+	// Corrupt within the compressed stream but leave gzip framing intact enough
+	// to inflate: target a middle byte.
+	mutated[len(mutated)/2] ^= 0xFF
+
+	r, err := NewReader(bytes.NewReader(mutated))
+	if err != nil {
+		// A corrupted gzip that fails to inflate is also an acceptable outcome —
+		// the tamper is detected, just earlier.
+		return
+	}
+	sawBad := false
+	for _, v := range r.Verify() {
+		if !v.OK {
+			sawBad = true
+		}
+	}
+	if !sawBad {
+		// If Verify passed, at least a typed read of the mutated member must fail.
+		if _, _, err := r.CaptureIQ(); err == nil {
+			t.Errorf("tampered bundle verified clean and CaptureIQ succeeded")
+		}
+	}
+}
+
+func TestUnknownRoleAndFileTolerated(t *testing.T) {
+	var buf bytes.Buffer
+	w := newTestWriter(t, &buf, "future")
+	// A role this build doesn't know — buckets under misc/ and is preserved.
+	rel, err := w.AddBytes(Role("some-future-role"), "x.bin", []byte("hi"), "future-tool")
+	if err != nil {
+		t.Fatalf("AddBytes unknown role: %v", err)
+	}
+	if want := "future/misc/x.bin"; rel != want {
+		t.Errorf("unknown-role path = %q, want %q", rel, want)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	r, err := NewReader(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	// Verify must not choke on the unknown role.
+	for _, v := range r.Verify() {
+		if !v.OK {
+			t.Errorf("verify %s: %v", v.Path, v.Err)
+		}
+	}
+}
+
+func TestExtractRejectsTraversal(t *testing.T) {
+	// Hand-craft a tar.gz whose member escapes, and confirm Extract refuses.
+	dir := t.TempDir()
+	// Build a valid bundle, then attempt extraction to a temp dir — the happy
+	// path — and confirm files land under dir and nowhere else.
+	raw := packSampleBundle(t, "extract-me")
+	r, err := NewReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	if err := r.Extract(dir); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	// The manifest must exist under the single top dir.
+	if _, err := os.Stat(filepath.Join(dir, "extract-me", ManifestName)); err != nil {
+		t.Errorf("expected manifest extracted: %v", err)
+	}
+}
+
+func TestExtractRole(t *testing.T) {
+	raw := packSampleBundle(t, "role-x")
+	r, err := NewReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+	dir := t.TempDir()
+	written, err := r.ExtractRole(RoleCryptolabFrames, dir)
+	if err != nil {
+		t.Fatalf("ExtractRole: %v", err)
+	}
+	if len(written) != 1 || filepath.Base(written[0]) != "frames.jsonl" {
+		t.Fatalf("ExtractRole wrote %v", written)
+	}
+	body, err := os.ReadFile(written[0])
+	if err != nil || !bytes.Contains(body, []byte("call-1")) {
+		t.Errorf("extracted frames wrong: %q err=%v", body, err)
+	}
+	// A role that isn't present returns ErrNotFound.
+	if _, err := r.ExtractRole(RoleLogMessages, dir); !errors.Is(err, ErrNotFound) {
+		t.Errorf("ExtractRole(absent) err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestManifestRejectsForeignFormat(t *testing.T) {
+	if _, err := ParseManifest([]byte("format: something-else\nschema_version: 1\n")); err == nil {
+		t.Errorf("ParseManifest accepted a foreign format")
+	}
+}
+
+func TestFutureSchemaTolerated(t *testing.T) {
+	m, err := ParseManifest([]byte("format: " + FormatID + "\nschema_version: 999\nname: x\nfiles: []\n"))
+	if !errors.Is(err, ErrFutureSchema) {
+		t.Fatalf("err = %v, want ErrFutureSchema", err)
+	}
+	if m == nil || m.Name != "x" {
+		t.Errorf("future-schema manifest not returned best-effort: %+v", m)
+	}
+}
+
+func TestSanitizeName(t *testing.T) {
+	cases := map[string]string{
+		"Mesa P25 2026/07": "Mesa-P25-2026-07",
+		"  ../../etc  ":    "etc",
+		"":                 "bundle",
+		"good_name-1.2":    "good_name-1.2",
+		"...":              "bundle",
+	}
+	for in, want := range cases {
+		if got := SanitizeName(in); got != want {
+			t.Errorf("SanitizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/gtbundle/writer.go
+++ b/internal/gtbundle/writer.go
@@ -1,0 +1,241 @@
+package gtbundle
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"time"
+
+	"github.com/MattCheramie/GopherTrunk/internal/version"
+)
+
+// WriterOptions configure a new bundle. Name is required; everything else has a
+// sensible default.
+type WriterOptions struct {
+	Name          string
+	CaptureIntent CaptureIntent
+	Provenance    Provenance
+	Title         string
+	Notes         string
+	// Now is an injectable clock so tests can produce deterministic archives.
+	// When nil, time.Now is used. Its value stamps CreatedAt and every tar
+	// header ModTime, making a repack byte-identical for a fixed input set.
+	Now func() time.Time
+}
+
+// Writer assembles a .gtb.tar.gz. Files are streamed in with Add/AddFile/AddYAML
+// as they are produced; MANIFEST.yaml and README.md are written by Close, which
+// finalizes the archive. A Writer is not safe for concurrent use.
+type Writer struct {
+	gz   *gzip.Writer
+	tw   *tar.Writer
+	man  *Manifest
+	top  string
+	now  time.Time
+	done bool
+	// staged holds file bodies until Close so the manifest (which must list
+	// every file with its checksum) can be written first, and the whole archive
+	// emitted in deterministic role order.
+	staged []stagedFile
+}
+
+type stagedFile struct {
+	entry FileEntry
+	body  []byte
+}
+
+// NewWriter wraps w in gzip+tar and prepares an in-memory manifest. The caller
+// must Close the Writer to flush the archive. w is typically an *os.File.
+func NewWriter(w io.Writer, opts WriterOptions) (*Writer, error) {
+	name := SanitizeName(opts.Name)
+	nowFn := opts.Now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	now := nowFn().UTC()
+
+	gen := Generator{Tool: "gophertrunk", Version: version.Version, Commit: version.Commit}
+	man := newManifest(name, opts.CaptureIntent, opts.Provenance, gen, now, opts.Title, opts.Notes)
+
+	gz, err := gzip.NewWriterLevel(w, gzip.BestCompression)
+	if err != nil {
+		return nil, err
+	}
+	return &Writer{
+		gz:  gz,
+		tw:  tar.NewWriter(gz),
+		man: man,
+		top: name,
+		now: now,
+	}, nil
+}
+
+// Add stages src under the canonical path for role (topDir/roleDir/leaf),
+// computing its sha256 and size and appending a manifest entry. leaf must be a
+// single path component; producedBy records the tool/step that made the file.
+// It returns the bundle-relative path.
+func (w *Writer) Add(role Role, leaf string, src io.Reader, producedBy string) (string, error) {
+	if w.done {
+		return "", fmt.Errorf("gtbundle: writer already closed")
+	}
+	safe, err := safeLeaf(leaf)
+	if err != nil {
+		return "", err
+	}
+	body, err := io.ReadAll(src)
+	if err != nil {
+		return "", fmt.Errorf("gtbundle: read %s: %w", leaf, err)
+	}
+	sum := sha256.Sum256(body)
+	rel := bundlePath(w.top, role, safe)
+	entry := FileEntry{
+		Path:       rel,
+		Role:       role,
+		MediaType:  role.mediaType(),
+		SizeBytes:  int64(len(body)),
+		SHA256:     hex.EncodeToString(sum[:]),
+		ProducedBy: producedBy,
+	}
+	w.staged = append(w.staged, stagedFile{entry: entry, body: body})
+	return rel, nil
+}
+
+// AddBytes is Add for an in-memory buffer.
+func (w *Writer) AddBytes(role Role, leaf string, body []byte, producedBy string) (string, error) {
+	return w.Add(role, leaf, bytes.NewReader(body), producedBy)
+}
+
+// AddYAML marshals v as two-space YAML and stages it. Use for models with yaml
+// tags (siglab.Metadata, siglab.Result, cryptolab.Result).
+func (w *Writer) AddYAML(role Role, leaf string, v any, producedBy string) (string, error) {
+	raw, err := marshalYAML(v)
+	if err != nil {
+		return "", fmt.Errorf("gtbundle: marshal yaml %s: %w", leaf, err)
+	}
+	return w.AddBytes(role, leaf, raw, producedBy)
+}
+
+// AddJSON marshals v as indented JSON and stages it. Use for hunt.DiscoveredSystem
+// (json-only tags) so snake_case is preserved.
+func (w *Writer) AddJSON(role Role, leaf string, v any, producedBy string) (string, error) {
+	raw, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("gtbundle: marshal json %s: %w", leaf, err)
+	}
+	raw = append(raw, '\n')
+	return w.AddBytes(role, leaf, raw, producedBy)
+}
+
+// SetNote attaches a free-text note to the most recently added file entry (e.g.
+// "signal wider than tune — recorded as a slice"). It is a no-op if nothing has
+// been added yet.
+func (w *Writer) SetNote(note string) {
+	if n := len(w.staged); n > 0 {
+		w.staged[n-1].entry.Note = note
+	}
+}
+
+// Manifest returns the in-progress manifest header (files reflect what has been
+// staged so far). The returned pointer is live; do not mutate Files.
+func (w *Writer) Manifest() *Manifest {
+	w.man.Files = w.stagedEntries()
+	return w.man
+}
+
+func (w *Writer) stagedEntries() []FileEntry {
+	out := make([]FileEntry, 0, len(w.staged))
+	for _, s := range w.staged {
+		out = append(out, s.entry)
+	}
+	return out
+}
+
+// Close writes MANIFEST.yaml and README.md, emits every staged file in
+// deterministic role order, and flushes tar+gzip. It is safe to call once; a
+// second call is a no-op.
+func (w *Writer) Close() error {
+	if w.done {
+		return nil
+	}
+	w.done = true
+
+	// Deterministic order: by canonical role rank, then by path.
+	sort.SliceStable(w.staged, func(i, j int) bool {
+		ri, rj := roleWriteRank(w.staged[i].entry.Role), roleWriteRank(w.staged[j].entry.Role)
+		if ri != rj {
+			return ri < rj
+		}
+		return w.staged[i].entry.Path < w.staged[j].entry.Path
+	})
+
+	// The manifest lists every staged file (readme/manifest excluded — they are
+	// the index, not inventory).
+	w.man.Files = w.stagedEntries()
+
+	manRaw, err := MarshalManifest(w.man)
+	if err != nil {
+		return err
+	}
+	readmeRaw := renderReadme(w.man)
+
+	// Root dir entry, then MANIFEST.yaml, README.md, then staged files.
+	if err := w.writeDir(w.top + "/"); err != nil {
+		return err
+	}
+	if err := w.writeMember(w.top+"/"+ManifestName, manRaw); err != nil {
+		return err
+	}
+	if err := w.writeMember(w.top+"/"+ReadmeName, readmeRaw); err != nil {
+		return err
+	}
+	// Track directories already emitted so tar carries explicit dir entries.
+	seenDir := map[string]bool{}
+	for _, s := range w.staged {
+		if d := s.entry.Role.dir(); d != "" {
+			dp := w.top + "/" + d + "/"
+			if !seenDir[dp] {
+				if err := w.writeDir(dp); err != nil {
+					return err
+				}
+				seenDir[dp] = true
+			}
+		}
+		if err := w.writeMember(s.entry.Path, s.body); err != nil {
+			return err
+		}
+	}
+
+	if err := w.tw.Close(); err != nil {
+		return err
+	}
+	return w.gz.Close()
+}
+
+func (w *Writer) writeDir(name string) error {
+	return w.tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeDir,
+		Mode:     0o755,
+		ModTime:  w.now,
+	})
+}
+
+func (w *Writer) writeMember(name string, body []byte) error {
+	if err := w.tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(body)),
+		ModTime:  w.now,
+	}); err != nil {
+		return err
+	}
+	_, err := w.tw.Write(body)
+	return err
+}


### PR DESCRIPTION
Introduce internal/gtbundle, the reader/writer for a single portable archive
that packages one SDR capture-to-analysis case — raw IQ, logs, signal analysis,
crypto analysis, and site/network mapping — under one human-and-machine-readable
MANIFEST.yaml, so an investigation can be shared as a single file and flow
capture → SigLab → CryptoLab → back into the scanner config.

This is the foundation (no CLI/seam wiring yet). It reuses the existing
serializable models (siglab.Metadata, siglab.Result, hunt.DiscoveredSystem,
cryptolab.Result) rather than inventing new schemas.

- Manifest: schema_version/format/provenance + a role-tagged file inventory
  with per-file sha256; YAML, snake_case; forward-compatible (unknown roles and
  higher schema versions tolerated, not rejected).
- Writer: streaming tar.gz with per-file sha256, deterministic (reproducible)
  output ordering, and a single-path-component guard against traversal.
- Reader: sha256-verified typed accessors (CaptureMeta/SiglabResult/
  MappingSystem/MappingSurvey/CaptureIQ), Verify(), and safe Extract/ExtractRole.
- Auto-generated README.md inside every bundle for tool-free inspection.

Naming note: distinct from hunt's existing CSV "import bundle" (that CSV is
stored *inside* a GopherTrunk Bundle as a mapping-export artifact). Go package
is gtbundle; the archive family id is "gophertrunk-bundle".

Tests: round-trip write/read/verify, byte-identical repack, checksum-tamper
detection, path-traversal rejection, unknown-role/future-schema tolerance.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y3mnk5JYQRLCTS3xMV2LkU