### PR TITLE
voice/p25p1: channel-select the wideband voice tap to fix short/garbled recordings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ for tagged releases.
   `go.mod` and every CI/build workflow.
 
 ### Fixed
+- **Wideband P25 Phase 1 voice recordings came out short and garbled next to
+  SDRTrunk** — on a busy multi-channel site a wideband DDC voice tap decoded
+  clean *foreign* talkgroups mid-call (e.g. a 16 s over recorded as ~9 s of the
+  wanted call spliced with dropped windows). The tap delivered a stream
+  band-limited only to its ±24 kHz output Nyquist, and the voice chain's
+  front end was a pass-through no-op at that rate — so the whole span, including
+  the ±12.5 kHz adjacent channels, reached the receiver's FM discriminator. The
+  capture effect then locked onto a stronger neighbour during the wanted talker's
+  syllable gaps: those LDUs decoded as another talkgroup and were gated out
+  (short recording), while the neighbour's energy raised in-band interference on
+  the frames that *were* kept (garbled audio). The chain now channel-selects each
+  wideband tap to ±6.25 kHz — half the P25 channel spacing — before the
+  discriminator, dropping an adjacent channel ~80 dB while passing the wanted
+  C4FM flat. The dedicated-tuner path (which already band-limits as it decimates)
+  is unchanged. For diagnosing any residual truncation, the `composer: p25p1
+  decode quality` log gains a `gated_ldus` count (delivered LDUs the talkgroup
+  gate dropped from the WAV), and the recorder now logs when a decoded call's
+  audio runs materially shorter than its wall-clock span.
 - **Webhook payloads reported every call as `encrypted: false` and gave unit
   calls no `call_type`.** On systems whose encryption only resolves on the
   traffic channel (P25 Phase 2 compressed grants, Phase 1 LDU2 Encryption Sync),

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -26,6 +26,45 @@ const p25p1VoiceIntermediateHz = 48_000
 // per TIA-102.BAAA. It calibrates the receiver's 4-level slicer.
 const p25p1DeviationHz = 1800.0
 
+// p25p1ChannelSelectHz caps the voice front-end channel filter at half the
+// 12.5 kHz P25 channel spacing. A wideband DDC voice tap hands the chain a
+// stream already at the intermediate rate but band-limited only to the tap's
+// output Nyquist (~±24 kHz), NOT to a single 12.5 kHz channel — so the old
+// pass-through front end fed that whole ±24 kHz span into the receiver's FM
+// discriminator, where the capture effect locks onto a stronger ±12.5 kHz
+// neighbour during the wanted talker's syllable gaps. That decodes foreign
+// talkgroups (gated out → short recordings) and raises in-band interference
+// (garbled audio) versus SDRTrunk's per-channel channelizer. Filtering to
+// ±6.25 kHz drops an adjacent channel centred at ±12.5 kHz deep into the
+// 81-tap front end's stopband (~>80 dB) while the wanted C4FM (Carson
+// bandwidth ≈ ±4.2 kHz) passes flat.
+const p25p1ChannelSelectHz = 6250.0
+
+// newP25P1VoiceFrontEnd builds the channel-select + decimation front end for
+// the P25 Phase 1 voice chain. On the dedicated-tuner path (iqHz well above
+// the intermediate rate) the decimating FIR already band-limits to the
+// operator voice bandwidth as it decimates, so it is left unchanged. On the
+// pass-through path (a wideband DDC tap already at the intermediate rate,
+// decim==1) the old front end applied NO filter at all; this now channel-
+// selects to ±min(bw, p25p1ChannelSelectHz) before the receiver's FM
+// discriminator so adjacent channels can't leak in. Factored out so the
+// selectivity is unit-testable without the full IQ → LDU pipeline.
+func newP25P1VoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
+	chanBW := float64(bw)
+	// decim mirrors newDecimatingFIR's own computation: decim==1 is the
+	// pass-through (wideband tap / pre-channelised) case that historically
+	// skipped filtering entirely.
+	decim := int(math.Round(iqHz)) / p25p1VoiceIntermediateHz
+	filterAtUnity := false
+	if decim <= 1 {
+		filterAtUnity = true
+		if chanBW > p25p1ChannelSelectHz {
+			chanBW = p25p1ChannelSelectHz
+		}
+	}
+	return newDecimatingFIR(iqHz, p25p1VoiceIntermediateHz, chanBW, filterAtUnity)
+}
+
 // resolveP25Phase1DemodMode parses the system-level
 // p25_phase1_demod_mode string carried on the grant into a receiver
 // mode. Unknown values warn-log and fall back to C4FM so a typo doesn't
