### PR TITLE
cryptolab/web: group the console by workflow stage + readable results

### DIFF
--- a/docs/cryptolab.md
+++ b/docs/cryptolab.md
@@ -51,10 +51,13 @@ gophertrunk cryptolab serve -open  # serve at http://127.0.0.1:8096/ and open a 
 The console exposes **every** tool, mode, and setting: it renders a form from
 the backend's `GET /api/v1/cryptolab/tools` schema, so each parameter (file
 upload, text, number, checkbox) gets a control, and new tools appear
-automatically. A run uploads inputs, streams the live log, and shows the
-structured result — summary, fields, ranked findings, notes, and downloadable
-artifacts (survivor logs, checkpoints, descrambled output). It runs entirely
-offline against uploaded files; no SDR or daemon required.
+automatically. The tool list is grouped by **workflow stage** (triage → attack
+→ verify — see the Tools table below) with a search box, and the console lands
+on `classify auto` so the first thing offered is "what am I looking at?". A run
+uploads inputs, streams the live log, and shows the structured result — summary,
+fields, ranked findings, notes, and downloadable artifacts (survivor logs,
+checkpoints, descrambled output). It runs entirely offline against uploaded
+files; no SDR or daemon required.
 
 When the main `gophertrunk` daemon is built with `-tags cryptolab`, the same
 console is also mounted inside it at `/cryptolab/` (its API lives under
@@ -97,7 +100,16 @@ Global flags precede the tool name (`-out`, `-resume`, `-format`,
 | `recipe` | `run` | CyberChef-style pipeline: chain transform + analysis ops, piping bytes between steps |
 | `crc` | `recover`, `compute` | recover / compute CRC parameters from sample frames |
 | `descramble` | `invert`, `splitband`, `rolling` | analog spectral / split-band / rolling-code voice inversion |
-| `alias` | `gauge`, `structure`, `cells`, `fromseed` | length-seeded byte-obfuscator recovery |
+| `alias` | `gauge`, `structure`, `cells`, `fromseed`, `propagate`, `sweep` | length-seeded Motorola byte-obfuscator recovery (five passive-corpus modes + one chosen-plaintext) |
+| `nxdn` | `descramble`, `brute` | NXDN 15-bit scrambler: descramble with a known key, or brute-force the 2¹⁵ keyspace against a CRC / known-plaintext oracle |
+
+In the web console these tools are grouped by **workflow stage** — Triage
+(`classify`, `stats`, `randomness`), Keystream & reuse (`ks`, `lfsr`), Classical
+ciphers (`brute`), Voice descrambling (`descramble`), Protocol subjects (`nxdn`,
+`alias`), Pipelines & CRC (`recipe`, `crc`), and the `assess` Security test — so
+the tool list reads as the triage → attack → verify pipeline rather than an
+alphabetical index. The console lands on `classify auto` (the "what am I looking
+at?" front door) and has a search box over the tool list.
 
 ### Examples
 
@@ -201,10 +213,10 @@ styling, and upload flow).
 The toolkit's subject framework studies length-seeded, keyless, byte-oriented
 obfuscators where the output substitution table and per-character decode
 `char = int8(Modd·(LUT[eo] − Hodd))` are established but the per-character
-state update is not. The `alias` tool provides four incremental, logging,
-resumable recovery modes over a user-supplied ground-truth corpus
+state update is not. The `alias` tool provides six incremental, logging,
+resumable recovery modes — five over a passive-capture ground-truth corpus
 (`rid,talkgroup,encoded_hex,alias`; a trailing 2-byte CRC is stripped
-automatically):
+automatically), plus one over a chosen-plaintext corpus:
 
 - **`gauge`** — brute-force all 32,768 affine gauges, looking for a
   coordinate frame in which the odd high byte becomes a clean function of a
@@ -218,6 +230,16 @@ automatically):
   feed the high-byte recurrence.
 - **`fromseed`** — simulate candidate accumulator updates from the length
   seed, auto-solve the affine output gauge, and cull by high-byte mismatch.
