### PR TITLE
Webhook encryption/call_type (#897) + dc_avoid self-suggesting diagnostic (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ for tagged releases.
   `go.mod` and every CI/build workflow.
 
 ### Fixed
+- **Webhook payloads reported every call as `encrypted: false` and gave unit
+  calls no `call_type`.** On systems whose encryption only resolves on the
+  traffic channel (P25 Phase 2 compressed grants, Phase 1 LDU2 Encryption Sync),
+  the recorder built its `CallComplete` from the grant-time session snapshot,
+  which never saw the mid-call update — so the webhook said `false` (and never
+  emitted `algorithm_id`/`key_id`) even though `/api/v1/calls/history`, fed from
+  the engine-backfilled `CallEnd` grant, correctly showed the call encrypted. The
+  recorder now mirrors the mid-call encryption / source facts onto its session
+  grant, so every broadcast backend agrees with the call log. A new `call_type`
+  field (`group` / `unit` / `data`, always emitted) lets a consumer tell a unit
+  call — whose `talkgroup` carries a destination RID, not a talkgroup — apart from
+  a group call, and unit-call `source` now populates when the RID resolves in-call
+  (issue #897).
 - **SoapyRemote stream arguments smuggled through `sdr.soapy_remote[].args`
   were silently ignored.** Everything in `args` is passed to the remote
   SoapySDR `make()` call, but GopherTrunk builds the `SETUP_STREAM` frame
@@ -73,6 +86,13 @@ for tagged releases.
   self-heals instead of quietly stopping.
 
 ### Added
+- **`dc_avoid` self-suggesting diagnostic on a poorly-decoding zero-IF control
+  channel.** When a P25 control channel is locked but running at zero-IF (no
+  DC-spike-avoidance LO offset) and its TSBK blocks are failing Viterbi/CRC at a
+  high rate, the daemon now emits one advisory WARN pointing the operator at
+  `dc_avoid: true` — the exact remedy for the on-DC front-end I/Q image / 1-f
+  degradation. Advisory only (it never changes tuning), silent once `dc_avoid` is
+  in effect, and fires at most once per lock session (issue #402).
 - **GopherTrunk Bundle (`.gtb.tar.gz`) — the capture-to-analysis case format.**
   A single portable archive that packages one SDR case — the raw IQ capture, an
   auto-carved narrowband DDC slice, logs, the SigLab signal analysis, the

--- a/internal/broadcast/broadcast.go
+++ b/internal/broadcast/broadcast.go
@@ -59,8 +59,15 @@ type Call struct {
 	// before the call ended. Aggregators that accept the fields can
 	// thread them into their API payload; aggregators that don't will
 	// just ignore them.
-	AlgorithmID   uint8
-	KeyID         uint16
+	AlgorithmID uint8
+	KeyID       uint16
+	// Individual marks a unit-to-unit / individual call, whose Talkgroup
+	// field carries a destination radio ID rather than a talkgroup, and
+	// DataCall a data (non-voice) grant. They let a metadata sink emit a
+	// call_type so a downstream consumer doesn't mistake a unit's target RID
+	// for a talkgroup (issue #897). Both false for an ordinary group call.
+	Individual    bool
+	DataCall      bool
 	Emergency     bool
 	PatchedGroups []uint32
 	StartedAt     time.Time
@@ -149,6 +156,8 @@ func callFromEvent(cc trunking.CallComplete) *Call {
 		Encrypted:     cc.Grant.Encrypted,
 		AlgorithmID:   cc.Grant.AlgorithmID,
 		KeyID:         cc.Grant.KeyID,
+		Individual:    cc.Grant.Individual,
+		DataCall:      cc.Grant.DataCall,
 		Emergency:     cc.Grant.Emergency,
 		PatchedGroups: cc.Grant.PatchedGroups,
 		StartedAt:     cc.StartedAt,

--- a/internal/broadcast/webhook.go
+++ b/internal/broadcast/webhook.go
@@ -84,14 +84,32 @@ func NewWebhook(cfg WebhookConfig, hc *http.Client) (Backend, error) {
 
 func (b *webhookBackend) Name() string { return b.name }
 
+// callType classifies a call for the webhook payload so a consumer can tell a
+// group call from a unit (individual) call — otherwise a unit call's
+// destination RID in the talkgroup field reads as a talkgroup (issue #897).
+func callType(c *Call) string {
+	switch {
+	case c.DataCall:
+		return "data"
+	case c.Individual:
+		return "unit"
+	default:
+		return "group"
+	}
+}
+
 // webhookPayload is the stable JSON schema POSTed for each call. Fields
 // that don't apply to a given call (site identity on non-P25, encryption
 // params on clear calls, audio when not requested) are omitted via
 // omitempty so a consumer can rely on presence meaning "known".
 type webhookPayload struct {
-	Event         string   `json:"event"` // always "call"
-	System        string   `json:"system"`
-	Protocol      string   `json:"protocol"`
+	Event    string `json:"event"` // always "call"
+	System   string `json:"system"`
+	Protocol string `json:"protocol"`
+	// CallType is "group", "unit" (individual / unit-to-unit — Talkgroup
+	// carries a destination RID, not a talkgroup), or "data". Always emitted
+	// so a consumer can classify Talkgroup without guessing (issue #897).
+	CallType      string   `json:"call_type"`
 	Talkgroup     uint32   `json:"talkgroup"`
 	TalkgroupID   string   `json:"talkgroup_label,omitempty"`
 	Source        uint32   `json:"source,omitempty"`
@@ -122,6 +140,7 @@ func (b *webhookBackend) Send(ctx context.Context, c *Call) error {
 		Event:         "call",
 		System:        c.System,
 		Protocol:      c.Protocol,
+		CallType:      callType(c),
 		Talkgroup:     c.Talkgroup,
 		TalkgroupID:   c.TalkgroupLabel,
 		Source:        c.Source,

--- a/internal/broadcast/webhook_test.go
+++ b/internal/broadcast/webhook_test.go
@@ -81,6 +81,71 @@ func TestWebhookPostsJSONMetadata(t *testing.T) {
 	}
 }
 
+// TestWebhookCallTypeAndEncrypted pins issue #897: the payload must carry a
+// call_type so a unit (individual) call's destination RID in the talkgroup
+// field isn't mistaken for a talkgroup, and it must faithfully report the
+// call's encryption state (the serializer used to hardcode neither, so unit
+// RIDs looked like talkgroups and every call read encrypted=false).
+func TestWebhookCallTypeAndEncrypted(t *testing.T) {
+	send := func(t *testing.T, mutate func(*Call)) webhookPayload {
+		t.Helper()
+		var got webhookPayload
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Errorf("decode body: %v", err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+		be, err := NewWebhook(WebhookConfig{URL: srv.URL}, srv.Client())
+		if err != nil {
+			t.Fatalf("NewWebhook: %v", err)
+		}
+		c := testCall(t)
+		mutate(c)
+		if err := be.Send(context.Background(), c); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+		return got
+	}
+
+	t.Run("group call", func(t *testing.T) {
+		got := send(t, func(c *Call) {})
+		if got.CallType != "group" {
+			t.Errorf("call_type = %q, want group", got.CallType)
+		}
+		if got.Encrypted {
+			t.Error("clear call reported encrypted")
+		}
+	})
+
+	t.Run("unit call surfaces call_type and encryption", func(t *testing.T) {
+		got := send(t, func(c *Call) {
+			c.Individual = true
+			c.Talkgroup = 206606 // a destination RID, not a talkgroup
+			c.Encrypted = true
+			c.AlgorithmID = 0x84
+			c.KeyID = 0x1234
+		})
+		if got.CallType != "unit" {
+			t.Errorf("call_type = %q, want unit", got.CallType)
+		}
+		if !got.Encrypted {
+			t.Error("encrypted call reported clear")
+		}
+		if got.AlgorithmID != 0x84 || got.KeyID != 0x1234 {
+			t.Errorf("alg/key not surfaced: alg=0x%02X key=0x%04X", got.AlgorithmID, got.KeyID)
+		}
+	})
+
+	t.Run("data call", func(t *testing.T) {
+		got := send(t, func(c *Call) { c.DataCall = true })
+		if got.CallType != "data" {
+			t.Errorf("call_type = %q, want data", got.CallType)
+		}
+	})
+}
+
 func TestWebhookIncludeAudioEmbedsMP3(t *testing.T) {
 	var got webhookPayload
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -438,13 +438,16 @@ func (r *Recorder) Run(ctx context.Context) error {
 				// In-call Encryption Sync recovered (P25 Phase 1 LDU2).
 				// AlgorithmID 0x80 is CLEAR; anything else is encrypted.
 				if ce, ok := ev.Payload.(trunking.CallEncryption); ok {
-					r.handleEncryptionUpdate(ce.DeviceSerial, ce.AlgorithmID != algorithmClear)
+					enc := ce.AlgorithmID != algorithmClear
+					r.backfillSessionGrant(ce.DeviceSerial, enc, ce.AlgorithmID, ce.KeyID, 0)
+					r.handleEncryptionUpdate(ce.DeviceSerial, enc)
 				}
 			case events.KindCallSourceUpdate:
 				// In-call source/encryption resolved on the traffic channel
 				// (e.g. a P25 Phase 2 compressed grant). Carries an explicit
 				// encrypted flag.
 				if su, ok := ev.Payload.(trunking.CallSourceUpdate); ok {
+					r.backfillSessionGrant(su.DeviceSerial, su.Encrypted, 0, 0, su.SourceID)
 					r.handleEncryptionUpdate(su.DeviceSerial, su.Encrypted)
 				}
 			}
@@ -678,6 +681,39 @@ func (r *Recorder) handleStart(cs trunking.CallStart) {
 // call advertises; anything else means the call is encrypted. Mirrors
 // p25.AlgorithmClear, kept local to avoid a radio-package import.
 const algorithmClear uint8 = 0x80
+
+// backfillSessionGrant mirrors onto the recorder's stored grant the encryption
+// and source facts the engine recovers mid-call — a P25 Phase 1 LDU2 Encryption
+// Sync or a Phase 2 traffic-channel GROUP_VOICE_CHANNEL_USER PDU — and backfills
+// onto the live ActiveCall. Without this the CallComplete the recorder later
+// publishes (built from the session's grant, see finalizeLocked) carries the
+// grant-time snapshot, so a call whose encryption only resolves on the traffic
+// channel broadcasts as encrypted=false even though the call log — fed from the
+// engine-backfilled CallEnd grant — correctly shows it encrypted (issue #897).
+// Encryption is sticky-true and never cleared here; alg/key are recorded only
+// for an encrypted call; a zero source is ignored so a later clear-source update
+// can't erase a known RID. No-op when no session is open for the device. Caller
+// must not hold r.mu.
+func (r *Recorder) backfillSessionGrant(deviceSerial string, encrypted bool, algID uint8, keyID uint16, sourceID uint32) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	s, ok := r.sessions[deviceSerial]
+	if !ok {
+		return
+	}
+	if encrypted {
+		s.cs.Grant.Encrypted = true
+		if algID != 0 {
+			s.cs.Grant.AlgorithmID = algID
+		}
+		if keyID != 0 {
+			s.cs.Grant.KeyID = keyID
+		}
+	}
+	if sourceID != 0 {
+		s.cs.Grant.SourceID = sourceID
+	}
+}
 
 // handleEncryptionUpdate aborts an in-flight recording when SkipEncrypted
 // is set and a call is discovered to be encrypted mid-stream — e.g. a P25

--- a/internal/voice/recorder_test.go
+++ b/internal/voice/recorder_test.go
@@ -1346,6 +1346,105 @@ func TestRecorderRecordsEncryptedWhenSkipDisabled(t *testing.T) {
 	}
 }
 
+// TestRecorderBackfillsMidCallEncryptionIntoCallComplete pins issue #897: when a
+// call's encryption / source only resolves on the traffic channel (a P25 Phase 2
+// compressed grant arrives src=0 + enc=false, or a Phase 1 LDU2 Encryption Sync
+// lands after the grant), the CallComplete the recorder publishes — the payload
+// the webhook / upload feeds serialize — must carry the updated encryption state
+// and source RID, not the stale grant-time snapshot. Runs with SkipEncrypted off
+// so the call records instead of aborting.
+func TestRecorderBackfillsMidCallEncryptionIntoCallComplete(t *testing.T) {
+	sourceUpdate := func(dev string) events.Event {
+		return events.Event{Kind: events.KindCallSourceUpdate, Payload: trunking.CallSourceUpdate{
+			DeviceSerial: dev, SourceID: 42, Encrypted: true, At: time.Now(),
+		}}
+	}
+	encSync := func(dev string) events.Event {
+		return events.Event{Kind: events.KindCallEncryption, Payload: trunking.CallEncryption{
+			DeviceSerial: dev, AlgorithmID: 0x84, KeyID: 0x1234, At: time.Now(),
+		}}
+	}
+
+	cases := []struct {
+		name       string
+		update     func(string) events.Event
+		wantSource uint32
+		wantAlg    uint8
+		wantKey    uint16
+	}{
+		{"phase2 source update", sourceUpdate, 42, 0, 0},
+		{"phase1 encryption sync", encSync, 0, 0x84, 0x1234},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r, bus, _ := mkRecorder(t, false) // SkipEncrypted off
+			defer r.Close()
+			defer bus.Close()
+
+			watch := bus.Subscribe()
+			defer watch.Close()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go r.Run(ctx)
+
+			// Grant arrives CLEAR — encryption is not yet known at grant time.
+			cs := trunking.CallStart{
+				Grant:        trunking.Grant{System: "S", Protocol: "p25", GroupID: 30301, SourceID: 0, Encrypted: false},
+				Talkgroup:    &trunking.TalkGroup{ID: 30301, AlphaTag: "EMS", Record: true},
+				DeviceSerial: "VOICE-1",
+				StartedAt:    time.Now(),
+			}
+			bus.Publish(events.Event{Kind: events.KindCallStart, Payload: cs})
+			waitSession(t, r, "VOICE-1", true)
+			if err := r.WritePCM("VOICE-1", make([]int16, 1600)); err != nil {
+				t.Fatal(err)
+			}
+
+			// Encryption / source resolves mid-call on the traffic channel.
+			bus.Publish(tc.update("VOICE-1"))
+			time.Sleep(30 * time.Millisecond) // let the update land before end
+
+			// End the call carrying the ORIGINAL clear grant, so the only path
+			// to an encrypted CallComplete is the recorder's session backfill.
+			bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+				Grant: cs.Grant, Talkgroup: cs.Talkgroup, DeviceSerial: "VOICE-1",
+				StartedAt: cs.StartedAt, EndedAt: cs.StartedAt.Add(2 * time.Second),
+				Reason: trunking.EndReasonNormal,
+			}})
+
+			var cc trunking.CallComplete
+			deadline := time.After(2 * time.Second)
+			for {
+				done := false
+				select {
+				case ev := <-watch.C:
+					if ev.Kind == events.KindCallComplete {
+						cc = ev.Payload.(trunking.CallComplete)
+						done = true
+					}
+				case <-deadline:
+					t.Fatal("timed out waiting for CallComplete")
+				}
+				if done {
+					break
+				}
+			}
+
+			if !cc.Grant.Encrypted {
+				t.Error("CallComplete.Grant.Encrypted = false, want true (mid-call update not backfilled)")
+			}
+			if cc.Grant.SourceID != tc.wantSource {
+				t.Errorf("CallComplete.Grant.SourceID = %d, want %d", cc.Grant.SourceID, tc.wantSource)
+			}
+			if cc.Grant.AlgorithmID != tc.wantAlg || cc.Grant.KeyID != tc.wantKey {
+				t.Errorf("alg/key = 0x%02X/0x%04X, want 0x%02X/0x%04X",
+					cc.Grant.AlgorithmID, cc.Grant.KeyID, tc.wantAlg, tc.wantKey)
+			}
+		})
+	}
+}
+
 // wavFiles returns every .wav path under root.
 func wavFiles(t *testing.T, root string) []string {
 	t.Helper()


### PR DESCRIPTION
## Summary

Two independent, self-contained fixes from an open-issue review, each with a failing-first regression test. Neither touches the DSP/RF decode path, so both are reproducible and verifiable without capture files or hardware.

- **#897** — webhook payloads reported every call as `encrypted: false` and gave unit calls no way to be told apart from group calls.
- **#402** — the verified root-cause fix (`dc_avoid` live LO-offset tuning) is opt-in, and nothing pointed a suffering operator at it; this adds a diagnostic that makes the fix self-announcing.

## Changes

**#897 — broadcast / recorder (`0336f34`)**
- `internal/voice/recorder.go`: on a mid-call `KindCallEncryption` / `KindCallSourceUpdate`, the recorder now mirrors the recovered encryption state, alg/key, and resolved source RID onto its stored session grant (`backfillSessionGrant`). Previously the `CallComplete` was built from the grant-time session snapshot, so a call whose encryption only resolves on the traffic channel (P25 Phase 2 compressed grants, Phase 1 LDU2 Encryption Sync) broadcast as `encrypted: false` even though `/api/v1/calls/history` — fed from the engine-backfilled `CallEnd` grant — showed it encrypted.
- `internal/broadcast/{broadcast,webhook}.go`: add a `call_type` field (`group` / `unit` / `data`, always emitted) derived from `Grant.Individual` / `Grant.DataCall`, so a consumer can classify the `talkgroup` value instead of treating a unit call's destination RID as a talkgroup. The source backfill above also populates `source` on unit calls whose RID resolves in-call.

**#402 — ccdecoder (`c42d847`)**
- `internal/scanner/ccdecoder/decoder.go`: `checkZeroIFHealthLocked` emits one advisory WARN when a P25 control channel is locked and running at zero-IF (`loOffsetHz == 0`) with a sustained TSBK error rate ≥ 20% over ≥ 100 attempts, pointing the operator at `dc_avoid: true`. Advisory only (never changes tuning), silent once `dc_avoid` is in effect, one-shot per lock session.
- New optional-capability interface `ccHealthReporter` (mirrors the existing `afcReporter`), implemented by the P25 Phase 1 pipeline via `TSBKCounts()`.

**Docs (`f9e4f05`)**
- `CHANGELOG.md`: `[Unreleased]` bullets for both changes.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — not run; neither change is exercised by the daemon/replay integration path (the webhook change is covered by unit tests against `httptest`, the ccdecoder nudge by direct unit tests)
- [x] Added tests where appropriate — all confirmed failing-first (reverting each fix reproduces the reported symptom):
  - `TestRecorderBackfillsMidCallEncryptionIntoCallComplete` (Phase 2 source-update + Phase 1 encryption-sync paths reach `CallComplete` with the updated grant)
  - `TestWebhookCallTypeAndEncrypted` (call_type for group/unit/data + encryption/alg/key passthrough)
  - `TestDecoderSuggestsDCAvoidOnZeroIFCRCFailures`, `TestDecoderDCAvoidNudgeFiresOnce` (positive signature + the low-rate / already-mitigated / too-few-attempts / not-locked negatives + one-shot latch); `-race` clean
- [ ] No SDR/USB/vocoder hardware code changed, so no hardware smoke test

## Breaking changes

None. The webhook `call_type` field is additive (always emitted; existing consumers ignore unknown fields), and the encryption/source backfill only makes the webhook payload agree with the call log it already disagreed with. The `dc_avoid` nudge is a log line only — it changes no tuning or config behaviour and `dc_avoid` remains opt-in.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (both are user-visible)
- [ ] No `README.md` / `docs/` change needed — `dc_avoid` and the webhook are already documented; this only adds a field and a diagnostic

## Linked issues

Refs #897, Refs #402

<!-- Both use Refs rather than Closes: #402 stays open until the CBD/RTL residual is verified per the issue-closing policy, and #897 until the reporter confirms a fresh webhook capture. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0188eQbit3ufNDHeXanAqFY4)_