### PR TITLE
Add profiles, sign-up split, public profiles, and content moderation (site)

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -101,6 +101,10 @@ groups:
         url: /forum/
       - title: Account
         url: /account/
+      - title: Profile
+        url: /profile/
+      - title: Moderation
+        url: /moderation/
   - label: Blog
     items:
       - title: All posts

--- a/docs/account.md
+++ b/docs/account.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Account
-description: Sign in to sync your GopherTrunk learning-path progress across devices — GitHub, Google, email, or a magic link.
+description: Create a free GopherTrunk account or sign in — GitHub, Google, email, or a magic link. Syncs your learning-path progress and unlocks the community forum and a public profile.
 permalink: /account/
 nav_group: Community
 hide_ctas: true
@@ -9,15 +9,18 @@ hide_ctas: true
 
 # Account
 
-Signing in is optional. It syncs your **learning-path progress** across devices — your
-completed lessons follow you from laptop to phone. Signed out, everything still works;
-progress just lives in this browser.
+A free account is optional. It **syncs your learning-path progress** across devices, and
+unlocks the **[community forum](/forum/)** and a **[public profile](/u/)**. Signed out,
+everything still works — progress just lives in this browser.
 
 <div class="account" data-account>
   <p class="account__loading" data-account-loading>Loading…</p>
 
   <section class="account__signin" data-account-signin hidden>
     <h2>Sign in or create an account</h2>
+    <p class="account__lede">New here? Use any method below — the first time you sign in,
+      your account is created automatically. Creating one lets you post in the forum and
+      gives you a public profile you can fill out.</p>
 
     <div class="account__oauth">
       <button type="button" class="btn btn--secondary" data-oauth="github">Continue with GitHub</button>
@@ -48,15 +51,10 @@ progress just lives in this browser.
     <p>Signed in as <strong data-account-name>…</strong> <span class="account__email" data-account-email></span>.
        Your learning-path progress syncs automatically.</p>
 
-    <form class="account__form" data-form="profile" novalidate>
-      <h3>Profile</h3>
-      <label>Display name <input type="text" name="display_name" maxlength="60" autocomplete="name"></label>
-      <label>Username <input type="text" name="username" maxlength="30" autocomplete="off"></label>
-      <div class="account__form-actions">
-        <button type="submit" class="btn">Save profile</button>
-      </div>
-      <p class="account__msg" data-account-profile-msg role="status" aria-live="polite"></p>
-    </form>
+    <p class="account__panel-links">
+      <a class="btn" data-profile-edit href="/profile/">Edit your profile</a>
+      <a class="btn btn--secondary" data-profile-view href="/u/">View public profile</a>
+    </p>
 
     <p class="account__panel-actions">
       <button type="button" class="btn btn--secondary" data-signout>Sign out</button>
