### PR TITLE
voice/imbe: squelch the P25 receiver-acquisition startup scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ for tagged releases.
 
 ## [Unreleased]
 
+### Fixed
+- **P25 Phase 1 recordings opened with a full-scale "startup scratch".** While
+  the receiver is still acquiring symbol lock at the start of a transmission, the
+  FEC layer resolves the marginal dibit stream to random-but-valid IMBE frames
+  that the vocoder synthesised as a loud burst — where a reference decoder
+  (TrunkRecorder) is silent. Measured across field captures, every call blasted
+  the soft-limiter rail (~24000–26000) for the first ~0.15–0.55 s. The IMBE
+  decoder now applies a **call-startup acquisition squelch**: it mutes output
+  until a sustained run of stable-pitch voiced frames confirms real speech
+  (acquisition garbage is idle / unvoiced / pitch-jumping), then releases for the
+  rest of the segment. Muted frames are zeroed, not dropped, so the recording
+  keeps its length. Enabled on the recorder/live path only (the raw decoder is
+  unchanged). This is a heuristic — the true acquisition state lives in the
+  receiver, not the vocoder frames — so a call that never presents a stable
+  voiced run (e.g. unvoiced-only) opens muted up to a failsafe window.
+
 ### Security
 - **Go toolchain bumped to 1.25.12** to close `GO-2026-5856` — an Encrypted
   Client Hello privacy leak in the standard library's `crypto/tls`, which

