### PR TITLE
cryptolab(#773): chosen-plaintext differential "sweep" mode

### DIFF
--- a/internal/cryptolab/schema.go
+++ b/internal/cryptolab/schema.go
@@ -155,6 +155,7 @@ var modeParams = map[string][]Param{
 	},
 	"alias/fromseed":  {{Name: "csv", Label: "Ground-truth corpus CSV", Kind: "file", Required: true}},
 	"alias/propagate": {{Name: "csv", Label: "Ground-truth corpus CSV", Kind: "file", Required: true}},
+	"alias/sweep":     {{Name: "csv", Label: "Chosen-plaintext corpus CSV (no CRC)", Kind: "file", Required: true, Help: "encoded_hex is pure cipher output, exactly 2·len(alias) bytes"}},
 }
 
 // Schema returns the web-facing description of every registered tool/mode,

--- a/internal/cryptolab/subjects/motorola/corpus.go
+++ b/internal/cryptolab/subjects/motorola/corpus.go
@@ -33,19 +33,33 @@ func StripCRC(encWithCRC []byte) (enc []byte, ok bool) {
 	return encWithCRC[:len(encWithCRC)-2], true
 }
 
-// LoadCSV reads rid,talkgroup,encoded_hex,alias rows from path, hex-decoding
-// and CRC-stripping each encoded field. A header row (non-hex first field)
-// is skipped. Rows too short to hold a CRC are skipped with a warning.
+// LoadCSV reads rid,talkgroup,encoded_hex,alias rows from a passive-capture
+// corpus, hex-decoding and CRC-stripping each encoded field. A header row
+// (non-hex first field) is skipped. Rows too short to hold a CRC are skipped
+// with a warning.
 func LoadCSV(path string, logger *slog.Logger) ([]Row, error) {
+	return loadCSV(path, logger, true)
+}
+
+// LoadChosenCSV reads the same rid,talkgroup,encoded_hex,alias shape but treats
+// encoded_hex as the *pure* cipher output with NO trailing CRC — the form a
+// chosen-plaintext encoder emits (e.g. moto_alias_t.zip's "Alias Encoded"
+// field, exactly 2·len(alias) bytes). Use this for the sweep mode; the CRC
+// strip that LoadCSV applies would otherwise eat two real cipher bytes.
+func LoadChosenCSV(path string, logger *slog.Logger) ([]Row, error) {
+	return loadCSV(path, logger, false)
+}
+
+func loadCSV(path string, logger *slog.Logger, stripCRC bool) ([]Row, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("alias: open corpus: %w", err)
 	}
 	defer f.Close()
-	return parseCSV(f, logger)
+	return parseCSV(f, logger, stripCRC)
 }
 