@@ -108,7 +106,22 @@ document.addEventListener('DOMContentLoaded', function () {
     return m.user_name || m.preferred_username || m.name ||
       (u.email ? u.email.split('@')[0] : 'you');
   }
-  var profileLoadedFor = null;
+
+  // Fill in the "view public profile" link with the user's username once known,
+  // so it points at /u/?u=<username> rather than the bare /u/ prompt page.
+  var viewLink = panel.querySelector('[data-profile-view]');
+  var profileLinkedFor = null;
+  function linkPublicProfile() {
+    if (!viewLink || !GT.user || profileLinkedFor === GT.user.id) return;
+    profileLinkedFor = GT.user.id;
+    GT.supabase.from('profiles').select('username').eq('id', GT.user.id).single()
+      .then(function (res) {
+        if (res && res.data && res.data.username) {
+          viewLink.setAttribute('href', '/u/?u=' + encodeURIComponent(res.data.username));
+        }
+      });
+  }
+
   function render() {
     hide(loading);
     if (GT.user) {
@@ -117,43 +130,14 @@ document.addEventListener('DOMContentLoaded', function () {
       var e = panel.querySelector('[data-account-email]');
       if (n) n.textContent = displayName(GT.user);
       if (e) e.textContent = GT.user.email ? '(' + GT.user.email + ')' : '';
-      if (profileLoadedFor !== GT.user.id) { profileLoadedFor = GT.user.id; loadProfile(); }
+      linkPublicProfile();
     } else {
       hide(panel); show(signin);
-      profileLoadedFor = null;
+      profileLinkedFor = null;
     }
   }
   GT.onChange(render);
   if (GT.ready && GT.ready.then) GT.ready.then(render);
-
-  // Profile (display name + username) — reads/writes the `profiles` table.
-  var pf = root.querySelector('[data-form="profile"]');
-  var pfMsg = root.querySelector('[data-account-profile-msg]');
-  function loadProfile() {
-    if (!pf || !GT.user) return;
-    GT.supabase.from('profiles').select('username, display_name').eq('id', GT.user.id).single()
-      .then(function (res) {
-        if (res.error || !res.data) return;
-        pf.querySelector('[name=display_name]').value = res.data.display_name || '';
-        pf.querySelector('[name=username]').value = res.data.username || '';
-      });
-  }
-  if (pf) pf.addEventListener('submit', function (ev) {
-    ev.preventDefault();
-    if (!GT.user) return;
-    var dn = pf.querySelector('[name=display_name]').value.trim();
-    var un = pf.querySelector('[name=username]').value.trim();
-    setMsg(pfMsg, 'Saving…', true);
-    GT.supabase.from('profiles').upsert({
-      id: GT.user.id, display_name: dn || null, username: un || null
-    }).then(function (res) {
-      if (res.error) {
-        setMsg(pfMsg, /duplicate|unique/i.test(res.error.message) ? 'That username is taken.' : res.error.message, false);
-      } else {
-        setMsg(pfMsg, 'Saved.', true);
-      }
-    });
-  });
 
   root.querySelectorAll('[data-oauth]').forEach(function (btn) {
     btn.addEventListener('click', function () {
@@ -175,7 +159,9 @@ document.addEventListener('DOMContentLoaded', function () {
             : GT.signInWithPassword(email, password)).then(function (res) {
       if (res.error) { setMsg(msg, res.error.message, false); return; }
       if (signup && res.data && res.data.user && !res.data.session) {
-        setMsg(msg, 'Check your email to confirm your account.', true);
+        setMsg(msg, 'Almost there — check your email to confirm your account, then you’re in.', true);
+      } else if (signup) {
+        setMsg(msg, 'Account created — you’re signed in.', true);
       } else {
         setMsg(msg, 'Signed in.', true);
       }

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1986,3 +1986,75 @@ a.category-chip:hover {
 .forum-post__act:disabled { opacity: 0.6; cursor: default; }
 
 .forum-mod { margin-top: 0.6rem; }
+
+.forum-thread__controls { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.6rem; }
+.forum-author { color: var(--accent); }
+.forum-author:hover { text-decoration: underline; }
+
+/* ---------- Account: auth-page extras ---------- */
+.account__lede { color: var(--fg-muted); margin: 0 0 1rem; }
+.account__panel-links { display: flex; flex-wrap: wrap; gap: 0.6rem; margin: 1rem 0; }
+
+/* ---------- Profile editor (/profile/) ---------- */
+.profile-edit { max-width: var(--maxw-prose); margin: 1.5rem 0 0; }
+.profile-edit__form { display: flex; flex-direction: column; gap: 1rem; }
+.profile-edit__hint { display: block; margin: 0.2rem 0 0; font-size: 0.8rem; color: var(--fg-muted); }
+.profile-edit__avatar { display: flex; gap: 1rem; align-items: flex-start; }
+.profile-edit__avatar-img {
+  width: 96px; height: 96px; border-radius: 50%; object-fit: cover;
+  background: var(--bg-elev); border: 1px solid var(--border); flex: 0 0 auto;
+}
+.profile-edit__avatar-controls { flex: 1 1 auto; min-width: 0; }
+.profile-edit__avatar-label { display: block; font-weight: 600; }
+.profile-edit__location {
+  border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 0.8rem 1rem 1rem; margin: 0; display: flex; flex-direction: column; gap: 0.8rem;
+}
+.profile-edit__location legend { font-weight: 600; padding: 0 0.4rem; }
+.profile-edit__since { margin: 0; font-size: 0.85rem; color: var(--fg-muted); }
+.profile-edit select {
+  width: 100%; padding: 0.45rem 0.5rem; font: inherit; color: var(--fg);
+  background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius-sm);
+}
+
+/* ---------- Public profile (/u/) ---------- */
+.profile { max-width: var(--maxw-prose); margin: 1.5rem 0 0; }
+.profile__head { display: flex; gap: 1rem; align-items: center; }
+.profile__avatar {
+  width: 96px; height: 96px; border-radius: 50%; object-fit: cover;
+  background: var(--bg-elev); border: 1px solid var(--border); flex: 0 0 auto;
+}
+.profile__name { margin: 0; }
+.profile__id { margin: 0.25rem 0 0; display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center; }
+.profile__username { color: var(--fg-muted); font-size: 0.9rem; }
+.profile__meta { margin: 0.8rem 0 0; font-size: 0.88rem; color: var(--fg-muted); }
+.profile__bio { margin: 1rem 0 0; overflow-wrap: anywhere; }
+.profile__website { margin: 0.6rem 0 0; overflow-wrap: anywhere; }
+.profile__activity { margin: 1.8rem 0 0; }
+.profile__activity-title { font-size: 1.05rem; margin: 0 0 0.6rem; }
+.profile__activity-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.profile__activity-list li { font-size: 0.92rem; }
+.profile__activity-date { color: var(--fg-muted); font-size: 0.82rem; }
+
+/* ---------- Moderation dashboard (/moderation/) ---------- */
+.moderation { max-width: var(--maxw-prose); margin: 1.5rem 0 0; }
+.mod-section { margin: 0 0 2rem; }
+.mod-section__title { font-size: 1.15rem; margin: 0 0 0.8rem; }
+.mod-report {
+  padding: 1rem; margin: 0 0 1rem; border: 1px solid var(--border);
+  border-radius: var(--radius); background: var(--bg-elev);
+  transition: opacity 0.4s ease;
+}
+.mod-report.is-resolved { opacity: 0.4; }
+.mod-report__target { margin: 0 0 0.4rem; font-weight: 600; overflow-wrap: anywhere; }
+.mod-report__excerpt { font-weight: 400; color: var(--fg-muted); }
+.mod-report__meta { margin: 0 0 0.3rem; font-size: 0.82rem; color: var(--fg-muted); }
+.mod-report__reason { margin: 0 0 0.6rem; font-style: italic; overflow-wrap: anywhere; }
+.mod-report__actions { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.mod-btn { padding: 0.3rem 0.7rem; font-size: 0.82rem; }
+.mod-ban { display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem; padding: 0.5rem 0; border-bottom: 1px solid var(--border); }
+.mod-ban__who { font-weight: 600; }
+.mod-ban__meta { color: var(--fg-muted); font-size: 0.85rem; }
+.mod-audit { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.4rem; }
+.mod-audit li { font-size: 0.85rem; color: var(--fg-muted); overflow-wrap: anywhere; }
+.mod-audit__action { color: var(--fg); font-weight: 600; }

--- a/docs/assets/js/forum.js
+++ b/docs/assets/js/forum.js
@@ -58,6 +58,15 @@
   }
   function fmtDate(iso) { try { return new Date(iso).toLocaleString(); } catch (e) { return ''; } }
   function authorName(a) { return (a && (a.display_name || a.username)) || 'someone'; }
+  // Author name as a link to their public profile (/u/?u=<username>) when a
+  // username is known; a plain text node otherwise. Returns a NODE so it drops
+  // straight into the h()/child arrays used for meta lines (stays XSS-safe).
+  function authorLink(a) {
+    if (a && a.username) {
+      return h('a', { class: 'forum-author', href: '/u/?u=' + encodeURIComponent(a.username) }, [authorName(a)]);
+    }
+    return document.createTextNode(authorName(a));
+  }
   function setMsg(box, text, ok) {
     if (!box) return;
     box.textContent = text || '';
@@ -73,7 +82,7 @@
   }
 
   var state = {
-    cats: [], activeCat: null, thread: null, isAdmin: false,
+    cats: [], activeCat: null, thread: null, isAdmin: false, isBanned: false,
     threadsOffset: 0, postsOffset: 0, postsFullyLoaded: false, channel: null
   };
 
@@ -84,6 +93,17 @@
       state.isAdmin = !!(res && !res.error && res.data === true);
       done();
     }, function () { state.isAdmin = false; done(); });
+  }
+
+  // is_banned() RPC (from schema-moderation.sql). Absent -> treat as not banned,
+  // so the forum keeps working before Phase 5 is applied. Banned users still get
+  // blocked server-side by the RESTRICTIVE RLS policy even if the UI misses it.
+  function checkBanned(done) {
+    if (!signedIn()) { state.isBanned = false; return done(); }
+    sb().rpc('is_banned').then(function (res) {
+      state.isBanned = !!(res && !res.error && res.data === true);
+      done();
+    }, function () { state.isBanned = false; done(); });
   }
 
   document.addEventListener('DOMContentLoaded', function () {
@@ -110,7 +130,7 @@
       .then(function (res) {
         state.cats = (res && res.data) || [];
         renderCategories(catBox);
-        renderNewThread(newBox);
+        checkBanned(function () { renderNewThread(newBox); });
         loadThreads(threadBox, true);
         subscribeList(threadBox);
       });
@@ -119,7 +139,7 @@
       var first = true;
       window.GT.onChange(function () {
         if (first) { first = false; return; }
-        checkAdmin(function () { renderNewThread(newBox); });
+        checkBanned(function () { renderNewThread(newBox); });
       });
     }
   }
@@ -159,7 +179,7 @@
     var posts = (t.replies && t.replies[0] && t.replies[0].count) || 0;
     var title = h('a', { class: 'forum-thread__title', href: threadUrl(t.id) }, [t.title]);
     var meta = h('p', { class: 'forum-thread__meta' }, [
-      (t.category ? t.category.title : ''), ' · by ', authorName(t.author),
+      (t.category ? t.category.title : ''), ' · by ', authorLink(t.author),
       ' · ', posts + (posts === 1 ? ' post' : ' posts'), ' · ', fmtDate(t.updated_at)
     ]);
     var kids = [title, meta];
@@ -182,6 +202,10 @@
     box.textContent = '';
     if (!signedIn()) {
       box.appendChild(h('p', { class: 'forum__signin' }, ['Want to post? ', h('a', { href: '/account/' }, ['Sign in']), '.']));
+      return;
+    }
+    if (state.isBanned) {
+      box.appendChild(h('p', { class: 'forum-msg', text: 'You’re currently suspended and can’t start new threads.' }));
       return;
     }
     if (!state.cats.length) return;
@@ -238,23 +262,25 @@
     if (!tid) { head.textContent = 'Thread not found.'; return; }
 
     sb().from('forum_threads')
-      .select('id, title, is_locked, created_at, category:forum_categories(slug,title), author:profiles(username,display_name)')
+      .select('id, title, is_locked, created_at, author_id, category:forum_categories(slug,title), author:profiles(username,display_name)')
       .eq('id', tid).single().then(function (res) {
         if (!res || res.error || !res.data) { head.textContent = 'Thread not found.'; return; }
         state.thread = res.data;
-        checkAdmin(function () {
+        checkAdmin(function () { checkBanned(function () {
           renderThreadHead(head);
           loadPosts(postsBox, true);
           renderReply(replyBox);
           subscribeThread(postsBox);
-        });
+        }); });
       });
 
     if (window.GT && window.GT.onChange) {
       var first = true;
       window.GT.onChange(function () {
         if (first) { first = false; return; }
-        if (state.thread) checkAdmin(function () { renderThreadHead(head); renderReply(replyBox); loadPosts(postsBox, true); });
+        if (state.thread) checkAdmin(function () { checkBanned(function () {
+          renderThreadHead(head); renderReply(replyBox); loadPosts(postsBox, true);
+        }); });
       });
     }
   }
@@ -265,10 +291,12 @@
     head.textContent = '';
     head.appendChild(h('h1', { class: 'forum-thread__heading', text: t.title }));
     var meta = h('p', { class: 'forum-thread__meta' }, [
-      (t.category ? t.category.title : ''), ' · started by ', authorName(t.author), ' · ', fmtDate(t.created_at)
+      (t.category ? t.category.title : ''), ' · started by ', authorLink(t.author), ' · ', fmtDate(t.created_at)
     ]);
     if (t.is_locked) meta.appendChild(h('span', { class: 'forum-badge', text: 'locked' }));
     head.appendChild(meta);
+
+    var controls = h('div', { class: 'forum-thread__controls' });
 
     if (state.isAdmin) {
       var lock = h('button', { class: 'btn btn--secondary forum-mod', type: 'button' }, [t.is_locked ? 'Unlock thread' : 'Lock thread']);
@@ -283,8 +311,27 @@
           renderReply(document.querySelector('[data-thread-reply]'));
         });
       });
-      head.appendChild(lock);
+      controls.appendChild(lock);
     }
+
+    // Report thread — any signed-in user who isn't the author. Feature-detected:
+    // the thread_id column on forum_reports arrives with schema-moderation.sql; if
+    // it isn't applied the insert fails and the button says so, harmlessly.
+    if (signedIn() && t.author_id !== uid()) {
+      var rep = h('button', { class: 'forum-post__act', type: 'button' }, ['Report thread']);
+      rep.addEventListener('click', function () { reportThread(t.id, rep); });
+      controls.appendChild(rep);
+    }
+
+    if (controls.childNodes.length) head.appendChild(controls);
+  }
+
+  function reportThread(threadId, btn) {
+    var reason = window.prompt('Report this thread — reason (optional):');
+    if (reason === null) return;
+    btn.disabled = true;
+    sb().from('forum_reports').insert({ thread_id: threadId, reporter_id: uid(), reason: reason || null })
+      .then(function (res) { btn.textContent = res.error ? 'Report unavailable' : 'Reported'; });
   }
 
   function loadPosts(box, reset) {
@@ -312,7 +359,7 @@
   function postCard(p) {
     var card = h('article', { class: 'forum-post', id: 'post-' + p.id });
     card.appendChild(h('p', { class: 'forum-post__meta' }, [
-      p.is_deleted ? 'unknown' : authorName(p.author), ' · ', fmtDate(p.created_at), p.edited_at ? ' · edited' : ''
+      p.is_deleted ? 'unknown' : authorLink(p.author), ' · ', fmtDate(p.created_at), p.edited_at ? ' · edited' : ''
     ]));
     var bodyEl = h('div', { class: 'forum-post__body' });
     if (p.is_deleted) bodyEl.appendChild(h('em', { text: '[deleted]' }));
@@ -380,6 +427,10 @@
     if (t.is_locked) { box.appendChild(h('p', { class: 'forum-msg', text: 'This thread is locked.' })); return; }
     if (!signedIn()) {
       box.appendChild(h('p', { class: 'forum__signin' }, ['Want to reply? ', h('a', { href: '/account/' }, ['Sign in']), '.']));
+      return;
+    }
+    if (state.isBanned) {
+      box.appendChild(h('p', { class: 'forum-msg', text: 'You’re currently suspended and can’t reply.' }));
       return;
     }
     var form = h('form', { class: 'forum-form' });

--- a/docs/assets/js/moderation.js
+++ b/docs/assets/js/moderation.js
@@ -1,0 +1,329 @@
+/*
+ * GopherTrunk moderation dashboard. Client-rendered into /moderation/, talks to
+ * Supabase via window.GT (auth.js). Requires the Phase 5 schema
+ * (docs/supabase/schema-moderation.sql) plus Phase 3
+ * (schema-forum-moderation.sql) for is_admin() and forum_reports.
+ *
+ * Gating is defence-in-depth: the page calls is_admin() to decide what to show,
+ * but the REAL gate is RLS — a non-admin who loads this page simply gets
+ * empty/denied results from forum_reports / user_bans / moderation_actions.
+ *
+ * Every action (dismiss/resolve a report, lock a thread, remove a post, ban or
+ * suspend a user) also writes a moderation_actions audit row, best-effort.
+ *
+ * Safety: all user content (report reasons, post bodies, names) is rendered as
+ * TEXT via createTextNode / textContent — never innerHTML.
+ */
+(function () {
+  'use strict';
+
+  function sb() { return (window.GT && window.GT.supabase) || null; }
+  function uid() { return window.GT && window.GT.user ? window.GT.user.id : null; }
+
+  function h(tag, attrs, kids) {
+    var e = document.createElement(tag);
+    if (attrs) Object.keys(attrs).forEach(function (k) {
+      if (k === 'class') e.className = attrs[k];
+      else if (k === 'text') e.textContent = attrs[k];
+      else e.setAttribute(k, attrs[k]);
+    });
+    (kids || []).forEach(function (c) {
+      if (c == null) return;
+      e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+    });
+    return e;
+  }
+  function fmtDate(iso) { try { return new Date(iso).toLocaleString(); } catch (e) { return ''; } }
+  function authorName(a) { return (a && (a.display_name || a.username)) || 'someone'; }
+  function userLink(a) {
+    if (a && a.username) return h('a', { href: '/u/?u=' + encodeURIComponent(a.username) }, [authorName(a)]);
+    return document.createTextNode(authorName(a));
+  }
+  function threadUrl(id) { return '/forum/thread/?t=' + encodeURIComponent(id); }
+  function truncate(s, n) { s = String(s == null ? '' : s); return s.length > n ? s.slice(0, n) + '…' : s; }
+
+  // Best-effort audit log write. Never blocks the action.
+  function audit(action, targetType, targetId, detail) {
+    if (!sb()) return;
+    sb().from('moderation_actions').insert({
+      actor_id: uid(), action: action, target_type: targetType,
+      target_id: targetId || null, detail: detail || null
+    }).then(function () {}, function () {});
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var root = document.querySelector('[data-moderation]');
+    if (!root) return;
+    var loading = root.querySelector('[data-mod-loading]');
+
+    function notice(text) {
+      root.textContent = '';
+      root.appendChild(h('p', { class: 'forum__empty', text: text }));
+    }
+
+    if (!sb()) { notice('The moderation tools aren’t set up on this site yet.'); return; }
+
+    function boot() {
+      if (!window.GT.user) { notice('Sign in as an administrator to view this page.'); return; }
+      sb().rpc('is_admin').then(function (res) {
+        if (!res || res.error || res.data !== true) {
+          notice('You must be an administrator to view this page.');
+          return;
+        }
+        renderDashboard();
+      }, function () { notice('You must be an administrator to view this page.'); });
+    }
+
+    if (window.GT.ready && window.GT.ready.then) window.GT.ready.then(boot);
+    else boot();
+
+    function renderDashboard() {
+      if (loading) loading.remove();
+      root.textContent = '';
+      root.appendChild(h('section', { class: 'mod-section', 'data-mod-reports': '' }, [
+        h('h2', { class: 'mod-section__title', text: 'Open reports' }),
+        h('p', { class: 'account__loading', text: 'Loading reports…' })
+      ]));
+      root.appendChild(h('section', { class: 'mod-section', 'data-mod-bans': '' }, [
+        h('h2', { class: 'mod-section__title', text: 'Active bans' }),
+        h('p', { class: 'account__loading', text: 'Loading bans…' })
+      ]));
+      root.appendChild(h('section', { class: 'mod-section', 'data-mod-audit': '' }, [
+        h('h2', { class: 'mod-section__title', text: 'Recent actions' }),
+        h('p', { class: 'account__loading', text: 'Loading log…' })
+      ]));
+      loadReports();
+      loadBans();
+      loadAudit();
+    }
+
+    /* ----------------------------- reports ----------------------------- */
+    var REPORT_COLS =
+      'id, reason, status, created_at, post_id, thread_id, ' +
+      'reporter:profiles!forum_reports_reporter_id_fkey(username, display_name), ' +
+      'post:forum_posts(id, body, is_deleted, thread_id, author:profiles(username, display_name)), ' +
+      'thread:forum_threads(id, title, is_locked, author:profiles(username, display_name))';
+
+    function loadReports() {
+      var box = root.querySelector('[data-mod-reports]');
+      // Feature-detect the Phase-5 `status` column: try the rich query first,
+      // fall back to a base query (no status filter / columns) on a column error.
+      sb().from('forum_reports').select(REPORT_COLS).eq('status', 'open')
+        .order('created_at', { ascending: false }).limit(100)
+        .then(function (res) {
+          if (res.error && /column|does not exist|schema cache/i.test(res.error.message || '')) {
+            return sb().from('forum_reports')
+              .select('id, reason, created_at, post_id, post:forum_posts(id, body, is_deleted, thread_id)')
+              .order('created_at', { ascending: false }).limit(100);
+          }
+          return res;
+        })
+        .then(function (res) { renderReports(box, res); });
+    }
+
+    function renderReports(box, res) {
+      box.textContent = '';
+      box.appendChild(h('h2', { class: 'mod-section__title', text: 'Open reports' }));
+      if (!res || res.error) { box.appendChild(h('p', { class: 'forum__empty', text: 'Couldn’t load reports.' })); return; }
+      var reports = res.data || [];
+      if (!reports.length) { box.appendChild(h('p', { class: 'forum__empty', text: 'No open reports. All clear.' })); return; }
+      reports.forEach(function (r) { box.appendChild(reportCard(r)); });
+    }
+
+    function reportCard(r) {
+      var card = h('article', { class: 'mod-report', id: 'report-' + r.id });
+      var isThread = !!r.thread_id;
+      var target = isThread ? r.thread : r.post;
+
+      // Target line.
+      var targetKids;
+      if (isThread && target) {
+        targetKids = ['Thread: ', h('a', { href: threadUrl(target.id) }, [target.title || 'a thread']),
+          target.is_locked ? h('span', { class: 'forum-badge', text: 'locked' }) : null];
+      } else if (target) {
+        targetKids = ['Post in ', h('a', { href: threadUrl(target.thread_id) }, ['thread']),
+          ': ', h('span', { class: 'mod-report__excerpt', text: truncate(target.body, 140) }),
+          target.is_deleted ? h('span', { class: 'forum-badge', text: 'removed' }) : null];
+      } else {
+        targetKids = [h('em', { text: 'target no longer exists' })];
+      }
+      card.appendChild(h('p', { class: 'mod-report__target' }, targetKids));
+
+      // Meta: reporter + reason + when.
+      var metaKids = ['Reported by ', userLink(r.reporter), ' · ', fmtDate(r.created_at)];
+      card.appendChild(h('p', { class: 'mod-report__meta' }, metaKids));
+      if (r.reason) card.appendChild(h('p', { class: 'mod-report__reason' }, ['“', r.reason, '”']));
+
+      // Actions.
+      var actions = h('div', { class: 'mod-report__actions' });
+      var msg = h('span', { class: 'account__msg', role: 'status', 'aria-live': 'polite' });
+
+      if (isThread && target) {
+        actions.appendChild(actBtn(target.is_locked ? 'Unlock thread' : 'Lock thread', function (btn) {
+          var next = !target.is_locked;
+          sb().from('forum_threads').update({ is_locked: next }).eq('id', target.id).then(function (res2) {
+            if (res2.error) { setBtnMsg(msg, res2.error.message, false); btn.disabled = false; return; }
+            target.is_locked = next; btn.textContent = next ? 'Unlock thread' : 'Lock thread'; btn.disabled = false;
+            audit(next ? 'lock_thread' : 'unlock_thread', 'thread', target.id, null);
+            setBtnMsg(msg, next ? 'Locked.' : 'Unlocked.', true);
+          });
+        }));
+      }
+      if (!isThread && target && !target.is_deleted) {
+        actions.appendChild(actBtn('Remove post', function (btn) {
+          sb().from('forum_posts').update({ is_deleted: true }).eq('id', target.id).then(function (res2) {
+            if (res2.error) { setBtnMsg(msg, res2.error.message, false); btn.disabled = false; return; }
+            target.is_deleted = true; btn.remove();
+            audit('remove_post', 'post', target.id, null);
+            setBtnMsg(msg, 'Post removed.', true);
+          });
+        }));
+      }
+
+      // Ban / suspend the reported author (if we know who it is). The report's
+      // embedded author carries username/display_name; the ban flow resolves the
+      // profile id from the username at click time.
+      var author = target && target.author;
+      if (author) {
+        actions.appendChild(actBtn('Ban author', function (btn) {
+          banFromReport(author, null, msg, btn);
+        }));
+        actions.appendChild(actBtn('Suspend author', function (btn) {
+          var days = promptDays();
+          if (!days) { btn.disabled = false; return; }   // cancelled/invalid -> don't fall through to a permanent ban
+          banFromReport(author, days, msg, btn);
+        }));
+      }
+
+      // Resolve / dismiss (status workflow; no-op-safe if column absent).
+      actions.appendChild(actBtn('Resolve', function (btn) {
+        setReportStatus(r.id, 'resolved', card, msg, btn);
+      }));
+      actions.appendChild(actBtn('Dismiss', function (btn) {
+        setReportStatus(r.id, 'dismissed', card, msg, btn);
+      }));
+
+      card.appendChild(actions);
+      card.appendChild(msg);
+      return card;
+    }
+
+    function actBtn(label, onClick) {
+      var b = h('button', { class: 'btn btn--secondary mod-btn', type: 'button' }, [label]);
+      b.addEventListener('click', function () { b.disabled = true; onClick(b); });
+      return b;
+    }
+    function setBtnMsg(msg, text, ok) {
+      msg.textContent = text || '';
+      msg.className = 'account__msg' + (ok === false ? ' is-error' : ok === true ? ' is-ok' : '');
+    }
+    function promptDays() {
+      var v = window.prompt('Suspend for how many days?', '7');
+      if (v === null) return null;
+      var n = parseInt(v, 10);
+      return (isNaN(n) || n <= 0) ? null : n;
+    }
+
+    // Resolve the target author's profile id from their username, then upsert a
+    // ban. We look up the id because the embedded author only carries username /
+    // display_name (author_id isn't in the report's foreign embed here).
+    function banFromReport(author, days, msg, btn) {
+      if (!author.username) { setBtnMsg(msg, 'Can’t identify that user.', false); btn.disabled = false; return; }
+      var reason = window.prompt('Reason (optional):') || null;
+      sb().from('profiles').select('id').eq('username', author.username).single().then(function (res) {
+        if (res.error || !res.data) { setBtnMsg(msg, 'Couldn’t find that user.', false); btn.disabled = false; return; }
+        var row = { user_id: res.data.id, banned_by: uid(), reason: reason };
+        if (days) row.expires_at = new Date(Date.now() + days * 86400000).toISOString();
+        sb().from('user_bans').upsert(row).then(function (res2) {
+          btn.disabled = false;
+          if (res2.error) { setBtnMsg(msg, res2.error.message, false); return; }
+          audit(days ? 'suspend_user' : 'ban_user', 'user', res.data.id, days ? (days + 'd: ' + (reason || '')) : reason);
+          setBtnMsg(msg, days ? ('Suspended for ' + days + ' days.') : 'User banned.', true);
+          loadBans();
+        });
+      });
+    }
+
+    function setReportStatus(reportId, status, card, msg, btn) {
+      sb().from('forum_reports')
+        .update({ status: status, resolved_by: uid(), resolved_at: new Date().toISOString() })
+        .eq('id', reportId)
+        .then(function (res) {
+          if (res.error) { setBtnMsg(msg, res.error.message, false); btn.disabled = false; return; }
+          audit(status === 'resolved' ? 'resolve_report' : 'dismiss_report', 'report', reportId, null);
+          card.classList.add('is-resolved');
+          setBtnMsg(msg, status === 'resolved' ? 'Resolved.' : 'Dismissed.', true);
+          setTimeout(function () { card.remove(); maybeEmptyReports(); }, 600);
+          loadAudit();
+        });
+    }
+    function maybeEmptyReports() {
+      var box = root.querySelector('[data-mod-reports]');
+      if (box && !box.querySelector('.mod-report')) {
+        box.appendChild(h('p', { class: 'forum__empty', text: 'No open reports. All clear.' }));
+      }
+    }
+
+    /* ------------------------------- bans ------------------------------ */
+    function loadBans() {
+      var box = root.querySelector('[data-mod-bans]');
+      if (!box) return;
+      sb().from('user_bans')
+        .select('user_id, reason, created_at, expires_at, user:profiles!user_bans_user_id_fkey(username, display_name)')
+        .order('created_at', { ascending: false }).limit(100)
+        .then(function (res) {
+          box.textContent = '';
+          box.appendChild(h('h2', { class: 'mod-section__title', text: 'Active bans' }));
+          if (!res || res.error) { box.appendChild(h('p', { class: 'forum__empty', text: 'Couldn’t load bans.' })); return; }
+          var now = Date.now();
+          var bans = (res.data || []).filter(function (b) { return !b.expires_at || new Date(b.expires_at).getTime() > now; });
+          if (!bans.length) { box.appendChild(h('p', { class: 'forum__empty', text: 'No active bans.' })); return; }
+          bans.forEach(function (b) { box.appendChild(banRow(b)); });
+        });
+    }
+
+    function banRow(b) {
+      var row = h('div', { class: 'mod-ban' });
+      var kind = b.expires_at ? ('suspended until ' + fmtDate(b.expires_at)) : 'permanent ban';
+      row.appendChild(h('span', { class: 'mod-ban__who' }, [userLink(b.user)]));
+      row.appendChild(h('span', { class: 'mod-ban__meta', text: ' · ' + kind + (b.reason ? ' · ' + b.reason : '') }));
+      var msg = h('span', { class: 'account__msg', role: 'status' });
+      var unban = actBtn('Unban', function (btn) {
+        sb().from('user_bans').delete().eq('user_id', b.user_id).then(function (res) {
+          if (res.error) { setBtnMsg(msg, res.error.message, false); btn.disabled = false; return; }
+          audit('unban_user', 'user', b.user_id, null);
+          row.remove();
+        });
+      });
+      row.appendChild(unban);
+      row.appendChild(msg);
+      return row;
+    }
+
+    /* ------------------------------ audit ------------------------------ */
+    function loadAudit() {
+      var box = root.querySelector('[data-mod-audit]');
+      if (!box) return;
+      sb().from('moderation_actions')
+        .select('id, action, target_type, detail, created_at, actor:profiles!moderation_actions_actor_id_fkey(username, display_name)')
+        .order('created_at', { ascending: false }).limit(25)
+        .then(function (res) {
+          box.textContent = '';
+          box.appendChild(h('h2', { class: 'mod-section__title', text: 'Recent actions' }));
+          if (!res || res.error) { box.appendChild(h('p', { class: 'forum__empty', text: 'No log yet.' })); return; }
+          var rows = res.data || [];
+          if (!rows.length) { box.appendChild(h('p', { class: 'forum__empty', text: 'No actions logged yet.' })); return; }
+          var list = h('ul', { class: 'mod-audit' });
+          rows.forEach(function (a) {
+            list.appendChild(h('li', {}, [
+              h('span', { class: 'mod-audit__action', text: a.action.replace(/_/g, ' ') }),
+              ' · ', a.target_type, a.detail ? ' (' + a.detail + ')' : '',
+              ' · by ', userLink(a.actor),
+              h('span', { class: 'mod-audit__date', text: ' · ' + fmtDate(a.created_at) })
+            ]));
+          });
+          box.appendChild(list);
+        });
+    }
+  });
+})();

--- a/docs/assets/js/profile.js
+++ b/docs/assets/js/profile.js
@@ -1,0 +1,183 @@
+/*
+ * GopherTrunk public profile. Client-rendered into /u/ (Jekyll can't
+ * pre-generate a page per user, same constraint as /forum/thread/), routed by
+ * ?u=<username> or ?id=<uuid>. Talks to the Supabase `profiles` table (and,
+ * for recent activity, `forum_posts`) via window.GT (auth.js).
+ *
+ * Safety: every piece of user content (names, bio, location, call sign) is
+ * rendered as TEXT via createTextNode / textContent — never innerHTML — so a
+ * malicious profile field cannot inject markup. The one attribute we set from
+ * data is an <img src>, pointed only at the stored avatar_url (a Supabase
+ * Storage public URL) with a same-origin default fallback.
+ *
+ * Progressive enhancement: with Supabase unconfigured, or before the Phase 4
+ * profile columns exist, the page degrades gracefully — it feature-detects the
+ * rich columns and falls back to the base set.
+ */
+(function () {
+  'use strict';
+
+  var DEFAULT_AVATAR = '/assets/gophertrunk-logo.png';
+  var BASE_COLS = 'id, username, display_name, avatar_url, created_at';
+  var RICH_COLS = BASE_COLS + ', bio, website, callsign, country, region, city';
+
+  function sb() { return (window.GT && window.GT.supabase) || null; }
+
+  // Minimal DOM builder — children are strings (text) or nodes, never HTML.
+  function h(tag, attrs, kids) {
+    var e = document.createElement(tag);
+    if (attrs) Object.keys(attrs).forEach(function (k) {
+      if (k === 'class') e.className = attrs[k];
+      else if (k === 'text') e.textContent = attrs[k];
+      else e.setAttribute(k, attrs[k]);
+    });
+    (kids || []).forEach(function (c) {
+      if (c == null) return;
+      e.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+    });
+    return e;
+  }
+  function multiline(text) {
+    var frag = document.createDocumentFragment();
+    String(text == null ? '' : text).split('\n').forEach(function (line, i) {
+      if (i) frag.appendChild(document.createElement('br'));
+      frag.appendChild(document.createTextNode(line));
+    });
+    return frag;
+  }
+  function fmtDate(iso) { try { return new Date(iso).toLocaleString(); } catch (e) { return ''; } }
+  function memberSince(iso) {
+    try { return new Date(iso).toLocaleDateString(undefined, { year: 'numeric', month: 'long' }); }
+    catch (e) { return ''; }
+  }
+  function threadUrl(id) { return '/forum/thread/?t=' + encodeURIComponent(id); }
+  function isHttpUrl(s) { return /^https?:\/\/[^ ]{3,200}$/i.test(String(s || '')); }
+
+  // ISO-3166 alpha-2 -> display name, for the location line. Small subset with a
+  // graceful fallback to the raw code if we don't have a name for it.
+  var COUNTRY_NAMES = {
+    AU:'Australia',AT:'Austria',BE:'Belgium',BR:'Brazil',CA:'Canada',CH:'Switzerland',
+    CL:'Chile',CN:'China',CZ:'Czechia',DE:'Germany',DK:'Denmark',ES:'Spain',FI:'Finland',
+    FR:'France',GB:'United Kingdom',GR:'Greece',HK:'Hong Kong',HU:'Hungary',IE:'Ireland',
+    IN:'India',IT:'Italy',JP:'Japan',KR:'South Korea',MX:'Mexico',NL:'Netherlands',
+    NO:'Norway',NZ:'New Zealand',PH:'Philippines',PL:'Poland',PT:'Portugal',RO:'Romania',
+    RU:'Russia',SE:'Sweden',SG:'Singapore',TR:'Türkiye',UA:'Ukraine',US:'United States',
+    ZA:'South Africa'
+  };
+  function countryName(code) { return COUNTRY_NAMES[code] || code; }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var root = document.querySelector('[data-profile]');
+    if (!root) return;
+    var loading = root.querySelector('[data-profile-loading]');
+
+    function fail(text) {
+      root.textContent = '';
+      root.appendChild(h('p', { class: 'forum__empty', text: text }));
+    }
+
+    if (!sb()) { fail('Profiles aren’t set up on this site yet.'); return; }
+
+    var params = new URLSearchParams(location.search);
+    var uname = params.get('u');
+    var uid = params.get('id');
+    if (!uname && !uid) {
+      root.textContent = '';
+      root.appendChild(h('p', { class: 'forum__empty' }, [
+        'No profile selected. Open a profile from a forum author’s name, or ',
+        h('a', { href: '/account/' }, ['sign in']), ' to edit your own.'
+      ]));
+      return;
+    }
+
+    fetchProfile(RICH_COLS);
+
+    function fetchProfile(cols) {
+      var q = sb().from('profiles').select(cols);
+      q = uname ? q.eq('username', uname) : q.eq('id', uid);
+      q.single().then(function (res) {
+        if (res.error && cols === RICH_COLS &&
+            /column|does not exist|schema cache/i.test(res.error.message || '')) {
+          return fetchProfile(BASE_COLS);   // Phase 4 columns not applied yet
+        }
+        if (!res || res.error || !res.data) { fail('No such user.'); return; }
+        render(res.data);
+      });
+    }
+
+    function render(p) {
+      var name = p.display_name || p.username || 'Operator';
+      try { document.title = name + ' · GopherTrunk'; } catch (e) {}
+      if (loading) loading.remove();
+      root.textContent = '';
+
+      // Header: avatar + name + @username + call-sign badge.
+      var img = h('img', { class: 'profile__avatar', alt: '', width: '96', height: '96', loading: 'lazy' });
+      img.src = p.avatar_url || DEFAULT_AVATAR;
+      img.addEventListener('error', function () { img.src = DEFAULT_AVATAR; });
+
+      var idLine = [];
+      if (p.username) idLine.push(h('span', { class: 'profile__username', text: '@' + p.username }));
+      if (p.callsign) idLine.push(h('span', { class: 'forum-badge', text: p.callsign }));
+
+      var headText = h('div', { class: 'profile__headtext' }, [
+        h('h1', { class: 'profile__name', text: name }),
+        idLine.length ? h('p', { class: 'profile__id' }, idLine) : null
+      ]);
+      root.appendChild(h('header', { class: 'profile__head' }, [img, headText]));
+
+      // Meta: location + member since.
+      var loc = [p.city, p.region, p.country ? countryName(p.country) : null]
+        .filter(function (x) { return x && String(x).trim(); }).join(', ');
+      var metaKids = [];
+      if (loc) metaKids.push(h('span', { class: 'profile__loc', text: loc }));
+      if (p.created_at) {
+        if (metaKids.length) metaKids.push(' · ');
+        metaKids.push('Member since ' + memberSince(p.created_at));
+      }
+      if (metaKids.length) root.appendChild(h('p', { class: 'profile__meta' }, metaKids));
+
+      // Bio.
+      if (p.bio) root.appendChild(h('div', { class: 'profile__bio' }, [multiline(p.bio)]));
+
+      // Website.
+      if (p.website && isHttpUrl(p.website)) {
+        root.appendChild(h('p', { class: 'profile__website' }, [
+          h('a', { href: p.website, rel: 'nofollow noopener', target: '_blank' }, [p.website])
+        ]));
+      }
+
+      loadActivity(root, p.id);
+    }
+
+    // Recent forum activity — last 10 non-deleted posts, linking to their threads.
+    function loadActivity(container, authorId) {
+      if (!authorId) return;
+      var section = h('section', { class: 'profile__activity' }, [
+        h('h2', { class: 'profile__activity-title', text: 'Recent forum activity' }),
+        h('p', { class: 'account__loading', text: 'Loading…' })
+      ]);
+      container.appendChild(section);
+
+      sb().from('forum_posts')
+        .select('id, created_at, thread:forum_threads(id, title)')
+        .eq('author_id', authorId).eq('is_deleted', false)
+        .order('created_at', { ascending: false }).limit(10)
+        .then(function (res) {
+          section.textContent = '';
+          section.appendChild(h('h2', { class: 'profile__activity-title', text: 'Recent forum activity' }));
+          if (!res || res.error) { section.appendChild(h('p', { class: 'forum__empty', text: 'Couldn’t load activity.' })); return; }
+          var posts = (res.data || []).filter(function (p) { return p.thread; });
+          if (!posts.length) { section.appendChild(h('p', { class: 'forum__empty', text: 'No forum posts yet.' })); return; }
+          var list = h('ul', { class: 'profile__activity-list' });
+          posts.forEach(function (p) {
+            list.appendChild(h('li', {}, [
+              h('a', { href: threadUrl(p.thread.id) }, [p.thread.title || 'a thread']),
+              h('span', { class: 'profile__activity-date', text: ' · ' + fmtDate(p.created_at) })
+            ]));
+          });
+          section.appendChild(list);
+        });
+    }
+  });
+})();