@@ -74,9 +113,13 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	// of the result. At 2.4 MS/s that wasted ~194M MACs/sec per voice call
 	// and starved the live IQ consumer until the SDR dropped chunks. Same
 	// coefficients and same kept samples as before, so the decode is
-	// byte-for-byte unchanged — only the wasted work is removed. decim==1
-	// (a source already at the intermediate rate) is a pass-through no-op.
-	fe := newDecimatingFIR(iqHz, p25p1VoiceIntermediateHz, float64(c.bw), false)
+	// byte-for-byte unchanged — only the wasted work is removed. decim==1 (a
+	// source already at the intermediate rate — a wideband DDC voice tap) is
+	// NOT a pass-through: it still channel-selects to a single P25 channel
+	// before the FM discriminator (see newP25P1VoiceFrontEnd /
+	// p25p1ChannelSelectHz) so an adjacent ±12.5 kHz channel can't capture the
+	// demod during the wanted talker's gaps.
+	fe := newP25P1VoiceFrontEnd(iqHz, c.bw)
 	symbolHz := fe.OutRateHz()
 
 	mode := c.resolveP25Phase1DemodMode(serial, demodMode)
@@ -184,6 +227,14 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 	var (
 		uncorrectableLDUs atomic.Uint64
 		corrErrBits       atomic.Uint64
+		// gatedLDUs counts LDUs whose audio was dropped by the talkgroup gate
+		// (the in-band talkgroup didn't match the grant). It is the direct
+		// measure of the audio the recording is missing: `frames` counts LDUs
+		// delivered, `gatedLDUs` counts how many of those never reached the
+		// WAV, so `frames - gatedLDUs` ≈ the recorded length in LDUs. A high
+		// value on a call whose wall-clock ran long is the fingerprint of
+		// adjacent-channel bleed on a wideband tap.
+		gatedLDUs atomic.Uint64
 	)
 	// Outer-RS telemetry for the Link Control (LDU1) and Encryption Sync
 	// (LDU2) words. A rising RS-uncorrectable rate is the measurable
@@ -265,6 +316,9 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 				}
 			}
 			write := bt.onVoice(tg)
