### PR TITLE
widebandt2: warn at startup when a multi-channel wideband dongle is pinned to a fixed gain

### DIFF
--- a/cmd/gophertrunk/daemon.go
+++ b/cmd/gophertrunk/daemon.go
@@ -1837,6 +1837,7 @@ func NewDaemonWithPath(cfg config.Config, cfgPath string, version string, log *s
 				Systems:       d.systems,
 				Serial:        entry.Info.Serial,
 				Metrics:       wbIQObs,
+				Gain:          devCfg.Gain,
 			})
 			if err != nil {
 				return nil, fmt.Errorf("daemon: widebandt2 %q: %w", devCfg.Serial, err)

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -773,6 +773,18 @@ B210 specifics worth knowing before the first run:
   the documented follow-up** (see the support matrix). Field reports from
   a real B210 are welcome.
 
+> **macOS loopback caps the stream MTU — bind to your NIC IP, not
+> `127.0.0.1`.** macOS limits the MTU on the loopback interface (`lo0`),
+> so a local `SoapySDRServer` bound to `127.0.0.1` can't negotiate a jumbo
+> `stream_mtu` — the stream falls back to the small loopback frame size and
+> a high-rate USRP can overrun. The workaround, even when the server and
+> GopherTrunk run on the **same** Mac, is to bind `SoapySDRServer` to the
+> host's real NIC address and point `addr:` at that same IP:
+> `SoapySDRServer --bind=192.168.1.50:55132` with
+> `addr: "192.168.1.50:55132"`. Linux loopback has no such cap, so
+> `127.0.0.1` is fine there. This is only relevant when you raise
+> `stream_mtu` above the ~1500-byte default (issue #876).
+
 For a B210 the `args` string is where the UHD device selection lives, e.g.
 `args: "type=b200,num_recv_frames=512,recv_frame_size=16384"` alongside
 `master_clock_rate: 61_440_000` and `sample_rate: 6_144_000`.

--- a/internal/scanner/widebandt2/engine.go
+++ b/internal/scanner/widebandt2/engine.go
@@ -50,6 +50,8 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -206,6 +208,18 @@ type Options struct {
 	// auto-selects by channel count; "ddc" forces DDCBank;
 	// "polyphase" forces ChannelizerBank.
 	TunerStrategy string
+
+	// Gain is this wideband dongle's configured tuner gain string,
+	// verbatim from sdr.devices[].gain. "" / "auto" selects AGC; any
+	// other value is a fixed gain (tenths of dB). When more than one
+	// channel shares this one front end and the gain is pinned to a
+	// fixed value, New emits a one-shot startup WARN suggesting
+	// gain: auto — a single fixed gain can only be right for one site,
+	// so the strongest co-tenant sets the level and a weaker site sits
+	// below the shared ADC floor and never decodes (issue #749).
+	// Empty (the zero value) is treated as AGC, so callers that don't
+	// set it get no warning.
+	Gain string
 
 	// Channels is the list of per-repeater carriers to monitor.
 	// All FrequencyHz values must fall inside the dongle's IQ
@@ -386,6 +400,31 @@ type engineChannel struct {
 	lastDecoded uint64
 }
 
+// fixedGainTenthDB interprets a configured gain string the same way the
+// daemon's parseGain does, but reports only whether it is a *fixed* gain
+// (and its value in tenths of a dB). "" / "auto" (any case) is AGC and
+// returns fixed=false; an unparseable value is treated as not-fixed so a
+// typo never trips the multi-channel gain WARN. Kept local to avoid a
+// dependency on the cmd package from this decoder package.
+func fixedGainTenthDB(s string) (tenthDB int, fixed bool) {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.EqualFold(s, "auto") {
+		return 0, false
+	}
+	if strings.ContainsAny(s, ".,") {
+		f, err := strconv.ParseFloat(strings.ReplaceAll(s, ",", "."), 64)
+		if err != nil {
+			return 0, false
+		}
+		return int(f*10 + 0.5), true
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
 // New constructs an Engine. The device is not opened or streamed
 // here; that happens in Run. Returns an error if construction
 // inputs are invalid (offset out of band, colliding channelizer
@@ -448,6 +487,24 @@ func New(opts Options) (*Engine, error) {
 				"sample_rate_hz", opts.SampleRateHz,
 				"channel_span_hz", uint64(2*maxAbsOffset),
 				"min_sample_rate_hz", uint64(math.Ceil(minRateHz)),
+			)
+		}
+	}
+
+	// A multi-channel wideband plan pinned to a single fixed gain can't
+	// serve sites at different signal strengths off one shared front end:
+	// the strongest co-tenant sets the level, and a weaker site sits below
+	// the shared ADC floor with "iq power very low" and never decodes
+	// (issue #749). AGC ("gain: auto") lets the front end run hot enough
+	// for the weak site to clear while the strong one still fits. Warn once
+	// at startup — before any traffic — so the operator sees the fix without
+	// having to wait for and correlate the per-channel runtime WARN.
+	if len(opts.Channels) > 1 {
+		if tenthDB, fixed := fixedGainTenthDB(opts.Gain); fixed {
+			log.Warn("widebandt2: multi-channel wideband device is pinned to a fixed gain — one gain can't serve sites at different signal strengths off a shared front end, so a weaker co-tenant site may sit below the ADC floor and never decode; try 'gain: auto' (AGC) on this dongle (issue #749)",
+				"serial", opts.Serial,
+				"channels", len(opts.Channels),
+				"gain_db", fmt.Sprintf("%.1f", float64(tenthDB)/10),
 			)
 		}
 	}

--- a/internal/scanner/widebandt2/engine_fixedgain_hint_test.go
+++ b/internal/scanner/widebandt2/engine_fixedgain_hint_test.go
@@ -1,0 +1,101 @@
+package widebandt2
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/trunking"
+)
+
+// buildFixedGainEngine constructs a multi-site wideband engine with the given
+// gain string and returns any captured startup WARN about a fixed gain. New()
+// emits the WARN at construction time, so the engine is never Run.
+func buildFixedGainEngine(t *testing.T, gain string, channels []ChannelConfig) (capturedRecord, bool) {
+	t.Helper()
+	handler, recs, mu := newRecordingHandler()
+	bus := events.NewBus(8)
+	defer bus.Close()
+	dev := newMockDevice(nil)
+
+	_, err := New(Options{
+		Log:          slog.New(handler),
+		Device:       dev,
+		Bus:          bus,
+		SampleRateHz: 2_400_000,
+		CenterFreqHz: 460_000_000,
+		Channels:     channels,
+		Systems:      []trunking.System{t2System("dmr-simplex")},
+		Gain:         gain,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, r := range *recs {
+		if r.level == slog.LevelWarn && strings.Contains(r.msg, "pinned to a fixed gain") {
+			return r, true
+		}
+	}
+	return capturedRecord{}, false
+}
+
+var twoSiteChannels = []ChannelConfig{
+	{FrequencyHz: 459_900_000, SystemName: "dmr-simplex"},
+	{FrequencyHz: 460_100_000, SystemName: "dmr-simplex"},
+}
+
+// TestFixedGainMultiChannelWarns: two sites on one wideband dongle pinned to a
+// fixed gain draws the startup WARN pointing the operator at gain: auto (issue
+// #749). A single fixed gain can only be right for one site.
+func TestFixedGainMultiChannelWarns(t *testing.T) {
+	r, ok := buildFixedGainEngine(t, "600", twoSiteChannels)
+	if !ok {
+		t.Fatal("expected a fixed-gain WARN for a multi-channel wideband device, got none")
+	}
+	if !strings.Contains(r.msg, "gain: auto") {
+		t.Errorf("WARN msg = %q, want the gain: auto (AGC) remedy", r.msg)
+	}
+	// The value is surfaced in dB so the operator can confirm it's the gain
+	// they set (600 tenths = 60.0 dB).
+	if g, ok := r.attrs["gain_db"].(string); !ok || g != "60.0" {
+		t.Errorf("gain_db attr = %v, want %q", r.attrs["gain_db"], "60.0")
+	}
+	if c, ok := r.attrs["channels"].(int64); !ok || c != 2 {
+		t.Errorf("channels attr = %v, want 2", r.attrs["channels"])
+	}
+}
+
+// TestFixedGainDecimalWarns: a decimal fixed gain ("49.6") is a fixed value too
+// and still draws the WARN.
+func TestFixedGainDecimalWarns(t *testing.T) {
+	r, ok := buildFixedGainEngine(t, "49.6", twoSiteChannels)
+	if !ok {
+		t.Fatal("expected a fixed-gain WARN for a decimal fixed gain, got none")
+	}
+	if g, ok := r.attrs["gain_db"].(string); !ok || g != "49.6" {
+		t.Errorf("gain_db attr = %v, want %q", r.attrs["gain_db"], "49.6")
+	}
+}
+
+// TestAutoGainMultiChannelNoWarn: gain: auto (AGC) is the recommended setting,
+// so it must NOT draw the WARN. Empty and "auto" (any case) both mean AGC.
+func TestAutoGainMultiChannelNoWarn(t *testing.T) {
+	for _, gain := range []string{"", "auto", "AUTO", "  ", "notanumber"} {
+		if _, ok := buildFixedGainEngine(t, gain, twoSiteChannels); ok {
+			t.Errorf("gain %q drew a fixed-gain WARN; want none (AGC / unparseable is not a fixed gain)", gain)
+		}
+	}
+}
+
+// TestFixedGainSingleChannelNoWarn: a single-site wideband device pinned to a
+// fixed gain is fine — one gain for one site is exactly right, so no WARN.
+func TestFixedGainSingleChannelNoWarn(t *testing.T) {
+	one := []ChannelConfig{{FrequencyHz: 460_000_000, SystemName: "dmr-simplex"}}
+	if _, ok := buildFixedGainEngine(t, "600", one); ok {
+		t.Error("single-channel fixed-gain device drew a fixed-gain WARN; want none")
+	}
+}


### PR DESCRIPTION
Every tap on a `role: wideband` dongle shares one antenna, one centre, and
one gain. A single fixed gain can only be right for one site: the strongest
co-tenant sets the level and a weaker site sits below the shared ADC floor
with "iq power very low" and never decodes. AGC (`gain: auto`) lets the
front end run hot enough for the weak site to clear while the strong one
still fits — in field testing this took a co-tenant control channel from
zero decoded TSBKs to hundreds.

widebandt2.New now emits a one-shot WARN at construction when more than one
channel is configured and the gain is a fixed value, pointing the operator
at `gain: auto` before any traffic — so the fix is visible without waiting
for and correlating the per-channel runtime low-power WARN. AGC / empty /
unparseable gain strings are treated as not-fixed and draw no warning.
docs/hardware.md already documents this behaviour; this makes it true.

Refs #749

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pnzst12dbFsuYspX1Qq3AD