--- a/docs/moderation.md
+++ b/docs/moderation.md
@@ -1,0 +1,19 @@
+---
+layout: page
+title: Moderation
+description: Admin-only moderation dashboard for the GopherTrunk community — review reports, lock threads, remove posts, and manage user bans.
+permalink: /moderation/
+nav_group: Community
+hide_ctas: true
+---
+
+# Moderation
+
+Admin-only. Review reported content, take action, and manage bans. Every action is
+recorded in the moderation log.
+
+<div class="moderation" data-moderation>
+  <p class="account__loading" data-mod-loading>Loading…</p>
+</div>
+
+<script defer src="{{ '/assets/js/moderation.js' | relative_url }}"></script>

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -1,0 +1,243 @@
+---
+layout: page
+title: Edit profile
+description: Edit your GopherTrunk profile — avatar, display name, amateur radio call sign, location, bio, and links. Shown on your public profile page.
+permalink: /profile/
+nav_group: Community
+hide_ctas: true
+---
+
+# Edit profile
+
+This is what other operators see on your **[public profile](/u/)**. Everything is
+optional — fill in as much or as little as you like.
+
+<div class="profile-edit" data-profile-edit>
+  <p class="account__loading" data-loading>Loading…</p>
+
+  <section class="profile-edit__signedout" data-signedout hidden>
+    <p>You need to <a href="/account/">sign in</a> to edit your profile.</p>
+  </section>
+
+  <form class="account__form profile-edit__form" data-form hidden novalidate>
+    <div class="profile-edit__avatar">
+      <img class="profile-edit__avatar-img" data-avatar-img alt="" width="96" height="96">
+      <div class="profile-edit__avatar-controls">
+        <label class="profile-edit__avatar-label">
+          Profile picture
+          <input type="file" name="avatar" accept="image/png,image/jpeg,image/webp" data-avatar-input>
+        </label>
+        <p class="account__msg" data-avatar-msg role="status" aria-live="polite"></p>
+        <p class="profile-edit__hint">PNG, JPEG, or WebP, up to 2&nbsp;MB.</p>
+      </div>
+    </div>
+
+    <label>Display name
+      <input type="text" name="display_name" maxlength="60" autocomplete="name">
+    </label>
+    <label>Username
+      <input type="text" name="username" maxlength="30" autocomplete="off" spellcheck="false">
+      <span class="profile-edit__hint">Letters, numbers, <code>_</code> and <code>-</code>. Your public profile lives at <code>/u/?u=&lt;username&gt;</code>.</span>
+    </label>
+    <label>Amateur radio call sign
+      <input type="text" name="callsign" maxlength="10" autocomplete="off" spellcheck="false" placeholder="e.g. W1AW">
+      <span class="profile-edit__hint">Optional. Shown as a badge on your profile.</span>
+    </label>
+
+    <fieldset class="profile-edit__location">
+      <legend>Location <span class="profile-edit__hint">(optional)</span></legend>
+      <label>Country
+        <select name="country" data-country>
+          <option value="">— Not set —</option>
+        </select>
+      </label>
+      <label>State / region
+        <input type="text" name="region" maxlength="80" autocomplete="address-level1">
+      </label>
+      <label>City
+        <input type="text" name="city" maxlength="80" autocomplete="address-level2">
+      </label>
+    </fieldset>
+
+    <label>Bio
+      <textarea name="bio" rows="4" maxlength="1000" placeholder="A short intro — rigs you run, systems you follow, what you’re decoding."></textarea>
+    </label>
+    <label>Website
+      <input type="url" name="website" maxlength="200" autocomplete="url" placeholder="https://…">
+    </label>
+
+    <p class="profile-edit__since" data-since hidden>Member since <span data-since-val></span>.</p>
+
+    <div class="account__form-actions">
+      <button type="submit" class="btn">Save profile</button>
+      <a class="btn btn--secondary" data-view-link href="/u/">View public profile</a>
+    </div>
+    <p class="account__msg" data-msg role="status" aria-live="polite"></p>
+  </form>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  'use strict';
+  var root = document.querySelector('[data-profile-edit]');
+  if (!root) return;
+  var loading   = root.querySelector('[data-loading]');
+  var signedout = root.querySelector('[data-signedout]');
+  var form      = root.querySelector('[data-form]');
+  var msg       = root.querySelector('[data-msg]');
+  var avatarImg = root.querySelector('[data-avatar-img]');
+  var avatarIn  = root.querySelector('[data-avatar-input]');
+  var avatarMsg = root.querySelector('[data-avatar-msg]');
+  var countrySel = root.querySelector('[data-country]');
+  var sinceBox  = root.querySelector('[data-since]');
+  var viewLink  = root.querySelector('[data-view-link]');
+
+  function show(el) { if (el) el.hidden = false; }
+  function hide(el) { if (el) el.hidden = true; }
+  function setMsg(box, text, ok) {
+    if (!box) return;
+    box.textContent = text || '';
+    box.className = 'account__msg' + (ok === false ? ' is-error' : ok === true ? ' is-ok' : '');
+  }
+  function field(name) { return form.querySelector('[name=' + name + ']'); }
+  var DEFAULT_AVATAR = '/assets/gophertrunk-logo.png';
+
+  // ISO-3166 alpha-2 country list, built into the <select> in code (keeps the
+  // markup clean; the data is ours, so it's safe to set via option text).
+  var COUNTRIES = [
+    ['AF','Afghanistan'],['AX','Åland Islands'],['AL','Albania'],['DZ','Algeria'],['AS','American Samoa'],['AD','Andorra'],['AO','Angola'],['AI','Anguilla'],['AQ','Antarctica'],['AG','Antigua and Barbuda'],['AR','Argentina'],['AM','Armenia'],['AW','Aruba'],['AU','Australia'],['AT','Austria'],['AZ','Azerbaijan'],['BS','Bahamas'],['BH','Bahrain'],['BD','Bangladesh'],['BB','Barbados'],['BY','Belarus'],['BE','Belgium'],['BZ','Belize'],['BJ','Benin'],['BM','Bermuda'],['BT','Bhutan'],['BO','Bolivia'],['BQ','Bonaire, Sint Eustatius and Saba'],['BA','Bosnia and Herzegovina'],['BW','Botswana'],['BV','Bouvet Island'],['BR','Brazil'],['IO','British Indian Ocean Territory'],['BN','Brunei Darussalam'],['BG','Bulgaria'],['BF','Burkina Faso'],['BI','Burundi'],['CV','Cabo Verde'],['KH','Cambodia'],['CM','Cameroon'],['CA','Canada'],['KY','Cayman Islands'],['CF','Central African Republic'],['TD','Chad'],['CL','Chile'],['CN','China'],['CX','Christmas Island'],['CC','Cocos (Keeling) Islands'],['CO','Colombia'],['KM','Comoros'],['CG','Congo'],['CD','Congo (Democratic Republic)'],['CK','Cook Islands'],['CR','Costa Rica'],['CI','Côte d’Ivoire'],['HR','Croatia'],['CU','Cuba'],['CW','Curaçao'],['CY','Cyprus'],['CZ','Czechia'],['DK','Denmark'],['DJ','Djibouti'],['DM','Dominica'],['DO','Dominican Republic'],['EC','Ecuador'],['EG','Egypt'],['SV','El Salvador'],['GQ','Equatorial Guinea'],['ER','Eritrea'],['EE','Estonia'],['SZ','Eswatini'],['ET','Ethiopia'],['FK','Falkland Islands'],['FO','Faroe Islands'],['FJ','Fiji'],['FI','Finland'],['FR','France'],['GF','French Guiana'],['PF','French Polynesia'],['TF','French Southern Territories'],['GA','Gabon'],['GM','Gambia'],['GE','Georgia'],['DE','Germany'],['GH','Ghana'],['GI','Gibraltar'],['GR','Greece'],['GL','Greenland'],['GD','Grenada'],['GP','Guadeloupe'],['GU','Guam'],['GT','Guatemala'],['GG','Guernsey'],['GN','Guinea'],['GW','Guinea-Bissau'],['GY','Guyana'],['HT','Haiti'],['HM','Heard Island and McDonald Islands'],['VA','Holy See'],['HN','Honduras'],['HK','Hong Kong'],['HU','Hungary'],['IS','Iceland'],['IN','India'],['ID','Indonesia'],['IR','Iran'],['IQ','Iraq'],['IE','Ireland'],['IM','Isle of Man'],['IL','Israel'],['IT','Italy'],['JM','Jamaica'],['JP','Japan'],['JE','Jersey'],['JO','Jordan'],['KZ','Kazakhstan'],['KE','Kenya'],['KI','Kiribati'],['KP','Korea (North)'],['KR','Korea (South)'],['KW','Kuwait'],['KG','Kyrgyzstan'],['LA','Laos'],['LV','Latvia'],['LB','Lebanon'],['LS','Lesotho'],['LR','Liberia'],['LY','Libya'],['LI','Liechtenstein'],['LT','Lithuania'],['LU','Luxembourg'],['MO','Macao'],['MG','Madagascar'],['MW','Malawi'],['MY','Malaysia'],['MV','Maldives'],['ML','Mali'],['MT','Malta'],['MH','Marshall Islands'],['MQ','Martinique'],['MR','Mauritania'],['MU','Mauritius'],['YT','Mayotte'],['MX','Mexico'],['FM','Micronesia'],['MD','Moldova'],['MC','Monaco'],['MN','Mongolia'],['ME','Montenegro'],['MS','Montserrat'],['MA','Morocco'],['MZ','Mozambique'],['MM','Myanmar'],['NA','Namibia'],['NR','Nauru'],['NP','Nepal'],['NL','Netherlands'],['NC','New Caledonia'],['NZ','New Zealand'],['NI','Nicaragua'],['NE','Niger'],['NG','Nigeria'],['NU','Niue'],['NF','Norfolk Island'],['MK','North Macedonia'],['MP','Northern Mariana Islands'],['NO','Norway'],['OM','Oman'],['PK','Pakistan'],['PW','Palau'],['PS','Palestine'],['PA','Panama'],['PG','Papua New Guinea'],['PY','Paraguay'],['PE','Peru'],['PH','Philippines'],['PN','Pitcairn'],['PL','Poland'],['PT','Portugal'],['PR','Puerto Rico'],['QA','Qatar'],['RE','Réunion'],['RO','Romania'],['RU','Russia'],['RW','Rwanda'],['BL','Saint Barthélemy'],['SH','Saint Helena, Ascension and Tristan da Cunha'],['KN','Saint Kitts and Nevis'],['LC','Saint Lucia'],['MF','Saint Martin (French part)'],['PM','Saint Pierre and Miquelon'],['VC','Saint Vincent and the Grenadines'],['WS','Samoa'],['SM','San Marino'],['ST','Sao Tome and Principe'],['SA','Saudi Arabia'],['SN','Senegal'],['RS','Serbia'],['SC','Seychelles'],['SL','Sierra Leone'],['SG','Singapore'],['SX','Sint Maarten (Dutch part)'],['SK','Slovakia'],['SI','Slovenia'],['SB','Solomon Islands'],['SO','Somalia'],['ZA','South Africa'],['GS','South Georgia and the South Sandwich Islands'],['SS','South Sudan'],['ES','Spain'],['LK','Sri Lanka'],['SD','Sudan'],['SR','Suriname'],['SJ','Svalbard and Jan Mayen'],['SE','Sweden'],['CH','Switzerland'],['SY','Syria'],['TW','Taiwan'],['TJ','Tajikistan'],['TZ','Tanzania'],['TH','Thailand'],['TL','Timor-Leste'],['TG','Togo'],['TK','Tokelau'],['TO','Tonga'],['TT','Trinidad and Tobago'],['TN','Tunisia'],['TR','Türkiye'],['TM','Turkmenistan'],['TC','Turks and Caicos Islands'],['TV','Tuvalu'],['UG','Uganda'],['UA','Ukraine'],['AE','United Arab Emirates'],['GB','United Kingdom'],['US','United States'],['UM','United States Minor Outlying Islands'],['UY','Uruguay'],['UZ','Uzbekistan'],['VU','Vanuatu'],['VE','Venezuela'],['VN','Vietnam'],['VG','Virgin Islands (British)'],['VI','Virgin Islands (U.S.)'],['WF','Wallis and Futuna'],['EH','Western Sahara'],['YE','Yemen'],['ZM','Zambia'],['ZW','Zimbabwe']
+  ];
+  if (countrySel) COUNTRIES.forEach(function (c) {
+    var o = document.createElement('option');
+    o.value = c[0]; o.textContent = c[1] + ' (' + c[0] + ')';
+    countrySel.appendChild(o);
+  });
+
+  var GT = window.GT;
+  if (!GT || !GT.isConfigured) {
+    hide(loading); show(signedout);
+    signedout.querySelector('p').textContent = 'Profiles aren’t set up on this site yet — check back soon.';
+    return;
+  }
+
+  // Base columns exist since Phase 1; the rest arrive with schema-profiles.sql.
+  var BASE_COLS = 'id, username, display_name, avatar_url, created_at';
+  var RICH_COLS = BASE_COLS + ', bio, website, callsign, country, region, city';
+  var hasRich = true;
+  var loadedFor = null;
+
+  function fillForm(p) {
+    field('display_name').value = p.display_name || '';
+    field('username').value = p.username || '';
+    avatarImg.src = p.avatar_url || DEFAULT_AVATAR;
+    if (p.username) viewLink.setAttribute('href', '/u/?u=' + encodeURIComponent(p.username));
+    if (p.created_at) {
+      try {
+        root.querySelector('[data-since-val]').textContent = new Date(p.created_at).toLocaleDateString(undefined, { year: 'numeric', month: 'long' });
+        show(sinceBox);
+      } catch (e) {}
+    }
+    if (hasRich) {
+      field('callsign').value = p.callsign || '';
+      if (countrySel) countrySel.value = p.country || '';
+      field('region').value = p.region || '';
+      field('city').value = p.city || '';
+      field('bio').value = p.bio || '';
+      field('website').value = p.website || '';
+    }
+  }
+
+  // Fields that only make sense once the rich columns exist. If the Phase 4 SQL
+  // isn't applied yet, hide them so /profile/ still saves name + username.
+  function hideRichFields() {
+    ['callsign', 'region', 'city', 'bio', 'website'].forEach(function (n) {
+      var el = field(n); var lbl = el && el.closest('label'); if (lbl) hide(lbl);
+    });
+    var loc = root.querySelector('.profile-edit__location'); if (loc) hide(loc);
+  }
+
+  function loadProfile() {
+    if (!GT.user || loadedFor === GT.user.id) return;
+    loadedFor = GT.user.id;
+    GT.supabase.from('profiles').select(RICH_COLS).eq('id', GT.user.id).single()
+      .then(function (res) {
+        if (res.error && /column|does not exist|schema cache/i.test(res.error.message || '')) {
+          hasRich = false; hideRichFields();
+          return GT.supabase.from('profiles').select(BASE_COLS).eq('id', GT.user.id).single();
+        }
+        return res;
+      })
+      .then(function (res) {
+        if (res && res.data) fillForm(res.data);
+      });
+  }
+
+  function render() {
+    hide(loading);
+    if (GT.user) { hide(signedout); show(form); loadProfile(); }
+    else { hide(form); show(signedout); loadedFor = null; }
+  }
+  GT.onChange(render);
+  if (GT.ready && GT.ready.then) GT.ready.then(render);
+
+  // Avatar upload -> Storage bucket `avatars`, path `<uid>/avatar`.
+  var MAX_AVATAR = 2 * 1024 * 1024;
+  if (avatarIn) avatarIn.addEventListener('change', function () {
+    var file = avatarIn.files && avatarIn.files[0];
+    if (!file || !GT.user) return;
+    if (!/^image\/(png|jpeg|webp)$/.test(file.type)) { setMsg(avatarMsg, 'Use a PNG, JPEG, or WebP image.', false); return; }
+    if (file.size > MAX_AVATAR) { setMsg(avatarMsg, 'That image is over 2 MB — pick a smaller one.', false); return; }
+    setMsg(avatarMsg, 'Uploading…', true);
+    var path = GT.user.id + '/avatar';
+    GT.supabase.storage.from('avatars').upload(path, file, { upsert: true, contentType: file.type })
+      .then(function (res) {
+        if (res.error) { setMsg(avatarMsg, 'Avatar uploads aren’t set up yet — the rest of your profile still saves.', false); return; }
+        var pub = GT.supabase.storage.from('avatars').getPublicUrl(path);
+        var url = (pub && pub.data && pub.data.publicUrl ? pub.data.publicUrl : '') + '?v=' + Date.now();
+        avatarImg.src = url;
+        return GT.supabase.from('profiles').upsert({ id: GT.user.id, avatar_url: url }).then(function (r2) {
+          setMsg(avatarMsg, r2.error ? r2.error.message : 'Picture updated.', r2.error ? false : true);
+        });
+      });
+  });
+
+  // Validation mirrors the DB CHECKs in schema-profiles.sql.
+  var RE_USER = /^[a-zA-Z0-9_-]{3,30}$/;
+  var RE_CALL = /^[A-Z0-9/]{3,10}$/;
+  var RE_SITE = /^https?:\/\/[^ ]{3,200}$/i;
+
+  form.addEventListener('submit', function (ev) {
+    ev.preventDefault();
+    if (!GT.user) return;
+    var dn = field('display_name').value.trim();
+    var un = field('username').value.trim().toLowerCase();
+    var row = { id: GT.user.id, display_name: dn || null, username: un || null };
+
+    if (un && !RE_USER.test(un)) { setMsg(msg, 'Username must be 3–30 characters: letters, numbers, _ or -.', false); return; }
+
+    if (hasRich) {
+      var call = field('callsign').value.trim().toUpperCase();
+      var site = field('website').value.trim();
+      if (call && !RE_CALL.test(call)) { setMsg(msg, 'Call sign should be 3–10 characters (letters, numbers, /).', false); return; }
+      if (site && !RE_SITE.test(site)) { setMsg(msg, 'Website should start with http:// or https://.', false); return; }
+      row.callsign = call || null;
+      row.country  = (countrySel && countrySel.value) || null;
+      row.region   = field('region').value.trim() || null;
+      row.city     = field('city').value.trim() || null;
+      row.bio      = field('bio').value.trim() || null;
+      row.website  = site || null;
+      field('callsign').value = call;   // reflect the uppercasing
+    }
+
+    setMsg(msg, 'Saving…', true);
+    GT.supabase.from('profiles').upsert(row).then(function (res) {
+      if (res.error) {
+        setMsg(msg, /duplicate|unique/i.test(res.error.message) ? 'That username is taken.' : res.error.message, false);
+      } else {
+        setMsg(msg, 'Saved.', true);
+        if (un) viewLink.setAttribute('href', '/u/?u=' + encodeURIComponent(un));
+      }
+    });
+  });
+});
+</script>