+			if !write {
+				gatedLDUs.Add(1)
+			}
 
 			if write && rs != nil {
 				fs, frameErrs, errBits, err := phase1.ExtractVoiceFramesDetailed(ldu)
@@ -422,6 +476,7 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 		c.log.Info("composer: p25p1 decode quality",
 			"serial", serial, "demod_mode", mode,
 			"ldus", n, "uncorrectable_ldus", uncorrectableLDUs.Load(),
+			"gated_ldus", gatedLDUs.Load(),
 			"corrected_bit_errs", corrErrBits.Load(),
 			"lc_rs_uncorrectable", lcRSUncorrectable.Load(),
 			"ess_rs_uncorrectable", essRSUncorrectable.Load())

--- a/internal/voice/composer/p25p1_voice_test.go
+++ b/internal/voice/composer/p25p1_voice_test.go
@@ -43,12 +43,19 @@ func p25p1VoiceInfo(seed int) []byte {
 // LDU1s preceded by a clock-settling lead-in. want holds every IMBE
 // frame it carries, in transmission order.
 func buildP25P1VoiceStream(t *testing.T, ldus int) (dibits []uint8, want [][]byte) {
+	return buildP25P1VoiceStreamSeed(t, ldus, 0)
+}
+
+// buildP25P1VoiceStreamSeed is buildP25P1VoiceStream with a seed offset so a
+// test can build two streams with DISTINCT voice frames (e.g. a wanted call
+// and an adjacent-channel neighbour) and tell which one the chain decoded.
+func buildP25P1VoiceStreamSeed(t *testing.T, ldus, seed0 int) (dibits []uint8, want [][]byte) {
 	t.Helper()
 	dibits = make([]uint8, 400)
 	for i := range dibits {
 		dibits[i] = uint8(i % 4)
 	}
-	frame := 0
+	frame := seed0
 	for l := 0; l < ldus; l++ {
 		var voice [phase1.LDUVoiceSubframeCount][]byte
 		for s := range voice {
@@ -235,6 +242,141 @@ func TestComposerP25Phase1VoiceChainDecodesWidebandIQ(t *testing.T) {
 	if matches < framesPerLDU {
 		t.Errorf("wideband path: only %d of %d captured frames round-tripped; want at least one LDU (%d)",
 			matches, len(got), framesPerLDU)
+	}
+}
+
+// TestP25P1VoiceFrontEndRejectsAdjacentChannel pins the channel selectivity
+// of the wideband voice tap's front end: an adjacent P25 channel centred at
+// ±12.5 kHz must be strongly rejected before the receiver's FM discriminator.
+// The old pass-through front end (decim==1) applied NO filter, so a ±12.5 kHz
+// neighbour reached the discriminator at full amplitude and the capture effect
+// decoded it as a foreign talkgroup — the root cause of short/garbled wideband
+// recordings. Fails first: pass-through leaves the neighbour at ~0 dB.
+func TestP25P1VoiceFrontEndRejectsAdjacentChannel(t *testing.T) {
+	const (
+		fs        = float64(p25p1VoiceIntermediateHz) // 48 kHz wideband tap output → decim==1
+		bw        = uint32(12_500)                    // default operator VoiceBandwidthHz
+		adjOffset = 12_500.0                          // adjacent P25 channel spacing
+		nSamples  = 24_000
+	)
+	// Amplitude at DC (wanted channel centre) vs at +12.5 kHz (adjacent centre).
+	// A fresh front end per tone keeps the filter history from carrying over.
+	respAt := func(offsetHz float64) float64 {
+		fe := newP25P1VoiceFrontEnd(fs, bw)
+		in := make([]complex64, nSamples)
+		for i := range in {
+			th := 2 * math.Pi * offsetHz * float64(i) / fs
+			in[i] = complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		}
+		out := fe.Process(nil, in)
+		// Peak magnitude over the settled tail (skip the filter warm-up).
+		var peak float64
+		for _, s := range out[len(out)/2:] {
+			if m := math.Hypot(float64(real(s)), float64(imag(s))); m > peak {
+				peak = m
+			}
+		}
+		return peak
+	}
+
+	wanted := respAt(0)
+	neighbour := respAt(adjOffset)
+	if wanted < 0.5 {
+		t.Fatalf("wanted channel (DC) attenuated to %.3f; front end should pass it flat", wanted)
+	}
+	rejectionDB := 20 * math.Log10(neighbour/wanted)
+	if rejectionDB > -40 {
+		t.Errorf("adjacent channel (+%.0f Hz) rejection = %.1f dB; want <= -40 dB "+
+			"(a ±12.5 kHz neighbour leaks into the voice tap and the FM discriminator "+
+			"captures it during the wanted talker's gaps)", adjOffset, rejectionDB)
+	}
+}
+
+// TestComposerP25Phase1VoiceChainSurvivesAdjacentChannel is the end-to-end
+// regression for the wideband truncation/quality report: a wanted call at DC
+// with a STRONGER adjacent call at +12.5 kHz present. Without a channel-select
+// filter the FM discriminator is captured by the louder neighbour and the
+// wanted call's frames are lost (short/garbled recording). With the filter the
+// neighbour is rejected and the wanted call decodes cleanly. Fails first.
+func TestComposerP25Phase1VoiceChainSurvivesAdjacentChannel(t *testing.T) {
+	const (
+		sampleRate = float64(p25p1VoiceIntermediateHz) // 48 kHz: wideband tap, decim==1
+		deviation  = 1800.0
+		ldus       = 12
+		adjOffset  = 12_500.0
+	)
+	framesPerLDU := phase1.LDUVoiceSubframeCount
+
+	// Wanted call (TG 42) at DC.
+	dibitsW, wantW := buildP25P1VoiceStreamSeed(t, ldus, 0)
+	iq := demod.ModulateP25C4FM(dibitsW, sampleRate, deviation)
+
+	// A DISTINCT, LOUDER neighbour on the adjacent channel (+12.5 kHz). At 2×
+	// amplitude it would win the FM capture and be decoded in place of the
+	// wanted call if it reached the discriminator unfiltered.
+	dibitsN, wantN := buildP25P1VoiceStreamSeed(t, ldus, 500_000)
+	iqN := demod.ModulateP25C4FM(dibitsN, sampleRate, deviation)
+	for i := range iq {
+		if i >= len(iqN) {
+			break
+		}
+		th := 2 * math.Pi * adjOffset * float64(i) / sampleRate
+		rot := complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		iq[i] += 2 * iqN[i] * rot
+	}
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "P25P1Site", Protocol: "p25",
+				GroupID: 42, FrequencyHz: 851_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 6*time.Second, func() bool {
+		return len(sink.rawFrames("VOICE-1")) >= 6*framesPerLDU
+	})
+	got := sink.rawFrames("VOICE-1")
+
+	matchW := bestAlignmentMatches(got, wantW)
+	matchN := bestAlignmentMatches(got, wantN)
+	if matchW < framesPerLDU {
+		t.Errorf("wanted call recovered only %d frames with a strong +%.0f Hz neighbour present; "+
+			"want >= %d (adjacent channel leaked into the tap and captured the demod)",
+			matchW, adjOffset, framesPerLDU)
+	}
+	if matchN >= framesPerLDU {
+		t.Errorf("adjacent-channel neighbour leaked: %d of its frames decoded; "+
+			"the channel-select filter should reject the +%.0f Hz channel", matchN, adjOffset)
 	}
 }
 
@@ -601,6 +743,12 @@ func TestComposerP25Phase1VoiceChainLogsDecodeQuality(t *testing.T) {
 	}
 	if !strings.Contains(out, "ldus=") || !strings.Contains(out, "uncorrectable_ldus=") {
 		t.Errorf("expected ldus= and uncorrectable_ldus= fields in decode quality log; got:\n%s", out)
+	}
+	// gated_ldus is the truncation metric: how many delivered LDUs the
+	// talkgroup gate dropped from the WAV. It must be surfaced so a field
+	// operator can see a short recording's cause without re-deriving it.
+	if !strings.Contains(out, "gated_ldus=") {
+		t.Errorf("expected gated_ldus= field in decode quality log; got:\n%s", out)
 	}
 }
 

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -917,6 +917,23 @@ func (r *Recorder) finalizeLocked(s *recordingSession, serial string, endedAt ti
 	dataBytes := s.wav.DataBytes()
 	vs, haveStats := r.voiceStatsFor(s)
 	r.logVoiceStats(serial, s)
+	// Audio-vs-wall-clock: a decoded (digital) call whose WAV runs much shorter
+	// than the call's wall-clock span lost voice frames upstream — talkgroup
+	// gating or undecoded windows — rather than being a genuinely short over.
+	// Surfacing both makes the "16 s call, 9 s recording" symptom self-evident
+	// in the log without diffing the WAV against the call record. Digital only
+	// (analog FM writes continuous PCM, so audio ≈ wall by construction). Logged
+	// at DEBUG: a multi-over call legitimately drops the silent gaps between
+	// overs, so this is an investigation aid, not a routine warning.
+	if s.vocoder != nil && dataBytes > 0 && s.sampleRate > 0 {
+		audioSec := float64(dataBytes) / (float64(s.sampleRate) * 2)
+		wallSec := endedAt.Sub(s.startedAt).Seconds()
+		if wallSec > 1 && audioSec < 0.75*wallSec {
+			r.log.Debug("recorder: recording shorter than call span",
+				"device", serial, "wav", s.wavPath,
+				"audio_seconds", round1(audioSec), "wall_seconds", round1(wallSec))
+		}
+	}
 	// Smooth an abrupt end-of-call cut on decoded digital voice. A short
 	// transmission that stops mid-waveform leaves a non-zero final sample
 	// that clicks/scratches on playback — the "trailing" artifact most


### PR DESCRIPTION
On a busy multi-channel P25 site a wideband DDC voice tap decoded clean
FOREIGN talkgroups mid-call: a 16 s over recorded as ~9 s of the wanted
call with dropped windows, and the surviving frames were garbled versus
SDRTrunk. The tap delivers a stream band-limited only to its ~±24 kHz
output Nyquist, and the Phase 1 voice front end was a pass-through no-op at
that rate (decim==1) -- so the whole ±24 kHz span, including the ±12.5 kHz
adjacent channels, reached the receiver's FM discriminator. The capture
effect then locked onto a stronger neighbour during the wanted talker's
syllable gaps: those LDUs decoded as another talkgroup and were gated out
of the WAV (short recording) while the neighbour's energy raised in-band
interference on the frames that were kept (garbled audio).

Channel-select each wideband tap to ±6.25 kHz -- half the P25 channel
spacing -- before the discriminator, dropping an adjacent channel centred
at ±12.5 kHz ~80 dB into the 81-tap front end's stopband while passing the
wanted C4FM (Carson bandwidth ≈ ±4.2 kHz) flat. The dedicated-tuner path,
which already band-limits as it decimates, is unchanged.

Regression tests (fail first, pass after): a front-end selectivity check
that the ±12.5 kHz neighbour is rejected ≥40 dB, and an end-to-end chain
test where a wanted call survives a 2x-stronger +12.5 kHz neighbour that
previously captured the demod (wanted recovered 0 frames, neighbour leaked
52, before the fix).

Also adds observability for any residual truncation: a gated_ldus counter
in the "p25p1 decode quality" log (delivered LDUs the talkgroup gate
dropped from the WAV) and a debug audio-vs-wall-clock line in the recorder.

The same decim==1 pass-through pattern exists in the Phase 2 and DMR voice
chains; those need their own captures to reproduce and are left as a
follow-up.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GcrJkV4YftF1f2hwx9UH5c