### PR TITLE
ccdecoder: suggest dc_avoid when a P25 CC locks at zero-IF but decodes poorly (#402)

### DIFF
--- a/internal/scanner/ccdecoder/decoder.go
+++ b/internal/scanner/ccdecoder/decoder.go
@@ -176,6 +176,25 @@ const iqClipWarnRatio = 0.002
 // dongle's 1-3 kHz crystal error stays under it.
 const defaultCarrierOffsetWarnHz = 4000
 
+// zeroIFHealthWindow is the accumulation window over which the decoder measures
+// the TSBK error rate before deciding a zero-IF lock is decoding poorly enough
+// to suggest dc_avoid (issue #402). ~30 s is long enough to average past
+// acquisition transients and short bursts, so the nudge only fires on a
+// sustained problem. Sized as a field on the Decoder (defaulted from this
+// const) so tests can drive the check without waiting real seconds.
+const zeroIFHealthWindow = 30 * time.Second
+
+// zeroIFHealthMinAttempts is the minimum number of TSBK decode attempts that
+// must accrue within a window before its error rate is trusted — below this the
+// sample is too small to distinguish a bad site from a quiet one. Issue #402.
+const zeroIFHealthMinAttempts = 100
+
+// zeroIFHealthErrPct is the TSBK frame-error-rate threshold (percent) above
+// which a locked, zero-IF control channel is deemed to be suffering the issue
+// #402 on-DC degradation. Clean sites sit near 0%; the reporter's marginal
+// zero-IF site ran ~33%. 20% sits well clear of both. Issue #402.
+const zeroIFHealthErrPct = 20
+
 // carrierOffsetWarnInterval throttles a sustained large-offset WARN, matching the
 // iqClipLog / iqDCLog 30 s cadence so a stuck adjacent-channel lock logs steadily.
 const carrierOffsetWarnInterval = 30 * time.Second
@@ -311,7 +330,21 @@ type Decoder struct {
 	// goroutine). Issue #815.
 	carrierOffsetWarnHz int
 	lastOffsetWarnAt    time.Time
-	systems             map[string]trunking.System
+
+	// zeroIF* back the issue #402 dc_avoid nudge: while locked at zero-IF
+	// (loOffsetHz == 0), the decoder measures the TSBK error rate over
+	// zeroIFHealthWindow and, if it stays high, emits one actionable WARN
+	// pointing the operator at dc_avoid. zeroIFHealthAt/BaseDecoded/BaseFailed
+	// hold the start-of-window snapshot; zeroIFWarned latches the one-shot so
+	// the nudge fires at most once per lock session (re-armed on a fresh
+	// KindCCLocked). All owned by the pump goroutine under mu.
+	zeroIFHealthWindow time.Duration
+	zeroIFHealthAt     time.Time
+	zeroIFBaseDecoded  int64
+	zeroIFBaseFailed   int64
+	zeroIFWarned       bool
+
+	systems map[string]trunking.System
 
 	// ddc decimates the raw SDR IQ stream to pipelineRateHz before
 	// the active pipeline sees a chunk; ddcTarget records the
@@ -475,6 +508,7 @@ func New(opts Options) (*Decoder, error) {
 	if d.carrierOffsetWarnHz <= 0 {
 		d.carrierOffsetWarnHz = defaultCarrierOffsetWarnHz
 	}
+	d.zeroIFHealthWindow = zeroIFHealthWindow
 	d.ddcRec = newDDCRecorder(opts.DDCRecordDir, log)
 	for _, s := range opts.Systems {
 		d.systems[s.Name] = s
@@ -535,6 +569,12 @@ func (d *Decoder) Run(ctx context.Context) error {
 				// only means anything once the FSW is correlating. Payload
 				// shape is per-protocol, so we only read the lock edge.
 				d.locked.Store(true)
+				// Re-arm the issue #402 dc_avoid nudge for this lock session,
+				// so a fresh acquisition gets one clean measurement window.
+				d.mu.Lock()
+				d.zeroIFWarned = false
+				d.zeroIFHealthAt = time.Time{}
+				d.mu.Unlock()
 				continue
 			case events.KindCCLost:
 				d.locked.Store(false)
@@ -723,6 +763,10 @@ func (d *Decoder) clearActiveLocked() {
 		_ = d.active.Close()
 		d.active = nil
 	}
+	// Drop the issue #402 zero-IF health window so the next pipeline
+	// re-baselines against its own fresh TSBK counters instead of
+	// diffing against the torn-down pipeline's totals.
+	d.zeroIFHealthAt = time.Time{}
 	if d.activeAt != "" && d.metrics != nil {
 		d.metrics.ClearIQPowerDbFS(d.activeAt)
 		d.metrics.ClearIQDCRatioDb(d.activeAt)
@@ -817,6 +861,7 @@ func (d *Decoder) pump(iq []complex64) {
 	d.active.Process(d.ddcOut)
 	d.sampleAutotuneLocked()
 	d.checkCarrierOffsetLocked()
+	d.checkZeroIFHealthLocked()
 }
 
 // afcReporter is the optional capability a pipeline exposes when its
@@ -825,6 +870,14 @@ func (d *Decoder) pump(iq []complex64) {
 // average. Pipelines without an AFC stage simply don't implement it.
 type afcReporter interface {
 	AFCOffsetHz() float64
+}
+
+// ccHealthReporter is the optional capability a pipeline exposes when it can
+// report cumulative TSBK decode success/failure counts. Today only the P25
+// Phase 1 pipeline implements it; the decoder uses it to nudge the operator
+// toward dc_avoid when a zero-IF control lock decodes poorly (issue #402).
+type ccHealthReporter interface {
+	TSBKCounts() (decoded, failed int64)
 }
 
 // sampleAutotuneLocked folds the active receiver's residual carrier offset
@@ -891,6 +944,60 @@ func (d *Decoder) checkCarrierOffsetLocked() {
 		"or the receiver oscillator is badly mistuned; verify the reported site against "+
 		"the configured frequency (issue #815)",
 		"offset_hz", total, "freq_hz", d.activeFreqHz, "system", d.activeAt)
+}
+
+// checkZeroIFHealthLocked emits one actionable WARN when a control channel is
+// locked, the receiver is running at zero-IF (no DC-spike-avoidance LO offset
+// applied), and TSBK blocks are failing Viterbi/CRC at a high rate over a full
+// zeroIFHealthWindow. That is the exact signature issue #402 chased for 44
+// comments: the R820T2's on-DC I/Q image and 1-f noise degrade EVM enough to
+// fail the TSBK trailer CRC while NID's stronger BCH survives, so the channel
+// stays locked but decodes poorly. The remedy is dc_avoid — tune the LO
+// off-channel and mix the wanted channel back to baseband, off the DC spur and
+// its image (the same offset tuning SDRTrunk / OP25 do by default). This nudge
+// points a suffering operator straight at that switch instead of leaving it to
+// be rediscovered. Advisory only — it never changes tuning, and it stays silent
+// once dc_avoid is in effect (loOffsetHz != 0). Caller holds d.mu.
+func (d *Decoder) checkZeroIFHealthLocked() {
+	if d.zeroIFWarned || d.loOffsetHz != 0 || !d.locked.Load() {
+		return
+	}
+	rep, ok := d.active.(ccHealthReporter)
+	if !ok {
+		return
+	}
+	decoded, failed := rep.TSBKCounts()
+	now := time.Now()
+	if d.zeroIFHealthAt.IsZero() {
+		// Start of a measurement window: snapshot the baseline and wait.
+		d.zeroIFHealthAt = now
+		d.zeroIFBaseDecoded = decoded
+		d.zeroIFBaseFailed = failed
+		return
+	}
+	if now.Sub(d.zeroIFHealthAt) < d.zeroIFHealthWindow {
+		return
+	}
+	dDecoded := decoded - d.zeroIFBaseDecoded
+	dFailed := failed - d.zeroIFBaseFailed
+	// Roll the window forward regardless of the verdict so the next window
+	// measures fresh traffic.
+	d.zeroIFHealthAt = now
+	d.zeroIFBaseDecoded = decoded
+	d.zeroIFBaseFailed = failed
+	attempts := dDecoded + dFailed
+	if attempts < zeroIFHealthMinAttempts || dFailed*100 < int64(zeroIFHealthErrPct)*attempts {
+		return
+	}
+	d.zeroIFWarned = true
+	d.log.Warn("ccdecoder: control channel locked but TSBK blocks are failing at a high rate "+
+		"while tuned at zero-IF — the issue #402 signature (front-end DC spur / I/Q image "+
+		"degrading the on-DC channel). Set dc_avoid: true on this device to tune the LO "+
+		"off-channel and mix the channel back to baseband; SDRTrunk / OP25 do this by default.",
+		"tsbk_err_pct", int(dFailed*100/attempts),
+		"tsbk_attempts", attempts,
+		"freq_hz", d.activeFreqHz,
+		"system", d.activeAt)
 }
 
 // observeIQPower folds one raw IQ chunk into the per-second power / DC /

--- a/internal/scanner/ccdecoder/decoder_test.go
+++ b/internal/scanner/ccdecoder/decoder_test.go
@@ -2073,6 +2073,91 @@ func TestDecoderWarnsOnLargeCarrierOffset(t *testing.T) {
 	}
 }
 
+// fakeCCHealthPipeline is a ProtocolPipeline that also satisfies the unexported
+// ccHealthReporter capability, reporting mutable cumulative TSBK decoded/failed
+// counts so a test can drive the pump's zero-IF health nudge without a real
+// receiver (issue #402).
+type fakeCCHealthPipeline struct{ decoded, failed int64 }
+
+func (f *fakeCCHealthPipeline) Process([]complex64)           {}
+func (f *fakeCCHealthPipeline) Reset()                        {}
+func (f *fakeCCHealthPipeline) Close() error                  { return nil }
+func (f *fakeCCHealthPipeline) TSBKCounts() (dec, fail int64) { return f.decoded, f.failed }
+
+const dcAvoidNudgeMsg = "Set dc_avoid: true"
+
+// TestDecoderSuggestsDCAvoidOnZeroIFCRCFailures pins the issue #402 nudge: while
+// a control channel is locked at zero-IF (no LO offset applied) and TSBK blocks
+// fail at a high rate over a full window, the decoder must emit exactly one
+// actionable WARN pointing the operator at dc_avoid. It must stay silent when
+// the error rate is low, when dc_avoid is already in effect (loOffsetHz != 0),
+// when too few attempts have accrued, and when the channel isn't locked — so the
+// nudge only fires on the real signature, not on quiet or already-mitigated sites.
+func TestDecoderSuggestsDCAvoidOnZeroIFCRCFailures(t *testing.T) {
+	cases := []struct {
+		name       string
+		decoded    int64
+		failed     int64
+		loOffsetHz float64
+		locked     bool
+		wantWarn   bool
+	}{
+		{"high crc rate at zero-IF", 200, 200, 0, true, true}, // 50% over 400 attempts
+		{"clean at zero-IF", 1000, 5, 0, true, false},         // ~0.5%
+		{"high crc but dc_avoid applied", 200, 200, 240_000, true, false},
+		{"too few attempts", 30, 30, 0, true, false}, // 60 < min 100
+		{"not locked", 200, 200, 0, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			d := newOffsetTestDecoder(t, &buf)
+			// Window 0 so the second check evaluates the accumulated delta at
+			// once, without waiting real seconds.
+			d.zeroIFHealthWindow = 0
+			d.loOffsetHz = tc.loOffsetHz
+			d.locked.Store(tc.locked)
+			fake := &fakeCCHealthPipeline{}
+			d.active = fake
+
+			// First check snapshots the window baseline (counts still zero);
+			// the second sees the window's traffic and decides.
+			d.checkZeroIFHealthLocked()
+			fake.decoded, fake.failed = tc.decoded, tc.failed
+			d.checkZeroIFHealthLocked()
+
+			got := strings.Contains(buf.String(), dcAvoidNudgeMsg)
+			if got != tc.wantWarn {
+				t.Fatalf("nudge emitted = %v, want %v (log: %q)", got, tc.wantWarn, buf.String())
+			}
+			if tc.wantWarn && !strings.Contains(buf.String(), "freq_hz=420075000") {
+				t.Errorf("WARN missing freq_hz=420075000; log: %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestDecoderDCAvoidNudgeFiresOnce pins the one-shot: a persistently-bad zero-IF
+// lock must warn at most once per lock session, not every window.
+func TestDecoderDCAvoidNudgeFiresOnce(t *testing.T) {
+	var buf bytes.Buffer
+	d := newOffsetTestDecoder(t, &buf)
+	d.zeroIFHealthWindow = 0
+	d.locked.Store(true)
+	fake := &fakeCCHealthPipeline{}
+	d.active = fake
+
+	// Three consecutive bad windows; the nudge must appear exactly once.
+	d.checkZeroIFHealthLocked() // baseline
+	for i := 1; i <= 3; i++ {
+		fake.decoded, fake.failed = int64(200*i), int64(200*i)
+		d.checkZeroIFHealthLocked()
+	}
+	if n := strings.Count(buf.String(), dcAvoidNudgeMsg); n != 1 {
+		t.Fatalf("nudge emitted %d times, want exactly 1 (log: %q)", n, buf.String())
+	}
+}
+
 // TestDecoderWarnsOnLargeCarrierOffsetEndToEnd is the end-to-end counterpart of
 // TestDecoderWarnsOnLargeCarrierOffset (which stubs AFCOffsetHz via
 // fakeAFCPipeline). It reproduces issue #815 through the REAL ccdecoder.Decoder:

--- a/internal/scanner/ccdecoder/pipelines.go
+++ b/internal/scanner/ccdecoder/pipelines.go
@@ -390,6 +390,16 @@ func (p *p25Phase1Pipeline) Close() error           { return nil }
 // the unexported afcReporter capability the decoder type-asserts for.
 func (p *p25Phase1Pipeline) AFCOffsetHz() float64 { return p.rx.AFCOffsetHz() }
 
+// TSBKCounts reports the control channel's cumulative decoded and failed
+// (Viterbi + CRC) TSBK block counts. Satisfies the unexported ccHealthReporter
+// capability the decoder type-asserts for, so it can watch the live TSBK error
+// rate and nudge the operator toward dc_avoid when a zero-IF lock decodes
+// poorly (issue #402).
+func (p *p25Phase1Pipeline) TSBKCounts() (decoded, failed int64) {
+	s := p.cc.Stats()
+	return s.TSBKDecoded, s.TSBKTrellisFailed + s.TSBKCRCFailed
+}
+
 // TopologySnapshot surfaces the P25 Phase 1 system topology (identity, primary/
 // secondary control channels, neighbours, band plan) the control channel
 // accumulated from its status broadcasts. Satisfies trunking.TopologyProvider so


### PR DESCRIPTION
Issue #402's root cause — a live control channel tuned at zero-IF, where
the R820T2's on-DC I/Q image and 1-f noise degrade EVM enough to fail TSBK
trailer CRCs while NID's stronger BCH survives — was found and fixed by the
dc_avoid live LO-offset tuning (#618). But dc_avoid is opt-in and there was
no signal pointing a suffering operator at it, which is largely why the
issue ran to 44 comments before the fix was discovered.

Add a proactive diagnostic so the fix is self-announcing. While a control
channel is locked and running at zero-IF (loOffsetHz == 0), the decoder
measures the TSBK Viterbi/CRC error rate over a 30 s window; if it stays at
or above 20% over at least 100 attempts, it emits one actionable WARN naming
dc_avoid as the remedy. It is advisory only (never changes tuning), stays
silent once dc_avoid is in effect, and fires at most once per lock session.

- New optional-capability interface ccHealthReporter (mirrors afcReporter),
  implemented by the P25 Phase 1 pipeline via TSBKCounts().
- Re-arm on a fresh KindCCLocked; the window re-baselines on pipeline swap
  in clearActiveLocked, so a retune never diffs against stale totals. Both
  the pump and event goroutines touch the new fields under d.mu (-race clean).
- Failing-first regression tests covering the positive signature, the
  low-rate / already-mitigated / too-few-attempts / not-locked negatives,
  and the one-shot latch.

Refs #402

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0188eQbit3ufNDHeXanAqFY4