### PR TITLE
GopherTrunk Bundle (.gtb.tar.gz): the capture-to-analysis case format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,22 @@ for tagged releases.
   self-heals instead of quietly stopping.
 
 ### Added
+- **GopherTrunk Bundle (`.gtb.tar.gz`) — the capture-to-analysis case format.**
+  A single portable archive that packages one SDR case — the raw IQ capture, an
+  auto-carved narrowband DDC slice, logs, the SigLab signal analysis, the
+  CryptoLab crypto analysis, and the hunt site/network mapping — under one
+  human-and-machine-readable `MANIFEST.yaml` with per-file SHA-256, so a whole
+  investigation is shared as one file and flows capture → SigLab → CryptoLab →
+  back into `config.yaml`. New `gophertrunk bundle` subcommand
+  (`pack`/`info`/`verify`/`extract`/`add`/`commit`), and `-bundle` on `capture`,
+  `hunt` (mapping and `-survey-capture`), `analyze` (reads the capture and writes
+  the result back), and `cryptolab assess` (tagged build). `commit` marks
+  talkgroups encrypted from the bundle's crypto frames (algorithm named via P25
+  ALGID) before merging into `config.yaml`. An opt-in `-sigmf` sidecar makes the
+  capture interoperable with SigMF tooling. The daemon serves
+  `/api/v1/bundle/{info,verify,download}` (confined to `recordings.dir`), and the
+  SigLab, CryptoLab, and main web consoles gain a **Bundles** view to inspect,
+  verify, and download a case. See [`docs/bundle.md`](docs/bundle.md).
 - **Per-call received signal level in the call log.** Each recorded voice call
   now carries a `signal_dbfs` figure — the mean received channel power in dBFS,
   measured by the voice composer over the call's baseband IQ. It surfaces in the

--- a/cmd/gophertrunk/bundle.go
+++ b/cmd/gophertrunk/bundle.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/diag"
 	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
 )
 
 // runBundle dispatches `gophertrunk bundle <subcommand>`. The GopherTrunk
