### PR TITLE
voice: extend wideband channel-select to P25 Phase 2 + DMR, and add per-call SNR/EVM (P25 P1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ for tagged releases.
   `go.mod` and every CI/build workflow.
 
 ### Fixed
+- **Extended the wideband voice-tap channel-select fix to P25 Phase 2 and DMR.**
+  The same defect fixed for P25 Phase 1 — a wideband DDC voice tap feeding the
+  receiver a ±24 kHz-wide stream with no channel filter (the front end was a
+  pass-through no-op at the tap rate) — was present in the Phase 2 and DMR voice
+  chains too. On DMR (4FSK/FM discriminator) a stronger adjacent channel could
+  be captured and, because DMR talkgroup gating is disabled, recorded *as* the
+  call. On P25 Phase 2 (linear H-DQPSK) adjacent energy instead pumped the AGC
+  and degraded carrier recovery, raising EVM. Both chains now channel-select each
+  wideband tap to ±6.25 kHz (half the 12.5 kHz channel spacing) before the
+  receiver, matching Phase 1; the dedicated-tuner path is unchanged.
 - **Wideband P25 Phase 1 voice recordings came out short and garbled next to
   SDRTrunk** — on a busy multi-channel site a wideband DDC voice tap decoded
   clean *foreign* talkgroups mid-call (e.g. a 16 s over recorded as ~9 s of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ for tagged releases.
   the rtl_tcp / import-client TLS paths. No source changes; the pin moves in
   `go.mod` and every CI/build workflow.
 
+### Added
+- **Per-call demod quality (EVM / SNR) on P25 Phase 1 calls.** Each decoded P25
+  Phase 1 voice call now carries a measured RMS error-vector magnitude (`evm_pct`)
+  and estimated symbol SNR (`snr_db`), surfaced in the call-history API and
+  `call_log` alongside `signal_dbfs` — the demod-quality numbers to compare
+  against another decoder (SDRTrunk). Measured over the settled decode from the
+  receiver's soft/symbol taps and stamped onto `CallEnd`; nil for calls with no
+  measurement (short blips, non-composer ends) and for the Phase 2 / DMR chains,
+  which don't yet expose the taps (#878 follow-up). The gRPC `RIDCallRow` surface
+  is unchanged (a separate proto change, as `signal_dbfs` also awaits).
+
 ### Fixed
 - **Extended the wideband voice-tap channel-select fix to P25 Phase 2 and DMR.**
   The same defect fixed for P25 Phase 1 — a wideband DDC voice tap feeding the

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -558,6 +558,11 @@ type CallRow struct {
 	// SignalDbFS is the call's mean received channel power in dBFS
 	// (channel power, not calibrated RSSI or SNR). nil when unmeasured.
 	SignalDbFS *float64 `json:"signal_dbfs,omitempty"`
+	// EVMPct / SNRDb are the call's demod quality — RMS error-vector
+	// magnitude (%) and estimated symbol SNR (dB) — the figures to compare
+	// against another decoder. nil when unmeasured (P25 Phase 1 only).
+	EVMPct *float64 `json:"evm_pct,omitempty"`
+	SNRDb  *float64 `json:"snr_db,omitempty"`
 }
 
 // ServerOptions configure a new Server.

--- a/internal/api/storage_adapter.go
+++ b/internal/api/storage_adapter.go
@@ -95,6 +95,8 @@ func (s *storageHistory) History(ctx context.Context, f HistoryFilter) ([]CallRo
 			EndReason:      r.EndReason,
 			TalkgroupAlpha: r.TalkgroupAlpha,
 			SignalDbFS:     r.SignalDbFS,
+			EVMPct:         r.EVMPct,
+			SNRDb:          r.SNRDb,
 		}
 	}
 	return out, nil

--- a/internal/storage/calllog.go
+++ b/internal/storage/calllog.go
@@ -137,6 +137,16 @@ func (c *CallLog) recordEnd(ce trunking.CallEnd) error {
 	if ce.SignalDbFS != nil {
 		sig = sql.NullFloat64{Float64: *ce.SignalDbFS, Valid: true}
 	}
+	// evm_pct / snr_db use the same COALESCE(?, col) never-clobber discipline
+	// as signal_dbfs: a non-composer end (or a non-Phase-1 chain) carries no
+	// measurement, so a NULL bind keeps whatever an earlier composer stamp wrote.
+	var evm, snr sql.NullFloat64
+	if ce.EVMPct != nil {
+		evm = sql.NullFloat64{Float64: *ce.EVMPct, Valid: true}
+	}
+	if ce.SNRDb != nil {
+		snr = sql.NullFloat64{Float64: *ce.SNRDb, Valid: true}
+	}
 	const q = `
 UPDATE call_log
    SET ended_at = ?,
@@ -146,7 +156,9 @@ UPDATE call_log
        encrypted    = CASE WHEN ? != 0 THEN 1 ELSE encrypted END,
        algorithm_id = COALESCE(NULLIF(?, 0), algorithm_id),
        key_id       = COALESCE(NULLIF(?, 0), key_id),
-       signal_dbfs  = COALESCE(?, signal_dbfs)
+       signal_dbfs  = COALESCE(?, signal_dbfs),
+       evm_pct      = COALESCE(?, evm_pct),
+       snr_db       = COALESCE(?, snr_db)
  WHERE device_serial = ? AND started_at = ?`
 	_, err := c.db.sql.Exec(q,
 		ce.EndedAt.UnixNano(),
@@ -157,6 +169,8 @@ UPDATE call_log
 		ce.Grant.AlgorithmID,
 		ce.Grant.KeyID,
 		sig,
+		evm,
+		snr,
 		ce.DeviceSerial, ce.StartedAt.UnixNano(),
 	)
 	return err
@@ -197,6 +211,12 @@ type CallRow struct {
 	// SignalDbFS is the call's mean received channel power in dBFS
 	// (channel power, not calibrated RSSI or SNR). nil when unmeasured.
 	SignalDbFS *float64 `json:"signal_dbfs,omitempty"`
+	// EVMPct / SNRDb are the call's demod quality — RMS error-vector
+	// magnitude (%) and estimated symbol SNR (dB). nil when unmeasured
+	// (only P25 Phase 1 chains measure them). These ARE the demod-quality
+	// figures to compare against another decoder, unlike SignalDbFS.
+	EVMPct *float64 `json:"evm_pct,omitempty"`
+	SNRDb  *float64 `json:"snr_db,omitempty"`
 }
 
 // History queries the call_log with the supplied filter, newest-first.
@@ -204,7 +224,7 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 	q := `SELECT id, system, protocol, group_id, source_id, frequency_hz,
 	             encrypted, algorithm_id, key_id, emergency, data_call, timeslot,
 	             device_serial, started_at, ended_at, duration_ms,
-	             end_reason, talkgroup_alpha, signal_dbfs
+	             end_reason, talkgroup_alpha, signal_dbfs, evm_pct, snr_db
 	      FROM call_log WHERE 1=1`
 	args := []any{}
 	if f.System != "" {
@@ -248,12 +268,12 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		var durMs sql.NullInt64
 		var reason sql.NullString
 		var alpha sql.NullString
-		var sig sql.NullFloat64
+		var sig, evm, snr sql.NullFloat64
 		var enc, emer, data, algID, keyID, slot int
 		if err := rows.Scan(
 			&r.ID, &r.System, &r.Protocol, &r.GroupID, &r.SourceID, &r.FrequencyHz,
 			&enc, &algID, &keyID, &emer, &data, &slot, &r.DeviceSerial,
-			&startNs, &endNs, &durMs, &reason, &alpha, &sig,
+			&startNs, &endNs, &durMs, &reason, &alpha, &sig, &evm, &snr,
 		); err != nil {
 			return nil, err
 		}
@@ -279,6 +299,14 @@ func (d *DB) History(ctx context.Context, f HistoryFilter) ([]CallRow, error) {
 		if sig.Valid {
 			v := sig.Float64
 			r.SignalDbFS = &v
+		}
+		if evm.Valid {
+			v := evm.Float64
+			r.EVMPct = &v
+		}
+		if snr.Valid {
+			v := snr.Float64
+			r.SNRDb = &v
 		}
 		out = append(out, r)
 	}

--- a/internal/storage/calllog_test.go
+++ b/internal/storage/calllog_test.go
@@ -512,6 +512,63 @@ func TestCallLogPersistsSignalDbFS(t *testing.T) {
 	}
 }
 
+// TestCallLogPersistsDemodMetrics verifies the composer-measured demod quality
+// (EVM % / SNR dB) survives the CallEnd → call_log round-trip, and that a call
+// ended with no measurement reads back nil (unset ≠ a legitimate 0).
+func TestCallLogPersistsDemodMetrics(t *testing.T) {
+	db, bus := runningCallLog(t)
+
+	f64 := func(v float64) *float64 { return &v }
+	startedAt := time.Now().UTC().Truncate(time.Microsecond)
+
+	// Call 1 carries measured EVM/SNR on CallEnd.
+	g1 := trunking.Grant{System: "Alpha", Protocol: "p25", GroupID: 1, SourceID: 10, FrequencyHz: 851_000_000}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: g1, DeviceSerial: "VOICE-1", StartedAt: startedAt,
+	}})
+	waitHistory(t, db, HistoryFilter{Limit: 1}, func(r []CallRow) bool { return len(r) == 1 })
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: g1, DeviceSerial: "VOICE-1", StartedAt: startedAt,
+		EndedAt: startedAt.Add(time.Second), Reason: trunking.EndReasonNormal,
+		EVMPct: f64(4.2), SNRDb: f64(27.5),
+	}})
+
+	rows := waitHistory(t, db, HistoryFilter{System: "Alpha", GroupID: 1, OnlyEnded: true}, func(r []CallRow) bool {
+		return len(r) == 1 && r[0].EVMPct != nil && r[0].SNRDb != nil
+	})
+	if len(rows) != 1 || rows[0].EVMPct == nil || rows[0].SNRDb == nil {
+		t.Fatalf("call-1 row = %+v, want EVMPct+SNRDb populated", rows)
+	}
+	if got := *rows[0].EVMPct; math.Abs(got-4.2) > 0.01 {
+		t.Errorf("EVMPct = %v, want 4.2", got)
+	}
+	if got := *rows[0].SNRDb; math.Abs(got-27.5) > 0.01 {
+		t.Errorf("SNRDb = %v, want 27.5", got)
+	}
+
+	// Call 2 ends with no measurement → columns stay NULL → read nil.
+	started2 := startedAt.Add(time.Minute)
+	g2 := trunking.Grant{System: "Alpha", Protocol: "dmr-tier3", GroupID: 2, SourceID: 20, FrequencyHz: 460_000_000}
+	bus.Publish(events.Event{Kind: events.KindCallStart, Payload: trunking.CallStart{
+		Grant: g2, DeviceSerial: "VOICE-2", StartedAt: started2,
+	}})
+	waitHistory(t, db, HistoryFilter{System: "Alpha", GroupID: 2}, func(r []CallRow) bool { return len(r) == 1 })
+	bus.Publish(events.Event{Kind: events.KindCallEnd, Payload: trunking.CallEnd{
+		Grant: g2, DeviceSerial: "VOICE-2", StartedAt: started2,
+		EndedAt: started2.Add(time.Second), Reason: trunking.EndReasonNormal,
+		// EVMPct/SNRDb deliberately nil (a non-Phase-1 chain measures neither).
+	}})
+	rows = waitHistory(t, db, HistoryFilter{System: "Alpha", GroupID: 2, OnlyEnded: true}, func(r []CallRow) bool {
+		return len(r) == 1
+	})
+	if len(rows) != 1 {
+		t.Fatalf("call-2 rows = %d, want 1", len(rows))
+	}
+	if rows[0].EVMPct != nil || rows[0].SNRDb != nil {
+		t.Errorf("unmeasured call demod = (%v,%v), want nil (unset ≠ 0)", rows[0].EVMPct, rows[0].SNRDb)
+	}
+}
+
 func TestOpenRejectsEmpty(t *testing.T) {
 	if _, err := Open(""); err == nil {
 		t.Error("expected error for empty path")

--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -86,7 +86,9 @@ CREATE TABLE IF NOT EXISTS call_log (
     duration_ms     INTEGER,
     end_reason      TEXT,
     talkgroup_alpha TEXT,
-    signal_dbfs     REAL   -- mean received channel power, dBFS; NULL = unmeasured
+    signal_dbfs     REAL,  -- mean received channel power, dBFS; NULL = unmeasured
+    evm_pct         REAL,  -- demod RMS error-vector magnitude, %; NULL = unmeasured
+    snr_db          REAL   -- demod estimated symbol SNR, dB; NULL = unmeasured
 );
 
 CREATE INDEX IF NOT EXISTS idx_call_log_started ON call_log(started_at);
@@ -379,6 +381,10 @@ func (d *DB) ensureCallLogColumns() error {
 		// Nullable (no DEFAULT) so a row with no measurement reads NULL —
 		// "unset" is distinct from a legitimate 0 dBFS reading.
 		{"signal_dbfs", `ALTER TABLE call_log ADD COLUMN signal_dbfs REAL`},
+		// Demod quality (EVM % / SNR dB), likewise nullable — NULL when the
+		// call's chain fed no demod taps (every protocol but P25 Phase 1).
+		{"evm_pct", `ALTER TABLE call_log ADD COLUMN evm_pct REAL`},
+		{"snr_db", `ALTER TABLE call_log ADD COLUMN snr_db REAL`},
 	}
 	for _, a := range adds {
 		if have[a.name] {

--- a/internal/trunking/engine.go
+++ b/internal/trunking/engine.go
@@ -623,6 +623,21 @@ func (e *Engine) UpdateSignal(deviceSerial string, dbfs float64) {
 	e.mu.Unlock()
 }
 
+// UpdateDemod stamps the call's demod quality (RMS EVM % and estimated SNR dB)
+// onto the bound trunked call and any synthetic call on the same serial, so the
+// engine carries it into CallEnd. Mirrors UpdateSignal; called by the composer
+// once at end-of-call, before EndCall.
+func (e *Engine) UpdateDemod(deviceSerial string, evmPct, snrDB float64) {
+	e.pool.UpdateDemod(deviceSerial, evmPct, snrDB)
+	e.mu.Lock()
+	if ac, ok := e.synthetic[deviceSerial]; ok {
+		evm, snr := evmPct, snrDB
+		ac.EVMPct = &evm
+		ac.SNRDb = &snr
+	}
+	e.mu.Unlock()
+}
+
 // ActiveCalls returns a snapshot of every active call — trunked
 // calls allocated through the voice pool plus synthetic calls owned
 // by external scanners (the conventional FM scanner publishes these
@@ -785,6 +800,8 @@ func (e *Engine) endCall(ac *ActiveCall, reason EndReason) {
 			EndedAt:      e.now(),
 			Reason:       reason,
 			SignalDbFS:   released.SignalDbFS,
+			EVMPct:       released.EVMPct,
+			SNRDb:        released.SNRDb,
 		},
 	})
 	e.log.Info("call ended",
@@ -917,6 +934,8 @@ func (e *Engine) EndSyntheticCall(deviceSerial string, reason EndReason) bool {
 			EndedAt:      e.now(),
 			Reason:       reason,
 			SignalDbFS:   ac.SignalDbFS,
+			EVMPct:       ac.EVMPct,
+			SNRDb:        ac.SNRDb,
 		},
 	})
 	e.log.Info("synthetic call ended",

--- a/internal/trunking/grant.go
+++ b/internal/trunking/grant.go
@@ -255,6 +255,14 @@ type CallEnd struct {
 	// shutdown, or decoded outside the composer). It is a channel-power /
 	// RSSI-style figure — NOT calibrated absolute RSSI and NOT SNR/EVM.
 	SignalDbFS *float64
+	// EVMPct and SNRDb are the call's demod quality — RMS error-vector
+	// magnitude (%) and estimated symbol SNR (dB) — measured by the voice
+	// composer over the settled decode. Unlike SignalDbFS these ARE the
+	// demod-quality figures to compare against another decoder (SDRTrunk).
+	// nil when unmeasured — currently only P25 Phase 1 chains feed the demod
+	// taps that populate them (issue #878 follow-up).
+	EVMPct *float64
+	SNRDb  *float64
 }
 
 // Duration returns how long the call ran.

--- a/internal/trunking/voicepool.go
+++ b/internal/trunking/voicepool.go
@@ -67,6 +67,12 @@ type ActiveCall struct {
 	// preemption, shutdown) leave it nil. See composer.boundaryTracker
 	// for the semantics (channel power, not calibrated RSSI or SNR).
 	SignalDbFS *float64
+	// EVMPct / SNRDb are the call's demod quality (RMS EVM % and estimated
+	// SNR dB), stamped in via UpdateDemod shortly before end-of-call. nil
+	// until measured; only chains that feed the receiver demod taps (P25
+	// Phase 1) populate them. Issue #878 follow-up.
+	EVMPct *float64
+	SNRDb  *float64
 }
 
 // NewVoicePool returns a pool over the supplied devices. The order of
@@ -342,6 +348,19 @@ func (p *VoicePool) UpdateSignal(serial string, dbfs float64) {
 	if ac, ok := p.active[serial]; ok {
 		v := dbfs
 		ac.SignalDbFS = &v
+	}
+}
+
+// UpdateDemod stamps the call's demod quality (RMS EVM % and estimated SNR dB)
+// onto the ActiveCall bound to serial. No-op when no call is bound. Fresh
+// pointers are stored per update so the values are stable once released.
+func (p *VoicePool) UpdateDemod(serial string, evmPct, snrDB float64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if ac, ok := p.active[serial]; ok {
+		evm, snr := evmPct, snrDB
+		ac.EVMPct = &evm
+		ac.SNRDb = &snr
 	}
 }
 

--- a/internal/voice/composer/boundary.go
+++ b/internal/voice/composer/boundary.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/p25/phase1/metrics"
 	"github.com/MattCheramie/GopherTrunk/internal/trunking"
 )
 
@@ -66,7 +67,36 @@ type boundaryTracker struct {
 	nSamp        uint64
 	meanDbFSBits atomic.Uint64
 	haveSignal   atomic.Bool
+
+	// Demod-quality accumulator (per-call SNR/EVM). Populated ONLY when the
+	// chain installs the receiver's soft/symbol taps — currently just P25
+	// Phase 1 — via observeSoft / observeSymbols; other protocols never call
+	// them, so their metrics stay unmeasured (nil in the call record). The
+	// taps write on the chain goroutine while end() reads on the bt.run
+	// goroutine, so the bounded buffers are guarded by demodMu. See
+	// demodMetrics for the estimator choice.
+	demodMu sync.Mutex
+	softBuf []float32   // C4FM 4-level soft symbols (FM-discriminator path)
+	symBuf  []complex64 // CQPSK / linear constellation points
 }
+
+// Demod-metric accumulation bounds, mirroring internal/siglab so a per-call
+// figure agrees with the `replay -diag` line an operator would compare against.
+const (
+	// demodWarmupSkip drops the receiver's sync/AGC/timing warm-up symbols,
+	// whose EVM is transient and unrepresentative of the settled decode.
+	demodWarmupSkip = 256
+	// demodMinSymbols is the minimum settled (post-warmup) symbol count before
+	// a stable EVM/SNR is reported; a shorter blip reports NULL rather than a
+	// noisy figure (mirrors how signal_dbfs is nil when unmeasured).
+	demodMinSymbols = 64
+	// demodMaxSymbols bounds the per-call buffer past the warm-up prefix —
+	// enough for a stable RMS EVM without holding a whole 30 s call in memory.
+	demodMaxSymbols = 8192
+	// demodSNRCapDB is the finite ceiling for a (near) noise-free residual,
+	// mirroring siglab's demodSNRCapDB so a capped value is JSON-marshalable.
+	demodSNRCapDB = 99.0
+)
 
 // foreignRunToEnd is how many consecutive frames carrying the SAME known
 // foreign talkgroup end the call. A couple of frames debounces a single
@@ -259,6 +289,78 @@ func (bt *boundaryTracker) signalDbFS() (float64, bool) {
 	return math.Float64frombits(bt.meanDbFSBits.Load()), true
 }
 
+// observeSoft accumulates a batch of C4FM 4-level soft symbols (the
+// FM-discriminator path's post-matched-filter symbol values) for the call's
+// EVM/SNR estimate, capped at the warm-up prefix plus demodMaxSymbols. Called
+// from the chain goroutine via the receiver's SoftSink.
+func (bt *boundaryTracker) observeSoft(soft []float32) {
+	if len(soft) == 0 {
+		return
+	}
+	bt.demodMu.Lock()
+	if room := demodWarmupSkip + demodMaxSymbols - len(bt.softBuf); room > 0 {
+		if len(soft) > room {
+			soft = soft[:room]
+		}
+		bt.softBuf = append(bt.softBuf, soft...)
+	}
+	bt.demodMu.Unlock()
+}
+
+// observeSymbols accumulates a batch of complex constellation points (the
+// linear CQPSK/LSM path) for the call's EVM/SNR estimate. Called from the chain
+// goroutine via the receiver's SymbolSink.
+func (bt *boundaryTracker) observeSymbols(pts []complex64) {
+	if len(pts) == 0 {
+		return
+	}
+	bt.demodMu.Lock()
+	if room := demodWarmupSkip + demodMaxSymbols - len(bt.symBuf); room > 0 {
+		if len(pts) > room {
+			pts = pts[:room]
+		}
+		bt.symBuf = append(bt.symBuf, pts...)
+	}
+	bt.demodMu.Unlock()
+}
+
+// demodMetrics computes the call's RMS EVM (%) and estimated SNR (dB) from the
+// buffered demod symbols, mirroring internal/siglab's demodMetrics: the complex
+// constellation (CQPSK/linear) when the receiver populated it, otherwise the
+// 4-level C4FM soft eye. Returns ok=false until enough settled (post-warmup)
+// symbols accumulated for a stable estimate, or when no soft/symbol tap fed the
+// tracker at all (every protocol but P25 Phase 1 today). Safe to call from any
+// goroutine.
+func (bt *boundaryTracker) demodMetrics() (evmPct, snrDB float64, ok bool) {
+	bt.demodMu.Lock()
+	defer bt.demodMu.Unlock()
+	if len(bt.symBuf) >= demodWarmupSkip+demodMinSymbols {
+		pts := bt.symBuf[demodWarmupSkip:]
+		return metrics.EVMConstellation(pts), capDemodSNR(metrics.SNRM2M4Constellation(pts)), true
+	}
+	if len(bt.softBuf) >= demodWarmupSkip+demodMinSymbols {
+		soft := bt.softBuf[demodWarmupSkip:]
+		outer := metrics.EstimateOuterRailC4FM(soft)
+		if outer <= 0 {
+			return 0, 0, false
+		}
+		return metrics.EVMC4FM(soft, outer), capDemodSNR(metrics.SNRResidualC4FM(soft, outer)), true
+	}
+	return 0, 0, false
+}
+
+// capDemodSNR clamps an SNR estimate to ±demodSNRCapDB so a noise-free residual
+// (SNR → ±Inf) stays finite and JSON-marshalable, mirroring siglab's capSNR.
+func capDemodSNR(db float64) float64 {
+	switch {
+	case math.IsInf(db, 1) || db > demodSNRCapDB:
+		return demodSNRCapDB
+	case math.IsInf(db, -1) || db < -demodSNRCapDB:
+		return -demodSNRCapDB
+	}
+	return db
+}
+
 // end ends the call exactly once via the engine, which publishes
 // CallEnd; the composer then cancels this chain's context.
 func (bt *boundaryTracker) end(reason trunking.EndReason) {
@@ -272,6 +374,12 @@ func (bt *boundaryTracker) end(reason trunking.EndReason) {
 		// preemption, shutdown) carry no measurement and read back NULL.
 		if d, ok := bt.signalDbFS(); ok {
 			bt.c.engine.UpdateSignal(bt.serial, d)
+		}
+		// Same for the demod-quality (EVM/SNR) figure — the number an operator
+		// compares against SDRTrunk. Only P25 Phase 1 feeds the soft/symbol
+		// taps today, so other protocols carry no measurement (NULL).
+		if evm, snr, ok := bt.demodMetrics(); ok {
+			bt.c.engine.UpdateDemod(bt.serial, evm, snr)
 		}
 		bt.c.engine.EndCall(bt.serial, reason)
 	})

--- a/internal/voice/composer/boundary_test.go
+++ b/internal/voice/composer/boundary_test.go
@@ -125,6 +125,48 @@ func TestBoundaryMeasuresSignalDbFS(t *testing.T) {
 	}
 }
 