--- a/docs/supabase/README.md
+++ b/docs/supabase/README.md
@@ -1,9 +1,10 @@
 # Supabase setup for gophertrunk.org
 
-The site adds optional learner **accounts** (and, in Phase 2, a **forum**) backed by a
-hosted Supabase project. Because GitHub Pages is static and keeps no secrets, everything
-runs client-side with the **public anon key**; all data safety comes from **Row Level
-Security**, defined in `schema.sql`.
+The site adds optional learner **accounts**, a community **forum**, richer **profiles**
+(with avatar uploads), **public profile pages**, and a **content-moderation** system,
+all backed by a hosted Supabase project. Because GitHub Pages is static and keeps no
+secrets, everything runs client-side with the **public anon key**; all data safety comes
+from **Row Level Security**, defined in the `schema*.sql` files.
 
 You never give anyone the `service_role`/secret key, the database password, or OAuth
 client secrets — those live only in the Supabase dashboard. The repo holds just the two
@@ -23,6 +24,25 @@ public values (project URL + anon key) in `docs/assets/js/supabase-config.js`.
    `insert into public.app_admins (user_id) values ('<your-user-uuid>');` (find the uuid
    under Authentication → Users). Everything is additive and the client feature-detects
    it, so the forum works even before this file is applied.
+
+   For richer profiles + avatar uploads (Phase 4), also run `schema-profiles.sql`, and
+   create the avatar storage bucket (step 2b below). For the moderation system —
+   report queue, user bans/suspensions, audit log (Phase 5) — also run
+   `schema-moderation.sql`. Both are additive and feature-detected: `/profile/`, `/u/`,
+   the forum, and `/moderation/` all work before they're applied — the new fields and
+   controls simply don't appear yet.
+2b. **Create the avatar storage bucket** (needed for Phase 4 avatar uploads) —
+   Storage → **New bucket**:
+   - **Name:** `avatars`
+   - **Public bucket:** ON (avatars must be readable by everyone, including signed-out
+     visitors viewing public profiles)
+   - **File size limit:** `2 MB`
+   - **Allowed MIME types:** `image/png, image/jpeg, image/webp`
+
+   The row-level policies that let a signed-in user write only their *own* avatar
+   (`avatars/<uid>/avatar`) are created by `schema-profiles.sql` — no manual policy
+   editing needed. If you skip this bucket, everything else still works; avatar uploads
+   just show a friendly "not set up yet" message and OAuth avatars keep working.
 3. **Enable auth providers** — Authentication → Providers:
    - **GitHub** and **Google** OAuth (create the OAuth apps on GitHub/Google, paste the
      client id + secret into Supabase). Set each provider's callback to the Supabase
