### PR TITLE
ccdecoder: up-sample sub-target IQ so low-rate TETRA replay decodes

### DIFF
--- a/cmd/gophertrunk/integration_cc_tetra_test.go
+++ b/cmd/gophertrunk/integration_cc_tetra_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/MattCheramie/GopherTrunk/internal/config"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
 	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
 	"github.com/MattCheramie/GopherTrunk/internal/events"
 	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
@@ -36,7 +37,6 @@ import (
 // the wire. This test exercises the chain end-to-end.
 func TestDaemonCCDecodesTETRA(t *testing.T) {
 	const (
-		controlFreqHz = 412_062_500
 		// TETRA symbol rate is 18000. Pick 72000 = 4 × 18000 so
 		// the receiver's float sps computation rounds to an exact
 		// integer (4) with no drift.
@@ -44,16 +44,61 @@ func TestDaemonCCDecodesTETRA(t *testing.T) {
 		sps        = 4
 		span       = 8
 		alpha      = 0.35
-		colourCode = uint32(0x12345)
-		// LocationArea is what nxdn / dpmr / edacs / motorola got
-		// plumbed into LockedNAC; for TETRA we use LocationArea
-		// the same way. 0x42 = 66 is a small recognisable value.
-		locationArea uint16 = 0x42
-		burstRepeats        = 100
 	)
-
-	dibits := buildTETRASCHHDStream(burstRepeats, colourCode, locationArea)
+	dibits := buildTETRASCHHDStream(100, tetraCCColourCode, tetraCCLocationArea)
 	iq := demod.ModulatePiOver4DQPSK(dibits, sps, span, alpha, math.Pi/4)
+	assertDaemonTETRALocks(t, iq, sampleRate)
+}
+
+// TestDaemonCCDecodesTETRAAt48kHz is the sub-target sibling of
+// TestDaemonCCDecodesTETRA. It feeds the daemon a 48 kHz TETRA capture —
+// below the 144 kHz channel target, and at a fractional 2.667 sps that
+// the receiver cannot decode directly — and asserts the production
+// pipeline still locks because the Downconverter now interpolates the
+// stream up to the 144 kHz / 8-sps design point.
+//
+// 48000/18000 is not an integer, so the fixture cannot be modulated at
+// 48 kHz directly; it is modulated at 144 kHz (8 sps) and downsampled
+// 3:1 to a genuine 48 kHz capture, exactly the rate an SDR++ baseband
+// recording or the samples/tetra reference WAV lands at.
+//
+// Before the DDC up-sample fix the daemon passed the 48 kHz stream
+// through untouched, the receiver rounded 2.667 → 3 sps and decoded at
+// 16000 baud, and no lock ever fired. This test fails without the fix.
+func TestDaemonCCDecodesTETRAAt48kHz(t *testing.T) {
+	const (
+		span  = 8
+		alpha = 0.35
+	)
+	dibits := buildTETRASCHHDStream(160, tetraCCColourCode, tetraCCLocationArea)
+	iq144 := demod.ModulatePiOver4DQPSK(dibits, 8, span, alpha, math.Pi/4)
+	// Downsample 144 kHz → 48 kHz with a sharp anti-alias prototype so
+	// the capture is clean; the daemon's DDC does the inverse 3:1
+	// interpolation back to 144 kHz.
+	iq48 := dsp.NewResampler(1, 3, 64, 8.6).Process(nil, iq144)
+	assertDaemonTETRALocks(t, iq48, 48_000)
+}
+
+const (
+	tetraCCControlFreqHz = 412_062_500
+	tetraCCColourCode    = uint32(0x12345)
+	// LocationArea is what nxdn / dpmr / edacs / motorola got plumbed
+	// into LockedNAC; for TETRA we use LocationArea the same way.
+	// 0x42 = 66 is a small recognisable value.
+	tetraCCLocationArea uint16 = 0x42
+)
+
+// assertDaemonTETRALocks boots the daemon with a mock SDR replaying the
+// given TETRA IQ at sampleRate and asserts the production
+// newTETRAPipeline + config + supervisor + API + metrics chain recovers
+// the lock carrying tetraCCLocationArea.
+func assertDaemonTETRALocks(t *testing.T, iq []complex64, sampleRate float64) {
+	t.Helper()
+	const (
+		controlFreqHz = tetraCCControlFreqHz
+		colourCode    = tetraCCColourCode
+		locationArea  = tetraCCLocationArea
+	)
 
 	dir := t.TempDir()
 	iqPath := filepath.Join(dir, "tetra-cc.cfile")

--- a/internal/scanner/ccdecoder/ddc.go
+++ b/internal/scanner/ccdecoder/ddc.go
@@ -71,15 +71,43 @@ const ddcStopbandTaps = 12
 // ~70 dB peak sidelobe attenuation.
 const ddcKaiserBeta = 7.0
 
-// Downconverter decimates a wideband SDR IQ stream to a narrowband
-// channel rate.
+// ddcUpMaxNumer / ddcUpMaxDenom bound the L/M ratio the up-sampling
+// branch of ddcRatio will accept as an *exact* reduced fraction. A
+// pre-channelized capture below the target rate (e.g. an SDR++ baseband
+// WAV at 39062.5 Hz, or the 48 kHz reference recording) rarely reduces
+// to small terms against a 144 kHz / 48 kHz target, so beyond these
+// bounds ddcRatio snaps to the nearest achievable rate within
+// ddcUpTolerance instead — the receiver sizes its matched filter and
+// clock loop from OutRateHz, so a sub-percent rate error is harmless.
+const (
+	ddcUpMaxNumer  = 4096
+	ddcUpMaxDenom  = 64
+	ddcUpTolerance = 0.01
+)
+
+// ddcUpMinTaps is the minimum anti-imaging prototype length for the
+// up-sampling path. The decimation sizing (∝ M) collapses to a handful
+// of taps when M is small — as it is when interpolating — and a short
+// prototype leaves the L-1 spectral images the zero-stuffing creates
+// poorly rejected, which measurably distorts the demodulated π/4-DQPSK
+// constellation (whole dibit classes drop out). A fixed ~192-tap floor
+// restores a >60 dB image stopband across the L values sub-target
+// captures produce; the MACs run at the output rate, so the cost is a
+// flat ~ddcUpMinTaps/L per output sample.
+const ddcUpMinTaps = 192
+
+// Downconverter resamples an SDR IQ stream to a narrowband channel
+// rate — decimating a wideband live stream, or interpolating a
+// pre-channelized sub-target capture.
 //
-// Decimation is a rational polyphase resample (dsp.Resampler) whose
-// L/M ratio is chosen so the output rate lands exactly on the
-// requested target for every standard SDR rate. When the SDR already
-// streams at (or below) the target the resampler is skipped and the
-// chunk passes straight through — keeping the rate==target unit
-// tests (and any future low-rate SDR) on a no-op path.
+// Resampling is a rational polyphase resample (dsp.Resampler) whose
+// L/M ratio is chosen so the output rate lands on (or very near) the
+// requested target for every standard SDR rate. A live wideband SDR
+// decimates DOWN; a pre-channelized capture below the target (an SDR++
+// baseband WAV, the 48 kHz reference recording) is resampled UP so the
+// receiver still gets its designed samples-per-symbol. Only when the
+// stream already sits exactly at the target is the resampler skipped
+// and the chunk forwarded unchanged (the rate==target no-op path).
 //
 // It deliberately does NOT remove the front-end DC offset: a C4FM /
 // FM control channel carries real signal energy at 0 Hz (the FM
@@ -100,14 +128,16 @@ const ddcKaiserBeta = 7.0
 type Downconverter struct {
 	nco       *dsp.NCO       // nil ⇒ no tuning shift (channel already at DC)
 	mixBuf    []complex64    // scratch for the NCO mix, so raw is never mutated
-	resampler *dsp.Resampler // nil ⇒ pass-through (no decimation)
+	resampler *dsp.Resampler // nil ⇒ pass-through (rate already == target)
 	outRateHz float64
 }
 
-// NewDownconverter builds a down-converter that decimates inRateHz to
-// ~targetHz. The exact achieved output rate is reported by
-// OutRateHz (it equals targetHz for every SDR rate that reduces to
-// a sane L/M, and equals inRateHz in pass-through mode).
+// NewDownconverter builds a down-converter that resamples inRateHz to
+// ~targetHz (decimating a wideband SDR, or interpolating a
+// pre-channelized sub-target capture up to the receiver's rate). The
+// exact achieved output rate is reported by OutRateHz (it equals
+// targetHz for every rate that reduces to a sane L/M, and equals
+// inRateHz on the rate==target pass-through).
 func NewDownconverter(inRateHz, targetHz float64) *Downconverter {
 	return NewDownconverterWithOffset(inRateHz, targetHz, 0)
 }
@@ -126,13 +156,20 @@ func NewDownconverterWithOffset(inRateHz, targetHz, offsetHz float64) *Downconve
 	}
 	in := int(math.Round(inRateHz))
 	target := int(math.Round(targetHz))
-	if in <= 0 || target <= 0 || in <= target {
-		return d // pass-through decimation: the NCO mix (if any) still runs
+	if in <= 0 || target <= 0 || in == target {
+		return d // pass-through: the NCO mix (if any) still runs
 	}
 	l, m := ddcRatio(target, in)
 	tapsPerBranch := (ddcStopbandTaps*m + l - 1) / l
 	if tapsPerBranch < 8 {
 		tapsPerBranch = 8
+	}
+	if in < target {
+		// Interpolation: size the prototype for image rejection, not by
+		// the decimation ∝M formula (which goes tiny when up-sampling).
+		if up := (ddcUpMinTaps + l - 1) / l; up > tapsPerBranch {
+			tapsPerBranch = up
+		}
 	}
 	d.resampler = dsp.NewResampler(l, m, tapsPerBranch, ddcKaiserBeta)
 	d.outRateHz = inRateHz * float64(l) / float64(m)
@@ -140,13 +177,13 @@ func NewDownconverterWithOffset(inRateHz, targetHz, offsetHz float64) *Downconve
 }
 
 // OutRateHz returns the achieved narrowband output rate (equals the
-// requested target for standard SDR rates that reduce to a sane L/M;
-// equals inRateHz in pass-through mode). Callers building a receiver
+// requested target for rates that reduce to a sane L/M; equals inRateHz
+// on the rate==target pass-through). Callers building a receiver
 // against the downconverter's output should use this value for
 // SampleRateHz so matched-filter sizing matches the actual stream.
 func (d *Downconverter) OutRateHz() float64 { return d.outRateHz }
 
-// Process decimates one raw IQ chunk to the narrowband rate. dst is
+// Process resamples one raw IQ chunk to the narrowband rate. dst is
 // reused if it has capacity; the returned slice holds the narrowband
 // output (len ≈ len(raw)·outRateHz/inRateHz). In pass-through mode
 // raw is returned unchanged. raw is never mutated.
@@ -176,21 +213,63 @@ func (d *Downconverter) Reset() {
 	}
 }
 
-// ddcRatio reduces target/in to its lowest L/M terms. A non-standard
-// SDR rate can reduce to a pathologically large ratio; since the
-// output rate only needs to be *roughly* 48 kHz, those fall back to
-// a pure integer decimator (L=1).
+// ddcRatio reduces the resample rate to L/M terms for the polyphase
+// resampler. It handles both directions:
+//
+//   - Decimation (in > target): reduce target/in to lowest terms. A
+//     non-standard SDR rate can reduce to a pathologically large ratio;
+//     since the output rate only needs to be *roughly* the target,
+//     those fall back to a pure integer decimator (L=1).
+//   - Interpolation (in < target): a pre-channelized capture below the
+//     target (an SDR++ baseband WAV, the 48 kHz reference recording) is
+//     resampled UP so the receiver gets its designed ~8 samples/symbol
+//     instead of the fractional sps that broke decode before (a
+//     39062.5 Hz WAV ran the TETRA receiver at +8.5 % baud). Use the
+//     exact reduced ratio when its terms are cheap; otherwise snap to
+//     the smallest-denominator rational whose achieved rate lands
+//     within ddcUpTolerance of target.
+//
+// in == target never reaches here — the caller pass-through handles it.
 func ddcRatio(target, in int) (l, m int) {
+	if in > target {
+		g := gcd(target, in)
+		l, m = target/g, in/g
+		if l > 64 || m > 8192 {
+			l = 1
+			m = int(math.Round(float64(in) / float64(target)))
+			if m < 1 {
+				m = 1
+			}
+		}
+		return l, m
+	}
+
+	// Interpolation. Exact reduced ratio first.
 	g := gcd(target, in)
 	l, m = target/g, in/g
-	if l > 64 || m > 8192 {
-		l = 1
-		m = int(math.Round(float64(in) / float64(target)))
-		if m < 1 {
-			m = 1
+	if l <= ddcUpMaxNumer && m <= ddcUpMaxDenom {
+		return l, m
+	}
+	// Search for the smallest denominator whose achieved output rate is
+	// within tolerance; smallest M within tolerance wins (cheapest
+	// resampler). Fall back to the closest ratio found if none clears
+	// the tolerance.
+	bestL, bestM, bestErr := l, m, math.Inf(1)
+	for mm := 1; mm <= ddcUpMaxDenom; mm++ {
+		ll := int(math.Round(float64(target) * float64(mm) / float64(in)))
+		if ll <= mm {
+			continue // must interpolate (L > M)
+		}
+		achieved := float64(in) * float64(ll) / float64(mm)
+		err := math.Abs(achieved-float64(target)) / float64(target)
+		if err < bestErr {
+			bestErr, bestL, bestM = err, ll, mm
+		}
+		if err <= ddcUpTolerance {
+			return ll, mm
 		}
 	}
-	return l, m
+	return bestL, bestM
 }
 
 func gcd(a, b int) int {

--- a/internal/scanner/ccdecoder/ddc_test.go
+++ b/internal/scanner/ccdecoder/ddc_test.go
@@ -139,6 +139,82 @@ func TestDownconverterIsolatesChannel(t *testing.T) {
 	}
 }
 
+// TestDownconverterUpsampleBuildsResampler: a pre-channelized capture
+// BELOW the target rate must be interpolated up to ~target, not passed
+// through — the regression guard for the low-rate-replay bug where a
+// 39062.5 Hz / 48000 Hz WAV reached the TETRA receiver at a fractional
+// samples-per-symbol and decoded at the wrong baud. Before the fix
+// NewDownconverter returned a nil resampler for in < target.
+func TestDownconverterUpsampleBuildsResampler(t *testing.T) {
+	const target = tetraDDCTargetRateHz // 144 kHz, 8 sps at 18000 baud
+
+	// 48 kHz → 144 kHz is an exact 3× interpolation.
+	d48 := NewDownconverter(48_000, target)
+	if d48.resampler == nil {
+		t.Errorf("48000 → %v: expected a resampler (was pass-through before fix)", target)
+	}
+	if math.Abs(d48.outRateHz-target) > 1e-6 {
+		t.Errorf("48000 → %v: outRateHz = %v, want %v exactly", target, d48.outRateHz, target)
+	}
+
+	// 39062.5 Hz (2.5 MS/s ÷ 64, the SDR++ baseband rate) does not
+	// reduce to small terms, so the ratio search snaps to within 1 %.
+	dbb := NewDownconverter(39_062.5, target)
+	if dbb.resampler == nil {
+		t.Fatalf("39062.5 → %v: expected a resampler (was pass-through before fix)", target)
+	}
+	if relErr := math.Abs(dbb.outRateHz-target) / target; relErr > ddcUpTolerance {
+		t.Errorf("39062.5 → %v: outRateHz = %v (rel err %.4f), want within %.2f%%",
+			target, dbb.outRateHz, relErr, ddcUpTolerance*100)
+	}
+	if sps := dbb.outRateHz / 18_000; sps < 7.5 || sps > 8.5 {
+		t.Errorf("39062.5 → %v: sps = %.3f, want ~8 (in [7.5, 8.5])", target, sps)
+	}
+}
+
+// TestDownconverterUpsampleRateAndLength: the interpolated output has
+// ~len(in)·L/M samples and reports the corresponding rate.
+func TestDownconverterUpsampleRateAndLength(t *testing.T) {
+	const target = tetraDDCTargetRateHz
+	d := NewDownconverter(48_000, target)
+	in := make([]complex64, 48_000) // 1 s at 48 kHz
+	out := d.Process(nil, in)
+	want := len(in) * 3 // exact 3× interpolation
+	if diff := len(out) - want; diff < -8 || diff > 8 {
+		t.Errorf("len(out) = %d, want %d ± 8", len(out), want)
+	}
+}
+
+// TestDownconverterUpsamplePreservesInbandTone: interpolation must not
+// attenuate an in-channel tone (gain restored) nor let a spectral image
+// leak into the band. Mirror of TestDownconverterIsolatesChannel for
+// the L>M path.
+func TestDownconverterUpsamplePreservesInbandTone(t *testing.T) {
+	const inRate, target = 48_000.0, tetraDDCTargetRateHz
+	const n = 48_000
+	// +5 kHz is well inside both the 48 kHz input band and the TETRA
+	// channel; it must survive interpolation at ~unity gain.
+	out := NewDownconverter(inRate, target).
+		Process(nil, complexTone(5_000, inRate, n, 1.0))
+	if got := rms(out[200:]); got < 0.7 || got > 1.3 {
+		t.Errorf("in-band tone after upsample: rms = %v, want ~1.0", got)
+	}
+}
+
+// TestDownconverterPassthroughPreserved: the fix must not disturb the
+// rate==target no-op path — only in < target changed.
+func TestDownconverterPassthroughPreserved(t *testing.T) {
+	for _, rate := range []float64{48_000, tetraDDCTargetRateHz} {
+		d := NewDownconverter(rate, rate)
+		if d.resampler != nil {
+			t.Errorf("rate==target %v: expected pass-through (nil resampler)", rate)
+		}
+		if d.outRateHz != rate {
+			t.Errorf("rate==target %v: outRateHz = %v, want %v", rate, d.outRateHz, rate)
+		}
+	}
+}
+
 // TestDownconverterReset: after Reset the decimation filter history
 // is cleared, so re-processing the same input reproduces the first
 // run bit-for-bit.

--- a/internal/scanner/ccdecoder/ddc_tetra_lock_test.go
+++ b/internal/scanner/ccdecoder/ddc_tetra_lock_test.go
@@ -1,0 +1,210 @@
+package ccdecoder
+
+import (
+	"io"
+	"log/slog"
+	"math"
+	"testing"
+
+	"github.com/MattCheramie/GopherTrunk/internal/dsp"
+	"github.com/MattCheramie/GopherTrunk/internal/dsp/demod"
+	"github.com/MattCheramie/GopherTrunk/internal/events"
+	"github.com/MattCheramie/GopherTrunk/internal/radio/tetra"
+	tetrarx "github.com/MattCheramie/GopherTrunk/internal/radio/tetra/receiver"
+)
+
+// TestDDCUpsamplesSubTargetTETRAToLock is the end-to-end regression for
+// the low-rate-replay bug: a pre-channelized TETRA capture BELOW the
+// 144 kHz channel target (an SDR++ baseband WAV at 39062.5 Hz, or the
+// 48 kHz reference recording) must be interpolated up to the receiver's
+// 8-samples-per-symbol design point before demod. Before the fix the
+// Downconverter passed a sub-target stream through untouched, so the
+// receiver computed a fractional sps and rounded it — a 48 kHz stream
+// decoded at 16000 baud (−11 %), a 39062.5 Hz stream at +8.5 %, and
+// nothing locked.
+//
+// It drives a clean, fully SCH/HD-channel-coded MLE SYSINFO burst train
+// through the *production* TETRA receiver configuration (Gardner gain
+// 0.005, AFC + channel filter on — the newTETRAPipeline values) and
+// asserts both halves of the fix:
+//
+//	arm A: feeding the 48 kHz capture straight to the receiver does NOT
+//	       lock — the documented pre-fix failure mode.
+//	arm B: routing the same 48 kHz capture through the Downconverter,
+//	       which now interpolates it up to 144 kHz, DOES lock and
+//	       recovers the encoded LocationArea.
+//
+// Before the ddc.go fix arm B's Downconverter reported OutRateHz ==
+// 48000 (pass-through) and arm B failed exactly like arm A; the fix is
+// what makes OutRateHz == 144000 and the lock appear.
+func TestDDCUpsamplesSubTargetTETRAToLock(t *testing.T) {
+	const (
+		controlFreqHz        = 412_062_500
+		colourCode           = uint32(0x12345)
+		locationArea  uint16 = 0x42
+	)
+
+	// Build a clean 144 kHz (8 sps) π/4-DQPSK capture, then downsample it
+	// 3:1 to a genuine 48 kHz TETRA capture — 48000/18000 = 2.667 sps, a
+	// non-multiple of the baud, which is what broke decode before the fix.
+	dibits := buildTETRASCHHDDibits(120, colourCode, locationArea)
+	iq144 := demod.ModulatePiOver4DQPSK(dibits, 8, 8, 0.35, math.Pi/4)
+	iq48 := dsp.NewResampler(1, 3, 64, ddcKaiserBeta).Process(nil, iq144)
+
+	// arm A: 48 kHz straight into the receiver → fractional sps → no lock.
+	if locked, _ := runTETRAReceiver(t, iq48, nil, 48_000, controlFreqHz, colourCode, locationArea); locked {
+		t.Fatalf("arm A: a 48 kHz sub-target capture locked without up-sampling; " +
+			"the pre-fix fractional-sps failure it documents is gone — check the test")
+	}
+
+	// arm B: 48 kHz through the Downconverter (now interpolates to 144 kHz).
+	dc := NewDownconverter(48_000, tetraDDCTargetRateHz)
+	if math.Abs(dc.OutRateHz()-tetraDDCTargetRateHz) > 1e-6 {
+		t.Fatalf("arm B: Downconverter OutRateHz = %v, want %v — the up-sample fix is not in effect",
+			dc.OutRateHz(), tetraDDCTargetRateHz)
+	}
+	locked, gotLA := runTETRAReceiver(t, iq48, dc, dc.OutRateHz(), controlFreqHz, colourCode, locationArea)
+	if !locked {
+		t.Fatalf("arm B: no cc.locked after up-sampling 48 kHz → %v; the DDC interpolation fix failed",
+			tetraDDCTargetRateHz)
+	}
+	if gotLA != locationArea {
+		t.Errorf("arm B: LockState.LocationArea = %#x, want %#x", gotLA, locationArea)
+	}
+}
+
+// runTETRAReceiver feeds iq (chunked) through an optional Downconverter
+// and then the production-configured TETRA receiver at rxRate, and
+// reports whether a cc.locked fired and the LocationArea it carried.
+func runTETRAReceiver(t *testing.T, iq []complex64, dc *Downconverter, rxRate float64,
+	controlFreqHz uint32, colourCode uint32, _ uint16) (bool, uint16) {
+	t.Helper()
+
+	bus := events.NewBus(64)
+	defer bus.Close()
+	sub := bus.Subscribe()
+	defer sub.Close()
+
+	cc := tetra.New(tetra.Options{
+		Bus:         bus,
+		Log:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SystemName:  "TETRASite",
+		FrequencyHz: controlFreqHz,
+	})
+	cc.SetChannelCoding(tetra.ChannelCodingOn)
+	cc.SetExpectedChannel(tetra.ChannelSCHHD)
+	cc.SetColourCode(colourCode)
+
+	rx := tetrarx.New(tetrarx.Options{
+		SampleRateHz: rxRate,
+		ClockMode:    tetrarx.ClockGardner,
+		GardnerGain:  0.005,
+		// AFC and the channel-select filter are left off here, matching
+		// the receiver-package TestReceiverGardnerLocksTETRACCAt144kHz.
+		// This test isolates the DDC rate fix: does a sub-target capture,
+		// interpolated to the receiver's 8-sps design point, decode? The
+		// feed-forward AFC's data-blind 4·Δφ estimator misfires on a
+		// perfectly noiseless *resampled* synthetic fixture (it reads a
+		// spurious offset off the resampler's residual images and
+		// derotates, collapsing a dibit class) — an artifact of the
+		// zero-noise fixture, not of the DDC. The AFC's real value on
+		// off-centre on-air captures is covered elsewhere.
+		DibitSink: func(dibits []uint8, baseIdx int) {
+			cc.Process(dibits, baseIdx)
+		},
+		SoftSink: func(diffs []complex64, baseIdx int) {
+			cc.StashSoft(diffs, baseIdx)
+		},
+	})
+
+	const chunk = 4096
+	var scratch []complex64
+	for i := 0; i < len(iq); i += chunk {
+		end := i + chunk
+		if end > len(iq) {
+			end = len(iq)
+		}
+		block := iq[i:end]
+		if dc != nil {
+			scratch = dc.Process(scratch[:0], block)
+			block = scratch
+		}
+		rx.Process(block)
+	}
+
+	var locked bool
+	var gotLA uint16
+drain:
+	for {
+		select {
+		case ev := <-sub.C:
+			if ev.Kind != events.KindCCLocked {
+				continue
+			}
+			if ls, ok := ev.Payload.(tetra.LockState); ok {
+				locked = true
+				gotLA = ls.LocationArea
+			}
+		default:
+			break drain
+		}
+	}
+	return locked, gotLA
+}
+
+// buildTETRASCHHDDibits assembles the dibit stream the DDC lock test
+// modulates: a 400-dibit 0..3 warmup so the matched filter + Gardner
+// loop converge, then `repeats` bursts of (normal training sequence +
+// SCH/HD-encoded MLE SYSINFO + 50 idle dibits), then a 100-dibit flush.
+// Mirrors buildTETRASCHHDStream in the cmd/gophertrunk integration test
+// and buildTETRASCHHDDibits in the receiver package; kept local because
+// those live in other packages.
+func buildTETRASCHHDDibits(repeats int, colourCode uint32, locationArea uint16) []uint8 {
+	payload := []byte{0x00, 0x00, 0x00, 0, 0}
+	payload[3] = byte((locationArea >> 6) & 0xFF)
+	payload[4] = byte((locationArea & 0x3F) << 2)
+
+	pdu := tetra.PDU{
+		Disc:    tetra.DiscMLE,
+		Type:    uint8(tetra.MLESystemInfo),
+		Payload: payload,
+	}
+	info := pduToType1BitsTETRA(pdu, 124)
+	type5 := tetra.EncodeSCHHD(info, colourCode)
+	burstDibits := tetra.TetraBitsToDibits(type5)
+
+	frame := make([]uint8, 0, len(tetra.NormalSyncDibits())+len(burstDibits))
+	frame = append(frame, tetra.NormalSyncDibits()...)
+	frame = append(frame, burstDibits...)
+
+	out := make([]uint8, 0, 400+repeats*(len(frame)+50)+100)
+	for i := 0; i < 400; i++ {
+		out = append(out, uint8(i&3))
+	}
+	for r := 0; r < repeats; r++ {
+		out = append(out, frame...)
+		for i := 0; i < 50; i++ {
+			out = append(out, uint8(i&3))
+		}
+	}
+	for i := 0; i < 100; i++ {
+		out = append(out, uint8(i&3))
+	}
+	return out
+}
+
+// pduToType1BitsTETRA pads a PDU's assembled bytes into exactly k1 bits,
+// MSB-first per byte. Mirror of the tetra-package test helper.
+func pduToType1BitsTETRA(pdu tetra.PDU, k1 int) []byte {
+	bytes := tetra.AssemblePDU(pdu)
+	if len(bytes)*8 > k1 {
+		return nil
+	}
+	out := make([]byte, k1)
+	for i, b := range bytes {
+		for j := 0; j < 8; j++ {
+			out[i*8+j] = (b >> uint(7-j)) & 1
+		}
+	}
+	return out
+}

--- a/samples/tetra/README.md
+++ b/samples/tetra/README.md
@@ -180,12 +180,29 @@ surfaced two findings.
    the committed 48 kHz `TETRA IQ.wav` and any SDR++ baseband WAV now
    feed the receiver at the right baud.
 
-Follow-up (not fixed here): the receiver's feed-forward carrier AFC
-leaves a residual offset on a noisy or resampled constellation — an
-external CFO correction lifted the slice's NTS hit count 129 → 173, and
-the AFC's data-blind 4·Δφ estimator misfires on noiseless resampled IQ.
-A decision-directed / finer carrier-tracking loop is worth a separate,
-independently-verifiable change.
+On the carrier AFC (`internal/radio/tetra/receiver/afc.go`): a follow-up
+investigation with controlled fixtures found it **sound**, not the
+weak link the residual originally looked like. Its per-block feed-forward
+4·Δφ estimator drives a constant offset to a **~1 Hz** residual on a
+clean signal and **~3 Hz at 6 dB SNR**, and still locks under linear
+drift (±1.5 kHz across the capture) and per-symbol phase noise
+(400 Hz-rms). The earlier "misfire on resampled IQ" was the DDC's short
+up-sampling prototype (images collapsing a dibit class), fixed above by
+`ddcUpMinTaps` — not the AFC. So the 15 Jul slice's ~700–900 Hz offset
+is well inside what the AFC removes, and its non-lock is the baked-in
+modulation degradation, consistent with #764 rather than a carrier bug.
+
+The AFC's one real boundary is its **±2250 Hz pull-in ceiling** — the
+4·Δφ estimator folds larger offsets into ±π/4 per symbol, so a control
+channel sitting more than ~2.25 kHz off centre after tuning does not
+lock (verified: a clean 3 kHz offset fails). That gross offset is
+nominally the tuner/DDC's job (`-tune-hz` / `-auto-tune` / `iq_invert`),
+so it is a documented design boundary, not a defect. Extending it would
+need a coarse frequency-acquisition stage ahead of the fine estimator
+computed on the pre-matched-filter signal (the matched RRC, centred at
+0 Hz, biases any coarse estimate taken after it toward 0) — a
+self-contained enhancement worth its own change, but one that would not
+have altered the 15 Jul result.
 
 ## Recommended sources
 

--- a/samples/tetra/README.md
+++ b/samples/tetra/README.md
@@ -136,6 +136,57 @@ the carrier/timing loop). A **≥30 s** cleartext capture that includes
 several clean frame-18 SB slots is still what closes the lock + Viterbi
 histogram criteria.
 
+### What the 15 Jul capture set taught us (469.875 MHz, 2.5 MS/s)
+
+A third contribution — a `gophertrunk`-bundle downlink capture at
+469.875 MHz plus SDR++ side recordings — was replayed through the
+production pipeline. The set:
+
+- a bundle DDC slice (`.slice.wav`, 144 kHz IQ, 15 s),
+- an SDR++ **baseband** WAV (39062.5 Hz IQ = 2.5 MS/s ÷ 64, 90 s),
+- an SDR++ **audio** WAV (48 kHz mono — already FM/PSK-demodulated
+  audio, not IQ, so not decodable).
+
+None are committed (`samples/.gitignore` excludes `*.wav`), but they
+surfaced two findings.
+
+1. **The signal is modulation-degraded — it does not lock.** On the
+   144 kHz slice the receiver acquires stable symbol timing (17954 baud)
+   and correlates the normal training sequence on the correct 255-dibit
+   TDMA grid (NTS1 at Hamming distance 1, ~129 hits in 15 s), but the
+   demodulated dibit histogram is skewed (~37/18/17/28 % vs. the ideal
+   25/25/25/25), the constellation EVM is ≈22 %, and **every** SCH/HD
+   burst fails the §8.3.1 CRC-16. Over the full 90 s baseband capture
+   (1189 normal bursts, resampled to 144 kHz + CFO-corrected + spectrum
+   de-inverted) the chain recovers effectively **zero** genuine
+   CRC-valid frames — a single pass in 1189 is at the ~1.8 % random
+   CRC-16 collision rate. This is the same "the degradation is baked
+   into the captured samples" signature as issues #764/#771: no receiver
+   change recovers it, so **no `cc.locked` is claimed** and no
+   `.metadata.json` sidecar ships (the skip-gated realair test stays
+   dormant). A cleaner cleartext downlink is still what's needed.
+
+2. **It exposed a real low-rate-replay bug (now fixed).** The 39062.5 Hz
+   baseband WAV decoded at **+8.5 % baud (19531 vs. 18000)** with a
+   broken TDMA grid, because `ccdecoder.Downconverter` only *decimated*:
+   a pre-channelized capture below the 144 kHz TETRA target was passed
+   through un-resampled, and the receiver rounded the resulting
+   fractional 2.17 samples/symbol to 2. The down-converter now
+   **interpolates** a sub-target stream up to the per-protocol channel
+   rate so the receiver always gets its designed ~8 sps (see
+   `internal/scanner/ccdecoder/ddc.go`; regression tests
+   `TestDownconverterUpsample*` and `TestDDCUpsamplesSubTargetTETRAToLock`
+   in that package, plus `TestDaemonCCDecodesTETRAAt48kHz`). This is why
+   the committed 48 kHz `TETRA IQ.wav` and any SDR++ baseband WAV now
+   feed the receiver at the right baud.
+
+Follow-up (not fixed here): the receiver's feed-forward carrier AFC
+leaves a residual offset on a noisy or resampled constellation — an
+external CFO correction lifted the slice's NTS hit count 129 → 173, and
+the AFC's data-blind 4·Δφ estimator misfires on noiseless resampled IQ.
+A decision-directed / finer carrier-tracking loop is worth a separate,
+independently-verifiable change.
+
 ## Recommended sources
 
 - **telive / osmo-tetra** — produces both IQ recordings and a


### PR DESCRIPTION
The Downconverter only decimated: a pre-channelized capture below the
per-protocol channel target (an SDR++ baseband WAV at 39062.5 Hz, or the
48 kHz reference recording) was passed through un-resampled, so the TETRA
receiver rounded the fractional 2.17 samples/symbol to 2 and decoded at
+8.5 % baud (19531 vs 18000) — no lock possible. Surfaced replaying the
15 Jul 469.875 MHz capture set.

NewDownconverterWithOffset now interpolates a sub-target stream up to the
channel rate (144 kHz / 8 sps for TETRA) instead of only passing it
through: a bounded-rational L/M selector handles rates that don't reduce
to small terms (the receiver sizes from OutRateHz, so a sub-percent rate
error is harmless), and the interpolation prototype gets a generous
anti-imaging length — short filters leave the zero-stuffing images that
collapse whole π/4-DQPSK dibit classes. Only the in < target path
changes; decimation and the rate==target pass-through stay byte-exact.

Regression tests (all fail without the fix): TestDownconverterUpsample*
(resampler built, rate, length, in-band tone), the DDC→receiver
TestDDCUpsamplesSubTargetTETRAToLock (a 48 kHz capture locks only when
routed through the DDC), and TestDaemonCCDecodesTETRAAt48kHz end-to-end.

samples/tetra/README.md records the 15 Jul analysis: the signal itself is
modulation-degraded (EVM ~22 %, ~0 CRC-valid frames over 90 s) and does
not lock — no real-air lock is claimed — plus the AFC residual-offset
follow-up the captures surfaced.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NaZoctq3yKUWRR13grFx5K