+// TestBoundaryMeasuresDemodMetrics feeds a clean 4-level C4FM soft eye into the
+// tracker's demod accumulator and confirms it stamps a finite EVM/SNR onto the
+// call at end-of-call (via UpdateDemod), and that too few symbols report nothing.
+func TestBoundaryMeasuresDemodMetrics(t *testing.T) {
+	c, _, eng := mkBoundaryComposer(t, false, 150*time.Millisecond)
+	bt := c.newBoundaryTracker("VOICE-1", 0, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go bt.run(ctx)
+
+	// Below the warm-up + minimum threshold: no metric yet.
+	bt.observeSoft(make([]float32, 100))
+	if _, _, ok := bt.demodMetrics(); ok {
+		t.Fatal("demodMetrics reported ok with too few symbols; want false")
+	}
+
+	// A clean 4-level C4FM soft eye (ideal rails ±3, ±1) past the warm-up prefix.
+	rails := []float32{-3, -1, 1, 3}
+	soft := make([]float32, demodWarmupSkip+1024)
+	for i := range soft {
+		soft[i] = rails[i%4]
+	}
+	bt.observeSoft(soft)
+	bt.onVoice(0) // one voice frame, then silence → hangtime ends the call
+
+	waitFor(t, time.Second, func() bool {
+		_, ok := eng.demod("VOICE-1")
+		return ok
+	})
+	m, ok := eng.demod("VOICE-1")
+	if !ok {
+		t.Fatal("UpdateDemod was never called at end-of-call")
+	}
+	evm, snr := m[0], m[1]
+	if evm < 0 || evm > 5 {
+		t.Errorf("EVM = %v%%, want ~0 for a clean eye", evm)
+	}
+	if snr < 20 {
+		t.Errorf("SNR = %v dB, want high (clean eye)", snr)
+	}
+}
+
 // TestBoundaryHangtimeEndsCall: after voice stops for longer than the
 // hangtime, the tracker ends the call.
 func TestBoundaryHangtimeEndsCall(t *testing.T) {

--- a/internal/voice/composer/composer.go
+++ b/internal/voice/composer/composer.go
@@ -112,6 +112,11 @@ type EngineHooks interface {
 	// (dBFS) onto the bound ActiveCall so the engine carries it into
 	// CallEnd. Called once at end-of-call, before EndCall.
 	UpdateSignal(deviceSerial string, dbfs float64)
+	// UpdateDemod stamps the call's measured demod quality — RMS EVM (%) and
+	// estimated SNR (dB) — onto the bound ActiveCall so the engine carries it
+	// into CallEnd. Called once at end-of-call, before EndCall, and only for a
+	// call whose chain fed the receiver soft/symbol taps (P25 Phase 1).
+	UpdateDemod(deviceSerial string, evmPct, snrDB float64)
 }
 
 // Options configure a Composer.

--- a/internal/voice/composer/composer_test.go
+++ b/internal/voice/composer/composer_test.go
@@ -111,6 +111,7 @@ type fakeEngine struct {
 	ended   []string
 	reasons map[string]trunking.EndReason
 	signals map[string]float64
+	demods  map[string][2]float64
 }
 
 func (e *fakeEngine) Touch(string) { e.touched.Add(1) }
@@ -132,6 +133,24 @@ func (e *fakeEngine) UpdateSignal(serial string, dbfs float64) {
 		e.signals = make(map[string]float64)
 	}
 	e.signals[serial] = dbfs
+}
+
+func (e *fakeEngine) UpdateDemod(serial string, evmPct, snrDB float64) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.demods == nil {
+		e.demods = make(map[string][2]float64)
+	}
+	e.demods[serial] = [2]float64{evmPct, snrDB}
+}
+
+// demod returns the last (evmPct, snrDB) UpdateDemod(serial) carried and
+// whether it was ever called for serial.
+func (e *fakeEngine) demod(serial string) ([2]float64, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	v, ok := e.demods[serial]
+	return v, ok
 }
 
 // signal returns the last dBFS UpdateSignal(serial) carried and whether