@@ -41,6 +61,36 @@ public values (project URL + anon key) in `docs/assets/js/supabase-config.js`.
    Settings → API into `docs/assets/js/supabase-config.js` (replace the `YOUR-…`
    placeholders). Until you do, auth stays dormant and the site is unchanged.
 
+## SQL files, in apply order
+
+Run each once in the SQL Editor. All are idempotent; re-running is safe.
+
+| File | Adds |
+|---|---|
+| `schema.sql` | Accounts: `profiles`, `learn_progress`, signup trigger, self-delete. |
+| `schema-forum.sql` | Forum: categories / threads / posts + RLS. |
+| `schema-forum-moderation.sql` | Admins (`app_admins` / `is_admin()`), `forum_reports`, rate limits, realtime. |
+| `schema-profiles.sql` | Profile fields (bio, website, call sign, country/region/city) + avatar storage policies. Needs the `avatars` bucket (step 2b). |
+| `schema-moderation.sql` | Bans/suspensions (`user_bans` / `is_banned()`), thread reports + report status, `moderation_actions` audit log. |
+
+## Moderation & bans
+
+- **Review reports** on the site at `/moderation/` — a dashboard visible only to admins
+  (it calls `is_admin()`; RLS denies the underlying rows to everyone else). From there you
+  resolve or dismiss reports, lock threads, remove posts, and ban or suspend users. Every
+  action is written to the `moderation_actions` audit log.
+- **Bans** (`schema-moderation.sql`): a banned user keeps a valid session but a
+  RESTRICTIVE RLS policy stops their posts/threads from being inserted, so the ban can't
+  be bypassed from the browser. Set `expires_at` in the future for a temporary
+  **suspension** (auto-lifts); leave it null for a permanent ban. You can also manage
+  bans directly in SQL:
+  ```sql
+  insert into public.user_bans (user_id, reason) values ('<uuid>', 'spam');            -- permanent
+  insert into public.user_bans (user_id, reason, expires_at)
+    values ('<uuid>', 'cooldown', now() + interval '7 days');                          -- 7-day suspension
+  delete from public.user_bans where user_id = '<uuid>';                               -- unban
+  ```
+
 ## Verify
 
 - Sign in on `/account/` with each enabled method; confirm the nav shows your name.