+- **`propagate`** — harvest the explicit `(state, eo) → state` transition and
+  length seed from the corpus, propagate forward, and report decode coverage —
+  measuring whether a passive corpus can close the cipher.
+- **`sweep`** — the chosen-plaintext differential attack. Its `-csv` is the
+  *pure* cipher output with **no CRC** (`2·len(alias)` bytes, as a chosen-
+  plaintext encoder emits). It detects single-character sweeps, pins the
+  odd-position state by the affine fit `value = char·(L|1)+H`, determines the
+  update's fold input (value vs. char), confirms the `Hnext = H + g(value) +
+  branch` law, and reports the low-byte observability floor. See
+  `research/p25-talker-alias-cryptanalysis.md`.
 
 ### What the data supports
 

--- a/internal/cryptolab/schema.go
+++ b/internal/cryptolab/schema.go
@@ -18,10 +18,68 @@ type Param struct {
 
 // ModeSchema is the web-facing description of one tool/mode and its inputs.
 type ModeSchema struct {
-	Tool     string  `json:"tool"`
-	Mode     string  `json:"mode"`
+	Tool string `json:"tool"`
+	Mode string `json:"mode"`
+	// Category is the workflow stage the tool serves, so the web console can
+	// group modes by what the analyst is trying to DO (triage → attack →
+	// verify) instead of an alphabetical tool list. Derived from the tool via
+	// toolCategory; unmapped tools fall back to "Other".
+	Category string  `json:"category"`
 	Synopsis string  `json:"synopsis"`
 	Params   []Param `json:"params"`
+}
+
+// categoryOrder is the workflow order the console lists categories in — the
+// triage → analyze → attack → verify pipeline cryptolab is designed around
+// (see doc.go). Schema() sorts by this order so the frontend can group the
+// returned list in place.
+var categoryOrder = []string{
+	"Triage",             // what am I looking at?
+	"Statistical",        // characterize the structure
+	"Keystream & reuse",  // the operator-misuse attacks
+	"Classical ciphers",  // XOR / shift / substitution keyspace brute
+	"Voice descrambling", // analog spectral inversion
+	"Protocol subjects",  // NXDN / Motorola proprietary obfuscators
+	"Pipelines & CRC",    // recipe chaining + CRC parameter recovery
+	"Security test",      // the assess harness verdict
+}
+
+// toolCategory maps each registered tool to its workflow category. Modes under
+// a tool share its category. Keep in sync with the registered tools; an
+// unlisted tool is grouped under "Other" (and the schema stays valid — the
+// coverage test only requires params, not a category).
+var toolCategory = map[string]string{
+	"classify":   "Triage",
+	"stats":      "Statistical",
+	"randomness": "Statistical",
+	"ks":         "Keystream & reuse",
+	"lfsr":       "Keystream & reuse",
+	"brute":      "Classical ciphers",
+	"descramble": "Voice descrambling",
+	"nxdn":       "Protocol subjects",
+	"alias":      "Protocol subjects",
+	"recipe":     "Pipelines & CRC",
+	"crc":        "Pipelines & CRC",
+	"assess":     "Security test",
+}
+
+// categoryFor returns a tool's workflow category, defaulting to "Other".
+func categoryFor(tool string) string {
+	if c, ok := toolCategory[tool]; ok {
+		return c
+	}
+	return "Other"
+}
+
+// categoryRank returns a category's position in categoryOrder, sorting any
+// unlisted category ("Other") to the end.
+func categoryRank(cat string) int {
+	for i, c := range categoryOrder {
+		if c == cat {
+			return i
+		}
+	}
+	return len(categoryOrder)
 }
 
 // modeParams maps "tool/mode" to its input parameters. It is the single
@@ -159,8 +217,9 @@ var modeParams = map[string][]Param{
 }
 
 // Schema returns the web-facing description of every registered tool/mode,
-// sorted by tool then mode. It joins the live registry (so every registered
-// mode appears with its synopsis) with the parameter table above.
+// sorted by workflow category (the triage → attack → verify order), then tool,
+// then mode. It joins the live registry (so every registered mode appears with
+// its synopsis) with the parameter table above and the workflow category.
 func Schema() []ModeSchema {
 	var out []ModeSchema
 	for _, t := range Tools() {
@@ -169,12 +228,16 @@ func Schema() []ModeSchema {
 			out = append(out, ModeSchema{
 				Tool:     t.Name(),
 				Mode:     m.Name(),
+				Category: categoryFor(t.Name()),
 				Synopsis: m.Synopsis(),
 				Params:   modeParams[key],
 			})
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
+		if ri, rj := categoryRank(out[i].Category), categoryRank(out[j].Category); ri != rj {
+			return ri < rj
+		}
 		if out[i].Tool != out[j].Tool {
 			return out[i].Tool < out[j].Tool
 		}

--- a/internal/cryptolab/schema_test.go
+++ b/internal/cryptolab/schema_test.go
@@ -46,3 +46,15 @@ func TestSchemaCoversEveryRegisteredMode(t *testing.T) {
 		}
 	}
 }
+
+// TestEveryToolHasAWorkflowCategory: every registered tool must map to a known
+// workflow category, so the web console groups it under a real heading rather
+// than the "Other" catch-all. A new tool that forgets its category trips this.
+func TestEveryToolHasAWorkflowCategory(t *testing.T) {
+	t.Parallel()
+	for _, ms := range cryptolab.Schema() {
+		if ms.Category == "" || ms.Category == "Other" {
+			t.Errorf("tool %q (mode %q) has no workflow category — add it to toolCategory in schema.go", ms.Tool, ms.Mode)
+		}
+	}
+}

--- a/web/cryptolab/src/App.tsx
+++ b/web/cryptolab/src/App.tsx
@@ -9,6 +9,7 @@ import { ConsoleNav } from "./ConsoleNav";
 export function App() {
   const [page, setPage] = useState<"tools" | "recipe" | "bundle">("tools");
   const [bundleEnabled, setBundleEnabled] = useState(false);
+  const [query, setQuery] = useState("");
   const loadSchema = useStore((s) => s.loadSchema);
   const schema = useStore((s) => s.schema);
   const loadingSchema = useStore((s) => s.loadingSchema);
@@ -40,15 +41,31 @@ export function App() {
     };
   }, [loadSchema]);
 
-  const tools = useMemo(() => {
-    const m = new Map<string, { mode: string; synopsis: string }[]>();
+  // Group the (already category→tool→mode sorted) schema into workflow
+  // categories so the sidebar reflects the triage → attack → verify pipeline
+  // instead of an alphabetical tool list. A search box filters across
+  // tool / mode / synopsis / category.
+  const groups = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const match = (s: (typeof schema)[number]) =>
+      !q ||
+      s.tool.toLowerCase().includes(q) ||
+      s.mode.toLowerCase().includes(q) ||
+      (s.synopsis ?? "").toLowerCase().includes(q) ||
+      (s.category ?? "").toLowerCase().includes(q);
+    const cats: { category: string; items: { tool: string; mode: string; synopsis: string }[] }[] = [];
     for (const s of schema) {
-      const arr = m.get(s.tool) ?? [];
-      arr.push({ mode: s.mode, synopsis: s.synopsis });
-      m.set(s.tool, arr);
+      if (!match(s)) continue;
+      const cat = s.category ?? "Other";
+      let c = cats.find((x) => x.category === cat);
+      if (!c) {
+        c = { category: cat, items: [] };
+        cats.push(c);
+      }
+      c.items.push({ tool: s.tool, mode: s.mode, synopsis: s.synopsis });
     }
-    return [...m.entries()];
-  }, [schema]);
+    return cats;
+  }, [schema, query]);
 
   const missingRequiredFile = (selected?.params ?? []).some(
     (p) => p.kind === "file" && p.required && !files[p.name],
@@ -99,30 +116,47 @@ export function App() {
         </main>
       ) : (
       <div className="flex min-h-0 flex-1">
-        <nav className="w-56 shrink-0 overflow-y-auto border-r border-line p-2">
-          {tools.length === 0 ? (
-            <p className="help p-2">{loadingSchema ? "Loading tools…" : "No tools."}</p>
-          ) : (
-            tools.map(([t, modes]) => (
-              <div key={t} className="mb-2">
-                <div className="px-2 py-1 text-xs uppercase tracking-wide text-muted">{t}</div>
-                {modes.map((m) => (
-                  <button
-                    key={m.mode}
-                    onClick={() => select(t, m.mode)}
-                    title={m.synopsis}
-                    className={`mb-0.5 block w-full truncate rounded px-2 py-1.5 text-left text-sm ${
-                      tool === t && mode === m.mode
-                        ? "bg-accent/20 text-fg"
-                        : "text-muted hover:bg-panel"
-                    }`}
-                  >
-                    {m.mode}
-                  </button>
-                ))}
-              </div>
-            ))
-          )}
+        <nav className="flex w-60 shrink-0 flex-col overflow-hidden border-r border-line">
+          <div className="border-b border-line p-2">
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search tools…"
+              aria-label="Search tools"
+              className="input w-full text-sm"
+            />
+          </div>
+          <div className="min-h-0 flex-1 overflow-y-auto p-2">
+            {schema.length === 0 ? (
+              <p className="help p-2">{loadingSchema ? "Loading tools…" : "No tools."}</p>
+            ) : groups.length === 0 ? (
+              <p className="help p-2">No tools match “{query}”.</p>
+            ) : (
+              groups.map((g) => (
+                <div key={g.category} className="mb-3">
+                  <div className="px-2 py-1 text-xs font-semibold uppercase tracking-wide text-accent">
+                    {g.category}
+                  </div>
+                  {g.items.map((m) => (
+                    <button
+                      key={`${m.tool}/${m.mode}`}
+                      onClick={() => select(m.tool, m.mode)}
+                      title={m.synopsis}
+                      className={`mb-0.5 block w-full truncate rounded px-2 py-1.5 text-left text-sm ${
+                        tool === m.tool && mode === m.mode
+                          ? "bg-accent/20 text-fg"
+                          : "text-muted hover:bg-panel"
+                      }`}
+                    >
+                      <span className="text-muted">{m.tool}</span>
+                      <span className="text-fg"> {m.mode}</span>
+                    </button>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
         </nav>
 
         <main className="min-w-0 flex-1 space-y-4 overflow-y-auto p-4">
@@ -135,6 +169,11 @@ export function App() {
           {selected ? (
             <>
               <div>
+                {selected.category ? (
+                  <div className="text-xs font-semibold uppercase tracking-wide text-accent">
+                    {selected.category}
+                  </div>
+                ) : null}
                 <h2 className="text-lg font-semibold">
                   {selected.tool} <span className="text-muted">/ {selected.mode}</span>
                 </h2>

--- a/web/cryptolab/src/api/types.ts
+++ b/web/cryptolab/src/api/types.ts
@@ -13,6 +13,9 @@ export interface Param {
 export interface ModeSchema {
   tool: string;
   mode: string;
+  /** Workflow category the mode belongs to (triage → attack → verify), used to
+   *  group the tool list. Older servers omit it; treat missing as "Other". */
+  category?: string;
   synopsis: string;
   params: Param[] | null;
 }

--- a/web/cryptolab/src/components/ResultView.tsx
+++ b/web/cryptolab/src/components/ResultView.tsx
@@ -14,10 +14,36 @@ function StateBadge({ state }: { state: RunState }) {
   return <span className={`rounded px-2 py-0.5 text-xs ${cls}`}>{state}</span>;
 }
 
-function renderValue(v: unknown): string {
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// formatScalar renders a leaf value: integers stay integers, floats trim to 4
+// significant decimals (so a count doesn't show 4.0000 and a ratio isn't a long
+// tail), everything else stringifies.
+function formatScalar(v: unknown): string {
   if (v === null || v === undefined) return "";
-  if (typeof v === "object") return JSON.stringify(v);
+  if (typeof v === "number") {
+    return Number.isInteger(v) ? String(v) : String(Number(v.toFixed(4)));
+  }
   return String(v);
+}
+
+// KeyVals renders an object as readable `key=value` chips instead of a
+// JSON one-liner, so a Field value or a Finding detail map is legible.
+function KeyVals({ obj }: { obj: Record<string, unknown> }) {
+  const entries = Object.entries(obj);
+  if (entries.length === 0) return <span className="text-muted">—</span>;
+  return (
+    <div className="flex flex-wrap gap-x-3 gap-y-0.5">
+      {entries.map(([k, v]) => (
+        <span key={k} className="whitespace-nowrap">
+          <span className="text-muted">{k}=</span>
+          <span>{isPlainObject(v) || Array.isArray(v) ? JSON.stringify(v) : formatScalar(v)}</span>
+        </span>
+      ))}
+    </div>
+  );
 }
 
 export function ResultView() {
@@ -49,7 +75,9 @@ export function ResultView() {
           {r.fields.map((f) => (
             <div key={f.key} className="card">
               <div className="text-xs uppercase tracking-wide text-muted">{f.key}</div>
-              <div className="mt-1 break-words font-mono text-sm">{renderValue(f.value)}</div>
+              <div className="mt-1 break-words font-mono text-sm">
+                {isPlainObject(f.value) ? <KeyVals obj={f.value} /> : formatScalar(f.value)}
+              </div>
             </div>
           ))}
         </div>
@@ -72,9 +100,9 @@ export function ResultView() {
                 <tr key={i} className="border-t border-line align-top">
                   <td className="py-1 pr-3 text-muted">{i + 1}</td>
                   <td className="py-1 pr-3 font-mono">{f.label}</td>
-                  <td className="py-1 pr-3 tabular-nums">{f.score.toFixed(4)}</td>
+                  <td className="py-1 pr-3 tabular-nums">{formatScalar(f.score)}</td>
                   <td className="py-1 font-mono text-muted">
-                    {f.detail ? JSON.stringify(f.detail) : ""}
+                    {f.detail ? <KeyVals obj={f.detail} /> : ""}
                   </td>
                 </tr>
               ))}

--- a/web/cryptolab/src/store/shared.ts
+++ b/web/cryptolab/src/store/shared.ts
@@ -45,9 +45,12 @@ export const useStore = create<Store>((set, get) => ({
     try {
       const schema = await api.tools();
       set({ schema, loadingSchema: false });
-      // Auto-select the first tool/mode for a non-empty initial view.
+      // Land on the triage front door (`classify auto` — "what am I looking
+      // at?") when present, else the first mode, for a sensible initial view.
       if (!get().tool && schema.length > 0) {
-        get().select(schema[0].tool, schema[0].mode);
+        const front =
+          schema.find((s) => s.tool === "classify" && s.mode === "auto") ?? schema[0];
+        get().select(front.tool, front.mode);
       }
     } catch (e) {
       set({ loadingSchema: false, schemaError: String(e) });


### PR DESCRIPTION
Review of the cryptolab web console found every registered mode is already
reachable (the schema-driven form list + the coverage test guarantee it), but
the tool list was a flat alphabetical index that didn't reflect what the
toolkit is designed to do, and it landed on an obscure Motorola alias mode.

- schema: add a workflow Category to each mode (triage → statistical →
  keystream & reuse → classical ciphers → voice descrambling → protocol
  subjects → pipelines & CRC → security test), derived from the tool via a
  toolCategory map, and sort Schema() by that order. A test asserts every
  registered tool has a category so a new tool can't silently fall to "Other".
- console: group the sidebar by Category with a search box over
  tool/mode/synopsis/category; land on `classify auto` (the "what am I looking
  at?" front door) instead of the alphabetically-first mode; show the category
  on the mode heading.
- results: render object-valued Fields and Finding detail maps as readable
  key=value chips instead of a JSON one-liner, and format scores/counts
  without spurious trailing decimals.
- docs/cryptolab.md: refresh the stale Tools table (alias now has six modes;
  add the nxdn tool) and document the workflow grouping.

Frontend typechecks, vitest passes, and the SPA builds; go test + vet green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pnzst12dbFsuYspX1Qq3AD