@@ -89,6 +90,7 @@ func runBundlePack(args []string) {
 	cryptoResult := fs.String("cryptolab-result", "", "CryptoLab result (yaml/json) → cryptolab-result")
 	notesFile := fs.String("notes", "", "notes.md file → notes")
 	fromDir := fs.String("from-dir", "", "pack a pre-laid-out directory (capture/, logs/, mapping/, …)")
+	sigmf := fs.Bool("sigmf", false, "emit a SigMF .sigmf-meta sidecar from -meta (interop with SigMF tooling)")
 	_ = fs.Parse(args)
 
 	rep := newReporter("bundle pack")
@@ -140,6 +142,22 @@ func runBundlePack(args []string) {
 	}
 	add(gtbundle.RoleCaptureIQ, *capture, "gophertrunk capture")
 	add(gtbundle.RoleCaptureMeta, *meta, "gophertrunk capture")
+	if *sigmf && *meta != "" {
+		m, lerr := siglab.LoadMetadata(*meta)
+		if lerr != nil {
+			rep.Fatal(1, fmt.Errorf("sigmf: load metadata: %w", lerr))
+		}
+		if doc, ok, serr := gtbundle.MetadataToSigMF(m); serr != nil {
+			rep.Fatal(1, fmt.Errorf("sigmf: %w", serr))
+		} else if ok {
+			if _, aerr := w.AddBytes(gtbundle.RoleCaptureSigMF, stemOf(baseName(*capture))+".sigmf-meta", doc, "gophertrunk bundle"); aerr != nil {
+				rep.Fatal(1, aerr)
+			}
+			added++
+		} else {
+			fmt.Fprintln(os.Stderr, "bundle: -sigmf skipped (capture format has no SigMF datatype equivalent)")
+		}
+	}
 	add(gtbundle.RoleCaptureSlice, *slice, "gophertrunk bundle")
 	add(gtbundle.RoleLogEvents, *events, "daemon")
 	add(gtbundle.RoleLogMessages, *messages, "daemon")

--- a/cmd/gophertrunk/bundle_slice.go
+++ b/cmd/gophertrunk/bundle_slice.go
@@ -116,6 +116,7 @@ type captureBundleParams struct {
 	protocol     string
 	source       string
 	meta         *siglab.Metadata
+	emitSigMF    bool
 }
 
 // writeCaptureBundle assembles a bundle from a just-recorded capture: the raw
@@ -157,6 +158,15 @@ func writeCaptureBundle(p captureBundleParams) error {
 	if p.meta != nil {
 		if _, err := w.AddYAML(gtbundle.RoleCaptureMeta, stemOf(iqLeaf)+".meta.yaml", p.meta, "gophertrunk capture"); err != nil {
 			return err
+		}
+		if p.emitSigMF {
+			if doc, ok, serr := gtbundle.MetadataToSigMF(p.meta); serr != nil {
+				return serr
+			} else if ok {
+				if _, err := w.AddBytes(gtbundle.RoleCaptureSigMF, stemOf(iqLeaf)+".sigmf-meta", doc, "gophertrunk bundle"); err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/cmd/gophertrunk/capture.go
+++ b/cmd/gophertrunk/capture.go
@@ -45,6 +45,7 @@ func runCapture(args []string) {
 	metaOut := fs.String("meta", "", "metadata sidecar path (default: <out stem>.metadata.json; \"none\" skips it)")
 	bundleOut := fs.String("bundle", "", "also package the capture (+ metadata + a carved narrowband slice) into a GopherTrunk Bundle (.gtb.tar.gz) at this path")
 	bundleIntent := fs.String("intent", "general", "bundle capture intent: cc-map | crypto | survey | general (sets the slice length)")
+	bundleSigMF := fs.Bool("sigmf", false, "with -bundle, also emit a SigMF .sigmf-meta sidecar for the capture (interop with SigMF tooling)")
 	listDevices := fs.Bool("list", false, "list the SDRs available to capture from and exit")
 	fs.Usage = func() {
 		fmt.Fprintln(fs.Output(), `gophertrunk capture — record raw IQ off a live SDR to a .cfile + metadata sidecar.
@@ -188,6 +189,7 @@ FLAGS:`)
 			protocol:     *protocol,
 			source:       *source,
 			meta:         meta,
+			emitSigMF:    *bundleSigMF,
 		}); err != nil {
 			rep.Fatal(1, fmt.Errorf("write bundle: %w", err))
 		}

--- a/cmd/gophertrunk/cryptolab_enabled.go
+++ b/cmd/gophertrunk/cryptolab_enabled.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
 	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/webserver"
+	"github.com/MattCheramie/GopherTrunk/internal/gtbundle"
 	cryptolabweb "github.com/MattCheramie/GopherTrunk/web/cryptolab"
 	// Blank imports register the toolkit's tools and subjects via init().
 	_ "github.com/MattCheramie/GopherTrunk/internal/cryptolab/subjects/motorola"
@@ -52,6 +53,7 @@ func runCryptolab(args []string) {
 	format := gfs.String("format", "text", "output format: text|json|jsonl|yaml|csv")
 	logLevel := gfs.String("log-level", "info", "log level: debug|info|warn|error")
 	logFormat := gfs.String("log-format", "text", "log format: text|json")
+	bundlePath := gfs.String("bundle", "", "read the frames from this GopherTrunk Bundle (.gtb.tar.gz) as -in, and write the result back into it (cryptolab/assess.result.yaml)")
 	gfs.Usage = func() { cryptolabUsage(os.Stderr) }
 	if err := gfs.Parse(args); err != nil {
 		os.Exit(2)
@@ -92,6 +94,20 @@ func runCryptolab(args []string) {
 		rep.Fatal(2, err)
 	}
 
+	// When a bundle is given, source the frames from it (as -in) so a bundled
+	// case is assessed without unpacking by hand. The result is written back
+	// into the bundle after the run.
+	if *bundlePath != "" {
+		framesPath, cleanup, ferr := extractBundleFrames(*bundlePath)
+		if ferr != nil {
+			rep.Fatal(1, ferr)
+		}
+		defer cleanup()
+		if !hasFlag(modeArgs, "in") {
+			modeArgs = append([]string{"-in", framesPath}, modeArgs...)
+		}
+	}
+
 	env := cryptolab.Env{
 		Logger:     gtlog.New(*logLevel, *logFormat),
 		OutDir:     *out,
@@ -110,6 +126,66 @@ func runCryptolab(args []string) {
 	if err := cryptolab.WriteResult(os.Stdout, res, fmtKind); err != nil {
 		rep.Fatal(1, err)
 	}
+
+	if *bundlePath != "" {
+		if err := writeCryptolabResultToBundle(*bundlePath, res); err != nil {
+			rep.Fatal(1, fmt.Errorf("write result to bundle: %w", err))
+		}
+		fmt.Fprintf(os.Stderr, "cryptolab: wrote result → %s (cryptolab/assess.result.yaml)\n", *bundlePath)
+	}
+}
+
+// extractBundleFrames pulls the cryptolab-frames stream out of a bundle to a
+// temp file so a mode's -in can point at it. The returned cleanup removes the
+// temp dir.
+func extractBundleFrames(bundlePath string) (framesPath string, cleanup func(), err error) {
+	r, err := gtbundle.Open(bundlePath)
+	if err != nil {
+		return "", func() {}, err
+	}
+	tmp, err := os.MkdirTemp("", "gtb-crypto-*")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup = func() { os.RemoveAll(tmp) }
+	written, err := r.ExtractRole(gtbundle.RoleCryptolabFrames, tmp)
+	if err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("bundle has no cryptolab-frames: %w", err)
+	}
+	return written[0], cleanup, nil
+}
+
+// writeCryptolabResultToBundle deposits a cryptolab result into an existing
+// bundle as cryptolab/assess.result.yaml via the bundle add (repack) path.
+func writeCryptolabResultToBundle(bundlePath string, res *cryptolab.Result) error {
+	tmp, err := os.MkdirTemp("", "gtb-cres-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+	resPath := tmp + "/assess.result.yaml"
+	f, err := os.Create(resPath)
+	if err != nil {
+		return err
+	}
+	if werr := cryptolab.WriteResult(f, res, cryptolab.FormatYAML); werr != nil {
+		f.Close()
+		return werr
+	}
+	f.Close()
+	return bundleAddFile(bundlePath, gtbundle.RoleCryptolabResult, resPath, "cryptolab assess")
+}
+
+// hasFlag reports whether -name (or -name=…) already appears in args.
+func hasFlag(args []string, name string) bool {
+	for _, a := range args {
+		if a == "-"+name || a == "--"+name ||
+			strings.HasPrefix(a, "-"+name+"=") || strings.HasPrefix(a, "--"+name+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 // runCryptolabServe launches the standalone cryptolab web console — the

--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -2298,6 +2298,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 			Systems:        d.systems,
 			Log:            log,
 			Version:        version,
+			BundleRoot:     cfg.Recordings.Dir,
 			Diagnostics:    d.newDiagCollector(),
 			VerboseErrors:  cfg.Diagnostics.VerboseErrors,
 			DisplayLoc:     d.displayLoc,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -593,6 +593,10 @@ type ServerOptions struct {
 	Log            *slog.Logger
 	// Version is reported by GET /api/v1/version.
 	Version string
+	// BundleRoot, when set, confines the /api/v1/bundle/* endpoints to
+	// GopherTrunk Bundles under this directory (the daemon passes the
+	// recordings dir). Empty allows any reachable .gtb path.
+	BundleRoot string
 	// AllowMutations is the legacy mutation gate. Deprecated in
 	// favour of Auth — set Auth.Mode = AuthModeDisabled to get the
 	// same wide-open semantics, or AuthModeAuto / AuthModeRequired
@@ -896,6 +900,7 @@ func NewServer(opts ServerOptions) (*Server, error) {
 		metrics:        opts.MetricsHandler,
 		log:            log,
 		version:        opts.Version,
+		bundleRoot:     opts.BundleRoot,
 		auth:           auth,
 		allowMutations: opts.AllowMutations,
 		tlsCert:        opts.TLSCert,

--- a/internal/gtbundle/sigmf.go
+++ b/internal/gtbundle/sigmf.go
@@ -1,0 +1,79 @@
+package gtbundle
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+// sigmfVersion is the SigMF spec version the emitter targets.
+const sigmfVersion = "1.0.0"
+
+// sigmfMeta is the minimal SigMF metadata document (a .sigmf-meta sidecar).
+// GopherTrunk does not read SigMF natively, but siglab.Metadata is a near-subset
+// of the SigMF global object, so emitting one makes a bundled capture/slice
+// interoperable with SigMF-aware tooling (inspectrum, GNU Radio, sigmf-python)
+// for the community-sharing goal. It is opt-in (WriterOptions.EmitSigMF).
+type sigmfMeta struct {
+	Global   sigmfGlobal    `json:"global"`
+	Captures []sigmfCapture `json:"captures"`
+	// Annotations is always present (empty) — the spec requires the key.
+	Annotations []any `json:"annotations"`
+}
+
+type sigmfGlobal struct {
+	Datatype    string  `json:"core:datatype"`
+	SampleRate  float64 `json:"core:sample_rate,omitempty"`
+	Version     string  `json:"core:version"`
+	Recorder    string  `json:"core:recorder,omitempty"`
+	Description string  `json:"core:description,omitempty"`
+}
+
+type sigmfCapture struct {
+	SampleStart int64   `json:"core:sample_start"`
+	Frequency   float64 `json:"core:frequency,omitempty"`
+}
+
+// sigmfDatatype maps a GopherTrunk sample-format name to the SigMF core:datatype
+// token. Returns "" for a format with no clean SigMF equivalent (e.g. the
+// 2-channel s16 baseband WAV, which carries its own header).
+func sigmfDatatype(format string) string {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", "u8", "cu8":
+		return "cu8"
+	case "f32", "cf32", "cf32_le":
+		return "cf32_le"
+	default:
+		return ""
+	}
+}
+
+// MetadataToSigMF renders a siglab.Metadata as a SigMF .sigmf-meta document. It
+// returns ok=false when the capture format has no SigMF datatype equivalent, so
+// the caller can skip emitting a sidecar rather than write a malformed one.
+func MetadataToSigMF(m *siglab.Metadata) ([]byte, bool, error) {
+	if m == nil {
+		return nil, false, nil
+	}
+	dt := sigmfDatatype(m.Format)
+	if dt == "" {
+		return nil, false, nil
+	}
+	doc := sigmfMeta{
+		Global: sigmfGlobal{
+			Datatype:    dt,
+			SampleRate:  m.SampleRateHz,
+			Version:     sigmfVersion,
+			Recorder:    "gophertrunk",
+			Description: m.Source,
+		},
+		Captures:    []sigmfCapture{{SampleStart: 0, Frequency: float64(m.CenterFreqHz)}},
+		Annotations: []any{},
+	}
+	raw, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return nil, false, err
+	}
+	return append(raw, '\n'), true, nil
+}

--- a/internal/gtbundle/sigmf_test.go
+++ b/internal/gtbundle/sigmf_test.go
@@ -1,0 +1,56 @@
+package gtbundle
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/siglab"
+)
+
+func TestMetadataToSigMF(t *testing.T) {
+	m := &siglab.Metadata{Protocol: "p25", SampleRateHz: 2_400_000, CenterFreqHz: 851_012_500, Format: "f32", Source: "unit"}
+	raw, ok, err := MetadataToSigMF(m)
+	if err != nil || !ok {
+		t.Fatalf("MetadataToSigMF ok=%v err=%v", ok, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("emitted SigMF is not valid JSON: %v", err)
+	}
+	global, _ := doc["global"].(map[string]any)
+	if global["core:datatype"] != "cf32_le" {
+		t.Errorf("datatype = %v, want cf32_le", global["core:datatype"])
+	}
+	if global["core:sample_rate"].(float64) != 2_400_000 {
+		t.Errorf("sample_rate = %v", global["core:sample_rate"])
+	}
+	caps, _ := doc["captures"].([]any)
+	if len(caps) != 1 {
+		t.Fatalf("captures = %v", caps)
+	}
+	if _, has := doc["annotations"]; !has {
+		t.Errorf("annotations key missing (SigMF requires it)")
+	}
+}
+
+func TestMetadataToSigMF_U8(t *testing.T) {
+	raw, ok, err := MetadataToSigMF(&siglab.Metadata{Protocol: "dmr", SampleRateHz: 2_400_000, Format: "u8"})
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	var doc map[string]any
+	json.Unmarshal(raw, &doc)
+	if doc["global"].(map[string]any)["core:datatype"] != "cu8" {
+		t.Errorf("u8 → datatype %v, want cu8", doc["global"].(map[string]any)["core:datatype"])
+	}
+}
+
+func TestMetadataToSigMF_SkipsWAV(t *testing.T) {
+	_, ok, err := MetadataToSigMF(&siglab.Metadata{Protocol: "p25", SampleRateHz: 48000, Format: "wav"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Errorf("wav format should have no SigMF datatype equivalent (ok should be false)")
+	}
+}

--- a/web/cryptolab/src/App.tsx
+++ b/web/cryptolab/src/App.tsx
@@ -3,10 +3,12 @@ import { useStore } from "./store/shared";
 import { ParamField } from "./components/ParamField";
 import { ResultView } from "./components/ResultView";
 import { RecipeBuilder } from "./components/RecipeBuilder";
+import { Bundle } from "./components/Bundle";
 import { ConsoleNav } from "./ConsoleNav";
 
 export function App() {
-  const [page, setPage] = useState<"tools" | "recipe">("tools");
+  const [page, setPage] = useState<"tools" | "recipe" | "bundle">("tools");
+  const [bundleEnabled, setBundleEnabled] = useState(false);
   const loadSchema = useStore((s) => s.loadSchema);
   const schema = useStore((s) => s.schema);
   const loadingSchema = useStore((s) => s.loadingSchema);
@@ -22,6 +24,20 @@ export function App() {
 
   useEffect(() => {
     void loadSchema();
+    // Gate the Bundles page on the daemon advertising the bundle endpoints.
+    // A standalone `cryptolab serve` 503s the runtime route, hiding the tab.
+    let alive = true;
+    fetch("/api/v1/runtime")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (alive && j && typeof j === "object" && j.bundle === true) setBundleEnabled(true);
+      })
+      .catch(() => {
+        /* standalone serve — leave the Bundles tab hidden */
+      });
+    return () => {
+      alive = false;
+    };
   }, [loadSchema]);
 
   const tools = useMemo(() => {
@@ -51,17 +67,21 @@ export function App() {
           ) : null}
         </div>
         <nav className="flex items-center gap-1">
-          {(["tools", "recipe"] as const).map((p) => (
-            <button
-              key={p}
-              onClick={() => setPage(p)}
-              className={`rounded px-2.5 py-1 text-sm ${
-                page === p ? "bg-accent/20 text-fg" : "text-muted hover:bg-panel"
-              }`}
-            >
-              {p === "tools" ? "Tools" : "Recipe Builder"}
-            </button>
-          ))}
+          {((bundleEnabled
+            ? (["tools", "recipe", "bundle"] as const)
+            : (["tools", "recipe"] as const)) as readonly ("tools" | "recipe" | "bundle")[]).map(
+            (p) => (
+              <button
+                key={p}
+                onClick={() => setPage(p)}
+                className={`rounded px-2.5 py-1 text-sm ${
+                  page === p ? "bg-accent/20 text-fg" : "text-muted hover:bg-panel"
+                }`}
+              >
+                {p === "tools" ? "Tools" : p === "recipe" ? "Recipe Builder" : "Bundles"}
+              </button>
+            ),
+          )}
         </nav>
         <div className="ml-auto flex items-center gap-3 text-xs text-muted">
           <ConsoleNav self="cryptolab" />
@@ -69,7 +89,11 @@ export function App() {
         </div>
       </header>
 
-      {page === "recipe" ? (
+      {page === "bundle" ? (
+        <main className="min-h-0 flex-1 overflow-y-auto p-4">
+          <Bundle />
+        </main>
+      ) : page === "recipe" ? (
         <main className="min-h-0 flex-1 overflow-y-auto p-4">
           <RecipeBuilder />
         </main>

--- a/web/cryptolab/src/components/Bundle.tsx
+++ b/web/cryptolab/src/components/Bundle.tsx
@@ -1,0 +1,193 @@
+import { useState } from "react";
+
+// Bundle inspects a GopherTrunk Bundle (.gtb.tar.gz) reachable on the daemon
+// host via the /api/v1/bundle/* endpoints (internal/api/handlers_bundle.go):
+// show its manifest + file inventory, verify every file's sha256, and offer a
+// download. Packing runs through the CLI; this is the read/inspect touch point.
+
+interface BundleFile {
+  path: string;
+  role: string;
+  media_type: string;
+  size_bytes: number;
+  sha256: string;
+  produced_by?: string;
+}
+
+interface BundleInfo {
+  name: string;
+  title?: string;
+  format: string;
+  schema_version: number;
+  capture_intent: string;
+  created_at: string;
+  generator: string;
+  protocol?: string;
+  source?: string;
+  future_schema?: boolean;
+  files: BundleFile[];
+  role_counts: Record<string, number>;
+}
+
+interface VerifyFile {
+  path: string;
+  role?: string;
+  ok: boolean;
+  untracked?: boolean;
+  error?: string;
+}
+
+interface VerifyResult {
+  ok: boolean;
+  files: VerifyFile[];
+  failures: number;
+  untracked: number;
+}
+
+function humanSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ["KiB", "MiB", "GiB", "TiB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+}
+
+export function Bundle() {
+  const [path, setPath] = useState("");
+  const [info, setInfo] = useState<BundleInfo | null>(null);
+  const [verify, setVerify] = useState<VerifyResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onInspect() {
+    if (!path) return;
+    setBusy(true);
+    setErr(null);
+    setVerify(null);
+    try {
+      const r = await fetch(`/api/v1/bundle/info?path=${encodeURIComponent(path)}`);
+      if (!r.ok) throw new Error(await r.text());
+      setInfo((await r.json()) as BundleInfo);
+    } catch (e) {
+      setInfo(null);
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onVerify() {
+    if (!path) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await fetch("/api/v1/bundle/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      setVerify((await r.json()) as VerifyResult);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4">
+      <div className="card space-y-2">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex-1">
+            <label className="label">Bundle path (on the daemon host)</label>
+            <input
+              className="input"
+              placeholder="/var/lib/gophertrunk/recordings/mesa-p25.gtb.tar.gz"
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && onInspect()}
+            />
+          </div>
+          <button className="btn" disabled={busy || !path} onClick={onInspect}>
+            {busy ? "Loading…" : "Inspect"}
+          </button>
+          <button className="btn" disabled={busy || !path} onClick={onVerify}>
+            Verify
+          </button>
+          {info && (
+            <a className="btn" href={`/api/v1/bundle/download?path=${encodeURIComponent(path)}`}>
+              Download
+            </a>
+          )}
+        </div>
+        <p className="text-xs text-muted">
+          Inspect a GopherTrunk Bundle already on the daemon host. Assess its frames with{" "}
+          <code>gophertrunk cryptolab -bundle &lt;path&gt; assess crypto</code>, which writes the
+          verdict back as <code>cryptolab/assess.result.yaml</code>.
+        </p>
+      </div>
+
+      {err && <div className="card text-xs text-err">{err}</div>}
+
+      {info && (
+        <div className="card space-y-3">
+          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+            <span className="font-semibold">{info.title || info.name}</span>
+            <span className="text-xs text-muted">intent: {info.capture_intent}</span>
+            {info.protocol && <span className="text-xs text-muted">protocol: {info.protocol}</span>}
+            <span className="text-xs text-muted">{info.generator}</span>
+            <span className="text-xs text-muted">{info.created_at}</span>
+          </div>
+          {info.future_schema && (
+            <div className="text-xs text-err">
+              schema v{info.schema_version} is newer than this build supports — reading best-effort
+            </div>
+          )}
+          {info.source && <div className="text-xs text-muted">{info.source}</div>}
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-muted">
+                <th className="py-1">Role</th>
+                <th>Path</th>
+                <th className="text-right">Size</th>
+                <th>By</th>
+                {verify && <th className="text-right">Verify</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {info.files.map((f) => {
+                const v = verify?.files.find((x) => x.path === f.path);
+                return (
+                  <tr key={f.path} className="border-t border-line/50">
+                    <td className="py-1 font-mono">{f.role}</td>
+                    <td className="font-mono">{f.path}</td>
+                    <td className="text-right">{humanSize(f.size_bytes)}</td>
+                    <td>{f.produced_by || "—"}</td>
+                    {verify && (
+                      <td className="text-right">
+                        {v ? (v.ok ? <span className="text-ok">✓</span> : <span className="text-err">✗</span>) : "—"}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {verify && (
+        <div className={`card text-xs ${verify.ok ? "text-ok" : "text-err"}`}>
+          {verify.ok
+            ? `Integrity OK — ${verify.files.length} file(s) checked, ${verify.untracked} untracked`
+            : `Integrity FAILED — ${verify.failures} file(s) do not match their sha256`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/siglab/src/App.tsx
+++ b/web/siglab/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { NavLink, Navigate, Route, Routes } from "react-router-dom";
 import { useStore } from "./store/shared";
 import { Captures } from "./panels/Captures";
@@ -7,9 +7,10 @@ import { Synthesize } from "./panels/Synthesize";
 import { Identify } from "./panels/Identify";
 import { Wideband } from "./panels/Wideband";
 import { Compare } from "./panels/Compare";
+import { Bundle } from "./panels/Bundle";
 import { ConsoleNav } from "./ConsoleNav";
 
-const tabs = [
+const baseTabs = [
   { to: "/captures", label: "Captures" },
   { to: "/synthesize", label: "Synthesize" },
   { to: "/identify", label: "Identify" },
@@ -19,12 +20,30 @@ const tabs = [
 
 export function App() {
   const loadProtocols = useStore((s) => s.loadProtocols);
+  // bundleEnabled gates the Bundles tab on the daemon advertising the bundle
+  // endpoints (GET /api/v1/runtime → { bundle: true }). Under a standalone
+  // `siglab serve` the runtime route 503s and the tab stays hidden.
+  const [bundleEnabled, setBundleEnabled] = useState(false);
 
   useEffect(() => {
     loadProtocols().catch(() => {
       /* surfaced lazily in the forms */
     });
+    let alive = true;
+    fetch("/api/v1/runtime")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((j) => {
+        if (alive && j && typeof j === "object" && j.bundle === true) setBundleEnabled(true);
+      })
+      .catch(() => {
+        /* standalone serve — leave the Bundles tab hidden */
+      });
+    return () => {
+      alive = false;
+    };
   }, [loadProtocols]);
+
+  const tabs = bundleEnabled ? [...baseTabs, { to: "/bundle", label: "Bundles" }] : baseTabs;
 
   return (
     <div className="flex min-h-full flex-col">
@@ -62,6 +81,7 @@ export function App() {
           <Route path="/identify" element={<Identify />} />
           <Route path="/wideband" element={<Wideband />} />
           <Route path="/compare" element={<Compare />} />
+          <Route path="/bundle" element={<Bundle />} />
           <Route path="*" element={<Navigate to="/captures" replace />} />
         </Routes>
       </main>

--- a/web/siglab/src/panels/Bundle.tsx
+++ b/web/siglab/src/panels/Bundle.tsx
@@ -1,0 +1,192 @@
+import { useState } from "react";
+
+// Bundle inspects a GopherTrunk Bundle (.gtb.tar.gz) reachable on the daemon
+// host via the /api/v1/bundle/* endpoints (internal/api/handlers_bundle.go):
+// show its manifest + file inventory, verify every file's sha256, and offer a
+// download. Packing runs through the CLI; this is the read/inspect touch point.
+
+interface BundleFile {
+  path: string;
+  role: string;
+  media_type: string;
+  size_bytes: number;
+  sha256: string;
+  produced_by?: string;
+}
+
+interface BundleInfo {
+  name: string;
+  title?: string;
+  format: string;
+  schema_version: number;
+  capture_intent: string;
+  created_at: string;
+  generator: string;
+  protocol?: string;
+  source?: string;
+  future_schema?: boolean;
+  files: BundleFile[];
+  role_counts: Record<string, number>;
+}
+
+interface VerifyFile {
+  path: string;
+  role?: string;
+  ok: boolean;
+  untracked?: boolean;
+  error?: string;
+}
+
+interface VerifyResult {
+  ok: boolean;
+  files: VerifyFile[];
+  failures: number;
+  untracked: number;
+}
+
+function humanSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ["KiB", "MiB", "GiB", "TiB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+}
+
+export function Bundle() {
+  const [path, setPath] = useState("");
+  const [info, setInfo] = useState<BundleInfo | null>(null);
+  const [verify, setVerify] = useState<VerifyResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onInspect() {
+    if (!path) return;
+    setBusy(true);
+    setErr(null);
+    setVerify(null);
+    try {
+      const r = await fetch(`/api/v1/bundle/info?path=${encodeURIComponent(path)}`);
+      if (!r.ok) throw new Error(await r.text());
+      setInfo((await r.json()) as BundleInfo);
+    } catch (e) {
+      setInfo(null);
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onVerify() {
+    if (!path) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await fetch("/api/v1/bundle/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      setVerify((await r.json()) as VerifyResult);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4">
+      <div className="card space-y-2">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex-1">
+            <label className="label">Bundle path (on the daemon host)</label>
+            <input
+              className="input"
+              placeholder="/var/lib/gophertrunk/recordings/mesa-p25.gtb.tar.gz"
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && onInspect()}
+            />
+          </div>
+          <button className="btn" disabled={busy || !path} onClick={onInspect}>
+            {busy ? "Loading…" : "Inspect"}
+          </button>
+          <button className="btn" disabled={busy || !path} onClick={onVerify}>
+            Verify
+          </button>
+          {info && (
+            <a className="btn" href={`/api/v1/bundle/download?path=${encodeURIComponent(path)}`}>
+              Download
+            </a>
+          )}
+        </div>
+        <p className="text-xs text-muted">
+          Reads a GopherTrunk Bundle already on the daemon host. Build one with{" "}
+          <code>gophertrunk capture -bundle …</code> or <code>gophertrunk bundle pack</code>.
+        </p>
+      </div>
+
+      {err && <div className="card text-xs text-err">{err}</div>}
+
+      {info && (
+        <div className="card space-y-3">
+          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+            <span className="font-semibold">{info.title || info.name}</span>
+            <span className="text-xs text-muted">intent: {info.capture_intent}</span>
+            {info.protocol && <span className="text-xs text-muted">protocol: {info.protocol}</span>}
+            <span className="text-xs text-muted">{info.generator}</span>
+            <span className="text-xs text-muted">{info.created_at}</span>
+          </div>
+          {info.future_schema && (
+            <div className="text-xs text-err">
+              schema v{info.schema_version} is newer than this build supports — reading best-effort
+            </div>
+          )}
+          {info.source && <div className="text-xs text-muted">{info.source}</div>}
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-muted">
+                <th className="py-1">Role</th>
+                <th>Path</th>
+                <th className="text-right">Size</th>
+                <th>By</th>
+                {verify && <th className="text-right">Verify</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {info.files.map((f) => {
+                const v = verify?.files.find((x) => x.path === f.path);
+                return (
+                  <tr key={f.path} className="border-t border-line/50">
+                    <td className="py-1 font-mono">{f.role}</td>
+                    <td className="font-mono">{f.path}</td>
+                    <td className="text-right">{humanSize(f.size_bytes)}</td>
+                    <td>{f.produced_by || "—"}</td>
+                    {verify && (
+                      <td className="text-right">
+                        {v ? (v.ok ? <span className="text-ok">✓</span> : <span className="text-err">✗</span>) : "—"}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {verify && (
+        <div className={`card text-xs ${verify.ok ? "text-ok" : "text-err"}`}>
+          {verify.ok
+            ? `Integrity OK — ${verify.files.length} file(s) checked, ${verify.untracked} untracked`
+            : `Integrity FAILED — ${verify.failures} file(s) do not match their sha256`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import { Pagers } from "./panels/Pagers";
 import { RadioIDs } from "./panels/RadioIDs";
 import { Scanner } from "./panels/Scanner";
 import { Hunt } from "./panels/Hunt";
+import { Bundles } from "./panels/Bundles";
 import { Settings } from "./panels/Settings";
 import { Spectrum } from "./panels/Spectrum";
 import { Systems } from "./panels/Systems";
@@ -53,6 +54,7 @@ export function App() {
   const setWSStatus = useShared((s) => s.setWSStatus);
   const setHiddenTabs = useShared((s) => s.setHiddenTabs);
   const setCryptolabConsole = useShared((s) => s.setCryptolabConsole);
+  const setBundleEnabled = useShared((s) => s.setBundleEnabled);
   const setSiglabConsole = useShared((s) => s.setSiglabConsole);
   const setRFScopeConsole = useShared((s) => s.setRFScopeConsole);
   const setIDBase = useShared((s) => s.setIDBase);
@@ -116,6 +118,7 @@ export function App() {
         setCryptolabConsole(rt.cryptolab_console === true);
         setSiglabConsole(rt.siglab_console === true);
         setRFScopeConsole(rt.rfscope_console === true);
+        setBundleEnabled(rt.bundle === true);
         setIDBase(rt.id_base === "dec" ? "dec" : "hex");
         setConfigPath(rt.config_path ?? "");
       })
@@ -139,6 +142,7 @@ export function App() {
     setCryptolabConsole,
     setSiglabConsole,
     setRFScopeConsole,
+    setBundleEnabled,
     setConfigPath,
   ]);
 
@@ -178,6 +182,7 @@ export function App() {
           <Route path="/active" element={<Active />} />
           <Route path="/scanner" element={<Scanner />} />
           <Route path="/hunt" element={<Hunt />} />
+          <Route path="/bundles" element={<Bundles />} />
           <Route path="/spectrum" element={<Spectrum />} />
           <Route path="/plots" element={<Plots />} />
           <Route path="/plots/:tab" element={<Plots />} />

--- a/web/src/components/shell/AppShell.test.tsx
+++ b/web/src/components/shell/AppShell.test.tsx
@@ -49,7 +49,12 @@ describe("AppShell navigation", () => {
     // Signal Lab / RF Scope links, shown only when the matching
     // runtime.*_console flag is set).
     for (const item of NAV_ITEMS) {
-      if (item.requiresCryptolab || item.requiresSiglab || item.requiresRFScope)
+      if (
+        item.requiresCryptolab ||
+        item.requiresSiglab ||
+        item.requiresRFScope ||
+        item.requiresBundle
+      )
         continue;
       expect(
         within(drawer).getByText(item.label),

--- a/web/src/nav/registry.ts
+++ b/web/src/nav/registry.ts
@@ -33,6 +33,9 @@ export interface NavItem {
   /** Shown only when the daemon advertises the RF Scope console
    *  (runtime.rfscope_console — the SPA is mounted at /rfscope/). */
   requiresRFScope?: boolean;
+  /** Shown only when the daemon serves the GopherTrunk Bundle endpoints
+   *  (runtime.bundle — part of the standard daemon build). */
+  requiresBundle?: boolean;
 }
 
 export interface NavGroup {
@@ -114,6 +117,13 @@ export const NAV_GROUPS: NavGroup[] = [
       { to: "/settings", label: "Settings", icon: "⚙", primary: true, keywords: ["preferences", "theme", "config"] },
       { to: "/devices", label: "Devices", icon: "⌗", keywords: ["sdr", "pool", "rtl", "dongle"] },
       { to: "/metrics", label: "Metrics", icon: "▰", keywords: ["prometheus", "stats", "graphs"] },
+      {
+        to: "/bundles",
+        label: "Bundles",
+        icon: "📦",
+        requiresBundle: true,
+        keywords: ["bundle", "gtb", "case", "capture", "archive", "manifest", "verify", "sigmf"],
+      },
       { to: "/config/", label: "Config Builder", icon: "🛠", external: true, keywords: ["yaml", "editor"] },
       {
         to: "/siglab/",
@@ -160,6 +170,7 @@ export function useVisibleNavGroups(): NavGroup[] {
   const cryptolabConsole = useShared((s) => s.cryptolabConsole);
   const siglabConsole = useShared((s) => s.siglabConsole);
   const rfscopeConsole = useShared((s) => s.rfscopeConsole);
+  const bundleEnabled = useShared((s) => s.bundleEnabled);
   return useMemo(() => {
     const hidden = new Set(hiddenTabs);
     return NAV_GROUPS.map((g) => ({
@@ -168,10 +179,11 @@ export function useVisibleNavGroups(): NavGroup[] {
         if (i.requiresCryptolab && !cryptolabConsole) return false;
         if (i.requiresSiglab && !siglabConsole) return false;
         if (i.requiresRFScope && !rfscopeConsole) return false;
+        if (i.requiresBundle && !bundleEnabled) return false;
         return i.external || !hidden.has(tabKey(i));
       }),
     })).filter((g) => g.items.length > 0);
-  }, [hiddenTabs, cryptolabConsole, siglabConsole, rfscopeConsole]);
+  }, [hiddenTabs, cryptolabConsole, siglabConsole, rfscopeConsole, bundleEnabled]);
 }
 
 /** Flat visible items (for the command palette and bottom nav). */

--- a/web/src/panels/Bundles.tsx
+++ b/web/src/panels/Bundles.tsx
@@ -1,0 +1,192 @@
+import { useState } from "react";
+
+// Bundle inspects a GopherTrunk Bundle (.gtb.tar.gz) reachable on the daemon
+// host via the /api/v1/bundle/* endpoints (internal/api/handlers_bundle.go):
+// show its manifest + file inventory, verify every file's sha256, and offer a
+// download. Packing runs through the CLI; this is the read/inspect touch point.
+
+interface BundleFile {
+  path: string;
+  role: string;
+  media_type: string;
+  size_bytes: number;
+  sha256: string;
+  produced_by?: string;
+}
+
+interface BundleInfo {
+  name: string;
+  title?: string;
+  format: string;
+  schema_version: number;
+  capture_intent: string;
+  created_at: string;
+  generator: string;
+  protocol?: string;
+  source?: string;
+  future_schema?: boolean;
+  files: BundleFile[];
+  role_counts: Record<string, number>;
+}
+
+interface VerifyFile {
+  path: string;
+  role?: string;
+  ok: boolean;
+  untracked?: boolean;
+  error?: string;
+}
+
+interface VerifyResult {
+  ok: boolean;
+  files: VerifyFile[];
+  failures: number;
+  untracked: number;
+}
+
+function humanSize(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ["KiB", "MiB", "GiB", "TiB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+}
+
+export function Bundles() {
+  const [path, setPath] = useState("");
+  const [info, setInfo] = useState<BundleInfo | null>(null);
+  const [verify, setVerify] = useState<VerifyResult | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onInspect() {
+    if (!path) return;
+    setBusy(true);
+    setErr(null);
+    setVerify(null);
+    try {
+      const r = await fetch(`/api/v1/bundle/info?path=${encodeURIComponent(path)}`);
+      if (!r.ok) throw new Error(await r.text());
+      setInfo((await r.json()) as BundleInfo);
+    } catch (e) {
+      setInfo(null);
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onVerify() {
+    if (!path) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const r = await fetch("/api/v1/bundle/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ path }),
+      });
+      if (!r.ok) throw new Error(await r.text());
+      setVerify((await r.json()) as VerifyResult);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4">
+      <div className="card space-y-2">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex-1">
+            <label className="label">Bundle path (on the daemon host)</label>
+            <input
+              className="input"
+              placeholder="/var/lib/gophertrunk/recordings/mesa-p25.gtb.tar.gz"
+              value={path}
+              onChange={(e) => setPath(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && onInspect()}
+            />
+          </div>
+          <button className="btn" disabled={busy || !path} onClick={onInspect}>
+            {busy ? "Loading…" : "Inspect"}
+          </button>
+          <button className="btn" disabled={busy || !path} onClick={onVerify}>
+            Verify
+          </button>
+          {info && (
+            <a className="btn" href={`/api/v1/bundle/download?path=${encodeURIComponent(path)}`}>
+              Download
+            </a>
+          )}
+        </div>
+        <p className="text-xs text-muted">
+          Reads a GopherTrunk Bundle already on the daemon host. Build one with{" "}
+          <code>gophertrunk capture -bundle …</code> or <code>gophertrunk bundle pack</code>.
+        </p>
+      </div>
+
+      {err && <div className="card text-xs text-err">{err}</div>}
+
+      {info && (
+        <div className="card space-y-3">
+          <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+            <span className="font-semibold">{info.title || info.name}</span>
+            <span className="text-xs text-muted">intent: {info.capture_intent}</span>
+            {info.protocol && <span className="text-xs text-muted">protocol: {info.protocol}</span>}
+            <span className="text-xs text-muted">{info.generator}</span>
+            <span className="text-xs text-muted">{info.created_at}</span>
+          </div>
+          {info.future_schema && (
+            <div className="text-xs text-err">
+              schema v{info.schema_version} is newer than this build supports — reading best-effort
+            </div>
+          )}
+          {info.source && <div className="text-xs text-muted">{info.source}</div>}
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-muted">
+                <th className="py-1">Role</th>
+                <th>Path</th>
+                <th className="text-right">Size</th>
+                <th>By</th>
+                {verify && <th className="text-right">Verify</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {info.files.map((f) => {
+                const v = verify?.files.find((x) => x.path === f.path);
+                return (
+                  <tr key={f.path} className="border-t border-line/50">
+                    <td className="py-1 font-mono">{f.role}</td>
+                    <td className="font-mono">{f.path}</td>
+                    <td className="text-right">{humanSize(f.size_bytes)}</td>
+                    <td>{f.produced_by || "—"}</td>
+                    {verify && (
+                      <td className="text-right">
+                        {v ? (v.ok ? <span className="text-ok">✓</span> : <span className="text-err">✗</span>) : "—"}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {verify && (
+        <div className={`card text-xs ${verify.ok ? "text-ok" : "text-err"}`}>
+          {verify.ok
+            ? `Integrity OK — ${verify.files.length} file(s) checked, ${verify.untracked} untracked`
+            : `Integrity FAILED — ${verify.failures} file(s) do not match their sha256`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/store/shared.ts
+++ b/web/src/store/shared.ts
@@ -78,6 +78,10 @@ interface SharedState {
    *  Gates the RF Scope nav link. */
   rfscopeConsole: boolean;
 
+  /** True when the daemon serves the GopherTrunk Bundle endpoints
+   *  (/api/v1/bundle/*). Gates the Bundles nav item. */
+  bundleEnabled: boolean;
+
   /** Base for rendering identity numbers (WACN, System ID, NAC, RFSS,
    *  Site): "hex" (default, P25 field convention) or "dec". Sourced from
    *  web.id_base config via /api/v1/runtime. */
@@ -112,6 +116,7 @@ interface SharedState {
   setCryptolabConsole(v: boolean): void;
   setSiglabConsole(v: boolean): void;
   setRFScopeConsole(v: boolean): void;
+  setBundleEnabled(v: boolean): void;
   setIDBase(base: "hex" | "dec"): void;
   setConfigPath(path: string | null): void;
   appendEvents(evs: EventDTO[]): void;
@@ -146,6 +151,7 @@ export const useShared = create<SharedState>((set, get) => ({
   cryptolabConsole: false,
   siglabConsole: false,
   rfscopeConsole: false,
+  bundleEnabled: false,
   idBase: "hex",
   configPath: null,
 
@@ -205,6 +211,9 @@ export const useShared = create<SharedState>((set, get) => ({
   },
   setRFScopeConsole(v) {
     set({ rfscopeConsole: v });
+  },
+  setBundleEnabled(v) {
+    set({ bundleEnabled: v });
   },
   setIDBase(base) {
     set({ idBase: base });
@@ -285,6 +294,7 @@ export const useShared = create<SharedState>((set, get) => ({
       cryptolabConsole: false,
       siglabConsole: false,
       rfscopeConsole: false,
+      bundleEnabled: false,
       idBase: "hex",
       configPath: null,
       lastError: null,


### PR DESCRIPTION
## Summary

Today the scanner → SigLab → CryptoLab → config workflow already exists, but each step produces **disconnected loose files** (`.cfile`, `.metadata.json`, `.frames.jsonl`, `survey.json`, result JSON/YAML, hunt CSV/RR…) with no container tying them together and no clean path back to the scanner. This adds the **GopherTrunk Bundle** (`.gtb.tar.gz`): one portable archive that packages a whole SDR case — raw IQ capture, an auto-carved narrowband DDC slice, logs, the SigLab signal analysis, the CryptoLab crypto analysis, and the hunt site/network mapping — under one human-and-machine-readable `MANIFEST.yaml` with per-file SHA-256, so an investigation is shared as a single file and flows **capture → SigLab → CryptoLab → back into `config.yaml`**.

## Changes

- **`internal/gtbundle`** — core reader/writer: YAML manifest (`schema_version`, provenance, role-tagged file inventory with sha256); streaming, deterministic/reproducible tar.gz; path-traversal guards on write **and** extract; typed accessors that reuse the existing models (`siglab.Metadata`/`siglab.Result`/`hunt.DiscoveredSystem`/cryptolab frames) rather than inventing schemas; forward-compatible (unknown roles + future schema tolerated); auto-generated `README.md` inside every bundle. Opt-in SigMF sidecar emitter.
- **`gophertrunk bundle` CLI** — `pack`, `info`/`ls`, `verify`, `extract` (whole or one role), `add`, `commit`. `commit` marks a talkgroup encrypted when the bundle's crypto frames show it under a non-clear ALGID (named via `internal/radio/p25`), then reuses hunt's existing `mergeIntoConfig`.
- **Seams wired to the format** — `capture -bundle` (raw IQ + metadata + carved DDC slice + optional `-sigmf`), `hunt -bundle` (mapping + survey + exports), `hunt -survey-capture … -bundle` (recorded signal + the SigLab/CryptoLab handoff), `analyze -bundle` (reads the capture and its protocol/rate from the bundle, writes the result back in), and `cryptolab -bundle … assess crypto` (tagged build; reads frames, writes the verdict back).
- **Web touch points** — daemon serves `/api/v1/bundle/{info,verify,download}` (confined to `recordings.dir`), surfaced via a `bundle` capability in `GET /api/v1/runtime`; SigLab, CryptoLab, and the main operator console each gain a gated **Bundles** view to inspect the manifest, verify sha256, and download a case.
- **Docs** — `docs/bundle.md` (format, capture-length policy, workflow, subcommands, web endpoints, forward-compat, and the hunt-CSV-"bundle" disambiguation); CLI usage line; `CHANGELOG.md` entry.

Naming note: distinct from hunt's existing CSV "import bundle" — that CSV is stored *inside* a GopherTrunk Bundle as a `mapping-export` artifact; the Go package is `gtbundle` and the archive family id is `gophertrunk-bundle`.

## Test plan

- [x] `make vet test` is green locally (full `go build ./...`, `go vet ./...`, `go test ./...`, plus the `-tags cryptolab` build and tests)
- [x] Added or updated tests where appropriate — gtbundle round-trip/determinism/checksum-tamper/path-traversal/unknown-role/SigMF; CLI crypto-verdict enrichment + from-dir role inference + slice carving; API info/verify/path-confinement handlers; all three web SPA suites (main console 283/283)
- [ ] `make integration` — n/a; the capture/DDC path change is covered by the slice-carving unit test (synthesized IQ), no daemon/replay behavior changed
- [ ] Smoke-tested against real hardware — n/a (no live SDR in CI); exercised end-to-end against synthesized captures: `gen` → `bundle pack`/`capture -bundle` → `analyze -bundle` (P25 locks, result folded back) → `cryptolab -bundle assess crypto` (IV reuse → PARTIAL, verdict folded back) → `bundle verify`/`extract`/`commit -dry-run` (correct talkgroup marked AES-256, CLEAR skipped)

## Breaking changes

None. All additions are new subcommands, new opt-in flags, a new package, and new REST routes; no existing config keys, CLI flags, endpoints, or default behavior change.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [x] Added `docs/bundle.md` and the `gophertrunk bundle` usage line

## Linked issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3mnk5JYQRLCTS3xMV2LkU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3mnk5JYQRLCTS3xMV2LkU)_