@@ -48,6 +98,12 @@ public values (project URL + anon key) in `docs/assets/js/supabase-config.js`.
   syncs and appears on a second browser/device.
 - Confirm a signed-in user can only read/write their own `learn_progress` rows (RLS).
 - Try the account-deletion control; confirm the profile + progress rows are gone.
+- **Profiles:** on `/profile/`, upload an avatar and save a call sign + location; confirm
+  they appear on your public profile at `/u/?u=<username>`. Confirm you cannot write into
+  another user's avatar folder (RLS rejects `avatars/<other-uid>/…`).
+- **Moderation:** with a second account, file a report; as admin, see it in `/moderation/`,
+  resolve it, and ban that user — confirm their next forum post is rejected. Confirm a
+  non-admin loading `/moderation/` sees only the "administrator" notice and no report data.
 
-`schema.sql` is documentation/version history — the site does not apply it. Keep it in
-sync with what you run in the dashboard.
+The `schema*.sql` files are documentation/version history — the site does not apply them.
+Keep them in sync with what you run in the dashboard.

--- a/docs/supabase/schema-moderation.sql
+++ b/docs/supabase/schema-moderation.sql
@@ -1,0 +1,156 @@
+-- GopherTrunk — Supabase schema (Phase 5: content moderation — bans, report
+-- workflow, and an audit log)
+--
+-- Apply AFTER schema-forum.sql and schema-forum-moderation.sql (this file builds
+-- on app_admins / is_admin() and the forum tables). SQL Editor -> paste -> Run.
+-- Idempotent: re-running is safe.
+--
+-- Everything is ADDITIVE and FEATURE-DETECTED by the client, so the forum and the
+-- /moderation/ dashboard keep working before this file is applied. Same security
+-- model as every phase: the browser holds only the public anon key; all writes
+-- are guarded by Row Level Security.
+--
+-- This file adds three things:
+--   1. User bans / suspensions, enforced server-side so a banned user cannot post
+--      even though they still hold a valid session and anon key.
+--   2. A report workflow: reports can target a THREAD as well as a post, and each
+--      report carries a status (open / reviewing / resolved / dismissed).
+--   3. A moderation audit log recording every admin action.
+
+create extension if not exists pgcrypto;   -- gen_random_uuid()
+
+-- ---------------------------------------------------------------------------
+-- 1. Bans / suspensions.
+--
+-- expires_at IS NULL  -> permanent ban.
+-- expires_at > now()  -> temporary suspension (auto-lifts when it passes).
+-- Grant/lift bans from the /moderation/ dashboard (admins), or directly via SQL:
+--   insert into public.user_bans (user_id, reason) values ('<uuid>', 'spam');
+--   delete from public.user_bans where user_id = '<uuid>';   -- unban
+-- ---------------------------------------------------------------------------
+create table if not exists public.user_bans (
+  user_id    uuid primary key references public.profiles(id) on delete cascade,
+  banned_by  uuid references public.profiles(id) on delete set null,
+  reason     text check (reason is null or char_length(reason) <= 500),
+  created_at timestamptz not null default now(),
+  expires_at timestamptz            -- null = permanent; future ts = suspension
+);
+alter table public.user_bans enable row level security;
+
+-- A signed-in user may read only their OWN ban row (so the forum can show
+-- "you're suspended until…"); admins may read every row.
+drop policy if exists "read own ban" on public.user_bans;
+create policy "read own ban" on public.user_bans
+  for select to authenticated using (user_id = auth.uid() or public.is_admin());
+
+-- Only admins write bans. RLS combines permissive policies with OR, and no other
+-- write policy exists, so non-admins are denied insert/update/delete.
+drop policy if exists "admins manage bans" on public.user_bans;
+create policy "admins manage bans" on public.user_bans
+  for all to authenticated using (public.is_admin()) with check (public.is_admin());
+
+-- is_banned() — true while the caller has an active (non-expired) ban. SECURITY
+-- DEFINER so it can read user_bans past RLS; it only ever checks auth.uid().
+create or replace function public.is_banned()
+returns boolean language sql stable security definer set search_path = public as $$
+  select exists (
+    select 1 from public.user_bans
+    where user_id = auth.uid()
+      and (expires_at is null or expires_at > now())
+  );
+$$;
+grant execute on function public.is_banned() to authenticated, anon;
+
+-- Enforcement. The insert-own policies in schema-forum.sql are PERMISSIVE, which
+-- OR together — so a new permissive policy could never *subtract* the right to
+-- post. RESTRICTIVE policies AND with everything else, which is exactly what we
+-- want: "you may post (existing rule) AND you are not banned". This keeps
+-- schema-forum.sql untouched.
+drop policy if exists "posts blocked while banned" on public.forum_posts;
+create policy "posts blocked while banned" on public.forum_posts
+  as restrictive for insert to authenticated with check (not public.is_banned());
+
+-- Also block edits, so a banned user can't rewrite an existing post to route
+-- around the insert block.
+drop policy if exists "post edits blocked while banned" on public.forum_posts;
+create policy "post edits blocked while banned" on public.forum_posts
+  as restrictive for update to authenticated with check (not public.is_banned());
+
+drop policy if exists "threads blocked while banned" on public.forum_threads;
+create policy "threads blocked while banned" on public.forum_threads
+  as restrictive for insert to authenticated with check (not public.is_banned());
+
+-- ---------------------------------------------------------------------------
+-- 2. Report workflow — extend forum_reports (from schema-forum-moderation.sql).
+--
+-- Adds thread reports (thread_id) and a status/resolution lifecycle. Additive:
+-- existing post-only reports keep their post_id and default to status 'open'.
+-- ---------------------------------------------------------------------------
+alter table public.forum_reports add column if not exists thread_id   uuid references public.forum_threads(id) on delete cascade;
+alter table public.forum_reports add column if not exists status      text not null default 'open';
+alter table public.forum_reports add column if not exists resolved_by uuid references public.profiles(id) on delete set null;
+alter table public.forum_reports add column if not exists resolved_at timestamptz;
+
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'forum_reports_status_chk') then
+    alter table public.forum_reports add constraint forum_reports_status_chk
+      check (status in ('open', 'reviewing', 'resolved', 'dismissed'));
+  end if;
+  -- Exactly one target: a report is about a post OR a thread, never both/neither.
+  -- Added NOT VALID so it applies to new/updated rows without re-checking any
+  -- legacy rows (all of which already have a post_id, so they'd pass anyway).
+  if not exists (select 1 from pg_constraint where conname = 'forum_reports_target_chk') then
+    alter table public.forum_reports add constraint forum_reports_target_chk
+      check ((post_id is not null) <> (thread_id is not null)) not valid;
+  end if;
+end $$;
+
+create index if not exists forum_reports_status_idx on public.forum_reports (status, created_at desc);
+
+-- Admins can update a report (change status, stamp resolved_by/at). The
+-- insert-as-self and admins-read policies from schema-forum-moderation.sql still
+-- apply.
+drop policy if exists "admins update reports" on public.forum_reports;
+create policy "admins update reports" on public.forum_reports
+  for update to authenticated using (public.is_admin()) with check (public.is_admin());
+
+-- ---------------------------------------------------------------------------
+-- 3. Moderation audit log — one row per admin action, written by the dashboard.
+-- Admin-only readable; admins insert rows stamped as themselves.
+-- ---------------------------------------------------------------------------
+create table if not exists public.moderation_actions (
+  id          uuid primary key default gen_random_uuid(),
+  actor_id    uuid not null references public.profiles(id) on delete set null,
+  action      text not null,   -- 'lock_thread','unlock_thread','remove_post','ban_user','suspend_user','unban_user','resolve_report','dismiss_report'
+  target_type text not null,   -- 'thread','post','user','report'
+  target_id   uuid,
+  detail      text check (detail is null or char_length(detail) <= 1000),
+  created_at  timestamptz not null default now()
+);
+alter table public.moderation_actions enable row level security;
+create index if not exists moderation_actions_created_idx on public.moderation_actions (created_at desc);
+
+drop policy if exists "admins read audit" on public.moderation_actions;
+create policy "admins read audit" on public.moderation_actions
+  for select to authenticated using (public.is_admin());
+
+drop policy if exists "admins write audit" on public.moderation_actions;
+create policy "admins write audit" on public.moderation_actions
+  for insert to authenticated with check (public.is_admin() and actor_id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- 4. Realtime (optional) — let the moderation queue live-update. Idempotent:
+-- skips tables already in the publication. Reads still pass through RLS, so only
+-- admins receive these rows.
+-- ---------------------------------------------------------------------------
+do $$
+begin
+  if not exists (select 1 from pg_publication_tables
+                 where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'forum_reports') then
+    alter publication supabase_realtime add table public.forum_reports;
+  end if;
+  if not exists (select 1 from pg_publication_tables
+                 where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'user_bans') then
+    alter publication supabase_realtime add table public.user_bans;
+  end if;
+end $$;

--- a/docs/supabase/schema-profiles.sql
+++ b/docs/supabase/schema-profiles.sql
@@ -1,0 +1,110 @@
+-- GopherTrunk — Supabase schema (Phase 4: richer profiles + avatar uploads)
+--
+-- Apply AFTER schema.sql (and, if you run the forum, after schema-forum.sql /
+-- schema-forum-moderation.sql — order between this file and the forum files does
+-- not matter, they touch different objects). SQL Editor -> paste -> Run, or
+-- `supabase db push`. Idempotent: re-running is safe.
+--
+-- Everything here is ADDITIVE and the site FEATURE-DETECTS it: /profile/, /u/,
+-- and the forum all keep working before this file is applied — the new fields
+-- simply don't appear yet. Same security model as the earlier phases: the browser
+-- holds only the public anon key, so every object is guarded by Row Level
+-- Security, never by key secrecy.
+--
+-- Two things this file does:
+--   1. Adds optional profile columns (bio, website, ham radio call sign, and an
+--      optional country / region / city) with light validation.
+--   2. Adds Row Level Security policies for a public `avatars` Storage bucket so a
+--      signed-in user can upload/replace only their OWN avatar. You must still
+--      CREATE the bucket in the dashboard first — see docs/supabase/README.md.
+
+-- ---------------------------------------------------------------------------
+-- 1. profiles — new optional columns.
+--
+-- All nullable, so existing rows and the handle_new_user() signup trigger keep
+-- working unchanged. `avatar_url` and `created_at` already exist (from schema.sql)
+-- and are reused for the uploaded avatar and the "member since" date — no new
+-- column needed for those.
+-- ---------------------------------------------------------------------------
+alter table public.profiles add column if not exists bio      text;
+alter table public.profiles add column if not exists website  text;
+alter table public.profiles add column if not exists callsign text;   -- amateur radio call sign
+alter table public.profiles add column if not exists country  text;   -- ISO-3166 alpha-2, e.g. 'US'
+alter table public.profiles add column if not exists region   text;   -- state / province (free text)
+alter table public.profiles add column if not exists city     text;   -- free text
+
+-- Constraints. ADD CONSTRAINT has no IF NOT EXISTS, so each is guarded on
+-- pg_constraint. The regexes are deliberately permissive supersets — real
+-- validation also happens client-side; these stop obviously bad or oversized
+-- values from reaching the table.
+do $$ begin
+  if not exists (select 1 from pg_constraint where conname = 'profiles_bio_chk') then
+    alter table public.profiles add constraint profiles_bio_chk
+      check (bio is null or char_length(bio) <= 1000);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'profiles_website_chk') then
+    alter table public.profiles add constraint profiles_website_chk
+      check (website is null or website ~* '^https?://[^ ]{3,200}$');
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'profiles_callsign_chk') then
+    -- 3–10 chars, A–Z / 0–9 / '/', e.g. W1AW or W1AW/4. The client uppercases
+    -- before saving, so lowercase input is normalised rather than rejected.
+    alter table public.profiles add constraint profiles_callsign_chk
+      check (callsign is null or callsign ~ '^[A-Z0-9/]{3,10}$');
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'profiles_country_chk') then
+    alter table public.profiles add constraint profiles_country_chk
+      check (country is null or country ~ '^[A-Z]{2}$');
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'profiles_region_chk') then
+    alter table public.profiles add constraint profiles_region_chk
+      check (region is null or char_length(region) <= 80);
+  end if;
+  if not exists (select 1 from pg_constraint where conname = 'profiles_city_chk') then
+    alter table public.profiles add constraint profiles_city_chk
+      check (city is null or char_length(city) <= 80);
+  end if;
+end $$;
+
+-- NOTE on `username`: it is intentionally NOT constrained here. Existing values
+-- are seeded from OAuth metadata (GitHub usernames allow hyphens), so a
+-- retroactive CHECK could fail this migration. Username format is validated in
+-- the client (^[a-zA-Z0-9_-]{3,30}$, lowercased) on top of the existing UNIQUE.
+-- The existing profiles RLS policies (public select, insert/update own) already
+-- cover every new column, so no policy change is needed.
+
+-- ---------------------------------------------------------------------------
+-- 2. Avatar uploads — Storage RLS.
+--
+-- PREREQUISITE (dashboard, one time): create a PUBLIC bucket named `avatars`
+--   Storage -> New bucket -> name `avatars`, Public = on,
+--   file size limit 2 MB, allowed MIME types: image/png, image/jpeg, image/webp.
+-- See docs/supabase/README.md. This file only adds the row-level policies.
+--
+-- Path convention: `avatars/<uid>/avatar` — one fixed object key per user,
+-- overwritten with upsert. The first path segment must equal the caller's uid,
+-- so a signed-in user can only write inside their own folder. Reads are public
+-- (the bucket is public, and read is world-open below) so avatars show for
+-- everyone, including signed-out visitors on public profiles.
+-- ---------------------------------------------------------------------------
+drop policy if exists "avatars public read" on storage.objects;
+create policy "avatars public read" on storage.objects
+  for select using (bucket_id = 'avatars');
+
+drop policy if exists "avatars insert own" on storage.objects;
+create policy "avatars insert own" on storage.objects
+  for insert to authenticated with check (
+    bucket_id = 'avatars' and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "avatars update own" on storage.objects;
+create policy "avatars update own" on storage.objects
+  for update to authenticated using (
+    bucket_id = 'avatars' and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+drop policy if exists "avatars delete own" on storage.objects;
+create policy "avatars delete own" on storage.objects
+  for delete to authenticated using (
+    bucket_id = 'avatars' and (storage.foldername(name))[1] = auth.uid()::text
+  );

--- a/docs/u.md
+++ b/docs/u.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Profile
+description: A GopherTrunk operator's public profile — call sign, location, bio, and recent forum activity.
+permalink: /u/
+nav_group: Community
+hide_ctas: true
+---
+
+<div class="profile" data-profile>
+  <p class="account__loading" data-profile-loading>Loading…</p>
+</div>
+
+<script defer src="{{ '/assets/js/profile.js' | relative_url }}"></script>


### PR DESCRIPTION
Extends the Supabase-backed GitHub Pages community (docs/) with richer
profiles, dedicated auth/profile/public-profile pages, and a real
content-moderation system. All work is additive, idempotent SQL applied by
hand in Supabase, and every server-dependent feature is feature-detected so
the site keeps working before the SQL is applied — matching the existing
Phase 1-3 pattern. Security stays entirely RLS-based (browser holds only the
public anon key).

SQL (run in the Supabase SQL Editor, in order):
- schema-profiles.sql (Phase 4): additive profile columns — bio, website,
  amateur radio call sign, and optional country/region/city — with light
  CHECK validation, plus Storage RLS policies for a public `avatars` bucket so
  a signed-in user can upload/replace only their own avatar
  (`avatars/<uid>/avatar`).
- schema-moderation.sql (Phase 5): user_bans + is_banned() with RESTRICTIVE
  RLS so a banned user cannot insert posts/threads even with a valid session;
  forum_reports extended with thread reports and an open/reviewing/resolved/
  dismissed status workflow; a moderation_actions audit log; realtime.

Frontend:
- account.md trimmed to auth only (OAuth + email/password + magic link),
  with clearer sign-up copy and links out to the profile pages.
- profile.md (/profile/): rich editor — avatar upload, display name,
  username, call sign, country dropdown + free-text region/city, bio,
  website, and a read-only "member since". Feature-detects the new columns.
- u.md + profile.js (/u/?u=<username>): public profile showing avatar, call
  sign, location, member-since, bio, website, and recent forum activity.
- moderation.md + moderation.js (/moderation/): admin-only dashboard (gated by
  is_admin(), RLS-enforced) — report queue with resolve/dismiss, lock thread,
  remove post, ban/suspend author; active-bans and audit-log panels.
- forum.js: author names link to /u/, a feature-detected "Report thread"
  control, and a suspension notice in place of the reply/new-thread box for
  banned users.
- style.scss + nav.yml: styles for the new pages and Community nav entries.
- supabase/README.md: Phase 4/5 operator steps (run SQL, create the avatars
  bucket, grant admin, manage bans).

All user content is rendered as text nodes (never innerHTML), continuing the
forum's stored-XSS guard.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VrXszByp7gmKnDRGvXhrTm