--- a/internal/voice/composer/dmr_voice.go
+++ b/internal/voice/composer/dmr_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -16,6 +17,40 @@ import (
 // filter and Mueller-Müller clock recovery, without the cost of
 // running them at the SDR's native multi-MS/s rate.
 const dmrVoiceIntermediateHz = 48_000
+
+// dmrVoiceChannelSelectHz caps the voice front-end channel filter at half the
+// 12.5 kHz DMR channel spacing. A wideband DDC voice tap hands the chain a
+// stream already at the intermediate rate but band-limited only to the tap's
+// output Nyquist (~±24 kHz), NOT to a single 12.5 kHz channel — so the old
+// pass-through front end fed that whole ±24 kHz span into the receiver's FM
+// discriminator, where the capture effect locks onto a stronger ±12.5 kHz
+// neighbour during voice gaps. DMR gating is disabled (grantTG 0), so a leaked
+// neighbour is recorded AS the call — wrong audio, not just dropped. Filtering
+// to ±6.25 kHz drops an adjacent channel centred at ±12.5 kHz deep into the
+// 81-tap front end's stopband while the wanted 4FSK (deviation ±1944 Hz,
+// Carson ≈ ±4.8 kHz) passes flat. Both DMR timeslots share the one 12.5 kHz
+// carrier, so the filter isolates the carrier without splitting the slots.
+const dmrVoiceChannelSelectHz = 6250.0
+
+// newDMRVoiceFrontEnd builds the channel-select + decimation front end for the
+// DMR voice chain. Mirrors newP25P1VoiceFrontEnd: the dedicated-tuner path
+// (iqHz well above the intermediate rate) already band-limits as it decimates;
+// the pass-through path (a wideband DDC tap already at the intermediate rate,
+// decim==1) applied NO filter, so this channel-selects to
+// ±min(bw, dmrVoiceChannelSelectHz) before the FM discriminator. Factored out
+// so the selectivity is unit-testable.
+func newDMRVoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
+	chanBW := float64(bw)
+	decim := int(math.Round(iqHz)) / dmrVoiceIntermediateHz
+	filterAtUnity := false
+	if decim <= 1 {
+		filterAtUnity = true
+		if chanBW > dmrVoiceChannelSelectHz {
+			chanBW = dmrVoiceChannelSelectHz
+		}
+	}
+	return newDecimatingFIR(iqHz, dmrVoiceIntermediateHz, chanBW, filterAtUnity)
+}
 
 // rawFrameSink is the subset of voice.Recorder the DMR voice chain
 // needs. The composer holds its sink as a PCMSink; runDMRVoiceChain
