### PR TITLE
release: v0.7.1 — fold changelog + bump doc version pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ for tagged releases.
 
 ## [Unreleased]
 
+## [v0.7.1] — 2026-07-16
+
 ### Fixed
 - **P25 Phase 1 recordings opened with a full-scale "startup scratch".** While
   the receiver is still acquiring symbol lock at the start of a transmission, the

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ this exist? Read **[The Story of GopherTrunk](https://gophertrunk.org/story.html
 
 ```sh
 # Linux x86_64 — see https://gophertrunk.org/downloads.html for macOS, Windows, ARM64.
-VERSION=v0.6.4
+VERSION=v0.7.1
 curl -L -o gophertrunk.tar.gz \
   https://github.com/MattCheramie/GopherTrunk/releases/download/${VERSION}/gophertrunk-${VERSION}-linux-amd64.tar.gz
 tar xzf gophertrunk.tar.gz && cd gophertrunk-${VERSION}-linux-amd64

--- a/docs/_includes/latest-version.html
+++ b/docs/_includes/latest-version.html
@@ -21,6 +21,6 @@ Three-tier resolution so callers stay useful no matter the release state:
 {%- elsif site.github.releases and site.github.releases[0] and site.github.releases[0].tag_name -%}
   {%- assign ver = site.github.releases[0].tag_name -%}
 {%- else -%}
-  {%- assign ver = "v0.6.4" -%}
+  {%- assign ver = "v0.7.1" -%}
 {%- endif -%}
 {%- assign rel_url = "https://github.com/MattCheramie/GopherTrunk/releases/download/" | append: ver -%}


### PR DESCRIPTION
Sync docs to the just-tagged v0.7.1 daily release:
- CHANGELOG: promote the accumulated [Unreleased] block to
  [v0.7.1] — 2026-07-16 and open a fresh empty [Unreleased].
- README Quick Start: VERSION=v0.6.4 -> v0.7.1.
- latest-version.html: bump the defensive fallback tag to v0.7.1
  (the live path resolves from GitHub release metadata).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AdsZ2GzJBX8ZwqBbvobuEv