--- a/internal/radio/p25/phase1/ldu_e2e_test.go
+++ b/internal/radio/p25/phase1/ldu_e2e_test.go
@@ -45,12 +45,21 @@ import (
 func TestLDUEndToEndIntoRecorder(t *testing.T) {
 	// Build 9 synthetic IMBE info-bit patterns, one per voice
 	// subframe.
+	// The recorder enables the call-startup acquisition squelch, which mutes
+	// output until a stable-pitch VOICED run confirms real speech. So build the
+	// 9 subframes with a FIXED fundamental (stable pitch) and a voiced-leaning
+	// payload — a real recording opens this way — otherwise the whole call is
+	// squelched and the WAV is silent. b0 bits live at info[0..5, 85, 86].
+	const b0 = 48
 	var infos [phase1.LDUVoiceSubframeCount][]byte
 	for i := 0; i < phase1.LDUVoiceSubframeCount; i++ {
 		bits := make([]byte, imbe.InfoBits)
 		for k := range bits {
-			bits[k] = byte((i*11 + k*3) % 2)
+			bits[k] = byte((k * 7) % 3 & 1)
 		}
+		bits[0], bits[1], bits[2] = byte((b0>>7)&1), byte((b0>>6)&1), byte((b0>>5)&1)
+		bits[3], bits[4], bits[5] = byte((b0>>4)&1), byte((b0>>3)&1), byte((b0>>2)&1)
+		bits[85], bits[86] = byte((b0>>1)&1), byte(b0&1)
 		infos[i] = bits
 	}
 

--- a/internal/voice/imbe/decoder.go
+++ b/internal/voice/imbe/decoder.go
@@ -49,6 +49,45 @@ const (
 // naturally.
 var recoveryRampFactors = [3]float64{0.4, 0.7, 1.0}
 
+// Call-startup acquisition squelch. While a P25 receiver is still acquiring
+// symbol lock at the very start of a transmission, the FEC layer can resolve
+// the marginal dibit stream to random-but-VALID IMBE parameters (jumping pitch,
+// brief invalid frames) that the synthesiser renders as a loud burst — the
+// "startup scratch" that reference decoders (TrunkRecorder / OP25) suppress.
+// There is no error signal to key off (the frames FEC-decode clean), so the
+// squelch gates on the SPEECH signature instead: real voice opens with a
+// sustained run of stable-pitch voiced frames, whereas acquisition garbage is
+// idle / unvoiced / pitch-jumping. Output is muted until that run appears, then
+// released for the rest of the segment; a failsafe releases after
+// acqMaxMuteFrames so an unusual call is never over-muted. Re-armed per
+// call/segment in ResetStats. This is a heuristic (the true acquisition state
+// lives in the receiver, not the vocoder frames) — see the field report /
+// tuning against the p25_16jul captures.
+const (
+	// acqRunFrames is how many consecutive stable-pitch voiced frames confirm
+	// real speech (each ~20 ms). 3 keeps the leaked onset under ~40 ms.
+	acqRunFrames = 4
+	// acqVoicedFracMin is the minimum voiced-harmonic fraction for a frame to
+	// count as a speech candidate — excludes the fully-unvoiced acquisition
+	// noise (voicedFrac 0) while still catching a real voiced onset (which
+	// runs well above this even on a breathy talker).
+	acqVoicedFracMin = 0.1
+	// acqMaxB0Jump is the largest frame-to-frame pitch-index change still
+	// counted as "stable". Real speech pitch glides by a few indices/frame;
+	// acquisition garbage jumps by ~100.
+	acqMaxB0Jump = 20
+	// acqMaxMuteFrames is the failsafe: never squelch more than this many
+	// frames (~2 s) of a call, so a pathological call can't be fully muted.
+	acqMaxMuteFrames = 100
+)
+
+func iabs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
 // IdleToneRunThreshold drives idle-tone suppression. An unmodulated/idle
 // voice-channel carrier (or the demod warm-up/decay transient at the very
 // start/end of a transmission) produces a dibit stream the per-vector FEC
@@ -185,6 +224,23 @@ type Decoder struct {
 	// recording opens cleanly. See the muteTone gate in Decode.
 	voiceStarted bool
 
+	// squelchEnabled turns on the call-startup acquisition squelch (see
+	// acqRunFrames). Off by default so the raw decoder (and its unit tests)
+	// behave exactly as before; the recorder enables it on the live/recording
+	// path via EnableStartupSquelch. Kept opt-in because it is a heuristic that
+	// can mute the opening of an atypical call.
+	squelchEnabled bool
+	// Call-startup acquisition squelch state (see acqRunFrames). acquired is
+	// false until a sustained stable-pitch voiced run confirms real speech;
+	// output is muted until then. acqRun counts the current run;
+	// acqLastVoicedB0 is the previous candidate frame's pitch index (−1 = none);
+	// acqFrames counts frames since (re)arm for the failsafe. Re-armed per
+	// call/segment in ResetStats.
+	acquired        bool
+	acqRun          int
+	acqLastVoicedB0 int
+	acqFrames       int
+
 	// stats accumulates the per-call VoiceStats summary. Cleared only by
 	// ResetStats (the recorder calls it at call/segment boundaries) — NOT
 	// by Reset, so a mid-call re-sync doesn't discard the running totals.
@@ -262,11 +318,20 @@ func NewWithConfig(seed int64, cfg mbe.AGCConfig) *Decoder {
 		agc:      mbe.NewAGC(cfg),
 		// Fade in the first frames of the very first segment (stream onset).
 		segFadeRemaining: len(recoveryRampFactors),
+		// Arm the call-startup acquisition squelch (see acqRunFrames).
+		acqLastVoicedB0: -1,
 	}
 }
 
 // Name returns the registry key. Matches VocoderName.
 func (d *Decoder) Name() string { return VocoderName }
+
+// EnableStartupSquelch turns on the call-startup acquisition squelch (see
+// acqRunFrames): the decoder mutes output at the start of a transmission until
+// a sustained stable-pitch voiced run confirms real speech, suppressing the
+// receiver-acquisition "startup scratch". Off by default (opt-in) because it is
+// a heuristic; the recorder enables it on the recording/live path.
+func (d *Decoder) EnableStartupSquelch() { d.squelchEnabled = true }
 
 // FrameSize returns the per-frame input byte count (11 bytes / 88
 // bits, packed MSB-first).
@@ -347,6 +412,40 @@ func (d *Decoder) Decode(frame []byte) ([]int16, error) {
 	// started, fall back to the run threshold so a lone idle frame inside
 	// speech still leaks once rather than clipping audio.
 	muteTone := tone && (d.lowB0RunCount >= IdleToneRunThreshold || !d.voiceStarted)
+
+	// Call-startup acquisition squelch (see acqRunFrames): advance the
+	// stable-pitch voiced run and confirm real speech before un-muting. Runs
+	// for every frame (before the switch) so idle/bad/silent frames break the
+	// run. accumStats (called on every return path) zeroes the output while
+	// !acquired, so the mute covers all dispositions uniformly.
+	if d.squelchEnabled && !d.acquired {
+		voiceCand := err == nil && !p.Silent && !p.IdleTone
+		vf := 0.0
+		if voiceCand && p.L > 0 {
+			vc := 0
+			for l := 1; l <= p.L; l++ {
+				if p.Vl[l] == 1 {
+					vc++
+				}
+			}
+			vf = float64(vc) / float64(p.L)
+		}
+		if voiceCand && vf >= acqVoicedFracMin {
+			if d.acqLastVoicedB0 >= 0 && iabs(b0-d.acqLastVoicedB0) <= acqMaxB0Jump {
+				d.acqRun++
+			} else {
+				d.acqRun = 1
+			}
+			d.acqLastVoicedB0 = b0
+		} else {
+			d.acqRun = 0
+			d.acqLastVoicedB0 = -1
+		}
+		d.acqFrames++
+		if d.acqRun >= acqRunFrames || d.acqFrames >= acqMaxMuteFrames {
+			d.acquired = true
+		}
+	}
 
 	switch {
 	case err != nil && d.lastGoodParams.L > 0 && d.badFrameCount < mbe.MaxBadFrames:
@@ -595,6 +694,17 @@ func (d *Decoder) SetVoiceEnhancer(cfg mbe.EnhancerConfig) {
 // samples into the per-call stats. Call immediately after agc.Apply on
 // every return path so the amplitude-health numbers cover all output.
 func (d *Decoder) accumStats(out []int16) {
+	// Call-startup acquisition squelch (see acqRunFrames): while the receiver
+	// is still acquiring, zero the output so the startup burst never reaches
+	// the WAV / live audio. The samples are muted, NOT dropped, so the
+	// recording keeps its length; they register as silence in the stats.
+	if d.squelchEnabled && !d.acquired {
+		for i := range out {
+			out[i] = 0
+		}
+		d.stats.sampleCount += len(out)
+		return
+	}
 	d.stats.clipSamples += d.agc.LastClipSamples()
 	if p := d.agc.LastMaxPreClipPeak(); p > d.stats.maxPreClipPeak {
 		d.stats.maxPreClipPeak = p
@@ -711,8 +821,15 @@ func (d *Decoder) SetFrameErrors(correctedBits int) { d.frameErrs = correctedBit
 // ResetStats clears the per-call telemetry. The recorder calls it at
 // call / segment boundaries. Kept separate from Reset (which clears
 // synthesis state on mid-call re-sync) so a re-sync doesn't discard the
-// call's running totals.
-func (d *Decoder) ResetStats() { d.stats = callStats{} }
+// call's running totals. Also re-arms the call-startup acquisition squelch
+// (see acqRunFrames) so each call/segment re-suppresses its own startup burst.
+func (d *Decoder) ResetStats() {
+	d.stats = callStats{}
+	d.acquired = false
+	d.acqRun = 0
+	d.acqLastVoicedB0 = -1
+	d.acqFrames = 0
+}
 
 // clearLastGood resets the frame-repeat cache + bad-frame counter.
 // Called on silence-window frames, on the bad-frame budget being

--- a/internal/voice/imbe/recorder_integration_test.go
+++ b/internal/voice/imbe/recorder_integration_test.go
@@ -62,12 +62,14 @@ func TestRecorderDecodesP25IntoWav(t *testing.T) {
 		t.Fatal("session never opened")
 	}
 
-	// Feed N IMBE frames. Each frame is 11 bytes; goodVoiceFrame is a
-	// valid non-idle voice frame (b₀ just outside the idle-tone corner)
-	// so synthesis runs from the first frame instead of the onset mute.
-	const n = 4
+	// Feed N IMBE frames. The recorder enables the call-startup acquisition
+	// squelch (EnableStartupSquelch), which mutes until a stable-pitch VOICED
+	// run confirms real speech — so use a voiced frame (speechBits), repeated
+	// for a stable pitch, and enough of them to release the squelch and emit.
+	voiceFrame := packInfo(speechBits(48))
+	const n = 8
 	for i := 0; i < n; i++ {
-		if err := rec.WriteRawFrame("VOICE-1", goodVoiceFrame()); err != nil {
+		if err := rec.WriteRawFrame("VOICE-1", voiceFrame); err != nil {
 			t.Fatalf("WriteRawFrame: %v", err)
 		}
 	}

--- a/internal/voice/imbe/startup_squelch_test.go
+++ b/internal/voice/imbe/startup_squelch_test.go
@@ -1,0 +1,120 @@
+package imbe
+
+import (
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/voice/mbe"
+)
+
+// packInfo packs an 88-element bit slice into an 11-byte frame (MSB-first),
+// the inverse of unpackInfoBits.
+func packInfo(bits []byte) []byte {
+	f := make([]byte, FrameBytes)
+	for i := 0; i < InfoBits && i < len(bits); i++ {
+		if bits[i]&1 == 1 {
+			f[i/8] |= 1 << (7 - uint(i)%8)
+		}
+	}
+	return f
+}
+
+// setB0 writes an 8-bit fundamental-frequency index into the info-bit slots
+// b0FromInfo reads (info[0..5] high bits, info[85..86] low bits).
+func setB0(bits []byte, b0 int) {
+	bits[0] = byte((b0 >> 7) & 1)
+	bits[1] = byte((b0 >> 6) & 1)
+	bits[2] = byte((b0 >> 5) & 1)
+	bits[3] = byte((b0 >> 4) & 1)
+	bits[4] = byte((b0 >> 3) & 1)
+	bits[5] = byte((b0 >> 2) & 1)
+	bits[85] = byte((b0 >> 1) & 1)
+	bits[86] = byte(b0 & 1)
+}
+
+// speechBits builds an info-bit pattern with a given (stable) b0 and a fixed
+// non-b0 payload that decodes to a valid, non-idle, partly-voiced frame.
+func speechBits(b0 int) []byte {
+	bits := make([]byte, InfoBits)
+	for i := range bits {
+		bits[i] = byte((i * 7) % 3 & 1) // deterministic non-trivial payload
+	}
+	setB0(bits, b0)
+	return bits
+}
+
+func firstNonZero(pcm []int16) int {
+	for i, s := range pcm {
+		if s != 0 {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestStartupSquelchMutesUntilStableVoice verifies the call-startup acquisition
+// squelch: with it enabled, jumping-pitch acquisition frames are muted and
+// output only begins once a stable-pitch voiced run confirms real speech; with
+// it disabled the decoder behaves as before (output from the first frame). The
+// muted frames are zeroed, not dropped, so the length is unchanged.
+func TestStartupSquelchMutesUntilStableVoice(t *testing.T) {
+	// A "speech" frame reused for a stable-pitch run.
+	speech := packInfo(speechBits(48))
+	// Sanity: it must decode to a real (non-idle, non-silent), partly-voiced
+	// frame, else the run can never confirm.
+	probe := New()
+	if s, err := probe.Decode(speech); err != nil || firstNonZero(s) < 0 {
+		t.Fatalf("constructed speech frame did not synthesize (err=%v); adjust speechBits", err)
+	}
+
+	// Garbage: valid frames with wildly jumping pitch (acquisition signature).
+	garbageB0 := []int{60, 190, 40, 175, 30, 200, 66}
+	var stream [][]byte
+	for _, b0 := range garbageB0 {
+		stream = append(stream, packInfo(speechBits(b0)))
+	}
+	for i := 0; i < 10; i++ { // stable-pitch voiced run → releases the squelch
+		stream = append(stream, speech)
+	}
+
+	decode := func(squelch bool) []int16 {
+		d := New()
+		if squelch {
+			d.EnableStartupSquelch()
+		}
+		var out []int16
+		for _, f := range stream {
+			s, _ := d.Decode(f)
+			out = append(out, s...)
+		}
+		return out
+	}
+
+	off := decode(false)
+	on := decode(true)
+
+	if len(on) != len(off) {
+		t.Fatalf("squelch changed length: on=%d off=%d (must mute, not drop)", len(on), len(off))
+	}
+	garbageSamples := len(garbageB0) * mbe.SamplesPerFrame
+	// Without the squelch, the garbage synthesizes within the garbage window —
+	// this is the "startup scratch" the squelch removes.
+	if off0 := firstNonZero(off); off0 < 0 || off0 >= garbageSamples {
+		t.Fatalf("baseline (squelch off) produced no output in the garbage window (first=%d); "+
+			"the fixture must exercise the scratch", off0)
+	}
+	// With the squelch, the jumping-pitch garbage stays muted: nothing in the
+	// first len(garbageB0) frames.
+	for i := 0; i < garbageSamples && i < len(on); i++ {
+		if on[i] != 0 {
+			t.Fatalf("squelch leaked garbage at sample %d (frame %d): got %d, want 0",
+				i, i/mbe.SamplesPerFrame, on[i])
+		}
+	}
+	// And it eventually releases on the stable-voiced run: the tail is non-zero.
+	if firstNonZero(on) < 0 {
+		t.Fatal("squelch never released on the stable-voiced run — whole call muted")
+	}
+	if firstNonZero(on) < garbageSamples {
+		t.Fatalf("squelch released during the garbage (sample %d < %d)", firstNonZero(on), garbageSamples)
+	}
+}

--- a/internal/voice/recorder.go
+++ b/internal/voice/recorder.go
@@ -30,6 +30,16 @@ type VoiceEnhanceable interface {
 	SetVoiceEnhancer(cfg mbe.EnhancerConfig)
 }
 
+// StartupSquelchable is the optional interface a software vocoder implements
+// to accept the call-startup acquisition squelch — muting the receiver's
+// acquisition "startup scratch" until real speech is confirmed. The recorder
+// enables it on every decoded call so recordings and the live fan-out both
+// open cleanly. Vocoders that don't implement it decode unchanged. The imbe
+// (P25 Phase 1) decoder implements it.
+type StartupSquelchable interface {
+	EnableStartupSquelch()
+}
+
 // Recorder writes per-call audio + raw-frame files. It subscribes to
 // events.KindCallStart and events.KindCallEnd from the trunking engine,
 // opens a WAV (and optional raw-frame sidecar) for each new call, and
@@ -792,6 +802,12 @@ func (r *Recorder) buildSession(cs trunking.CallStart, startedAt time.Time) *rec
 			// SetVoiceEnhance take effect on the next call.
 			if enh, ok := v.(VoiceEnhanceable); ok {
 				enh.SetVoiceEnhancer(r.VoiceEnhance())
+			}
+			// Suppress the receiver-acquisition "startup scratch" on the
+			// recording/live path (opt-in on the vocoder; off in the raw
+			// decoder so unit tests are unaffected).
+			if sq, ok := v.(StartupSquelchable); ok {
+				sq.EnableStartupSquelch()
 			}
 			s.vocoder = v
 			s.vocoderName = name


### PR DESCRIPTION
## Summary

P25 Phase 1 recordings opened with a full-scale noise burst — the "startup
scratch." While the receiver is still acquiring symbol lock at the start of a
transmission, the FEC layer resolves the marginal dibit stream to
random-but-*valid* IMBE frames (jumping pitch, brief invalid frames) that the
vocoder synthesises as a loud blast, where a reference decoder (TrunkRecorder)
is silent. Frame-by-frame analysis of three field captures showed every call
railing the soft-limiter (~24000–26000) for the first ~0.15–0.55 s. The frames
FEC-decode clean, so there is no error signal to key off.

## Changes

- **Call-startup acquisition squelch in the IMBE decoder.** Since energy and FEC
  can't tell the garbage from speech, it gates on the *speech signature*: mute
  output until a sustained run of stable-pitch **voiced** frames confirms real
  speech (acquisition garbage is idle / unvoiced / pitch-jumping), then release
  for the rest of the segment. Muted frames are **zeroed, not dropped**, so the
  recording keeps its length. A failsafe releases after a bounded window so a
  call is never fully muted. Re-armed per call/segment.
- **Opt-in on the vocoder** (`EnableStartupSquelch`): the recorder turns it on
  for the recording/live path via a new `StartupSquelchable` interface, while
  the raw decoder — and its unit tests — behave exactly as before.
- Two recorder integration tests that fed *unvoiced* synthetic frames now feed a
  voiced-stable run (what a real recording presents), plus a new synthetic
  regression test for the squelch state machine.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — not run (no daemon/replay path changed)
- [x] Added or updated tests (new `startup_squelch_test.go`; two integration
      tests updated)
- [ ] Smoke-tested against real hardware — not available here. Validated instead
      by decoding the reporter's three `.raw` captures through the vocoder: with
      the squelch the first-0.6 s peak drops from the 26213 rail to **0** (male,
      male2) or to the real-speech onset (female), with the body and length
      unchanged.

**Heuristic caveat (please listen-test):** the true acquisition state lives in
the receiver, not the vocoder frames, so a call that never presents a stable
voiced run (e.g. unvoiced-only) opens muted up to the failsafe. `acqRunFrames`
is the confidence knob. The residual ~1-LDU tail-length difference and the
demod-side tonal/loudness gap versus TrunkRecorder need the narrowband DDC IQ
(`gophertrunk iq record`) to reproduce and are left as follow-ups.

## Breaking changes

None — the raw decoder is unchanged (squelch off by default); only the recorder
path enables it. No config keys, flags, or schemas change.

## Docs / CHANGELOG

- [x] Added a `## [Unreleased]` bullet to `CHANGELOG.md`
- [ ] No operator-facing README/docs change needed

## Linked issues

Refs #644

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcrJkV4YftF1f2hwx9UH5c

---
_Generated by [Claude Code](https://claude.ai/code/session_01GcrJkV4YftF1f2hwx9UH5c)_