### PR TITLE
web: stop the service worker shadowing sibling-console tabs (blank RF Scope / Signal Lab)

### DIFF
--- a/web/src/lib/swDenylist.test.ts
+++ b/web/src/lib/swDenylist.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { SW_NAVIGATE_FALLBACK_DENYLIST } from "./swDenylist";
+import { NAV_ITEMS } from "../nav/registry";
+
+// Every `external` nav item is a daemon-served sibling console living at a
+// subpath under the main console's service-worker "/" scope, opened in a new
+// tab via a plain <a href> navigation. If such a path is not on the SW's
+// navigateFallbackDenylist, the SW answers the navigation with our own cached
+// index.html and the console opens blank (the RFScope/SigLab blank-page bug;
+// previously seen and fixed for /config/). This pins that invariant so adding
+// a new external console without denylisting it fails CI.
+describe("SW navigateFallbackDenylist", () => {
+  it("denylists every external console path so the SW doesn't shadow it", () => {
+    const external = NAV_ITEMS.filter((i) => i.external);
+    expect(external.length).toBeGreaterThan(0);
+    for (const item of external) {
+      const matched = SW_NAVIGATE_FALLBACK_DENYLIST.some((re) => re.test(item.to));
+      expect(matched, `${item.to} must be on the SW navigateFallbackDenylist`).toBe(true);
+    }
+  });
+});

--- a/web/src/lib/swDenylist.ts
+++ b/web/src/lib/swDenylist.ts
@@ -1,0 +1,16 @@
+// Paths the main console's service worker must NOT answer with its own
+// index.html navigateFallback. Every daemon-mounted sibling console
+// (Config Builder, Signal Lab, RF Scope, Crypto Lab) lives at a subpath under
+// the service worker's "/" scope. Without an entry here the SW shadows the
+// new-tab navigation to that subpath with our own cached index.html; the main
+// SPA then boots at a path React Router has no route for and the tab opens
+// blank. Keep this in sync with the external console links in
+// src/nav/registry.ts (enforced by swDenylist.test.ts).
+export const SW_NAVIGATE_FALLBACK_DENYLIST: RegExp[] = [
+  /^\/api\//,
+  /^\/metrics/,
+  /^\/config\//,
+  /^\/siglab\//,
+  /^\/rfscope\//,
+  /^\/cryptolab\//,
+];

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
+import { SW_NAVIGATE_FALLBACK_DENYLIST } from "./src/lib/swDenylist";
 
 // Vite bundles every dependency listed in package.json into the
 // shipped `dist/`. The output has no runtime Node dependency and
@@ -53,11 +54,12 @@ export default defineConfig({
         // works without a network round-trip for the assets).
         globPatterns: ["**/*.{js,css,html,svg,png,ico,webmanifest}"],
         // API responses are always fetched live; the SW never caches
-        // /api/* or /metrics responses. The Config Builder SPA mounted at
-        // /config/ on the daemon is also denied so this console's SW
-        // (scope "/") doesn't shadow its navigations with our own
-        // index.html — otherwise the Config Builder tab opens blank.
-        navigateFallbackDenylist: [/^\/api\//, /^\/metrics/, /^\/config\//],
+        // /api/* or /metrics responses. The daemon-mounted sibling consoles
+        // (Config Builder /config/, Signal Lab /siglab/, RF Scope /rfscope/,
+        // Crypto Lab /cryptolab/) are also denied so this console's SW
+        // (scope "/") doesn't shadow their navigations with our own
+        // index.html — otherwise those tabs open blank. See swDenylist.ts.
+        navigateFallbackDenylist: SW_NAVIGATE_FALLBACK_DENYLIST,
       },
       devOptions: { enabled: false },
     }),


### PR DESCRIPTION
The dashboard's Signal Lab, RF Scope and Crypto Lab links are external
new-tab navigations to /siglab/, /rfscope/ and /cryptolab/ — all subpaths
under the main console PWA's service-worker "/" scope. Workbox's
navigateFallback answered those navigations with our own cached index.html,
so the main SPA booted at a path React Router has no route for and the tab
opened blank. Only /config/ was on the navigateFallbackDenylist (fixed once
before, with the same symptom); the other three consoles were never added.

Extract the denylist to a shared SW_NAVIGATE_FALLBACK_DENYLIST constant that
also covers /siglab/, /rfscope/ and /cryptolab/, and add a regression test
tying it to the external nav items so a new console can't be added without
denylisting it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HgYcZfhEyJya9Y9hNrwx3e