@@ -152,9 +187,13 @@ func (c *Composer) runDMRVoiceChain(ctx context.Context, serial string, iqCh <-c
 	// of the result. At 2.4 MS/s that wasted ~194M MACs/sec per voice call
 	// and starved the live IQ consumer until the SDR dropped chunks. Same
 	// coefficients and same kept samples as before, so the decode is
-	// byte-for-byte unchanged — only the wasted work is removed. decim==1
-	// (a source already at the intermediate rate) is a pass-through no-op.
-	fe := newDecimatingFIR(iqHz, dmrVoiceIntermediateHz, float64(c.bw), false)
+	// byte-for-byte unchanged — only the wasted work is removed. decim==1 (a
+	// source already at the intermediate rate — a wideband DDC voice tap) is NOT
+	// a pass-through: it still channel-selects to a single DMR channel before the
+	// FM discriminator (see newDMRVoiceFrontEnd / dmrVoiceChannelSelectHz) so an
+	// adjacent ±12.5 kHz channel can't capture the demod and be recorded as this
+	// call.
+	fe := newDMRVoiceFrontEnd(iqHz, c.bw)
 	symbolHz := fe.OutRateHz()
 
 	rs, _ := c.sink.(rawFrameSink)

--- a/internal/voice/composer/dmr_voice_test.go
+++ b/internal/voice/composer/dmr_voice_test.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"bytes"
 	"context"
+	"math"
 	"testing"
 	"time"
 
@@ -69,6 +70,13 @@ func voiceBurstDibits(frames [][]byte, sync [24]uint8) []uint8 {
 // carries is the FEC-encoding of mkInfo(frameIndex); the returned
 // slice holds those 49-bit payloads in order.
 func buildVoiceStream(t *testing.T, n int) (dibits []uint8, infos [][]byte) {
+	return buildVoiceStreamSeed(t, n, 0)
+}
+
+// buildVoiceStreamSeed is buildVoiceStream with a seed offset so a test can
+// build two streams with DISTINCT AMBE payloads (a wanted call and an
+// adjacent-channel neighbour) and tell which one the chain decoded.
+func buildVoiceStreamSeed(t *testing.T, n, seed0 int) (dibits []uint8, infos [][]byte) {
 	t.Helper()
 	dibits = make([]uint8, 240)
 	for i := range dibits {
@@ -76,7 +84,7 @@ func buildVoiceStream(t *testing.T, n int) (dibits []uint8, infos [][]byte) {
 	}
 	var onair [][]byte
 	for f := 0; f < n*dmrvoice.FramesPerSuperframe; f++ {
-		info := mkInfo(f)
+		info := mkInfo(seed0 + f)
 		frame, err := dmrvoice.EncodeAMBEFrame(info)
 		if err != nil {
 			t.Fatalf("EncodeAMBEFrame: %v", err)
@@ -376,5 +384,132 @@ func TestComposerDMRInterleavedRoutesBySlot(t *testing.T) {
 	}
 	if matchesAnySuperframe(got, bInfos) {
 		t.Errorf("the other timeslot's (TG %d) audio leaked into our call", otherTG)
+	}
+}
+
+// TestDMRVoiceFrontEndRejectsAdjacentChannel pins the channel selectivity of
+// the wideband DMR voice tap's front end: an adjacent 12.5 kHz channel centred
+// at ±12.5 kHz must be strongly rejected before the FM discriminator. The old
+// pass-through front end (decim==1) applied NO filter, so a neighbour reached
+// the discriminator at full amplitude and — DMR gating being disabled — could
+// be recorded as the call. Fails first: pass-through leaves the neighbour at
+// ~0 dB.
+func TestDMRVoiceFrontEndRejectsAdjacentChannel(t *testing.T) {
+	const (
+		fs        = float64(dmrVoiceIntermediateHz) // 48 kHz wideband tap output → decim==1
+		bw        = uint32(12_500)
+		adjOffset = 12_500.0
+		nSamples  = 24_000
+	)
+	respAt := func(offsetHz float64) float64 {
+		fe := newDMRVoiceFrontEnd(fs, bw)
+		in := make([]complex64, nSamples)
+		for i := range in {
+			th := 2 * math.Pi * offsetHz * float64(i) / fs
+			in[i] = complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		}
+		out := fe.Process(nil, in)
+		var peak float64
+		for _, s := range out[len(out)/2:] {
+			if m := math.Hypot(float64(real(s)), float64(imag(s))); m > peak {
+				peak = m
+			}
+		}
+		return peak
+	}
+	wanted := respAt(0)
+	neighbour := respAt(adjOffset)
+	if wanted < 0.5 {
+		t.Fatalf("wanted channel (DC) attenuated to %.3f; front end should pass it flat", wanted)
+	}
+	rejectionDB := 20 * math.Log10(neighbour/wanted)
+	if rejectionDB > -40 {
+		t.Errorf("adjacent channel (+%.0f Hz) rejection = %.1f dB; want <= -40 dB "+
+			"(a ±12.5 kHz neighbour leaks into the DMR voice tap and the discriminator captures it)",
+			adjOffset, rejectionDB)
+	}
+}
+
+// TestComposerDMRVoiceChainSurvivesAdjacentChannel is the end-to-end regression:
+// a wanted DMR call at DC with a STRONGER adjacent call at +12.5 kHz present.
+// Without a channel-select filter the FM discriminator is captured by the louder
+// neighbour and — gating disabled — the neighbour's audio is recorded in place
+// of the wanted call. With the filter the neighbour is rejected and the wanted
+// call decodes. Fails first.
+func TestComposerDMRVoiceChainSurvivesAdjacentChannel(t *testing.T) {
+	const (
+		sampleRate  = float64(dmrVoiceIntermediateHz) // 48 kHz: wideband tap, decim==1
+		sps         = 10
+		span        = 8
+		alpha       = 0.20
+		deviation   = 1944.0
+		superframes = 12
+		adjOffset   = 12_500.0
+	)
+
+	dibitsW, wantW := buildVoiceStreamSeed(t, superframes, 0)
+	iq := demod.ModulateC4FM(dibitsW, sps, span, alpha, sampleRate, deviation)
+
+	dibitsN, wantN := buildVoiceStreamSeed(t, superframes, 500_000)
+	iqN := demod.ModulateC4FM(dibitsN, sps, span, alpha, sampleRate, deviation)
+	for i := range iq {
+		if i >= len(iqN) {
+			break
+		}
+		th := 2 * math.Pi * adjOffset * float64(i) / sampleRate
+		rot := complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		iq[i] += 2 * iqN[i] * rot
+	}
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "DMRSite", Protocol: "dmr-tier3",
+				GroupID: 7, FrequencyHz: 460_000_000,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 8*time.Second, func() bool {
+		return len(sink.rawFrames("VOICE-1")) >= 4*dmrvoice.FramesPerSuperframe
+	})
+	got := sink.rawFrames("VOICE-1")
+	got = got[:len(got)-len(got)%dmrvoice.FramesPerSuperframe]
+
+	if !matchesAnySuperframe(got, wantW) {
+		t.Errorf("wanted DMR call did not round-trip with a strong +%.0f Hz neighbour present "+
+			"(adjacent channel captured the demod and was recorded instead)", adjOffset)
+	}
+	if matchesAnySuperframe(got, wantN) {
+		t.Errorf("adjacent-channel neighbour leaked: its superframes were recorded as the call; "+
+			"the channel-select filter should reject the +%.0f Hz channel", adjOffset)
 	}
 }

--- a/internal/voice/composer/p25p1_voice.go
+++ b/internal/voice/composer/p25p1_voice.go
@@ -249,6 +249,14 @@ func (c *Composer) runP25Phase1VoiceChain(ctx context.Context, serial, system st
 		SampleRateHz: symbolHz,
 		DeviationHz:  p25p1DeviationHz,
 		DemodMode:    mode,
+		// Feed the demod symbol taps into the boundary tracker's per-call
+		// EVM/SNR accumulator. C4FM populates SoftSink (the 4-level soft eye);
+		// the CQPSK/LSM path populates SymbolSink (the complex constellation).
+		// The tracker computes one figure at end-of-call and stamps it onto the
+		// CallEnd, so operators get a per-call demod-quality number to compare
+		// against SDRTrunk (issue #878 follow-up).
+		SoftSink:   bt.observeSoft,
+		SymbolSink: bt.observeSymbols,
 		Sink: func(ldu []byte) {
 			duid, derr := phase1.LDUDuid(ldu)
 			// A Terminator Data Unit (with or without LC) marks the end

--- a/internal/voice/composer/p25p2_voice.go
+++ b/internal/voice/composer/p25p2_voice.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"context"
+	"math"
 	"sync/atomic"
 	"time"
 
@@ -19,6 +20,40 @@ import (
 // filter and Gardner clock recovery without running them at the SDR's
 // native multi-MS/s rate.
 const p25p2VoiceIntermediateHz = 48_000
+
+// p25p2ChannelSelectHz caps the voice front-end channel filter at half the
+// 12.5 kHz P25 channel spacing. A wideband DDC voice tap hands the chain a
+// stream already at the intermediate rate but band-limited only to the tap's
+// output Nyquist (~±24 kHz), NOT to a single 12.5 kHz channel — so the old
+// pass-through front end fed that whole ±24 kHz span into the receiver. Unlike
+// Phase 1 (C4FM/FM discriminator) there is no FM capture effect here: Phase 2
+// is linear H-DQPSK, and adjacent-channel energy instead pumps the receiver's
+// AGC down (shrinking the wanted constellation's decision margin) and raises the
+// noise floor the coarse-carrier / Costas loops estimate against — degrading
+// carrier recovery and raising EVM. Filtering to ±6.25 kHz drops an adjacent
+// channel centred at ±12.5 kHz deep into the 81-tap front end's stopband while
+// the wanted H-DQPSK (occupied ≈ ±3.6 kHz at 6000 baud, α=0.2) passes flat.
+const p25p2ChannelSelectHz = 6250.0
+
+// newP25P2VoiceFrontEnd builds the channel-select + decimation front end for
+// the P25 Phase 2 voice chain. Mirrors newP25P1VoiceFrontEnd: on the
+// dedicated-tuner path (iqHz well above the intermediate rate) the decimating
+// FIR already band-limits as it decimates; on the pass-through path (a wideband
+// DDC tap already at the intermediate rate, decim==1) the old front end applied
+// NO filter at all, so this channel-selects to ±min(bw, p25p2ChannelSelectHz)
+// before the receiver. Factored out so the selectivity is unit-testable.
+func newP25P2VoiceFrontEnd(iqHz float64, bw uint32) *decimatingFIR {
+	chanBW := float64(bw)
+	decim := int(math.Round(iqHz)) / p25p2VoiceIntermediateHz
+	filterAtUnity := false
+	if decim <= 1 {
+		filterAtUnity = true
+		if chanBW > p25p2ChannelSelectHz {
+			chanBW = p25p2ChannelSelectHz
+		}
+	}
+	return newDecimatingFIR(iqHz, p25p2VoiceIntermediateHz, chanBW, filterAtUnity)
+}
 
 // p25p2VoiceGardnerGain matches the value newP25Phase2Pipeline settled
 // on for the H-DQPSK symbol clock (smaller than the receiver default
@@ -101,9 +136,12 @@ func (c *Composer) runP25Phase2VoiceChain(ctx context.Context, serial string, sy
 	// of the result. At 2.4 MS/s that wasted ~194M MACs/sec per voice call
 	// and starved the live IQ consumer until the SDR dropped chunks. Same
 	// coefficients and same kept samples as before, so the decode is
-	// byte-for-byte unchanged — only the wasted work is removed. decim==1
-	// (a source already at the intermediate rate) is a pass-through no-op.
-	fe := newDecimatingFIR(iqHz, p25p2VoiceIntermediateHz, float64(c.bw), false)
+	// byte-for-byte unchanged — only the wasted work is removed. decim==1 (a
+	// source already at the intermediate rate — a wideband DDC voice tap) is NOT
+	// a pass-through: it still channel-selects to a single P25 channel before the
+	// receiver (see newP25P2VoiceFrontEnd / p25p2ChannelSelectHz) so an adjacent
+	// ±12.5 kHz channel can't pump the AGC / degrade carrier recovery.
+	fe := newP25P2VoiceFrontEnd(iqHz, c.bw)
 	symbolHz := fe.OutRateHz()
 
 	rs, _ := c.sink.(rawFrameSink)

--- a/internal/voice/composer/p25p2_voice_test.go
+++ b/internal/voice/composer/p25p2_voice_test.go
@@ -678,12 +678,12 @@ func TestP25P2VoiceFrontEndRejectsAdjacentChannel(t *testing.T) {
 // wanted call survives, not that the neighbour decodes.)
 func TestComposerP25Phase2VoiceChainSurvivesAdjacentChannel(t *testing.T) {
 	const (
-		sampleRate = float64(p25p2VoiceIntermediateHz) // 48 kHz: wideband tap, decim==1
-		sps        = 8
-		span       = 8
-		alpha      = 0.20
+		sampleRate  = float64(p25p2VoiceIntermediateHz) // 48 kHz: wideband tap, decim==1
+		sps         = 8
+		span        = 8
+		alpha       = 0.20
 		superframes = 8
-		adjOffset  = 12_500.0
+		adjOffset   = 12_500.0
 	)
 	framesPerSuperframe := p25p2.SubframesPerSuperframe * p25p2.Voice4VFrameCount
 

--- a/internal/voice/composer/p25p2_voice_test.go
+++ b/internal/voice/composer/p25p2_voice_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"math"
 	"strings"
 	"testing"
 	"time"
@@ -32,11 +33,18 @@ func p25p2VoicePayload(seed int) []byte {
 // superframes preceded by a clock-settling lead-in. want holds every
 // AMBE+2 payload it carries, in transmission order.
 func buildP25P2VoiceStream(n int) (dibits []uint8, want [][]byte) {
+	return buildP25P2VoiceStreamSeed(n, 0)
+}
+
+// buildP25P2VoiceStreamSeed is buildP25P2VoiceStream with a seed offset so a
+// test can build two streams with DISTINCT AMBE+2 payloads (a wanted call and
+// an adjacent-channel neighbour) and tell which one the chain decoded.
+func buildP25P2VoiceStreamSeed(n, seed0 int) (dibits []uint8, want [][]byte) {
 	dibits = make([]uint8, 600)
 	for i := range dibits {
 		dibits[i] = uint8(i % 4) // never matches the outbound sync
 	}
-	frame := 0
+	frame := seed0
 	for s := 0; s < n; s++ {
 		var subs [p25p2.SubframesPerSuperframe][]uint8
 		for i := range subs {
@@ -615,5 +623,130 @@ func TestComposerP25Phase2CallCensusCountsMAC(t *testing.T) {
 	}
 	if !strings.Contains(out, "slot_"+p25p2.SlotTypeMACSignaling.String()+"=") {
 		t.Fatalf("census missing slot_%s bucket, got:\n%s", p25p2.SlotTypeMACSignaling, out)
+	}
+}
+
+// TestP25P2VoiceFrontEndRejectsAdjacentChannel pins the channel selectivity of
+// the wideband Phase 2 voice tap's front end: an adjacent P25 channel centred
+// at ±12.5 kHz must be strongly rejected. The old pass-through front end
+// (decim==1) applied NO filter, so a neighbour reached the linear H-DQPSK
+// receiver at full amplitude, pumping its AGC and degrading carrier recovery.
+// Fails first: pass-through leaves the neighbour at ~0 dB.
+func TestP25P2VoiceFrontEndRejectsAdjacentChannel(t *testing.T) {
+	const (
+		fs        = float64(p25p2VoiceIntermediateHz) // 48 kHz wideband tap output → decim==1
+		bw        = uint32(12_500)
+		adjOffset = 12_500.0
+		nSamples  = 24_000
+	)
+	respAt := func(offsetHz float64) float64 {
+		fe := newP25P2VoiceFrontEnd(fs, bw)
+		in := make([]complex64, nSamples)
+		for i := range in {
+			th := 2 * math.Pi * offsetHz * float64(i) / fs
+			in[i] = complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		}
+		out := fe.Process(nil, in)
+		var peak float64
+		for _, s := range out[len(out)/2:] {
+			if m := math.Hypot(float64(real(s)), float64(imag(s))); m > peak {
+				peak = m
+			}
+		}
+		return peak
+	}
+	wanted := respAt(0)
+	neighbour := respAt(adjOffset)
+	if wanted < 0.5 {
+		t.Fatalf("wanted channel (DC) attenuated to %.3f; front end should pass it flat", wanted)
+	}
+	rejectionDB := 20 * math.Log10(neighbour/wanted)
+	if rejectionDB > -40 {
+		t.Errorf("adjacent channel (+%.0f Hz) rejection = %.1f dB; want <= -40 dB "+
+			"(a ±12.5 kHz neighbour leaks into the Phase 2 voice tap and degrades the demod)",
+			adjOffset, rejectionDB)
+	}
+}
+
+// TestComposerP25Phase2VoiceChainSurvivesAdjacentChannel is the end-to-end
+// regression: a wanted Phase 2 call at DC with a STRONGER adjacent call at
+// +12.5 kHz present. Without a channel-select filter the neighbour corrupts the
+// linear demod (AGC pumping, carrier-recovery degradation, raised EVM) and the
+// wanted call's frames are lost. With the filter the neighbour is rejected and
+// the wanted call decodes. Fails first. (Unlike the FM Phase 1 path the linear
+// demod does not cleanly "capture" the neighbour, so we assert only that the
+// wanted call survives, not that the neighbour decodes.)
+func TestComposerP25Phase2VoiceChainSurvivesAdjacentChannel(t *testing.T) {
+	const (
+		sampleRate = float64(p25p2VoiceIntermediateHz) // 48 kHz: wideband tap, decim==1
+		sps        = 8
+		span       = 8
+		alpha      = 0.20
+		superframes = 8
+		adjOffset  = 12_500.0
+	)
+	framesPerSuperframe := p25p2.SubframesPerSuperframe * p25p2.Voice4VFrameCount
+
+	dibitsW, wantW := buildP25P2VoiceStreamSeed(superframes, 0)
+	iq := demod.ModulateHDQPSKSpec(dibitsW, sps, span, alpha)
+
+	dibitsN, _ := buildP25P2VoiceStreamSeed(superframes, 500_000)
+	iqN := demod.ModulateHDQPSKSpec(dibitsN, sps, span, alpha)
+	for i := range iq {
+		if i >= len(iqN) {
+			break
+		}
+		th := 2 * math.Pi * adjOffset * float64(i) / sampleRate
+		rot := complex(float32(math.Cos(th)), float32(math.Sin(th)))
+		iq[i] += 2 * iqN[i] * rot
+	}
+
+	src := newFakeSource()
+	bus := events.NewBus(8)
+	sink := &recordingSink{}
+	eng := &fakeEngine{}
+	c, err := New(Options{
+		Bus:           bus,
+		Devices:       &fakeDevices{src: map[string]IQSource{"VOICE-1": src}},
+		Sink:          sink,
+		Engine:        eng,
+		IQSampleRate:  uint32(sampleRate),
+		PCMSampleRate: 8000,
+		TouchInterval: 30 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go c.Run(ctx)
+	defer c.Close()
+	defer bus.Close()
+
+	bus.Publish(events.Event{
+		Kind: events.KindCallStart,
+		Payload: trunking.CallStart{
+			Grant: trunking.Grant{
+				System: "P25P2Site", Protocol: "p25-phase2",
+				GroupID: 42, FrequencyHz: 851_062_500,
+			},
+			DeviceSerial: "VOICE-1",
+			StartedAt:    time.Now().UTC(),
+		},
+	})
+
+	waitFor(t, 2*time.Second, func() bool { return len(c.ActiveChains()) == 1 })
+	src.SendIQ(iq)
+
+	waitFor(t, 6*time.Second, func() bool {
+		return len(sink.rawFrames("VOICE-1")) >= framesPerSuperframe
+	})
+	got := sink.rawFrames("VOICE-1")
+
+	matchW := bestAlignmentMatches(got, wantW)
+	if matchW < framesPerSuperframe {
+		t.Errorf("wanted call recovered only %d frames with a strong +%.0f Hz neighbour present; "+
+			"want >= %d (adjacent channel leaked into the tap and degraded the demod)",
+			matchW, adjOffset, framesPerSuperframe)
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to the merged Phase 1 wideband voice-tap fix (#901). It finishes the
two items that fix explicitly deferred: the same wideband channel-select leak in
the **P25 Phase 2 and DMR** voice chains, and a **per-call SNR/EVM** demod-quality
metric for P25 Phase 1 (the number an operator compares against SDRTrunk).

Two logically-separate commits — the leak fix and the metric — kept apart per
CONTRIBUTING.md.

## Changes

- **P2 + DMR channel-select filter (commit 1).** Both chains had the identical
  `decim==1` pass-through front end, feeding the receiver a ±24 kHz-wide 48 kHz
  wideband-tap stream with no channel filter, so adjacent ±12.5 kHz channels
  leaked in. Added `newP25P2VoiceFrontEnd` / `newDMRVoiceFrontEnd` mirroring the
  merged `newP25P1VoiceFrontEnd` (channel-select to ±6.25 kHz — half the 12.5 kHz
  spacing). DMR is 4FSK/FM-discriminator (a leaked neighbour is captured and,
  with gating disabled, recorded *as* the call); P25 Phase 2 is linear H-DQPSK
  (no FM capture — adjacent energy instead pumps the AGC and degrades carrier
  recovery), and the code comment states the correct mechanism for each. The
  dedicated-tuner path is unchanged.
- **Per-call SNR/EVM metric for P25 Phase 1 (commit 2).** The chain installs the
  receiver's `SoftSink` (C4FM eye) / `SymbolSink` (CQPSK constellation) taps into
  a bounded per-call accumulator on the boundary tracker; at end-of-call it
  computes one figure (reusing `internal/radio/p25/phase1/metrics`, mirroring
  siglab's `demodMetrics`) and stamps `evm_pct` / `snr_db` onto the call via a new
  `UpdateDemod` engine hook — the exact path `signal_dbfs` already uses. Plumbed
  `CallEnd → ActiveCall → call_log` (new nullable columns + migration) →
  call-history REST DTO. `nil` for unmeasured calls and for the Phase 2 / DMR
  chains (their receivers expose no demod taps yet — a further follow-up). The
  gRPC `RIDCallRow` surface is unchanged, consistent with `signal_dbfs`.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — not run (no daemon/replay behaviour changed; the DSP
      change is unit-covered by the front-end selectivity + end-to-end chain tests)
- [x] Added or updated tests where appropriate
- [ ] Smoke-tested against real hardware — not available in this environment;
      the DSP paths are covered by synthetic modulated-IQ tests instead

New tests (all fail-first where they guard a behaviour change):
- `TestP25P2VoiceFrontEndRejectsAdjacentChannel` / `TestComposerP25Phase2VoiceChainSurvivesAdjacentChannel`
- `TestDMRVoiceFrontEndRejectsAdjacentChannel` / `TestComposerDMRVoiceChainSurvivesAdjacentChannel`
  (reverting the one-line front-end swap fails both end-to-end tests)
- `TestBoundaryMeasuresDemodMetrics` (clean eye → finite low EVM / high SNR + stamp; too few symbols → nothing)
- `TestCallLogPersistsDemodMetrics` (evm_pct/snr_db round-trip; nil stays NULL)

## Breaking changes

None — additive only. New API fields (`evm_pct` / `snr_db`) are `omitempty`; the
new `call_log` columns are nullable and added by an idempotent migration; the
`gated_ldus` decode-quality log field is additive.

## Docs / CHANGELOG

- [x] Added `## [Unreleased]` bullets to `CHANGELOG.md` (Added: per-call EVM/SNR;
      Fixed: P2 + DMR channel-select)
- [ ] No operator-facing README/docs change needed

## Linked issues

Refs #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcrJkV4YftF1f2hwx9UH5c

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcrJkV4YftF1f2hwx9UH5c)_