-func parseCSV(r io.Reader, logger *slog.Logger) ([]Row, error) {
+func parseCSV(r io.Reader, logger *slog.Logger, stripCRC bool) ([]Row, error) {
 	cr := csv.NewReader(r)
 	cr.FieldsPerRecord = -1
 	var rows []Row
@@ -70,12 +84,16 @@ func parseCSV(r io.Reader, logger *slog.Logger) ([]Row, error) {
 			}
 			continue
 		}
-		enc, ok := StripCRC(raw)
-		if !ok {
-			if logger != nil {
-				logger.Warn("skipping row too short for CRC", "line", line)
+		enc := raw
+		if stripCRC {
+			var ok bool
+			enc, ok = StripCRC(raw)
+			if !ok {
+				if logger != nil {
+					logger.Warn("skipping row too short for CRC", "line", line)
+				}
+				continue
 			}
-			continue
 		}
 		var rid uint32
 		if v, err := strconv.ParseUint(strings.TrimSpace(rec[0]), 10, 32); err == nil {

--- a/internal/cryptolab/subjects/motorola/motorola_test.go
+++ b/internal/cryptolab/subjects/motorola/motorola_test.go
@@ -380,7 +380,17 @@ func TestAliasToolRegistered(t *testing.T) {
 	if !ok {
 		t.Fatal("alias tool not registered")
 	}
-	if len(tool.Modes()) != 5 {
-		t.Fatalf("alias has %d modes, want 5", len(tool.Modes()))
+	if len(tool.Modes()) != 6 {
+		t.Fatalf("alias has %d modes, want 6", len(tool.Modes()))
+	}
+	// The chosen-plaintext differential mode must be registered by name.
+	var haveSweep bool
+	for _, m := range tool.Modes() {
+		if m.Name() == "sweep" {
+			haveSweep = true
+		}
+	}
+	if !haveSweep {
+		t.Fatal("alias tool missing the 'sweep' mode")
 	}
 }

--- a/internal/cryptolab/subjects/motorola/register.go
+++ b/internal/cryptolab/subjects/motorola/register.go
@@ -3,7 +3,8 @@ package motorola
 import "github.com/MattCheramie/GopherTrunk/internal/cryptolab"
 
 // aliasTool is a cryptolab subject: a length-seeded, keyless, byte-oriented
-// alias obfuscator, with five recovery modes.
+// alias obfuscator, with six recovery modes (five passive-corpus, plus the
+// chosen-plaintext differential "sweep" mode).
 type aliasTool struct{}
 
 func (aliasTool) Name() string     { return "alias" }
@@ -15,6 +16,7 @@ func (aliasTool) Modes() []cryptolab.Mode {
 		cellsMode{},
 		fromseedMode{},
 		propagateMode{},
+		sweepMode{},
 	}
 }
 

--- a/internal/cryptolab/subjects/motorola/sweep.go
+++ b/internal/cryptolab/subjects/motorola/sweep.go
@@ -1,0 +1,345 @@
+package motorola
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/gauge"
+)
+
+// This file implements the chosen-plaintext differential analysis developed on
+// #773 — the techniques that a controlled sweep corpus (moto_alias_t.zip)
+// unlocks and that the passive-corpus modes (gauge/structure/cells/fromseed)
+// cannot do. In order:
+//
+//   - sweep detection: group records that share plaintext at every character
+//     but one, at a single message length;
+//   - differential state pinning: at the swept character the pre-char state is
+//     fixed, so value = char·(L|1) + H fits exactly and pins (Hodd, Modd);
+//   - fold-input determination: cross-sweep, match the next-high-byte by char
+//     vs by value and count distinct deltas — the input the update folds is the
+//     one that collapses the deltas;
+//   - the g-law / two-state test: match by value and confirm the delta is two
+//     values, one equal to the state high-byte difference, i.e.
+//     Hnext = H_state + g(value) + branch;
+//   - g(value) recovery and coverage;
+//   - the low-byte observability accounting: how many (L_in → L_out) update
+//     transitions the sweeps actually expose (the wall documented on #773).
+
+// Sweep is a set of chosen-plaintext records that share plaintext at every
+// character except CharPos, at one message Length. Varying a single character
+// while holding the rest fixed holds the cipher state constant up to that
+// character, which is what makes the state pinnable.
+type Sweep struct {
+	Length  int
+	CharPos int // 0-based character index that varies across Rows
+	Rows    []Row
+}
+
+// PinnedState is a fully recovered odd-position accumulator byte pair, fitted
+// from one sweep: value = char·(L|1) + H at the swept byte.
+type PinnedState struct {
+	Length  int
+	CharPos int
+	BytePos int   // odd cipher byte index = 2·CharPos+1
+	Hodd    uint8 // accumulator high byte at the swept position
+	LoddOr1 uint8 // low byte forced odd (L|1); the decode multiplier is its inverse
+	Modd    uint8 // decode multiplier = inv(L|1)
+	Total   int   // records in the sweep
+}
+
+// detectSweeps groups a chosen-plaintext corpus into single-position sweeps.
+// Blanking the varied position collapses a sweep's rows to one bucket; blanking
+// any other position leaves them differing at the varied one, so only the true
+// varied position forms a bucket with several distinct characters. minDistinct
+// guards against coincidental 2-row groups.
+func detectSweeps(rows []Row, minDistinct int) []Sweep {
+	type key struct {
+		n, pos int
+		blank  string
+	}
+	buckets := map[key][]Row{}
+	for _, r := range rows {
+		n := len(r.Enc) / 2
+		if r.Alias == "" || n == 0 || n != len(r.Alias) {
+			continue
+		}
+		for p := 0; p < n; p++ {
+			b := []byte(r.Alias)
+			b[p] = 0
+			k := key{n: n, pos: p, blank: string(b)}
+			buckets[k] = append(buckets[k], r)
+		}
+	}
+	var out []Sweep
+	for k, rs := range buckets {
+		distinct := map[byte]bool{}
+		for _, r := range rs {
+			distinct[r.Alias[k.pos]] = true
+		}
+		if len(distinct) < minDistinct {
+			continue
+		}
+		out = append(out, Sweep{Length: k.n, CharPos: k.pos, Rows: rs})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Length != out[j].Length {
+			return out[i].Length < out[j].Length
+		}
+		return out[i].CharPos < out[j].CharPos
+	})
+	return out
+}
+
+// pinSweep fits value = char·(L|1) + H at the swept odd byte and returns the
+// pinned odd-position state. ok is false when the fit is not a clean affine map
+// with an odd slope over every record (i.e. the "sweep" is not a single fixed
+// state — e.g. rows of differing prefixes slipped into the group).
+func pinSweep(t *Table, sw Sweep) (PinnedState, bool) {
+	bytePos := 2*sw.CharPos + 1
+	type pt struct{ char, val uint8 }
+	pts := make([]pt, 0, len(sw.Rows))
+	for _, r := range sw.Rows {
+		if bytePos >= len(r.Enc) {
+			return PinnedState{}, false
+		}
+		pts = append(pts, pt{char: r.Alias[sw.CharPos], val: t.Fwd[r.Enc[bytePos]]})
+	}
+	// Solve the slope from a pair with an odd character difference (invertible
+	// mod 256), then verify it against every record.
+	var s, b uint8
+	found := false
+	for i := 1; i < len(pts) && !found; i++ {
+		dc := pts[i].char - pts[0].char
+		if dc&1 == 1 {
+			s = (pts[i].val - pts[0].val) * gauge.ModInv(dc)
+			b = pts[0].val - s*pts[0].char
+			found = true
+		}
+	}
+	if !found || s&1 == 0 {
+		return PinnedState{}, false
+	}
+	for _, p := range pts {
+		if s*p.char+b != p.val {
+			return PinnedState{}, false
+		}
+	}
+	return PinnedState{
+		Length: sw.Length, CharPos: sw.CharPos, BytePos: bytePos,
+		Hodd: b, LoddOr1: s, Modd: gauge.ModInv(s), Total: len(pts),
+	}, true
+}
+
+// transferMap returns, for a pinned sweep that has a following even byte, the
+// map value → next high byte: value = FWD[C] at the swept byte (the update
+// input), next high byte = FWD[C] at the following even byte (the update output
+// high byte). Empty when the swept character is the last one.
+func transferMap(t *Table, sw Sweep) map[uint8]uint8 {
+	nextEven := 2 * (sw.CharPos + 1)
+	out := map[uint8]uint8{}
+	for _, r := range sw.Rows {
+		if nextEven >= len(r.Enc) {
+			return nil
+		}
+		out[t.Fwd[r.Enc[2*sw.CharPos+1]]] = t.Fwd[r.Enc[nextEven]]
+	}
+	return out
+}
+
+// charTransferMap is transferMap keyed by the plaintext char instead of the
+// value — used only to contrast the two fold-input hypotheses.
+func charTransferMap(t *Table, sw Sweep) map[uint8]uint8 {
+	nextEven := 2 * (sw.CharPos + 1)
+	out := map[uint8]uint8{}
+	for _, r := range sw.Rows {
+		if nextEven >= len(r.Enc) {
+			return nil
+		}
+		out[r.Alias[sw.CharPos]] = t.Fwd[r.Enc[nextEven]]
+	}
+	return out
+}
+
+// distinctDeltas counts the distinct (mb[k] − ma[k]) mod 256 over the shared
+// keys of two maps, and reports whether one of them equals want (the state
+// high-byte difference, the g-law's signature).
+func distinctDeltas(ma, mb map[uint8]uint8, want uint8) (distinct int, hasWant bool, common int) {
+	set := map[uint8]bool{}
+	for k, va := range ma {
+		vb, ok := mb[k]
+		if !ok {
+			continue
+		}
+		common++
+		d := vb - va
+		set[d] = true
+		if d == want {
+			hasWant = true
+		}
+	}
+	return len(set), hasWant, common
+}
+
+// ---- Mode: chosen-plaintext sweep analysis ----
+
+type sweepMode struct{}
+
+func (sweepMode) Name() string { return "sweep" }
+func (sweepMode) Synopsis() string {
+	return "chosen-plaintext differential: detect sweeps, pin states, find the fold input and Hnext law"
+}
+
+func (sweepMode) Run(ctx context.Context, args []string, env cryptolab.Env) (*cryptolab.Result, error) {
+	rows, err := parseChosen("sweep", args, env)
+	if err != nil {
+		return nil, err
+	}
+	t := Recovered()
+
+	sweeps := detectSweeps(rows, 3)
+	env.Logf("sweeps detected", "count", len(sweeps))
+
+	// Pin the odd-position state for each sweep (differential state pinning).
+	type pinned struct {
+		st  PinnedState
+		val map[uint8]uint8 // value -> next high byte (nil if last char)
+		chr map[uint8]uint8 // char  -> next high byte
+	}
+	var pins []pinned
+	for _, sw := range sweeps {
+		ps, ok := pinSweep(t, sw)
+		if !ok {
+			continue
+		}
+		pins = append(pins, pinned{st: ps, val: transferMap(t, sw), chr: charTransferMap(t, sw)})
+		env.Logf("state pinned", "len", ps.Length, "char_pos", ps.CharPos,
+			"H", ps.Hodd, "L_or1", ps.LoddOr1, "Modd", ps.Modd, "records", ps.Total)
+	}
+
+	res := &cryptolab.Result{Tool: "alias", Mode: "sweep"}
+	res.AddField("rows", len(rows))
+	res.AddField("sweeps_detected", len(sweeps))
+	res.AddField("states_pinned", len(pins))
+	for _, p := range pins {
+		res.AddFinding(fmt.Sprintf("state len=%d pos=%d: H=%d L|1=%d Modd=%d",
+			p.st.Length, p.st.CharPos, p.st.Hodd, p.st.LoddOr1, p.st.Modd), 1.0,
+			map[string]any{"length": p.st.Length, "char_pos": p.st.CharPos,
+				"H": p.st.Hodd, "L_or1": p.st.LoddOr1, "Modd": p.st.Modd, "records": p.st.Total})
+	}
+	if len(pins) < 2 {
+		res.Summary = fmt.Sprintf("detected %d sweeps, pinned %d states (need >=2 with a following char for the transfer analysis)", len(sweeps), len(pins))
+		res.Note("differential state pinning works; supply sweeps at >=2 positions that each have a following character to run the fold-input and Hnext-law analysis.")
+		return res, nil
+	}
+
+	// Fold-input determination + g-law, over every pair of pinned states that
+	// each have a transfer map (a following even byte).
+	var withTransfer []pinned
+	for _, p := range pins {
+		if len(p.val) > 0 {
+			withTransfer = append(withTransfer, p)
+		}
+	}
+	byCharTotal, byValTotal := 0, 0
+	pairs := 0
+	glawOK := 0
+	for i := 0; i < len(withTransfer); i++ {
+		for j := i + 1; j < len(withTransfer); j++ {
+			a, b := withTransfer[i], withTransfer[j]
+			want := b.st.Hodd - a.st.Hodd
+			dChar, _, _ := distinctDeltas(a.chr, b.chr, want)
+			dVal, hasWant, common := distinctDeltas(a.val, b.val, want)
+			if common == 0 {
+				continue
+			}
+			pairs++
+			byCharTotal += dChar
+			byValTotal += dVal
+			if dVal <= 2 && hasWant {
+				glawOK++
+			}
+			env.Logf("pair analysed",
+				"a", fmt.Sprintf("H%d", a.st.Hodd), "b", fmt.Sprintf("H%d", b.st.Hodd),
+				"deltas_by_char", dChar, "deltas_by_value", dVal, "hdiff_present", hasWant)
+		}
+	}
+
+	// g(value) recovery + coverage: value -> H_next − H_state, state-independent.
+	gseen := map[uint8]bool{}
+	for _, p := range withTransfer {
+		for v := range p.val {
+			gseen[v] = true
+		}
+	}
+
+	// Low-byte observability: L is exposed (as L|1) only at swept odd bytes,
+	// which are >=2 bytes apart, so no (L_in → L_out) single-step transition is
+	// observed. Count adjacent-byte pinned pairs to make the floor explicit.
+	lowTransitions := 0
+	for i := 0; i < len(pins); i++ {
+		for j := 0; j < len(pins); j++ {
+			if pins[i].st.Length == pins[j].st.Length && pins[j].st.BytePos == pins[i].st.BytePos+1 {
+				lowTransitions++
+			}
+		}
+	}
+
+	res.AddField("input_fold_by_char_avg_deltas", ratio(byCharTotal, pairs))
+	res.AddField("input_fold_by_value_avg_deltas", ratio(byValTotal, pairs))
+	res.AddField("glaw_pairs_confirmed", fmt.Sprintf("%d/%d", glawOK, pairs))
+	res.AddField("g_value_coverage", fmt.Sprintf("%d/256", len(gseen)))
+	res.AddField("low_byte_transitions_observed", lowTransitions)
+	res.Summary = fmt.Sprintf("pinned %d states; fold input = %s; g-law confirmed %d/%d pairs; g covers %d/256; low-byte transitions observed %d",
+		len(pins), foldVerdict(byCharTotal, byValTotal), glawOK, pairs, len(gseen), lowTransitions)
+
+	if byValTotal < byCharTotal {
+		res.Note("the update folds the ciphertext byte / value FWD[C], not the plaintext char: matching next-high-byte by value collapses the cross-state deltas far below matching by char.")
+	}
+	if glawOK == pairs && pairs > 0 {
+		res.Note("Hnext = H_state + g(value) + branch confirmed: every state pair's next-high-byte delta is two values, one equal to the state high-byte difference. g(value) is state-independent; the residual branch is the hidden-low-byte selector.")
+	}
+	if lowTransitions == 0 {
+		res.Note("low-byte observability floor: L is exposed only as L|1 at the swept (non-consecutive) odd bytes, so ZERO (L_in -> L_out) update transitions are observed — the low-byte update and branch table cannot be fitted from these sweeps. The decisive capture sweeps CONSECUTIVE positions so L_in -> L_out becomes observable.")
+	}
+	return res, nil
+}
+
+// parseChosen loads a chosen-plaintext corpus (encoded_hex is pure cipher
+// output, no CRC) via the shared -csv flag.
+func parseChosen(modeName string, args []string, env cryptolab.Env) ([]Row, error) {
+	fs := flag.NewFlagSet("cryptolab alias "+modeName, flag.ContinueOnError)
+	csvPath := fs.String("csv", "", "chosen-plaintext corpus CSV (rid,talkgroup,encoded_hex,alias); encoded_hex is pure cipher output, no CRC — required")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+	if *csvPath == "" {
+		return nil, fmt.Errorf("alias %s: -csv is required", modeName)
+	}
+	rows, err := LoadChosenCSV(*csvPath, env.Logger)
+	if err != nil {
+		return nil, err
+	}
+	env.Logf("chosen-plaintext corpus loaded", "rows", len(rows))
+	return rows, nil
+}
+
+func ratio(n, d int) float64 {
+	if d == 0 {
+		return 0
+	}
+	return float64(n) / float64(d)
+}
+
+func foldVerdict(byChar, byVal int) string {
+	if byVal < byChar {
+		return "value/ciphertext-byte"
+	}
+	if byChar < byVal {
+		return "plaintext-char"
+	}
+	return "indeterminate"
+}

--- a/internal/cryptolab/subjects/motorola/sweep_test.go
+++ b/internal/cryptolab/subjects/motorola/sweep_test.go
@@ -1,0 +1,187 @@
+package motorola
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab"
+	"github.com/MattCheramie/GopherTrunk/internal/cryptolab/engine/gauge"
+)
+
+// plantEvenHigh / plantOdd define a synthetic chosen-plaintext cipher whose
+// per-position state depends only on the byte position (not the character), so
+// the state at any swept position is constant across that sweep — exactly the
+// property differential pinning relies on. Values are arbitrary but odd where
+// an odd multiplier is required.
+func plantEvenHigh(k int) uint8    { return uint8(50 + 7*k) }
+func plantOddMul(k int) uint8      { return uint8(5+2*k) | 1 }
+func plantOddHi(k int) uint8       { return uint8(80 + 13*k) }
+func plantState(k int) gauge.State { return gauge.State{Hi: plantOddHi(k), Mul: plantOddMul(k)} }
+
+// synthSweepCSV writes a chosen-plaintext corpus (pure cipher output, NO CRC)
+// containing two single-position sweeps at length 6: position 0 and position 1,
+// each varying the character over a distinct set while the rest stay 'A'.
+func synthSweepCSV(t *testing.T) string {
+	t.Helper()
+	tab := Recovered()
+	const n = 6
+	encodeAlias := func(a string) string {
+		enc := make([]byte, 2*n)
+		for k := 0; k < n; k++ {
+			enc[2*k] = tab.EncodeEven(plantEvenHigh(k))
+			st := plantState(k)
+			enc[2*k+1] = tab.EncodeOdd(st.Hi, st.Mul, a[k])
+		}
+		return hex.EncodeToString(enc)
+	}
+	var buf bytes.Buffer
+	buf.WriteString("rid,talkgroup,encoded_hex,alias\n")
+	id := 0
+	emit := func(src, a string) {
+		fmt.Fprintf(&buf, "%d,%s,%s,%s\n", id, src, encodeAlias(a), a)
+		id++
+	}
+	for _, c := range "ABCDEFGH" { // sweep at position 0
+		emit("s0", string(c)+"AAAAA")
+	}
+	for _, c := range "ABCDEFGH" { // sweep at position 1
+		emit("s1", "A"+string(c)+"AAAA")
+	}
+	path := filepath.Join(t.TempDir(), "sweep.csv")
+	if err := os.WriteFile(path, buf.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestLoadChosenCSVKeepsAllBytes: LoadChosenCSV must NOT strip a trailing CRC —
+// chosen-plaintext encoded_hex is pure cipher output, exactly 2·len(alias).
+func TestLoadChosenCSVKeepsAllBytes(t *testing.T) {
+	t.Parallel()
+	rows, err := LoadChosenCSV(synthSweepCSV(t), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 16 {
+		t.Fatalf("loaded %d rows, want 16", len(rows))
+	}
+	for _, r := range rows {
+		if len(r.Enc) != 2*len(r.Alias) {
+			t.Fatalf("alias %q: Enc=%d bytes, want %d (no CRC strip)", r.Alias, len(r.Enc), 2*len(r.Alias))
+		}
+	}
+	// Contrast: LoadCSV would strip two bytes, shrinking Enc below 2·len.
+	stripped, err := LoadCSV(synthSweepCSV(t), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stripped[0].Enc) != 2*len(stripped[0].Alias)-2 {
+		t.Fatalf("LoadCSV Enc=%d, want CRC-stripped %d", len(stripped[0].Enc), 2*len(stripped[0].Alias)-2)
+	}
+}
+
+// TestDetectSweepsAndPin: the two planted sweeps are detected, and differential
+// pinning recovers the exact planted odd-position state (H and Modd).
+func TestDetectSweepsAndPin(t *testing.T) {
+	t.Parallel()
+	tab := Recovered()
+	rows, err := LoadChosenCSV(synthSweepCSV(t), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sweeps := detectSweeps(rows, 3)
+	if len(sweeps) != 2 {
+		t.Fatalf("detected %d sweeps, want 2 (positions 0 and 1)", len(sweeps))
+	}
+	wantPos := map[int]bool{0: true, 1: true}
+	for _, sw := range sweeps {
+		if sw.Length != 6 || !wantPos[sw.CharPos] {
+			t.Fatalf("unexpected sweep len=%d pos=%d", sw.Length, sw.CharPos)
+		}
+		delete(wantPos, sw.CharPos)
+		ps, ok := pinSweep(tab, sw)
+		if !ok {
+			t.Fatalf("pinSweep failed for pos=%d", sw.CharPos)
+		}
+		if ps.Hodd != plantOddHi(sw.CharPos) || ps.Modd != plantOddMul(sw.CharPos) {
+			t.Fatalf("pos=%d pinned H=%d Modd=%d, want H=%d Modd=%d",
+				sw.CharPos, ps.Hodd, ps.Modd, plantOddHi(sw.CharPos), plantOddMul(sw.CharPos))
+		}
+		// L|1 must be the inverse of Modd and odd.
+		if ps.LoddOr1&1 == 0 || ps.LoddOr1 != gauge.ModInv(ps.Modd) {
+			t.Fatalf("pos=%d L|1=%d not a valid odd inverse of Modd=%d", sw.CharPos, ps.LoddOr1, ps.Modd)
+		}
+	}
+}
+
+// TestPinSweepRejectsMixedPrefix: a "sweep" whose rows do not actually share a
+// fixed pre-char state must not pin (guards against a false positive).
+func TestPinSweepRejectsMixedPrefix(t *testing.T) {
+	t.Parallel()
+	tab := Recovered()
+	// Rows where the swept-byte value is not an affine function of the char
+	// (odd byte scrambled) — pinning must reject.
+	sw := Sweep{Length: 3, CharPos: 0, Rows: []Row{
+		{Enc: []byte{tab.EncodeEven(10), 0x11, tab.EncodeEven(20), 0x22, tab.EncodeEven(30), 0x33}, Alias: "AAA"},
+		{Enc: []byte{tab.EncodeEven(10), 0x99, tab.EncodeEven(20), 0x22, tab.EncodeEven(30), 0x33}, Alias: "BAA"},
+		{Enc: []byte{tab.EncodeEven(10), 0x04, tab.EncodeEven(20), 0x22, tab.EncodeEven(30), 0x33}, Alias: "CAA"},
+	}}
+	if _, ok := pinSweep(tab, sw); ok {
+		t.Fatal("pinSweep accepted a non-affine sweep; want reject")
+	}
+}
+
+// TestDistinctDeltas exercises the two-state delta counter and its
+// high-byte-difference detector.
+func TestDistinctDeltas(t *testing.T) {
+	t.Parallel()
+	a := map[uint8]uint8{1: 10, 2: 20, 3: 30, 4: 40}
+	// b = a + {61 for some, 200 for others}: two-value delta, one == want(61).
+	b := map[uint8]uint8{1: 10 + 61, 2: 20 + 200, 3: 30 + 61, 4: 40 + 200}
+	distinct, hasWant, common := distinctDeltas(a, b, 61)
+	if common != 4 || distinct != 2 || !hasWant {
+		t.Fatalf("distinctDeltas = distinct %d, hasWant %v, common %d; want 2,true,4", distinct, hasWant, common)
+	}
+	// A single-value delta not equal to want.
+	c := map[uint8]uint8{1: 15, 2: 25, 3: 35, 4: 45}
+	if d, has, _ := distinctDeltas(a, c, 61); d != 1 || has {
+		t.Fatalf("uniform delta: distinct %d hasWant %v, want 1,false", d, has)
+	}
+}
+
+// TestSweepModeRuns drives the full mode and checks the headline fields: two
+// states pinned, and the low-byte observability floor reported (the sweeps are
+// non-consecutive, so zero L_in->L_out transitions).
+func TestSweepModeRuns(t *testing.T) {
+	t.Parallel()
+	env := cryptolab.Env{Stdout: io.Discard}
+	res, err := sweepMode{}.Run(context.Background(), []string{"-csv", synthSweepCSV(t)}, env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fields := map[string]any{}
+	for _, f := range res.Fields {
+		fields[f.Key] = f.Value
+	}
+	if fields["states_pinned"] != 2 {
+		t.Fatalf("states_pinned = %v, want 2", fields["states_pinned"])
+	}
+	if fields["low_byte_transitions_observed"] != 0 {
+		t.Fatalf("low_byte_transitions_observed = %v, want 0", fields["low_byte_transitions_observed"])
+	}
+	var sawFloor bool
+	for _, n := range res.Notes {
+		if bytes.Contains([]byte(n), []byte("observability floor")) {
+			sawFloor = true
+		}
+	}
+	if !sawFloor {
+		t.Fatalf("expected the low-byte observability-floor note; notes=%v", res.Notes)
+	}
+}

--- a/research/p25-talker-alias-cryptanalysis.md
+++ b/research/p25-talker-alias-cryptanalysis.md
@@ -348,8 +348,9 @@ see `p25-talker-alias-chosen-plaintext.md`.
 ## Reproducing
 
 The recovery toolkit is committed under `internal/cryptolab/subjects/motorola`
-(build tag `cryptolab`). Point any mode at a `rid,talkgroup,encoded_hex,alias`
-corpus — the trailing 2 CRC bytes are stripped on load:
+(build tag `cryptolab`). The first five modes take a passive-capture
+`rid,talkgroup,encoded_hex,alias` corpus (the trailing 2 CRC bytes are stripped
+on load):
 
 ```
 gophertrunk cryptolab alias gauge     -csv corpus.csv   # affine gauge sweep
@@ -359,8 +360,22 @@ gophertrunk cryptolab alias fromseed  -csv corpus.csv   # simulate candidate upd
 gophertrunk cryptolab alias propagate -csv corpus.csv   # harvest (state,eo)->state transition + seed; coverage
 ```
 
-The `propagate` mode produced the dense-corpus results above. Earlier scratch
-tooling (not committed) covered even-H extraction and determinism sweeps, the
-LUT/keystream recovery, the simulate-from-seed brutes (linear / mod-prime / MWC /
-nonlinear / both-feedback), the train/test table decoder, and the NLFSR/S-box
-search.
+The **`sweep`** mode takes a *chosen-plaintext* corpus — same columns, but
+`encoded_hex` is the pure cipher output with **no CRC** (e.g. `moto_alias_t.zip`'s
+`Alias Encoded` field, exactly `2·len(alias)` bytes). It reproduces every
+chosen-plaintext technique from the 2026-07 results above — sweep detection,
+differential state pinning, fold-input determination, the `Hnext = H + g(value) +
+branch` law, `g` coverage, and the low-byte observability accounting:
+
+```
+gophertrunk cryptolab alias sweep     -csv chosen.csv   # differential: pin states, find fold input + Hnext law
+```
+
+On the `moto_alias_t.zip` sweeps it pins the three states `(H56,L|1 161)`,
+`(H117,L|1 225)`, `(H206,L|1 11)`, reports the fold input as the value/ciphertext
+byte (≈2 vs ≈77 cross-state deltas), confirms the g-law on every state pair,
+covers `g` over 197/256, and reports `0` observed low-byte transitions.
+
+Earlier scratch tooling (not committed) covered the simulate-from-seed brutes
+(linear / mod-prime / MWC / nonlinear / both-feedback), the train/test table
+decoder, and the NLFSR/S-box search.


### PR DESCRIPTION
## Summary

The research notes from #909 (now merged) documented what the chosen-plaintext corpus established, but the *techniques* lived only in throwaway scripts. This PR makes them first-class, reusable `cryptolab` capabilities so the analysis is reproducible and extends to future chosen-plaintext captures. The passive-corpus modes (`gauge`/`structure`/`cells`/`fromseed`/`propagate`) cannot exploit a controlled sweep corpus; this adds a mode that does. No change to the live decode or the `CipherVerified` gate.

## Changes

- **`LoadChosenCSV`** — loads a corpus whose `encoded_hex` is the pure cipher output with **no CRC** (the form a chosen-plaintext encoder emits, exactly `2·len(alias)` bytes), instead of the passive-capture CRC-stripped form. `LoadCSV` is unchanged.
- **New `sweep` mode** (`internal/cryptolab/subjects/motorola/sweep.go`) that reproduces every chosen-plaintext technique used in the analysis:
  - **sweep detection** — group records that vary a single plaintext character at one length;
  - **differential state pinning** — at the swept character the pre-char state is fixed, so `value = char·(L|1)+H` fits exactly and pins the odd-position state `(Hodd, Modd)`;
  - **fold-input determination** — cross-state, match the next-high-byte by char vs by value and count distinct deltas; the input the update folds is the one that collapses them;
  - **the `Hnext = H_state + g(value) + branch` law** — two-state test: each state pair's next-high-byte delta is two values, one equal to the state high-byte difference;
  - **`g(value)` coverage**;
  - **low-byte observability accounting** — counts observed `(L_in → L_out)` transitions (zero for non-consecutive swept positions), making the documented wall explicit.
- Registers the mode (six total) and documents it in the research doc's *Reproducing* section.

Run against the `moto_alias_t.zip` sweeps, the mode reproduces the session's findings exactly: three pinned states `(H56,L|1 161)`, `(H117,L|1 225)`, `(H206,L|1 11)`; fold input = value/ciphertext byte (≈2 vs ≈77 cross-state deltas); g-law confirmed on all pairs; `g` covers 197/256; `0` low-byte transitions observed.

## Test plan

- [x] `make vet test` is green locally
- [ ] `make integration` — n/a (research tooling; no daemon/DSP change)
- [x] Added or updated tests — `sweep_test.go` synthesizes a planted sweep corpus and asserts detection, exact state recovery, no-CRC loading, the delta counter, `pinSweep` rejection of a non-affine group, and the end-to-end mode; `motorola_test.go` asserts the mode is registered
- [ ] Smoke-tested against real hardware — n/a

## Breaking changes

none — additive: a new loader and a new mode. Existing modes, `LoadCSV`, and the `CipherVerified` gate (still `false`) are unchanged.

## Docs / CHANGELOG

- [ ] CHANGELOG `## [Unreleased]` — n/a (research toolkit, gated behind `-tags cryptolab`, not operator-facing runtime behaviour)
- [x] Updated `docs/` — the research doc's *Reproducing* section documents the new mode

## Linked issues

Refs #773 (research tooling; the cipher is not solved and the gate stays closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pnzst12dbFsuYspX1Qq3AD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pnzst12dbFsuYspX1Qq3AD)_